### PR TITLE
feat(ticketing): Phase 3 frontend — time tracking + parts UI

### DIFF
--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -84,7 +84,12 @@ vi.mock('../db/schema', () => ({
   tickets: { id: 'id', partnerId: 'partnerId', orgId: 'orgId', categoryId: 'categoryId', internalNumber: 'internalNumber', subject: 'subject' },
   ticketCategories: { id: 'id', partnerId: 'partnerId', defaultBillable: 'defaultBillable', defaultHourlyRate: 'defaultHourlyRate' },
   organizations: { id: 'id', partnerId: 'partnerId', name: 'name' },
-  users: { id: 'id', name: 'name' }
+  users: { id: 'id', name: 'name' },
+  ticketComments: {
+    id: 'id', ticketId: 'ticketId', userId: 'userId', authorName: 'authorName',
+    authorType: 'authorType', commentType: 'commentType', content: 'content',
+    isPublic: 'isPublic', oldValue: 'oldValue', newValue: 'newValue', createdAt: 'createdAt'
+  }
 }));
 
 import {
@@ -488,5 +493,58 @@ describe('query helpers', () => {
     expect(rows.map((r) => r.amount)).not.toContain('NaN');
     expect(consoleSpy).toHaveBeenCalledTimes(2);
     consoleSpy.mockRestore();
+  });
+});
+
+describe('time_entry feed comments', () => {
+  it('createTimeEntry with ticketId inserts a ticketComments row (logged, billable suffix)', async () => {
+    dbMocks.selectResults.push([{ id: 't-1', partnerId: 'p-1', orgId: 'o-1', categoryId: null }]);
+    dbMocks.insertResult = [{ id: 'te-1', partnerId: 'p-1', ticketId: 't-1', userId: 'u-1', durationMinutes: 45, isBillable: true }];
+    await createTimeEntry(
+      { ticketId: 't-1', startedAt: new Date('2026-06-11T09:00:00Z'), endedAt: new Date('2026-06-11T09:45:00Z'), isBillable: true },
+      ACTOR
+    );
+    // Two inserts: first is timeEntries, second is ticketComments
+    expect(dbMocks.insertedValues).toHaveLength(2);
+    const commentVals = dbMocks.insertedValues[1]!;
+    expect(commentVals.ticketId).toBe('t-1');
+    expect(commentVals.commentType).toBe('time_entry');
+    expect(commentVals.isPublic).toBe(false);
+    expect(commentVals.authorType).toBe('internal');
+    expect(String(commentVals.content)).toContain('logged 45m');
+    expect(String(commentVals.content)).toContain('(billable)');
+  });
+
+  it('createTimeEntry WITHOUT ticketId does not insert a ticketComments row', async () => {
+    dbMocks.insertResult = [{ id: 'te-2', partnerId: 'p-1', ticketId: null, userId: 'u-1', durationMinutes: 60, isBillable: false }];
+    await createTimeEntry(
+      { startedAt: new Date('2026-06-11T09:00:00Z'), endedAt: new Date('2026-06-11T10:00:00Z') },
+      ACTOR
+    );
+    // Only the timeEntries insert — no ticketComments insert
+    expect(dbMocks.insertedValues).toHaveLength(1);
+  });
+
+  it('stopTimer on a ticket-linked entry inserts a ticketComments row with logged wording and correct duration', async () => {
+    // stopRunningEntry does an UPDATE; the returned row has ticketId + durationMinutes
+    dbMocks.updateResult = [{ id: 'te-3', partnerId: 'p-1', ticketId: 't-2', userId: 'u-1', durationMinutes: 90, isBillable: false }];
+    await stopTimer({}, ACTOR);
+    const commentVals = dbMocks.insertedValues[0]!;
+    expect(commentVals.ticketId).toBe('t-2');
+    expect(commentVals.commentType).toBe('time_entry');
+    expect(commentVals.isPublic).toBe(false);
+    expect(String(commentVals.content)).toContain('logged 1h 30m');
+    expect(String(commentVals.content)).not.toContain('(billable)');
+  });
+
+  it('deleteTimeEntry on a ticket-linked entry inserts a ticketComments row with removed wording', async () => {
+    dbMocks.selectResults.push([{ id: 'te-4', userId: 'u-1', isApproved: false, partnerId: 'p-1', ticketId: 't-3', durationMinutes: 45 }]);
+    await deleteTimeEntry('te-4', ACTOR);
+    const commentVals = dbMocks.insertedValues[0]!;
+    expect(commentVals.ticketId).toBe('t-3');
+    expect(commentVals.commentType).toBe('time_entry');
+    expect(commentVals.isPublic).toBe(false);
+    expect(String(commentVals.content)).toContain('removed a');
+    expect(String(commentVals.content)).toContain('45m');
   });
 });

--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -563,4 +563,34 @@ describe('time_entry feed comments', () => {
     expect(String(commentVals.content)).toContain('removed a');
     expect(String(commentVals.content)).toContain('45m');
   });
+
+  it('deleting a running (null-duration) entry produces "removed a time entry" with no duration', async () => {
+    dbMocks.selectResults.push([{ id: 'te-5', userId: 'u-1', isApproved: false, partnerId: 'p-1', ticketId: 't-4', durationMinutes: null }]);
+    await deleteTimeEntry('te-5', ACTOR);
+    const commentVals = dbMocks.insertedValues[0]!;
+    expect(String(commentVals.content)).toBe('Tess removed a time entry');
+  });
+
+  it('a feed-comment insert failure does not reject createTimeEntry and the event is still emitted', async () => {
+    dbMocks.selectResults.push([{ id: 't-1', partnerId: 'p-1', orgId: 'o-1', categoryId: null }]);
+    dbMocks.insertResult = [{ id: 'te-6', partnerId: 'p-1', ticketId: 't-1', userId: 'u-1', durationMinutes: 30, isBillable: false }];
+    // Make the ticketComments insert fail (first insert uses insertResult, second rejects).
+    // We push null for the timeEntries returning() call (null is falsy → falls through to insertResult),
+    // then the actual error for the ticketComments returning() call.
+    const feedError = new Error('DB connection lost');
+    dbMocks.insertErrors.push(null as unknown as Error, feedError);
+    // createTimeEntry must not reject even though the feed comment insert fails;
+    // if it rejects this line itself will throw and the test fails appropriately.
+    const entry = await createTimeEntry(
+      { ticketId: 't-1', startedAt: new Date('2026-06-11T09:00:00Z'), endedAt: new Date('2026-06-11T09:30:00Z') },
+      ACTOR
+    );
+    expect(entry.id).toBe('te-6');
+    // Event must still be emitted after the swallowed feed-comment failure
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'time_entry.created' }));
+    // Both values() calls were made (timeEntries + ticketComments) confirming the insert was attempted
+    expect(dbMocks.insertedValues).toHaveLength(2);
+    expect(dbMocks.insertedValues[0]!.billingStatus).toBe('not_billed'); // timeEntries row
+    expect(dbMocks.insertedValues[1]!.commentType).toBe('time_entry'); // ticketComments row attempted
+  });
 });

--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -537,6 +537,22 @@ describe('time_entry feed comments', () => {
     expect(String(commentVals.content)).not.toContain('(billable)');
   });
 
