### PR TITLE
feat(devices): make every Devices-list column sortable by header click

### DIFF
--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DeviceList, { type Device } from './DeviceList';
 
@@ -166,6 +166,126 @@ describe('DeviceList — advanced filter via serverFilterIds prop (uncapped id s
     expect(screen.getByText('host-aa')).toBeTruthy();
     expect(screen.getByText('host-bb')).toBeTruthy();
     expect(screen.queryByText(/Advanced filter active/i)).toBeNull();
+  });
+});
+
+describe('DeviceList — sortable columns (every column sorts on header click)', () => {
+  // Hostnames of rendered rows, in DOM order. Each fixture uses a unique
+  // hostname so order assertions read naturally.
+  const rowOrder = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('tbody tr td:nth-child(2) span')).map(el => el.textContent);
+
+  const clickHeader = (title: string) => fireEvent.click(screen.getByTitle(title));
+
+  // jsdom in this setup exposes no window.localStorage; install the same
+  // in-memory stub columnVisibility.test.ts uses so column prefs read/write.
+  beforeEach(() => {
+    const data = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        get length() {
+          return data.size;
+        },
+        clear: () => data.clear(),
+        getItem: (key: string) => data.get(key) ?? null,
+        setItem: (key: string, value: string) => void data.set(key, String(value)),
+        removeItem: (key: string) => void data.delete(key),
+        key: (i: number) => Array.from(data.keys())[i] ?? null,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('sorts a previously-unsortable column (Organization) alphabetically and toggles direction on second click', () => {
+    const devices: Device[] = [
+      { ...baseDevice, id: 'a1a1a1a1-0000-0000-0000-000000000001', hostname: 'host-zeta', orgName: 'Zeta Corp' },
+      { ...baseDevice, id: 'a1a1a1a1-0000-0000-0000-000000000002', hostname: 'host-acme', orgName: 'Acme' },
+      { ...baseDevice, id: 'a1a1a1a1-0000-0000-0000-000000000003', hostname: 'host-mid', orgName: 'Midway' },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by organization');
+    expect(rowOrder(container)).toEqual(['host-acme', 'host-mid', 'host-zeta']);
+
+    clickHeader('Sort by organization');
+    expect(rowOrder(container)).toEqual(['host-zeta', 'host-mid', 'host-acme']);
+  });
+
+  it('sorts hostnames with numeric collation (host-2 before host-10)', () => {
+    const devices: Device[] = [
+      { ...baseDevice, id: 'b1b1b1b1-0000-0000-0000-000000000001', hostname: 'host-10' },
+      { ...baseDevice, id: 'b1b1b1b1-0000-0000-0000-000000000002', hostname: 'host-2' },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by hostname');
+    expect(rowOrder(container)).toEqual(['host-2', 'host-10']);
+  });
+
+  it('sorts status by operational rank (online → maintenance → offline), not enum alphabetics', () => {
+    const devices: Device[] = [
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000001', hostname: 'host-off', status: 'offline' },
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000002', hostname: 'host-on', status: 'online' },
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000003', hostname: 'host-maint', status: 'maintenance' },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by status');
+    expect(rowOrder(container)).toEqual(['host-on', 'host-maint', 'host-off']);
+  });
+
+  it('keeps dash cells last in BOTH directions (offline device has no CPU reading)', () => {
+    const devices: Device[] = [
+      { ...baseDevice, id: 'd1d1d1d1-0000-0000-0000-000000000001', hostname: 'host-no-cpu', status: 'offline', cpuPercent: 0 },
+      { ...baseDevice, id: 'd1d1d1d1-0000-0000-0000-000000000002', hostname: 'host-busy', cpuPercent: 90 },
+      { ...baseDevice, id: 'd1d1d1d1-0000-0000-0000-000000000003', hostname: 'host-idle', cpuPercent: 5 },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by CPU usage');
+    expect(rowOrder(container)).toEqual(['host-idle', 'host-busy', 'host-no-cpu']);
+
+    clickHeader('Sort by CPU usage');
+    expect(rowOrder(container)).toEqual(['host-busy', 'host-idle', 'host-no-cpu']);
+  });
+
+  it('sorts agent versions numerically aware (0.9.0 before 0.10.0) on an opted-in column', () => {
+    // agentVersion is not in DEFAULT_VISIBLE_COLUMNS; opt it in via the same
+    // versioned localStorage shape columnVisibility.ts persists.
+    window.localStorage.setItem(
+      'breeze.devices.columns',
+      JSON.stringify({ v: 1, columns: [{ id: 'agentVersion', visible: true }] }),
+    );
+    const devices: Device[] = [
+      { ...baseDevice, id: 'e1e1e1e1-0000-0000-0000-000000000001', hostname: 'host-ten', agentVersion: '0.10.0' },
+      { ...baseDevice, id: 'e1e1e1e1-0000-0000-0000-000000000002', hostname: 'host-nine', agentVersion: '0.9.0' },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by agent version');
+    // agentVersion was stored first, so it renders as the first data column.
+    const hostCol = Array.from(container.querySelectorAll('tbody tr td:nth-child(3) span')).map(el => el.textContent);
+    expect(hostCol).toEqual(['host-nine', 'host-ten']);
+  });
+
+  it('renders every rendered column header as sortable (clickable with a sort hint)', () => {
+    const { container } = render(<DeviceList devices={[baseDevice]} />);
+
+    const headers = Array.from(container.querySelectorAll('thead th'));
+    // First (checkbox) and last (Actions) are structural; everything between
+    // must carry a "Sort by ..." hint wired to handleSort.
+    const dataHeaders = headers.slice(1, -1);
+    expect(dataHeaders.length).toBeGreaterThan(0);
+    for (const th of dataHeaders) {
+      expect(th.getAttribute('title')).toMatch(/^Sort by /);
+      expect(th.className).toContain('cursor-pointer');
+    }
   });
 });
 

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import DeviceList, { type Device } from './DeviceList';
+import { COLUMN_IDS } from './columnVisibility';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -177,9 +178,15 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
 
   const clickHeader = (title: string) => fireEvent.click(screen.getByTitle(title));
 
-  // jsdom in this setup exposes no window.localStorage; install the same
-  // in-memory stub columnVisibility.test.ts uses so column prefs read/write.
+  // Install a fresh in-memory localStorage per test (same stub shape as
+  // columnVisibility.test.ts). The point is isolation: jsdom's storage
+  // persists across tests within a file, so a column-visibility write in
+  // one test (e.g. the agentVersion opt-in below) would leak into later
+  // tests. afterEach restores whatever the environment had, so describe
+  // blocks running after this one keep exercising the real fallback path.
+  let originalLocalStorage: PropertyDescriptor | undefined;
   beforeEach(() => {
+    originalLocalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage');
     const data = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
       value: {
@@ -195,6 +202,14 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
       writable: true,
       configurable: true,
     });
+  });
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      Object.defineProperty(window, 'localStorage', originalLocalStorage);
+    } else {
+      Reflect.deleteProperty(window, 'localStorage');
+    }
   });
 
   it('sorts a previously-unsortable column (Organization) alphabetically and toggles direction on second click', () => {
@@ -225,17 +240,25 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     expect(rowOrder(container)).toEqual(['host-2', 'host-10']);
   });
 
-  it('sorts status by operational rank (online → maintenance → offline), not enum alphabetics', () => {
+  it('sorts status by operational rank, not enum alphabetics, across every co-renderable status', () => {
+    // All statuses except decommissioned, which can never co-render with the
+    // others (the default "all" filter hides it; selecting it shows only it),
+    // so its rank entry is untestable through the rendered table. A dropped
+    // statusSortRank entry for any of these six would produce NaN comparisons
+    // and scramble this expected order.
     const devices: Device[] = [
       { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000001', hostname: 'host-off', status: 'offline' },
-      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000002', hostname: 'host-on', status: 'online' },
-      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000003', hostname: 'host-maint', status: 'maintenance' },
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000002', hostname: 'host-quar', status: 'quarantined' },
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000003', hostname: 'host-on', status: 'online' },
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000004', hostname: 'host-pend', status: 'pending' },
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000005', hostname: 'host-maint', status: 'maintenance' },
+      { ...baseDevice, id: 'c1c1c1c1-0000-0000-0000-000000000006', hostname: 'host-upd', status: 'updating' },
     ];
 
     const { container } = render(<DeviceList devices={devices} />);
 
     clickHeader('Sort by status');
-    expect(rowOrder(container)).toEqual(['host-on', 'host-maint', 'host-off']);
+    expect(rowOrder(container)).toEqual(['host-on', 'host-upd', 'host-pend', 'host-maint', 'host-quar', 'host-off']);
   });
 
   it('keeps dash cells last in BOTH directions (offline device has no CPU reading)', () => {
@@ -274,18 +297,82 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     expect(hostCol).toEqual(['host-nine', 'host-ten']);
   });
 
-  it('renders every rendered column header as sortable (clickable with a sort hint)', () => {
+  it('renders all 24 catalog columns with a sort hint and pointer cursor when every column is visible', () => {
+    // Default visibility shows only 9 columns, which would let the other 15
+    // silently regress to plain <th> elements. Opt every catalog column in.
+    window.localStorage.setItem(
+      'breeze.devices.columns',
+      JSON.stringify({ v: 1, columns: COLUMN_IDS.map(id => ({ id, visible: true })) }),
+    );
+
     const { container } = render(<DeviceList devices={[baseDevice]} />);
 
     const headers = Array.from(container.querySelectorAll('thead th'));
     // First (checkbox) and last (Actions) are structural; everything between
-    // must carry a "Sort by ..." hint wired to handleSort.
+    // must carry the "Sort by ..." hint and the clickable styling. (The
+    // click-actually-reorders behavior is covered by the row-order tests.)
     const dataHeaders = headers.slice(1, -1);
-    expect(dataHeaders.length).toBeGreaterThan(0);
+    expect(dataHeaders.length).toBe(COLUMN_IDS.length);
     for (const th of dataHeaders) {
       expect(th.getAttribute('title')).toMatch(/^Sort by /);
       expect(th.className).toContain('cursor-pointer');
     }
+  });
+
+  // Seeds hostname first (keeps the rowOrder helper's td:nth-child(2) valid)
+  // plus the named extra column, so default-hidden columns can be sorted.
+  const seedColumns = (...extra: string[]) =>
+    window.localStorage.setItem(
+      'breeze.devices.columns',
+      JSON.stringify({ v: 1, columns: ['hostname', ...extra].map(id => ({ id, visible: true })) }),
+    );
+
+  it('sorts tags by the joined displayed list with untagged rows last in both directions', () => {
+    seedColumns('tags');
+    const devices: Device[] = [
+      { ...baseDevice, id: 'f1f1f1f1-0000-0000-0000-000000000001', hostname: 'host-zulu', tags: ['zulu'] },
+      { ...baseDevice, id: 'f1f1f1f1-0000-0000-0000-000000000002', hostname: 'host-untagged', tags: [] },
+      { ...baseDevice, id: 'f1f1f1f1-0000-0000-0000-000000000003', hostname: 'host-alpha', tags: ['alpha', 'beta'] },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by tags');
+    expect(rowOrder(container)).toEqual(['host-alpha', 'host-zulu', 'host-untagged']);
+
+    clickHeader('Sort by tags');
+    expect(rowOrder(container)).toEqual(['host-zulu', 'host-alpha', 'host-untagged']);
+  });
+
+  it('sorts uptime only for online devices — a non-online device with uptimeSeconds renders a dash and sorts last', () => {
+    seedColumns('uptime');
+    const devices: Device[] = [
+      { ...baseDevice, id: 'a2a2a2a2-0000-0000-0000-000000000001', hostname: 'host-offline-stale', status: 'offline', uptimeSeconds: 999_999 },
+      { ...baseDevice, id: 'a2a2a2a2-0000-0000-0000-000000000002', hostname: 'host-long-up', uptimeSeconds: 50_000 },
+      { ...baseDevice, id: 'a2a2a2a2-0000-0000-0000-000000000003', hostname: 'host-fresh-boot', uptimeSeconds: 100 },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by uptime');
+    expect(rowOrder(container)).toEqual(['host-fresh-boot', 'host-long-up', 'host-offline-stale']);
+  });
+
+  it('treats pendingReboot false/absent as a dash cell: sorts last in both directions, true rows first', () => {
+    seedColumns('pendingReboot');
+    const devices: Device[] = [
+      { ...baseDevice, id: 'b2b2b2b2-0000-0000-0000-000000000001', hostname: 'host-clean', pendingReboot: false },
+      { ...baseDevice, id: 'b2b2b2b2-0000-0000-0000-000000000002', hostname: 'host-needs-reboot', pendingReboot: true },
+      { ...baseDevice, id: 'b2b2b2b2-0000-0000-0000-000000000003', hostname: 'host-old-agent' },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by pending reboot');
+    expect(rowOrder(container)).toEqual(['host-needs-reboot', 'host-clean', 'host-old-agent']);
+
+    clickHeader('Sort by pending reboot');
+    expect(rowOrder(container)).toEqual(['host-needs-reboot', 'host-clean', 'host-old-agent']);
   });
 });
 

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -319,6 +319,27 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     }
   });
 
+  it('reflects sort state via aria-sort on the active header (a11y parity with Patches)', () => {
+    const devices: Device[] = [
+      { ...baseDevice, id: 'a1a1a1a1-0000-0000-0000-0000000000a1', hostname: 'host-b' },
+      { ...baseDevice, id: 'a1a1a1a1-0000-0000-0000-0000000000a2', hostname: 'host-a' },
+    ];
+    render(<DeviceList devices={devices} />);
+
+    const hostHeader = screen.getByTitle('Sort by hostname');
+    const osHeader = screen.getByTitle('Sort by operating system');
+    // Unsorted: every header advertises aria-sort="none".
+    expect(hostHeader.getAttribute('aria-sort')).toBe('none');
+    expect(osHeader.getAttribute('aria-sort')).toBe('none');
+
+    fireEvent.click(hostHeader);
+    expect(hostHeader.getAttribute('aria-sort')).toBe('ascending');
+    expect(osHeader.getAttribute('aria-sort')).toBe('none');
+
+    fireEvent.click(hostHeader);
+    expect(hostHeader.getAttribute('aria-sort')).toBe('descending');
+  });
+
   // Seeds hostname first (keeps the rowOrder helper's td:nth-child(2) valid)
   // plus the named extra column, so default-hidden columns can be sorted.
   const seedColumns = (...extra: string[]) =>

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -498,6 +498,7 @@ export default function DeviceList({
       key={id}
       className={`px-3 py-3 cursor-pointer select-none hover:text-foreground${alignRight ? ' text-right' : ''}`}
       title={hint}
+      aria-sort={sortField === id ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
       onClick={() => handleSort(id)}
     >
       <span className="inline-flex items-center gap-1">

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -206,7 +206,9 @@ const sortValue: Record<ColumnId, (d: Device) => string | number | null> = {
   role: d => getDeviceRoleLabel(d.deviceRole ?? 'unknown'),
   isHeadless: d => (typeof d.isHeadless === 'boolean' ? (d.isHeadless ? 1 : 0) : null),
   status: d => statusSortRank[d.status],
-  pendingReboot: d => (d.pendingReboot ? 1 : 0),
+  // false/absent renders as a dash (see the cell), so it maps to null like
+  // isHeadless — keeping the blanks-last invariant consistent for booleans.
+  pendingReboot: d => (d.pendingReboot ? 1 : null),
   cpu: d => (d.status === 'online' ? d.cpuPercent : null),
   ram: d => (d.status === 'online' ? d.ramPercent : null),
   cpuModel: d => d.hardware?.cpuModel || null,

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -176,8 +176,51 @@ const osLabels: Record<OSType, string> = {
   linux: 'Linux'
 };
 
-type SortField = 'hostname' | 'status' | 'cpuPercent' | 'ramPercent' | 'lastSeen' | null;
+type SortField = ColumnId | null;
 type SortDirection = 'asc' | 'desc';
+
+// Meaningful ordering for the Status sort. Raw enum alphabetics would put
+// "decommissioned" before "online"; rank by operational severity instead.
+const statusSortRank: Record<DeviceStatus, number> = {
+  online: 0,
+  updating: 1,
+  pending: 2,
+  maintenance: 3,
+  quarantined: 4,
+  offline: 5,
+  decommissioned: 6,
+};
+
+// One comparable value per column, mirroring what the cell displays.
+// `null` means "renders as a dash" — those rows sort last in BOTH
+// directions so blanks never bury the real data. Strings compare with
+// numeric collation (host-2 < host-10, agent 0.9.x < 0.10.x).
+const sortValue: Record<ColumnId, (d: Device) => string | number | null> = {
+  hostname: d => d.displayName || d.hostname,
+  organization: d => d.orgName || null,
+  site: d => d.siteName || null,
+  os: d => osLabels[d.os],
+  osVersion: d => d.osVersion || null,
+  osBuild: d => d.osBuild || null,
+  architecture: d => d.architecture || null,
+  role: d => getDeviceRoleLabel(d.deviceRole ?? 'unknown'),
+  isHeadless: d => (typeof d.isHeadless === 'boolean' ? (d.isHeadless ? 1 : 0) : null),
+  status: d => statusSortRank[d.status],
+  pendingReboot: d => (d.pendingReboot ? 1 : 0),
+  cpu: d => (d.status === 'online' ? d.cpuPercent : null),
+  ram: d => (d.status === 'online' ? d.ramPercent : null),
+  cpuModel: d => d.hardware?.cpuModel || null,
+  cores: d => (typeof d.hardware?.cpuCores === 'number' ? d.hardware.cpuCores : null),
+  ramTotal: d => (typeof d.hardware?.ramTotalMb === 'number' ? d.hardware.ramTotalMb : null),
+  diskTotal: d => (typeof d.hardware?.diskTotalGb === 'number' ? d.hardware.diskTotalGb : null),
+  lastSeen: d => new Date(d.lastSeen).getTime() || null,
+  agentVersion: d => d.agentVersion || null,
+  tags: d => (d.tags && d.tags.length > 0 ? d.tags.join(', ') : null),
+  lastUser: d => d.lastUser || null,
+  uptime: d => (d.status === 'online' && d.uptimeSeconds != null ? d.uptimeSeconds : null),
+  enrolled: d => (d.enrolledAt ? new Date(d.enrolledAt).getTime() || null : null),
+  desktopAccess: d => d.desktopAccess?.mode || null,
+};
 
 export default function DeviceList({
   devices,
@@ -363,7 +406,7 @@ export default function DeviceList({
     });
   }, [devices, query, statusFilter, osFilter, roleFilter, orgFilter, siteFilter, groupFilter, groupMembershipMap, serverFilterIds]);
 
-  const handleSort = (field: SortField) => {
+  const handleSort = (field: ColumnId) => {
     if (sortField === field) {
       setSortDirection(d => d === 'asc' ? 'desc' : 'asc');
     } else {
@@ -374,30 +417,19 @@ export default function DeviceList({
 
   const sortedDevices = useMemo(() => {
     if (!sortField) return filteredDevices;
+    const value = sortValue[sortField];
+    const dir = sortDirection === 'desc' ? -1 : 1;
 
     return [...filteredDevices].sort((a, b) => {
-      let cmp = 0;
-      switch (sortField) {
-        case 'hostname':
-          cmp = a.hostname.localeCompare(b.hostname);
-          break;
-        case 'status':
-          cmp = a.status.localeCompare(b.status);
-          break;
-        case 'cpuPercent':
-          cmp = a.cpuPercent - b.cpuPercent;
-          break;
-        case 'ramPercent':
-          cmp = a.ramPercent - b.ramPercent;
-          break;
-        case 'lastSeen': {
-          const aTime = new Date(a.lastSeen).getTime() || 0;
-          const bTime = new Date(b.lastSeen).getTime() || 0;
-          cmp = aTime - bTime;
-          break;
-        }
-      }
-      return sortDirection === 'desc' ? -cmp : cmp;
+      const av = value(a);
+      const bv = value(b);
+      // Dash cells sort last regardless of direction.
+      if (av === null || bv === null) return av === bv ? 0 : av === null ? 1 : -1;
+      const cmp =
+        typeof av === 'number' && typeof bv === 'number'
+          ? av - bv
+          : String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' });
+      return dir * cmp;
     });
   }, [filteredDevices, sortField, sortDirection]);
 
@@ -457,17 +489,18 @@ export default function DeviceList({
   const renderedColumns = columnOrder.filter(id => visibleColumns.has(id));
 
   // sortHeader factors out the repeated header pattern for sortable
-  // columns to keep the column-defs table below readable.
-  const sortHeader = (id: ColumnId, label: string, sortKey: SortField, hint: string) => (
+  // columns to keep the column-defs table below readable. The column id
+  // doubles as the sort key.
+  const sortHeader = (id: ColumnId, label: string, hint: string, alignRight = false) => (
     <th
       key={id}
-      className="px-3 py-3 cursor-pointer select-none hover:text-foreground"
+      className={`px-3 py-3 cursor-pointer select-none hover:text-foreground${alignRight ? ' text-right' : ''}`}
       title={hint}
-      onClick={() => handleSort(sortKey)}
+      onClick={() => handleSort(id)}
     >
       <span className="inline-flex items-center gap-1">
         {label}
-        {sortField === sortKey ? (
+        {sortField === id ? (
           sortDirection === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
         ) : (
           <ArrowUpDown className="h-3 w-3 opacity-30" />
@@ -512,7 +545,7 @@ export default function DeviceList({
   const dash = <span className="text-muted-foreground">&mdash;</span>;
   const columnDefs: Record<ColumnId, { header: () => React.ReactNode; cell: (device: Device) => React.ReactNode }> = {
     hostname: {
-      header: () => sortHeader('hostname', 'Hostname', 'hostname', 'Sort by hostname'),
+      header: () => sortHeader('hostname', 'Hostname', 'Sort by hostname'),
       cell: (device) => (
         <td key="hostname" className="max-w-[200px] px-3 py-3 text-sm font-medium">
           <span className="block truncate" title={device.displayName || device.hostname}>{device.displayName || device.hostname}</span>
@@ -520,7 +553,7 @@ export default function DeviceList({
       ),
     },
     organization: {
-      header: () => <th key="organization" className="px-3 py-3">Organization</th>,
+      header: () => sortHeader('organization', 'Organization', 'Sort by organization'),
       cell: (device) => (
         <td key="organization" className="max-w-[160px] px-3 py-3 text-sm text-muted-foreground">
           <span className="block truncate" title={device.orgName}>{device.orgName}</span>
@@ -528,7 +561,7 @@ export default function DeviceList({
       ),
     },
     site: {
-      header: () => <th key="site" className="px-3 py-3">Site</th>,
+      header: () => sortHeader('site', 'Site', 'Sort by site'),
       cell: (device) => (
         <td key="site" className="max-w-[160px] px-3 py-3 text-sm text-muted-foreground">
           <span className="block truncate" title={device.siteName}>{device.siteName}</span>
@@ -536,7 +569,7 @@ export default function DeviceList({
       ),
     },
     os: {
-      header: () => <th key="os" className="px-3 py-3">OS</th>,
+      header: () => sortHeader('os', 'OS', 'Sort by operating system'),
       cell: (device) => (
         <td key="os" className="px-3 py-3 text-sm">
           <OSIcon os={device.os} className="h-4 w-4 text-muted-foreground" />
@@ -544,7 +577,7 @@ export default function DeviceList({
       ),
     },
     osVersion: {
-      header: () => <th key="osVersion" className="px-3 py-3">OS Version</th>,
+      header: () => sortHeader('osVersion', 'OS Version', 'Sort by OS version'),
       cell: (device) => (
         <td key="osVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
           {device.osVersion || dash}
@@ -552,7 +585,7 @@ export default function DeviceList({
       ),
     },
     osBuild: {
-      header: () => <th key="osBuild" className="px-3 py-3">OS Build</th>,
+      header: () => sortHeader('osBuild', 'OS Build', 'Sort by OS build'),
       cell: (device) => (
         <td key="osBuild" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
           {device.osBuild || dash}
@@ -560,7 +593,7 @@ export default function DeviceList({
       ),
     },
     architecture: {
-      header: () => <th key="architecture" className="px-3 py-3">Arch</th>,
+      header: () => sortHeader('architecture', 'Arch', 'Sort by architecture'),
       cell: (device) => (
         <td key="architecture" className="px-3 py-3 text-sm text-muted-foreground">
           {device.architecture || dash}
@@ -568,7 +601,7 @@ export default function DeviceList({
       ),
     },
     role: {
-      header: () => <th key="role" className="px-3 py-3">Role</th>,
+      header: () => sortHeader('role', 'Role', 'Sort by role'),
       cell: (device) => {
         const role = device.deviceRole ?? 'unknown';
         const RoleIcon = getDeviceRoleIcon(role);
@@ -587,7 +620,7 @@ export default function DeviceList({
       },
     },
     isHeadless: {
-      header: () => <th key="isHeadless" className="px-3 py-3">Headless</th>,
+      header: () => sortHeader('isHeadless', 'Headless', 'Sort by headless flag'),
       cell: (device) => (
         <td key="isHeadless" className="px-3 py-3 text-sm text-muted-foreground">
           {typeof device.isHeadless === 'boolean' ? (device.isHeadless ? 'Yes' : 'No') : dash}
@@ -595,7 +628,7 @@ export default function DeviceList({
       ),
     },
     status: {
-      header: () => sortHeader('status', 'Status', 'status', 'Sort by status'),
+      header: () => sortHeader('status', 'Status', 'Sort by status'),
       cell: (device) => (
         <td key="status" className="px-3 py-3 text-sm">
           <div className="flex flex-wrap items-center gap-1">
@@ -628,7 +661,7 @@ export default function DeviceList({
       ),
     },
     pendingReboot: {
-      header: () => <th key="pendingReboot" className="px-3 py-3">Pending Reboot</th>,
+      header: () => sortHeader('pendingReboot', 'Pending Reboot', 'Sort by pending reboot'),
       cell: (device) => (
         <td key="pendingReboot" className="px-3 py-3 text-sm whitespace-nowrap">
           {device.pendingReboot ? (
@@ -642,19 +675,19 @@ export default function DeviceList({
       ),
     },
     cpu: {
-      header: () => sortHeader('cpu', 'CPU %', 'cpuPercent', 'Sort by CPU usage'),
+      header: () => sortHeader('cpu', 'CPU %', 'Sort by CPU usage'),
       cell: (device) => (
         <td key="cpu" className="px-3 py-3 text-sm">{metricBar(device.cpuPercent, device.status === 'online')}</td>
       ),
     },
     ram: {
-      header: () => sortHeader('ram', 'RAM %', 'ramPercent', 'Sort by RAM usage'),
+      header: () => sortHeader('ram', 'RAM %', 'Sort by RAM usage'),
       cell: (device) => (
         <td key="ram" className="px-3 py-3 text-sm">{metricBar(device.ramPercent, device.status === 'online')}</td>
       ),
     },
     cpuModel: {
-      header: () => <th key="cpuModel" className="px-3 py-3">CPU Model</th>,
+      header: () => sortHeader('cpuModel', 'CPU Model', 'Sort by CPU model'),
       cell: (device) => (
         <td key="cpuModel" className="max-w-[220px] px-3 py-3 text-sm text-muted-foreground">
           <span className="block truncate" title={device.hardware?.cpuModel ?? ''}>
@@ -664,7 +697,7 @@ export default function DeviceList({
       ),
     },
     cores: {
-      header: () => <th key="cores" className="px-3 py-3 text-right">Cores</th>,
+      header: () => sortHeader('cores', 'Cores', 'Sort by core count', true),
       cell: (device) => (
         <td key="cores" className="px-3 py-3 text-right text-sm tabular-nums">
           {typeof device.hardware?.cpuCores === 'number' ? device.hardware.cpuCores : dash}
@@ -672,7 +705,7 @@ export default function DeviceList({
       ),
     },
     ramTotal: {
-      header: () => <th key="ramTotal" className="px-3 py-3 text-right">RAM</th>,
+      header: () => sortHeader('ramTotal', 'RAM', 'Sort by total RAM', true),
       cell: (device) => (
         <td key="ramTotal" className="px-3 py-3 text-right text-sm tabular-nums">
           {fmtRamGb(device.hardware?.ramTotalMb) ?? dash}
@@ -680,7 +713,7 @@ export default function DeviceList({
       ),
     },
     diskTotal: {
-      header: () => <th key="diskTotal" className="px-3 py-3 text-right">Disk</th>,
+      header: () => sortHeader('diskTotal', 'Disk', 'Sort by total disk', true),
       cell: (device) => (
         <td key="diskTotal" className="px-3 py-3 text-right text-sm tabular-nums">
           {fmtDiskGb(device.hardware?.diskTotalGb) ?? dash}
@@ -688,7 +721,7 @@ export default function DeviceList({
       ),
     },
     lastSeen: {
-      header: () => sortHeader('lastSeen', 'Last Seen', 'lastSeen', 'Sort by last seen time'),
+      header: () => sortHeader('lastSeen', 'Last Seen', 'Sort by last seen time'),
       cell: (device) => (
         <td key="lastSeen" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
           {formatLastSeen(device.lastSeen, effectiveTimezone)}
@@ -696,7 +729,7 @@ export default function DeviceList({
       ),
     },
     agentVersion: {
-      header: () => <th key="agentVersion" className="px-3 py-3">Agent Version</th>,
+      header: () => sortHeader('agentVersion', 'Agent Version', 'Sort by agent version'),
       cell: (device) => (
         <td key="agentVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
           {device.agentVersion || dash}
@@ -704,7 +737,7 @@ export default function DeviceList({
       ),
     },
     tags: {
-      header: () => <th key="tags" className="px-3 py-3">Tags</th>,
+      header: () => sortHeader('tags', 'Tags', 'Sort by tags'),
       cell: (device) => (
         <td key="tags" className="max-w-[220px] px-3 py-3 text-sm text-muted-foreground">
           {device.tags && device.tags.length > 0 ? (
@@ -728,7 +761,7 @@ export default function DeviceList({
       ),
     },
     lastUser: {
-      header: () => <th key="lastUser" className="px-3 py-3">Last User</th>,
+      header: () => sortHeader('lastUser', 'Last User', 'Sort by last user'),
       cell: (device) => (
         <td key="lastUser" className="max-w-[160px] px-3 py-3 text-sm text-muted-foreground">
           <span className="block truncate" title={device.lastUser ?? ''}>{device.lastUser || dash}</span>
@@ -736,7 +769,7 @@ export default function DeviceList({
       ),
     },
     uptime: {
-      header: () => <th key="uptime" className="px-3 py-3">Uptime</th>,
+      header: () => sortHeader('uptime', 'Uptime', 'Sort by uptime'),
       cell: (device) => (
         <td key="uptime" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
           {device.status === 'online' && device.uptimeSeconds != null
@@ -746,7 +779,7 @@ export default function DeviceList({
       ),
     },
     enrolled: {
-      header: () => <th key="enrolled" className="px-3 py-3">Enrolled</th>,
+      header: () => sortHeader('enrolled', 'Enrolled', 'Sort by enrollment date'),
       cell: (device) => (
         <td key="enrolled" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
           {fmtDate(device.enrolledAt) ?? dash}
@@ -754,7 +787,7 @@ export default function DeviceList({
       ),
     },
     desktopAccess: {
-      header: () => <th key="desktopAccess" className="px-3 py-3">Desktop Access</th>,
+      header: () => sortHeader('desktopAccess', 'Desktop Access', 'Sort by desktop access'),
       cell: (device) => {
         const da = device.desktopAccess;
         if (!da) return <td key="desktopAccess" className="px-3 py-3 text-sm text-muted-foreground">{dash}</td>;


### PR DESCRIPTION
## What

Sorting on the Devices list existed for only 5 of the 24 columns (Hostname, Status, CPU %, RAM %, Last Seen); the other 19 rendered plain headers. This makes **every** column in `columnDefs` sortable by clicking its header, with the usual asc/desc toggle and the existing chevron/arrow indicators.

## How

- `SortField` is now `ColumnId | null` — the column id doubles as the sort key.
- A module-level `sortValue` map provides one comparable value per column, mirroring what the cell displays. The comparator is generic: numbers compare numerically, strings with numeric collation (`host-2` < `host-10`, agent `0.9.x` < `0.10.x`).
- All 24 headers route through the existing `sortHeader()` helper (right-aligned headers — Cores, RAM, Disk — keep their alignment via a new flag).

## Sort semantics

- **Blanks last, both directions.** Cells that render as a dash (missing hardware info, offline CPU/RAM/uptime, missing last user / enrolled date) sort after real values whether ascending or descending, so blanks never bury the data you sorted for.
- **Status sorts by operational rank** (online → updating → pending → maintenance → quarantined → offline → decommissioned) instead of raw enum alphabetics, which previously put "decommissioned" before "online".
- **CPU/RAM/Uptime follow the cell**: non-online devices show a dash there, so they sort as blanks.
- **Tags** sort by the comma-joined displayed list; untagged rows last.

## Why no API change

The full device list is already client-side (`fetchAllDevices` walks the keyset cursor from #777/#778), and filtering + pagination already happen in the browser, so a client sort is correct across all pages of the table.

## Tests

6 new tests in `DeviceList.test.tsx` (16 total in the file, all green): alphabetic sort + direction toggle on a previously-unsortable column, numeric collation on hostnames and agent versions, status rank order, blanks-last in both directions, and a structural check that every rendered data header carries a sort hint and click handler. `tsc --noEmit` and `eslint` clean.