### PR TITLE
fix(agent): report instantaneous CPU% in Process Manager, not lifetime average

### DIFF
--- a/agent/internal/remote/tools/incident_response.go
+++ b/agent/internal/remote/tools/incident_response.go
@@ -102,6 +102,11 @@ func collectProcessEvidence() ([]EvidenceProcessInfo, error) {
 		return nil, fmt.Errorf("failed to list processes: %w", err)
 	}
 
+	// Instantaneous CPU% (100% == one core) measured over a window, so the
+	// evidence reflects what each process is doing *now* rather than a lifetime
+	// average that stays high long after a burst ends.
+	cpuPercents := sampleProcessCPUPercents(procs, cpuSampleInterval)
+
 	infos := make([]EvidenceProcessInfo, 0, len(procs))
 	for _, p := range procs {
 		name, err := p.Name()
@@ -123,9 +128,7 @@ func collectProcessEvidence() ([]EvidenceProcessInfo, error) {
 		if ct, err := p.CreateTime(); err == nil {
 			info.CreateTime = ct
 		}
-		if cpu, err := p.CPUPercent(); err == nil {
-			info.CPUPercent = cpu
-		}
+		info.CPUPercent = cpuPercents[p.Pid]
 		if mem, err := p.MemoryInfo(); err == nil && mem != nil {
 			info.RSS = mem.RSS
 		}

--- a/agent/internal/remote/tools/processes.go
+++ b/agent/internal/remote/tools/processes.go
@@ -7,13 +7,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/process"
 )
 
 // ListProcesses returns a paginated list of running processes.
 // On Windows, gopsutil's Username() calls LookupAccountSid per process which
-// can be very slow with AzureAD/domain accounts. We use 2 workers to overlap
-// IO-bound SID lookups without saturating CPU.
+// can be very slow with AzureAD/domain accounts. We use a small worker pool
+// (see workers below) to overlap IO-bound SID lookups without saturating CPU.
 func ListProcesses(payload map[string]any) CommandResult {
 	startTime := time.Now()
 
@@ -35,6 +36,11 @@ func ListProcesses(payload map[string]any) CommandResult {
 	if err != nil {
 		return NewErrorResult(err, time.Since(startTime).Milliseconds())
 	}
+
+	// Measure instantaneous CPU% across all processes up front: one shared
+	// sleep window, then the worker pool reads the precomputed value. This is
+	// what makes the list show *current* CPU rather than a lifetime average.
+	cpuPercents := sampleProcessCPUPercents(procs, cpuSampleInterval)
 
 	// 8 workers: overlaps IO-bound SID lookups (the bottleneck on Windows with
 	// AzureAD). The earlier 400% CPU spike was from leaked timeout goroutines
@@ -60,7 +66,7 @@ func ListProcesses(payload map[string]any) CommandResult {
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
-				info := getProcessInfo(job.p)
+				info := getProcessInfo(job.p, cpuPercents[job.p.Pid])
 				if info != nil {
 					mu.Lock()
 					results = append(results, indexedInfo{idx: job.idx, info: info})
@@ -198,26 +204,96 @@ func KillProcess(payload map[string]any) CommandResult {
 	return NewSuccessResult(result, time.Since(startTime).Milliseconds())
 }
 
-// getProcessInfo collects lightweight fields for the list view.
+// cpuSampleInterval is how long we observe processes to compute *instantaneous*
+// CPU usage. Like Activity Monitor / top, CPU% is a rate measured over a window,
+// not a lifetime total. 250ms keeps the process list responsive while producing
+// a stable reading.
+const cpuSampleInterval = 250 * time.Millisecond
+
+// cpuPercentFromCPUSeconds converts the CPU-seconds a process consumed over a
+// wall-clock window into a percentage where 100% == one full core (Activity
+// Monitor / top convention) — so a process pinning two cores reads 200%.
+//
+// This replaces gopsutil's Process.CPUPercent(), which returns a *lifetime
+// average* (total CPU time / process uptime). That average stays misleadingly
+// high long after a burst ends — e.g. a process that did heavy work and then
+// went idle keeps reporting a large number even when its threads are parked,
+// which is exactly the idle-but-"86%" symptom that motivated this change.
+func cpuPercentFromCPUSeconds(prevSeconds, curSeconds float64, elapsed time.Duration) float64 {
+	secs := elapsed.Seconds()
+	if secs <= 0 {
+		return 0
+	}
+	delta := curSeconds - prevSeconds
+	if delta < 0 {
+		// Counter went backwards (PID reused / process replaced mid-sample).
+		delta = 0
+	}
+	return 100 * delta / secs
+}
+
+// cpuSeconds returns the CPU time a process has consumed, in seconds. We use
+// User+System (matching top's per-process %CPU) rather than TimesStat.Total(),
+// which on Linux also folds in Iowait (time blocked on I/O, not CPU burn) and
+// would inflate the reading for I/O-bound processes.
+func cpuSeconds(ts *cpu.TimesStat) float64 {
+	return ts.User + ts.System
+}
+
+// sampleProcessCPUPercents measures instantaneous CPU usage for every process by
+// reading CPU-time counters, sleeping once for interval, then reading again and
+// diffing. The cost is interval + two O(n) counter-read passes — the key point
+// is a single shared sleep, never one sleep per process. Returns pid -> percent
+// (100% == one core).
+func sampleProcessCPUPercents(procs []*process.Process, interval time.Duration) map[int32]float64 {
+	type snapshot struct {
+		seconds float64
+		at      time.Time
+	}
+
+	first := make(map[int32]snapshot, len(procs))
+	for _, p := range procs {
+		if ts, err := p.Times(); err == nil {
+			first[p.Pid] = snapshot{seconds: cpuSeconds(ts), at: time.Now()}
+		}
+	}
+
+	time.Sleep(interval)
+
+	out := make(map[int32]float64, len(procs))
+	for _, p := range procs {
+		prev, ok := first[p.Pid]
+		if !ok {
+			continue
+		}
+		ts, err := p.Times()
+		if err != nil {
+			continue
+		}
+		out[p.Pid] = cpuPercentFromCPUSeconds(prev.seconds, cpuSeconds(ts), time.Since(prev.at))
+	}
+	return out
+}
+
+// getProcessInfo collects lightweight fields for the list view. CPU% is supplied
+// by the caller (measured over a window via sampleProcessCPUPercents) rather than
+// read here, so the value reflects current usage instead of a lifetime average.
 // Expensive fields (CommandLine, CreateTime, Status, Threads, ParentPID)
 // are fetched on demand via GetProcess when the user expands a row.
-func getProcessInfo(p *process.Process) *ProcessInfo {
+func getProcessInfo(p *process.Process, cpuPercent float64) *ProcessInfo {
 	name, err := p.Name()
 	if err != nil {
 		return nil
 	}
 
 	info := &ProcessInfo{
-		PID:    p.Pid,
-		Name:   name,
-		Status: "running",
+		PID:        p.Pid,
+		Name:       name,
+		Status:     "running",
+		CPUPercent: cpuPercent,
 	}
 
 	info.User = resolveUsername(p)
-
-	if cpuPercent, err := p.CPUPercent(); err == nil {
-		info.CPUPercent = cpuPercent
-	}
 
 	if memInfo, err := p.MemoryInfo(); err == nil && memInfo != nil {
 		info.MemoryMB = float64(memInfo.RSS) / 1024 / 1024
@@ -229,7 +305,10 @@ func getProcessInfo(p *process.Process) *ProcessInfo {
 // getFullProcessInfo collects all fields including expensive ones.
 // Used by GetProcess for the single-process detail view.
 func getFullProcessInfo(p *process.Process) *ProcessInfo {
-	info := getProcessInfo(p)
+	// Single-process view: sample this one process over the interval.
+	cpuPercent := sampleProcessCPUPercents([]*process.Process{p}, cpuSampleInterval)[p.Pid]
+
+	info := getProcessInfo(p, cpuPercent)
 	if info == nil {
 		return nil
 	}

--- a/agent/internal/remote/tools/processes_cpu_test.go
+++ b/agent/internal/remote/tools/processes_cpu_test.go
@@ -1,0 +1,154 @@
+package tools
+
+import (
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+// cpuPercentFromCPUSeconds is the pure core of the instantaneous-CPU
+// calculation. 100% == one full core (Activity Monitor / top convention),
+// so a process pinning two cores reads 200%.
+func TestCPUPercentFromCPUSeconds(t *testing.T) {
+	cases := []struct {
+		name      string
+		prevTotal float64
+		curTotal  float64
+		elapsed   time.Duration
+		want      float64
+	}{
+		{"idle: no cpu consumed", 10, 10, time.Second, 0},
+		{"one core fully busy for 1s", 5, 6, time.Second, 100},
+		{"half a core", 5, 5.5, time.Second, 50},
+		{"two cores over a 250ms window", 1, 1.5, 250 * time.Millisecond, 200},
+		{"zero elapsed is not a divide-by-zero", 1, 2, 0, 0},
+		{"negative elapsed clamps to zero", 1, 2, -time.Second, 0},
+		{"counter reset (proc replaced) clamps to zero", 100, 1, time.Second, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cpuPercentFromCPUSeconds(tc.prevTotal, tc.curTotal, tc.elapsed)
+			if got != tc.want {
+				t.Fatalf("cpuPercentFromCPUSeconds(%v, %v, %v) = %v, want %v",
+					tc.prevTotal, tc.curTotal, tc.elapsed, got, tc.want)
+			}
+		})
+	}
+}
+
+// A process that did heavy work in the past but is idle during the sample
+// window must read ~0 — this is the bug we are fixing (gopsutil's
+// Process.CPUPercent reports a lifetime average that stays high after a burst).
+// We approximate "idle now" by sampling a process that is not spinning.
+func TestSampleProcessCPUPercents_IdleProcessReadsLow(t *testing.T) {
+	self, err := process.NewProcess(int32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("NewProcess: %v", err)
+	}
+
+	// No CPU burned during the window -> should be near zero, definitely not
+	// pinned. We assert a generous ceiling to stay non-flaky on busy CI.
+	got := sampleProcessCPUPercents([]*process.Process{self}, 200*time.Millisecond)
+	pct, ok := got[self.Pid]
+	if !ok {
+		t.Fatalf("no sample returned for self pid %d", self.Pid)
+	}
+	if pct > 50 {
+		t.Fatalf("idle process reported %.1f%% CPU, expected near-idle", pct)
+	}
+}
+
+// A process burning a full core during the window must read meaningfully
+// above zero, proving the sampler reflects *current* usage.
+func TestSampleProcessCPUPercents_BusyProcessReadsHigh(t *testing.T) {
+	self, err := process.NewProcess(int32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("NewProcess: %v", err)
+	}
+
+	var stop atomic.Bool
+	var burners int
+	// Pin a couple of cores so the reading clears any noise floor.
+	for i := 0; i < 2 && i < runtime.NumCPU(); i++ {
+		burners++
+		go func() {
+			x := 0
+			for !stop.Load() {
+				x++ // busy loop
+				_ = x
+			}
+		}()
+	}
+	defer stop.Store(true)
+	if burners == 0 {
+		t.Skip("single-core environment; cannot create a busy burner")
+	}
+
+	got := sampleProcessCPUPercents([]*process.Process{self}, 300*time.Millisecond)
+	pct := got[self.Pid]
+	if pct < 25 {
+		t.Fatalf("busy process reported only %.1f%% CPU, expected clearly active", pct)
+	}
+}
+
+// This is the regression test for the actual bug: CPU that was burned in the
+// PAST must not inflate the CURRENT reading. The old gopsutil CPUPercent()
+// (lifetime average) would stay high here because the burst raised the lifetime
+// total; the interval sampler must read low because the burst ended before the
+// sample window opened.
+func TestSampleProcessCPUPercents_PastBurstDoesNotInflateCurrent(t *testing.T) {
+	if runtime.NumCPU() < 2 {
+		t.Skip("single-core environment; cannot burn then idle deterministically")
+	}
+	self, err := process.NewProcess(int32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("NewProcess: %v", err)
+	}
+
+	// Burn a couple of cores for a while to push up the lifetime CPU total.
+	var stop atomic.Bool
+	for i := 0; i < 2; i++ {
+		go func() {
+			x := 0
+			for !stop.Load() {
+				x++
+				_ = x
+			}
+		}()
+	}
+	time.Sleep(600 * time.Millisecond)
+	stop.Store(true)
+	time.Sleep(50 * time.Millisecond) // let the burners actually wind down
+
+	// Sample AFTER the burst is over. Instantaneous usage should be low even
+	// though the process has a high lifetime CPU total.
+	got := sampleProcessCPUPercents([]*process.Process{self}, 250*time.Millisecond)
+	if pct := got[self.Pid]; pct > 50 {
+		t.Fatalf("post-burst idle process reported %.1f%% CPU; interval sampler must "+
+			"reflect current usage, not the earlier burst", pct)
+	}
+}
+
+// A process that cannot be read (gone / invalid PID) is absent from the result
+// map, and callers fall back to the 0.0 zero value rather than crashing. This
+// pins the graceful-degradation contract that getProcessInfo / collectProcessEvidence
+// rely on (cpuPercents[pid]).
+func TestSampleProcessCPUPercents_UnreadableProcessDefaultsToZero(t *testing.T) {
+	// A PID that does not exist: both Times() reads fail, so it never enters
+	// the map.
+	ghost := &process.Process{Pid: 0x7fffffff}
+
+	got := sampleProcessCPUPercents([]*process.Process{ghost}, 50*time.Millisecond)
+	if _, present := got[ghost.Pid]; present {
+		t.Fatalf("unreadable process should be absent from the result map, got entry %v", got[ghost.Pid])
+	}
+	// Caller access pattern: map miss yields 0.0, not a panic.
+	if pct := got[ghost.Pid]; pct != 0 {
+		t.Fatalf("absent pid lookup = %v, want 0", pct)
+	}
+}


### PR DESCRIPTION
## Problem

A customer reported `breeze-desktop-helper` v0.69 showing **86.6% CPU at idle** in Remote Tools → Process Manager (fresh install, rebooted, 2019 Intel iMac, macOS 15.7.7). A macOS `sample` of the live PID proved **every thread was parked** (`__psynch_cvwait`/`semaphore_wait_trap`/`kevent`/`read`, zero on-CPU) — the process was idle.

**Root cause:** the Process Manager used gopsutil's `Process.CPUPercent()`, which returns a **lifetime average** (`total_cpu_time ÷ process_uptime`), not instantaneous CPU. After a real burst (here, software-H264 encoding during an earlier remote session — `libopenh264` was loaded, 288 MB peak), the average decays slowly, so an idle process keeps reading high.

## Fix

Measure **instantaneous** CPU like Activity Monitor / `top`: read CPU-time counters for all processes, sleep **one shared 250 ms window**, read again, divide the delta by elapsed wall-time (**100% == one core**, so a process on two cores reads 200%).

- New pure helper `cpuPercentFromCPUSeconds` (clamps divide-by-zero and counter-reset/PID-reuse to 0) + `sampleProcessCPUPercents` (prime → single sleep → read).
- CPU seconds use **User+System**, not `TimesStat.Total()` — `Total()` folds in `Iowait` on Linux, which would inflate I/O-bound processes.
- `ListProcesses` computes the map once before the worker pool; `getProcessInfo` takes the precomputed value; `getFullProcessInfo` samples the single process.
- `incident_response.go`'s `collectProcessEvidence` migrated to the same helper so forensic snapshots reflect current CPU too.

## Trade-offs (intentional)

- **+250 ms latency floor** on each process-list refresh and `GetProcess` — inherent to rate sampling (every OS monitor samples over a window). Front-end auto-refresh interval comfortably exceeds this.
- A process whose counters **can't be read** now reads **0%** and sorts to the bottom of the CPU-desc view, instead of retaining a stale non-zero value. Acceptable false-negative and the whole point of dropping lifetime-average.

## Tests

`processes_cpu_test.go`:
- `cpuPercentFromCPUSeconds` — 7 table cases (idle, one/half/two cores, zero/negative elapsed, counter reset).
- Live sampler: idle-reads-low, busy-reads-high, **past-burst-idle reads low** (regression test for the actual bug — would stay high under the old lifetime-average code), unreadable-PID → 0 (graceful-degradation contract).

`go vet` clean · `go test -race` clean · builds for windows/linux/darwin amd64.

## Reviewed

Ran the pr-review-toolkit (code / tests / silent-failures / comments) before opening; all important findings addressed in this branch (Linux iowait, regression-test gap, absent-PID coverage, stale worker-count comment, overstated O(interval) claim).

## Follow-up (separate, not in this PR)

The elevated lifetime average was the residue of a *genuinely* heavy earlier workload — software OpenH264 encoding on a 5K Intel iMac. Worth a separate issue to confirm the **VideoToolbox hardware encoder** is actually engaged on Intel Macs so live sessions don't fall back to CPU encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)