+  it('startTimer auto-stops a ticket-linked entry and inserts a ticketComments row for the stopped entry', async () => {
+    // updateResult = the auto-stopped previous entry (ticket-linked, 60m, billable)
+    dbMocks.updateResult = [{ id: 'te-prev', partnerId: 'p-1', ticketId: 't-X', userId: 'u-1', durationMinutes: 60, isBillable: true }];
+    // insertResult = the new running timer (no ticket, non-billable)
+    dbMocks.insertResult = [{ id: 'te-next', partnerId: 'p-1', ticketId: null, userId: 'u-1', endedAt: null, durationMinutes: null, isBillable: false }];
+    await startTimer({ description: 'next task' }, ACTOR);
+    // Two inserts: first is ticketComments for the auto-stopped entry, second is the new timeEntries row
+    const feedComment = dbMocks.insertedValues.find((v) => v.commentType === 'time_entry');
+    expect(feedComment).toBeDefined();
+    expect(feedComment!.ticketId).toBe('t-X');
+    expect(feedComment!.commentType).toBe('time_entry');
+    expect(feedComment!.isPublic).toBe(false);
+    expect(String(feedComment!.content)).toContain('1h');
+    expect(String(feedComment!.content)).toContain('(billable)');
+  });
+
   it('deleteTimeEntry on a ticket-linked entry inserts a ticketComments row with removed wording', async () => {
     dbMocks.selectResults.push([{ id: 'te-4', userId: 'u-1', isApproved: false, partnerId: 'p-1', ticketId: 't-3', durationMinutes: 45 }]);
     await deleteTimeEntry('te-4', ACTOR);

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, gte, inArray, isNull, lt, lte, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { timeEntries, ticketParts, tickets, ticketCategories, organizations, users } from '../db/schema';
+import { timeEntries, ticketParts, tickets, ticketCategories, organizations, users, ticketComments } from '../db/schema';
 import { emitTimeEntryEvent } from './timeEntryEvents';
 import type { CreateTimeEntryInput, UpdateTimeEntryInput, TicketPartInput, BillingStatus } from '@breeze/shared';
 
@@ -125,6 +125,35 @@ async function resolveTicketLink(ticketId: string, actorPartnerId: string | null
   };
 }
 
+/** "45m", "1h 30m", "2h" — shared wording for feed comments. */
+function fmtMinutes(minutes: number | null): string {
+  const m = Math.max(0, minutes ?? 0);
+  const h = Math.floor(m / 60);
+  const rest = m % 60;
+  if (h === 0) return `${rest}m`;
+  return rest === 0 ? `${h}h` : `${h}h ${rest}m`;
+}
+
+/** D4: internal-only system feed line; never isPublic. No-op without a ticket. */
+async function insertTimeEntryFeedComment(
+  ticketId: string | null,
+  actor: TimeEntryActor,
+  content: string
+): Promise<void> {
+  if (!ticketId) return;
+  await db.insert(ticketComments).values({
+    ticketId,
+    userId: actor.userId,
+    authorName: actor.name ?? null,
+    authorType: 'internal',
+    commentType: 'time_entry',
+    content,
+    isPublic: false,
+    oldValue: null,
+    newValue: null
+  });
+}
+
 export async function createTimeEntry(input: CreateTimeEntryInput, actor: TimeEntryActor) {
   let partnerId = actor.partnerId;
   let orgId: string | null = null;
@@ -164,6 +193,12 @@ export async function createTimeEntry(input: CreateTimeEntryInput, actor: TimeEn
     })
     .returning();
   const entry = rows[0]!;
+
+  await insertTimeEntryFeedComment(
+    entry.ticketId,
+    actor,
+    `${actor.name ?? 'Technician'} logged ${fmtMinutes(entry.durationMinutes)}${entry.isBillable ? ' (billable)' : ''}`
+  );
 
   await emitTimeEntryEvent({
     type: 'time_entry.created',
@@ -225,7 +260,14 @@ export async function startTimer(input: { ticketId?: string; description?: strin
   const attempt = async () => {
     // D3: auto-stop the previous timer, then start the new one. The partial
     // unique index time_entries_one_running_per_user_uq is the race backstop.
-    await stopRunningEntry(actor);
+    const autoStopped = await stopRunningEntry(actor);
+    if (autoStopped) {
+      await insertTimeEntryFeedComment(
+        autoStopped.ticketId,
+        actor,
+        `${actor.name ?? 'Technician'} logged ${fmtMinutes(autoStopped.durationMinutes)}${autoStopped.isBillable ? ' (billable)' : ''}`
+      );
+    }
     const rows = await db
       .insert(timeEntries)
       .values({
@@ -278,6 +320,13 @@ export async function stopTimer(input: { description?: string; isBillable?: bool
   if (!stopped) {
     throw new TimeEntryServiceError('No running timer', 404, 'NO_RUNNING_TIMER');
   }
+
+  await insertTimeEntryFeedComment(
+    stopped.ticketId,
+    actor,
+    `${actor.name ?? 'Technician'} logged ${fmtMinutes(stopped.durationMinutes)}${stopped.isBillable ? ' (billable)' : ''}`
+  );
+
   await emitTimeEntryEvent({
     type: 'time_entry.updated',
     timeEntryId: stopped.id,
@@ -369,6 +418,13 @@ export async function deleteTimeEntry(id: string, actor: TimeEntryActor) {
   const entry = await getEntryOr404(id);
   assertCanMutate(entry, actor);
   await db.delete(timeEntries).where(eq(timeEntries.id, id));
+
+  await insertTimeEntryFeedComment(
+    entry.ticketId,
+    actor,
+    `${actor.name ?? 'Technician'} removed a ${fmtMinutes(entry.durationMinutes)} time entry`
+  );
+
   await emitTimeEntryEvent({
     type: 'time_entry.deleted',
     timeEntryId: id,

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -134,24 +134,29 @@ function fmtMinutes(minutes: number | null): string {
   return rest === 0 ? `${h}h` : `${h}h ${rest}m`;
 }
 
-/** D4: internal-only system feed line; never isPublic. No-op without a ticket. */
+/** D4: internal-only system feed line; never isPublic. No-op without a ticket.
+ *  Swallows insert errors so a failed comment never rolls back a committed mutation. */
 async function insertTimeEntryFeedComment(
   ticketId: string | null,
   actor: TimeEntryActor,
   content: string
 ): Promise<void> {
   if (!ticketId) return;
-  await db.insert(ticketComments).values({
-    ticketId,
-    userId: actor.userId,
-    authorName: actor.name ?? null,
-    authorType: 'internal',
-    commentType: 'time_entry',
-    content,
-    isPublic: false,
-    oldValue: null,
-    newValue: null
-  });
+  try {
+    await db.insert(ticketComments).values({
+      ticketId,
+      userId: actor.userId,
+      authorName: actor.name ?? null,
+      authorType: 'internal',
+      commentType: 'time_entry',
+      content,
+      isPublic: false,
+      oldValue: null,
+      newValue: null
+    });
+  } catch (err) {
+    console.error('[timeEntryService] feed comment insert failed', err);
+  }
 }
 
 export async function createTimeEntry(input: CreateTimeEntryInput, actor: TimeEntryActor) {
@@ -422,7 +427,7 @@ export async function deleteTimeEntry(id: string, actor: TimeEntryActor) {
   await insertTimeEntryFeedComment(
     entry.ticketId,
     actor,
-    `${actor.name ?? 'Technician'} removed a ${fmtMinutes(entry.durationMinutes)} time entry`
+    `${actor.name ?? 'Technician'} removed a${entry.durationMinutes != null ? ` ${fmtMinutes(entry.durationMinutes)}` : ''} time entry`
   );
 
   await emitTimeEntryEvent({

--- a/apps/docs/src/content/docs/features/ticketing.mdx
+++ b/apps/docs/src/content/docs/features/ticketing.mdx
@@ -105,6 +105,38 @@ Categories also carry SLA targets (response and resolution times) and billing de
   Today the SLA targets drive the at-risk and breached chips in the queue. The full automated SLA engine -- enforcement, escalations, and business-hours schedules -- arrives in a later release.
 </Aside>
 
+## Time Tracking & Parts
+
+Breeze lets technicians log time and record parts against any ticket. These records feed the billing summary on the ticket's properties rail and the weekly Timesheet view -- but are **never shown in the customer portal**.
+
+### Timer widget
+
+When you are working a ticket, click **Start timer** in the Time & Billing rail to begin tracking. A live clock appears in the top navigation bar, anchored to the ticket number, so the timer follows you across the queue. Only one timer can run per technician at a time -- starting a new timer automatically stops the previous one.
+
+Click the stop icon in the header widget to open the stop popover, where you can add a description and mark the entry as billable before saving.
+
+### Manual time entry
+
+Click **Log time** in the ticket's Time & Billing rail to open the quick-add form. Enter the number of minutes, an optional description, and whether the entry is billable, then click **Save**. The entry is back-dated so the end time is now and the start time is now minus the minutes you entered.
+
+### Parts
+
+The Parts card on the ticket rail lets you record physical or consumable items used on a job. Each part has a **description**, **quantity**, **unit price**, and an optional **cost basis** for margin tracking. Parts default to billable; uncheck the box for internal-only consumables.
+
+### Timesheet
+
+Open **/timesheet** from the sidebar to see a week-at-a-glance view of all your time entries, grouped by day with billable totals. Use the week navigation buttons to move backwards and forwards. Technicians with a wildcard-permission admin role can switch to any other technician's timesheet via the dropdown.
+
+Admins can select one or more completed entries and click **Approve selected** to mark them approved. Approved entries become immutable for non-admins.
+
+### Billables export
+
+Under **Settings → Ticketing**, the Billables Export card lets you download a CSV of all time entries and parts for any date range up to 366 days. The export includes each entry's approval status, billable flag, and computed amounts -- useful for invoicing or importing into external accounting tools.
+
+<Aside>
+  Time entries and parts are technician-facing only. End-users accessing the customer portal never see time logs, cost data, or parts records.
+</Aside>
+
 ## Tickets on a Device
 
 Every device page has a **Tickets** tab listing the tickets attached to that device, with status, priority, and SLA chips. It is the fastest way to check whether the machine you are about to work on already has open issues.

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import OrgSwitcher from './OrgSwitcher';
 import NotificationCenter from './NotificationCenter';
+import TimerWidget from '../time/TimerWidget';
 import CommandPalette from './CommandPalette';
 import SupportModal from '../support/SupportModal';
 import { useAuthStore, apiLogout, fetchWithAuth } from '../../stores/auth';
@@ -303,6 +304,7 @@ export default function Header() {
         )}
 
         {/* Notifications */}
+        {mounted && isAuthenticated && <TimerWidget />}
         {mounted && isAuthenticated && <NotificationCenter />}
 
         {/* Theme Picker */}

--- a/apps/web/src/components/settings/BillablesExportCard.test.tsx
+++ b/apps/web/src/components/settings/BillablesExportCard.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (...a: unknown[]) => showToast(...a) }));
+
+// jsdom doesn't support anchor .click() navigation — stub it so the download
+// path doesn't throw.
+vi.stubGlobal('HTMLAnchorElement', class extends HTMLAnchorElement {
+  click() { /* no-op in jsdom */ }
+});
+
+import BillablesExportCard from './BillablesExportCard';
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  showToast.mockReset();
+  fetchWithAuth.mockImplementation(async (url: string) =>
+    url.startsWith('/orgs/organizations')
+      ? ({ ok: true, status: 200, json: async () => ({ data: [{ id: 'o-1', name: 'Acme' }] }) } as Response)
+      : ({ ok: true, status: 200, blob: async () => new Blob(['date,type'], { type: 'text/csv' }) } as unknown as Response));
+  URL.createObjectURL = vi.fn(() => 'blob:x');
+  URL.revokeObjectURL = vi.fn();
+});
+
+describe('BillablesExportCard', () => {
+  it('downloads the CSV with from/to/orgId params', async () => {
+    render(<BillablesExportCard />);
+    await screen.findByTestId('billables-export-org');
+    fireEvent.change(screen.getByTestId('billables-export-from'), { target: { value: '2026-06-01' } });
+    fireEvent.change(screen.getByTestId('billables-export-to'), { target: { value: '2026-06-12' } });
+    fireEvent.change(screen.getByTestId('billables-export-org'), { target: { value: 'o-1' } });
+    fireEvent.click(screen.getByTestId('billables-export-download'));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(expect.stringMatching(/^\/tickets\/export\/billables\.csv\?from=2026-06-01&to=2026-06-12&orgId=o-1$/)));
+  });
+
+  it('shows an error toast when the export fails', async () => {
+    render(<BillablesExportCard />);
+    await screen.findByTestId('billables-export-org');
+    fetchWithAuth.mockResolvedValueOnce({ ok: false, status: 400, json: async () => ({ error: 'window too large' }) } as Response);
+    fireEvent.click(screen.getByTestId('billables-export-download'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+  });
+});

--- a/apps/web/src/components/settings/BillablesExportCard.test.tsx
+++ b/apps/web/src/components/settings/BillablesExportCard.test.tsx
@@ -34,6 +34,7 @@ describe('BillablesExportCard', () => {
     fireEvent.change(screen.getByTestId('billables-export-org'), { target: { value: 'o-1' } });
     fireEvent.click(screen.getByTestId('billables-export-download'));
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(expect.stringMatching(/^\/tickets\/export\/billables\.csv\?from=2026-06-01&to=2026-06-12&orgId=o-1$/)));
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
   });
 
   it('shows an error toast when the export fails', async () => {

--- a/apps/web/src/components/settings/BillablesExportCard.tsx
+++ b/apps/web/src/components/settings/BillablesExportCard.tsx
@@ -2,12 +2,15 @@ import { useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { showToast } from '../shared/Toast';
 
+function localDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
 function firstOfMonth(): string {
   const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
+  return localDateStr(new Date(d.getFullYear(), d.getMonth(), 1));
 }
 function today(): string {
-  return new Date().toISOString().slice(0, 10);
+  return localDateStr(new Date());
 }
 
 export default function BillablesExportCard() {

--- a/apps/web/src/components/settings/BillablesExportCard.tsx
+++ b/apps/web/src/components/settings/BillablesExportCard.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+function firstOfMonth(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
+}
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default function BillablesExportCard() {
+  const [from, setFrom] = useState(firstOfMonth());
+  const [to, setTo] = useState(today());
+  const [orgId, setOrgId] = useState('');
+  const [orgs, setOrgs] = useState<Array<{ id: string; name: string }>>([]);
+  const [downloading, setDownloading] = useState(false);
+
+  useEffect(() => {
+    void fetchWithAuth('/orgs/organizations?limit=100')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((b) => { if (b?.data) setOrgs(b.data); })
+      .catch(() => {});
+  }, []);
+
+  const download = async () => {
+    setDownloading(true);
+    try {
+      const qs = new URLSearchParams({ from, to });
+      if (orgId) qs.set('orgId', orgId);
+      const res = await fetchWithAuth(`/tickets/export/billables.csv?${qs.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        showToast({ type: 'error', message: (body as { error?: string } | null)?.error ?? 'Export failed' });
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `billables-${from}-to-${to}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      showToast({ type: 'error', message: 'Export failed' });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <section className="mt-6 rounded-lg border p-4" data-testid="billables-export-card">
+      <h2 className="mb-1 text-sm font-semibold">Billables export</h2>
+      <p className="mb-3 text-xs text-muted-foreground">Billable time entries and parts as CSV (up to 366 days). Includes approval status.</p>
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="text-xs">
+          From
+          <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm" data-testid="billables-export-from" />
+        </label>
+        <label className="text-xs">
+          To
+          <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm" data-testid="billables-export-to" />
+        </label>
+        <label className="text-xs">
+          Organization
+          <select value={orgId} onChange={(e) => setOrgId(e.target.value)} className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm" data-testid="billables-export-org">
+            <option value="">All organizations</option>
+            {orgs.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+          </select>
+        </label>
+        <button type="button" onClick={() => void download()} disabled={downloading} className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50" data-testid="billables-export-download">
+          {downloading ? 'Exporting…' : 'Download CSV'}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/TicketCategoriesPage.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.tsx
@@ -5,6 +5,7 @@ import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 import { priorityConfig, type TicketPriority } from '../tickets/ticketConfig';
+import BillablesExportCard from './BillablesExportCard';
 
 interface Category {
   id: string;
@@ -484,6 +485,7 @@ export default function TicketCategoriesPage() {
           ))}
         </tbody>
       </table>
+      <BillablesExportCard />
     </div>
   );
 }

--- a/apps/web/src/components/tickets/TicketFeed.test.tsx
+++ b/apps/web/src/components/tickets/TicketFeed.test.tsx
@@ -92,4 +92,37 @@ describe('TicketFeed', () => {
     expect(screen.getByTestId('ticket-feed-empty')).toBeInTheDocument();
     expect(screen.queryByTestId('ticket-feed')).toBeNull();
   });
+
+  it('renders time_entry comments as system lines with their content', () => {
+    render(
+      <TicketFeed
+        comments={[
+          makeComment({ id: 'te-1', commentType: 'time_entry', content: 'Todd logged 45m (billable)', authorName: 'Todd' })
+        ]}
+      />
+    );
+    expect(screen.getByText(/Todd logged 45m \(billable\)/)).toBeInTheDocument();
+  });
+
+  it('renders a fallback label for time_entry comments with empty content', () => {
+    render(
+      <TicketFeed
+        comments={[
+          makeComment({ id: 'te-empty', commentType: 'time_entry', content: '', authorName: 'Todd' })
+        ]}
+      />
+    );
+    expect(screen.getByText('Todd logged time')).toBeInTheDocument();
+  });
+
+  it('renders "Technician logged time" for time_entry comments with empty content and null authorName', () => {
+    render(
+      <TicketFeed
+        comments={[
+          makeComment({ id: 'te-noauth', commentType: 'time_entry', content: '', authorName: null })
+        ]}
+      />
+    );
+    expect(screen.getByText('Technician logged time')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/tickets/TicketFeed.tsx
+++ b/apps/web/src/components/tickets/TicketFeed.tsx
@@ -13,6 +13,9 @@ function systemLine(c: TicketComment): string {
   if (c.commentType === 'assignment') {
     return c.newValue ? `${c.authorName ?? 'System'} assigned this ticket` : `${c.authorName ?? 'System'} unassigned this ticket`;
   }
+  if (c.commentType === 'time_entry') {
+    return c.content || `${c.authorName ?? 'Technician'} logged time`;
+  }
   return c.content || 'System event';
 }
 

--- a/apps/web/src/components/tickets/TicketPartsCard.test.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+import TicketPartsCard from './TicketPartsCard';
+
+const parts = [{ id: 'p-1', ticketId: 'tk-1', description: 'SSD 1TB', partNumber: null, vendor: null, quantity: '2.00', unitPrice: '99.00', costBasis: '60.00', isBillable: true, billingStatus: 'not_billed', notes: null }];
+const jsonRes = (data: unknown, status = 200) => ({ ok: status < 400, status, json: async () => ({ data }) }) as Response;
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  fetchWithAuth.mockImplementation(async (url: string) =>
+    url === '/tickets/tk-1/parts' ? jsonRes(parts) : jsonRes({}));
+});
+
+describe('TicketPartsCard', () => {
+  it('lists parts with line totals and margin', async () => {
+    render(<TicketPartsCard ticketId="tk-1" />);
+    const row = await screen.findByTestId('ticket-part-p-1');
+    expect(row.textContent).toContain('SSD 1TB');
+    expect(row.textContent).toContain('2 × $99.00');
+    expect(row.textContent).toContain('$198.00');
+    expect(row.textContent).toContain('$78.00');
+  });
+
+  it('adds a part', async () => {
+    render(<TicketPartsCard ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-parts-add-toggle'));
+    fireEvent.change(screen.getByTestId('ticket-parts-form-description'), { target: { value: 'RAM 16GB' } });
+    fireEvent.change(screen.getByTestId('ticket-parts-form-quantity'), { target: { value: '1' } });
+    fireEvent.change(screen.getByTestId('ticket-parts-form-unit-price'), { target: { value: '45.50' } });
+    fireEvent.click(screen.getByTestId('ticket-parts-form-submit'));
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((args) => args[0] === '/tickets/tk-1/parts' && (args[1] as RequestInit)?.method === 'POST');
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toMatchObject({ description: 'RAM 16GB', quantity: 1, unitPrice: 45.5 });
+    });
+  });
+
+  it('deletes a part via /tickets/parts/:id', async () => {
+    render(<TicketPartsCard ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-part-delete-p-1'));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/tickets/parts/p-1', expect.objectContaining({ method: 'DELETE' })));
+  });
+});

--- a/apps/web/src/components/tickets/TicketPartsCard.test.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.test.tsx
@@ -45,4 +45,22 @@ describe('TicketPartsCard', () => {
     fireEvent.click(await screen.findByTestId('ticket-part-delete-p-1'));
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/tickets/parts/p-1', expect.objectContaining({ method: 'DELETE' })));
   });
+
+  it('edits a part — preserves costBasis as number, omits sparse fields', async () => {
+    render(<TicketPartsCard ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-part-edit-p-1'));
+    fireEvent.change(screen.getByTestId('ticket-parts-form-description'), { target: { value: 'SSD 2TB' } });
+    fireEvent.click(screen.getByTestId('ticket-parts-form-submit'));
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find(
+        (args) => args[0] === '/tickets/parts/p-1' && (args[1] as RequestInit)?.method === 'PATCH',
+      );
+      expect(call).toBeTruthy();
+      const body = JSON.parse((call![1] as RequestInit).body as string) as Record<string, unknown>;
+      expect(body.costBasis).toBe(60);
+      expect(Object.keys(body)).not.toContain('partNumber');
+      expect(Object.keys(body)).not.toContain('vendor');
+      expect(Object.keys(body)).not.toContain('notes');
+    });
+  });
 });

--- a/apps/web/src/components/tickets/TicketPartsCard.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
-import { runAction, ActionError } from '../../lib/runAction';
-import { showToast } from '../shared/Toast';
+import { runAction, handleActionError } from '../../lib/runAction';
 import { formatMoney } from '../../lib/timeFormat';
 
 interface PartRow {
@@ -51,11 +50,6 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
     setBillable(true);
   }, [ticketId]);
 
-  const handleActionError = (err: unknown, fallback: string) => {
-    if (err instanceof ActionError && err.status === 401) return;
-    if (!(err instanceof ActionError)) showToast({ type: 'error', message: fallback });
-  };
-
   const resetForm = () => {
     setFormOpen(false);
     setEditingId(null);
@@ -66,15 +60,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
     setBillable(true);
   };
 
-  const openAdd = () => {
-    setEditingId(null);
-    setDescription('');
-    setQuantity('');
-    setUnitPrice('');
-    setCostBasis('');
-    setBillable(true);
-    setFormOpen(true);
-  };
+  const openAdd = () => { resetForm(); setFormOpen(true); };
 
   const openEdit = (part: PartRow) => {
     setEditingId(part.id);

--- a/apps/web/src/components/tickets/TicketPartsCard.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.tsx
@@ -2,19 +2,15 @@ import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { formatMoney } from '../../lib/timeFormat';
+import { broadcastBillingChanged } from '../../lib/timerActions';
 
 interface PartRow {
   id: string;
-  ticketId: string;
   description: string;
-  partNumber: string | null;
-  vendor: string | null;
   quantity: string;
   unitPrice: string;
   costBasis: string | null;
   isBillable: boolean;
-  billingStatus: string;
-  notes: string | null;
 }
 
 export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
@@ -117,6 +113,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
       }
       resetForm();
       await refresh();
+      broadcastBillingChanged();
     } catch (err) {
       handleActionError(err, editingId ? 'Failed to update part.' : 'Failed to add part.');
     } finally {
@@ -133,6 +130,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
         successMessage: 'Part deleted',
       });
       await refresh();
+      broadcastBillingChanged();
     } catch (err) {
       handleActionError(err, 'Failed to delete part.');
     }
@@ -284,6 +282,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
               type="button"
               onClick={resetForm}
               className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+              data-testid="ticket-parts-form-cancel"
             >
               Cancel
             </button>

--- a/apps/web/src/components/tickets/TicketPartsCard.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.tsx
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { formatMoney } from '../../lib/timeFormat';
+
+interface PartRow {
+  id: string;
+  ticketId: string;
+  description: string;
+  partNumber: string | null;
+  vendor: string | null;
+  quantity: string;
+  unitPrice: string;
+  costBasis: string | null;
+  isBillable: boolean;
+  billingStatus: string;
+  notes: string | null;
+}
+
+export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
+  const [parts, setParts] = useState<PartRow[]>([]);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [description, setDescription] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [unitPrice, setUnitPrice] = useState('');
+  const [costBasis, setCostBasis] = useState('');
+  const [billable, setBillable] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const res = await fetchWithAuth(`/tickets/${ticketId}/parts`)
+      .then((r) => (r.ok ? r.json() : null))
+      .catch(() => null);
+    if (res?.data) setParts(res.data as PartRow[]);
+  }, [ticketId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Reset form and list state when ticketId changes (mirror TicketTimeBilling)
+  useEffect(() => {
+    setFormOpen(false);
+    setEditingId(null);
+    setDescription('');
+    setQuantity('');
+    setUnitPrice('');
+    setCostBasis('');
+    setBillable(true);
+  }, [ticketId]);
+
+  const handleActionError = (err: unknown, fallback: string) => {
+    if (err instanceof ActionError && err.status === 401) return;
+    if (!(err instanceof ActionError)) showToast({ type: 'error', message: fallback });
+  };
+
+  const resetForm = () => {
+    setFormOpen(false);
+    setEditingId(null);
+    setDescription('');
+    setQuantity('');
+    setUnitPrice('');
+    setCostBasis('');
+    setBillable(true);
+  };
+
+  const openAdd = () => {
+    setEditingId(null);
+    setDescription('');
+    setQuantity('');
+    setUnitPrice('');
+    setCostBasis('');
+    setBillable(true);
+    setFormOpen(true);
+  };
+
+  const openEdit = (part: PartRow) => {
+    setEditingId(part.id);
+    setDescription(part.description);
+    setQuantity(String(Number(part.quantity)));
+    setUnitPrice(String(Number(part.unitPrice)));
+    setCostBasis(part.costBasis != null ? String(Number(part.costBasis)) : '');
+    setBillable(part.isBillable);
+    setFormOpen(true);
+  };
+
+  const submitForm = async () => {
+    if (!description.trim()) return;
+    const qty = Number(quantity);
+    const price = Number(unitPrice);
+    if (!Number.isFinite(qty) || qty <= 0) return;
+    if (!Number.isFinite(price) || price < 0) return;
+
+    const body: Record<string, unknown> = {
+      description: description.trim(),
+      quantity: qty,
+      unitPrice: price,
+      isBillable: billable,
+    };
+    const cb = costBasis.trim();
+    if (cb !== '') {
+      body.costBasis = Number(cb);
+    } else {
+      body.costBasis = null;
+    }
+
+    setBusy(true);
+    try {
+      if (editingId) {
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/tickets/parts/${editingId}`, {
+              method: 'PATCH',
+              body: JSON.stringify(body),
+            }),
+          errorFallback: 'Failed to update part',
+          successMessage: 'Part updated',
+        });
+      } else {
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/tickets/${ticketId}/parts`, {
+              method: 'POST',
+              body: JSON.stringify(body),
+            }),
+          errorFallback: 'Failed to add part',
+          successMessage: 'Part added',
+        });
+      }
+      resetForm();
+      await refresh();
+    } catch (err) {
+      handleActionError(err, editingId ? 'Failed to update part.' : 'Failed to add part.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const deletePart = async (id: string) => {
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/tickets/parts/${id}`, { method: 'DELETE' }),
+        errorFallback: 'Failed to delete part',
+        successMessage: 'Part deleted',
+      });
+      await refresh();
+    } catch (err) {
+      handleActionError(err, 'Failed to delete part.');
+    }
+  };
+
+  return (
+    <div className="mt-3 border-t pt-3" data-testid="ticket-parts-card">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Parts</p>
+
+      {parts.length === 0 && !formOpen && (
+        <p className="mt-1 text-xs text-muted-foreground" data-testid="ticket-parts-empty">No parts.</p>
+      )}
+
+      {parts.length > 0 && (
+        <ul className="mt-2 space-y-1" data-testid="ticket-parts-list">
+          {parts.map((part) => {
+            const qty = Number(part.quantity);
+            const price = Number(part.unitPrice);
+            const lineTotal = qty * price;
+            const margin =
+              part.costBasis != null
+                ? lineTotal - qty * Number(part.costBasis)
+                : null;
+            return (
+              <li
+                key={part.id}
+                className="text-xs"
+                data-testid={`ticket-part-${part.id}`}
+              >
+                <div className="flex items-start justify-between gap-1">
+                  <span className="min-w-0 flex-1 truncate font-medium">
+                    {part.description}
+                  </span>
+                  <span className="shrink-0 font-medium">{formatMoney(lineTotal)}</span>
+                </div>
+                <div className="flex items-center justify-between gap-1 text-muted-foreground">
+                  <span>
+                    {qty} × {formatMoney(price)}
+                    {!part.isBillable && ' · non-billable'}
+                  </span>
+                  {margin != null && (
+                    <span
+                      className="shrink-0"
+                      title="Margin"
+                    >
+                      {formatMoney(margin)}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-0.5 flex gap-1">
+                  <button
+                    type="button"
+                    onClick={() => openEdit(part)}
+                    className="rounded px-1 py-0.5 text-xs hover:bg-muted"
+                    data-testid={`ticket-part-edit-${part.id}`}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void deletePart(part.id)}
+                    className="rounded px-1 py-0.5 text-xs text-destructive hover:bg-muted"
+                    data-testid={`ticket-part-delete-${part.id}`}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="mt-2">
+        <button
+          type="button"
+          onClick={openAdd}
+          className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+          data-testid="ticket-parts-add-toggle"
+        >
+          Add part
+        </button>
+      </div>
+
+      {formOpen && (
+        <div className="mt-2 space-y-1.5 rounded-md border bg-muted/30 p-2" data-testid="ticket-parts-form">
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Description"
+            aria-label="Description"
+            className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="ticket-parts-form-description"
+          />
+          <input
+            type="number"
+            min={0.01}
+            step={0.01}
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value)}
+            placeholder="Quantity"
+            aria-label="Quantity"
+            className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="ticket-parts-form-quantity"
+          />
+          <input
+            type="number"
+            min={0}
+            step={0.01}
+            value={unitPrice}
+            onChange={(e) => setUnitPrice(e.target.value)}
+            placeholder="Unit price"
+            aria-label="Unit price"
+            className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="ticket-parts-form-unit-price"
+          />
+          <input
+            type="number"
+            min={0}
+            step={0.01}
+            value={costBasis}
+            onChange={(e) => setCostBasis(e.target.value)}
+            placeholder="Cost (optional)"
+            aria-label="Cost"
+            className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="ticket-parts-form-cost-basis"
+          />
+          <label className="flex items-center gap-1.5 text-xs">
+            <input
+              type="checkbox"
+              checked={billable}
+              onChange={(e) => setBillable(e.target.checked)}
+              data-testid="ticket-parts-form-billable"
+            />
+            Billable
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void submitForm()}
+              disabled={busy}
+              className="flex-1 rounded-md bg-primary px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+              data-testid="ticket-parts-form-submit"
+            >
+              {busy ? 'Saving…' : editingId ? 'Update' : 'Add part'}
+            </button>
+            <button
+              type="button"
+              onClick={resetForm}
+              className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/tickets/TicketTimeBilling.test.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
 vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 
 import TicketTimeBilling from './TicketTimeBilling';
+import { BILLING_CHANGED_EVENT } from '../../lib/timerActions';
 
 const summary = { time: { totalMinutes: 90, billableMinutes: 60, billableAmount: '150.00' }, parts: { partsCount: 2, billableTotal: '49.98' } };
 const entries = [{ id: 'te-1', startedAt: '2026-06-12T09:00:00Z', endedAt: '2026-06-12T09:45:00Z', durationMinutes: 45, description: 'diag', isBillable: true, userName: 'Todd', ticketNumber: null, ticketSubject: null, ticketId: 'tk-1', isApproved: false }];
@@ -47,5 +48,15 @@ describe('TicketTimeBilling', () => {
       expect(body.description).toBe('patched');
       expect(new Date(body.endedAt).getTime() - new Date(body.startedAt).getTime()).toBe(30 * 60_000);
     });
+  });
+
+  it('refetches when breeze:billing-changed fires', async () => {
+    render(<TicketTimeBilling ticketId="tk-1" />);
+    // Wait for the initial load
+    expect(await screen.findByTestId('ticket-billing-time-total')).toBeTruthy();
+    const callsBefore = fetchWithAuth.mock.calls.length;
+    // Dispatch billing-changed event
+    act(() => { window.dispatchEvent(new CustomEvent(BILLING_CHANGED_EVENT)); });
+    await waitFor(() => expect(fetchWithAuth.mock.calls.length).toBeGreaterThan(callsBefore));
   });
 });

--- a/apps/web/src/components/tickets/TicketTimeBilling.test.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+import TicketTimeBilling from './TicketTimeBilling';
+
+const summary = { time: { totalMinutes: 90, billableMinutes: 60, billableAmount: '150.00' }, parts: { partsCount: 2, billableTotal: '49.98' } };
+const entries = [{ id: 'te-1', startedAt: '2026-06-12T09:00:00Z', endedAt: '2026-06-12T09:45:00Z', durationMinutes: 45, description: 'diag', isBillable: true, userName: 'Todd', ticketNumber: null, ticketSubject: null, ticketId: 'tk-1', isApproved: false }];
+const route = (url: string) => {
+  if (url.startsWith('/tickets/tk-1/billing-summary')) return { ok: true, status: 200, json: async () => ({ data: summary }) } as Response;
+  if (url.startsWith('/tickets/tk-1/time-entries')) return { ok: true, status: 200, json: async () => ({ data: entries, total: 1 }) } as Response;
+  return { ok: true, status: 200, json: async () => ({ data: {} }) } as Response;
+};
+
+beforeEach(() => { fetchWithAuth.mockReset(); fetchWithAuth.mockImplementation(async (url: string) => route(url)); });
+
+describe('TicketTimeBilling', () => {
+  it('renders totals from the billing summary', async () => {
+    render(<TicketTimeBilling ticketId="tk-1" />);
+    expect((await screen.findByTestId('ticket-billing-time-total')).textContent).toContain('1h 30m');
+    expect(screen.getByTestId('ticket-billing-amount').textContent).toContain('$150.00');
+    expect(screen.getByTestId('ticket-billing-parts-total').textContent).toContain('$49.98');
+  });
+
+  it('starts a timer scoped to the ticket', async () => {
+    render(<TicketTimeBilling ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-billing-start-timer'));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/time-entries/start', expect.objectContaining({
+      method: 'POST', body: JSON.stringify({ ticketId: 'tk-1' })
+    })));
+  });
+
+  it('quick-add posts a manual entry with computed start/end', async () => {
+    render(<TicketTimeBilling ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-billing-quick-add-toggle'));
+    fireEvent.change(screen.getByTestId('ticket-billing-quick-add-minutes'), { target: { value: '30' } });
+    fireEvent.change(screen.getByTestId('ticket-billing-quick-add-description'), { target: { value: 'patched' } });
+    fireEvent.click(screen.getByTestId('ticket-billing-quick-add-submit'));
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((args) => args[0] === '/time-entries');
+      expect(call).toBeTruthy();
+      const body = JSON.parse((call![1] as RequestInit).body as string);
+      expect(body.ticketId).toBe('tk-1');
+      expect(body.description).toBe('patched');
+      expect(new Date(body.endedAt).getTime() - new Date(body.startedAt).getTime()).toBe(30 * 60_000);
+    });
+  });
+});

--- a/apps/web/src/components/tickets/TicketTimeBilling.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.tsx
@@ -48,6 +48,12 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
     return onTimerChanged(() => void refresh());
   }, [refresh]);
 
+  useEffect(() => {
+    setQuickAddOpen(false);
+    setMinutes('');
+    setDescription('');
+  }, [ticketId]);
+
   const handleActionError = (err: unknown, fallback: string) => {
     if (err instanceof ActionError && err.status === 401) return;
     if (!(err instanceof ActionError)) showToast({ type: 'error', message: fallback });
@@ -55,12 +61,11 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
 
   const startTimer = () => {
     void startTimerAction({ ticketId })
-      .then(refresh)
       .catch((err) => handleActionError(err, 'Failed to start timer.'));
   };
 
   const submitQuickAdd = async () => {
-    const mins = parseInt(minutes, 10);
+    const mins = Math.round(Number(minutes));
     if (!Number.isFinite(mins) || mins <= 0) return;
     setBusy(true);
     try {
@@ -94,7 +99,7 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
 
   return (
     <div className="mt-3 border-t pt-3" data-testid="ticket-time-billing">
-      <p className="text-xs font-medium uppercase text-muted-foreground">Time &amp; Billing</p>
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Time &amp; Billing</p>
 
       {summary && (
         <dl className="mt-2 space-y-1">
@@ -141,6 +146,7 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
           <input
             type="number"
             min={1}
+            step={1}
             value={minutes}
             onChange={(e) => setMinutes(e.target.value)}
             placeholder="Minutes"

--- a/apps/web/src/components/tickets/TicketTimeBilling.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { startTimerAction, onTimerChanged } from '../../lib/timerActions';
+import { formatMinutes, formatMoney } from '../../lib/timeFormat';
+
+interface BillingSummary {
+  time: { totalMinutes: number; billableMinutes: number; billableAmount: string };
+  parts: { partsCount: number; billableTotal: string };
+}
+
+interface EntryRow {
+  id: string;
+  durationMinutes: number | null;
+  description: string | null;
+  isBillable: boolean;
+  userName: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  isApproved: boolean;
+}
+
+export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
+  const [summary, setSummary] = useState<BillingSummary | null>(null);
+  const [entries, setEntries] = useState<EntryRow[]>([]);
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const [minutes, setMinutes] = useState('');
+  const [description, setDescription] = useState('');
+  const [billable, setBillable] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const [sumRes, listRes] = await Promise.all([
+      fetchWithAuth(`/tickets/${ticketId}/billing-summary`)
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+      fetchWithAuth(`/tickets/${ticketId}/time-entries?limit=5`)
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+    ]);
+    if (sumRes?.data) setSummary(sumRes.data as BillingSummary);
+    if (listRes?.data) setEntries(listRes.data as EntryRow[]);
+  }, [ticketId]);
+
+  useEffect(() => {
+    void refresh();
+    return onTimerChanged(() => void refresh());
+  }, [refresh]);
+
+  const handleActionError = (err: unknown, fallback: string) => {
+    if (err instanceof ActionError && err.status === 401) return;
+    if (!(err instanceof ActionError)) showToast({ type: 'error', message: fallback });
+  };
+
+  const startTimer = () => {
+    void startTimerAction({ ticketId })
+      .then(refresh)
+      .catch((err) => handleActionError(err, 'Failed to start timer.'));
+  };
+
+  const submitQuickAdd = async () => {
+    const mins = parseInt(minutes, 10);
+    if (!Number.isFinite(mins) || mins <= 0) return;
+    setBusy(true);
+    try {
+      const end = new Date();
+      const start = new Date(end.getTime() - mins * 60_000);
+      await runAction({
+        request: () =>
+          fetchWithAuth('/time-entries', {
+            method: 'POST',
+            body: JSON.stringify({
+              ticketId,
+              startedAt: start.toISOString(),
+              endedAt: end.toISOString(),
+              description: description || undefined,
+              isBillable: billable,
+            }),
+          }),
+        errorFallback: 'Failed to log time',
+        successMessage: 'Time logged',
+      });
+      setQuickAddOpen(false);
+      setMinutes('');
+      setDescription('');
+      await refresh();
+    } catch (err) {
+      handleActionError(err, 'Failed to log time.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 border-t pt-3" data-testid="ticket-time-billing">
+      <p className="text-xs font-medium uppercase text-muted-foreground">Time &amp; Billing</p>
+
+      {summary && (
+        <dl className="mt-2 space-y-1">
+          <div className="flex justify-between text-xs">
+            <dt className="text-muted-foreground">Total time</dt>
+            <dd data-testid="ticket-billing-time-total">{formatMinutes(summary.time.totalMinutes)}</dd>
+          </div>
+          <div className="flex justify-between text-xs">
+            <dt className="text-muted-foreground">Billable</dt>
+            <dd data-testid="ticket-billing-time-billable">{formatMinutes(summary.time.billableMinutes)}</dd>
+          </div>
+          <div className="flex justify-between text-xs">
+            <dt className="text-muted-foreground">Time amount</dt>
+            <dd data-testid="ticket-billing-amount">{formatMoney(summary.time.billableAmount)}</dd>
+          </div>
+          <div className="flex justify-between text-xs">
+            <dt className="text-muted-foreground">Parts ({summary.parts.partsCount})</dt>
+            <dd data-testid="ticket-billing-parts-total">{formatMoney(summary.parts.billableTotal)}</dd>
+          </div>
+        </dl>
+      )}
+
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          onClick={startTimer}
+          className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+          data-testid="ticket-billing-start-timer"
+        >
+          Start timer
+        </button>
+        <button
+          type="button"
+          onClick={() => setQuickAddOpen((o) => !o)}
+          className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+          data-testid="ticket-billing-quick-add-toggle"
+        >
+          Log time
+        </button>
+      </div>
+
+      {quickAddOpen && (
+        <div className="mt-2 space-y-1.5 rounded-md border bg-muted/30 p-2" data-testid="ticket-billing-quick-add">
+          <input
+            type="number"
+            min={1}
+            value={minutes}
+            onChange={(e) => setMinutes(e.target.value)}
+            placeholder="Minutes"
+            aria-label="Minutes"
+            className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="ticket-billing-quick-add-minutes"
+          />
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Description (optional)"
+            aria-label="Description"
+            className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="ticket-billing-quick-add-description"
+          />
+          <label className="flex items-center gap-1.5 text-xs">
+            <input
+              type="checkbox"
+              checked={billable}
+              onChange={(e) => setBillable(e.target.checked)}
+              data-testid="ticket-billing-quick-add-billable"
+            />
+            Billable
+          </label>
+          <button
+            type="button"
+            onClick={() => void submitQuickAdd()}
+            disabled={busy}
+            className="w-full rounded-md bg-primary px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+            data-testid="ticket-billing-quick-add-submit"
+          >
+            {busy ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      )}
+
+      {entries.length > 0 && (
+        <ul className="mt-2 space-y-1" data-testid="ticket-billing-entries">
+          {entries.map((entry) => (
+            <li key={entry.id} className="flex items-start justify-between gap-1 text-xs">
+              <span className="min-w-0 truncate text-muted-foreground">
+                {entry.userName ?? 'Tech'}
+                {entry.description ? ` — ${entry.description}` : ''}
+              </span>
+              <span className="shrink-0">
+                {entry.endedAt == null ? 'running' : formatMinutes(entry.durationMinutes)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/tickets/TicketTimeBilling.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
-import { runAction, ActionError } from '../../lib/runAction';
-import { showToast } from '../shared/Toast';
+import { runAction, handleActionError } from '../../lib/runAction';
 import { startTimerAction, onTimerChanged } from '../../lib/timerActions';
 import { formatMinutes, formatMoney } from '../../lib/timeFormat';
 
@@ -53,11 +52,6 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
     setMinutes('');
     setDescription('');
   }, [ticketId]);
-
-  const handleActionError = (err: unknown, fallback: string) => {
-    if (err instanceof ActionError && err.status === 401) return;
-    if (!(err instanceof ActionError)) showToast({ type: 'error', message: fallback });
-  };
 
   const startTimer = () => {
     void startTimerAction({ ticketId })

--- a/apps/web/src/components/tickets/TicketTimeBilling.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
-import { startTimerAction, onTimerChanged } from '../../lib/timerActions';
+import { startTimerAction, onTimerChanged, onBillingChanged } from '../../lib/timerActions';
 import { formatMinutes, formatMoney } from '../../lib/timeFormat';
 
 interface BillingSummary {
@@ -15,9 +15,7 @@ interface EntryRow {
   description: string | null;
   isBillable: boolean;
   userName: string | null;
-  startedAt: string;
   endedAt: string | null;
-  isApproved: boolean;
 }
 
 export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
@@ -44,13 +42,16 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
 
   useEffect(() => {
     void refresh();
-    return onTimerChanged(() => void refresh());
+    const unsubTimer = onTimerChanged(() => void refresh());
+    const unsubBilling = onBillingChanged(() => void refresh());
+    return () => { unsubTimer(); unsubBilling(); };
   }, [refresh]);
 
   useEffect(() => {
     setQuickAddOpen(false);
     setMinutes('');
     setDescription('');
+    setBillable(true);
   }, [ticketId]);
 
   const startTimer = () => {

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -12,6 +12,7 @@ import { SlaTimers } from './SlaTimers';
 import TicketTimeBilling from './TicketTimeBilling';
 import TicketPartsCard from './TicketPartsCard';
 import { statusConfig, priorityConfig, slaState, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
+import { onTimerChanged, onBillingChanged } from '../../lib/timerActions';
 
 interface Props {
   ticketId: string;
@@ -117,6 +118,13 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
       .catch(() => { /* degraded mode keeps the unassign-only affordance */ });
     return () => { cancelled = true; };
   }, [assigneesProvided]);
+
+  // Reload the feed (time-entry lines appear) when timer stops or parts/time change.
+  useEffect(() => {
+    const unsubTimer = onTimerChanged(() => void load());
+    const unsubBilling = onBillingChanged(() => void load());
+    return () => { unsubTimer(); unsubBilling(); };
+  }, [load]);
 
   // Returns true on success, false on a swallowed ActionError — callers with
   // form state (resolve/pending) must only close/clear when the POST landed.

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -9,6 +9,7 @@ import TicketFeed from './TicketFeed';
 import TicketComposer from './TicketComposer';
 import SlaChip from './SlaChip';
 import { SlaTimers } from './SlaTimers';
+import TicketTimeBilling from './TicketTimeBilling';
 import { statusConfig, priorityConfig, slaState, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
 
 interface Props {
@@ -346,6 +347,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
             <div className="space-y-3">
               {/* Per-target SLA timers; renders nothing (no gap) when the ticket has no SLA targets. */}
               <SlaTimers ticket={ticket} />
+              <TicketTimeBilling ticketId={ticket.id} />
               <dl className="space-y-3">
                 <div><dt className="text-xs text-muted-foreground">Requester</dt><dd>{ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}</dd></div>
                 <div><dt className="text-xs text-muted-foreground">Source</dt><dd className="capitalize">{ticket.source}</dd></div>

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -10,6 +10,7 @@ import TicketComposer from './TicketComposer';
 import SlaChip from './SlaChip';
 import { SlaTimers } from './SlaTimers';
 import TicketTimeBilling from './TicketTimeBilling';
+import TicketPartsCard from './TicketPartsCard';
 import { statusConfig, priorityConfig, slaState, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
 
 interface Props {
@@ -348,6 +349,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
               {/* Per-target SLA timers; renders nothing (no gap) when the ticket has no SLA targets. */}
               <SlaTimers ticket={ticket} />
               <TicketTimeBilling ticketId={ticket.id} />
+              <TicketPartsCard ticketId={ticket.id} />
               <dl className="space-y-3">
                 <div><dt className="text-xs text-muted-foreground">Requester</dt><dd>{ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}</dd></div>
                 <div><dt className="text-xs text-muted-foreground">Source</dt><dd className="capitalize">{ticket.source}</dd></div>

--- a/apps/web/src/components/time/TimerWidget.test.tsx
+++ b/apps/web/src/components/time/TimerWidget.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+import TimerWidget from './TimerWidget';
+import { TIMER_CHANGED_EVENT } from '../../lib/timerActions';
+
+const running = {
+  id: 'te-1', ticketId: 'tk-1', startedAt: new Date(Date.now() - 90_000).toISOString(),
+  description: null, isBillable: false, ticketNumber: 'T-2026-0042', ticketSubject: 'Printer on fire'
+};
+const jsonRes = (data: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: async () => ({ data }) }) as Response;
+
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('TimerWidget', () => {
+  it('renders nothing when no timer is running', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(null));
+    const { container } = render(<TimerWidget />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/time-entries/running'));
+    expect(container.querySelector('[data-testid="timer-widget"]')).toBeNull();
+  });
+
+  it('shows elapsed time and the ticket number when running', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(running));
+    render(<TimerWidget />);
+    expect(await screen.findByTestId('timer-widget')).toBeTruthy();
+    expect(screen.getByTestId('timer-widget-ticket').textContent).toContain('T-2026-0042');
+    expect(screen.getByTestId('timer-widget-elapsed').textContent).toMatch(/01:3\d/);
+  });
+
+  it('stop popover posts /time-entries/stop with description + billable', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(running));
+    render(<TimerWidget />);
+    fireEvent.click(await screen.findByTestId('timer-widget-stop'));
+    fireEvent.change(screen.getByTestId('timer-stop-description'), { target: { value: 'fixed it' } });
+    fireEvent.click(screen.getByTestId('timer-stop-billable'));
+    fetchWithAuth.mockResolvedValueOnce(jsonRes({ id: 'te-1' }));
+    fireEvent.click(screen.getByTestId('timer-stop-submit'));
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith('/time-entries/stop', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ description: 'fixed it', isBillable: true })
+      }));
+    });
+  });
+
+  it('refetches when breeze:timer-changed fires', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(null));
+    render(<TimerWidget />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
+    fetchWithAuth.mockResolvedValue(jsonRes(running));
+    act(() => { window.dispatchEvent(new CustomEvent(TIMER_CHANGED_EVENT)); });
+    expect(await screen.findByTestId('timer-widget')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/time/TimerWidget.test.tsx
+++ b/apps/web/src/components/time/TimerWidget.test.tsx
@@ -39,7 +39,8 @@ describe('TimerWidget', () => {
     fireEvent.click(await screen.findByTestId('timer-widget-stop'));
     fireEvent.change(screen.getByTestId('timer-stop-description'), { target: { value: 'fixed it' } });
     fireEvent.click(screen.getByTestId('timer-stop-billable'));
-    fetchWithAuth.mockResolvedValueOnce(jsonRes({ id: 'te-1' }));
+    fetchWithAuth.mockResolvedValueOnce(jsonRes({ id: 'te-1' }))
+      .mockResolvedValueOnce(jsonRes(null));
     fireEvent.click(screen.getByTestId('timer-stop-submit'));
     await waitFor(() => {
       expect(fetchWithAuth).toHaveBeenCalledWith('/time-entries/stop', expect.objectContaining({
@@ -47,6 +48,7 @@ describe('TimerWidget', () => {
         body: JSON.stringify({ description: 'fixed it', isBillable: true })
       }));
     });
+    await waitFor(() => expect(screen.queryByTestId('timer-widget')).toBeNull());
   });
 
   it('refetches when breeze:timer-changed fires', async () => {

--- a/apps/web/src/components/time/TimerWidget.tsx
+++ b/apps/web/src/components/time/TimerWidget.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Clock, Square } from 'lucide-react';
+import { fetchRunningTimer, stopTimerAction, onTimerChanged, type RunningTimer } from '../../lib/timerActions';
+import { ActionError } from '../../lib/runAction';
+import { formatElapsedSeconds } from '../../lib/timeFormat';
+
+const POLL_MS = 60_000;
+
+export default function TimerWidget() {
+  const [timer, setTimer] = useState<RunningTimer | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [description, setDescription] = useState('');
+  const [billable, setBillable] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const refresh = useCallback(() => {
+    void fetchRunningTimer().then(setTimer).catch(() => setTimer(null));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const poll = setInterval(refresh, POLL_MS);
+    const unsubscribe = onTimerChanged(refresh);
+    return () => { clearInterval(poll); unsubscribe(); };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!timer) return;
+    const tick = () => setElapsed(Math.floor((Date.now() - new Date(timer.startedAt).getTime()) / 1000));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [timer]);
+
+  useEffect(() => {
+    if (!popoverOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) setPopoverOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [popoverOpen]);
+
+  if (!timer) return null;
+
+  const openStop = () => {
+    setDescription(timer.description ?? '');
+    setBillable(timer.isBillable);
+    setPopoverOpen(true);
+  };
+
+  const submitStop = async () => {
+    setStopping(true);
+    try {
+      await stopTimerAction({ description: description || undefined, isBillable: billable });
+      setPopoverOpen(false);
+      setTimer(null);
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err; // ActionError already toasted by runAction
+    } finally {
+      setStopping(false);
+    }
+  };
+
+  return (
+    <div className="relative flex items-center gap-1 rounded-md border border-primary/40 bg-primary/5 px-2 py-1" data-testid="timer-widget">
+      <Clock className="h-3.5 w-3.5 text-primary" aria-hidden />
+      <span className="font-mono text-xs tabular-nums" data-testid="timer-widget-elapsed">{formatElapsedSeconds(elapsed)}</span>
+      {timer.ticketId && (
+        <a href={`/tickets/${timer.ticketId}`} className="max-w-32 truncate text-xs text-primary hover:underline" data-testid="timer-widget-ticket" title={timer.ticketSubject ?? undefined}>
+          {timer.ticketNumber ?? 'ticket'}
+        </a>
+      )}
+      <button type="button" onClick={openStop} className="rounded p-0.5 text-muted-foreground hover:text-destructive" title="Stop timer" data-testid="timer-widget-stop">
+        <Square className="h-3.5 w-3.5" aria-hidden />
+      </button>
+      {popoverOpen && (
+        <div ref={popoverRef} className="absolute right-0 top-full z-50 mt-2 w-72 rounded-lg border bg-popover p-3 shadow-lg" data-testid="timer-stop-popover">
+          <p className="mb-2 text-sm font-medium">Stop timer</p>
+          <textarea value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What did you work on?" rows={2} className="mb-2 w-full rounded-md border bg-background px-2 py-1.5 text-sm" data-testid="timer-stop-description" />
+          <label className="mb-3 flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={billable} onChange={(e) => setBillable(e.target.checked)} data-testid="timer-stop-billable" />
+            Billable
+          </label>
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={() => setPopoverOpen(false)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
+            <button type="button" onClick={() => void submitStop()} disabled={stopping} className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50" data-testid="timer-stop-submit">
+              {stopping ? 'Saving…' : 'Stop & save'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/time/TimerWidget.tsx
+++ b/apps/web/src/components/time/TimerWidget.tsx
@@ -3,6 +3,7 @@ import { Clock, Square } from 'lucide-react';
 import { fetchRunningTimer, stopTimerAction, onTimerChanged, type RunningTimer } from '../../lib/timerActions';
 import { ActionError } from '../../lib/runAction';
 import { formatElapsedSeconds } from '../../lib/timeFormat';
+import { showToast } from '../shared/Toast';
 
 const POLL_MS = 60_000;
 
@@ -14,6 +15,8 @@ export default function TimerWidget() {
   const [billable, setBillable] = useState(false);
   const [stopping, setStopping] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const refresh = useCallback(() => {
     void fetchRunningTimer().then(setTimer).catch(() => setTimer(null));
@@ -43,6 +46,25 @@ export default function TimerWidget() {
     return () => document.removeEventListener('mousedown', onDown);
   }, [popoverOpen]);
 
+  // Escape closes the popover and returns focus to the stop button.
+  useEffect(() => {
+    if (!popoverOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setPopoverOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [popoverOpen]);
+
+  // Focus the description textarea when the popover opens.
+  useEffect(() => {
+    if (popoverOpen) textareaRef.current?.focus();
+  }, [popoverOpen]);
+
   if (!timer) return null;
 
   const openStop = () => {
@@ -58,7 +80,8 @@ export default function TimerWidget() {
       setPopoverOpen(false);
       setTimer(null);
     } catch (err) {
-      if (!(err instanceof ActionError)) throw err; // ActionError already toasted by runAction
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Failed to stop timer.' });
     } finally {
       setStopping(false);
     }
@@ -73,13 +96,13 @@ export default function TimerWidget() {
           {timer.ticketNumber ?? 'ticket'}
         </a>
       )}
-      <button type="button" onClick={openStop} className="rounded p-0.5 text-muted-foreground hover:text-destructive" title="Stop timer" data-testid="timer-widget-stop">
+      <button type="button" ref={buttonRef} onClick={openStop} className="rounded p-0.5 text-muted-foreground hover:text-destructive" title="Stop timer" aria-label="Stop timer" aria-expanded={popoverOpen} aria-haspopup="dialog" data-testid="timer-widget-stop">
         <Square className="h-3.5 w-3.5" aria-hidden />
       </button>
       {popoverOpen && (
-        <div ref={popoverRef} className="absolute right-0 top-full z-50 mt-2 w-72 rounded-lg border bg-popover p-3 shadow-lg" data-testid="timer-stop-popover">
+        <div ref={popoverRef} role="dialog" aria-label="Stop timer" className="absolute right-0 top-full z-50 mt-2 w-72 rounded-lg border bg-popover p-3 shadow-lg" data-testid="timer-stop-popover">
           <p className="mb-2 text-sm font-medium">Stop timer</p>
-          <textarea value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What did you work on?" rows={2} className="mb-2 w-full rounded-md border bg-background px-2 py-1.5 text-sm" data-testid="timer-stop-description" />
+          <textarea ref={textareaRef} value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What did you work on?" rows={2} aria-label="Description" className="mb-2 w-full rounded-md border bg-background px-2 py-1.5 text-sm" data-testid="timer-stop-description" />
           <label className="mb-3 flex items-center gap-2 text-sm">
             <input type="checkbox" checked={billable} onChange={(e) => setBillable(e.target.checked)} data-testid="timer-stop-billable" />
             Billable

--- a/apps/web/src/components/time/TimerWidget.tsx
+++ b/apps/web/src/components/time/TimerWidget.tsx
@@ -108,7 +108,7 @@ export default function TimerWidget() {
             Billable
           </label>
           <div className="flex justify-end gap-2">
-            <button type="button" onClick={() => setPopoverOpen(false)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
+            <button type="button" onClick={() => setPopoverOpen(false)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted" data-testid="timer-stop-cancel">Cancel</button>
             <button type="button" onClick={() => void submitStop()} disabled={stopping} className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50" data-testid="timer-stop-submit">
               {stopping ? 'Saving…' : 'Stop & save'}
             </button>

--- a/apps/web/src/components/time/TimesheetPage.test.tsx
+++ b/apps/web/src/components/time/TimesheetPage.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (...a: unknown[]) => showToast(...a) }));
+
+import TimesheetPage from './TimesheetPage';
+
+const entry = { id: 'te-1', startedAt: '2026-06-08T09:00:00Z', endedAt: '2026-06-08T10:30:00Z', durationMinutes: 90, description: 'patching', isBillable: true, hourlyRate: '100.00', isApproved: false, ticketId: 'tk-1', ticketNumber: 'T-2026-0042', ticketSubject: 'x', userName: 'Todd', billingStatus: 'not_billed' };
+const week = {
+  weekStart: '2026-06-08',
+  days: [
+    { date: '2026-06-08', totalMinutes: 90, billableMinutes: 90, entries: [entry] },
+    ...['09', '10', '11', '12', '13', '14'].map((d) => ({ date: `2026-06-${d}`, totalMinutes: 0, billableMinutes: 0, entries: [] }))
+  ],
+  totals: { totalMinutes: 90, billableMinutes: 90 }
+};
+const jsonRes = (data: unknown, status = 200) => ({ ok: status < 400, status, json: async () => ({ data }) }) as Response;
+
+beforeEach(() => {
+  window.location.hash = '#week=2026-06-08';
+  fetchWithAuth.mockReset();
+  fetchWithAuth.mockImplementation(async (url: string) => {
+    if (url.startsWith('/time-entries/timesheet')) return jsonRes(week);
+    if (url.startsWith('/users')) return jsonRes([{ id: 'u-1', name: 'Todd', email: 't@x' }]);
+    return jsonRes({});
+  });
+});
+
+describe('TimesheetPage', () => {
+  it('fetches the week from the hash and renders day totals + entries', async () => {
+    render(<TimesheetPage />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/time-entries/timesheet?weekStart=2026-06-08')));
+    expect((await screen.findByTestId('timesheet-day-2026-06-08')).textContent).toContain('1h 30m');
+    expect(screen.getByTestId('timesheet-entry-te-1').textContent).toContain('T-2026-0042');
+    expect(screen.getByTestId('timesheet-total').textContent).toContain('1h 30m');
+  });
+
+  it('week navigation updates the hash and refetches', async () => {
+    render(<TimesheetPage />);
+    await screen.findByTestId('timesheet-day-2026-06-08');
+    fireEvent.click(screen.getByTestId('timesheet-prev-week'));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('weekStart=2026-06-01')));
+    expect(window.location.hash).toContain('week=2026-06-01');
+  });
+
+  it('bulk-approves selected entries and surfaces skippedReasons', async () => {
+    render(<TimesheetPage />);
+    fireEvent.click(await screen.findByTestId('timesheet-select-te-1'));
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/time-entries/bulk-approve') return jsonRes({ updated: 0, skipped: 1, skippedReasons: { ENTRY_RUNNING: 1 }, total: 1 });
+      if (url.startsWith('/time-entries/timesheet')) return jsonRes(week);
+      if (url.startsWith('/users')) return jsonRes([{ id: 'u-1', name: 'Todd', email: 't@x' }]);
+      return jsonRes({});
+    });
+    fireEvent.click(screen.getByTestId('timesheet-approve-selected'));
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((args) => args[0] === '/time-entries/bulk-approve');
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toEqual({ ids: ['te-1'], approve: true });
+    });
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' })));
+  });
+
+  it('falls back to own timesheet with a notice when another tech 403s', async () => {
+    window.location.hash = '#week=2026-06-08&tech=u-2';
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url.includes('userId=u-2')) return { ok: false, status: 403, json: async () => ({ error: 'admin required' }) } as Response;
+      if (url.startsWith('/time-entries/timesheet')) return jsonRes(week);
+      if (url.startsWith('/users')) return jsonRes([{ id: 'u-2', name: 'Bo', email: 'b@x' }]);
+      return jsonRes({});
+    });
+    render(<TimesheetPage />);
+    expect(await screen.findByTestId('timesheet-admin-notice')).toBeTruthy();
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(expect.not.stringContaining('userId=u-2')));
+  });
+});

--- a/apps/web/src/components/time/TimesheetPage.tsx
+++ b/apps/web/src/components/time/TimesheetPage.tsx
@@ -441,6 +441,7 @@ export default function TimesheetPage() {
                             aria-label="Rate"
                             placeholder="Rate"
                             className="w-24 rounded-md border bg-background px-2 py-1 text-sm"
+                            data-testid={`timesheet-edit-rate-${entry.id}`}
                           />
                           <button
                             type="button"

--- a/apps/web/src/components/time/TimesheetPage.tsx
+++ b/apps/web/src/components/time/TimesheetPage.tsx
@@ -22,7 +22,6 @@ interface TsEntry {
   ticketNumber: string;
   ticketSubject: string;
   userName: string;
-  billingStatus: string;
 }
 
 interface TsDay {
@@ -151,6 +150,7 @@ export default function TimesheetPage() {
         return;
       }
       const body = await res.json().catch(() => null) as { data?: TsSheet } | null;
+      if (body?.data?.weekStart && body.data.weekStart !== loadWeek) return; // stale response from rapid navigation
       setSheet(body?.data ?? null);
       setSelected(new Set()); // clear selection on new load
     } catch {
@@ -183,6 +183,7 @@ export default function TimesheetPage() {
   }, [week, tech]);
 
   const goToThisWeek = useCallback(() => {
+    // mondayUtc(new Date()) buckets by UTC — late-Sunday users west of UTC may land on "next" week; matches the API's UTC day-bucketing.
     const newWeek = mondayUtc(new Date());
     setWeek(newWeek);
     writeHash(newWeek, tech);

--- a/apps/web/src/components/time/TimesheetPage.tsx
+++ b/apps/web/src/components/time/TimesheetPage.tsx
@@ -1,0 +1,537 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError, handleActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { formatMinutes } from '../../lib/timeFormat';
+import { onTimerChanged } from '../../lib/timerActions';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TsEntry {
+  id: string;
+  startedAt: string;
+  endedAt: string | null;
+  durationMinutes: number;
+  description: string | null;
+  isBillable: boolean;
+  hourlyRate: string | null;
+  isApproved: boolean;
+  ticketId: string;
+  ticketNumber: string;
+  ticketSubject: string;
+  userName: string;
+  billingStatus: string;
+}
+
+interface TsDay {
+  date: string;
+  totalMinutes: number;
+  billableMinutes: number;
+  entries: TsEntry[];
+}
+
+interface TsSheet {
+  weekStart: string;
+  days: TsDay[];
+  totals: { totalMinutes: number; billableMinutes: number };
+}
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface EditForm {
+  description: string;
+  isBillable: boolean;
+  hourlyRate: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hash-state helpers
+// ---------------------------------------------------------------------------
+
+function mondayUtc(d: Date): string {
+  const utc = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dow = (utc.getUTCDay() + 6) % 7; // Mon=0 … Sun=6
+  utc.setUTCDate(utc.getUTCDate() - dow);
+  return utc.toISOString().slice(0, 10);
+}
+
+function shiftWeek(weekStart: string, delta: number): string {
+  const [y, mo, d] = weekStart.split('-').map(Number);
+  const base = new Date(Date.UTC(y, mo - 1, d));
+  base.setUTCDate(base.getUTCDate() + delta * 7);
+  return base.toISOString().slice(0, 10);
+}
+
+function parseHash(): { week: string; tech: string | null } {
+  if (typeof window === 'undefined') return { week: mondayUtc(new Date()), tech: null };
+  let week: string | null = null;
+  let tech: string | null = null;
+  for (const part of window.location.hash.replace('#', '').split('&')) {
+    if (!part) continue;
+    if (part.startsWith('week=')) {
+      const v = part.slice('week='.length);
+      if (/^\d{4}-\d{2}-\d{2}$/.test(v)) week = v;
+    } else if (part.startsWith('tech=')) {
+      tech = part.slice('tech='.length) || null;
+    }
+  }
+  return { week: week ?? mondayUtc(new Date()), tech };
+}
+
+function writeHash(week: string, tech: string | null): void {
+  const parts: string[] = [`week=${week}`];
+  if (tech) parts.push(`tech=${tech}`);
+  history.replaceState(null, '', `#${parts.join('&')}`);
+}
+
+// ---------------------------------------------------------------------------
+// Friendly error codes
+// ---------------------------------------------------------------------------
+
+const FRIENDLY: Record<string, string> = {
+  ADMIN_REQUIRED: 'Approving timesheets requires an admin role.',
+  APPROVED_IMMUTABLE: 'Approved entries can only be changed by an admin.',
+  NOT_OWN_ENTRY: 'You can only edit your own time entries.',
+};
+
+const friendly = (code: string): string | undefined => FRIENDLY[code];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function TimesheetPage() {
+  const initial = parseHash();
+  const [week, setWeek] = useState<string>(initial.week);
+  const [tech, setTech] = useState<string | null>(initial.tech);
+  const [sheet, setSheet] = useState<TsSheet | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+  const [adminDenied, setAdminDenied] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<EditForm>({ description: '', isBillable: true, hourlyRate: '' });
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+
+  // Load users once on mount
+  useEffect(() => {
+    void (async () => {
+      const res = await fetchWithAuth('/users');
+      if (!res.ok) return;
+      const body = await res.json().catch(() => null) as { data?: User[] } | User[] | null;
+      const rows = Array.isArray(body) ? body : body?.data ?? [];
+      setUsers(rows);
+    })();
+  }, []);
+
+  // Load timesheet when week or tech changes
+  const loadSheet = useCallback(async (loadWeek: string, loadTech: string | null) => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const params = new URLSearchParams({ weekStart: loadWeek });
+      if (loadTech) params.set('userId', loadTech);
+      const res = await fetchWithAuth(`/time-entries/timesheet?${params.toString()}`);
+      if (!res.ok) {
+        if (res.status === 403 && loadTech) {
+          // No admin access to another tech's sheet — fall back to own
+          setAdminDenied(true);
+          setTech(null);
+          writeHash(loadWeek, null);
+          // The effect will re-run with tech=null
+          return;
+        }
+        setLoadError(true);
+        return;
+      }
+      const body = await res.json().catch(() => null) as { data?: TsSheet } | null;
+      setSheet(body?.data ?? null);
+      setSelected(new Set()); // clear selection on new load
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSheet(week, tech);
+  }, [week, tech, loadSheet]);
+
+  // Subscribe to timer changes
+  useEffect(() => {
+    return onTimerChanged(() => void loadSheet(week, tech));
+  }, [week, tech, loadSheet]);
+
+  // Navigation helpers
+  const goToPrevWeek = useCallback(() => {
+    const newWeek = shiftWeek(week, -1);
+    setWeek(newWeek);
+    writeHash(newWeek, tech);
+  }, [week, tech]);
+
+  const goToNextWeek = useCallback(() => {
+    const newWeek = shiftWeek(week, 1);
+    setWeek(newWeek);
+    writeHash(newWeek, tech);
+  }, [week, tech]);
+
+  const goToThisWeek = useCallback(() => {
+    const newWeek = mondayUtc(new Date());
+    setWeek(newWeek);
+    writeHash(newWeek, tech);
+  }, [tech]);
+
+  const handleTechChange = useCallback((userId: string) => {
+    const newTech = userId || null;
+    setTech(newTech);
+    setAdminDenied(false);
+    writeHash(week, newTech);
+  }, [week]);
+
+  // Selection
+  const toggleSelect = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // Bulk approve/unapprove
+  const bulkApprove = useCallback(async (approve: boolean) => {
+    const ids = Array.from(selected);
+    if (ids.length === 0) return;
+    try {
+      const result = await runAction<{ updated: number; skipped: number; skippedReasons: Record<string, number>; total: number }>({
+        request: () => fetchWithAuth('/time-entries/bulk-approve', {
+          method: 'POST',
+          body: JSON.stringify({ ids, approve }),
+        }),
+        errorFallback: 'Bulk approval failed. Retry.',
+        parseSuccess: (data) => {
+          const d = data as { data: { updated: number; skipped: number; skippedReasons: Record<string, number>; total: number } };
+          return d.data;
+        },
+        friendly,
+      });
+      if (result.skipped > 0) {
+        const reasons = Object.entries(result.skippedReasons ?? {})
+          .map(([code, count]) => `${count}× ${code.toLowerCase().replace(/_/g, ' ')}`)
+          .join(', ');
+        showToast({ type: 'warning', message: `${result.updated} updated, ${result.skipped} skipped (${reasons})` });
+      } else {
+        showToast({ type: 'success', message: `${result.updated} ${approve ? 'approved' : 'unapproved'}` });
+      }
+      setSelected(new Set());
+      void loadSheet(week, tech);
+    } catch (err) {
+      handleActionError(err, 'Bulk approval failed. Retry.');
+    }
+  }, [selected, week, tech, loadSheet]);
+
+  // Inline edit
+  const startEdit = useCallback((entry: TsEntry) => {
+    setEditingId(entry.id);
+    setEditForm({
+      description: entry.description ?? '',
+      isBillable: entry.isBillable,
+      hourlyRate: entry.hourlyRate ?? '',
+    });
+  }, []);
+
+  const saveEdit = useCallback(async (id: string) => {
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/time-entries/${id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({
+            description: editForm.description || null,
+            isBillable: editForm.isBillable,
+            hourlyRate: editForm.hourlyRate === '' ? null : Number(editForm.hourlyRate),
+          }),
+        }),
+        errorFallback: 'Failed to save entry. Retry.',
+        successMessage: 'Entry updated',
+        friendly,
+      });
+      setEditingId(null);
+      void loadSheet(week, tech);
+    } catch (err) {
+      handleActionError(err, 'Failed to save entry. Retry.');
+    }
+  }, [editForm, week, tech, loadSheet]);
+
+  // Formatted week label
+  const weekLabel = (() => {
+    const [y, mo, d] = week.split('-').map(Number);
+    return new Date(Date.UTC(y, mo - 1, d)).toLocaleDateString(undefined, { timeZone: 'UTC', month: 'long', day: 'numeric', year: 'numeric' });
+  })();
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="timesheet-page">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-xl font-semibold">Timesheet</h1>
+
+        {users.length > 0 && (
+          <select
+            value={tech ?? ''}
+            onChange={(e) => handleTechChange(e.target.value)}
+            aria-label="Select technician"
+            data-testid="timesheet-tech-select"
+            className="h-8 rounded-md border bg-background px-2 text-sm"
+          >
+            <option value="">My timesheet</option>
+            {users.map((u) => (
+              <option key={u.id} value={u.id}>{u.name || u.email}</option>
+            ))}
+          </select>
+        )}
+
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={goToPrevWeek}
+            data-testid="timesheet-prev-week"
+            aria-label="Previous week"
+            className="rounded-md border px-2.5 py-1.5 text-sm hover:bg-muted"
+          >
+            ←
+          </button>
+          <span className="px-2 text-sm" data-testid="timesheet-week-label">Week of {weekLabel}</span>
+          <button
+            type="button"
+            onClick={goToNextWeek}
+            data-testid="timesheet-next-week"
+            aria-label="Next week"
+            className="rounded-md border px-2.5 py-1.5 text-sm hover:bg-muted"
+          >
+            →
+          </button>
+          <button
+            type="button"
+            onClick={goToThisWeek}
+            data-testid="timesheet-this-week"
+            className="rounded-md border px-2.5 py-1.5 text-sm hover:bg-muted"
+          >
+            This week
+          </button>
+        </div>
+      </div>
+
+      {/* Admin notice */}
+      {adminDenied && (
+        <div
+          data-testid="timesheet-admin-notice"
+          className="rounded-md border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-800"
+        >
+          Viewing other technicians&apos; timesheets requires an admin role — showing yours.
+        </div>
+      )}
+
+      {/* Bulk action bar */}
+      {selected.size > 0 && (
+        <div
+          data-testid="timesheet-bulk-bar"
+          className="flex items-center gap-3 rounded-md border bg-background px-3 py-2 shadow"
+        >
+          <span className="text-sm font-medium tabular-nums">{selected.size} selected</span>
+          <button
+            type="button"
+            onClick={() => void bulkApprove(true)}
+            data-testid="timesheet-approve-selected"
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90"
+          >
+            Approve selected
+          </button>
+          <button
+            type="button"
+            onClick={() => void bulkApprove(false)}
+            data-testid="timesheet-unapprove-selected"
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Unapprove
+          </button>
+        </div>
+      )}
+
+      {/* Loading / error states */}
+      {loading && !sheet && (
+        <div data-testid="timesheet-loading" className="py-8 text-center text-sm text-muted-foreground">
+          Loading…
+        </div>
+      )}
+      {!loading && !sheet && loadError && (
+        <div data-testid="timesheet-error" className="py-8 text-center text-sm text-destructive">
+          Failed to load timesheet. Retry.
+        </div>
+      )}
+
+      {/* Days */}
+      {sheet && (
+        <div className="flex flex-col gap-3">
+          {sheet.days.map((day) => (
+            <section
+              key={day.date}
+              data-testid={`timesheet-day-${day.date}`}
+              className="rounded-lg border"
+            >
+              <div className="flex items-center justify-between border-b bg-muted/30 px-4 py-2">
+                <span className="text-sm font-medium">
+                  {new Date(`${day.date}T00:00:00Z`).toLocaleDateString(undefined, {
+                    timeZone: 'UTC',
+                    weekday: 'short',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {day.totalMinutes > 0 ? (
+                    <>
+                      {formatMinutes(day.totalMinutes)}
+                      {day.billableMinutes > 0 && ` · ${formatMinutes(day.billableMinutes)} billable`}
+                    </>
+                  ) : '—'}
+                </span>
+              </div>
+
+              {day.entries.length === 0 ? (
+                <div className="px-4 py-3 text-sm text-muted-foreground">No entries</div>
+              ) : (
+                <div className="divide-y">
+                  {day.entries.map((entry) => (
+                    <div
+                      key={entry.id}
+                      data-testid={`timesheet-entry-${entry.id}`}
+                      className="flex flex-wrap items-start gap-3 px-4 py-3"
+                    >
+                      {editingId === entry.id ? (
+                        // Inline edit form
+                        <div className="flex flex-1 flex-wrap items-center gap-2">
+                          <input
+                            type="text"
+                            value={editForm.description}
+                            onChange={(e) => setEditForm((f) => ({ ...f, description: e.target.value }))}
+                            data-testid={`timesheet-edit-description-${entry.id}`}
+                            placeholder="Description"
+                            className="min-w-0 flex-1 rounded-md border bg-background px-2 py-1 text-sm"
+                          />
+                          <label className="flex items-center gap-1 text-sm">
+                            <input
+                              type="checkbox"
+                              checked={editForm.isBillable}
+                              onChange={(e) => setEditForm((f) => ({ ...f, isBillable: e.target.checked }))}
+                              data-testid={`timesheet-edit-billable-${entry.id}`}
+                            />
+                            Billable
+                          </label>
+                          <input
+                            type="number"
+                            value={editForm.hourlyRate}
+                            onChange={(e) => setEditForm((f) => ({ ...f, hourlyRate: e.target.value }))}
+                            aria-label="Rate"
+                            placeholder="Rate"
+                            className="w-24 rounded-md border bg-background px-2 py-1 text-sm"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => void saveEdit(entry.id)}
+                            data-testid={`timesheet-edit-save-${entry.id}`}
+                            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-primary/90"
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setEditingId(null)}
+                            className="rounded-md border px-2.5 py-1.5 text-xs hover:bg-muted"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        // Normal row
+                        <>
+                          <input
+                            type="checkbox"
+                            checked={selected.has(entry.id)}
+                            onChange={() => toggleSelect(entry.id)}
+                            disabled={!entry.endedAt}
+                            data-testid={`timesheet-select-${entry.id}`}
+                            aria-label={`Select entry ${entry.id}`}
+                            className="mt-0.5"
+                          />
+                          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <a
+                                href={`/tickets/${entry.ticketId}`}
+                                className="text-sm font-medium text-primary hover:underline"
+                              >
+                                {entry.ticketNumber}
+                              </a>
+                              {entry.description ? (
+                                <span className="text-sm">{entry.description}</span>
+                              ) : (
+                                <span className="text-sm text-muted-foreground">No description</span>
+                              )}
+                              {entry.isApproved && (
+                                <span
+                                  data-testid={`timesheet-approved-${entry.id}`}
+                                  className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700"
+                                >
+                                  Approved
+                                </span>
+                              )}
+                              {!entry.isBillable && (
+                                <span className="text-xs text-muted-foreground">non-billable</span>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm tabular-nums text-muted-foreground">
+                              {entry.endedAt ? formatMinutes(entry.durationMinutes) : 'running'}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => startEdit(entry)}
+                              data-testid={`timesheet-edit-${entry.id}`}
+                              aria-label={`Edit entry ${entry.id}`}
+                              className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                            >
+                              Edit
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          ))}
+        </div>
+      )}
+
+      {/* Footer totals */}
+      {sheet && (
+        <div
+          data-testid="timesheet-total"
+          className="flex items-center gap-4 rounded-lg border bg-muted/30 px-4 py-3 text-sm font-medium"
+        >
+          <span>Total: {formatMinutes(sheet.totals.totalMinutes)}</span>
+          {sheet.totals.billableMinutes > 0 && (
+            <span className="text-muted-foreground">Billable: {formatMinutes(sheet.totals.billableMinutes)}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/time/TimesheetPage.tsx
+++ b/apps/web/src/components/time/TimesheetPage.tsx
@@ -452,6 +452,7 @@ export default function TimesheetPage() {
                           <button
                             type="button"
                             onClick={() => setEditingId(null)}
+                            data-testid={`timesheet-edit-cancel-${entry.id}`}
                             className="rounded-md border px-2.5 py-1.5 text-xs hover:bg-muted"
                           >
                             Cancel

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -45,6 +45,11 @@ const TARGET_GLOBS = [
   'src/components/settings/TicketCategoriesPage.tsx',
   'src/components/settings/OrgPortalSettingsEditor.tsx',
   'src/components/alerts/CreateTicketFromAlertDialog.tsx',
+  'src/lib/timerActions.ts',
+  'src/components/time/TimerWidget.tsx',
+  'src/components/time/TimesheetPage.tsx',
+  'src/components/tickets/TicketTimeBilling.tsx',
+  'src/components/tickets/TicketPartsCard.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -236,7 +241,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(17);
+    expect(absoluteFiles.length).toBe(22);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/timeFormat.test.ts
+++ b/apps/web/src/lib/__tests__/timeFormat.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { formatMinutes, formatElapsedSeconds, formatMoney } from '../timeFormat';
+
+describe('formatMinutes', () => {
+  it('renders sub-hour as minutes', () => expect(formatMinutes(45)).toBe('45m'));
+  it('renders exact hours without minutes', () => expect(formatMinutes(120)).toBe('2h'));
+  it('renders mixed', () => expect(formatMinutes(90)).toBe('1h 30m'));
+  it('treats null/negative as zero', () => {
+    expect(formatMinutes(null)).toBe('0m');
+    expect(formatMinutes(-5)).toBe('0m');
+  });
+});
+
+describe('formatElapsedSeconds', () => {
+  it('renders mm:ss under an hour', () => expect(formatElapsedSeconds(125)).toBe('02:05'));
+  it('renders h:mm:ss over an hour', () => expect(formatElapsedSeconds(3725)).toBe('1:02:05'));
+});
+
+describe('formatMoney', () => {
+  it('formats numeric strings from the API', () => expect(formatMoney('1234.5')).toBe('$1,234.50'));
+  it('falls back to $0.00 on garbage', () => expect(formatMoney('not-a-number')).toBe('$0.00'));
+});

--- a/apps/web/src/lib/runAction.ts
+++ b/apps/web/src/lib/runAction.ts
@@ -80,3 +80,11 @@ export async function runAction<T = unknown>(opts: RunActionOptions<T>): Promise
   }
   return result;
 }
+
+/** Standard catch handler for runAction callers: 401s are handled by the auth
+ *  redirect, other ActionErrors were already toasted by runAction, anything
+ *  else gets the fallback toast. */
+export function handleActionError(err: unknown, fallback: string): void {
+  if (err instanceof ActionError && err.status === 401) return;
+  if (!(err instanceof ActionError)) showToast({ message: fallback, type: 'error' });
+}

--- a/apps/web/src/lib/timeFormat.ts
+++ b/apps/web/src/lib/timeFormat.ts
@@ -1,0 +1,24 @@
+export function formatMinutes(minutes: number | null | undefined): string {
+  const m = Math.max(0, minutes ?? 0);
+  const h = Math.floor(m / 60);
+  const rest = m % 60;
+  if (h === 0) return `${rest}m`;
+  return rest === 0 ? `${h}h` : `${h}h ${rest}m`;
+}
+
+export function formatElapsedSeconds(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const mm = String(m).padStart(2, '0');
+  const ss = String(sec).padStart(2, '0');
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/** API money fields arrive as numeric strings (numeric(12,2) → '123.40'). */
+export function formatMoney(value: string | number | null | undefined): string {
+  const n = typeof value === 'number' ? value : Number(value);
+  const safe = Number.isFinite(n) ? n : 0;
+  return safe.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+}

--- a/apps/web/src/lib/timerActions.ts
+++ b/apps/web/src/lib/timerActions.ts
@@ -1,0 +1,53 @@
+import { fetchWithAuth } from '../stores/auth';
+import { runAction } from './runAction';
+
+export const TIMER_CHANGED_EVENT = 'breeze:timer-changed';
+
+export interface RunningTimer {
+  id: string;
+  ticketId: string | null;
+  startedAt: string;
+  description: string | null;
+  isBillable: boolean;
+  ticketNumber: string | null;
+  ticketSubject: string | null;
+}
+
+function broadcastTimerChanged(): void {
+  window.dispatchEvent(new CustomEvent(TIMER_CHANGED_EVENT));
+}
+
+export async function fetchRunningTimer(): Promise<RunningTimer | null> {
+  const res = await fetchWithAuth('/time-entries/running');
+  if (!res.ok) return null;
+  const body = (await res.json().catch(() => null)) as { data?: RunningTimer | null } | null;
+  return body?.data ?? null;
+}
+
+const FRIENDLY_MESSAGES: Record<string, string> = {
+  NO_RUNNING_TIMER: 'No timer is currently running.',
+  TICKET_NOT_FOUND: 'That ticket no longer exists.',
+  APPROVED_IMMUTABLE: 'Approved entries can only be changed by an admin.',
+};
+
+const friendly = (code: string): string | undefined => FRIENDLY_MESSAGES[code];
+
+export async function startTimerAction(input: { ticketId?: string; description?: string } = {}): Promise<void> {
+  await runAction({
+    request: () => fetchWithAuth('/time-entries/start', { method: 'POST', body: JSON.stringify(input) }),
+    errorFallback: 'Failed to start timer',
+    successMessage: 'Timer started',
+    friendly,
+  });
+  broadcastTimerChanged();
+}
+
+export async function stopTimerAction(input: { description?: string; isBillable?: boolean } = {}): Promise<void> {
+  await runAction({
+    request: () => fetchWithAuth('/time-entries/stop', { method: 'POST', body: JSON.stringify(input) }),
+    errorFallback: 'Failed to stop timer',
+    successMessage: 'Time entry saved',
+    friendly,
+  });
+  broadcastTimerChanged();
+}

--- a/apps/web/src/lib/timerActions.ts
+++ b/apps/web/src/lib/timerActions.ts
@@ -2,6 +2,17 @@ import { fetchWithAuth } from '../stores/auth';
 import { runAction } from './runAction';
 
 export const TIMER_CHANGED_EVENT = 'breeze:timer-changed';
+export const BILLING_CHANGED_EVENT = 'breeze:billing-changed';
+
+export function broadcastBillingChanged(): void {
+  window.dispatchEvent(new CustomEvent(BILLING_CHANGED_EVENT));
+}
+
+/** Subscribe to billing-affecting changes (parts/time mutations); returns unsubscribe. */
+export function onBillingChanged(cb: () => void): () => void {
+  window.addEventListener(BILLING_CHANGED_EVENT, cb);
+  return () => window.removeEventListener(BILLING_CHANGED_EVENT, cb);
+}
 
 export interface RunningTimer {
   id: string;

--- a/apps/web/src/lib/timerActions.ts
+++ b/apps/web/src/lib/timerActions.ts
@@ -28,10 +28,22 @@ const FRIENDLY_MESSAGES: Record<string, string> = {
   NO_RUNNING_TIMER: 'No timer is currently running.',
   TICKET_NOT_FOUND: 'That ticket no longer exists.',
   APPROVED_IMMUTABLE: 'Approved entries can only be changed by an admin.',
+  ENTRY_RUNNING: 'A timer is already running — stop it first.',
+  TICKET_WRONG_PARTNER: 'That ticket belongs to a different partner.',
 };
 
 const friendly = (code: string): string | undefined => FRIENDLY_MESSAGES[code];
 
+/** Subscribe to timer changes; returns an unsubscribe function for effect cleanup. */
+export function onTimerChanged(cb: () => void): () => void {
+  window.addEventListener(TIMER_CHANGED_EVENT, cb);
+  return () => window.removeEventListener(TIMER_CHANGED_EVENT, cb);
+}
+
+/**
+ * @throws {ActionError} Failures are already toasted by runAction — callers should swallow
+ * ActionError (return early on 401) and only toast non-ActionError.
+ */
 export async function startTimerAction(input: { ticketId?: string; description?: string } = {}): Promise<void> {
   await runAction({
     request: () => fetchWithAuth('/time-entries/start', { method: 'POST', body: JSON.stringify(input) }),
@@ -42,6 +54,10 @@ export async function startTimerAction(input: { ticketId?: string; description?:
   broadcastTimerChanged();
 }
 
+/**
+ * @throws {ActionError} Failures are already toasted by runAction — callers should swallow
+ * ActionError (return early on 401) and only toast non-ActionError.
+ */
 export async function stopTimerAction(input: { description?: string; isBillable?: boolean } = {}): Promise<void> {
   await runAction({
     request: () => fetchWithAuth('/time-entries/stop', { method: 'POST', body: JSON.stringify(input) }),

--- a/apps/web/src/pages/timesheet.astro
+++ b/apps/web/src/pages/timesheet.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../layouts/DashboardLayout.astro';
+import TimesheetPage from '../components/time/TimesheetPage';
+---
+
+<DashboardLayout title="Timesheet">
+  <TimesheetPage client:load />
+</DashboardLayout>


### PR DESCRIPTION
Phase 3 PR 2 of 2 (frontend, against the merged #1276 backend). Spec: `docs/superpowers/specs/2026-06-11-ticketing-phase3-time-tracking-parts-design.md` §5; plan: `docs/superpowers/plans/2026-06-12-ticketing-phase3-frontend.md`.

**Surfaces:**

- **Header timer widget** (`components/time/TimerWidget.tsx`) — shows the running entry with live elapsed + ticket link; stop popover (description + billable); 60s poll + `breeze:timer-changed` event sync; renders nothing when idle.
- **Ticket detail rail** — `TicketTimeBilling.tsx` (billing summary, start-timer, quick-add manual entry) and `TicketPartsCard.tsx` (parts add/edit/delete with cost basis + margin, internal-only per D4); both live-refresh on timer/billing events.
- **Feed** — `TicketFeed.tsx` renders `commentType='time_entry'` lines; workbench reloads the feed on timer/billing events.
- **`/timesheet`** (`components/time/TimesheetPage.tsx`) — Monday-UTC week view, hash state `#week=…&tech=…`, admin tech-selector with graceful 403 fallback, inline edit, approval checkboxes + bulk approve/unapprove with `skippedReasons` warning toasts, weekly totals.
- **Settings → Ticketing** — `BillablesExportCard.tsx` CSV export (date range + org picker, authed blob download).

**Backend addition (closes a spec §3 gap found during planning):** #1276 emitted `TimeEntryEvent`s but never wrote the `commentType='time_entry'` feed rows the spec expects the UI to render. `timeEntryService.ts` now inserts internal-only (`isPublic:false`) feed comments on ticket-linked create/stop/auto-stop/delete; insert failures are logged and swallowed so a committed mutation never 500s; portal comment listing filters `isPublic=true`, so D4 holds.

**Conventions:** all mutations through `runAction`; 5 new files enrolled in `no-silent-mutations` (count 17→22); shared `handleActionError` extracted to `lib/runAction.ts`; hash-based URL state; `data-testid` coverage throughout; docs section added to `features/ticketing.mdx`.

**Tests:** web 1157 passed (baseline 1123; +34 incl. widget/timesheet/cards/feed/export), api targeted 152 passed (feed-comment paths incl. regression-verified auto-stop coverage, null-duration wording, insert-failure tolerance). `tsc` + eslint clean.

**Known deferred:** Playwright e2e (existing ticketing-e2e backlog item), parts fields partNumber/vendor/notes not yet surfaced in the form, parts delete has no confirm dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)