### PR TITLE
feat(web): app-wide interface density control + UI polish

### DIFF
--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Rows3, Rows4, AlignJustify } from 'lucide-react';
+import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3 } from 'lucide-react';
 import type { DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { widthPercentClass, formatUptime } from '@/lib/utils';
@@ -21,11 +21,9 @@ import {
   type ColumnId,
 } from './columnVisibility';
 import {
-  DENSITY_OPTIONS,
   densityTableClasses,
   readDensity,
   subscribeDensity,
-  writeDensity,
   type Density,
 } from '@/lib/density';
 import { OSIcon } from './osIcons';
@@ -222,15 +220,11 @@ export default function DeviceList({
   const [columnOrder, setColumnOrder] = useState<ColumnId[]>(() => readColumnOrder());
   const [columnsMenuOpen, setColumnsMenuOpen] = useState(false);
   const columnsMenuRef = useRef<HTMLDivElement>(null);
-  // Table density preference (account-wide via localStorage). Subscribe so
-  // a sibling instance on the same page that flips density updates this
-  // one without a reload.
+  // Table density reflects the account-wide preference (breeze.density),
+  // which is now set from the top-bar theme/display menu. Subscribe so the
+  // table re-renders when it changes, without a reload.
   const [density, setDensity] = useState<Density>(() => readDensity());
   useEffect(() => subscribeDensity(setDensity), []);
-  const handleDensityChange = (next: Density) => {
-    setDensity(next);
-    writeDensity(next);
-  };
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkMenuOpen, setBulkMenuOpen] = useState(false);
   const [rowMenuOpenId, setRowMenuOpenId] = useState<string | null>(null);
@@ -839,32 +833,10 @@ export default function DeviceList({
                 </span>
               )}
             </button>
-            {/* Density toggle: comfortable / compact / dense. Single
-                account-wide preference (breeze.density in localStorage),
-                applied to descendant td/th via Tailwind arbitrary
-                variants on the table element. */}
-            <div className="inline-flex h-10 items-center rounded-md border" role="group" aria-label="Row density">
-              {DENSITY_OPTIONS.map((opt, idx) => {
-                const Icon = opt === 'comfortable' ? Rows3 : opt === 'compact' ? Rows4 : AlignJustify;
-                const label = opt.charAt(0).toUpperCase() + opt.slice(1);
-                const isActive = density === opt;
-                return (
-                  <button
-                    key={opt}
-                    type="button"
-                    onClick={() => handleDensityChange(opt)}
-                    aria-pressed={isActive}
-                    aria-label={`${label} row density`}
-                    title={`${label} row density`}
-                    className={`flex h-full items-center justify-center px-2.5 text-sm transition ${
-                      isActive ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/60'
-                    } ${idx === 0 ? 'rounded-l-md' : ''} ${idx === DENSITY_OPTIONS.length - 1 ? 'rounded-r-md' : 'border-r'}`}
-                  >
-                    <Icon className="h-3.5 w-3.5" />
-                  </button>
-                );
-              })}
-            </div>
+            {/* Interface density is now an account-wide control in the
+                top-bar theme/display menu (Header.tsx). The table still
+                reflects the saved preference via densityTableClasses +
+                subscribeDensity below. */}
             <div className="relative" ref={columnsMenuRef}>
               <button
                 type="button"

--- a/apps/web/src/components/help/HelpPanel.tsx
+++ b/apps/web/src/components/help/HelpPanel.tsx
@@ -7,8 +7,20 @@ export default function HelpPanel() {
   const { isOpen, docsUrl, label, toggle, close } = useHelpStore();
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const [iframeError, setIframeError] = useState(false);
+  // Only mount the docs iframe once the panel has actually been opened. The
+  // panel is always rendered (it slides in/out via CSS transform), but a
+  // mounted iframe loads docs.breezermm.com (+ its Cloudflare RUM beacon) on
+  // every page — those external requests trip the app CSP and spam
+  // report-only violations into the console on every navigation. Latching on
+  // first open means zero docs traffic until the user asks for help, and it
+  // stays mounted afterwards so reopening on the same page is instant.
+  const [hasOpened, setHasOpened] = useState(isOpen);
   const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
   const canEmbedDocs = currentOrigin ? isDocsEmbeddableOrigin(currentOrigin) : true;
+
+  useEffect(() => {
+    if (isOpen) setHasOpened(true);
+  }, [isOpen]);
 
   // Keyboard shortcut: Cmd+Shift+H to toggle
   useEffect(() => {
@@ -78,7 +90,7 @@ export default function HelpPanel() {
         </div>
 
         <div className="relative flex flex-1">
-          {canEmbedDocs && !iframeLoaded && !iframeError && (
+          {canEmbedDocs && hasOpened && !iframeLoaded && !iframeError && (
             <div className="absolute inset-0 flex items-center justify-center bg-card">
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
             </div>
@@ -105,7 +117,7 @@ export default function HelpPanel() {
             </div>
           )}
 
-          {canEmbedDocs && (
+          {canEmbedDocs && hasOpened && (
             <iframe
               key={docsUrl}
               src={docsUrl}

--- a/apps/web/src/components/integrations/HuntressIntegration.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.tsx
@@ -343,7 +343,19 @@ export default function HuntressIntegration() {
           <span>{statusError}</span>
         </div>
       )}
-      {!isPartnerView && !mappedForOrg && (
+      {!isPartnerView && !integration && (
+        <div className="rounded-xl border bg-card p-8 text-center shadow-sm">
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+            <Unplug className="h-5 w-5" />
+          </div>
+          <h2 className="mt-3 text-lg font-semibold">Huntress isn&apos;t connected yet</h2>
+          <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+            Huntress is configured once at the partner level and shared across every organization. Switch your scope to{' '}
+            <span className="font-medium text-foreground">All orgs</span> to add the API Key and Secret.
+          </p>
+        </div>
+      )}
+      {!isPartnerView && integration && !mappedForOrg && (
         <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
           This Breeze organization is not mapped to a Huntress organization yet. Switch to All orgs as a partner admin to map it.
         </div>

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -17,7 +17,10 @@ import {
   BookOpen,
   Menu,
   LifeBuoy,
-  CreditCard
+  CreditCard,
+  Rows3,
+  Rows4,
+  AlignJustify
 } from 'lucide-react';
 import OrgSwitcher from './OrgSwitcher';
 import NotificationCenter from './NotificationCenter';
@@ -32,10 +35,15 @@ import { useFeaturesStore } from '../../stores/featuresStore';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '../../lib/navigation';
 import { useAvatarBlobUrl } from '../../lib/avatarBlobCache';
+import { readDensity, writeDensity, subscribeDensity, type Density } from '../../lib/density';
 
 export default function Header() {
   const [mounted, setMounted] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('light');
+  // Interface density: account-wide preference (breeze.density) shared with
+  // any table that opts in. The control lives in this theme/display submenu;
+  // changing it re-skins the whole app via <html data-density> (globals.css).
+  const [density, setDensity] = useState<Density>('comfortable');
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showThemeMenu, setShowThemeMenu] = useState(false);
   const [showSupportModal, setShowSupportModal] = useState(false);
@@ -64,7 +72,12 @@ export default function Header() {
     const raw = localStorage.getItem('theme');
     const stored = (raw === 'light' || raw === 'dark' || raw === 'system') ? raw : null;
     setTheme(stored || 'system');
+    // Hydrate density from storage and stay in sync if another component
+    // (e.g. a table toolbar) ever flips it.
+    setDensity(readDensity());
   }, []);
+
+  useEffect(() => subscribeDensity(setDensity), []);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -177,6 +190,13 @@ export default function Header() {
         body: JSON.stringify({ preferences: { theme: next } })
       }).catch((err) => console.warn('[theme] Failed to persist preference:', err));
     }
+  };
+
+  // writeDensity persists the choice, mirrors data-density onto <html> so the
+  // page-level CSS in globals.css applies app-wide, and notifies subscribers
+  // (subscribeDensity above keeps this menu's checkmark in sync).
+  const applyDensity = (next: Density) => {
+    writeDensity(next);
   };
 
   // Listen for OS theme changes when in system mode
@@ -327,7 +347,8 @@ export default function Header() {
           </button>
 
           {showThemeMenu && (
-            <div ref={themePanelRef} className="absolute right-0 top-full z-50 mt-2 w-36 rounded-lg border bg-popover py-1 shadow-lg">
+            <div ref={themePanelRef} className="absolute right-0 top-full z-50 mt-2 w-52 rounded-lg border bg-popover py-1 shadow-lg">
+              <p className="px-3 pb-1 pt-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Theme</p>
               {([
                 { value: 'light' as const, label: 'Light', Icon: Sun },
                 { value: 'dark' as const, label: 'Dark', Icon: Moon },
@@ -344,6 +365,28 @@ export default function Header() {
                   {theme === value && <Check className="h-4 w-4 text-primary" />}
                 </button>
               ))}
+
+              {/* Interface density — account-wide; applies across the whole app. */}
+              <div className="my-1 border-t" />
+              <p className="px-3 pb-1 pt-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Interface density</p>
+              {([
+                { value: 'comfortable' as const, label: 'Comfortable', Icon: Rows3 },
+                { value: 'compact' as const, label: 'Compact', Icon: Rows4 },
+                { value: 'dense' as const, label: 'Dense', Icon: AlignJustify },
+              ]).map(({ value, label, Icon }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => applyDensity(value)}
+                  aria-label={`${label} interface density`}
+                  className="flex w-full items-center gap-3 px-3 py-2 text-sm transition hover:bg-muted"
+                >
+                  <Icon className="h-4 w-4 text-muted-foreground" />
+                  <span className="flex-1 text-left">{label}</span>
+                  {density === value && <Check className="h-4 w-4 text-primary" />}
+                </button>
+              ))}
+              <p className="px-3 pb-1.5 pt-1 text-[11px] leading-snug text-muted-foreground">Applies across the entire app.</p>
             </div>
           )}
         </div>

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -388,7 +388,10 @@ export default function TicketsPage() {
 
   const filterSelectClass = (active: boolean) =>
     cn(
-      'h-8 max-w-[180px] rounded-md border bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
+      // py-1 + leading-tight overrides the @tailwindcss/forms base padding
+      // (0.5rem) + 1.5rem line-height that otherwise overflow the fixed h-8
+      // box and clip descenders on the displayed value (e.g. "All categories").
+      'h-8 max-w-[180px] rounded-md border bg-background px-2 py-1 text-sm leading-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
       active ? 'text-foreground' : 'text-muted-foreground'
     );
 
@@ -570,7 +573,7 @@ export default function TicketsPage() {
                     onChange={(e) => { setBulkAssignee(e.target.value); if (e.target.value) setBulkStatus(''); }}
                     aria-label="Bulk assign to"
                     data-testid="tickets-bulk-assignee"
-                    className="h-8 max-w-[150px] rounded-md border bg-background px-2 text-sm"
+                    className="h-8 max-w-[150px] rounded-md border bg-background px-2 py-1 text-sm leading-tight"
                   >
                     <option value="">Assign to…</option>
                     <option value="unassign">Unassign</option>
@@ -583,7 +586,7 @@ export default function TicketsPage() {
                     onChange={(e) => { setBulkStatus(e.target.value); if (e.target.value) setBulkAssignee(''); }}
                     aria-label="Bulk set status"
                     data-testid="tickets-bulk-status"
-                    className="h-8 max-w-[130px] rounded-md border bg-background px-2 text-sm"
+                    className="h-8 max-w-[130px] rounded-md border bg-background px-2 py-1 text-sm leading-tight"
                   >
                     <option value="">Set status…</option>
                     {BULK_STATUSES.map((s) => (


### PR DESCRIPTION
## Summary
Grouped web-only UI improvements (no API/schema changes):

- **Interface density** — moved the row-density toggle out of the Devices table toolbar (`DeviceList`) into the top-bar **theme/display menu** (`Header`), so it's now an account-wide preference applied across the whole app via `<html data-density>`. The Devices table still reflects the saved value (`densityTableClasses` + `subscribeDensity`).
- **HelpPanel** — lazy-mount the docs iframe on first open. Previously it loaded `docs.breezermm.com` (+ its Cloudflare RUM beacon) on every page, tripping the app CSP and spamming report-only violations on each navigation. Now zero docs traffic until the user opens Help; stays mounted afterwards for instant reopen.
- **HuntressIntegration** — show a clear "Huntress isn't connected yet" empty state at org scope, instead of only the mapping warning.
- **TicketsPage** — `py-1` + `leading-tight` on the filter/bulk selects so `@tailwindcss/forms` base padding stops clipping descenders inside the fixed `h-8` boxes.

## Test plan
- Manual: density control in the theme menu re-skins tables app-wide and persists; Help panel opens without CSP console spam; Huntress org-scope shows the empty state; ticket filter selects render without clipped text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)