### PR TITLE
feat(pam): config-policy enablement for UAC interception

### DIFF
--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -127,6 +127,10 @@ type Subscriber interface {
 // handler).
 type HeartbeatPoster interface {
 	SendElevationRequest(req Event) error
+	// IsUACInterceptionEnabled reports the server-resolved 'pam' config
+	// policy state. While false, handleEvent drops events entirely (no
+	// post, no offline queue) and the periodic queue drain is paused.
+	IsUACInterceptionEnabled() bool
 }
 
 // ErrNotPrivileged is returned by Start when the process is not running as
@@ -201,7 +205,7 @@ func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster) error {
 			handleEvent(ev, limiter, hb, q)
 
 		case <-ticker.C:
-			if q != nil {
+			if q != nil && hb.IsUACInterceptionEnabled() {
 				if drained, err := q.Drain(hb); err != nil {
 					log.Debug("etwlua: periodic drain failed", "error", err.Error())
 				} else if drained > 0 {
@@ -215,6 +219,9 @@ func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster) error {
 // handleEvent is the per-event hot path, extracted so tests can exercise it
 // without spinning up the full Start loop.
 func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queue) {
+	if !hb.IsUACInterceptionEnabled() {
+		return
+	}
 	key := dedupeKey(ev)
 	if !limiter.Allow(key) {
 		log.Debug("etwlua: event deduped",

--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -67,6 +67,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/ipc"
@@ -75,6 +76,16 @@ import (
 )
 
 var log = logging.L("etwlua")
+
+// dropObserved tracks suppressed-event observability while the 'pam' config
+// policy has interception disabled: one Info log on the first drop of each
+// disable interval (not per event — a busy desktop would spam), and a counter
+// so the re-enable transition can quantify the window. Package-level because
+// handleEvent is a free function; reset by the re-enable path in handleEvent.
+var (
+	dropLogged  atomic.Bool
+	dropCounter atomic.Int64
+)
 
 // Event is the platform-neutral representation of a UAC consent prompt.
 // Windows-side decoders populate it from ConsentUI ETW events; the cross-
@@ -211,6 +222,8 @@ func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster) error {
 				} else if drained > 0 {
 					log.Info("etwlua: periodic drain succeeded", "events", drained)
 				}
+			} else if q != nil {
+				log.Debug("etwlua: periodic drain paused — interception disabled by configuration policy")
 			}
 		}
 	}
@@ -220,8 +233,23 @@ func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster) error {
 // without spinning up the full Start loop.
 func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queue) {
 	if !hb.IsUACInterceptionEnabled() {
+		dropCounter.Add(1)
+		if dropLogged.CompareAndSwap(false, true) {
+			log.Info("etwlua: dropping UAC events — interception disabled by configuration policy")
+		}
 		return
 	}
+
+	// Interception is enabled. If a disable window just ended, log the
+	// re-enable transition with the count of events dropped. This fires
+	// lazily on the first event after re-enable, not at the exact moment
+	// the policy flips — acceptable for diagnostic purposes.
+	if dropLogged.Load() {
+		dropped := dropCounter.Swap(0)
+		dropLogged.Store(false)
+		log.Info("etwlua: interception re-enabled by configuration policy", "dropped_during_disable", dropped)
+	}
+
 	key := dedupeKey(ev)
 	if !limiter.Allow(key) {
 		log.Debug("etwlua: event deduped",

--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -252,7 +252,8 @@ func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queu
 	)
 	// Opportunistic drain on every successful post — quickly catches up
 	// after a network blip.
-	if q != nil {
+	// Mirror the ticker-drain gate: both drain sites must check the policy flag.
+	if q != nil && hb.IsUACInterceptionEnabled() {
 		if _, err := q.Drain(hb); err != nil {
 			log.Debug("etwlua: opportunistic drain failed", "error", err.Error())
 		}

--- a/agent/internal/etwlua/etwlua_test.go
+++ b/agent/internal/etwlua/etwlua_test.go
@@ -157,6 +157,10 @@ func TestHandleEventOpportunisticDrainAfterSuccess(t *testing.T) {
 }
 
 func TestHandleEventDroppedWhenInterceptionDisabled(t *testing.T) {
+	// Reset package-level drop state so this test is independent of run order.
+	dropLogged.Store(false)
+	dropCounter.Store(0)
+
 	hb := &fakeHB{}
 	hb.disabled.Store(true)
 	limiter := ipc.NewRateLimiter(1, dedupeWindow)
@@ -176,6 +180,54 @@ func TestHandleEventDroppedWhenInterceptionDisabled(t *testing.T) {
 	handleEvent(ev, limiter, hb, nil)
 	if got := len(hb.Received()); got != 1 {
 		t.Fatalf("expected 1 post after re-enable, got %d", got)
+	}
+}
+
+// TestHandleEventDropCounterAndReenableReset verifies:
+//   - dropCounter increments for every event dropped while disabled
+//   - dropLogged is set to true after the first drop (one-shot)
+//   - on re-enable (first enabled event), the counter resets to 0 and dropLogged resets to false
+func TestHandleEventDropCounterAndReenableReset(t *testing.T) {
+	// Reset package-level drop state so this test is independent of run order.
+	dropLogged.Store(false)
+	dropCounter.Store(0)
+
+	hb := &fakeHB{}
+	hb.disabled.Store(true)
+	// Use a fresh limiter with a short window so re-enable events are not deduped.
+	limiter := ipc.NewRateLimiter(1, dedupeWindow)
+
+	ev1 := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+	ev2 := sampleEvent("bob", `C:\Windows\System32\cmd.exe`)
+	ev3 := sampleEvent("carol", `C:\foo.exe`)
+
+	handleEvent(ev1, limiter, hb, nil)
+	handleEvent(ev2, limiter, hb, nil)
+	handleEvent(ev3, limiter, hb, nil)
+
+	if got := dropCounter.Load(); got != 3 {
+		t.Fatalf("expected dropCounter=3 after 3 disabled drops, got %d", got)
+	}
+	if !dropLogged.Load() {
+		t.Fatalf("expected dropLogged=true after first drop")
+	}
+	if got := len(hb.Received()); got != 0 {
+		t.Fatalf("expected 0 posts while disabled, got %d", got)
+	}
+
+	// Re-enable and send a new (unique) event — this should post and reset drop state.
+	hb.disabled.Store(false)
+	evNew := sampleEvent("dave", `C:\unique.exe`)
+	handleEvent(evNew, limiter, hb, nil)
+
+	if got := len(hb.Received()); got != 1 {
+		t.Fatalf("expected 1 post after re-enable, got %d", got)
+	}
+	if got := dropCounter.Load(); got != 0 {
+		t.Fatalf("expected dropCounter reset to 0 after re-enable, got %d", got)
+	}
+	if dropLogged.Load() {
+		t.Fatalf("expected dropLogged reset to false after re-enable")
 	}
 }
 

--- a/agent/internal/etwlua/etwlua_test.go
+++ b/agent/internal/etwlua/etwlua_test.go
@@ -18,6 +18,11 @@ type fakeHB struct {
 	received []Event
 	failNext atomic.Int32 // number of next posts to fail
 	failErr  error
+	disabled atomic.Bool // simulates uacInterceptionEnabled=false from the server
+}
+
+func (f *fakeHB) IsUACInterceptionEnabled() bool {
+	return !f.disabled.Load()
 }
 
 func (f *fakeHB) SendElevationRequest(req Event) error {
@@ -148,6 +153,26 @@ func TestHandleEventOpportunisticDrainAfterSuccess(t *testing.T) {
 	}
 	if n != 0 {
 		t.Fatalf("queue should be empty after opportunistic drain, got %d", n)
+	}
+}
+
+func TestHandleEventDroppedWhenInterceptionDisabled(t *testing.T) {
+	hb := &fakeHB{}
+	hb.disabled.Store(true)
+	limiter := ipc.NewRateLimiter(1, dedupeWindow)
+
+	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+	handleEvent(ev, limiter, hb, nil)
+	if got := len(hb.Received()); got != 0 {
+		t.Fatalf("expected 0 posts while interception disabled, got %d", got)
+	}
+
+	// Re-enable: the same event must post — proving the disabled event was
+	// dropped BEFORE the dedupe limiter consumed its slot.
+	hb.disabled.Store(false)
+	handleEvent(ev, limiter, hb, nil)
+	if got := len(hb.Received()); got != 1 {
+		t.Fatalf("expected 1 post after re-enable, got %d", got)
 	}
 }
 

--- a/agent/internal/etwlua/etwlua_test.go
+++ b/agent/internal/etwlua/etwlua_test.go
@@ -167,8 +167,11 @@ func TestHandleEventDroppedWhenInterceptionDisabled(t *testing.T) {
 		t.Fatalf("expected 0 posts while interception disabled, got %d", got)
 	}
 
-	// Re-enable: the same event must post — proving the disabled event was
-	// dropped BEFORE the dedupe limiter consumed its slot.
+	// Re-enable: dropping before limiter.Allow means the drop did not
+	// consume a dedupe slot, so this first-occurrence event posts
+	// immediately on re-enable. (An event that ALREADY posted within the
+	// dedupe window before a disable would still be deduped — the guard
+	// guarantees drops are free, not that re-enables always post.)
 	hb.disabled.Store(false)
 	handleEvent(ev, limiter, hb, nil)
 	if got := len(hb.Received()); got != 1 {

--- a/agent/internal/heartbeat/handlers_elevation.go
+++ b/agent/internal/heartbeat/handlers_elevation.go
@@ -21,8 +21,10 @@ import (
 // 30s context timeout, error on non-2xx with capped LimitReader on the
 // error body.
 //
-// Implements the etwlua.HeartbeatPoster interface so etwlua doesn't need
-// to import the heartbeat package.
+// Implements the SendElevationRequest method of the etwlua.HeartbeatPoster
+// interface; IsUACInterceptionEnabled lives in heartbeat.go. Together they
+// satisfy the full interface so etwlua doesn't need to import the heartbeat
+// package.
 func (h *Heartbeat) SendElevationRequest(req etwlua.Event) error {
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -96,6 +96,7 @@ type HeartbeatResponse struct {
 	RenewCert              bool                   `json:"renewCert,omitempty"`
 	RotateToken            bool                   `json:"rotateToken,omitempty"`
 	HelperEnabled          bool                   `json:"helperEnabled,omitempty"`
+	UacInterceptionEnabled *bool                  `json:"uacInterceptionEnabled,omitempty"`
 	HelperSettings         *HelperSettings        `json:"helperSettings,omitempty"`
 	HelperUpgradeTo        string                 `json:"helperUpgradeTo,omitempty"`
 	ManageRemoteManagement bool                   `json:"manageRemoteManagement,omitempty"`
@@ -200,6 +201,12 @@ type Heartbeat struct {
 	// Helper chat enabled flag from org settings
 	helperEnabled atomic.Bool
 	helperMgr     *helper.Manager
+
+	// uacInterceptionDisabled is set when the server's 'pam' config policy
+	// turns UAC capture off for this device. Inverted so the zero value
+	// (enabled) matches the default-ON contract before the first heartbeat
+	// and against older servers that never send the field.
+	uacInterceptionDisabled atomic.Bool
 
 	// Service & process monitoring
 	monitor *monitoring.Monitor
@@ -2341,6 +2348,7 @@ func (h *Heartbeat) sendHeartbeat() {
 
 	// Update helper enabled state and apply full settings
 	h.handleHelperEnabled(response.HelperEnabled)
+	h.handleUACInterception(response.UacInterceptionEnabled)
 	if response.HelperSettings != nil {
 		h.helperMgr.Apply(&helper.Settings{
 			Enabled:            response.HelperSettings.Enabled,
@@ -2365,6 +2373,28 @@ func (h *Heartbeat) handleHelperEnabled(enabled bool) {
 			log.Info("helper chat enabled for this device")
 		} else {
 			log.Info("helper chat disabled for this device")
+		}
+	}
+}
+
+// IsUACInterceptionEnabled reports whether etwlua should post UAC elevation
+// events. Default true; only an explicit uacInterceptionEnabled=false from
+// the server's resolved 'pam' config policy disables it.
+func (h *Heartbeat) IsUACInterceptionEnabled() bool {
+	return !h.uacInterceptionDisabled.Load()
+}
+
+// handleUACInterception updates the UAC interception flag from the heartbeat
+// response and logs state transitions. nil (field absent — older server)
+// means enabled.
+func (h *Heartbeat) handleUACInterception(enabled *bool) {
+	disabled := enabled != nil && !*enabled
+	prev := h.uacInterceptionDisabled.Swap(disabled)
+	if prev != disabled {
+		if disabled {
+			log.Info("UAC interception disabled by configuration policy")
+		} else {
+			log.Info("UAC interception enabled by configuration policy")
 		}
 	}
 }

--- a/agent/internal/heartbeat/uac_interception_test.go
+++ b/agent/internal/heartbeat/uac_interception_test.go
@@ -1,0 +1,32 @@
+package heartbeat
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestUACInterceptionFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		sequence    []*bool // values passed to handleUACInterception in order
+		wantEnabled bool
+	}{
+		{"default before any heartbeat", nil, true},
+		{"nil from old server keeps default on", []*bool{nil}, true},
+		{"explicit true stays on", []*bool{boolPtr(true)}, true},
+		{"explicit false disables", []*bool{boolPtr(false)}, false},
+		{"false then true re-enables", []*bool{boolPtr(false), boolPtr(true)}, true},
+		{"false then nil re-enables (policy unassigned on old server)", []*bool{boolPtr(false), nil}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Heartbeat{}
+			for _, v := range tt.sequence {
+				h.handleUACInterception(v)
+			}
+			if got := h.IsUACInterceptionEnabled(); got != tt.wantEnabled {
+				t.Fatalf("IsUACInterceptionEnabled() = %v, want %v", got, tt.wantEnabled)
+			}
+		})
+	}
+}

--- a/apps/api/migrations/2026-06-12-pam-feature-type.sql
+++ b/apps/api/migrations/2026-06-12-pam-feature-type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "config_feature_type" ADD VALUE IF NOT EXISTS 'pam';

--- a/apps/api/src/db/schema/configurationPolicies.ts
+++ b/apps/api/src/db/schema/configurationPolicies.ts
@@ -41,6 +41,7 @@ export const configFeatureTypeEnum = pgEnum('config_feature_type', [
   'warranty',
   'helper',
   'remote_access',
+  'pam',
 ]);
 
 export const configAssignmentLevelEnum = pgEnum('config_assignment_level', [

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -939,4 +939,19 @@ describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () =>
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.uacInterceptionEnabled).toBe(false);
   });
+
+  it('fails open to uacInterceptionEnabled=true when the pam resolver throws', async () => {
+    const { buildPamConfigUpdate } = await import('./helpers');
+    vi.mocked(buildPamConfigUpdate).mockRejectedValueOnce(new Error('boom'));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.uacInterceptionEnabled).toBe(true);
+  });
 });

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -94,6 +94,7 @@ vi.mock('./helpers', () => ({
   buildEventLogConfigUpdate: vi.fn(() => undefined),
   buildMonitoringConfigUpdate: vi.fn(() => undefined),
   buildHelperConfigUpdate: vi.fn(() => undefined),
+  buildPamConfigUpdate: vi.fn(async () => ({ uacInterceptionEnabled: false })),
 }));
 
 vi.mock('../../services/auditEvents', () => ({
@@ -876,5 +877,66 @@ describe('pendingReboot persistence', () => {
     // arg) before asserting the flag is absent from it.
     expect(updateArg).toHaveProperty('watchdogStatus');
     expect(updateArg).not.toHaveProperty('pendingReboot');
+  });
+});
+
+// ---------------------------------------------------------------------
+// PAM config delivery (#uacInterceptionEnabled in heartbeat response)
+// ---------------------------------------------------------------------
+
+describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Device lookup → returns a row
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host-1',
+          osType: 'windows',
+          osVersion: 'Windows 11',
+          osBuild: null,
+          architecture: 'amd64',
+          agentVersion: '0.70.0',
+          deviceRole: 'workstation',
+          deviceRoleSource: 'auto',
+          agentTokenHash: 'hash',
+          tokenIssuedAt: new Date(),
+        },
+      ]),
+    );
+
+    // db.update for devices → no return needed
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue(undefined),
+      })),
+    });
+
+    // db.insert for deviceMetrics → no return
+    insertMock.mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // Any further selects → empty
+    selectMock.mockReturnValue(selectChainResolving([]));
+
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+  });
+
+  it('delivers uacInterceptionEnabled: false when buildPamConfigUpdate returns false', async () => {
+    // buildPamConfigUpdate mock returns { uacInterceptionEnabled: false } from vi.mock factory above
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.uacInterceptionEnabled).toBe(false);
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -599,6 +599,7 @@ if (latestHelper) {
     pamSettings = await buildPamConfigUpdate(device.id);
   } catch (err) {
     console.error(`[agents] failed to build pam config update for ${agentId}:`, err);
+    captureException(err);
   }
 
   let mergedConfigUpdate: Record<string, unknown> | null = null;

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -20,6 +20,7 @@ import {
   buildEventLogConfigUpdate,
   buildMonitoringConfigUpdate,
   buildHelperConfigUpdate,
+  buildPamConfigUpdate,
 } from './helpers';
 import { processDeviceIPHistoryUpdate } from '../../services/deviceIpHistory';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
@@ -593,6 +594,13 @@ if (latestHelper) {
     console.error(`[agents] failed to build monitoring config update for ${agentId}:`, err);
   }
 
+  let pamSettings: { uacInterceptionEnabled: boolean } | null = null;
+  try {
+    pamSettings = await buildPamConfigUpdate(device.id);
+  } catch (err) {
+    console.error(`[agents] failed to build pam config update for ${agentId}:`, err);
+  }
+
   let mergedConfigUpdate: Record<string, unknown> | null = null;
   if (configUpdate || eventLogSettings || monitoringSettings) {
     mergedConfigUpdate = { ...(configUpdate ?? {}) };
@@ -634,6 +642,7 @@ if (latestHelper) {
       rotateToken: rotateToken || undefined,
       helperEnabled: helperSettings?.enabled ?? false,
       helperSettings: helperSettings ?? undefined,
+      uacInterceptionEnabled: pamSettings?.uacInterceptionEnabled ?? true,
       manageRemoteManagement: manageRemoteManagement || undefined,
     },
   };

--- a/apps/api/src/routes/agents/helpers.pam.test.ts
+++ b/apps/api/src/routes/agents/helpers.pam.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Tests for resolveDevicePamSettings (via buildPamConfigUpdate) and
+ * buildPamConfigUpdate Redis cache behavior.
+ *
+ * resolveDevicePamSettings is not exported, so we exercise it through
+ * buildPamConfigUpdate with Redis mocked to a miss (no cached value). The
+ * function runs 4 db.select calls in sequence:
+ *   1. device row (orgId, siteId)
+ *   2. org row (partnerId)
+ *   3. device group memberships
+ *   4. join query (assignments → policies → feature links) — returns winner rows
+ *
+ * We drive the mock with a call-counter queue so each call returns a
+ * different result set.
+ *
+ * NOTE: The SQL WHERE on query 4 filters by status='active' and orgId — those
+ * conditions live inside Drizzle's `.where(and(...))`. We cannot assert them
+ * through a mocked db because the mock returns rows unconditionally. The
+ * closest-wins sorting and PAM_DEFAULTS fallback are fully testable here;
+ * the WHERE-level org/status guards are exercised only by integration tests
+ * that hit a real DB.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.hoisted() must run before any import.
+// ---------------------------------------------------------------------------
+
+const { dbMock, redisMock, getRedisImpl } = vi.hoisted(() => {
+  // Queue of return values for successive db.select calls within one test.
+  // Each entry is the resolved value of that call's .limit() or the final
+  // await for the chained query.
+  let selectCallQueue: unknown[][] = [];
+  let selectCallIdx = 0;
+
+  const makeSelectChain = () => {
+    const result = selectCallQueue[selectCallIdx] ?? [];
+    selectCallIdx++;
+
+    // Build a chainable mock that resolves to `result` at the terminal call.
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(result)),
+      // For the 4th query (no .limit — it's the terminal .where that returns
+      // rows directly when awaited). We make `where` thenable.
+    };
+
+    // Make the chain itself thenable so `await db.select()...from()...innerJoin()...where()` works
+    chain.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
+
+    return chain;
+  };
+
+  const dbMock = {
+    select: vi.fn(() => makeSelectChain()),
+    // Reset helper used in beforeEach
+    _resetQueue(queue: unknown[][]) {
+      selectCallQueue = queue;
+      selectCallIdx = 0;
+      dbMock.select.mockImplementation(() => makeSelectChain());
+    },
+  };
+
+  const redisMock = {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue('OK'),
+  };
+
+  const getRedisImpl = vi.fn(() => redisMock as any);
+
+  return { dbMock, redisMock, getRedisImpl };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks (must come before any import of the module under test)
+// ---------------------------------------------------------------------------
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: dbMock,
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  organizations: { id: 'orgs.id', partnerId: 'orgs.partnerId' },
+  deviceGroupMemberships: { groupId: 'dgm.groupId', deviceId: 'dgm.deviceId' },
+  configPolicyAssignments: {
+    level: 'cpa.level',
+    targetId: 'cpa.targetId',
+    configPolicyId: 'cpa.configPolicyId',
+    priority: 'cpa.priority',
+  },
+  configurationPolicies: {
+    id: 'cp.id',
+    status: 'cp.status',
+    orgId: 'cp.orgId',
+  },
+  configPolicyFeatureLinks: {
+    configPolicyId: 'cpfl.configPolicyId',
+    featureType: 'cpfl.featureType',
+    inlineSettings: 'cpfl.inlineSettings',
+  },
+  // Stub out everything else helpers.ts references so the module loads
+  softwarePolicies: {},
+  softwareComplianceStatus: {},
+  deviceCommands: { $inferSelect: {} },
+  deviceDisks: {},
+  deviceFilesystemSnapshots: {},
+  automationPolicies: {},
+  cisBaselines: {},
+  cisBaselineResults: {},
+  cisRemediationActions: {},
+  securityStatus: {},
+  securityThreats: {},
+  securityScans: {},
+  sensitiveDataFindings: {},
+  sensitiveDataScans: {},
+  sites: {},
+  users: {},
+  deviceGroups: {},
+  configPolicyMonitoringSettings: {},
+  configPolicyMonitoringWatches: {},
+  configPolicyEventLogSettings: {},
+}));
+
+vi.mock('../../services/redis', () => ({
+  getRedis: getRedisImpl,
+}));
+
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/commandQueue', () => ({ queueCommandForExecution: vi.fn() }));
+vi.mock('../../services/cisHardening', () => ({ parseCisCollectorOutput: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../services/cloudflareMtls', () => ({ CloudflareMtlsService: vi.fn() }));
+vi.mock('../../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit: vi.fn() }));
+vi.mock('../../services/filesystemAnalysis', () => ({
+  getFilesystemScanState: vi.fn(),
+  mergeFilesystemAnalysisPayload: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  readCheckpointPendingDirectories: vi.fn(),
+  readHotDirectories: vi.fn(),
+  saveFilesystemSnapshot: vi.fn(),
+  upsertFilesystemScanState: vi.fn(),
+}));
+vi.mock('../metrics', () => ({
+  recordSoftwareRemediationDecision: vi.fn(),
+  recordSensitiveDataFinding: vi.fn(),
+  recordSensitiveDataRemediationDecision: vi.fn(),
+}));
+vi.mock('../../jobs/softwareComplianceWorker', () => ({
+  scheduleSoftwareComplianceCheck: vi.fn(),
+}));
+vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => true) }));
+
+// ---------------------------------------------------------------------------
+// Import under test — AFTER all mocks are installed.
+// ---------------------------------------------------------------------------
+import { buildPamConfigUpdate } from './helpers';
+import { PAM_DEFAULTS } from './pamSettings';
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
+const ORG_ID = '00000000-0000-4000-8000-000000000002';
+const SITE_ID = '00000000-0000-4000-8000-000000000003';
+const PARTNER_ID = '00000000-0000-4000-8000-000000000004';
+const GROUP_ID = '00000000-0000-4000-8000-000000000005';
+
+/** Queue the 4 db.select calls: [deviceRow[], orgRow[], groupRows[], policyRows[]] */
+function setDbQueue(
+  deviceRows: unknown[],
+  orgRows: unknown[],
+  groupRows: unknown[],
+  policyRows: unknown[],
+) {
+  dbMock._resetQueue([deviceRows, orgRows, groupRows, policyRows]);
+}
+
+// ---------------------------------------------------------------------------
+// Gap 1: resolveDevicePamSettings closest-wins table tests
+// ---------------------------------------------------------------------------
+
+describe('resolveDevicePamSettings (via buildPamConfigUpdate, cache miss)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: Redis returns no cached value (cache miss)
+    getRedisImpl.mockReturnValue(redisMock);
+    redisMock.get.mockResolvedValue(null);
+    redisMock.set.mockResolvedValue('OK');
+  });
+
+  it('case 1: device-level disable beats org-level enable', async () => {
+    // Org row has enabled:true, device row has enabled:false.
+    // Device has level priority 5, org has 2 → device wins → uacInterceptionEnabled: false.
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [
+        { level: 'organization', assignmentPriority: 10, inlineSettings: { uacInterceptionEnabled: true } },
+        { level: 'device', assignmentPriority: 10, inlineSettings: { uacInterceptionEnabled: false } },
+      ],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('case 2: device_group beats site; site beats org; org beats partner', async () => {
+    // Four rows at decreasing level priorities; device_group (4) should win
+    // over site (3), site over org (2), org over partner (1).
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [{ groupId: GROUP_ID }],
+      [
+        { level: 'partner', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: true } },
+        { level: 'organization', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: true } },
+        { level: 'site', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: true } },
+        { level: 'device_group', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: false } },
+      ],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    // device_group (priority 4) should win over site (3), org (2), partner (1)
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('case 2b: site beats org when no device or device_group row', async () => {
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [], // no group memberships
+      [
+        { level: 'organization', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: true } },
+        { level: 'site', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: false } },
+      ],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('case 3: same level — assignment priority 5 beats priority 10 (lower number wins)', async () => {
+    // Two org-level rows. Priority 5 should win over priority 10.
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [
+        { level: 'organization', assignmentPriority: 10, inlineSettings: { uacInterceptionEnabled: true } },
+        { level: 'organization', assignmentPriority: 5, inlineSettings: { uacInterceptionEnabled: false } },
+      ],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('case 4: zero policy rows → returns PAM_DEFAULTS (uacInterceptionEnabled: true)', async () => {
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [], // no policy rows
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result).toEqual(PAM_DEFAULTS);
+    expect(result.uacInterceptionEnabled).toBe(true);
+  });
+
+  it('case 5: device not found (first query returns []) → returns PAM_DEFAULTS', async () => {
+    setDbQueue(
+      [], // device not found
+      [],
+      [],
+      [],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result).toEqual(PAM_DEFAULTS);
+  });
+
+  it('case 6: winner has malformed inlineSettings (uacInterceptionEnabled as string "false") → parses to default true', async () => {
+    // parsePamSettings treats non-boolean as default → true
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [
+        { level: 'device', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: 'false' } },
+      ],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    // 'false' (string) is not a boolean, so parsePamSettings falls back to default (true)
+    expect(result.uacInterceptionEnabled).toBe(true);
+  });
+
+  it('winner with null inlineSettings → returns PAM_DEFAULTS', async () => {
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [
+        { level: 'device', assignmentPriority: 1, inlineSettings: null },
+      ],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result).toEqual(PAM_DEFAULTS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 2: buildPamConfigUpdate Redis cache behavior
+// ---------------------------------------------------------------------------
+
+describe('buildPamConfigUpdate — Redis cache behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRedisImpl.mockReturnValue(redisMock);
+  });
+
+  it('cache hit returns parsed value WITHOUT running resolver queries (db.select not called)', async () => {
+    const cachedSettings = { uacInterceptionEnabled: false };
+    redisMock.get.mockResolvedValue(JSON.stringify(cachedSettings));
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+
+    expect(result).toEqual(cachedSettings);
+    expect(dbMock.select).not.toHaveBeenCalled();
+    expect(redisMock.get).toHaveBeenCalledWith(`pam:settings:device:${DEVICE_ID}`);
+  });
+
+  it('cache miss → resolves from DB → redis.set called with correct key, value, and TTL', async () => {
+    redisMock.get.mockResolvedValue(null);
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [{ level: 'device', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: false } }],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+
+    expect(result.uacInterceptionEnabled).toBe(false);
+    // DB should have been called
+    expect(dbMock.select).toHaveBeenCalled();
+    // Redis set should be called with the correct cache key, serialized value, EX, and 120s TTL
+    expect(redisMock.set).toHaveBeenCalledWith(
+      `pam:settings:device:${DEVICE_ID}`,
+      JSON.stringify({ uacInterceptionEnabled: false }),
+      'EX',
+      120,
+    );
+  });
+
+  it('redis.get throws → still resolves from DB (fail-open) and returns settings', async () => {
+    redisMock.get.mockRejectedValue(new Error('Redis connection error'));
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [{ level: 'organization', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: true } }],
+    );
+
+    // Should not throw
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+
+    // Falls through to DB resolution despite Redis error
+    expect(result.uacInterceptionEnabled).toBe(true);
+    expect(dbMock.select).toHaveBeenCalled();
+  });
+
+  it('redis.set throws → still returns resolved settings (cache-write failure is non-fatal)', async () => {
+    redisMock.get.mockResolvedValue(null);
+    redisMock.set.mockRejectedValue(new Error('Redis write error'));
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result).toEqual(PAM_DEFAULTS);
+  });
+
+  it('getRedis() returns null (no Redis configured) → resolves from DB normally', async () => {
+    getRedisImpl.mockReturnValue(null);
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [{ level: 'site', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: false } }],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result.uacInterceptionEnabled).toBe(false);
+    expect(redisMock.get).not.toHaveBeenCalled();
+    expect(redisMock.set).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -2297,6 +2297,7 @@ const PAM_CACHE_TTL_SECONDS = 120;
  * Build PAM config update payload for heartbeat response.
  * Resolves pam policy settings via the config policy hierarchy.
  * Falls back to PAM_DEFAULTS (uacInterceptionEnabled: true) if no policy found.
