### PR TITLE
feat(ticketing): configuration frontend — settings tabs, org tiers, custom statuses in UI

### DIFF
--- a/apps/docs/src/content/docs/features/ticketing.mdx
+++ b/apps/docs/src/content/docs/features/ticketing.mdx
@@ -105,6 +105,28 @@ Categories also carry SLA targets (response and resolution times) and billing de
   Today the SLA targets drive the at-risk and breached chips in the queue. The full automated SLA engine -- enforcement, escalations, and business-hours schedules -- arrives in a later release.
 </Aside>
 
+## Custom Statuses & SLA Configuration
+
+Go to **Settings → Ticketing** to configure statuses, priority labels, and SLA defaults. The page is tabbed: **Statuses**, **Priorities**, **Categories**, and **Export**.
+
+### Custom ticket statuses
+
+Every ticket status maps to one of six core states: **New**, **Open**, **Pending**, **On Hold**, **Resolved**, and **Closed**. Within each core state you can create as many custom statuses as your workflow needs -- for example "Waiting on vendor" under Pending, or "Needs review" under Resolved. Custom statuses appear in the workbench status picker, grouped by their core state. Tickets that pre-date custom statuses show the core state label directly.
+
+Statuses are partner-wide and apply across all your customer organizations. Built-in statuses cannot be deleted. Custom statuses can be deactivated (they disappear from the picker but existing tickets keep their status). Use the up/down arrows on any row to reorder statuses, which sets the order they appear in the picker.
+
+### Priority labels and partner-wide SLA defaults
+
+Under the **Priorities** tab you can rename each of the four priority levels (Low, Normal, High, Urgent) to match your team's language. For each priority you can also set partner-wide default **response** and **resolution** SLA targets (in minutes). These defaults apply to every ticket that doesn't have a more-specific override.
+
+### Per-organization SLA tiers
+
+In an organization's settings, open the **Ticketing** tab to set per-priority SLA overrides for that customer. You can also set the organization's **default hourly rate** and whether new time entries default to billable.
+
+<Aside>
+  Saving organization-level ticketing settings requires MFA confirmation. SLA precedence: a category's SLA beats an organization override, which beats the partner-wide priority default.
+</Aside>
+
 ## Time Tracking & Parts
 
 Breeze lets technicians log time and record parts against any ticket. These records feed the billing summary on the ticket's properties rail and the weekly Timesheet view -- but are **never shown in the customer portal**.

