### PR TITLE
feat(devices): power-actions menu + fix reboot-pending list badge (#1273)

### DIFF
--- a/apps/api/src/routes/devices/core.list-response-shape.test.ts
+++ b/apps/api/src/routes/devices/core.list-response-shape.test.ts
@@ -10,6 +10,11 @@ import { Hono } from 'hono';
 //
 // This test asserts the response body contains both keys with the values
 // from the DB row — a check the existing permission tests didn't make.
+//
+// Extended for #1273: the "Reboot pending" list badge has the identical
+// failure mode — `pendingReboot` is selected from the DB in core.ts but was
+// omitted by the same response mapper, so the list/grid badge never rendered
+// (the device-detail page worked because it returns the full row).
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -120,6 +125,7 @@ describe('GET /devices — response shape', () => {
         status: 'offline',
         watchdogStatus: 'connected',
         mainAgentSilentSince: silentSince,
+        pendingReboot: true,
         lastSeenAt: new Date('2026-05-26T19:19:57.519Z'),
         enrolledAt: new Date('2026-04-26T19:39:57.519Z'),
         tags: ['e2e'],
@@ -147,9 +153,11 @@ describe('GET /devices — response shape', () => {
     expect(body.data).toHaveLength(1);
     const row = body.data[0];
 
-    // The two fields the response mapper was silently dropping.
+    // The fields the response mapper was silently dropping.
     expect(row).toHaveProperty('watchdogStatus', 'connected');
     expect(row).toHaveProperty('mainAgentSilentSince', silentSince.toISOString());
+    // #1273 regression — pendingReboot must survive the mapper for the list badge.
+    expect(row).toHaveProperty('pendingReboot', true);
   });
 
   it('returns null watchdogStatus / mainAgentSilentSince for healthy rows (still present in shape)', async () => {
@@ -171,6 +179,7 @@ describe('GET /devices — response shape', () => {
         status: 'online',
         watchdogStatus: null,
         mainAgentSilentSince: null,
+        pendingReboot: false,
         lastSeenAt: new Date(),
         enrolledAt: new Date(),
         tags: [],
@@ -202,7 +211,9 @@ describe('GET /devices — response shape', () => {
     // (healthy device on a new API).
     expect(Object.prototype.hasOwnProperty.call(row, 'watchdogStatus')).toBe(true);
     expect(Object.prototype.hasOwnProperty.call(row, 'mainAgentSilentSince')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(row, 'pendingReboot')).toBe(true);
     expect(row.watchdogStatus).toBeNull();
     expect(row.mainAgentSilentSince).toBeNull();
+    expect(row.pendingReboot).toBe(false);
   });
 });

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -624,6 +624,7 @@ coreRoutes.get(
         status: d.status,
         watchdogStatus: d.watchdogStatus,
         mainAgentSilentSince: d.mainAgentSilentSince,
+        pendingReboot: d.pendingReboot,
         lastSeenAt: d.lastSeenAt,
         enrolledAt: d.enrolledAt,
         tags: d.tags,

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -15,7 +15,8 @@ import {
   XCircle,
   Package,
   MapPin,
-  Zap
+  Zap,
+  ChevronDown
 } from 'lucide-react';
 import type { Device } from './DeviceList';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
@@ -30,13 +31,19 @@ type ModalType = 'none' | 'reboot' | 'reboot_safe_mode' | 'shutdown' | 'maintena
 
 export default function DeviceActions({ device, onAction, compact = false }: DeviceActionsProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [powerMenuOpen, setPowerMenuOpen] = useState(false);
   const [modalType, setModalType] = useState<ModalType>('none');
   const [loading, setLoading] = useState(false);
+
+  const closeMenus = () => {
+    setMenuOpen(false);
+    setPowerMenuOpen(false);
+  };
 
   const handleAction = async (action: string) => {
     if (action === 'reboot' || action === 'reboot_safe_mode' || action === 'shutdown' || action === 'maintenance' || action === 'decommission' || action === 'clear-sessions') {
       setModalType(action);
-      setMenuOpen(false);
+      closeMenus();
       return;
     }
 
@@ -45,7 +52,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
       await onAction?.(action, device);
     } finally {
       setLoading(false);
-      setMenuOpen(false);
+      closeMenus();
     }
   };
 
@@ -223,42 +230,69 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
           <Wrench className="h-4 w-4" />
           Remote Tools
         </button>
-        <button
-          type="button"
-          onClick={() => handleAction('refresh')}
-          disabled={device.status === 'offline' || loading}
-          title="Re-run agent inventory collectors so the UI sees fresh hardware/software/network data without waiting for the next heartbeat cycle"
-          className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <RefreshCw className="h-4 w-4" />
-          Refresh
-        </button>
-        <button
-          type="button"
-          onClick={() => handleAction('reboot')}
-          disabled={device.status === 'offline' || loading}
-          className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <RotateCcw className="h-4 w-4" />
-          Reboot
-        </button>
-        {device.status === 'offline' && (
-          <button
-            type="button"
-            onClick={() => handleAction('wake')}
-            disabled={loading}
-            className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-            title="Send a Wake-on-LAN packet via an online peer agent on the device's LAN"
-          >
-            <Zap className="h-4 w-4" />
-            Wake
-          </button>
-        )}
-
         <div className="relative">
           <button
             type="button"
-            onClick={() => setMenuOpen(!menuOpen)}
+            onClick={() => { setPowerMenuOpen(!powerMenuOpen); setMenuOpen(false); }}
+            disabled={loading}
+            aria-haspopup="true"
+            aria-expanded={powerMenuOpen}
+            className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Power className="h-4 w-4" />
+            Power
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+          </button>
+          {powerMenuOpen && (
+            <div className="absolute right-0 top-full z-10 mt-1 w-48 rounded-md border bg-card shadow-lg">
+              <button
+                type="button"
+                onClick={() => handleAction('reboot')}
+                disabled={device.status === 'offline'}
+                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RotateCcw className="h-4 w-4" />
+                Reboot
+              </button>
+              {device.os === 'windows' && (
+                <button
+                  type="button"
+                  onClick={() => handleAction('reboot_safe_mode')}
+                  disabled={device.status === 'offline'}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-yellow-600 hover:bg-yellow-500/10 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Shield className="h-4 w-4" />
+                  Reboot to Safe Mode
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => handleAction('shutdown')}
+                disabled={device.status === 'offline'}
+                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Power className="h-4 w-4" />
+                Shutdown
+              </button>
+              {device.status === 'offline' && (
+                <button
+                  type="button"
+                  onClick={() => handleAction('wake')}
+                  disabled={loading}
+                  title="Send a Wake-on-LAN packet via an online peer agent on the device's LAN"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Zap className="h-4 w-4" />
+                  Wake
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => { setMenuOpen(!menuOpen); setPowerMenuOpen(false); }}
             disabled={loading}
             className="flex h-10 w-10 items-center justify-center rounded-md border bg-background transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
           >
@@ -266,6 +300,16 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
           </button>
           {menuOpen && (
             <div className="absolute right-0 top-full z-10 mt-1 w-48 rounded-md border bg-card shadow-lg">
+              <button
+                type="button"
+                onClick={() => handleAction('refresh')}
+                disabled={device.status === 'offline' || loading}
+                title="Re-run agent inventory collectors so the UI sees fresh hardware/software/network data without waiting for the next heartbeat cycle"
+                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Refresh
+              </button>
               <button
                 type="button"
                 onClick={() => handleAction('maintenance')}
@@ -282,26 +326,6 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
                 <Package className="h-4 w-4" />
                 Deploy Software
               </button>
-              <button
-                type="button"
-                onClick={() => handleAction('shutdown')}
-                disabled={device.status === 'offline'}
-                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <Power className="h-4 w-4" />
-                Shutdown
-              </button>
-              {device.os === 'windows' && (
-                <button
-                  type="button"
-                  onClick={() => handleAction('reboot_safe_mode')}
-                  disabled={device.status === 'offline'}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-yellow-600 hover:bg-yellow-500/10 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  <Shield className="h-4 w-4" />
-                  Reboot to Safe Mode
-                </button>
-              )}
               <button
                 type="button"
                 onClick={() => handleAction('clear-sessions')}

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -21,13 +21,11 @@ import {
   Layers,
   Timer,
   Usb,
-  Sparkles,
   Ticket,
 } from 'lucide-react';
 import { formatUptime } from '../../lib/utils';
 import type { Device, DeviceStatus, OSType } from './DeviceList';
 import DeviceActions from './DeviceActions';
-import { useAiStore } from '../../stores/aiStore';
 import DeviceInfoTab from './DeviceInfoTab';
 import DeviceHardwareInventory from './DeviceHardwareInventory';
 import DeviceSoftwareInventory from './DeviceSoftwareInventory';
@@ -155,7 +153,6 @@ function getTabFromHash(): Tab {
 
 export default function DeviceDetails({ device, timezone, onBack, onAction }: DeviceDetailsProps) {
   const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
-  const startDeviceTask = useAiStore((s) => s.startDeviceTask);
 
   useEffect(() => {
     const onHashChange = () => setActiveTab(getTabFromHash());
@@ -232,24 +229,6 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              data-testid="device-fix-with-ai"
-              onClick={() =>
-                void startDeviceTask(device.id, {
-                  type: 'device',
-                  id: device.id,
-                  hostname: device.hostname,
-                  os: device.os,
-                  status: device.status,
-                })
-              }
-              className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted"
-              title="Start an AI task scoped to this device"
-            >
-              <Sparkles className="h-4 w-4" />
-              Fix with AI
-            </button>
             <DeviceActions device={device} onAction={onAction} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
Two related Devices changes:

**Power actions UX** — `DeviceActions` now groups **Reboot / Reboot to Safe Mode / Shutdown / Wake** under a single **Power** dropdown, and moves **Refresh** into the overflow menu. `DeviceDetails` drops the standalone "Fix with AI" button.

**Fix #1273 — "Reboot pending" badge missing from list/grid** — the devices list response mapper (`devices/core.ts`) selected `pendingReboot` from the DB but dropped it before serialization, so the list/grid badge never rendered (device-detail worked because it returns the full row). Added it to the mapper.

## Test plan
- `core.list-response-shape.test.ts` extended for #1273 — asserts `pendingReboot` survives the mapper (true and false). **2/2 pass.**
- Manual: Power dropdown groups the four power actions; reboot-pending badge now shows in list/grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)