+ * Cached per-device in Redis for 120s — policy changes propagate within ~2min + heartbeat interval.
  */
 export async function buildPamConfigUpdate(deviceId: string): Promise<PamSettings> {
   const redis = getRedis();

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -51,6 +51,7 @@ import { recordSoftwarePolicyAudit } from '../../services/softwarePolicyService'
 import { captureException } from '../../services/sentry';
 import { CloudflareMtlsService } from '../../services/cloudflareMtls';
 import { isAllowedPolicyConfigProbe } from './policyProbeSafety';
+import { PAM_DEFAULTS, parsePamSettings, type PamSettings } from './pamSettings';
 import {
   type SecurityProviderValue,
   type SecurityStatusPayload,
@@ -2205,6 +2206,118 @@ export async function buildHelperConfigUpdate(deviceId: string, orgId: string): 
       await redis.set(cacheKey, JSON.stringify(settings), 'EX', HELPER_CACHE_TTL_SECONDS);
     } catch (cacheErr) {
       console.warn(`[helper] Redis cache write failed for device ${deviceId}:`, cacheErr);
+    }
+  }
+
+  return settings;
+}
+
+// ============================================
+// PAM Settings (policy-driven)
+// ============================================
+
+async function resolveDevicePamSettings(deviceId: string): Promise<PamSettings> {
+  // 1. Load device
+  const [device] = await db
+    .select({ orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.id, deviceId))
+    .limit(1);
+
+  if (!device) return PAM_DEFAULTS;
+
+  // 2. Load org (for partnerId)
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, device.orgId))
+    .limit(1);
+
+  // 3. Load device group memberships
+  const groupRows = await db
+    .select({ groupId: deviceGroupMemberships.groupId })
+    .from(deviceGroupMemberships)
+    .where(eq(deviceGroupMemberships.deviceId, deviceId));
+  const groupIds = groupRows.map((r) => r.groupId);
+
+  // 4. Build target match conditions
+  const targetConditions = [
+    and(eq(configPolicyAssignments.level, 'device'), eq(configPolicyAssignments.targetId, deviceId)),
+    and(eq(configPolicyAssignments.level, 'site'), eq(configPolicyAssignments.targetId, device.siteId)),
+    and(eq(configPolicyAssignments.level, 'organization'), eq(configPolicyAssignments.targetId, device.orgId)),
+  ];
+  if (groupIds.length > 0) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'device_group'), inArray(configPolicyAssignments.targetId, groupIds))!
+    );
+  }
+  if (org?.partnerId) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'partner'), eq(configPolicyAssignments.targetId, org.partnerId))!
+    );
+  }
+
+  // 5. Single query: assignments → active policies → pam feature link (pure JSONB)
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      inlineSettings: configPolicyFeatureLinks.inlineSettings,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'pam'),
+    ))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      eq(configurationPolicies.orgId, device.orgId),
+      or(...targetConditions),
+    ));
+
+  if (rows.length === 0) return PAM_DEFAULTS;
+
+  // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
+  rows.sort((a, b) => {
+    const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
+    if (levelDiff !== 0) return levelDiff;
+    return a.assignmentPriority - b.assignmentPriority;
+  });
+
+  const winner = rows[0];
+  if (!winner?.inlineSettings) return PAM_DEFAULTS;
+
+  return parsePamSettings(winner.inlineSettings);
+}
+
+const PAM_CACHE_TTL_SECONDS = 120;
+
+/**
+ * Build PAM config update payload for heartbeat response.
+ * Resolves pam policy settings via the config policy hierarchy.
+ * Falls back to PAM_DEFAULTS (uacInterceptionEnabled: true) if no policy found.
+ */
+export async function buildPamConfigUpdate(deviceId: string): Promise<PamSettings> {
+  const redis = getRedis();
+  const cacheKey = `pam:settings:device:${deviceId}`;
+
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey);
+      if (cached) return JSON.parse(cached) as PamSettings;
+    } catch (cacheErr) {
+      console.warn(`[pam] Redis cache read failed for device ${deviceId}:`, cacheErr);
+    }
+  }
+
+  const settings = await resolveDevicePamSettings(deviceId);
+
+  if (redis) {
+    try {
+      await redis.set(cacheKey, JSON.stringify(settings), 'EX', PAM_CACHE_TTL_SECONDS);
+    } catch (cacheErr) {
+      console.warn(`[pam] Redis cache write failed for device ${deviceId}:`, cacheErr);
     }
   }
 

--- a/apps/api/src/routes/agents/pamSettings.test.ts
+++ b/apps/api/src/routes/agents/pamSettings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { PAM_DEFAULTS, parsePamSettings } from './pamSettings';
+
+describe('parsePamSettings', () => {
+  it('defaults to interception enabled', () => {
+    expect(PAM_DEFAULTS.uacInterceptionEnabled).toBe(true);
+  });
+
+  it('returns defaults for null/undefined/non-object input', () => {
+    expect(parsePamSettings(null)).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings(undefined)).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings('nope')).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings(42)).toEqual(PAM_DEFAULTS);
+  });
+
+  it('honors an explicit false', () => {
+    expect(parsePamSettings({ uacInterceptionEnabled: false })).toEqual({
+      uacInterceptionEnabled: false,
+    });
+  });
+
+  it('honors an explicit true', () => {
+    expect(parsePamSettings({ uacInterceptionEnabled: true })).toEqual({
+      uacInterceptionEnabled: true,
+    });
+  });
+
+  it('falls back to default when the key is missing or mistyped', () => {
+    expect(parsePamSettings({})).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings({ uacInterceptionEnabled: 'false' })).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings({ uacInterceptionEnabled: 0 })).toEqual(PAM_DEFAULTS);
+  });
+});

--- a/apps/api/src/routes/agents/pamSettings.ts
+++ b/apps/api/src/routes/agents/pamSettings.ts
@@ -1,0 +1,30 @@
+/**
+ * PAM config-policy feature ('pam') — inline settings shape.
+ *
+ * Controls whether the agent's ETW UAC interception posts elevation events.
+ * Rule authoring / approvals / audit are NOT configured here — they live in
+ * the standalone /pam control plane (pam_rules, elevation_requests).
+ */
+export interface PamSettings {
+  uacInterceptionEnabled: boolean;
+}
+
+/**
+ * Default ON: UAC capture has always been unconditional on Windows agents.
+ * A device with no 'pam' feature link anywhere in its hierarchy must keep
+ * capturing, so upgrades are behavior-preserving. Admins opt OUT via policy.
+ */
+export const PAM_DEFAULTS: PamSettings = {
+  uacInterceptionEnabled: true,
+};
+
+export function parsePamSettings(inlineSettings: unknown): PamSettings {
+  if (!inlineSettings || typeof inlineSettings !== 'object') return PAM_DEFAULTS;
+  const s = inlineSettings as Record<string, unknown>;
+  return {
+    uacInterceptionEnabled:
+      typeof s.uacInterceptionEnabled === 'boolean'
+        ? s.uacInterceptionEnabled
+        : PAM_DEFAULTS.uacInterceptionEnabled,
+  };
+}

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -18,14 +18,18 @@ const {
   validateFeaturePolicyExistsMock: vi.fn(),
 }));
 
-vi.mock('../../services/configurationPolicy', () => ({
-  getConfigPolicy: getConfigPolicyMock,
-  addFeatureLink: addFeatureLinkMock,
-  updateFeatureLink: updateFeatureLinkMock,
-  removeFeatureLink: removeFeatureLinkMock,
-  listFeatureLinks: listFeatureLinksMock,
-  validateFeaturePolicyExists: validateFeaturePolicyExistsMock,
-}));
+vi.mock('../../services/configurationPolicy', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../services/configurationPolicy')>();
+  return {
+    ...original,
+    getConfigPolicy: getConfigPolicyMock,
+    addFeatureLink: addFeatureLinkMock,
+    updateFeatureLink: updateFeatureLinkMock,
+    removeFeatureLink: removeFeatureLinkMock,
+    listFeatureLinks: listFeatureLinksMock,
+    validateFeaturePolicyExists: validateFeaturePolicyExistsMock,
+  };
+});
 
 vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Hoist mock values so they're available in vi.mock factories
+const {
+  getConfigPolicyMock,
+  addFeatureLinkMock,
+  updateFeatureLinkMock,
+  removeFeatureLinkMock,
+  listFeatureLinksMock,
+  validateFeaturePolicyExistsMock,
+} = vi.hoisted(() => ({
+  getConfigPolicyMock: vi.fn(),
+  addFeatureLinkMock: vi.fn(),
+  updateFeatureLinkMock: vi.fn(),
+  removeFeatureLinkMock: vi.fn(),
+  listFeatureLinksMock: vi.fn(),
+  validateFeaturePolicyExistsMock: vi.fn(),
+}));
+
+vi.mock('../../services/configurationPolicy', () => ({
+  getConfigPolicy: getConfigPolicyMock,
+  addFeatureLink: addFeatureLinkMock,
+  updateFeatureLink: updateFeatureLinkMock,
+  removeFeatureLink: removeFeatureLinkMock,
+  listFeatureLinks: listFeatureLinksMock,
+  validateFeaturePolicyExists: validateFeaturePolicyExistsMock,
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => next()),
+  requireScope: vi.fn(() => (c: any, next: any) => next()),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  hasSatisfiedMfa: vi.fn(() => true),
+}));
+
+import { featureLinkRoutes } from './featureLinks';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const POLICY_ID = '22222222-2222-2222-2222-222222222222';
+const LINK_ID = '33333333-3333-3333-3333-333333333333';
+
+function makeAuth(overrides: Record<string, unknown> = {}): any {
+  return {
+    scope: 'organization',
+    orgId: ORG_ID,
+    partnerId: null,
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    token: { scope: 'organization' },
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    orgCondition: () => undefined,
+    ...overrides,
+  };
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', makeAuth());
+    await next();
+  });
+  app.route('/', featureLinkRoutes);
+  return app;
+}
+
+const STUB_POLICY = {
+  id: POLICY_ID,
+  orgId: ORG_ID,
+  name: 'Test Policy',
+  featureLinks: [],
+};
+
+const STUB_POLICY_WITH_PATCH_LINK = {
+  ...STUB_POLICY,
+  featureLinks: [{ id: LINK_ID, featureType: 'patch' }],
+};
+
+const STUB_POLICY_WITH_PAM_LINK = {
+  ...STUB_POLICY,
+  featureLinks: [{ id: LINK_ID, featureType: 'pam' }],
+};
+
+describe('featureLinks routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  // ============================================================
+  // POST /:id/features — pam inlineSettings validation (Fix A)
+  // ============================================================
+
+  describe('POST /:id/features — pam inlineSettings validation', () => {
+    beforeEach(() => {
+      getConfigPolicyMock.mockResolvedValue(STUB_POLICY);
+      validateFeaturePolicyExistsMock.mockResolvedValue({ valid: true });
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'pam' });
+    });
+
+    it('rejects pam inlineSettings with uacInterceptionEnabled as string "false" → 400', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'pam',
+          inlineSettings: { uacInterceptionEnabled: 'false' },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toMatch(/pam/i);
+      // Must name the field
+      const details = body.details as any;
+      expect(details?.fieldErrors?.uacInterceptionEnabled ?? body.issues).toBeTruthy();
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects pam inlineSettings with uacInterceptionEnabled as number 0 → 400', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'pam',
+          inlineSettings: { uacInterceptionEnabled: 0 },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts pam inlineSettings with uacInterceptionEnabled: false (boolean) → 201', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'pam',
+          inlineSettings: { uacInterceptionEnabled: false },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+
+    it('accepts pam inlineSettings: {} (omitted key treated as default) → 201', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'pam',
+          inlineSettings: {},
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+
+    it('accepts pam link with only featurePolicyId (no inlineSettings) → 201', async () => {
+      // addFeatureLinkSchema requires at least one of featurePolicyId or inlineSettings;
+      // providing featurePolicyId alone skips the pam inlineSettings validation branch.
+      validateFeaturePolicyExistsMock.mockResolvedValue({ valid: true });
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'pam',
+          featurePolicyId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+
+    it('rejects pam inlineSettings with unknown extra key (strict passthrough behavior)', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'pam',
+          inlineSettings: { uacInterceptionEnabled: true, unknownKey: 'extra' },
+        }),
+      });
+
+      // strict() rejects unknown keys → 400
+      expect(res.status).toBe(400);
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================
+  // PATCH /:id/features/:linkId — pam inlineSettings validation (Fix A)
+  // ============================================================
+
+  describe('PATCH /:id/features/:linkId — pam inlineSettings validation', () => {
+    beforeEach(() => {
+      getConfigPolicyMock.mockResolvedValue(STUB_POLICY_WITH_PAM_LINK);
+      updateFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'pam' });
+    });
+
+    it('rejects update pam inlineSettings with uacInterceptionEnabled as string "false" → 400', async () => {
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          inlineSettings: { uacInterceptionEnabled: 'false' },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toMatch(/pam/i);
+      expect(updateFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts update pam inlineSettings with uacInterceptionEnabled: true (boolean) → 200', async () => {
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          inlineSettings: { uacInterceptionEnabled: true },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(updateFeatureLinkMock).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================
+  // Sanity: patch feature type validation still works
+  // ============================================================
+
+  describe('POST /:id/features — patch inlineSettings validation (regression guard)', () => {
+    beforeEach(() => {
+      getConfigPolicyMock.mockResolvedValue(STUB_POLICY);
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'patch' });
+    });
+
+    it('rejects patch inlineSettings with invalid scheduleTime → 400', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'patch',
+          inlineSettings: { scheduleTime: '99:99' },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -3,18 +3,6 @@ import { zValidator } from '@hono/zod-validator';
 import type { AuthContext } from '../../middleware/auth';
 import { hasSatisfiedMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { backupInlineSettingsSchema, patchInlineSettingsSchema } from '@breeze/shared/validators';
-import { z } from 'zod';
-
-// Inline settings for the 'pam' feature type.
-// uacInterceptionEnabled defaults to true on the read side (parsePamSettings),
-// so {} is well-formed. Non-boolean present values are rejected to prevent the
-// silent-inversion bug where "false" (string) gets coerced back to true.
-// .strict() matches the posture of patch/backup: unknown keys are rejected.
-const pamInlineSettingsSchema = z
-  .object({
-    uacInterceptionEnabled: z.boolean().optional(),
-  })
-  .strict();
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
 import {
@@ -24,6 +12,7 @@ import {
   removeFeatureLink,
   listFeatureLinks,
   validateFeaturePolicyExists,
+  pamInlineSettingsSchema,
 } from '../../services/configurationPolicy';
 import {
   addFeatureLinkSchema,

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -3,6 +3,18 @@ import { zValidator } from '@hono/zod-validator';
 import type { AuthContext } from '../../middleware/auth';
 import { hasSatisfiedMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { backupInlineSettingsSchema, patchInlineSettingsSchema } from '@breeze/shared/validators';
+import { z } from 'zod';
+
+// Inline settings for the 'pam' feature type.
+// uacInterceptionEnabled defaults to true on the read side (parsePamSettings),
+// so {} is well-formed. Non-boolean present values are rejected to prevent the
+// silent-inversion bug where "false" (string) gets coerced back to true.
+// .strict() matches the posture of patch/backup: unknown keys are rejected.
+const pamInlineSettingsSchema = z
+  .object({
+    uacInterceptionEnabled: z.boolean().optional(),
+  })
+  .strict();
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
 import {
@@ -96,6 +108,17 @@ featureLinkRoutes.post(
       data.inlineSettings = parsed.data;
     }
 
+    if (data.featureType === 'pam' && data.inlineSettings) {
+      const parsed = pamInlineSettingsSchema.safeParse(data.inlineSettings);
+      if (!parsed.success) {
+        return c.json(
+          { error: 'Invalid pam settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          400
+        );
+      }
+      data.inlineSettings = parsed.data;
+    }
+
     try {
       const link = await addFeatureLink(
         id,
@@ -174,6 +197,16 @@ featureLinkRoutes.patch(
         if (!parsed.success) {
           return c.json(
             { error: 'Invalid backup settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            400
+          );
+        }
+        data.inlineSettings = parsed.data;
+      }
+      if (existingLink.featureType === 'pam') {
+        const parsed = pamInlineSettingsSchema.safeParse(data.inlineSettings);
+        if (!parsed.success) {
+          return c.json(
+            { error: 'Invalid pam settings', details: parsed.error.flatten(), issues: parsed.error.issues },
             400
           );
         }

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -919,4 +919,140 @@ describe('POST /pam/rules/preview', () => {
     expect(body.statusBreakdown.pending).toBe(9);
     expect(body.statusBreakdown.auto_approved).toBe(5);
   });
+
+  // ---------------------------------------------------------------------------
+  // Gap 3: preview site-scope authorization
+  // ---------------------------------------------------------------------------
+
+  it('Gap 3a: site-scoped technician posting siteId outside their allowedSiteIds → 403 Site access denied', async () => {
+    const ALLOWED_SITE = '7b41c9a2-0000-4000-8000-000000000010';
+    const OTHER_SITE = '7b41c9a2-0000-4000-8000-000000000011';
+
+    // Auth sets permissions with allowedSiteIds that does NOT include OTHER_SITE.
+    authMocks.authMiddlewareMock.mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        user: { id: USER_ID, email: 't@example.com' },
+        scope: 'organization',
+        orgId: ORG_ID,
+        canAccessOrg: (orgId: string) => orgId === ORG_ID,
+        orgCondition: () => undefined,
+      });
+      c.set('permissions', { allowedSiteIds: [ALLOWED_SITE] });
+      return next();
+    });
+
+    mockPreviewSelect([]);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'Acme Corp', siteId: OTHER_SITE }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Site access denied');
+  });
+
+  it('Gap 3b: site-scoped technician WITHOUT body.siteId — siteScopeCondition narrows rows to allowed sites', async () => {
+    // NOTE: The WHERE predicate from siteScopeCondition is injected into the Drizzle query,
+    // which our mocked db ignores (mock returns all rows regardless of WHERE). We therefore
+    // assert the observable outcome: only rows whose siteId is in allowedSiteIds are
+    // actually matched — the route's JS-layer matching does NOT filter siteId, but
+    // the DB layer would. Since we cannot assert SQL WHERE through a mock, we test what IS
+    // assertable: the request succeeds (200) and the full scan is returned. The actual
+    // site-narrowing is an integration-test concern.
+    //
+    // We DO assert the 403 path via Gap 3a above (which exercises the route's explicit
+    // siteId+canAccessSite check). This test ensures the no-siteId path reaches the DB
+    // without error when the tech is site-scoped.
+    const ALLOWED_SITE = '7b41c9a2-0000-4000-8000-000000000010';
+
+    authMocks.authMiddlewareMock.mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        user: { id: USER_ID, email: 't@example.com' },
+        scope: 'organization',
+        orgId: ORG_ID,
+        canAccessOrg: (orgId: string) => orgId === ORG_ID,
+        orgCondition: () => undefined,
+      });
+      c.set('permissions', { allowedSiteIds: [ALLOWED_SITE] });
+      return next();
+    });
+
+    mockPreviewSelect([previewRow({ id: 'er-1' })]);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'Acme Corp' }),
+    });
+
+    // Request should succeed; site narrowing is applied at DB layer (not testable via mock).
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gap 4: non-UTC timeWindow wiring
+  //
+  // Timestamp analysis:
+  //   Window: 00:00–05:00 in America/Chicago (UTC-5 in standard time, UTC-6 in DST).
+  //   requestedAt: 2026-06-10T06:00:00Z
+  //   In UTC: 06:00 — outside the window 00:00–05:00 UTC.
+  //   In America/Chicago (CDT = UTC-5 in June 2026):
+  //     06:00Z - 5h = 01:00 CDT → inside window 00:00–05:00.
+  //
+  //   Test A (Chicago): window 00:00–05:00, timezone: 'America/Chicago'
+  //     → 06:00Z = 01:00 Chicago → INSIDE → totalMatched = 1
+  //   Test B (UTC):     window 00:00–05:00, timezone: 'UTC'
+  //     → 06:00Z = 06:00 UTC → OUTSIDE → totalMatched = 0
+  //
+  //   This discriminates: different values from the same row + same window + different TZ.
+  // ---------------------------------------------------------------------------
+
+  it('Gap 4a: timezone America/Chicago — 06:00Z falls inside 00:00–05:00 Chicago window (match)', async () => {
+    const rows = [
+      previewRow({ id: 'er-1', requestedAt: new Date('2026-06-10T06:00:00Z'), subjectUsername: 'ACME\\jdoe' }),
+    ];
+    mockPreviewSelect(rows);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        matchUser: 'ACME\\jdoe',
+        timeWindow: { start: '00:00', end: '05:00', timezone: 'America/Chicago' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // 06:00Z = 01:00 America/Chicago (CDT, UTC-5) → inside 00:00–05:00
+    expect(body.totalMatched).toBe(1);
+    expect(body.totalScanned).toBe(1);
+  });
+
+  it('Gap 4b: same window 00:00–05:00 in UTC — 06:00Z falls OUTSIDE (no match)', async () => {
+    const rows = [
+      previewRow({ id: 'er-1', requestedAt: new Date('2026-06-10T06:00:00Z'), subjectUsername: 'ACME\\jdoe' }),
+    ];
+    mockPreviewSelect(rows);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        matchUser: 'ACME\\jdoe',
+        timeWindow: { start: '00:00', end: '05:00', timezone: 'UTC' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // 06:00Z = 06:00 UTC → outside 00:00–05:00
+    expect(body.totalMatched).toBe(0);
+    expect(body.totalScanned).toBe(1);
+  });
 });

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -51,6 +51,13 @@ vi.mock('../db/schema', () => ({
     revokedByUserId: 'revokedByUserId',
     softwarePolicyMatchId: 'softwarePolicyMatchId',
     metadata: 'metadata',
+    subjectUsername: 'subjectUsername',
+    targetExecutablePath: 'targetExecutablePath',
+    targetExecutableHash: 'targetExecutableHash',
+    targetExecutableSigner: 'targetExecutableSigner',
+    toolName: 'toolName',
+    riskTier: 'riskTier',
+    denialReason: 'denialReason',
   },
   elevationAudit: { id: 'id' },
   pamRules: {
@@ -736,5 +743,180 @@ describe('PATCH /pam/rules/:id shape validation (Phase 1)', () => {
     });
     expect(res.status).toBe(400);
     expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /pam/rules/preview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+  });
+
+  // Helper: builds a minimal elevation_requests row for the preview SELECT.
+  const previewRow = (over: Partial<Record<string, unknown>> = {}): Record<string, unknown> => ({
+    id: 'er-1',
+    requestedAt: new Date('2026-06-10T18:00:00Z'),
+    flowType: 'uac_intercept',
+    status: 'pending',
+    subjectUsername: 'ACME\\jdoe',
+    targetExecutablePath: 'C:\\Tools\\installer.exe',
+    targetExecutableHash: null,
+    targetExecutableSigner: 'Acme Corp',
+    toolName: null,
+    riskTier: null,
+    metadata: {},
+    ...over,
+  });
+
+  /** Rig db.select so it resolves to `rows` (no count branch needed for preview). */
+  function mockPreviewSelect(rows: unknown[]) {
+    vi.mocked(db.select).mockImplementation((() => {
+      const chain: any = Promise.resolve(rows);
+      chain.from = vi.fn(() => chain);
+      chain.where = vi.fn(() => chain);
+      chain.orderBy = vi.fn(() => chain);
+      chain.limit = vi.fn(() => chain);
+      return chain;
+    }) as any);
+  }
+
+  it('counts signer matches case-insensitively', async () => {
+    const rows = [
+      previewRow({ id: 'er-1', targetExecutableSigner: 'Acme Corp' }),
+      previewRow({ id: 'er-2', targetExecutableSigner: 'ACME CORP' }),
+      previewRow({ id: 'er-3', targetExecutableSigner: 'acme corp' }),
+      previewRow({ id: 'er-4', targetExecutableSigner: 'Other Inc' }),
+      previewRow({ id: 'er-5', targetExecutableSigner: 'Other Inc' }),
+    ];
+    mockPreviewSelect(rows);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'acme corp', windowDays: 30 }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMatched).toBe(3);
+    expect(body.totalScanned).toBe(5);
+    expect(body.sample).toHaveLength(3);
+  });
+
+  it('does not match tool-action rows against executable criteria', async () => {
+    const rows = [
+      previewRow({ id: 'er-1', flowType: 'uac_intercept', targetExecutableSigner: 'Acme Corp', toolName: null }),
+      previewRow({ id: 'er-2', flowType: 'ai_tool_action', targetExecutableSigner: null, toolName: 'manage_services' }),
+    ];
+    mockPreviewSelect(rows);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'Acme Corp' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMatched).toBe(1);
+  });
+
+  it('evaluates timeWindow against each row requestedAt', async () => {
+    // 23:00 row is inside the overnight window (22:00–06:00); 12:00 row is not
+    const rows = [
+      previewRow({ id: 'er-1', requestedAt: new Date('2026-06-10T23:00:00Z') }),
+      previewRow({ id: 'er-2', requestedAt: new Date('2026-06-10T12:00:00Z') }),
+    ];
+    mockPreviewSelect(rows);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        matchUser: 'ACME\\jdoe',
+        timeWindow: { start: '22:00', end: '06:00', timezone: 'UTC' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMatched).toBe(1);
+  });
+
+  it('returns zeroed shape on empty scan', async () => {
+    mockPreviewSelect([]);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'Acme Corp' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMatched).toBe(0);
+    expect(body.totalScanned).toBe(0);
+    expect(body.truncated).toBe(false);
+    expect(body.sample).toEqual([]);
+  });
+
+  it('rejects criterion-less, mixed, and out-of-range bodies', async () => {
+    // No criteria
+    const r1 = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(r1.status).toBe(400);
+
+    // Mixed executable + tool-action
+    const r2 = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'x', matchToolName: 'y' }),
+    });
+    expect(r2.status).toBe(400);
+
+    // windowDays = 0 (below min 1)
+    const r3 = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'x', windowDays: 0 }),
+    });
+    expect(r3.status).toBe(400);
+
+    // windowDays = 91 (above max 90)
+    const r4 = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'x', windowDays: 91 }),
+    });
+    expect(r4.status).toBe(400);
+  });
+
+  it('caps sample at 10 and tallies statusBreakdown', async () => {
+    // 14 matching rows: 9 pending, 5 auto_approved
+    const rows = [
+      ...Array.from({ length: 9 }, (_, i) =>
+        previewRow({ id: `er-p${i}`, status: 'pending', targetExecutableSigner: 'Acme Corp' }),
+      ),
+      ...Array.from({ length: 5 }, (_, i) =>
+        previewRow({ id: `er-a${i}`, status: 'auto_approved', targetExecutableSigner: 'Acme Corp' }),
+      ),
+    ];
+    mockPreviewSelect(rows);
+
+    const res = await app().request('/pam/rules/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matchSigner: 'Acme Corp' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMatched).toBe(14);
+    expect(body.sample.length).toBe(10);
+    expect(body.statusBreakdown.pending).toBe(9);
+    expect(body.statusBreakdown.auto_approved).toBe(5);
   });
 });

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -49,6 +49,8 @@ vi.mock('../db/schema', () => ({
     approvedByUserId: 'approvedByUserId',
     deniedByUserId: 'deniedByUserId',
     revokedByUserId: 'revokedByUserId',
+    softwarePolicyMatchId: 'softwarePolicyMatchId',
+    metadata: 'metadata',
   },
   elevationAudit: { id: 'id' },
   pamRules: {
@@ -58,6 +60,7 @@ vi.mock('../db/schema', () => ({
     createdAt: 'createdAt',
   },
   aiToolExecutions: { id: 'id', status: 'status' },
+  softwarePolicies: { id: 'id', name: 'name' },
 }));
 
 vi.mock('../services/auditEvents', () => ({
@@ -232,6 +235,119 @@ describe('GET /pam/elevation-requests and /pam/active — decider display names'
     expect(projection).toHaveProperty('approvedByName');
     expect(projection).toHaveProperty('deniedByName');
     expect(projection).toHaveProperty('revokedByName');
+  });
+
+  it('surfaces software-policy provenance as first-class fields', async () => {
+    const policyRow = {
+      request: {
+        id: REQ_ID,
+        orgId: ORG_ID,
+        deviceId: 'dev-1',
+        flowType: 'uac_intercept',
+        status: 'denied',
+        approvedByUserId: null,
+        deniedByUserId: null,
+        revokedByUserId: null,
+        softwarePolicyMatchId: 'policy-1',
+        metadata: {},
+      },
+      deviceHostname: 'WS-ALPHA',
+      siteName: 'HQ',
+      approvedByName: null,
+      deniedByName: null,
+      revokedByName: null,
+      matchedPolicyName: 'Engineering Blocklist',
+    };
+    mockListSelect([policyRow], 1);
+
+    const res = await app().request('/pam/elevation-requests');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const row = body.requests[0];
+    expect(row.matchedPolicyName).toBe('Engineering Blocklist');
+    expect(row.decisionSource).toBe('software_policy');
+  });
+
+  it('surfaces pam-rule provenance from metadata and computes decisionSource', async () => {
+    const ruleRow = {
+      request: {
+        id: REQ_ID,
+        orgId: ORG_ID,
+        deviceId: 'dev-1',
+        flowType: 'uac_intercept',
+        status: 'auto_approved',
+        approvedByUserId: null,
+        deniedByUserId: null,
+        revokedByUserId: null,
+        softwarePolicyMatchId: null,
+        metadata: { pam_rule_id: 'rule-1', pam_rule_name: 'Allow signed installers' },
+      },
+      deviceHostname: 'WS-BETA',
+      siteName: 'Branch',
+      approvedByName: null,
+      deniedByName: null,
+      revokedByName: null,
+      matchedPolicyName: null,
+    };
+    mockListSelect([ruleRow], 1);
+
+    const res = await app().request('/pam/elevation-requests');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const row = body.requests[0];
+    expect(row.pamRuleId).toBe('rule-1');
+    expect(row.pamRuleName).toBe('Allow signed installers');
+    expect(row.decisionSource).toBe('pam_rule');
+  });
+
+  it('computes decisionSource=human for human-decided rows and null for pending', async () => {
+    const humanRow = {
+      request: {
+        id: REQ_ID,
+        orgId: ORG_ID,
+        deviceId: 'dev-1',
+        flowType: 'uac_intercept',
+        status: 'approved',
+        approvedByUserId: USER_ID,
+        deniedByUserId: null,
+        revokedByUserId: null,
+        softwarePolicyMatchId: null,
+        metadata: {},
+      },
+      deviceHostname: 'WS-ALPHA',
+      siteName: 'HQ',
+      approvedByName: 'Jane Admin',
+      deniedByName: null,
+      revokedByName: null,
+      matchedPolicyName: null,
+    };
+    const pendingRow = {
+      request: {
+        id: '7b41c9a2-0000-4000-8000-000000000099',
+        orgId: ORG_ID,
+        deviceId: 'dev-2',
+        flowType: 'uac_intercept',
+        status: 'pending',
+        approvedByUserId: null,
+        deniedByUserId: null,
+        revokedByUserId: null,
+        softwarePolicyMatchId: null,
+        metadata: {},
+      },
+      deviceHostname: 'WS-GAMMA',
+      siteName: 'HQ',
+      approvedByName: null,
+      deniedByName: null,
+      revokedByName: null,
+      matchedPolicyName: null,
+    };
+    mockListSelect([humanRow, pendingRow], 2);
+
+    const res = await app().request('/pam/elevation-requests');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.requests[0].decisionSource).toBe('human');
+    expect(body.requests[1].decisionSource).toBeNull();
   });
 });
 

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -31,6 +31,7 @@ import {
   elevationRequests,
   pamRules,
   sites,
+  softwarePolicies,
   users,
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
@@ -164,6 +165,7 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
         approvedByName: approvedByUser.name,
         deniedByName: deniedByUser.name,
         revokedByName: revokedByUser.name,
+        matchedPolicyName: softwarePolicies.name,
       })
       .from(elevationRequests)
       .leftJoin(devices, eq(elevationRequests.deviceId, devices.id))
@@ -171,6 +173,7 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
       .leftJoin(approvedByUser, eq(elevationRequests.approvedByUserId, approvedByUser.id))
       .leftJoin(deniedByUser, eq(elevationRequests.deniedByUserId, deniedByUser.id))
       .leftJoin(revokedByUser, eq(elevationRequests.revokedByUserId, revokedByUser.id))
+      .leftJoin(softwarePolicies, eq(elevationRequests.softwarePolicyMatchId, softwarePolicies.id))
       .where(where)
       .orderBy(desc(elevationRequests.requestedAt))
       .limit(limit)
@@ -183,14 +186,30 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
 
   return c.json({
     success: true,
-    requests: rows.map((r) => ({
-      ...r.request,
-      deviceHostname: r.deviceHostname,
-      siteName: r.siteName,
-      approvedByName: r.approvedByName,
-      deniedByName: r.deniedByName,
-      revokedByName: r.revokedByName,
-    })),
+    requests: rows.map((r) => {
+      const meta = (r.request.metadata ?? {}) as Record<string, unknown>;
+      const pamRuleId = typeof meta.pam_rule_id === 'string' ? meta.pam_rule_id : null;
+      const pamRuleName = typeof meta.pam_rule_name === 'string' ? meta.pam_rule_name : null;
+      const decisionSource = r.request.softwarePolicyMatchId
+        ? ('software_policy' as const)
+        : pamRuleId
+          ? ('pam_rule' as const)
+          : r.request.approvedByUserId || r.request.deniedByUserId || r.request.revokedByUserId
+            ? ('human' as const)
+            : null;
+      return {
+        ...r.request,
+        deviceHostname: r.deviceHostname,
+        siteName: r.siteName,
+        approvedByName: r.approvedByName,
+        deniedByName: r.deniedByName,
+        revokedByName: r.revokedByName,
+        matchedPolicyName: r.matchedPolicyName,
+        pamRuleId,
+        pamRuleName,
+        decisionSource,
+      };
+    }),
     pagination: { page, limit, total: countRows[0]?.total ?? 0 },
   });
 });

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -39,6 +39,7 @@ import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/pe
 import { writeAuditEvent } from '../services/auditEvents';
 import { publishEvent, type EventType } from '../services/eventBus';
 import { mirrorElevationDecisionToExecution } from '../services/pamToolActionGovernance';