--- a/apps/web/src/components/settings/OrgSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.test.tsx
@@ -31,6 +31,7 @@ vi.mock('./OrgNotificationSettings', () => ({ default: () => <div data-testid="n
 vi.mock('./OrgSecuritySettings', () => ({ default: () => <div data-testid="security" /> }));
 vi.mock('./OrgEventLogSettings', () => ({ default: () => <div data-testid="event-logs" /> }));
 vi.mock('./OrgRemoteAccessSettings', () => ({ default: () => <div data-testid="remote-access" /> }));
+vi.mock('./OrgTicketSettingsEditor', () => ({ default: () => <div data-testid="org-ticket-settings" /> }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 const useOrgStoreMock = vi.mocked(useOrgStore);

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -11,10 +11,12 @@ import {
   Monitor,
   Paintbrush,
   ScrollText,
-  Shield
+  Shield,
+  Ticket
 } from 'lucide-react';
 import OrgBrandingEditor from './OrgBrandingEditor';
 import OrgPortalSettingsEditor from './OrgPortalSettingsEditor';
+import OrgTicketSettingsEditor from './OrgTicketSettingsEditor';
 import OrgDefaultsEditor from './OrgDefaultsEditor';
 import OrgNotificationSettings from './OrgNotificationSettings';
 import OrgSecuritySettings from './OrgSecuritySettings';
@@ -67,6 +69,12 @@ const tabs = [
     label: 'Remote Access',
     description: 'VNC, proxy, and tunnel settings',
     icon: Monitor
+  },
+  {
+    id: 'ticketing',
+    label: 'Ticketing',
+    description: 'SLA overrides and billing defaults',
+    icon: Ticket
   }
 ] as const;
 
@@ -429,6 +437,14 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
           <OrgRemoteAccessSettings
             orgId={effectiveOrgId}
             onDirty={handleDirty}
+          />
+        ) : null;
+      case 'ticketing':
+        return effectiveOrgId ? (
+          <OrgTicketSettingsEditor
+            orgId={effectiveOrgId}
+            onDirty={handleDirty}
+            onSave={() => handleSave()}
           />
         ) : null;
       case 'general':

--- a/apps/web/src/components/settings/OrgTicketSettingsEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgTicketSettingsEditor.test.tsx
@@ -1,0 +1,264 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrgTicketSettingsEditor from './OrgTicketSettingsEditor';
+import { fetchWithAuth } from '../../stores/auth';
+import { __resetTicketConfigCacheForTests } from '@/lib/ticketConfigApi';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ORG_ID = '7c0a1f7e-2222-4333-9444-555566667777';
+
+const SETTINGS = {
+  orgId: ORG_ID,
+  slaOverrides: {
+    urgent: { responseMinutes: 15, resolutionMinutes: 60 },
+    high: { responseMinutes: 60, resolutionMinutes: 240 }
+  },
+  defaultHourlyRate: '125.00',
+  defaultBillable: true
+};
+
+const PARTNER_CONFIG = {
+  data: {
+    statuses: [],
+    priorities: {
+      urgent: { label: null, responseSlaMinutes: 30, resolutionSlaMinutes: 120 },
+      high: { label: null, responseSlaMinutes: 120, resolutionSlaMinutes: 480 },
+      normal: { label: null, responseSlaMinutes: 240, resolutionSlaMinutes: 960 },
+      low: { label: null, responseSlaMinutes: null, resolutionSlaMinutes: null }
+    }
+  }
+};
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+function mockApi(settings: unknown = SETTINGS) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === `/orgs/organizations/${ORG_ID}/ticket-settings` && !init?.method) {
+      return makeJsonResponse({ data: settings });
+    }
+    if (url === `/orgs/organizations/${ORG_ID}/ticket-settings` && init?.method === 'PATCH') {
+      return makeJsonResponse({ data: settings });
+    }
+    if (url === '/ticket-config') {
+      return makeJsonResponse(PARTNER_CONFIG);
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 404);
+  });
+}
+
+describe('OrgTicketSettingsEditor', () => {
+  const onDirty = vi.fn();
+  const onSave = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetTicketConfigCacheForTests();
+  });
+
+  it('loads and renders the fetched settings including existing overrides', async () => {
+    mockApi();
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-settings')).toBeInTheDocument());
+
+    // Existing override values should be pre-populated
+    expect((screen.getByTestId('org-ticket-sla-urgent-response') as HTMLInputElement).value).toBe('15');
+    expect((screen.getByTestId('org-ticket-sla-urgent-resolution') as HTMLInputElement).value).toBe('60');
+    expect((screen.getByTestId('org-ticket-sla-high-response') as HTMLInputElement).value).toBe('60');
+    expect((screen.getByTestId('org-ticket-sla-high-resolution') as HTMLInputElement).value).toBe('240');
+
+    // Priorities without overrides should be blank
+    expect((screen.getByTestId('org-ticket-sla-normal-response') as HTMLInputElement).value).toBe('');
+    expect((screen.getByTestId('org-ticket-sla-low-response') as HTMLInputElement).value).toBe('');
+
+    // Billing defaults
+    expect((screen.getByTestId('org-ticket-rate') as HTMLInputElement).value).toBe('125.00');
+    expect((screen.getByTestId('org-ticket-billable') as HTMLSelectElement).value).toBe('true');
+  });
+
+  it('renders partner default values as placeholders when config is available', async () => {
+    mockApi();
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-settings')).toBeInTheDocument());
+
+    // Partner config provides values — should show numbers as placeholders
+    expect((screen.getByTestId('org-ticket-sla-urgent-response') as HTMLInputElement).placeholder).toBe('30');
+    expect((screen.getByTestId('org-ticket-sla-urgent-resolution') as HTMLInputElement).placeholder).toBe('120');
+
+    // Low priority has null SLA in partner config — should show "Partner default"
+    expect((screen.getByTestId('org-ticket-sla-low-response') as HTMLInputElement).placeholder).toBe('Partner default');
+    expect((screen.getByTestId('org-ticket-sla-low-resolution') as HTMLInputElement).placeholder).toBe('Partner default');
+  });
+
+  it('shows "Partner default" placeholder when no partner config is available', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === `/orgs/organizations/${ORG_ID}/ticket-settings` && !init?.method) {
+        return makeJsonResponse({ data: SETTINGS });
+      }
+      if (url === `/orgs/organizations/${ORG_ID}/ticket-settings` && init?.method === 'PATCH') {
+        return makeJsonResponse({ data: SETTINGS });
+      }
+      if (url === '/ticket-config') {
+        return makeJsonResponse({ error: 'fail' }, false, 500);
+      }
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-settings')).toBeInTheDocument());
+    expect((screen.getByTestId('org-ticket-sla-urgent-response') as HTMLInputElement).placeholder).toBe('Partner default');
+  });
+
+  it('sends wholesale slaOverrides (all non-blank cells), rate as number, billable correctly on save', async () => {
+    mockApi({
+      orgId: ORG_ID,
+      slaOverrides: {},
+      defaultHourlyRate: null,
+      defaultBillable: null
+    });
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-save')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('org-ticket-sla-urgent-response'), { target: { value: '15' } });
+    fireEvent.change(screen.getByTestId('org-ticket-sla-urgent-resolution'), { target: { value: '60' } });
+    fireEvent.change(screen.getByTestId('org-ticket-sla-high-response'), { target: { value: '120' } });
+    // high resolution left blank — key absent from urgent's object
+    fireEvent.change(screen.getByTestId('org-ticket-rate'), { target: { value: '150' } });
+    fireEvent.change(screen.getByTestId('org-ticket-billable'), { target: { value: 'false' } });
+
+    fireEvent.click(screen.getByTestId('org-ticket-save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const patchCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PATCH');
+    expect(patchCall).toBeDefined();
+    const body = JSON.parse(String(patchCall![1]!.body));
+
+    // slaOverrides replaces wholesale — only non-blank cells present
+    expect(body.slaOverrides).toEqual({
+      urgent: { responseMinutes: 15, resolutionMinutes: 60 },
+      high: { responseMinutes: 120 }
+    });
+
+    // defaultHourlyRate is sent as a number, not string
+    expect(body.defaultHourlyRate).toBe(150);
+    expect(typeof body.defaultHourlyRate).toBe('number');
+
+    // defaultBillable is boolean false
+    expect(body.defaultBillable).toBe(false);
+  });
+
+  it('sends null defaultHourlyRate when hourly rate field is blank', async () => {
+    mockApi({
+      orgId: ORG_ID,
+      slaOverrides: {},
+      defaultHourlyRate: null,
+      defaultBillable: null
+    });
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-save')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('org-ticket-save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const patchCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PATCH');
+    const body = JSON.parse(String(patchCall![1]!.body));
+    expect(body.defaultHourlyRate).toBeNull();
+    expect(body.defaultBillable).toBeNull();
+    expect(body.slaOverrides).toEqual({});
+  });
+
+  it('sends empty slaOverrides object when all cells are blank (clears all overrides)', async () => {
+    // Start with existing overrides to confirm they get cleared
+    mockApi();
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-save')).toBeInTheDocument());
+
+    // Clear all the pre-populated override values
+    fireEvent.change(screen.getByTestId('org-ticket-sla-urgent-response'), { target: { value: '' } });
+    fireEvent.change(screen.getByTestId('org-ticket-sla-urgent-resolution'), { target: { value: '' } });
+    fireEvent.change(screen.getByTestId('org-ticket-sla-high-response'), { target: { value: '' } });
+    fireEvent.change(screen.getByTestId('org-ticket-sla-high-resolution'), { target: { value: '' } });
+
+    fireEvent.click(screen.getByTestId('org-ticket-save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const patchCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PATCH');
+    const body = JSON.parse(String(patchCall![1]!.body));
+    expect(body.slaOverrides).toEqual({});
+  });
+
+  it('shows an error state with retry when the load fails', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ error: 'boom' }, false, 500));
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-load-error')).toBeInTheDocument());
+  });
+
+  it('does not call onSave when the PATCH fails (runAction toasts the error)', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (init?.method === 'PATCH') return makeJsonResponse({ error: 'nope' }, false, 500);
+      if (url === '/ticket-config') return makeJsonResponse(PARTNER_CONFIG);
+      return makeJsonResponse({ data: SETTINGS });
+    });
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-save')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('org-ticket-save'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /login on 401 during load', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({}, false, 401));
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith('/login', { replace: true }));
+  });
+
+  it('marks dirty when an SLA field changes', async () => {
+    mockApi();
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-sla-normal-response')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('org-ticket-sla-normal-response'), { target: { value: '240' } });
+    expect(onDirty).toHaveBeenCalled();
+  });
+
+  it('save button is disabled while saving', async () => {
+    // Use a slow PATCH to observe the in-flight state
+    let resolvePatch!: (r: Response) => void;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (init?.method === 'PATCH') {
+        return new Promise<Response>(resolve => { resolvePatch = resolve; });
+      }
+      if (url === '/ticket-config') return makeJsonResponse(PARTNER_CONFIG);
+      return makeJsonResponse({ data: SETTINGS });
+    });
+    render(<OrgTicketSettingsEditor orgId={ORG_ID} onDirty={onDirty} onSave={onSave} />);
+    await waitFor(() => expect(screen.getByTestId('org-ticket-save')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('org-ticket-save'));
+    await waitFor(() => expect((screen.getByTestId('org-ticket-save') as HTMLButtonElement).disabled).toBe(true));
+
+    // Resolve so the component doesn't linger
+    resolvePatch(makeJsonResponse({ data: SETTINGS }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/components/settings/OrgTicketSettingsEditor.tsx
+++ b/apps/web/src/components/settings/OrgTicketSettingsEditor.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { runAction, ActionError } from '@/lib/runAction';
+import { fetchTicketConfig, priorityLabel } from '@/lib/ticketConfigApi';
+import type { TicketConfig } from '@/lib/ticketConfigApi';
+import { priorityConfig } from '../tickets/ticketConfig';
+import type { TicketPriority } from '../tickets/ticketConfig';
+
+const PRIORITIES = Object.keys(priorityConfig) as TicketPriority[];
+
+type SlaOverride = {
+  responseMinutes?: number;
+  resolutionMinutes?: number;
+};
+
+type OrgTicketSettings = {
+  orgId: string;
+  slaOverrides: Partial<Record<TicketPriority, SlaOverride>>;
+  defaultHourlyRate: string | null;
+  defaultBillable: boolean | null;
+};
+
+type DraftSlaRow = {
+  responseMinutes: string;
+  resolutionMinutes: string;
+};
+
+type OrgTicketSettingsEditorProps = {
+  orgId: string;
+  onDirty: () => void;
+  onSave: () => void;
+};
+
+export default function OrgTicketSettingsEditor({ orgId, onDirty, onSave }: OrgTicketSettingsEditorProps) {
+  const [settings, setSettings] = useState<OrgTicketSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [partnerConfig, setPartnerConfig] = useState<TicketConfig | null>(null);
+
+  // Draft state for the form
+  const [slaRows, setSlaRows] = useState<Record<TicketPriority, DraftSlaRow>>(
+    () => Object.fromEntries(PRIORITIES.map(p => [p, { responseMinutes: '', resolutionMinutes: '' }])) as Record<TicketPriority, DraftSlaRow>
+  );
+  const [hourlyRate, setHourlyRate] = useState('');
+  const [billable, setBillable] = useState<'inherit' | 'true' | 'false'>('inherit');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const [res, config] = await Promise.all([
+        fetchWithAuth(`/orgs/organizations/${orgId}/ticket-settings`),
+        fetchTicketConfig()
+      ]);
+      if (res.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      if (!res.ok) throw new Error(`ticket settings load failed: ${res.status}`);
+      const body = (await res.json()) as { data: OrgTicketSettings };
+      const data = body.data;
+      setSettings(data);
+      setPartnerConfig(config);
+
+      // Populate draft fields from fetched settings
+      const newRows = Object.fromEntries(
+        PRIORITIES.map(p => {
+          const override = data.slaOverrides?.[p];
+          return [p, {
+            responseMinutes: override?.responseMinutes != null ? String(override.responseMinutes) : '',
+            resolutionMinutes: override?.resolutionMinutes != null ? String(override.resolutionMinutes) : ''
+          }];
+        })
+      ) as Record<TicketPriority, DraftSlaRow>;
+      setSlaRows(newRows);
+      setHourlyRate(data.defaultHourlyRate ?? '');
+      setBillable(
+        data.defaultBillable === true ? 'true' :
+        data.defaultBillable === false ? 'false' :
+        'inherit'
+      );
+    } catch (err) {
+      console.warn('[OrgTicketSettingsEditor] load failed', err);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const updateSlaRow = (priority: TicketPriority, field: keyof DraftSlaRow, value: string) => {
+    setSlaRows(prev => ({ ...prev, [priority]: { ...prev[priority], [field]: value } }));
+    onDirty();
+  };
+
+  const save = useCallback(async () => {
+    if (!settings || saving) return;
+    setSaving(true);
+    try {
+      // Build slaOverrides from all non-blank cells (blank means absent = cleared)
+      const slaOverrides: Partial<Record<TicketPriority, SlaOverride>> = {};
+      for (const p of PRIORITIES) {
+        const row = slaRows[p];
+        const responseMinutes = row.responseMinutes.trim() !== '' ? Number(row.responseMinutes) : undefined;
+        const resolutionMinutes = row.resolutionMinutes.trim() !== '' ? Number(row.resolutionMinutes) : undefined;
+        if (responseMinutes !== undefined || resolutionMinutes !== undefined) {
+          slaOverrides[p] = {};
+          if (responseMinutes !== undefined) slaOverrides[p]!.responseMinutes = responseMinutes;
+          if (resolutionMinutes !== undefined) slaOverrides[p]!.resolutionMinutes = resolutionMinutes;
+        }
+      }
+
+      const rateStr = hourlyRate.trim();
+      const defaultHourlyRate = rateStr !== '' ? Number(rateStr) : null;
+      const defaultBillable = billable === 'true' ? true : billable === 'false' ? false : null;
+
+      await runAction({
+        request: () => fetchWithAuth(`/orgs/organizations/${orgId}/ticket-settings`, {
+          method: 'PATCH',
+          body: JSON.stringify({ slaOverrides, defaultHourlyRate, defaultBillable })
+        }),
+        errorFallback: 'Failed to save ticket settings',
+        successMessage: 'Ticket settings saved',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      onSave();
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setSaving(false);
+    }
+  }, [settings, saving, slaRows, hourlyRate, billable, orgId, onSave]);
+
+  // Compute placeholder for a given priority+field:
+  // If partnerConfig has a value, show the number; otherwise show "Partner default"
+  const getPlaceholder = (priority: TicketPriority, field: 'response' | 'resolution'): string => {
+    if (!partnerConfig) return 'Partner default';
+    const pSetting = partnerConfig.priorities[priority];
+    if (!pSetting) return 'Partner default';
+    const val = field === 'response' ? pSetting.responseSlaMinutes : pSetting.resolutionSlaMinutes;
+    return val != null ? String(val) : 'Partner default';
+  };
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading ticket settings…</p>;
+  }
+
+  if (loadError || !settings) {
+    return (
+      <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground" data-testid="org-ticket-load-error">
+        Ticket settings failed to load.{' '}
+        <button type="button" onClick={() => void load()} className="underline hover:text-foreground">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6" data-testid="org-ticket-settings">
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">SLA overrides</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Override the partner-wide SLA defaults for this organization. Leave a cell blank to inherit the partner default.
+        </p>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-muted-foreground">
+                <th className="pb-2 pr-4 font-medium">Priority</th>
+                <th className="pb-2 pr-4 font-medium">Response (min)</th>
+                <th className="pb-2 font-medium">Resolution (min)</th>
+              </tr>
+            </thead>
+            <tbody className="space-y-2">
+              {PRIORITIES.map(p => (
+                <tr key={p}>
+                  <td className="py-1.5 pr-4 font-medium capitalize">
+                    {priorityLabel(partnerConfig, p)}
+                  </td>
+                  <td className="py-1.5 pr-4">
+                    <input
+                      type="number"
+                      min={1}
+                      value={slaRows[p].responseMinutes}
+                      onChange={(e) => updateSlaRow(p, 'responseMinutes', e.target.value)}
+                      placeholder={getPlaceholder(p, 'response')}
+                      className="w-28 rounded-md border bg-background px-3 py-1.5 text-sm"
+                      data-testid={`org-ticket-sla-${p}-response`}
+                    />
+                  </td>
+                  <td className="py-1.5">
+                    <input
+                      type="number"
+                      min={1}
+                      value={slaRows[p].resolutionMinutes}
+                      onChange={(e) => updateSlaRow(p, 'resolutionMinutes', e.target.value)}
+                      placeholder={getPlaceholder(p, 'resolution')}
+                      className="w-28 rounded-md border bg-background px-3 py-1.5 text-sm"
+                      data-testid={`org-ticket-sla-${p}-resolution`}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Billing defaults</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Default billing settings for time entries on tickets for this organization.
+        </p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="text-sm font-medium" htmlFor="org-ticket-rate">Default hourly rate ($)</label>
+            <input
+              id="org-ticket-rate"
+              type="number"
+              min={0}
+              step="0.01"
+              value={hourlyRate}
+              onChange={(e) => { setHourlyRate(e.target.value); onDirty(); }}
+              placeholder="Partner default"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+              data-testid="org-ticket-rate"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="org-ticket-billable">Default billable</label>
+            <select
+              id="org-ticket-billable"
+              value={billable}
+              onChange={(e) => { setBillable(e.target.value as 'inherit' | 'true' | 'false'); onDirty(); }}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+              data-testid="org-ticket-billable"
+            >
+              <option value="inherit">Inherit</option>
+              <option value="true">Billable</option>
+              <option value="false">Non-billable</option>
+            </select>
+          </div>
+        </div>
+      </section>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={saving}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          data-testid="org-ticket-save"
+        >
+          {saving ? 'Saving…' : 'Save ticket settings'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/TicketCategoriesPage.tsx
+++ b/apps/web/src/components/settings/TicketCategoriesPage.tsx
@@ -5,7 +5,6 @@ import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 import { priorityConfig, type TicketPriority } from '../tickets/ticketConfig';
-import BillablesExportCard from './BillablesExportCard';
 
 interface Category {
   id: string;
@@ -485,7 +484,6 @@ export default function TicketCategoriesPage() {
           ))}
         </tbody>
       </table>
-      <BillablesExportCard />
     </div>
   );
 }

--- a/apps/web/src/components/settings/TicketPrioritiesTab.test.tsx
+++ b/apps/web/src/components/settings/TicketPrioritiesTab.test.tsx
@@ -1,0 +1,319 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TicketPrioritiesTab from './TicketPrioritiesTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+vi.mock('../../lib/authScope', () => ({
+  loginPathWithNext: () => '/login?next=%2Fsettings%2Ftickets'
+}));
+
+const invalidateTicketConfig = vi.fn();
+vi.mock('../../lib/ticketConfigApi', () => ({
+  invalidateTicketConfig: () => invalidateTicketConfig()
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const FETCHED_PRIORITIES = {
+  urgent: { label: 'Critical', responseSlaMinutes: 30, resolutionSlaMinutes: 120 },
+  high:   { label: null,       responseSlaMinutes: 240, resolutionSlaMinutes: 1440 },
+  normal: { label: null,       responseSlaMinutes: null, resolutionSlaMinutes: null },
+  low:    { label: null,       responseSlaMinutes: null, resolutionSlaMinutes: null },
+};
+
+function mockGetPriorities(priorities: unknown) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+      return makeJsonResponse({ data: { statuses: [], priorities } });
+    }
+    if (url === '/ticket-config/priorities' && init?.method === 'PUT') {
+      return makeJsonResponse({ data: { priorities } });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 404);
+  });
+}
+
+describe('TicketPrioritiesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('renders fetched values', () => {
+    it('pre-fills label input with fetched label', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      const urgentLabel = await screen.findByTestId('priority-label-urgent') as HTMLInputElement;
+      expect(urgentLabel.value).toBe('Critical');
+    });
+
+    it('pre-fills response input with fetched minutes as string', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      const urgentResponse = await screen.findByTestId('priority-response-urgent') as HTMLInputElement;
+      expect(urgentResponse.value).toBe('30');
+    });
+
+    it('pre-fills resolution input with fetched minutes as string', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      const urgentResolution = await screen.findByTestId('priority-resolution-urgent') as HTMLInputElement;
+      expect(urgentResolution.value).toBe('120');
+    });
+
+    it('leaves inputs blank when fetched value is null', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      const normalResponse = await screen.findByTestId('priority-response-normal') as HTMLInputElement;
+      expect(normalResponse.value).toBe('');
+
+      const lowResolution = screen.getByTestId('priority-resolution-low') as HTMLInputElement;
+      expect(lowResolution.value).toBe('');
+    });
+
+    it('renders all four priority rows', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priority-row-urgent');
+      expect(screen.getByTestId('priority-row-high')).toBeInTheDocument();
+      expect(screen.getByTestId('priority-row-normal')).toBeInTheDocument();
+      expect(screen.getByTestId('priority-row-low')).toBeInTheDocument();
+    });
+
+    it('renders all required testids', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priorities-save');
+      for (const p of ['urgent', 'high', 'normal', 'low']) {
+        expect(screen.getByTestId(`priority-label-${p}`)).toBeInTheDocument();
+        expect(screen.getByTestId(`priority-response-${p}`)).toBeInTheDocument();
+        expect(screen.getByTestId(`priority-resolution-${p}`)).toBeInTheDocument();
+      }
+    });
+
+    it('renders the precedence note', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priorities-save');
+      expect(screen.getByText(/Order of precedence: category SLA → org override → these defaults/)).toBeInTheDocument();
+    });
+  });
+
+  describe('save — PUTs the correct body shape', () => {
+    it('sends full four-priority object with parsed integers', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priorities-save');
+
+      // Change urgent label
+      fireEvent.change(screen.getByTestId('priority-label-urgent'), { target: { value: 'P1' } });
+      // Change normal response to a number
+      fireEvent.change(screen.getByTestId('priority-response-normal'), { target: { value: '120' } });
+
+      let putBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [], priorities: FETCHED_PRIORITIES } });
+        }
+        if (url === '/ticket-config/priorities' && init?.method === 'PUT') {
+          putBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: {} });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId('priorities-save'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/ticket-config/priorities',
+          expect.objectContaining({ method: 'PUT' })
+        );
+      });
+
+      const sent = putBody.priorities as Record<string, unknown>;
+      expect(sent).toBeDefined();
+      // All four priorities present
+      expect(Object.keys(sent)).toHaveLength(4);
+      // label change applied
+      expect((sent.urgent as Record<string, unknown>).label).toBe('P1');
+      // number parsed as int
+      expect((sent.normal as Record<string, unknown>).responseSlaMinutes).toBe(120);
+    });
+
+    it('sends null for blank label input', async () => {
+      mockGetPriorities({
+        urgent: { label: null, responseSlaMinutes: null, resolutionSlaMinutes: null },
+        high:   { label: null, responseSlaMinutes: null, resolutionSlaMinutes: null },
+        normal: { label: null, responseSlaMinutes: null, resolutionSlaMinutes: null },
+        low:    { label: null, responseSlaMinutes: null, resolutionSlaMinutes: null },
+      });
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priorities-save');
+
+      // Verify urgent label is blank
+      const urgentLabel = screen.getByTestId('priority-label-urgent') as HTMLInputElement;
+      expect(urgentLabel.value).toBe('');
+
+      let putBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [], priorities: {} } });
+        }
+        if (url === '/ticket-config/priorities' && init?.method === 'PUT') {
+          putBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: {} });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId('priorities-save'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/ticket-config/priorities',
+          expect.objectContaining({ method: 'PUT' })
+        );
+      });
+
+      const sent = putBody.priorities as Record<string, unknown>;
+      expect((sent.urgent as Record<string, unknown>).label).toBeNull();
+    });
+
+    it('sends null for blank minutes input', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priorities-save');
+
+      // Clear urgent response
+      fireEvent.change(screen.getByTestId('priority-response-urgent'), { target: { value: '' } });
+
+      let putBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [], priorities: FETCHED_PRIORITIES } });
+        }
+        if (url === '/ticket-config/priorities' && init?.method === 'PUT') {
+          putBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: {} });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId('priorities-save'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/ticket-config/priorities',
+          expect.objectContaining({ method: 'PUT' })
+        );
+      });
+
+      const sent = putBody.priorities as Record<string, unknown>;
+      expect((sent.urgent as Record<string, unknown>).responseSlaMinutes).toBeNull();
+    });
+
+    it('calls invalidateTicketConfig after successful save', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priorities-save');
+      fireEvent.click(screen.getByTestId('priorities-save'));
+
+      await waitFor(() => {
+        expect(invalidateTicketConfig).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('non-admin 403', () => {
+    it('surfaces API error message via toast on 403', async () => {
+      mockGetPriorities(FETCHED_PRIORITIES);
+      render(<TicketPrioritiesTab />);
+
+      await screen.findByTestId('priorities-save');
+
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [], priorities: FETCHED_PRIORITIES } });
+        }
+        if (url === '/ticket-config/priorities' && init?.method === 'PUT') {
+          return makeJsonResponse(
+            { error: 'Managing ticket configuration requires an admin role' },
+            false,
+            403
+          );
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId('priorities-save'));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({
+          type: 'error',
+          message: 'Managing ticket configuration requires an admin role'
+        });
+      });
+    });
+  });
+
+  describe('loading and error states', () => {
+    it('shows loading state initially', () => {
+      fetchMock.mockImplementation(() => new Promise(() => {})); // never resolves
+      render(<TicketPrioritiesTab />);
+      expect(screen.getByTestId('ticket-priorities-loading')).toBeInTheDocument();
+    });
+
+    it('shows error state on fetch failure with retry button', async () => {
+      fetchMock.mockResolvedValue(makeJsonResponse({ error: 'boom' }, false, 500));
+      render(<TicketPrioritiesTab />);
+      await screen.findByTestId('ticket-priorities-error');
+      expect(screen.getByTestId('ticket-priorities-retry')).toBeInTheDocument();
+    });
+
+    it('retry button reloads priorities', async () => {
+      fetchMock.mockResolvedValue(makeJsonResponse({ error: 'boom' }, false, 500));
+      render(<TicketPrioritiesTab />);
+      await screen.findByTestId('ticket-priorities-retry');
+
+      mockGetPriorities(FETCHED_PRIORITIES);
+      fireEvent.click(screen.getByTestId('ticket-priorities-retry'));
+      await screen.findByTestId('priorities-save');
+      expect(screen.queryByTestId('ticket-priorities-error')).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/settings/TicketPrioritiesTab.tsx
+++ b/apps/web/src/components/settings/TicketPrioritiesTab.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+import { invalidateTicketConfig } from '../../lib/ticketConfigApi';
+import { priorityConfig, type TicketPriority } from '../tickets/ticketConfig';
+
+// Authoritative built-in SLA defaults (mirrors PRIORITY_SLA_DEFAULTS in apps/api).
+const PRIORITY_SLA_PLACEHOLDER: Record<TicketPriority, { response: string; resolution: string }> = {
+  urgent: { response: '60', resolution: '240' },
+  high:   { response: '240', resolution: '1440' },
+  normal: { response: '—', resolution: '—' },
+  low:    { response: '—', resolution: '—' },
+};
+
+// Display order: urgent → high → normal → low.
+const PRIORITY_ORDER: TicketPriority[] = ['urgent', 'high', 'normal', 'low'];
+
+interface PrioritySetting {
+  label: string | null;
+  responseSlaMinutes: number | null;
+  resolutionSlaMinutes: number | null;
+}
+
+type PrioritiesState = Record<TicketPriority, PrioritySetting>;
+
+interface RowDraft {
+  label: string;
+  response: string;
+  resolution: string;
+}
+
+type DraftState = Record<TicketPriority, RowDraft>;
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+function buildDraft(priorities: PrioritiesState): DraftState {
+  return Object.fromEntries(
+    PRIORITY_ORDER.map((p) => {
+      const s = priorities[p];
+      return [
+        p,
+        {
+          label: s.label ?? '',
+          response: s.responseSlaMinutes !== null ? String(s.responseSlaMinutes) : '',
+          resolution: s.resolutionSlaMinutes !== null ? String(s.resolutionSlaMinutes) : '',
+        },
+      ];
+    })
+  ) as DraftState;
+}
+
+function buildPayload(draft: DraftState): Record<TicketPriority, { label: string | null; responseSlaMinutes: number | null; resolutionSlaMinutes: number | null }> {
+  return Object.fromEntries(
+    PRIORITY_ORDER.map((p) => {
+      const d = draft[p];
+      const label = d.label.trim() === '' ? null : d.label.trim();
+      const responseSlaMinutes = d.response.trim() === '' ? null : parseInt(d.response.trim(), 10);
+      const resolutionSlaMinutes = d.resolution.trim() === '' ? null : parseInt(d.resolution.trim(), 10);
+      return [p, { label, responseSlaMinutes, resolutionSlaMinutes }];
+    })
+  ) as Record<TicketPriority, { label: string | null; responseSlaMinutes: number | null; resolutionSlaMinutes: number | null }>;
+}
+
+const EMPTY_PRIORITIES: PrioritiesState = Object.fromEntries(
+  PRIORITY_ORDER.map((p) => [p, { label: null, responseSlaMinutes: null, resolutionSlaMinutes: null }])
+) as PrioritiesState;
+
+export default function TicketPrioritiesTab() {
+  const [priorities, setPriorities] = useState<PrioritiesState>(EMPTY_PRIORITIES);
+  const [draft, setDraft] = useState<DraftState>(buildDraft(EMPTY_PRIORITIES));
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetchWithAuth('/ticket-config');
+      if (res.ok) {
+        const body = (await res.json()) as { data: { priorities: PrioritiesState } };
+        const loaded = body.data?.priorities ?? EMPTY_PRIORITIES;
+        setPriorities(loaded);
+        setDraft(buildDraft(loaded));
+      } else {
+        setError(true);
+      }
+    } catch {
+      setError(true);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const updateRow = useCallback((p: TicketPriority, field: keyof RowDraft, value: string) => {
+    setDraft((prev) => ({ ...prev, [p]: { ...prev[p], [field]: value } }));
+  }, []);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth('/ticket-config/priorities', {
+            method: 'PUT',
+            body: JSON.stringify({ priorities: buildPayload(draft) }),
+          }),
+        errorFallback: 'Failed to save priority settings. Retry.',
+        successMessage: 'Priority settings saved',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      invalidateTicketConfig();
+      void load();
+    } catch (err) {
+      handleActionError(err, 'Failed to save priority settings. Retry.');
+    }
+    setSaving(false);
+  }, [draft, load]);
+
+  return (
+    <div className="max-w-3xl" data-testid="ticket-priorities-tab">
+      <div>
+        <h2 className="text-lg font-semibold">Ticket Priorities</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Customize priority labels and set default SLA response and resolution times.
+        </p>
+      </div>
+
+      <div className="mt-6">
+        {loading ? (
+          <p className="text-center text-sm text-muted-foreground" data-testid="ticket-priorities-loading">
+            Loading.
+          </p>
+        ) : error ? (
+          <p className="text-center text-sm text-muted-foreground" data-testid="ticket-priorities-error">
+            Priority settings failed to load.{' '}
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="underline hover:text-foreground"
+              data-testid="ticket-priorities-retry"
+            >
+              Retry
+            </button>
+          </p>
+        ) : (
+          <>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="pb-2 text-left text-xs font-semibold text-muted-foreground">Priority</th>
+                  <th className="pb-2 text-left text-xs font-semibold text-muted-foreground">Label</th>
+                  <th className="pb-2 text-left text-xs font-semibold text-muted-foreground">Response (min)</th>
+                  <th className="pb-2 text-left text-xs font-semibold text-muted-foreground">Resolution (min)</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {PRIORITY_ORDER.map((p) => (
+                  <tr key={p} data-testid={`priority-row-${p}`}>
+                    <td className="py-3 pr-4 font-medium">{priorityConfig[p].label}</td>
+                    <td className="py-3 pr-4">
+                      <input
+                        type="text"
+                        value={draft[p].label}
+                        onChange={(e) => updateRow(p, 'label', e.target.value)}
+                        maxLength={40}
+                        placeholder={priorityConfig[p].label}
+                        className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                        data-testid={`priority-label-${p}`}
+                      />
+                    </td>
+                    <td className="py-3 pr-4">
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={draft[p].response}
+                        onChange={(e) => updateRow(p, 'response', e.target.value)}
+                        placeholder={PRIORITY_SLA_PLACEHOLDER[p].response}
+                        className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                        data-testid={`priority-response-${p}`}
+                      />
+                    </td>
+                    <td className="py-3">
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={draft[p].resolution}
+                        onChange={(e) => updateRow(p, 'resolution', e.target.value)}
+                        placeholder={PRIORITY_SLA_PLACEHOLDER[p].resolution}
+                        className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                        data-testid={`priority-resolution-${p}`}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            <p className="mt-3 text-xs text-muted-foreground">
+              Order of precedence: category SLA → org override → these defaults.
+            </p>
+
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={() => void save()}
+                disabled={saving}
+                className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                data-testid="priorities-save"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/TicketStatusesTab.test.tsx
+++ b/apps/web/src/components/settings/TicketStatusesTab.test.tsx
@@ -1,0 +1,511 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TicketStatusesTab, { moveFlatList, type StatusRow } from './TicketStatusesTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+vi.mock('../../lib/authScope', () => ({
+  loginPathWithNext: () => '/login?next=%2Fsettings%2Ftickets'
+}));
+
+const invalidateTicketConfig = vi.fn();
+vi.mock('../../lib/ticketConfigApi', () => ({
+  invalidateTicketConfig: () => invalidateTicketConfig()
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const STATUS_NEW_SYSTEM = {
+  id: 's-new', partnerId: 'p1', name: 'New', coreStatus: 'new' as const,
+  color: '#1c8a9e', sortOrder: 0, isSystem: true, isActive: true
+} satisfies StatusRow;
+const STATUS_OPEN_SYSTEM = {
+  id: 's-open', partnerId: 'p1', name: 'Open', coreStatus: 'open' as const,
+  color: '#00aa00', sortOrder: 1, isSystem: true, isActive: true
+} satisfies StatusRow;
+const STATUS_CUSTOM_OPEN = {
+  id: 's-custom', partnerId: 'p1', name: 'In Progress', coreStatus: 'open' as const,
+  color: '#aabbcc', sortOrder: 2, isSystem: false, isActive: true
+} satisfies StatusRow;
+const STATUS_INACTIVE = {
+  id: 's-inactive', partnerId: 'p1', name: 'Dormant', coreStatus: 'pending' as const,
+  color: null, sortOrder: 3, isSystem: false, isActive: false
+} satisfies StatusRow;
+
+function mockGetStatuses(statuses: unknown[]) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+      return makeJsonResponse({ data: { statuses, priorities: {} } });
+    }
+    if (url === '/ticket-config/statuses' && init?.method === 'POST') {
+      return makeJsonResponse({ data: { id: 'new-id', ...((statuses[0] as object) ?? {}) } }, true, 201);
+    }
+    if (url.match(/\/ticket-config\/statuses\/.+/) && init?.method === 'PATCH') {
+      return makeJsonResponse({ data: {} });
+    }
+    if (url === '/ticket-config/statuses/reorder' && init?.method === 'POST') {
+      return makeJsonResponse({ data: {} });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 404);
+  });
+}
+
+describe('TicketStatusesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('groups render', () => {
+    it('renders groups from mocked GET, grouped by coreStatus', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM, STATUS_OPEN_SYSTEM, STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      // Wait for rows to appear
+      await screen.findByTestId(`status-row-${STATUS_NEW_SYSTEM.id}`);
+      expect(screen.getByTestId(`status-row-${STATUS_OPEN_SYSTEM.id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`status-row-${STATUS_CUSTOM_OPEN.id}`)).toBeInTheDocument();
+
+      // Groups should be present for the statuses' coreStatuses
+      expect(screen.getByTestId('status-group-new')).toBeInTheDocument();
+      expect(screen.getByTestId('status-group-open')).toBeInTheDocument();
+    });
+
+    it('renders "new" group header before "open" group (canonical order)', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM, STATUS_OPEN_SYSTEM]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId('status-group-new');
+      const newGroup = screen.getByTestId('status-group-new');
+      const openGroup = screen.getByTestId('status-group-open');
+
+      // new should appear before open in DOM
+      expect(
+        newGroup.compareDocumentPosition(openGroup) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it('renders system badge for isSystem rows', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-system-badge-${STATUS_NEW_SYSTEM.id}`);
+    });
+
+    it('does not render system badge for non-system rows', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-row-${STATUS_CUSTOM_OPEN.id}`);
+      expect(screen.queryByTestId(`status-system-badge-${STATUS_CUSTOM_OPEN.id}`)).toBeNull();
+    });
+
+    it('shows Inactive badge for inactive statuses', async () => {
+      mockGetStatuses([STATUS_INACTIVE]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-row-${STATUS_INACTIVE.id}`);
+      const row = screen.getByTestId(`status-row-${STATUS_INACTIVE.id}`);
+      expect(row.textContent).toContain('Inactive');
+    });
+  });
+
+  describe('add form', () => {
+    it('is hidden by default', () => {
+      mockGetStatuses([]);
+      render(<TicketStatusesTab />);
+      expect(screen.queryByTestId('status-form-name')).toBeNull();
+    });
+
+    it('toggles open on add-toggle click', async () => {
+      mockGetStatuses([]);
+      render(<TicketStatusesTab />);
+      fireEvent.click(screen.getByTestId('status-add-toggle'));
+      expect(screen.getByTestId('status-form-name')).toBeInTheDocument();
+      expect(screen.getByTestId('status-form-core')).toBeInTheDocument();
+      expect(screen.getByTestId('status-form-color')).toBeInTheDocument();
+      expect(screen.getByTestId('status-form-submit')).toBeInTheDocument();
+    });
+
+    it('submit is disabled when name is empty', async () => {
+      mockGetStatuses([]);
+      render(<TicketStatusesTab />);
+      fireEvent.click(screen.getByTestId('status-add-toggle'));
+      expect(screen.getByTestId('status-form-submit')).toBeDisabled();
+    });
+
+    it('POSTs correct body on add', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+      fireEvent.click(screen.getByTestId('status-add-toggle'));
+
+      fireEvent.change(screen.getByTestId('status-form-name'), { target: { value: 'Waiting' } });
+      fireEvent.change(screen.getByTestId('status-form-core'), { target: { value: 'pending' } });
+
+      let postBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [STATUS_CUSTOM_OPEN], priorities: {} } });
+        }
+        if (url === '/ticket-config/statuses' && init?.method === 'POST') {
+          postBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: { id: 'new-id' } }, true, 201);
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId('status-form-submit'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/ticket-config/statuses',
+          expect.objectContaining({ method: 'POST' })
+        );
+      });
+
+      expect(postBody.name).toBe('Waiting');
+      expect(postBody.coreStatus).toBe('pending');
+      expect(postBody).toHaveProperty('color');
+    });
+
+    it('calls invalidateTicketConfig after successful add', async () => {
+      mockGetStatuses([]);
+      render(<TicketStatusesTab />);
+      fireEvent.click(screen.getByTestId('status-add-toggle'));
+      fireEvent.change(screen.getByTestId('status-form-name'), { target: { value: 'Waiting' } });
+      fireEvent.click(screen.getByTestId('status-form-submit'));
+
+      await waitFor(() => {
+        expect(invalidateTicketConfig).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('reorder', () => {
+    it('POSTs full ids array (flat across groups) on move-down', async () => {
+      // s-new (sortOrder 0, new) and s-custom (sortOrder 2, open)
+      mockGetStatuses([STATUS_NEW_SYSTEM, STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-down-${STATUS_NEW_SYSTEM.id}`);
+
+      let postBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [STATUS_NEW_SYSTEM, STATUS_CUSTOM_OPEN], priorities: {} } });
+        }
+        if (url === '/ticket-config/statuses/reorder' && init?.method === 'POST') {
+          postBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: {} });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId(`status-down-${STATUS_NEW_SYSTEM.id}`));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/ticket-config/statuses/reorder',
+          expect.objectContaining({ method: 'POST' })
+        );
+      });
+
+      // Full flat ids array — swapped order
+      expect(postBody.ids).toEqual([STATUS_CUSTOM_OPEN.id, STATUS_NEW_SYSTEM.id]);
+    });
+
+    it('disables up arrow on first item and down arrow on last item', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM, STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-up-${STATUS_NEW_SYSTEM.id}`);
+      expect(screen.getByTestId(`status-up-${STATUS_NEW_SYSTEM.id}`)).toBeDisabled();
+      expect(screen.getByTestId(`status-down-${STATUS_NEW_SYSTEM.id}`)).not.toBeDisabled();
+      expect(screen.getByTestId(`status-down-${STATUS_CUSTOM_OPEN.id}`)).toBeDisabled();
+    });
+
+    it('calls invalidateTicketConfig after successful reorder', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM, STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-down-${STATUS_NEW_SYSTEM.id}`);
+      fireEvent.click(screen.getByTestId(`status-down-${STATUS_NEW_SYSTEM.id}`));
+
+      await waitFor(() => {
+        expect(invalidateTicketConfig).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('isSystem rows', () => {
+    it('hides Deactivate button for isSystem rows', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-row-${STATUS_NEW_SYSTEM.id}`);
+      expect(screen.queryByTestId(`status-toggle-${STATUS_NEW_SYSTEM.id}`)).toBeNull();
+    });
+
+    it('shows Deactivate button for non-system rows', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-toggle-${STATUS_CUSTOM_OPEN.id}`);
+    });
+
+    it('disables core-state select in edit for isSystem rows', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-edit-${STATUS_NEW_SYSTEM.id}`);
+      fireEvent.click(screen.getByTestId(`status-edit-${STATUS_NEW_SYSTEM.id}`));
+
+      const coreSelect = screen.getByTestId(`status-edit-core-${STATUS_NEW_SYSTEM.id}`);
+      expect(coreSelect).toBeDisabled();
+    });
+
+    it('enables core-state select in edit for non-system rows', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`);
+      fireEvent.click(screen.getByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`));
+
+      const coreSelect = screen.getByTestId(`status-edit-core-${STATUS_CUSTOM_OPEN.id}`);
+      expect(coreSelect).not.toBeDisabled();
+    });
+  });
+
+  describe('edit flow', () => {
+    it('edit form pre-fills from row data', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`);
+      fireEvent.click(screen.getByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`));
+
+      const nameInput = screen.getByTestId(`status-edit-name-${STATUS_CUSTOM_OPEN.id}`) as HTMLInputElement;
+      expect(nameInput.value).toBe(STATUS_CUSTOM_OPEN.name);
+
+      const coreSelect = screen.getByTestId(`status-edit-core-${STATUS_CUSTOM_OPEN.id}`) as HTMLSelectElement;
+      expect(coreSelect.value).toBe(STATUS_CUSTOM_OPEN.coreStatus);
+    });
+
+    it('PATCHes correct body on save', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`);
+      fireEvent.click(screen.getByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`));
+
+      fireEvent.change(screen.getByTestId(`status-edit-name-${STATUS_CUSTOM_OPEN.id}`), {
+        target: { value: 'Working On It' }
+      });
+
+      let patchBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [STATUS_CUSTOM_OPEN], priorities: {} } });
+        }
+        if (url === `/ticket-config/statuses/${STATUS_CUSTOM_OPEN.id}` && init?.method === 'PATCH') {
+          patchBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: {} });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId(`status-save-${STATUS_CUSTOM_OPEN.id}`));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          `/ticket-config/statuses/${STATUS_CUSTOM_OPEN.id}`,
+          expect.objectContaining({ method: 'PATCH' })
+        );
+      });
+
+      expect(patchBody.name).toBe('Working On It');
+      expect(patchBody.coreStatus).toBe(STATUS_CUSTOM_OPEN.coreStatus);
+    });
+
+    it('does not include coreStatus in PATCH body for isSystem rows', async () => {
+      mockGetStatuses([STATUS_NEW_SYSTEM]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-edit-${STATUS_NEW_SYSTEM.id}`);
+      fireEvent.click(screen.getByTestId(`status-edit-${STATUS_NEW_SYSTEM.id}`));
+
+      fireEvent.change(screen.getByTestId(`status-edit-name-${STATUS_NEW_SYSTEM.id}`), {
+        target: { value: 'Fresh' }
+      });
+
+      let patchBody: Record<string, unknown> = {};
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [STATUS_NEW_SYSTEM], priorities: {} } });
+        }
+        if (url === `/ticket-config/statuses/${STATUS_NEW_SYSTEM.id}` && init?.method === 'PATCH') {
+          patchBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return makeJsonResponse({ data: {} });
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId(`status-save-${STATUS_NEW_SYSTEM.id}`));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          `/ticket-config/statuses/${STATUS_NEW_SYSTEM.id}`,
+          expect.objectContaining({ method: 'PATCH' })
+        );
+      });
+
+      expect(patchBody).not.toHaveProperty('coreStatus');
+    });
+
+    it('closes edit panel on cancel without saving', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`);
+      fireEvent.click(screen.getByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`));
+
+      expect(screen.getByTestId(`status-edit-name-${STATUS_CUSTOM_OPEN.id}`)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId(`status-cancel-${STATUS_CUSTOM_OPEN.id}`));
+
+      expect(screen.queryByTestId(`status-edit-name-${STATUS_CUSTOM_OPEN.id}`)).toBeNull();
+
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('/ticket-config/statuses/'),
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
+
+    it('calls invalidateTicketConfig after successful edit', async () => {
+      mockGetStatuses([STATUS_CUSTOM_OPEN]);
+      render(<TicketStatusesTab />);
+
+      await screen.findByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`);
+      fireEvent.click(screen.getByTestId(`status-edit-${STATUS_CUSTOM_OPEN.id}`));
+
+      fireEvent.click(screen.getByTestId(`status-save-${STATUS_CUSTOM_OPEN.id}`));
+
+      await waitFor(() => {
+        expect(invalidateTicketConfig).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('STATUS_NAME_TAKEN error path', () => {
+    it('shows friendly message when STATUS_NAME_TAKEN code is returned', async () => {
+      mockGetStatuses([]);
+      render(<TicketStatusesTab />);
+      fireEvent.click(screen.getByTestId('status-add-toggle'));
+      fireEvent.change(screen.getByTestId('status-form-name'), { target: { value: 'Duplicate' } });
+
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === '/ticket-config' && (!init?.method || init.method === 'GET')) {
+          return makeJsonResponse({ data: { statuses: [], priorities: {} } });
+        }
+        if (url === '/ticket-config/statuses' && init?.method === 'POST') {
+          return makeJsonResponse(
+            { error: 'Status name already taken', code: 'STATUS_NAME_TAKEN' },
+            false,
+            422
+          );
+        }
+        return makeJsonResponse({ error: 'unexpected' }, false, 404);
+      });
+
+      fireEvent.click(screen.getByTestId('status-form-submit'));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({
+          type: 'error',
+          message: 'A status with that name already exists.'
+        });
+      });
+    });
+  });
+
+  describe('loading and error states', () => {
+    it('shows loading state initially', () => {
+      fetchMock.mockImplementation(() => new Promise(() => {})); // never resolves
+      render(<TicketStatusesTab />);
+      expect(screen.getByTestId('ticket-statuses-loading')).toBeInTheDocument();
+    });
+
+    it('shows error state on fetch failure with retry button', async () => {
+      fetchMock.mockResolvedValue(makeJsonResponse({ error: 'boom' }, false, 500));
+      render(<TicketStatusesTab />);
+      await screen.findByTestId('ticket-statuses-error');
+      expect(screen.getByTestId('ticket-statuses-retry')).toBeInTheDocument();
+    });
+
+    it('retry button reloads statuses', async () => {
+      fetchMock.mockResolvedValue(makeJsonResponse({ error: 'boom' }, false, 500));
+      render(<TicketStatusesTab />);
+      await screen.findByTestId('ticket-statuses-retry');
+
+      mockGetStatuses([STATUS_NEW_SYSTEM]);
+      fireEvent.click(screen.getByTestId('ticket-statuses-retry'));
+      await screen.findByTestId(`status-row-${STATUS_NEW_SYSTEM.id}`);
+      expect(screen.queryByTestId('ticket-statuses-error')).toBeNull();
+    });
+  });
+});
+
+describe('moveFlatList', () => {
+  const statuses = [
+    { ...STATUS_NEW_SYSTEM, sortOrder: 0 },
+    { ...STATUS_OPEN_SYSTEM, sortOrder: 1 },
+    { ...STATUS_CUSTOM_OPEN, sortOrder: 2 },
+  ];
+
+  it('moves an item down: swaps with the next item in flat list', () => {
+    expect(moveFlatList(statuses, STATUS_NEW_SYSTEM.id, 1)).toEqual([
+      STATUS_OPEN_SYSTEM.id, STATUS_NEW_SYSTEM.id, STATUS_CUSTOM_OPEN.id
+    ]);
+  });
+
+  it('moves an item up', () => {
+    expect(moveFlatList(statuses, STATUS_CUSTOM_OPEN.id, -1)).toEqual([
+      STATUS_NEW_SYSTEM.id, STATUS_CUSTOM_OPEN.id, STATUS_OPEN_SYSTEM.id
+    ]);
+  });
+
+  it('returns null at the top edge', () => {
+    expect(moveFlatList(statuses, STATUS_NEW_SYSTEM.id, -1)).toBeNull();
+  });
+
+  it('returns null at the bottom edge', () => {
+    expect(moveFlatList(statuses, STATUS_CUSTOM_OPEN.id, 1)).toBeNull();
+  });
+
+  it('returns null for unknown id', () => {
+    expect(moveFlatList(statuses, 'nonexistent', 1)).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/TicketStatusesTab.tsx
+++ b/apps/web/src/components/settings/TicketStatusesTab.tsx
@@ -1,0 +1,449 @@
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+import { invalidateTicketConfig } from '../../lib/ticketConfigApi';
+import { statusConfig, type TicketStatus } from '../tickets/ticketConfig';
+
+export interface StatusRow {
+  id: string;
+  partnerId: string;
+  name: string;
+  coreStatus: TicketStatus;
+  color: string | null;
+  sortOrder: number;
+  isSystem: boolean;
+  isActive: boolean;
+}
+
+interface EditDraft {
+  name: string;
+  coreStatus: TicketStatus;
+  color: string;
+}
+
+// Canonical core-status order: new → closed (derived from statusConfig key order).
+const CORE_STATUS_ORDER = Object.keys(statusConfig) as TicketStatus[];
+
+// Flat list sorted by sortOrder asc (name tiebreak mirrors server ordering).
+const byRank = (a: StatusRow, b: StatusRow) =>
+  a.sortOrder - b.sortOrder || a.name.localeCompare(b.name);
+
+// Compute the new id order after a one-step move in the FLAT list (all statuses
+// regardless of coreStatus, sorted by current sortOrder). Returns null when the
+// move would fall off either edge. Exported for testing.
+export function moveFlatList(statuses: StatusRow[], id: string, dir: -1 | 1): string[] | null {
+  const sorted = [...statuses].sort(byRank);
+  const idx = sorted.findIndex((s) => s.id === id);
+  if (idx === -1) return null;
+  const swap = idx + dir;
+  if (swap < 0 || swap >= sorted.length) return null;
+  const order = sorted.map((s) => s.id);
+  [order[idx], order[swap]] = [order[swap], order[idx]];
+  return order;
+}
+
+const FRIENDLY_CODES: Record<string, string> = {
+  STATUS_NAME_TAKEN: 'A status with that name already exists.',
+  SYSTEM_STATUS_IMMUTABLE: "Built-in statuses can't change their core state.",
+  SYSTEM_STATUS_REQUIRED: "Built-in statuses can't be deactivated.",
+  STATUS_INACTIVE: 'That status is deactivated.',
+};
+
+const friendlyCode = (code: string): string | undefined => FRIENDLY_CODES[code];
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+const DEFAULT_COLOR = '#1c8a9e';
+
+export default function TicketStatusesTab() {
+  const [statuses, setStatuses] = useState<StatusRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  // Add form state
+  const [addOpen, setAddOpen] = useState(false);
+  const [addName, setAddName] = useState('');
+  const [addCore, setAddCore] = useState<TicketStatus>('new');
+  const [addColor, setAddColor] = useState(DEFAULT_COLOR);
+
+  // Edit state
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<EditDraft>({ name: '', coreStatus: 'new', color: DEFAULT_COLOR });
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetchWithAuth('/ticket-config');
+      if (res.ok) {
+        const body = (await res.json()) as { data: { statuses: StatusRow[] } };
+        setStatuses(body.data?.statuses ?? []);
+      } else {
+        setError(true);
+      }
+    } catch {
+      setError(true);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const create = useCallback(async () => {
+    if (!addName.trim()) return;
+    const body: Record<string, unknown> = {
+      name: addName.trim(),
+      coreStatus: addCore,
+      color: addColor,
+    };
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth('/ticket-config/statuses', { method: 'POST', body: JSON.stringify(body) }),
+        errorFallback: 'Status creation failed. Retry.',
+        successMessage: `Status "${addName.trim()}" created`,
+        friendly: friendlyCode,
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setAddName('');
+      setAddCore('new');
+      setAddColor(DEFAULT_COLOR);
+      setAddOpen(false);
+      invalidateTicketConfig();
+      void load();
+    } catch (err) {
+      handleActionError(err, 'Status creation failed. Retry.');
+    }
+  }, [addName, addCore, addColor, load]);
+
+  const startEdit = useCallback((s: StatusRow) => {
+    setEditingId(s.id);
+    setDraft({ name: s.name, coreStatus: s.coreStatus, color: s.color ?? DEFAULT_COLOR });
+  }, []);
+
+  const saveEdit = useCallback(async (id: string, isSystem: boolean) => {
+    if (!draft.name.trim()) return;
+    const payload: Record<string, unknown> = { name: draft.name.trim(), color: draft.color };
+    if (!isSystem) payload.coreStatus = draft.coreStatus;
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/ticket-config/statuses/${id}`, { method: 'PATCH', body: JSON.stringify(payload) }),
+        errorFallback: 'Update failed. Retry.',
+        successMessage: 'Status updated',
+        friendly: friendlyCode,
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setEditingId(null);
+      invalidateTicketConfig();
+      void load();
+    } catch (err) {
+      handleActionError(err, 'Update failed. Retry.');
+    }
+  }, [draft, load]);
+
+  const toggleActive = useCallback(async (s: StatusRow) => {
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/ticket-config/statuses/${s.id}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ isActive: !s.isActive }),
+          }),
+        errorFallback: 'Update failed. Retry.',
+        friendly: friendlyCode,
+        onUnauthorized: UNAUTHORIZED,
+      });
+      invalidateTicketConfig();
+      void load();
+    } catch (err) {
+      handleActionError(err, 'Update failed. Retry.');
+    }
+  }, [load]);
+
+  const move = useCallback(async (s: StatusRow, dir: -1 | 1) => {
+    const order = moveFlatList(statuses, s.id, dir);
+    if (!order) return;
+    // Optimistic: apply the new ranks locally, restore on failure.
+    const rank = new Map(order.map((id, i) => [id, i]));
+    setStatuses((prev) => prev.map((row) => (rank.has(row.id) ? { ...row, sortOrder: rank.get(row.id)! } : row)));
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth('/ticket-config/statuses/reorder', {
+            method: 'POST',
+            body: JSON.stringify({ ids: order }),
+          }),
+        errorFallback: 'Reorder failed. Retry.',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      invalidateTicketConfig();
+    } catch (err) {
+      void load();
+      handleActionError(err, 'Reorder failed. Retry.');
+    }
+  }, [statuses, load]);
+
+  // Group statuses by coreStatus in canonical order; within each group sort by rank.
+  const groups = useMemo(() => {
+    return CORE_STATUS_ORDER.map((coreStatus) => ({
+      coreStatus,
+      statuses: statuses.filter((s) => s.coreStatus === coreStatus).sort(byRank),
+    }));
+  }, [statuses]);
+
+  const flatSorted = useMemo(() => [...statuses].sort(byRank), [statuses]);
+
+  return (
+    <div className="max-w-3xl" data-testid="ticket-statuses-tab">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Ticket Statuses</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Manage the statuses available in your ticketing queue. Built-in statuses are required and cannot be removed.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setAddOpen((o) => !o)}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white"
+          data-testid="status-add-toggle"
+        >
+          {addOpen ? 'Cancel' : 'Add status'}
+        </button>
+      </div>
+
+      {addOpen && (
+        <div className="mt-4 rounded-md border bg-muted/30 p-4" data-testid="status-add-form">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs font-medium" htmlFor="status-form-name-input">Name</label>
+              <input
+                id="status-form-name-input"
+                value={addName}
+                onChange={(e) => setAddName(e.target.value)}
+                className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                placeholder="Status name"
+                data-testid="status-form-name"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium" htmlFor="status-form-core-select">Core state</label>
+              <select
+                id="status-form-core-select"
+                value={addCore}
+                onChange={(e) => setAddCore(e.target.value as TicketStatus)}
+                className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                data-testid="status-form-core"
+              >
+                {CORE_STATUS_ORDER.map((cs) => (
+                  <option key={cs} value={cs}>{statusConfig[cs].label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs font-medium" htmlFor="status-form-color-input">Color</label>
+              <input
+                id="status-form-color-input"
+                type="color"
+                value={addColor}
+                onChange={(e) => setAddColor(e.target.value)}
+                className="h-9 w-full rounded-md border"
+                data-testid="status-form-color"
+              />
+            </div>
+          </div>
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={() => void create()}
+              disabled={!addName.trim()}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              data-testid="status-form-submit"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => setAddOpen(false)}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-6 space-y-6">
+        {loading ? (
+          <p className="text-center text-sm text-muted-foreground" data-testid="ticket-statuses-loading">
+            Loading.
+          </p>
+        ) : error ? (
+          <p className="text-center text-sm text-muted-foreground" data-testid="ticket-statuses-error">
+            Statuses failed to load.{' '}
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="underline hover:text-foreground"
+              data-testid="ticket-statuses-retry"
+            >
+              Retry
+            </button>
+          </p>
+        ) : statuses.length === 0 ? (
+          <p className="text-center text-sm text-muted-foreground" data-testid="ticket-statuses-empty">
+            No statuses found.
+          </p>
+        ) : (
+          groups.map(({ coreStatus, statuses: groupStatuses }) => {
+            if (groupStatuses.length === 0) return null;
+            return (
+              <div key={coreStatus} data-testid={`status-group-${coreStatus}`}>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {statusConfig[coreStatus].label}
+                </h3>
+                <table className="min-w-full divide-y">
+                  <tbody className="divide-y">
+                    {groupStatuses.map((s) => (
+                      <Fragment key={s.id}>
+                        <tr data-testid={`status-row-${s.id}`}>
+                          <td className="px-4 py-2 text-sm">
+                            <span
+                              className="mr-1.5 inline-block h-3 w-3 rounded-full align-middle"
+                              style={{ backgroundColor: s.color ?? undefined }}
+                              aria-hidden="true"
+                            />
+                            {s.name}
+                            {s.isSystem && (
+                              <span
+                                className="ml-2 rounded border px-1 py-0.5 text-xs text-muted-foreground"
+                                data-testid={`status-system-badge-${s.id}`}
+                              >
+                                Built-in
+                              </span>
+                            )}
+                            {!s.isActive && (
+                              <span className="ml-2 rounded border px-1 py-0.5 text-xs text-muted-foreground">
+                                Inactive
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-4 py-2 text-right space-x-2">
+                            <button
+                              type="button"
+                              onClick={() => void move(s, -1)}
+                              disabled={moveFlatList(flatSorted, s.id, -1) === null}
+                              className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-30"
+                              aria-label={`Move ${s.name} up`}
+                              data-testid={`status-up-${s.id}`}
+                            >
+                              ▲
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => void move(s, 1)}
+                              disabled={moveFlatList(flatSorted, s.id, 1) === null}
+                              className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-30"
+                              aria-label={`Move ${s.name} down`}
+                              data-testid={`status-down-${s.id}`}
+                            >
+                              ▼
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => startEdit(s)}
+                              className="text-sm text-muted-foreground hover:text-foreground"
+                              data-testid={`status-edit-${s.id}`}
+                            >
+                              Edit
+                            </button>
+                            {!s.isSystem && (
+                              <button
+                                type="button"
+                                onClick={() => void toggleActive(s)}
+                                className="text-sm text-muted-foreground hover:text-foreground"
+                                data-testid={`status-toggle-${s.id}`}
+                              >
+                                {s.isActive ? 'Deactivate' : 'Activate'}
+                              </button>
+                            )}
+                          </td>
+                        </tr>
+                        {editingId === s.id && (
+                          <tr key={`edit-${s.id}`}>
+                            <td colSpan={2} className="bg-muted/30 px-4 py-3">
+                              <div className="grid grid-cols-2 gap-3">
+                                <div>
+                                  <label className="text-xs font-medium" htmlFor={`edit-name-${s.id}`}>Name</label>
+                                  <input
+                                    id={`edit-name-${s.id}`}
+                                    value={draft.name}
+                                    onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+                                    className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+                                    data-testid={`status-edit-name-${s.id}`}
+                                  />
+                                </div>
+                                <div>
+                                  <label className="text-xs font-medium" htmlFor={`edit-core-${s.id}`}>Core state</label>
+                                  <select
+                                    id={`edit-core-${s.id}`}
+                                    value={draft.coreStatus}
+                                    onChange={(e) => setDraft((d) => ({ ...d, coreStatus: e.target.value as TicketStatus }))}
+                                    disabled={s.isSystem}
+                                    className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm disabled:opacity-50"
+                                    data-testid={`status-edit-core-${s.id}`}
+                                  >
+                                    {CORE_STATUS_ORDER.map((cs) => (
+                                      <option key={cs} value={cs}>{statusConfig[cs].label}</option>
+                                    ))}
+                                  </select>
+                                </div>
+                                <div>
+                                  <label className="text-xs font-medium" htmlFor={`edit-color-${s.id}`}>Color</label>
+                                  <input
+                                    id={`edit-color-${s.id}`}
+                                    type="color"
+                                    value={draft.color}
+                                    onChange={(e) => setDraft((d) => ({ ...d, color: e.target.value }))}
+                                    className="h-9 w-full rounded-md border"
+                                    data-testid={`status-edit-color-${s.id}`}
+                                  />
+                                </div>
+                              </div>
+                              <div className="mt-3 flex gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => void saveEdit(s.id, s.isSystem)}
+                                  disabled={!draft.name.trim()}
+                                  className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                                  data-testid={`status-save-${s.id}`}
+                                >
+                                  Save
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => setEditingId(null)}
+                                  className="rounded-md border px-3 py-1.5 text-sm font-medium"
+                                  data-testid={`status-cancel-${s.id}`}
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/TicketingSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.test.tsx
@@ -8,6 +8,9 @@ vi.mock('./TicketCategoriesPage', () => ({
 vi.mock('./BillablesExportCard', () => ({
   default: () => <div data-testid="stub-billables-export-card">ExportStub</div>
 }));
+vi.mock('./TicketStatusesTab', () => ({
+  default: () => <div data-testid="stub-ticket-statuses-tab">StatusesStub</div>
+}));
 
 import TicketingSettingsPage from './TicketingSettingsPage';
 

--- a/apps/web/src/components/settings/TicketingSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub child components — we test only the shell's tab switching behaviour.
+vi.mock('./TicketCategoriesPage', () => ({
+  default: () => <div data-testid="stub-ticket-categories-page">CategoriesStub</div>
+}));
+vi.mock('./BillablesExportCard', () => ({
+  default: () => <div data-testid="stub-billables-export-card">ExportStub</div>
+}));
+
+import TicketingSettingsPage from './TicketingSettingsPage';
+
+describe('TicketingSettingsPage', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('renders the tab bar with all four tabs', () => {
+    render(<TicketingSettingsPage />);
+    const tabBar = screen.getByTestId('ticketing-settings-tabs');
+    expect(tabBar).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-statuses')).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-priorities')).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-categories')).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-export')).toBeInTheDocument();
+  });
+
+  it('defaults to the statuses tab when no hash is set', () => {
+    render(<TicketingSettingsPage />);
+    expect(screen.getByTestId('ticketing-tab-panel-statuses')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-ticket-categories-page')).toBeNull();
+    expect(screen.queryByTestId('stub-billables-export-card')).toBeNull();
+  });
+
+  it('switching to categories tab renders TicketCategoriesPage', () => {
+    render(<TicketingSettingsPage />);
+    fireEvent.click(screen.getByTestId('ticketing-tab-categories'));
+    expect(screen.getByTestId('stub-ticket-categories-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('ticketing-tab-panel-statuses')).toBeNull();
+  });
+
+  it('switching to export tab renders BillablesExportCard', () => {
+    render(<TicketingSettingsPage />);
+    fireEvent.click(screen.getByTestId('ticketing-tab-export'));
+    expect(screen.getByTestId('stub-billables-export-card')).toBeInTheDocument();
+  });
+
+  it('switching to priorities tab renders the priorities placeholder', () => {
+    render(<TicketingSettingsPage />);
+    fireEvent.click(screen.getByTestId('ticketing-tab-priorities'));
+    expect(screen.getByTestId('ticketing-tab-panel-priorities')).toBeInTheDocument();
+  });
+
+  it('tab click updates the URL hash', () => {
+    render(<TicketingSettingsPage />);
+    fireEvent.click(screen.getByTestId('ticketing-tab-categories'));
+    expect(window.location.hash).toBe('#tab=categories');
+  });
+
+  it('tab click for statuses sets hash to #tab=statuses', () => {
+    render(<TicketingSettingsPage />);
+    // Switch away first
+    fireEvent.click(screen.getByTestId('ticketing-tab-export'));
+    fireEvent.click(screen.getByTestId('ticketing-tab-statuses'));
+    expect(window.location.hash).toBe('#tab=statuses');
+  });
+
+  it('deep-link #tab=export opens the Export tab', () => {
+    window.location.hash = '#tab=export';
+    render(<TicketingSettingsPage />);
+    expect(screen.getByTestId('stub-billables-export-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('ticketing-tab-panel-statuses')).toBeNull();
+  });
+
+  it('deep-link #tab=categories opens the Categories tab', () => {
+    window.location.hash = '#tab=categories';
+    render(<TicketingSettingsPage />);
+    expect(screen.getByTestId('stub-ticket-categories-page')).toBeInTheDocument();
+  });
+
+  it('deep-link #tab=priorities opens the Priorities tab', () => {
+    window.location.hash = '#tab=priorities';
+    render(<TicketingSettingsPage />);
+    expect(screen.getByTestId('ticketing-tab-panel-priorities')).toBeInTheDocument();
+  });
+
+  it('only the active tab mounts (lazy-render)', () => {
+    render(<TicketingSettingsPage />);
+    // Default tab is statuses — categories and export should NOT be in the DOM
+    expect(screen.queryByTestId('stub-ticket-categories-page')).toBeNull();
+    expect(screen.queryByTestId('stub-billables-export-card')).toBeNull();
+  });
+
+  it('responds to external hashchange event', () => {
+    render(<TicketingSettingsPage />);
+    // Simulate browser back/forward or external hash change
+    window.location.hash = '#tab=export';
+    fireEvent(window, new HashChangeEvent('hashchange'));
+    expect(screen.getByTestId('stub-billables-export-card')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/TicketingSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.test.tsx
@@ -11,6 +11,9 @@ vi.mock('./BillablesExportCard', () => ({
 vi.mock('./TicketStatusesTab', () => ({
   default: () => <div data-testid="stub-ticket-statuses-tab">StatusesStub</div>
 }));
+vi.mock('./TicketPrioritiesTab', () => ({
+  default: () => <div data-testid="stub-ticket-priorities-tab">PrioritiesStub</div>
+}));
 
 import TicketingSettingsPage from './TicketingSettingsPage';
 
@@ -53,10 +56,11 @@ describe('TicketingSettingsPage', () => {
     expect(screen.getByTestId('stub-billables-export-card')).toBeInTheDocument();
   });
 
-  it('switching to priorities tab renders the priorities placeholder', () => {
+  it('switching to priorities tab renders TicketPrioritiesTab', () => {
     render(<TicketingSettingsPage />);
     fireEvent.click(screen.getByTestId('ticketing-tab-priorities'));
     expect(screen.getByTestId('ticketing-tab-panel-priorities')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-ticket-priorities-tab')).toBeInTheDocument();
   });
 
   it('tab click updates the URL hash', () => {
@@ -90,6 +94,7 @@ describe('TicketingSettingsPage', () => {
     window.location.hash = '#tab=priorities';
     render(<TicketingSettingsPage />);
     expect(screen.getByTestId('ticketing-tab-panel-priorities')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-ticket-priorities-tab')).toBeInTheDocument();
   });
 
   it('only the active tab mounts (lazy-render)', () => {

--- a/apps/web/src/components/settings/TicketingSettingsPage.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import TicketCategoriesPage from './TicketCategoriesPage';
+import BillablesExportCard from './BillablesExportCard';
+
+const VALID_TABS = ['statuses', 'priorities', 'categories', 'export'] as const;
+type Tab = (typeof VALID_TABS)[number];
+
+const TABS: Array<{ id: Tab; label: string }> = [
+  { id: 'statuses', label: 'Statuses' },
+  { id: 'priorities', label: 'Priorities' },
+  { id: 'categories', label: 'Categories' },
+  { id: 'export', label: 'Export' }
+];
+
+function parseHash(): Tab {
+  if (typeof window === 'undefined') return 'statuses';
+  for (const part of window.location.hash.replace('#', '').split('&')) {
+    if (part.startsWith('tab=')) {
+      const value = part.slice('tab='.length);
+      if ((VALID_TABS as readonly string[]).includes(value)) return value as Tab;
+    }
+  }
+  return 'statuses';
+}
+
+function hashFor(tab: Tab): string {
+  return `#tab=${tab}`;
+}
+
+export default function TicketingSettingsPage() {
+  const [activeTab, setActiveTab] = useState<Tab>(parseHash);
+
+  const switchTab = (tab: Tab) => {
+    history.replaceState(null, '', hashFor(tab));
+    setActiveTab(tab);
+  };
+
+  useEffect(() => {
+    const onHashChange = () => setActiveTab(parseHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  return (
+    <div className="space-y-6" data-testid="ticketing-settings-page">
+      <div>
+        <h1 className="text-xl font-semibold">Ticketing Settings</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Configure ticket statuses, priority SLA defaults, categories, and billing exports.
+        </p>
+      </div>
+
+      <div role="tablist" className="flex gap-1 border-b" data-testid="ticketing-settings-tabs">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === t.id}
+            onClick={() => switchTab(t.id)}
+            data-testid={`ticketing-tab-${t.id}`}
+            className={cn(
+              'border-b-2 px-4 py-2 text-sm font-medium transition-colors -mb-px',
+              activeTab === t.id
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'statuses' && (
+        <div data-testid="ticketing-tab-panel-statuses">
+          {/* TicketStatusesTab will be wired up in a follow-on task */}
+          <p className="text-sm text-muted-foreground">Status configuration coming soon.</p>
+        </div>
+      )}
+
+      {activeTab === 'priorities' && (
+        <div data-testid="ticketing-tab-panel-priorities">
+          {/* TicketPrioritiesTab will be wired up in a follow-on task */}
+          <p className="text-sm text-muted-foreground">Priority SLA configuration coming soon.</p>
+        </div>
+      )}
+
+      {activeTab === 'categories' && <TicketCategoriesPage />}
+
+      {activeTab === 'export' && <BillablesExportCard />}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/TicketingSettingsPage.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import TicketCategoriesPage from './TicketCategoriesPage';
 import BillablesExportCard from './BillablesExportCard';
 import TicketStatusesTab from './TicketStatusesTab';
+import TicketPrioritiesTab from './TicketPrioritiesTab';
 
 const VALID_TABS = ['statuses', 'priorities', 'categories', 'export'] as const;
 type Tab = (typeof VALID_TABS)[number];
@@ -81,8 +82,7 @@ export default function TicketingSettingsPage() {
 
       {activeTab === 'priorities' && (
         <div data-testid="ticketing-tab-panel-priorities">
-          {/* TicketPrioritiesTab will be wired up in a follow-on task */}
-          <p className="text-sm text-muted-foreground">Priority SLA configuration coming soon.</p>
+          <TicketPrioritiesTab />
         </div>
       )}
 

--- a/apps/web/src/components/settings/TicketingSettingsPage.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import TicketCategoriesPage from './TicketCategoriesPage';
 import BillablesExportCard from './BillablesExportCard';
+import TicketStatusesTab from './TicketStatusesTab';
 
 const VALID_TABS = ['statuses', 'priorities', 'categories', 'export'] as const;
 type Tab = (typeof VALID_TABS)[number];
@@ -74,8 +75,7 @@ export default function TicketingSettingsPage() {
 
       {activeTab === 'statuses' && (
         <div data-testid="ticketing-tab-panel-statuses">
-          {/* TicketStatusesTab will be wired up in a follow-on task */}
-          <p className="text-sm text-muted-foreground">Status configuration coming soon.</p>
+          <TicketStatusesTab />
         </div>
       )}
 

--- a/apps/web/src/components/tickets/TicketQueueList.tsx
+++ b/apps/web/src/components/tickets/TicketQueueList.tsx
@@ -1,12 +1,15 @@
 import { cn } from '@/lib/utils';
 import SlaChip from './SlaChip';
 import { statusConfig, priorityConfig, type TicketSummary } from './ticketConfig';
+import { priorityLabel, statusLabel, type TicketConfig } from '../../lib/ticketConfigApi';
 
 interface Props {
   tickets: TicketSummary[];
   selectedId: string | null;
   onSelect: (t: TicketSummary) => void;
   loading: boolean;
+  /** Ticket config for custom-status names/colors and priority labels; null falls back to core config. */
+  config?: TicketConfig | null;
   /** When set, the empty state offers a "Clear filters" action (UI brief: "View empty (filters)"). */
   onClearFilters?: () => void;
   /** Bulk selection (UI brief §6). Checkboxes render only when onToggleSelect is provided. */
@@ -21,7 +24,7 @@ function timeAgo(iso: string): string {
   return `${Math.floor(mins / (60 * 24))}d ago`;
 }
 
-export default function TicketQueueList({ tickets, selectedId, onSelect, loading, onClearFilters, bulkSelectedIds, onToggleSelect }: Props) {
+export default function TicketQueueList({ tickets, selectedId, onSelect, loading, config = null, onClearFilters, bulkSelectedIds, onToggleSelect }: Props) {
   const anyBulkSelected = (bulkSelectedIds?.size ?? 0) > 0;
 
   if (loading) {
@@ -97,12 +100,19 @@ export default function TicketQueueList({ tickets, selectedId, onSelect, loading
               <span
                 className={cn('inline-flex items-center rounded-md border px-1.5 py-0.5 font-medium', priorityConfig[t.priority].color)}
               >
-                {priorityConfig[t.priority].label}
+                {priorityLabel(config, t.priority)}
               </span>
               <span
-                className={cn('inline-flex items-center rounded-md border px-1.5 py-0.5 font-medium', statusConfig[t.status].color)}
+                className={cn('inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 font-medium', statusConfig[t.status].color)}
               >
-                {statusConfig[t.status].label}
+                {t.statusColor && (
+                  <span
+                    className="inline-block h-2 w-2 rounded-full"
+                    style={{ backgroundColor: t.statusColor }}
+                    aria-hidden="true"
+                  />
+                )}
+                {statusLabel(config, t.status, t.statusName)}
               </span>
               <span className="truncate">{t.orgName ?? ''}</span>
               <span className="ml-auto shrink-0 flex items-center gap-2">

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -3,11 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TicketWorkbench from './TicketWorkbench';
 import { fetchWithAuth } from '../../stores/auth';
+import { fetchTicketConfig, type TicketConfig } from '../../lib/ticketConfigApi';
 import type { TicketDetail } from './ticketConfig';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn()
 }));
+
+// Stub only fetchTicketConfig; the real display/grouping helpers run unchanged.
+vi.mock('../../lib/ticketConfigApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/ticketConfigApi')>();
+  return { ...actual, fetchTicketConfig: vi.fn().mockResolvedValue(null) };
+});
+const fetchConfigMock = vi.mocked(fetchTicketConfig);
 
 const showToast = vi.fn();
 vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
@@ -635,5 +643,190 @@ describe('TicketWorkbench host-supplied assignees prop', () => {
     await screen.findByTestId('ticket-workbench-unassign');
     expect(screen.queryByTestId('ticket-workbench-assignee')).toBeNull();
     expect(fetchMock.mock.calls.filter(([url]) => String(url) === '/users')).toHaveLength(0);
+  });
+});
+
+// ─── Custom statuses (config path) ───────────────────────────────────────────
+
+const makeConfig = (overrides: Partial<TicketConfig> = {}): TicketConfig => ({
+  statuses: [
+    { id: 'st-new', name: 'New', coreStatus: 'new', color: null, sortOrder: 0, isSystem: true, isActive: true },
+    { id: 'st-open', name: 'Open', coreStatus: 'open', color: null, sortOrder: 0, isSystem: true, isActive: true },
+    { id: 'st-waiting', name: 'Waiting on customer', coreStatus: 'pending', color: '#ffaa00', sortOrder: 1, isSystem: false, isActive: true },
+    { id: 'st-pending', name: 'Pending', coreStatus: 'pending', color: null, sortOrder: 0, isSystem: true, isActive: true },
+    { id: 'st-hold', name: 'On hold', coreStatus: 'on_hold', color: null, sortOrder: 0, isSystem: true, isActive: true },
+    { id: 'st-done', name: 'Done & verified', coreStatus: 'resolved', color: '#00aa55', sortOrder: 1, isSystem: false, isActive: true },
+    { id: 'st-resolved', name: 'Resolved', coreStatus: 'resolved', color: null, sortOrder: 0, isSystem: true, isActive: true },
+    { id: 'st-closed', name: 'Closed', coreStatus: 'closed', color: null, sortOrder: 0, isSystem: true, isActive: true }
+  ],
+  priorities: {
+    urgent: { label: 'Urgent', responseSlaMinutes: null, resolutionSlaMinutes: null },
+    high: { label: 'High', responseSlaMinutes: null, resolutionSlaMinutes: null },
+    normal: { label: 'Normal', responseSlaMinutes: null, resolutionSlaMinutes: null },
+    low: { label: 'Low', responseSlaMinutes: null, resolutionSlaMinutes: null }
+  },
+  ...overrides
+});
+
+describe('TicketWorkbench custom-status select (config path)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchConfigMock.mockResolvedValue(null);
+  });
+
+  it('renders optgroups from config and selecting a non-gated custom status posts {statusId}', async () => {
+    fetchConfigMock.mockResolvedValue(makeConfig());
+    mockTicketApi({ 'tk-1': makeTicket({ status: 'open' }) });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-status');
+    // optgroups render once config resolves.
+    await waitFor(() => {
+      expect(select.querySelectorAll('optgroup').length).toBeGreaterThan(0);
+    });
+    expect(screen.getByRole('option', { name: 'Waiting on customer' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Done & verified' })).toBeInTheDocument();
+
+    // Pick the built-in Closed row → posts statusId, never status.
+    fireEvent.change(select, { target: { value: 'st-closed' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ statusId: 'st-closed' }) })
+      );
+    });
+  });
+
+  it('picking a custom RESOLVED-core status opens the resolve form and submits {statusId, resolutionNote}', async () => {
+    fetchConfigMock.mockResolvedValue(makeConfig());
+    mockTicketApi({ 'tk-1': makeTicket({ status: 'open' }) });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-status');
+    await waitFor(() => expect(select.querySelectorAll('optgroup').length).toBeGreaterThan(0));
+
+    fireEvent.change(select, { target: { value: 'st-done' } });
+
+    // Same resolve form as the core path; no mutation until the note submits.
+    expect(screen.getByTestId('ticket-workbench-resolve-form')).toBeInTheDocument();
+    expect(mutationCalls()).toHaveLength(0);
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-resolve-note'), {
+      target: { value: 'Verified the fix.' }
+    });
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ statusId: 'st-done', resolutionNote: 'Verified the fix.' })
+        })
+      );
+    });
+  });
+
+  it('picking a custom PENDING-core status opens the pending form and submits {statusId, pendingReason}', async () => {
+    fetchConfigMock.mockResolvedValue(makeConfig());
+    mockTicketApi({ 'tk-1': makeTicket({ status: 'open' }) });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-status');
+    await waitFor(() => expect(select.querySelectorAll('optgroup').length).toBeGreaterThan(0));
+
+    fireEvent.change(select, { target: { value: 'st-waiting' } });
+
+    expect(screen.getByTestId('ticket-workbench-pending-form')).toBeInTheDocument();
+    expect(mutationCalls()).toHaveLength(0);
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-pending-reason'), {
+      target: { value: 'Awaiting reply' }
+    });
+    fireEvent.click(screen.getByTestId('ticket-workbench-pending-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ statusId: 'st-waiting', pendingReason: 'Awaiting reply' })
+        })
+      );
+    });
+  });
+
+  it('fallback path: with config null the select posts {status} (core enum), never statusId', async () => {
+    fetchConfigMock.mockResolvedValue(null);
+    mockTicketApi({ 'tk-1': makeTicket({ status: 'open' }) });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-status');
+    // No optgroups in the fallback select.
+    expect(select.querySelectorAll('optgroup')).toHaveLength(0);
+
+    fireEvent.change(select, { target: { value: 'closed' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ status: 'closed' }) })
+      );
+    });
+  });
+
+  it('current status display prefers statusName over the core label', async () => {
+    fetchConfigMock.mockResolvedValue(makeConfig());
+    mockTicketApi({ 'tk-1': makeTicket({ status: 'pending', statusName: 'Waiting on customer' }) });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    const select = await screen.findByTestId('ticket-workbench-status') as HTMLSelectElement;
+    await waitFor(() => expect(select.querySelectorAll('optgroup').length).toBeGreaterThan(0));
+    // Selected option is the matching custom row.
+    await waitFor(() => expect(select.value).toBe('st-waiting'));
+  });
+
+  it('cancelling the resolve form clears pendingStatusId so a subsequent `e` shortcut posts {status:resolved}', async () => {
+    fetchConfigMock.mockResolvedValue(makeConfig());
+    mockTicketApi({ 'tk-1': makeTicket({ status: 'open' }) });
+    const { rerender } = render(<TicketWorkbench ticketId="tk-1" resolveRequestToken={0} />);
+
+    const select = await screen.findByTestId('ticket-workbench-status');
+    await waitFor(() => expect(select.querySelectorAll('optgroup').length).toBeGreaterThan(0));
+
+    // Step 1: pick the custom resolved-core status → sets pendingStatusId='st-done', opens resolve form.
+    fireEvent.change(select, { target: { value: 'st-done' } });
+    expect(screen.getByTestId('ticket-workbench-resolve-form')).toBeInTheDocument();
+
+    // Step 2: click Cancel → form closes, pendingStatusId must be cleared.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByTestId('ticket-workbench-resolve-form')).toBeNull();
+
+    // Step 3: press `e` (resolveRequestToken increment) → reopens the resolve form.
+    rerender(<TicketWorkbench ticketId="tk-1" resolveRequestToken={1} />);
+    expect(screen.getByTestId('ticket-workbench-resolve-form')).toBeInTheDocument();
+
+    // Step 4: submit with a note → must POST {status:'resolved'}, NOT {statusId:'st-done'}.
+    fireEvent.change(screen.getByTestId('ticket-workbench-resolve-note'), {
+      target: { value: 'Fixed it.' }
+    });
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'resolved', resolutionNote: 'Fixed it.' })
+        })
+      );
+    });
+    // Sanity: must NOT have posted statusId at all.
+    const statusCalls = fetchMock.mock.calls.filter(
+      ([url, init]) => init?.method === 'POST' && String(url).endsWith('/status')
+    );
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0][1]?.body).not.toContain('statusId');
   });
 });

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -12,6 +12,7 @@ import { SlaTimers } from './SlaTimers';
 import TicketTimeBilling from './TicketTimeBilling';
 import TicketPartsCard from './TicketPartsCard';
 import { statusConfig, priorityConfig, slaState, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
+import { fetchTicketConfig, statusLabel, priorityLabel, activeStatusesByCore, type TicketConfig } from '../../lib/ticketConfigApi';
 import { onTimerChanged, onBillingChanged } from '../../lib/timerActions';
 
 interface Props {
@@ -39,7 +40,13 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   const [resolutionNote, setResolutionNote] = useState('');
   const [pendingOpen, setPendingOpen] = useState<'pending' | 'on_hold' | null>(null);
   const [pendingReason, setPendingReason] = useState('');
+  // When the user picks a custom-status row (config path), its id is stashed so
+  // the gated resolve/pending POST sends {statusId}; null means the core path.
+  const [pendingStatusId, setPendingStatusId] = useState<string | null>(null);
   const [railOpen] = useState(true);
+  // Ticket configuration (custom statuses + priority labels). null = not loaded
+  // or fetch failed; every render falls back to the static core config.
+  const [config, setConfig] = useState<TicketConfig | null>(null);
 
   // null = picker hidden (no USERS_READ etc.); degrade to a label + unassign-only button.
   const [fetchedAssignees, setFetchedAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
@@ -95,6 +102,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     setResolutionNote('');
     setPendingOpen(null);
     setPendingReason('');
+    setPendingStatusId(null);
   }, [ticketId]);
 
   // Page-level `e` shortcut: open the inline resolve form (UI brief: `e` opens the resolution-note form)
@@ -118,6 +126,16 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
       .catch(() => { /* degraded mode keeps the unassign-only affordance */ });
     return () => { cancelled = true; };
   }, [assigneesProvided]);
