### PR TITLE
fix(agent): self-heal VideoToolbox after software demotion on macOS (#1292)

### DIFF
--- a/agent/internal/remote/desktop/adaptive_test.go
+++ b/agent/internal/remote/desktop/adaptive_test.go
@@ -7,8 +7,9 @@ import (
 
 // stubEncoder satisfies encoderBackend for testing adaptive bitrate.
 type stubEncoder struct {
-	bitrate int
-	quality QualityPreset
+	bitrate  int
+	quality  QualityPreset
+	hardware bool // reported by IsHardware(); defaults to software
 }
 
 func (s *stubEncoder) Encode([]byte) ([]byte, error)         { return nil, nil }
@@ -20,7 +21,7 @@ func (s *stubEncoder) SetDimensions(int, int) error          { return nil }
 func (s *stubEncoder) SetPixelFormat(PixelFormat)            {}
 func (s *stubEncoder) Close() error                          { return nil }
 func (s *stubEncoder) Name() string                          { return "stub" }
-func (s *stubEncoder) IsHardware() bool                      { return false }
+func (s *stubEncoder) IsHardware() bool                      { return s.hardware }
 func (s *stubEncoder) IsPlaceholder() bool                   { return false }
 func (s *stubEncoder) SetD3D11Device(uintptr, uintptr)       {}
 func (s *stubEncoder) SupportsGPUInput() bool                { return false }

--- a/agent/internal/remote/desktop/encoder.go
+++ b/agent/internal/remote/desktop/encoder.go
@@ -411,8 +411,19 @@ func validateConfig(cfg EncoderConfig) error {
 func newBackend(cfg EncoderConfig) (encoderBackend, error) {
 	if cfg.PreferHardware {
 		if backend := tryHardware(cfg); backend != nil {
+			slog.Info("Selected hardware H264 encoder",
+				"backend", backend.Name(), "gpuVendor", cfg.GPUVendor)
 			return backend, nil
 		}
+		// Hardware was requested but no factory produced a backend. On a cgo
+		// macOS build this should not happen (VideoToolbox registers a factory),
+		// so logging it makes a missing-cgo or registration gap diagnosable from
+		// shipped logs instead of a process sample. See issue #1292.
+		hardwareFactoriesMu.Lock()
+		registered := len(hardwareFactories)
+		hardwareFactoriesMu.Unlock()
+		slog.Warn("No hardware H264 encoder available despite PreferHardware, using software",
+			"gpuVendor", cfg.GPUVendor, "registeredFactories", registered)
 	}
 	return newSoftwareEncoder(cfg)
 }

--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -98,6 +98,14 @@ type Session struct {
 	// encoder is swapped to software (OpenH264) mid-session.
 	cpuEncodeErrors int
 
+	// hwRestore governs retrying the hardware encoder after a software
+	// fallback. On macOS, VideoToolbox can stall on a cold first frame and get
+	// demoted to OpenH264; since the CPU capture path has no Windows-style
+	// hardware-restore trigger, this periodically tries to swap back so a
+	// transient stall doesn't pin a CPU core software-encoding 5K for the whole
+	// session. Driven from the ticker capture loop. See session_encoder_restore.go.
+	hwRestore hardwareRestorePolicy
+
 	// cursorOffsetX/Y store the active monitor's virtual desktop origin so
 	// cursorStreamLoop can convert absolute GetCursorInfo coords to
 	// display-relative coords before sending to the viewer.

--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -679,6 +679,11 @@ func (s *Session) captureLoopTicker() captureMode {
 				}
 			}
 
+			// Self-heal: if a hardware encoder was demoted to software (e.g.
+			// VideoToolbox stalled on a cold 5K first frame), periodically retry
+			// hardware so we don't software-encode for the whole session.
+			s.maybeRestoreHardwareEncoder(time.Now())
+
 			if s.lastVideoWriteUnixNano.Load() == 0 && time.Now().Before(startupWarmupUntil) && time.Since(lastStartupRepaint) >= startupFrameRepaintEvery {
 				nudgeSecureDesktop()
 				forceDesktopRepaint()
@@ -1202,8 +1207,10 @@ func (s *Session) swapToSoftwareEncoder() {
 	if enc == nil {
 		return
 	}
+	fromHardware := enc.BackendIsHardware()
 	slog.Warn("Hardware encoder stalling, swapping to software encoder",
 		"session", s.id, "backend", enc.BackendName(),
+		"fromHardware", fromHardware,
 		"consecutiveErrors", s.cpuEncodeErrors)
 
 	// Get current dimensions from capturer
@@ -1261,8 +1268,18 @@ func (s *Session) swapToSoftwareEncoder() {
 		s.adaptive.CapForSoftwareEncoder()
 	}
 
+	// If we demoted a real hardware encoder (e.g. VideoToolbox stalled on a cold
+	// 5K first frame), arm the self-heal so the capture loop periodically retries
+	// hardware instead of software-encoding for the rest of the session. The
+	// Windows desktop-switch path has its own restoreHardwareEncoder trigger, so
+	// only arm here for the CPU capture path that lacks one.
+	if fromHardware {
+		s.hwRestore.onDemotedFromHardware(time.Now())
+	}
+
 	slog.Info("Swapped to software encoder",
 		"session", s.id,
 		"backend", newEnc.BackendName(),
+		"fromHardware", fromHardware,
 		"dimensions", fmt.Sprintf("%dx%d", w, h))
 }

--- a/agent/internal/remote/desktop/session_encoder_restore.go
+++ b/agent/internal/remote/desktop/session_encoder_restore.go
@@ -1,0 +1,185 @@
+package desktop
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// maxHardwareRestoreAttempts bounds how many times a session will try to swap a
+// software-fallback encoder back to hardware before giving up for the rest of
+// the session. Without a cap, a hardware encoder that is genuinely broken on a
+// given machine would thrash between hardware (stall) and software every backoff
+// interval, producing a visible glitch each cycle.
+const maxHardwareRestoreAttempts = 3
+
+// hardwareRestoreBackoff returns how long to wait before the Nth restore attempt
+// (1-based). The interval grows so a flaky hardware encoder is retried promptly
+// once but backs off quickly if it keeps failing.
+func hardwareRestoreBackoff(attempt int) time.Duration {
+	switch {
+	case attempt <= 1:
+		return 5 * time.Second
+	case attempt == 2:
+		return 15 * time.Second
+	default:
+		return 45 * time.Second
+	}
+}
+
+// hardwareRestorePolicy is a pure state machine governing when a session that
+// fell back to a software encoder should retry restoring the hardware encoder.
+//
+// On macOS, VideoToolbox can stall on the first frame(s) of a large (5K) capture
+// and get demoted to OpenH264 software encoding (see swapToSoftwareEncoder).
+// Software-encoding a 5120x2880 frame pins a CPU core, so we periodically try to
+// restore VideoToolbox instead of latching software for the whole session. The
+// scheduling/cap logic lives here (and is unit tested) while the encoder rebuild
+// itself lives in Session.maybeRestoreHardwareEncoder.
+//
+// Owned by the capture-loop goroutine; like reattachWatchdog it uses no atomics
+// or locks and must not be driven concurrently.
+type hardwareRestorePolicy struct {
+	demoted  bool
+	attempts int
+	nextAt   time.Time
+}
+
+// onDemotedFromHardware arms the policy after a hardware->software swap. The
+// attempt counter is intentionally preserved across re-demotions so the total
+// number of restore attempts per session stays bounded even if hardware keeps
+// stalling immediately after each successful restore.
+func (p *hardwareRestorePolicy) onDemotedFromHardware(now time.Time) {
+	p.demoted = true
+	p.nextAt = now.Add(hardwareRestoreBackoff(p.attempts + 1))
+}
+
+// shouldAttempt reports whether a restore attempt is due now.
+func (p *hardwareRestorePolicy) shouldAttempt(now time.Time) bool {
+	return p.demoted && p.attempts < maxHardwareRestoreAttempts && !now.Before(p.nextAt)
+}
+
+// recordAttempt counts a restore attempt and schedules the next backoff window.
+// Call immediately before performing the rebuild.
+func (p *hardwareRestorePolicy) recordAttempt(now time.Time) {
+	p.attempts++
+	p.nextAt = now.Add(hardwareRestoreBackoff(p.attempts + 1))
+}
+
+// onRestored clears the demoted flag after a successful restore to hardware. The
+// attempt counter is preserved so a subsequent re-demotion remains capped.
+func (p *hardwareRestorePolicy) onRestored() {
+	p.demoted = false
+}
+
+// giveUp permanently stops restore attempts (e.g. the machine has no usable
+// hardware encoder).
+func (p *hardwareRestorePolicy) giveUp() {
+	p.attempts = maxHardwareRestoreAttempts
+}
+
+// maybeRestoreHardwareEncoder periodically tries to swap a software-fallback
+// encoder back to a hardware one (VideoToolbox on macOS). It is the CPU-capture
+// counterpart to restoreHardwareEncoder, which is DXGI/TextureProvider-specific
+// and event-driven (fires on a Windows secure-desktop->Default transition); this
+// path is timer/backoff-driven instead. The macOS ticker capture path has no
+// D3D11 device to bind, so we only accept a hardware backend that consumes CPU
+// pixels (a non-GPU-only encoder, i.e. VideoToolbox).
+//
+// Must be called from the capture loop goroutine (same as swapToSoftwareEncoder).
+func (s *Session) maybeRestoreHardwareEncoder(now time.Time) {
+	if !s.hwRestore.shouldAttempt(now) {
+		return
+	}
+	enc := s.encoder.Load()
+	if enc == nil || enc.BackendIsHardware() {
+		// Nothing to restore (already on hardware, or no encoder yet).
+		s.hwRestore.onRestored()
+		return
+	}
+
+	s.hwRestore.recordAttempt(now)
+
+	var w, h int
+	if c := s.capturer; c != nil {
+		if bw, bh, err := c.GetScreenBounds(); err == nil {
+			w, h = bw, bh
+		}
+	}
+	if w == 0 || h == 0 {
+		// Capturer has no bounds yet (nil or a transient GetScreenBounds error).
+		// recordAttempt already advanced the backoff, so this won't tight-loop;
+		// log so a session that never recovers hardware is diagnosable.
+		slog.Info("maybeRestoreHardwareEncoder: no screen bounds yet, staying on software",
+			"session", s.id, "attempt", s.hwRestore.attempts)
+		return
+	}
+
+	fps := s.getFPS()
+	if fps <= 0 {
+		fps = 30
+	}
+	newEnc, err := NewVideoEncoder(EncoderConfig{
+		Codec:          CodecH264,
+		Quality:        QualityAuto,
+		Bitrate:        2_500_000,
+		FPS:            fps,
+		PreferHardware: true,
+		GPUVendor:      s.gpuVendor,
+	})
+	if err != nil {
+		slog.Info("maybeRestoreHardwareEncoder: factory failed, staying on software",
+			"session", s.id, "attempt", s.hwRestore.attempts, "error", err.Error())
+		return
+	}
+
+	// The CPU capture path has no TextureProvider/D3D11 device to bind, so a
+	// GPU-only hardware encoder (MFT/AMF/NVENC) can't run here — IsGPUOnly()
+	// reports those (SupportsGPUInput() is false until a device is bound, so it
+	// would wrongly accept them). Only an encoder that consumes CPU pixels and is
+	// truly hardware (VideoToolbox) qualifies. The factory result is deterministic
+	// for this machine, so if we don't get a usable backend, stop retrying.
+	// (Read name/flags before Close(), which nils the backend.)
+	backendName := newEnc.BackendName()
+	placeholder := newEnc.BackendIsPlaceholder()
+	isHardware := newEnc.BackendIsHardware()
+	gpuOnly := newEnc.IsGPUOnly()
+	if placeholder || !isHardware || gpuOnly {
+		newEnc.Close()
+		slog.Info("maybeRestoreHardwareEncoder: no CPU-input hardware encoder available, staying on software permanently",
+			"session", s.id, "backend", backendName,
+			"placeholder", placeholder, "hardware", isHardware, "gpuOnly", gpuOnly)
+		s.hwRestore.giveUp()
+		return
+	}
+
+	if err := newEnc.SetDimensions(w, h); err != nil {
+		slog.Warn("maybeRestoreHardwareEncoder: SetDimensions failed, staying on software",
+			"session", s.id, "attempt", s.hwRestore.attempts, "error", err.Error())
+		newEnc.Close()
+		return
+	}
+	newEnc.SetPixelFormat(s.encoderPF)
+
+	s.atomicEncoderSwap(newEnc)
+	s.gpuEncodeErrors = 0
+
+	// Lift the software bitrate cap — hardware sustains much higher rates.
+	// Mirror the resolution-based ceiling used in StartSession.
+	if s.adaptive != nil {
+		s.adaptive.SetEncoder(newEnc)
+		hwMaxBitrate := 8_000_000
+		if w*h > 1920*1080 {
+			hwMaxBitrate = 15_000_000
+		}
+		s.adaptive.SetMaxBitrate(hwMaxBitrate)
+	}
+
+	s.hwRestore.onRestored()
+	_ = newEnc.ForceKeyframe()
+	slog.Info("Restored hardware encoder after software fallback",
+		"session", s.id,
+		"backend", newEnc.BackendName(),
+		"attempt", s.hwRestore.attempts,
+		"dimensions", fmt.Sprintf("%dx%d", w, h))
+}

--- a/agent/internal/remote/desktop/session_encoder_restore_test.go
+++ b/agent/internal/remote/desktop/session_encoder_restore_test.go
@@ -1,0 +1,203 @@
+package desktop
+
+import (
+	"testing"
+	"time"
+)
+
+// hardwareRestorePolicy governs when a session that fell back to a software
+// encoder (e.g. VideoToolbox demoted to OpenH264 after a cold-start stall on an
+// Intel Mac) should retry restoring the hardware encoder. It is a pure state
+// machine — the actual encoder rebuild lives in Session — so the backoff/cap
+// logic can be unit tested in isolation, mirroring reattachWatchdog.
+
+func TestHardwareRestorePolicy_FreshNeverAttempts(t *testing.T) {
+	var p hardwareRestorePolicy
+	now := time.Unix(0, 0)
+	if p.shouldAttempt(now) {
+		t.Fatalf("a policy that was never demoted should not attempt a restore")
+	}
+}
+
+func TestHardwareRestorePolicy_WaitsForBackoffAfterDemotion(t *testing.T) {
+	var p hardwareRestorePolicy
+	t0 := time.Unix(100, 0)
+	p.onDemotedFromHardware(t0)
+
+	if p.shouldAttempt(t0) {
+		t.Fatalf("should not attempt immediately after demotion")
+	}
+	if p.shouldAttempt(t0.Add(4 * time.Second)) {
+		t.Fatalf("should not attempt before the first backoff (5s) elapses")
+	}
+	if !p.shouldAttempt(t0.Add(5 * time.Second)) {
+		t.Fatalf("should attempt once the first backoff (5s) has elapsed")
+	}
+}
+
+func TestHardwareRestorePolicy_BackoffEscalatesPerAttempt(t *testing.T) {
+	var p hardwareRestorePolicy
+	t0 := time.Unix(0, 0)
+	p.onDemotedFromHardware(t0)
+
+	// First attempt due at +5s.
+	if !p.shouldAttempt(t0.Add(5 * time.Second)) {
+		t.Fatalf("attempt 1 should be due at +5s")
+	}
+	p.recordAttempt(t0.Add(5 * time.Second))
+
+	// Second attempt waits 15s more.
+	if p.shouldAttempt(t0.Add(5*time.Second + 14*time.Second)) {
+		t.Fatalf("attempt 2 should not be due before +15s after attempt 1")
+	}
+	if !p.shouldAttempt(t0.Add(5*time.Second + 15*time.Second)) {
+		t.Fatalf("attempt 2 should be due +15s after attempt 1")
+	}
+	p.recordAttempt(t0.Add(20 * time.Second))
+
+	// Third attempt waits 45s more.
+	if !p.shouldAttempt(t0.Add(20*time.Second + 45*time.Second)) {
+		t.Fatalf("attempt 3 should be due +45s after attempt 2")
+	}
+}
+
+func TestHardwareRestorePolicy_CapsAtMaxAttempts(t *testing.T) {
+	var p hardwareRestorePolicy
+	now := time.Unix(0, 0)
+	p.onDemotedFromHardware(now)
+
+	for i := 0; i < maxHardwareRestoreAttempts; i++ {
+		now = now.Add(time.Hour) // always past backoff
+		if !p.shouldAttempt(now) {
+			t.Fatalf("attempt %d should be due", i+1)
+		}
+		p.recordAttempt(now)
+	}
+
+	now = now.Add(time.Hour)
+	if p.shouldAttempt(now) {
+		t.Fatalf("should stop attempting after %d attempts", maxHardwareRestoreAttempts)
+	}
+}
+
+func TestHardwareRestorePolicy_RestoreClearsButKeepsAttemptCount(t *testing.T) {
+	var p hardwareRestorePolicy
+	t0 := time.Unix(0, 0)
+	p.onDemotedFromHardware(t0)
+	p.recordAttempt(t0.Add(5 * time.Second))
+	p.onRestored()
+
+	// Back on hardware: no pending attempt.
+	if p.shouldAttempt(t0.Add(time.Hour)) {
+		t.Fatalf("after a successful restore there should be no pending attempt")
+	}
+
+	// If hardware stalls again, re-arming must keep the prior attempt count so
+	// total restore churn across the session stays bounded.
+	reDemote := t0.Add(time.Hour)
+	p.onDemotedFromHardware(reDemote)
+	// Only one attempt remains (we already used 1 of maxHardwareRestoreAttempts=3,
+	// wait — used 1, so 2 remain). Drive to the cap.
+	remaining := 0
+	now := reDemote
+	for i := 0; i < maxHardwareRestoreAttempts+2; i++ {
+		now = now.Add(time.Hour)
+		if p.shouldAttempt(now) {
+			remaining++
+			p.recordAttempt(now)
+		}
+	}
+	if remaining != maxHardwareRestoreAttempts-1 {
+		t.Fatalf("expected %d attempts remaining after one prior attempt, got %d", maxHardwareRestoreAttempts-1, remaining)
+	}
+}
+
+func TestHardwareRestorePolicy_GiveUpStopsRetries(t *testing.T) {
+	var p hardwareRestorePolicy
+	now := time.Unix(0, 0)
+	p.onDemotedFromHardware(now)
+	p.giveUp()
+	if p.shouldAttempt(now.Add(time.Hour)) {
+		t.Fatalf("giveUp() must permanently stop restore attempts")
+	}
+}
+
+func TestHardwareRestorePolicy_ReDemotionWithoutRestorePreservesCountAndEscalates(t *testing.T) {
+	// Hardware that re-stalls before any successful restore (no intervening
+	// onRestored) must keep the attempt count and re-arm with the escalated
+	// backoff, not reset to the first (5s) interval.
+	var p hardwareRestorePolicy
+	t0 := time.Unix(0, 0)
+	p.onDemotedFromHardware(t0)
+	p.recordAttempt(t0.Add(5 * time.Second)) // attempts == 1
+
+	reDemote := t0.Add(30 * time.Second)
+	p.onDemotedFromHardware(reDemote)
+	if p.attempts != 1 {
+		t.Fatalf("re-demotion without restore must preserve attempt count, got %d", p.attempts)
+	}
+	if p.shouldAttempt(reDemote.Add(14 * time.Second)) {
+		t.Fatalf("re-demotion should re-arm with the escalated 15s backoff, not 5s")
+	}
+	if !p.shouldAttempt(reDemote.Add(15 * time.Second)) {
+		t.Fatalf("attempt should be due 15s after re-demotion")
+	}
+}
+
+// The following exercise the hardware-independent early-exit branches of
+// Session.maybeRestoreHardwareEncoder. They avoid the encoder-rebuild tail
+// (NewVideoEncoder), which requires cgo/VideoToolbox, so they run identically
+// on every platform/CI runner.
+
+func TestMaybeRestoreHardwareEncoder_NotDueConsumesNothing(t *testing.T) {
+	s := &Session{}
+	sw := &stubEncoder{} // IsHardware()==false
+	s.encoder.Store(&VideoEncoder{backend: sw})
+
+	t0 := time.Unix(0, 0)
+	s.hwRestore.onDemotedFromHardware(t0)
+	// Before the 5s backoff: not due.
+	s.maybeRestoreHardwareEncoder(t0)
+
+	if s.hwRestore.attempts != 0 {
+		t.Fatalf("a not-due tick must not consume a restore attempt, got %d", s.hwRestore.attempts)
+	}
+	if !s.hwRestore.demoted {
+		t.Fatalf("a not-due tick must leave the policy armed")
+	}
+	if s.encoder.Load().backend != sw {
+		t.Fatalf("a not-due tick must not swap the encoder")
+	}
+}
+
+func TestMaybeRestoreHardwareEncoder_AlreadyHardwareDisarms(t *testing.T) {
+	// If something else restored hardware (e.g. the Windows desktop-switch
+	// path), the next due tick must observe hardware and disarm the policy so
+	// it stops scheduling retries — without consuming an attempt.
+	s := &Session{}
+	hw := &stubEncoder{hardware: true}
+	s.encoder.Store(&VideoEncoder{backend: hw})
+
+	t0 := time.Unix(0, 0)
+	s.hwRestore.onDemotedFromHardware(t0)
+	s.maybeRestoreHardwareEncoder(t0.Add(10 * time.Second)) // past backoff → due
+
+	if s.hwRestore.demoted {
+		t.Fatalf("observing hardware on a due tick must disarm the policy")
+	}
+	if s.hwRestore.attempts != 0 {
+		t.Fatalf("disarming on already-hardware must not consume an attempt, got %d", s.hwRestore.attempts)
+	}
+}
+
+func TestMaybeRestoreHardwareEncoder_NilEncoderDisarms(t *testing.T) {
+	s := &Session{} // no encoder stored
+	t0 := time.Unix(0, 0)
+	s.hwRestore.onDemotedFromHardware(t0)
+
+	s.maybeRestoreHardwareEncoder(t0.Add(10 * time.Second)) // must not panic
+
+	if s.hwRestore.demoted {
+		t.Fatalf("a nil encoder must disarm the policy rather than spin")
+	}
+}

--- a/docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md
+++ b/docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md
@@ -1,0 +1,140 @@
+# Breeze AI for Office — Design Spec
+
+**Date:** 2026-06-12
+**Status:** Approved design, pre-implementation
+**Product:** Excel add-in delivering a governed AI assistant to MSP *client end-users*, with Breeze as the control plane (auth, tenancy, policy, DLP, audit, metering). Client users never see RMM concepts.
+
+## 1. Positioning & decisions
+
+The pitch: *"MSPs can safely deliver AI inside Excel to their clients, with centralized security, auditing, data controls, and provider flexibility."* The differentiator vs. generic ChatGPT/Copilot add-ins is governance, client separation, supportability, and resale controls.
+
+Decisions locked during brainstorm:
+
+| Decision | Choice |
+|---|---|
+| v1 capability | Chat + read/write workbook, writes approval-gated by the end user |
+| End-user auth | Microsoft SSO (Entra ID) via Office SSO/NAA, tenant → org mapping, auto-provisioning |
+| Providers | Anthropic only in v1, but router-shaped: policy stores `allowedProviders`/`allowedModels`; OpenAI/Azure are fast-follows with no schema change |
+| Harness | Claude Agent SDK (`streamingSessionManager`) now; thin custom multi-provider harness later. All client-facing contracts (REST + SSE + policy schema) are harness-agnostic so the swap touches nothing outside the loop |
+| Billing | Existing partner-level AI-credits billing unchanged; new per-org/per-user metering + budgets + CSV reports so the MSP marks up and invoices clients themselves |
+| Governance in v1 | All four pillars: prompt/output logging + MSP audit view, per-org policy controls, DLP/redaction, prompt template library |
+| Backend architecture | Shared stack, new surface: reuse `ai_sessions`/`ai_messages`, `streamingSessionManager`, cost tracker, guardrails patterns; add a client principal, `/client-ai` route namespace, workbook-only tool registry, DLP, per-org policy |
+
+## 2. Components
+
+1. **Excel add-in** — new app `apps/office-addin/` (Office.js + React task pane). Distribution: M365 **centralized deployment** pushed by the MSP via the client tenant's M365 admin center (the MSP already manages these tenants). Sideload manifest for dev. AppSource listing is post-v1.
+2. **Client AI API** — new route namespace `apps/api/src/routes/clientAi/` mounted at `/client-ai/*`. Separate from technician `/ai` routes and portal routes, with its own auth middleware.
+3. **MSP admin surface** — new "AI for Office" section in the existing Breeze web dashboard (no separate app).
+
+## 3. Identity & tenancy
+
+- The add-in acquires an Entra ID token silently via Office SSO/NAA (the user is already signed into Excel with their work account). It calls `POST /client-ai/auth/exchange`; Breeze verifies the JWT against Microsoft's JWKS (signature, audience, expiry), extracts `tid` (Entra tenant), `oid`, and email.
+- **Interactive fallback:** when silent SSO fails (or for non-centrally-deployed installs), the add-in falls back to an MSAL popup sign-in; first-run user consent lands there too.
+- **Tenant mapping:** `client_ai_tenant_mappings` binds Entra tenant ID → Breeze `org_id`. Unique on tenant ID — a tenant maps to exactly one org. This is the tenant-isolation linchpin. No mapping → the add-in shows "not provisioned by your IT provider."
+- **User principal:** extend `portal_users` (the established end-user concept) with `entraOid`, `entraTenantId`, `authMethod` (`password` | `entra`); `passwordHash` nullable for SSO rows. Users auto-provision on first exchange, subject to org policy (`all` vs `selected` users). Add-in sessions are Redis-backed bearer tokens (24h TTL), org-bound — same shape as portal sessions.
+- **Entra app registration:** one Breeze multi-tenant app; the MSP grants admin consent per client tenant during onboarding.
+- **Reuse check (plan-phase task):** the repo already has per-org M365 customer-tenant connections (see `delegantM365ConnectionId` on `ai_sessions` and the M365 integration that established those connections, including its consent flow). Audit it first — best case the onboarding wizard reuses the existing connection's tenant ID and adds one more admin-consent grant for the add-in app, rather than building a parallel consent system.
+
+## 4. AI loop & session model
+
+- Client sessions are `ai_sessions` rows with new `type: 'excel_client'` and a nullable `clientUserId` (FK → `portal_users`) alongside `userId`, with a CHECK that exactly one is set. Cost columns, flagging (`flaggedAt`/`flagReason`), and lifecycle are inherited.
+- The loop runs on the existing Claude Agent SDK `streamingSessionManager`. Harness-agnostic seams: the add-in talks only to `/client-ai/sessions/*` REST + SSE; policy stores providers/models as data; the later custom harness swap changes nothing client-facing or schema-side.
+- Streaming: SSE on `GET /client-ai/sessions/:id/events` (reusing the `SessionEventBus` pattern).
+- Pre-flight per message (existing `checkBudget` pattern): org daily/monthly budget → per-user rate limit → per-org rate limit → partner AI credits (`checkBillingCredits`). Reject upfront with a user-readable reason.
+
+## 5. Workbook tools & client-side execution protocol
+
+**Tool registry:** a separate `CLIENT_TOOL_REGISTRY` of ~9 workbook tools: `get_workbook_overview` (sheet names, used ranges, headers), `read_selection`, `read_range`, `write_range`, `insert_formula`, `create_sheet`, `format_range`, `create_table`, `search_workbook`. The technician tool registry is **not reachable** from client sessions — a hard allowlist, not tier filtering.
+
+**Execution protocol** (Office.js only runs inside Excel, so tools execute in the add-in — the Helper-chat remote-execution pattern transplanted to SSE):
+
+1. Model emits `tool_use` → server tool handler publishes a `tool_request` SSE event and awaits.
+2. Add-in executes via Office.js, posts `POST /client-ai/sessions/:id/tool-results`.
+3. Handler resolves and the loop continues. Timeouts: 60s for reads, 5min for pending write approvals; timeout fails the tool call gracefully (e.g. user closed Excel) and the model is told.
+
+**Write approval:** read tools auto-execute (Tier-1 equivalent). All mutating tools are approval-gated **by the end user in the task pane**: preview card showing target range and before/after diff (≤200 cells; summary above that) with Apply/Reject. Apply executes then reports; Reject returns a rejection `tool_result` so the model can adjust. Org policy `writeMode: 'readonly'` removes write tools from the model's toolset entirely. Every request/approve/reject/apply lands in `ai_tool_executions` + `audit_logs` with the client user as actor.
+
+## 6. DLP / redaction pipeline
+
+New service `clientAiDlp.ts`, a single chokepoint: **every payload leaving Breeze for the provider** (user prompt, workbook `tool_result` data, template content) passes through it. Nothing reaches the model un-scanned.
+
+- **Built-in detectors:** credit cards (Luhn-validated), SSN/national IDs, IBAN, API-key/token shapes, email/phone (off by default). Per-org **custom regex rules**. The existing `aiInputSanitizer` patterns seed this; workbook-scale scanning (thousands of cells per `read_range`) with cell-level granularity is new code.
+- **Per-rule actions:** `redact` (replace with `[REDACTED:type]`; the model sees the redacted form), `block` (refuse the request and tell the user why), `log-only`. Defaults: redact for financial/credential types.
+- **Redact before logging:** `ai_messages` stores the redacted form, so the audit trail never retains the sensitive values. Each redaction event (rule, count, location) is recorded in message metadata for the MSP audit view.
+
+v1 is regex/Luhn only; ML-based DLP is out of scope.
+
+## 7. Per-org policy
+
+`client_ai_org_policies` — one row per org, RLS shape 1, separate from technician `aiBudgets` so the two products' knobs never interfere. Partner defaults are **copy-on-create**: when the MSP enables an org, the dashboard pre-fills from the partner's last-used/default values — no live inheritance chain, no NULL-org rows (keeps the table single-axis).
+
+Fields: `enabled`; user access (`all` | `selected` + user list); `allowedModels` / `allowedProviders` (router-ready); `writeMode` (`readwrite` | `readonly`); DLP rule config (jsonb); daily/monthly budget cents; per-user and per-org rate limits; data retention days; branding (MSP display name/logo shown in the add-in footer).
+
+## 8. Metering & billing
+
+- Provider spend keeps flowing through the existing partner-level AI-credits integration (`checkBillingCredits` / `deductBillingCredits`) — Breeze bills the MSP; nothing new there.
+- New `client_ai_usage` table mirrors the `ai_cost_usage` daily/monthly bucket pattern **plus a per-user dimension**: `(org_id, client_user_id, period, period_key)` → tokens, cost cents, session/message counts. This enables MSP resale invoicing.
+- Dashboard usage report per org/user/month with **CSV export** — the MSP's invoicing artifact. Resale margin is the MSP's business; Breeze does not bill client orgs directly.
+
+## 9. MSP admin surface (Breeze dashboard)
+
+1. **Onboarding wizard per client org** — reuse/verify existing M365 connection for tenant ID; generate the admin-consent URL for the add-in app registration; poll/confirm consent; write the tenant mapping; link to centralized-deployment instructions. Status chip per org (not provisioned / consent pending / active).
+2. **Policy editor** — all `client_ai_org_policies` knobs; DLP rules get a toggle list for built-ins plus custom-regex entry with a live test box.
+3. **Audit & session viewer** — searchable client-session list (org, user, date, cost, flagged); transcript drill-in including workbook context sent, redaction events, and every tool approval/apply. Reuses existing session-viewer + flag/unflag machinery.
+4. **Usage & billing report** — per org/user/month, CSV export.
+5. **Template manager** — CRUD for partner- and org-scope templates.
+
+## 10. Prompt templates
+
+`client_ai_prompt_templates`: partner-scope rows (`org_id` NULL → visible to all the partner's orgs) and org-scope rows. Fields: name, description, prompt body, category. Surfaced as a template picker on the add-in's empty-chat state.
+
+> ⚠️ **Dual-axis RLS trap:** this table has partner-wide rows with NULL `org_id` — exactly the `custom_field_definitions` failure mode (fixed 2026-06-11-i). Policies MUST cover both axes (org **and** partner), and the PR MUST include a functional `breeze_app` insert test for the partner-axis write path. The rls-coverage contract test provably does not catch a missing second axis.
+
+## 11. Add-in UX
+
+- Chat thread with streaming responses.
+- **Context chip** showing exactly what will be shared ("Selection B2:F40" / "Sheet: Q3 Budget") with an explicit per-message toggle: include selection / include sheet / no workbook data. The user controls data egress.
+- Write-preview cards with Apply/Reject (section 5).
+- Template picker on empty state.
+- "Governed by your IT provider" footer with MSP-brandable name/logo from policy — the white-label hook.
+- Sign-in invisible via silent SSO; MSAL popup fallback.
+
+## 12. Schema & RLS summary
+
+All changes ship as idempotent dated migrations with RLS policies in the same migration (per CLAUDE.md tenant-isolation rules), with allowlist updates + contract-test runs in the same PR.
+
+| Table | Change | RLS shape |
+|---|---|---|
+| `client_ai_tenant_mappings` | new | 1 (direct `org_id`) |
+| `client_ai_org_policies` | new | 1 |
+| `client_ai_usage` | new | 1 |
+| `client_ai_prompt_templates` | new | dual-axis (org + partner) — see §10 warning |
+| `portal_users` | + `entraOid`, `entraTenantId`, `authMethod`; `passwordHash` nullable | existing |
+| `ai_sessions` | + `clientUserId` FK → portal_users; new `type` value `excel_client`; CHECK exactly one of (`userId`, `clientUserId`) | existing |
+
+## 13. Testing
+
+- Vitest route tests for every `/client-ai` endpoint: auth exchange, session lifecycle, tool-result protocol, policy enforcement, budget rejection paths.
+- Token-exchange negative tests: forged signature, expired, wrong audience, unmapped tenant.
+- DLP detector unit tests with cell-matrix fixtures (per detector, per action, redact-before-log).
+- RLS: contract-test allowlist updates **plus** functional cross-tenant `breeze_app` insert tests for the dual-axis templates table.
+- Add-in: Office.js-mocked unit tests for the tool executor and preview rendering; manual test checklist for in-Excel behavior (Playwright cannot drive Excel).
+
+## 14. Delivery phasing
+
+One spec, ~5 implementation plans / PR trains:
+
+1. **Foundation** — schema + RLS, Entra token exchange, tenant mapping, user auto-provisioning, policy table + enforcement middleware. (Includes the M365-connection reuse audit, §3.)
+2. **Session loop** — `/client-ai` session routes, SDK wiring with client tool registry, SSE tool round-trip protocol, cost/budget enforcement, audit events.
+3. **DLP service** — detectors, per-org rules, redacted logging.
+4. **Dashboard** — onboarding wizard, policy editor, audit viewer, usage report, template manager.
+5. **Excel add-in** — scaffold, SSO + MSAL fallback, chat UI, tool executor, write-preview, templates. (Parallelizable with 3–4 once the loop API from 2 is stable.)
+
+## 15. Out of scope for v1 (designed-for, deferred)
+
+- OpenAI / Azure OpenAI providers and the custom multi-provider harness (schema + policy are ready; the swap is isolated to the loop).
+- External data connectors.
+- Word / PowerPoint / Outlook add-ins.
+- AppSource listing.
+- Password-fallback portal auth inside the add-in.
+- ML-based DLP (v1 is regex/Luhn).


### PR DESCRIPTION
## Summary

Fixes #1292. On Intel Macs, a remote-desktop session could software-encode (OpenH264) a 5K frame for its **entire** lifetime, pinning a CPU core (the real cost behind the "86% CPU" field report; the measurement side was #1289).

**Root cause (not a missing-cgo build):** the shipped `breeze-desktop-helper-darwin-amd64` *is* a cgo build — `release.yml` builds it with `CGO_ENABLED=1` on `macos-latest`, so VideoToolbox is registered and selected initially. But a Windows-oriented guard then demotes it to software via `swapToSoftwareEncoder` (the 3s startup-stall check at `session_capture.go:432/671`, or `cpuEncodeErrors >= 5`). macOS could **never recover**: `restoreHardwareEncoder` is only reachable from the Windows DXGI desktop-switch path and requires a `TextureProvider`. Once demoted, the session latched on software.

## Fix — self-heal retry

- **`hardwareRestorePolicy`** (new, `session_encoder_restore.go`): a pure backoff/cap state machine mirroring the existing `reattachWatchdog`. Schedules hardware-restore attempts at 5s / 15s / 45s, capped at 3 per session to prevent restore↔stall thrash; gives up permanently if no usable hardware exists.
- **`swapToSoftwareEncoder`** arms the policy when demoting *from* hardware; the **ticker capture loop** (used by macOS/Linux) calls `maybeRestoreHardwareEncoder`, which rebuilds a **CPU-input** hardware encoder (VideoToolbox) and rejects GPU-only MFT/AMF/NVENC via `IsGPUOnly()`. The Windows DXGI path is untouched.
- **Diagnostics:** `newBackend` now warns when `PreferHardware` was requested but no hardware factory produced a backend (with the registered-factory count), so a missing-cgo / registration gap is diagnosable from shipped logs instead of a process `sample`.

## Tests

- `hardwareRestorePolicy` fully unit-tested: backoff escalation, the 3-attempt cap, re-demotion preserving the attempt count, `giveUp`, fresh-never-attempts.
- Hardware-independent coverage of `maybeRestoreHardwareEncoder`'s early-exit branches (not-due, already-on-hardware disarm, nil-encoder disarm).
- The encoder-rebuild tail needs cgo/VideoToolbox and sits at the same untested boundary as the existing `restoreHardwareEncoder`/`swapToSoftwareEncoder`.

## Verification

- `go vet ./internal/remote/desktop/` clean
- `go test -race ./internal/remote/desktop/` ok
- `CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build ./cmd/breeze-desktop-helper` exit 0 (the shipped VT path compiles)

## Review

Incorporated a multi-agent PR review: fixed a real predicate bug (`SupportsGPUInput()` → `IsGPUOnly()` in the GPU-only guard) and a silent retry-consuming return (added a log), added the test coverage above, and a struct-level concurrency note.

## Caveat

I couldn't reproduce on the exact 2019 Intel 5K iMac, so the *precise* stall trigger (cold-start 2s encode timeout vs. a genuine VT limit at 5120×2880) is still unconfirmed. The new diagnostics will pin it down from the next field session — and self-heal makes the session recover to hardware either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)