+import { evaluatePamRules, type PamRuleCandidate } from '../services/pamRuleEngine';
 import { resolveOrgIdForWrite } from './softwarePolicies';
 
 /**
@@ -71,6 +72,12 @@ const requirePamExecute = requirePermission(
 // default in routes/agents/elevationRequests.ts.
 const DEFAULT_APPROVAL_DURATION_MINUTES = 15;
 const MAX_APPROVAL_DURATION_MINUTES = 24 * 60;
+
+// Bounds for the rule preview endpoint.
+const PREVIEW_MAX_WINDOW_DAYS = 90;
+const PREVIEW_DEFAULT_WINDOW_DAYS = 30;
+const PREVIEW_SCAN_CAP = 5000; // rows pulled into JS — totalScanned/truncated keep this honest
+const PREVIEW_SAMPLE_CAP = 10;
 
 const ACTIVE_STATUSES = ['approved', 'auto_approved', 'actuating'] as const;
 
@@ -671,6 +678,36 @@ const createRuleSchema = ruleBaseSchema.superRefine((rule, ctx) => {
   if (err) ctx.addIssue({ code: z.ZodIssueCode.custom, message: err });
 });
 
+// Preview schema: subset of criteria fields (no name/verdict/priority — those
+// are irrelevant to matching), plus windowDays/flowType overrides.
+// Hand-rolled (not .pick) to avoid Zod inference issues with superRefine on
+// a picked object; validators are identical to ruleBaseSchema's counterparts.
+const previewRuleSchema = z
+  .object({
+    siteId: z.string().uuid().nullable().optional(),
+    matchSigner: z.string().min(1).max(255).nullable().optional(),
+    matchHash: z
+      .string()
+      .regex(/^[0-9a-fA-F]{64}$/, 'must be a sha256 hex digest')
+      .nullable()
+      .optional(),
+    matchPathGlob: z.string().min(1).max(4096).nullable().optional(),
+    matchParentImage: z.string().min(1).max(4096).nullable().optional(),
+    matchUser: z.string().min(1).max(255).nullable().optional(),
+    matchAdGroup: z.string().min(1).max(255).nullable().optional(),
+    matchToolName: z.string().min(1).max(100).nullable().optional(),
+    matchRiskTier: z.number().int().min(0).max(4).nullable().optional(),
+    timeWindow: timeWindowSchema.nullable().optional(),
+    windowDays: z.number().int().min(1).max(PREVIEW_MAX_WINDOW_DAYS).optional(),
+    flowType: z.enum(['uac_intercept', 'tech_jit_admin', 'ai_tool_action']).optional(),
+  })
+  .superRefine((rule, ctx) => {
+    // Same shape rules as create (≥1 criterion, no executable/tool mixing).
+    // verdict is irrelevant to matching; inject a synthetic one for the validator.
+    const err = validateRuleShape({ ...rule, verdict: 'require_approval' });
+    if (err) ctx.addIssue({ code: z.ZodIssueCode.custom, message: err });
+  });
+
 pamRoutes.get('/rules', requirePamRead, async (c) => {
   const auth = c.get('auth');
   const rows = await db
@@ -730,6 +767,136 @@ pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', creat
 
   return c.json({ success: true, rule: created }, 201);
 });
+
+// ============================================================
+// Rules — preview (dry-run draft criteria against history)
+// ============================================================
+// Pure per-rule matching: "would these criteria match these historical
+// requests". NOT a chain replay (no priority shadowing, no software-policy
+// bridge) — that variant is future work. Known limitation: historical rows
+// don't store AD groups, so matchAdGroup-only drafts report 0 (mirrors the
+// live uac_intercept ingest gap).
+pamRoutes.post(
+  '/rules/preview',
+  requirePamWrite,
+  zValidator('json', previewRuleSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const body = c.req.valid('json');
+
+    const windowDays = body.windowDays ?? PREVIEW_DEFAULT_WINDOW_DAYS;
+    const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+
+    const conditions: (SQL | undefined)[] = [
+      auth.orgCondition(elevationRequests.orgId),
+      siteScopeCondition(perms),
+      gte(elevationRequests.requestedAt, since),
+    ];
+    if (body.flowType) conditions.push(eq(elevationRequests.flowType, body.flowType));
+    if (body.siteId) {
+      if (perms && !canAccessSite(perms, body.siteId)) {
+        return c.json({ error: 'Site access denied' }, 403);
+      }
+      conditions.push(eq(elevationRequests.siteId, body.siteId));
+    }
+
+    const rows = await db
+      .select({
+        id: elevationRequests.id,
+        requestedAt: elevationRequests.requestedAt,
+        flowType: elevationRequests.flowType,
+        status: elevationRequests.status,
+        subjectUsername: elevationRequests.subjectUsername,
+        targetExecutablePath: elevationRequests.targetExecutablePath,
+        targetExecutableHash: elevationRequests.targetExecutableHash,
+        targetExecutableSigner: elevationRequests.targetExecutableSigner,
+        toolName: elevationRequests.toolName,
+        riskTier: elevationRequests.riskTier,
+        metadata: elevationRequests.metadata,
+      })
+      .from(elevationRequests)
+      .where(and(...conditions.filter((cn): cn is SQL => cn !== undefined)))
+      .orderBy(desc(elevationRequests.requestedAt))
+      .limit(PREVIEW_SCAN_CAP);
+
+    // Engine-shaped draft rule; matching reads match*/timeWindow/enabled only.
+    const draftRule = {
+      id: 'preview',
+      orgId: auth.orgId ?? '',
+      siteId: body.siteId ?? null,
+      name: 'preview',
+      description: null,
+      enabled: true,
+      priority: 0,
+      verdict: 'require_approval' as const,
+      approvalDurationMinutes: null,
+      createdByUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      matchSigner: body.matchSigner ?? null,
+      matchHash: body.matchHash ? body.matchHash.toLowerCase() : null,
+      matchPathGlob: body.matchPathGlob ?? null,
+      matchParentImage: body.matchParentImage ?? null,
+      matchUser: body.matchUser ?? null,
+      matchAdGroup: body.matchAdGroup ?? null,
+      matchToolName: body.matchToolName ?? null,
+      matchRiskTier: body.matchRiskTier ?? null,
+      timeWindow: body.timeWindow ?? null,
+    };
+
+    let totalMatched = 0;
+    const statusBreakdown: Record<string, number> = {
+      pending: 0,
+      approved: 0,
+      auto_approved: 0,
+      denied: 0,
+      expired: 0,
+      revoked: 0,
+      actuating: 0,
+    };
+    const sample: Array<Record<string, unknown>> = [];
+
+    for (const r of rows) {
+      const meta = (r.metadata ?? {}) as Record<string, unknown>;
+      const candidate: PamRuleCandidate = {
+        targetExecutablePath: r.targetExecutablePath ?? undefined,
+        targetExecutableHash: r.targetExecutableHash ?? undefined,
+        targetExecutableSigner: r.targetExecutableSigner ?? undefined,
+        subjectUsername: r.subjectUsername,
+        parentImage: typeof meta.parent_image === 'string' ? meta.parent_image : undefined,
+        toolName: r.toolName ?? undefined,
+        riskTier: r.riskTier ?? undefined,
+        at: r.requestedAt,
+      };
+      if (evaluatePamRules([draftRule], candidate)) {
+        totalMatched++;
+        statusBreakdown[r.status] = (statusBreakdown[r.status] ?? 0) + 1;
+        if (sample.length < PREVIEW_SAMPLE_CAP) {
+          sample.push({
+            id: r.id,
+            requestedAt: r.requestedAt,
+            flowType: r.flowType,
+            subjectUsername: r.subjectUsername,
+            targetExecutablePath: r.targetExecutablePath ?? null,
+            toolName: r.toolName ?? null,
+            status: r.status,
+          });
+        }
+      }
+    }
+
+    return c.json({
+      success: true,
+      totalMatched,
+      totalScanned: rows.length,
+      windowDays,
+      truncated: rows.length === PREVIEW_SCAN_CAP,
+      statusBreakdown,
+      sample,
+    });
+  },
+);
 
 const updateRuleSchema = ruleBaseSchema.partial().omit({ orgId: true });
 

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -197,6 +197,9 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
       const meta = (r.request.metadata ?? {}) as Record<string, unknown>;
       const pamRuleId = typeof meta.pam_rule_id === 'string' ? meta.pam_rule_id : null;
       const pamRuleName = typeof meta.pam_rule_name === 'string' ? meta.pam_rule_name : null;
+      // Note: revokedByUserId also maps to 'human' — for auto-decided-then-revoked rows the
+      // ORIGINAL decision source is policy/rule (still reflected via softwarePolicyMatchId/metadata);
+      // the web layer prefers the revoker for display.
       const decisionSource = r.request.softwarePolicyMatchId
         ? ('software_policy' as const)
         : pamRuleId
@@ -588,13 +591,10 @@ const timeWindowSchema = z.object({
   timezone: z.string().max(64).optional(),
 });
 
-const ruleBaseSchema = z.object({
-  orgId: z.string().uuid().optional(),
+// Criteria fields shared verbatim between ruleBaseSchema and previewRuleSchema.
+// Spread into both z.object calls so any validator change applies to both.
+const ruleCriteriaValidators = {
   siteId: z.string().uuid().nullable().optional(),
-  name: z.string().min(1).max(255),
-  description: z.string().max(2000).nullable().optional(),
-  enabled: z.boolean().optional(),
-  priority: z.number().int().min(0).max(100000).optional(),
   matchSigner: z.string().min(1).max(255).nullable().optional(),
   matchHash: z
     .string()
@@ -608,6 +608,15 @@ const ruleBaseSchema = z.object({
   matchToolName: z.string().min(1).max(100).nullable().optional(),
   matchRiskTier: z.number().int().min(0).max(4).nullable().optional(),
   timeWindow: timeWindowSchema.nullable().optional(),
+};
+
+const ruleBaseSchema = z.object({
+  orgId: z.string().uuid().optional(),
+  ...ruleCriteriaValidators,
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).nullable().optional(),
+  enabled: z.boolean().optional(),
+  priority: z.number().int().min(0).max(100000).optional(),
   verdict: z.enum(['auto_approve', 'auto_deny', 'require_approval', 'ignore']),
   approvalDurationMinutes: z
     .number()
@@ -681,29 +690,17 @@ const createRuleSchema = ruleBaseSchema.superRefine((rule, ctx) => {
 // Preview schema: subset of criteria fields (no name/verdict/priority — those
 // are irrelevant to matching), plus windowDays/flowType overrides.
 // Hand-rolled (not .pick) to avoid Zod inference issues with superRefine on
-// a picked object; validators are identical to ruleBaseSchema's counterparts.
+// a picked object; criteria validators are structurally shared via ruleCriteriaValidators.
 const previewRuleSchema = z
   .object({
-    siteId: z.string().uuid().nullable().optional(),
-    matchSigner: z.string().min(1).max(255).nullable().optional(),
-    matchHash: z
-      .string()
-      .regex(/^[0-9a-fA-F]{64}$/, 'must be a sha256 hex digest')
-      .nullable()
-      .optional(),
-    matchPathGlob: z.string().min(1).max(4096).nullable().optional(),
-    matchParentImage: z.string().min(1).max(4096).nullable().optional(),
-    matchUser: z.string().min(1).max(255).nullable().optional(),
-    matchAdGroup: z.string().min(1).max(255).nullable().optional(),
-    matchToolName: z.string().min(1).max(100).nullable().optional(),
-    matchRiskTier: z.number().int().min(0).max(4).nullable().optional(),
-    timeWindow: timeWindowSchema.nullable().optional(),
+    ...ruleCriteriaValidators,
     windowDays: z.number().int().min(1).max(PREVIEW_MAX_WINDOW_DAYS).optional(),
     flowType: z.enum(['uac_intercept', 'tech_jit_admin', 'ai_tool_action']).optional(),
   })
   .superRefine((rule, ctx) => {
     // Same shape rules as create (≥1 criterion, no executable/tool mixing).
-    // verdict is irrelevant to matching; inject a synthetic one for the validator.
+    // validateRuleShape rejects tool-action rules with verdict 'ignore'; inject any
+    // non-'ignore' verdict so that create-only constraint can't fire on previews.
     const err = validateRuleShape({ ...rule, verdict: 'require_approval' });
     if (err) ctx.addIssue({ code: z.ZodIssueCode.custom, message: err });
   });
@@ -774,8 +771,9 @@ pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', creat
 // Pure per-rule matching: "would these criteria match these historical
 // requests". NOT a chain replay (no priority shadowing, no software-policy
 // bridge) — that variant is future work. Known limitation: historical rows
-// don't store AD groups, so matchAdGroup-only drafts report 0 (mirrors the
-// live uac_intercept ingest gap).
+// don't store AD groups, so ANY draft containing matchAdGroup reports 0 matches
+// (criteria are ANDed) — including tech_jit_admin rows where groups matched live
+// but weren't persisted.
 pamRoutes.post(
   '/rules/preview',
   requirePamWrite,

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -548,6 +548,7 @@ Inline settings shapes by feature type:
 - sensitive_data: { detectionClasses: ["credential","pci","phi","pii","financial"], includePaths: [], excludePaths: [], fileTypes: [], maxFileSizeBytes: 104857600, workers: 4, timeoutSeconds: 300, scheduleType: "manual"|"interval"|"cron", intervalMinutes?: 60, cron?: "...", timezone: "UTC" }
 - warranty: { enabled: true, warnDays: 90, criticalDays: 30 }
 - helper: { enabled: true, showOpenPortal: true, showDeviceInfo: true, showRequestSupport: true, portalUrl?: "" }
+- pam: inlineSettings {uacInterceptionEnabled: boolean} — Windows UAC elevation prompt capture (default true when no policy assigns it). PAM rules/approvals are managed separately in the /pam console, not via config policies.
 
 For link-only types, set featurePolicyId instead of inlineSettings:
 - software_policy: featurePolicyId → existing software policy UUID
@@ -566,7 +567,7 @@ For link-only types, set featurePolicyId instead of inlineSettings:
               'patch', 'alert_rule', 'backup', 'security', 'monitoring',
               'maintenance', 'compliance', 'automation', 'event_log',
               'software_policy', 'sensitive_data', 'peripheral_control',
-              'warranty', 'helper',
+              'warranty', 'helper', 'remote_access', 'pam',
             ],
             description: 'Feature type (required for add)',
           },

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -13,7 +13,7 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
-import { addFeatureLink, updateFeatureLink, listFeatureLinks } from './configurationPolicy';
+import { addFeatureLink, updateFeatureLink, listFeatureLinks, pamInlineSettingsSchema } from './configurationPolicy';
 import { db } from '../db';
 
 // Chain for `db.select().from(...).where(...)` awaited directly (links query)
@@ -331,5 +331,174 @@ describe('patch feature link round-trip (apps + autoApproveDeferralDays)', () =>
 
     const result = await listFeatureLinks('policy-1');
     expect(result[0]!.inlineSettings).toEqual(helperSettings);
+  });
+});
+
+// ============================================================
+// pamInlineSettingsSchema — unit tests for the exported schema
+// ============================================================
+
+describe('pamInlineSettingsSchema', () => {
+  it('accepts {} (all fields optional)', () => {
+    expect(() => pamInlineSettingsSchema.parse({})).not.toThrow();
+  });
+
+  it('accepts { uacInterceptionEnabled: true }', () => {
+    const result = pamInlineSettingsSchema.parse({ uacInterceptionEnabled: true });
+    expect(result.uacInterceptionEnabled).toBe(true);
+  });
+
+  it('accepts { uacInterceptionEnabled: false }', () => {
+    const result = pamInlineSettingsSchema.parse({ uacInterceptionEnabled: false });
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('rejects uacInterceptionEnabled as string "false"', () => {
+    expect(() => pamInlineSettingsSchema.parse({ uacInterceptionEnabled: 'false' })).toThrow();
+  });
+
+  it('rejects uacInterceptionEnabled as number 0', () => {
+    expect(() => pamInlineSettingsSchema.parse({ uacInterceptionEnabled: 0 })).toThrow();
+  });
+
+  it('rejects unknown keys (strict)', () => {
+    expect(() => pamInlineSettingsSchema.parse({ uacInterceptionEnabled: true, extra: 'nope' })).toThrow();
+  });
+});
+
+// ============================================================
+// addFeatureLink — pam inlineSettings service-layer validation
+// ============================================================
+
+describe('addFeatureLink — pam inlineSettings service-layer validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws ZodError before entering the transaction when uacInterceptionEnabled is string "false"', async () => {
+    // transaction should never be called — validation is pre-transaction
+    await expect(
+      addFeatureLink('policy-1', 'pam', null, { uacInterceptionEnabled: 'false' })
+    ).rejects.toThrow();
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
+  it('throws ZodError for unknown extra key on pam inlineSettings', async () => {
+    await expect(
+      addFeatureLink('policy-1', 'pam', null, { uacInterceptionEnabled: true, rogue: 'x' })
+    ).rejects.toThrow();
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
+  it('does not throw and enters the transaction for valid pam inlineSettings { uacInterceptionEnabled: false }', async () => {
+    const tx = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() =>
+            Promise.resolve([
+              { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: { uacInterceptionEnabled: false } },
+            ])
+          ),
+        })),
+      })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const link = await addFeatureLink('policy-1', 'pam', null, { uacInterceptionEnabled: false });
+    expect(link).toBeDefined();
+    expect(vi.mocked(db.transaction)).toHaveBeenCalledOnce();
+  });
+
+  it('does not throw and enters the transaction for valid pam inlineSettings {}', async () => {
+    const tx = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() =>
+            Promise.resolve([
+              { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: {} },
+            ])
+          ),
+        })),
+      })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const link = await addFeatureLink('policy-1', 'pam', null, {});
+    expect(link).toBeDefined();
+  });
+
+  it('skips pam validation when inlineSettings is null/undefined', async () => {
+    const tx = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() =>
+            Promise.resolve([
+              { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: null },
+            ])
+          ),
+        })),
+      })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    // Should not throw — pam validation is skipped for null/undefined inlineSettings
+    await expect(addFeatureLink('policy-1', 'pam', null, null)).resolves.toBeDefined();
+    await expect(addFeatureLink('policy-1', 'pam', null, undefined)).resolves.toBeDefined();
+  });
+});
+
+// ============================================================
+// updateFeatureLink — pam inlineSettings service-layer validation
+// ============================================================
+
+describe('updateFeatureLink — pam inlineSettings service-layer validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeTxWithExistingPamLink() {
+    const tx: any = {
+      select: vi.fn(() => selectLimitRows([
+        { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: {} },
+      ])),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve([{ id: 'link-pam', featureType: 'pam' }])),
+          })),
+        })),
+      })),
+      delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) })),
+      insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve([])) })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+    return tx;
+  }
+
+  it('throws ZodError when updating pam link with uacInterceptionEnabled as string "false"', async () => {
+    makeTxWithExistingPamLink();
+    await expect(
+      updateFeatureLink('link-pam', { inlineSettings: { uacInterceptionEnabled: 'false' } }, 'policy-1')
+    ).rejects.toThrow();
+  });
+
+  it('throws ZodError when updating pam link with unknown extra key', async () => {
+    makeTxWithExistingPamLink();
+    await expect(
+      updateFeatureLink('link-pam', { inlineSettings: { rogue: true } }, 'policy-1')
+    ).rejects.toThrow();
+  });
+
+  it('succeeds when updating pam link with valid inlineSettings { uacInterceptionEnabled: false }', async () => {
+    makeTxWithExistingPamLink();
+    const result = await updateFeatureLink('link-pam', { inlineSettings: { uacInterceptionEnabled: false } }, 'policy-1');
+    expect(result).not.toBeNull();
+  });
+
+  it('succeeds when updating pam link with inlineSettings: null (clear settings)', async () => {
+    makeTxWithExistingPamLink();
+    // null inlineSettings means "clear" — pam validation is skipped
+    const result = await updateFeatureLink('link-pam', { inlineSettings: null }, 'policy-1');
+    expect(result).not.toBeNull();
   });
 });

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -29,9 +29,25 @@ import {
   peripheralPolicies,
 } from '../db/schema';
 import { and, eq, desc, sql, inArray, asc, SQL } from 'drizzle-orm';
+import { z } from 'zod';
 import { eventLogInlineSettingsSchema, monitoringInlineSettingsSchema } from '@breeze/shared/validators';
 import type { AuthContext } from '../middleware/auth';
 import { normalizePatchInlineSettings, tryNormalizePatchInlineSettings } from './configPolicyPatching';
+
+// ============================================
+// Inline settings schemas
+// ============================================
+
+// Exported so the route can import the same schema (single source of truth).
+// uacInterceptionEnabled defaults to true on the read side (parsePamSettings),
+// so {} is well-formed. Non-boolean values are rejected to prevent the silent-
+// inversion bug where "false" (string) is coerced back to true on read-back.
+// .strict() matches the posture of patch/backup: unknown keys are rejected.
+export const pamInlineSettingsSchema = z
+  .object({
+    uacInterceptionEnabled: z.boolean().optional(),
+  })
+  .strict();
 
 // ============================================
 // Types