+
+  // Fetch ticket config once (module-cached across islands). Failure leaves
+  // config null, which keeps the six-core-status fallback select fully working.
+  useEffect(() => {
+    let cancelled = false;
+    void fetchTicketConfig().then((c) => {
+      if (!cancelled && c) setConfig(c);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // Reload the feed (time-entry lines appear) when timer stops or parts/time change.
   useEffect(() => {
@@ -145,28 +163,50 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     }
   }, [ticketId, load, onChanged]);
 
+  // Fallback path: option values are the six core enums; POST {status}.
   const onStatusChange = useCallback(async (status: TicketStatus) => {
+    setPendingStatusId(null);
     if (status === 'resolved') { setResolveOpen(true); return; }
     if (status === 'pending' || status === 'on_hold') { setPendingOpen(status); return; }
     await mutate('/status', { status }, 'Status updated');
   }, [mutate]);
 
+  // Config path: option values are custom-status row ids; the chosen row's
+  // coreStatus drives the same resolve/pending forms, and the POST sends
+  // {statusId} so resolved/pending custom statuses behave like their core peers.
+  const onCustomStatusChange = useCallback(async (statusId: string) => {
+    const row = config?.statuses.find((s) => s.id === statusId);
+    if (!row) return;
+    if (row.coreStatus === 'resolved') { setPendingStatusId(statusId); setResolveOpen(true); return; }
+    if (row.coreStatus === 'pending' || row.coreStatus === 'on_hold') {
+      setPendingStatusId(statusId);
+      setPendingOpen(row.coreStatus);
+      return;
+    }
+    setPendingStatusId(null);
+    await mutate('/status', { statusId }, 'Status updated');
+  }, [config, mutate]);
+
   const submitResolve = useCallback(async () => {
     if (!resolutionNote.trim()) return;
-    const ok = await mutate('/status', { status: 'resolved', resolutionNote: resolutionNote.trim() }, 'Ticket resolved');
+    const target = pendingStatusId ? { statusId: pendingStatusId } : { status: 'resolved' as const };
+    const ok = await mutate('/status', { ...target, resolutionNote: resolutionNote.trim() }, 'Ticket resolved');
     if (!ok) return; // keep the form open and the typed note intact on failure
     setResolveOpen(false);
     setResolutionNote('');
-  }, [mutate, resolutionNote]);
+    setPendingStatusId(null);
+  }, [mutate, resolutionNote, pendingStatusId]);
 
   const submitPending = useCallback(async () => {
     if (!pendingOpen) return;
     const reason = pendingReason.trim();
-    const ok = await mutate('/status', { status: pendingOpen, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated');
+    const target = pendingStatusId ? { statusId: pendingStatusId } : { status: pendingOpen };
+    const ok = await mutate('/status', { ...target, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated');
     if (!ok) return; // keep the form open and the typed reason intact on failure
     setPendingOpen(null);
     setPendingReason('');
-  }, [mutate, pendingOpen, pendingReason]);
+    setPendingStatusId(null);
+  }, [mutate, pendingOpen, pendingReason, pendingStatusId]);
 
   const sendComment = useCallback(async (content: string, isPublic: boolean) => {
     await runAction({
@@ -199,6 +239,16 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     );
   }
 
+  // Which option is selected in the config-path select: the active row whose
+  // name matches the ticket's custom status within its core state, else the
+  // system row for that core state (so legacy/null statusName tickets land on
+  // the built-in option rather than showing an empty select).
+  const selectedStatusId = config
+    ? (config.statuses.find((s) => s.coreStatus === ticket.status && s.isActive && ticket.statusName && s.name === ticket.statusName)
+        ?? config.statuses.find((s) => s.coreStatus === ticket.status && s.isSystem))?.id ?? null
+    : null;
+  const headerStatusColor = ticket.statusColor ?? config?.statuses.find((s) => s.id === selectedStatusId)?.color ?? null;
+
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="ticket-workbench" aria-busy={loading || undefined}>
       {/* Header */}
@@ -229,15 +279,38 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
           )}
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-2">
-          <select
-            value={ticket.status}
-            onChange={(e) => void onStatusChange(e.target.value as TicketStatus)}
-            className={cn('rounded-md border px-2 py-1 text-xs font-medium', statusConfig[ticket.status].color)}
-            data-testid="ticket-workbench-status"
-            aria-label="Status"
-          >
-            {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{statusConfig[s].label}</option>)}
-          </select>
+          {config ? (
+            // Config path: optgroup per core state with the active custom statuses
+            // (option value = row id). The selected value is the row matching the
+            // ticket's custom status name within its core state, falling back to
+            // the system row for that core state.
+            <select
+              value={selectedStatusId ?? ''}
+              onChange={(e) => void onCustomStatusChange(e.target.value)}
+              className={cn('rounded-md border border-l-4 px-2 py-1 text-xs font-medium', statusConfig[ticket.status].color)}
+              style={headerStatusColor ? { borderLeftColor: headerStatusColor } : undefined}
+              data-testid="ticket-workbench-status"
+              aria-label="Status"
+            >
+              {activeStatusesByCore(config).map(({ coreStatus, statuses }) =>
+                statuses.length > 0 ? (
+                  <optgroup key={coreStatus} label={statusConfig[coreStatus].label}>
+                    {statuses.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+                  </optgroup>
+                ) : null
+              )}
+            </select>
+          ) : (
+            <select
+              value={ticket.status}
+              onChange={(e) => void onStatusChange(e.target.value as TicketStatus)}
+              className={cn('rounded-md border px-2 py-1 text-xs font-medium', statusConfig[ticket.status].color)}
+              data-testid="ticket-workbench-status"
+              aria-label="Status"
+            >
+              {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{statusConfig[s].label}</option>)}
+            </select>
+          )}
           <select
             value={ticket.priority}
             onChange={(e) => {
@@ -251,7 +324,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
             data-testid="ticket-workbench-priority"
             aria-label="Priority"
           >
-            {PRIORITY_OPTIONS.map((p) => <option key={p} value={p}>{priorityConfig[p].label}</option>)}
+            {PRIORITY_OPTIONS.map((p) => <option key={p} value={p}>{priorityLabel(config, p)}</option>)}
           </select>
           {assignees !== null ? (
             <select
@@ -298,7 +371,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
               data-testid="ticket-workbench-resolve-note"
             />
             <div className="mt-1.5 flex justify-end gap-2">
-              <button type="button" onClick={() => setResolveOpen(false)} className="rounded-md border px-2 py-1 text-xs hover:bg-muted">Cancel</button>
+              <button type="button" onClick={() => { setResolveOpen(false); setPendingStatusId(null); }} className="rounded-md border px-2 py-1 text-xs hover:bg-muted">Cancel</button>
               <button
                 type="button"
                 onClick={() => void submitResolve()}
@@ -324,7 +397,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
               data-testid="ticket-workbench-pending-reason"
             />
             <div className="mt-1.5 flex justify-end gap-2">
-              <button type="button" onClick={() => { setPendingOpen(null); setPendingReason(''); }} className="rounded-md border px-2 py-1 text-xs hover:bg-muted">Cancel</button>
+              <button type="button" onClick={() => { setPendingOpen(null); setPendingReason(''); setPendingStatusId(null); }} className="rounded-md border px-2 py-1 text-xs hover:bg-muted">Cancel</button>
               <button
                 type="button"
                 onClick={() => void submitPending()}

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TicketsPage from './TicketsPage';
 import { fetchWithAuth } from '../../stores/auth';
+import { fetchTicketConfig, type TicketConfig } from '../../lib/ticketConfigApi';
 import type { TicketSummary } from './ticketConfig';
 
 vi.mock('../../stores/auth', () => ({
@@ -11,6 +12,13 @@ vi.mock('../../stores/auth', () => ({
     getState: () => ({ user: { id: 'user-1' } })
   })
 }));
+
+// Stub fetchTicketConfig; real display helpers (statusLabel/priorityLabel) run unchanged.
+vi.mock('../../lib/ticketConfigApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/ticketConfigApi')>();
+  return { ...actual, fetchTicketConfig: vi.fn().mockResolvedValue(null) };
+});
+const fetchConfigMock = vi.mocked(fetchTicketConfig);
 
 const showToast = vi.fn();
 vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
@@ -125,6 +133,7 @@ describe('TicketsPage', () => {
     capturedWorkbenchProps.length = 0;
     // Default to partner scope so existing tests behave as before.
     mockGetJwtClaims.mockReturnValue({ scope: 'partner', orgId: null, partnerId: 'p-1' });
+    fetchConfigMock.mockResolvedValue(null);
     // jsdom defaults to 1024, which is below the 1100px split-pane breakpoint;
     // select() would navigate to the full page instead of selecting in-pane.
     Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1280 });
@@ -676,6 +685,57 @@ describe('TicketsPage', () => {
 
       await waitFor(() => {
         expect(showToast).toHaveBeenCalledWith({ type: 'success', message: '3 updated' });
+      });
+    });
+  });
+
+  describe('custom-status queue chips', () => {
+    const CONFIG: TicketConfig = {
+      statuses: [
+        { id: 'st-open', name: 'Open', coreStatus: 'open', color: null, sortOrder: 0, isSystem: true, isActive: true },
+        { id: 'st-waiting', name: 'Waiting on customer', coreStatus: 'pending', color: '#ffaa00', sortOrder: 1, isSystem: false, isActive: true }
+      ],
+      priorities: {
+        urgent: { label: 'Urgent', responseSlaMinutes: null, resolutionSlaMinutes: null },
+        high: { label: 'High', responseSlaMinutes: null, resolutionSlaMinutes: null },
+        normal: { label: 'Normal', responseSlaMinutes: null, resolutionSlaMinutes: null },
+        low: { label: 'Low', responseSlaMinutes: null, resolutionSlaMinutes: null }
+      }
+    };
+
+    it('row chip prefers statusName over the core label and shows the color dot', async () => {
+      fetchConfigMock.mockResolvedValue(CONFIG);
+      const custom = makeTicket({
+        id: 'tk-custom',
+        internalNumber: 'T-2026-0009',
+        subject: 'Custom status ticket',
+        status: 'pending',
+        statusName: 'Waiting on customer',
+        statusColor: '#ffaa00'
+      });
+      mockListApi([custom]);
+      render(<TicketsPage />);
+
+      const row = await screen.findByTestId('ticket-row-tk-custom');
+      await waitFor(() => {
+        expect(row).toHaveTextContent('Waiting on customer');
+      });
+      // Core label is replaced, not appended.
+      expect(row).not.toHaveTextContent('Pending');
+      // The color dot renders an inline style accent.
+      const dot = row.querySelector('span[style*="background"]');
+      expect(dot).not.toBeNull();
+    });
+
+    it('falls back to the core label when statusName is null', async () => {
+      fetchConfigMock.mockResolvedValue(CONFIG);
+      const legacy = makeTicket({ id: 'tk-legacy', internalNumber: 'T-2026-0010', status: 'open', statusName: null });
+      mockListApi([legacy]);
+      render(<TicketsPage />);
+
+      const row = await screen.findByTestId('ticket-row-tk-legacy');
+      await waitFor(() => {
+        expect(row).toHaveTextContent('Open');
       });
     });
   });

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -9,7 +9,8 @@ import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import TicketQueueList from './TicketQueueList';
 import TicketWorkbench from './TicketWorkbench';
 import { useQueueKeyboard } from './useQueueKeyboard';
-import { priorityConfig, statusConfig, type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
+import { type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
+import { fetchTicketConfig, priorityLabel, statusLabel, type TicketConfig } from '../../lib/ticketConfigApi';
 
 // Human-readable labels for bulk-skip reason codes returned by POST /tickets/bulk.
 const SKIP_REASON_LABELS: Record<string, string> = {
@@ -118,6 +119,9 @@ export default function TicketsPage() {
   const [bulkSelectedIds, setBulkSelectedIds] = useState<Set<string>>(new Set());
   const [bulkAssignee, setBulkAssignee] = useState(''); // '' = none; 'unassign' sentinel = null assignee
   const [bulkStatus, setBulkStatus] = useState('');
+  // Ticket config (custom statuses + priority labels). null = not loaded / fetch
+  // failed; chips and bulk-status options fall back to the static core config.
+  const [config, setConfig] = useState<TicketConfig | null>(null);
   const fetchSeq = useRef(0);
 
   // 'mine'/'unassigned' tabs already pin the assignee param; the filter select is locked there.
@@ -212,6 +216,16 @@ export default function TicketsPage() {
   }, []);
 
   useEffect(() => { void fetchTickets(); void fetchStats(); }, [fetchTickets, fetchStats]);
+
+  // Fetch ticket config once (module-cached). Failure leaves config null, so
+  // chips and the bulk-status menu keep using the static core labels.
+  useEffect(() => {
+    let cancelled = false;
+    void fetchTicketConfig().then((c) => {
+      if (!cancelled && c) setConfig(c);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // Selection survives tab switches (POST /tickets/bulk takes raw ids; the bar's
   // count chip reports off-view rows) but clears when a filter or the search
@@ -441,7 +455,7 @@ export default function TicketsPage() {
         >
           <option value="">All priorities</option>
           {PRIORITY_ORDER.map((p) => (
-            <option key={p} value={p}>{priorityConfig[p].label}</option>
+            <option key={p} value={p}>{priorityLabel(config, p)}</option>
           ))}
         </select>
         <select
@@ -527,6 +541,7 @@ export default function TicketsPage() {
                 selectedId={selected?.id ?? null}
                 onSelect={select}
                 loading={loading}
+                config={config}
                 onClearFilters={filtersActive ? clearFilters : undefined}
                 bulkSelectedIds={bulkSelectedIds}
                 onToggleSelect={toggleBulkSelect}
@@ -572,7 +587,7 @@ export default function TicketsPage() {
                   >
                     <option value="">Set status…</option>
                     {BULK_STATUSES.map((s) => (
-                      <option key={s} value={s}>{statusConfig[s].label}</option>
+                      <option key={s} value={s}>{statusLabel(config, s)}</option>
                     ))}
                   </select>
                   <button

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -7,6 +7,10 @@ export interface TicketSummary {
   internalNumber: string | null;
   subject: string;
   status: TicketStatus;
+  // Custom-status decoration from the API (null for legacy tickets). `status`
+  // remains the core state; `statusName`/`statusColor` describe the custom row.
+  statusName?: string | null;
+  statusColor?: string | null;
   priority: TicketPriority;
   source: string;
   orgId: string;

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -46,6 +46,7 @@ const TARGET_GLOBS = [
   'src/components/settings/TicketStatusesTab.tsx',
   'src/components/settings/TicketPrioritiesTab.tsx',
   'src/components/settings/OrgPortalSettingsEditor.tsx',
+  'src/components/settings/OrgTicketSettingsEditor.tsx',
   'src/components/alerts/CreateTicketFromAlertDialog.tsx',
   'src/lib/timerActions.ts',
   'src/components/time/TimerWidget.tsx',
@@ -243,7 +244,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(24);
+    expect(absoluteFiles.length).toBe(25);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -43,6 +43,7 @@ const TARGET_GLOBS = [
   'src/components/pam/PamRuleModal.tsx',
   'src/components/pam/PamRulesTab.tsx',
   'src/components/settings/TicketCategoriesPage.tsx',
+  'src/components/settings/TicketStatusesTab.tsx',
   'src/components/settings/OrgPortalSettingsEditor.tsx',
   'src/components/alerts/CreateTicketFromAlertDialog.tsx',
   'src/lib/timerActions.ts',
@@ -241,7 +242,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(22);
+    expect(absoluteFiles.length).toBe(23);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -44,6 +44,7 @@ const TARGET_GLOBS = [
   'src/components/pam/PamRulesTab.tsx',
   'src/components/settings/TicketCategoriesPage.tsx',
   'src/components/settings/TicketStatusesTab.tsx',
+  'src/components/settings/TicketPrioritiesTab.tsx',
   'src/components/settings/OrgPortalSettingsEditor.tsx',
   'src/components/alerts/CreateTicketFromAlertDialog.tsx',
   'src/lib/timerActions.ts',
@@ -242,7 +243,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(23);
+    expect(absoluteFiles.length).toBe(24);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/ticketConfigApi.test.ts
+++ b/apps/web/src/lib/__tests__/ticketConfigApi.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { fetchWithAuth } from '../../stores/auth';
+import {
+  fetchTicketConfig,
+  invalidateTicketConfig,
+  statusLabel,
+  priorityLabel,
+  activeStatusesByCore,
+  __resetTicketConfigCacheForTests,
+  type TicketConfig,
+} from '../ticketConfigApi';
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+// Helper to build a minimal valid API response body.
+function makeApiResponse(overrides?: Partial<{ statuses: unknown[]; priorities: unknown }>) {
+  return {
+    data: {
+      statuses: overrides?.statuses ?? [
+        { id: 'sys-new', partnerId: 'p1', name: 'New', coreStatus: 'new', color: null, sortOrder: 0, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+        { id: 'sys-open', partnerId: 'p1', name: 'Open', coreStatus: 'open', color: '#00ff00', sortOrder: 1, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+        { id: 'custom-pending', partnerId: 'p1', name: 'Waiting', coreStatus: 'pending', color: '#ffcc00', sortOrder: 2, isSystem: false, isActive: true, createdAt: '', updatedAt: '' },
+        { id: 'inactive-open', partnerId: 'p1', name: 'OldOpen', coreStatus: 'open', color: null, sortOrder: 10, isSystem: false, isActive: false, createdAt: '', updatedAt: '' },
+        { id: 'sys-on-hold', partnerId: 'p1', name: 'On Hold', coreStatus: 'on_hold', color: null, sortOrder: 3, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+        { id: 'sys-resolved', partnerId: 'p1', name: 'Resolved', coreStatus: 'resolved', color: null, sortOrder: 4, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+        { id: 'sys-closed', partnerId: 'p1', name: 'Closed', coreStatus: 'closed', color: null, sortOrder: 5, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+      ],
+      priorities: overrides?.priorities ?? {
+        low: { label: 'Low', responseSlaMinutes: 120, resolutionSlaMinutes: 480 },
+        normal: { label: null, responseSlaMinutes: 60, resolutionSlaMinutes: 240 },
+        high: { label: 'High', responseSlaMinutes: 30, resolutionSlaMinutes: 120 },
+        urgent: { label: 'Critical', responseSlaMinutes: 15, resolutionSlaMinutes: 60 },
+      },
+    },
+  };
+}
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  __resetTicketConfigCacheForTests();
+  fetchWithAuthMock.mockReset();
+});
+
+// ─── Caching tests ────────────────────────────────────────────────────────────
+
+describe('fetchTicketConfig — caching', () => {
+  it('returns same promise to concurrent callers (single fetch)', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+
+    const [p1, p2] = await Promise.all([fetchTicketConfig(), fetchTicketConfig()]);
+    // Same object reference — resolved from the same promise.
+    expect(p1).toBe(p2);
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the cached result on a second sequential call (no refetch)', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+
+    const first = await fetchTicketConfig();
+    const second = await fetchTicketConfig();
+    expect(first).toBe(second);
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidateTicketConfig forces a refetch on the next call', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+
+    const first = await fetchTicketConfig();
+    invalidateTicketConfig();
+
+    const second = await fetchTicketConfig();
+    // Was re-fetched.
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
+    // Both should be structurally equal (same API response).
+    expect(second).toEqual(first);
+  });
+});
+
+// ─── Failure handling tests ───────────────────────────────────────────────────
+
+describe('fetchTicketConfig — failure handling', () => {
+  it('returns null when the API responds !ok', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse({}, false, 500));
+
+    const result = await fetchTicketConfig();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when fetchWithAuth throws (network error)', async () => {
+    fetchWithAuthMock.mockRejectedValue(new Error('network down'));
+
+    const result = await fetchTicketConfig();
+    expect(result).toBeNull();
+  });
+
+  it('clears the cache after a null result so the next call retries', async () => {
+    // First call fails.
+    fetchWithAuthMock.mockRejectedValueOnce(new Error('down'));
+    const first = await fetchTicketConfig();
+    expect(first).toBeNull();
+
+    // No invalidate needed — failed fetch must not cache.
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse(makeApiResponse()));
+    const second = await fetchTicketConfig();
+    expect(second).not.toBeNull();
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── Response shape tests ─────────────────────────────────────────────────────
+
+describe('fetchTicketConfig — response shape', () => {
+  it('maps API response to TicketConfig correctly', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+
+    const config = await fetchTicketConfig();
+    expect(config).not.toBeNull();
+    // Statuses are mapped
+    expect(config!.statuses.length).toBeGreaterThan(0);
+    const newRow = config!.statuses.find((s) => s.coreStatus === 'new');
+    expect(newRow).toBeDefined();
+    expect(newRow!.id).toBe('sys-new');
+    expect(newRow!.isSystem).toBe(true);
+    // Priorities are mapped
+    expect(config!.priorities.low.label).toBe('Low');
+    expect(config!.priorities.normal.label).toBeNull();
+    expect(config!.priorities.urgent.label).toBe('Critical');
+    expect(config!.priorities.high.responseSlaMinutes).toBe(30);
+  });
+});
+
+// ─── statusLabel tests ────────────────────────────────────────────────────────
+
+describe('statusLabel', () => {
+  it('returns the system row name from config when available', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+    const config = await fetchTicketConfig();
+
+    // 'new' system row is named 'New'
+    expect(statusLabel(config, 'new')).toBe('New');
+  });
+
+  it('prefers explicit statusName over system row name', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+    const config = await fetchTicketConfig();
+
+    expect(statusLabel(config, 'new', 'Custom Label')).toBe('Custom Label');
+  });
+
+  it('falls back to static statusConfig label when config is null', () => {
+    expect(statusLabel(null, 'new')).toBe('New');
+    expect(statusLabel(null, 'on_hold')).toBe('On hold');
+    expect(statusLabel(null, 'resolved')).toBe('Resolved');
+  });
+
+  it('falls back to static statusConfig label when no system row exists for that coreStatus', async () => {
+    // Config with no system row for 'resolved'.
+    const response = makeApiResponse({
+      statuses: [
+        { id: 'sys-new', partnerId: 'p1', name: 'New', coreStatus: 'new', color: null, sortOrder: 0, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+      ],
+    });
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(response));
+    const config = await fetchTicketConfig();
+
+    // Falls back to static config label for 'resolved'
+    expect(statusLabel(config, 'resolved')).toBe('Resolved');
+  });
+
+  it('prefers statusName over config and static fallback', () => {
+    expect(statusLabel(null, 'pending', 'Waiting on customer')).toBe('Waiting on customer');
+  });
+});
+
+// ─── priorityLabel tests ──────────────────────────────────────────────────────
+
+describe('priorityLabel', () => {
+  it('returns config label when available and non-null', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+    const config = await fetchTicketConfig();
+
+    expect(priorityLabel(config, 'urgent')).toBe('Critical');
+    expect(priorityLabel(config, 'low')).toBe('Low');
+  });
+
+  it('falls back to static priorityConfig label when config label is null', async () => {
+    // normal.label is null in makeApiResponse
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+    const config = await fetchTicketConfig();
+
+    expect(priorityLabel(config, 'normal')).toBe('Normal');
+  });
+
+  it('falls back to static priorityConfig label when config is null', () => {
+    expect(priorityLabel(null, 'urgent')).toBe('Urgent');
+    expect(priorityLabel(null, 'high')).toBe('High');
+    expect(priorityLabel(null, 'normal')).toBe('Normal');
+    expect(priorityLabel(null, 'low')).toBe('Low');
+  });
+});
+
+// ─── activeStatusesByCore tests ───────────────────────────────────────────────
+
+describe('activeStatusesByCore', () => {
+  it('groups active statuses by coreStatus in new→closed order', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+    const config = await fetchTicketConfig();
+
+    const groups = activeStatusesByCore(config!);
+    const coreOrder = groups.map((g) => g.coreStatus);
+    expect(coreOrder).toEqual(['new', 'open', 'pending', 'on_hold', 'resolved', 'closed']);
+  });
+
+  it('excludes inactive statuses', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(makeApiResponse()));
+    const config = await fetchTicketConfig();
+
+    const groups = activeStatusesByCore(config!);
+    const openGroup = groups.find((g) => g.coreStatus === 'open');
+    expect(openGroup).toBeDefined();
+    // The inactive 'OldOpen' row should not appear.
+    expect(openGroup!.statuses.every((s) => s.isActive)).toBe(true);
+    expect(openGroup!.statuses.find((s) => s.id === 'inactive-open')).toBeUndefined();
+  });
+
+  it('returns all six core groups even when some have no active statuses', async () => {
+    // Only 'new' has any statuses.
+    const response = makeApiResponse({
+      statuses: [
+        { id: 'sys-new', partnerId: 'p1', name: 'New', coreStatus: 'new', color: null, sortOrder: 0, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+      ],
+    });
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(response));
+    const config = await fetchTicketConfig();
+
+    const groups = activeStatusesByCore(config!);
+    expect(groups).toHaveLength(6);
+    expect(groups.find((g) => g.coreStatus === 'new')!.statuses).toHaveLength(1);
+    expect(groups.find((g) => g.coreStatus === 'open')!.statuses).toHaveLength(0);
+  });
+
+  it('sorts statuses within a group by sortOrder', async () => {
+    const response = makeApiResponse({
+      statuses: [
+        { id: 'open-b', partnerId: 'p1', name: 'OpenB', coreStatus: 'open', color: null, sortOrder: 5, isSystem: false, isActive: true, createdAt: '', updatedAt: '' },
+        { id: 'open-a', partnerId: 'p1', name: 'OpenA', coreStatus: 'open', color: null, sortOrder: 1, isSystem: true, isActive: true, createdAt: '', updatedAt: '' },
+      ],
+    });
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(response));
+    const config = await fetchTicketConfig();
+
+    const groups = activeStatusesByCore(config!);
+    const openGroup = groups.find((g) => g.coreStatus === 'open');
+    expect(openGroup!.statuses[0].id).toBe('open-a');
+    expect(openGroup!.statuses[1].id).toBe('open-b');
+  });
+});

--- a/apps/web/src/lib/ticketConfigApi.ts
+++ b/apps/web/src/lib/ticketConfigApi.ts
@@ -1,0 +1,198 @@
+/**
+ * Cached ticket-configuration client.
+ *
+ * Fetches `GET /ticket-config` and stores the in-flight/resolved promise at
+ * module scope so multiple islands on the same page share a single network
+ * request. A failed fetch (null result) is NOT cached — the next caller will
+ * retry. A successful fetch is cached until `invalidateTicketConfig()` is
+ * called (settings pages call it after writing config changes).
+ */
+import { fetchWithAuth } from '../stores/auth';
+import {
+  statusConfig,
+  priorityConfig,
+  type TicketStatus,
+  type TicketPriority,
+} from '../components/tickets/ticketConfig';
+
+// Re-export the types we alias as CoreStatus / Priority in the spec.
+export type CoreStatus = TicketStatus;
+export type Priority = TicketPriority;
+
+export interface TicketStatusRow {
+  id: string;
+  name: string;
+  coreStatus: CoreStatus;
+  color: string | null;
+  sortOrder: number;
+  isSystem: boolean;
+  isActive: boolean;
+}
+
+export interface PrioritySetting {
+  label: string | null;
+  responseSlaMinutes: number | null;
+  resolutionSlaMinutes: number | null;
+}
+
+export interface TicketConfig {
+  statuses: TicketStatusRow[];
+  priorities: Record<Priority, PrioritySetting>;
+}
+
+// The canonical order of core statuses (new → closed).
+// Derived from the static statusConfig key order rather than duplicated.
+const CORE_STATUS_ORDER: CoreStatus[] = Object.keys(statusConfig) as CoreStatus[];
+
+// ─── Module-level cache ──────────────────────────────────────────────────────
+
+// Stores the pending/resolved promise. Cleared on failure or by invalidate().
+let cachedPromise: Promise<TicketConfig | null> | null = null;
+
+// ─── API response shape (internal, not exported) ─────────────────────────────
+
+interface ApiStatusRow {
+  id: string;
+  partnerId: string;
+  name: string;
+  coreStatus: CoreStatus;
+  color: string | null;
+  sortOrder: number;
+  isSystem: boolean;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ApiResponse {
+  data: {
+    statuses: ApiStatusRow[];
+    priorities: Record<Priority, { label: string | null; responseSlaMinutes: number | null; resolutionSlaMinutes: number | null }>;
+  };
+}
+
+// ─── Fetch logic ─────────────────────────────────────────────────────────────
+
+async function doFetch(): Promise<TicketConfig | null> {
+  try {
+    const response = await fetchWithAuth('/ticket-config');
+    if (!response.ok) {
+      return null;
+    }
+    const body = (await response.json()) as ApiResponse;
+    const config: TicketConfig = {
+      statuses: body.data.statuses.map((row) => ({
+        id: row.id,
+        name: row.name,
+        coreStatus: row.coreStatus,
+        color: row.color,
+        sortOrder: row.sortOrder,
+        isSystem: row.isSystem,
+        isActive: row.isActive,
+      })),
+      priorities: body.data.priorities,
+    };
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns the ticket configuration for the current partner, cached at module
+ * scope for the page lifetime. Returns null on any failure; callers must fall
+ * back to static config.
+ *
+ * Failed fetches are not cached — the next call retries automatically.
+ */
+export async function fetchTicketConfig(): Promise<TicketConfig | null> {
+  if (cachedPromise !== null) {
+    return cachedPromise;
+  }
+
+  const promise = doFetch().then((result) => {
+    // If the fetch failed, clear the cache so the next caller retries.
+    if (result === null) {
+      cachedPromise = null;
+    }
+    return result;
+  });
+
+  cachedPromise = promise;
+  return promise;
+}
+
+/**
+ * Clears the module-level cache. Settings pages should call this after
+ * successfully writing a config change so the next read reflects the update.
+ */
+export function invalidateTicketConfig(): void {
+  cachedPromise = null;
+}
+
+/**
+ * Test-only: resets the module-level cache so each test starts clean.
+ * Production callers should use invalidateTicketConfig() instead.
+ */
+export function __resetTicketConfigCacheForTests(): void {
+  cachedPromise = null;
+}
+
+// ─── Display helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Returns the display label for a status.
+ *
+ * Fallback chain:
+ *   1. `statusName` (explicit override, e.g. a custom status name from the DB row)
+ *   2. The system row name from config for the given coreStatus
+ *   3. The static statusConfig label (always defined)
+ */
+export function statusLabel(
+  config: TicketConfig | null,
+  coreStatus: CoreStatus,
+  statusName?: string | null,
+): string {
+  if (statusName) return statusName;
+  if (config) {
+    const systemRow = config.statuses.find((s) => s.coreStatus === coreStatus && s.isSystem);
+    if (systemRow) return systemRow.name;
+  }
+  return statusConfig[coreStatus].label;
+}
+
+/**
+ * Returns the display label for a priority.
+ *
+ * Fallback chain:
+ *   1. Config label (non-null)
+ *   2. The static priorityConfig label (always defined)
+ */
+export function priorityLabel(config: TicketConfig | null, priority: Priority): string {
+  if (config) {
+    const setting = config.priorities[priority];
+    if (setting?.label) return setting.label;
+  }
+  return priorityConfig[priority].label;
+}
+
+/**
+ * Groups active statuses by their coreStatus in canonical order (new → closed),
+ * with statuses within each group sorted by sortOrder ascending.
+ *
+ * Returns all six core groups, even if a group has no active statuses.
+ */
+export function activeStatusesByCore(
+  config: TicketConfig,
+): Array<{ coreStatus: CoreStatus; statuses: TicketStatusRow[] }> {
+  const activeStatuses = config.statuses.filter((s) => s.isActive);
+
+  return CORE_STATUS_ORDER.map((coreStatus) => ({
+    coreStatus,
+    statuses: activeStatuses
+      .filter((s) => s.coreStatus === coreStatus)
+      .sort((a, b) => a.sortOrder - b.sortOrder),
+  }));
+}

--- a/apps/web/src/pages/settings/index.astro
+++ b/apps/web/src/pages/settings/index.astro
@@ -12,6 +12,19 @@ import PartnerSettingsCard from '../../components/settings/PartnerSettingsCard';
 
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       <PartnerSettingsCard client:load />
+
+      <a
+        href="/settings/ticketing"
+        class="rounded-lg border bg-card p-6 shadow-sm transition hover:border-primary hover:shadow-md"
+      >
+        <div class="space-y-2">
+          <h2 class="text-lg font-semibold">Ticketing</h2>
+          <p class="text-sm text-muted-foreground">
+            Configure ticket statuses, priority SLAs, categories, and export defaults.
+          </p>
+        </div>
+      </a>
+
       <a
         href="/settings/organizations"
         class="rounded-lg border bg-card p-6 shadow-sm transition hover:border-primary hover:shadow-md"
@@ -44,18 +57,6 @@ import PartnerSettingsCard from '../../components/settings/PartnerSettingsCard';
           <h2 class="text-lg font-semibold">Sites</h2>
           <p class="text-sm text-muted-foreground">
             Configure locations, timezones, and site-specific settings.
-          </p>
-        </div>
-      </a>
-
-      <a
-        href="/settings/ticketing"
-        class="rounded-lg border bg-card p-6 shadow-sm transition hover:border-primary hover:shadow-md"
-      >
-        <div class="space-y-2">
-          <h2 class="text-lg font-semibold">Ticketing</h2>
-          <p class="text-sm text-muted-foreground">
-            Ticket categories and queue defaults.
           </p>
         </div>
       </a>

--- a/apps/web/src/pages/settings/ticketing.astro
+++ b/apps/web/src/pages/settings/ticketing.astro
@@ -1,8 +1,8 @@
 ---
 import DashboardLayout from '../../layouts/DashboardLayout.astro';
-import TicketCategoriesPage from '../../components/settings/TicketCategoriesPage';
+import TicketingSettingsPage from '../../components/settings/TicketingSettingsPage';
 ---
 
 <DashboardLayout title="Ticketing Settings">
-  <TicketCategoriesPage client:load />
+  <TicketingSettingsPage client:load />
 </DashboardLayout>


### PR DESCRIPTION
PR 2 of the ticketing configuration feature — the UI for the merged #1287 backend, per `docs/superpowers/plans/2026-06-12-ticketing-configuration-frontend.md` (spec §5).

**What's included:**

- **Cached config client** (`apps/web/src/lib/ticketConfigApi.ts`) — module-cached `fetchTicketConfig()` shared by all islands on a page, `invalidateTicketConfig()` after writes, and `statusLabel`/`priorityLabel`/`activeStatusesByCore` display helpers that fall back to the static `statusConfig`/`priorityConfig` (which stay in place).
- **Tabbed `/settings/ticketing`** (`TicketingSettingsPage.tsx`) — Statuses | Priorities | Categories | Export with `#tab=` hash state, lazy-mounted panels. The existing `TicketCategoriesPage` renders unchanged as the Categories tab.
- **Statuses tab** (`TicketStatusesTab.tsx`) — six core-state groups, add/edit with color, activate/deactivate, ▲/▼ flat-list reorder POSTing the full id array; friendly error mapping for `STATUS_NAME_TAKEN` / `SYSTEM_STATUS_IMMUTABLE` / `SYSTEM_STATUS_REQUIRED` / `STATUS_INACTIVE`; built-in rows can't be deactivated or change core state.
- **Priorities tab** (`TicketPrioritiesTab.tsx`) — per-priority label + response/resolution SLA minutes (placeholders show the SLA-engine defaults), single wholesale `PUT /ticket-config/priorities`.
- **Org settings → Ticketing tab** (`OrgTicketSettingsEditor.tsx`) — per-priority SLA overrides (placeholders show partner defaults), default hourly rate, tri-state default billable; mirrors `OrgPortalSettingsEditor` incl. the MFA-required save path; `slaOverrides` sent wholesale (blank cell = cleared).
- **Custom statuses across the ticket UI** — workbench select renders `<optgroup>` per core state and posts `{statusId}`; resolve/pending note forms key off the target row's core state; queue/workbench chips prefer `statusName` with a `statusColor` dot; priority chips use custom labels. Additive `statusName?`/`statusColor?` on the ticket types.
- **Nav + docs** — Ticketing card moved next to the Partner settings card on `/settings`; user docs section added to `apps/docs/.../ticketing.mdx`.

**BillablesExportCard relocation:** it now renders only in the Export tab of `/settings/ticketing` — it was moved out of `TicketCategoriesPage` so it doesn't render twice.

**Fallback behavior:** if the `/ticket-config` fetch fails, the workbench keeps today's six-core-status select posting `{status}`, and chips fall back to core-state labels — legacy tickets (null `statusName`) always show the core label. The static configs remain the fallback path and were not removed.

**Guard rails:** the three new mutating components are enrolled in `no-silent-mutations` (`TARGET_GLOBS` 22 → 25); all mutations go through `runAction`.

**Tests:** full web suite green — 159 files / 1260 tests (baseline 154/1161 + 99 new); `tsc --noEmit` clean; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)