### PR TITLE
fix(security): close tenant-isolation & authz gaps from multi-tenant review

### DIFF
--- a/apps/api/migrations/2026-06-13-b-fk-child-rls-backstop.sql
+++ b/apps/api/migrations/2026-06-13-b-fk-child-rls-backstop.sql
@@ -1,0 +1,243 @@
+-- 2026-06-13-b: RLS backstop for seven tenant CHILD tables keyed by a parent
+-- FK (no org_id column), plus a tightening of the over-permissive
+-- ticket_comments INSERT policy.
+--
+-- Root cause (security review): the RLS coverage contract test auto-discovers
+-- tenant tables by the presence of an `org_id` column. Tenant child tables that
+-- reach their tenant only through a parent FK (and carry no denormalized
+-- org_id) are invisible to that auto-discovery and these seven shipped with NO
+-- row-level security at all — violating the CLAUDE.md invariant "no
+-- app-layer-only fallback". This migration installs ENABLE + FORCE RLS and
+-- per-command parent-join policies on each, mirroring the canonical shape from
+-- 2026-05-30-fk-child-tables-rls.sql. The companion change to
+-- rls-coverage.integration.test.ts adds all seven to PARENT_FK_JOIN_POLICY_TABLES
+-- so the class stops recurring.
+--
+-- Shape: a single FLAT EXISTS over the parent table, gated by
+-- public.breeze_has_org_access(parent.org_id). FLAT (not nested / multi-branch)
+-- deliberately — the repo hit a postgres.js bound-param bug with nested EXISTS
+-- through a nullable-org parent (#1016/#1026); keeping each branch a single
+-- flat EXISTS avoids it. System/background writers run under
+-- withSystemDbAccessContext, where breeze_has_org_access short-circuits TRUE.
+--
+-- Special case: role_permissions' parent `roles` is DUAL-AXIS (org_id and
+-- partner_id both nullable) with system-role templates (is_system = true,
+-- both axes NULL). Its policy mirrors 2026-04-11-roles-rls-fix.sql's access
+-- predicate so partner-owned and system roles stay reachable:
+--   breeze_has_partner_access(r.partner_id) OR breeze_has_org_access(r.org_id)
+--   OR (is_system AND both axes NULL AND a real scope).
+--
+-- Idempotent: DROP POLICY IF EXISTS x4 before each CREATE; ENABLE/FORCE are
+-- no-ops when already set. Re-running converges to the same state.
+-- autoMigrate wraps each migration file in a transaction — no inner BEGIN/COMMIT.
+
+-- ---------------------------------------------------------------------------
+-- webhook_deliveries  ->  webhooks(webhook_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON webhook_deliveries;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON webhook_deliveries;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON webhook_deliveries;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON webhook_deliveries;
+ALTER TABLE webhook_deliveries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE webhook_deliveries FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON webhook_deliveries FOR SELECT USING (
+  EXISTS (SELECT 1 FROM webhooks w WHERE w.id = webhook_deliveries.webhook_id AND public.breeze_has_org_access(w.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON webhook_deliveries FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM webhooks w WHERE w.id = webhook_deliveries.webhook_id AND public.breeze_has_org_access(w.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON webhook_deliveries FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM webhooks w WHERE w.id = webhook_deliveries.webhook_id AND public.breeze_has_org_access(w.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM webhooks w WHERE w.id = webhook_deliveries.webhook_id AND public.breeze_has_org_access(w.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON webhook_deliveries FOR DELETE USING (
+  EXISTS (SELECT 1 FROM webhooks w WHERE w.id = webhook_deliveries.webhook_id AND public.breeze_has_org_access(w.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- network_monitor_alert_rules  ->  network_monitors(monitor_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON network_monitor_alert_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON network_monitor_alert_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON network_monitor_alert_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON network_monitor_alert_rules;
+ALTER TABLE network_monitor_alert_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE network_monitor_alert_rules FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON network_monitor_alert_rules FOR SELECT USING (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_alert_rules.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON network_monitor_alert_rules FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_alert_rules.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON network_monitor_alert_rules FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_alert_rules.monitor_id AND public.breeze_has_org_access(m.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_alert_rules.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON network_monitor_alert_rules FOR DELETE USING (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_alert_rules.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- network_monitor_results  ->  network_monitors(monitor_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON network_monitor_results;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON network_monitor_results;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON network_monitor_results;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON network_monitor_results;
+ALTER TABLE network_monitor_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE network_monitor_results FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON network_monitor_results FOR SELECT USING (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_results.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON network_monitor_results FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_results.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON network_monitor_results FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_results.monitor_id AND public.breeze_has_org_access(m.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_results.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON network_monitor_results FOR DELETE USING (
+  EXISTS (SELECT 1 FROM network_monitors m WHERE m.id = network_monitor_results.monitor_id AND public.breeze_has_org_access(m.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- role_permissions  ->  roles(role_id)   [dual-axis parent + system-role carve-out]
+-- ---------------------------------------------------------------------------
+-- `roles` is dual-axis (org_id/partner_id both nullable) with global system
+-- templates. Mirror 2026-04-11-roles-rls-fix.sql's predicate so partner-owned
+-- and system roles stay reachable. The flat EXISTS keeps the #1016 bound-param
+-- bug at bay. breeze_has_org_access is present (required by the contract test);
+-- breeze_has_partner_access + the is_system carve-out widen access correctly.
+DROP POLICY IF EXISTS breeze_org_isolation_select ON role_permissions;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON role_permissions;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON role_permissions;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON role_permissions;
+ALTER TABLE role_permissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE role_permissions FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON role_permissions FOR SELECT USING (
+  EXISTS (SELECT 1 FROM roles r WHERE r.id = role_permissions.role_id AND (
+    public.breeze_has_partner_access(r.partner_id)
+    OR public.breeze_has_org_access(r.org_id)
+    OR (r.is_system = true AND r.partner_id IS NULL AND r.org_id IS NULL
+        AND public.breeze_current_scope() IS NOT NULL
+        AND public.breeze_current_scope() <> 'none')))
+);
+CREATE POLICY breeze_org_isolation_insert ON role_permissions FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM roles r WHERE r.id = role_permissions.role_id AND (
+    public.breeze_has_partner_access(r.partner_id)
+    OR public.breeze_has_org_access(r.org_id)))
+);
+CREATE POLICY breeze_org_isolation_update ON role_permissions FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM roles r WHERE r.id = role_permissions.role_id AND (
+    public.breeze_has_partner_access(r.partner_id)
+    OR public.breeze_has_org_access(r.org_id)))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM roles r WHERE r.id = role_permissions.role_id AND (
+    public.breeze_has_partner_access(r.partner_id)
+    OR public.breeze_has_org_access(r.org_id)))
+);
+CREATE POLICY breeze_org_isolation_delete ON role_permissions FOR DELETE USING (
+  EXISTS (SELECT 1 FROM roles r WHERE r.id = role_permissions.role_id AND (
+    public.breeze_has_partner_access(r.partner_id)
+    OR public.breeze_has_org_access(r.org_id)))
+);
+
+-- ---------------------------------------------------------------------------
+-- plugin_logs  ->  plugin_installations(installation_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON plugin_logs;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON plugin_logs;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON plugin_logs;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON plugin_logs;
+ALTER TABLE plugin_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE plugin_logs FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON plugin_logs FOR SELECT USING (
+  EXISTS (SELECT 1 FROM plugin_installations pi WHERE pi.id = plugin_logs.installation_id AND public.breeze_has_org_access(pi.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON plugin_logs FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM plugin_installations pi WHERE pi.id = plugin_logs.installation_id AND public.breeze_has_org_access(pi.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON plugin_logs FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM plugin_installations pi WHERE pi.id = plugin_logs.installation_id AND public.breeze_has_org_access(pi.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM plugin_installations pi WHERE pi.id = plugin_logs.installation_id AND public.breeze_has_org_access(pi.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON plugin_logs FOR DELETE USING (
+  EXISTS (SELECT 1 FROM plugin_installations pi WHERE pi.id = plugin_logs.installation_id AND public.breeze_has_org_access(pi.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- report_runs  ->  reports(report_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON report_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON report_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON report_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON report_runs;
+ALTER TABLE report_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE report_runs FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON report_runs FOR SELECT USING (
+  EXISTS (SELECT 1 FROM reports r WHERE r.id = report_runs.report_id AND public.breeze_has_org_access(r.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON report_runs FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM reports r WHERE r.id = report_runs.report_id AND public.breeze_has_org_access(r.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON report_runs FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM reports r WHERE r.id = report_runs.report_id AND public.breeze_has_org_access(r.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM reports r WHERE r.id = report_runs.report_id AND public.breeze_has_org_access(r.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON report_runs FOR DELETE USING (
+  EXISTS (SELECT 1 FROM reports r WHERE r.id = report_runs.report_id AND public.breeze_has_org_access(r.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- maintenance_occurrences  ->  maintenance_windows(window_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON maintenance_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON maintenance_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON maintenance_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON maintenance_occurrences;
+ALTER TABLE maintenance_occurrences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE maintenance_occurrences FORCE ROW LEVEL SECURITY;
+CREATE POLICY breeze_org_isolation_select ON maintenance_occurrences FOR SELECT USING (
+  EXISTS (SELECT 1 FROM maintenance_windows mw WHERE mw.id = maintenance_occurrences.window_id AND public.breeze_has_org_access(mw.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON maintenance_occurrences FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM maintenance_windows mw WHERE mw.id = maintenance_occurrences.window_id AND public.breeze_has_org_access(mw.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON maintenance_occurrences FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM maintenance_windows mw WHERE mw.id = maintenance_occurrences.window_id AND public.breeze_has_org_access(mw.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM maintenance_windows mw WHERE mw.id = maintenance_occurrences.window_id AND public.breeze_has_org_access(mw.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON maintenance_occurrences FOR DELETE USING (
+  EXISTS (SELECT 1 FROM maintenance_windows mw WHERE mw.id = maintenance_occurrences.window_id AND public.breeze_has_org_access(mw.org_id))
+);
+
+-- ---------------------------------------------------------------------------
+-- ticket_comments INSERT tightening
+-- ---------------------------------------------------------------------------
+-- The Phase 6 user-scoped INSERT policy (breeze_user_isolation_insert,
+-- 2026-04-11-bucket-c-phase-6-user-scoped-rls.sql) authorized ANY row where
+-- user_id = breeze_current_user_id() with NO parent-ticket org check, letting a
+-- user post a comment onto a ticket in any org. Recreate it so the WITH CHECK
+-- also requires the parent ticket to be org-accessible. tickets.org_id is NOT
+-- NULL and the tickets policy has no OR branches, so the EXISTS join is
+-- #1016-safe. The NULL-user system carve-out and the partner/org-admin EXISTS
+-- branch from the original are preserved (each still gated by the parent ticket
+-- being org-accessible).
+DROP POLICY IF EXISTS breeze_user_isolation_insert ON ticket_comments;
+CREATE POLICY breeze_user_isolation_insert ON ticket_comments
+  FOR INSERT WITH CHECK (
+    EXISTS (SELECT 1 FROM tickets t WHERE t.id = ticket_comments.ticket_id AND public.breeze_has_org_access(t.org_id))
+    AND (
+      (user_id IS NULL AND public.breeze_current_scope() = 'system')
+      OR user_id = public.breeze_current_user_id()
+      OR EXISTS (SELECT 1 FROM users u WHERE u.id = ticket_comments.user_id
+                 AND (public.breeze_has_partner_access(u.partner_id)
+                      OR public.breeze_has_org_access(u.org_id)))
+    )
+  );

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -159,6 +159,18 @@ const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new
   ['software_versions', ['software_catalog']],
   ['alert_correlations', ['alerts']],
   ['alert_notifications', ['alerts']],
+  // 2026-06-13-b backstop: seven more child tables that shipped with NO rls and
+  // reach their tenant only through a parent FK. role_permissions' parent
+  // `roles` is dual-axis (org_id/partner_id) — its policy ORs in
+  // breeze_has_partner_access + a system-role carve-out, but still references
+  // breeze_has_org_access and joins through `roles`, so this assertion holds.
+  ['webhook_deliveries', ['webhooks']],
+  ['network_monitor_alert_rules', ['network_monitors']],
+  ['network_monitor_results', ['network_monitors']],
+  ['role_permissions', ['roles']],
+  ['plugin_logs', ['plugin_installations']],
+  ['report_runs', ['reports']],
+  ['maintenance_occurrences', ['maintenance_windows']],
 ]);
 
 // Tables scoped to the calling user via breeze_current_user_id().

--- a/apps/api/src/__tests__/integration/ticket-config-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-config-rls.integration.test.ts
@@ -591,7 +591,7 @@ describe('time-entry org-rate end-to-end (D6 chain, real DB)', () => {
       );
     });
 
-    const actor = { userId: userA.id, partnerId: partnerA.id, manageAll: false as const };
+    const actor = { userId: userA.id, partnerId: partnerA.id, manageAll: false as const, accessibleOrgIds: [orgA.id] };
     let entry: any;
     await withDbAccessContext(partnerAContext, async () => {
       entry = await createTimeEntry(
@@ -649,7 +649,7 @@ describe('time-entry org-rate end-to-end (D6 chain, real DB)', () => {
       );
     });
 
-    const actor = { userId: userA.id, partnerId: partnerA.id, manageAll: false as const };
+    const actor = { userId: userA.id, partnerId: partnerA.id, manageAll: false as const, accessibleOrgIds: [orgA.id] };
     let entry: any;
     await withDbAccessContext(partnerAContext, async () => {
       entry = await createTimeEntry(

--- a/apps/api/src/__tests__/integration/time-entries-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/time-entries-rls.integration.test.ts
@@ -66,8 +66,8 @@ interface Fixture {
   techB: { id: string };
   partnerAContext: DbAccessContext;
   orgAContext: DbAccessContext;
-  techAActor: { userId: string; partnerId: string; manageAll: false };
-  adminAActor: { userId: string; partnerId: string; manageAll: true };
+  techAActor: { userId: string; partnerId: string; manageAll: false; accessibleOrgIds: string[] | null };
+  adminAActor: { userId: string; partnerId: string; manageAll: true; accessibleOrgIds: string[] | null };
 }
 
 async function seedFixture(): Promise<Fixture> {
@@ -152,8 +152,8 @@ async function seedFixture(): Promise<Fixture> {
     userId: techA.id,
   };
 
-  const techAActor = { userId: techA.id, partnerId: partnerA.id, manageAll: false as const };
-  const adminAActor = { userId: adminA.id, partnerId: partnerA.id, manageAll: true as const };
+  const techAActor = { userId: techA.id, partnerId: partnerA.id, manageAll: false as const, accessibleOrgIds: [orgA.id] };
+  const adminAActor = { userId: adminA.id, partnerId: partnerA.id, manageAll: true as const, accessibleOrgIds: [orgA.id] };
 
   return {
     partnerA, orgA, categoryA, ticketA, techA, adminA,

--- a/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
@@ -69,6 +69,7 @@ vi.mock('../../db/schema', () => ({
   devices: {
     id: 'devices.id',
     orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
     hostname: 'devices.hostname',
   },
 }));
@@ -450,6 +451,83 @@ describe('configurationPolicies patchJob routes', () => {
       expect(json.error).toContain('policy organization');
       expect(json.skipped.crossOrgDeviceIds).toEqual([device2]);
       expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    const SITE_ALLOWED = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const SITE_FORBIDDEN = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    it('denies patch jobs for a device outside the caller site allowlist before any insert', async () => {
+      getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, status: 'active', orgId: ORG_ID, name: 'P1' });
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal());
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: DEVICE_ID, orgId: ORG_ID, siteId: SITE_FORBIDDEN, hostname: 'host-1' },
+            ]),
+          }),
+        } as any);
+
+      checkDeviceMaintenanceWindowMock.mockResolvedValue(inactiveMaintenance);
+
+      app = new Hono();
+      app.use('*', async (c, next) => {
+        c.set('auth', makeAuth());
+        c.set('permissions', { allowedSiteIds: [SITE_ALLOWED] } as any);
+        await next();
+      });
+      app.route('/', patchJobRoutes);
+
+      const res = await app.request(`/${POLICY_ID}/patch-job`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_ID] }),
+      });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error).toContain('site');
+      expect(json.skipped.siteDeniedDeviceIds).toEqual([DEVICE_ID]);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('allows patch jobs for a device inside the caller site allowlist', async () => {
+      getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, status: 'active', orgId: ORG_ID, name: 'P1' });
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal());
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: DEVICE_ID, orgId: ORG_ID, siteId: SITE_ALLOWED, hostname: 'host-1' },
+            ]),
+          }),
+        } as any);
+
+      checkDeviceMaintenanceWindowMock.mockResolvedValue(inactiveMaintenance);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'job-1' }]),
+        }),
+      } as any);
+
+      app = new Hono();
+      app.use('*', async (c, next) => {
+        c.set('auth', makeAuth());
+        c.set('permissions', { allowedSiteIds: [SITE_ALLOWED] } as any);
+        await next();
+      });
+      app.route('/', patchJobRoutes);
+
+      const res = await app.request(`/${POLICY_ID}/patch-job`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_ID] }),
+      });
+
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.success).toBe(true);
+      expect(json.totalDevices).toBe(1);
     });
   });
 

--- a/apps/api/src/routes/configurationPolicies/patchJobs.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.ts
@@ -76,6 +76,7 @@ patchJobRoutes.post(
   zValidator('json', createPatchJobFromConfigPolicySchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
+    const userPerms = c.get('permissions') as UserPermissions | undefined;
     const { id: configPolicyId } = c.req.valid('param');
     const data = c.req.valid('json');
 
@@ -104,6 +105,7 @@ patchJobRoutes.post(
       .select({
         id: devices.id,
         orgId: devices.orgId,
+        siteId: devices.siteId,
         hostname: devices.hostname,
       })
       .from(devices)
@@ -111,6 +113,27 @@ patchJobRoutes.post(
 
     const foundDeviceIds = new Set(targetDevices.map((d) => d.id));
     const missingDeviceIds = data.deviceIds.filter((id) => !foundDeviceIds.has(id));
+
+    // Site-scope gate: `requirePatchExecute` populated permissions in context;
+    // enforce `allowedSiteIds` BEFORE any patch_jobs insert / enqueuePatchJob
+    // since RLS does not defend the site axis (it is intra-org). Mirrors the
+    // sibling GET /:id/resolve-patch-config/:deviceId and resolution.ts.
+    if (userPerms?.allowedSiteIds) {
+      const siteDeniedDeviceIds = targetDevices
+        .filter(
+          (d) =>
+            auth.canAccessOrg(d.orgId) &&
+            (typeof d.siteId !== 'string' || !canAccessSite(userPerms, d.siteId))
+        )
+        .map((d) => d.id);
+      if (siteDeniedDeviceIds.length > 0) {
+        return c.json({
+          error: 'Access to one or more device sites denied',
+          skipped: { missingDeviceIds, siteDeniedDeviceIds },
+        }, 403);
+      }
+    }
+
     const accessibleDevices = targetDevices.filter((d) => auth.canAccessOrg(d.orgId));
     const inaccessibleDeviceIds = targetDevices
       .filter((d) => !auth.canAccessOrg(d.orgId))

--- a/apps/api/src/routes/deployments.ts
+++ b/apps/api/src/routes/deployments.ts
@@ -274,6 +274,7 @@ deploymentRoutes.post(
   '/',
   requireScope('organization', 'partner', 'system'),
   requireDeploymentWrite,
+  requireMfa(),
   zValidator('json', createDeploymentSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -377,6 +378,7 @@ deploymentRoutes.put(
   '/:id',
   requireScope('organization', 'partner', 'system'),
   requireDeploymentWrite,
+  requireMfa(),
   zValidator('param', idParamSchema),
   zValidator('json', updateDeploymentSchema),
   async (c) => {
@@ -436,6 +438,7 @@ deploymentRoutes.delete(
   '/:id',
   requireScope('organization', 'partner', 'system'),
   requireDeploymentWrite,
+  requireMfa(),
   zValidator('param', idParamSchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/deployments_get_update_delete.test.ts
+++ b/apps/api/src/routes/deployments_get_update_delete.test.ts
@@ -94,7 +94,16 @@ vi.mock('../middleware/auth', () => ({
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
-  requireMfa: vi.fn(() => async (_c: any, next: any) => next())
+  // The MFA gate added in this PR on create/update/delete. Built once at import
+  // time, so it consults a mutable global flag: tests flip `__denyMfa` to assert
+  // a request without satisfied MFA gets 403. Default (false) keeps the existing
+  // happy-path tests passing.
+  requireMfa: vi.fn(() => async (_c: any, next: any) => {
+    if ((globalThis as any).__denyMfa) {
+      return _c.json({ error: 'MFA required' }, 403);
+    }
+    await next();
+  })
 }));
 
 import { db } from '../db';
@@ -270,6 +279,21 @@ describe('deployment routes', () => {
       expect(body.data.name).toBe('Updated Deploy');
     });
 
+    it('should return 403 when MFA is not satisfied', async () => {
+      (globalThis as any).__denyMfa = true;
+      try {
+        const res = await app.request(`/deployments/${DEPLOYMENT_ID_1}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'Updated Deploy' })
+        });
+        expect(res.status).toBe(403);
+        expect(db.update).not.toHaveBeenCalled();
+      } finally {
+        (globalThis as any).__denyMfa = false;
+      }
+    });
+
     it('should reject update for non-draft deployment', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
@@ -357,6 +381,20 @@ describe('deployment routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data.id).toBe(DEPLOYMENT_ID_1);
+    });
+
+    it('should return 403 when MFA is not satisfied', async () => {
+      (globalThis as any).__denyMfa = true;
+      try {
+        const res = await app.request(`/deployments/${DEPLOYMENT_ID_1}`, {
+          method: 'DELETE',
+          headers: { Authorization: 'Bearer token' }
+        });
+        expect(res.status).toBe(403);
+        expect(db.delete).not.toHaveBeenCalled();
+      } finally {
+        (globalThis as any).__denyMfa = false;
+      }
     });
 
     it('should reject deleting non-draft deployment', async () => {

--- a/apps/api/src/routes/deployments_list_create.test.ts
+++ b/apps/api/src/routes/deployments_list_create.test.ts
@@ -94,7 +94,16 @@ vi.mock('../middleware/auth', () => ({
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
-  requireMfa: vi.fn(() => async (_c: any, next: any) => next())
+  // The MFA gate added in this PR on create/update/delete. Built once at import
+  // time, so it consults a mutable global flag: tests flip `__denyMfa` to assert
+  // a request without satisfied MFA gets 403. Default (false) keeps the existing
+  // happy-path tests passing.
+  requireMfa: vi.fn(() => async (_c: any, next: any) => {
+    if ((globalThis as any).__denyMfa) {
+      return _c.json({ error: 'MFA required' }, 403);
+    }
+    await next();
+  })
 }));
 
 import { db } from '../db';
@@ -261,6 +270,22 @@ describe('deployment routes', () => {
       const body = await res.json();
       expect(body.data.id).toBe(DEPLOYMENT_ID_1);
       expect(body.data.status).toBe('draft');
+    });
+
+    it('should return 403 when MFA is not satisfied', async () => {
+      (globalThis as any).__denyMfa = true;
+      try {
+        const res = await app.request('/deployments', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify(validCreatePayload)
+        });
+        expect(res.status).toBe(403);
+        // The MFA gate must run before any DB write.
+        expect(db.insert).not.toHaveBeenCalled();
+      } finally {
+        (globalThis as any).__denyMfa = false;
+      }
     });
 
     it('should reject when org user has no orgId', async () => {

--- a/apps/api/src/routes/playbooks.test.ts
+++ b/apps/api/src/routes/playbooks.test.ts
@@ -228,14 +228,195 @@ describe('playbook routes', () => {
     expect(body.error).toContain('same organization');
   });
 
+  it('rejects execution when site-restricted caller targets a device outside their site allowlist', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: PLAYBOOK_ID,
+              name: 'Service Restart',
+              category: 'service',
+              steps: [],
+              orgId: '11111111-1111-1111-1111-111111111111',
+              isBuiltIn: false,
+              isActive: true,
+              requiredPermissions: ['devices:execute'],
+            }]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: DEVICE_ID,
+              orgId: '11111111-1111-1111-1111-111111111111',
+              siteId: SITE_FORBIDDEN,
+              hostname: 'server-01',
+            }]),
+          }),
+        }),
+      } as any);
+    vi.mocked(checkPlaybookRequiredPermissions).mockResolvedValueOnce({
+      allowed: true,
+      missingPermissions: [],
+    });
+
+    const res = await app.request(`/playbooks/${PLAYBOOK_ID}/execute`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+        'x-restrict-site': SITE_ALLOWED,
+      },
+      body: JSON.stringify({ deviceId: DEVICE_ID }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Device not found or access denied');
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('allows execution when site-restricted caller targets a device inside their site allowlist', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: PLAYBOOK_ID,
+              name: 'Service Restart',
+              description: 'Restart a service',
+              category: 'service',
+              steps: [],
+              orgId: '11111111-1111-1111-1111-111111111111',
+              isBuiltIn: false,
+              isActive: true,
+              requiredPermissions: ['devices:execute'],
+            }]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: DEVICE_ID,
+              orgId: '11111111-1111-1111-1111-111111111111',
+              siteId: SITE_ALLOWED,
+              hostname: 'server-01',
+            }]),
+          }),
+        }),
+      } as any);
+    vi.mocked(checkPlaybookRequiredPermissions).mockResolvedValueOnce({
+      allowed: true,
+      missingPermissions: [],
+    });
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: EXECUTION_ID,
+          status: 'pending',
+          currentStepIndex: 0,
+        }]),
+      }),
+    } as any);
+
+    const res = await app.request(`/playbooks/${PLAYBOOK_ID}/execute`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+        'x-restrict-site': SITE_ALLOWED,
+      },
+      body: JSON.stringify({ deviceId: DEVICE_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.execution.id).toBe(EXECUTION_ID);
+  });
+
+  it('rejects PATCH when site-restricted caller updates an execution for an out-of-site device', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: EXECUTION_ID,
+              status: 'pending',
+              deviceSiteId: SITE_FORBIDDEN,
+            }]),
+          }),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request(`/playbooks/executions/${EXECUTION_ID}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+        'x-restrict-site': SITE_ALLOWED,
+      },
+      body: JSON.stringify({ status: 'running' }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Execution not found or access denied');
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('allows PATCH when site-restricted caller updates an execution for an in-site device', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: EXECUTION_ID,
+              status: 'pending',
+              deviceSiteId: SITE_ALLOWED,
+            }]),
+          }),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request(`/playbooks/executions/${EXECUTION_ID}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+        'x-restrict-site': SITE_ALLOWED,
+      },
+      body: JSON.stringify({ status: 'running' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.execution.status).toBe('running');
+  });
+
   it('rejects invalid execution status transitions', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{
-            id: EXECUTION_ID,
-            status: 'pending',
-          }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: EXECUTION_ID,
+              status: 'pending',
+            }]),
+          }),
         }),
       }),
     } as any);
@@ -254,8 +435,10 @@ describe('playbook routes', () => {
   it('allows valid transition pending → running', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'pending' }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'pending' }]),
+          }),
         }),
       }),
     } as any);
@@ -281,8 +464,10 @@ describe('playbook routes', () => {
   it('allows valid transition running → completed', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+          }),
         }),
       }),
     } as any);
@@ -306,8 +491,10 @@ describe('playbook routes', () => {
   it('allows valid transition running → failed with error message', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+          }),
         }),
       }),
     } as any);
@@ -333,8 +520,10 @@ describe('playbook routes', () => {
   it('allows valid transition running → rolled_back', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+          }),
         }),
       }),
     } as any);
@@ -369,8 +558,10 @@ describe('playbook routes', () => {
   ])('rejects terminal transition %s → %s', async (from, to) => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: from }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: from }]),
+          }),
         }),
       }),
     } as any);
@@ -389,8 +580,10 @@ describe('playbook routes', () => {
   it('returns 409 on concurrent modification (optimistic lock)', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+          }),
         }),
       }),
     } as any);
@@ -447,8 +640,10 @@ describe('playbook routes', () => {
   it('updates step results and currentStepIndex without status change', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: EXECUTION_ID, status: 'running' }]),
+          }),
         }),
       }),
     } as any);

--- a/apps/api/src/routes/playbooks.ts
+++ b/apps/api/src/routes/playbooks.ts
@@ -240,6 +240,7 @@ playbookRoutes.post(
   async (c) => {
     const { id: playbookId } = c.req.valid('param');
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const body = c.req.valid('json');
 
     try {
@@ -279,6 +280,7 @@ playbookRoutes.post(
         .select({
           id: devices.id,
           orgId: devices.orgId,
+          siteId: devices.siteId,
           hostname: devices.hostname,
         })
         .from(devices)
@@ -287,6 +289,16 @@ playbookRoutes.post(
 
       if (!device) {
         return c.json({ error: 'Device not found or access denied' }, 404);
+      }
+
+      // Site-scope gate: RLS does not defend the site axis (it is intra-org).
+      // Reject site-restricted callers targeting a device outside their site
+      // allowlist. Mirrors GET /executions in this file.
+      if (
+        perms?.allowedSiteIds &&
+        (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))
+      ) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
       }
 
       if (playbook.orgId !== null && playbook.orgId !== device.orgId) {
@@ -353,6 +365,7 @@ playbookRoutes.patch(
   async (c) => {
     const { id } = c.req.valid('param');
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const body = c.req.valid('json');
 
     try {
@@ -364,13 +377,25 @@ playbookRoutes.patch(
         .select({
           id: playbookExecutions.id,
           status: playbookExecutions.status,
+          deviceSiteId: devices.siteId,
         })
         .from(playbookExecutions)
+        .leftJoin(devices, eq(playbookExecutions.deviceId, devices.id))
         .where(and(...accessConditions))
         .limit(1);
 
       if (!existing) {
         return c.json({ error: 'Execution not found' }, 404);
+      }
+
+      // Site-scope gate: RLS does not defend the site axis (it is intra-org).
+      // Reject site-restricted callers updating an execution whose target
+      // device is outside their site allowlist. Mirrors GET /executions/:id.
+      if (
+        perms?.allowedSiteIds &&
+        (typeof existing.deviceSiteId !== 'string' || !canAccessSite(perms, existing.deviceSiteId))
+      ) {
+        return c.json({ error: 'Execution not found or access denied' }, 403);
       }
 
       const updateData: Partial<typeof playbookExecutions.$inferInsert> = {

--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { automationPolicies, automationRuns, automations } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { evaluatePolicy, resolvePolicyRemediationAutomationId } from '../../services/policyEvaluationService';
 import { AuthContext, policyIdSchema } from './schemas';
@@ -15,6 +15,9 @@ export const actionRoutes = new Hono();
 actionRoutes.post(
   '/:id/activate',
   requireScope('organization', 'partner', 'system'),
+  // requireScope only checks tenancy tier, not role. Toggling policy state
+  // mutates enforcement that drives device automations, so gate on device-write.
+  requirePermission('devices', 'write'),
   zValidator('param', policyIdSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
@@ -48,6 +51,8 @@ actionRoutes.post(
 actionRoutes.post(
   '/:id/deactivate',
   requireScope('organization', 'partner', 'system'),
+  // Mutates policy enforcement state (see activate) — requires device-write.
+  requirePermission('devices', 'write'),
   zValidator('param', policyIdSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
@@ -81,6 +86,9 @@ actionRoutes.post(
 actionRoutes.post(
   '/:id/evaluate',
   requireScope('organization', 'partner', 'system'),
+  // Evaluate is a read-trigger (assesses compliance, may request remediation).
+  // Gate on at least device-read so a no-permission user can't trigger it.
+  requirePermission('devices', 'read'),
   zValidator('param', policyIdSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;
@@ -117,6 +125,9 @@ actionRoutes.post(
 actionRoutes.post(
   '/:id/remediate',
   requireScope('organization', 'partner', 'system'),
+  // Triggers a remediation automation run against devices — a state-mutating,
+  // execute-like action. Gate on device-write (mirrors activate/deactivate).
+  requirePermission('devices', 'write'),
   zValidator('param', policyIdSchema),
   async (c) => {
     const auth = c.get('auth') as AuthContext;

--- a/apps/api/src/routes/policyManagement_actions.test.ts
+++ b/apps/api/src/routes/policyManagement_actions.test.ts
@@ -128,7 +128,16 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next())
+  // The RBAC gate added in this PR. Built once at import time, so it consults a
+  // mutable global flag rather than a re-mocked implementation. Tests flip
+  // `__denyPermission` to assert a user lacking the permission gets 403; default
+  // (false) lets every gate pass so the existing happy-path tests stay green.
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if ((globalThis as any).__denyPermission) {
+      return c.json({ error: 'Permission denied' }, 403);
+    }
+    await next();
+  })
 }));
 
 import { db } from '../db';
@@ -159,6 +168,7 @@ describe('policyManagement routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (globalThis as any).__denyPermission = false;
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', {
         user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
@@ -427,6 +437,31 @@ describe('policyManagement routes', () => {
 
       expect(res.status).toBe(404);
     });
+  });
+
+  // ----------------------------------------------------------------
+  // RBAC permission gate (added with the requirePermission fix). requireScope
+  // alone only checks tenancy tier, so a read-only role would pass. Each action
+  // route now also requires a devices permission; assert a caller lacking it
+  // gets 403 before any policy state is read or mutated.
+  // ----------------------------------------------------------------
+  describe('RBAC permission gate', () => {
+    it.each(['activate', 'deactivate', 'evaluate', 'remediate'])(
+      'should return 403 on POST /:id/%s when caller lacks the required permission',
+      async (action) => {
+        (globalThis as any).__denyPermission = true;
+
+        const res = await app.request(`/policies/${POLICY_ID}/${action}`, {
+          method: 'POST',
+          headers: { Authorization: 'Bearer token' }
+        });
+
+        expect(res.status).toBe(403);
+        // Gate runs before the handler — no policy lookup/mutation should occur.
+        expect(db.select).not.toHaveBeenCalled();
+        expect(db.update).not.toHaveBeenCalled();
+      }
+    );
   });
 
 });

--- a/apps/api/src/routes/security.test.ts
+++ b/apps/api/src/routes/security.test.ts
@@ -53,7 +53,18 @@ vi.mock('../middleware/auth', () => ({
     });
     return next();
   }),
-  requireScope: vi.fn(() => (c: any, next: any) => next())
+  requireScope: vi.fn(() => (c: any, next: any) => next()),
+  // The RBAC gate added in this PR. The gate middleware is built once at import
+  // time, so it consults a mutable global flag rather than relying on a
+  // re-mocked implementation: tests flip `__denyPermission` to assert a user
+  // lacking the permission gets 403. Default (false) lets every gate pass so
+  // the existing route tests keep exercising the happy path.
+  requirePermission: vi.fn(() => async (_c: any, next: any) => {
+    if ((globalThis as any).__denyPermission) {
+      return _c.json({ error: 'Permission denied' }, 403);
+    }
+    await next();
+  })
 }));
 
 vi.mock('../services/permissions', () => ({
@@ -157,6 +168,7 @@ describe('security routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (globalThis as any).__denyPermission = false;
     vi.mocked(listLatestSecurityPosture).mockResolvedValue([]);
     vi.mocked(getSecurityPostureTrend).mockResolvedValue([]);
     vi.mocked(getLatestSecurityPostureForDevice).mockResolvedValue(null);
@@ -304,6 +316,20 @@ describe('security routes', () => {
 
       expect(res.status).toBe(404);
     });
+
+    it('should return 403 when caller lacks the devices:execute permission', async () => {
+      (globalThis as any).__denyPermission = true;
+
+      const res = await app.request('/security/scan/f1bd7f85-1df4-44aa-8147-6b4dba0b7e05', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scanType: 'quick' })
+      });
+
+      expect(res.status).toBe(403);
+      // Gate runs before the handler — no command should be dispatched.
+      expect(queueCommand).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /security/scans/:deviceId', () => {
@@ -340,6 +366,65 @@ describe('security routes', () => {
       const body = await res.json();
       expect(body.data.length).toBeGreaterThan(0);
       expect(body.data.every((scan: any) => scan.status === 'completed')).toBe(true);
+    });
+  });
+
+  describe('POST /security/threats/:id/{quarantine,remove,restore} RBAC gate', () => {
+    const threatId = '9b0ce8f4-21c0-4f65-8b0a-0b9f8bbf9a11';
+
+    it.each(['quarantine', 'remove', 'restore'] as const)(
+      'should return 403 on /%s when caller lacks devices:execute',
+      async (action) => {
+        (globalThis as any).__denyPermission = true;
+
+        const res = await app.request(`/security/threats/${threatId}/${action}`, {
+          method: 'POST',
+          headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+          body: JSON.stringify({})
+        });
+
+        expect(res.status).toBe(403);
+        // Destructive agent command must not be dispatched when RBAC denies.
+        expect(queueCommand).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('POST/PUT /security/policies RBAC gate', () => {
+    const validPolicyBody = {
+      name: 'Test AV Policy',
+      scanSchedule: 'weekly',
+      realTimeProtection: true,
+      autoQuarantine: true,
+      severityThreshold: 'medium',
+      exclusions: []
+    };
+
+    it('should return 403 on POST when caller lacks devices:write', async () => {
+      (globalThis as any).__denyPermission = true;
+
+      const res = await app.request('/security/policies', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPolicyBody)
+      });
+
+      expect(res.status).toBe(403);
+      // Gate runs before the handler — nothing should be written.
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 on PUT when caller lacks devices:write', async () => {
+      (globalThis as any).__denyPermission = true;
+
+      const res = await app.request('/security/policies/9b0ce8f4-21c0-4f65-8b0a-0b9f8bbf9a11', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/security/helpers.ts
+++ b/apps/api/src/routes/security/helpers.ts
@@ -8,6 +8,7 @@ import {
   securityThreats
 } from '../../db/schema';
 import type { AuthContext } from '../../middleware/auth';
+import { canAccessSite, getUserPermissions, type UserPermissions } from '../../services/permissions';
 import { CommandTypes, queueCommand } from '../../services/commandQueue';
 import type { SecurityPostureItem } from '../../services/securityPosture';
 import {
@@ -700,6 +701,14 @@ export function impactFromAffected(affectedDevices: number, totalDevices: number
 
 export async function queueThreatAction(c: any, action: 'quarantine' | 'remove' | 'restore') {
   const auth = c.get('auth') as AuthContext;
+  let userPerms = c.get('permissions') as UserPermissions | undefined;
+  if (!userPerms) {
+    const fetched = await getUserPermissions(auth.user.id, {
+      partnerId: auth.partnerId || undefined,
+      orgId: auth.orgId || undefined,
+    });
+    userPerms = fetched || undefined;
+  }
   const { id } = c.req.valid('param') as { id: string };
 
   const orgCondition = auth.orgCondition(devices.orgId);
@@ -710,6 +719,7 @@ export async function queueThreatAction(c: any, action: 'quarantine' | 'remove' 
     .select({
       id: securityThreats.id,
       deviceId: securityThreats.deviceId,
+      deviceSiteId: devices.siteId,
       provider: securityThreats.provider,
       threatName: securityThreats.threatName,
       threatType: securityThreats.threatType,
@@ -724,6 +734,16 @@ export async function queueThreatAction(c: any, action: 'quarantine' | 'remove' 
 
   if (!threat) {
     return c.json({ error: 'Threat not found' }, 404);
+  }
+
+  // Site-scope gate: RLS does not defend the site axis (it is intra-org).
+  // Reject site-restricted callers acting on a threat whose device is outside
+  // their site allowlist. Mirrors the GET /threats/:deviceId read path.
+  if (
+    userPerms?.allowedSiteIds &&
+    (typeof threat.deviceSiteId !== 'string' || !canAccessSite(userPerms, threat.deviceSiteId))
+  ) {
+    return c.json({ error: 'Access to this site denied' }, 403);
   }
 
   const commandType = action === 'quarantine'

--- a/apps/api/src/routes/security/policies.ts
+++ b/apps/api/src/routes/security/policies.ts
@@ -4,7 +4,7 @@ import { and, desc, eq } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { securityPolicies } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope } from '../../middleware/auth';
 import {
   listPoliciesQuerySchema,
   createPolicySchema,
@@ -76,6 +76,11 @@ policiesRoutes.get(
 policiesRoutes.post(
   '/policies',
   requireScope('organization', 'partner', 'system'),
+  // requireScope only checks tenancy tier, not role. Security policies are
+  // device-security settings (AV scan schedule, real-time protection,
+  // auto-quarantine, exclusions), so mutating them requires a device-write
+  // permission — matches sensitiveData policy writes (DEVICES_WRITE).
+  requirePermission('devices', 'write'),
   zValidator('json', createPolicySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -125,6 +130,8 @@ policiesRoutes.post(
 policiesRoutes.put(
   '/policies/:id',
   requireScope('organization', 'partner', 'system'),
+  // Device-security config mutation requires device-write (see POST /policies).
+  requirePermission('devices', 'write'),
   zValidator('param', policyIdParamSchema),
   zValidator('json', updatePolicySchema),
   async (c) => {

--- a/apps/api/src/routes/security/scans.ts
+++ b/apps/api/src/routes/security/scans.ts
@@ -5,7 +5,7 @@ import { and, desc, eq } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { devices, securityScans } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope } from '../../middleware/auth';
 import { CommandTypes, queueCommand } from '../../services/commandQueue';
 import { canAccessSite, getUserPermissions, type UserPermissions } from '../../services/permissions';
 import type { AuthContext } from '../../middleware/auth';
@@ -43,6 +43,10 @@ export const scansRoutes = new Hono();
 scansRoutes.post(
   '/scan/:deviceId',
   requireScope('organization', 'partner', 'system'),
+  // requireScope only checks tenancy tier, not the caller's role — a read-only
+  // Org Viewer would otherwise pass. Dispatching an agent security scan is a
+  // device-execute action; matches sensitiveData /scan (DEVICES_EXECUTE).
+  requirePermission('devices', 'execute'),
   zValidator('param', deviceIdParamSchema),
   zValidator('json', scanRequestSchema),
   async (c) => {

--- a/apps/api/src/routes/security/threats.test.ts
+++ b/apps/api/src/routes/security/threats.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    status: 'devices.status',
+    hostname: 'devices.hostname',
+  },
+  securityThreats: {
+    id: 'securityThreats.id',
+    deviceId: 'securityThreats.deviceId',
+    provider: 'securityThreats.provider',
+    threatName: 'securityThreats.threatName',
+    threatType: 'securityThreats.threatType',
+    severity: 'securityThreats.severity',
+    filePath: 'securityThreats.filePath',
+    status: 'securityThreats.status',
+    resolvedAt: 'securityThreats.resolvedAt',
+    resolvedBy: 'securityThreats.resolvedBy',
+  },
+  securityStatus: {},
+  auditLogs: {},
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+const { queueCommandMock, getUserPermissionsMock } = vi.hoisted(() => ({
+  queueCommandMock: vi.fn(async () => undefined),
+  getUserPermissionsMock: vi.fn(),
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: {
+    SECURITY_THREAT_QUARANTINE: 'security_threat_quarantine',
+    SECURITY_THREAT_REMOVE: 'security_threat_remove',
+    SECURITY_THREAT_RESTORE: 'security_threat_restore',
+  },
+  queueCommand: queueCommandMock,
+}));
+
+vi.mock('../../services/permissions', async () => {
+  const actual = await vi.importActual<any>('../../services/permissions');
+  return {
+    ...actual,
+    getUserPermissions: getUserPermissionsMock,
+  };
+});
+
+import { db } from '../../db';
+import { threatsRoutes } from './threats';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
+const THREAT_ID = '33333333-3333-4333-8333-333333333333';
+const SITE_ALLOWED = '44444444-4444-4444-8444-444444444444';
+const SITE_FORBIDDEN = '55555555-5555-4555-8555-555555555555';
+
+function buildApp(permissions?: { allowedSiteIds?: string[] }): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      scope: 'partner',
+      orgId: null,
+      partnerId: 'partner-1',
+      accessibleOrgIds: [ORG_ID],
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      canAccessOrg: () => true,
+      orgCondition: () => undefined,
+    } as any);
+    if (permissions) c.set('permissions', permissions as any);
+    await next();
+  });
+  app.route('/security', threatsRoutes);
+  return app;
+}
+
+function mockThreatSelect(siteId: string | null) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: THREAT_ID,
+            deviceId: DEVICE_ID,
+            deviceSiteId: siteId,
+            provider: 'defender',
+            threatName: 'EICAR',
+            threatType: 'malware',
+            severity: 'high',
+            filePath: '/tmp/x',
+            status: 'detected',
+          }]),
+        }),
+      }),
+    }),
+  } as any);
+}
+
+describe('security threats action routes (site-scope enforcement)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserPermissionsMock.mockResolvedValue(null);
+  });
+
+  it('rejects quarantine when the threat device is outside the caller site allowlist', async () => {
+    mockThreatSelect(SITE_FORBIDDEN);
+    const app = buildApp({ allowedSiteIds: [SITE_ALLOWED] });
+
+    const res = await app.request(`/security/threats/${THREAT_ID}/quarantine`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Access to this site denied');
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('allows quarantine when the threat device is inside the caller site allowlist', async () => {
+    mockThreatSelect(SITE_ALLOWED);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    } as any);
+    const app = buildApp({ allowedSiteIds: [SITE_ALLOWED] });
+
+    const res = await app.request(`/security/threats/${THREAT_ID}/quarantine`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.id).toBe(THREAT_ID);
+    expect(body.data.status).toBe('quarantined');
+    expect(queueCommandMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects remove for an out-of-site device even when permissions are fetched lazily', async () => {
+    mockThreatSelect(SITE_FORBIDDEN);
+    // No permissions set in context; handler must fetch them.
+    getUserPermissionsMock.mockResolvedValue({ allowedSiteIds: [SITE_ALLOWED] });
+    const app = buildApp();
+
+    const res = await app.request(`/security/threats/${THREAT_ID}/remove`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('allows restore when the caller has no site restriction', async () => {
+    mockThreatSelect(SITE_FORBIDDEN);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    } as any);
+    // permissions has no allowedSiteIds → unrestricted
+    const app = buildApp({});
+
+    const res = await app.request(`/security/threats/${THREAT_ID}/restore`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(queueCommandMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/routes/security/threats.ts
+++ b/apps/api/src/routes/security/threats.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { devices } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope } from '../../middleware/auth';
 import { canAccessSite, getUserPermissions, type UserPermissions } from '../../services/permissions';
 import {
   listThreatsQuerySchema,
@@ -195,9 +195,14 @@ threatsRoutes.get(
   }
 );
 
+// These dispatch destructive agent commands (quarantine/remove/restore a
+// threat on a device). requireScope only checks tenancy tier, not role — a
+// read-only Org Viewer would otherwise pass. Gate on device-execute, matching
+// sensitiveData /scan and /remediate (DEVICES_EXECUTE).
 threatsRoutes.post(
   '/threats/:id/quarantine',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'execute'),
   zValidator('param', threatIdParamSchema),
   async (c) => queueThreatAction(c, 'quarantine')
 );
@@ -205,6 +210,7 @@ threatsRoutes.post(
 threatsRoutes.post(
   '/threats/:id/remove',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'execute'),
   zValidator('param', threatIdParamSchema),
   async (c) => queueThreatAction(c, 'remove')
 );
@@ -212,6 +218,7 @@ threatsRoutes.post(
 threatsRoutes.post(
   '/threats/:id/restore',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'execute'),
   zValidator('param', threatIdParamSchema),
   async (c) => queueThreatAction(c, 'restore')
 );

--- a/apps/api/src/routes/timeEntries/timeEntries.ts
+++ b/apps/api/src/routes/timeEntries/timeEntries.ts
@@ -34,6 +34,10 @@ export function timeActorFrom(c: Ctx): TimeEntryActor {
     name: auth.user.name,
     email: auth.user.email,
     partnerId: auth.partnerId,
+    // Org-axis allowlist (null = system scope). Threaded so the service's
+    // system-context ticket read is re-gated against the caller's granted orgs —
+    // closes a cross-org ticket write for orgAccess='selected' partner users.
+    accessibleOrgIds: auth.accessibleOrgIds,
     // v1 admin proxy (plan decision): wildcard-permission roles approve + manage others
     manageAll: auth.user.isPlatformAdmin || (perms ? hasPermission(perms, '*', '*') : false)
   };

--- a/apps/api/src/services/aiToolsTicketing.ts
+++ b/apps/api/src/services/aiToolsTicketing.ts
@@ -36,6 +36,7 @@ function timeEntryActorFrom(auth: AuthContext) {
     userId: auth.user.id,
     name: auth.user.name,
     partnerId: auth.partnerId,
+    accessibleOrgIds: auth.accessibleOrgIds,
     // AI tools always operate on the calling user's own entries — never admin-manage others'.
     manageAll: false as const
   };

--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -105,7 +105,9 @@ import {
   getTimesheet, getTicketBillingSummary, listBillables
 } from './timeEntryService';
 
-const ACTOR = { userId: 'u-1', name: 'Tess', partnerId: 'p-1', manageAll: false };
+// accessibleOrgIds null = unrestricted within partner (orgAccess='all' / system).
+// Existing fixtures use 'o-1'/'o-9' etc., so null keeps prior tests passing.
+const ACTOR = { userId: 'u-1', name: 'Tess', partnerId: 'p-1', manageAll: false, accessibleOrgIds: null as string[] | null };
 const ADMIN = { ...ACTOR, userId: 'u-admin', manageAll: true };
 
 beforeEach(() => {
@@ -266,6 +268,71 @@ describe('createTimeEntry', () => {
       expect(vals.isBillable).toBe(false);
       expect(vals.hourlyRate).toBe('200.00');
     });
+  });
+});
+
+describe('org-axis ticket gate (orgAccess=selected)', () => {
+  // A partner user granted only org o-1 must not write onto a ticket in o-OTHER,
+  // even though both orgs share the same partner (p-1). The ticket is read under
+  // system scope, so the org-axis allowlist is the only thing standing between
+  // the caller and a cross-org ticket write + feed comment.
+  const SELECTED = { ...ACTOR, accessibleOrgIds: ['o-1'] as string[] | null };
+
+  it('createTimeEntry rejects a same-partner ticket in a non-granted org (404 TICKET_ORG_DENIED)', async () => {
+    dbMocks.selectResults.push([{ id: 't-x', partnerId: 'p-1', orgId: 'o-OTHER', categoryId: null }]);
+    await expect(createTimeEntry(
+      { ticketId: 't-x', startedAt: new Date('2026-06-11T09:00:00Z'), endedAt: new Date('2026-06-11T09:30:00Z') },
+      SELECTED
+    )).rejects.toMatchObject({ code: 'TICKET_ORG_DENIED', status: 404 });
+    // No time-entry insert and no feed comment for the denied org.
+    expect(dbMocks.insertedValues).toHaveLength(0);
+  });
+
+  it('createTimeEntry allows a ticket in a granted org', async () => {
+    dbMocks.selectResults.push([{ id: 't-1', partnerId: 'p-1', orgId: 'o-1', categoryId: null }]);
+    dbMocks.insertResult = [{ id: 'te-ok', partnerId: 'p-1', ticketId: 't-1', userId: 'u-1', durationMinutes: 30, isBillable: false }];
+    const entry = await createTimeEntry(
+      { ticketId: 't-1', startedAt: new Date('2026-06-11T09:00:00Z'), endedAt: new Date('2026-06-11T09:30:00Z') },
+      SELECTED
+    );
+    expect(entry.id).toBe('te-ok');
+    expect(dbMocks.insertedValues[0]!.orgId).toBe('o-1');
+  });
+
+  it('startTimer rejects a same-partner ticket in a non-granted org', async () => {
+    dbMocks.selectResults.push([{ id: 't-x', partnerId: 'p-1', orgId: 'o-OTHER', categoryId: null }]);
+    await expect(startTimer({ ticketId: 't-x' }, SELECTED))
+      .rejects.toMatchObject({ code: 'TICKET_ORG_DENIED', status: 404 });
+    expect(dbMocks.insertedValues).toHaveLength(0);
+  });
+
+  it('updateTimeEntry rejects relinking to a ticket in a non-granted org', async () => {
+    dbMocks.selectResults.push([{
+      id: 'te-1', partnerId: 'p-1', orgId: 'o-1', ticketId: null, userId: 'u-1',
+      startedAt: new Date('2026-06-11T09:00:00Z'), endedAt: new Date('2026-06-11T09:30:00Z'),
+      durationMinutes: 30, isApproved: false
+    }]);
+    dbMocks.selectResults.push([{ id: 't-x', partnerId: 'p-1', orgId: 'o-OTHER', categoryId: null }]);
+    await expect(updateTimeEntry('te-1', { ticketId: 't-x' }, SELECTED))
+      .rejects.toMatchObject({ code: 'TICKET_ORG_DENIED', status: 404 });
+    expect(dbMocks.updateSetArgs).toHaveLength(0);
+  });
+
+  it('addTicketPart rejects a same-partner ticket in a non-granted org', async () => {
+    dbMocks.selectResults.push([{ id: 't-x', partnerId: 'p-1', orgId: 'o-OTHER', categoryId: null }]);
+    await expect(addTicketPart('t-x', { description: 'SSD', quantity: 1, unitPrice: 100 }, SELECTED))
+      .rejects.toMatchObject({ code: 'TICKET_ORG_DENIED', status: 404 });
+    expect(dbMocks.insertedValues).toHaveLength(0);
+  });
+
+  it('system scope (accessibleOrgIds null) is unrestricted across orgs', async () => {
+    dbMocks.selectResults.push([{ id: 't-sys', partnerId: 'p-1', orgId: 'o-OTHER', categoryId: null }]);
+    dbMocks.insertResult = [{ id: 'te-sys', partnerId: 'p-1', ticketId: 't-sys', userId: 'u-admin', durationMinutes: 30, isBillable: false }];
+    const entry = await createTimeEntry(
+      { ticketId: 't-sys', startedAt: new Date('2026-06-11T09:00:00Z'), endedAt: new Date('2026-06-11T09:30:00Z') },
+      { ...ADMIN, partnerId: null, accessibleOrgIds: null }
+    );
+    expect(entry.id).toBe('te-sys');
   });
 });
 

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -8,6 +8,7 @@ import type { CreateTimeEntryInput, UpdateTimeEntryInput, TicketPartInput, Billi
 export type TimeEntryServiceErrorCode =
   | 'TICKET_NOT_FOUND'
   | 'TICKET_WRONG_PARTNER'
+  | 'TICKET_ORG_DENIED'
   | 'ENTRY_NOT_FOUND'
   | 'PART_NOT_FOUND'
   | 'NOT_OWN_ENTRY'
@@ -37,6 +38,15 @@ export interface TimeEntryActor {
   partnerId: string | null;
   /** wildcard-permission holders (computed in routes): may manage others' entries + approve */
   manageAll: boolean;
+  /**
+   * auth.accessibleOrgIds — the org-axis allowlist. `null` = system scope
+   * (unrestricted). A partner user with orgAccess='selected' carries only the
+   * granted org ids here, so a ticket in a non-granted org under the same
+   * partner is denied (org-axis check in resolveTicketLink). Threaded from the
+   * route's AuthContext so the system-context ticket read can't be used to
+   * write onto a ticket the caller can't actually see.
+   */
+  accessibleOrgIds: string[] | null;
 }
 
 /** Floored whole minutes — matches the SLA pause-folding convention. */
@@ -104,18 +114,29 @@ async function getCategoryDefaults(categoryId: string): Promise<{ defaultBillabl
 }
 
 /**
- * Validates a ticket link for the acting partner and resolves billing defaults
- * (spec D2: category default + manual override). Returns the denormalization
- * payload for the time-entry/part row.
+ * Validates a ticket link for the acting partner AND org axis, then resolves
+ * billing defaults (spec D2: category default + manual override). Returns the
+ * denormalization payload for the time-entry/part row.
+ *
+ * The ticket is read under system scope (see getTicketForTimeTracking), so the
+ * request's org-axis RLS does NOT gate it. We therefore re-apply the caller's
+ * org-axis allowlist here: a partner user with orgAccess='selected' can target
+ * only tickets in granted orgs, never an arbitrary org under the same partner.
+ * `accessibleOrgIds === null` is system scope (unrestricted) — behavior
+ * unchanged. Mirrors getScopedTicketOr404 / auth.canAccessOrg semantics.
  */
-async function resolveTicketLink(ticketId: string, actorPartnerId: string | null) {
+async function resolveTicketLink(ticketId: string, actor: TimeEntryActor) {
   const ticket = await getTicketForTimeTracking(ticketId);
   const ticketPartnerId = await resolveTicketPartner(ticket);
   if (!ticketPartnerId) {
     throw new TimeEntryServiceError('Ticket partner is unresolvable', 400, 'PARTNER_UNRESOLVABLE');
   }
-  if (actorPartnerId && ticketPartnerId !== actorPartnerId) {
+  if (actor.partnerId && ticketPartnerId !== actor.partnerId) {
     throw new TimeEntryServiceError('Ticket must belong to the same partner', 400, 'TICKET_WRONG_PARTNER');
+  }
+  // Org-axis gate: non-system callers must have access to the ticket's org.
+  if (actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(ticket.orgId)) {
+    throw new TimeEntryServiceError('Ticket not found', 404, 'TICKET_ORG_DENIED');
   }
   const [org, category] = await Promise.all([
     getOrgBillingDefaults(ticket.orgId),
@@ -171,7 +192,7 @@ export async function createTimeEntry(input: CreateTimeEntryInput, actor: TimeEn
   let defaultRate: string | null = null;
 
   if (input.ticketId) {
-    const link = await resolveTicketLink(input.ticketId, actor.partnerId);
+    const link = await resolveTicketLink(input.ticketId, actor);
     partnerId = link.partnerId;
     orgId = link.ticket.orgId;
     defaultBillable = link.defaultBillable;
@@ -257,7 +278,7 @@ export async function startTimer(input: { ticketId?: string; description?: strin
   let defaultRate: string | null = null;
 
   if (input.ticketId) {
-    const link = await resolveTicketLink(input.ticketId, actor.partnerId);
+    const link = await resolveTicketLink(input.ticketId, actor);
     partnerId = link.partnerId;
     orgId = link.ticket.orgId;
     defaultBillable = link.defaultBillable;
@@ -391,7 +412,7 @@ export async function updateTimeEntry(id: string, input: UpdateTimeEntryInput, a
       set.ticketId = null;
       set.orgId = null;
     } else {
-      const link = await resolveTicketLink(input.ticketId, actor.partnerId);
+      const link = await resolveTicketLink(input.ticketId, actor);
       if (link.partnerId !== entry.partnerId) {
         throw new TimeEntryServiceError('Ticket must belong to the same partner as the time entry', 400, 'TICKET_WRONG_PARTNER');
       }
@@ -507,7 +528,7 @@ export async function approveTimeEntries(ids: string[], approve: boolean, actor:
 // ── Parts ────────────────────────────────────────────────────────────────
 
 export async function addTicketPart(ticketId: string, input: TicketPartInput, actor: TimeEntryActor) {
-  const link = await resolveTicketLink(ticketId, actor.partnerId);
+  const link = await resolveTicketLink(ticketId, actor);
   const rows = await db
     .insert(ticketParts)
     .values({


### PR DESCRIPTION
## Summary

Two-pass deep security review (multi-tenant isolation + authz across **all** API routes, per-resource-group fan-out with adversarial verification) surfaced **12 confirmed findings** (0 critical, 1 high, 11 medium). This PR fixes all of them.

## Findings & fixes

### 1. RLS backstop — 7 unprotected FK-child tables (new migration `2026-06-13-b-fk-child-rls-backstop.sql`)
These tenant child tables shipped with **no row-level security at all** because they reach their tenant only through a parent FK (no `org_id` column) and so were invisible to the rls-coverage contract test's `org_id`-based auto-discovery — the third recurrence of this class (after `script_execution_batches` #1016/#1026 and `custom_field_definitions`):

`webhook_deliveries`, `network_monitor_alert_rules`, `network_monitor_results`, `role_permissions`, `plugin_logs`, `report_runs`, `maintenance_occurrences`.

- `ENABLE` + `FORCE` RLS + per-command **flat** `EXISTS`-join policies through each parent (flat, not nested, to avoid the postgres.js bound-param bug from #1016/#1026).
- `role_permissions` mirrors the dual-axis `roles` predicate (`breeze_has_partner_access OR breeze_has_org_access` + system-role carve-out) so partner/system roles stay reachable.
- All 7 registered in `PARENT_FK_JOIN_POLICY_TABLES` so the class stops recurring.

### 2. `ticket_comments` INSERT policy tightened (same migration)
Previously authorized any row where `user_id = breeze_current_user_id()` with **no parent-ticket org check**, letting a user post a comment onto a ticket in any org. `WITH CHECK` now also requires the parent ticket to be org-accessible.

### 3. Site-axis (`allowedSiteIds`) enforcement — HIGH + 2× medium
RLS deliberately does not defend the intra-org site axis; these write paths checked only org. Now mirror the sibling read-path checks:
- **`playbooks.ts`** `POST /:id/execute` and `PATCH /executions/:id` (**HIGH** — remediation playbook on out-of-site device)
- **`configurationPolicies/patchJobs.ts`** `POST /:id/patch-job`
- **`security/helpers.ts`** `queueThreatAction` (threat quarantine/remove/restore)

### 4. RBAC — `requirePermission` on mutating routes that were `requireScope`-only
A read-only role passed the scope check and could mutate:
- **`security/scans.ts`**, **`security/policies.ts`**, **`security/threats.ts`**
- **`policyManagement/actions.ts`** (activate/deactivate/evaluate/remediate)
- **`deployments.ts`** create/update/delete now require **MFA**, matching the lifecycle actions in the same file

### 5. Cross-org write via time-entries
**`timeEntryService.ts`** now verifies the caller's `accessibleOrgIds` after the system-context ticket read, closing an `orgAccess=selected` partner user writing a time entry + feed comment onto a non-granted org's ticket.

## Verification
- ✅ API package **type-checks clean** (only the two known pre-existing `agents.test.ts`/`apiKeyAuth.test.ts` errors remain).
- ✅ Affected **unit suites green**, including new site-axis, RBAC, and MFA-403 tests.
- ✅ **RLS migration proven against a live `breeze_app` role**: rls-coverage contract test **27/27**; a forged cross-tenant read/insert/update on `webhook_deliveries` is rejected (`new row violates row-level security policy`) while same-org access works.

### Reviewer notes / before merge
- The two RLS **integration** suites (`time-entries-rls`, `ticket-config-rls`) had their `TimeEntryActor` fixtures updated for the new `accessibleOrgIds` field; they need a full **live-DB CI run** (not executed end-to-end here).
- Several `requirePermission` identifier choices (esp. `security/policies.ts` config writes) are called out in the diff — worth a sanity check against your RBAC intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)