@@ -793,6 +809,10 @@ export async function addFeatureLink(
   featurePolicyId?: string | null,
   inlineSettings?: unknown
 ) {
+  if (featureType === 'pam' && inlineSettings !== undefined && inlineSettings !== null) {
+    pamInlineSettingsSchema.parse(inlineSettings);
+  }
+
   return db.transaction(async (tx) => {
     const effectiveInlineSettings =
       featureType === 'patch'
@@ -838,6 +858,10 @@ export async function updateFeatureLink(
       .where(and(...conditions))
       .limit(1);
     if (!existing) return null;
+
+    if (existing.featureType === 'pam' && updates.inlineSettings !== undefined && updates.inlineSettings !== null) {
+      pamInlineSettingsSchema.parse(updates.inlineSettings);
+    }
 
     const setValues: Record<string, unknown> = { updatedAt: new Date() };
     const normalizedInlineSettings =

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -37,7 +37,7 @@ import { normalizePatchInlineSettings, tryNormalizePatchInlineSettings } from '.
 // Types
 // ============================================
 
-type ConfigFeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access';
+type ConfigFeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam';
 export type ConfigAssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device';
 
 const LEVEL_PRIORITY: Record<ConfigAssignmentLevel, number> = {

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -456,6 +456,7 @@ async function decomposeInlineSettings(
     case 'warranty':
     case 'helper':
     case 'remote_access':
+    case 'pam':
       // Pure JSONB — no normalized table needed
       break;
 
@@ -509,6 +510,7 @@ async function deleteNormalizedRows(
     case 'warranty':
     case 'helper':
     case 'remote_access':
+    case 'pam':
       // Pure JSONB — no normalized table to delete
       break;
     default:
@@ -772,6 +774,7 @@ async function assembleInlineSettings(
     case 'warranty':
     case 'helper':
     case 'remote_access':
+    case 'pam':
       // Pure JSONB — settings stored directly on feature link
       return null;
 

--- a/apps/api/src/services/pamBridge.test.ts
+++ b/apps/api/src/services/pamBridge.test.ts
@@ -75,6 +75,82 @@ describe('matchPathGlob', () => {
   });
 });
 
+describe('matchPathGlob — semantic table & ReDoS hardening', () => {
+  it('matches a representative Program Files ** glob', () => {
+    expect(matchPathGlob('C:\\Program Files\\Adobe\\**\\*.exe',
+      'c:/program files/adobe/reader/11/acrord32.exe')).toBe(true);
+    // readme.txt does not end in .exe, and is directly under adobe/
+    expect(matchPathGlob('C:\\Program Files\\Adobe\\**\\*.exe',
+      'c:/program files/adobe/readme.txt')).toBe(false);
+  });
+
+  it('single * does not cross a path separator', () => {
+    expect(matchPathGlob('C:\\Tools\\*.exe', 'c:/tools/a.exe')).toBe(true);
+    expect(matchPathGlob('C:\\Tools\\*.exe', 'c:/tools/sub/a.exe')).toBe(false);
+  });
+
+  it('** at start, middle, and end', () => {
+    expect(matchPathGlob('**\\foo.exe', 'c:/a/b/foo.exe')).toBe(true);
+    expect(matchPathGlob('c:\\**\\foo.exe', 'c:/a/b/foo.exe')).toBe(true);
+    expect(matchPathGlob('c:\\a\\**', 'c:/a/b/c/foo.exe')).toBe(true);
+  });
+
+  it('bare ** matches everything (including empty)', () => {
+    expect(matchPathGlob('**', 'c:/anything/at/all.exe')).toBe(true);
+    expect(matchPathGlob('**', '')).toBe(true);
+    expect(matchPathGlob('**', 'x')).toBe(true);
+  });
+
+  it('empty glob matches only the empty path', () => {
+    expect(matchPathGlob('', '')).toBe(true);
+    expect(matchPathGlob('', 'x')).toBe(false);
+  });
+
+  it('regex-meta characters are literal (?, (, ), [, ], ., +)', () => {
+    // `?` is a LITERAL in this dialect, not a single-char wildcard
+    expect(matchPathGlob('c:\\a?.exe', 'c:/a?.exe')).toBe(true);
+    expect(matchPathGlob('c:\\a?.exe', 'c:/ab.exe')).toBe(false);
+    expect(matchPathGlob('c:\\f(x).exe', 'c:/f(x).exe')).toBe(true);
+    expect(matchPathGlob('c:\\f[1].exe', 'c:/f[1].exe')).toBe(true);
+    expect(matchPathGlob('c:\\a.exe', 'c:/axexe')).toBe(false); // `.` literal
+    expect(matchPathGlob('c:\\a+b.exe', 'c:/a+b.exe')).toBe(true);
+    expect(matchPathGlob('c:\\a+b.exe', 'c:/ab.exe')).toBe(false); // `+` literal
+  });
+
+  it('is case-insensitive and slash-agnostic', () => {
+    expect(matchPathGlob('C:\\FOO\\*.EXE', 'c:/foo/bar.exe')).toBe(true);
+    expect(matchPathGlob('c:/foo/*.exe', 'C:\\FOO\\BAR.EXE')).toBe(true);
+  });
+
+  it('* matches zero chars', () => {
+    expect(matchPathGlob('c:\\foo\\*.exe', 'c:/foo/.exe')).toBe(true);
+    expect(matchPathGlob('c:\\foo*bar', 'c:/foobar')).toBe(true);
+  });
+
+  it('preserves *** semantics (** greedy first, then single *)', () => {
+    // Empirically pinned against the prior regex impl: *** => `.*[^/]*`
+    expect(matchPathGlob('***', 'abc/def')).toBe(true);
+    expect(matchPathGlob('***', '')).toBe(true);
+    expect(matchPathGlob('a***b', 'a/x/b')).toBe(true);
+    expect(matchPathGlob('a***b', 'ab')).toBe(true);
+    // **** => `.*.*` (two ** blocks), still matches across separators
+    expect(matchPathGlob('a****b', 'a/x/y/b')).toBe(true);
+  });
+
+  it('runs in linear time on a catastrophic-backtracking glob (ReDoS guard)', () => {
+    // The prior regex impl translated this to `^a[^/]*a[^/]*...b$`, which
+    // exhibits catastrophic backtracking against an all-`a` non-matching
+    // path: it hangs for >8s. The iterative matcher must return promptly.
+    const evil = 'a*'.repeat(20) + 'b';
+    const path = 'a'.repeat(50);
+    const t0 = Date.now();
+    const result = matchPathGlob(evil, path);
+    const elapsed = Date.now() - t0;
+    expect(result).toBe(false);
+    expect(elapsed).toBeLessThan(1000);
+  });
+});
+
 describe('matchPoliciesAgainst — single-policy match by field', () => {
   it('matches by hash (strongest)', () => {
     const v = matchPoliciesAgainst(adobeInstall, [

--- a/apps/api/src/services/pamBridge.ts
+++ b/apps/api/src/services/pamBridge.ts
@@ -297,29 +297,90 @@ function matchRule(
 
 /**
  * Windows-style case-insensitive glob: `*` matches anything except path
- * separator, `**` matches anything including separators. Normalizes both
- * sides to forward slashes before comparison.
+ * separator, `**` matches anything including separators. All other characters
+ * — including `?`, `.`, `+`, `(`, spaces, etc. — are LITERAL (this dialect has
+ * no single-char wildcard). Normalizes both sides to forward slashes and
+ * lowercases before comparison; the match is full-string anchored.
  *
  * Mirrors the wildcard handling in softwarePolicyService.matchesSoftwareRule
  * (softwarePolicyService.ts:185-214) but extended for `**` since PAM rules
  * commonly say `C:\Program Files\Adobe\**\*.exe`.
+ *
+ * Implemented as a bottom-up dynamic-programming matcher (no RegExp, no
+ * recursion). The prior regex compilation (`*`→`[^/]*`, `**`→`.*`) exhibited
+ * catastrophic backtracking — a crafted, user-supplied glob such as
+ * `a*a*a*...*b` against an all-`a` path would pin an API worker for seconds
+ * (saved PAM rules + the `/pam/rules/preview` endpoint both feed
+ * attacker-influenced globs in). The DP table below visits each (glob token,
+ * text position) pair at most once, giving O(|glob|·|text|) worst case with no
+ * backtracking explosion and a stack depth independent of input. Matching
+ * characters literally also keeps a blocklist rule for
+ * `C:\Program Files\Evil.exe` from leaking into attacker-controlled
+ * non-default install paths like `c:/programXfilesY/evil.exe`.
  */
 export function matchPathGlob(glob: string, path: string): boolean {
   const norm = (s: string) => s.replace(/\\/g, '/').toLowerCase();
-  const target = norm(path);
-  // Use a NUL sentinel for `**` so a literal space in the glob (e.g. the
-  // `Program Files` segment of every Windows install path) can never be
-  // misinterpreted as the wildcard placeholder. A printable placeholder
-  // here is a security bug: a blocklist rule for `C:\Program Files\Evil.exe`
-  // would otherwise produce regex `^c:/program.*files/evil\.exe$` and match
-  // attacker-controlled non-default install paths like `c:/programXfilesY/`.
-  const escaped = norm(glob)
-    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')   // escape regex metas (space NOT included — good)
-    .replace(/\*\*/g, '\x00')                  // ** → NUL sentinel
-    .replace(/\*/g, '[^/]*')                   // * → single-segment wildcard
-    .replace(/\x00/g, '.*');                   // sentinel → real .*
-  const re = new RegExp(`^${escaped}$`);
-  return re.test(target);
+  const g = norm(glob);
+  const t = norm(path);
+
+  // Tokenize the glob into a flat program of literals and star spans. Each
+  // star span is collapsed from a run of consecutive `*`: two or more stars
+  // become a `**` span (crosses '/'); a lone `*` stays single-segment. This
+  // keeps `***` == `**` (a slash-crossing span), matching the legacy regex.
+  type Tok = { star: true; crossesSlash: boolean } | { star: false; ch: string };
+  const toks: Tok[] = [];
+  for (let i = 0; i < g.length; ) {
+    if (g[i] === '*') {
+      let count = 0;
+      while (i < g.length && g[i] === '*') {
+        i++;
+        count++;
+      }
+      toks.push({ star: true, crossesSlash: count >= 2 });
+    } else {
+      toks.push({ star: false, ch: g[i] as string });
+      i++;
+    }
+  }
+
+  const pn = toks.length;
+  const tn = t.length;
+
+  // Bottom-up DP, no recursion (glob runs may be up to the 4096-char schema
+  // cap; recursion depth must not scale with the path). dp[ti] = does the
+  // remaining glob (from the current token) match t[ti..]? We fill it for
+  // each token from the last token backward.
+  // dp after processing tokens [k..] : dp[ti] true ⇔ toks[k..] matches t[ti..].
+  let dp = new Array<boolean>(tn + 1).fill(false);
+  dp[tn] = true; // empty glob matches only empty remaining text
+
+  for (let k = pn - 1; k >= 0; k--) {
+    const tok = toks[k] as Tok;
+    const next = new Array<boolean>(tn + 1).fill(false);
+    if (tok.star) {
+      // A star span matches zero or more text chars. next[ti] is true if the
+      // span matches an empty span here (dp[ti]) OR it can absorb t[ti] and
+      // the span continues (next[ti+1]) — subject to the no-'/' constraint
+      // for a single `*`. Scanning ti high→low lets next[ti+1] feed next[ti].
+      for (let ti = tn; ti >= 0; ti--) {
+        let v = dp[ti] as boolean; // span matches empty here
+        if (!v && ti < tn && (tok.crossesSlash || t[ti] !== '/')) {
+          v = next[ti + 1] as boolean; // absorb one more char, span continues
+        }
+        next[ti] = v;
+      }
+    } else {
+      // Literal token: matches t[ti] iff equal, then defer to dp[ti+1].
+      const ch = tok.ch;
+      for (let ti = 0; ti < tn; ti++) {
+        next[ti] = ch === t[ti] && (dp[ti + 1] as boolean);
+      }
+      // next[tn] stays false: a literal cannot match past end of text.
+    }
+    dp = next;
+  }
+
+  return dp[0] as boolean;
 }
 
 // ============================================================

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -42,6 +42,7 @@ import MonitoringTab from './featureTabs/MonitoringTab';
 import WarrantyTab from './featureTabs/WarrantyTab';
 import HelperTab from './featureTabs/HelperTab';
 import RemoteAccessTab from './featureTabs/RemoteAccessTab';
+import PamTab from './featureTabs/PamTab';
 
 type Tab = 'overview' | FeatureType | 'assignments';
 
@@ -78,9 +79,10 @@ const featureTabIcons: Partial<Record<FeatureType, React.ReactNode>> = {
   warranty: <ShieldCheck className="h-4 w-4" />,
   helper: <LifeBuoy className="h-4 w-4" />,
   remote_access: <Monitor className="h-4 w-4" />,
+  pam: <ShieldCheck className="h-4 w-4" />,
 };
 
-const FEATURE_TYPES: FeatureType[] = ['patch', 'alert_rule', 'backup', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access'];
+const FEATURE_TYPES: FeatureType[] = ['patch', 'alert_rule', 'backup', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam'];
 
 type ConfigPolicyDetailPageProps = {
   policyId?: string;
@@ -294,6 +296,7 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
       case 'warranty': return <WarrantyTab {...props} />;
       case 'helper': return <HelperTab {...props} />;
       case 'remote_access': return <RemoteAccessTab {...props} />;
+      case 'pam': return <PamTab {...props} />;
     }
   };
 

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   HardDrive,
   Shield,
   ShieldCheck,
+  KeyRound,
   ScrollText,
   ScanSearch,
   Usb,
@@ -79,7 +80,7 @@ const featureTabIcons: Partial<Record<FeatureType, React.ReactNode>> = {
   warranty: <ShieldCheck className="h-4 w-4" />,
   helper: <LifeBuoy className="h-4 w-4" />,
   remote_access: <Monitor className="h-4 w-4" />,
-  pam: <ShieldCheck className="h-4 w-4" />,
+  pam: <KeyRound className="h-4 w-4" />,
 };
 
 const FEATURE_TYPES: FeatureType[] = ['patch', 'alert_rule', 'backup', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam'];

--- a/apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PamTab from './PamTab';
+
+// useFeatureLink wraps the save/remove API calls; stub it so we can assert the
+// payload the tab submits without hitting the network.
+const saveMock = vi.fn(async () => ({ id: 'link-1' }));
+const removeMock = vi.fn(async () => true);
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+import type { FeatureTabProps } from './types';
+
+const baseProps: FeatureTabProps = {
+  policyId: 'policy-1',
+  existingLink: undefined,
+  linkedPolicyId: null,
+  onLinkChanged: vi.fn(),
+};
+
+function inlineSettingsFromCall(call: unknown[]): Record<string, unknown> | undefined {
+  for (const arg of call) {
+    if (arg && typeof arg === 'object' && 'inlineSettings' in (arg as object)) {
+      return (arg as { inlineSettings: Record<string, unknown> }).inlineSettings;
+    }
+  }
+  return undefined;
+}
+
+describe('PamTab', () => {
+  beforeEach(() => {
+    saveMock.mockClear();
+    removeMock.mockClear();
+  });
+
+  it('renders the UAC interception toggle, defaulted ON', () => {
+    render(<PamTab {...baseProps} />);
+    expect(screen.getByText('Capture Windows UAC elevation prompts')).toBeTruthy();
+  });
+
+  it('links rule management out to the /pam console', () => {
+    render(<PamTab {...baseProps} />);
+    const link = screen.getByRole('link', { name: /privileged access console/i }) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/pam');
+  });
+
+  it('saves uacInterceptionEnabled=false after toggling off', async () => {
+    render(<PamTab {...baseProps} />);
+
+    const label = screen.getByText('Capture Windows UAC elevation prompts');
+    const row = label.closest('div')?.parentElement as HTMLElement;
+    const toggleButton = row.querySelector('button') as HTMLButtonElement;
+    fireEvent.click(toggleButton);
+
+    const saveButton = screen
+      .getAllByRole('button')
+      .find((b) => /save/i.test(b.textContent ?? '')) as HTMLButtonElement;
+    expect(saveButton).toBeTruthy();
+    fireEvent.click(saveButton);
+
+    expect(saveMock).toHaveBeenCalled();
+    const settings = inlineSettingsFromCall(saveMock.mock.calls[0]);
+    expect(settings).toEqual({ uacInterceptionEnabled: false });
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx
@@ -55,9 +55,7 @@ describe('PamTab', () => {
   it('saves uacInterceptionEnabled=false after toggling off', async () => {
     render(<PamTab {...baseProps} />);
 
-    const label = screen.getByText('Capture Windows UAC elevation prompts');
-    const row = label.closest('div')?.parentElement as HTMLElement;
-    const toggleButton = row.querySelector('button') as HTMLButtonElement;
+    const toggleButton = screen.getByTestId('pam-tab-capture-toggle') as HTMLButtonElement;
     fireEvent.click(toggleButton);
 
     const saveButton = screen

--- a/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
@@ -1,0 +1,110 @@
+import { useState, useEffect } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import type { FeatureTabProps } from './types';
+import { FEATURE_META } from './types';
+import { useFeatureLink } from './useFeatureLink';
+import FeatureTabShell from './FeatureTabShell';
+
+type PamSettings = {
+  uacInterceptionEnabled: boolean;
+};
+
+// Default ON — matches agent behavior when no policy assigns this feature.
+const defaults: PamSettings = {
+  uacInterceptionEnabled: true,
+};
+
+export default function PamTab({ policyId, existingLink, onLinkChanged, linkedPolicyId, parentLink }: FeatureTabProps) {
+  const { save, remove, saving, error, clearError } = useFeatureLink(policyId);
+  const isInherited = !!parentLink && !existingLink;
+  const effectiveLink = existingLink ?? parentLink;
+  const [settings, setSettings] = useState<PamSettings>(() => ({
+    ...defaults,
+    ...(effectiveLink?.inlineSettings as Partial<PamSettings> | undefined),
+  }));
+
+  useEffect(() => {
+    const link = existingLink ?? parentLink;
+    if (link?.inlineSettings) {
+      setSettings((prev) => ({ ...prev, ...(link.inlineSettings as Partial<PamSettings>) }));
+    }
+  }, [existingLink, parentLink]);
+
+  const handleSave = async () => {
+    clearError();
+    const result = await save(existingLink?.id ?? null, {
+      featureType: 'pam',
+      featurePolicyId: linkedPolicyId,
+      inlineSettings: { ...settings },
+    });
+    if (result) onLinkChanged(result, 'pam');
+  };
+
+  const handleRemove = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, 'pam');
+  };
+
+  const handleOverride = async () => {
+    clearError();
+    const result = await save(null, {
+      featureType: 'pam',
+      featurePolicyId: linkedPolicyId,
+      inlineSettings: { ...settings },
+    });
+    if (result) onLinkChanged(result, 'pam');
+  };
+
+  const handleRevert = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, 'pam');
+  };
+
+  const meta = FEATURE_META.pam;
+
+  return (
+    <FeatureTabShell
+      title={meta.label}
+      description={meta.description}
+      icon={<ShieldCheck className="h-5 w-5" />}
+      isConfigured={!!existingLink || isInherited}
+      saving={saving}
+      error={error}
+      onSave={handleSave}
+      onRemove={existingLink && !linkedPolicyId ? handleRemove : undefined}
+      isInherited={isInherited}
+      onOverride={isInherited ? handleOverride : undefined}
+      onRevert={!isInherited && !!linkedPolicyId && !!existingLink ? handleRevert : undefined}
+    >
+      <div className="space-y-6">
+        {/* UAC interception toggle */}
+        <div className="flex items-center justify-between rounded-md border bg-background px-4 py-3">
+          <div>
+            <p className="text-sm font-medium">Capture Windows UAC elevation prompts</p>
+            <p className="text-xs text-muted-foreground">
+              The agent observes UAC consent prompts and records them as elevation requests for PAM review. Capture is on by default when no policy sets this.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setSettings((prev) => ({ ...prev, uacInterceptionEnabled: !prev.uacInterceptionEnabled }))}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full border transition ${settings.uacInterceptionEnabled ? 'bg-emerald-500/80' : 'bg-muted'}`}
+          >
+            <span className={`inline-block h-5 w-5 rounded-full bg-white transition ${settings.uacInterceptionEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
+          </button>
+        </div>
+
+        {/* Pointer to the PAM control plane */}
+        <div className="rounded-md border bg-muted/40 px-4 py-3">
+          <p className="text-sm font-medium">Approval rules live in the PAM console</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            This policy only controls whether devices capture elevation prompts. Verdicts (auto-approve, deny, require approval), the request queue, and audit history are managed in the{' '}
+            <a href="/pam" className="underline underline-offset-2 hover:text-foreground">Privileged Access console</a>.
+          </p>
+        </div>
+      </div>
+    </FeatureTabShell>
+  );
+}

--- a/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ShieldCheck } from 'lucide-react';
+import { KeyRound } from 'lucide-react';
 import type { FeatureTabProps } from './types';
 import { FEATURE_META } from './types';
 import { useFeatureLink } from './useFeatureLink';
@@ -68,7 +68,7 @@ export default function PamTab({ policyId, existingLink, onLinkChanged, linkedPo
     <FeatureTabShell
       title={meta.label}
       description={meta.description}
-      icon={<ShieldCheck className="h-5 w-5" />}
+      icon={<KeyRound className="h-5 w-5" />}
       isConfigured={!!existingLink || isInherited}
       saving={saving}
       error={error}

--- a/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
@@ -89,6 +89,7 @@ export default function PamTab({ policyId, existingLink, onLinkChanged, linkedPo
           </div>
           <button
             type="button"
+            data-testid="pam-tab-capture-toggle"
             onClick={() => setSettings((prev) => ({ ...prev, uacInterceptionEnabled: !prev.uacInterceptionEnabled }))}
             className={`relative inline-flex h-6 w-11 items-center rounded-full border transition ${settings.uacInterceptionEnabled ? 'bg-emerald-500/80' : 'bg-muted'}`}
           >

--- a/apps/web/src/components/configurationPolicies/featureTabs/SoftwarePolicyTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/SoftwarePolicyTab.tsx
@@ -132,6 +132,10 @@ export default function SoftwarePolicyTab({ policyId, existingLink, onLinkChange
             <p className="mt-1 text-xs text-muted-foreground capitalize">
               Mode: {linkedPolicySummary.mode}
             </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Executable rules in this policy also gate UAC elevation requests on assigned devices —
+              an allowlist match auto-approves, a blocklist match auto-denies, before any PAM rules run.
+            </p>
             {linkedPolicySummary.rules?.software && linkedPolicySummary.rules.software.length > 0 && (
               <div className="mt-2">
                 <p className="text-xs font-medium text-muted-foreground">

--- a/apps/web/src/components/configurationPolicies/featureTabs/types.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/types.ts
@@ -1,4 +1,4 @@
-export type FeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access';
+export type FeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam';
 
 export type FeatureLink = {
   id: string;
@@ -39,4 +39,5 @@ export const FEATURE_META: Record<FeatureType, {
   warranty:    { label: 'Warranty',    fetchUrl: null,                   description: 'Warranty expiry alert thresholds' },
   helper:      { label: 'Breeze Assist',     fetchUrl: null,                   description: 'End-user Breeze Assist tray application' },
   remote_access: { label: 'Remote Access',  fetchUrl: null,                   description: 'Remote desktop, proxy tunnels, and session limits' },
+  pam:         { label: 'Privileged Access', fetchUrl: null,              description: 'Windows UAC elevation prompt capture (PAM)' },
 };

--- a/apps/web/src/components/pam/PamAuditTab.test.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.test.tsx
@@ -170,4 +170,30 @@ describe('buildAuditCsv', () => {
     const fallbackCsv = buildAuditCsv([{ ...decided, deniedByName: null }]);
     expect(fallbackCsv.split('\n')[1]).toContain('deadbeef-0000-4000-8000-000000000001');
   });
+
+  it('exports decision provenance columns (source + matched policy/rule names)', () => {
+    const csv = buildAuditCsv([
+      {
+        ...decided,
+        decisionSource: 'pam_rule',
+        pamRuleName: 'Allow run_script',
+        matchedPolicyName: null,
+      },
+    ]);
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('decisionSource');
+    expect(lines[0]).toContain('matchedPolicyName');
+    expect(lines[0]).toContain('pamRuleName');
+    expect(lines[1]).toContain('pam_rule');
+    expect(lines[1]).toContain('Allow run_script');
+  });
+
+  it('emits empty provenance cells when null', () => {
+    const csv = buildAuditCsv([decided]);
+    const header = csv.split('\n')[0].split(',');
+    const row = csv.split('\n')[1].split(',');
+    for (const col of ['decisionSource', 'matchedPolicyName', 'pamRuleName']) {
+      expect(row[header.indexOf(col)]).toBe('');
+    }
+  });
 });

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -6,6 +6,7 @@ import {
   type ElevationFlowType,
   type ElevationRequest,
   type ElevationStatus,
+  FLOW_ICONS,
   FLOW_LABELS,
   type Pagination,
   STATUS_LABELS,
@@ -56,6 +57,9 @@ export function buildAuditCsv(rows: ElevationRequest[]): string {
     'revokedBy',
     'approvedAt',
     'expiresAt',
+    'decisionSource',
+    'matchedPolicyName',
+    'pamRuleName',
   ];
   const lines = [header.join(',')];
   for (const r of rows) {
@@ -83,6 +87,9 @@ export function buildAuditCsv(rows: ElevationRequest[]): string {
         r.revokedByName ?? r.revokedByUserId ?? '',
         r.approvedAt ?? '',
         r.expiresAt ?? '',
+        r.decisionSource ?? '',
+        r.matchedPolicyName ?? '',
+        r.pamRuleName ?? '',
       ]
         .map(csvEscape)
         .join(','),
@@ -336,7 +343,17 @@ export default function PamAuditTab({ liveTick }: { liveTick: number }) {
                       )}
                     </div>
                   </td>
-                  <td className="whitespace-nowrap px-3 py-2">{FLOW_LABELS[r.flowType]}</td>
+                  <td className="whitespace-nowrap px-3 py-2">
+                    {(() => {
+                      const FlowIcon = FLOW_ICONS[r.flowType];
+                      return (
+                        <span className="inline-flex items-center gap-1.5">
+                          <FlowIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                          {FLOW_LABELS[r.flowType]}
+                        </span>
+                      );
+                    })()}
+                  </td>
                   <td className="px-3 py-2">
                     <span
                       className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -9,7 +9,7 @@ import {
   FLOW_LABELS,
   type Pagination,
   STATUS_LABELS,
-  decidedByLabel,
+  decisionAttribution,
   requestTarget,
   statusBadgeClass,
 } from './types';
@@ -308,7 +308,7 @@ export default function PamAuditTab({ liveTick }: { liveTick: number }) {
             </thead>
             <tbody>
               {rows.map((r) => {
-                const decidedBy = decidedByLabel(r);
+                const attribution = decisionAttribution(r);
                 return (
                 <tr key={r.id} className="border-b last:border-0" data-testid={`pam-audit-row-${r.id}`}>
                   <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
@@ -343,13 +343,13 @@ export default function PamAuditTab({ liveTick }: { liveTick: number }) {
                     >
                       {STATUS_LABELS[r.status]}
                     </span>
-                    {decidedBy && (
+                    {attribution && (
                       <div
                         className="mt-0.5 max-w-[180px] truncate text-xs text-muted-foreground"
                         data-testid={`pam-audit-decided-by-${r.id}`}
-                        title={`by ${decidedBy}`}
+                        title={attribution}
                       >
-                        by {decidedBy}
+                        {attribution}
                       </div>
                     )}
                   </td>

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -348,7 +348,7 @@ export default function PamAuditTab({ liveTick }: { liveTick: number }) {
                       const FlowIcon = FLOW_ICONS[r.flowType];
                       return (
                         <span className="inline-flex items-center gap-1.5">
-                          <FlowIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                          <FlowIcon aria-hidden="true" className="h-3.5 w-3.5 text-muted-foreground" />
                           {FLOW_LABELS[r.flowType]}
                         </span>
                       );

--- a/apps/web/src/components/pam/PamOverviewTab.test.tsx
+++ b/apps/web/src/components/pam/PamOverviewTab.test.tsx
@@ -84,6 +84,45 @@ describe('PamOverviewTab', () => {
     expect(screen.getByText('No decided requests yet.')).toBeInTheDocument();
   });
 
+  it('renders the first-run setup block with a Configuration Policies link when all-zero', async () => {
+    fetchWithAuthMock.mockImplementation(async () =>
+      makeJsonResponse({
+        success: true,
+        active: [],
+        requests: [],
+        pagination: { page: 1, limit: 10, total: 0 },
+      }),
+    );
+    render(<PamOverviewTab liveTick={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-setup-steps')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('pam-setup-steps')).toHaveTextContent('Configuration Policy');
+  });
+
+  it('hides the first-run setup block once there is activity', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url === '/pam/active') {
+        return makeJsonResponse({ success: true, active: [activeElevation] });
+      }
+      if (url.includes('status=pending')) {
+        return makeJsonResponse({
+          success: true,
+          requests: [],
+          pagination: { page: 1, limit: 1, total: 0 },
+        });
+      }
+      return makeJsonResponse({
+        success: true,
+        requests: [],
+        pagination: { page: 1, limit: 10, total: 0 },
+      });
+    });
+    render(<PamOverviewTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-active-row-act-1'));
+    expect(screen.queryByTestId('pam-setup-steps')).toBeNull();
+  });
+
   it('shows the decider display name on recent decisions when joined by the API', async () => {
     fetchWithAuthMock.mockImplementation(async (url: string) => {
       if (url === '/pam/active') {

--- a/apps/web/src/components/pam/PamOverviewTab.tsx
+++ b/apps/web/src/components/pam/PamOverviewTab.tsx
@@ -6,7 +6,7 @@ import {
   type ElevationRequest,
   FLOW_LABELS,
   STATUS_LABELS,
-  decidedByLabel,
+  decisionAttribution,
   requestTarget,
   statusBadgeClass,
 } from './types';
@@ -163,7 +163,7 @@ export default function PamOverviewTab({ liveTick }: { liveTick: number }) {
         ) : (
           <ul className="divide-y rounded-md border bg-card">
             {data.recent.map((r) => {
-              const decidedBy = decidedByLabel(r);
+              const attribution = decisionAttribution(r);
               return (
                 <li key={r.id} className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
                   <span className="min-w-0 flex-1 truncate" title={requestTarget(r)}>
@@ -171,12 +171,13 @@ export default function PamOverviewTab({ liveTick }: { liveTick: number }) {
                     <span className="text-muted-foreground"> · {r.subjectUsername} · </span>
                     {requestTarget(r)}
                   </span>
-                  {decidedBy && (
+                  {attribution && (
                     <span
                       className="shrink-0 text-xs text-muted-foreground"
                       data-testid={`pam-decided-by-${r.id}`}
+                      title={attribution}
                     >
-                      by {decidedBy}
+                      {attribution}
                     </span>
                   )}
                   <span

--- a/apps/web/src/components/pam/PamOverviewTab.tsx
+++ b/apps/web/src/components/pam/PamOverviewTab.tsx
@@ -72,6 +72,9 @@ export default function PamOverviewTab({ liveTick }: { liveTick: number }) {
     );
   }
 
+  const isFirstRun =
+    !!data && data.active.length === 0 && data.pendingTotal === 0 && data.recent.length === 0;
+
   return (
     <div className="space-y-6">
       {error && (
@@ -80,6 +83,23 @@ export default function PamOverviewTab({ liveTick }: { liveTick: number }) {
           className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
         >
           {error}
+        </div>
+      )}
+
+      {isFirstRun && (
+        <div className="rounded-md border bg-muted/20 p-4" data-testid="pam-setup-steps">
+          <p className="text-sm font-medium">Getting started with Privileged Access</p>
+          <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-muted-foreground">
+            <li>
+              UAC prompt capture is on by default. Scope it per device with a{' '}
+              <a href="/configuration-policies" className="underline underline-offset-2 hover:text-foreground">
+                Configuration Policy → Privileged Access
+              </a>{' '}
+              feature link.
+            </li>
+            <li>Elevation prompts, JIT admin requests, and AI tool actions queue in the Requests tab.</li>
+            <li>Approve or deny each request — or create a rule from it so the decision is automatic next time.</li>
+          </ol>
         </div>
       )}
 

--- a/apps/web/src/components/pam/PamPage.tsx
+++ b/apps/web/src/components/pam/PamPage.tsx
@@ -122,7 +122,7 @@ export default function PamPage() {
 
       {activeTab === 'overview' && <PamOverviewTab liveTick={liveTick} />}
       {activeTab === 'requests' && <PamRequestsTab liveTick={liveTick} />}
-      {activeTab === 'rules' && <PamRulesTab />}
+      {activeTab === 'rules' && <PamRulesTab liveTick={liveTick} />}
       {activeTab === 'audit' && <PamAuditTab liveTick={liveTick} />}
     </div>
   );

--- a/apps/web/src/components/pam/PamRequestsTab.test.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.test.tsx
@@ -182,6 +182,56 @@ describe('PamRequestsTab', () => {
     expect(screen.getByTestId('pam-decided-by-req-4')).toHaveTextContent('by deadbeef…');
   });
 
+  it('attributes an auto-approved request to its PAM rule', async () => {
+    const autoApproved: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-rule',
+      status: 'auto_approved',
+      decisionSource: 'pam_rule',
+      pamRuleName: 'Allow signed installers',
+    };
+    fetchWithAuthMock.mockResolvedValueOnce(listResponse([autoApproved]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-request-row-req-rule'));
+    expect(screen.getByTestId('pam-decided-by-req-rule')).toHaveTextContent(
+      'Rule · Allow signed installers',
+    );
+  });
+
+  it('attributes a denied request to the matched software policy', async () => {
+    const denied: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-policy',
+      status: 'denied',
+      decisionSource: 'software_policy',
+      matchedPolicyName: 'Engineering Blocklist',
+      denialReason: 'Blocked by software policy',
+    };
+    fetchWithAuthMock.mockResolvedValueOnce(listResponse([denied]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-request-row-req-policy'));
+    expect(screen.getByTestId('pam-decided-by-req-policy')).toHaveTextContent(
+      'Policy · Engineering Blocklist',
+    );
+    // The raw denialReason is redundant once the policy is named, so it is hidden.
+    expect(screen.queryByText('Blocked by software policy')).toBeNull();
+  });
+
+  it('attributes a human revoke over the original auto-decision', async () => {
+    const revoked: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-revoked',
+      status: 'revoked',
+      decisionSource: 'pam_rule',
+      pamRuleName: 'Allow signed installers',
+      revokedByName: 'Jane Admin',
+    };
+    fetchWithAuthMock.mockResolvedValueOnce(listResponse([revoked]));
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-request-row-req-revoked'));
+    expect(screen.getByTestId('pam-decided-by-req-revoked')).toHaveTextContent('by Jane Admin');
+  });
+
   it('fetches page=2 on Next and updates the footer range', async () => {
     fetchWithAuthMock.mockImplementation(async (url) => {
       const requestedPage = Number(

--- a/apps/web/src/components/pam/PamRequestsTab.test.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.test.tsx
@@ -287,6 +287,54 @@ describe('PamRequestsTab', () => {
     });
   });
 
+  it('shows a Rule… action on every row and opens the rule modal pre-filled', async () => {
+    const signedPending: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-signed',
+      targetExecutableSigner: 'Acme Corp',
+      targetExecutablePath: 'C:\\Temp\\installer.exe',
+    };
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+      if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+      return listResponse([signedPending]);
+    });
+
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-request-row-req-signed'));
+    // Every row has a create-rule button regardless of status.
+    expect(screen.getByTestId('pam-create-rule-btn-req-signed')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('pam-create-rule-btn-req-signed'));
+    // The rule modal opens in create mode, seeded from the request.
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-rule-submit')).toHaveTextContent('Create rule');
+    });
+    await waitFor(() => {
+      expect((screen.getByTestId('pam-rule-signer') as HTMLInputElement).value).toBe('Acme Corp');
+    });
+  });
+
+  it('offers a create-rule link in the respond modal that swaps to the rule modal', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+      if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+      return listResponse([pendingRequest]);
+    });
+
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-respond-btn-req-1'));
+    fireEvent.click(screen.getByTestId('pam-respond-btn-req-1'));
+    await waitFor(() => screen.getByTestId('pam-respond-create-rule'));
+
+    fireEvent.click(screen.getByTestId('pam-respond-create-rule'));
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-rule-submit')).toHaveTextContent('Create rule');
+    });
+    // The respond modal is dismissed when switching to the rule modal.
+    expect(screen.queryByTestId('pam-respond-submit')).toBeNull();
+  });
+
   it('revokes an active elevation with a required reason', async () => {
     const active: ElevationRequest = { ...pendingRequest, id: 'req-2', status: 'approved' };
     fetchWithAuthMock

--- a/apps/web/src/components/pam/PamRequestsTab.test.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.test.tsx
@@ -315,6 +315,36 @@ describe('PamRequestsTab', () => {
     });
   });
 
+  it('seeds the rule modal org select from the request org for multi-org users', async () => {
+    // pendingRequest.orgId is 'org-1'; with two accessible orgs the modal must
+    // default the org select to the request's org, not items[0] (#1286 Fix A).
+    const signedPending: ElevationRequest = {
+      ...pendingRequest,
+      id: 'req-org',
+      orgId: 'org-2',
+      targetExecutableSigner: 'Acme Corp',
+    };
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/orgs/organizations'))
+        return makeJsonResponse({
+          data: [
+            { id: 'org-1', name: 'Acme' },
+            { id: 'org-2', name: 'Globex' },
+          ],
+        });
+      if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+      return listResponse([signedPending]);
+    });
+
+    render(<PamRequestsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-create-rule-btn-req-org'));
+    fireEvent.click(screen.getByTestId('pam-create-rule-btn-req-org'));
+
+    await waitFor(() => {
+      expect((screen.getByTestId('pam-rule-org') as HTMLSelectElement).value).toBe('org-2');
+    });
+  });
+
   it('offers a create-rule link in the respond modal that swaps to the rule modal', async () => {
     fetchWithAuthMock.mockImplementation(async (url: string) => {
       if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -4,6 +4,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import PamRespondModal from './PamRespondModal';
 import PamRevokeModal from './PamRevokeModal';
+import PamRuleModal from './PamRuleModal';
 import {
   ACTIVE_STATUSES,
   type ElevationFlowType,
@@ -14,6 +15,7 @@ import {
   STATUS_LABELS,
   decisionAttribution,
   requestTarget,
+  requestToRuleDraft,
   statusBadgeClass,
 } from './types';
 
@@ -39,6 +41,7 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
   const [error, setError] = useState<string | null>(null);
   const [responding, setResponding] = useState<ElevationRequest | null>(null);
   const [revoking, setRevoking] = useState<ElevationRequest | null>(null);
+  const [ruleDraft, setRuleDraft] = useState<ElevationRequest | null>(null);
 
   const fetchRequests = useCallback(
     async (signal?: AbortSignal) => {
@@ -248,6 +251,15 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
                           Revoke
                         </button>
                       )}
+                      <button
+                        type="button"
+                        onClick={() => setRuleDraft(r)}
+                        data-testid={`pam-create-rule-btn-${r.id}`}
+                        title="Create a PAM rule pre-filled from this request"
+                        className="ml-1.5 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent"
+                      >
+                        Rule…
+                      </button>
                     </td>
                   </tr>
                 );
@@ -287,6 +299,21 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
           onClose={() => setResponding(null)}
           onActioned={() => {
             setResponding(null);
+            void fetchRequests();
+          }}
+          onCreateRule={() => {
+            setRuleDraft(responding);
+            setResponding(null);
+          }}
+        />
+      )}
+      {ruleDraft && (
+        <PamRuleModal
+          rule={null}
+          initial={requestToRuleDraft(ruleDraft)}
+          onClose={() => setRuleDraft(null)}
+          onSaved={() => {
+            setRuleDraft(null);
             void fetchRequests();
           }}
         />

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -12,7 +12,7 @@ import {
   FLOW_LABELS,
   type Pagination,
   STATUS_LABELS,
-  decidedByLabel,
+  decisionAttribution,
   requestTarget,
   statusBadgeClass,
 } from './types';
@@ -163,7 +163,11 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
               {requests.map((r) => {
                 const canRespond = r.status === 'pending';
                 const canRevoke = (ACTIVE_STATUSES as readonly string[]).includes(r.status);
-                const decidedBy = decidedByLabel(r);
+                const attribution = decisionAttribution(r);
+                // Policy/rule denials already name their source — the raw
+                // "Blocked by…" string is then redundant.
+                const showDenialReason =
+                  r.decisionSource === 'human' || r.decisionSource == null;
                 return (
                   <tr key={r.id} className="border-b align-top last:border-0" data-testid={`pam-request-row-${r.id}`}>
                     <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
@@ -208,16 +212,16 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
                       >
                         {STATUS_LABELS[r.status]}
                       </span>
-                      {decidedBy && (
+                      {attribution && (
                         <div
                           className="mt-0.5 max-w-[180px] truncate text-xs text-muted-foreground"
                           data-testid={`pam-decided-by-${r.id}`}
-                          title={`by ${decidedBy}`}
+                          title={attribution}
                         >
-                          by {decidedBy}
+                          {attribution}
                         </div>
                       )}
-                      {r.denialReason && (
+                      {showDenialReason && r.denialReason && (
                         <div className="mt-0.5 max-w-[180px] truncate text-xs text-muted-foreground" title={r.denialReason}>
                           {r.denialReason}
                         </div>

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -10,6 +10,7 @@ import {
   type ElevationFlowType,
   type ElevationRequest,
   type ElevationStatus,
+  FLOW_ICONS,
   FLOW_LABELS,
   type Pagination,
   STATUS_LABELS,
@@ -145,7 +146,15 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
           <Inbox className="mx-auto h-8 w-8 text-muted-foreground" />
           <p className="mt-2 text-sm font-medium">No elevation requests</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Requests matching the current filters will appear here.
+            {status === 'pending'
+              ? 'Nothing waiting on you. New UAC prompts, JIT admin requests, and AI tool actions queue here.'
+              : 'Requests matching the current filters will appear here.'}
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Not seeing expected requests? UAC capture is controlled per device by{' '}
+            <a href="/configuration-policies" className="underline underline-offset-2 hover:text-foreground">
+              Configuration Policies → Privileged Access
+            </a>.
           </p>
         </div>
       ) : (
@@ -208,7 +217,17 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
                         </div>
                       )}
                     </td>
-                    <td className="whitespace-nowrap px-3 py-2">{FLOW_LABELS[r.flowType]}</td>
+                    <td className="whitespace-nowrap px-3 py-2">
+                      {(() => {
+                        const FlowIcon = FLOW_ICONS[r.flowType];
+                        return (
+                          <span className="inline-flex items-center gap-1.5">
+                            <FlowIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                            {FLOW_LABELS[r.flowType]}
+                          </span>
+                        );
+                      })()}
+                    </td>
                     <td className="px-3 py-2">
                       <span
                         className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(r.status)}`}

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -222,7 +222,7 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
                         const FlowIcon = FLOW_ICONS[r.flowType];
                         return (
                           <span className="inline-flex items-center gap-1.5">
-                            <FlowIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                            <FlowIcon aria-hidden="true" className="h-3.5 w-3.5 text-muted-foreground" />
                             {FLOW_LABELS[r.flowType]}
                           </span>
                         );

--- a/apps/web/src/components/pam/PamRespondModal.tsx
+++ b/apps/web/src/components/pam/PamRespondModal.tsx
@@ -158,8 +158,9 @@ export default function PamRespondModal({
             <button
               type="button"
               onClick={onCreateRule}
+              disabled={submitting}
               data-testid="pam-respond-create-rule"
-              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
             >
               Create rule from this request…
             </button>

--- a/apps/web/src/components/pam/PamRespondModal.tsx
+++ b/apps/web/src/components/pam/PamRespondModal.tsx
@@ -9,10 +9,12 @@ export default function PamRespondModal({
   request,
   onClose,
   onActioned,
+  onCreateRule,
 }: {
   request: ElevationRequest;
   onClose: () => void;
   onActioned: () => void;
+  onCreateRule?: () => void;
 }) {
   const [decision, setDecision] = useState<'approve' | 'deny'>('approve');
   const [reason, setReason] = useState('');
@@ -151,24 +153,38 @@ export default function PamRespondModal({
           </div>
         )}
 
-        <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            disabled={submitting}
-            data-testid="pam-respond-submit"
-            className={`rounded-md px-3 py-2 text-sm font-medium text-white disabled:opacity-50 ${
-              decision === 'approve' ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'
-            }`}
-          >
-            {submitting ? 'Submitting…' : decision === 'approve' ? 'Approve elevation' : 'Deny request'}
-          </button>
+        <div className="flex items-center justify-between gap-2">
+          {onCreateRule ? (
+            <button
+              type="button"
+              onClick={onCreateRule}
+              data-testid="pam-respond-create-rule"
+              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Create rule from this request…
+            </button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="pam-respond-submit"
+              className={`rounded-md px-3 py-2 text-sm font-medium text-white disabled:opacity-50 ${
+                decision === 'approve' ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'
+              }`}
+            >
+              {submitting ? 'Submitting…' : decision === 'approve' ? 'Approve elevation' : 'Deny request'}
+            </button>
+          </div>
         </div>
       </form>
     </Dialog>

--- a/apps/web/src/components/pam/PamRuleModal.test.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.test.tsx
@@ -85,6 +85,28 @@ describe('PamRuleModal', () => {
     expect((screen.getByTestId('pam-rule-risktier') as HTMLInputElement).value).toBe('3');
   });
 
+  it('seeds selectedOrgId from the draft org for multi-org create (seed wins over default)', async () => {
+    // Two orgs → the org select renders; the orgs-load effect would otherwise
+    // default to items[0] (org-1), but the seed's org-2 must win (#1286 Fix A).
+    installFetchRoutes({
+      orgs: [
+        { id: 'org-1', name: 'Acme' },
+        { id: 'org-2', name: 'Globex' },
+      ],
+    });
+    const initial: PamRuleDraft = {
+      shape: 'executable',
+      matchSigner: 'Acme Corp',
+      orgId: 'org-2',
+      siteId: '',
+    };
+    render(<PamRuleModal rule={null} initial={initial} onClose={() => {}} onSaved={() => {}} />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('pam-rule-org') as HTMLSelectElement).value).toBe('org-2');
+    });
+  });
+
   describe('rule preview', () => {
     const previewResult = {
       success: true,
@@ -183,6 +205,39 @@ describe('PamRuleModal', () => {
       });
       expect(previewCalls).toBe(0);
       expect(screen.queryByTestId('pam-rule-preview-result')).not.toBeInTheDocument();
+    });
+
+    it('surfaces the server zod error message on a 400 preview response', async () => {
+      const user = userEvent.setup();
+      fetchWithAuthMock.mockImplementation(async (url: string) => {
+        if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+        if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+        if (url.startsWith('/pam/rules/preview')) {
+          // @hono/zod-validator 400 shape: { success:false, error: ZodError }.
+          return makeJsonResponse(
+            { success: false, error: { issues: [{ message: 'matchHash must be a 64-char sha256 hex string' }] } },
+            false,
+            400,
+          );
+        }
+        return makeJsonResponse({ success: true });
+      });
+
+      render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pam-rule-hash')).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByTestId('pam-rule-signer'), 'Acme Corp');
+      await user.click(screen.getByTestId('pam-rule-preview-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert').textContent).toContain(
+          'matchHash must be a 64-char sha256 hex string',
+        );
+      });
+      expect(screen.getByRole('alert').textContent).not.toContain('HTTP 400');
     });
   });
 });

--- a/apps/web/src/components/pam/PamRuleModal.test.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PamRuleModal from './PamRuleModal';
+import { fetchWithAuth } from '../../stores/auth';
+import type { PamRuleDraft } from './types';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+/** The modal fetches /orgs/organizations and /orgs/sites on mount. */
+function installFetchRoutes({
+  sites = [] as Array<{ id: string; name: string }>,
+  orgs = [{ id: 'org-1', name: 'Acme' }],
+}: {
+  sites?: Array<{ id: string; name: string }>;
+  orgs?: Array<{ id: string; name: string }>;
+} = {}) {
+  fetchWithAuthMock.mockImplementation(async (url: string) => {
+    if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: orgs });
+    if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: sites });
+    return makeJsonResponse({ success: true });
+  });
+}
+
+describe('PamRuleModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills create-mode inputs from the initial draft', async () => {
+    installFetchRoutes();
+    const initial: PamRuleDraft = {
+      shape: 'executable',
+      matchSigner: 'Acme Corp',
+      name: 'Rule for installer.exe',
+      siteId: '',
+    };
+    render(<PamRuleModal rule={null} initial={initial} onClose={() => {}} onSaved={() => {}} />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('pam-rule-name') as HTMLInputElement).value).toBe(
+        'Rule for installer.exe',
+      );
+    });
+    expect((screen.getByTestId('pam-rule-signer') as HTMLInputElement).value).toBe('Acme Corp');
+    // Executable shape selected by the seed.
+    expect(screen.getByTestId('pam-rule-shape-executable')).toHaveClass('border-primary');
+  });
+
+  it('seeds tool-shape fields from a draft', async () => {
+    installFetchRoutes();
+    const initial: PamRuleDraft = {
+      shape: 'tool',
+      name: 'Rule for run_script',
+      matchToolName: 'run_script',
+      matchRiskTier: 3,
+      siteId: null,
+    };
+    render(<PamRuleModal rule={null} initial={initial} onClose={() => {}} onSaved={() => {}} />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('pam-rule-toolname') as HTMLInputElement).value).toBe('run_script');
+    });
+    expect((screen.getByTestId('pam-rule-risktier') as HTMLInputElement).value).toBe('3');
+  });
+});

--- a/apps/web/src/components/pam/PamRuleModal.test.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PamRuleModal from './PamRuleModal';
 import { fetchWithAuth } from '../../stores/auth';
@@ -82,5 +83,106 @@ describe('PamRuleModal', () => {
       expect((screen.getByTestId('pam-rule-toolname') as HTMLInputElement).value).toBe('run_script');
     });
     expect((screen.getByTestId('pam-rule-risktier') as HTMLInputElement).value).toBe('3');
+  });
+
+  describe('rule preview', () => {
+    const previewResult = {
+      success: true,
+      totalMatched: 14,
+      totalScanned: 240,
+      windowDays: 30,
+      truncated: false,
+      statusBreakdown: {
+        pending: 9,
+        auto_approved: 5,
+        approved: 0,
+        denied: 0,
+        expired: 0,
+        revoked: 0,
+        actuating: 0,
+      },
+      sample: [
+        {
+          id: 'er-1',
+          requestedAt: '2026-06-10T18:00:00Z',
+          flowType: 'uac_intercept',
+          subjectUsername: 'ACME\\jdoe',
+          targetExecutablePath: 'C:\\Tools\\installer.exe',
+          toolName: null,
+          status: 'pending',
+        },
+        {
+          id: 'er-2',
+          requestedAt: '2026-06-09T12:00:00Z',
+          flowType: 'uac_intercept',
+          subjectUsername: 'ACME\\asmith',
+          targetExecutablePath: 'C:\\Tools\\setup.exe',
+          toolName: null,
+          status: 'auto_approved',
+        },
+      ],
+    };
+
+    it('previews matches against recent requests', async () => {
+      const user = userEvent.setup();
+      let previewCalls = 0;
+      fetchWithAuthMock.mockImplementation(async (url: string) => {
+        if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+        if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+        if (url.startsWith('/pam/rules/preview')) {
+          previewCalls += 1;
+          return makeJsonResponse(previewResult);
+        }
+        return makeJsonResponse({ success: true });
+      });
+
+      render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pam-rule-signer')).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByTestId('pam-rule-signer'), 'Acme Corp');
+      await user.click(screen.getByTestId('pam-rule-preview-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pam-rule-preview-result')).toBeInTheDocument();
+      });
+      expect(previewCalls).toBe(1);
+      const result = screen.getByTestId('pam-rule-preview-result');
+      expect(result.textContent).toContain('Would have matched');
+      expect(result.textContent).toContain('14');
+      expect(result.textContent).toContain('240');
+      expect(result.textContent).toContain('30 days');
+      expect(result.textContent).toContain('9 pending');
+    });
+
+    it('shows the criterion error and does not call preview when no criteria entered', async () => {
+      const user = userEvent.setup();
+      let previewCalls = 0;
+      fetchWithAuthMock.mockImplementation(async (url: string) => {
+        if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+        if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+        if (url.startsWith('/pam/rules/preview')) {
+          previewCalls += 1;
+          return makeJsonResponse(previewResult);
+        }
+        return makeJsonResponse({ success: true });
+      });
+
+      render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pam-rule-preview-btn')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('pam-rule-preview-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert').textContent).toContain('At least one match criterion is required.');
+      });
+      expect(previewCalls).toBe(0);
+      expect(screen.queryByTestId('pam-rule-preview-result')).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -311,6 +311,7 @@ export default function PamRuleModal({
     setPreviewing(true);
     setPreview(null);
     try {
+      // runaction-exempt: read-only dry-run (POST carries the draft criteria); failures render inline in the modal, no toast
       const res = await fetchWithAuth('/pam/rules/preview', {
         method: 'POST',
         body: JSON.stringify({

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -14,6 +14,26 @@ import {
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
+/**
+ * Pull a human-readable message out of an API error body. The preview route
+ * returns either a plain `{ error: string }` (e.g. 'Site access denied') or the
+ * @hono/zod-validator 400 shape `{ success:false, error: { issues: [{ message }] } }`
+ * (a serialized ZodError — the superRefine criterion/shape messages, the
+ * sha256 hash validator). Without this, those messages collapse to a bare HTTP
+ * status. Returns '' when no message can be extracted.
+ */
+function extractApiError(body: unknown): string {
+  if (!body || typeof body !== 'object') return '';
+  const b = body as { message?: unknown; error?: unknown; issues?: unknown };
+  if (typeof b.message === 'string' && b.message) return b.message;
+  if (typeof b.error === 'string' && b.error) return b.error;
+  const issues =
+    (b.error as { issues?: Array<{ message?: unknown }> } | undefined)?.issues ??
+    (b.issues as Array<{ message?: unknown }> | undefined);
+  const zodMsg = issues?.[0]?.message;
+  return typeof zodMsg === 'string' && zodMsg ? zodMsg : '';
+}
+
 interface NamedOption {
   id: string;
   name: string;
@@ -64,6 +84,10 @@ export default function PamRuleModal({
   // when there's no rule being edited; verdict/priority/timeWindow are left at
   // their defaults intentionally.
   const seed = rule === null ? initial : undefined;
+  // Narrowed accessors for the discriminated-union seed: executable-only and
+  // tool-only fields are read via `in` guards so each branch typechecks.
+  const seedExec = seed?.shape === 'executable' ? seed : undefined;
+  const seedTool = seed?.shape === 'tool' ? seed : undefined;
   const [name, setName] = useState(rule?.name ?? seed?.name ?? '');
   const [description, setDescription] = useState(rule?.description ?? '');
   const [priority, setPriority] = useState(String(rule?.priority ?? 100));
@@ -76,18 +100,18 @@ export default function PamRuleModal({
         : 'executable'
       : seed?.shape ?? 'executable',
   );
-  const [matchSigner, setMatchSigner] = useState(rule?.matchSigner ?? seed?.matchSigner ?? '');
-  const [matchHash, setMatchHash] = useState(rule?.matchHash ?? seed?.matchHash ?? '');
-  const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? seed?.matchPathGlob ?? '');
+  const [matchSigner, setMatchSigner] = useState(rule?.matchSigner ?? seedExec?.matchSigner ?? '');
+  const [matchHash, setMatchHash] = useState(rule?.matchHash ?? seedExec?.matchHash ?? '');
+  const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? seedExec?.matchPathGlob ?? '');
   const [matchParentImage, setMatchParentImage] = useState(rule?.matchParentImage ?? '');
-  const [matchUser, setMatchUser] = useState(rule?.matchUser ?? seed?.matchUser ?? '');
+  const [matchUser, setMatchUser] = useState(rule?.matchUser ?? seedExec?.matchUser ?? '');
   const [matchAdGroup, setMatchAdGroup] = useState(rule?.matchAdGroup ?? '');
-  const [matchToolName, setMatchToolName] = useState(rule?.matchToolName ?? seed?.matchToolName ?? '');
+  const [matchToolName, setMatchToolName] = useState(rule?.matchToolName ?? seedTool?.matchToolName ?? '');
   const [matchRiskTier, setMatchRiskTier] = useState(
     rule?.matchRiskTier !== null && rule?.matchRiskTier !== undefined
       ? String(rule.matchRiskTier)
-      : seed?.matchRiskTier !== null && seed?.matchRiskTier !== undefined
-        ? String(seed.matchRiskTier)
+      : seedTool?.matchRiskTier !== null && seedTool?.matchRiskTier !== undefined
+        ? String(seedTool.matchRiskTier)
         : '',
   );
   const [windowStart, setWindowStart] = useState(rule?.timeWindow?.start ?? '');
@@ -102,9 +126,15 @@ export default function PamRuleModal({
   // ("orgId is required for this scope" — resolveOrgIdForWrite).
   const [orgs, setOrgs] = useState<NamedOption[]>([]);
   const [orgsLoaded, setOrgsLoaded] = useState(false);
-  const [selectedOrgId, setSelectedOrgId] = useState('');
+  // Seed the org from the originating request so a rule-from-request keeps the
+  // request's org. This initial value wins over the orgs-load default because
+  // that effect only fills an empty selection (`prev || items[0]`).
+  const [selectedOrgId, setSelectedOrgId] = useState(seed?.orgId ?? '');
   const [sites, setSites] = useState<NamedOption[]>([]);
   const [siteId, setSiteId] = useState(rule?.siteId ?? seed?.siteId ?? '');
+  // Surfaced when a seeded site can't survive the selected org (cross-org
+  // request → org-wide fallback), so the scope change isn't silent.
+  const [siteScopeNotice, setSiteScopeNotice] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<PreviewResult | null>(null);
@@ -148,7 +178,19 @@ export default function PamRuleModal({
           const data = await res.json();
           const items = (data.data ?? data.sites ?? data ?? []) as NamedOption[];
           setSites(items.map((s) => ({ id: s.id, name: s.name })));
-          setSiteId((prev) => (prev && !items.some((s) => s.id === prev) ? '' : prev));
+          setSiteId((prev) => {
+            if (prev && !items.some((s) => s.id === prev)) {
+              // The seeded site doesn't belong to the selected org — fall back to
+              // org-wide and tell the user rather than silently re-scoping.
+              if (!isEdit && prev === (seed?.siteId ?? '')) {
+                setSiteScopeNotice(
+                  "The site from the original request isn't available in the selected organization — scope reset to org-wide.",
+                );
+              }
+              return '';
+            }
+            return prev;
+          });
         }
       })
       .catch(() => {});
@@ -277,7 +319,15 @@ export default function PamRuleModal({
           siteId: siteId || null,
         }),
       });
-      if (!res.ok) throw new Error(`Preview failed (HTTP ${res.status})`);
+      if (!res.ok) {
+        let msg = `Preview failed (HTTP ${res.status})`;
+        try {
+          msg = extractApiError(await res.json()) || msg;
+        } catch {
+          /* non-JSON body — keep status fallback */
+        }
+        throw new Error(msg);
+      }
       setPreview((await res.json()) as PreviewResult);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Preview failed');
@@ -419,6 +469,7 @@ export default function PamRuleModal({
                   onChange={(e) => {
                     setSelectedOrgId(e.target.value);
                     setSiteId('');
+                    setSiteScopeNotice(null);
                   }}
                   data-testid="pam-rule-org"
                   className={inputClass}
@@ -439,7 +490,10 @@ export default function PamRuleModal({
             <select
               id={siteSelectId}
               value={siteId}
-              onChange={(e) => setSiteId(e.target.value)}
+              onChange={(e) => {
+                setSiteId(e.target.value);
+                setSiteScopeNotice(null);
+              }}
               data-testid="pam-rule-site"
               className={inputClass}
             >
@@ -450,6 +504,11 @@ export default function PamRuleModal({
                 </option>
               ))}
             </select>
+            {siteScopeNotice && (
+              <p className="mt-1 text-xs text-muted-foreground" data-testid="pam-rule-site-scope-notice">
+                {siteScopeNotice}
+              </p>
+            )}
           </div>
         </div>
 
@@ -621,7 +680,7 @@ export default function PamRuleModal({
                 <p className="text-xs text-muted-foreground">
                   {Object.entries(preview.statusBreakdown)
                     .filter(([, n]) => n > 0)
-                    .map(([s, n]) => `${n} ${STATUS_LABELS[s as ElevationStatus].toLowerCase()}`)
+                    .map(([s, n]) => `${n} ${(STATUS_LABELS[s as ElevationStatus] ?? s).toLowerCase()}`)
                     .join(' · ')}
                 </p>
               )}
@@ -635,7 +694,8 @@ export default function PamRuleModal({
               </ul>
               {matchAdGroup.trim() && (
                 <p className="text-xs text-muted-foreground">
-                  Note: historical requests don't record AD groups, so group criteria preview as 0.
+                  Note: historical requests don't record AD groups, so any draft that includes an AD
+                  group criterion previews as 0 matches.
                 </p>
               )}
             </div>

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -120,6 +120,7 @@ export default function PamRuleModal({
           const data = await res.json();
           const items = (data.data ?? data.sites ?? data ?? []) as NamedOption[];
           setSites(items.map((s) => ({ id: s.id, name: s.name })));
+          setSiteId((prev) => (prev && !items.some((s) => s.id === prev) ? '' : prev));
         }
       })
       .catch(() => {});

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -3,7 +3,7 @@ import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
-import { type PamRule, type PamVerdict, VERDICT_LABELS } from './types';
+import { type PamRule, type PamRuleDraft, type PamVerdict, VERDICT_LABELS } from './types';
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
@@ -24,31 +24,45 @@ interface NamedOption {
  */
 export default function PamRuleModal({
   rule,
+  initial,
   onClose,
   onSaved,
 }: {
   rule: PamRule | null;
+  initial?: PamRuleDraft;
   onClose: () => void;
   onSaved: () => void;
 }) {
   const isEdit = rule !== null;
-  const [name, setName] = useState(rule?.name ?? '');
+  // Seed create-mode initializers from a request-derived draft. Only applies
+  // when there's no rule being edited; verdict/priority/timeWindow are left at
+  // their defaults intentionally.
+  const seed = rule === null ? initial : undefined;
+  const [name, setName] = useState(rule?.name ?? seed?.name ?? '');
   const [description, setDescription] = useState(rule?.description ?? '');
   const [priority, setPriority] = useState(String(rule?.priority ?? 100));
   const [verdict, setVerdict] = useState<PamVerdict>(rule?.verdict ?? 'require_approval');
   const [enabled, setEnabled] = useState(rule?.enabled ?? true);
   const [shape, setShape] = useState<'executable' | 'tool'>(
-    rule && (rule.matchToolName || typeof rule.matchRiskTier === 'number') ? 'tool' : 'executable',
+    rule
+      ? rule.matchToolName || typeof rule.matchRiskTier === 'number'
+        ? 'tool'
+        : 'executable'
+      : seed?.shape ?? 'executable',
   );
-  const [matchSigner, setMatchSigner] = useState(rule?.matchSigner ?? '');
-  const [matchHash, setMatchHash] = useState(rule?.matchHash ?? '');
-  const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? '');
+  const [matchSigner, setMatchSigner] = useState(rule?.matchSigner ?? seed?.matchSigner ?? '');
+  const [matchHash, setMatchHash] = useState(rule?.matchHash ?? seed?.matchHash ?? '');
+  const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? seed?.matchPathGlob ?? '');
   const [matchParentImage, setMatchParentImage] = useState(rule?.matchParentImage ?? '');
-  const [matchUser, setMatchUser] = useState(rule?.matchUser ?? '');
+  const [matchUser, setMatchUser] = useState(rule?.matchUser ?? seed?.matchUser ?? '');
   const [matchAdGroup, setMatchAdGroup] = useState(rule?.matchAdGroup ?? '');
-  const [matchToolName, setMatchToolName] = useState(rule?.matchToolName ?? '');
+  const [matchToolName, setMatchToolName] = useState(rule?.matchToolName ?? seed?.matchToolName ?? '');
   const [matchRiskTier, setMatchRiskTier] = useState(
-    rule?.matchRiskTier !== null && rule?.matchRiskTier !== undefined ? String(rule.matchRiskTier) : '',
+    rule?.matchRiskTier !== null && rule?.matchRiskTier !== undefined
+      ? String(rule.matchRiskTier)
+      : seed?.matchRiskTier !== null && seed?.matchRiskTier !== undefined
+        ? String(seed.matchRiskTier)
+        : '',
   );
   const [windowStart, setWindowStart] = useState(rule?.timeWindow?.start ?? '');
   const [windowEnd, setWindowEnd] = useState(rule?.timeWindow?.end ?? '');
@@ -64,7 +78,7 @@ export default function PamRuleModal({
   const [orgsLoaded, setOrgsLoaded] = useState(false);
   const [selectedOrgId, setSelectedOrgId] = useState('');
   const [sites, setSites] = useState<NamedOption[]>([]);
-  const [siteId, setSiteId] = useState(rule?.siteId ?? '');
+  const [siteId, setSiteId] = useState(rule?.siteId ?? seed?.siteId ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -3,13 +3,39 @@ import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
-import { type PamRule, type PamRuleDraft, type PamVerdict, VERDICT_LABELS } from './types';
+import {
+  type ElevationStatus,
+  type PamRule,
+  type PamRuleDraft,
+  type PamVerdict,
+  STATUS_LABELS,
+  VERDICT_LABELS,
+} from './types';
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
 interface NamedOption {
   id: string;
   name: string;
+}
+
+interface PreviewSampleRow {
+  id: string;
+  requestedAt: string;
+  subjectUsername: string;
+  targetExecutablePath?: string | null;
+  toolName?: string | null;
+  status: string;
+}
+
+interface PreviewResult {
+  success: boolean;
+  totalMatched: number;
+  totalScanned: number;
+  windowDays: number;
+  truncated: boolean;
+  statusBreakdown: Record<string, number>;
+  sample: PreviewSampleRow[];
 }
 
 /**
@@ -81,6 +107,8 @@ export default function PamRuleModal({
   const [siteId, setSiteId] = useState(rule?.siteId ?? seed?.siteId ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewResult | null>(null);
+  const [previewing, setPreviewing] = useState(false);
 
   const nameId = useId();
   const descId = useId();
@@ -137,17 +165,44 @@ export default function PamRuleModal({
     }
   }, [windowStart, windowEnd]);
 
+  // A draft change invalidates a stale preview result so the user never reads
+  // a "would match N" line that no longer reflects the on-screen criteria.
+  useEffect(() => {
+    setPreview(null);
+  }, [
+    shape,
+    matchSigner,
+    matchHash,
+    matchPathGlob,
+    matchParentImage,
+    matchUser,
+    matchAdGroup,
+    matchToolName,
+    matchRiskTier,
+    windowStart,
+    windowEnd,
+    windowDays,
+    windowTimezone,
+    siteId,
+  ]);
+
   const toggleDay = (day: number) => {
     setWindowDays((prev) =>
       prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day].sort((a, b) => a - b),
     );
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (submitting) return;
-    setError(null);
-
+  /**
+   * Assemble the active match criteria + time window from the form, applying
+   * the shared shape validation (≥1 criterion, window start/end pairing). On a
+   * validation failure it sets the inline `error` and returns null. Shared by
+   * submit and preview; the tool/verdict 'ignore' check stays submit-only since
+   * preview is verdict-independent.
+   */
+  const buildCriteria = (): {
+    activeCriteria: Record<string, unknown>;
+    timeWindow: Record<string, unknown> | null;
+  } | null => {
     const executable = {
       matchSigner: matchSigner.trim() || null,
       matchHash: matchHash.trim() || null,
@@ -180,15 +235,11 @@ export default function PamRuleModal({
     );
     if (!hasCriterion) {
       setError('At least one match criterion is required.');
-      return;
-    }
-    if (shape === 'tool' && verdict === 'ignore') {
-      setError('Tool-action rules cannot use the Ignore verdict.');
-      return;
+      return null;
     }
     if (Boolean(windowStart) !== Boolean(windowEnd)) {
       setError('Time window start and end must both be set (or both left empty).');
-      return;
+      return null;
     }
 
     // Omit days when none or all are selected — the rule engine treats a
@@ -196,6 +247,58 @@ export default function PamRuleModal({
     const days =
       windowDays.length > 0 && windowDays.length < 7 ? [...windowDays].sort((a, b) => a - b) : undefined;
     const timezone = windowTimezone.trim() || undefined;
+
+    const timeWindow =
+      windowStart && windowEnd
+        ? {
+            start: windowStart,
+            end: windowEnd,
+            ...(days ? { days } : {}),
+            ...(timezone ? { timezone } : {}),
+          }
+        : null;
+
+    return { activeCriteria, timeWindow };
+  };
+
+  const handlePreview = async () => {
+    if (previewing) return;
+    setError(null);
+    const built = buildCriteria();
+    if (!built) return;
+    setPreviewing(true);
+    setPreview(null);
+    try {
+      const res = await fetchWithAuth('/pam/rules/preview', {
+        method: 'POST',
+        body: JSON.stringify({
+          ...built.activeCriteria,
+          timeWindow: built.timeWindow,
+          siteId: siteId || null,
+        }),
+      });
+      if (!res.ok) throw new Error(`Preview failed (HTTP ${res.status})`);
+      setPreview((await res.json()) as PreviewResult);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Preview failed');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    setError(null);
+
+    const built = buildCriteria();
+    if (!built) return;
+    const { activeCriteria, timeWindow } = built;
+
+    if (shape === 'tool' && verdict === 'ignore') {
+      setError('Tool-action rules cannot use the Ignore verdict.');
+      return;
+    }
 
     const payload: Record<string, unknown> = {
       name: name.trim(),
@@ -208,15 +311,7 @@ export default function PamRuleModal({
       // Create only: the server resolves the org when omitted; multi-org
       // partner users must send an explicit choice. PATCH never carries orgId.
       ...(!isEdit && orgs.length > 1 && selectedOrgId ? { orgId: selectedOrgId } : {}),
-      timeWindow:
-        windowStart && windowEnd
-          ? {
-              start: windowStart,
-              end: windowEnd,
-              ...(days ? { days } : {}),
-              ...(timezone ? { timezone } : {}),
-            }
-          : null,
+      timeWindow,
       approvalDurationMinutes: approvalDuration
         ? Number.parseInt(approvalDuration, 10) || null
         : null,
@@ -501,6 +596,51 @@ export default function PamRuleModal({
             {error}
           </div>
         )}
+
+        <div className="rounded-md border bg-muted/20 p-3">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium">Preview against recent requests</p>
+            <button
+              type="button"
+              onClick={() => void handlePreview()}
+              disabled={previewing}
+              data-testid="pam-rule-preview-btn"
+              className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent disabled:opacity-50"
+            >
+              {previewing ? 'Previewing…' : 'Preview matches'}
+            </button>
+          </div>
+          {preview && (
+            <div className="mt-2 space-y-2 text-sm" data-testid="pam-rule-preview-result">
+              <p>
+                Would have matched <span className="font-semibold">{preview.totalMatched}</span> of{' '}
+                {preview.totalScanned} requests in the last {preview.windowDays} days
+                {preview.truncated ? ' (newest 5000 scanned)' : ''}.
+              </p>
+              {preview.totalMatched > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {Object.entries(preview.statusBreakdown)
+                    .filter(([, n]) => n > 0)
+                    .map(([s, n]) => `${n} ${STATUS_LABELS[s as ElevationStatus].toLowerCase()}`)
+                    .join(' · ')}
+                </p>
+              )}
+              <ul className="space-y-1">
+                {preview.sample.slice(0, 5).map((s) => (
+                  <li key={s.id} className="truncate text-xs text-muted-foreground">
+                    {new Date(s.requestedAt).toLocaleString()} · {s.subjectUsername} ·{' '}
+                    {s.targetExecutablePath ?? s.toolName ?? '—'}
+                  </li>
+                ))}
+              </ul>
+              {matchAdGroup.trim() && (
+                <p className="text-xs text-muted-foreground">
+                  Note: historical requests don't record AD groups, so group criteria preview as 0.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
 
         <div className="flex justify-end gap-2">
           <button type="button" onClick={onClose} className="rounded-md border px-3 py-2 text-sm hover:bg-accent">

--- a/apps/web/src/components/pam/PamRulesTab.test.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+// rerender is used by the liveTick refetch test below.
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PamRulesTab from './PamRulesTab';
 import { fetchWithAuth } from '../../stores/auth';
@@ -92,6 +93,30 @@ describe('PamRulesTab', () => {
     render(<PamRulesTab />);
     await waitFor(() => {
       expect(screen.getByText('No PAM rules yet')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the evaluation-order copy: software policies are evaluated first', async () => {
+    installFetchRoutes({ rules: [] });
+    render(<PamRulesTab />);
+    await waitFor(() => screen.getByTestId('pam-add-rule-btn'));
+    expect(
+      screen.getByText(/Software policies are evaluated first/i),
+    ).toBeInTheDocument();
+  });
+
+  it('re-fetches rules when the liveTick prop changes', async () => {
+    installFetchRoutes({ rules: [signedRule] });
+    const { rerender } = render(<PamRulesTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-rule-row-rule-1'));
+    const rulesCallsBefore = fetchWithAuthMock.mock.calls.filter(
+      (c) => c[0] === '/pam/rules',
+    ).length;
+
+    rerender(<PamRulesTab liveTick={1} />);
+    await waitFor(() => {
+      const after = fetchWithAuthMock.mock.calls.filter((c) => c[0] === '/pam/rules').length;
+      expect(after).toBe(rulesCallsBefore + 1);
     });
   });
 

--- a/apps/web/src/components/pam/PamRulesTab.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.tsx
@@ -23,7 +23,7 @@ function ruleCriteriaSummary(rule: PamRule): string {
   return parts.join(' · ');
 }
 
-export default function PamRulesTab() {
+export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number }) {
   const [rules, setRules] = useState<PamRule[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -74,7 +74,7 @@ export default function PamRulesTab() {
     const controller = new AbortController();
     void fetchRules(controller.signal);
     return () => controller.abort();
-  }, [fetchRules]);
+  }, [fetchRules, liveTick]);
 
   const toggleEnabled = async (rule: PamRule) => {
     try {
@@ -124,7 +124,8 @@ export default function PamRulesTab() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          Rules are evaluated in priority order (lowest first); the first match decides.
+          Software policies are evaluated first — an allowlist/blocklist match decides before these rules.
+          Rules then run in priority order (lowest first); the first match decides.
         </p>
         <button
           type="button"

--- a/apps/web/src/components/pam/types.test.ts
+++ b/apps/web/src/components/pam/types.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { requestToRuleDraft, type ElevationRequest } from './types';
+
+/**
+ * Base request used by the precedence table. Individual rows override only the
+ * fields that drive the criterion choice; orgId/siteId stay fixed so we can
+ * assert they're carried into every draft branch (#1286 review — Fix A/H).
+ */
+const base: ElevationRequest = {
+  id: 'req-1',
+  orgId: 'org-7',
+  siteId: 'site-3',
+  deviceId: 'dev-1',
+  flowType: 'uac_intercept',
+  subjectUsername: 'DOMAIN\\alice',
+  reason: 'install',
+  status: 'pending',
+  requestedAt: '2026-06-01T00:00:00Z',
+};
+
+describe('requestToRuleDraft precedence', () => {
+  it('uac with signer+hash+path → signer only', () => {
+    const d = requestToRuleDraft({
+      ...base,
+      targetExecutableSigner: 'Acme Corp',
+      targetExecutableHash: 'a'.repeat(64),
+      targetExecutablePath: 'C:\\Temp\\x.exe',
+    });
+    expect(d.shape).toBe('executable');
+    if (d.shape !== 'executable') throw new Error('unreachable');
+    expect(d.matchSigner).toBe('Acme Corp');
+    expect(d.matchHash).toBeUndefined();
+    expect(d.matchPathGlob).toBeUndefined();
+    expect(d.orgId).toBe('org-7');
+    expect(d.siteId).toBe('site-3');
+  });
+
+  it('uac with hash+path (no signer) → hash', () => {
+    const d = requestToRuleDraft({
+      ...base,
+      targetExecutableHash: 'b'.repeat(64),
+      targetExecutablePath: 'C:\\Temp\\x.exe',
+    });
+    if (d.shape !== 'executable') throw new Error('unreachable');
+    expect(d.matchHash).toBe('b'.repeat(64));
+    expect(d.matchSigner).toBeUndefined();
+    expect(d.matchPathGlob).toBeUndefined();
+    expect(d.orgId).toBe('org-7');
+    expect(d.siteId).toBe('site-3');
+  });
+
+  it('uac with path only → pathGlob', () => {
+    const d = requestToRuleDraft({ ...base, targetExecutablePath: 'C:\\Temp\\x.exe' });
+    if (d.shape !== 'executable') throw new Error('unreachable');
+    expect(d.matchPathGlob).toBe('C:\\Temp\\x.exe');
+    expect(d.orgId).toBe('org-7');
+    expect(d.siteId).toBe('site-3');
+  });
+
+  it('uac with nothing → pathGlob null', () => {
+    const d = requestToRuleDraft({ ...base });
+    if (d.shape !== 'executable') throw new Error('unreachable');
+    expect(d.matchPathGlob).toBeNull();
+    expect(d.orgId).toBe('org-7');
+    expect(d.siteId).toBe('site-3');
+  });
+
+  it('tech_jit_admin → matchUser', () => {
+    const d = requestToRuleDraft({ ...base, flowType: 'tech_jit_admin' });
+    if (d.shape !== 'executable') throw new Error('unreachable');
+    expect(d.matchUser).toBe('DOMAIN\\alice');
+    expect(d.orgId).toBe('org-7');
+    expect(d.siteId).toBe('site-3');
+  });
+
+  it('ai_tool_action → toolName + riskTier + shape tool', () => {
+    const d = requestToRuleDraft({
+      ...base,
+      flowType: 'ai_tool_action',
+      toolName: 'run_script',
+      riskTier: 3,
+    });
+    expect(d.shape).toBe('tool');
+    if (d.shape !== 'tool') throw new Error('unreachable');
+    expect(d.matchToolName).toBe('run_script');
+    expect(d.matchRiskTier).toBe(3);
+    expect(d.orgId).toBe('org-7');
+    expect(d.siteId).toBe('site-3');
+  });
+});

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -54,6 +54,10 @@ export interface ElevationRequest {
   matchedPolicyName?: string | null;
   pamRuleId?: string | null;
   pamRuleName?: string | null;
+  // 'human' and null are display-equivalent today (both fall through to
+  // decidedByLabel); the variant exists to mirror the API's derivation — do not
+  // assume 'human' implies decidedByLabel() is non-null (older rows may lack
+  // joined names).
   decisionSource?: 'software_policy' | 'pam_rule' | 'human' | null;
 }
 
@@ -93,17 +97,25 @@ export interface Pagination {
   total: number;
 }
 
-export interface PamRuleDraft {
-  shape: 'executable' | 'tool';
-  name?: string;
-  siteId?: string | null;
-  matchSigner?: string | null;
-  matchHash?: string | null;
-  matchPathGlob?: string | null;
-  matchUser?: string | null;
-  matchToolName?: string | null;
-  matchRiskTier?: number | null;
-}
+export type PamRuleDraft =
+  | {
+      shape: 'executable';
+      name?: string;
+      orgId?: string;
+      siteId?: string | null;
+      matchSigner?: string | null;
+      matchHash?: string | null;
+      matchPathGlob?: string | null;
+      matchUser?: string | null;
+    }
+  | {
+      shape: 'tool';
+      name?: string;
+      orgId?: string;
+      siteId?: string | null;
+      matchToolName?: string | null;
+      matchRiskTier?: number | null;
+    };
 
 function baseName(path: string): string {
   const i = Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/'));
@@ -120,22 +132,23 @@ export function requestToRuleDraft(r: ElevationRequest): PamRuleDraft {
     return {
       shape: 'tool',
       name: r.toolName ? `Rule for ${r.toolName}` : undefined,
+      orgId: r.orgId,
       siteId: r.siteId ?? null,
       matchToolName: r.toolName ?? null,
       matchRiskTier: r.riskTier ?? null,
     };
   }
   if (r.flowType === 'tech_jit_admin') {
-    return { shape: 'executable', siteId: r.siteId ?? null, matchUser: r.subjectUsername };
+    return { shape: 'executable', orgId: r.orgId, siteId: r.siteId ?? null, matchUser: r.subjectUsername };
   }
   const name = r.targetExecutablePath ? `Rule for ${baseName(r.targetExecutablePath)}` : undefined;
   if (r.targetExecutableSigner) {
-    return { shape: 'executable', name, siteId: r.siteId ?? null, matchSigner: r.targetExecutableSigner };
+    return { shape: 'executable', name, orgId: r.orgId, siteId: r.siteId ?? null, matchSigner: r.targetExecutableSigner };
   }
   if (r.targetExecutableHash) {
-    return { shape: 'executable', name, siteId: r.siteId ?? null, matchHash: r.targetExecutableHash };
+    return { shape: 'executable', name, orgId: r.orgId, siteId: r.siteId ?? null, matchHash: r.targetExecutableHash };
   }
-  return { shape: 'executable', name, siteId: r.siteId ?? null, matchPathGlob: r.targetExecutablePath ?? null };
+  return { shape: 'executable', name, orgId: r.orgId, siteId: r.siteId ?? null, matchPathGlob: r.targetExecutablePath ?? null };
 }
 
 export const STATUS_LABELS: Record<ElevationStatus, string> = {

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -1,5 +1,7 @@
 /** Shared shapes for the /pam admin UI (#1159), mirroring routes/pam.ts responses. */
 
+import { Bot, MonitorCog, UserCog, type LucideIcon } from 'lucide-react';
+
 export type ElevationStatus =
   | 'pending'
   | 'approved'
@@ -150,6 +152,13 @@ export const FLOW_LABELS: Record<ElevationFlowType, string> = {
   uac_intercept: 'UAC intercept',
   tech_jit_admin: 'Tech JIT admin',
   ai_tool_action: 'AI tool action',
+};
+
+/** Per-flow lucide glyph, paired with FLOW_LABELS in the Flow cells. */
+export const FLOW_ICONS: Record<ElevationFlowType, LucideIcon> = {
+  uac_intercept: MonitorCog,
+  tech_jit_admin: UserCog,
+  ai_tool_action: Bot,
 };
 
 export const VERDICT_LABELS: Record<PamVerdict, string> = {

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -91,6 +91,51 @@ export interface Pagination {
   total: number;
 }
 
+export interface PamRuleDraft {
+  shape: 'executable' | 'tool';
+  name?: string;
+  siteId?: string | null;
+  matchSigner?: string | null;
+  matchHash?: string | null;
+  matchPathGlob?: string | null;
+  matchUser?: string | null;
+  matchToolName?: string | null;
+  matchRiskTier?: number | null;
+}
+
+function baseName(path: string): string {
+  const i = Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/'));
+  return i >= 0 ? path.slice(i + 1) : path;
+}
+
+/**
+ * Seed a rule draft from a request. Prefers the stable criterion: signer
+ * over hash (hashes churn with updates) over path; tool actions seed
+ * toolName + riskTier; JIT admin seeds the subject user.
+ */
+export function requestToRuleDraft(r: ElevationRequest): PamRuleDraft {
+  if (r.flowType === 'ai_tool_action') {
+    return {
+      shape: 'tool',
+      name: r.toolName ? `Rule for ${r.toolName}` : undefined,
+      siteId: r.siteId ?? null,
+      matchToolName: r.toolName ?? null,
+      matchRiskTier: r.riskTier ?? null,
+    };
+  }
+  if (r.flowType === 'tech_jit_admin') {
+    return { shape: 'executable', siteId: r.siteId ?? null, matchUser: r.subjectUsername };
+  }
+  const name = r.targetExecutablePath ? `Rule for ${baseName(r.targetExecutablePath)}` : undefined;
+  if (r.targetExecutableSigner) {
+    return { shape: 'executable', name, siteId: r.siteId ?? null, matchSigner: r.targetExecutableSigner };
+  }
+  if (r.targetExecutableHash) {
+    return { shape: 'executable', name, siteId: r.siteId ?? null, matchHash: r.targetExecutableHash };
+  }
+  return { shape: 'executable', name, siteId: r.siteId ?? null, matchPathGlob: r.targetExecutablePath ?? null };
+}
+
 export const STATUS_LABELS: Record<ElevationStatus, string> = {
   pending: 'Pending',
   approved: 'Approved',

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -46,6 +46,13 @@ export interface ElevationRequest {
   approvedByName?: string | null;
   deniedByName?: string | null;
   revokedByName?: string | null;
+  // Decision provenance joined by the API (#1159 follow-up): which software
+  // policy / PAM rule auto-decided the request, and the kind of decider.
+  softwarePolicyMatchId?: string | null;
+  matchedPolicyName?: string | null;
+  pamRuleId?: string | null;
+  pamRuleName?: string | null;
+  decisionSource?: 'software_policy' | 'pam_rule' | 'human' | null;
 }
 
 export interface PamTimeWindow {
@@ -160,4 +167,28 @@ export function decidedByLabel(r: ElevationRequest): string | null {
     default:
       return null;
   }
+}
+
+/**
+ * Who/what decided the request, for display under the status badge.
+ * Auto decisions name their source (software policy / PAM rule); human
+ * decisions defer to decidedByLabel. Null while pending/undecided.
+ *
+ * A human revoke supersedes the original auto-decision for display: an
+ * auto-approved request later revoked by a person keeps decisionSource
+ * 'pam_rule', but the revoker is the more actionable attribution.
+ */
+export function decisionAttribution(r: ElevationRequest): string | null {
+  if (r.status === 'revoked') {
+    const revoker = decidedByLabel(r);
+    if (revoker) return `by ${revoker}`;
+  }
+  if (r.decisionSource === 'software_policy') {
+    return `Policy · ${r.matchedPolicyName ?? 'Software policy'}`;
+  }
+  if (r.decisionSource === 'pam_rule') {
+    return `Rule · ${r.pamRuleName ?? 'PAM rule'}`;
+  }
+  const human = decidedByLabel(r);
+  return human ? `by ${human}` : null;
 }

--- a/docs/superpowers/plans/2026-06-12-pam-config-policy-enablement.md
+++ b/docs/superpowers/plans/2026-06-12-pam-config-policy-enablement.md
@@ -1,0 +1,1034 @@
+# PAM Config-Policy Enablement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `pam` feature type to the Config Policy system that controls whether the agent's Windows UAC interception (ETW elevation capture) is enabled per device, delivered via heartbeat — while rule authoring, approvals, and audit stay in the standalone `/pam` control plane.
+
+**Architecture:** Pattern B (inline settings, no normalized table). A new `pam` config-policy feature link carries `{ uacInterceptionEnabled: boolean }`. The API resolves it through the standard closest-wins hierarchy (device > device_group > site > organization > partner) exactly like the existing `helper` feature, and ships the resolved flag in the heartbeat response as a top-level `uacInterceptionEnabled` field. The Go agent stores it in an atomic flag (default **ON**) and `etwlua` drops UAC events while disabled. **Default is ON**: today every Windows agent captures UAC prompts unconditionally, so a device with no `pam` feature link must keep capturing — this preserves production behavior on upgrade, and the flag is a `*bool` on the agent so an old server that doesn't send the field also resolves to ON.
+
+**What this plan deliberately does NOT do:** PAM rules, the elevation request queue, and audit stay org/site-scoped in `/pam` (`pam_rules` table). Closest-wins override semantics are correct for an enable toggle but wrong for security rule chains (a device-level policy would silently shadow org baseline rules), so rules are not folded into config policies. See the design discussion summarized at the end of this doc.
+
+**Tech Stack:** Hono + Drizzle (API), React/Astro (web), Go (agent), Vitest + Go `testing`.
+
+**Environment note:** Prefix all `pnpm` / `npx` commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict). Go agent code lives in `agent/`, **not** `apps/agent/`.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/api/migrations/2026-06-12-pam-feature-type.sql` | Create | Add `pam` to the `config_feature_type` Postgres enum |
+| `apps/api/src/db/schema/configurationPolicies.ts` | Modify (line 43) | Add `'pam'` to `configFeatureTypeEnum` |
+| `apps/api/src/services/configurationPolicy.ts` | Modify (line 40) | Add `'pam'` to `ConfigFeatureType` union |
+| `packages/shared/src/validators/index.ts` | Modify (line 435) | Add `'pam'` to `addFeatureLinkSchema.featureType` enum |
+| `apps/api/src/services/aiToolsConfigPolicy.ts` | Modify (~lines 555-570) | Add `'pam'` to `manage_policy_feature_link` enum + document its settings shape |
+| `apps/api/src/routes/agents/pamSettings.ts` | Create | Pure `PamSettings` type, `PAM_DEFAULTS`, `parsePamSettings()` (dependency-free, unit-testable) |
+| `apps/api/src/routes/agents/pamSettings.test.ts` | Create | Unit tests for `parsePamSettings` |
+| `apps/api/src/routes/agents/helpers.ts` | Modify (append after line 2213) | `resolveDevicePamSettings()` (hierarchy query) + `buildPamConfigUpdate()` (Redis-cached) |
+| `apps/api/src/routes/agents/heartbeat.ts` | Modify (~lines 22, 594, 636) | Resolve pam config, add `uacInterceptionEnabled` to heartbeat response |
+| `apps/api/src/routes/agents/heartbeat.test.ts` | Modify (~line 96 + new test) | Mock `buildPamConfigUpdate`, assert response field |
+| `apps/web/src/components/configurationPolicies/featureTabs/types.ts` | Modify (lines 1, 42) | Add `'pam'` to `FeatureType` union + `FEATURE_META` |
+| `apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx` | Create | Feature tab: enable toggle + link out to `/pam` console |
+| `apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx` | Create | Tab render + save payload tests |
+| `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx` | Modify (lines ~44, 65-83, 296) | Wire PamTab into tabs/icons/render switch |
+| `agent/internal/heartbeat/heartbeat.go` | Modify (~lines 98, 201, 2343, +new funcs) | `UacInterceptionEnabled *bool` response field, atomic flag, handler, getter |
+| `agent/internal/heartbeat/uac_interception_test.go` | Create | Table-driven test for the handler |
+| `agent/internal/etwlua/etwlua.go` | Modify (lines 128-130, 187-213, 217+) | Extend `HeartbeatPoster` interface, gate `handleEvent` + ticker drain |
+| `agent/internal/etwlua/etwlua_test.go` | Modify | Extend `fakeHB`, add gating test |
+
+---
+
+### Task 1: API feature-type plumbing (enum, validator, AI tool)
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-12-pam-feature-type.sql`
+- Modify: `apps/api/src/db/schema/configurationPolicies.ts:43`
+- Modify: `apps/api/src/services/configurationPolicy.ts:40`
+- Modify: `packages/shared/src/validators/index.ts:435`
+- Modify: `apps/api/src/services/aiToolsConfigPolicy.ts:555-570`
+
+- [ ] **Step 1: Create the migration**
+
+Write `apps/api/migrations/2026-06-12-pam-feature-type.sql` (exact content, mirroring `2026-04-04-remote-access-feature-type.sql` — idempotent, no inner BEGIN/COMMIT):
+
+```sql
+ALTER TYPE "config_feature_type" ADD VALUE IF NOT EXISTS 'pam';
+```
+
+- [ ] **Step 2: Add `'pam'` to the Drizzle enum**
+
+In `apps/api/src/db/schema/configurationPolicies.ts`, the enum currently ends:
+
+```typescript
+export const configFeatureTypeEnum = pgEnum('config_feature_type', [
+  'patch',
+  'alert_rule',
+  'backup',
+  'security',
+  'monitoring',
+  'maintenance',
+  'compliance',
+  'automation',
+  'event_log',
+  'software_policy',
+  'sensitive_data',
+  'peripheral_control',
+  'warranty',
+  'helper',
+  'remote_access',
+]);
+```
+
+Add `'pam',` after `'remote_access',` (before the closing `]`).
+
+- [ ] **Step 3: Add `'pam'` to the service union**
+
+In `apps/api/src/services/configurationPolicy.ts:40`, append `| 'pam'` to the union:
+
+```typescript
+type ConfigFeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam';
+```
+
+- [ ] **Step 4: Add `'pam'` to the shared Zod validator**
+
+In `packages/shared/src/validators/index.ts:435`, append `'pam'` to the enum array:
+
+```typescript
+  featureType: z.enum(['patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam']),
+```
+
+- [ ] **Step 5: Add `'pam'` to the AI tool**
+
+In `apps/api/src/services/aiToolsConfigPolicy.ts`, the `manage_policy_feature_link` tool's `featureType` enum (lines 565-570) currently ends with `'warranty', 'helper',`. Append `'remote_access', 'pam',` **only if** `'remote_access'` is also missing (it was absent at last read — add both so the tool catches up with the schema); otherwise just add `'pam',`:
+
+```typescript
+            enum: [
+              'patch', 'alert_rule', 'backup', 'security', 'monitoring',
+              'maintenance', 'compliance', 'automation', 'event_log',
+              'software_policy', 'sensitive_data', 'peripheral_control',
+              'warranty', 'helper', 'remote_access', 'pam',
+            ],
+```
+
+In the same tool's `description` string (the block above line 557 that documents per-feature inline settings shapes — find the `- helper:` bullet), add this line after the helper bullet:
+
+```
+- pam: inlineSettings {uacInterceptionEnabled: boolean} — Windows UAC elevation prompt capture (default true when no policy assigns it). PAM rules/approvals are managed separately in the /pam console, not via config policies.
+```
+
+- [ ] **Step 6: Verify drift + type-check**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+
+Expected: no drift; tsc shows only the pre-existing errors in `agents.test.ts` and `apiKeyAuth.test.ts` (known baseline — anything else is yours).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-12-pam-feature-type.sql apps/api/src/db/schema/configurationPolicies.ts apps/api/src/services/configurationPolicy.ts packages/shared/src/validators/index.ts apps/api/src/services/aiToolsConfigPolicy.ts
+git commit -m "feat(pam): add 'pam' config-policy feature type (enum, validator, AI tool)"
+```
+
+---
+
+### Task 2: Pure settings parser (`pamSettings.ts`)
+
+**Files:**
+- Create: `apps/api/src/routes/agents/pamSettings.ts`
+- Test: `apps/api/src/routes/agents/pamSettings.test.ts`
+
+This is a dependency-free module so it can be unit-tested without the heavy Drizzle/module mocks that `helpers.ts` requires.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/agents/pamSettings.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { PAM_DEFAULTS, parsePamSettings } from './pamSettings';
+
+describe('parsePamSettings', () => {
+  it('defaults to interception enabled', () => {
+    expect(PAM_DEFAULTS.uacInterceptionEnabled).toBe(true);
+  });
+
+  it('returns defaults for null/undefined/non-object input', () => {
+    expect(parsePamSettings(null)).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings(undefined)).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings('nope')).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings(42)).toEqual(PAM_DEFAULTS);
+  });
+
+  it('honors an explicit false', () => {
+    expect(parsePamSettings({ uacInterceptionEnabled: false })).toEqual({
+      uacInterceptionEnabled: false,
+    });
+  });
+
+  it('honors an explicit true', () => {
+    expect(parsePamSettings({ uacInterceptionEnabled: true })).toEqual({
+      uacInterceptionEnabled: true,
+    });
+  });
+
+  it('falls back to default when the key is missing or mistyped', () => {
+    expect(parsePamSettings({})).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings({ uacInterceptionEnabled: 'false' })).toEqual(PAM_DEFAULTS);
+    expect(parsePamSettings({ uacInterceptionEnabled: 0 })).toEqual(PAM_DEFAULTS);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/pamSettings.test.ts
+```
+
+Expected: FAIL — `Cannot find module './pamSettings'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/routes/agents/pamSettings.ts`:
+
+```typescript
+/**
+ * PAM config-policy feature ('pam') — inline settings shape.
+ *
+ * Controls whether the agent's ETW UAC interception posts elevation events.
+ * Rule authoring / approvals / audit are NOT configured here — they live in
+ * the standalone /pam control plane (pam_rules, elevation_requests).
+ */
+export interface PamSettings {
+  uacInterceptionEnabled: boolean;
+}
+
+/**
+ * Default ON: UAC capture has always been unconditional on Windows agents.
+ * A device with no 'pam' feature link anywhere in its hierarchy must keep
+ * capturing, so upgrades are behavior-preserving. Admins opt OUT via policy.
+ */
+export const PAM_DEFAULTS: PamSettings = {
+  uacInterceptionEnabled: true,
+};
+
+export function parsePamSettings(inlineSettings: unknown): PamSettings {
+  if (!inlineSettings || typeof inlineSettings !== 'object') return PAM_DEFAULTS;
+  const s = inlineSettings as Record<string, unknown>;
+  return {
+    uacInterceptionEnabled:
+      typeof s.uacInterceptionEnabled === 'boolean'
+        ? s.uacInterceptionEnabled
+        : PAM_DEFAULTS.uacInterceptionEnabled,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/pamSettings.test.ts
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/agents/pamSettings.ts apps/api/src/routes/agents/pamSettings.test.ts
+git commit -m "feat(pam): pure PamSettings parser with default-on semantics"
+```
+
+---
+
+### Task 3: Hierarchy resolver + heartbeat delivery
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/helpers.ts` (append after `buildHelperConfigUpdate`, line 2213)
+- Modify: `apps/api/src/routes/agents/heartbeat.ts` (import block ~line 22; after line 594; response object line 636)
+- Test: `apps/api/src/routes/agents/heartbeat.test.ts`
+
+- [ ] **Step 1: Add the resolver + cached builder to `helpers.ts`**
+
+Append at the end of `apps/api/src/routes/agents/helpers.ts` (after line 2213). All Drizzle imports (`devices`, `organizations`, `deviceGroupMemberships`, `configPolicyAssignments`, `configurationPolicies`, `configPolicyFeatureLinks`, `eq`, `and`, `or`, `inArray`) and `LEVEL_PRIORITY` / `getRedis` are already imported/defined in this file for the helper resolver — only add the `pamSettings` import at the top of the file:
+
+```typescript
+import { PAM_DEFAULTS, parsePamSettings, type PamSettings } from './pamSettings';
+```
+
+Then append:
+
+```typescript
+// ---------------------------------------------------------------------------
+// PAM (config-policy feature 'pam') — UAC interception enablement
+// ---------------------------------------------------------------------------
+
+async function resolveDevicePamSettings(deviceId: string): Promise<PamSettings> {
+  // 1. Load device
+  const [device] = await db
+    .select({ orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.id, deviceId))
+    .limit(1);
+
+  if (!device) return PAM_DEFAULTS;
+
+  // 2. Load org (for partnerId)
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, device.orgId))
+    .limit(1);
+
+  // 3. Load device group memberships
+  const groupRows = await db
+    .select({ groupId: deviceGroupMemberships.groupId })
+    .from(deviceGroupMemberships)
+    .where(eq(deviceGroupMemberships.deviceId, deviceId));
+  const groupIds = groupRows.map((r) => r.groupId);
+
+  // 4. Build target match conditions
+  const targetConditions = [
+    and(eq(configPolicyAssignments.level, 'device'), eq(configPolicyAssignments.targetId, deviceId)),
+    and(eq(configPolicyAssignments.level, 'site'), eq(configPolicyAssignments.targetId, device.siteId)),
+    and(eq(configPolicyAssignments.level, 'organization'), eq(configPolicyAssignments.targetId, device.orgId)),
+  ];
+  if (groupIds.length > 0) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'device_group'), inArray(configPolicyAssignments.targetId, groupIds))!
+    );
+  }
+  if (org?.partnerId) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'partner'), eq(configPolicyAssignments.targetId, org.partnerId))!
+    );
+  }
+
+  // 5. Single query: assignments → active policies → pam feature link (pure JSONB)
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      inlineSettings: configPolicyFeatureLinks.inlineSettings,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'pam'),
+    ))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      eq(configurationPolicies.orgId, device.orgId),
+      or(...targetConditions),
+    ));
+
+  if (rows.length === 0) return PAM_DEFAULTS;
+
+  // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
+  rows.sort((a, b) => {
+    const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
+    if (levelDiff !== 0) return levelDiff;
+    return a.assignmentPriority - b.assignmentPriority;
+  });
+
+  return parsePamSettings(rows[0]?.inlineSettings);
+}
+
+const PAM_CACHE_TTL_SECONDS = 120;
+
+/**
+ * Build PAM config update payload for heartbeat response.
+ * Resolves the 'pam' feature link via the config policy hierarchy;
+ * defaults to interception ENABLED when no policy assigns the feature.
+ */
+export async function buildPamConfigUpdate(deviceId: string): Promise<PamSettings> {
+  const redis = getRedis();
+  const cacheKey = `pam:settings:device:${deviceId}`;
+
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey);
+      if (cached) return JSON.parse(cached) as PamSettings;
+    } catch (cacheErr) {
+      console.warn(`[pam] Redis cache read failed for device ${deviceId}:`, cacheErr);
+    }
+  }
+
+  const settings = await resolveDevicePamSettings(deviceId);
+
+  if (redis) {
+    try {
+      await redis.set(cacheKey, JSON.stringify(settings), 'EX', PAM_CACHE_TTL_SECONDS);
+    } catch (cacheErr) {
+      console.warn(`[pam] Redis cache write failed for device ${deviceId}:`, cacheErr);
+    }
+  }
+
+  return settings;
+}
+```
+
+- [ ] **Step 2: Write the failing heartbeat test**
+
+In `apps/api/src/routes/agents/heartbeat.test.ts`, the `vi.mock('./helpers', ...)` block (lines 89-97) currently ends with `buildHelperConfigUpdate: vi.fn(() => undefined),`. Add one line so the block becomes:
+
+```typescript
+vi.mock('./helpers', () => ({
+  maybeQueueThresholdFilesystemAnalysis: vi.fn(),
+  buildPolicyProbeConfigUpdate: vi.fn(() => undefined),
+  normalizeAgentArchitecture: vi.fn((s: string) => s),
+  compareAgentVersions: vi.fn(() => 0),
+  buildEventLogConfigUpdate: vi.fn(() => undefined),
+  buildMonitoringConfigUpdate: vi.fn(() => undefined),
+  buildHelperConfigUpdate: vi.fn(() => undefined),
+  buildPamConfigUpdate: vi.fn(async () => ({ uacInterceptionEnabled: false })),
+}));
+```
+
+Then add a new test. Locate the file's existing happy-path heartbeat test (one that does a successful `app.request(...)` POST and reads the JSON body — use the same `buildApp()` + request invocation and DB select-chain setup verbatim from that test; only the assertions below are new):
+
+```typescript
+it('includes uacInterceptionEnabled resolved from the pam config policy', async () => {
+  // ...same arrange + request invocation as the existing happy-path heartbeat test...
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // The ./helpers mock returns { uacInterceptionEnabled: false } — assert it
+  // flows through to the top-level response field (not nested in configUpdate).
+  expect(body.uacInterceptionEnabled).toBe(false);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/heartbeat.test.ts
+```
+
+Expected: the new test FAILS (`body.uacInterceptionEnabled` is `undefined`); all pre-existing tests still pass.
+
+- [ ] **Step 4: Wire it into `heartbeat.ts`**
+
+In `apps/api/src/routes/agents/heartbeat.ts`:
+
+(a) Add `buildPamConfigUpdate` to the existing `./helpers` import block (around line 22, next to `buildHelperConfigUpdate`).
+
+(b) After the `monitoringSettings` block (which ends at line 594), insert:
+
+```typescript
+  let pamSettings: { uacInterceptionEnabled: boolean } | null = null;
+  try {
+    pamSettings = await buildPamConfigUpdate(device.id);
+  } catch (err) {
+    console.error(`[agents] failed to build pam config update for ${agentId}:`, err);
+  }
+```
+
+(c) In the `mainResponse` object (lines 622-638), add one field after `helperSettings`:
+
+```typescript
+      helperEnabled: helperSettings?.enabled ?? false,
+      helperSettings: helperSettings ?? undefined,
+      uacInterceptionEnabled: pamSettings?.uacInterceptionEnabled ?? true,
+      manageRemoteManagement: manageRemoteManagement || undefined,
+```
+
+Note the `?? true` — if the resolver threw, fail OPEN (interception stays on), consistent with default-ON. Do **not** use `|| undefined` here: an explicit `false` must be serialized.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/agents/heartbeat.test.ts src/routes/agents/pamSettings.test.ts
+```
+
+Expected: PASS. (Memory note: the full API suite has known parallel flakiness — verify via these affected files only; trust CI for the rest.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/agents/helpers.ts apps/api/src/routes/agents/heartbeat.ts apps/api/src/routes/agents/heartbeat.test.ts
+git commit -m "feat(pam): resolve pam config policy per device and deliver uacInterceptionEnabled via heartbeat"
+```
+
+---
+
+### Task 4: Web UI — PamTab feature tab
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/types.ts`
+- Create: `apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx`
+- Test: `apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx`
+- Modify: `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx`
+
+- [ ] **Step 1: Add `pam` to the frontend types**
+
+In `featureTabs/types.ts` line 1, append `| 'pam'` to the `FeatureType` union:
+
+```typescript
+export type FeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam';
+```
+
+In `FEATURE_META` (after the `remote_access` entry, line 41), add:
+
+```typescript
+  pam:         { label: 'Privileged Access', fetchUrl: null,              description: 'Windows UAC elevation prompt capture (PAM)' },
+```
+
+- [ ] **Step 2: Write the failing tab test**
+
+Create `featureTabs/PamTab.test.tsx` (harness identical to `RemoteAccessTab.test.tsx`):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PamTab from './PamTab';
+
+// useFeatureLink wraps the save/remove API calls; stub it so we can assert the
+// payload the tab submits without hitting the network.
+const saveMock = vi.fn(async () => ({ id: 'link-1' }));
+const removeMock = vi.fn(async () => true);
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+import type { FeatureTabProps } from './types';
+
+const baseProps: FeatureTabProps = {
+  policyId: 'policy-1',
+  existingLink: undefined,
+  linkedPolicyId: null,
+  onLinkChanged: vi.fn(),
+};
+
+function inlineSettingsFromCall(call: unknown[]): Record<string, unknown> | undefined {
+  for (const arg of call) {
+    if (arg && typeof arg === 'object' && 'inlineSettings' in (arg as object)) {
+      return (arg as { inlineSettings: Record<string, unknown> }).inlineSettings;
+    }
+  }
+  return undefined;
+}
+
+describe('PamTab', () => {
+  beforeEach(() => {
+    saveMock.mockClear();
+    removeMock.mockClear();
+  });
+
+  it('renders the UAC interception toggle, defaulted ON', () => {
+    render(<PamTab {...baseProps} />);
+    expect(screen.getByText('Capture Windows UAC elevation prompts')).toBeTruthy();
+  });
+
+  it('links rule management out to the /pam console', () => {
+    render(<PamTab {...baseProps} />);
+    const link = screen.getByRole('link', { name: /privileged access console/i }) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/pam');
+  });
+
+  it('saves uacInterceptionEnabled=false after toggling off', async () => {
+    render(<PamTab {...baseProps} />);
+
+    const label = screen.getByText('Capture Windows UAC elevation prompts');
+    const row = label.closest('div')?.parentElement as HTMLElement;
+    const toggleButton = row.querySelector('button') as HTMLButtonElement;
+    fireEvent.click(toggleButton);
+
+    const saveButton = screen
+      .getAllByRole('button')
+      .find((b) => /save/i.test(b.textContent ?? '')) as HTMLButtonElement;
+    expect(saveButton).toBeTruthy();
+    fireEvent.click(saveButton);
+
+    expect(saveMock).toHaveBeenCalled();
+    const settings = inlineSettingsFromCall(saveMock.mock.calls[0]);
+    expect(settings).toEqual({ uacInterceptionEnabled: false });
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/configurationPolicies/featureTabs/PamTab.test.tsx
+```
+
+Expected: FAIL — `Cannot find module './PamTab'`.
+
+- [ ] **Step 4: Create `PamTab.tsx`**
+
+Create `featureTabs/PamTab.tsx` (skeleton mirrors `HelperTab.tsx` exactly — same inherit/override/revert plumbing):
+
+```tsx
+import { useState, useEffect } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import type { FeatureTabProps } from './types';
+import { FEATURE_META } from './types';
+import { useFeatureLink } from './useFeatureLink';
+import FeatureTabShell from './FeatureTabShell';
+
+type PamSettings = {
+  uacInterceptionEnabled: boolean;
+};
+
+// Default ON — matches agent behavior when no policy assigns this feature.
+const defaults: PamSettings = {
+  uacInterceptionEnabled: true,
+};
+
+export default function PamTab({ policyId, existingLink, onLinkChanged, linkedPolicyId, parentLink }: FeatureTabProps) {
+  const { save, remove, saving, error, clearError } = useFeatureLink(policyId);
+  const isInherited = !!parentLink && !existingLink;
+  const effectiveLink = existingLink ?? parentLink;
+  const [settings, setSettings] = useState<PamSettings>(() => ({
+    ...defaults,
+    ...(effectiveLink?.inlineSettings as Partial<PamSettings> | undefined),
+  }));
+
+  useEffect(() => {
+    const link = existingLink ?? parentLink;
+    if (link?.inlineSettings) {
+      setSettings((prev) => ({ ...prev, ...(link.inlineSettings as Partial<PamSettings>) }));
+    }
+  }, [existingLink, parentLink]);
+
+  const handleSave = async () => {
+    clearError();
+    const result = await save(existingLink?.id ?? null, {
+      featureType: 'pam',
+      featurePolicyId: linkedPolicyId,
+      inlineSettings: { ...settings },
+    });
+    if (result) onLinkChanged(result, 'pam');
+  };
+
+  const handleRemove = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, 'pam');
+  };
+
+  const handleOverride = async () => {
+    clearError();
+    const result = await save(null, {
+      featureType: 'pam',
+      featurePolicyId: linkedPolicyId,
+      inlineSettings: { ...settings },
+    });
+    if (result) onLinkChanged(result, 'pam');
+  };
+
+  const handleRevert = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, 'pam');
+  };
+
+  const meta = FEATURE_META.pam;
+
+  return (
+    <FeatureTabShell
+      title={meta.label}
+      description={meta.description}
+      icon={<ShieldCheck className="h-5 w-5" />}
+      isConfigured={!!existingLink || isInherited}
+      saving={saving}
+      error={error}
+      onSave={handleSave}
+      onRemove={existingLink && !linkedPolicyId ? handleRemove : undefined}
+      isInherited={isInherited}
+      onOverride={isInherited ? handleOverride : undefined}
+      onRevert={!isInherited && !!linkedPolicyId && !!existingLink ? handleRevert : undefined}
+    >
+      <div className="space-y-6">
+        {/* UAC interception toggle */}
+        <div className="flex items-center justify-between rounded-md border bg-background px-4 py-3">
+          <div>
+            <p className="text-sm font-medium">Capture Windows UAC elevation prompts</p>
+            <p className="text-xs text-muted-foreground">
+              The agent observes UAC consent prompts and records them as elevation requests for PAM review. Capture is on by default when no policy sets this.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setSettings((prev) => ({ ...prev, uacInterceptionEnabled: !prev.uacInterceptionEnabled }))}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full border transition ${settings.uacInterceptionEnabled ? 'bg-emerald-500/80' : 'bg-muted'}`}
+          >
+            <span className={`inline-block h-5 w-5 rounded-full bg-white transition ${settings.uacInterceptionEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
+          </button>
+        </div>
+
+        {/* Pointer to the PAM control plane */}
+        <div className="rounded-md border bg-muted/40 px-4 py-3">
+          <p className="text-sm font-medium">Approval rules live in the PAM console</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            This policy only controls whether devices capture elevation prompts. Verdicts (auto-approve, deny, require approval), the request queue, and audit history are managed in the{' '}
+            <a href="/pam" className="underline underline-offset-2 hover:text-foreground">Privileged Access console</a>.
+          </p>
+        </div>
+      </div>
+    </FeatureTabShell>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/configurationPolicies/featureTabs/PamTab.test.tsx
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Wire into `ConfigPolicyDetailPage.tsx`**
+
+Four edits:
+
+(a) After the `RemoteAccessTab` import (line 44):
+```typescript
+import PamTab from './featureTabs/PamTab';
+```
+
+(b) Add `ShieldCheck` to the existing `lucide-react` import at the top of the file (it already imports `Monitor` and others — append `ShieldCheck` to that list).
+
+(c) In `featureTabIcons` (lines 65-81), after the `remote_access` entry:
+```typescript
+  pam: <ShieldCheck className="h-4 w-4" />,
+```
+
+(d) In `FEATURE_TYPES` (line 83), append `'pam'`:
+```typescript
+const FEATURE_TYPES: FeatureType[] = ['patch', 'alert_rule', 'backup', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam'];
+```
+
+(e) In `renderFeatureTab` switch (line 296 area), after the `remote_access` case:
+```typescript
+      case 'pam': return <PamTab {...props} />;
+```
+
+- [ ] **Step 7: Type-check web + run the feature-tab tests**
+
+```bash
+cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/configurationPolicies/featureTabs/
+```
+
+Expected: clean tsc; all featureTabs tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/configurationPolicies/featureTabs/types.ts apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+git commit -m "feat(pam): Privileged Access feature tab in config policies (UAC capture toggle)"
+```
+
+---
+
+### Task 5: Go agent — heartbeat flag
+
+**Files:**
+- Modify: `agent/internal/heartbeat/heartbeat.go` (struct field ~line 98, atomic ~line 201, response handler ~line 2343, new funcs near `handleHelperEnabled` ~line 2360)
+- Test: `agent/internal/heartbeat/uac_interception_test.go`
+
+Design note: the response field is a `*bool` so three states decode distinctly — `nil` (old server, field absent) → enabled; `true` → enabled; `false` → disabled. The stored atomic is **inverted** (`uacInterceptionDisabled`) so the Go zero value means *enabled* — correct before the first heartbeat and with no constructor change needed.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/heartbeat/uac_interception_test.go`:
+
+```go
+package heartbeat
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestUACInterceptionFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		sequence    []*bool // values passed to handleUACInterception in order
+		wantEnabled bool
+	}{
+		{"default before any heartbeat", nil, true},
+		{"nil from old server keeps default on", []*bool{nil}, true},
+		{"explicit true stays on", []*bool{boolPtr(true)}, true},
+		{"explicit false disables", []*bool{boolPtr(false)}, false},
+		{"false then true re-enables", []*bool{boolPtr(false), boolPtr(true)}, true},
+		{"false then nil re-enables (policy unassigned on old server)", []*bool{boolPtr(false), nil}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Heartbeat{}
+			for _, v := range tt.sequence {
+				h.handleUACInterception(v)
+			}
+			if got := h.IsUACInterceptionEnabled(); got != tt.wantEnabled {
+				t.Fatalf("IsUACInterceptionEnabled() = %v, want %v", got, tt.wantEnabled)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run TestUACInterceptionFlag
+```
+
+Expected: FAIL — `h.handleUACInterception undefined` (compile error).
+
+- [ ] **Step 3: Implement in `heartbeat.go`**
+
+(a) In `HeartbeatResponse` (line 92-103), after `HelperEnabled`:
+
+```go
+	HelperEnabled          bool                   `json:"helperEnabled,omitempty"`
+	UacInterceptionEnabled *bool                  `json:"uacInterceptionEnabled,omitempty"`
+```
+
+(b) In the `Heartbeat` struct's atomic flag block (after `helperEnabled atomic.Bool`, line 201):
+
+```go
+	// uacInterceptionDisabled is set when the server's 'pam' config policy
+	// turns UAC capture off for this device. Inverted so the zero value
+	// (enabled) matches the default-ON contract before the first heartbeat
+	// and against older servers that never send the field.
+	uacInterceptionDisabled atomic.Bool
+```
+
+(c) In the response-processing function, directly after `h.handleHelperEnabled(response.HelperEnabled)` (line 2343):
+
+```go
+	h.handleUACInterception(response.UacInterceptionEnabled)
+```
+
+(d) New funcs after `handleHelperEnabled` (line 2370):
+
+```go
+// IsUACInterceptionEnabled reports whether etwlua should post UAC elevation
+// events. Default true; only an explicit uacInterceptionEnabled=false from
+// the server's resolved 'pam' config policy disables it.
+func (h *Heartbeat) IsUACInterceptionEnabled() bool {
+	return !h.uacInterceptionDisabled.Load()
+}
+
+// handleUACInterception updates the UAC interception flag from the heartbeat
+// response and logs state transitions. nil (field absent — older server)
+// means enabled.
+func (h *Heartbeat) handleUACInterception(enabled *bool) {
+	disabled := enabled != nil && !*enabled
+	prev := h.uacInterceptionDisabled.Swap(disabled)
+	if prev != disabled {
+		if disabled {
+			log.Info("UAC interception disabled by configuration policy")
+		} else {
+			log.Info("UAC interception enabled by configuration policy")
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd agent && go test -race ./internal/heartbeat/ -run TestUACInterceptionFlag
+```
+
+Expected: PASS (6 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/heartbeat/heartbeat.go agent/internal/heartbeat/uac_interception_test.go
+git commit -m "feat(pam): agent honors uacInterceptionEnabled from heartbeat (default on, *bool for old servers)"
+```
+
+---
+
+### Task 6: Go agent — gate etwlua on the flag
+
+**Files:**
+- Modify: `agent/internal/etwlua/etwlua.go` (`HeartbeatPoster` interface lines 128-130, `Start` ticker case ~line 203, `handleEvent` line 217)
+- Test: `agent/internal/etwlua/etwlua_test.go` (extend `fakeHB` lines 16-43, add test)
+
+Note: `fakeHB` is shared by `etwlua_test.go` and `queue_test.go` (same package), so extending it once covers both. `*heartbeat.Heartbeat` satisfies the extended interface via Task 5's `IsUACInterceptionEnabled()` — no change needed in `etwlua_start_windows.go`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `agent/internal/etwlua/etwlua_test.go`, first extend `fakeHB` (the test won't compile until the interface change, which is fine — that IS the failing state). Add a field and method:
+
+```go
+// fakeHB records every event it's asked to post and lets tests inject a
+// custom error to simulate API outages.
+type fakeHB struct {
+	mu       sync.Mutex
+	received []Event
+	failNext atomic.Int32 // number of next posts to fail
+	failErr  error
+	disabled atomic.Bool // simulates uacInterceptionEnabled=false from the server
+}
+
+func (f *fakeHB) IsUACInterceptionEnabled() bool {
+	return !f.disabled.Load()
+}
+```
+
+Then add the test:
+
+```go
+func TestHandleEventDroppedWhenInterceptionDisabled(t *testing.T) {
+	hb := &fakeHB{}
+	hb.disabled.Store(true)
+	limiter := ipc.NewRateLimiter(1, dedupeWindow)
+
+	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+	handleEvent(ev, limiter, hb, nil)
+	if got := len(hb.Received()); got != 0 {
+		t.Fatalf("expected 0 posts while interception disabled, got %d", got)
+	}
+
+	// Re-enable: the same event must post — proving the disabled event was
+	// dropped BEFORE the dedupe limiter consumed its slot.
+	hb.disabled.Store(false)
+	handleEvent(ev, limiter, hb, nil)
+	if got := len(hb.Received()); got != 1 {
+		t.Fatalf("expected 1 post after re-enable, got %d", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cd agent && go test -race ./internal/etwlua/
+```
+
+Expected: FAIL — the new test fails (event posts even while disabled) since `handleEvent` doesn't check the flag yet. (If you extended `fakeHB` before touching the interface, everything still compiles — extra methods on a fake are fine.)
+
+- [ ] **Step 3: Implement the gate**
+
+In `agent/internal/etwlua/etwlua.go`:
+
+(a) Extend the interface (lines 128-130):
+
+```go
+type HeartbeatPoster interface {
+	SendElevationRequest(req Event) error
+	// IsUACInterceptionEnabled reports the server-resolved 'pam' config
+	// policy state. While false, handleEvent drops events entirely (no
+	// post, no offline queue) and the periodic queue drain is paused.
+	IsUACInterceptionEnabled() bool
+}
+```
+
+(b) Gate `handleEvent` (line 217) — first statement, BEFORE the dedupe limiter so disabled events don't consume limiter slots:
+
+```go
+func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queue) {
+	if !hb.IsUACInterceptionEnabled() {
+		return
+	}
+	key := dedupeKey(ev)
+	if !limiter.Allow(key) {
+```
+
+(c) Gate the periodic drain in `Start`'s ticker case (line 203-210):
+
+```go
+		case <-ticker.C:
+			if q != nil && hb.IsUACInterceptionEnabled() {
+				if drained, err := q.Drain(hb); err != nil {
+					log.Debug("etwlua: periodic drain failed", "error", err.Error())
+				} else if drained > 0 {
+					log.Info("etwlua: periodic drain succeeded", "events", drained)
+				}
+			}
+```
+
+- [ ] **Step 4: Run the full agent test suite**
+
+```bash
+cd agent && go test -race ./internal/etwlua/ ./internal/heartbeat/ && go build ./...
+```
+
+Expected: PASS, clean build (the build proves `*heartbeat.Heartbeat` still satisfies `HeartbeatPoster` at the `main.go:624` call site).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/etwlua/etwlua.go agent/internal/etwlua/etwlua_test.go
+git commit -m "feat(pam): etwlua drops UAC events while interception is policy-disabled"
+```
+
+---
+
+### Task 7: Docs + reference sync
+
+**Files:**
+- Modify: `~/.claude/skills/configuration-policy/SKILL.md` (local skill, not committed to repo)
+- Modify: `docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md` (append a short note)
+
+- [ ] **Step 1: Update the configuration-policy skill**
+
+In `~/.claude/skills/configuration-policy/SKILL.md`:
+- Add `pam` to the "Current Feature Type Registry" table: `| pam | Inline | no normalized table | - |`
+- Add `pam` to the inline-settings-only list in "Standalone Policy Prerequisites": append `pam` after `helper`.
+- In the "All 14 Feature Type Inline Settings Shapes" area, note the shape: `pam: { uacInterceptionEnabled: boolean }` (default true; rules/approvals live in /pam, not config policies).
+
+- [ ] **Step 2: Append a scope note to the PAM design spec**
+
+At the end of `docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md`, append:
+
+```markdown
+## Addendum (2026-06-12): Config-Policy enablement split
+
+UAC interception enablement is now a `pam` config-policy feature (inline
+settings `{uacInterceptionEnabled: boolean}`, default ON, closest-wins),
+delivered to the agent via the heartbeat `uacInterceptionEnabled` field and
+gated in `etwlua.handleEvent`. Rule authoring, the elevation request queue,
+and audit remain org/site-scoped in the standalone `/pam` control plane —
+closest-wins override semantics are intentionally NOT applied to the rule
+chain (a device-level policy must not silently shadow org baseline security
+rules). If partner-level rule baselines or device-group rule scoping become
+a requirement, revisit as a Pattern A linked feature with explicit
+merge (not override) semantics. Plan:
+`docs/superpowers/plans/2026-06-12-pam-config-policy-enablement.md`.
+```
+
+- [ ] **Step 3: Commit (repo files only)**
+
+```bash
+git add docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md
+git commit -m "docs(pam): record config-policy enablement split in PAM design spec"
+```
+
+---
+
+## Verification checklist (post-implementation)
+
+- [ ] `pnpm db:check-drift` clean (Task 1 enum matches migration)
+- [ ] `apps/api`: `npx vitest run src/routes/agents/pamSettings.test.ts src/routes/agents/heartbeat.test.ts` green
+- [ ] `apps/web`: `npx vitest run src/components/configurationPolicies/featureTabs/` green, `npx tsc --noEmit` clean
+- [ ] `agent`: `go test -race ./...` green, `go build ./...` clean
+- [ ] Manual smoke (optional, needs local stack): create a config policy with the Privileged Access tab toggled OFF, assign to a Windows device's org, wait one heartbeat, confirm agent logs `UAC interception disabled by configuration policy` and no new `uac_intercept` elevation requests appear while triggering a UAC prompt on the device
+- [ ] RLS: no new tables were created (inline JSONB on existing `config_policy_feature_links`), so no RLS work or allowlist changes are needed
+
+## Design rationale (for future readers)
+
+- **Why a toggle in Config Policies but rules in /pam:** Config-policy resolution is closest-level-wins with a single winner per feature type. That's correct for an enable flag ("org turns it on, this one server turns it off") but dangerous for security rule chains — a device-level feature link would silently shadow org baseline rules like "require approval for unsigned executables." PAM rules need union/priority-merge semantics, which the resolver doesn't have; they stay in `pam_rules` (org/site-scoped, fine-grained targeting via match criteria).
+- **Why default ON:** UAC capture has been unconditional on all Windows agents since the feature shipped. Default-OFF would silently stop elevation discovery fleet-wide on upgrade. Decision confirmed by Todd 2026-06-12.
+- **Why `*bool` on the agent:** an old API that doesn't send the field must decode as "enabled," not Go's `false` zero value.
+- **Why the agent drops events instead of stopping the ETW session:** mirrors the `helperEnabled` atomic-flag precedent; avoids start/stop lifecycle complexity in `etwlua` (session teardown/re-subscribe races). The ETW session keeps running but nothing is posted or queued. If resource usage on disabled devices ever matters, a follow-up can add full session lifecycle management following the `monitor.ApplyConfig` stop-restart pattern.

--- a/docs/superpowers/plans/2026-06-12-pam-workflow-ux.md
+++ b/docs/superpowers/plans/2026-06-12-pam-workflow-ux.md
@@ -1,0 +1,811 @@
+# PAM Workflow & UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the loops in the PAM elevation workflow: decision provenance visible on every request, rule-from-request one click away, a rule-preview endpoint ("would have matched N requests"), teaching empty states, evaluation-order copy, and live-refresh fixes — per the confirmed design brief (impeccable shape, 2026-06-12).
+
+**Architecture:** Two API tasks (response-shape extension + new read-only preview endpoint reusing `pamRuleEngine` as the single matching source of truth — no schema changes, no migrations), then four web tasks layered on the existing `/pam` console components. All mutations stay on `runAction`. Restrained color strategy; existing badge/select/table idioms only.
+
+**Tech Stack:** Hono + Drizzle + Zod (API), React (web), Vitest both sides.
+
+**Branch/worktree:** continue on `worktree-pam-config-policy-enablement` at `/Users/toddhebebrand/breeze/.claude/worktrees/pam-config-policy-enablement` (follow-up to PR #1286). ALL file paths below are relative to that worktree root. NEVER touch `/Users/toddhebebrand/breeze` (main checkout).
+
+**Environment:** prefix all pnpm/npx with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`.
+
+---
+
+## Established facts (verified by research — don't re-derive)
+
+- `GET /pam/elevation-requests` handler: `apps/api/src/routes/pam.ts:134-196`. SELECT already returns the whole `elevationRequests` row (including `metadata` jsonb and `softwarePolicyMatchId`) plus joined `deviceHostname`/`siteName`/`approvedByName`/`deniedByName`/`revokedByName` via aliased leftJoins.
+- Decision provenance is already STORED: `softwarePolicyMatchId` column (policy-decided), `metadata.pam_rule_id` + `metadata.pam_rule_name` (rule-decided, written in `apps/api/src/routes/agents/elevationRequests.ts` ~308-315), `denialReason` text. Missing only: the software policy NAME (needs a join) and first-class surfacing.
+- `softwarePolicies` table has `id`, `name`, `mode` columns.
+- Rule-creation Zod: `ruleBaseSchema` (pam.ts:565-593), `validateRuleShape` (pam.ts:637), `createRuleSchema` (pam.ts:~654). `POST /rules` at pam.ts:665 guarded by `requirePamWrite` + `requireMfa()`; `PATCH/DELETE /rules/:id` at pam.ts:717/781. Router-level: `authMiddleware` + `requireScope('organization','partner','system')` (pam.ts:85-86); `requirePamWrite` = DEVICES_WRITE permission (pam.ts:60-63). `siteScopeCondition` helper at pam.ts:102.
+- `pamRuleEngine.ts`: `evaluatePamRules(rules, candidate)` (line 181) sorts by priority and returns the first `PamRuleMatch` or null — passing a single-element array makes it a pure per-rule matcher. `PamRuleCandidate.at` is injectable ("Evaluation instant; injectable for tests. Defaults to now.") and `isWithinTimeWindow` is already folded into matching (line 169-171). Candidate fields: `targetExecutablePath/Hash/Signer`, `subjectUsername`, `parentImage`, `subjectAdGroups`, `toolName`, `riskTier`, `at`.
+- Web `apps/web/src/components/pam/types.ts`: `ElevationRequest` interface (lines 16-49, has `denialReason`, `toolName`, `riskTier` but NOT `metadata`/`softwarePolicyMatchId`), `FLOW_LABELS`, `STATUS_LABELS`, `VERDICT_LABELS`, `statusBadgeClass()` (yellow/green/blue/red/muted recipe), `requestTarget()`, `decidedByLabel()` (lines ~150-163 — returns **null** for `auto_approved` and for policy/rule-denied rows: the provenance gap).
+- `PamRequestsTab.tsx`: status+flow filter selects exist (lines 84-124); row table at 149-253; row actions Respond/Revoke (226-247); empty state at 140-147 ("No elevation requests / Requests matching the current filters will appear here."); refetches on `liveTick` (line 78).
+- `PamRespondModal.tsx` (176 lines): approve/deny toggle, duration, reason, `runAction` POST to `/pam/elevation-requests/:id/respond`; footer Cancel/Submit at 154-172.
+- `PamRuleModal.tsx` (540 lines): props `{ rule: PamRule | null; onClose; onSaved }`; full criteria state at lines 33-64 incl. `shape: 'executable' | 'tool'` toggle; submit handler 131-233 builds `payload` and POSTs `/pam/rules` (or PATCH `/rules/:id`); "Rule shape" section heading at line ~366.
+- `PamRulesTab.tsx`: header text "Rules are evaluated in priority order (lowest first); the first match decides." (line ~125); does NOT accept/consume `liveTick` (useEffect deps `[fetchRules]`, line 73-77); `PamPage.tsx` renders `<PamRulesTab />` without the prop while Overview/Requests/Audit get `liveTick`.
+- `PamOverviewTab.tsx`: 3 StatCards (Active/Pending/Recent), per-section empty states; fetches `/pam/active` + two `/pam/elevation-requests` queries.
+- `SoftwarePolicyTab.tsx` (configurationPolicies/featureTabs): linked-policy summary block at lines ~129-156 shows name/mode/`rules.software` only — no PAM mention.
+- Badge idiom: `inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(...)}`. Dialogs: `../shared/Dialog`.
+- API tests: `apps/api/src/routes/pam.test.ts` exists with `vi.mock('../db')` chain rigs, `setAuth()` helper, `app()` mounting `pamRoutes` (representative list test ~line 151).
+- Known limitation to carry through: historical rows don't store AD groups → a `matchAdGroup`-only draft previews 0 matches (faithful to live `uac_intercept` matching; pamRuleEngine.ts:23-25).
+
+---
+
+## File Map
+
+| File | Action | Task |
+|---|---|---|
+| `apps/api/src/routes/pam.ts` | Modify: provenance join+fields in list response; add `POST /rules/preview` | 1, 2 |
+| `apps/api/src/routes/pam.test.ts` | Modify: provenance + preview tests | 1, 2 |
+| `apps/web/src/components/pam/types.ts` | Modify: new fields, `decisionAttribution()`, `FLOW_ICONS`, `requestToRuleDraft()` | 3, 4, 6 |
+| `apps/web/src/components/pam/PamRequestsTab.tsx` | Modify: attribution display, Create-rule action, empty states | 3, 4, 6 |
+| `apps/web/src/components/pam/PamOverviewTab.tsx` | Modify: attribution in Recent decisions; first-run setup empty state | 3, 6 |
+| `apps/web/src/components/pam/PamAuditTab.tsx` | Modify: attribution display | 3 |
+| `apps/web/src/components/pam/PamRespondModal.tsx` | Modify: "create rule from request" path | 4 |
+| `apps/web/src/components/pam/PamRuleModal.tsx` | Modify: `initial` prop; preview section | 4, 5 |
+| `apps/web/src/components/pam/PamRulesTab.tsx` | Modify: liveTick; evaluation-order sentence | 6 |
+| `apps/web/src/components/pam/PamPage.tsx` | Modify: pass liveTick to RulesTab | 6 |
+| `apps/web/src/components/configurationPolicies/featureTabs/SoftwarePolicyTab.tsx` | Modify: UAC-gating note | 6 |
+| `apps/web/src/components/pam/*.test.tsx` | Modify/create: coverage per task | 3-6 |
+
+---
+
+### Task 1: API — decision provenance in the elevation-request list
+
+**Files:**
+- Modify: `apps/api/src/routes/pam.ts:158-196` (the GET `/elevation-requests` SELECT + response mapping)
+- Test: `apps/api/src/routes/pam.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `pam.test.ts`, find the existing GET `/elevation-requests` list test (~line 151) and its db rig. Add two tests in the same describe, reusing the rig verbatim and changing only the rigged row + assertions:
+
+```typescript
+it('surfaces software-policy provenance as first-class fields', async () => {
+  // Rig one row: status 'denied', softwarePolicyMatchId set, joined policy name present.
+  // (Extend the select-chain rig the existing list test uses: the row object gains
+  //  `matchedPolicyName: 'Engineering Blocklist'` alongside request/deviceHostname/etc.)
+  // ...same arrange + app().request invocation as the existing list test...
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  const row = body.requests[0];
+  expect(row.matchedPolicyName).toBe('Engineering Blocklist');
+  expect(row.decisionSource).toBe('software_policy');
+});
+
+it('surfaces pam-rule provenance from metadata and computes decisionSource', async () => {
+  // Rig one row: status 'auto_approved', softwarePolicyMatchId null,
+  // metadata: { pam_rule_id: 'rule-1', pam_rule_name: 'Allow signed installers' }.
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  const row = body.requests[0];
+  expect(row.pamRuleId).toBe('rule-1');
+  expect(row.pamRuleName).toBe('Allow signed installers');
+  expect(row.decisionSource).toBe('pam_rule');
+});
+```
+
+Also add a third quick case to an existing human-decided row assertion (or new test): a row with `approvedByUserId` set and neither policy nor rule metadata → `decisionSource === 'human'`; an untouched pending row → `decisionSource === null`.
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/pam.test.ts` — new tests FAIL (fields undefined), existing pass.
+
+- [ ] **Step 2: Implement in `pam.ts`**
+
+(a) Import `softwarePolicies` from the schema module pam.ts already imports tables from (check the top-of-file schema import and extend it).
+
+(b) In the list SELECT (lines 160-167), add a join + field:
+
+```typescript
+        matchedPolicyName: softwarePolicies.name,
+```
+and after the other leftJoins (line 173):
+```typescript
+      .leftJoin(softwarePolicies, eq(elevationRequests.softwarePolicyMatchId, softwarePolicies.id))
+```
+
+(c) Replace the response mapping (lines 186-193) with:
+
+```typescript
+    requests: rows.map((r) => {
+      const meta = (r.request.metadata ?? {}) as Record<string, unknown>;
+      const pamRuleId = typeof meta.pam_rule_id === 'string' ? meta.pam_rule_id : null;
+      const pamRuleName = typeof meta.pam_rule_name === 'string' ? meta.pam_rule_name : null;
+      const decisionSource = r.request.softwarePolicyMatchId
+        ? ('software_policy' as const)
+        : pamRuleId
+          ? ('pam_rule' as const)
+          : r.request.approvedByUserId || r.request.deniedByUserId || r.request.revokedByUserId
+            ? ('human' as const)
+            : null;
+      return {
+        ...r.request,
+        deviceHostname: r.deviceHostname,
+        siteName: r.siteName,
+        approvedByName: r.approvedByName,
+        deniedByName: r.deniedByName,
+        revokedByName: r.revokedByName,
+        matchedPolicyName: r.matchedPolicyName,
+        pamRuleId,
+        pamRuleName,
+        decisionSource,
+      };
+    }),
+```
+
+- [ ] **Step 3: Run tests** — all pass. Run `npx tsc --noEmit` (clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/routes/pam.ts apps/api/src/routes/pam.test.ts
+git commit -m "feat(pam): first-class decision provenance in elevation-request list
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: API — `POST /pam/rules/preview` (rule dry-run)
+
+**Files:**
+- Modify: `apps/api/src/routes/pam.ts` (constants near line 71; schema after `createRuleSchema` ~653; handler after the `POST /rules` block ~713, BEFORE `PATCH /rules/:id`)
+- Test: `apps/api/src/routes/pam.test.ts`
+
+Implements the agreed endpoint spec (Plan-agent design, 2026-06-12). Semantics: **pure per-rule criteria matching** against historical `elevation_requests` (NOT chain replay — no priority context, no software-policy bridge replay; that's documented future work). Reuses `evaluatePamRules([draftRule], candidate)` so matching has a single source of truth. Time windows are evaluated against each row's real `requestedAt` via `candidate.at`. No `verdict` in the request body (matching is verdict-independent; handler injects synthetic `require_approval` for `validateRuleShape`). No `excludeRuleId` (only meaningful for chain replay). `requirePamWrite`, **no** `requireMfa` (read-only dry-run). No migrations.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a `describe('POST /rules/preview', ...)` to `pam.test.ts` reusing the file's `setAuth()`/`app()`/db-rig harness. **Do NOT mock `../services/pamRuleEngine`** — the real engine must run (it's pure); rig only `db.select` rows. Six cases:
+
+```typescript
+// Helper for rigged elevation rows (only the columns preview selects):
+const previewRow = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: 'er-1', requestedAt: new Date('2026-06-10T18:00:00Z'), flowType: 'uac_intercept',
+  status: 'pending', subjectUsername: 'ACME\\jdoe',
+  targetExecutablePath: 'C:\\Tools\\installer.exe', targetExecutableHash: null,
+  targetExecutableSigner: 'Acme Corp', toolName: null, riskTier: null, metadata: {},
+  ...over,
+});
+
+it('counts signer matches case-insensitively', async () => {
+  // rig 5 rows, 3 with signer 'Acme Corp'/'ACME CORP'/'acme corp', 2 with 'Other Inc'
+  // body: { matchSigner: 'acme corp', windowDays: 30 }
+  expect(body.totalMatched).toBe(3);
+  expect(body.totalScanned).toBe(5);
+  expect(body.sample).toHaveLength(3);
+});
+
+it('does not match tool-action rows against executable criteria', async () => {
+  // rig 2 rows: one uac with signer, one ai_tool_action (toolName set, no signer)
+  // body: { matchSigner: 'Acme Corp' } → totalMatched 1
+});
+
+it('evaluates timeWindow against each row requestedAt', async () => {
+  // rows at 23:00Z and 12:00Z, body { matchUser: 'ACME\\jdoe',
+  //   timeWindow: { start: '22:00', end: '06:00', timezone: 'UTC' } }
+  // → totalMatched 1 (the 23:00 row; overnight wrap)
+});
+
+it('returns zeroed shape on empty scan', async () => {
+  // rig [] → 200, totalMatched 0, totalScanned 0, truncated false, sample []
+});
+
+it('rejects criterion-less, mixed, and out-of-range bodies', async () => {
+  // {} → 400; { matchSigner: 'x', matchToolName: 'y' } → 400;
+  // { matchSigner: 'x', windowDays: 0 } → 400; windowDays: 91 → 400
+});
+
+it('caps sample at 10 and tallies statusBreakdown', async () => {
+  // rig 14 matching rows: 9 pending, 5 auto_approved
+  // → totalMatched 14, sample.length 10, statusBreakdown.pending 9, statusBreakdown.auto_approved 5
+});
+```
+
+Run — all FAIL (404 route not found).
+
+- [ ] **Step 2: Implement**
+
+(a) Constants near the file's other bounds (~line 71):
+
+```typescript
+const PREVIEW_MAX_WINDOW_DAYS = 90;
+const PREVIEW_DEFAULT_WINDOW_DAYS = 30;
+const PREVIEW_SCAN_CAP = 5000;  // rows pulled into JS — totalScanned/truncated keep this honest
+const PREVIEW_SAMPLE_CAP = 10;
+```
+
+(b) Schema immediately after `createRuleSchema` (~line 653):
+
+```typescript
+const previewRuleSchema = ruleBaseSchema
+  .pick({
+    siteId: true,
+    matchSigner: true,
+    matchHash: true,
+    matchPathGlob: true,
+    matchParentImage: true,
+    matchUser: true,
+    matchAdGroup: true,
+    matchToolName: true,
+    matchRiskTier: true,
+    timeWindow: true,
+  })
+  .extend({
+    windowDays: z.number().int().min(1).max(PREVIEW_MAX_WINDOW_DAYS).optional(),
+    flowType: z.enum(['uac_intercept', 'tech_jit_admin', 'ai_tool_action']).optional(),
+  })
+  .superRefine((rule, ctx) => {
+    // Same shape rules as create (≥1 criterion, no executable/tool mixing).
+    // verdict is irrelevant to matching; inject a synthetic one for the validator.
+    const err = validateRuleShape({ ...rule, verdict: 'require_approval' });
+    if (err) ctx.addIssue({ code: z.ZodIssueCode.custom, message: err });
+  });
+```
+
+(If `ruleBaseSchema.pick` fights Zod typing on any field, fall back to a hand-rolled `z.object` duplicating exactly those field validators from `ruleBaseSchema` — keep validators identical.)
+
+(c) Handler after the `POST /rules` block (~line 713), before `PATCH /rules/:id`:
+
+```typescript
+// ============================================================
+// Rules — preview (dry-run draft criteria against history)
+// ============================================================
+// Pure per-rule matching: "would these criteria match these historical
+// requests". NOT a chain replay (no priority shadowing, no software-policy
+// bridge) — that variant is future work. Known limitation: historical rows
+// don't store AD groups, so matchAdGroup-only drafts report 0 (mirrors the
+// live uac_intercept ingest gap).
+pamRoutes.post('/rules/preview', requirePamWrite, zValidator('json', previewRuleSchema), async (c) => {
+  const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const body = c.req.valid('json');
+
+  const windowDays = body.windowDays ?? PREVIEW_DEFAULT_WINDOW_DAYS;
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+
+  const conditions: (SQL | undefined)[] = [
+    auth.orgCondition(elevationRequests.orgId),
+    siteScopeCondition(perms),
+    gte(elevationRequests.requestedAt, since),
+  ];
+  if (body.flowType) conditions.push(eq(elevationRequests.flowType, body.flowType));
+  if (body.siteId) {
+    if (perms && !canAccessSite(perms, body.siteId)) {
+      return c.json({ error: 'Site access denied' }, 403);
+    }
+    conditions.push(eq(elevationRequests.siteId, body.siteId));
+  }
+
+  const rows = await db
+    .select({
+      id: elevationRequests.id,
+      requestedAt: elevationRequests.requestedAt,
+      flowType: elevationRequests.flowType,
+      status: elevationRequests.status,
+      subjectUsername: elevationRequests.subjectUsername,
+      targetExecutablePath: elevationRequests.targetExecutablePath,
+      targetExecutableHash: elevationRequests.targetExecutableHash,
+      targetExecutableSigner: elevationRequests.targetExecutableSigner,
+      toolName: elevationRequests.toolName,
+      riskTier: elevationRequests.riskTier,
+      metadata: elevationRequests.metadata,
+    })
+    .from(elevationRequests)
+    .where(and(...conditions.filter((cn): cn is SQL => cn !== undefined)))
+    .orderBy(desc(elevationRequests.requestedAt))
+    .limit(PREVIEW_SCAN_CAP);
+
+  // Engine-shaped draft rule; matching reads match*/timeWindow/enabled only.
+  const draftRule = {
+    id: 'preview', name: 'preview', enabled: true, priority: 0,
+    verdict: 'ignore' as const, approvalDurationMinutes: null,
+    createdAt: new Date(),
+    matchSigner: body.matchSigner ?? null,
+    matchHash: body.matchHash ? body.matchHash.toLowerCase() : null,
+    matchPathGlob: body.matchPathGlob ?? null,
+    matchParentImage: body.matchParentImage ?? null,
+    matchUser: body.matchUser ?? null,
+    matchAdGroup: body.matchAdGroup ?? null,
+    matchToolName: body.matchToolName ?? null,
+    matchRiskTier: body.matchRiskTier ?? null,
+    timeWindow: body.timeWindow ?? null,
+  };
+
+  let totalMatched = 0;
+  const statusBreakdown: Record<string, number> = {
+    pending: 0, approved: 0, auto_approved: 0, denied: 0, expired: 0, revoked: 0, actuating: 0,
+  };
+  const sample: Array<Record<string, unknown>> = [];
+
+  for (const r of rows) {
+    const meta = (r.metadata ?? {}) as Record<string, unknown>;
+    const candidate = {
+      targetExecutablePath: r.targetExecutablePath ?? undefined,
+      targetExecutableHash: r.targetExecutableHash ?? undefined,
+      targetExecutableSigner: r.targetExecutableSigner ?? undefined,
+      subjectUsername: r.subjectUsername,
+      parentImage: typeof meta.parent_image === 'string' ? meta.parent_image : undefined,
+      toolName: r.toolName ?? undefined,
+      riskTier: r.riskTier ?? undefined,
+      at: r.requestedAt,
+    };
+    if (evaluatePamRules([draftRule], candidate)) {
+      totalMatched++;
+      statusBreakdown[r.status] = (statusBreakdown[r.status] ?? 0) + 1;
+      if (sample.length < PREVIEW_SAMPLE_CAP) {
+        sample.push({
+          id: r.id, requestedAt: r.requestedAt, flowType: r.flowType,
+          subjectUsername: r.subjectUsername,
+          targetExecutablePath: r.targetExecutablePath ?? null,
+          toolName: r.toolName ?? null, status: r.status,
+        });
+      }
+    }
+  }
+
+  return c.json({
+    success: true,
+    totalMatched,
+    totalScanned: rows.length,
+    windowDays,
+    truncated: rows.length === PREVIEW_SCAN_CAP,
+    statusBreakdown,
+    sample,
+  });
+});
+```
+
+Adapt the `draftRule`/`candidate` literals to the engine's actual exported types (`PamRule`-shape, `PamRuleCandidate`) — import what's needed from `../services/pamRuleEngine`; if `PamRule` there has extra required fields, satisfy them with nulls. `desc`/`gte`/`and`/`eq` are already imported (pam.ts:23).
+
+- [ ] **Step 3: Run tests** — 6 preview tests + whole pam.test.ts pass; `npx tsc --noEmit` clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/routes/pam.ts apps/api/src/routes/pam.test.ts
+git commit -m "feat(pam): POST /rules/preview — dry-run draft rule criteria against recent requests
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Web — decision attribution on every decided request
+
+**Files:**
+- Modify: `apps/web/src/components/pam/types.ts`
+- Modify: `apps/web/src/components/pam/PamRequestsTab.tsx` (status cell, lines 205-225)
+- Modify: `apps/web/src/components/pam/PamOverviewTab.tsx` (Recent decisions list)
+- Modify: `apps/web/src/components/pam/PamAuditTab.tsx` (status cell)
+- Test: `apps/web/src/components/pam/PamRequestsTab.test.tsx` (extend)
+
+- [ ] **Step 1: Failing test** — in `PamRequestsTab.test.tsx` (read its existing fetch-mock harness first), add: a rigged row with `status: 'auto_approved'`, `decisionSource: 'pam_rule'`, `pamRuleName: 'Allow signed installers'` renders the text `Rule · Allow signed installers`; a row with `decisionSource: 'software_policy'`, `matchedPolicyName: 'Engineering Blocklist'`, `status: 'denied'` renders `Policy · Engineering Blocklist`. Run — FAIL.
+
+- [ ] **Step 2: types.ts** — extend `ElevationRequest`:
+
+```typescript
+  softwarePolicyMatchId?: string | null;
+  matchedPolicyName?: string | null;
+  pamRuleId?: string | null;
+  pamRuleName?: string | null;
+  decisionSource?: 'software_policy' | 'pam_rule' | 'human' | null;
+```
+
+Add below `decidedByLabel` (keep `decidedByLabel` for human attribution):
+
+```typescript
+/**
+ * Who/what decided the request, for display under the status badge.
+ * Auto decisions name their source (software policy / PAM rule); human
+ * decisions defer to decidedByLabel. Null while pending/undecided.
+ */
+export function decisionAttribution(r: ElevationRequest): string | null {
+  if (r.decisionSource === 'software_policy') {
+    return `Policy · ${r.matchedPolicyName ?? 'Software policy'}`;
+  }
+  if (r.decisionSource === 'pam_rule') {
+    return `Rule · ${r.pamRuleName ?? 'PAM rule'}`;
+  }
+  const human = decidedByLabel(r);
+  return human ? `by ${human}` : null;
+}
+```
+
+- [ ] **Step 3: Render it** — in all three list surfaces, replace the `decidedBy`-only block with `decisionAttribution(r)`:
+
+`PamRequestsTab.tsx` (status cell, lines ~211-224): replace the `{decidedBy && (...)}` div with the same markup driven by `const attribution = decisionAttribution(r)`; keep `data-testid={`pam-decided-by-${r.id}`}` and the `title` attr. Keep the `denialReason` div but only when `decisionSource === 'human'` or `decisionSource == null` (policy/rule denials already name their source — the raw "Blocked by..." string is then redundant). Also update the row-map prelude (`const decidedBy = decidedByLabel(r);` → `const attribution = decisionAttribution(r);`).
+
+`PamOverviewTab.tsx` Recent-decisions list and `PamAuditTab.tsx` status cell: same substitution (their blocks are near-identical; keep their testids).
+
+- [ ] **Step 4: Run** `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/pam/` — all pass (fix any existing tests that asserted the old `by …` rendering for auto rows). `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/pam/types.ts apps/web/src/components/pam/PamRequestsTab.tsx apps/web/src/components/pam/PamOverviewTab.tsx apps/web/src/components/pam/PamAuditTab.tsx apps/web/src/components/pam/PamRequestsTab.test.tsx
+git commit -m "feat(pam): show decision provenance (policy/rule/human) on request rows
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Web — create a rule from a request
+
+**Files:**
+- Modify: `apps/web/src/components/pam/types.ts` (add `requestToRuleDraft`)
+- Modify: `apps/web/src/components/pam/PamRuleModal.tsx` (accept `initial` draft)
+- Modify: `apps/web/src/components/pam/PamRequestsTab.tsx` (row action + modal mount)
+- Modify: `apps/web/src/components/pam/PamRespondModal.tsx` (tertiary path)
+- Test: `apps/web/src/components/pam/PamRuleModal.test.tsx` / `PamRequestsTab.test.tsx` (extend)
+
+- [ ] **Step 1: Failing tests**
+  - `PamRuleModal.test.tsx`: rendering with `rule={null}` and `initial={{ shape: 'executable', matchSigner: 'Acme Corp', name: 'Allow installer.exe', siteId: 'site-1' }}` shows those values pre-filled (assert input values).
+  - `PamRequestsTab.test.tsx`: each row has a `pam-create-rule-btn-${id}` button; clicking it opens the rule modal (assert the dialog title appears).
+
+- [ ] **Step 2: `requestToRuleDraft` in types.ts**
+
+```typescript
+export interface PamRuleDraft {
+  shape: 'executable' | 'tool';
+  name?: string;
+  siteId?: string | null;
+  matchSigner?: string | null;
+  matchHash?: string | null;
+  matchPathGlob?: string | null;
+  matchUser?: string | null;
+  matchToolName?: string | null;
+  matchRiskTier?: number | null;
+}
+
+function baseName(path: string): string {
+  const i = Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/'));
+  return i >= 0 ? path.slice(i + 1) : path;
+}
+
+/**
+ * Seed a rule draft from a request. Prefers the stable criterion: signer
+ * over hash (hashes churn with updates) over path; tool actions seed
+ * toolName + riskTier; JIT admin seeds the subject user.
+ */
+export function requestToRuleDraft(r: ElevationRequest): PamRuleDraft {
+  if (r.flowType === 'ai_tool_action') {
+    return {
+      shape: 'tool',
+      name: r.toolName ? `Rule for ${r.toolName}` : undefined,
+      siteId: r.siteId ?? null,
+      matchToolName: r.toolName ?? null,
+      matchRiskTier: r.riskTier ?? null,
+    };
+  }
+  if (r.flowType === 'tech_jit_admin') {
+    return { shape: 'executable', siteId: r.siteId ?? null, matchUser: r.subjectUsername };
+  }
+  const name = r.targetExecutablePath ? `Rule for ${baseName(r.targetExecutablePath)}` : undefined;
+  if (r.targetExecutableSigner) {
+    return { shape: 'executable', name, siteId: r.siteId ?? null, matchSigner: r.targetExecutableSigner };
+  }
+  if (r.targetExecutableHash) {
+    return { shape: 'executable', name, siteId: r.siteId ?? null, matchHash: r.targetExecutableHash };
+  }
+  return { shape: 'executable', name, siteId: r.siteId ?? null, matchPathGlob: r.targetExecutablePath ?? null };
+}
+```
+
+- [ ] **Step 3: `PamRuleModal` accepts `initial`** — add optional prop `initial?: PamRuleDraft` and seed the create-mode state initializers (only when `rule === null`):
+
+```typescript
+export default function PamRuleModal({ rule, initial, onClose, onSaved }: {
+  rule: PamRule | null;
+  initial?: PamRuleDraft;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const seed = rule === null ? initial : undefined;
+  const [name, setName] = useState(rule?.name ?? seed?.name ?? '');
+  // ... shape: rule ? (existing logic) : (seed?.shape ?? 'executable')
+  // ... matchSigner: rule?.matchSigner ?? seed?.matchSigner ?? ''
+  // ... matchHash / matchPathGlob / matchUser / matchToolName analogous
+  // ... matchRiskTier: rule?.matchRiskTier ?? seed?.matchRiskTier (stringified as existing)
+  // ... siteId: rule?.siteId ?? seed?.siteId ?? ''
+```
+
+(Apply the `?? seed?.X ??` middle term to each existing `useState(rule?.X ?? fallback)` initializer for the seeded fields; leave verdict/priority/timeWindow untouched.)
+
+- [ ] **Step 4: Requests-tab action + RespondModal path**
+
+`PamRequestsTab.tsx`: add state `const [ruleDraft, setRuleDraft] = useState<ElevationRequest | null>(null);`, import `PamRuleModal` and `requestToRuleDraft`. In the actions cell (after the Revoke button, lines ~237-246) add for ALL rows:
+
+```tsx
+<button
+  type="button"
+  onClick={() => setRuleDraft(r)}
+  data-testid={`pam-create-rule-btn-${r.id}`}
+  title="Create a PAM rule pre-filled from this request"
+  className="ml-1.5 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent"
+>
+  Rule…
+</button>
+```
+
+Mount next to the other modals (lines ~280-299):
+
+```tsx
+{ruleDraft && (
+  <PamRuleModal
+    rule={null}
+    initial={requestToRuleDraft(ruleDraft)}
+    onClose={() => setRuleDraft(null)}
+    onSaved={() => {
+      setRuleDraft(null);
+      void fetchRequests();
+    }}
+  />
+)}
+```
+
+`PamRespondModal.tsx`: add optional prop `onCreateRule?: () => void`; render a quiet link-button on the LEFT of the footer (line ~154, inside the flex, before Cancel — change `justify-end` to `justify-between` with a left group):
+
+```tsx
+<div className="flex items-center justify-between gap-2">
+  {onCreateRule ? (
+    <button
+      type="button"
+      onClick={onCreateRule}
+      data-testid="pam-respond-create-rule"
+      className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+    >
+      Create rule from this request…
+    </button>
+  ) : <span />}
+  <div className="flex gap-2">
+    {/* existing Cancel + submit buttons unchanged */}
+  </div>
+</div>
+```
+
+In `PamRequestsTab.tsx`, pass `onCreateRule={() => { setRuleDraft(responding); setResponding(null); }}` to `PamRespondModal`.
+
+- [ ] **Step 5: Run** pam web tests + tsc — green. **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/pam/
+git commit -m "feat(pam): create rule pre-filled from an elevation request (row action + respond modal)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Web — rule preview in PamRuleModal
+
+**Files:**
+- Modify: `apps/web/src/components/pam/PamRuleModal.tsx`
+- Test: `apps/web/src/components/pam/PamRuleModal.test.tsx` (extend)
+
+- [ ] **Step 1: Failing test** — mock `fetchWithAuth` for `/pam/rules/preview` returning `{ success: true, totalMatched: 14, totalScanned: 240, windowDays: 30, truncated: false, statusBreakdown: { pending: 9, auto_approved: 5, approved: 0, denied: 0, expired: 0, revoked: 0, actuating: 0 }, sample: [ ...two rows... ] }`. Fill `matchSigner`, click the `pam-rule-preview-btn`, assert the result text `Would have matched 14 of 240 requests in the last 30 days` appears and the breakdown mentions `9 pending`.
+
+- [ ] **Step 2: Implement** — in `PamRuleModal.tsx`:
+
+State: `const [preview, setPreview] = useState<PreviewResult | null>(null);` `const [previewing, setPreviewing] = useState(false);` (local `type PreviewResult` mirroring the response). Stale-guard: clear `setPreview(null)` whenever any criteria/timeWindow/siteId state changes (a small `useEffect` over those deps).
+
+Handler (reuses the same criteria assembly as `handleSubmit` — extract the `activeCriteria`/window construction into a local `buildCriteria()` used by both):
+
+```typescript
+const handlePreview = async () => {
+  const built = buildCriteria();           // { activeCriteria, timeWindow } or sets error + returns null
+  if (!built) return;
+  setPreviewing(true);
+  setPreview(null);
+  try {
+    const res = await fetchWithAuth('/pam/rules/preview', {
+      method: 'POST',
+      body: JSON.stringify({
+        ...built.activeCriteria,
+        timeWindow: built.timeWindow,
+        siteId: siteId || null,
+      }),
+    });
+    if (!res.ok) throw new Error(`Preview failed (HTTP ${res.status})`);
+    setPreview(await res.json());
+  } catch (err) {
+    setError(err instanceof Error ? err.message : 'Preview failed');
+  } finally {
+    setPreviewing(false);
+  }
+};
+```
+
+(Read-only fetch — `runAction` is for mutations; a failed preview sets the modal's existing inline `error`, no toast.)
+
+UI, placed directly above the modal's footer buttons:
+
+```tsx
+<div className="rounded-md border bg-muted/20 p-3">
+  <div className="flex items-center justify-between">
+    <p className="text-sm font-medium">Preview against recent requests</p>
+    <button
+      type="button"
+      onClick={() => void handlePreview()}
+      disabled={previewing}
+      data-testid="pam-rule-preview-btn"
+      className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent disabled:opacity-50"
+    >
+      {previewing ? 'Previewing…' : 'Preview matches'}
+    </button>
+  </div>
+  {preview && (
+    <div className="mt-2 space-y-2 text-sm" data-testid="pam-rule-preview-result">
+      <p>
+        Would have matched <span className="font-semibold">{preview.totalMatched}</span> of{' '}
+        {preview.totalScanned} requests in the last {preview.windowDays} days
+        {preview.truncated ? ' (newest 5000 scanned)' : ''}.
+      </p>
+      {preview.totalMatched > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {Object.entries(preview.statusBreakdown)
+            .filter(([, n]) => n > 0)
+            .map(([s, n]) => `${n} ${STATUS_LABELS[s as ElevationStatus].toLowerCase()}`)
+            .join(' · ')}
+        </p>
+      )}
+      <ul className="space-y-1">
+        {preview.sample.slice(0, 5).map((s) => (
+          <li key={s.id} className="truncate text-xs text-muted-foreground">
+            {new Date(s.requestedAt).toLocaleString()} · {s.subjectUsername} ·{' '}
+            {s.targetExecutablePath ?? s.toolName ?? '—'}
+          </li>
+        ))}
+      </ul>
+      {/* AD-group caveat: historical rows lack group data */}
+      {matchAdGroup.trim() && (
+        <p className="text-xs text-muted-foreground">
+          Note: historical requests don't record AD groups, so group criteria preview as 0.
+        </p>
+      )}
+    </div>
+  )}
+</div>
+```
+
+Imports: `STATUS_LABELS`, `type ElevationStatus` from `./types`.
+
+- [ ] **Step 3: Run** tests + tsc — green. **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/pam/PamRuleModal.tsx apps/web/src/components/pam/PamRuleModal.test.tsx
+git commit -m "feat(pam): preview draft rule matches against recent requests in rule modal
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Web — teaching states, evaluation-order copy, flow icons, live fixes
+
+**Files:**
+- Modify: `apps/web/src/components/pam/types.ts` (FLOW_ICONS)
+- Modify: `apps/web/src/components/pam/PamRequestsTab.tsx` (empty state, flow cell)
+- Modify: `apps/web/src/components/pam/PamOverviewTab.tsx` (first-run state)
+- Modify: `apps/web/src/components/pam/PamAuditTab.tsx` (flow cell)
+- Modify: `apps/web/src/components/pam/PamRulesTab.tsx` (header copy + liveTick)
+- Modify: `apps/web/src/components/pam/PamPage.tsx` (pass liveTick)
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/SoftwarePolicyTab.tsx` (UAC note)
+- Tests: extend `PamRulesTab.test.tsx`, `PamOverviewTab.test.tsx`
+
+- [ ] **Step 1: Failing tests** — (a) `PamRulesTab.test.tsx`: component accepts `liveTick` and re-fetches when it changes (mock fetch, rerender with bumped prop, assert second call); header contains "Software policies are evaluated first". (b) `PamOverviewTab.test.tsx`: with all-zero data, the first-run block (`pam-setup-steps` testid) renders and mentions "Configuration Policies".
+
+- [ ] **Step 2: Flow icons** — `types.ts`: PAM components import lucide directly, so export a mapping component-side:
+
+```typescript
+import { Bot, MonitorCog, UserCog, type LucideIcon } from 'lucide-react';
+
+export const FLOW_ICONS: Record<ElevationFlowType, LucideIcon> = {
+  uac_intercept: MonitorCog,
+  tech_jit_admin: UserCog,
+  ai_tool_action: Bot,
+};
+```
+
+In `PamRequestsTab.tsx` (flow cell, line ~204) and `PamAuditTab.tsx` flow cell:
+
+```tsx
+<td className="whitespace-nowrap px-3 py-2">
+  {(() => {
+    const FlowIcon = FLOW_ICONS[r.flowType];
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <FlowIcon className="h-3.5 w-3.5 text-muted-foreground" />
+        {FLOW_LABELS[r.flowType]}
+      </span>
+    );
+  })()}
+</td>
+```
+
+(If `lucide-react` exports differ — `MonitorCog` missing — use `Monitor`. Verify with a grep in node_modules or existing usages.)
+
+- [ ] **Step 3: Requests empty state** — replace lines 140-147 block: keep icon + "No elevation requests"; the sub-copy becomes status-aware:
+
+```tsx
+<p className="mt-1 text-xs text-muted-foreground">
+  {status === 'pending'
+    ? 'Nothing waiting on you. New UAC prompts, JIT admin requests, and AI tool actions queue here.'
+    : 'Requests matching the current filters will appear here.'}
+</p>
+<p className="mt-2 text-xs text-muted-foreground">
+  Not seeing expected requests? UAC capture is controlled per device by{' '}
+  <a href="/configuration-policies" className="underline underline-offset-2 hover:text-foreground">
+    Configuration Policies → Privileged Access
+  </a>.
+</p>
+```
+
+- [ ] **Step 4: Overview first-run block** — in `PamOverviewTab.tsx`, when `data` is loaded and `data.active.length === 0 && data.pendingTotal === 0 && data.recent.length === 0`, render ABOVE the stat cards:
+
+```tsx
+<div className="rounded-md border bg-muted/20 p-4" data-testid="pam-setup-steps">
+  <p className="text-sm font-medium">Getting started with Privileged Access</p>
+  <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-muted-foreground">
+    <li>
+      UAC prompt capture is on by default. Scope it per device with a{' '}
+      <a href="/configuration-policies" className="underline underline-offset-2 hover:text-foreground">
+        Configuration Policy → Privileged Access
+      </a>{' '}
+      feature link.
+    </li>
+    <li>Elevation prompts, JIT admin requests, and AI tool actions queue in the Requests tab.</li>
+    <li>Approve or deny each request — or create a rule from it so the decision is automatic next time.</li>
+  </ol>
+</div>
+```
+
+- [ ] **Step 5: Rules header + liveTick** — `PamRulesTab.tsx`: header paragraph (line ~125) becomes:
+
+```tsx
+<p className="text-sm text-muted-foreground">
+  Software policies are evaluated first — an allowlist/blocklist match decides before these rules.
+  Rules then run in priority order (lowest first); the first match decides.
+</p>
+```
+
+Accept and consume `liveTick`: `export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number })` and add it to the fetch effect deps (line 73-77: `}, [fetchRules, liveTick]);`). `PamPage.tsx`: `<PamRulesTab liveTick={liveTick} />`.
+
+- [ ] **Step 6: SoftwarePolicyTab note** — in the linked-policy summary block (after the `Mode:` paragraph, ~line 134):
+
+```tsx
+<p className="mt-1 text-xs text-muted-foreground">
+  Executable rules in this policy also gate UAC elevation requests on assigned devices —
+  an allowlist match auto-approves, a blocklist match auto-denies, before any PAM rules run.
+</p>
+```
+
+- [ ] **Step 7: Run** all pam web tests + featureTabs tests + `npx tsc --noEmit` — green. **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/pam/ apps/web/src/components/configurationPolicies/featureTabs/SoftwarePolicyTab.tsx
+git commit -m "feat(pam): teaching empty states, evaluation-order copy, flow icons, rules live-refresh
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Verification checklist (post-implementation)
+
+- [ ] `apps/api`: `npx vitest run src/routes/pam.test.ts` green (provenance + 6 preview cases)
+- [ ] `apps/web`: `npx vitest run src/components/pam/ src/components/configurationPolicies/featureTabs/` green; `npx tsc --noEmit` clean both apps
+- [ ] No migrations added; no new tables (RLS untouched)
+- [ ] Spot-check copy: no raw `denialReason` shown for policy/rule denials; evaluation-order sentences present on Rules tab + SoftwarePolicyTab
+- [ ] Visual pass (optional, needs dev stack): provenance chips legible at a glance; "Rule…" action doesn't crowd the actions cell on narrow widths
+
+## Design rationale
+
+- **Provenance pattern `{Source} · {name}`** replaces both the silent auto-decisions and raw `denialReason` strings — Stripe-Radar anchor: every decision names its decider.
+- **Preview is pure per-rule matching, not chain replay** — deterministic, reuses `evaluatePamRules` with a single-element array; chain replay (priority shadowing + software-policy bridge replay, with `excludeRuleId`) is explicitly future work.
+- **`requestToRuleDraft` prefers signer > hash > path** — signers survive app updates; hashes churn.
+- **Preview has no MFA** — read-only dry-run; MFA stays on the mutating rule CRUD.
+- **AD-group caveat** surfaced in the preview UI because historical rows don't store groups (mirrors the live ingest gap).

--- a/docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md
+++ b/docs/superpowers/specs/2026-06-10-helper-privileged-action-pam-governance-design.md
@@ -250,3 +250,17 @@ Helper chat → tool call → preToolUse gate
   ingest routing, status bridge, `/respond` integration.
 - RLS/site-scope contract coverage for the new `ai_tool_action` rows.
 - No change to `waitForApproval`'s polling contract — verified by reuse.
+
+## Addendum (2026-06-12): Config-Policy enablement split
+
+UAC interception enablement is now a `pam` config-policy feature (inline
+settings `{uacInterceptionEnabled: boolean}`, default ON, closest-wins),
+delivered to the agent via the heartbeat `uacInterceptionEnabled` field and
+gated in `etwlua.handleEvent`. Rule authoring, the elevation request queue,
+and audit remain org/site-scoped in the standalone `/pam` control plane —
+closest-wins override semantics are intentionally NOT applied to the rule
+chain (a device-level policy must not silently shadow org baseline security
+rules). If partner-level rule baselines or device-group rule scoping become
+a requirement, revisit as a Pattern A linked feature with explicit
+merge (not override) semantics. Plan:
+`docs/superpowers/plans/2026-06-12-pam-config-policy-enablement.md`.

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -432,7 +432,7 @@ export const updateConfigPolicySchema = z.object({
 });
 
 export const addFeatureLinkSchema = z.object({
-  featureType: z.enum(['patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access']),
+  featureType: z.enum(['patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam']),
   featurePolicyId: z.string().uuid().optional(),
   inlineSettings: z.record(z.unknown()).optional(),
 }).refine(


### PR DESCRIPTION
## Summary
- Adds a `pam` config-policy feature type (inline settings, Pattern B) carrying `{ uacInterceptionEnabled: boolean }` — admins can now scope Windows UAC elevation capture per device/group/site/org/partner via the standard closest-wins hierarchy. Previously the agent's ETW listener was unconditionally on for every Windows agent running as a service.
- **Default is ON at every layer** (web tab, parser, resolver, heartbeat `?? true` fail-open, Go `*bool` nil-decode, agent pre-first-heartbeat) so existing deployments are behavior-preserving; admins opt *out* via policy. Old-agent/new-server and new-agent/old-server matrices both hold.
- API: per-device resolver + Redis-cached (120s) `buildPamConfigUpdate`, delivered as top-level `uacInterceptionEnabled` in the heartbeat response. Web: new "Privileged Access" feature tab (toggle + link-out to the `/pam` console). Agent: inverted `atomic.Bool` flag; `etwlua` drops events before the dedupe limiter and pauses both queue-drain sites while disabled (ETW session stays up — mirrors the `helperEnabled` precedent).
- **Deliberately out of scope:** PAM rule authoring/approvals/audit stay org/site-scoped in `/pam`. Closest-wins override semantics are wrong for security rule chains (a device-level policy must not silently shadow org baseline rules) — rationale recorded in an addendum to the 2026-06-10 PAM governance design spec.
- Migration is a single idempotent `ALTER TYPE ... ADD VALUE IF NOT EXISTS 'pam'`; no new tables, so no RLS work.

## Test Plan
- [x] `apps/api`: `pamSettings` parser unit tests (5) + heartbeat delivery/fail-open tests (25 incl. 2 new) — passing
- [x] `apps/web`: PamTab tests (3 new, featureTabs suite 33) + `tsc --noEmit` clean
- [x] `agent`: `go test -race ./internal/etwlua/ ./internal/heartbeat/` (incl. 6-case flag table test + drop-before-limiter test) + `GOOS=windows go build ./...` clean
- [ ] Post-merge smoke on a live Windows device: assign a policy with capture toggled OFF, confirm agent logs `UAC interception disabled by configuration policy` and no new `uac_intercept` elevation requests while triggering a UAC prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)