### PR TITLE
fix(ticketing): timer-start 500 on concurrent start + feed live-refresh after Log time

### DIFF
--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -380,6 +380,37 @@ describe('startTimer / stopTimer', () => {
       consoleSpy.mockRestore();
     }
   });
+
+  // Regression: real postgres.js/Drizzle errors nest the PG code under `.cause`
+  // (the top-level DrizzleQueryError has no `.code`). A flat `{ code: '23505' }`
+  // mock hid this — in production the unique-violation guard never matched and a
+  // raw 500 leaked instead of the retry/409 path. isUniqueViolation must unwrap.
+  it('detects a unique violation wrapped in a DrizzleQueryError cause (no top-level code)', async () => {
+    const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
+    const wrapped = Object.assign(new Error('Failed query: insert into "time_entries" ...'), { cause: pgError }); // no .code on the wrapper
+    dbMocks.insertErrors.push(wrapped, wrapped);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(startTimer({ description: 'race' }, ACTOR))
+        .rejects.toMatchObject({ code: 'ENTRY_RUNNING', status: 409 });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('retries once and succeeds when only the first start hits a wrapped unique violation', async () => {
+    const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
+    const wrapped = Object.assign(new Error('Failed query: insert ...'), { cause: pgError });
+    dbMocks.updateResult = []; // no running timer to stop
+    dbMocks.insertErrors.push(wrapped); // first attempt fails, retry uses insertResult
+    dbMocks.insertResult = [{ id: 'te-retry', endedAt: null }];
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(startTimer({ description: 'race' }, ACTOR)).resolves.toMatchObject({ id: 'te-retry' });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
 });
 
 describe('updateTimeEntry — own-vs-all + approval semantics (D5)', () => {

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -268,7 +268,15 @@ async function stopRunningEntry(
 }
 
 function isUniqueViolation(err: unknown): boolean {
-  return typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505';
+  // postgres.js raises a PostgresError with code '23505', but Drizzle wraps it
+  // in a DrizzleQueryError whose own `.code` is undefined — the PG code lives on
+  // `.cause`. Walk the cause chain so the retry/409 path actually fires.
+  let cur: unknown = err;
+  for (let depth = 0; cur && typeof cur === 'object' && depth < 5; depth++) {
+    if ((cur as { code?: string }).code === '23505') return true;
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 export async function startTimer(input: { ticketId?: string; description?: string }, actor: TimeEntryActor) {

--- a/apps/web/src/components/tickets/TicketTimeBilling.test.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.test.tsx
@@ -50,6 +50,38 @@ describe('TicketTimeBilling', () => {
     });
   });
 
+  it('broadcasts billing-changed after a quick-add so the workbench feed live-refreshes', async () => {
+    const onBillingChanged = vi.fn();
+    window.addEventListener(BILLING_CHANGED_EVENT, onBillingChanged);
+    try {
+      render(<TicketTimeBilling ticketId="tk-1" />);
+      fireEvent.click(await screen.findByTestId('ticket-billing-quick-add-toggle'));
+      fireEvent.change(screen.getByTestId('ticket-billing-quick-add-minutes'), { target: { value: '15' } });
+      fireEvent.click(screen.getByTestId('ticket-billing-quick-add-submit'));
+      await waitFor(() => expect(onBillingChanged).toHaveBeenCalled());
+    } finally {
+      window.removeEventListener(BILLING_CHANGED_EVENT, onBillingChanged);
+    }
+  });
+
+  it('disables the start-timer button while a start is in flight', async () => {
+    let resolveStart: (v: Response) => void = () => {};
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/time-entries/start') return new Promise<Response>((res) => { resolveStart = res; });
+      return route(url);
+    });
+    render(<TicketTimeBilling ticketId="tk-1" />);
+    const btn = await screen.findByTestId('ticket-billing-start-timer');
+    fireEvent.click(btn);
+    await waitFor(() => expect((btn as HTMLButtonElement).disabled).toBe(true));
+    // A second click while disabled must not fire a second start request.
+    fireEvent.click(btn);
+    const startCalls = fetchWithAuth.mock.calls.filter((a) => a[0] === '/time-entries/start').length;
+    expect(startCalls).toBe(1);
+    act(() => resolveStart({ ok: true, status: 201, json: async () => ({ data: { id: 'te-x' } }) } as Response));
+    await waitFor(() => expect((btn as HTMLButtonElement).disabled).toBe(false));
+  });
+
   it('refetches when breeze:billing-changed fires', async () => {
     render(<TicketTimeBilling ticketId="tk-1" />);
     // Wait for the initial load

--- a/apps/web/src/components/tickets/TicketTimeBilling.tsx
+++ b/apps/web/src/components/tickets/TicketTimeBilling.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
-import { startTimerAction, onTimerChanged, onBillingChanged } from '../../lib/timerActions';
+import { startTimerAction, onTimerChanged, onBillingChanged, broadcastBillingChanged } from '../../lib/timerActions';
 import { formatMinutes, formatMoney } from '../../lib/timeFormat';
 
 interface BillingSummary {
@@ -26,6 +26,7 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
   const [description, setDescription] = useState('');
   const [billable, setBillable] = useState(true);
   const [busy, setBusy] = useState(false);
+  const [startingTimer, setStartingTimer] = useState(false);
 
   const refresh = useCallback(async () => {
     const [sumRes, listRes] = await Promise.all([
@@ -55,8 +56,14 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
   }, [ticketId]);
 
   const startTimer = () => {
+    // Guard against double-fire: a start request takes a beat server-side, and
+    // overlapping starts race the one-running-timer unique index. Disabling the
+    // button in flight keeps the happy path single-shot.
+    if (startingTimer) return;
+    setStartingTimer(true);
     void startTimerAction({ ticketId })
-      .catch((err) => handleActionError(err, 'Failed to start timer.'));
+      .catch((err) => handleActionError(err, 'Failed to start timer.'))
+      .finally(() => setStartingTimer(false));
   };
 
   const submitQuickAdd = async () => {
@@ -85,6 +92,10 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
       setMinutes('');
       setDescription('');
       await refresh();
+      // Notify the workbench feed (and other billing listeners) so the new
+      // time-entry line appears without a manual reload — mirrors the timer
+      // start/stop and parts-mutation paths.
+      broadcastBillingChanged();
     } catch (err) {
       handleActionError(err, 'Failed to log time.');
     } finally {
@@ -121,10 +132,11 @@ export default function TicketTimeBilling({ ticketId }: { ticketId: string }) {
         <button
           type="button"
           onClick={startTimer}
-          className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+          disabled={startingTimer}
+          className="rounded-md border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
           data-testid="ticket-billing-start-timer"
         >
-          Start timer
+          {startingTimer ? 'Starting…' : 'Start timer'}
         </button>
         <button
           type="button"

--- a/docs/superpowers/plans/2026-06-12-ai-for-office-1-foundation.md
+++ b/docs/superpowers/plans/2026-06-12-ai-for-office-1-foundation.md
@@ -1,0 +1,3321 @@
+# Breeze AI for Office — Plan 1: Foundation (schema, Entra auth, tenancy, policy)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the control-plane foundation for the Excel add-in: client tenancy tables with RLS, Entra ID token exchange with auto-provisioned portal users, Redis-backed client sessions, per-org policy storage + enforcement, and partner-facing admin routes for tenant mapping and policy.
+
+**Architecture:** A new `/client-ai` route namespace (separate from technician `/ai` and `/portal`) authenticates Excel add-in users by verifying Entra ID tokens against Microsoft's common JWKS, mapping `tid` → Breeze org via `client_ai_tenant_mappings`, and upserting the user into the existing `portal_users` table. Sessions are Redis-backed bearer tokens mirroring the portal session pattern; a dedicated middleware attaches `{clientUserId, orgId}` and wraps handlers in an org-scoped `withDbAccessContext`. All new tables ship with RLS policies in the same migration (shape 1 for the three org-scoped tables, dual-axis for `client_ai_prompt_templates`).
+
+**Tech Stack:** Hono, Drizzle, PostgreSQL RLS, jose (JWT/JWKS), Redis, Vitest
+
+**Spec:** docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md
+
+---
+
+## Deviations from spec (decided during planning — already validated against the real schema)
+
+1. **`ai_sessions` CHECK is "at most one principal", not "exactly one".** The spec (§4, §12) asks for a CHECK that exactly one of (`user_id`, `client_user_id`) is set. But `user_id` is **already nullable** (`apps/api/src/db/schema/ai.ts:27`) and rows with `user_id IS NULL` legitimately exist today: helper device sessions insert `userId: null` (`apps/api/src/routes/helper/index.ts:309-314`) and MCP ledger sessions insert a nullable userId (`apps/api/src/services/mcpToolExecutionLedger.ts:96-100`). An "exactly one" CHECK would corrupt those write paths and fail on existing rows. Instead we add two constraints: `CHECK (user_id IS NULL OR client_user_id IS NULL)` (never both) and `CHECK (type <> 'excel_client' OR client_user_id IS NOT NULL)` (client sessions always carry a client principal).
+2. **`client_ai_tenant_mappings` is also unique on `org_id`** (one tenant per org in v1), because the admin route is the singular `/orgs/:orgId/tenant-mapping`. The spec only requires uniqueness on `entra_tenant_id`; the extra org uniqueness keeps GET/PUT semantics unambiguous and can be relaxed later without breaking anything.
+3. **`selected_user_ids` holds `portal_users` UUIDs** and is enforced *after* upsert (the user row must exist before the MSP can select it; a denied user's row exists but cannot mint a session). Spec §3 left the key unspecified.
+4. **Redis is required for client-AI sessions** (503 when unavailable) — no in-memory dev fallback like the portal's. This is a brand-new surface; every compose mode ships Redis, and skipping the fallback removes ~80 lines of sweep/cap bookkeeping.
+5. **`ai_sessions.type = 'excel_client'` needs no migration** — `type` is a plain `text` column with default `'general'` (`ai.ts:30`), not an enum.
+
+## Verification notes for workers
+
+- Node pin: prefix every pnpm/vitest/tsc command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict).
+- The full `vitest run` suite is known-flaky in parallel on a pristine tree — verify with the **affected files only**; trust CI for the full sweep.
+- `npx tsc --noEmit` has pre-existing errors in `agents.test.ts` and `apiKeyAuth.test.ts` — those two are not yours.
+- Integration/RLS tests need the docker test stack: `pnpm test:docker:up` (postgres on 5433, redis on 6380). The integration setup (`src/__tests__/integration/setup.ts`) runs `autoMigrate` itself, so new migration files are picked up automatically on the next test run.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `docs/superpowers/plans/notes/2026-06-12-m365-reuse-audit.md` | Create | Output of the M365-connection reuse audit (Task 1) |
+| `apps/api/migrations/2026-06-12-b-client-ai-foundation.sql` | Create | All schema: 4 new tables + RLS, `portal_users` Entra columns, `ai_sessions` client principal |
+| `apps/api/src/db/schema/clientAi.ts` | Create | Drizzle definitions for the 4 `client_ai_*` tables |
+| `apps/api/src/db/schema/portal.ts` | Modify (~line 34-46) | `portalUsers`: add `entraOid`, `entraTenantId`, `authMethod` |
+| `apps/api/src/db/schema/ai.ts` | Modify (~line 24-53) | `aiSessions`: add `clientUserId` |
+| `apps/api/src/db/schema/index.ts` | Modify (end of file) | `export * from './clientAi'` |
+| `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` | Modify (~line 114) | Add `client_ai_prompt_templates` to `DUAL_AXIS_TENANT_TABLES` |
+| `apps/api/src/__tests__/integration/client-ai-templates-rls.integration.test.ts` | Create | Functional `breeze_app` dual-axis insert tests (the custom_field_definitions lesson) |
+| `apps/api/src/config/env.ts` | Modify (near `M365_ENABLED`, ~line 18) | `CLIENT_AI_ENTRA_CLIENT_ID` |
+| `.env.example` | Modify (after AI Brain block, ~line 174) | `CLIENT_AI_ENTRA_CLIENT_ID=` placeholder |
+| `apps/api/src/services/clientAiEntraJwt.ts` (+ `.test.ts`) | Create | Entra ID token verification (jose, common JWKS, tid-bound issuer) |
+| `apps/api/src/services/clientAiPolicy.ts` (+ `.test.ts`) | Create | `getOrgPolicy` with defaults, `isClientUserPermitted`, `requireClientAiEnabled` |
+| `apps/api/src/routes/clientAi/schemas.ts` | Create | Constants (TTLs, Redis keys), Zod schemas, Hono context types |
+| `apps/api/src/routes/clientAi/auth.ts` (+ `auth.test.ts`) | Create | `POST /client-ai/auth/exchange` |
+| `apps/api/src/middleware/clientAiAuth.ts` (+ `.test.ts`) | Create | Bearer→Redis session middleware + policy-enforcement middleware |
+| `apps/api/src/routes/clientAi/admin.ts` (+ `admin.test.ts`) | Create | Partner-scope tenant-mapping + policy CRUD |
+| `apps/api/src/routes/clientAi/index.ts` | Create | Route hub for the namespace |
+| `apps/api/src/index.ts` | Modify (import ~line 72, mount ~line 780) | Mount `/client-ai` |
+
+---
+
+### Task 1: M365-connection reuse audit (read-only investigation)
+
+The spec (§3 "Reuse check") requires auditing the existing per-org M365 connection machinery before Plan 4 builds the onboarding wizard, to decide whether tenant IDs and admin-consent flows can be reused instead of building a parallel consent system.
+
+**Files:**
+- Create: docs/superpowers/plans/notes/2026-06-12-m365-reuse-audit.md
+- Read-only inputs (do NOT modify): apps/api/src/db/schema/m365.ts, apps/api/src/db/schema/delegant.ts, apps/api/src/db/schema/c2c.ts, apps/api/src/services/c2cM365.ts, apps/api/src/routes/m365.ts
+
+- [ ] **Step 1: Investigate the three existing M365 tenant-ID sources**
+
+Read each of these and record findings (file:line citations) in your notes:
+
+1. `apps/api/src/db/schema/m365.ts` — `m365_connections`: one per org (`m365_connections_org_uniq`), stores `tenantId` (varchar 64), `clientId`, encrypted `clientSecret`. Created/validated by `apps/api/src/routes/m365.ts` (POST validates with a live Graph call, GUID-checked by `isM365TenantId`).
+2. `apps/api/src/db/schema/delegant.ts` — `delegant_m365_connections`: per-org, **multiple per org** (`delegant_m365_org_customer_uniq` on (org_id, customer_label)), stores `m365TenantId` but no secret. This is the table `ai_sessions.delegant_m365_connection_id` references.
+3. `apps/api/src/db/schema/c2c.ts` — `c2c_connections.tenant_id` (line ~29) plus the platform-app admin-consent flow in `apps/api/src/services/c2cM365.ts`: `getPlatformConfig()` (C2C_M365_CLIENT_ID/SECRET env), `buildAdminConsentUrl()` (builds `https://login.microsoftonline.com/common/adminconsent?...`), `getCallbackUri()` (`/api/v1/c2c/m365/callback`).
+
+Questions the note must answer:
+- Which table is the best tenant-ID pre-fill source for the Plan-4 onboarding wizard, and what's the lookup (org → tenant GUID)? (Expected answer: `m365_connections.tenant_id` when present, falling back to `delegant_m365_connections.m365_tenant_id`; note multiplicity caveat for delegant rows.)
+- Can `buildAdminConsentUrl` from `services/c2cM365.ts` be reused verbatim for the add-in app registration (different `clientId` = `CLIENT_AI_ENTRA_CLIENT_ID`, different redirect)? It takes `{clientId, state, redirectUri}` params, so: yes/no + what a `/client-ai` consent callback route would need.
+- Does any existing code verify *user* tokens from customer tenants (vs. client-credentials app tokens)? (Expected: no — `c2cM365.ts` is client-credentials only; `cfAccessJwt.ts` is the only remote-JWKS user-token verifier, hence the new `clientAiEntraJwt.ts` in Task 7 mirrors it.)
+- Tenant-GUID validation precedent: `isM365TenantId` / `M365_TENANT_ID_REGEX` in `services/c2cM365.ts` and the CHECK in `apps/api/migrations/2026-05-31-c2c-tenant-id-guid-check.sql` — confirm the regex shape so Task 2's CHECK matches.
+
+- [ ] **Step 2: Write the note**
+
+Create `docs/superpowers/plans/notes/2026-06-12-m365-reuse-audit.md` (create the `notes/` dir if missing) with sections: **Tenant-ID sources** (table per source: table, column, cardinality per org, populated-by), **Consent-flow reuse** (verdict + what Plan 4 reuses vs. builds), **Token-verification reuse** (verdict), **Recommendation for Plan 4 wizard** (concrete: pre-fill query + consent URL construction). Keep it under ~80 lines, every claim cited file:line.
+
+- [ ] **Step 3: Verify the note exists and cites real paths**
+
+Run: `ls docs/superpowers/plans/notes/2026-06-12-m365-reuse-audit.md && grep -c 'apps/api' docs/superpowers/plans/notes/2026-06-12-m365-reuse-audit.md`
+Expected: file listed, grep count ≥ 6.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/plans/notes/2026-06-12-m365-reuse-audit.md
+git commit -m "docs(client-ai): M365-connection reuse audit note (Plan 1 Task 1)" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Migration — tables, RLS, portal_users + ai_sessions alters
+
+No TDD for hand-written SQL; verification is: apply against local docker postgres twice (idempotency), forge a cross-tenant insert as `breeze_app` (must fail with an RLS violation), then the contract test in Task 4.
+
+Naming: two `2026-06-12-a-*` files already exist (`-a-huntress-partner-mapping`, `-a-ticketing-time-parts`) and a future-dated `2026-06-13-a-ticketing-configuration.sql` is already committed. `2026-06-12-b-` sorts after both `-a-` files and before `2026-06-13-a-` — correct.
+
+**Files:**
+- Create: apps/api/migrations/2026-06-12-b-client-ai-foundation.sql
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 2026-06-12-b-client-ai-foundation.sql
+-- Breeze AI for Office, Plan 1 (Foundation).
+-- Spec: docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md §3, §7, §8, §10, §12.
+--
+-- 1. portal_users: Entra identity columns + partial unique identity index.
+-- 2. client_ai_tenant_mappings  — Entra tenant GUID -> org (RLS shape 1).
+-- 3. client_ai_org_policies     — per-org product policy (RLS shape 1).
+-- 4. client_ai_usage            — per-org/per-user metering buckets (RLS shape 1).
+-- 5. client_ai_prompt_templates — org-scoped OR partner-wide rows (dual-axis RLS,
+--    the custom_field_definitions shape — see 2026-06-11-i and spec §10 warning).
+-- 6. ai_sessions: client_user_id principal + principal CHECKs.
+--
+-- Idempotent throughout. autoMigrate wraps the file in a transaction — no inner
+-- BEGIN/COMMIT.
+
+-- ── 1. portal_users: Entra identity ─────────────────────────────────────────
+ALTER TABLE portal_users ADD COLUMN IF NOT EXISTS entra_oid TEXT;
+ALTER TABLE portal_users ADD COLUMN IF NOT EXISTS entra_tenant_id TEXT;
+ALTER TABLE portal_users ADD COLUMN IF NOT EXISTS auth_method TEXT NOT NULL DEFAULT 'password';
+
+-- password_hash is already nullable in the current schema (schema/portal.ts:39
+-- declares text with no notNull). Guarded DROP NOT NULL for any DB whose
+-- baseline predates that — re-runs are no-ops.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'portal_users'
+      AND column_name = 'password_hash' AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE portal_users ALTER COLUMN password_hash DROP NOT NULL;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'portal_users_auth_method_check'
+      AND conrelid = 'portal_users'::regclass
+  ) THEN
+    ALTER TABLE portal_users
+      ADD CONSTRAINT portal_users_auth_method_check
+      CHECK (auth_method IN ('password', 'entra'));
+  END IF;
+END $$;
+
+-- One portal user per (tenant, oid); password-only rows (entra_oid NULL) exempt.
+CREATE UNIQUE INDEX IF NOT EXISTS portal_users_entra_identity_uniq
+  ON portal_users (entra_tenant_id, entra_oid)
+  WHERE entra_oid IS NOT NULL;
+
+-- ── 2. client_ai_tenant_mappings (RLS shape 1) ───────────────────────────────
+-- The tenant-isolation linchpin: an Entra tenant maps to exactly ONE org
+-- (unique on entra_tenant_id), and in v1 an org carries at most one mapping
+-- (unique on org_id; the admin route is the singular /tenant-mapping).
+-- GUID CHECK mirrors 2026-05-31-c2c-tenant-id-guid-check.sql.
+CREATE TABLE IF NOT EXISTS client_ai_tenant_mappings (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id           UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  entra_tenant_id  TEXT NOT NULL,
+  created_by       UUID,
+  created_at       TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT client_ai_tenant_mappings_tenant_guid_check
+    CHECK (entra_tenant_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS client_ai_tenant_mappings_tenant_uniq
+  ON client_ai_tenant_mappings (entra_tenant_id);
+CREATE UNIQUE INDEX IF NOT EXISTS client_ai_tenant_mappings_org_uniq
+  ON client_ai_tenant_mappings (org_id);
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON client_ai_tenant_mappings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON client_ai_tenant_mappings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON client_ai_tenant_mappings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON client_ai_tenant_mappings;
+
+ALTER TABLE client_ai_tenant_mappings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE client_ai_tenant_mappings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON client_ai_tenant_mappings
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON client_ai_tenant_mappings
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON client_ai_tenant_mappings
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON client_ai_tenant_mappings
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- ── 3. client_ai_org_policies (RLS shape 1) ──────────────────────────────────
+-- One row per org; absence == product disabled with defaults (the service layer
+-- materialises defaults — see services/clientAiPolicy.ts). Separate from the
+-- technician ai budgets table by design (spec §7).
+CREATE TABLE IF NOT EXISTS client_ai_org_policies (
+  id                            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                        UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  enabled                       BOOLEAN NOT NULL DEFAULT false,
+  user_access                   TEXT NOT NULL DEFAULT 'all',
+  selected_user_ids             JSONB NOT NULL DEFAULT '[]',
+  allowed_providers             JSONB NOT NULL DEFAULT '["anthropic"]',
+  allowed_models                JSONB NOT NULL DEFAULT '[]',
+  write_mode                    TEXT NOT NULL DEFAULT 'readwrite',
+  dlp_config                    JSONB NOT NULL DEFAULT '{}',
+  daily_budget_cents            INTEGER,
+  monthly_budget_cents          INTEGER,
+  per_user_messages_per_minute  INTEGER NOT NULL DEFAULT 10,
+  org_messages_per_hour         INTEGER NOT NULL DEFAULT 500,
+  retention_days                INTEGER,
+  branding                      JSONB NOT NULL DEFAULT '{}',
+  created_at                    TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at                    TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT client_ai_org_policies_user_access_check
+    CHECK (user_access IN ('all', 'selected')),
+  CONSTRAINT client_ai_org_policies_write_mode_check
+    CHECK (write_mode IN ('readwrite', 'readonly'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS client_ai_org_policies_org_uniq
+  ON client_ai_org_policies (org_id);
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON client_ai_org_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON client_ai_org_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON client_ai_org_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON client_ai_org_policies;
+
+ALTER TABLE client_ai_org_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE client_ai_org_policies FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON client_ai_org_policies
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON client_ai_org_policies
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON client_ai_org_policies
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON client_ai_org_policies
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- ── 4. client_ai_usage (RLS shape 1) ─────────────────────────────────────────
+-- ai_cost_usage bucket pattern + a per-user dimension (spec §8). Written by the
+-- Plan-2 session loop under org scope.
+CREATE TABLE IF NOT EXISTS client_ai_usage (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id            UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  client_user_id    UUID NOT NULL REFERENCES portal_users(id) ON DELETE CASCADE,
+  period            TEXT NOT NULL,
+  period_key        VARCHAR(10) NOT NULL,
+  input_tokens      INTEGER NOT NULL DEFAULT 0,
+  output_tokens     INTEGER NOT NULL DEFAULT 0,
+  total_cost_cents  REAL NOT NULL DEFAULT 0,
+  session_count     INTEGER NOT NULL DEFAULT 0,
+  message_count     INTEGER NOT NULL DEFAULT 0,
+  updated_at        TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT client_ai_usage_period_check CHECK (period IN ('daily', 'monthly'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS client_ai_usage_bucket_uniq
+  ON client_ai_usage (org_id, client_user_id, period, period_key);
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON client_ai_usage;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON client_ai_usage;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON client_ai_usage;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON client_ai_usage;
+
+ALTER TABLE client_ai_usage ENABLE ROW LEVEL SECURITY;
+ALTER TABLE client_ai_usage FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON client_ai_usage
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON client_ai_usage
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON client_ai_usage
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON client_ai_usage
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- ── 5. client_ai_prompt_templates (dual-axis RLS) ────────────────────────────
+-- Partner-wide rows: org_id NULL, partner_id set. Org rows: org_id set,
+-- partner_id NULL. EXACTLY the custom_field_definitions failure mode fixed in
+-- 2026-06-11-i — created dual-axis from day one. breeze_has_org_access(NULL) is
+-- FALSE, so the partner branch is load-bearing, not decorative. A functional
+-- breeze_app insert test for the partner axis is REQUIRED in the same PR
+-- (spec §10 warning; client-ai-templates-rls.integration.test.ts).
+CREATE TABLE IF NOT EXISTS client_ai_prompt_templates (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id       UUID REFERENCES organizations(id) ON DELETE CASCADE,
+  partner_id   UUID REFERENCES partners(id) ON DELETE CASCADE,
+  name         VARCHAR(200) NOT NULL,
+  description  TEXT,
+  prompt_body  TEXT NOT NULL,
+  category     VARCHAR(100),
+  created_by   UUID,
+  created_at   TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT client_ai_prompt_templates_scope_check
+    CHECK (num_nonnulls(org_id, partner_id) = 1)
+);
+
+CREATE INDEX IF NOT EXISTS client_ai_prompt_templates_org_idx
+  ON client_ai_prompt_templates (org_id);
+CREATE INDEX IF NOT EXISTS client_ai_prompt_templates_partner_idx
+  ON client_ai_prompt_templates (partner_id);
+
+DROP POLICY IF EXISTS breeze_dual_axis_select ON client_ai_prompt_templates;
+DROP POLICY IF EXISTS breeze_dual_axis_insert ON client_ai_prompt_templates;
+DROP POLICY IF EXISTS breeze_dual_axis_update ON client_ai_prompt_templates;
+DROP POLICY IF EXISTS breeze_dual_axis_delete ON client_ai_prompt_templates;
+
+ALTER TABLE client_ai_prompt_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE client_ai_prompt_templates FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_dual_axis_select ON client_ai_prompt_templates FOR SELECT
+  USING (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_dual_axis_insert ON client_ai_prompt_templates FOR INSERT
+  WITH CHECK (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_dual_axis_update ON client_ai_prompt_templates FOR UPDATE
+  USING (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id))
+  WITH CHECK (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_dual_axis_delete ON client_ai_prompt_templates FOR DELETE
+  USING (public.breeze_has_org_access(org_id) OR public.breeze_has_partner_access(partner_id));
+
+-- ── 6. ai_sessions: client principal ─────────────────────────────────────────
+ALTER TABLE ai_sessions
+  ADD COLUMN IF NOT EXISTS client_user_id UUID REFERENCES portal_users(id);
+
+CREATE INDEX IF NOT EXISTS ai_sessions_client_user_id_idx
+  ON ai_sessions (client_user_id) WHERE client_user_id IS NOT NULL;
+
+-- user_id is ALREADY nullable and rows with user_id IS NULL legitimately exist
+-- (helper device sessions: routes/helper/index.ts inserts userId: null; MCP
+-- ledger sessions: services/mcpToolExecutionLedger.ts). The spec's "exactly one
+-- of (user_id, client_user_id)" is therefore relaxed to:
+--   (a) never BOTH set;
+--   (b) excel_client sessions always carry a client principal.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ai_sessions_single_principal_check'
+      AND conrelid = 'ai_sessions'::regclass
+  ) THEN
+    ALTER TABLE ai_sessions
+      ADD CONSTRAINT ai_sessions_single_principal_check
+      CHECK (user_id IS NULL OR client_user_id IS NULL);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ai_sessions_excel_client_principal_check'
+      AND conrelid = 'ai_sessions'::regclass
+  ) THEN
+    ALTER TABLE ai_sessions
+      ADD CONSTRAINT ai_sessions_excel_client_principal_check
+      CHECK (type <> 'excel_client' OR client_user_id IS NOT NULL);
+  END IF;
+END $$;
+```
+
+- [ ] **Step 2: Apply against local docker postgres — twice (idempotency proof)**
+
+```bash
+cd /Users/toddhebebrand/breeze
+docker exec -i breeze-postgres psql -U breeze -d breeze -v ON_ERROR_STOP=1 < apps/api/migrations/2026-06-12-b-client-ai-foundation.sql
+# Re-run: a clean no-op (CREATE ... IF NOT EXISTS skips, DO-blocks skip, policies recreate)
+docker exec -i breeze-postgres psql -U breeze -d breeze -v ON_ERROR_STOP=1 < apps/api/migrations/2026-06-12-b-client-ai-foundation.sql
+```
+
+Expected: both runs exit 0, no ERROR lines. (Manual psql application does not register in `breeze_migrations` — that is fine; the file is idempotent, so `autoMigrate` re-applying it on next API boot is a no-op.)
+
+- [ ] **Step 3: Verify RLS as breeze_app (forge a cross-tenant insert — must fail)**
+
+```bash
+docker exec -i breeze-postgres psql -U breeze_app -d breeze <<'SQL'
+-- No breeze.scope GUC set => breeze_current_scope() = 'none' => both access
+-- helpers return FALSE. Use a literal random org UUID (an org subselect would
+-- itself be RLS-filtered to zero rows). RLS WITH CHECK fires before the FK is
+-- validated, so the expected failure is the RLS violation, not an FK error.
+INSERT INTO client_ai_tenant_mappings (org_id, entra_tenant_id)
+VALUES (gen_random_uuid(), '11111111-2222-3333-4444-555555555555');
+SQL
+docker exec -i breeze-postgres psql -U breeze_app -d breeze <<'SQL'
+INSERT INTO client_ai_prompt_templates (partner_id, name, prompt_body)
+VALUES (gen_random_uuid(), 'forged', 'x');
+SQL
+```
+
+Expected: BOTH inserts fail with `new row violates row-level security policy`.
+
+- [ ] **Step 4: Verify the constraints behave**
+
+```bash
+docker exec -i breeze-postgres psql -U breeze -d breeze <<'SQL'
+-- As the table owner RLS is forced too, but owner bypasses policies via
+-- superuser breeze? The dev superuser bypasses RLS, which is exactly what we
+-- want here: test CONSTRAINTS, not policies.
+DO $$ BEGIN
+  BEGIN
+    INSERT INTO client_ai_prompt_templates (org_id, partner_id, name, prompt_body)
+    VALUES (NULL, NULL, 'bad', 'x');
+    RAISE EXCEPTION 'scope_check failed to fire';
+  EXCEPTION WHEN check_violation THEN RAISE NOTICE 'scope_check OK'; END;
+  BEGIN
+    INSERT INTO client_ai_tenant_mappings (org_id, entra_tenant_id)
+    VALUES (gen_random_uuid(), 'not-a-guid');
+    RAISE EXCEPTION 'tenant_guid_check failed to fire';
+  EXCEPTION WHEN check_violation THEN RAISE NOTICE 'tenant_guid_check OK';
+           WHEN foreign_key_violation THEN RAISE EXCEPTION 'guid check did not fire first'; END;
+END $$;
+SQL
+```
+
+Expected: two `NOTICE: ... OK` lines, no exceptions. (The first insert violates `client_ai_prompt_templates_scope_check`; the second violates the GUID CHECK before the FK is evaluated at statement end.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-12-b-client-ai-foundation.sql
+git commit -m "feat(client-ai): foundation migration — tenant mappings, org policies, usage, templates + RLS" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Drizzle schema — clientAi.ts + portal.ts/ai.ts edits
+
+Schema files don't need TDD; verification is type-check + drift check.
+
+**Files:**
+- Create: apps/api/src/db/schema/clientAi.ts
+- Modify: apps/api/src/db/schema/portal.ts (portalUsers, ~lines 34-46)
+- Modify: apps/api/src/db/schema/ai.ts (aiSessions, ~lines 24-53)
+- Modify: apps/api/src/db/schema/index.ts (append export)
+
+- [ ] **Step 1: Create `apps/api/src/db/schema/clientAi.ts`**
+
+```ts
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  boolean,
+  jsonb,
+  integer,
+  real,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { organizations, partners } from './orgs';
+import { portalUsers } from './portal';
+
+/**
+ * Breeze AI for Office — client-AI control-plane tables.
+ * Spec: docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md §3, §7, §8, §10, §12.
+ *
+ * RLS lives in apps/api/migrations/2026-06-12-b-client-ai-foundation.sql:
+ *  - client_ai_tenant_mappings / client_ai_org_policies / client_ai_usage: shape 1
+ *    (breeze_org_isolation_* on breeze_has_org_access(org_id)).
+ *  - client_ai_prompt_templates: DUAL-AXIS (org OR partner) — partner-wide rows
+ *    have org_id NULL. See the custom_field_definitions lesson (2026-06-11-i).
+ */
+
+/** Entra tenant GUID → Breeze org. The tenant-isolation linchpin (spec §3). */
+export const clientAiTenantMappings = pgTable('client_ai_tenant_mappings', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  // GUID-shape CHECK lives in SQL (client_ai_tenant_mappings_tenant_guid_check).
+  entraTenantId: text('entra_tenant_id').notNull(),
+  createdBy: uuid('created_by'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  tenantUniq: uniqueIndex('client_ai_tenant_mappings_tenant_uniq').on(t.entraTenantId),
+  orgUniq: uniqueIndex('client_ai_tenant_mappings_org_uniq').on(t.orgId),
+}));
+
+/** Per-org product policy (spec §7). Absence == disabled-with-defaults. */
+export const clientAiOrgPolicies = pgTable('client_ai_org_policies', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  enabled: boolean('enabled').notNull().default(false),
+  userAccess: text('user_access').notNull().default('all'), // 'all' | 'selected' (SQL CHECK)
+  selectedUserIds: jsonb('selected_user_ids').notNull().default([]), // portal_users UUIDs
+  allowedProviders: jsonb('allowed_providers').notNull().default(['anthropic']),
+  allowedModels: jsonb('allowed_models').notNull().default([]), // [] = provider defaults
+  writeMode: text('write_mode').notNull().default('readwrite'), // 'readwrite' | 'readonly' (SQL CHECK)
+  dlpConfig: jsonb('dlp_config').notNull().default({}),
+  dailyBudgetCents: integer('daily_budget_cents'), // NULL = unlimited
+  monthlyBudgetCents: integer('monthly_budget_cents'), // NULL = unlimited
+  perUserMessagesPerMinute: integer('per_user_messages_per_minute').notNull().default(10),
+  orgMessagesPerHour: integer('org_messages_per_hour').notNull().default(500),
+  retentionDays: integer('retention_days'), // NULL = keep forever
+  branding: jsonb('branding').notNull().default({}),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  orgUniq: uniqueIndex('client_ai_org_policies_org_uniq').on(t.orgId),
+}));
+
+/** Daily/monthly metering buckets with a per-user dimension (spec §8). */
+export const clientAiUsage = pgTable('client_ai_usage', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  clientUserId: uuid('client_user_id').notNull().references(() => portalUsers.id, { onDelete: 'cascade' }),
+  period: text('period').notNull(), // 'daily' | 'monthly' (SQL CHECK)
+  periodKey: varchar('period_key', { length: 10 }).notNull(), // '2026-06-12' | '2026-06'
+  inputTokens: integer('input_tokens').notNull().default(0),
+  outputTokens: integer('output_tokens').notNull().default(0),
+  totalCostCents: real('total_cost_cents').notNull().default(0),
+  sessionCount: integer('session_count').notNull().default(0),
+  messageCount: integer('message_count').notNull().default(0),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  bucketUniq: uniqueIndex('client_ai_usage_bucket_uniq').on(t.orgId, t.clientUserId, t.period, t.periodKey),
+}));
+
+/**
+ * Prompt templates (spec §10). Partner-wide rows: org_id NULL + partner_id set.
+ * Org rows: org_id set + partner_id NULL. SQL CHECK enforces exactly one axis
+ * (client_ai_prompt_templates_scope_check).
+ */
+export const clientAiPromptTemplates = pgTable('client_ai_prompt_templates', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').references(() => organizations.id, { onDelete: 'cascade' }),
+  partnerId: uuid('partner_id').references(() => partners.id, { onDelete: 'cascade' }),
+  name: varchar('name', { length: 200 }).notNull(),
+  description: text('description'),
+  promptBody: text('prompt_body').notNull(),
+  category: varchar('category', { length: 100 }),
+  createdBy: uuid('created_by'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  orgIdx: index('client_ai_prompt_templates_org_idx').on(t.orgId),
+  partnerIdx: index('client_ai_prompt_templates_partner_idx').on(t.partnerId),
+}));
+
+export type ClientAiTenantMappingRow = typeof clientAiTenantMappings.$inferSelect;
+export type ClientAiOrgPolicyRow = typeof clientAiOrgPolicies.$inferSelect;
+export type ClientAiUsageRow = typeof clientAiUsage.$inferSelect;
+export type ClientAiPromptTemplateRow = typeof clientAiPromptTemplates.$inferSelect;
+```
+
+- [ ] **Step 2: Edit `apps/api/src/db/schema/portal.ts` — portalUsers Entra columns**
+
+In the `portalUsers` table (currently lines 34-46), add three columns after `passwordHash`:
+
+```ts
+export const portalUsers = pgTable('portal_users', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  email: varchar('email', { length: 255 }).notNull(),
+  name: varchar('name', { length: 255 }),
+  passwordHash: text('password_hash'),
+  // Entra ID (AI for Office) identity. Partial unique index
+  // portal_users_entra_identity_uniq on (entra_tenant_id, entra_oid)
+  // WHERE entra_oid IS NOT NULL is created via SQL migration
+  // (2026-06-12-b-client-ai-foundation.sql), mirroring the ai_sessions
+  // partial-index convention.
+  entraOid: text('entra_oid'),
+  entraTenantId: text('entra_tenant_id'),
+  authMethod: text('auth_method').notNull().default('password'), // 'password' | 'entra' (SQL CHECK)
+  linkedUserId: uuid('linked_user_id').references(() => users.id),
+  receiveNotifications: boolean('receive_notifications').notNull().default(true),
+  lastLoginAt: timestamp('last_login_at'),
+  status: varchar('status', { length: 20 }).notNull().default('active'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+});
+```
+
+- [ ] **Step 3: Edit `apps/api/src/db/schema/ai.ts` — aiSessions client principal**
+
+Add the import at the top (after the existing `./devices` import):
+
+```ts
+import { portalUsers } from './portal';
+```
+
+In `aiSessions` (lines 24-53), add after `delegantM365ConnectionId`:
+
+```ts
+  // AI for Office client principal (FK → portal_users). CHECKs in SQL:
+  // ai_sessions_single_principal_check (never both user_id and client_user_id),
+  // ai_sessions_excel_client_principal_check (type='excel_client' ⇒ set).
+  // Partial index ai_sessions_client_user_id_idx created via SQL migration.
+  clientUserId: uuid('client_user_id').references(() => portalUsers.id),
+```
+
+(No import cycle: `portal.ts` imports only `orgs`/`devices`/`users`, none of which import `ai.ts`.)
+
+- [ ] **Step 4: Edit `apps/api/src/db/schema/index.ts` — export the new module**
+
+Append alongside the existing `export * from` lines:
+
+```ts
+export * from './clientAi';
+```
+
+- [ ] **Step 5: Verify — type-check and drift check**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+cd /Users/toddhebebrand/breeze
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+```
+
+Expected: tsc shows only the pre-existing `agents.test.ts` / `apiKeyAuth.test.ts` errors; drift check reports no drift (Task 2's migration must already be applied to the local DB — it was in Task 2 Step 2).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/db/schema/clientAi.ts apps/api/src/db/schema/portal.ts apps/api/src/db/schema/ai.ts apps/api/src/db/schema/index.ts
+git commit -m "feat(client-ai): Drizzle schema for client AI tables + portal_users/ai_sessions extensions" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: rls-coverage contract-test allowlist update
+
+**Exactly one allowlist changes.** The three shape-1 tables (`client_ai_tenant_mappings`, `client_ai_org_policies`, `client_ai_usage`) are **auto-discovered** by the org-axis check via their `org_id` column (the `org_id_tables` CTE at rls-coverage.integration.test.ts:479-491) — no list entry needed. `client_ai_prompt_templates` also has an `org_id` column, so it is auto-checked on the org axis too — its dual-axis policies pass that check because they contain `breeze_has_org_access` — but it must ALSO be added to `DUAL_AXIS_TENANT_TABLES` so the dual-axis assertion (both helpers present, all four DML commands) covers it.
+
+**Files:**
+- Modify: apps/api/src/__tests__/integration/rls-coverage.integration.test.ts (`DUAL_AXIS_TENANT_TABLES`, ~line 114-122)
+
+- [ ] **Step 1: Add the table to `DUAL_AXIS_TENANT_TABLES`**
+
+```ts
+const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
+  'users',
+  'deployment_invites',
+  'access_reviews',
+  // custom_field_definitions: a field is org-scoped (org_id set) OR
+  // partner-wide (partner_id set, org_id NULL). Shipped org-only in the
+  // baseline; converted to dual-axis in 2026-06-11-i-custom-fields-dual-axis-rls.
+  'custom_field_definitions',
+  // client_ai_prompt_templates: org-scoped rows OR partner-wide rows
+  // (partner_id set, org_id NULL) — spec §10 dual-axis warning. Created
+  // dual-axis from day one (2026-06-12-b-client-ai-foundation.sql); the
+  // functional partner-axis insert test lives in
+  // client-ai-templates-rls.integration.test.ts.
+  'client_ai_prompt_templates',
+]);
+```
+
+- [ ] **Step 2: Run the contract test against the docker test stack**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm test:docker:up
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm test:rls-coverage
+```
+
+Expected: PASS. If a `client_ai_*` table shows up as an offender, the migration's policy block for it is wrong — fix the migration (it has not shipped yet), `pnpm test:docker:down && pnpm test:docker:up`, re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "test(client-ai): register client_ai_prompt_templates as dual-axis in rls-coverage contract" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Functional dual-axis RLS test for client_ai_prompt_templates
+
+The rls-coverage contract test provably does NOT catch a missing second axis (it accepts org OR partner coverage — the custom_field_definitions lesson, memory note `rls_dual_axis_contract_test_blindspot`). Spec §10 requires a functional `breeze_app` insert test for the partner-axis write path. Modeled exactly on `custom-fields-rls.integration.test.ts`.
+
+**Files:**
+- Create: apps/api/src/__tests__/integration/client-ai-templates-rls.integration.test.ts
+
+- [ ] **Step 1: Write the test**
+
+```ts
+/**
+ * client_ai_prompt_templates RLS — dual-axis (org OR partner) enforcement.
+ *
+ * Migration under test: 2026-06-12-b-client-ai-foundation.sql (§5).
+ *
+ * Partner-wide template rows carry org_id NULL + partner_id set — exactly the
+ * custom_field_definitions failure mode (fixed 2026-06-11-i), where org-only
+ * Shape-1 policies made every partner-wide row structurally uncreatable
+ * (breeze_has_org_access(NULL) = FALSE → 42501 on INSERT). The rls-coverage
+ * contract test does NOT catch a missing second axis, so this functional test
+ * through the REAL postgres.js driver (breeze_app role) is the required guard
+ * (spec §10).
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { clientAiPromptTemplates } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const created: string[] = [];
+
+afterEach(async () => {
+  if (created.length === 0) return;
+  await withDbAccessContext(
+    { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null },
+    async () => {
+      for (const id of created) {
+        await db.delete(clientAiPromptTemplates).where(eq(clientAiPromptTemplates.id, id));
+      }
+    },
+  );
+  created.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+async function seedPartnerTemplate(partnerId: string, track = true): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(clientAiPromptTemplates)
+      .values({
+        orgId: null,
+        partnerId,
+        name: 'Seed template',
+        promptBody: 'Summarize the selected range.',
+        category: 'finance',
+      })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  if (track) created.push(id);
+  return id;
+}
+
+describe('client_ai_prompt_templates RLS — dual-axis (2026-06-12-b migration)', () => {
+  it('partner scope can INSERT a partner-wide template (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(clientAiPromptTemplates)
+        .values({
+          orgId: null,
+          partnerId: partner.id,
+          name: 'Quarterly variance walkthrough',
+          promptBody: 'Explain the variance between the selected columns.',
+        })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) created.push(rows[0].id);
+  });
+
+  it('partner scope can SELECT back its own partner-wide template', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerTemplate(partner.id);
+
+    const visible = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .select({ id: clientAiPromptTemplates.id })
+        .from(clientAiPromptTemplates)
+        .where(eq(clientAiPromptTemplates.partnerId, partner.id)),
+    );
+
+    expect(visible.map((r) => r.id)).toContain(id);
+  });
+
+  it('a different partner can neither see nor forge a template attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerTemplate(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .select({ id: clientAiPromptTemplates.id })
+        .from(clientAiPromptTemplates)
+        .where(eq(clientAiPromptTemplates.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // WITH CHECK denies the forge. Drizzle wraps the driver error, so the RLS
+    // signal is Postgres code 42501 on the cause (custom-fields-rls precedent).
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(clientAiPromptTemplates)
+          .values({ orgId: null, partnerId: partnerA.id, name: 'Forged', promptBody: 'x' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('org scope can INSERT and SELECT an org-scoped template', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(clientAiPromptTemplates)
+        .values({ orgId: org.id, partnerId: null, name: 'Org template', promptBody: 'y' })
+        .returning(),
+    );
+    if (inserted[0]) created.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: clientAiPromptTemplates.id })
+        .from(clientAiPromptTemplates)
+        .where(eq(clientAiPromptTemplates.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide template', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerTemplate(partner.id, false);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(clientAiPromptTemplates)
+        .set({ name: 'Renamed' })
+        .where(eq(clientAiPromptTemplates.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.name).toBe('Renamed');
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .delete(clientAiPromptTemplates)
+        .where(eq(clientAiPromptTemplates.id, id))
+        .returning(),
+    );
+    expect(deleted).toHaveLength(1);
+  });
+
+  it('a different partner UPDATE/DELETE silently match zero rows', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerTemplate(partnerA.id);
+
+    const updatedByB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .update(clientAiPromptTemplates)
+        .set({ name: 'Hijacked' })
+        .where(eq(clientAiPromptTemplates.id, id))
+        .returning(),
+    );
+    expect(updatedByB).toEqual([]);
+
+    const deletedByB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .delete(clientAiPromptTemplates)
+        .where(eq(clientAiPromptTemplates.id, id))
+        .returning(),
+    );
+    expect(deletedByB).toEqual([]);
+  });
+
+  it('stays fail-closed without a DB access context (scope "none")', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerTemplate(partner.id);
+
+    const rows = await db
+      .select({ id: clientAiPromptTemplates.id })
+      .from(clientAiPromptTemplates)
+      .where(eq(clientAiPromptTemplates.id, id));
+
+    expect(rows).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it (test stack must be up from Task 4)**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run --config vitest.integration.config.ts src/__tests__/integration/client-ai-templates-rls.integration.test.ts
+```
+
+Expected: 7 tests PASS. (If the test DB predates the migration: `pnpm test:docker:down && pnpm test:docker:up` — setup re-runs autoMigrate.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/client-ai-templates-rls.integration.test.ts
+git commit -m "test(client-ai): functional breeze_app dual-axis RLS test for prompt templates" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Env plumbing — CLIENT_AI_ENTRA_CLIENT_ID
+
+**Files:**
+- Modify: apps/api/src/config/env.ts (near `M365_ENABLED`, ~line 18)
+- Modify: .env.example (after the "AI Brain (BYOK)" block, ~line 174)
+
+- [ ] **Step 1: Add the export to `apps/api/src/config/env.ts`**
+
+Insert after the `M365_ENABLED` block:
+
+```ts
+// Breeze AI for Office (Excel add-in / client AI). The Entra application
+// (client) ID of the multi-tenant add-in app registration. Empty = the whole
+// /client-ai surface is dark (exchange and admin routes return 404), mirroring
+// the M365_ENABLED gating style.
+export const CLIENT_AI_ENTRA_CLIENT_ID = process.env.CLIENT_AI_ENTRA_CLIENT_ID?.trim() ?? '';
+```
+
+- [ ] **Step 2: Add the placeholder to `.env.example`**
+
+Insert after the `ANTHROPIC_API_KEY=` line (keep the generic placeholder — NEVER a real value):
+
+```bash
+# --------------------------------------------
+# Breeze AI for Office (Excel add-in)
+# --------------------------------------------
+# Entra application (client) ID of the multi-tenant add-in app registration.
+# Leave empty to disable the /client-ai surface entirely.
+CLIENT_AI_ENTRA_CLIENT_ID=
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+grep -n "CLIENT_AI_ENTRA_CLIENT_ID" /Users/toddhebebrand/breeze/.env.example
+```
+
+Expected: tsc clean (modulo pre-existing), grep hits the new placeholder line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/config/env.ts .env.example
+git commit -m "feat(client-ai): CLIENT_AI_ENTRA_CLIENT_ID env plumbing" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Entra ID token verification service (TDD)
+
+Mirrors `services/cfAccessJwt.ts` (the repo's only remote-JWKS user-token verifier) including its error taxonomy and JWKS caching, with one Entra-specific twist: the v2.0 issuer is **per-tenant** (`https://login.microsoftonline.com/{tid}/v2.0`), so we verify signature+audience first against Microsoft's common JWKS, then bind `iss` to the token's own `tid` claim.
+
+**Files:**
+- Create: apps/api/src/services/clientAiEntraJwt.ts
+- Test: apps/api/src/services/clientAiEntraJwt.test.ts
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/services/clientAiEntraJwt.test.ts` (JWKS mocking idiom copied from `cfAccessJwt.test.ts`):
+
+```ts
+import { randomUUID } from 'crypto';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const jwksState = vi.hoisted(() => ({
+  importedPublicKey: undefined as unknown,
+}));
+
+vi.mock('jose', async () => {
+  const actual = await vi.importActual<typeof import('jose')>('jose');
+  return {
+    ...actual,
+    jwtVerify: vi.fn(actual.jwtVerify),
+    createRemoteJWKSet: vi.fn(
+      () => async () => jwksState.importedPublicKey as Awaited<ReturnType<typeof actual.importJWK>>
+    ),
+  };
+});
+
+import {
+  exportJWK,
+  generateKeyPair,
+  importJWK,
+  jwtVerify,
+  SignJWT,
+  type JWK,
+} from 'jose';
+import {
+  ClientAiEntraInvalidTokenError,
+  ClientAiEntraJwksUnavailableError,
+  _resetClientAiEntraJwksCacheForTests,
+  verifyEntraIdToken,
+} from './clientAiEntraJwt';
+
+interface RsaKeypair {
+  privateJwk: JWK;
+  publicJwk: JWK;
+  kid: string;
+}
+
+async function generateRsaKeypair(): Promise<RsaKeypair> {
+  const { privateKey, publicKey } = await generateKeyPair('RS256', {
+    modulusLength: 2048,
+    extractable: true,
+  });
+  const kid = randomUUID();
+  return {
+    privateJwk: { ...(await exportJWK(privateKey)), kid, alg: 'RS256', use: 'sig' },
+    publicJwk: { ...(await exportJWK(publicKey)), kid, alg: 'RS256', use: 'sig' },
+    kid,
+  };
+}
+
+const audience = '00000000-aaaa-bbbb-cccc-000000000001';
+const tid = '6f4f4f4f-1111-4222-8333-444455556666';
+const oid = '7a7a7a7a-2222-4333-8444-555566667777';
+const issuer = `https://login.microsoftonline.com/${tid}/v2.0`;
+
+let keypair: RsaKeypair;
+
+async function mintEntraToken(
+  claims: Record<string, unknown>,
+  opts: {
+    issuer?: string;
+    audience?: string;
+    ttlSeconds?: number;
+    signerKey?: JWK;
+    signerKid?: string;
+  } = {}
+): Promise<string> {
+  const signerJwk = opts.signerKey ?? keypair.privateJwk;
+  const signerKid = opts.signerKid ?? keypair.kid;
+  const key = await importJWK(signerJwk, 'RS256');
+
+  const builder = new SignJWT(claims)
+    .setProtectedHeader({ alg: 'RS256', kid: signerKid })
+    .setIssuer(opts.issuer ?? issuer)
+    .setAudience(opts.audience ?? audience)
+    .setIssuedAt();
+
+  if (opts.ttlSeconds !== 0) {
+    builder.setExpirationTime(`${opts.ttlSeconds ?? 600}s`);
+  }
+
+  return builder.sign(key);
+}
+
+describe('verifyEntraIdToken', () => {
+  beforeAll(async () => {
+    keypair = await generateRsaKeypair();
+    jwksState.importedPublicKey = await importJWK(keypair.publicJwk, 'RS256');
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetClientAiEntraJwksCacheForTests();
+  });
+
+  it('accepts a valid token and returns normalized claims', async () => {
+    const token = await mintEntraToken({
+      tid,
+      oid,
+      preferred_username: 'Finance.User@Contoso.com',
+      name: 'Finance User',
+    });
+
+    const claims = await verifyEntraIdToken(token, { audience });
+
+    expect(claims.tid).toBe(tid);
+    expect(claims.oid).toBe(oid);
+    expect(claims.email).toBe('finance.user@contoso.com');
+    expect(claims.name).toBe('Finance User');
+    expect(claims.iss).toBe(issuer);
+    expect(typeof claims.exp).toBe('number');
+  });
+
+  it('falls back to the email claim when preferred_username is not an address', async () => {
+    const token = await mintEntraToken({
+      tid,
+      oid,
+      preferred_username: 'CONTOSO\\finance.user',
+      email: 'Finance.User@Contoso.com',
+    });
+
+    const claims = await verifyEntraIdToken(token, { audience });
+    expect(claims.email).toBe('finance.user@contoso.com');
+  });
+
+  it('returns null email when no usable address claim exists', async () => {
+    const token = await mintEntraToken({ tid, oid });
+    const claims = await verifyEntraIdToken(token, { audience });
+    expect(claims.email).toBeNull();
+  });
+
+  it('rejects a token signed by a different key (forged signature)', async () => {
+    const attacker = await generateRsaKeypair();
+    const token = await mintEntraToken(
+      { tid, oid },
+      { signerKey: attacker.privateJwk, signerKid: attacker.kid }
+    );
+
+    await expect(verifyEntraIdToken(token, { audience })).rejects.toBeInstanceOf(
+      ClientAiEntraInvalidTokenError
+    );
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    const token = await mintEntraToken({ tid, oid }, { audience: 'some-other-app' });
+
+    await expect(verifyEntraIdToken(token, { audience })).rejects.toBeInstanceOf(
+      ClientAiEntraInvalidTokenError
+    );
+  });
+
+  it('rejects an expired token', async () => {
+    const token = await mintEntraToken({ tid, oid }, { ttlSeconds: -60 });
+
+    await expect(verifyEntraIdToken(token, { audience })).rejects.toBeInstanceOf(
+      ClientAiEntraInvalidTokenError
+    );
+  });
+
+  it('rejects a token whose issuer does not match its own tid (tenant spoof)', async () => {
+    const otherTid = '9b9b9b9b-3333-4444-8555-666677778888';
+    const token = await mintEntraToken(
+      { tid, oid },
+      { issuer: `https://login.microsoftonline.com/${otherTid}/v2.0` }
+    );
+
+    await expect(verifyEntraIdToken(token, { audience })).rejects.toBeInstanceOf(
+      ClientAiEntraInvalidTokenError
+    );
+  });
+
+  it('rejects a token missing the tid claim', async () => {
+    const token = await mintEntraToken({ oid });
+
+    await expect(verifyEntraIdToken(token, { audience })).rejects.toBeInstanceOf(
+      ClientAiEntraInvalidTokenError
+    );
+  });
+
+  it('rejects a token with a malformed oid claim', async () => {
+    const token = await mintEntraToken({ tid, oid: 'not-a-guid' });
+
+    await expect(verifyEntraIdToken(token, { audience })).rejects.toBeInstanceOf(
+      ClientAiEntraInvalidTokenError
+    );
+  });
+
+  it('surfaces ClientAiEntraJwksUnavailableError when the JWKS fetch fails', async () => {
+    vi.mocked(jwtVerify).mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    await expect(verifyEntraIdToken('any-token', { audience })).rejects.toBeInstanceOf(
+      ClientAiEntraJwksUnavailableError
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiEntraJwt.test.ts`
+Expected: FAIL with `Cannot find module './clientAiEntraJwt'` (or equivalent resolution error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/api/src/services/clientAiEntraJwt.ts`:
+
+```ts
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyResult,
+} from 'jose';
+
+/**
+ * Entra ID (Azure AD) access-token verification for Breeze AI for Office.
+ *
+ * The Excel add-in acquires a token via Office SSO / NAA in the END CUSTOMER's
+ * tenant and posts it to POST /client-ai/auth/exchange (spec §3). This service
+ * verifies it:
+ *
+ *   - signature against Microsoft's COMMON JWKS (multi-tenant app — keys are
+ *     shared across tenants, the issuer is not),
+ *   - audience pinned to our app registration (CLIENT_AI_ENTRA_CLIENT_ID),
+ *   - expiry / algorithm via jose,
+ *   - issuer bound to the token's OWN tid claim
+ *     (https://login.microsoftonline.com/{tid}/v2.0) — prevents a token from
+ *     tenant A presenting itself as tenant B, which would be a cross-org
+ *     mapping bypass.
+ *
+ * Modeled on services/cfAccessJwt.ts (error taxonomy, JWKS caching, test
+ * seams). Distinct from services/c2cM365.ts, which is client-credentials
+ * APP-token acquisition, not user-token verification.
+ */
+
+export interface ClientAiEntraClaims {
+  /** Entra tenant id (GUID, lowercased). */
+  tid: string;
+  /** Entra object id of the user within the tenant (GUID, lowercased). */
+  oid: string;
+  /** Best-effort email (preferred_username when address-shaped, else email claim), lowercased. */
+  email: string | null;
+  /** Display name when present. */
+  name: string | null;
+  aud: string | string[];
+  iss: string;
+  exp: number;
+  iat: number;
+}
+
+export class ClientAiEntraJwksUnavailableError extends Error {
+  override readonly name = 'ClientAiEntraJwksUnavailableError';
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+  }
+}
+
+export class ClientAiEntraInvalidTokenError extends Error {
+  override readonly name = 'ClientAiEntraInvalidTokenError';
+  constructor(message: string, readonly code?: string) {
+    super(message);
+  }
+}
+
+const ENTRA_COMMON_JWKS_URL = 'https://login.microsoftonline.com/common/discovery/v2.0/keys';
+const ENTRA_GUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ALLOWED_ALGS = ['RS256'] as const;
+
+let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJwks(): ReturnType<typeof createRemoteJWKSet> {
+  if (cachedJwks === null) {
+    cachedJwks = createRemoteJWKSet(new URL(ENTRA_COMMON_JWKS_URL), {
+      cacheMaxAge: 10 * 60 * 1000, // 10 minutes; jose refreshes on `kid` miss
+      cooldownDuration: 30 * 1000,
+    });
+  }
+  return cachedJwks;
+}
+
+/** Test-only: reset the JWKS cache so a subsequent call rebuilds it. */
+export function _resetClientAiEntraJwksCacheForTests(): void {
+  cachedJwks = null;
+}
+
+function invalid(message: string, code = 'ERR_JWT_CLAIM_VALIDATION_FAILED'): never {
+  throw new ClientAiEntraInvalidTokenError(message, code);
+}
+
+export async function verifyEntraIdToken(
+  token: string,
+  config: { audience: string },
+): Promise<ClientAiEntraClaims> {
+  let result: JWTVerifyResult;
+  try {
+    result = await jwtVerify(token, getJwks(), {
+      audience: config.audience,
+      algorithms: [...ALLOWED_ALGS],
+      // No `issuer` option: the v2.0 issuer is per-tenant and we don't know the
+      // tenant until we read the (signature-verified) tid claim below.
+      requiredClaims: ['exp', 'iat', 'aud', 'iss', 'tid', 'oid'],
+    });
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    const isJoseError = typeof code === 'string' && code.startsWith('ERR_');
+    if (!isJoseError) {
+      // No jose ERR_* code => network/IO problem reaching the JWKS endpoint.
+      // Distinct type so the exchange route can 503 instead of 401.
+      throw new ClientAiEntraJwksUnavailableError(
+        `Failed to verify Entra ID token: ${(err as Error).message ?? 'unknown error'}`,
+        err,
+      );
+    }
+    throw new ClientAiEntraInvalidTokenError(`Entra ID token rejected: ${code}`, code);
+  }
+
+  const payload = result.payload as JWTPayload & {
+    tid?: unknown;
+    oid?: unknown;
+    preferred_username?: unknown;
+    email?: unknown;
+    name?: unknown;
+  };
+
+  const tid = typeof payload.tid === 'string' ? payload.tid.toLowerCase() : '';
+  const oid = typeof payload.oid === 'string' ? payload.oid.toLowerCase() : '';
+  if (!ENTRA_GUID_REGEX.test(tid)) invalid('Entra ID token missing a valid tid claim');
+  if (!ENTRA_GUID_REGEX.test(oid)) invalid('Entra ID token missing a valid oid claim');
+
+  // Signature is already proven against Microsoft's common JWKS; binding iss to
+  // the token's own tid closes the cross-tenant spoof.
+  const expectedIssuer = `https://login.microsoftonline.com/${tid}/v2.0`;
+  if (payload.iss !== expectedIssuer) {
+    invalid(`Entra ID token issuer mismatch (expected ${expectedIssuer})`);
+  }
+
+  const preferred =
+    typeof payload.preferred_username === 'string' && payload.preferred_username.includes('@')
+      ? payload.preferred_username.toLowerCase()
+      : null;
+  const emailClaim =
+    typeof payload.email === 'string' && payload.email.includes('@')
+      ? payload.email.toLowerCase()
+      : null;
+
+  return {
+    tid,
+    oid,
+    email: preferred ?? emailClaim,
+    name: typeof payload.name === 'string' ? payload.name : null,
+    aud: payload.aud as string | string[],
+    iss: payload.iss as string,
+    exp: payload.exp as number,
+    iat: payload.iat as number,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiEntraJwt.test.ts`
+Expected: 11 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiEntraJwt.ts apps/api/src/services/clientAiEntraJwt.test.ts
+git commit -m "feat(client-ai): Entra ID token verification service (common JWKS, tid-bound issuer)" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Policy service — clientAiPolicy.ts (TDD)
+
+**Files:**
+- Create: apps/api/src/services/clientAiPolicy.ts
+- Test: apps/api/src/services/clientAiPolicy.test.ts
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/services/clientAiPolicy.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { dbSelectMock } = vi.hoisted(() => ({
+  dbSelectMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: { select: dbSelectMock },
+}));
+
+import {
+  defaultClientAiPolicy,
+  getOrgPolicy,
+  isClientUserPermitted,
+  requireClientAiEnabled,
+} from './clientAiPolicy';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const USER_A = 'aaaaaaaa-1111-4222-8333-444455556666';
+const USER_B = 'bbbbbbbb-1111-4222-8333-444455556666';
+
+function mockPolicyRow(row: object | undefined) {
+  dbSelectMock.mockImplementation(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(() => Promise.resolve(row ? [row] : [])),
+      })),
+    })),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('defaultClientAiPolicy', () => {
+  it('is disabled with anthropic-only providers and sane limits', () => {
+    const policy = defaultClientAiPolicy(ORG_ID);
+    expect(policy).toMatchObject({
+      orgId: ORG_ID,
+      enabled: false,
+      userAccess: 'all',
+      selectedUserIds: [],
+      allowedProviders: ['anthropic'],
+      allowedModels: [],
+      writeMode: 'readwrite',
+      dlpConfig: {},
+      dailyBudgetCents: null,
+      monthlyBudgetCents: null,
+      perUserMessagesPerMinute: 10,
+      orgMessagesPerHour: 500,
+      retentionDays: null,
+      branding: {},
+    });
+  });
+});
+
+describe('getOrgPolicy', () => {
+  it('returns the disabled default when no row exists', async () => {
+    mockPolicyRow(undefined);
+    const policy = await getOrgPolicy(ORG_ID);
+    expect(policy.enabled).toBe(false);
+    expect(policy.orgId).toBe(ORG_ID);
+  });
+
+  it('normalizes a stored row (jsonb columns coerced defensively)', async () => {
+    mockPolicyRow({
+      orgId: ORG_ID,
+      enabled: true,
+      userAccess: 'selected',
+      selectedUserIds: [USER_A],
+      allowedProviders: ['anthropic'],
+      allowedModels: ['claude-sonnet-4-5-20250929'],
+      writeMode: 'readonly',
+      dlpConfig: { creditCards: 'redact' },
+      dailyBudgetCents: 500,
+      monthlyBudgetCents: 10000,
+      perUserMessagesPerMinute: 5,
+      orgMessagesPerHour: 100,
+      retentionDays: 90,
+      branding: { displayName: 'Acme IT' },
+    });
+
+    const policy = await getOrgPolicy(ORG_ID);
+    expect(policy.enabled).toBe(true);
+    expect(policy.userAccess).toBe('selected');
+    expect(policy.selectedUserIds).toEqual([USER_A]);
+    expect(policy.writeMode).toBe('readonly');
+    expect(policy.dailyBudgetCents).toBe(500);
+    expect(policy.retentionDays).toBe(90);
+    expect(policy.branding).toEqual({ displayName: 'Acme IT' });
+  });
+
+  it('falls back to safe values when jsonb columns hold non-array garbage', async () => {
+    mockPolicyRow({
+      orgId: ORG_ID,
+      enabled: true,
+      userAccess: 'all',
+      selectedUserIds: 'not-an-array',
+      allowedProviders: null,
+      allowedModels: 42,
+      writeMode: 'readwrite',
+      dlpConfig: null,
+      dailyBudgetCents: null,
+      monthlyBudgetCents: null,
+      perUserMessagesPerMinute: 10,
+      orgMessagesPerHour: 500,
+      retentionDays: null,
+      branding: null,
+    });
+
+    const policy = await getOrgPolicy(ORG_ID);
+    expect(policy.selectedUserIds).toEqual([]);
+    expect(policy.allowedProviders).toEqual(['anthropic']);
+    expect(policy.allowedModels).toEqual([]);
+    expect(policy.dlpConfig).toEqual({});
+    expect(policy.branding).toEqual({});
+  });
+});
+
+describe('isClientUserPermitted', () => {
+  it('permits everyone under userAccess=all', () => {
+    const policy = { ...defaultClientAiPolicy(ORG_ID), enabled: true };
+    expect(isClientUserPermitted(policy, USER_A)).toBe(true);
+  });
+
+  it('enforces the selected list under userAccess=selected', () => {
+    const policy = {
+      ...defaultClientAiPolicy(ORG_ID),
+      enabled: true,
+      userAccess: 'selected' as const,
+      selectedUserIds: [USER_A],
+    };
+    expect(isClientUserPermitted(policy, USER_A)).toBe(true);
+    expect(isClientUserPermitted(policy, USER_B)).toBe(false);
+  });
+});
+
+describe('requireClientAiEnabled', () => {
+  it('returns the policy when enabled', async () => {
+    mockPolicyRow({ ...defaultClientAiPolicy(ORG_ID), enabled: true });
+    const policy = await requireClientAiEnabled(ORG_ID);
+    expect(policy?.enabled).toBe(true);
+  });
+
+  it('returns null when disabled or absent', async () => {
+    mockPolicyRow(undefined);
+    expect(await requireClientAiEnabled(ORG_ID)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiPolicy.test.ts`
+Expected: FAIL with module-not-found for `./clientAiPolicy`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/api/src/services/clientAiPolicy.ts`:
+
+```ts
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { clientAiOrgPolicies } from '../db/schema/clientAi';
+
+/**
+ * Per-org policy for Breeze AI for Office (spec §7).
+ *
+ * One row per org in client_ai_org_policies; ABSENCE of a row means
+ * "disabled, defaults" — defaultClientAiPolicy() materialises that so callers
+ * never branch on null. Deliberately separate from the technician AI budget
+ * knobs so the two products never interfere.
+ *
+ * Callers must already be inside a DB access context that can see the org's
+ * row (request path: clientAiAuthMiddleware / authMiddleware; pre-auth
+ * exchange path: withSystemDbAccessContext).
+ */
+
+export interface ClientAiOrgPolicy {
+  orgId: string;
+  enabled: boolean;
+  userAccess: 'all' | 'selected';
+  /** portal_users UUIDs permitted when userAccess === 'selected'. */
+  selectedUserIds: string[];
+  allowedProviders: string[];
+  /** Empty = all models of the allowed providers (provider defaults). */
+  allowedModels: string[];
+  writeMode: 'readwrite' | 'readonly';
+  dlpConfig: Record<string, unknown>;
+  dailyBudgetCents: number | null;
+  monthlyBudgetCents: number | null;
+  perUserMessagesPerMinute: number;
+  orgMessagesPerHour: number;
+  retentionDays: number | null;
+  branding: Record<string, unknown>;
+}
+
+export function defaultClientAiPolicy(orgId: string): ClientAiOrgPolicy {
+  return {
+    orgId,
+    enabled: false,
+    userAccess: 'all',
+    selectedUserIds: [],
+    allowedProviders: ['anthropic'],
+    allowedModels: [],
+    writeMode: 'readwrite',
+    dlpConfig: {},
+    dailyBudgetCents: null,
+    monthlyBudgetCents: null,
+    perUserMessagesPerMinute: 10,
+    orgMessagesPerHour: 500,
+    retentionDays: null,
+    branding: {},
+  };
+}
+
+function asStringArray(value: unknown, fallback: string[]): string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string')
+    ? (value as string[])
+    : fallback;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export async function getOrgPolicy(orgId: string): Promise<ClientAiOrgPolicy> {
+  const [row] = await db
+    .select()
+    .from(clientAiOrgPolicies)
+    .where(eq(clientAiOrgPolicies.orgId, orgId))
+    .limit(1);
+
+  if (!row) return defaultClientAiPolicy(orgId);
+
+  const defaults = defaultClientAiPolicy(orgId);
+  return {
+    orgId,
+    enabled: row.enabled === true,
+    userAccess: row.userAccess === 'selected' ? 'selected' : 'all',
+    selectedUserIds: asStringArray(row.selectedUserIds, defaults.selectedUserIds),
+    allowedProviders: asStringArray(row.allowedProviders, defaults.allowedProviders),
+    allowedModels: asStringArray(row.allowedModels, defaults.allowedModels),
+    writeMode: row.writeMode === 'readonly' ? 'readonly' : 'readwrite',
+    dlpConfig: asRecord(row.dlpConfig),
+    dailyBudgetCents: row.dailyBudgetCents ?? null,
+    monthlyBudgetCents: row.monthlyBudgetCents ?? null,
+    perUserMessagesPerMinute: row.perUserMessagesPerMinute ?? defaults.perUserMessagesPerMinute,
+    orgMessagesPerHour: row.orgMessagesPerHour ?? defaults.orgMessagesPerHour,
+    retentionDays: row.retentionDays ?? null,
+    branding: asRecord(row.branding),
+  };
+}
+
+export function isClientUserPermitted(policy: ClientAiOrgPolicy, clientUserId: string): boolean {
+  if (policy.userAccess === 'all') return true;
+  return policy.selectedUserIds.includes(clientUserId);
+}
+
+/** Returns the policy when the product is enabled for the org, else null. */
+export async function requireClientAiEnabled(orgId: string): Promise<ClientAiOrgPolicy | null> {
+  const policy = await getOrgPolicy(orgId);
+  return policy.enabled ? policy : null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiPolicy.test.ts`
+Expected: 9 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiPolicy.ts apps/api/src/services/clientAiPolicy.test.ts
+git commit -m "feat(client-ai): per-org policy service with disabled-by-default semantics" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: POST /client-ai/auth/exchange (TDD)
+
+The token-exchange endpoint (spec §3): Entra token in → tenant mapping → policy gate → portal-user upsert → Redis-backed bearer session out. Pre-auth route (no auth middleware), so all DB work runs under `withSystemDbAccessContext` — in ONE block of fast queries, with Redis work OUTSIDE it (#1105 pool-poison lesson).
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/schemas.ts
+- Create: apps/api/src/routes/clientAi/auth.ts
+- Test: apps/api/src/routes/clientAi/auth.test.ts
+
+- [ ] **Step 1: Create `apps/api/src/routes/clientAi/schemas.ts`** (shared constants/types — needed by the test's imports)
+
+```ts
+import { z } from 'zod';
+import type { ClientAiOrgPolicy } from '../../services/clientAiPolicy';
+
+// ============================================
+// Constants (mirrors routes/portal/schemas.ts)
+// ============================================
+
+/** Add-in sessions are 24h Redis-backed bearer tokens, org-bound (spec §3). */
+export const CLIENT_AI_SESSION_TTL_MS = 1000 * 60 * 60 * 24;
+export const CLIENT_AI_SESSION_TTL_SECONDS = Math.floor(CLIENT_AI_SESSION_TTL_MS / 1000);
+
+export const CLIENT_AI_REDIS_KEYS = {
+  session: (token: string) => `clientai:session:${token}`,
+  userSessions: (portalUserId: string) => `clientai:user-sessions:${portalUserId}`,
+};
+
+/** Per-IP exchange rate limit (rateLimiter sliding window). */
+export const EXCHANGE_RATE_LIMIT = { limit: 20, windowSeconds: 300 } as const;
+
+/** Same shape as services/c2cM365.ts M365_TENANT_ID_REGEX / the SQL CHECK. */
+export const ENTRA_TENANT_GUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ============================================
+// Zod schemas
+// ============================================
+
+export const exchangeSchema = z.object({
+  /** Entra ID access token from Office SSO / NAA. */
+  accessToken: z.string().min(1).max(8192),
+});
+
+export const putTenantMappingSchema = z.object({
+  entraTenantId: z
+    .string()
+    .regex(ENTRA_TENANT_GUID_REGEX, 'must be an Entra tenant GUID (Directory ID)'),
+});
+
+export const putPolicySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    userAccess: z.enum(['all', 'selected']).optional(),
+    selectedUserIds: z.array(z.string().uuid()).max(1000).optional(),
+    allowedProviders: z.array(z.string().min(1).max(50)).min(1).max(10).optional(),
+    allowedModels: z.array(z.string().min(1).max(100)).max(50).optional(),
+    writeMode: z.enum(['readwrite', 'readonly']).optional(),
+    dlpConfig: z.record(z.unknown()).optional(),
+    dailyBudgetCents: z.number().int().min(0).nullable().optional(),
+    monthlyBudgetCents: z.number().int().min(0).nullable().optional(),
+    perUserMessagesPerMinute: z.number().int().min(1).max(600).optional(),
+    orgMessagesPerHour: z.number().int().min(1).max(100000).optional(),
+    retentionDays: z.number().int().min(1).max(3650).nullable().optional(),
+    branding: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+// ============================================
+// Types
+// ============================================
+
+export type ClientAiSessionPayload = {
+  portalUserId: string;
+  orgId: string;
+  createdAt: string;
+};
+
+export type ClientAiAuthContext = {
+  clientUserId: string;
+  orgId: string;
+  email: string;
+  name: string | null;
+  token: string;
+};
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    clientAiAuth: ClientAiAuthContext;
+    clientAiPolicy: ClientAiOrgPolicy;
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`apps/api/src/routes/clientAi/auth.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// ── Mocks (vi.mock factories are hoisted — literals only) ────────────────────
+
+const {
+  verifyMock,
+  dbSelectMock,
+  dbInsertMock,
+  dbUpdateMock,
+  redisMock,
+  getRedisMock,
+  rateLimiterMock,
+  writeAuditEventMock,
+  getOrgPolicyMock,
+} = vi.hoisted(() => {
+  const redis = {
+    setex: vi.fn(() => Promise.resolve('OK')),
+    sadd: vi.fn(() => Promise.resolve(1)),
+    expire: vi.fn(() => Promise.resolve(1)),
+  };
+  return {
+    verifyMock: vi.fn(),
+    dbSelectMock: vi.fn(),
+    dbInsertMock: vi.fn(),
+    dbUpdateMock: vi.fn(),
+    redisMock: redis,
+    getRedisMock: vi.fn(() => redis),
+    rateLimiterMock: vi.fn(() =>
+      Promise.resolve({ allowed: true, remaining: 19, resetAt: new Date() })
+    ),
+    writeAuditEventMock: vi.fn(),
+    getOrgPolicyMock: vi.fn(),
+  };
+});
+
+vi.mock('../../config/env', () => ({
+  CLIENT_AI_ENTRA_CLIENT_ID: '00000000-aaaa-bbbb-cccc-000000000001',
+}));
+
+vi.mock('../../services/clientAiEntraJwt', () => {
+  class ClientAiEntraInvalidTokenError extends Error {}
+  class ClientAiEntraJwksUnavailableError extends Error {}
+  return {
+    verifyEntraIdToken: verifyMock,
+    ClientAiEntraInvalidTokenError,
+    ClientAiEntraJwksUnavailableError,
+  };
+});
+
+vi.mock('../../db', () => ({
+  db: { select: dbSelectMock, insert: dbInsertMock, update: dbUpdateMock },
+  withSystemDbAccessContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: getRedisMock }));
+vi.mock('../../services/rate-limit', () => ({ rateLimiter: rateLimiterMock }));
+vi.mock('../../services/clientIp', () => ({ getTrustedClientIp: vi.fn(() => '203.0.113.7') }));
+vi.mock('../../services/auditEvents', () => ({ writeAuditEvent: writeAuditEventMock }));
+vi.mock('../../services/clientAiPolicy', () => ({
+  getOrgPolicy: getOrgPolicyMock,
+  isClientUserPermitted: (
+    policy: { userAccess: string; selectedUserIds: string[] },
+    id: string
+  ) => policy.userAccess === 'all' || policy.selectedUserIds.includes(id),
+}));
+
+import { clientAiAuthRoutes } from './auth';
+import {
+  ClientAiEntraInvalidTokenError,
+  ClientAiEntraJwksUnavailableError,
+} from '../../services/clientAiEntraJwt';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const PORTAL_USER_ID = 'beefbeef-1111-4222-8333-444455556666';
+const TID = '6f4f4f4f-1111-4222-8333-444455556666';
+const OID = '7a7a7a7a-2222-4333-8444-555566667777';
+
+const CLAIMS = {
+  tid: TID,
+  oid: OID,
+  email: 'finance.user@contoso.com',
+  name: 'Finance User',
+  aud: '00000000-aaaa-bbbb-cccc-000000000001',
+  iss: `https://login.microsoftonline.com/${TID}/v2.0`,
+  exp: Math.floor(Date.now() / 1000) + 600,
+  iat: Math.floor(Date.now() / 1000),
+};
+
+const MAPPING_ROW = { id: 'a1a1a1a1-1111-4222-8333-444455556666', orgId: ORG_ID, entraTenantId: TID };
+const USER_ROW = {
+  id: PORTAL_USER_ID,
+  orgId: ORG_ID,
+  email: 'finance.user@contoso.com',
+  name: 'Finance User',
+  status: 'active',
+};
+
+const ENABLED_POLICY = {
+  orgId: ORG_ID,
+  enabled: true,
+  userAccess: 'all',
+  selectedUserIds: [] as string[],
+};
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve(rows)) })),
+    })),
+  };
+}
+
+/** call 1 = tenant mapping lookup, call 2 = portal user lookup. */
+function setupDb({ mapping, user }: { mapping: object | null; user: object | null }) {
+  let call = 0;
+  dbSelectMock.mockImplementation(() => {
+    call++;
+    if (call === 1) return selectChain(mapping ? [mapping] : []);
+    return selectChain(user ? [user] : []);
+  });
+  dbInsertMock.mockImplementation(() => ({
+    values: vi.fn(() => ({
+      returning: vi.fn(() => Promise.resolve([{ ...USER_ROW }])),
+    })),
+  }));
+  dbUpdateMock.mockImplementation(() => ({
+    set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+  }));
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.route('/client-ai', clientAiAuthRoutes);
+  return app;
+}
+
+function postExchange(app: Hono, accessToken = 'entra-token') {
+  return app.request('/client-ai/auth/exchange', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accessToken }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRedisMock.mockReturnValue(redisMock);
+  rateLimiterMock.mockResolvedValue({ allowed: true, remaining: 19, resetAt: new Date() });
+  verifyMock.mockResolvedValue(CLAIMS);
+  getOrgPolicyMock.mockResolvedValue({ ...ENABLED_POLICY });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /client-ai/auth/exchange', () => {
+  it('401s on an invalid Entra token', async () => {
+    verifyMock.mockRejectedValue(new ClientAiEntraInvalidTokenError('bad'));
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'invalid_token' });
+  });
+
+  it('503s when Microsoft JWKS is unreachable', async () => {
+    verifyMock.mockRejectedValue(new ClientAiEntraJwksUnavailableError('down'));
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(503);
+  });
+
+  it('429s when the per-IP rate limit is exhausted', async () => {
+    rateLimiterMock.mockResolvedValue({ allowed: false, remaining: 0, resetAt: new Date() });
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(429);
+  });
+
+  it('404s with tenant_not_provisioned when no mapping exists, and audits the denial', async () => {
+    setupDb({ mapping: null, user: null });
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'tenant_not_provisioned' });
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'client_ai.auth.exchange',
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'tenant_not_provisioned', tid: TID }),
+      })
+    );
+  });
+
+  it('403s with disabled when the org policy is off', async () => {
+    setupDb({ mapping: MAPPING_ROW, user: USER_ROW });
+    getOrgPolicyMock.mockResolvedValue({ ...ENABLED_POLICY, enabled: false });
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'disabled' });
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ result: 'denied', orgId: ORG_ID })
+    );
+  });
+
+  it('403s with user_not_permitted under userAccess=selected when the user is not listed', async () => {
+    setupDb({ mapping: MAPPING_ROW, user: USER_ROW });
+    getOrgPolicyMock.mockResolvedValue({
+      ...ENABLED_POLICY,
+      userAccess: 'selected',
+      selectedUserIds: ['ffffffff-1111-4222-8333-444455556666'],
+    });
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'user_not_permitted' });
+  });
+
+  it('403s when the portal user is not active', async () => {
+    setupDb({ mapping: MAPPING_ROW, user: { ...USER_ROW, status: 'disabled' } });
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'account_inactive' });
+  });
+
+  it('mints a clientai: Redis session for an existing user and audits success', async () => {
+    setupDb({ mapping: MAPPING_ROW, user: USER_ROW });
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(typeof body.accessToken).toBe('string');
+    expect(body.accessToken.length).toBeGreaterThanOrEqual(32);
+    expect(body.expiresInSeconds).toBe(86400);
+    expect(body.user).toEqual({
+      id: PORTAL_USER_ID,
+      email: 'finance.user@contoso.com',
+      name: 'Finance User',
+    });
+
+    expect(redisMock.setex).toHaveBeenCalledWith(
+      `clientai:session:${body.accessToken}`,
+      86400,
+      expect.stringContaining(PORTAL_USER_ID)
+    );
+    expect(dbInsertMock).not.toHaveBeenCalled();
+    expect(dbUpdateMock).toHaveBeenCalled(); // lastLoginAt refresh
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'client_ai.auth.exchange',
+        result: 'success',
+        orgId: ORG_ID,
+        actorId: PORTAL_USER_ID,
+      })
+    );
+  });
+
+  it('auto-provisions a portal user (authMethod=entra) on first exchange', async () => {
+    setupDb({ mapping: MAPPING_ROW, user: null });
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(200);
+
+    expect(dbInsertMock).toHaveBeenCalled();
+    const valuesFn = dbInsertMock.mock.results[0]!.value.values;
+    expect(valuesFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: ORG_ID,
+        email: 'finance.user@contoso.com',
+        entraOid: OID,
+        entraTenantId: TID,
+        authMethod: 'entra',
+        passwordHash: null,
+      })
+    );
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        result: 'success',
+        details: expect.objectContaining({ provisioned: true }),
+      })
+    );
+  });
+
+  it('503s when Redis is unavailable', async () => {
+    getRedisMock.mockReturnValue(null as never);
+    const res = await postExchange(buildApp());
+    expect(res.status).toBe(503);
+  });
+
+  it('400s on a missing accessToken body field', async () => {
+    const app = buildApp();
+    const res = await app.request('/client-ai/auth/exchange', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/auth.test.ts`
+Expected: FAIL with module-not-found for `./auth`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+`apps/api/src/routes/clientAi/auth.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { db, withSystemDbAccessContext } from '../../db';
+import { portalUsers } from '../../db/schema';
+import { clientAiTenantMappings } from '../../db/schema/clientAi';
+import { getRedis } from '../../services/redis';
+import { rateLimiter } from '../../services/rate-limit';
+import { getTrustedClientIp } from '../../services/clientIp';
+import { writeAuditEvent, type RequestLike } from '../../services/auditEvents';
+import { CLIENT_AI_ENTRA_CLIENT_ID } from '../../config/env';
+import {
+  verifyEntraIdToken,
+  ClientAiEntraInvalidTokenError,
+  ClientAiEntraJwksUnavailableError,
+} from '../../services/clientAiEntraJwt';
+import { getOrgPolicy, isClientUserPermitted } from '../../services/clientAiPolicy';
+import {
+  exchangeSchema,
+  CLIENT_AI_REDIS_KEYS,
+  CLIENT_AI_SESSION_TTL_SECONDS,
+  EXCHANGE_RATE_LIMIT,
+} from './schemas';
+
+/**
+ * POST /client-ai/auth/exchange — Entra ID token → Breeze client-AI session.
+ * Spec §3. Pre-auth route: tenant context comes FROM the verified token (tid →
+ * client_ai_tenant_mappings), so DB work runs under system scope. One fast DB
+ * block; Redis work stays outside it (#1105).
+ */
+
+export const clientAiAuthRoutes = new Hono();
+
+type ExchangeUser = {
+  id: string;
+  orgId: string;
+  email: string;
+  name: string | null;
+  status: string;
+};
+
+type Denied = {
+  denied: {
+    status: 403 | 404;
+    error: string;
+    orgId: string | null;
+    details: Record<string, unknown>;
+  };
+};
+type Resolved = { user: ExchangeUser; provisioned: boolean };
+
+const USER_COLUMNS = {
+  id: portalUsers.id,
+  orgId: portalUsers.orgId,
+  email: portalUsers.email,
+  name: portalUsers.name,
+  status: portalUsers.status,
+};
+
+function auditExchange(
+  c: RequestLike,
+  params: {
+    orgId: string | null;
+    result: 'success' | 'denied';
+    actorId?: string | null;
+    actorEmail?: string | null;
+    details: Record<string, unknown>;
+  }
+): void {
+  writeAuditEvent(c, {
+    orgId: params.orgId,
+    action: 'client_ai.auth.exchange',
+    resourceType: 'client_ai_session',
+    actorType: 'user',
+    actorId: params.actorId ?? null,
+    actorEmail: params.actorEmail ?? null,
+    result: params.result,
+    details: { principalType: 'portal_user', ...params.details },
+  });
+}
+
+clientAiAuthRoutes.post('/auth/exchange', zValidator('json', exchangeSchema), async (c) => {
+  if (!CLIENT_AI_ENTRA_CLIENT_ID) {
+    return c.json({ error: 'not_enabled' }, 404);
+  }
+
+  // Client-AI sessions are Redis-only (no in-memory fallback — new surface,
+  // every compose mode ships Redis).
+  const redis = getRedis();
+  if (!redis) {
+    return c.json({ error: 'service_unavailable' }, 503);
+  }
+
+  const ip = getTrustedClientIp(c);
+  const rate = await rateLimiter(
+    redis,
+    `clientai-exchange-${ip}`,
+    EXCHANGE_RATE_LIMIT.limit,
+    EXCHANGE_RATE_LIMIT.windowSeconds
+  );
+  if (!rate.allowed) {
+    return c.json({ error: 'rate_limited' }, 429);
+  }
+
+  const { accessToken } = c.req.valid('json');
+
+  let claims;
+  try {
+    claims = await verifyEntraIdToken(accessToken, { audience: CLIENT_AI_ENTRA_CLIENT_ID });
+  } catch (err) {
+    if (err instanceof ClientAiEntraJwksUnavailableError) {
+      console.error('[client-ai] Entra JWKS unavailable during exchange:', (err as Error).message);
+      return c.json({ error: 'service_unavailable' }, 503);
+    }
+    if (err instanceof ClientAiEntraInvalidTokenError) {
+      return c.json({ error: 'invalid_token' }, 401);
+    }
+    throw err;
+  }
+
+  const resolution = await withSystemDbAccessContext(async (): Promise<Denied | Resolved> => {
+    const [mapping] = await db
+      .select()
+      .from(clientAiTenantMappings)
+      .where(eq(clientAiTenantMappings.entraTenantId, claims.tid))
+      .limit(1);
+
+    if (!mapping) {
+      return {
+        denied: {
+          status: 404,
+          error: 'tenant_not_provisioned',
+          orgId: null,
+          details: { reason: 'tenant_not_provisioned', tid: claims.tid },
+        },
+      };
+    }
+
+    const policy = await getOrgPolicy(mapping.orgId);
+    if (!policy.enabled) {
+      return {
+        denied: {
+          status: 403,
+          error: 'disabled',
+          orgId: mapping.orgId,
+          details: { reason: 'disabled', tid: claims.tid, oid: claims.oid },
+        },
+      };
+    }
+
+    const now = new Date();
+    let provisioned = false;
+    let [user] = await db
+      .select(USER_COLUMNS)
+      .from(portalUsers)
+      .where(
+        and(eq(portalUsers.entraTenantId, claims.tid), eq(portalUsers.entraOid, claims.oid))
+      )
+      .limit(1);
+
+    if (!user) {
+      // portal_users.email is NOT NULL; some Entra token shapes carry no usable
+      // address — fall back to a synthetic, non-routable one.
+      const email = claims.email ?? `${claims.oid}@${claims.tid}.entra.invalid`;
+      try {
+        const inserted = await db
+          .insert(portalUsers)
+          .values({
+            orgId: mapping.orgId,
+            email,
+            name: claims.name,
+            passwordHash: null,
+            entraOid: claims.oid,
+            entraTenantId: claims.tid,
+            authMethod: 'entra',
+            lastLoginAt: now,
+          })
+          .returning(USER_COLUMNS);
+        user = inserted[0];
+        provisioned = true;
+      } catch (err) {
+        // Concurrent first-exchange race: portal_users_entra_identity_uniq
+        // makes the loser 23505 — re-select the winner's row.
+        if ((err as { cause?: { code?: string } }).cause?.code !== '23505') throw err;
+        [user] = await db
+          .select(USER_COLUMNS)
+          .from(portalUsers)
+          .where(
+            and(eq(portalUsers.entraTenantId, claims.tid), eq(portalUsers.entraOid, claims.oid))
+          )
+          .limit(1);
+      }
+    } else {
+      await db
+        .update(portalUsers)
+        .set({ lastLoginAt: now, updatedAt: now, ...(claims.name ? { name: claims.name } : {}) })
+        .where(eq(portalUsers.id, user.id));
+    }
+
+    if (!user) {
+      return {
+        denied: {
+          status: 403,
+          error: 'provisioning_failed',
+          orgId: mapping.orgId,
+          details: { reason: 'provisioning_failed', tid: claims.tid, oid: claims.oid },
+        },
+      };
+    }
+
+    if (user.status !== 'active') {
+      return {
+        denied: {
+          status: 403,
+          error: 'account_inactive',
+          orgId: mapping.orgId,
+          details: { reason: 'account_inactive', portalUserId: user.id },
+        },
+      };
+    }
+
+    if (!isClientUserPermitted(policy, user.id)) {
+      return {
+        denied: {
+          status: 403,
+          error: 'user_not_permitted',
+          orgId: mapping.orgId,
+          details: { reason: 'user_not_permitted', portalUserId: user.id },
+        },
+      };
+    }
+
+    return { user, provisioned };
+  });
+
+  if ('denied' in resolution) {
+    auditExchange(c, {
+      orgId: resolution.denied.orgId,
+      result: 'denied',
+      details: resolution.denied.details,
+    });
+    return c.json({ error: resolution.denied.error }, resolution.denied.status);
+  }
+
+  const { user, provisioned } = resolution;
+  const token = nanoid(48);
+  await redis.setex(
+    CLIENT_AI_REDIS_KEYS.session(token),
+    CLIENT_AI_SESSION_TTL_SECONDS,
+    JSON.stringify({ portalUserId: user.id, orgId: user.orgId, createdAt: new Date().toISOString() })
+  );
+  await redis.sadd(CLIENT_AI_REDIS_KEYS.userSessions(user.id), token);
+  await redis.expire(CLIENT_AI_REDIS_KEYS.userSessions(user.id), CLIENT_AI_SESSION_TTL_SECONDS * 2);
+
+  auditExchange(c, {
+    orgId: user.orgId,
+    result: 'success',
+    actorId: user.id,
+    actorEmail: user.email,
+    details: { tid: claims.tid, oid: claims.oid, provisioned },
+  });
+
+  return c.json({
+    accessToken: token,
+    expiresInSeconds: CLIENT_AI_SESSION_TTL_SECONDS,
+    user: { id: user.id, email: user.email, name: user.name },
+  });
+});
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/auth.test.ts`
+Expected: 11 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/schemas.ts apps/api/src/routes/clientAi/auth.ts apps/api/src/routes/clientAi/auth.test.ts
+git commit -m "feat(client-ai): POST /client-ai/auth/exchange — Entra token exchange with auto-provisioning" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Client auth middleware + policy-enforcement middleware (TDD)
+
+Mirrors `portalAuthMiddleware` (`apps/api/src/routes/portal/auth.ts:52-191`): bearer token → Redis lookup → system-scope `portal_users` hydration → sliding TTL → `withDbAccessContext` org scope around `next()`. Differences: bearer-only (no cookies, the add-in is not a browser-cookie surface), Redis-only.
+
+**Files:**
+- Create: apps/api/src/middleware/clientAiAuth.ts
+- Test: apps/api/src/middleware/clientAiAuth.test.ts
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/middleware/clientAiAuth.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  redisMock,
+  getRedisMock,
+  dbSelectMock,
+  withDbAccessContextMock,
+  capturedDbContexts,
+  getOrgPolicyMock,
+} = vi.hoisted(() => {
+  const redis = {
+    get: vi.fn(),
+    del: vi.fn(() => Promise.resolve(1)),
+    expire: vi.fn(() => Promise.resolve(1)),
+  };
+  const captured: unknown[] = [];
+  return {
+    redisMock: redis,
+    getRedisMock: vi.fn(() => redis),
+    dbSelectMock: vi.fn(),
+    withDbAccessContextMock: vi.fn((ctx: unknown, fn: () => unknown) => {
+      captured.push(ctx);
+      return fn();
+    }),
+    capturedDbContexts: captured,
+    getOrgPolicyMock: vi.fn(),
+  };
+});
+
+vi.mock('../db', () => ({
+  db: { select: dbSelectMock },
+  withDbAccessContext: withDbAccessContextMock,
+  withSystemDbAccessContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('../services/redis', () => ({ getRedis: getRedisMock }));
+
+vi.mock('../services/clientAiPolicy', () => ({
+  getOrgPolicy: getOrgPolicyMock,
+  isClientUserPermitted: (
+    policy: { userAccess: string; selectedUserIds: string[] },
+    id: string
+  ) => policy.userAccess === 'all' || policy.selectedUserIds.includes(id),
+}));
+
+import { clientAiAuthMiddleware, requireClientAiEnabledMiddleware } from './clientAiAuth';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const PORTAL_USER_ID = 'beefbeef-1111-4222-8333-444455556666';
+const TOKEN = 'tok_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJK';
+
+const USER_ROW = {
+  id: PORTAL_USER_ID,
+  orgId: ORG_ID,
+  email: 'finance.user@contoso.com',
+  name: 'Finance User',
+  status: 'active',
+};
+
+function setupUserSelect(row: object | null) {
+  dbSelectMock.mockImplementation(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve(row ? [row] : [])) })),
+    })),
+  }));
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', clientAiAuthMiddleware);
+  app.get('/me', (c) => {
+    const auth = c.get('clientAiAuth');
+    return c.json({ clientUserId: auth.clientUserId, orgId: auth.orgId });
+  });
+  return app;
+}
+
+function get(app: Hono, headers: Record<string, string> = {}) {
+  return app.request('/me', { method: 'GET', headers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedDbContexts.length = 0;
+  getRedisMock.mockReturnValue(redisMock);
+  redisMock.get.mockResolvedValue(
+    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, createdAt: new Date().toISOString() })
+  );
+  setupUserSelect(USER_ROW);
+});
+
+describe('clientAiAuthMiddleware', () => {
+  it('401s without a bearer token', async () => {
+    const res = await get(buildApp());
+    expect(res.status).toBe(401);
+  });
+
+  it('401s on an unknown/expired token and does not touch the DB', async () => {
+    redisMock.get.mockResolvedValue(null);
+    const res = await get(buildApp(), { Authorization: `Bearer ${TOKEN}` });
+    expect(res.status).toBe(401);
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('401s and clears the session when the portal user row is gone', async () => {
+    setupUserSelect(null);
+    const res = await get(buildApp(), { Authorization: `Bearer ${TOKEN}` });
+    expect(res.status).toBe(401);
+    expect(redisMock.del).toHaveBeenCalledWith(`clientai:session:${TOKEN}`);
+  });
+
+  it('403s when the portal user is not active', async () => {
+    setupUserSelect({ ...USER_ROW, status: 'disabled' });
+    const res = await get(buildApp(), { Authorization: `Bearer ${TOKEN}` });
+    expect(res.status).toBe(403);
+  });
+
+  it('503s when Redis is unavailable', async () => {
+    getRedisMock.mockReturnValue(null as never);
+    const res = await get(buildApp(), { Authorization: `Bearer ${TOKEN}` });
+    expect(res.status).toBe(503);
+  });
+
+  it('attaches clientAiAuth, slides the TTL, and runs the handler inside an org-scoped DB context', async () => {
+    const res = await get(buildApp(), { Authorization: `Bearer ${TOKEN}` });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ clientUserId: PORTAL_USER_ID, orgId: ORG_ID });
+
+    expect(redisMock.expire).toHaveBeenCalledWith(`clientai:session:${TOKEN}`, 86400);
+    expect(capturedDbContexts[0]).toMatchObject({
+      scope: 'organization',
+      orgId: ORG_ID,
+      accessibleOrgIds: [ORG_ID],
+      accessiblePartnerIds: [],
+      userId: null,
+    });
+  });
+});
+
+describe('requireClientAiEnabledMiddleware', () => {
+  function buildGuardedApp() {
+    const app = new Hono();
+    app.use('*', clientAiAuthMiddleware);
+    app.use('*', requireClientAiEnabledMiddleware);
+    app.get('/guarded', (c) => c.json({ writeMode: c.get('clientAiPolicy').writeMode }));
+    return app;
+  }
+
+  it('403s with disabled when the org policy is off', async () => {
+    getOrgPolicyMock.mockResolvedValue({
+      orgId: ORG_ID,
+      enabled: false,
+      userAccess: 'all',
+      selectedUserIds: [],
+      writeMode: 'readwrite',
+    });
+    const res = await buildGuardedApp().request('/guarded', {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'disabled' });
+  });
+
+  it('403s with user_not_permitted when the user falls off the selected list mid-session', async () => {
+    getOrgPolicyMock.mockResolvedValue({
+      orgId: ORG_ID,
+      enabled: true,
+      userAccess: 'selected',
+      selectedUserIds: ['ffffffff-1111-4222-8333-444455556666'],
+      writeMode: 'readwrite',
+    });
+    const res = await buildGuardedApp().request('/guarded', {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'user_not_permitted' });
+  });
+
+  it('passes the policy through to the handler when enabled', async () => {
+    getOrgPolicyMock.mockResolvedValue({
+      orgId: ORG_ID,
+      enabled: true,
+      userAccess: 'all',
+      selectedUserIds: [],
+      writeMode: 'readonly',
+    });
+    const res = await buildGuardedApp().request('/guarded', {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ writeMode: 'readonly' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/middleware/clientAiAuth.test.ts`
+Expected: FAIL with module-not-found for `./clientAiAuth`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/api/src/middleware/clientAiAuth.ts`:
+
+```ts
+import type { Context, Next } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
+import { portalUsers } from '../db/schema';
+import { getRedis } from '../services/redis';
+import { getOrgPolicy, isClientUserPermitted } from '../services/clientAiPolicy';
+import {
+  CLIENT_AI_REDIS_KEYS,
+  CLIENT_AI_SESSION_TTL_SECONDS,
+  type ClientAiSessionPayload,
+} from '../routes/clientAi/schemas';
+
+/**
+ * Auth middleware for the /client-ai surface (Excel add-in end-users).
+ *
+ * Mirrors portalAuthMiddleware (routes/portal/auth.ts): bearer token →
+ * Redis session → system-scope portal_users hydration (the row sits behind
+ * org-forced RLS, pre-auth) → sliding TTL → handlers run inside an org-scoped
+ * withDbAccessContext so RLS on every table is satisfied AND enforced under
+ * the unprivileged breeze_app pool. Differences from the portal: bearer-only
+ * (no cookies/CSRF — the add-in task pane is not a cookie surface) and
+ * Redis-only (no in-memory dev fallback).
+ *
+ * Redis/session work happens BEFORE the DB context opens so the wrapping
+ * transaction is never held across slow I/O (#1105).
+ */
+export async function clientAiAuthMiddleware(c: Context, next: Next) {
+  const authHeader = c.req.header('Authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token) {
+    return c.json({ error: 'Missing or invalid authorization header' }, 401);
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const raw = await redis.get(CLIENT_AI_REDIS_KEYS.session(token));
+  if (!raw) {
+    return c.json({ error: 'Invalid or expired session' }, 401);
+  }
+
+  let session: ClientAiSessionPayload;
+  try {
+    session = JSON.parse(raw) as ClientAiSessionPayload;
+  } catch {
+    return c.json({ error: 'Invalid or expired session' }, 401);
+  }
+  if (!session?.portalUserId || !session?.orgId) {
+    return c.json({ error: 'Invalid or expired session' }, 401);
+  }
+
+  const [user] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: portalUsers.id,
+        orgId: portalUsers.orgId,
+        email: portalUsers.email,
+        name: portalUsers.name,
+        status: portalUsers.status,
+      })
+      .from(portalUsers)
+      .where(and(eq(portalUsers.id, session.portalUserId), eq(portalUsers.orgId, session.orgId)))
+      .limit(1)
+  );
+
+  if (!user) {
+    await redis.del(CLIENT_AI_REDIS_KEYS.session(token));
+    return c.json({ error: 'Invalid or expired session' }, 401);
+  }
+
+  if (user.status !== 'active') {
+    return c.json({ error: 'Account is not active' }, 403);
+  }
+
+  // Sliding session timeout: any authenticated activity pushes expiry forward.
+  try {
+    await redis.expire(CLIENT_AI_REDIS_KEYS.session(token), CLIENT_AI_SESSION_TTL_SECONDS);
+  } catch (error) {
+    console.error('[client-ai] Failed to extend session TTL:', error);
+  }
+
+  c.set('clientAiAuth', {
+    clientUserId: user.id,
+    orgId: user.orgId,
+    email: user.email,
+    name: user.name,
+    token,
+  });
+
+  return withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId: user.orgId,
+      accessibleOrgIds: [user.orgId],
+      accessiblePartnerIds: [],
+      userId: null,
+    },
+    () => next()
+  );
+}
+
+/**
+ * Policy gate for /client-ai feature routes (everything beyond /auth/exchange).
+ * Re-checks enabled + selected-list on EVERY request so disabling the org or
+ * de-selecting a user takes effect immediately, not at next token mint.
+ * Runs inside the org context opened by clientAiAuthMiddleware; caches the
+ * policy on the context for handlers (c.get('clientAiPolicy')).
+ */
+export async function requireClientAiEnabledMiddleware(c: Context, next: Next) {
+  const auth = c.get('clientAiAuth');
+  if (!auth) {
+    return c.json({ error: 'Not authenticated' }, 401);
+  }
+
+  const policy = await getOrgPolicy(auth.orgId);
+  if (!policy.enabled) {
+    return c.json({ error: 'disabled' }, 403);
+  }
+  if (!isClientUserPermitted(policy, auth.clientUserId)) {
+    return c.json({ error: 'user_not_permitted' }, 403);
+  }
+
+  c.set('clientAiPolicy', policy);
+  await next();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/middleware/clientAiAuth.test.ts`
+Expected: 9 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/middleware/clientAiAuth.ts apps/api/src/middleware/clientAiAuth.test.ts
+git commit -m "feat(client-ai): bearer session middleware + per-request policy gate" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Admin routes — tenant mapping + policy CRUD (TDD)
+
+Partner-scope routes for the (Plan 4) dashboard. Mirrors `routes/m365.ts` exactly: group-level `authMiddleware`, feature-flag 404 gate, `requirePermission(PERMISSIONS.ORGS_READ/WRITE)`, `requireMfa()` on the isolation-critical mapping mutations, org access resolved via `resolveScopedOrgId` (`routes/c2c/helpers.ts`), audits via `writeRouteAudit`.
+
+Design notes:
+- Path-param `:orgId` + `resolveScopedOrgId(auth, orgId)` → `null` means no access → **404** (no cross-tenant existence oracle).
+- PUT tenant-mapping upserts on `org_id`; a 23505 on `client_ai_tenant_mappings_tenant_uniq` (tenant already mapped to a DIFFERENT org) → **409 `tenant_already_mapped`** with no hint of which org owns it.
+- `requireMfa()` on mapping PUT/DELETE only (the mapping is the tenant-isolation linchpin, like the m365 secret routes); the policy editor is a frequent-touch surface and stays MFA-free.
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/admin.ts
+- Create: apps/api/src/routes/clientAi/index.ts
+- Test: apps/api/src/routes/clientAi/admin.test.ts
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/routes/clientAi/admin.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  dbSelectMock,
+  dbInsertMock,
+  dbDeleteMock,
+  writeRouteAuditMock,
+  getOrgPolicyMock,
+} = vi.hoisted(() => ({
+  dbSelectMock: vi.fn(),
+  dbInsertMock: vi.fn(),
+  dbDeleteMock: vi.fn(),
+  writeRouteAuditMock: vi.fn(),
+  getOrgPolicyMock: vi.fn(),
+}));
+
+// Accessible org for the partner-scoped test auth context. Literal because
+// vi.mock factories are hoisted.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    if (!c.req.header('authorization')) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    c.set('auth', {
+      scope: 'partner',
+      partnerId: 'f0f0f0f0-1111-4222-8333-444455556666',
+      orgId: null,
+      accessibleOrgIds: ['0c0c0c0c-1111-4222-8333-444455556666'],
+      user: { id: 'ce11ce11-1111-4222-8333-444455556666', email: 'msp@example.com' },
+    });
+    return next();
+  }),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (c: any, next: any) => next()),
+}));
+
+vi.mock('../../config/env', () => ({
+  CLIENT_AI_ENTRA_CLIENT_ID: '00000000-aaaa-bbbb-cccc-000000000001',
+}));
+
+vi.mock('../../db', () => ({
+  db: { select: dbSelectMock, insert: dbInsertMock, delete: dbDeleteMock },
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
+vi.mock('../../services/clientAiPolicy', () => ({ getOrgPolicy: getOrgPolicyMock }));
+
+import { clientAiAdminRoutes } from './admin';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const OTHER_ORG_ID = '9d9d9d9d-1111-4222-8333-444455556666'; // not accessible
+const TID = '6f4f4f4f-1111-4222-8333-444455556666';
+
+const MAPPING_ROW = {
+  id: 'a1a1a1a1-1111-4222-8333-444455556666',
+  orgId: ORG_ID,
+  entraTenantId: TID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve(rows)) })),
+    })),
+  };
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.route('/client-ai/admin', clientAiAdminRoutes);
+  return app;
+}
+
+const AUTHED = { Authorization: 'Bearer token', 'Content-Type': 'application/json' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbSelectMock.mockImplementation(() => selectChain([MAPPING_ROW]));
+  dbInsertMock.mockImplementation(() => ({
+    values: vi.fn(() => ({
+      onConflictDoUpdate: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([MAPPING_ROW])),
+      })),
+    })),
+  }));
+  dbDeleteMock.mockImplementation(() => ({
+    where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([MAPPING_ROW])) })),
+  }));
+});
+
+describe('client-ai admin — tenant mapping', () => {
+  it('rejects unauthenticated requests', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`);
+    expect(res.status).toBe(401);
+  });
+
+  it('404s for an org outside the caller scope (no existence oracle)', async () => {
+    const res = await buildApp().request(
+      `/client-ai/admin/orgs/${OTHER_ORG_ID}/tenant-mapping`,
+      { headers: AUTHED }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('GET returns the mapping when present', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mapping).toMatchObject({ orgId: ORG_ID, entraTenantId: TID });
+  });
+
+  it('GET returns mapping: null when absent', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([]));
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).mapping).toBeNull();
+  });
+
+  it('PUT rejects a non-GUID tenant id with 400', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ entraTenantId: 'contoso.onmicrosoft.com' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT upserts the mapping and audits', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ entraTenantId: TID }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).mapping).toMatchObject({ entraTenantId: TID });
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: ORG_ID,
+        action: 'client_ai.tenant_mapping.upsert',
+        resourceType: 'client_ai_tenant_mapping',
+      })
+    );
+  });
+
+  it('PUT maps a tenant-uniqueness violation to 409 tenant_already_mapped', async () => {
+    dbInsertMock.mockImplementation(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn(() => ({
+          returning: vi.fn(() =>
+            Promise.reject(Object.assign(new Error('duplicate'), { cause: { code: '23505' } }))
+          ),
+        })),
+      })),
+    }));
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ entraTenantId: TID }),
+    });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'tenant_already_mapped' });
+  });
+
+  it('DELETE removes the mapping and audits', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`, {
+      method: 'DELETE',
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).mapping).toBeNull();
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'client_ai.tenant_mapping.delete' })
+    );
+  });
+});
+
+describe('client-ai admin — policy', () => {
+  it('GET returns the effective policy (defaults when no row)', async () => {
+    getOrgPolicyMock.mockResolvedValue({
+      orgId: ORG_ID,
+      enabled: false,
+      userAccess: 'all',
+      selectedUserIds: [],
+      allowedProviders: ['anthropic'],
+      allowedModels: [],
+      writeMode: 'readwrite',
+      dlpConfig: {},
+      dailyBudgetCents: null,
+      monthlyBudgetCents: null,
+      perUserMessagesPerMinute: 10,
+      orgMessagesPerHour: 500,
+      retentionDays: null,
+      branding: {},
+    });
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/policy`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.policy).toMatchObject({ enabled: false, allowedProviders: ['anthropic'] });
+  });
+
+  it('PUT rejects unknown fields (strict schema)', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/policy`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ enabled: true, surprise: 1 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT upserts provided knobs only and audits the changed keys', async () => {
+    getOrgPolicyMock.mockResolvedValue({ orgId: ORG_ID, enabled: true });
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/policy`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ enabled: true, writeMode: 'readonly', dailyBudgetCents: 500 }),
+    });
+    expect(res.status).toBe(200);
+    expect(dbInsertMock).toHaveBeenCalled();
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'client_ai.policy.update',
+        details: expect.objectContaining({
+          changedKeys: expect.arrayContaining(['enabled', 'writeMode', 'dailyBudgetCents']),
+        }),
+      })
+    );
+  });
+
+  it('404s policy routes for an inaccessible org', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${OTHER_ORG_ID}/policy`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/admin.test.ts`
+Expected: FAIL with module-not-found for `./admin`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/api/src/routes/clientAi/admin.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { clientAiOrgPolicies, clientAiTenantMappings } from '../../db/schema/clientAi';
+import { authMiddleware, requireMfa, requirePermission } from '../../middleware/auth';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { PERMISSIONS } from '../../services/permissions';
+import { CLIENT_AI_ENTRA_CLIENT_ID } from '../../config/env';
+import { resolveScopedOrgId } from '../c2c/helpers';
+import { getOrgPolicy } from '../../services/clientAiPolicy';
+import { putPolicySchema, putTenantMappingSchema } from './schemas';
+
+/**
+ * MSP-facing admin surface for Breeze AI for Office (spec §9, consumed by the
+ * Plan-4 dashboard): tenant mapping + per-org policy. Mirrors routes/m365.ts:
+ * group authMiddleware, feature 404 gate, ORGS_READ/ORGS_WRITE permissions,
+ * MFA on the isolation-critical mapping mutations, writeRouteAudit on writes.
+ *
+ * Org access: resolveScopedOrgId(auth, :orgId) returns null when the caller
+ * cannot access the org → respond 404 (never reveal cross-tenant existence).
+ */
+
+export const clientAiAdminRoutes = new Hono();
+
+const requireOrgsRead = requirePermission(
+  PERMISSIONS.ORGS_READ.resource,
+  PERMISSIONS.ORGS_READ.action
+);
+const requireOrgsWrite = requirePermission(
+  PERMISSIONS.ORGS_WRITE.resource,
+  PERMISSIONS.ORGS_WRITE.action
+);
+
+clientAiAdminRoutes.use('*', authMiddleware);
+
+// Whole group is dark unless the add-in app registration is configured.
+clientAiAdminRoutes.use('*', async (c, next) => {
+  if (!CLIENT_AI_ENTRA_CLIENT_ID) {
+    return c.json({ error: 'Breeze AI for Office is not enabled' }, 404);
+  }
+  await next();
+});
+
+function resolveOrgOr404(c: Parameters<typeof writeRouteAudit>[0] & { req: { param: (k: string) => string } }) {
+  const auth = (c as { get: (k: 'auth') => Parameters<typeof resolveScopedOrgId>[0] }).get('auth');
+  return resolveScopedOrgId(auth, (c as { req: { param: (k: string) => string } }).req.param('orgId'));
+}
+
+function toMappingResponse(row: typeof clientAiTenantMappings.$inferSelect) {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    entraTenantId: row.entraTenantId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ── Tenant mapping ────────────────────────────────────────────────────────────
+
+clientAiAdminRoutes.get('/orgs/:orgId/tenant-mapping', requireOrgsRead, async (c) => {
+  const orgId = resolveOrgOr404(c as never);
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+
+  const [row] = await db
+    .select()
+    .from(clientAiTenantMappings)
+    .where(eq(clientAiTenantMappings.orgId, orgId))
+    .limit(1);
+
+  return c.json({ mapping: row ? toMappingResponse(row) : null });
+});
+
+clientAiAdminRoutes.put(
+  '/orgs/:orgId/tenant-mapping',
+  requireOrgsWrite,
+  requireMfa(),
+  zValidator('json', putTenantMappingSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const orgId = resolveOrgOr404(c as never);
+    if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+
+    const { entraTenantId } = c.req.valid('json');
+    const now = new Date();
+
+    let row: typeof clientAiTenantMappings.$inferSelect | undefined;
+    try {
+      [row] = await db
+        .insert(clientAiTenantMappings)
+        .values({
+          orgId,
+          entraTenantId: entraTenantId.toLowerCase(),
+          createdBy: auth.user?.id ?? null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: clientAiTenantMappings.orgId,
+          set: { entraTenantId: entraTenantId.toLowerCase(), updatedAt: now },
+        })
+        .returning();
+    } catch (err) {
+      // client_ai_tenant_mappings_tenant_uniq: the tenant is already mapped to
+      // a DIFFERENT org. Deliberately opaque — do not reveal which org.
+      if ((err as { cause?: { code?: string } }).cause?.code === '23505') {
+        return c.json({ error: 'tenant_already_mapped' }, 409);
+      }
+      throw err;
+    }
+
+    if (!row) return c.json({ error: 'Failed to save tenant mapping' }, 500);
+
+    writeRouteAudit(c, {
+      orgId,
+      action: 'client_ai.tenant_mapping.upsert',
+      resourceType: 'client_ai_tenant_mapping',
+      resourceId: row.id,
+      resourceName: row.entraTenantId,
+      details: { entraTenantId: row.entraTenantId },
+    });
+
+    return c.json({ mapping: toMappingResponse(row) });
+  }
+);
+
+clientAiAdminRoutes.delete(
+  '/orgs/:orgId/tenant-mapping',
+  requireOrgsWrite,
+  requireMfa(),
+  async (c) => {
+    const orgId = resolveOrgOr404(c as never);
+    if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+
+    const [row] = await db
+      .delete(clientAiTenantMappings)
+      .where(eq(clientAiTenantMappings.orgId, orgId))
+      .returning();
+
+    if (row) {
+      writeRouteAudit(c, {
+        orgId,
+        action: 'client_ai.tenant_mapping.delete',
+        resourceType: 'client_ai_tenant_mapping',
+        resourceId: row.id,
+        resourceName: row.entraTenantId,
+      });
+    }
+
+    return c.json({ mapping: null });
+  }
+);
+
+// ── Policy ────────────────────────────────────────────────────────────────────
+
+clientAiAdminRoutes.get('/orgs/:orgId/policy', requireOrgsRead, async (c) => {
+  const orgId = resolveOrgOr404(c as never);
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+
+  const policy = await getOrgPolicy(orgId);
+  return c.json({ policy });
+});
+
+clientAiAdminRoutes.put(
+  '/orgs/:orgId/policy',
+  requireOrgsWrite,
+  zValidator('json', putPolicySchema),
+  async (c) => {
+    const orgId = resolveOrgOr404(c as never);
+    if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+
+    const body = c.req.valid('json');
+    const now = new Date();
+
+    // Only persist the knobs the caller provided; DB defaults fill the rest on
+    // first insert, existing values survive on update.
+    const set: Partial<typeof clientAiOrgPolicies.$inferInsert> = { updatedAt: now };
+    if (body.enabled !== undefined) set.enabled = body.enabled;
+    if (body.userAccess !== undefined) set.userAccess = body.userAccess;
+    if (body.selectedUserIds !== undefined) set.selectedUserIds = body.selectedUserIds;
+    if (body.allowedProviders !== undefined) set.allowedProviders = body.allowedProviders;
+    if (body.allowedModels !== undefined) set.allowedModels = body.allowedModels;
+    if (body.writeMode !== undefined) set.writeMode = body.writeMode;
+    if (body.dlpConfig !== undefined) set.dlpConfig = body.dlpConfig;
+    if (body.dailyBudgetCents !== undefined) set.dailyBudgetCents = body.dailyBudgetCents;
+    if (body.monthlyBudgetCents !== undefined) set.monthlyBudgetCents = body.monthlyBudgetCents;
+    if (body.perUserMessagesPerMinute !== undefined)
+      set.perUserMessagesPerMinute = body.perUserMessagesPerMinute;
+    if (body.orgMessagesPerHour !== undefined) set.orgMessagesPerHour = body.orgMessagesPerHour;
+    if (body.retentionDays !== undefined) set.retentionDays = body.retentionDays;
+    if (body.branding !== undefined) set.branding = body.branding;
+
+    await db
+      .insert(clientAiOrgPolicies)
+      .values({ orgId, ...set })
+      .onConflictDoUpdate({ target: clientAiOrgPolicies.orgId, set })
+      .returning();
+
+    const changedKeys = Object.keys(set).filter((k) => k !== 'updatedAt');
+    writeRouteAudit(c, {
+      orgId,
+      action: 'client_ai.policy.update',
+      resourceType: 'client_ai_org_policy',
+      details: { changedKeys },
+    });
+
+    const policy = await getOrgPolicy(orgId);
+    return c.json({ policy });
+  }
+);
+```
+
+`apps/api/src/routes/clientAi/index.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { clientAiAuthRoutes } from './auth';
+import { clientAiAdminRoutes } from './admin';
+
+/**
+ * /client-ai — Breeze AI for Office namespace (spec §2).
+ *  - /auth/exchange        pre-auth Entra token exchange (auth.ts)
+ *  - /admin/orgs/:orgId/*  MSP admin surface (admin.ts, authMiddleware inside)
+ * Plan 2 adds /sessions/* here behind clientAiAuthMiddleware +
+ * requireClientAiEnabledMiddleware.
+ */
+export const clientAiRoutes = new Hono();
+
+clientAiRoutes.route('/', clientAiAuthRoutes);
+clientAiRoutes.route('/admin', clientAiAdminRoutes);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/admin.test.ts`
+Expected: 12 tests PASS.
+
+Note: if the `resolveOrgOr404` helper's casts fight the type-checker, inline the two lines at each call site instead (`const auth = c.get('auth'); const orgId = resolveScopedOrgId(auth, c.req.param('orgId'));`) — that is exactly what routes/m365.ts does and is the preferred fallback.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/admin.ts apps/api/src/routes/clientAi/admin.test.ts apps/api/src/routes/clientAi/index.ts
+git commit -m "feat(client-ai): partner-scope admin routes for tenant mapping + org policy" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Mount the namespace + final verification sweep
+
+**Files:**
+- Modify: apps/api/src/index.ts (import near line 72 `import { portalRoutes } from './routes/portal';`; mount near line 779 `api.route('/portal', portalRoutes);`)
+
+- [ ] **Step 1: Mount the routes**
+
+Add the import next to the portalRoutes import (~line 72):
+
+```ts
+import { clientAiRoutes } from './routes/clientAi';
+```
+
+Add the mount immediately after `api.route('/portal', portalRoutes);` (~line 779):
+
+```ts
+api.route('/client-ai', clientAiRoutes);
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit`
+Expected: only the pre-existing `agents.test.ts` / `apiKeyAuth.test.ts` errors.
+
+- [ ] **Step 3: Run every test file this plan added or touched (single command, no full-suite flake)**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run \
+  src/services/clientAiEntraJwt.test.ts \
+  src/services/clientAiPolicy.test.ts \
+  src/routes/clientAi/auth.test.ts \
+  src/routes/clientAi/admin.test.ts \
+  src/middleware/clientAiAuth.test.ts
+```
+
+Expected: all PASS (~52 tests).
+
+- [ ] **Step 4: Re-run the DB-backed checks once more against the test stack**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm test:rls-coverage
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run --config vitest.integration.config.ts src/__tests__/integration/client-ai-templates-rls.integration.test.ts
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Smoke the mounted route against the dev stack (optional but cheap)**
+
+With the dev compose stack running (`docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up -d`):
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost/api/v1/client-ai/auth/exchange \
+  -H 'Content-Type: application/json' -d '{"accessToken":"x"}'
+```
+
+Expected: `404` when `CLIENT_AI_ENTRA_CLIENT_ID` is unset in the dev env (the dark-gate), `401` once it is set (invalid token). Either proves the mount.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/index.ts
+git commit -m "feat(client-ai): mount /client-ai route namespace" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope for this plan (later plans)
+
+- `/client-ai/sessions/*`, SDK wiring, SSE tool protocol, budget pre-flight (`checkBudget`/`checkBillingCredits` integration) — Plan 2. (`requireClientAiEnabledMiddleware` + `clientAiPolicy` from this plan are its entry points.)
+- DLP service (`clientAiDlp.ts`) — Plan 3; `client_ai_org_policies.dlp_config` is already in place.
+- Dashboard UI (onboarding wizard, policy editor, audit viewer, usage report, template CRUD routes + UI) — Plan 4. The template **table** ships here (all schema in one PR train per spec §12); the template **routes** ship with the manager in Plan 4.
+- Excel add-in (`apps/office-addin/`) — Plan 5.
+- Writes to `client_ai_usage` and `ai_sessions.type='excel_client'` rows — Plan 2 (schema + constraints land here so Plan 2 is purely additive code).
+
+## Open questions embedded above (for the implementer/reviewer)
+
+1. **MFA scope on admin mutations** — this plan requires MFA on tenant-mapping PUT/DELETE only (mirroring m365.ts's secret mutations) and not on policy PUT. If review wants MFA on `enabled` flips too, it is a one-line `requireMfa()` insertion.
+2. **Synthetic email fallback** (`{oid}@{tid}.entra.invalid`) for tokens without a usable address — alternative is rejecting such tokens with 403; chosen fallback keeps legitimate guest/service identities working. Revisit if the MSP-facing user list looks confusing in Plan 4.
+3. **`auth_method` CHECK** is `('password','entra')`; a future SSO method needs a migration to relax it — intentional, mirrors the enum+CHECK convention.

--- a/docs/superpowers/plans/2026-06-12-ai-for-office-2-session-loop.md
+++ b/docs/superpowers/plans/2026-06-12-ai-for-office-2-session-loop.md
@@ -1,0 +1,3937 @@
+# Breeze AI for Office — Plan 2: Session Loop (routes, SDK wiring, tool round-trip)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the client AI loop: `/client-ai/sessions/*` routes behind Plan 1's auth + policy middleware, Claude Agent SDK wiring on the existing `streamingSessionManager` with a hard-allowlisted 9-tool workbook registry, the SSE tool round-trip protocol (tools execute in the Excel add-in, the server awaits the result), per-message cost/budget/rate-limit enforcement incl. per-user `client_ai_usage` buckets, the DLP seam stub at every payload chokepoint, and `ai.client_session.*` audit events.
+
+**Architecture:** Client sessions are `ai_sessions` rows (`type='excel_client'`, `client_user_id` set — Plan 1 migration) driven by the existing `streamingSessionManager` singleton (`apps/api/src/services/streamingSessionManager.ts`), exactly like helper chat (`routes/helper/index.ts:359`) and the script builder (`routes/scriptAi.ts:195`): a synthetic org-scoped `AuthContext` + a custom `mcpServerFactory`. The custom MCP server registers ONLY the `CLIENT_TOOL_REGISTRY` workbook tools; their handlers do not execute anything server-side — they publish a `tool_request` event on the session's `SessionEventBus` and await `POST /client-ai/sessions/:id/tool-results` (the `waitForPlanApproval` in-memory-resolver shape from `services/aiAgent.ts:323`, not the DB-polling `waitForApproval` shape — no DB row needs polling because the resolver and the SDK subprocess live in the same process). The add-in consumes one persistent `GET /sessions/:id/events` SSE stream; internal `AiStreamEvent`s are translated to five pinned client-facing event names.
+
+**Single-instance affinity (verified):** the SDK session is a child subprocess of the API process; `streamingSessionManager`'s session map, each session's `SessionEventBus`, and this plan's pending-tool-request map are all in-process memory. This is safe because (a) production runs exactly one `api` container per droplet (`docker-compose.yml` `api` service, no replicas), and (b) the technician `/ai` surface already depends on the same affinity (`streamingSessionManager` singleton + the separate `/sessions/:id/approve/:executionId` endpoint resolving in-memory state, `routes/ai.ts:589-622`). An in-memory pending map is therefore fine; no Redis indirection needed.
+
+**Tech Stack:** Hono (+ `hono/streaming` `streamSSE`), `@anthropic-ai/claude-agent-sdk` (`tool`/`createSdkMcpServer`), Drizzle, Redis `rateLimiter`, Vitest.
+
+**Spec:** docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md
+**Depends on:** Plan 1 (2026-06-12-ai-for-office-1-foundation.md)
+---
+
+## Pinned cross-plan contracts this plan creates (Plans 3/4/5 depend on these — do not rename)
+
+1. **Tool registry** — `apps/api/src/services/clientAiTools.ts` exports `CLIENT_TOOL_REGISTRY` with exactly 9 tools: `get_workbook_overview`, `read_selection`, `read_range`, `write_range`, `insert_formula`, `create_sheet`, `format_range`, `create_table`, `search_workbook`. The 5 write tools (`write_range`, `insert_formula`, `create_sheet`, `format_range`, `create_table`) are `mutating: true`. Reads auto-execute; mutating-tool approval happens **client-side in the add-in** (preview card). Policy `writeMode: 'readonly'` strips mutating tools from the model's toolset at session start AND the handler rejects them server-side if invoked anyway.
+2. **Tool bridge** — `apps/api/src/services/clientAiToolBridge.ts`: handler publishes SSE event `tool_request` with payload `{ toolUseId, toolName, input, mutating }`, awaits `POST /client-ai/sessions/:id/tool-results` body `{ toolUseId, status: 'success'|'error'|'rejected', output }`. Timeouts: 60s non-mutating, 300s mutating → resolves with a timeout-error tool_result so the model can react (well inside the manager's 6-min `SDK_TURN_TIMEOUT_MS`, `streamingSessionManager.ts:37`).
+3. **DLP seam stub** — `apps/api/src/services/clientAiDlp.ts` with the EXACT pinned signature (Plan 3 replaces internals, keeps the interface):
+   ```ts
+   export interface DlpRedactionEvent { rule: string; count: number; location: string }
+   export interface DlpResult { action: 'allow' | 'block'; text?: string; cells?: unknown[][]; redactions: DlpRedactionEvent[]; blockReason?: string }
+   export async function applyDlp(input: { text?: string; cells?: unknown[][]; dlpConfig: unknown; orgId: string }): Promise<DlpResult>
+   ```
+   Called at the chokepoints: (a) user message text before entering the SDK loop, (b) every tool_result payload (incl. `workbookContext.cells`) before returning to the model, (c) template bodies arrive inside the user message text in v1 (the add-in's template picker, Plan 5, inserts the template into the chat input), so chokepoint (a) covers them. Persistence stores `result.text` / `result.redactions` ONLY — never the raw input (Plan 3 Task 6 contract; the integration assertion lives in Task 11 here). Redactions are persisted in `ai_messages.content_blocks` as a `{ type: 'dlp_redactions', redactions }` block (`ai_messages` has no metadata column — `content_blocks` jsonb at `db/schema/ai.ts:64` is the structured-content slot).
+4. **Routes** — under `/client-ai/sessions` behind Plan 1's `clientAiAuthMiddleware` + `requireClientAiEnabledMiddleware` (`apps/api/src/middleware/clientAiAuth.ts`): `POST /`, `POST /:id/messages`, `GET /:id/events` (SSE; bearer header AND `?token=` fallback), `POST /:id/tool-results`, `POST /:id/close`, `GET /:id`. Every session route checks `session.clientUserId === auth.clientUserId AND session.orgId === auth.orgId`.
+5. **SSE event names** (Plan 5 mirrors this table; exported as `CLIENT_AI_SSE_EVENTS` in `apps/api/src/routes/clientAi/sse.ts`):
+
+   | Client event | Source (internal bus event) | Payload |
+   |---|---|---|
+   | `message_delta` | `content_delta` | `{ text: string }` |
+   | `tool_request` | `tool_request` (bridge) | `{ toolUseId, toolName, input, mutating }` |
+   | `tool_completed` | `tool_completed` (handler) | `{ toolUseId, toolName, status: 'success'\|'error'\|'rejected'\|'timeout', redactions, blockReason }` |
+   | `turn_complete` | `done` | `{ usage: { inputTokens, outputTokens, costCents } \| null }` |
+   | `session_error` | `error` | `{ message: string }` |
+   | `ping` | server keepalive timer | `{}` every 25s |
+
+   Internal-only events (`message_start`, `message_end`, `tool_use_start`, `title_updated`, plan/approval events) are dropped by the translator — the add-in never sees technician concepts.
+6. **Usage helper** — `recordClientUsage(orgId, clientUserId, delta)` in `apps/api/src/services/clientAiUsage.ts` upserting `(org_id, client_user_id, period, period_key)` daily+monthly buckets (mirrors `recordUsageFromSdkResult`'s upsert idiom, `aiCostTracker.ts:297-325`).
+7. **Audit actions** — `ai.client_session.create` / `ai.client_session.message` / `ai.client_session.tool_execute` / `ai.client_session.tool_reject` / `ai.client_session.close`, written via `writeAuditEvent` with `actorType: 'user'`, `actorId: <portal_users.id>`, `actorEmail`, `details.principalType: 'portal_user'` — the exact convention Plan 1 established for `client_ai.auth.exchange` (there is no portal-specific actor type in `auditEvents.ts:8`; portal/client principals are `'user'` actors disambiguated by `principalType`).
+
+## Design decisions (read before implementing)
+
+- **Reuse `streamingSessionManager`, not a parallel manager** (spec §4 locked decision). Client sessions enter via `getOrCreate` with a custom `mcpServerFactory` (the `scriptAi.ts:211-215` pattern) and a synthetic org-scoped `AuthContext` (the helper pattern, `routes/helper/index.ts:133-160`). Consequences accepted and documented:
+  - The shared `MAX_ACTIVE_SESSIONS = 200` LRU cap (`streamingSessionManager.ts:35`) now covers technician + helper + script-builder + client sessions together. Acceptable for v1; revisit if add-in concurrency approaches that.
+  - `recordUsageFromSdkResult` (called by the background processor) also writes the **org-level** `ai_cost_usage` buckets and deducts partner billing credits — exactly what spec §8 wants for partner billing. Side effect: technician `aiBudgets` daily/monthly caps now also "see" client spend in `ai_cost_usage`. Accepted: it is real provider spend; the client product has its own budget knobs in `client_ai_org_policies`.
+- **The technician `createSessionPreToolUse`/`createSessionPostToolUse` callbacks are deliberately NOT wired** into the client tool handlers: `createSessionPreToolUse` rejects any tool absent from `TOOL_TIERS` (`aiAgentSdk.ts:222-225`) — every workbook tool would be rejected as "Unknown tool" — and `createSessionPostToolUse` encodes technician persistence/guardrail semantics. The client handlers own their persistence, audit, and `tool_completed` events end-to-end (Task 6).
+- **toolUseId correlation**: the background processor pushes the model's real `tool_use` block ids into `session.toolUseIdQueue` on `content_block_start` (`streamingSessionManager.ts:611`); the technician path drains it in `createSessionPostToolUse` (`aiAgentSdk.ts:640`). Since client handlers bypass that callback, the client handler shifts the queue itself at handler start (else the queue would grow for the session's lifetime), falling back to a minted UUID when empty. Same FIFO-ordering caveat as the existing technician path.
+- **`getOrCreate` gets one new optional `options` param** (`{ injectApprovalModeInstructions?: boolean }`): client sessions must not get the technician "## Approval Mode" prompt suffix that `getOrCreate` appends when the org's `aiBudgets.approvalMode` ≠ `per_step` (`streamingSessionManager.ts:406-414`) — it talks about Tier-2 tools and `propose_action_plan`, pure RMM leakage. Default `true` preserves existing technician/helper/script-builder behavior.
+- **`done` events now carry turn usage** so `turn_complete` can include it (pinned contract): `AiStreamEvent`'s `done` member gains an optional `usage` field, populated in the manager's `result` case. Additive; the technician web UI ignores unknown fields.
+- **Per-user usage hook**: `ActiveSession` gains optional `recordExtraUsage` invoked once per turn in the `result` case, alongside (not instead of) `recordUsageFromSdkResult`. The route wires it to `recordClientUsage` for client sessions; technician sessions never set it.
+- **POST /messages returns `202 { accepted: true }`** (JSON, not SSE) — the add-in consumes the persistent `GET /events` channel instead. This differs from the technician/helper routes (which stream the turn from the POST) because the tool round-trip requires a channel that outlives any single POST.
+- **`GET /events` creates the active session if absent** (via the same `ensureActiveClientSession` helper as `/messages`), so the add-in can connect the stream right after session create with no race against the first message. Cost: an idle SDK subprocess per connected pane (evicted after 2h idle, `SESSION_IDLE_TIMEOUT_MS`).
+- **`?token=` fallback is GET-only** in `clientAiAuthMiddleware` (EventSource cannot set headers). Documented caveat: query tokens can land in proxy access logs — the add-in (Plan 5) should prefer fetch-based SSE with the `Authorization` header; `?token=` exists as the EventSource fallback only.
+- **DLP-stub test stability**: Task 1's stub test asserts only behavior that remains true after Plan 3 replaces the internals (clean payloads pass through unchanged, input matrix never mutated, empty-input shape) — fixtures chosen to match Plan 3's own Task 4 expectations, so merge order between Plans 2 and 3 doesn't matter.
+
+## Verification notes for workers
+
+- Node pin: prefix every pnpm/vitest/tsc command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`.
+- The full api `vitest run` is known-flaky in parallel — verify with the affected files only; trust CI for the full sweep.
+- `npx tsc --noEmit` has pre-existing errors in `agents.test.ts` and `apiKeyAuth.test.ts` — not yours.
+- No new migrations in this plan (Plan 1 shipped all schema, including `client_ai_usage` and the `ai_sessions.client_user_id` constraints). No RLS allowlist changes.
+- Plan 1 must be merged (or its branch checked out underneath) — this plan imports `clientAiAuthMiddleware`, `requireClientAiEnabledMiddleware`, `ClientAiOrgPolicy`, `getOrgPolicy`, `clientAiUsage` (Drizzle), and edits `routes/clientAi/index.ts` + `middleware/clientAiAuth.ts` + `routes/clientAi/schemas.ts`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/api/src/services/clientAiDlp.ts` (+ `clientAiDlp.stub.test.ts`) | Create | Pinned `applyDlp` seam — v1 passthrough stub (Plan 3 replaces internals) |
+| `packages/shared/src/types/ai.ts` | Modify (~line 103-119) | `AiStreamEvent`: add `tool_request`/`tool_completed` members; `done` gains optional `usage` |
+| `apps/api/src/services/streamingSessionManager.ts` | Modify | `ActiveSession` client fields (`clientWriteMode`, `clientDlpConfig`, `recordExtraUsage`), `getOrCreate` `options` param, usage-bearing `done` |
+| `apps/api/src/services/streamingSessionManager.clientLoop.test.ts` | Create | Tests for the three manager changes (mocked SDK) |
+| `apps/api/src/services/clientAiUsage.ts` (+ `.test.ts`) | Create | `recordClientUsage` upserts, period keys, `checkClientBudget`, `getRemainingClientBudgetUsd` |
+| `apps/api/src/services/aiCostTracker.ts` | Modify (line 23) | `export` the existing `checkBillingCredits` |
+| `apps/api/src/services/clientAiToolBridge.ts` (+ `.test.ts`) | Create | In-memory pending map, `requestClientToolExecution`, `resolveClientToolResult`, `failPendingForSession`, timeouts |
+| `apps/api/src/services/clientAiTools.ts` | Create | `CLIENT_TOOL_REGISTRY` (9 tools), MCP server factory, handler (write-mode gate, DLP chokepoint b, persistence, audit, `tool_completed`) |
+| `apps/api/src/services/clientAiTools.registry.test.ts` | Create | Hard-isolation test vs technician registry |
+| `apps/api/src/services/clientAiTools.handler.test.ts` | Create | Handler behavior tests |
+| `apps/api/src/services/clientAiSessions.ts` (+ `.test.ts`) | Create | Excel system prompt, synthetic `AuthContext`, client rate limits, title helper |
+| `apps/api/src/middleware/clientAiAuth.ts` | Modify | GET-only `?token=` query fallback for SSE |
+| `apps/api/src/middleware/clientAiAuth.queryToken.test.ts` | Create | Query-token fallback tests |
+| `apps/api/src/routes/clientAi/sse.ts` (+ `sse.test.ts`) | Create | `CLIENT_AI_SSE_EVENTS`, `toClientSseEvent` bus→client translation |
+| `apps/api/src/routes/clientAi/schemas.ts` | Modify (append) | `sendClientMessageSchema`, `workbookContextSchema`, `clientToolResultSchema` |
+| `apps/api/src/routes/clientAi/sessions.ts` | Create | All six session routes + `ensureActiveClientSession` + audit helper |
+| `apps/api/src/routes/clientAi/sessions.lifecycle.test.ts` | Create | create / get / close route tests |
+| `apps/api/src/routes/clientAi/sessions.messages.test.ts` | Create | messages route tests incl. the redact-before-log contract assertion (Plan 3 Task 6 note) |
+| `apps/api/src/routes/clientAi/sessions.events-toolresults.test.ts` | Create | SSE events + tool-results route tests |
+| `apps/api/src/routes/clientAi/index.ts` | Modify | Mount `/sessions` |
+
+---
+
+### Task 1: DLP seam — passthrough stub (pinned interface)
+
+Plan 3 owns the real engine and pins this exact interface (its plan doc, "Pinned cross-plan contract" section). If Plan 3 has somehow already landed, **skip this task entirely** — the file and interface will already exist.
+
+**Files:**
+- Create: apps/api/src/services/clientAiDlp.ts
+- Create: apps/api/src/services/clientAiDlp.stub.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiDlp.stub.test.ts`
+
+Only Plan-3-stable assertions (clean payloads, no-mutation, empty-input shape) so this file keeps passing after Plan 3 replaces the internals:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { applyDlp } from './clientAiDlp';
+
+const ORG = '0a1b2c3d-1111-4222-8333-444455556666';
+
+describe('applyDlp seam (Plan-2 stub — assertions stay valid against the Plan-3 engine)', () => {
+  it('passes clean text through unchanged', async () => {
+    const r = await applyDlp({ text: 'sum column B please', dlpConfig: {}, orgId: ORG });
+    expect(r).toEqual({ action: 'allow', text: 'sum column B please', redactions: [] });
+  });
+
+  it('passes clean cells through with equal values and does not mutate the input', async () => {
+    const cells = [['Name', 'Qty'], ['Widget', 12]];
+    const r = await applyDlp({ cells, dlpConfig: {}, orgId: ORG });
+    expect(r.action).toBe('allow');
+    expect(r.cells).toEqual(cells);
+    expect(r.redactions).toEqual([]);
+    expect(cells).toEqual([['Name', 'Qty'], ['Widget', 12]]); // never mutated
+  });
+
+  it('handles empty input (no text, no cells)', async () => {
+    const r = await applyDlp({ dlpConfig: {}, orgId: ORG });
+    expect(r).toEqual({ action: 'allow', redactions: [] });
+  });
+
+  it('scans text and cells in the same call', async () => {
+    const r = await applyDlp({ text: 'hello', cells: [['x']], dlpConfig: {}, orgId: ORG });
+    expect(r.text).toBe('hello');
+    expect(r.cells).toEqual([['x']]);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (module not found)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiDlp.stub.test.ts
+```
+
+- [ ] **Step 3: Create `apps/api/src/services/clientAiDlp.ts`**
+
+```ts
+/**
+ * Client AI DLP / redaction seam (spec §6) — v1 PASSTHROUGH STUB.
+ *
+ * Plan 3 (docs/superpowers/plans/2026-06-12-ai-for-office-3-dlp.md) replaces
+ * the internals with the real detector/redaction engine. The interface below
+ * is PINNED across plans — do not change it here.
+ *
+ * Call sites (owned by Plan 2 — the chokepoints; spec §6 "nothing reaches the
+ * model un-scanned"):
+ *  (a) user message text — routes/clientAi/sessions.ts POST /:id/messages
+ *  (b) every tool_result payload + workbookContext cells —
+ *      services/clientAiTools.ts (applyDlpToToolOutput) and the messages route
+ *  (c) template bodies — arrive inside (a) in v1 (the add-in inserts templates
+ *      into the chat input).
+ *
+ * Persistence contract: callers store result.text / result.redactions, never
+ * the raw input (Plan 3 Task 6 ships the unit-level proof; Plan 2's
+ * sessions.messages.test.ts carries the integration assertion).
+ *
+ * `input.orgId` and `input.dlpConfig` are unused by the stub but pinned in the
+ * signature (Plan 3's engine parses dlpConfig itself; orgId is reserved for
+ * per-org compiled-rule caching/telemetry).
+ */
+
+export interface DlpRedactionEvent {
+  rule: string;
+  count: number;
+  location: string;
+}
+
+export interface DlpResult {
+  action: 'allow' | 'block';
+  text?: string;
+  cells?: unknown[][];
+  redactions: DlpRedactionEvent[];
+  blockReason?: string;
+}
+
+export async function applyDlp(input: {
+  text?: string;
+  cells?: unknown[][];
+  dlpConfig: unknown;
+  orgId: string;
+}): Promise<DlpResult> {
+  const result: DlpResult = { action: 'allow', redactions: [] };
+  if (typeof input.text === 'string') result.text = input.text;
+  if (input.cells !== undefined) {
+    // Row-copied like the Plan-3 engine — callers may rely on a fresh matrix.
+    result.cells = input.cells.map((row) => [...(row ?? [])]);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (4 tests; same command as Step 2)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiDlp.ts apps/api/src/services/clientAiDlp.stub.test.ts
+git commit -m "feat(client-ai): applyDlp passthrough seam (pinned interface for Plan 3)" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Stream-event types + streamingSessionManager client hooks (TDD)
+
+Three additive changes to the shared loop, verified with a mocked SDK:
+1. `AiStreamEvent` gains `tool_request` / `tool_completed` members; `done` gains optional `usage`.
+2. `ActiveSession` gains `clientWriteMode` / `clientDlpConfig` / `recordExtraUsage` optional fields.
+3. `getOrCreate` gains `options?: { injectApprovalModeInstructions?: boolean }`; the `result` case publishes usage on `done` and invokes `recordExtraUsage`.
+
+**Files:**
+- Modify: packages/shared/src/types/ai.ts (~lines 103-119)
+- Modify: apps/api/src/services/streamingSessionManager.ts
+- Create: apps/api/src/services/streamingSessionManager.clientLoop.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/streamingSessionManager.clientLoop.test.ts`
+
+```ts
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+
+const { queryMock, recordUsageMock, capturedQueryArgs } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  recordUsageMock: vi.fn(() => Promise.resolve()),
+  capturedQueryArgs: [] as Array<{ prompt: unknown; options: Record<string, unknown> }>,
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
+
+vi.mock('../db', () => ({
+  db: {
+    // Only DB read on this path: the aiBudgets approvalMode lookup
+    // (streamingSessionManager.getOrCreate). Return auto_approve so the
+    // approval-mode prompt injection is observable.
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([{ approvalMode: 'auto_approve' }])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+    insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+  },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('./aiCostTracker', () => ({ recordUsageFromSdkResult: recordUsageMock }));
+vi.mock('./aiAgent', () => ({ sanitizeErrorForClient: (e: unknown) => String(e) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./aiAgentSdkTools', () => ({
+  createBreezeMcpServer: vi.fn(() => ({ type: 'sdk' })),
+  BREEZE_MCP_TOOL_NAMES: ['mcp__breeze__query_devices'],
+}));
+vi.mock('./aiAgentSdk', () => ({
+  createSessionPreToolUse: vi.fn(() => vi.fn()),
+  createSessionPostToolUse: vi.fn(() => vi.fn()),
+}));
+vi.mock('./aiToolOutput', () => ({ redactAiToolOutputText: (s: string) => s }));
+vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
+
+import { StreamingSessionManager } from './streamingSessionManager';
+import type { AuthContext } from '../middleware/auth';
+import type { AiStreamEvent } from '@breeze/shared/types/ai';
+
+const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
+
+const DB_SESSION = {
+  orgId: ORG,
+  sdkSessionId: null,
+  model: 'claude-sonnet-4-5-20250929',
+  maxTurns: 50,
+  turnCount: 0,
+  systemPrompt: null,
+};
+
+const AUTH = {
+  orgId: ORG,
+  scope: 'organization',
+  accessibleOrgIds: [ORG],
+  user: { id: 'beefbeef-1111-4222-8333-444455556666', email: 'finance.user@contoso.com' },
+} as unknown as AuthContext;
+
+const RESULT_MSG = {
+  type: 'result',
+  subtype: 'success',
+  total_cost_usd: 0.03,
+  usage: { input_tokens: 100, output_tokens: 50 },
+  num_turns: 1,
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+/** queryMock returns an async-iterable Query stub gated on `gate`. */
+function mockSdkQuery(messages: unknown[], gate: Promise<void>) {
+  queryMock.mockImplementation((args: { prompt: unknown; options: Record<string, unknown> }) => {
+    capturedQueryArgs.push(args);
+    return {
+      async *[Symbol.asyncIterator]() {
+        await gate;
+        yield* messages as never[];
+      },
+      interrupt: vi.fn(),
+      close: vi.fn(),
+    };
+  });
+}
+
+let manager: StreamingSessionManager;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedQueryArgs.length = 0;
+  manager = new StreamingSessionManager();
+});
+
+afterEach(() => {
+  manager.shutdown();
+});
+
+describe('getOrCreate — approval-mode prompt injection option', () => {
+  it('injects the technician approval-mode suffix by default (existing behavior)', async () => {
+    const gate = deferred();
+    gate.resolve();
+    mockSdkQuery([], gate.promise);
+
+    const session = await manager.getOrCreate('sess-default', DB_SESSION, AUTH, undefined, 'BASE PROMPT', undefined);
+    await session.processorPromise;
+
+    expect(capturedQueryArgs[0]!.options.systemPrompt).toContain('BASE PROMPT');
+    expect(capturedQueryArgs[0]!.options.systemPrompt).toContain('## Approval Mode');
+  });
+
+  it('suppresses the suffix when injectApprovalModeInstructions is false (client sessions)', async () => {
+    const gate = deferred();
+    gate.resolve();
+    mockSdkQuery([], gate.promise);
+
+    const session = await manager.getOrCreate(
+      'sess-client', DB_SESSION, AUTH, undefined, 'BASE PROMPT', undefined,
+      undefined, undefined, { injectApprovalModeInstructions: false },
+    );
+    await session.processorPromise;
+
+    expect(capturedQueryArgs[0]!.options.systemPrompt).toBe('BASE PROMPT');
+  });
+});
+
+describe('result handling — usage-bearing done + recordExtraUsage', () => {
+  it('publishes done with usage and invokes recordExtraUsage with the turn cost', async () => {
+    const gate = deferred();
+    mockSdkQuery([RESULT_MSG], gate.promise);
+
+    const session = await manager.getOrCreate(
+      'sess-usage', DB_SESSION, AUTH, undefined, 'BASE PROMPT', undefined,
+      undefined, undefined, { injectApprovalModeInstructions: false },
+    );
+
+    const recordExtraUsage = vi.fn(() => Promise.resolve());
+    session.recordExtraUsage = recordExtraUsage;
+    session.clientWriteMode = 'readwrite'; // type-level: field exists on ActiveSession
+
+    const events: AiStreamEvent[] = [];
+    const sub = session.eventBus.subscribe('test-sub');
+    const consumer = (async () => {
+      for await (const e of sub) events.push(e);
+    })();
+
+    gate.resolve();
+    await session.processorPromise;
+    await consumer;
+
+    // 0.03 USD → 3 cents (recordUsageFromSdkResult rounding, aiCostTracker.ts:272)
+    expect(recordExtraUsage).toHaveBeenCalledWith({ inputTokens: 100, outputTokens: 50, costCents: 3 });
+    expect(recordUsageMock).toHaveBeenCalled(); // org-level recording still happens
+    expect(events).toContainEqual({
+      type: 'done',
+      usage: { inputTokens: 100, outputTokens: 50, costCents: 3 },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/streamingSessionManager.clientLoop.test.ts
+```
+
+Expected: type/compile failure on the `options` 9th argument and `recordExtraUsage`/`clientWriteMode` fields, and the default-injection test passing while the other two fail.
+
+- [ ] **Step 3: Edit `packages/shared/src/types/ai.ts`** — in the `AiStreamEvent` union (lines 103-119), replace the final member `| { type: 'done' };` with:
+
+```ts
+  // ── AI for Office (client sessions) — published by the client tool bridge/handlers ──
+  | { type: 'tool_request'; toolUseId: string; toolName: string; input: Record<string, unknown>; mutating: boolean }
+  | {
+      type: 'tool_completed';
+      toolUseId: string;
+      toolName: string;
+      status: 'success' | 'error' | 'rejected' | 'timeout';
+      redactions?: Array<{ rule: string; count: number; location: string }>;
+      blockReason?: string;
+    }
+  // `usage` is set by the streaming manager's result case so client surfaces
+  // can render turn cost (turn_complete). Technician UI ignores it.
+  | { type: 'done'; usage?: { inputTokens: number; outputTokens: number; costCents: number } };
+```
+
+- [ ] **Step 4: Edit `apps/api/src/services/streamingSessionManager.ts`** — four edits:
+
+**(a)** In `interface ActiveSession`, after the `planApprovalResolver` field (line ~259), add:
+
+```ts
+  // ── AI for Office (client sessions) — set by routes/clientAi/sessions.ts ──
+  /** Client org policy writeMode, refreshed on every client message; the
+   *  client tool handler rejects mutating tools when 'readonly'. */
+  clientWriteMode?: 'readonly' | 'readwrite';
+  /** client_ai_org_policies.dlp_config (jsonb, unknown — the DLP engine parses
+   *  it itself), refreshed on every client message. */
+  clientDlpConfig?: unknown;
+  /** Extra per-turn usage recorder invoked in the result case alongside
+   *  recordUsageFromSdkResult (client sessions: per-user client_ai_usage buckets). */
+  recordExtraUsage?: (usage: { inputTokens: number; outputTokens: number; costCents: number }) => Promise<void>;
+```
+
+**(b)** In `getOrCreate`, add a final optional parameter after `mcpServerFactory` (line ~313):
+
+```ts
+    options?: { injectApprovalModeInstructions?: boolean },
+```
+
+**(c)** Gate the approval-mode prompt injection (line ~407). Replace:
+
+```ts
+    if (approvalMode !== 'per_step') {
+```
+
+with:
+
+```ts
+    if (options?.injectApprovalModeInstructions !== false && approvalMode !== 'per_step') {
+```
+
+**(d)** In the `case 'result':` block, replace the final two statements of the non-early-return path (currently, after the success/else usage-recording branches):
+
+```ts
+            // Signal this turn is done, but DON'T close the event bus —
+            // session stays alive for follow-up messages
+            session.eventBus.publish({ type: 'done' });
+            session.state = 'idle';
+            break;
+```
+
+with:
+
+```ts
+            // Per-user usage hook (AI for Office): runs alongside the org-level
+            // recordUsageFromSdkResult above, never instead of it.
+            const turnCostCents = Math.round(usageData.total_cost_usd * 100 * 100) / 100;
+            if (session.recordExtraUsage) {
+              try {
+                await session.recordExtraUsage({
+                  inputTokens: usageData.usage.input_tokens,
+                  outputTokens: usageData.usage.output_tokens,
+                  costCents: turnCostCents,
+                });
+              } catch (err) {
+                captureException(err);
+                console.error('[StreamingSessionManager] recordExtraUsage failed:', err);
+              }
+            }
+
+            // Signal this turn is done, but DON'T close the event bus —
+            // session stays alive for follow-up messages. Carries usage so
+            // client surfaces can render turn cost (turn_complete).
+            session.eventBus.publish({
+              type: 'done',
+              usage: {
+                inputTokens: usageData.usage.input_tokens,
+                outputTokens: usageData.usage.output_tokens,
+                costCents: turnCostCents,
+              },
+            });
+            session.state = 'idle';
+            break;
+```
+
+(The early `!orgId` branch at the top of the case keeps its plain `{ type: 'done' }` — `usage` is optional.)
+
+- [ ] **Step 5: Run, expect PASS** (3 tests; same command as Step 2). Then typecheck both packages:
+
+```bash
+cd /Users/toddhebebrand/breeze/packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm typecheck
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+
+Expected: clean (modulo the two pre-existing test-file errors). Also run the existing manager security suite to confirm no regression:
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/streamingSessionManager.security.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/types/ai.ts apps/api/src/services/streamingSessionManager.ts apps/api/src/services/streamingSessionManager.clientLoop.test.ts
+git commit -m "feat(client-ai): client hooks in streaming session loop — usage-bearing done, recordExtraUsage, prompt-injection opt-out" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: clientAiUsage service + export checkBillingCredits (TDD)
+
+Per-user metering buckets (spec §8) keyed `(org_id, client_user_id, period, period_key)` on Plan 1's `client_ai_usage` table, mirroring `recordUsageFromSdkResult`'s onConflictDoUpdate idiom (`aiCostTracker.ts:297-325`). Budget checks SUM across the org's users. Also makes `checkBillingCredits` importable (it is currently module-private at `aiCostTracker.ts:23`; `checkBudget` calls it internally, but the client preflight needs the credits check WITHOUT the technician `aiBudgets` gating that `checkBudget` adds).
+
+**Files:**
+- Create: apps/api/src/services/clientAiUsage.ts
+- Create: apps/api/src/services/clientAiUsage.test.ts
+- Modify: apps/api/src/services/aiCostTracker.ts (line 23: add `export`)
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiUsage.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { dbInsertMock, dbSelectMock } = vi.hoisted(() => ({
+  dbInsertMock: vi.fn(),
+  dbSelectMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: { insert: dbInsertMock, select: dbSelectMock },
+}));
+
+import {
+  clientUsageDailyKey,
+  clientUsageMonthlyKey,
+  recordClientUsage,
+  getOrgPeriodCostCents,
+  checkClientBudget,
+  getRemainingClientBudgetUsd,
+} from './clientAiUsage';
+import { defaultClientAiPolicy } from './clientAiPolicy';
+
+const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
+const USER = 'beefbeef-1111-4222-8333-444455556666';
+
+function setupInsert() {
+  const onConflict = vi.fn(() => Promise.resolve());
+  const values = vi.fn(() => ({ onConflictDoUpdate: onConflict }));
+  dbInsertMock.mockImplementation(() => ({ values }));
+  return { values, onConflict };
+}
+
+function setupSumSelect(totalCents: number) {
+  dbSelectMock.mockImplementation(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve([{ total: totalCents }])),
+    })),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('period keys (UTC, mirrors aiCostTracker)', () => {
+  it('formats daily and monthly keys', () => {
+    const d = new Date(Date.UTC(2026, 5, 12, 23, 59));
+    expect(clientUsageDailyKey(d)).toBe('2026-06-12');
+    expect(clientUsageMonthlyKey(d)).toBe('2026-06');
+  });
+});
+
+describe('recordClientUsage', () => {
+  it('upserts a daily AND a monthly bucket keyed by (org, user, period, periodKey)', async () => {
+    const { values, onConflict } = setupInsert();
+    await recordClientUsage(ORG, USER, { inputTokens: 100, outputTokens: 50, costCents: 3, messageCount: 1 });
+
+    expect(dbInsertMock).toHaveBeenCalledTimes(2);
+    expect(values).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      orgId: ORG,
+      clientUserId: USER,
+      period: 'daily',
+      periodKey: clientUsageDailyKey(),
+      inputTokens: 100,
+      outputTokens: 50,
+      totalCostCents: 3,
+      messageCount: 1,
+      sessionCount: 0,
+    }));
+    expect(values).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      period: 'monthly',
+      periodKey: clientUsageMonthlyKey(),
+    }));
+    expect(onConflict).toHaveBeenCalledTimes(2);
+  });
+
+  it('defaults absent delta fields to 0 (sessionCount-only bump on create)', async () => {
+    const { values } = setupInsert();
+    await recordClientUsage(ORG, USER, { sessionCount: 1 });
+    expect(values).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      sessionCount: 1, messageCount: 0, inputTokens: 0, outputTokens: 0, totalCostCents: 0,
+    }));
+  });
+
+  it('a failed daily upsert does not prevent the monthly upsert (additive counters)', async () => {
+    const onConflict = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+    dbInsertMock.mockImplementation(() => ({ values: vi.fn(() => ({ onConflictDoUpdate: onConflict })) }));
+    await expect(recordClientUsage(ORG, USER, { messageCount: 1 })).resolves.toBeUndefined();
+    expect(dbInsertMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getOrgPeriodCostCents', () => {
+  it('returns the SUM across the org users for the bucket', async () => {
+    setupSumSelect(642.5);
+    await expect(getOrgPeriodCostCents(ORG, 'daily', '2026-06-12')).resolves.toBe(642.5);
+  });
+
+  it('returns 0 when the bucket has no rows', async () => {
+    dbSelectMock.mockImplementation(() => ({
+      from: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) })),
+    }));
+    await expect(getOrgPeriodCostCents(ORG, 'daily', '2026-06-12')).resolves.toBe(0);
+  });
+});
+
+describe('checkClientBudget', () => {
+  it('returns null when no budgets configured (no DB reads)', async () => {
+    const policy = { ...defaultClientAiPolicy(ORG), enabled: true };
+    await expect(checkClientBudget(policy)).resolves.toBeNull();
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when daily spend reaches the cap', async () => {
+    setupSumSelect(500);
+    const policy = { ...defaultClientAiPolicy(ORG), enabled: true, dailyBudgetCents: 500 };
+    const msg = await checkClientBudget(policy);
+    expect(msg).toContain('Daily AI budget');
+  });
+
+  it('rejects when monthly spend reaches the cap', async () => {
+    setupSumSelect(10_000);
+    const policy = { ...defaultClientAiPolicy(ORG), enabled: true, monthlyBudgetCents: 10_000 };
+    const msg = await checkClientBudget(policy);
+    expect(msg).toContain('Monthly AI budget');
+  });
+
+  it('allows when under both caps', async () => {
+    setupSumSelect(10);
+    const policy = { ...defaultClientAiPolicy(ORG), enabled: true, dailyBudgetCents: 500, monthlyBudgetCents: 10_000 };
+    await expect(checkClientBudget(policy)).resolves.toBeNull();
+  });
+});
+
+describe('getRemainingClientBudgetUsd', () => {
+  it('returns undefined when unlimited', async () => {
+    const policy = { ...defaultClientAiPolicy(ORG), enabled: true };
+    await expect(getRemainingClientBudgetUsd(policy)).resolves.toBeUndefined();
+  });
+
+  it('returns the tighter of daily/monthly remaining, in USD', async () => {
+    setupSumSelect(400); // both buckets report 400c spent
+    const policy = {
+      ...defaultClientAiPolicy(ORG), enabled: true,
+      dailyBudgetCents: 500,    // 100c remaining
+      monthlyBudgetCents: 10_000, // 9600c remaining
+    };
+    await expect(getRemainingClientBudgetUsd(policy)).resolves.toBe(1); // $1.00
+  });
+
+  it('clamps at 0 when overspent', async () => {
+    setupSumSelect(900);
+    const policy = { ...defaultClientAiPolicy(ORG), enabled: true, dailyBudgetCents: 500 };
+    await expect(getRemainingClientBudgetUsd(policy)).resolves.toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (module not found)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiUsage.test.ts
+```
+
+- [ ] **Step 3: Create `apps/api/src/services/clientAiUsage.ts`**
+
+```ts
+/**
+ * AI for Office — per-user metering buckets (spec §8).
+ *
+ * client_ai_usage (Plan 1 migration; RLS shape 1) mirrors the ai_cost_usage
+ * daily/monthly bucket pattern PLUS a client_user_id dimension so the MSP can
+ * invoice per end-user. recordClientUsage runs ALONGSIDE the org-level
+ * recordUsageFromSdkResult (which keeps partner billing-credit deduction and
+ * ai_cost_usage flowing unchanged) — wired via ActiveSession.recordExtraUsage.
+ *
+ * Budget semantics (spec §4/§7): org daily/monthly caps live in
+ * client_ai_org_policies; spend is the SUM of this table's org buckets across
+ * users. Upserts mirror aiCostTracker.ts:297-325 (no transaction — additive
+ * counters, partial failure acceptable).
+ *
+ * Callers must be inside a DB access context that can see the org's rows
+ * (request path: clientAiAuthMiddleware org scope; background path: the
+ * recordExtraUsage closure opens its own org-scoped context).
+ */
+
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { clientAiUsage } from '../db/schema/clientAi';
+import type { ClientAiOrgPolicy } from './clientAiPolicy';
+
+export function clientUsageDailyKey(now: Date = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+}
+
+export function clientUsageMonthlyKey(now: Date = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+export interface ClientUsageDelta {
+  inputTokens?: number;
+  outputTokens?: number;
+  costCents?: number;
+  messageCount?: number;
+  sessionCount?: number;
+}
+
+export async function recordClientUsage(
+  orgId: string,
+  clientUserId: string,
+  delta: ClientUsageDelta,
+): Promise<void> {
+  const now = new Date();
+  const inputTokens = delta.inputTokens ?? 0;
+  const outputTokens = delta.outputTokens ?? 0;
+  const costCents = delta.costCents ?? 0;
+  const messageCount = delta.messageCount ?? 0;
+  const sessionCount = delta.sessionCount ?? 0;
+
+  for (const [period, periodKey] of [
+    ['daily', clientUsageDailyKey(now)],
+    ['monthly', clientUsageMonthlyKey(now)],
+  ] as const) {
+    try {
+      await db
+        .insert(clientAiUsage)
+        .values({
+          orgId,
+          clientUserId,
+          period,
+          periodKey,
+          inputTokens,
+          outputTokens,
+          totalCostCents: costCents,
+          sessionCount,
+          messageCount,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [
+            clientAiUsage.orgId,
+            clientAiUsage.clientUserId,
+            clientAiUsage.period,
+            clientAiUsage.periodKey,
+          ],
+          set: {
+            inputTokens: sql`${clientAiUsage.inputTokens} + ${inputTokens}`,
+            outputTokens: sql`${clientAiUsage.outputTokens} + ${outputTokens}`,
+            totalCostCents: sql`${clientAiUsage.totalCostCents} + ${costCents}`,
+            sessionCount: sql`${clientAiUsage.sessionCount} + ${sessionCount}`,
+            messageCount: sql`${clientAiUsage.messageCount} + ${messageCount}`,
+            updatedAt: now,
+          },
+        });
+    } catch (err) {
+      console.error(
+        `[client-ai] Failed to update ${period} usage bucket for org=${orgId}, user=${clientUserId}:`,
+        err,
+      );
+      // Continue to attempt the other period (aiCostTracker convention).
+    }
+  }
+}
+
+/** Org-wide spend for a bucket: SUM across all the org's client users. */
+export async function getOrgPeriodCostCents(
+  orgId: string,
+  period: 'daily' | 'monthly',
+  periodKey: string,
+): Promise<number> {
+  const [row] = await db
+    .select({ total: sql<number>`COALESCE(SUM(${clientAiUsage.totalCostCents}), 0)` })
+    .from(clientAiUsage)
+    .where(
+      and(
+        eq(clientAiUsage.orgId, orgId),
+        eq(clientAiUsage.period, period),
+        eq(clientAiUsage.periodKey, periodKey),
+      ),
+    );
+  return Number(row?.total ?? 0);
+}
+
+/**
+ * Pre-flight org budget gate (spec §4). Returns a user-readable rejection
+ * reason or null. NULL budget = unlimited (no DB read for that period).
+ */
+export async function checkClientBudget(policy: ClientAiOrgPolicy): Promise<string | null> {
+  const now = new Date();
+
+  if (policy.dailyBudgetCents != null) {
+    const spent = await getOrgPeriodCostCents(policy.orgId, 'daily', clientUsageDailyKey(now));
+    if (spent >= policy.dailyBudgetCents) {
+      return `Daily AI budget for your organization has been reached ($${(policy.dailyBudgetCents / 100).toFixed(2)}). Try again tomorrow or contact your IT provider.`;
+    }
+  }
+
+  if (policy.monthlyBudgetCents != null) {
+    const spent = await getOrgPeriodCostCents(policy.orgId, 'monthly', clientUsageMonthlyKey(now));
+    if (spent >= policy.monthlyBudgetCents) {
+      return `Monthly AI budget for your organization has been reached ($${(policy.monthlyBudgetCents / 100).toFixed(2)}). Contact your IT provider to raise it.`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Remaining budget in USD for the SDK's maxBudgetUsd hard stop — the tighter
+ * of the configured daily/monthly remainders. undefined = unlimited.
+ */
+export async function getRemainingClientBudgetUsd(
+  policy: ClientAiOrgPolicy,
+): Promise<number | undefined> {
+  const now = new Date();
+  const remainders: number[] = [];
+
+  if (policy.dailyBudgetCents != null) {
+    const spent = await getOrgPeriodCostCents(policy.orgId, 'daily', clientUsageDailyKey(now));
+    remainders.push(Math.max(0, policy.dailyBudgetCents - spent));
+  }
+  if (policy.monthlyBudgetCents != null) {
+    const spent = await getOrgPeriodCostCents(policy.orgId, 'monthly', clientUsageMonthlyKey(now));
+    remainders.push(Math.max(0, policy.monthlyBudgetCents - spent));
+  }
+
+  if (remainders.length === 0) return undefined;
+  return Math.min(...remainders) / 100;
+}
+```
+
+- [ ] **Step 4: Export `checkBillingCredits`** — in `apps/api/src/services/aiCostTracker.ts` line 23, change:
+
+```ts
+async function checkBillingCredits(orgId: string): Promise<string | null> {
+```
+
+to:
+
+```ts
+export async function checkBillingCredits(orgId: string): Promise<string | null> {
+```
+
+(No other change. The client preflight calls it directly because `checkBudget` couples it to the technician `aiBudgets`/`ai_cost_usage` gating, which must not apply to client sessions — spec §7 keeps the two products' knobs separate.)
+
+- [ ] **Step 5: Run, expect PASS** (13 tests; same command as Step 2). Then:
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/clientAiUsage.ts apps/api/src/services/clientAiUsage.test.ts apps/api/src/services/aiCostTracker.ts
+git commit -m "feat(client-ai): per-user client_ai_usage buckets + client budget checks; export checkBillingCredits" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Client tool bridge — pending map + timeouts (TDD)
+
+The round-trip core: handler publishes `tool_request` on the session bus and awaits an in-memory resolver keyed by `toolUseId` (the `waitForPlanApproval` shape, `aiAgent.ts:323-345`). `POST /tool-results` resolves it; timeouts resolve with a timeout-error result so the model can react.
+
+**Files:**
+- Create: apps/api/src/services/clientAiToolBridge.ts
+- Create: apps/api/src/services/clientAiToolBridge.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiToolBridge.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  requestClientToolExecution,
+  resolveClientToolResult,
+  failPendingForSession,
+  CLIENT_TOOL_TIMEOUT_MS,
+  CLIENT_MUTATING_TOOL_TIMEOUT_MS,
+  _pendingCountForTests,
+} from './clientAiToolBridge';
+import type { ActiveSession } from './streamingSessionManager';
+
+function fakeSession(id: string) {
+  const publish = vi.fn();
+  return {
+    session: { breezeSessionId: id, eventBus: { publish } } as unknown as ActiveSession,
+    publish,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  // Drain anything a test left pending so timers don't leak across tests.
+  failPendingForSession('sess-1');
+  failPendingForSession('sess-2');
+  vi.useRealTimers();
+});
+
+describe('requestClientToolExecution', () => {
+  it('publishes the pinned tool_request event payload and resolves on resolveClientToolResult', async () => {
+    const { session, publish } = fakeSession('sess-1');
+    const p = requestClientToolExecution(session, 'tu-1', 'read_range', { address: 'A1:B2' }, false);
+
+    expect(publish).toHaveBeenCalledWith({
+      type: 'tool_request',
+      toolUseId: 'tu-1',
+      toolName: 'read_range',
+      input: { address: 'A1:B2' },
+      mutating: false,
+    });
+
+    expect(resolveClientToolResult('sess-1', 'tu-1', { status: 'success', output: { cells: [[1]] } })).toBe(true);
+    await expect(p).resolves.toEqual({ status: 'success', output: { cells: [[1]] } });
+    expect(_pendingCountForTests()).toBe(0);
+  });
+
+  it('rejects resolution from a different session (cross-session guard)', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientToolExecution(session, 'tu-2', 'read_selection', {}, false);
+
+    expect(resolveClientToolResult('sess-2', 'tu-2', { status: 'success', output: null })).toBe(false);
+    expect(resolveClientToolResult('sess-1', 'tu-2', { status: 'error', output: { error: 'x' } })).toBe(true);
+    await expect(p).resolves.toEqual({ status: 'error', output: { error: 'x' } });
+  });
+
+  it('returns false for unknown toolUseIds and for double resolution', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientToolExecution(session, 'tu-3', 'read_selection', {}, false);
+    expect(resolveClientToolResult('sess-1', 'nope', { status: 'success', output: null })).toBe(false);
+    expect(resolveClientToolResult('sess-1', 'tu-3', { status: 'success', output: 1 })).toBe(true);
+    expect(resolveClientToolResult('sess-1', 'tu-3', { status: 'success', output: 2 })).toBe(false);
+    await p;
+  });
+
+  it('times out non-mutating tools after 60s with a timeout-error result', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientToolExecution(session, 'tu-4', 'read_range', { address: 'A1' }, false);
+
+    vi.advanceTimersByTime(CLIENT_TOOL_TIMEOUT_MS - 1);
+    expect(_pendingCountForTests()).toBe(1);
+    vi.advanceTimersByTime(1);
+
+    const result = await p;
+    expect(result.status).toBe('timeout');
+    expect(JSON.stringify(result.output)).toContain('timed out');
+    expect(_pendingCountForTests()).toBe(0);
+  });
+
+  it('gives mutating tools the 300s window (pending write approval in the task pane)', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientToolExecution(session, 'tu-5', 'write_range', { address: 'A1', cells: [[1]] }, true);
+
+    vi.advanceTimersByTime(CLIENT_TOOL_TIMEOUT_MS); // 60s: still pending
+    expect(_pendingCountForTests()).toBe(1);
+    vi.advanceTimersByTime(CLIENT_MUTATING_TOOL_TIMEOUT_MS - CLIENT_TOOL_TIMEOUT_MS);
+    await expect(p).resolves.toMatchObject({ status: 'timeout' });
+  });
+});
+
+describe('failPendingForSession', () => {
+  it('fails every pending request of the session (and only that session)', async () => {
+    const a = fakeSession('sess-1');
+    const b = fakeSession('sess-2');
+    const p1 = requestClientToolExecution(a.session, 'tu-6', 'read_range', {}, false);
+    const p2 = requestClientToolExecution(b.session, 'tu-7', 'read_range', {}, false);
+
+    expect(failPendingForSession('sess-1', 'session_closed')).toBe(1);
+    await expect(p1).resolves.toEqual({ status: 'error', output: { error: 'session_closed' } });
+    expect(_pendingCountForTests()).toBe(1);
+
+    expect(resolveClientToolResult('sess-2', 'tu-7', { status: 'success', output: null })).toBe(true);
+    await p2;
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (module not found)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiToolBridge.test.ts
+```
+
+- [ ] **Step 3: Create `apps/api/src/services/clientAiToolBridge.ts`**
+
+```ts
+/**
+ * AI for Office — client-side tool execution bridge (spec §5).
+ *
+ * Office.js only runs inside Excel, so workbook tools execute IN THE ADD-IN:
+ *   1. The MCP tool handler (services/clientAiTools.ts) calls
+ *      requestClientToolExecution → publishes a `tool_request` SSE event on
+ *      the session's SessionEventBus and parks an in-memory resolver here.
+ *   2. The add-in executes via Office.js (write tools behind the user's
+ *      Apply/Reject preview card) and posts
+ *      POST /client-ai/sessions/:id/tool-results { toolUseId, status, output }.
+ *   3. The route calls resolveClientToolResult → the handler resumes and the
+ *      SDK loop continues.
+ *
+ * Timeouts resolve (never reject) with a timeout-shaped result so the model is
+ * told and can react (e.g. the user closed Excel). 60s reads / 300s mutating —
+ * the mutating window covers the in-pane approval wait and stays inside the
+ * manager's 6-min SDK_TURN_TIMEOUT_MS (streamingSessionManager.ts:37).
+ *
+ * The pending map is in-process memory by design: the SDK session is a child
+ * subprocess of this API instance and production runs a single api container
+ * per region — the same affinity the technician /ai approval endpoint already
+ * relies on. This is the waitForPlanApproval in-memory-resolver shape
+ * (services/aiAgent.ts:323), not the DB-polling waitForApproval shape.
+ */
+
+import type { ActiveSession } from './streamingSessionManager';
+
+export const CLIENT_TOOL_TIMEOUT_MS = 60_000;
+export const CLIENT_MUTATING_TOOL_TIMEOUT_MS = 300_000;
+
+export interface ClientToolResult {
+  status: 'success' | 'error' | 'rejected' | 'timeout';
+  output: unknown;
+}
+
+interface PendingClientToolRequest {
+  sessionId: string;
+  toolName: string;
+  timer: ReturnType<typeof setTimeout>;
+  resolve: (result: ClientToolResult) => void;
+}
+
+const pending = new Map<string, PendingClientToolRequest>();
+
+export function requestClientToolExecution(
+  session: ActiveSession,
+  toolUseId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+  mutating: boolean,
+): Promise<ClientToolResult> {
+  return new Promise<ClientToolResult>((resolve) => {
+    const timeoutMs = mutating ? CLIENT_MUTATING_TOOL_TIMEOUT_MS : CLIENT_TOOL_TIMEOUT_MS;
+    const timer = setTimeout(() => {
+      pending.delete(toolUseId);
+      resolve({
+        status: 'timeout',
+        output: {
+          error: `Tool '${toolName}' timed out after ${Math.round(timeoutMs / 1000)}s — the user may have closed Excel or not responded to the approval prompt.`,
+        },
+      });
+    }, timeoutMs);
+
+    pending.set(toolUseId, { sessionId: session.breezeSessionId, toolName, timer, resolve });
+
+    session.eventBus.publish({ type: 'tool_request', toolUseId, toolName, input, mutating });
+  });
+}
+
+/**
+ * Resolve a pending request from POST /tool-results. Returns false when the
+ * id is unknown, already resolved/timed out, or belongs to ANOTHER session
+ * (cross-session guard — toolUseIds are not secrets).
+ */
+export function resolveClientToolResult(
+  sessionId: string,
+  toolUseId: string,
+  result: { status: 'success' | 'error' | 'rejected'; output: unknown },
+): boolean {
+  const entry = pending.get(toolUseId);
+  if (!entry || entry.sessionId !== sessionId) return false;
+  clearTimeout(entry.timer);
+  pending.delete(toolUseId);
+  entry.resolve({ status: result.status, output: result.output ?? null });
+  return true;
+}
+
+/** Fail every pending request of a session (close/teardown). Returns the count failed. */
+export function failPendingForSession(sessionId: string, reason = 'session_closed'): number {
+  let failed = 0;
+  for (const [toolUseId, entry] of [...pending.entries()]) {
+    if (entry.sessionId !== sessionId) continue;
+    clearTimeout(entry.timer);
+    pending.delete(toolUseId);
+    entry.resolve({ status: 'error', output: { error: reason } });
+    failed++;
+  }
+  return failed;
+}
+
+/** Test-only visibility into the pending map. */
+export function _pendingCountForTests(): number {
+  return pending.size;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (6 tests; same command as Step 2)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiToolBridge.ts apps/api/src/services/clientAiToolBridge.test.ts
+git commit -m "feat(client-ai): in-memory tool bridge — tool_request publish + tool-results resolution + timeouts" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: CLIENT_TOOL_REGISTRY + hard-isolation test (TDD)
+
+The pinned 9-tool registry and the structural proof that no technician tool is reachable from client sessions — a hard allowlist, not tier filtering (spec §5).
+
+**Files:**
+- Create: apps/api/src/services/clientAiTools.ts (registry + names/prefix exports only in this task; handlers come in Task 6)
+- Create: apps/api/src/services/clientAiTools.registry.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiTools.registry.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  CLIENT_TOOL_REGISTRY,
+  CLIENT_TOOL_NAMES,
+  CLIENT_MCP_SERVER_NAME,
+  CLIENT_MCP_TOOL_PREFIX,
+  CLIENT_MCP_TOOL_NAMES,
+  clientMcpToolNamesForWriteMode,
+} from './clientAiTools';
+import { TOOL_TIERS, BREEZE_MCP_TOOL_NAMES } from './aiAgentSdkTools';
+import { aiTools } from './aiTools';
+
+const PINNED_NAMES = [
+  'create_sheet',
+  'create_table',
+  'format_range',
+  'get_workbook_overview',
+  'insert_formula',
+  'read_range',
+  'read_selection',
+  'search_workbook',
+  'write_range',
+];
+
+const PINNED_MUTATING = ['create_sheet', 'create_table', 'format_range', 'insert_formula', 'write_range'];
+
+describe('CLIENT_TOOL_REGISTRY — pinned shape (Plans 3/4/5 depend on these names)', () => {
+  it('contains exactly the 9 pinned workbook tools', () => {
+    expect(Object.keys(CLIENT_TOOL_REGISTRY).sort()).toEqual(PINNED_NAMES);
+    expect(CLIENT_TOOL_NAMES.slice().sort()).toEqual(PINNED_NAMES);
+  });
+
+  it('flags exactly the 5 write tools as mutating', () => {
+    const mutating = CLIENT_TOOL_NAMES.filter((n) => CLIENT_TOOL_REGISTRY[n].mutating).sort();
+    expect(mutating).toEqual(PINNED_MUTATING);
+  });
+
+  it('every tool has a non-empty description and an inputSchema object', () => {
+    for (const name of CLIENT_TOOL_NAMES) {
+      expect(CLIENT_TOOL_REGISTRY[name].description.length).toBeGreaterThan(20);
+      expect(typeof CLIENT_TOOL_REGISTRY[name].inputSchema).toBe('object');
+    }
+  });
+});
+
+describe('hard isolation from the technician registry (spec §5: allowlist, not tier filtering)', () => {
+  it('shares no tool name with the technician TOOL_TIERS map', () => {
+    for (const name of CLIENT_TOOL_NAMES) {
+      expect(TOOL_TIERS[name as keyof typeof TOOL_TIERS]).toBeUndefined();
+    }
+  });
+
+  it('shares no tool name with the technician aiTools execution registry', () => {
+    for (const name of CLIENT_TOOL_NAMES) {
+      expect(aiTools.has(name)).toBe(false);
+    }
+  });
+
+  it('uses its own MCP namespace — no overlap with BREEZE_MCP_TOOL_NAMES', () => {
+    expect(CLIENT_MCP_SERVER_NAME).toBe('excel');
+    expect(CLIENT_MCP_TOOL_PREFIX).toBe('mcp__excel__');
+    for (const mcpName of CLIENT_MCP_TOOL_NAMES) {
+      expect(mcpName.startsWith('mcp__excel__')).toBe(true);
+      expect(BREEZE_MCP_TOOL_NAMES).not.toContain(mcpName);
+    }
+    expect(CLIENT_MCP_TOOL_NAMES).toHaveLength(9);
+  });
+});
+
+describe('clientMcpToolNamesForWriteMode', () => {
+  it('readwrite exposes all 9 tools', () => {
+    expect(clientMcpToolNamesForWriteMode('readwrite')).toHaveLength(9);
+  });
+
+  it('readonly strips every mutating tool from the toolset', () => {
+    const names = clientMcpToolNamesForWriteMode('readonly');
+    expect(names.sort()).toEqual([
+      'mcp__excel__get_workbook_overview',
+      'mcp__excel__read_range',
+      'mcp__excel__read_selection',
+      'mcp__excel__search_workbook',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (module not found)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiTools.registry.test.ts
+```
+
+- [ ] **Step 3: Create `apps/api/src/services/clientAiTools.ts`** (registry portion; Task 6 appends the handlers to this same file)
+
+```ts
+/**
+ * AI for Office — client workbook tool registry (spec §5).
+ *
+ * A SEPARATE registry from the technician aiTools map / TOOL_TIERS — client
+ * sessions can only ever see these 9 tools (hard allowlist; proven by
+ * clientAiTools.registry.test.ts). Tools do NOT execute on the server:
+ * Office.js only runs inside Excel, so the handler (Task 6) round-trips
+ * through services/clientAiToolBridge.ts to the add-in.
+ *
+ * inputSchema entries are zod RAW SHAPES consumed by the Agent SDK's tool()
+ * helper (the aiAgentSdkTools.ts:766+ convention). They describe/validate the
+ * model's arguments; actual workbook semantics live in the add-in's Office.js
+ * executor (Plan 5).
+ */
+
+import { z } from 'zod';
+
+const addressSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .describe('A1-style address or range, e.g. "B2" or "B2:F40"');
+const sheetNameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .optional()
+  .describe('Sheet name; defaults to the active sheet when omitted');
+const cellValueSchema = z.union([z.string().max(32767), z.number(), z.boolean(), z.null()]);
+const cellMatrixSchema = z
+  .array(z.array(cellValueSchema).min(1).max(500))
+  .min(1)
+  .max(5000)
+  .describe('Row-major matrix of cell values matching the target range shape');
+
+export interface ClientWorkbookTool {
+  description: string;
+  /** Mutating tools are approval-gated CLIENT-SIDE (preview card in the task
+   *  pane) and stripped/rejected under policy writeMode 'readonly'. */
+  mutating: boolean;
+  inputSchema: Record<string, z.ZodTypeAny>;
+}
+
+export const CLIENT_TOOL_REGISTRY = {
+  get_workbook_overview: {
+    description:
+      'List the sheets in the open workbook with their used ranges and first-row headers. Call this first to orient yourself before reading or writing data.',
+    mutating: false,
+    inputSchema: {},
+  },
+  read_selection: {
+    description:
+      "Read the user's current selection: its address, sheet, and cell values. Use when the user refers to 'this', 'the selected cells', or similar.",
+    mutating: false,
+    inputSchema: {},
+  },
+  read_range: {
+    description:
+      'Read the cell values of a specific range. Returns a row-major matrix. Read data before answering questions about it — never guess values.',
+    mutating: false,
+    inputSchema: { address: addressSchema, sheetName: sheetNameSchema },
+  },
+  write_range: {
+    description:
+      'Write a matrix of values into a range. The user sees a before/after preview in the task pane and must click Apply before anything changes.',
+    mutating: true,
+    inputSchema: { address: addressSchema, sheetName: sheetNameSchema, cells: cellMatrixSchema },
+  },
+  insert_formula: {
+    description:
+      'Insert an Excel formula (starting with "=") into a cell or fill it across a range. Approval-gated like all writes.',
+    mutating: true,
+    inputSchema: {
+      address: addressSchema,
+      sheetName: sheetNameSchema,
+      formula: z.string().min(2).max(8192).startsWith('=').describe('Excel formula, e.g. "=SUM(B2:B40)"'),
+    },
+  },
+  create_sheet: {
+    description:
+      'Create a new worksheet in the workbook. Sheet names are limited to 31 characters (Excel limit). Approval-gated.',
+    mutating: true,
+    inputSchema: { name: z.string().min(1).max(31).describe('New sheet name (max 31 chars)') },
+  },
+  format_range: {
+    description:
+      'Apply formatting to a range: bold/italic, font and fill colors (hex), number format string, font size. Approval-gated.',
+    mutating: true,
+    inputSchema: {
+      address: addressSchema,
+      sheetName: sheetNameSchema,
+      format: z
+        .object({
+          bold: z.boolean().optional(),
+          italic: z.boolean().optional(),
+          fontColor: z.string().max(20).optional().describe('Hex color, e.g. "#1F4E79"'),
+          fillColor: z.string().max(20).optional().describe('Hex color, e.g. "#FFF2CC"'),
+          numberFormat: z.string().max(100).optional().describe('Excel number format, e.g. "$#,##0.00"'),
+          fontSize: z.number().min(6).max(72).optional(),
+        })
+        .strict(),
+    },
+  },
+  create_table: {
+    description:
+      'Convert a range into an Excel table (sortable, filterable, banded rows). Approval-gated.',
+    mutating: true,
+    inputSchema: {
+      address: addressSchema,
+      sheetName: sheetNameSchema,
+      hasHeaders: z.boolean().optional().describe('Whether the first row of the range is a header row'),
+      tableName: z.string().min(1).max(255).optional(),
+    },
+  },
+  search_workbook: {
+    description:
+      'Search the workbook (or one sheet) for a text value. Returns matching cell addresses and their values.',
+    mutating: false,
+    inputSchema: {
+      query: z.string().min(1).max(255),
+      sheetName: sheetNameSchema,
+      matchCase: z.boolean().optional(),
+    },
+  },
+} as const satisfies Record<string, ClientWorkbookTool>;
+
+export type ClientToolName = keyof typeof CLIENT_TOOL_REGISTRY;
+
+export const CLIENT_TOOL_NAMES = Object.keys(CLIENT_TOOL_REGISTRY) as ClientToolName[];
+
+export const CLIENT_MUTATING_TOOL_NAMES = CLIENT_TOOL_NAMES.filter(
+  (name) => CLIENT_TOOL_REGISTRY[name].mutating,
+);
+
+/** MCP server name → SDK tool prefix mcp__excel__<tool> (own namespace,
+ *  disjoint from mcp__breeze__ — see registry.test.ts). */
+export const CLIENT_MCP_SERVER_NAME = 'excel';
+export const CLIENT_MCP_TOOL_PREFIX = `mcp__${CLIENT_MCP_SERVER_NAME}__`;
+
+export const CLIENT_MCP_TOOL_NAMES = CLIENT_TOOL_NAMES.map(
+  (name) => `${CLIENT_MCP_TOOL_PREFIX}${name}`,
+);
+
+/**
+ * The SDK-level allowlist for a session: policy writeMode 'readonly' strips
+ * mutating tools from the model's toolset at session start (pinned contract).
+ * The handler additionally rejects mutating calls server-side (Task 6) in
+ * case a resumed/stale SDK process still advertises them.
+ */
+export function clientMcpToolNamesForWriteMode(writeMode: 'readwrite' | 'readonly'): string[] {
+  return CLIENT_TOOL_NAMES.filter(
+    (name) => writeMode === 'readwrite' || !CLIENT_TOOL_REGISTRY[name].mutating,
+  ).map((name) => `${CLIENT_MCP_TOOL_PREFIX}${name}`);
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (8 tests; same command as Step 2)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiTools.ts apps/api/src/services/clientAiTools.registry.test.ts
+git commit -m "feat(client-ai): CLIENT_TOOL_REGISTRY — 9 workbook tools, hard-isolated from technician registry" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Client tool MCP handlers — bridge, DLP chokepoint (b), persistence, audit (TDD)
+
+The handler is the server side of the round-trip. It deliberately does NOT use the technician `createSessionPreToolUse`/`createSessionPostToolUse` callbacks (they reject unknown tools at `aiAgentSdk.ts:222-225` and encode technician persistence). It owns, per call:
+1. toolUseId correlation (FIFO shift from `session.toolUseIdQueue`, the `aiAgentSdk.ts:640` mechanism),
+2. server-side `readonly` rejection of mutating tools,
+3. the bridge round-trip,
+4. DLP chokepoint (b) on the returned payload (cell-matrix scan + JSON-text scan),
+5. persistence (`ai_messages` tool_result row with redactions in `content_blocks`, `ai_tool_executions` row),
+6. `ai.client_session.tool_execute` / `.tool_reject` audit events (actor = the portal user),
+7. the `tool_completed` bus event.
+
+**Files:**
+- Modify: apps/api/src/services/clientAiTools.ts (append handlers + server factory)
+- Create: apps/api/src/services/clientAiTools.handler.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiTools.handler.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  requestToolMock,
+  applyDlpMock,
+  writeAuditEventMock,
+  messagesValuesMock,
+  executionsValuesMock,
+  dbInsertMock,
+} = vi.hoisted(() => {
+  const messagesValues = vi.fn(() => Promise.resolve());
+  const executionsValues = vi.fn(() => Promise.resolve());
+  return {
+    requestToolMock: vi.fn(),
+    applyDlpMock: vi.fn(),
+    writeAuditEventMock: vi.fn(),
+    messagesValuesMock: messagesValues,
+    executionsValuesMock: executionsValues,
+    // First insert per handler call = ai_messages, second = ai_tool_executions
+    dbInsertMock: vi.fn(),
+  };
+});
+
+vi.mock('./clientAiToolBridge', () => ({
+  requestClientToolExecution: requestToolMock,
+}));
+vi.mock('./clientAiDlp', () => ({ applyDlp: applyDlpMock }));
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: writeAuditEventMock,
+  requestLikeFromSnapshot: (s: { ip?: string; userAgent?: string }) => ({
+    req: { header: () => s.userAgent },
+  }),
+}));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../db', () => ({
+  db: { insert: dbInsertMock },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+import { makeClientToolHandler } from './clientAiTools';
+import type { ActiveSession } from './streamingSessionManager';
+
+const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
+const CLIENT_USER = 'beefbeef-1111-4222-8333-444455556666';
+const SESSION_ID = 'a1a1a1a1-1111-4222-8333-444455556666';
+
+function makeSession(overrides: Partial<{ clientWriteMode: 'readonly' | 'readwrite'; queue: string[] }> = {}) {
+  const publish = vi.fn();
+  const session = {
+    breezeSessionId: SESSION_ID,
+    orgId: ORG,
+    eventBus: { publish },
+    toolUseIdQueue: overrides.queue ?? ['toolu_abc123'],
+    auditSnapshot: { ip: '203.0.113.7', userAgent: 'office-addin' },
+    auth: { user: { id: CLIENT_USER, email: 'finance.user@contoso.com' } },
+    clientWriteMode: overrides.clientWriteMode ?? 'readwrite',
+    clientDlpConfig: {},
+  } as unknown as ActiveSession;
+  return { session, publish };
+}
+
+function passthroughDlp() {
+  applyDlpMock.mockImplementation(
+    async (input: { text?: string; cells?: unknown[][] }) => ({
+      action: 'allow',
+      ...(input.text !== undefined ? { text: input.text } : {}),
+      ...(input.cells !== undefined ? { cells: input.cells.map((r) => [...r]) } : {}),
+      redactions: [],
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  let call = 0;
+  dbInsertMock.mockImplementation(() => {
+    call++;
+    return { values: call % 2 === 1 ? messagesValuesMock : executionsValuesMock };
+  });
+  passthroughDlp();
+});
+
+describe('makeClientToolHandler — readonly write-mode gate', () => {
+  it('rejects mutating tools server-side without calling the bridge, audits tool_reject', async () => {
+    const { session, publish } = makeSession({ clientWriteMode: 'readonly' });
+    const handler = makeClientToolHandler('write_range', () => session);
+
+    const result = await handler({ address: 'A1', cells: [[1]] });
+
+    expect(result.isError).toBe(true);
+    expect(requestToolMock).not.toHaveBeenCalled();
+    expect(executionsValuesMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'rejected' }));
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'ai.client_session.tool_reject',
+        result: 'denied',
+        actorType: 'user',
+        actorId: CLIENT_USER,
+        orgId: ORG,
+        details: expect.objectContaining({ principalType: 'portal_user', reason: 'readonly_policy' }),
+      }),
+    );
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tool_completed', status: 'rejected', toolName: 'write_range' }),
+    );
+  });
+
+  it('still allows read tools under readonly', async () => {
+    const { session } = makeSession({ clientWriteMode: 'readonly' });
+    requestToolMock.mockResolvedValue({ status: 'success', output: { cells: [['x']] } });
+    const handler = makeClientToolHandler('read_range', () => session);
+    const result = await handler({ address: 'A1' });
+    expect(result.isError).toBeFalsy();
+    expect(requestToolMock).toHaveBeenCalled();
+  });
+});
+
+describe('makeClientToolHandler — success path', () => {
+  it('round-trips through the bridge with the FIFO toolUseId, persists redacted output, audits, publishes tool_completed', async () => {
+    const { session, publish } = makeSession({ queue: ['toolu_real'] });
+    requestToolMock.mockResolvedValue({ status: 'success', output: { address: 'A1:B1', cells: [['v1', 'v2']] } });
+    applyDlpMock.mockImplementation(async (input: { text?: string; cells?: unknown[][] }) => {
+      if (input.cells) {
+        return {
+          action: 'allow',
+          cells: [['[REDACTED:creditCard]', 'v2']],
+          redactions: [{ rule: 'creditCard', count: 1, location: 'cell[0][0]' }],
+        };
+      }
+      return { action: 'allow', text: input.text, redactions: [] };
+    });
+
+    const handler = makeClientToolHandler('read_range', () => session);
+    const result = await handler({ address: 'A1:B1' });
+
+    expect(requestToolMock).toHaveBeenCalledWith(session, 'toolu_real', 'read_range', { address: 'A1:B1' }, false);
+
+    // Persisted form is the REDACTED form, with redactions in content_blocks
+    expect(messagesValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: SESSION_ID,
+      role: 'tool_result',
+      toolUseId: 'toolu_real',
+      toolName: 'read_range',
+      toolOutput: expect.objectContaining({ cells: [['[REDACTED:creditCard]', 'v2']] }),
+      contentBlocks: [
+        { type: 'dlp_redactions', redactions: [{ rule: 'creditCard', count: 1, location: 'cell[0][0]' }] },
+      ],
+    }));
+    expect(executionsValuesMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed' }));
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'ai.client_session.tool_execute', result: 'success' }),
+    );
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'tool_completed', status: 'success' }));
+
+    // The model sees the redacted form
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain('[REDACTED:creditCard]');
+    expect(result.content[0]!.text).not.toContain('v1');
+  });
+
+  it('mints a toolUseId when the FIFO queue is empty', async () => {
+    const { session } = makeSession({ queue: [] });
+    requestToolMock.mockResolvedValue({ status: 'success', output: { ok: true } });
+    const handler = makeClientToolHandler('read_selection', () => session);
+    await handler({});
+    const usedId = requestToolMock.mock.calls[0]![1] as string;
+    expect(usedId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe('makeClientToolHandler — DLP block on tool output', () => {
+  it('returns a block-reason error tool_result and never persists the raw payload', async () => {
+    const { session, publish } = makeSession();
+    requestToolMock.mockResolvedValue({ status: 'success', output: { cells: [['4111111111111111']] } });
+    applyDlpMock.mockResolvedValue({
+      action: 'block',
+      blockReason: 'dlp_blocked:creditCard',
+      redactions: [{ rule: 'creditCard', count: 1, location: 'cell[0][0]' }],
+    });
+
+    const handler = makeClientToolHandler('read_range', () => session);
+    const result = await handler({ address: 'A1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('dlp_blocked:creditCard');
+    expect(JSON.stringify(messagesValuesMock.mock.calls)).not.toContain('4111111111111111');
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tool_completed', status: 'error', blockReason: 'dlp_blocked:creditCard' }),
+    );
+  });
+});
+
+describe('makeClientToolHandler — rejection and timeout results', () => {
+  it('user rejection → rejected execution + tool_reject audit + isError result', async () => {
+    const { session, publish } = makeSession();
+    requestToolMock.mockResolvedValue({ status: 'rejected', output: null });
+    const handler = makeClientToolHandler('write_range', () => session);
+
+    const result = await handler({ address: 'A1', cells: [[1]] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('rejected');
+    expect(executionsValuesMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'rejected' }));
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'ai.client_session.tool_reject',
+        details: expect.objectContaining({ reason: 'user_rejected' }),
+      }),
+    );
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'tool_completed', status: 'rejected' }));
+  });
+
+  it('timeout → failed execution + failure audit + timeout tool_completed', async () => {
+    const { session, publish } = makeSession();
+    requestToolMock.mockResolvedValue({
+      status: 'timeout',
+      output: { error: "Tool 'read_range' timed out after 60s — the user may have closed Excel or not responded to the approval prompt." },
+    });
+    const handler = makeClientToolHandler('read_range', () => session);
+
+    const result = await handler({ address: 'A1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('timed out');
+    expect(executionsValuesMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'ai.client_session.tool_execute', result: 'failure' }),
+    );
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'tool_completed', status: 'timeout' }));
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`makeClientToolHandler` not exported)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiTools.handler.test.ts
+```
+
+- [ ] **Step 3: Append the handlers to `apps/api/src/services/clientAiTools.ts`**
+
+Add these imports at the top of the file (after the existing `import { z } from 'zod';`):
+
+```ts
+import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { db, withDbAccessContext, runOutsideDbContext } from '../db';
+import { aiMessages, aiToolExecutions } from '../db/schema';
+import type { ActiveSession } from './streamingSessionManager';
+import { requestClientToolExecution } from './clientAiToolBridge';
+import { applyDlp, type DlpRedactionEvent } from './clientAiDlp';
+import { writeAuditEvent, requestLikeFromSnapshot } from './auditEvents';
+import { captureException } from './sentry';
+```
+
+Then append at the end of the file:
+
+```ts
+// ============================================
+// Handlers — the server side of the tool round-trip (spec §5)
+// ============================================
+
+export type ClientToolHandlerResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+};
+
+function textResult(text: string, isError = false): ClientToolHandlerResult {
+  return { content: [{ type: 'text' as const, text }], isError };
+}
+
+function extractErrorText(output: unknown): string {
+  if (output && typeof output === 'object' && typeof (output as { error?: unknown }).error === 'string') {
+    return (output as { error: string }).error;
+  }
+  if (typeof output === 'string' && output.length > 0) return output;
+  return 'Tool execution failed in the add-in.';
+}
+
+/**
+ * DLP chokepoint (b): every tool_result payload is scanned before the model
+ * sees it (spec §6). Two passes:
+ *  1. If the output carries a `cells` matrix (read_range/read_selection/
+ *     search_workbook shapes), scan it cell-by-cell for cell-level redaction.
+ *  2. The whole (post-pass-1) output is scanned as JSON text — catches
+ *     addresses, found-value strings, error text etc. If a redaction breaks
+ *     JSON syntax (e.g. a bare numeric value replaced by a token), the result
+ *     degrades to { redacted: <text> } rather than leaking the original.
+ * Pass 2 re-sees pass-1 tokens, which is safe: [REDACTED:*] re-scans to zero
+ * findings (Plan 3 idempotency contract).
+ */
+export async function applyDlpToToolOutput(
+  output: unknown,
+  orgId: string,
+  dlpConfig: unknown,
+): Promise<{ blocked: string | null; output: unknown; redactions: DlpRedactionEvent[] }> {
+  const redactions: DlpRedactionEvent[] = [];
+  let working: unknown = output ?? null;
+
+  if (working && typeof working === 'object' && Array.isArray((working as { cells?: unknown }).cells)) {
+    const cells = (working as { cells: unknown[][] }).cells;
+    const cellResult = await applyDlp({ cells, dlpConfig, orgId });
+    if (cellResult.action === 'block') {
+      return { blocked: cellResult.blockReason ?? 'dlp_blocked', output: null, redactions: cellResult.redactions };
+    }
+    redactions.push(...cellResult.redactions);
+    working = { ...(working as Record<string, unknown>), cells: cellResult.cells };
+  }
+
+  const asText = JSON.stringify(working ?? null);
+  const textResultDlp = await applyDlp({ text: asText, dlpConfig, orgId });
+  if (textResultDlp.action === 'block') {
+    return {
+      blocked: textResultDlp.blockReason ?? 'dlp_blocked',
+      output: null,
+      redactions: [...redactions, ...textResultDlp.redactions],
+    };
+  }
+  redactions.push(...textResultDlp.redactions);
+
+  let finalOutput: unknown = working;
+  if (textResultDlp.text !== undefined && textResultDlp.text !== asText) {
+    try {
+      finalOutput = JSON.parse(textResultDlp.text);
+    } catch {
+      finalOutput = { redacted: textResultDlp.text };
+    }
+  }
+
+  return { blocked: null, output: finalOutput, redactions };
+}
+
+interface PersistParams {
+  toolUseId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  output: unknown;
+  status: 'completed' | 'failed' | 'rejected';
+  durationMs: number;
+  errorMessage: string | null;
+  redactions: DlpRedactionEvent[];
+}
+
+/** Persist the REDACTED tool result (spec §6 redact-before-log) + execution audit row. */
+async function persistClientToolResult(session: ActiveSession, params: PersistParams): Promise<void> {
+  try {
+    await withDbAccessContext(
+      { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+      async () => {
+        await db.insert(aiMessages).values({
+          sessionId: session.breezeSessionId,
+          role: 'tool_result',
+          toolName: params.toolName,
+          toolUseId: params.toolUseId,
+          toolOutput: (params.output ?? null) as Record<string, unknown>,
+          contentBlocks:
+            params.redactions.length > 0
+              ? ([{ type: 'dlp_redactions', redactions: params.redactions }] as unknown as Record<string, unknown>[])
+              : null,
+        });
+        await db.insert(aiToolExecutions).values({
+          sessionId: session.breezeSessionId,
+          toolName: params.toolName,
+          toolInput: params.input,
+          toolOutput: (params.output ?? null) as Record<string, unknown>,
+          status: params.status,
+          durationMs: params.durationMs,
+          errorMessage: params.errorMessage,
+          completedAt: new Date(),
+        });
+      },
+    );
+  } catch (err) {
+    captureException(err);
+    console.error(`[client-ai] Failed to persist tool result for ${params.toolName}:`, err);
+  }
+}
+
+function auditClientTool(
+  session: ActiveSession,
+  action: 'ai.client_session.tool_execute' | 'ai.client_session.tool_reject',
+  params: {
+    toolUseId: string;
+    toolName: string;
+    result: 'success' | 'failure' | 'denied';
+    details?: Record<string, unknown>;
+  },
+): void {
+  // No Hono context in the SDK callback chain — rebuild a RequestLike from the
+  // session's audit snapshot (streamingSessionManager AuditSnapshot +
+  // requestLikeFromSnapshot, auditEvents.ts:18). Actor convention matches
+  // Plan 1's exchange route: actorType 'user' + principalType 'portal_user'.
+  writeAuditEvent(requestLikeFromSnapshot(session.auditSnapshot), {
+    orgId: session.orgId,
+    action,
+    resourceType: 'ai_tool_execution',
+    resourceId: params.toolUseId,
+    actorType: 'user',
+    actorId: session.auth.user.id,
+    actorEmail: session.auth.user.email,
+    result: params.result,
+    details: {
+      principalType: 'portal_user',
+      sessionId: session.breezeSessionId,
+      toolName: params.toolName,
+      toolUseId: params.toolUseId,
+      ...(params.details ?? {}),
+    },
+  });
+}
+
+export function makeClientToolHandler(toolName: ClientToolName, getSession: () => ActiveSession) {
+  const entry: ClientWorkbookTool = CLIENT_TOOL_REGISTRY[toolName];
+
+  return async (args: Record<string, unknown>): Promise<ClientToolHandlerResult> => {
+    // Escape any inherited AsyncLocalStorage DB context from the SDK callback
+    // chain (the makeHandler precedent, aiAgentSdkTools.ts — stale-transaction hangs).
+    return runOutsideDbContext(async () => {
+      const session = getSession();
+      // Correlate with the model's tool_use block id: the background processor
+      // pushes ids on content_block_start (streamingSessionManager.ts:611) and
+      // the technician path drains them in createSessionPostToolUse
+      // (aiAgentSdk.ts:640). Client handlers bypass that callback, so drain here.
+      const toolUseId = session.toolUseIdQueue.shift() ?? crypto.randomUUID();
+      const startTime = Date.now();
+
+      // Server-side write-mode enforcement (pinned contract): 'readonly'
+      // strips mutating tools from the toolset at session start AND rejects
+      // them here if invoked anyway (e.g. resumed SDK process).
+      if (entry.mutating && session.clientWriteMode === 'readonly') {
+        const error =
+          'Workbook writes are disabled for this organization (read-only policy). Offer the change as formula text or step-by-step instructions instead.';
+        await persistClientToolResult(session, {
+          toolUseId, toolName, input: args, output: { error },
+          status: 'rejected', durationMs: 0, errorMessage: error, redactions: [],
+        });
+        auditClientTool(session, 'ai.client_session.tool_reject', {
+          toolUseId, toolName, result: 'denied', details: { reason: 'readonly_policy' },
+        });
+        session.eventBus.publish({ type: 'tool_completed', toolUseId, toolName, status: 'rejected' });
+        return textResult(JSON.stringify({ error }), true);
+      }
+
+      const result = await requestClientToolExecution(session, toolUseId, toolName, args, entry.mutating);
+      const durationMs = Date.now() - startTime;
+
+      if (result.status === 'rejected') {
+        const error =
+          'The user rejected this action in the task pane. Do not retry the same change — adjust your approach or ask what they would prefer.';
+        await persistClientToolResult(session, {
+          toolUseId, toolName, input: args, output: { error },
+          status: 'rejected', durationMs, errorMessage: error, redactions: [],
+        });
+        auditClientTool(session, 'ai.client_session.tool_reject', {
+          toolUseId, toolName, result: 'denied', details: { reason: 'user_rejected' },
+        });
+        session.eventBus.publish({ type: 'tool_completed', toolUseId, toolName, status: 'rejected' });
+        return textResult(JSON.stringify({ error }), true);
+      }
+
+      if (result.status !== 'success') {
+        // 'error' (add-in reported failure) or 'timeout' (bridge timer fired)
+        const error = extractErrorText(result.output);
+        await persistClientToolResult(session, {
+          toolUseId, toolName, input: args, output: { error },
+          status: 'failed', durationMs, errorMessage: error, redactions: [],
+        });
+        auditClientTool(session, 'ai.client_session.tool_execute', {
+          toolUseId, toolName, result: 'failure', details: { reason: result.status, durationMs },
+        });
+        session.eventBus.publish({ type: 'tool_completed', toolUseId, toolName, status: result.status });
+        return textResult(JSON.stringify({ error }), true);
+      }
+
+      // DLP chokepoint (b): scan before the model sees the payload (spec §6).
+      const dlp = await applyDlpToToolOutput(result.output, session.orgId, session.clientDlpConfig ?? {});
+      if (dlp.blocked) {
+        const error = `Result blocked by your organization's data protection policy (${dlp.blocked}).`;
+        await persistClientToolResult(session, {
+          toolUseId, toolName, input: args, output: { error },
+          status: 'failed', durationMs, errorMessage: error, redactions: dlp.redactions,
+        });
+        auditClientTool(session, 'ai.client_session.tool_execute', {
+          toolUseId, toolName, result: 'denied', details: { reason: 'dlp_blocked', blockReason: dlp.blocked },
+        });
+        session.eventBus.publish({
+          type: 'tool_completed', toolUseId, toolName, status: 'error',
+          blockReason: dlp.blocked, redactions: dlp.redactions,
+        });
+        return textResult(JSON.stringify({ error }), true);
+      }
+
+      await persistClientToolResult(session, {
+        toolUseId, toolName, input: args, output: dlp.output,
+        status: 'completed', durationMs, errorMessage: null, redactions: dlp.redactions,
+      });
+      auditClientTool(session, 'ai.client_session.tool_execute', {
+        toolUseId, toolName, result: 'success',
+        details: { durationMs, redactionCount: dlp.redactions.length },
+      });
+      session.eventBus.publish({
+        type: 'tool_completed', toolUseId, toolName, status: 'success', redactions: dlp.redactions,
+      });
+      return textResult(typeof dlp.output === 'string' ? dlp.output : JSON.stringify(dlp.output ?? null));
+    });
+  };
+}
+
+/**
+ * SDK MCP server for a client session — constructed ONLY from
+ * CLIENT_TOOL_REGISTRY (hard isolation; registry.test.ts). Plugged into
+ * streamingSessionManager.getOrCreate via the mcpServerFactory parameter
+ * (the scriptAi.ts:211-215 precedent).
+ */
+export function createClientWorkbookMcpServer(getSession: () => ActiveSession) {
+  return createSdkMcpServer({
+    name: CLIENT_MCP_SERVER_NAME,
+    version: '1.0.0',
+    tools: CLIENT_TOOL_NAMES.map((name) =>
+      tool(
+        name,
+        CLIENT_TOOL_REGISTRY[name].description,
+        CLIENT_TOOL_REGISTRY[name].inputSchema,
+        makeClientToolHandler(name, getSession),
+      ),
+    ),
+  });
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (8 tests), plus the registry suite stays green:
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiTools.handler.test.ts src/services/clientAiTools.registry.test.ts
+```
+
+(If the SDK's `tool()` typing fights the heterogeneous `inputSchema` map, type the `tools:` array as `ReturnType<typeof tool>[]` — the aiAgentSdkTools.ts file builds its array the same way without that cast, so this should not be needed.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiTools.ts apps/api/src/services/clientAiTools.handler.test.ts
+git commit -m "feat(client-ai): workbook tool handlers — bridge round-trip, DLP chokepoint, persistence, audit" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: clientAiSessions service — system prompt, synthetic AuthContext, rate limits (TDD)
+
+**Files:**
+- Create: apps/api/src/services/clientAiSessions.ts
+- Create: apps/api/src/services/clientAiSessions.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiSessions.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { rateLimiterMock, getRedisMock } = vi.hoisted(() => ({
+  rateLimiterMock: vi.fn(),
+  getRedisMock: vi.fn(() => ({}) as never),
+}));
+
+vi.mock('./redis', () => ({ getRedis: getRedisMock }));
+vi.mock('./rate-limit', () => ({ rateLimiter: rateLimiterMock }));
+
+import {
+  DEFAULT_CLIENT_AI_MODEL,
+  EXCEL_CLIENT_SYSTEM_PROMPT,
+  buildExcelClientSystemPrompt,
+  buildClientAuthContext,
+  checkClientRateLimits,
+  generateClientSessionTitle,
+} from './clientAiSessions';
+import { defaultClientAiPolicy } from './clientAiPolicy';
+
+const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
+const USER = 'beefbeef-1111-4222-8333-444455556666';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rateLimiterMock.mockResolvedValue({ allowed: true, remaining: 9, resetAt: new Date() });
+});
+
+describe('system prompt', () => {
+  it('pins the workbook-only scope and the no-RMM-claims rule', () => {
+    expect(EXCEL_CLIENT_SYSTEM_PROMPT).toContain('ONLY work with the open workbook');
+    expect(EXCEL_CLIENT_SYSTEM_PROMPT).toContain('never claim or imply such capabilities');
+    expect(EXCEL_CLIENT_SYSTEM_PROMPT).toContain('Never fabricate cell values');
+    expect(EXCEL_CLIENT_SYSTEM_PROMPT).toContain('click Apply');
+    expect(EXCEL_CLIENT_SYSTEM_PROMPT).toContain('[REDACTED:');
+    expect(EXCEL_CLIENT_SYSTEM_PROMPT).toContain('Be concise');
+  });
+
+  it('readwrite mode returns the base prompt; readonly appends the read-only addendum', () => {
+    expect(buildExcelClientSystemPrompt('readwrite')).toBe(EXCEL_CLIENT_SYSTEM_PROMPT);
+    const ro = buildExcelClientSystemPrompt('readonly');
+    expect(ro).toContain(EXCEL_CLIENT_SYSTEM_PROMPT);
+    expect(ro).toContain('READ-ONLY');
+  });
+});
+
+describe('buildClientAuthContext', () => {
+  it('builds an org-pinned synthetic AuthContext (the helper-chat shape)', () => {
+    const auth = buildClientAuthContext({
+      clientUserId: USER, orgId: ORG, email: 'finance.user@contoso.com', name: 'Finance User',
+    });
+    expect(auth.user.id).toBe(USER);
+    expect(auth.user.isPlatformAdmin).toBe(false);
+    expect(auth.scope).toBe('organization');
+    expect(auth.orgId).toBe(ORG);
+    expect(auth.accessibleOrgIds).toEqual([ORG]);
+    expect(auth.canAccessOrg(ORG)).toBe(true);
+    expect(auth.canAccessOrg('9d9d9d9d-1111-4222-8333-444455556666')).toBe(false);
+    expect(auth.partnerId).toBeNull();
+    expect(auth.token.mfa).toBe(false);
+  });
+
+  it('falls back to the email when the user has no display name', () => {
+    const auth = buildClientAuthContext({ clientUserId: USER, orgId: ORG, email: 'a@b.com', name: null });
+    expect(auth.user.name).toBe('a@b.com');
+  });
+});
+
+describe('checkClientRateLimits', () => {
+  it('passes when both limiters allow, using policy-driven limits and clientai keys', async () => {
+    const policy = { ...defaultClientAiPolicy(ORG), perUserMessagesPerMinute: 7, orgMessagesPerHour: 123 };
+    await expect(checkClientRateLimits(USER, ORG, policy)).resolves.toBeNull();
+    expect(rateLimiterMock).toHaveBeenNthCalledWith(1, expect.anything(), `clientai:msg:user:${USER}`, 7, 60);
+    expect(rateLimiterMock).toHaveBeenNthCalledWith(2, expect.anything(), `clientai:msg:org:${ORG}`, 123, 3600);
+  });
+
+  it('rejects on the per-user limit without consulting the org limiter', async () => {
+    rateLimiterMock.mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date('2026-06-12T10:00:00Z') });
+    const msg = await checkClientRateLimits(USER, ORG, defaultClientAiPolicy(ORG));
+    expect(msg).toContain('too quickly');
+    expect(rateLimiterMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects on the org limit', async () => {
+    rateLimiterMock
+      .mockResolvedValueOnce({ allowed: true, remaining: 1, resetAt: new Date() })
+      .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date('2026-06-12T10:00:00Z') });
+    const msg = await checkClientRateLimits(USER, ORG, defaultClientAiPolicy(ORG));
+    expect(msg).toContain("organization's AI message limit");
+  });
+});
+
+describe('generateClientSessionTitle', () => {
+  it('collapses whitespace and passes short content through', () => {
+    expect(generateClientSessionTitle('  sum   column B ')).toBe('sum column B');
+  });
+  it('truncates at a word boundary with ellipsis', () => {
+    const title = generateClientSessionTitle('word '.repeat(40));
+    expect(title.length).toBeLessThanOrEqual(81);
+    expect(title.endsWith('…')).toBe(true);
+  });
+});
+
+describe('DEFAULT_CLIENT_AI_MODEL', () => {
+  it('matches the platform default model', () => {
+    expect(DEFAULT_CLIENT_AI_MODEL).toBe('claude-sonnet-4-5-20250929');
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (module not found)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiSessions.test.ts
+```
+
+- [ ] **Step 3: Create `apps/api/src/services/clientAiSessions.ts`**
+
+```ts
+/**
+ * AI for Office — session-loop helpers shared by routes/clientAi/sessions.ts.
+ *
+ * The synthetic AuthContext mirrors the helper-chat shape
+ * (routes/helper/index.ts:133-160): an org-pinned 'organization'-scope context
+ * whose "user" is the portal user, so streamingSessionManager's background
+ * callbacks (recordUsageFromSdkResult via session.auth.orgId, audit actor ids)
+ * and RLS DB contexts all resolve to the client org. No helperDeviceId — the
+ * client surface has no device axis.
+ */
+
+import { eq } from 'drizzle-orm';
+import type { AuthContext } from '../middleware/auth';
+import { getRedis } from './redis';
+import { rateLimiter } from './rate-limit';
+import type { ClientAiOrgPolicy } from './clientAiPolicy';
+
+export const DEFAULT_CLIENT_AI_MODEL = 'claude-sonnet-4-5-20250929';
+
+/**
+ * The Excel-assistant system prompt (spec §5/§11; pinned in the plan).
+ * Stored on the ai_sessions row at create time, passed to getOrCreate with
+ * injectApprovalModeInstructions: false so no technician approval-mode text
+ * is appended.
+ */
+export const EXCEL_CLIENT_SYSTEM_PROMPT = `You are a spreadsheet assistant embedded in Microsoft Excel, provided to this user by their IT provider.
+You help business users understand, analyze, build, and edit the workbook that is currently open in Excel.
+
+Rules:
+- You can ONLY work with the open workbook, through the workbook tools provided. You have no access to devices, other files, email, the internet, or any IT systems — never claim or imply such capabilities.
+- Never fabricate cell values, ranges, sheet names, or statistics. If you have not read the relevant data in this conversation, call get_workbook_overview, read_selection, or read_range first, and answer only from what the tools actually returned.
+- Workbook changes (write_range, insert_formula, create_sheet, format_range, create_table) are shown to the user as a preview card in the task pane and only take effect when they click Apply. If the user rejects a change, do not retry the same change — adjust your approach or ask what they would prefer.
+- Propose the smallest change that satisfies the request, and tell the user what you are about to change before calling a write tool.
+- Some values may appear as [REDACTED:...]. That is the organization's data-protection policy at work — never try to guess or reconstruct redacted values.
+- Use A1-style addresses, and include the sheet name when the workbook has more than one sheet.
+- Be concise. Business users want answers, working formulas, and clean tables — not essays.
+- If a request is unrelated to this workbook or spreadsheets, politely explain that you can only help with the workbook.`;
+
+const READONLY_ADDENDUM = `
+
+This session is READ-ONLY: write tools are not available and you cannot modify the workbook. Offer analysis, explanations, and formula text the user can apply manually instead.`;
+
+export function buildExcelClientSystemPrompt(writeMode: 'readwrite' | 'readonly'): string {
+  return writeMode === 'readonly' ? EXCEL_CLIENT_SYSTEM_PROMPT + READONLY_ADDENDUM : EXCEL_CLIENT_SYSTEM_PROMPT;
+}
+
+export function buildClientAuthContext(params: {
+  clientUserId: string;
+  orgId: string;
+  email: string;
+  name: string | null;
+}): AuthContext {
+  const { clientUserId, orgId, email, name } = params;
+  return {
+    user: {
+      id: clientUserId,
+      email,
+      name: name ?? email,
+      isPlatformAdmin: false,
+    },
+    token: {
+      sub: clientUserId,
+      email,
+      roleId: null,
+      type: 'access' as const,
+      scope: 'organization' as const,
+      orgId,
+      partnerId: null,
+      iat: Math.floor(Date.now() / 1000),
+      mfa: false,
+    },
+    partnerId: null,
+    orgId,
+    scope: 'organization',
+    accessibleOrgIds: [orgId],
+    orgCondition: (orgIdColumn) => eq(orgIdColumn, orgId),
+    canAccessOrg: (id) => id === orgId,
+  };
+}
+
+/**
+ * Pre-flight rate limits (spec §4): per-user msgs/min then org msgs/hour,
+ * limits from client_ai_org_policies. rateLimiter fails closed when Redis is
+ * down (services/rate-limit.ts:29-33).
+ */
+export async function checkClientRateLimits(
+  clientUserId: string,
+  orgId: string,
+  policy: ClientAiOrgPolicy,
+): Promise<string | null> {
+  const redis = getRedis();
+
+  const userResult = await rateLimiter(
+    redis,
+    `clientai:msg:user:${clientUserId}`,
+    policy.perUserMessagesPerMinute,
+    60,
+  );
+  if (!userResult.allowed) {
+    return `You are sending messages too quickly. Try again at ${userResult.resetAt.toISOString()}.`;
+  }
+
+  const orgResult = await rateLimiter(
+    redis,
+    `clientai:msg:org:${orgId}`,
+    policy.orgMessagesPerHour,
+    3600,
+  );
+  if (!orgResult.allowed) {
+    return `Your organization's AI message limit was reached. Try again at ${orgResult.resetAt.toISOString()}.`;
+  }
+
+  return null;
+}
+
+/** Short title from the first user message (duplicated tiny helper — same as routes/ai.ts:104-113). */
+export function generateClientSessionTitle(content: string): string {
+  const cleaned = content.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= 80) return cleaned;
+  const truncated = cleaned.slice(0, 80);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return (lastSpace > 20 ? truncated.slice(0, lastSpace) : truncated) + '…';
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (11 tests; same command as Step 2)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiSessions.ts apps/api/src/services/clientAiSessions.test.ts
+git commit -m "feat(client-ai): session helpers — Excel system prompt, synthetic auth context, client rate limits" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: `?token=` fallback for SSE in clientAiAuthMiddleware (TDD)
+
+EventSource cannot set request headers, so the SSE GET accepts `?token=` when no `Authorization` header is present — **GET-only**, header always wins. Documented preference: fetch-based SSE with the bearer header (Plan 5's client); `?token=` is the EventSource fallback and can land in proxy access logs.
+
+**Files:**
+- Modify: apps/api/src/middleware/clientAiAuth.ts (Plan 1 file — small additive edit)
+- Create: apps/api/src/middleware/clientAiAuth.queryToken.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/middleware/clientAiAuth.queryToken.test.ts` (mock skeleton copied from Plan 1's `clientAiAuth.test.ts`)
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { redisMock, getRedisMock, dbSelectMock } = vi.hoisted(() => {
+  const redis = {
+    get: vi.fn(),
+    del: vi.fn(() => Promise.resolve(1)),
+    expire: vi.fn(() => Promise.resolve(1)),
+  };
+  return { redisMock: redis, getRedisMock: vi.fn(() => redis), dbSelectMock: vi.fn() };
+});
+
+vi.mock('../db', () => ({
+  db: { select: dbSelectMock },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: () => unknown) => fn()),
+}));
+vi.mock('../services/redis', () => ({ getRedis: getRedisMock }));
+vi.mock('../services/clientAiPolicy', () => ({
+  getOrgPolicy: vi.fn(),
+  isClientUserPermitted: vi.fn(() => true),
+}));
+
+import { clientAiAuthMiddleware } from './clientAiAuth';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const PORTAL_USER_ID = 'beefbeef-1111-4222-8333-444455556666';
+const TOKEN = 'tok_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJK';
+
+const USER_ROW = {
+  id: PORTAL_USER_ID, orgId: ORG_ID, email: 'finance.user@contoso.com',
+  name: 'Finance User', status: 'active',
+};
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', clientAiAuthMiddleware);
+  app.get('/events', (c) => c.json({ clientUserId: c.get('clientAiAuth').clientUserId }));
+  app.post('/messages', (c) => c.json({ ok: true }));
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRedisMock.mockReturnValue(redisMock);
+  redisMock.get.mockResolvedValue(
+    JSON.stringify({ portalUserId: PORTAL_USER_ID, orgId: ORG_ID, createdAt: new Date().toISOString() }),
+  );
+  dbSelectMock.mockImplementation(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([USER_ROW])) })),
+    })),
+  }));
+});
+
+describe('clientAiAuthMiddleware — ?token= query fallback (SSE/EventSource)', () => {
+  it('authenticates a GET via ?token= when no Authorization header is present', async () => {
+    const res = await buildApp().request(`/events?token=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ clientUserId: PORTAL_USER_ID });
+    expect(redisMock.get).toHaveBeenCalledWith(`clientai:session:${TOKEN}`);
+  });
+
+  it('the Authorization header wins over a conflicting ?token=', async () => {
+    await buildApp().request(`/events?token=query-token`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(redisMock.get).toHaveBeenCalledWith(`clientai:session:${TOKEN}`);
+  });
+
+  it('does NOT accept ?token= on non-GET requests', async () => {
+    const res = await buildApp().request(`/messages?token=${TOKEN}`, { method: 'POST' });
+    expect(res.status).toBe(401);
+    expect(redisMock.get).not.toHaveBeenCalled();
+  });
+
+  it('still 401s a GET with neither header nor query token', async () => {
+    const res = await buildApp().request('/events');
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (query-token GET returns 401 today)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/middleware/clientAiAuth.queryToken.test.ts
+```
+
+- [ ] **Step 3: Edit `apps/api/src/middleware/clientAiAuth.ts`** — in `clientAiAuthMiddleware`, replace:
+
+```ts
+  const authHeader = c.req.header('Authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token) {
+    return c.json({ error: 'Missing or invalid authorization header' }, 401);
+  }
+```
+
+with:
+
+```ts
+  const authHeader = c.req.header('Authorization');
+  let token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token && c.req.method === 'GET') {
+    // EventSource cannot set request headers, so GET endpoints (the SSE
+    // stream) accept ?token= as a fallback. Header always wins; non-GET
+    // requests are header-only. Prefer fetch-based SSE with the Authorization
+    // header (Plan 5's client) — query tokens can land in proxy access logs.
+    token = c.req.query('token') || null;
+  }
+  if (!token) {
+    return c.json({ error: 'Missing or invalid authorization header' }, 401);
+  }
+```
+
+- [ ] **Step 4: Run, expect PASS** (4 tests), and re-run Plan 1's middleware suite to prove no regression:
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/middleware/clientAiAuth.queryToken.test.ts src/middleware/clientAiAuth.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/middleware/clientAiAuth.ts apps/api/src/middleware/clientAiAuth.queryToken.test.ts
+git commit -m "feat(client-ai): GET-only ?token= auth fallback for the SSE stream" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: SSE translation layer — sse.ts (TDD)
+
+The bus→client translator: internal `AiStreamEvent`s become the five pinned client-facing events; everything else (technician/internal events) is dropped so the add-in never sees RMM concepts. Plan 5 mirrors `CLIENT_AI_SSE_EVENTS` exactly.
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/sse.ts
+- Create: apps/api/src/routes/clientAi/sse.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/routes/clientAi/sse.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { CLIENT_AI_SSE_EVENTS, toClientSseEvent } from './sse';
+import type { AiStreamEvent } from '@breeze/shared/types/ai';
+
+describe('CLIENT_AI_SSE_EVENTS — pinned names (Plan 5 mirrors this list)', () => {
+  it('exposes exactly the pinned event names', () => {
+    expect(CLIENT_AI_SSE_EVENTS).toEqual([
+      'message_delta', 'tool_request', 'tool_completed', 'turn_complete', 'session_error', 'ping',
+    ]);
+  });
+});
+
+describe('toClientSseEvent', () => {
+  it('content_delta → message_delta { text }', () => {
+    expect(toClientSseEvent({ type: 'content_delta', delta: 'Hello' })).toEqual({
+      event: 'message_delta',
+      data: JSON.stringify({ text: 'Hello' }),
+    });
+  });
+
+  it('tool_request passes through with the pinned payload', () => {
+    const out = toClientSseEvent({
+      type: 'tool_request', toolUseId: 'tu-1', toolName: 'read_range',
+      input: { address: 'A1' }, mutating: false,
+    });
+    expect(out!.event).toBe('tool_request');
+    expect(JSON.parse(out!.data)).toEqual({
+      toolUseId: 'tu-1', toolName: 'read_range', input: { address: 'A1' }, mutating: false,
+    });
+  });
+
+  it('tool_completed carries status, redactions, blockReason', () => {
+    const out = toClientSseEvent({
+      type: 'tool_completed', toolUseId: 'tu-1', toolName: 'read_range', status: 'success',
+      redactions: [{ rule: 'creditCard', count: 1, location: 'cell[0][0]' }],
+    });
+    expect(out!.event).toBe('tool_completed');
+    expect(JSON.parse(out!.data)).toEqual({
+      toolUseId: 'tu-1', toolName: 'read_range', status: 'success',
+      redactions: [{ rule: 'creditCard', count: 1, location: 'cell[0][0]' }],
+      blockReason: null,
+    });
+  });
+
+  it('done → turn_complete with usage (null when absent)', () => {
+    expect(toClientSseEvent({ type: 'done', usage: { inputTokens: 100, outputTokens: 50, costCents: 3 } })).toEqual({
+      event: 'turn_complete',
+      data: JSON.stringify({ usage: { inputTokens: 100, outputTokens: 50, costCents: 3 } }),
+    });
+    expect(toClientSseEvent({ type: 'done' })).toEqual({
+      event: 'turn_complete',
+      data: JSON.stringify({ usage: null }),
+    });
+  });
+
+  it('error → session_error { message }', () => {
+    expect(toClientSseEvent({ type: 'error', message: 'boom' })).toEqual({
+      event: 'session_error',
+      data: JSON.stringify({ message: 'boom' }),
+    });
+  });
+
+  it('drops internal/technician events (no RMM leakage to the add-in)', () => {
+    const internal: AiStreamEvent[] = [
+      { type: 'message_start', messageId: 'm1' },
+      { type: 'message_end', inputTokens: 0, outputTokens: 5 },
+      { type: 'tool_use_start', toolName: 'read_range', toolUseId: 'tu-1', input: {} },
+      { type: 'title_updated', title: 'T' },
+      { type: 'approval_mode_changed', mode: 'per_step' },
+    ];
+    for (const event of internal) {
+      expect(toClientSseEvent(event)).toBeNull();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (module not found)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/sse.test.ts
+```
+
+- [ ] **Step 3: Create `apps/api/src/routes/clientAi/sse.ts`**
+
+```ts
+/**
+ * AI for Office — SSE protocol for GET /client-ai/sessions/:id/events.
+ *
+ * Translates internal AiStreamEvents (SessionEventBus) into the PINNED
+ * client-facing event names the add-in consumes (Plan 5 mirrors this table):
+ *
+ *   message_delta   ← content_delta          { text }
+ *   tool_request    ← tool_request (bridge)  { toolUseId, toolName, input, mutating }
+ *   tool_completed  ← tool_completed         { toolUseId, toolName, status, redactions, blockReason }
+ *   turn_complete   ← done                   { usage: { inputTokens, outputTokens, costCents } | null }
+ *   session_error   ← error                  { message }
+ *   ping            ← server keepalive timer { } every CLIENT_AI_SSE_PING_INTERVAL_MS
+ *
+ * Everything else (message_start/message_end/tool_use_start/title_updated/
+ * plan + approval events) is INTERNAL and dropped — the add-in must never see
+ * technician/RMM concepts (spec §1).
+ */
+
+import type { AiStreamEvent } from '@breeze/shared/types/ai';
+
+export const CLIENT_AI_SSE_PING_INTERVAL_MS = 25_000;
+
+export const CLIENT_AI_SSE_EVENTS = [
+  'message_delta',
+  'tool_request',
+  'tool_completed',
+  'turn_complete',
+  'session_error',
+  'ping',
+] as const;
+
+export type ClientAiSseEventName = (typeof CLIENT_AI_SSE_EVENTS)[number];
+
+export function toClientSseEvent(
+  event: AiStreamEvent,
+): { event: ClientAiSseEventName; data: string } | null {
+  switch (event.type) {
+    case 'content_delta':
+      return { event: 'message_delta', data: JSON.stringify({ text: event.delta }) };
+    case 'tool_request':
+      return {
+        event: 'tool_request',
+        data: JSON.stringify({
+          toolUseId: event.toolUseId,
+          toolName: event.toolName,
+          input: event.input,
+          mutating: event.mutating,
+        }),
+      };
+    case 'tool_completed':
+      return {
+        event: 'tool_completed',
+        data: JSON.stringify({
+          toolUseId: event.toolUseId,
+          toolName: event.toolName,
+          status: event.status,
+          redactions: event.redactions ?? [],
+          blockReason: event.blockReason ?? null,
+        }),
+      };
+    case 'done':
+      return { event: 'turn_complete', data: JSON.stringify({ usage: event.usage ?? null }) };
+    case 'error':
+      return { event: 'session_error', data: JSON.stringify({ message: event.message }) };
+    default:
+      return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (6 tests; same command as Step 2)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/sse.ts apps/api/src/routes/clientAi/sse.test.ts
+git commit -m "feat(client-ai): SSE event translation — pinned client-facing event names" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Session routes — schemas, create / get / close, mount (TDD)
+
+Creates `routes/clientAi/sessions.ts` with the shared helpers (`loadClientSession`, `auditClient`, `ensureActiveClientSession`) and three of the six routes; Tasks 11/12 append the rest to the same file. Mounts the router in the namespace hub.
+
+**Files:**
+- Modify: apps/api/src/routes/clientAi/schemas.ts (append message/tool-result schemas)
+- Create: apps/api/src/routes/clientAi/sessions.ts
+- Create: apps/api/src/routes/clientAi/sessions.lifecycle.test.ts
+- Modify: apps/api/src/routes/clientAi/index.ts (mount)
+
+- [ ] **Step 1: Append to `apps/api/src/routes/clientAi/schemas.ts`** (after `putPolicySchema`, before the Types section):
+
+```ts
+// ============================================
+// Session-loop schemas (Plan 2)
+// ============================================
+
+/** Per-message workbook context chip (spec §11): the user controls data egress. */
+export const workbookContextSchema = z.object({
+  kind: z.enum(['selection', 'sheet', 'none']),
+  address: z.string().max(100).optional(),
+  sheetName: z.string().max(255).optional(),
+  /** Row-major cell values. Caps mirror the DLP engine's fail-closed limits
+   *  (Plan 3: 50k cells / 32,767 chars per cell). */
+  cells: z
+    .array(z.array(z.union([z.string().max(32767), z.number(), z.boolean(), z.null()])).max(500))
+    .max(5000)
+    .optional(),
+});
+
+export const sendClientMessageSchema = z.object({
+  content: z.string().min(1).max(20000),
+  workbookContext: workbookContextSchema.optional(),
+});
+
+/** Body of POST /sessions/:id/tool-results (pinned bridge contract). */
+export const clientToolResultSchema = z.object({
+  toolUseId: z.string().min(1).max(100),
+  status: z.enum(['success', 'error', 'rejected']),
+  output: z.unknown().optional(),
+});
+```
+
+- [ ] **Step 2: Write the failing test** — `apps/api/src/routes/clientAi/sessions.lifecycle.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  CLIENT_USER_ID, ORG_ID, SESSION_ID,
+  policyState,
+  dbSelectMock, dbInsertMock, dbUpdateMock,
+  managerMock,
+  writeAuditEventMock,
+  recordClientUsageMock, checkClientBudgetMock, getRemainingBudgetMock,
+  checkBillingCreditsMock, rateLimiterMock,
+  resolveToolResultMock, failPendingMock,
+  applyDlpMock,
+} = vi.hoisted(() => ({
+  CLIENT_USER_ID: 'beefbeef-1111-4222-8333-444455556666',
+  ORG_ID: '0c0c0c0c-1111-4222-8333-444455556666',
+  SESSION_ID: 'a1a1a1a1-1111-4222-8333-444455556666',
+  policyState: { policy: {} as Record<string, unknown> },
+  dbSelectMock: vi.fn(),
+  dbInsertMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+  managerMock: {
+    getOrCreate: vi.fn(),
+    get: vi.fn(),
+    remove: vi.fn(),
+    tryTransitionToProcessing: vi.fn(() => true),
+    startTurnTimeout: vi.fn(),
+  },
+  writeAuditEventMock: vi.fn(),
+  recordClientUsageMock: vi.fn(() => Promise.resolve()),
+  checkClientBudgetMock: vi.fn(() => Promise.resolve(null)),
+  getRemainingBudgetMock: vi.fn(() => Promise.resolve(undefined)),
+  checkBillingCreditsMock: vi.fn(() => Promise.resolve(null)),
+  rateLimiterMock: vi.fn(() => Promise.resolve({ allowed: true, remaining: 9, resetAt: new Date() })),
+  resolveToolResultMock: vi.fn(() => true),
+  failPendingMock: vi.fn(() => 0),
+  applyDlpMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/clientAiAuth', () => ({
+  clientAiAuthMiddleware: (c: any, next: any) => {
+    if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);
+    c.set('clientAiAuth', {
+      clientUserId: CLIENT_USER_ID, orgId: ORG_ID,
+      email: 'finance.user@contoso.com', name: 'Finance User', token: 'tok',
+    });
+    return next();
+  },
+  requireClientAiEnabledMiddleware: (c: any, next: any) => {
+    c.set('clientAiPolicy', policyState.policy);
+    return next();
+  },
+}));
+
+vi.mock('../../db', () => ({
+  db: { select: dbSelectMock, insert: dbInsertMock, update: dbUpdateMock },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+}));
+vi.mock('../../services/streamingSessionManager', () => ({ streamingSessionManager: managerMock }));
+vi.mock('../../services/auditEvents', () => ({ writeAuditEvent: writeAuditEventMock }));
+vi.mock('../../services/clientAiUsage', () => ({
+  recordClientUsage: recordClientUsageMock,
+  checkClientBudget: checkClientBudgetMock,
+  getRemainingClientBudgetUsd: getRemainingBudgetMock,
+}));
+vi.mock('../../services/aiCostTracker', () => ({ checkBillingCredits: checkBillingCreditsMock }));
+vi.mock('../../services/rate-limit', () => ({ rateLimiter: rateLimiterMock }));
+vi.mock('../../services/redis', () => ({ getRedis: vi.fn(() => ({}) as never) }));
+vi.mock('../../services/clientAiToolBridge', () => ({
+  resolveClientToolResult: resolveToolResultMock,
+  failPendingForSession: failPendingMock,
+}));
+vi.mock('../../services/clientAiDlp', () => ({ applyDlp: applyDlpMock }));
+
+import { clientAiSessionRoutes } from './sessions';
+import { defaultClientAiPolicy } from '../../services/clientAiPolicy';
+
+const SESSION_ROW = {
+  id: SESSION_ID, orgId: ORG_ID, clientUserId: CLIENT_USER_ID, type: 'excel_client',
+  status: 'active', title: 'Budget review', model: 'claude-sonnet-4-5-20250929',
+  systemPrompt: 'P', sdkSessionId: null, maxTurns: 50, turnCount: 0,
+  totalInputTokens: 10, totalOutputTokens: 20, totalCostCents: 1.5,
+  createdAt: new Date(), lastActivityAt: new Date(),
+};
+
+function selectChain(rows: unknown[]) {
+  const limit = vi.fn(() => Promise.resolve(rows));
+  const orderBy = vi.fn(() => ({ limit }));
+  const where = vi.fn(() => ({ limit, orderBy }));
+  return { from: vi.fn(() => ({ where })) };
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.route('/client-ai/sessions', clientAiSessionRoutes);
+  return app;
+}
+
+const AUTHED = { Authorization: 'Bearer tok', 'Content-Type': 'application/json' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  managerMock.tryTransitionToProcessing.mockReturnValue(true);
+  checkClientBudgetMock.mockResolvedValue(null);
+  checkBillingCreditsMock.mockResolvedValue(null);
+  rateLimiterMock.mockResolvedValue({ allowed: true, remaining: 9, resetAt: new Date() });
+  policyState.policy = { ...defaultClientAiPolicy(ORG_ID), enabled: true };
+  dbSelectMock.mockImplementation(() => selectChain([SESSION_ROW]));
+  dbInsertMock.mockImplementation(() => ({
+    values: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([{ id: SESSION_ID }])) })),
+  }));
+  dbUpdateMock.mockImplementation(() => ({
+    set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+  }));
+});
+
+describe('POST /client-ai/sessions (create)', () => {
+  it('rejects unauthenticated requests', async () => {
+    const res = await buildApp().request('/client-ai/sessions', { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+
+  it('creates an excel_client session with the client principal, bumps sessionCount, audits', async () => {
+    const valuesSpy = vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([{ id: SESSION_ID }])) }));
+    dbInsertMock.mockImplementation(() => ({ values: valuesSpy }));
+
+    const res = await buildApp().request('/client-ai/sessions', { method: 'POST', headers: AUTHED });
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ sessionId: SESSION_ID });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_ID,
+      userId: null,
+      clientUserId: CLIENT_USER_ID,
+      type: 'excel_client',
+      model: 'claude-sonnet-4-5-20250929',
+      systemPrompt: expect.stringContaining('spreadsheet assistant'),
+    }));
+    expect(recordClientUsageMock).toHaveBeenCalledWith(ORG_ID, CLIENT_USER_ID, { sessionCount: 1 });
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'ai.client_session.create',
+        actorType: 'user',
+        actorId: CLIENT_USER_ID,
+        orgId: ORG_ID,
+        details: expect.objectContaining({ principalType: 'portal_user' }),
+      }),
+    );
+  });
+
+  it('uses the policy allowedModels[0] when configured', async () => {
+    policyState.policy = {
+      ...defaultClientAiPolicy(ORG_ID), enabled: true,
+      allowedModels: ['claude-haiku-4-5-20251001'],
+    };
+    const valuesSpy = vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([{ id: SESSION_ID }])) }));
+    dbInsertMock.mockImplementation(() => ({ values: valuesSpy }));
+    await buildApp().request('/client-ai/sessions', { method: 'POST', headers: AUTHED });
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-haiku-4-5-20251001' }));
+  });
+
+  it('appends the read-only addendum to the stored system prompt under writeMode readonly', async () => {
+    policyState.policy = { ...defaultClientAiPolicy(ORG_ID), enabled: true, writeMode: 'readonly' };
+    const valuesSpy = vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([{ id: SESSION_ID }])) }));
+    dbInsertMock.mockImplementation(() => ({ values: valuesSpy }));
+    await buildApp().request('/client-ai/sessions', { method: 'POST', headers: AUTHED });
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({
+      systemPrompt: expect.stringContaining('READ-ONLY'),
+    }));
+  });
+
+  it('402s when the org budget is exhausted', async () => {
+    checkClientBudgetMock.mockResolvedValue('Daily AI budget for your organization has been reached ($5.00).');
+    const res = await buildApp().request('/client-ai/sessions', { method: 'POST', headers: AUTHED });
+    expect(res.status).toBe(402);
+  });
+
+  it('402s when partner AI credits are exhausted', async () => {
+    checkBillingCreditsMock.mockResolvedValue('You are out of AI credits. Purchase more credits to continue.');
+    const res = await buildApp().request('/client-ai/sessions', { method: 'POST', headers: AUTHED });
+    expect(res.status).toBe(402);
+  });
+
+  it('429s when rate limited', async () => {
+    rateLimiterMock.mockResolvedValue({ allowed: false, remaining: 0, resetAt: new Date() });
+    const res = await buildApp().request('/client-ai/sessions', { method: 'POST', headers: AUTHED });
+    expect(res.status).toBe(429);
+  });
+});
+
+describe('GET /client-ai/sessions/:id', () => {
+  it('404s when the session belongs to another client user (access check)', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([]));
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}`, { headers: AUTHED });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the session plus its (already-redacted) message history', async () => {
+    const MESSAGES = [
+      { id: 'm1', role: 'user', content: 'card [REDACTED:creditCard]', contentBlocks: null, toolName: null, toolInput: null, toolOutput: null, toolUseId: null, createdAt: new Date() },
+    ];
+    let call = 0;
+    dbSelectMock.mockImplementation(() => {
+      call++;
+      return selectChain(call === 1 ? [SESSION_ROW] : MESSAGES);
+    });
+
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}`, { headers: AUTHED });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.session).toMatchObject({ id: SESSION_ID, status: 'active', title: 'Budget review' });
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].content).toContain('[REDACTED:creditCard]');
+  });
+});
+
+describe('POST /client-ai/sessions/:id/close', () => {
+  it('closes the session, fails pending tool requests, evicts the active session, audits', async () => {
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/close`, {
+      method: 'POST', headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+
+    expect(failPendingMock).toHaveBeenCalledWith(SESSION_ID, 'session_closed');
+    expect(managerMock.remove).toHaveBeenCalledWith(SESSION_ID);
+    expect(dbUpdateMock).toHaveBeenCalled();
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'ai.client_session.close', resourceId: SESSION_ID }),
+    );
+  });
+
+  it('404s for an inaccessible session', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([]));
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/close`, {
+      method: 'POST', headers: AUTHED,
+    });
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 3: Run, expect FAIL** (module not found)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/sessions.lifecycle.test.ts
+```
+
+- [ ] **Step 4: Create `apps/api/src/routes/clientAi/sessions.ts`** (helpers + three routes; Tasks 11/12 append the rest)
+
+```ts
+/**
+ * AI for Office — /client-ai/sessions/* (spec §4, §5, §8).
+ *
+ * All routes run behind Plan 1's clientAiAuthMiddleware (bearer session →
+ * org-scoped DB context) + requireClientAiEnabledMiddleware (per-request
+ * enabled/selected-user policy gate, policy on c.get('clientAiPolicy')).
+ *
+ * Access rule on every session route: the ai_sessions row must match BOTH
+ * auth.clientUserId and auth.orgId (and type='excel_client') — enforced by
+ * loadClientSession's WHERE in addition to RLS.
+ *
+ * Audit actor convention (Plan 1's exchange route): actorType 'user',
+ * actorId = portal_users.id, details.principalType 'portal_user'.
+ */
+
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { streamSSE } from 'hono/streaming';
+import { and, asc, eq } from 'drizzle-orm';
+import { db, withDbAccessContext } from '../../db';
+import { aiMessages, aiSessions } from '../../db/schema';
+import {
+  clientAiAuthMiddleware,
+  requireClientAiEnabledMiddleware,
+} from '../../middleware/clientAiAuth';
+import {
+  streamingSessionManager,
+  type ActiveSession,
+} from '../../services/streamingSessionManager';
+import { writeAuditEvent } from '../../services/auditEvents';
+import { applyDlp, type DlpRedactionEvent } from '../../services/clientAiDlp';
+import { checkBillingCredits } from '../../services/aiCostTracker';
+import {
+  checkClientBudget,
+  getRemainingClientBudgetUsd,
+  recordClientUsage,
+} from '../../services/clientAiUsage';
+import {
+  DEFAULT_CLIENT_AI_MODEL,
+  buildClientAuthContext,
+  buildExcelClientSystemPrompt,
+  checkClientRateLimits,
+  generateClientSessionTitle,
+} from '../../services/clientAiSessions';
+import {
+  CLIENT_MCP_SERVER_NAME,
+  clientMcpToolNamesForWriteMode,
+  createClientWorkbookMcpServer,
+} from '../../services/clientAiTools';
+import {
+  failPendingForSession,
+  resolveClientToolResult,
+} from '../../services/clientAiToolBridge';
+import type { ClientAiOrgPolicy } from '../../services/clientAiPolicy';
+import { toClientSseEvent, CLIENT_AI_SSE_PING_INTERVAL_MS } from './sse';
+import {
+  clientToolResultSchema,
+  sendClientMessageSchema,
+  type ClientAiAuthContext,
+} from './schemas';
+
+export const clientAiSessionRoutes = new Hono();
+
+clientAiSessionRoutes.use('*', clientAiAuthMiddleware);
+clientAiSessionRoutes.use('*', requireClientAiEnabledMiddleware);
+
+type ClientSessionRow = typeof aiSessions.$inferSelect;
+
+/** The per-route access check: id + type + client principal + org, all in the WHERE. */
+async function loadClientSession(
+  sessionId: string,
+  auth: ClientAiAuthContext,
+): Promise<ClientSessionRow | null> {
+  const [row] = await db
+    .select()
+    .from(aiSessions)
+    .where(
+      and(
+        eq(aiSessions.id, sessionId),
+        eq(aiSessions.type, 'excel_client'),
+        eq(aiSessions.clientUserId, auth.clientUserId),
+        eq(aiSessions.orgId, auth.orgId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+function auditClient(
+  c: Context,
+  auth: ClientAiAuthContext,
+  event: {
+    action: string;
+    resourceId?: string | null;
+    result?: 'success' | 'denied';
+    details?: Record<string, unknown>;
+  },
+): void {
+  writeAuditEvent(c, {
+    orgId: auth.orgId,
+    action: event.action,
+    resourceType: 'ai_session',
+    resourceId: event.resourceId ?? null,
+    actorType: 'user',
+    actorId: auth.clientUserId,
+    actorEmail: auth.email,
+    result: event.result ?? 'success',
+    details: { principalType: 'portal_user', ...(event.details ?? {}) },
+  });
+}
+
+/** Shared preflight (spec §4 order): rate limits → org budget → partner credits. */
+async function runClientPreflight(
+  c: Context,
+  auth: ClientAiAuthContext,
+  policy: ClientAiOrgPolicy,
+): Promise<Response | null> {
+  const rateError = await checkClientRateLimits(auth.clientUserId, auth.orgId, policy);
+  if (rateError) return c.json({ error: rateError }, 429);
+
+  const budgetError = await checkClientBudget(policy);
+  if (budgetError) return c.json({ error: budgetError }, 402);
+
+  const creditError = await checkBillingCredits(auth.orgId);
+  if (creditError) return c.json({ error: creditError }, 402);
+
+  return null;
+}
+
+/**
+ * Get-or-create the in-memory SDK session for a client DB session: synthetic
+ * org-pinned auth, the workbook-only MCP server (scriptAi.ts:211-215 factory
+ * pattern), write-mode-filtered SDK toolset, remaining-budget hard stop, no
+ * technician approval-mode prompt injection — then refresh the per-message
+ * client fields the tool handlers read.
+ */
+async function ensureActiveClientSession(
+  c: Context,
+  sessionRow: ClientSessionRow,
+  auth: ClientAiAuthContext,
+  policy: ClientAiOrgPolicy,
+): Promise<ActiveSession> {
+  const maxBudgetUsd = await getRemainingClientBudgetUsd(policy);
+
+  const active = await streamingSessionManager.getOrCreate(
+    sessionRow.id,
+    {
+      orgId: sessionRow.orgId,
+      sdkSessionId: sessionRow.sdkSessionId,
+      model: sessionRow.model,
+      maxTurns: sessionRow.maxTurns,
+      turnCount: sessionRow.turnCount,
+      systemPrompt: sessionRow.systemPrompt,
+    },
+    buildClientAuthContext({
+      clientUserId: auth.clientUserId,
+      orgId: auth.orgId,
+      email: auth.email,
+      name: auth.name,
+    }),
+    c,
+    sessionRow.systemPrompt ?? buildExcelClientSystemPrompt(policy.writeMode),
+    maxBudgetUsd,
+    clientMcpToolNamesForWriteMode(policy.writeMode),
+    (_getAuth, _onPreToolUse, _onPostToolUse, getSession) => ({
+      // The technician pre/post callbacks are deliberately unused: they reject
+      // tools absent from TOOL_TIERS (aiAgentSdk.ts:222-225) and encode
+      // technician persistence. Client handlers own their pipeline.
+      server: createClientWorkbookMcpServer(getSession),
+      name: CLIENT_MCP_SERVER_NAME,
+    }),
+    { injectApprovalModeInstructions: false },
+  );
+
+  // Refresh per-message client state read by the tool handlers and the result hook.
+  active.clientWriteMode = policy.writeMode;
+  active.clientDlpConfig = policy.dlpConfig;
+  const { orgId, clientUserId } = auth;
+  active.recordExtraUsage = (usage) =>
+    withDbAccessContext(
+      { scope: 'organization', orgId, accessibleOrgIds: [orgId] },
+      () =>
+        recordClientUsage(orgId, clientUserId, {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          costCents: usage.costCents,
+          messageCount: 1,
+        }),
+    );
+
+  return active;
+}
+
+// ============================================
+// POST / — create a session (spec §4 pre-flight at create)
+// ============================================
+
+clientAiSessionRoutes.post('/', async (c) => {
+  const auth = c.get('clientAiAuth');
+  const policy = c.get('clientAiPolicy');
+
+  const rejection = await runClientPreflight(c, auth, policy);
+  if (rejection) return rejection;
+
+  const model = policy.allowedModels[0] ?? DEFAULT_CLIENT_AI_MODEL;
+  const systemPrompt = buildExcelClientSystemPrompt(policy.writeMode);
+
+  const [session] = await db
+    .insert(aiSessions)
+    .values({
+      orgId: auth.orgId,
+      userId: null,
+      clientUserId: auth.clientUserId,
+      type: 'excel_client',
+      model,
+      systemPrompt,
+    })
+    .returning({ id: aiSessions.id });
+
+  if (!session) {
+    return c.json({ error: 'Failed to create session' }, 500);
+  }
+
+  await recordClientUsage(auth.orgId, auth.clientUserId, { sessionCount: 1 });
+
+  auditClient(c, auth, {
+    action: 'ai.client_session.create',
+    resourceId: session.id,
+    details: { model, writeMode: policy.writeMode },
+  });
+
+  return c.json({ sessionId: session.id }, 201);
+});
+
+// ============================================
+// GET /:id — session + (already-redacted) message history
+// ============================================
+
+clientAiSessionRoutes.get('/:id', async (c) => {
+  const auth = c.get('clientAiAuth');
+  const sessionId = c.req.param('id')!;
+
+  const session = await loadClientSession(sessionId, auth);
+  if (!session) return c.json({ error: 'Session not found' }, 404);
+
+  // Messages were persisted in redacted form (spec §6) — return them as-is.
+  const messages = await db
+    .select({
+      id: aiMessages.id,
+      role: aiMessages.role,
+      content: aiMessages.content,
+      contentBlocks: aiMessages.contentBlocks,
+      toolName: aiMessages.toolName,
+      toolInput: aiMessages.toolInput,
+      toolOutput: aiMessages.toolOutput,
+      toolUseId: aiMessages.toolUseId,
+      createdAt: aiMessages.createdAt,
+    })
+    .from(aiMessages)
+    .where(eq(aiMessages.sessionId, sessionId))
+    .orderBy(asc(aiMessages.createdAt))
+    .limit(500);
+
+  return c.json({
+    session: {
+      id: session.id,
+      status: session.status,
+      title: session.title,
+      model: session.model,
+      turnCount: session.turnCount,
+      totalInputTokens: session.totalInputTokens,
+      totalOutputTokens: session.totalOutputTokens,
+      totalCostCents: session.totalCostCents,
+      createdAt: session.createdAt,
+      lastActivityAt: session.lastActivityAt,
+    },
+    messages,
+  });
+});
+
+// ============================================
+// POST /:id/close
+// ============================================
+
+clientAiSessionRoutes.post('/:id/close', async (c) => {
+  const auth = c.get('clientAiAuth');
+  const sessionId = c.req.param('id')!;
+
+  const session = await loadClientSession(sessionId, auth);
+  if (!session) return c.json({ error: 'Session not found' }, 404);
+
+  // Resolve any parked tool requests first so the SDK loop unblocks, then
+  // tear down the in-memory session, then mark the row closed.
+  failPendingForSession(sessionId, 'session_closed');
+  streamingSessionManager.remove(sessionId);
+
+  await db
+    .update(aiSessions)
+    .set({ status: 'closed', updatedAt: new Date() })
+    .where(eq(aiSessions.id, sessionId));
+
+  auditClient(c, auth, { action: 'ai.client_session.close', resourceId: sessionId });
+
+  return c.json({ success: true });
+});
+```
+
+- [ ] **Step 5: Mount the router** — in `apps/api/src/routes/clientAi/index.ts`, add the import and route:
+
+```ts
+import { clientAiSessionRoutes } from './sessions';
+```
+
+and after `clientAiRoutes.route('/admin', clientAiAdminRoutes);`:
+
+```ts
+clientAiRoutes.route('/sessions', clientAiSessionRoutes);
+```
+
+- [ ] **Step 6: Run, expect PASS** (12 tests)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/sessions.lifecycle.test.ts
+```
+
+(`sendClientMessageSchema`/`clientToolResultSchema`/`toClientSseEvent` etc. are imported but the message/events/tool-results routes land in Tasks 11/12 — unused imports would fail lint/tsc `noUnusedLocals`; if so, add the imports in the task that uses them instead. The plan lists them here for the final file shape.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/schemas.ts apps/api/src/routes/clientAi/sessions.ts apps/api/src/routes/clientAi/sessions.lifecycle.test.ts apps/api/src/routes/clientAi/index.ts
+git commit -m "feat(client-ai): session routes — create/get/close with preflight, metering, audit" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: POST /:id/messages — preflight, DLP chokepoint (a), redact-before-log contract (TDD)
+
+The message ingress. Returns `202 { accepted: true }`; the turn streams over `GET /events`. **This task carries the Plan-3 contract assertion** (Plan 3 Task 6 integration note): the `ai_messages` insert must receive `applyDlp(...).text` and `result.redactions` — never the raw input.
+
+**Files:**
+- Modify: apps/api/src/routes/clientAi/sessions.ts (append the route)
+- Create: apps/api/src/routes/clientAi/sessions.messages.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/routes/clientAi/sessions.messages.test.ts`
+
+Uses the exact mock preamble from `sessions.lifecycle.test.ts` (Task 10 Step 2 — copy the entire `vi.hoisted` block, the `vi.mock` calls, the imports, `SESSION_ROW`, `selectChain`, `buildApp`, `AUTHED`, and the `beforeEach`). Then add (replacing the lifecycle describes):
+
+```ts
+function passthroughDlp() {
+  applyDlpMock.mockImplementation(async (input: { text?: string; cells?: unknown[][] }) => ({
+    action: 'allow',
+    ...(input.text !== undefined ? { text: input.text } : {}),
+    ...(input.cells !== undefined ? { cells: input.cells.map((r: unknown[]) => [...r]) } : {}),
+    redactions: [],
+  }));
+}
+
+function makeActiveSession() {
+  return {
+    state: 'idle',
+    orgId: ORG_ID,
+    breezeSessionId: SESSION_ID,
+    inputController: { pushMessage: vi.fn() },
+    eventBus: { publish: vi.fn() },
+    toolUseIdQueue: [],
+  } as Record<string, unknown>;
+}
+
+function postMessage(body: Record<string, unknown>) {
+  return buildApp().request(`/client-ai/sessions/${SESSION_ID}/messages`, {
+    method: 'POST',
+    headers: AUTHED,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /client-ai/sessions/:id/messages', () => {
+  let activeSession: ReturnType<typeof makeActiveSession>;
+
+  beforeEach(() => {
+    passthroughDlp();
+    activeSession = makeActiveSession();
+    managerMock.getOrCreate.mockResolvedValue(activeSession);
+    managerMock.get.mockReturnValue(undefined);
+  });
+
+  it('404s for an inaccessible session', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([]));
+    expect((await postMessage({ content: 'hi' })).status).toBe(404);
+  });
+
+  it('410s when the session is closed', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([{ ...SESSION_ROW, status: 'closed' }]));
+    expect((await postMessage({ content: 'hi' })).status).toBe(410);
+  });
+
+  it('402s on budget exhaustion, 429s on rate limit (preflight per message)', async () => {
+    checkClientBudgetMock.mockResolvedValueOnce('Daily AI budget for your organization has been reached ($5.00).');
+    expect((await postMessage({ content: 'hi' })).status).toBe(402);
+
+    rateLimiterMock.mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date() });
+    expect((await postMessage({ content: 'hi' })).status).toBe(429);
+  });
+
+  it('accepts a message: persists the user row, pushes to the SDK, starts the turn timeout, audits, 202', async () => {
+    const valuesSpy = vi.fn(() => Promise.resolve());
+    dbInsertMock.mockImplementation(() => ({ values: valuesSpy }));
+
+    const res = await postMessage({ content: 'sum column B please' });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ accepted: true });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: SESSION_ID, role: 'user', content: 'sum column B please',
+    }));
+    expect(activeSession.inputController).toMatchObject({});
+    expect((activeSession.inputController as { pushMessage: ReturnType<typeof vi.fn> }).pushMessage)
+      .toHaveBeenCalledWith('sum column B please');
+    expect(managerMock.startTurnTimeout).toHaveBeenCalledWith(activeSession);
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'ai.client_session.message',
+        actorId: CLIENT_USER_ID,
+        details: expect.objectContaining({ principalType: 'portal_user', workbookContextKind: 'none' }),
+      }),
+    );
+  });
+
+  it('REDACT-BEFORE-LOG CONTRACT (Plan 3 Task 6): persists applyDlp().text + redactions, never the raw input', async () => {
+    const RAW = 'card 4111111111111111 please check';
+    applyDlpMock.mockResolvedValueOnce({
+      action: 'allow',
+      text: 'card [REDACTED:creditCard] please check',
+      redactions: [{ rule: 'creditCard', count: 1, location: 'text' }],
+    });
+    const valuesSpy = vi.fn(() => Promise.resolve());
+    dbInsertMock.mockImplementation(() => ({ values: valuesSpy }));
+
+    const res = await postMessage({ content: RAW });
+    expect(res.status).toBe(202);
+
+    // applyDlp received the raw text with the policy's dlpConfig + orgId
+    expect(applyDlpMock).toHaveBeenCalledWith({ text: RAW, dlpConfig: policyState.policy.dlpConfig, orgId: ORG_ID });
+
+    // Persisted form: result.text + result.redactions (in content_blocks), never the raw value
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({
+      content: 'card [REDACTED:creditCard] please check',
+      contentBlocks: expect.arrayContaining([
+        { type: 'dlp_redactions', redactions: [{ rule: 'creditCard', count: 1, location: 'text' }] },
+      ]),
+    }));
+    expect(JSON.stringify(valuesSpy.mock.calls)).not.toContain('4111111111111111');
+
+    // The model sees the redacted form too
+    const pushed = (activeSession.inputController as { pushMessage: ReturnType<typeof vi.fn> }).pushMessage.mock.calls[0]![0] as string;
+    expect(pushed).toContain('[REDACTED:creditCard]');
+    expect(pushed).not.toContain('4111111111111111');
+  });
+
+  it('DLP block → 400 with the reason, session_error published, audit denied, nothing persisted or pushed', async () => {
+    applyDlpMock.mockResolvedValueOnce({
+      action: 'block',
+      blockReason: 'dlp_blocked:iban',
+      redactions: [{ rule: 'iban', count: 1, location: 'text' }],
+    });
+    managerMock.get.mockReturnValue(activeSession);
+
+    const res = await postMessage({ content: 'acct DE89370400440532013000' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('dlp_blocked');
+    expect(body.reason).toBe('dlp_blocked:iban');
+
+    expect((activeSession.eventBus as { publish: ReturnType<typeof vi.fn> }).publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: expect.stringContaining('dlp_blocked:iban') }),
+    );
+    expect(dbInsertMock).not.toHaveBeenCalled();
+    expect(writeAuditEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'ai.client_session.message', result: 'denied' }),
+    );
+  });
+
+  it('workbookContext cells go through applyDlp and the redacted matrix is persisted + sent', async () => {
+    const cells = [['Card'], ['4111111111111111']];
+    applyDlpMock
+      .mockResolvedValueOnce({ action: 'allow', text: 'summarize this', redactions: [] }) // text pass
+      .mockResolvedValueOnce({
+        action: 'allow',
+        cells: [['Card'], ['[REDACTED:creditCard]']],
+        redactions: [{ rule: 'creditCard', count: 1, location: 'cell[1][0]' }],
+      }); // cells pass
+    const valuesSpy = vi.fn(() => Promise.resolve());
+    dbInsertMock.mockImplementation(() => ({ values: valuesSpy }));
+
+    const res = await postMessage({
+      content: 'summarize this',
+      workbookContext: { kind: 'selection', address: 'A1:A2', cells },
+    });
+    expect(res.status).toBe(202);
+
+    expect(applyDlpMock).toHaveBeenNthCalledWith(2, { cells, dlpConfig: policyState.policy.dlpConfig, orgId: ORG_ID });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({
+      contentBlocks: expect.arrayContaining([
+        expect.objectContaining({ type: 'workbook_context', kind: 'selection', address: 'A1:A2', cells: [['Card'], ['[REDACTED:creditCard]']] }),
+        expect.objectContaining({ type: 'dlp_redactions' }),
+      ]),
+    }));
+
+    const pushed = (activeSession.inputController as { pushMessage: ReturnType<typeof vi.fn> }).pushMessage.mock.calls[0]![0] as string;
+    expect(pushed).toContain('[Workbook context — Current selection (A1:A2)]');
+    expect(pushed).toContain('[REDACTED:creditCard]');
+    expect(pushed).not.toContain('4111111111111111');
+  });
+
+  it('409s when a message is already processing', async () => {
+    managerMock.tryTransitionToProcessing.mockReturnValue(false);
+    expect((await postMessage({ content: 'hi' })).status).toBe(409);
+  });
+
+  it('auto-titles the session from the first (redacted) message', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([{ ...SESSION_ROW, title: null }]));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) }));
+    dbUpdateMock.mockImplementation(() => ({ set: setSpy }));
+
+    await postMessage({ content: 'sum column B please' });
+    expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ title: 'sum column B please' }));
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (route does not exist → 404s where 202/400 expected)
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/sessions.messages.test.ts
+```
+
+- [ ] **Step 3: Append the route to `apps/api/src/routes/clientAi/sessions.ts`**
+
+```ts
+// ============================================
+// POST /:id/messages — message ingress (spec §4 pre-flight per message;
+// DLP chokepoint (a) + workbookContext cells; redact-before-log)
+// ============================================
+
+function dlpBlockedResponse(
+  c: Context,
+  auth: ClientAiAuthContext,
+  sessionId: string,
+  blockReason: string | undefined,
+): Response {
+  const reason = blockReason ?? 'dlp_blocked';
+  const message = `Your message was blocked by your organization's data protection policy (${reason}).`;
+  // Surface on the SSE channel too (pinned contract) when the session is live.
+  const active = streamingSessionManager.get(sessionId);
+  if (active) {
+    active.eventBus.publish({ type: 'error', message });
+  }
+  auditClient(c, auth, {
+    action: 'ai.client_session.message',
+    resourceId: sessionId,
+    result: 'denied',
+    details: { reason },
+  });
+  return c.json({ error: 'dlp_blocked', reason, message }, 400);
+}
+
+clientAiSessionRoutes.post(
+  '/:id/messages',
+  zValidator('json', sendClientMessageSchema),
+  async (c) => {
+    const auth = c.get('clientAiAuth');
+    const policy = c.get('clientAiPolicy');
+    const sessionId = c.req.param('id')!;
+    const body = c.req.valid('json');
+
+    const session = await loadClientSession(sessionId, auth);
+    if (!session) return c.json({ error: 'Session not found' }, 404);
+    if (session.status !== 'active') {
+      return c.json({ error: 'Session is no longer active' }, 410);
+    }
+
+    const rejection = await runClientPreflight(c, auth, policy);
+    if (rejection) return rejection;
+
+    // ── DLP chokepoint (a): the user prompt (templates ride inside it in v1) ──
+    const textResult = await applyDlp({
+      text: body.content,
+      dlpConfig: policy.dlpConfig,
+      orgId: auth.orgId,
+    });
+    if (textResult.action === 'block') {
+      return dlpBlockedResponse(c, auth, sessionId, textResult.blockReason);
+    }
+
+    // ── workbookContext cells leave Breeze for the provider too — same chokepoint ──
+    const redactions: DlpRedactionEvent[] = [...textResult.redactions];
+    const wb = body.workbookContext;
+    let contextCells: unknown[][] | undefined;
+    if (wb && wb.kind !== 'none' && wb.cells) {
+      const cellsResult = await applyDlp({
+        cells: wb.cells,
+        dlpConfig: policy.dlpConfig,
+        orgId: auth.orgId,
+      });
+      if (cellsResult.action === 'block') {
+        return dlpBlockedResponse(c, auth, sessionId, cellsResult.blockReason);
+      }
+      redactions.push(...cellsResult.redactions);
+      contextCells = cellsResult.cells;
+    }
+
+    const redactedContent = textResult.text ?? body.content;
+    let modelContent = redactedContent;
+    if (wb && wb.kind !== 'none') {
+      const label =
+        wb.kind === 'selection'
+          ? `Current selection${wb.address ? ` (${wb.address})` : ''}`
+          : `Sheet "${wb.sheetName ?? 'unknown'}"`;
+      modelContent += `\n\n[Workbook context — ${label}]\n${
+        contextCells ? JSON.stringify(contextCells) : '(no cell data provided)'
+      }`;
+    }
+
+    const activeSession = await ensureActiveClientSession(c, session, auth, policy);
+
+    // Concurrent message guard — atomic check-and-set (ai.ts:467 convention).
+    if (!streamingSessionManager.tryTransitionToProcessing(activeSession)) {
+      return c.json({ error: 'A message is already being processed for this session' }, 409);
+    }
+
+    // Persist the REDACTED form only: result.text + result.redactions
+    // (spec §6; Plan 3 Task 6 contract — the raw input is never stored).
+    const contentBlocks: Record<string, unknown>[] = [];
+    if (redactions.length > 0) {
+      contentBlocks.push({ type: 'dlp_redactions', redactions });
+    }
+    if (wb && wb.kind !== 'none') {
+      contentBlocks.push({
+        type: 'workbook_context',
+        kind: wb.kind,
+        address: wb.address ?? null,
+        sheetName: wb.sheetName ?? null,
+        cells: contextCells ?? null,
+      });
+    }
+
+    try {
+      await db.insert(aiMessages).values({
+        sessionId,
+        role: 'user',
+        content: redactedContent,
+        contentBlocks: contentBlocks.length > 0 ? contentBlocks : null,
+      });
+    } catch (err) {
+      console.error('[client-ai] Failed to save user message:', err);
+      activeSession.state = 'idle';
+      return c.json({ error: 'Failed to save message' }, 500);
+    }
+
+    if (!session.title) {
+      const title = generateClientSessionTitle(redactedContent);
+      try {
+        await db.update(aiSessions).set({ title }).where(eq(aiSessions.id, sessionId));
+      } catch (err) {
+        console.error('[client-ai] Failed to auto-set session title:', err);
+      }
+    }
+
+    activeSession.inputController.pushMessage(modelContent);
+    streamingSessionManager.startTurnTimeout(activeSession);
+
+    auditClient(c, auth, {
+      action: 'ai.client_session.message',
+      resourceId: sessionId,
+      details: {
+        contentLength: body.content.length,
+        workbookContextKind: wb?.kind ?? 'none',
+        redactionCount: redactions.length,
+      },
+    });
+
+    // The turn streams over GET /:id/events — see sse.ts for the event names.
+    return c.json({ accepted: true }, 202);
+  },
+);
+```
+
+- [ ] **Step 4: Run, expect PASS** (9 tests), plus the lifecycle suite stays green:
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/sessions.messages.test.ts src/routes/clientAi/sessions.lifecycle.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/sessions.ts apps/api/src/routes/clientAi/sessions.messages.test.ts
+git commit -m "feat(client-ai): message ingress — per-message preflight, DLP chokepoint, redact-before-log persistence" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: GET /:id/events (SSE) + POST /:id/tool-results (TDD)
+
+The persistent stream and the bridge resolution endpoint. The events route creates the in-memory session when absent (so the add-in can connect right after create — see Design decisions) and never breaks on `turn_complete`: the channel persists across turns until the client disconnects or the session is torn down.
+
+**Files:**
+- Modify: apps/api/src/routes/clientAi/sessions.ts (append the two routes)
+- Create: apps/api/src/routes/clientAi/sessions.events-toolresults.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/routes/clientAi/sessions.events-toolresults.test.ts`
+
+Same mock preamble as Task 10 Step 2 (copy the `vi.hoisted` block, `vi.mock` calls, imports, `SESSION_ROW`, `selectChain`, `buildApp`, `AUTHED`, `beforeEach`). Then add:
+
+```ts
+import { AsyncEventQueue } from '../../utils/asyncQueue';
+
+/** Minimal real-semantics bus for SSE tests (single subscriber). */
+class TestEventBus {
+  queue = new AsyncEventQueue<unknown>();
+  published: unknown[] = [];
+  subscribe(_id: string) { return this.queue; }
+  unsubscribe(_id: string) { this.queue.close(); }
+  publish(e: unknown) { this.published.push(e); this.queue.push(e); }
+  closeAll() { this.queue.close(); }
+}
+
+function makeStreamingSession() {
+  return {
+    state: 'idle',
+    orgId: ORG_ID,
+    breezeSessionId: SESSION_ID,
+    inputController: { pushMessage: vi.fn() },
+    eventBus: new TestEventBus(),
+    toolUseIdQueue: [],
+  } as Record<string, unknown>;
+}
+
+describe('GET /client-ai/sessions/:id/events', () => {
+  it('404s for an inaccessible session', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([]));
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/events`, { headers: AUTHED });
+    expect(res.status).toBe(404);
+  });
+
+  it('410s when the session is closed', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([{ ...SESSION_ROW, status: 'closed' }]));
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/events`, { headers: AUTHED });
+    expect(res.status).toBe(410);
+  });
+
+  it('streams translated client events and persists across turn_complete', async () => {
+    const active = makeStreamingSession();
+    managerMock.get.mockReturnValue(active);
+
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/events`, { headers: AUTHED });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    // Give the streaming callback a tick to subscribe, then publish a full turn.
+    await new Promise((r) => setTimeout(r, 20));
+    const bus = active.eventBus as TestEventBus;
+    bus.publish({ type: 'content_delta', delta: 'Sure — ' });
+    bus.publish({ type: 'tool_request', toolUseId: 'tu-1', toolName: 'read_range', input: { address: 'A1' }, mutating: false });
+    bus.publish({ type: 'tool_completed', toolUseId: 'tu-1', toolName: 'read_range', status: 'success', redactions: [] });
+    bus.publish({ type: 'done', usage: { inputTokens: 10, outputTokens: 5, costCents: 1 } });
+    bus.publish({ type: 'content_delta', delta: 'next turn still streams' }); // proves no break on done
+    bus.publish({ type: 'message_start', messageId: 'm1' }); // internal — must be dropped
+    await new Promise((r) => setTimeout(r, 20));
+    bus.closeAll(); // ends the stream so res.text() resolves
+
+    const text = await res.text();
+    expect(text).toContain('event: message_delta');
+    expect(text).toContain('event: tool_request');
+    expect(text).toContain('event: tool_completed');
+    expect(text).toContain('event: turn_complete');
+    expect(text).toContain('"costCents":1');
+    expect(text).toContain('next turn still streams');
+    expect(text).not.toContain('message_start');
+  });
+
+  it('creates the in-memory session when absent (connect-before-first-message)', async () => {
+    const active = makeStreamingSession();
+    managerMock.get.mockReturnValue(undefined);
+    managerMock.getOrCreate.mockResolvedValue(active);
+
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/events`, { headers: AUTHED });
+    expect(res.status).toBe(200);
+    expect(managerMock.getOrCreate).toHaveBeenCalled();
+    // 9th positional arg pins the client loop config
+    const args = managerMock.getOrCreate.mock.calls[0]!;
+    expect(args[8]).toEqual({ injectApprovalModeInstructions: false });
+    // SDK toolset is the write-mode-filtered client allowlist
+    expect(args[6]).toEqual(expect.arrayContaining(['mcp__excel__read_range']));
+    expect(args[6]).not.toEqual(expect.arrayContaining(['mcp__breeze__query_devices']));
+
+    await new Promise((r) => setTimeout(r, 20));
+    (active.eventBus as TestEventBus).closeAll();
+    await res.text();
+  });
+});
+
+describe('POST /client-ai/sessions/:id/tool-results', () => {
+  it('resolves a pending bridge request scoped to THIS session', async () => {
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/tool-results`, {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ toolUseId: 'tu-1', status: 'success', output: { cells: [['v']] } }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(resolveToolResultMock).toHaveBeenCalledWith(SESSION_ID, 'tu-1', {
+      status: 'success',
+      output: { cells: [['v']] },
+    });
+  });
+
+  it('404s for an unknown/expired toolUseId', async () => {
+    resolveToolResultMock.mockReturnValue(false);
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/tool-results`, {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ toolUseId: 'nope', status: 'success', output: null }),
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'unknown_tool_request' });
+  });
+
+  it('404s when the session is not accessible (cross-user guard before any resolution)', async () => {
+    dbSelectMock.mockImplementation(() => selectChain([]));
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/tool-results`, {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ toolUseId: 'tu-1', status: 'success', output: null }),
+    });
+    expect(res.status).toBe(404);
+    expect(resolveToolResultMock).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid status value', async () => {
+    const res = await buildApp().request(`/client-ai/sessions/${SESSION_ID}/tool-results`, {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ toolUseId: 'tu-1', status: 'pending' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/sessions.events-toolresults.test.ts
+```
+
+- [ ] **Step 3: Append the two routes to `apps/api/src/routes/clientAi/sessions.ts`**
+
+```ts
+// ============================================
+// GET /:id/events — the persistent SSE channel (spec §4)
+//
+// Preferred client: fetch-based SSE with the Authorization header. EventSource
+// fallback: ?token= (GET-only, clientAiAuthMiddleware). The stream does NOT
+// end on turn_complete — it persists across turns until the client
+// disconnects or the session is evicted/closed (the bus subscription closes).
+//
+// NOTE on DB access: loadClientSession runs inside the middleware's
+// org-scoped request context; the streaming callback itself does NO DB work
+// (it runs after the request transaction commits — the #1105 lesson).
+// ============================================
+
+clientAiSessionRoutes.get('/:id/events', async (c) => {
+  const auth = c.get('clientAiAuth');
+  const policy = c.get('clientAiPolicy');
+  const sessionId = c.req.param('id')!;
+
+  const session = await loadClientSession(sessionId, auth);
+  if (!session) return c.json({ error: 'Session not found' }, 404);
+  if (session.status !== 'active') {
+    return c.json({ error: 'Session is no longer active' }, 410);
+  }
+
+  // Create the in-memory session if absent so the add-in can connect the
+  // stream immediately after POST /sessions, before the first message.
+  const activeSession =
+    streamingSessionManager.get(sessionId) ??
+    (await ensureActiveClientSession(c, session, auth, policy));
+
+  const subscriptionId = crypto.randomUUID();
+
+  return streamSSE(c, async (stream) => {
+    const events = activeSession.eventBus.subscribe(subscriptionId);
+
+    const ping = setInterval(() => {
+      stream.writeSSE({ event: 'ping', data: '{}' }).catch(() => {
+        /* client gone — the abort handler tears down */
+      });
+    }, CLIENT_AI_SSE_PING_INTERVAL_MS);
+
+    stream.onAbort(() => {
+      clearInterval(ping);
+      activeSession.eventBus.unsubscribe(subscriptionId);
+    });
+
+    try {
+      for await (const event of events) {
+        const sse = toClientSseEvent(event);
+        if (sse) {
+          await stream.writeSSE(sse);
+        }
+        // Deliberately NO break on 'done' — the channel persists across turns.
+      }
+    } catch (err) {
+      console.error('[client-ai] SSE stream error:', err);
+      await stream
+        .writeSSE({ event: 'session_error', data: JSON.stringify({ message: 'Stream failed' }) })
+        .catch(() => {});
+    } finally {
+      clearInterval(ping);
+      activeSession.eventBus.unsubscribe(subscriptionId);
+    }
+  });
+});
+
+// ============================================
+// POST /:id/tool-results — the add-in reports a tool outcome (spec §5 step 2)
+//
+// Execution/rejection audit + persistence + tool_completed publishing happen
+// in the MCP handler (services/clientAiTools.ts) once this resolution lands —
+// the route only authenticates, access-checks, and resolves the bridge.
+// ============================================
+
+clientAiSessionRoutes.post(
+  '/:id/tool-results',
+  zValidator('json', clientToolResultSchema),
+  async (c) => {
+    const auth = c.get('clientAiAuth');
+    const sessionId = c.req.param('id')!;
+
+    const session = await loadClientSession(sessionId, auth);
+    if (!session) return c.json({ error: 'Session not found' }, 404);
+
+    const { toolUseId, status, output } = c.req.valid('json');
+
+    const resolved = resolveClientToolResult(sessionId, toolUseId, {
+      status,
+      output: output ?? null,
+    });
+    if (!resolved) {
+      // Unknown id, already resolved/timed out, or owned by another session.
+      return c.json({ error: 'unknown_tool_request' }, 404);
+    }
+
+    return c.json({ ok: true });
+  },
+);
+```
+
+- [ ] **Step 4: Run, expect PASS** (8 tests), plus the other two route suites stay green:
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/sessions.events-toolresults.test.ts src/routes/clientAi/sessions.messages.test.ts src/routes/clientAi/sessions.lifecycle.test.ts
+```
+
+(If the SSE-stream test flakes on the 20ms subscribe tick, raise the two `setTimeout` waits to 50ms — the stream callback in `hono/streaming` starts when the ReadableStream is constructed, but scheduling is not guaranteed within one tick.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/sessions.ts apps/api/src/routes/clientAi/sessions.events-toolresults.test.ts
+git commit -m "feat(client-ai): persistent SSE events channel + tool-results bridge resolution" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Final verification sweep
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Run every test file this plan added or touched (single command, no full-suite flake)**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run \
+  src/services/clientAiDlp.stub.test.ts \
+  src/services/streamingSessionManager.clientLoop.test.ts \
+  src/services/streamingSessionManager.security.test.ts \
+  src/services/clientAiUsage.test.ts \
+  src/services/clientAiToolBridge.test.ts \
+  src/services/clientAiTools.registry.test.ts \
+  src/services/clientAiTools.handler.test.ts \
+  src/services/clientAiSessions.test.ts \
+  src/middleware/clientAiAuth.queryToken.test.ts \
+  src/middleware/clientAiAuth.test.ts \
+  src/routes/clientAi/sse.test.ts \
+  src/routes/clientAi/sessions.lifecycle.test.ts \
+  src/routes/clientAi/sessions.messages.test.ts \
+  src/routes/clientAi/sessions.events-toolresults.test.ts
+```
+
+Expected: all PASS (~90 tests).
+
+- [ ] **Step 2: Run the Plan-1 suites this plan's edits could regress**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/ src/services/clientAiPolicy.test.ts
+```
+
+Expected: PASS (the schemas.ts append and index.ts mount are additive).
+
+- [ ] **Step 3: Type-check both packages**
+
+```bash
+cd /Users/toddhebebrand/breeze/packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm typecheck
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+
+Expected: only the pre-existing `agents.test.ts` / `apiKeyAuth.test.ts` errors.
+
+- [ ] **Step 4: Smoke the mounted routes against the dev stack (optional but cheap)**
+
+With the dev compose stack running:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost/api/v1/client-ai/sessions \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+Expected: `401` (no bearer session) — proves the mount + middleware chain. A full live round-trip needs the add-in (Plan 5) or a scripted SSE client; defer to Plan 5's manual checklist.
+
+- [ ] **Step 5: Commit any straggler fixes**
+
+```bash
+git status --short   # should be clean; commit fixes with a fix(client-ai): prefix if not
+```
+
+---
+
+## Out of scope for this plan (later plans)
+
+- The real DLP engine (detectors, custom rules, ReDoS guards, action precedence) — Plan 3 replaces `clientAiDlp.ts` internals; the chokepoint call sites and the redact-before-log persistence shape ship HERE and must not move.
+- Dashboard surfaces (session/audit viewer reading `content_blocks.dlp_redactions` + `workbook_context` blocks, usage report/CSV over `client_ai_usage`, template manager) — Plan 4.
+- The Excel add-in (Office.js executor for the 9 tools, write-preview Apply/Reject cards, fetch-SSE client consuming the `CLIENT_AI_SSE_EVENTS` table, template picker) — Plan 5.
+- Multi-provider routing (`allowedProviders` beyond `['anthropic']` is stored but not interpreted; the model picker uses `allowedModels[0]` only) — spec §15.
+- SSE replay/Last-Event-ID resume after mid-turn reconnects — v1 reconnect starts from live events only (the add-in re-renders history via `GET /:id`).
+
+## Open questions / accepted risks (for the implementer & reviewer)
+
+1. **Shared LRU pressure**: client sessions share `MAX_ACTIVE_SESSIONS = 200` with technician/helper/script-builder sessions, and `GET /events` eagerly spawns the SDK subprocess. If add-in adoption makes eviction of technician sessions plausible, split the cap (or lazily spawn on first message and accept the connect-after-first-message ordering in Plan 5).
+2. **`ai_cost_usage` overlap**: client spend lands in the org-level `ai_cost_usage` via `recordUsageFromSdkResult` (keeps partner credit deduction working) — technician budget caps therefore include client spend. Accepted v1; if MSPs complain, add a `source` dimension to `ai_cost_usage` later.
+3. **`allowedModels` is trusted as-is**: the policy editor (Plan 1 admin PUT) accepts arbitrary model strings; an invalid model fails at the SDK/provider level mid-session rather than at preflight. Consider validating against a known-model list in Plan 4's policy editor.
+4. **Mid-session `writeMode` flip**: the SDK-level toolset (`options.allowedTools`) is fixed at subprocess creation; flipping the policy to `readonly` mid-session is enforced by the handler's server-side rejection (and takes full toolset effect on the next subprocess spawn). Documented in `clientMcpToolNamesForWriteMode`'s comment.
+5. **`?token=` in access logs**: GET-only, header-wins; Plan 5 must use fetch-SSE with the header. If Caddy access-log scrubbing is ever audited, add `token` to the query-param redaction list there.
+
+
+
+
+
+

--- a/docs/superpowers/plans/2026-06-12-ai-for-office-3-dlp.md
+++ b/docs/superpowers/plans/2026-06-12-ai-for-office-3-dlp.md
@@ -1,0 +1,1510 @@
+# Breeze AI for Office — Plan 3: DLP / Redaction Pipeline
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Plan-2 `clientAiDlp.ts` passthrough stub with the real DLP/redaction engine (spec §6): built-in Luhn/mod-97-validated detectors, per-org custom regex rules with layered ReDoS guards, cell-level workbook scanning, block > redact > log action precedence, and a strict `dlp_config` schema so the audit trail (`ai_messages`) only ever stores the redacted form.
+
+**Architecture:** Three layers, all pure computation (no DB, no Redis — the engine receives `dlpConfig` from `getOrgPolicy()` via its Plan-2 callers, so there are no `withDbAccessContext` concerns):
+1. `packages/shared/src/validators/clientAiDlp.ts` — the `dlp_config` Zod schema + `validateDlpPattern` custom-pattern safety gate. Shared so the API PUT route, the engine, and the Plan-4 policy-editor live test box all use the identical contract.
+2. `apps/api/src/services/clientAiDlpDetectors.ts` — built-in detectors as pure `string → match spans` functions (Luhn, IBAN mod-97 included here in full).
+3. `apps/api/src/services/clientAiDlp.ts` — the scanning engine behind the **pinned** `applyDlp` interface Plan 2 calls on (a) user message text, (b) every workbook `tool_result` cell matrix, (c) template content. This plan does NOT touch those call sites.
+
+**Tech Stack:** TypeScript, Zod v3 (`^3.24.1`, same in shared + api), Vitest. No new dependencies — the repo has no RE2-style regex engine (checked root, `apps/api`, and `packages/shared` package.json), so ReDoS mitigation is layered guards, not an engine swap.
+
+**Spec:** docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md
+**Depends on:** Plan 1 (foundation), Plan 2 (session loop — owns the applyDlp call sites)
+---
+
+## Pinned cross-plan contract
+
+Plan 2 creates `apps/api/src/services/clientAiDlp.ts` as a passthrough stub with EXACTLY this interface. This plan replaces the internals and **must keep the signature**:
+
+```ts
+export interface DlpRedactionEvent { rule: string; count: number; location: string }
+export interface DlpResult { action: 'allow' | 'block'; text?: string; cells?: unknown[][]; redactions: DlpRedactionEvent[]; blockReason?: string }
+export async function applyDlp(input: { text?: string; cells?: unknown[][]; dlpConfig: unknown; orgId: string }): Promise<DlpResult>
+```
+
+If Plan 2 has not landed when this plan executes, create the file fresh — the interface is pinned either way, so merge order between Plan 2 and Plan 3 does not matter. (`input.orgId` is unused by the v1 engine — config arrives pre-fetched — but stays in the signature for future per-org compiled-rule caching/telemetry.)
+
+`dlpConfig` arrives as `unknown` straight from `getOrgPolicy().dlpConfig` (Plan 1, `apps/api/src/services/clientAiPolicy.ts` — jsonb column, DB default `'{}'`). The engine parses it itself; callers never pre-validate.
+
+## Design decisions (read before implementing)
+
+- **Defaults (spec §6):** `creditCard`, `ssn`, `iban`, `apiKey` → `redact`; `email`, `phone` → `off`. `dlpConfigSchema.parse({})` materialises exactly this, so an org that has never touched the policy editor still gets financial/credential redaction the moment the product is enabled.
+- **Invalid stored config degrades to defaults, never to "off".** If a `dlp_config` row fails strict parsing (only possible via out-of-band DB writes — the PUT path validates with the same schema after Task 5), the engine falls back to `DEFAULT_DLP_CONFIG`. Trade-off: an invalid config's custom rules are dropped; the built-in redactions stay on. Documented in the engine header.
+- **Action order: block → redact → log.** All enabled rules scan first; if ANY block-rule matched anywhere, the whole payload is refused (`action:'block'`, `blockReason:'dlp_blocked:<ruleName>'`) with **no partial results** (`text`/`cells` omitted) — but the value-free `redactions` events ARE returned so the MSP audit view can show what tripped. Otherwise redact rules rewrite content (`[REDACTED:<rule>]`, per spec §6's `[REDACTED:type]`), and log rules contribute events without modifying anything.
+- **Oversize payloads block with `payload_too_large_for_dlp`** (cells > 50 000, any single stringified cell > 32 768 chars — Excel's own cell limit is 32 767 — or total > 2 000 000 chars). Justification: fail closed. Scanning a prefix and passing the rest would let data ride past the chokepoint inside padded payloads; Plan 2's read tools chunk well below these caps, so hitting one is a tool-layer bug that should surface loudly, not silently leak.
+- **ReDoS mitigation (no RE2 dependency exists, so layered guards):** (1) 200-char pattern length cap; (2) backreference ban (`\1`–`\9` enable exponential backtracking); (3) nested-quantifier heuristic rejecting a quantified atom immediately before a quantified closing paren — `(a+)+`, `(\d{2,})*`, `(x*)+`; deliberately conservative (it also rejects some safe escaped-paren patterns — acceptable, custom DLP rules are short PII matchers); (4) bounded timed probes: the candidate pattern runs against ≤25-char adversarial inputs under a 50 ms budget, short enough that even a fully catastrophic pattern costs at most a few hundred ms once at config-save time; (5) engine-side per-call wall-clock budget (`DLP_SCAN_BUDGET_MS`, blocks with `dlp_scan_budget_exceeded`) plus the input size caps. The timing-based guards (4)(5) are intentionally NOT unit-tested — wall-clock assertions flake; the deterministic guards (1)(2)(3) are.
+- **Custom rule fails to compile at scan time → block** (`dlp_rule_compile_failed:<name>`). Near-unreachable (the schema compiles every pattern at save time), but silently skipping a rule the MSP believes is active would disable DLP without anyone noticing.
+- **Cell granularity:** every cell is a scan location labelled `cell[r][c]` (row-major, 0-based); redaction replaces *within* the cell string. Non-string cells are stringified for scanning (`String()` for number/boolean/bigint — Excel stores card numbers as numbers; `JSON.stringify` for objects; `null`/`undefined` skipped); a redacted numeric cell becomes a redacted **string** in the output. Untouched cells keep their original value and type. The input matrix is never mutated.
+- **Redaction events** are aggregated per rule: `count` = total matches across the payload, `location` = the single location, or `'<first> (+N more)'` when matches span multiple locations. Bounded by construction (≤ 6 builtins + 50 custom rules = 56 events max).
+- **SSN context guard:** the dashed form (`\d{3}-\d{2}-\d{4}` + area/group/serial plausibility) always matches. The bare 9-digit form only activates when an SSN keyword (`ssn`, `social security`) appears **anywhere in the payload** — this covers an `SSN` header cell above a column of bare numbers. False-positive trade-off documented in Task 2.
+- **Idempotency:** `[REDACTED:<rule>]` tokens contain no digits and no 32+ char hex/base64 runs, so re-scanning redacted output yields zero findings (tested). A custom rule could theoretically match the literal token text — that is the org's own foot-gun, not guarded.
+
+## File Structure
+
+```
+packages/shared/src/validators/
+  clientAiDlp.ts               (new — dlp_config schema, pattern safety, DEFAULT_DLP_CONFIG)
+  clientAiDlp.test.ts          (new)
+  index.ts                     (edit — add barrel export)
+apps/api/src/services/
+  clientAiDlpDetectors.ts      (new — built-in detectors, luhnCheck, ibanMod97, mergeMatches)
+  clientAiDlpDetectors.test.ts (new)
+  clientAiDlp.ts               (replace Plan-2 stub internals — pinned interface)
+  clientAiDlp.test.ts          (new)
+apps/api/src/routes/clientAi/
+  schemas.ts                   (edit — putPolicySchema.dlpConfig: z.record → dlpConfigSchema)
+  schemas.dlp.test.ts          (new)
+```
+
+---
+
+### Task 1: dlp_config Zod schema + custom-pattern safety validator (TDD)
+
+**Files:**
+- Create: packages/shared/src/validators/clientAiDlp.ts
+- Create: packages/shared/src/validators/clientAiDlp.test.ts
+- Edit: packages/shared/src/validators/index.ts
+
+- [ ] **Step 1: Write the failing test** — `packages/shared/src/validators/clientAiDlp.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  dlpConfigSchema,
+  dlpCustomRuleSchema,
+  validateDlpPattern,
+  DEFAULT_DLP_CONFIG,
+  DLP_MAX_CUSTOM_RULES,
+  DLP_MAX_PATTERN_LENGTH,
+} from './clientAiDlp';
+
+const RULE_ID = '0b8f8f54-1111-4222-8333-444455556666';
+
+describe('dlpConfigSchema — defaults', () => {
+  it('parses {} to the documented defaults (financial/credential redact, email/phone off)', () => {
+    expect(dlpConfigSchema.parse({})).toEqual({
+      builtins: {
+        creditCard: 'redact',
+        ssn: 'redact',
+        iban: 'redact',
+        apiKey: 'redact',
+        email: 'off',
+        phone: 'off',
+      },
+      customRules: [],
+    });
+  });
+
+  it('DEFAULT_DLP_CONFIG matches parse({})', () => {
+    expect(DEFAULT_DLP_CONFIG).toEqual(dlpConfigSchema.parse({}));
+  });
+
+  it('fills missing builtin keys with their defaults', () => {
+    const config = dlpConfigSchema.parse({ builtins: { email: 'redact' } });
+    expect(config.builtins.email).toBe('redact');
+    expect(config.builtins.creditCard).toBe('redact');
+    expect(config.builtins.phone).toBe('off');
+  });
+});
+
+describe('dlpConfigSchema — strictness', () => {
+  it('rejects unknown builtin keys', () => {
+    expect(dlpConfigSchema.safeParse({ builtins: { creditCards: 'redact' } }).success).toBe(false);
+  });
+
+  it('rejects unknown top-level keys', () => {
+    expect(dlpConfigSchema.safeParse({ rules: [] }).success).toBe(false);
+  });
+
+  it('rejects invalid action values', () => {
+    expect(dlpConfigSchema.safeParse({ builtins: { ssn: 'mask' } }).success).toBe(false);
+  });
+});
+
+describe('dlpConfigSchema — custom rules', () => {
+  it('accepts a valid custom rule', () => {
+    const result = dlpConfigSchema.safeParse({
+      customRules: [{ id: RULE_ID, name: 'Employee ID', pattern: 'EMP-\\d{6}', action: 'redact' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects duplicate custom rule ids', () => {
+    const rule = { id: RULE_ID, name: 'A', pattern: 'x\\d+', action: 'log' as const };
+    expect(
+      dlpConfigSchema.safeParse({ customRules: [rule, { ...rule, name: 'B' }] }).success,
+    ).toBe(false);
+  });
+
+  it(`caps customRules at ${DLP_MAX_CUSTOM_RULES}`, () => {
+    const rules = Array.from({ length: DLP_MAX_CUSTOM_RULES + 1 }, (_, i) => ({
+      id: `0b8f8f54-1111-4222-8333-${String(i).padStart(12, '0')}`,
+      name: `r${i}`,
+      pattern: 'abc',
+      action: 'log' as const,
+    }));
+    expect(dlpConfigSchema.safeParse({ customRules: rules }).success).toBe(false);
+  });
+
+  it('rejects an unsafe pattern inside a custom rule', () => {
+    expect(
+      dlpCustomRuleSchema.safeParse({
+        id: RULE_ID,
+        name: 'bad',
+        pattern: '(a+)+$',
+        action: 'block',
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('validateDlpPattern — ReDoS guards', () => {
+  const rejected: Array<[string, string]> = [
+    ['(a+)+$', 'nested_quantifier'],
+    ['(\\d{2,})*', 'nested_quantifier'],
+    ['(x*)+', 'nested_quantifier'],
+    ['(abc)\\1', 'backreference_not_allowed'],
+    ['[unclosed', 'invalid_regex'],
+    ['a'.repeat(DLP_MAX_PATTERN_LENGTH + 1), 'pattern_too_long'],
+  ];
+  it.each(rejected)('rejects %s (%s)', (pattern, reason) => {
+    const v = validateDlpPattern(pattern);
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe(reason);
+  });
+
+  const accepted = ['EMP-\\d{6}', '\\bACME-[A-Z]{2}\\d{4}\\b', '(colou?r){1,3}', 'invoice #?\\d+'];
+  it.each(accepted)('accepts %s', (pattern) => {
+    expect(validateDlpPattern(pattern)).toEqual({ ok: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, expect FAIL** (module does not exist)
+
+```bash
+cd /Users/toddhebebrand/breeze/packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/validators/clientAiDlp.test.ts
+```
+
+Expected: failure — `Cannot find module './clientAiDlp'`.
+
+- [ ] **Step 3: Create `packages/shared/src/validators/clientAiDlp.ts`**
+
+```ts
+import { z } from 'zod';
+
+/**
+ * DLP configuration for Breeze AI for Office (spec §6).
+ *
+ * Stored in client_ai_org_policies.dlp_config (jsonb, DB default '{}').
+ * `dlpConfigSchema.parse({})` materialises the documented defaults: redact
+ * for financial/credential detectors (creditCard, ssn, iban, apiKey),
+ * email/phone off. The engine (apps/api/src/services/clientAiDlp.ts) parses
+ * stored configs with this schema and degrades invalid configs to
+ * DEFAULT_DLP_CONFIG — never to "everything off".
+ *
+ * ReDoS mitigation for custom patterns. The repo has no RE2-style regex
+ * dependency (checked root / apps/api / packages/shared package.json), so
+ * instead of an engine swap we layer guards:
+ *   1. pattern length cap (DLP_MAX_PATTERN_LENGTH)
+ *   2. backreference ban — \1..\9 enable exponential backtracking
+ *   3. nested-quantifier heuristic: a quantified atom directly before a
+ *      closing paren that is itself quantified — (a+)+, (\d{2,})*, (x*)+.
+ *      Conservative: it can also reject safe escaped-paren patterns like
+ *      x+\)+ ; custom DLP rules are short PII matchers, so over-rejection
+ *      is acceptable. Bounded inner quantifiers like (colou?r){1,3} pass.
+ *   4. bounded timed probes: the pattern executes against short (≤25 char)
+ *      adversarial inputs under a wall-clock budget. Probes are short enough
+ *      that even a fully catastrophic pattern that slips past (3) costs at
+ *      most a few hundred ms ONCE at config-save time, never per message.
+ *   5. (engine-side) per-call scan budget + input size caps in
+ *      apps/api/src/services/clientAiDlp.ts (DLP_SCAN_BUDGET_MS et al.).
+ *
+ * The Plan-4 policy editor's live regex test box should call
+ * validateDlpPattern directly for instant feedback.
+ */
+
+export const DLP_BUILTIN_RULES = ['creditCard', 'ssn', 'iban', 'apiKey', 'email', 'phone'] as const;
+export type DlpBuiltinRule = (typeof DLP_BUILTIN_RULES)[number];
+
+/** Actions a custom rule can take. */
+export const dlpRuleActionSchema = z.enum(['redact', 'block', 'log']);
+export type DlpRuleAction = z.infer<typeof dlpRuleActionSchema>;
+
+/** Built-ins additionally support 'off'. */
+export const dlpBuiltinSettingSchema = z.enum(['redact', 'block', 'log', 'off']);
+export type DlpBuiltinSetting = z.infer<typeof dlpBuiltinSettingSchema>;
+
+export const DLP_MAX_CUSTOM_RULES = 50;
+export const DLP_MAX_PATTERN_LENGTH = 200;
+
+/**
+ * Short adversarial probe inputs (≤25 chars — see header, guard #4). Repeated
+ * single chars trigger classic catastrophic shapes; the mixed tails vary the
+ * failure position.
+ */
+const PATTERN_PROBES = [
+  'a'.repeat(24) + '!',
+  'A'.repeat(24) + '!',
+  '0'.repeat(24) + '!',
+  ' '.repeat(24) + '!',
+  'ab'.repeat(12) + '!',
+  'a0a0'.repeat(6) + '!',
+];
+const PROBE_BUDGET_MS = 50;
+
+const BACKREFERENCE = /\\[1-9]/;
+// Quantified atom (+, *, or a closing {m,n} brace) immediately before a
+// closing paren that is itself quantified.
+const NESTED_QUANTIFIER = /[+*}]\)[+*{?]/;
+
+export type DlpPatternValidation = { ok: true } | { ok: false; reason: string };
+
+/** Gate for custom rule patterns. Used by the schema below AND the Plan-4 live test box. */
+export function validateDlpPattern(pattern: string): DlpPatternValidation {
+  if (pattern.length === 0) return { ok: false, reason: 'empty_pattern' };
+  if (pattern.length > DLP_MAX_PATTERN_LENGTH) return { ok: false, reason: 'pattern_too_long' };
+  if (BACKREFERENCE.test(pattern)) return { ok: false, reason: 'backreference_not_allowed' };
+  if (NESTED_QUANTIFIER.test(pattern)) return { ok: false, reason: 'nested_quantifier' };
+
+  let re: RegExp;
+  try {
+    // 'gu' — the exact flags the engine compiles with; unicode mode is the
+    // stricter parse, so anything accepted here compiles at scan time too.
+    re = new RegExp(pattern, 'gu');
+  } catch {
+    return { ok: false, reason: 'invalid_regex' };
+  }
+
+  const start = Date.now();
+  for (const probe of PATTERN_PROBES) {
+    re.lastIndex = 0;
+    re.test(probe);
+    if (Date.now() - start > PROBE_BUDGET_MS) return { ok: false, reason: 'pattern_too_slow' };
+  }
+  return { ok: true };
+}
+
+export const dlpCustomRuleSchema = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string().trim().min(1).max(60),
+    pattern: z
+      .string()
+      .min(1)
+      .max(DLP_MAX_PATTERN_LENGTH)
+      .superRefine((pattern, ctx) => {
+        const v = validateDlpPattern(pattern);
+        if (!v.ok) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `unsafe or invalid pattern: ${v.reason}`,
+          });
+        }
+      }),
+    action: dlpRuleActionSchema,
+  })
+  .strict();
+export type DlpCustomRule = z.infer<typeof dlpCustomRuleSchema>;
+
+export const dlpBuiltinsSchema = z
+  .object({
+    creditCard: dlpBuiltinSettingSchema.default('redact'),
+    ssn: dlpBuiltinSettingSchema.default('redact'),
+    iban: dlpBuiltinSettingSchema.default('redact'),
+    apiKey: dlpBuiltinSettingSchema.default('redact'),
+    email: dlpBuiltinSettingSchema.default('off'),
+    phone: dlpBuiltinSettingSchema.default('off'),
+  })
+  .strict()
+  .default({});
+
+export const dlpConfigSchema = z
+  .object({
+    builtins: dlpBuiltinsSchema,
+    customRules: z
+      .array(dlpCustomRuleSchema)
+      .max(DLP_MAX_CUSTOM_RULES)
+      .refine((rules) => new Set(rules.map((r) => r.id)).size === rules.length, {
+        message: 'custom rule ids must be unique',
+      })
+      .default([]),
+  })
+  .strict()
+  .default({});
+export type DlpConfig = z.infer<typeof dlpConfigSchema>;
+
+/** The materialised defaults — what an untouched org gets. */
+export const DEFAULT_DLP_CONFIG: DlpConfig = dlpConfigSchema.parse({});
+```
+
+- [ ] **Step 4: Add the barrel export** — in `packages/shared/src/validators/index.ts`, directly after the existing `export * from './ticketConfig';` line, add:
+
+```ts
+export * from './clientAiDlp';
+```
+
+- [ ] **Step 5: Run the test, expect PASS** (same command as Step 2 — 17 tests). Also run the package typecheck:
+
+```bash
+cd /Users/toddhebebrand/breeze/packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/validators/clientAiDlp.ts packages/shared/src/validators/clientAiDlp.test.ts packages/shared/src/validators/index.ts
+git commit -m "feat(client-ai): dlp_config schema + custom-pattern safety validator" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Credit-card (Luhn) and SSN detectors (TDD)
+
+False-positive trade-offs (documented here, cited in code comments):
+- **creditCard:** any 13–19 digit run (single space/dash separators allowed) that passes Luhn. Luhn passes ~10% of random digit runs — that residual FP rate is the spec'd accepted bound (spec §6: "credit cards (Luhn-validated)"). Runs of 20+ digits never match, not even a sub-span (both edges are digit-lookaround pinned), so long numeric IDs are safe.
+- **ssn:** the dashed form always matches (after area/group/serial plausibility: area ∉ {000, 666, 900–999}, group ≠ 00, serial ≠ 0000). The bare 9-digit form is gated on payload context because bare 9-digit numbers are routinely order IDs, ZIP+4 concatenations, and account numbers in spreadsheets — precision over recall. MSPs wanting aggressive matching can add a `\d{9}` custom rule.
+
+**Files:**
+- Create: apps/api/src/services/clientAiDlpDetectors.ts
+- Create: apps/api/src/services/clientAiDlpDetectors.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiDlpDetectors.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  detectCreditCard,
+  detectSsn,
+  luhnCheck,
+  ssnContextPresent,
+} from './clientAiDlpDetectors';
+
+describe('luhnCheck', () => {
+  it.each([
+    ['4111111111111111', true], // Visa 16-digit test number
+    ['378282246310005', true], // Amex 15-digit test number
+    ['4222222222222', true], // Visa 13-digit test number
+    ['4111111111111112', false], // checksum off by one
+    ['1234567890123456', false],
+  ])('%s → %s', (digits, expected) => {
+    expect(luhnCheck(digits)).toBe(expected);
+  });
+
+  it('rejects out-of-range lengths', () => {
+    expect(luhnCheck('411111111111')).toBe(false); // 12 digits
+    expect(luhnCheck('41111111111111111111')).toBe(false); // 20 digits
+  });
+});
+
+describe('detectCreditCard', () => {
+  it.each([
+    ['plain 16-digit', 'card 4111111111111111 ok', 1],
+    ['dash separators', 'card 4111-1111-1111-1111', 1],
+    ['space separators', '4111 1111 1111 1111', 1],
+    ['Amex 15-digit', 'amex 378282246310005', 1],
+    ['Visa 13-digit', '4222222222222', 1],
+    ['Luhn-invalid 16 digits NOT matched', '4111111111111112', 0],
+    ['12 digits too short', '411111111111', 0],
+    ['inside a 20-digit run — no sub-span matching', '41111111111111110000', 0],
+    ['two cards', '4111111111111111 and 4111-1111-1111-1111', 2],
+  ])('%s', (_name, text, hits) => {
+    expect(detectCreditCard(text)).toHaveLength(hits);
+  });
+
+  it('returns exact spans', () => {
+    expect(detectCreditCard('pay 4111111111111111 now')).toEqual([{ start: 4, end: 20 }]);
+  });
+});
+
+describe('detectSsn', () => {
+  it.each([
+    ['dashed form, no context needed', 'id 536-22-1234', false, 1],
+    ['invalid area 000', '000-12-3456', false, 0],
+    ['invalid area 666', '666-12-3456', false, 0],
+    ['invalid area 9xx', '912-12-3456', false, 0],
+    ['invalid group 00', '536-00-1234', false, 0],
+    ['invalid serial 0000', '536-22-0000', false, 0],
+    ['bare 9 digits without context', 'id 536221234', false, 0],
+    ['bare 9 digits with context active', 'num 536221234', true, 1],
+    ['bare digits inside a longer run', 'ref 5362212345', true, 0],
+    ['bare implausible area even with context', 'num 666221234', true, 0],
+  ])('%s', (_name, text, contextActive, hits) => {
+    expect(detectSsn(text, contextActive)).toHaveLength(hits);
+  });
+
+  it('ssnContextPresent detects keywords', () => {
+    expect(ssnContextPresent('Employee SSN list')).toBe(true);
+    expect(ssnContextPresent('social security numbers')).toBe(true);
+    expect(ssnContextPresent('sales figures')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiDlpDetectors.test.ts
+```
+
+Expected: failure — `Cannot find module './clientAiDlpDetectors'`.
+
+- [ ] **Step 3: Create `apps/api/src/services/clientAiDlpDetectors.ts`**
+
+```ts
+/**
+ * Built-in DLP detectors for Breeze AI for Office (spec §6).
+ *
+ * Pure functions: string in → match spans out. Validation gates (Luhn for
+ * cards, mod-97 for IBAN, plausibility for SSN, mixed-class post-filters for
+ * generic token blobs) keep false positives down; the residual trade-offs are
+ * documented per detector in the Plan-3 doc
+ * (docs/superpowers/plans/2026-06-12-ai-for-office-3-dlp.md, Tasks 2–3).
+ *
+ * The apiKey shapes are seeded from BARE_SECRET_PATTERNS in
+ * services/aiToolOutput.ts (sk-, GitHub token family, github_pat_, AKIA, JWT)
+ * plus Breeze brz_ tokens (services/apiKeys.ts generates brz_ + 48 hex) and
+ * generic 32+ char hex/base64 bearer-ish blobs.
+ *
+ * (services/aiInputSanitizer.ts was reviewed as a seed source per spec §6:
+ * its patterns target prompt-injection/Unicode, not PII/secrets, so nothing
+ * is reused from it — the secret shapes above come from aiToolOutput.ts.)
+ */
+
+export interface DlpMatch {
+  /** Inclusive start offset in the scanned string. */
+  start: number;
+  /** Exclusive end offset. */
+  end: number;
+}
+
+/** Merge overlapping/nested spans (sorted output). Used per-detector and by the engine. */
+export function mergeMatches(matches: DlpMatch[]): DlpMatch[] {
+  if (matches.length <= 1) return matches;
+  const sorted = [...matches].sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: DlpMatch[] = [{ ...sorted[0] }];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = merged[merged.length - 1];
+    if (sorted[i].start <= last.end) {
+      last.end = Math.max(last.end, sorted[i].end);
+    } else {
+      merged.push({ ...sorted[i] });
+    }
+  }
+  return merged;
+}
+
+function spansOf(text: string, re: RegExp): DlpMatch[] {
+  const out: DlpMatch[] = [];
+  for (const m of text.matchAll(re)) {
+    out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+  }
+  return out;
+}
+
+// ── creditCard ───────────────────────────────────────────────────────────────
+// 13–19 digits with optional single space/dash separators, Luhn-validated.
+// The digit lookarounds pin BOTH edges, so runs of 20+ digits never match —
+// not even a sub-span (long numeric IDs are safe).
+const CARD_CANDIDATE = /(?<!\d)(?:\d[ -]?){12,18}\d(?!\d)/g;
+
+export function luhnCheck(digits: string): boolean {
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (d < 0 || d > 9) return false;
+    if (double) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+export function detectCreditCard(text: string): DlpMatch[] {
+  const out: DlpMatch[] = [];
+  for (const m of text.matchAll(CARD_CANDIDATE)) {
+    const digits = m[0].replace(/[ -]/g, '');
+    if (digits.length >= 13 && digits.length <= 19 && luhnCheck(digits)) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+    }
+  }
+  return out;
+}
+
+// ── ssn ──────────────────────────────────────────────────────────────────────
+const SSN_DASHED = /\b(\d{3})-(\d{2})-(\d{4})\b/g;
+const SSN_BARE = /(?<![\d.-])\d{9}(?![\d.-])/g;
+const SSN_CONTEXT = /\bssns?\b|social\s*security/i;
+
+/** Engine computes this over the WHOLE payload to activate bare-9-digit matching. */
+export function ssnContextPresent(text: string): boolean {
+  return SSN_CONTEXT.test(text);
+}
+
+function plausibleSsn(area: string, group: string, serial: string): boolean {
+  const a = Number(area);
+  if (a === 0 || a === 666 || a >= 900) return false;
+  if (group === '00') return false;
+  if (serial === '0000') return false;
+  return true;
+}
+
+export function detectSsn(text: string, bareContextActive: boolean): DlpMatch[] {
+  const out: DlpMatch[] = [];
+  for (const m of text.matchAll(SSN_DASHED)) {
+    if (plausibleSsn(m[1], m[2], m[3])) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+    }
+  }
+  if (bareContextActive) {
+    for (const m of text.matchAll(SSN_BARE)) {
+      const v = m[0];
+      if (plausibleSsn(v.slice(0, 3), v.slice(3, 5), v.slice(5))) {
+        out.push({ start: m.index ?? 0, end: (m.index ?? 0) + v.length });
+      }
+    }
+  }
+  return mergeMatches(out);
+}
+
+// ── iban ─────────────────────────────────────────────────────────────────────
+// Unspaced canonical IBAN shape (spec §6 pattern). Spaced presentation
+// ("DE89 3704 ...") is a documented v1 non-goal.
+const IBAN_CANDIDATE = /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g;
+
+/** ISO 13616 mod-97: move first 4 chars to the end, A→10..Z→35, remainder must be 1. */
+export function ibanMod97(candidate: string): boolean {
+  const rearranged = candidate.slice(4) + candidate.slice(0, 4);
+  let remainder = 0;
+  for (let i = 0; i < rearranged.length; i++) {
+    const ch = rearranged[i];
+    const value = ch >= 'A' && ch <= 'Z' ? String(ch.charCodeAt(0) - 55) : ch;
+    for (let j = 0; j < value.length; j++) {
+      const digit = value.charCodeAt(j) - 48;
+      if (digit < 0 || digit > 9) return false;
+      remainder = (remainder * 10 + digit) % 97;
+    }
+  }
+  return remainder === 1;
+}
+
+export function detectIban(text: string): DlpMatch[] {
+  const out: DlpMatch[] = [];
+  for (const m of text.matchAll(IBAN_CANDIDATE)) {
+    if (ibanMod97(m[0])) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+    }
+  }
+  return out;
+}
+
+// ── apiKey ───────────────────────────────────────────────────────────────────
+// Specific token shapes — seeded from BARE_SECRET_PATTERNS in
+// services/aiToolOutput.ts, plus Breeze brz_ tokens (services/apiKeys.ts).
+const API_KEY_PATTERNS: RegExp[] = [
+  /\bsk-(?:ant-|proj-)?[A-Za-z0-9_-]{16,}\b/g,
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{16,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\b/g, // JWT
+  /\bbrz_[0-9a-f]{32,64}\b/g,
+];
+
+// Bearer-ish generic blobs: 32+ char hex / base64 runs, post-filtered for
+// mixed character classes so plain words and plain numbers never match.
+// Residual FP: 32+ char mixed-case alphanumeric identifiers will match —
+// accepted (spec asks for bearer-ish blobs; action is redact by default and
+// the MSP can set apiKey to 'off').
+const HEX_BLOB = /\b[0-9a-f]{32,128}\b/g;
+const BASE64_BLOB = /(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{32,256}={0,2}(?![A-Za-z0-9+/=])/g;
+
+export function detectApiKey(text: string): DlpMatch[] {
+  const out: DlpMatch[] = [];
+  for (const re of API_KEY_PATTERNS) {
+    out.push(...spansOf(text, re));
+  }
+  for (const m of text.matchAll(HEX_BLOB)) {
+    const v = m[0];
+    if (/\d/.test(v) && /[a-f]/.test(v)) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + v.length });
+    }
+  }
+  for (const m of text.matchAll(BASE64_BLOB)) {
+    const v = m[0];
+    if (/[a-z]/.test(v) && /[A-Z]/.test(v) && /\d/.test(v)) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + v.length });
+    }
+  }
+  // JWTs/keys often double-match the generic blobs — merge so counts are honest.
+  return mergeMatches(out);
+}
+
+// ── email / phone (off by default) ───────────────────────────────────────────
+const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+
+// NANP-ish with required separators or +country/parens. Bare 10-digit runs do
+// NOT match (precision-first — they collide with IDs and partial card runs).
+const PHONE =
+  /(?<![\d.-])(?:\+\d{1,3}[ .-]?)?(?:\(\d{3}\)[ .-]?|\d{3}[ .-])\d{3}[ .-]?\d{4}(?![\d-])/g;
+
+export function detectEmail(text: string): DlpMatch[] {
+  return spansOf(text, EMAIL);
+}
+
+export function detectPhone(text: string): DlpMatch[] {
+  return spansOf(text, PHONE);
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (same command as Step 2 — the iban/apiKey/email/phone exports exist but are untested until Task 3; that is fine, Task 3 adds their tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiDlpDetectors.ts apps/api/src/services/clientAiDlpDetectors.test.ts
+git commit -m "feat(client-ai): DLP detectors — credit card (Luhn), SSN, IBAN (mod-97), API keys, email, phone" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+> Note: the full detector file ships in this task (splitting the file mid-way would churn it); Task 3 is purely the remaining detectors' test coverage, written before any further engine work depends on them.
+
+---
+
+### Task 3: IBAN / apiKey / email / phone detector tests (TDD coverage completion)
+
+**Files:**
+- Edit: apps/api/src/services/clientAiDlpDetectors.test.ts
+
+- [ ] **Step 1: Append these describe blocks** to `clientAiDlpDetectors.test.ts` (extend the existing import line with `detectApiKey, detectEmail, detectIban, detectPhone, ibanMod97, mergeMatches`):
+
+```ts
+describe('ibanMod97', () => {
+  it('validates the rearranged mod-97 == 1 rule', () => {
+    expect(ibanMod97('DE89370400440532013000')).toBe(true);
+    expect(ibanMod97('GB82WEST12345698765432')).toBe(true);
+    expect(ibanMod97('DE89370400440532013001')).toBe(false); // single digit mutated
+  });
+});
+
+describe('detectIban', () => {
+  it.each([
+    ['German IBAN', 'acct DE89370400440532013000', 1],
+    ['UK IBAN', 'GB82WEST12345698765432', 1],
+    ['mod-97 invalid NOT matched', 'DE89370400440532013001', 0],
+    ['lowercase not matched (canonical uppercase shape only)', 'de89370400440532013000', 0],
+    ['too short', 'DE8937040044', 0],
+  ])('%s', (_name, text, hits) => {
+    expect(detectIban(text)).toHaveLength(hits);
+  });
+});
+
+describe('detectApiKey', () => {
+  it.each([
+    ['anthropic-style key', 'key sk-ant-abcdefghijklmnop1234', 1],
+    ['github pat', 'ghp_abcdefghijklmnop1234', 1],
+    ['aws access key id', 'AKIAIOSFODNN7EXAMPLE', 1],
+    ['breeze brz_ token', `brz_${'ab12'.repeat(12)}`, 1],
+    [
+      'jwt (merged with its base64 segments)',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N7flQ',
+      1,
+    ],
+    ['generic 32-char hex blob', 'token 3fa85f6457174562b3fc2c963f66afa6', 1],
+    ['generic mixed-class base64 blob', 'dGhpc0lzQVZlcnlMb25nU2VjcmV0VG9rZW4xMjM0', 1],
+    ['all-letter run NOT matched', 'abcdefabcdefabcdefabcdefabcdefab', 0],
+    ['digits-only run NOT matched', '11111111111111111111111111111111', 0],
+    ['short hex NOT matched', 'deadbeef1234', 0],
+  ])('%s', (_name, text, hits) => {
+    expect(detectApiKey(text)).toHaveLength(hits);
+  });
+});
+
+describe('detectEmail', () => {
+  it('matches standard addresses', () => {
+    expect(detectEmail('contact alice@example.com today')).toHaveLength(1);
+  });
+  it('ignores non-addresses', () => {
+    expect(detectEmail('not an email @ nowhere')).toHaveLength(0);
+  });
+});
+
+describe('detectPhone', () => {
+  it.each([
+    ['dashed NANP', 'call 555-123-4567', 1],
+    ['parenthesised area code', '(555) 123-4567', 1],
+    ['dotted', '555.123.4567', 1],
+    ['international prefix', '+1 555 123 4567', 1],
+    ['bare 10-digit run NOT matched (precision-first)', '5551234567', 0],
+    ['not inside card numbers', '4111-1111-1111-1111', 0],
+  ])('%s', (_name, text, hits) => {
+    expect(detectPhone(text)).toHaveLength(hits);
+  });
+});
+
+describe('mergeMatches', () => {
+  it('merges overlapping and nested spans', () => {
+    expect(
+      mergeMatches([
+        { start: 0, end: 10 },
+        { start: 5, end: 15 },
+        { start: 20, end: 25 },
+        { start: 21, end: 23 },
+      ]),
+    ).toEqual([
+      { start: 0, end: 15 },
+      { start: 20, end: 25 },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect PASS** (these detectors already exist from Task 2; if any fixture fails, fix the DETECTOR, not the fixture — the fixtures encode the contract):
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiDlpDetectors.test.ts
+```
+
+Expected: ~51 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/services/clientAiDlpDetectors.test.ts
+git commit -m "test(client-ai): IBAN/apiKey/email/phone detector fixtures incl. mod-97 negatives" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: The scanning engine — applyDlp (TDD)
+
+Replaces the Plan-2 passthrough stub internals of `apps/api/src/services/clientAiDlp.ts` (or creates the file if Plan 2 has not landed). Interface pinned — see the contract section above.
+
+**Files:**
+- Replace/Create: apps/api/src/services/clientAiDlp.ts
+- Create: apps/api/src/services/clientAiDlp.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/services/clientAiDlp.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { applyDlp, DLP_MAX_CELL_CHARS } from './clientAiDlp';
+
+const ORG = '0a1b2c3d-1111-4222-8333-444455556666';
+const RULE_ID = '0b8f8f54-1111-4222-8333-444455556666';
+
+const VISA = '4111111111111111'; // Luhn-valid test number
+const VISA_SPACED = '4111 1111 1111 1111';
+const IBAN = 'DE89370400440532013000'; // mod-97 valid
+const SK_KEY = 'sk-ant-abcdefghijklmnop1234';
+
+describe('applyDlp — config handling', () => {
+  it('treats {} as the documented defaults (financial redact, email/phone off)', async () => {
+    const r = await applyDlp({
+      text: `card ${VISA} mail alice@example.com`,
+      dlpConfig: {},
+      orgId: ORG,
+    });
+    expect(r.action).toBe('allow');
+    expect(r.text).toContain('[REDACTED:creditCard]');
+    expect(r.text).toContain('alice@example.com'); // email off by default
+    expect(r.redactions).toEqual([{ rule: 'creditCard', count: 1, location: 'text' }]);
+  });
+
+  it('degrades an invalid stored config to defaults (never to off)', async () => {
+    const r = await applyDlp({
+      text: `card ${VISA}`,
+      dlpConfig: { creditCards: 'nope' }, // strict-parse failure
+      orgId: ORG,
+    });
+    expect(r.text).toContain('[REDACTED:creditCard]');
+  });
+
+  it('passes clean payloads through untouched', async () => {
+    const r = await applyDlp({ text: 'sum column B please', dlpConfig: {}, orgId: ORG });
+    expect(r).toEqual({ action: 'allow', text: 'sum column B please', redactions: [] });
+  });
+
+  it('handles empty input (no text, no cells)', async () => {
+    const r = await applyDlp({ dlpConfig: {}, orgId: ORG });
+    expect(r).toEqual({ action: 'allow', redactions: [] });
+  });
+});
+
+describe('applyDlp — action precedence (block > redact > log)', () => {
+  it('any block-rule match blocks the whole payload with no partial results', async () => {
+    const r = await applyDlp({
+      text: `${VISA} and ${IBAN}`,
+      dlpConfig: { builtins: { iban: 'block' } },
+      orgId: ORG,
+    });
+    expect(r.action).toBe('block');
+    expect(r.blockReason).toBe('dlp_blocked:iban');
+    expect(r.text).toBeUndefined();
+    expect(r.cells).toBeUndefined();
+    // value-free events still recorded for the MSP audit view
+    expect(r.redactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ rule: 'iban', count: 1 }),
+        expect.objectContaining({ rule: 'creditCard', count: 1 }),
+      ]),
+    );
+  });
+
+  it('a custom block rule wins over builtin redacts', async () => {
+    const r = await applyDlp({
+      text: `${VISA} PROJECT-AURORA`,
+      dlpConfig: {
+        customRules: [
+          { id: RULE_ID, name: 'Codename', pattern: 'PROJECT-[A-Z]+', action: 'block' },
+        ],
+      },
+      orgId: ORG,
+    });
+    expect(r.action).toBe('block');
+    expect(r.blockReason).toBe('dlp_blocked:Codename');
+  });
+
+  it('log rules record events without modifying content', async () => {
+    const r = await applyDlp({
+      text: 'mail alice@example.com',
+      dlpConfig: { builtins: { email: 'log' } },
+      orgId: ORG,
+    });
+    expect(r.action).toBe('allow');
+    expect(r.text).toBe('mail alice@example.com');
+    expect(r.redactions).toEqual([{ rule: 'email', count: 1, location: 'text' }]);
+  });
+
+  it('custom redact rules replace with [REDACTED:<name>]', async () => {
+    const r = await applyDlp({
+      text: 'badge EMP-123456 active',
+      dlpConfig: {
+        customRules: [{ id: RULE_ID, name: 'Employee ID', pattern: 'EMP-\\d{6}', action: 'redact' }],
+      },
+      orgId: ORG,
+    });
+    expect(r.text).toBe('badge [REDACTED:Employee ID] active');
+    expect(r.redactions).toEqual([{ rule: 'Employee ID', count: 1, location: 'text' }]);
+  });
+
+  it('overlapping redact spans merge into a single token', async () => {
+    const r = await applyDlp({
+      text: VISA,
+      dlpConfig: {
+        customRules: [{ id: RULE_ID, name: 'quad', pattern: '\\d{4}', action: 'redact' }],
+      },
+      orgId: ORG,
+    });
+    // creditCard span [0,16) and the custom quads merge into one token
+    expect(r.text).toMatch(/^\[REDACTED:[^\]]+\]$/);
+  });
+});
+
+describe('applyDlp — cell matrices', () => {
+  it('redacts within cells, preserves untouched cells and their types', async () => {
+    const cells = [
+      ['Name', 'Card', 'Balance'],
+      ['Alice', VISA_SPACED, 1200.5],
+      ['Bob', `note ${VISA} end`, true],
+    ];
+    const r = await applyDlp({ cells, dlpConfig: {}, orgId: ORG });
+    expect(r.action).toBe('allow');
+    expect(r.cells![0]).toEqual(['Name', 'Card', 'Balance']);
+    expect(r.cells![1][1]).toBe('[REDACTED:creditCard]');
+    expect(r.cells![1][2]).toBe(1200.5);
+    expect(r.cells![2][1]).toBe('note [REDACTED:creditCard] end');
+    expect(r.cells![2][2]).toBe(true);
+    expect(r.redactions).toEqual([
+      { rule: 'creditCard', count: 2, location: 'cell[1][1] (+1 more)' },
+    ]);
+  });
+
+  it('stringifies numeric cells before scanning (Excel stores card numbers as numbers)', async () => {
+    const r = await applyDlp({ cells: [[4111111111111111]], dlpConfig: {}, orgId: ORG });
+    expect(r.cells![0][0]).toBe('[REDACTED:creditCard]');
+  });
+
+  it('leaves null/undefined/empty cells alone', async () => {
+    const r = await applyDlp({ cells: [[null, undefined, '']], dlpConfig: {}, orgId: ORG });
+    expect(r.cells).toEqual([[null, undefined, '']]);
+    expect(r.redactions).toEqual([]);
+  });
+
+  it('does not mutate the input matrix', async () => {
+    const cells = [[VISA]];
+    await applyDlp({ cells, dlpConfig: {}, orgId: ORG });
+    expect(cells[0][0]).toBe(VISA);
+  });
+
+  it('activates bare-SSN matching from a header cell elsewhere in the payload', async () => {
+    const withHeader = await applyDlp({ cells: [['SSN'], ['536221234']], dlpConfig: {}, orgId: ORG });
+    expect(withHeader.cells![1][0]).toBe('[REDACTED:ssn]');
+
+    const noContext = await applyDlp({ cells: [['ID'], ['536221234']], dlpConfig: {}, orgId: ORG });
+    expect(noContext.cells![1][0]).toBe('536221234');
+  });
+
+  it('dashed SSNs in cells redact without any context', async () => {
+    const r = await applyDlp({ cells: [['536-22-1234']], dlpConfig: {}, orgId: ORG });
+    expect(r.cells![0][0]).toBe('[REDACTED:ssn]');
+  });
+
+  it('scans text and cells in the same call', async () => {
+    const r = await applyDlp({ text: `IBAN ${IBAN}`, cells: [[VISA]], dlpConfig: {}, orgId: ORG });
+    expect(r.text).toBe('IBAN [REDACTED:iban]');
+    expect(r.cells![0][0]).toBe('[REDACTED:creditCard]');
+  });
+});
+
+describe('applyDlp — redaction event accuracy', () => {
+  it('reports rule, total count, and first location with overflow note', async () => {
+    const r = await applyDlp({
+      text: VISA,
+      cells: [[VISA, `${VISA} ${VISA}`]],
+      dlpConfig: {},
+      orgId: ORG,
+    });
+    expect(r.redactions).toEqual([{ rule: 'creditCard', count: 4, location: 'text (+2 more)' }]);
+  });
+});
+
+describe('applyDlp — size caps (fail closed)', () => {
+  it('blocks when cell count exceeds DLP_MAX_CELLS', async () => {
+    const rows = Array.from({ length: 501 }, () => new Array(100).fill('x')); // 50,100 cells
+    const r = await applyDlp({ cells: rows, dlpConfig: {}, orgId: ORG });
+    expect(r).toEqual({
+      action: 'block',
+      blockReason: 'payload_too_large_for_dlp',
+      redactions: [],
+    });
+  });
+
+  it('blocks when a single cell exceeds the per-cell char cap', async () => {
+    const r = await applyDlp({
+      cells: [['a'.repeat(DLP_MAX_CELL_CHARS + 1)]],
+      dlpConfig: {},
+      orgId: ORG,
+    });
+    expect(r.action).toBe('block');
+    expect(r.blockReason).toBe('payload_too_large_for_dlp');
+  });
+});
+
+describe('applyDlp — idempotency', () => {
+  it('re-scanning redacted output produces no new findings', async () => {
+    const first = await applyDlp({
+      text: `card ${VISA}, ssn 536-22-1234, iban ${IBAN}, key ${SK_KEY}, brz_${'ab12'.repeat(12)}`,
+      dlpConfig: {},
+      orgId: ORG,
+    });
+    expect(first.action).toBe('allow');
+    expect(first.redactions.length).toBeGreaterThan(0);
+
+    const second = await applyDlp({ text: first.text!, dlpConfig: {}, orgId: ORG });
+    expect(second.redactions).toEqual([]);
+    expect(second.text).toBe(first.text);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiDlp.test.ts
+```
+
+Expected: failures — against the Plan-2 passthrough stub everything that asserts redaction/blocking fails; if the file doesn't exist yet, module-not-found.
+
+- [ ] **Step 3: Write `apps/api/src/services/clientAiDlp.ts`** (full replacement of the stub body; interface unchanged)
+
+```ts
+/**
+ * Client AI DLP / redaction pipeline (spec §6) — the single chokepoint for
+ * every payload leaving Breeze for the model provider: user prompts, workbook
+ * tool_result cell matrices, and template content. The call sites live in the
+ * Plan-2 session loop; this module owns only the scanning.
+ *
+ * Order of operations: size guard → scan all enabled rules → block (any
+ * block-rule match refuses the whole payload, no partial results) → redact
+ * ([REDACTED:<rule>] in place) → log (events only).
+ *
+ * Config handling: dlpConfig arrives as unknown (jsonb via getOrgPolicy).
+ * Invalid configs degrade to DEFAULT_DLP_CONFIG — financial/credential
+ * redaction stays ON, never "everything off". Note this also drops the custom
+ * rules of an invalid config; acceptable because the policy PUT path
+ * validates with the same schema, so invalid rows only arise from
+ * out-of-band DB writes.
+ *
+ * Fail-closed guards: oversize payloads (cells/chars caps) and scan-budget
+ * exhaustion BLOCK rather than pass unscanned content — passing unscanned
+ * data would defeat the chokepoint. Plan 2's read tools chunk well below the
+ * caps, so tripping one is a tool-layer bug that should surface loudly.
+ *
+ * Pure computation: no DB, no Redis, no db-access-context requirements.
+ */
+
+import {
+  DEFAULT_DLP_CONFIG,
+  dlpConfigSchema,
+  type DlpConfig,
+  type DlpRuleAction,
+} from '@breeze/shared/validators';
+import {
+  detectApiKey,
+  detectCreditCard,
+  detectEmail,
+  detectIban,
+  detectPhone,
+  detectSsn,
+  ssnContextPresent,
+  type DlpMatch,
+} from './clientAiDlpDetectors';
+
+export interface DlpRedactionEvent {
+  rule: string;
+  count: number;
+  location: string;
+}
+
+export interface DlpResult {
+  action: 'allow' | 'block';
+  text?: string;
+  cells?: unknown[][];
+  redactions: DlpRedactionEvent[];
+  blockReason?: string;
+}
+
+/** Hard cap on scanned cells per call. Exceeding it BLOCKS (fail closed). */
+export const DLP_MAX_CELLS = 50_000;
+/** Excel's own cell limit is 32,767 chars; anything bigger is not workbook data. */
+export const DLP_MAX_CELL_CHARS = 32_768;
+/** Hard cap on total scanned characters per call (text + stringified cells). */
+export const DLP_MAX_TOTAL_CHARS = 2_000_000;
+/** Wall-clock budget for one applyDlp call; exceeding it BLOCKS (fail closed). */
+export const DLP_SCAN_BUDGET_MS = 2_000;
+
+const BUILTIN_ORDER = ['creditCard', 'ssn', 'iban', 'apiKey', 'email', 'phone'] as const;
+
+interface CompiledRule {
+  name: string;
+  action: DlpRuleAction;
+  detect: (text: string) => DlpMatch[];
+}
+
+interface ScanLocation {
+  label: string;
+  content: string;
+  /** [row, col] for cells; null for the text input. */
+  coords: [number, number] | null;
+}
+
+function block(reason: string, redactions: DlpRedactionEvent[] = []): DlpResult {
+  return { action: 'block', blockReason: reason, redactions };
+}
+
+function stringifyCell(cell: unknown): string | null {
+  if (cell === null || cell === undefined) return null;
+  if (typeof cell === 'string') return cell === '' ? null : cell;
+  if (typeof cell === 'number' || typeof cell === 'boolean' || typeof cell === 'bigint') {
+    return String(cell);
+  }
+  try {
+    return JSON.stringify(cell) ?? null;
+  } catch {
+    // Circular / non-serializable — nothing scannable, and the SSE layer
+    // cannot forward it to the provider as JSON either. Leave untouched.
+    return null;
+  }
+}
+
+/** Compile the enabled rule list, or return a block reason (fail closed). */
+function compileRules(config: DlpConfig, ssnActive: boolean): CompiledRule[] | string {
+  const builtinDetectors: Record<(typeof BUILTIN_ORDER)[number], (text: string) => DlpMatch[]> = {
+    creditCard: detectCreditCard,
+    ssn: (text) => detectSsn(text, ssnActive),
+    iban: detectIban,
+    apiKey: detectApiKey,
+    email: detectEmail,
+    phone: detectPhone,
+  };
+
+  const rules: CompiledRule[] = [];
+  for (const name of BUILTIN_ORDER) {
+    const setting = config.builtins[name];
+    if (setting === 'off') continue;
+    rules.push({ name, action: setting, detect: builtinDetectors[name] });
+  }
+
+  for (const custom of config.customRules) {
+    let re: RegExp;
+    try {
+      re = new RegExp(custom.pattern, 'gu');
+    } catch {
+      // The shared schema compiles every pattern at save time, so this is
+      // only reachable for out-of-band DB writes. Fail CLOSED: silently
+      // skipping a rule the MSP believes is active would disable DLP
+      // without anyone noticing.
+      return `dlp_rule_compile_failed:${custom.name}`;
+    }
+    rules.push({
+      name: custom.name,
+      action: custom.action,
+      detect: (text: string) => {
+        const out: DlpMatch[] = [];
+        for (const m of text.matchAll(re)) {
+          if (m[0].length === 0) break; // zero-width match safety
+          out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+        }
+        return out;
+      },
+    });
+  }
+  return rules;
+}
+
+/** Replace spans right-to-left; overlapping spans merge, earliest span's rule labels the token. */
+function replaceSpans(content: string, spans: Array<{ span: DlpMatch; rule: string }>): string {
+  const sorted = [...spans].sort(
+    (a, b) => a.span.start - b.span.start || a.span.end - b.span.end,
+  );
+  const merged: Array<{ start: number; end: number; rule: string }> = [];
+  for (const { span, rule } of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && span.start < last.end) {
+      last.end = Math.max(last.end, span.end);
+    } else {
+      merged.push({ start: span.start, end: span.end, rule });
+    }
+  }
+  let out = content;
+  for (let i = merged.length - 1; i >= 0; i--) {
+    const m = merged[i];
+    out = `${out.slice(0, m.start)}[REDACTED:${m.rule}]${out.slice(m.end)}`;
+  }
+  return out;
+}
+
+export async function applyDlp(input: {
+  text?: string;
+  cells?: unknown[][];
+  dlpConfig: unknown;
+  orgId: string;
+}): Promise<DlpResult> {
+  const started = Date.now();
+
+  const parsedConfig = dlpConfigSchema.safeParse(input.dlpConfig ?? {});
+  const config: DlpConfig = parsedConfig.success ? parsedConfig.data : DEFAULT_DLP_CONFIG;
+
+  // ── Bound + collect scan locations (fail closed on oversize) ──────────────
+  const locations: ScanLocation[] = [];
+  let totalChars = 0;
+
+  if (typeof input.text === 'string') {
+    totalChars += input.text.length;
+    if (totalChars > DLP_MAX_TOTAL_CHARS) return block('payload_too_large_for_dlp');
+    locations.push({ label: 'text', content: input.text, coords: null });
+  }
+
+  if (input.cells !== undefined) {
+    let cellCount = 0;
+    for (let r = 0; r < input.cells.length; r++) {
+      const row = input.cells[r] ?? [];
+      for (let c = 0; c < row.length; c++) {
+        cellCount += 1;
+        if (cellCount > DLP_MAX_CELLS) return block('payload_too_large_for_dlp');
+        const content = stringifyCell(row[c]);
+        if (content === null) continue;
+        if (content.length > DLP_MAX_CELL_CHARS) return block('payload_too_large_for_dlp');
+        totalChars += content.length;
+        if (totalChars > DLP_MAX_TOTAL_CHARS) return block('payload_too_large_for_dlp');
+        locations.push({ label: `cell[${r}][${c}]`, content, coords: [r, c] });
+      }
+    }
+  }
+
+  // Bare-9-digit SSN matching activates when an SSN keyword appears ANYWHERE
+  // in the payload (covers "SSN" header cells above bare-number columns).
+  const ssnActive = locations.some((l) => ssnContextPresent(l.content));
+
+  const compiled = compileRules(config, ssnActive);
+  if (typeof compiled === 'string') return block(compiled);
+
+  // ── Scan every location with every enabled rule ────────────────────────────
+  interface LocationMatches {
+    rule: CompiledRule;
+    spans: DlpMatch[];
+  }
+  const perLocation: LocationMatches[][] = locations.map(() => []);
+  const perRule = new Map<string, { count: number; locations: string[] }>();
+  let blockedBy: string | null = null;
+
+  for (const rule of compiled) {
+    for (let i = 0; i < locations.length; i++) {
+      if (Date.now() - started > DLP_SCAN_BUDGET_MS) return block('dlp_scan_budget_exceeded');
+      const spans = rule.detect(locations[i].content);
+      if (spans.length === 0) continue;
+      perLocation[i].push({ rule, spans });
+      const agg = perRule.get(rule.name) ?? { count: 0, locations: [] };
+      agg.count += spans.length;
+      agg.locations.push(locations[i].label);
+      perRule.set(rule.name, agg);
+      if (rule.action === 'block' && blockedBy === null) blockedBy = rule.name;
+    }
+  }
+
+  // Per-rule aggregated, value-free events (≤ 6 builtins + 50 custom rules).
+  const redactions: DlpRedactionEvent[] = [];
+  for (const [rule, agg] of perRule) {
+    const location =
+      agg.locations.length === 1
+        ? agg.locations[0]
+        : `${agg.locations[0]} (+${agg.locations.length - 1} more)`;
+    redactions.push({ rule, count: agg.count, location });
+  }
+
+  // ── 1. Block wins outright: no partial results. Events stay so the MSP
+  //       audit view can show what tripped (rule/count/location only — no
+  //       sensitive values). ──────────────────────────────────────────────────
+  if (blockedBy !== null) {
+    return { action: 'block', blockReason: `dlp_blocked:${blockedBy}`, redactions };
+  }
+
+  // ── 2. Redact (3. log rules contribute events only, content untouched) ─────
+  const result: DlpResult = { action: 'allow', redactions };
+  let outCells: unknown[][] | null = null;
+  if (input.cells !== undefined) {
+    outCells = input.cells.map((row) => [...(row ?? [])]); // never mutate the input
+    result.cells = outCells;
+  }
+  if (typeof input.text === 'string') result.text = input.text;
+
+  for (let i = 0; i < locations.length; i++) {
+    const spans: Array<{ span: DlpMatch; rule: string }> = [];
+    for (const { rule, spans: ruleSpans } of perLocation[i]) {
+      if (rule.action !== 'redact') continue;
+      for (const span of ruleSpans) spans.push({ span, rule: rule.name });
+    }
+    if (spans.length === 0) continue;
+    const redacted = replaceSpans(locations[i].content, spans);
+    const coords = locations[i].coords;
+    if (coords === null) {
+      result.text = redacted;
+    } else {
+      // Numeric/object cells that matched become redacted STRINGS by design.
+      outCells![coords[0]][coords[1]] = redacted;
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** (same command as Step 2 — 19 tests). Also re-run the detector suite to confirm nothing regressed:
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiDlp.test.ts src/services/clientAiDlpDetectors.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/clientAiDlp.ts apps/api/src/services/clientAiDlp.test.ts
+git commit -m "feat(client-ai): DLP scanning engine — applyDlp with block/redact/log precedence" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Validate dlp_config on the policy PUT path (TDD)
+
+Plan 1's `putPolicySchema` (apps/api/src/routes/clientAi/schemas.ts) currently accepts `dlpConfig: z.record(z.unknown()).optional()`. Tighten it to the shared schema so the policy editor cannot persist a config the engine would reject (which would silently degrade the org to defaults). Persisted values become the **normalized** full shape (defaults filled) — canonical storage. No route-handler change needed: the PUT handler already persists `body.dlpConfig` only when provided.
+
+**Files:**
+- Edit: apps/api/src/routes/clientAi/schemas.ts
+- Create: apps/api/src/routes/clientAi/schemas.dlp.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/routes/clientAi/schemas.dlp.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { putPolicySchema } from './schemas';
+
+const RULE_ID = '0b8f8f54-1111-4222-8333-444455556666';
+
+describe('putPolicySchema.dlpConfig', () => {
+  it('accepts a valid dlp config and normalizes defaults into the stored shape', () => {
+    const parsed = putPolicySchema.parse({ dlpConfig: { builtins: { email: 'redact' } } });
+    expect(parsed.dlpConfig).toEqual({
+      builtins: {
+        creditCard: 'redact',
+        ssn: 'redact',
+        iban: 'redact',
+        apiKey: 'redact',
+        email: 'redact',
+        phone: 'off',
+      },
+      customRules: [],
+    });
+  });
+
+  it('leaves dlpConfig undefined when omitted (partial-PUT semantics)', () => {
+    expect(putPolicySchema.parse({ enabled: true }).dlpConfig).toBeUndefined();
+  });
+
+  it('rejects unknown builtin keys', () => {
+    expect(
+      putPolicySchema.safeParse({ dlpConfig: { builtins: { creditCards: 'redact' } } }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unsafe custom patterns (ReDoS heuristic)', () => {
+    expect(
+      putPolicySchema.safeParse({
+        dlpConfig: {
+          customRules: [{ id: RULE_ID, name: 'bad', pattern: '(a+)+$', action: 'redact' }],
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('accepts a safe custom rule', () => {
+    expect(
+      putPolicySchema.safeParse({
+        dlpConfig: {
+          customRules: [
+            { id: RULE_ID, name: 'Employee ID', pattern: 'EMP-\\d{6}', action: 'redact' },
+          ],
+        },
+      }).success,
+    ).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/schemas.dlp.test.ts
+```
+
+Expected: the "normalizes defaults" / "rejects unknown builtin keys" / "rejects unsafe custom patterns" tests fail against `z.record(z.unknown())`.
+
+- [ ] **Step 3: Edit `apps/api/src/routes/clientAi/schemas.ts`** — two changes:
+
+Add to the imports at the top of the file:
+
+```ts
+import { dlpConfigSchema } from '@breeze/shared/validators';
+```
+
+In `putPolicySchema`, replace the line
+
+```ts
+    dlpConfig: z.record(z.unknown()).optional(),
+```
+
+with
+
+```ts
+    /** Validated + normalized (defaults filled) — see packages/shared/src/validators/clientAiDlp.ts. */
+    dlpConfig: dlpConfigSchema.optional(),
+```
+
+- [ ] **Step 4: Run, expect PASS** (5 tests). Then run the Plan-1 admin route + policy service suites to confirm no regression (Plan 1's fixtures never PUT a `dlpConfig`, and `getOrgPolicy`'s lenient `Record<string, unknown>` read path is intentionally unchanged — the engine does its own parsing):
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/ src/services/clientAiPolicy.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/schemas.ts apps/api/src/routes/clientAi/schemas.dlp.test.ts
+git commit -m "feat(client-ai): validate dlp_config on the policy PUT path" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Redact-before-log contract proof + full verification
+
+Spec §6: `ai_messages` stores the redacted form — the audit trail never retains sensitive values. Plan 2's session-loop plan file does not exist yet (checked 2026-06-12: `docs/superpowers/plans/2026-06-12-ai-for-office-2-session-loop.md` absent), so the proof is pinned at the `applyDlp` unit level here, with the integration hook noted for the Plan-2 executor.
+
+> **Integration note for the Plan-2 executor:** Plan 2's message-persistence test MUST assert that the `ai_messages` insert mock receives `applyDlp(...).text` (and `result.redactions` in message metadata) — never the raw `input.text`. One assertion in Plan 2's session-route test closes the loop on this contract.
+
+**Files:**
+- Edit: apps/api/src/services/clientAiDlp.test.ts
+
+- [ ] **Step 1: Append the contract test** to `apps/api/src/services/clientAiDlp.test.ts`:
+
+```ts
+describe('applyDlp — redact-before-log contract (spec §6)', () => {
+  it('the persisted form (result.text) never contains the raw sensitive values', async () => {
+    const raw = `Card ${VISA_SPACED}, key ${SK_KEY}, acct ${IBAN}`;
+    const result = await applyDlp({ text: raw, dlpConfig: {}, orgId: ORG });
+
+    // Plan 2's persistence path MUST store result.text + result.redactions —
+    // never input.text. This is the unit-level proof; the integration
+    // assertion lives in Plan 2's session-route test (the ai_messages insert
+    // mock receives result.text).
+    expect(result.action).toBe('allow');
+    expect(result.text).not.toContain(VISA_SPACED);
+    expect(result.text).not.toContain(SK_KEY);
+    expect(result.text).not.toContain(IBAN);
+    expect(result.text).toContain('[REDACTED:creditCard]');
+    expect(result.text).toContain('[REDACTED:apiKey]');
+    expect(result.text).toContain('[REDACTED:iban]');
+
+    // The events persisted alongside are value-free: rule/count/location only.
+    for (const event of result.redactions) {
+      expect(Object.keys(event).sort()).toEqual(['count', 'location', 'rule']);
+    }
+
+    // And storing the redacted form is stable: re-scanning it finds nothing.
+    const second = await applyDlp({ text: result.text!, dlpConfig: {}, orgId: ORG });
+    expect(second.redactions).toEqual([]);
+    expect(second.text).toBe(result.text);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect PASS**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiDlp.test.ts
+```
+
+- [ ] **Step 3: Full verification sweep** — all four new/edited test files plus typechecks:
+
+```bash
+cd /Users/toddhebebrand/breeze/packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/validators/clientAiDlp.test.ts && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm typecheck
+cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/services/clientAiDlpDetectors.test.ts src/services/clientAiDlp.test.ts src/routes/clientAi/schemas.dlp.test.ts && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+
+Expected: all DLP suites PASS (~93 tests). `tsc --noEmit` may show the pre-existing errors in `agents.test.ts` / `apiKeyAuth.test.ts` (known, unrelated); no NEW errors. Do NOT run the full api vitest suite as a gate — it has known parallel-run flakiness on a pristine tree (verify affected files single-fork; trust CI).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/services/clientAiDlp.test.ts
+git commit -m "test(client-ai): redact-before-log contract proof for the DLP chokepoint" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope for this plan (later plans)
+
+- The `applyDlp` **call sites** — user message, tool_result, template content — Plan 2 owns those; this plan must not touch them.
+- The policy editor UI for DLP toggles + custom-regex entry with live test box — Plan 4 (it should call `validateDlpPattern` from `@breeze/shared/validators` for the test box, and render `redactions` events in the audit viewer).
+- ML-based DLP, spaced-IBAN presentation forms, national IDs beyond US SSN — spec §15 / documented v1 limits.
+
+## Open questions embedded above (for the implementer/reviewer)
+
+1. **Oversize behavior** is block-with-`payload_too_large_for_dlp` (fail closed). If Plan 2's `read_range` legitimately needs >50k cells, raise `DLP_MAX_CELLS` there and here in lockstep — do not switch to partial scanning.
+2. **Invalid stored config → defaults** drops that config's custom rules (including custom `block` rules). Safe direction for builtins, debatable for custom blocks; acceptable v1 because the PUT path (Task 5) makes invalid rows out-of-band-only. Revisit if a config-migration ever loosens the schema.
+3. **Event `location` for multi-location matches** is `'<first> (+N more)'` — human-oriented for the MSP audit view. If Plan 4 wants machine-parseable per-location drill-down, split the event shape there (the pinned `DlpRedactionEvent` is intentionally minimal).

--- a/docs/superpowers/plans/2026-06-12-ai-for-office-4-dashboard.md
+++ b/docs/superpowers/plans/2026-06-12-ai-for-office-4-dashboard.md
@@ -1,0 +1,6963 @@
+# Breeze AI for Office — Plan 4: MSP Admin Dashboard
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the MSP-facing "AI for Office" dashboard section (spec §9): per-org onboarding wizard with Entra admin-consent flow and tenant mapping, full policy editor with DLP rule builder, client-session audit viewer with transcript drill-in and flag/unflag, per-org/per-user usage report with CSV export, and a prompt-template manager — plus the remaining `/client-ai/admin/*` API endpoints those screens need and the client-facing `GET /client-ai/templates` the Plan-5 add-in consumes.
+
+**Architecture:** API side extends the Plan-1 `/client-ai/admin` Hono group (`apps/api/src/routes/clientAi/admin.ts` — group `authMiddleware` + `CLIENT_AI_ENTRA_CLIENT_ID` dark-gate already in place) with four sub-routers (orgs/sessions/usage/templates) mounted onto it, so every new admin route inherits auth + the feature gate. Org access uses `resolveScopedOrgId` (`apps/api/src/routes/c2c/helpers.ts`) → 404, permissions use `PERMISSIONS.ORGS_READ/ORGS_WRITE` (the same pair the technician AI admin routes use, `routes/ai.ts:116-117`), writes audit via `writeRouteAudit`. Web side is one new Astro page (`/ai-for-office`) + a React island tree under `apps/web/src/components/clientAi/`, tabs driven by `window.location.hash` (the `DeviceDetails.tsx:149-166` pattern), every mutation through `runAction`.
+
+**Tech Stack:** Hono, Drizzle, Zod, Vitest (API); Astro + React islands, Tailwind, lucide-react, Vitest + jsdom + @testing-library/react (web)
+
+**Spec:** docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md
+
+**Depends on:** Plans 1–2
+
+---
+
+## Deviations & decisions (validated against the real codebase before writing)
+
+1. **`consentStatus` is derived from `portal_users`, no schema change.** The pinned contract offered two options (a `lastExchangeAt` column on the mapping, or deriving from portal-user existence). Chosen: **derive** — Plan 1's `/auth/exchange` auto-provisions a `portal_users` row with `auth_method='entra'` on the first successful token exchange, so `mapped=false → 'unknown'`, `mapped && no entra users in org → 'pending'`, `mapped && ≥1 entra user → 'granted'`. Zero migrations in this plan; consent state self-heals if a mapping is re-pointed.
+2. **Flag/unflag is mirrored, not reused.** The technician handlers (`apps/api/src/routes/ai.ts:285-360`) are inline `db.update(aiSessions)` calls with no extracted service — there is nothing to call. The client-AI handlers mirror them exactly (same columns, same `requireMfa()`, audit actions `client_ai.session.flag`/`client_ai.session.unflag`), constrained to `type='excel_client'`.
+3. **Redaction-event metadata is derived from redaction markers.** Plan 3 (DLP) is not yet written; per spec §6 the model and the stored `ai_messages` rows only ever contain the redacted form `[REDACTED:type]`. The transcript endpoint counts `\[REDACTED:([A-Za-z0-9_-]+)\]` markers per message (`countRedactions`, Task 3) instead of depending on a Plan-3 metadata format that doesn't exist yet. If Plan 3 later records structured redaction events, the endpoint can additionally surface them — the UI badge contract (`redactionCounts: Record<string, number>`) stays stable.
+4. **The client-facing `GET /client-ai/templates` needs a re-scoped DB context.** Plan 1's `clientAiAuthMiddleware` opens `withDbAccessContext` with `accessiblePartnerIds: []` (Plan 1 Task 10), and `withDbAccessContext` is a no-op when a context is already open (`apps/api/src/db/index.ts:103-105`) — so partner-wide template rows (`org_id NULL`, dual-axis RLS) are **invisible** inside the middleware's context (`breeze_has_partner_access` checks `breeze_accessible_partner_ids()`, `migrations/2026-04-11-a-rls-function-bootstrap.sql:105-115`). The route therefore reads the org's `partner_id` (its own `organizations` row is readable under org scope — id-keyed shape 2), then runs the single template SELECT under `runOutsideDbContext(() => withDbAccessContext({...accessiblePartnerIds: [partnerId]}, ...))` — the narrowest possible grant, read-only, one query, with an explicit `WHERE` on top of RLS. This is NOT a broadening of the middleware: client sessions get the partner axis for this one statement only.
+5. **`dlp_config` shape is pinned here and Plan 3 must consume it.** `client_ai_org_policies.dlp_config` is a free `jsonb` (Plan 1). This plan pins the concrete shape (Task 1: `clientAiDlpConfigSchema` — `builtins` map over `creditCard|ssn|iban|apiKey|email|phone` with actions `redact|block|log|off`, plus `customRules: [{id,name,pattern,action}]`, defaults per spec §6: redact for financial/credential types, email/phone off) and tightens Plan 1's `putPolicySchema.dlpConfig` from `z.record(z.unknown())` to it. Plan 1's `admin.test.ts` policy tests don't send `dlpConfig`, so they keep passing. **Coordination note for the Plan-3 implementer: read this shape from Task 1 before writing `clientAiDlp.ts`.**
+6. **`GET /client-ai/templates` returns a bare JSON array** (`[{ id, name, description, category, body }]`) — the pinned contract Plan 5 consumes — even though the codebase usually wraps in `{data:[...]}`. Deliberate: the pinned shape wins.
+7. **The consent callback is a static confirmation page with no state binding.** Unlike the C2C M365 callback (`apps/api/src/routes/c2c/m365Auth.ts:154` — cookie-bound, exchanges tokens, writes connections), `GET /client-ai/consent/callback` mutates **nothing**: consent state is derived from token exchanges (decision 1), so the callback only tells the admin "you can close this window". No CSRF surface, no cookie, no DB write.
+8. **Component tests are implement-then-test.** Explored norm: web components in this repo ship tests alongside (`OrgPortalSettingsEditor.test.tsx`, `BillablesExportCard.test.tsx`) but are not built test-first. API routes in this plan are strict TDD; React components are implemented in full, then covered by the required component tests in the same task.
+9. **One endpoint added beyond the pinned list:** `GET /client-ai/admin/orgs/:orgId/users` (the org's `auth_method='entra'` portal users). The policy editor's `userAccess='selected'` picker needs the candidate list (Plan 1 deviation 3: `selected_user_ids` hold `portal_users` UUIDs), and no existing route exposes portal users to partner admins in this shape.
+10. **`fetchWithAuth` auto-injects `?orgId=`** from the org store when set (`apps/web/src/stores/auth.ts:406-413`). Every new admin list endpoint therefore treats an `orgId` query param as an access-checked filter rather than rejecting it — same tolerance `routes/ai.ts` admin endpoints and `tickets/export.ts` already have.
+
+## Verification notes for workers
+
+- Node pin: prefix every pnpm/vitest/tsc command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict).
+- The full `vitest run` suite is known-flaky in parallel on a pristine tree — verify with the **affected files only**; trust CI for the full sweep.
+- `npx tsc --noEmit` (apps/api) has pre-existing errors in `agents.test.ts` and `apiKeyAuth.test.ts` — those two are not yours.
+- Integration tests need the docker test stack: `cd apps/api && pnpm test:docker:up` (postgres 5433 / redis 6380); `src/__tests__/integration/setup.ts` runs `autoMigrate` itself.
+- Plans 1–2 are assumed merged: `routes/clientAi/{admin,auth,index,schemas}.ts`, `middleware/clientAiAuth.ts`, `services/clientAiPolicy.ts`, the `clientAi.ts` Drizzle schema, and `ai_sessions.client_user_id` + `type='excel_client'` session rows all exist.
+- This plan ships **zero migrations** — all tables come from Plan 1.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/api/src/routes/clientAi/schemas.ts` | Modify | + DLP config schema, template/usage/session query schemas, month regex; tighten `putPolicySchema.dlpConfig` |
+| `apps/api/src/routes/clientAi/schemas.test.ts` | Create | Validator coverage for the new schemas |
+| `apps/api/src/routes/clientAi/adminOrgs.ts` (+ `.test.ts`) | Create | GET /orgs status list, GET /orgs/:orgId/consent-url, GET /orgs/:orgId/users, public consent callback |
+| `apps/api/src/routes/clientAi/adminSessions.ts` (+ `.test.ts`) | Create | Session list/detail/flag/unflag (excel_client only) |
+| `apps/api/src/routes/clientAi/adminUsage.ts` (+ `.test.ts`) | Create | Usage report JSON + CSV export |
+| `apps/api/src/routes/clientAi/adminTemplates.ts` (+ `.test.ts`) | Create | Template CRUD (org + partner-wide scopes) |
+| `apps/api/src/routes/clientAi/templates.ts` (+ `.test.ts`) | Create | Client-facing template list for the add-in (Plan 5 consumer) |
+| `apps/api/src/routes/clientAi/admin.ts` | Modify (end) | Mount the four admin sub-routers |
+| `apps/api/src/routes/clientAi/index.ts` | Modify | Mount consent callback + client template routes |
+| `apps/api/src/__tests__/integration/client-ai-template-routes.integration.test.ts` | Create | Route-level partner-wide insert as `breeze_app` (spec §10 warning) |
+| `apps/web/src/pages/ai-for-office.astro` | Create | Page shell (`DashboardLayout` + island) |
+| `apps/web/src/components/layout/Sidebar.tsx` | Modify (~line 119) | Nav entry in the "AI & Fleet" section, gated by a new `partnerScopeOnly` NavItem flag |
+| `apps/web/src/components/clientAi/AiForOfficePage.tsx` (+ `.test.tsx`) | Create | Hash-tab shell (#orgs, #policy/<orgId>, #sessions, #usage, #templates) |
+| `apps/web/src/components/clientAi/OrgsTab.tsx` (+ `.test.tsx`) | Create | Status table + onboarding wizard drawer |
+| `apps/web/src/components/clientAi/PolicyEditor.tsx` (+ `.test.tsx`) | Create | Full policy editor incl. DLP builder + live regex test |
+| `apps/web/src/components/clientAi/SessionsTab.tsx` (+ `.test.tsx`) | Create | Session audit table + transcript drawer + flag/unflag |
+| `apps/web/src/components/clientAi/UsageTab.tsx` (+ `.test.tsx`) | Create | Usage report + CSV download |
+| `apps/web/src/components/clientAi/TemplatesTab.tsx` (+ `.test.tsx`) | Create | Template CRUD UI |
+| `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` | Modify (`TARGET_GLOBS`) | Adopt the four mutating components (OrgsTab, PolicyEditor, SessionsTab, TemplatesTab — UsageTab is GET-only) into the WS-A guard |
+
+---
+
+### Task 1: Shared schema additions — DLP config + query schemas (TDD)
+
+Everything later route tasks import. The DLP shape is the cross-plan contract (decision 5).
+
+**Files:**
+- Modify: apps/api/src/routes/clientAi/schemas.ts
+- Test: apps/api/src/routes/clientAi/schemas.test.ts
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/routes/clientAi/schemas.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  clientAiDlpConfigSchema,
+  CLIENT_AI_DLP_DEFAULT_BUILTINS,
+  adminUsageQuerySchema,
+  adminSessionListQuerySchema,
+  templateBodySchema,
+  templateUpdateSchema,
+  USAGE_MONTH_REGEX,
+} from './schemas';
+
+describe('clientAiDlpConfigSchema', () => {
+  it('accepts the empty object (Plan-1 column default)', () => {
+    expect(clientAiDlpConfigSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts a full config with builtins and custom rules', () => {
+    const result = clientAiDlpConfigSchema.safeParse({
+      builtins: { creditCard: 'redact', email: 'off', phone: 'log' },
+      customRules: [
+        { id: 'r1', name: 'Project codes', pattern: 'PRJ-\\d{4}', action: 'block' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown builtin key', () => {
+    expect(
+      clientAiDlpConfigSchema.safeParse({ builtins: { dna: 'redact' } }).success
+    ).toBe(false);
+  });
+
+  it('rejects an unknown action', () => {
+    expect(
+      clientAiDlpConfigSchema.safeParse({ builtins: { ssn: 'obliterate' } }).success
+    ).toBe(false);
+  });
+
+  it('rejects a custom rule whose pattern does not compile', () => {
+    expect(
+      clientAiDlpConfigSchema.safeParse({
+        customRules: [{ id: 'r1', name: 'broken', pattern: '([', action: 'redact' }],
+      }).success
+    ).toBe(false);
+  });
+
+  it('pins the spec §6 defaults: redact financial/credential, email/phone off', () => {
+    expect(CLIENT_AI_DLP_DEFAULT_BUILTINS).toEqual({
+      creditCard: 'redact',
+      ssn: 'redact',
+      iban: 'redact',
+      apiKey: 'redact',
+      email: 'off',
+      phone: 'off',
+    });
+  });
+});
+
+describe('adminUsageQuerySchema', () => {
+  it('accepts a YYYY-MM range', () => {
+    expect(adminUsageQuerySchema.safeParse({ from: '2026-01', to: '2026-06' }).success).toBe(true);
+  });
+  it('rejects a non-month value', () => {
+    expect(adminUsageQuerySchema.safeParse({ from: '2026-13', to: '2026-06' }).success).toBe(false);
+    expect(adminUsageQuerySchema.safeParse({ from: '2026-01-05', to: '2026-06' }).success).toBe(false);
+  });
+  it('rejects from > to', () => {
+    expect(adminUsageQuerySchema.safeParse({ from: '2026-06', to: '2026-01' }).success).toBe(false);
+  });
+  it('USAGE_MONTH_REGEX matches only calendar months', () => {
+    expect(USAGE_MONTH_REGEX.test('2026-06')).toBe(true);
+    expect(USAGE_MONTH_REGEX.test('2026-00')).toBe(false);
+  });
+});
+
+describe('adminSessionListQuerySchema', () => {
+  it('defaults limit/offset and accepts filters', () => {
+    const parsed = adminSessionListQuerySchema.parse({
+      orgId: '0c0c0c0c-1111-4222-8333-444455556666',
+      flagged: 'true',
+      from: '2026-06-01',
+      to: '2026-06-12T23:59:59Z',
+    });
+    expect(parsed.limit).toBe(50);
+    expect(parsed.offset).toBe(0);
+  });
+  it('rejects an unparsable date', () => {
+    expect(adminSessionListQuerySchema.safeParse({ from: 'yesterday-ish' }).success).toBe(false);
+  });
+  it('caps limit at 100', () => {
+    expect(adminSessionListQuerySchema.safeParse({ limit: '500' }).success).toBe(false);
+  });
+});
+
+describe('template schemas', () => {
+  it('templateBodySchema accepts an org-scoped body', () => {
+    const r = templateBodySchema.safeParse({
+      name: 'Variance summary',
+      promptBody: 'Explain the variance in the selection.',
+      orgId: '0c0c0c0c-1111-4222-8333-444455556666',
+    });
+    expect(r.success).toBe(true);
+  });
+  it('templateBodySchema accepts orgId null (partner-wide)', () => {
+    expect(
+      templateBodySchema.safeParse({ name: 'A', promptBody: 'B', orgId: null }).success
+    ).toBe(true);
+  });
+  it('templateBodySchema is strict', () => {
+    expect(
+      templateBodySchema.safeParse({ name: 'A', promptBody: 'B', surprise: 1 }).success
+    ).toBe(false);
+  });
+  it('templateUpdateSchema forbids moving scope (no orgId key)', () => {
+    expect(templateUpdateSchema.safeParse({ orgId: null }).success).toBe(false);
+    expect(templateUpdateSchema.safeParse({ name: 'Renamed' }).success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/schemas.test.ts`
+Expected: FAIL — the new exports don't exist yet.
+
+- [ ] **Step 3: Extend `apps/api/src/routes/clientAi/schemas.ts`**
+
+Append after the existing `putPolicySchema` block (and change its `dlpConfig` line):
+
+```ts
+// ============================================
+// DLP config (spec §6) — THE cross-plan contract shape.
+// Stored in client_ai_org_policies.dlp_config (jsonb). The Plan-4 policy
+// editor writes it; the Plan-3 clientAiDlp.ts service MUST read this exact
+// shape. Absent keys fall back to CLIENT_AI_DLP_DEFAULT_BUILTINS.
+// ============================================
+
+export const DLP_BUILTIN_TYPES = ['creditCard', 'ssn', 'iban', 'apiKey', 'email', 'phone'] as const;
+export type DlpBuiltinType = (typeof DLP_BUILTIN_TYPES)[number];
+
+export const DLP_ACTIONS = ['redact', 'block', 'log', 'off'] as const;
+export type DlpAction = (typeof DLP_ACTIONS)[number];
+
+/** Spec §6 defaults: redact for financial/credential types; email/phone off. */
+export const CLIENT_AI_DLP_DEFAULT_BUILTINS: Record<DlpBuiltinType, DlpAction> = {
+  creditCard: 'redact',
+  ssn: 'redact',
+  iban: 'redact',
+  apiKey: 'redact',
+  email: 'off',
+  phone: 'off',
+};
+
+export const clientAiDlpCustomRuleSchema = z
+  .object({
+    id: z.string().min(1).max(64),
+    name: z.string().min(1).max(100),
+    pattern: z
+      .string()
+      .min(1)
+      .max(500)
+      .refine((p) => {
+        try {
+          new RegExp(p);
+          return true;
+        } catch {
+          return false;
+        }
+      }, 'pattern must be a valid regular expression'),
+    action: z.enum(DLP_ACTIONS),
+  })
+  .strict();
+
+export const clientAiDlpConfigSchema = z
+  .object({
+    builtins: z.record(z.enum(DLP_BUILTIN_TYPES), z.enum(DLP_ACTIONS)).optional(),
+    customRules: z.array(clientAiDlpCustomRuleSchema).max(50).optional(),
+  })
+  .strict();
+
+export type ClientAiDlpConfig = z.infer<typeof clientAiDlpConfigSchema>;
+
+// ============================================
+// Plan-4 admin query/body schemas
+// ============================================
+
+export const USAGE_MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export const adminUsageQuerySchema = z
+  .object({
+    from: z.string().regex(USAGE_MONTH_REGEX, 'must be YYYY-MM'),
+    to: z.string().regex(USAGE_MONTH_REGEX, 'must be YYYY-MM'),
+    orgId: z.string().uuid().optional(),
+  })
+  .refine((q) => q.from <= q.to, { message: 'from must be <= to' });
+
+const parsableDate = z
+  .string()
+  .refine((v) => !Number.isNaN(Date.parse(v)), 'must be a parsable date');
+
+export const adminSessionListQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  clientUserId: z.string().uuid().optional(),
+  from: parsableDate.optional(),
+  to: parsableDate.optional(),
+  flagged: z.enum(['true', 'false']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const flagSessionSchema = z
+  .object({ reason: z.string().max(1000).optional() })
+  .optional();
+
+export const templateBodySchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    description: z.string().max(2000).nullable().optional(),
+    promptBody: z.string().min(1).max(20000),
+    category: z.string().max(100).nullable().optional(),
+    /** null/absent ⇒ partner-wide row (org_id NULL, partner_id set). */
+    orgId: z.string().uuid().nullable().optional(),
+  })
+  .strict();
+
+export const templateUpdateSchema = templateBodySchema
+  .omit({ orgId: true })
+  .partial()
+  .strict();
+
+export const templateListQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  scope: z.enum(['partner', 'org']).optional(),
+});
+```
+
+And change one line inside the existing `putPolicySchema` (Plan 1):
+
+```ts
+    // BEFORE: dlpConfig: z.record(z.unknown()).optional(),
+    dlpConfig: clientAiDlpConfigSchema.optional(),
+```
+
+(`clientAiDlpConfigSchema` must therefore be declared **above** `putPolicySchema` in the file, or hoist the consts; simplest is to place the whole DLP block before `putPolicySchema` and the query schemas after it.)
+
+- [ ] **Step 4: Run tests to verify they pass — including Plan 1's**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/schemas.test.ts src/routes/clientAi/admin.test.ts src/routes/clientAi/auth.test.ts
+```
+
+Expected: all PASS (the Plan-1 admin/auth tests prove the `putPolicySchema` tightening broke nothing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/schemas.ts apps/api/src/routes/clientAi/schemas.test.ts
+git commit -m "feat(client-ai): DLP config contract schema + Plan-4 admin query schemas" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Admin org status list + consent URL + consent callback (TDD)
+
+The onboarding wizard's API: `GET /orgs` (status table), `GET /orgs/:orgId/consent-url`, `GET /orgs/:orgId/users` (decision 9), and the public consent-callback landing page (decision 7). Tenant-ID pre-fill follows the Plan-1 Task-1 audit recommendation: `m365_connections.tenant_id` first (one per org, `apps/api/src/db/schema/m365.ts:25-46`), falling back to `delegant_m365_connections.m365_tenant_id` (multiple per org possible, `apps/api/src/db/schema/delegant.ts:10-31`) — only GUID-shaped values are suggested.
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/adminOrgs.ts
+- Test: apps/api/src/routes/clientAi/adminOrgs.test.ts
+- Modify: apps/api/src/routes/clientAi/admin.ts (mount, end of file)
+- Modify: apps/api/src/routes/clientAi/index.ts (mount callback)
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/routes/clientAi/adminOrgs.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { dbSelectMock } = vi.hoisted(() => ({ dbSelectMock: vi.fn() }));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);
+    c.set('auth', {
+      scope: 'partner',
+      partnerId: 'f0f0f0f0-1111-4222-8333-444455556666',
+      orgId: null,
+      accessibleOrgIds: ['0c0c0c0c-1111-4222-8333-444455556666'],
+      user: { id: 'ce11ce11-1111-4222-8333-444455556666', email: 'msp@example.com' },
+    });
+    return next();
+  }),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (c: any, next: any) => next()),
+}));
+
+vi.mock('../../config/env', () => ({
+  CLIENT_AI_ENTRA_CLIENT_ID: '00000000-aaaa-bbbb-cccc-000000000001',
+}));
+
+vi.mock('../../db', () => ({ db: { select: dbSelectMock } }));
+
+import {
+  clientAiAdminOrgRoutes,
+  clientAiConsentCallbackRoute,
+  buildClientAiConsentUrl,
+  getClientAiConsentRedirectUri,
+  currentMonthKey,
+} from './adminOrgs';
+import { authMiddleware } from '../../middleware/auth';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const OTHER_ORG_ID = '9d9d9d9d-1111-4222-8333-444455556666';
+const TID = '6f4f4f4f-1111-4222-8333-444455556666';
+
+/** Flexible thenable Drizzle chain: awaitable after any builder method. */
+function chain(rows: unknown[]) {
+  const c: Record<string, unknown> = {};
+  const self = vi.fn(() => c);
+  for (const m of ['from', 'where', 'orderBy', 'groupBy', 'leftJoin', 'limit', 'offset']) {
+    c[m] = self;
+  }
+  c.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return c;
+}
+
+/** GET /orgs issues 7 selects in a fixed order (see route comment). */
+function setupOrgListDb(overrides: Partial<Record<number, unknown[]>> = {}) {
+  const defaults: unknown[][] = [
+    /* 1 orgs        */ [{ id: ORG_ID, name: 'Contoso Accounting' }],
+    /* 2 mappings    */ [{ orgId: ORG_ID, entraTenantId: TID }],
+    /* 3 policies    */ [{ orgId: ORG_ID, enabled: true }],
+    /* 4 entra users */ [{ orgId: ORG_ID, n: 3 }],
+    /* 5 usage       */ [{ orgId: ORG_ID, costCents: '1234.5', messages: '87' }],
+    /* 6 m365        */ [{ orgId: ORG_ID, tenantId: TID }],
+    /* 7 delegant    */ [],
+  ];
+  let call = 0;
+  dbSelectMock.mockImplementation(() => {
+    call++;
+    return chain((overrides[call] as unknown[]) ?? defaults[call - 1] ?? []);
+  });
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/client-ai/admin', clientAiAdminOrgRoutes);
+  return app;
+}
+
+const AUTHED = { Authorization: 'Bearer token' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /client-ai/admin/orgs', () => {
+  it('rejects unauthenticated requests', async () => {
+    const res = await buildApp().request('/client-ai/admin/orgs');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the merged per-org status row', async () => {
+    setupOrgListDb();
+    const res = await buildApp().request('/client-ai/admin/orgs', { headers: AUTHED });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toMatchObject({
+      orgId: ORG_ID,
+      orgName: 'Contoso Accounting',
+      mapped: true,
+      entraTenantId: TID,
+      suggestedEntraTenantId: TID,
+      consentStatus: 'granted',
+      policyEnabled: true,
+      currentMonthCostCents: 1234.5,
+      currentMonthMessages: 87,
+    });
+  });
+
+  it("derives consentStatus 'unknown' when unmapped and 'pending' when mapped without entra users", async () => {
+    setupOrgListDb({ 2: [], 4: [] }); // no mapping, no entra users
+    let res = await buildApp().request('/client-ai/admin/orgs', { headers: AUTHED });
+    expect((await res.json()).data[0].consentStatus).toBe('unknown');
+
+    setupOrgListDb({ 4: [] }); // mapped, no entra users
+    res = await buildApp().request('/client-ai/admin/orgs', { headers: AUTHED });
+    const row = (await res.json()).data[0];
+    expect(row.consentStatus).toBe('pending');
+    expect(row.mapped).toBe(true);
+  });
+
+  it('honors the orgId filter param (fetchWithAuth auto-injection tolerance)', async () => {
+    setupOrgListDb({
+      1: [
+        { id: ORG_ID, name: 'Contoso Accounting' },
+        { id: OTHER_ORG_ID, name: 'Fabrikam' },
+      ],
+    });
+    const res = await buildApp().request(`/client-ai/admin/orgs?orgId=${ORG_ID}`, {
+      headers: AUTHED,
+    });
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].orgId).toBe(ORG_ID);
+  });
+
+  it('suggests the delegant tenant when no m365 connection exists, GUIDs only', async () => {
+    setupOrgListDb({
+      2: [],
+      4: [],
+      6: [],
+      7: [
+        { orgId: ORG_ID, tenantId: 'contoso.onmicrosoft.com' }, // non-GUID — skipped
+        { orgId: ORG_ID, tenantId: TID },
+      ],
+    });
+    const res = await buildApp().request('/client-ai/admin/orgs', { headers: AUTHED });
+    expect((await res.json()).data[0].suggestedEntraTenantId).toBe(TID);
+  });
+});
+
+describe('GET /client-ai/admin/orgs/:orgId/consent-url', () => {
+  it('404s for an org outside the caller scope', async () => {
+    dbSelectMock.mockImplementation(() => chain([]));
+    const res = await buildApp().request(
+      `/client-ai/admin/orgs/${OTHER_ORG_ID}/consent-url`,
+      { headers: AUTHED }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('builds a tenant-pinned URL when a mapping exists', async () => {
+    dbSelectMock.mockImplementation(() => chain([{ orgId: ORG_ID, entraTenantId: TID }]));
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/consent-url`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const url = new URL(body.url);
+    expect(url.pathname).toBe(`/${TID}/adminconsent`);
+    expect(url.searchParams.get('client_id')).toBe('00000000-aaaa-bbbb-cccc-000000000001');
+    expect(url.searchParams.get('redirect_uri')).toContain('/api/v1/client-ai/consent/callback');
+  });
+
+  it("falls back to the 'organizations' segment when unmapped", async () => {
+    dbSelectMock.mockImplementation(() => chain([]));
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/consent-url`, {
+      headers: AUTHED,
+    });
+    const body = await res.json();
+    expect(new URL(body.url).pathname).toBe('/organizations/adminconsent');
+  });
+});
+
+describe('GET /client-ai/admin/orgs/:orgId/users', () => {
+  it('lists the entra portal users of the org', async () => {
+    dbSelectMock.mockImplementation(() =>
+      chain([
+        { id: 'beefbeef-1111-4222-8333-444455556666', email: 'a@contoso.com', name: 'A', lastLoginAt: null },
+      ])
+    );
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/users`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data[0].email).toBe('a@contoso.com');
+  });
+
+  it('404s outside the caller scope', async () => {
+    const res = await buildApp().request(`/client-ai/admin/orgs/${OTHER_ORG_ID}/users`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /client-ai/consent/callback (public)', () => {
+  function callbackApp() {
+    const app = new Hono();
+    app.route('/client-ai', clientAiConsentCallbackRoute);
+    return app;
+  }
+
+  it('renders the success page when admin_consent=True', async () => {
+    const res = await callbackApp().request(
+      `/client-ai/consent/callback?admin_consent=True&tenant=${TID}`
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Consent granted');
+  });
+
+  it('renders the failure page (escaped) otherwise', async () => {
+    const res = await callbackApp().request(
+      '/client-ai/consent/callback?error=access_denied&error_description=<script>alert(1)</script>'
+    );
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('helpers', () => {
+  it('currentMonthKey is YYYY-MM (UTC)', () => {
+    expect(currentMonthKey(new Date('2026-06-12T10:00:00Z'))).toBe('2026-06');
+    expect(currentMonthKey(new Date('2026-01-01T00:30:00Z'))).toBe('2026-01');
+  });
+  it('buildClientAiConsentUrl encodes the redirect uri', () => {
+    const url = buildClientAiConsentUrl({ clientId: 'cid', entraTenantId: null });
+    expect(url).toContain('organizations/adminconsent');
+    expect(url).toContain(encodeURIComponent(getClientAiConsentRedirectUri()));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminOrgs.test.ts`
+Expected: FAIL with module-not-found for `./adminOrgs`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/api/src/routes/clientAi/adminOrgs.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { and, asc, count, eq, sum } from 'drizzle-orm';
+import { db } from '../../db';
+import {
+  clientAiOrgPolicies,
+  clientAiTenantMappings,
+  clientAiUsage,
+} from '../../db/schema/clientAi';
+import { organizations } from '../../db/schema/orgs';
+import { portalUsers } from '../../db/schema/portal';
+import { m365Connections } from '../../db/schema/m365';
+import { delegantM365Connections } from '../../db/schema/delegant';
+import { requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { CLIENT_AI_ENTRA_CLIENT_ID } from '../../config/env';
+import { resolveScopedOrgId } from '../c2c/helpers';
+import { ENTRA_TENANT_GUID_REGEX } from './schemas';
+
+/**
+ * AI for Office — onboarding/status endpoints for the dashboard OrgsTab
+ * (spec §9.1). Mounted onto clientAiAdminRoutes (admin.ts), so the Plan-1
+ * group authMiddleware + CLIENT_AI_ENTRA_CLIENT_ID dark-gate already apply.
+ *
+ * consentStatus derivation (Plan-4 decision 1): the /auth/exchange route
+ * (Plan 1) auto-provisions portal_users rows with auth_method='entra' on the
+ * first successful token exchange, so
+ *   no mapping                       → 'unknown'
+ *   mapping, no entra users in org   → 'pending'
+ *   mapping + ≥1 entra user          → 'granted'
+ */
+
+export const clientAiAdminOrgRoutes = new Hono();
+
+const requireOrgsRead = requirePermission(
+  PERMISSIONS.ORGS_READ.resource,
+  PERMISSIONS.ORGS_READ.action
+);
+
+export function currentMonthKey(now: Date = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+/** Mirrors services/c2cM365.ts getCallbackUri() — same env fallbacks. */
+export function getClientAiConsentRedirectUri(): string {
+  const base = (
+    process.env.PUBLIC_URL ||
+    process.env.PUBLIC_APP_URL ||
+    process.env.DASHBOARD_URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
+  return `${base}/api/v1/client-ai/consent/callback`;
+}
+
+/**
+ * Mirrors services/c2cM365.ts buildAdminConsentUrl(), but with the tenant
+ * segment pinned by the spec: the mapped tenant GUID when known, otherwise
+ * the 'organizations' multi-tenant endpoint.
+ */
+export function buildClientAiConsentUrl(params: {
+  clientId: string;
+  entraTenantId: string | null;
+}): string {
+  const segment = params.entraTenantId ?? 'organizations';
+  const url = new URL(`https://login.microsoftonline.com/${segment}/adminconsent`);
+  url.searchParams.set('client_id', params.clientId);
+  url.searchParams.set('redirect_uri', getClientAiConsentRedirectUri());
+  return url.toString();
+}
+
+// ── GET /orgs — per-org status list ──────────────────────────────────────────
+// Seven sequential selects, merged in JS (no N+1; each is one indexed scan).
+// Order matters — the unit test mocks them positionally:
+//   1 organizations  2 tenant mappings  3 policies  4 entra-user counts
+//   5 current-month usage  6 m365 connections  7 delegant connections
+clientAiAdminOrgRoutes.get('/orgs', requireOrgsRead, async (c) => {
+  const orgFilter = c.req.query('orgId') || null;
+
+  const orgs = await db
+    .select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .orderBy(asc(organizations.name));
+
+  const mappings = await db
+    .select({
+      orgId: clientAiTenantMappings.orgId,
+      entraTenantId: clientAiTenantMappings.entraTenantId,
+    })
+    .from(clientAiTenantMappings);
+
+  const policies = await db
+    .select({ orgId: clientAiOrgPolicies.orgId, enabled: clientAiOrgPolicies.enabled })
+    .from(clientAiOrgPolicies);
+
+  const entraUsers = await db
+    .select({ orgId: portalUsers.orgId, n: count() })
+    .from(portalUsers)
+    .where(eq(portalUsers.authMethod, 'entra'))
+    .groupBy(portalUsers.orgId);
+
+  const usage = await db
+    .select({
+      orgId: clientAiUsage.orgId,
+      costCents: sum(clientAiUsage.totalCostCents),
+      messages: sum(clientAiUsage.messageCount),
+    })
+    .from(clientAiUsage)
+    .where(
+      and(eq(clientAiUsage.period, 'monthly'), eq(clientAiUsage.periodKey, currentMonthKey()))
+    )
+    .groupBy(clientAiUsage.orgId);
+
+  const m365 = await db
+    .select({ orgId: m365Connections.orgId, tenantId: m365Connections.tenantId })
+    .from(m365Connections);
+
+  const delegant = await db
+    .select({
+      orgId: delegantM365Connections.orgId,
+      tenantId: delegantM365Connections.m365TenantId,
+    })
+    .from(delegantM365Connections);
+
+  const mappingByOrg = new Map(mappings.map((m) => [m.orgId, m.entraTenantId]));
+  const policyByOrg = new Map(policies.map((p) => [p.orgId, p.enabled === true]));
+  const entraCountByOrg = new Map(entraUsers.map((u) => [u.orgId, Number(u.n ?? 0)]));
+  const usageByOrg = new Map(
+    usage.map((u) => [
+      u.orgId,
+      {
+        costCents: Math.round(Number(u.costCents ?? 0) * 100) / 100,
+        messages: Number(u.messages ?? 0),
+      },
+    ])
+  );
+  // Pre-fill preference per the Plan-1 Task-1 M365 reuse audit:
+  // m365_connections.tenant_id first (one per org), then the first GUID-shaped
+  // delegant_m365_connections.m365_tenant_id. Non-GUID values never suggested.
+  const suggestedByOrg = new Map<string, string>();
+  for (const row of delegant) {
+    if (!suggestedByOrg.has(row.orgId) && ENTRA_TENANT_GUID_REGEX.test(row.tenantId)) {
+      suggestedByOrg.set(row.orgId, row.tenantId.toLowerCase());
+    }
+  }
+  for (const row of m365) {
+    if (ENTRA_TENANT_GUID_REGEX.test(row.tenantId)) {
+      suggestedByOrg.set(row.orgId, row.tenantId.toLowerCase());
+    }
+  }
+
+  const data = orgs
+    .filter((org) => !orgFilter || org.id === orgFilter)
+    .map((org) => {
+      const entraTenantId = mappingByOrg.get(org.id) ?? null;
+      const mapped = entraTenantId !== null;
+      const granted = mapped && (entraCountByOrg.get(org.id) ?? 0) > 0;
+      const orgUsage = usageByOrg.get(org.id);
+      return {
+        orgId: org.id,
+        orgName: org.name,
+        mapped,
+        entraTenantId,
+        suggestedEntraTenantId: suggestedByOrg.get(org.id) ?? null,
+        consentStatus: !mapped ? ('unknown' as const) : granted ? ('granted' as const) : ('pending' as const),
+        policyEnabled: policyByOrg.get(org.id) ?? false,
+        currentMonthCostCents: orgUsage?.costCents ?? 0,
+        currentMonthMessages: orgUsage?.messages ?? 0,
+      };
+    });
+
+  return c.json({ data });
+});
+
+// ── GET /orgs/:orgId/consent-url ──────────────────────────────────────────────
+clientAiAdminOrgRoutes.get('/orgs/:orgId/consent-url', requireOrgsRead, async (c) => {
+  const auth = c.get('auth');
+  const orgId = resolveScopedOrgId(auth, c.req.param('orgId'));
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+
+  const [mapping] = await db
+    .select({ entraTenantId: clientAiTenantMappings.entraTenantId })
+    .from(clientAiTenantMappings)
+    .where(eq(clientAiTenantMappings.orgId, orgId))
+    .limit(1);
+
+  const entraTenantId = mapping?.entraTenantId ?? null;
+  return c.json({
+    url: buildClientAiConsentUrl({ clientId: CLIENT_AI_ENTRA_CLIENT_ID, entraTenantId }),
+    tenantSegment: entraTenantId ?? 'organizations',
+    redirectUri: getClientAiConsentRedirectUri(),
+  });
+});
+
+// ── GET /orgs/:orgId/users — entra portal users (policy-editor picker) ───────
+clientAiAdminOrgRoutes.get('/orgs/:orgId/users', requireOrgsRead, async (c) => {
+  const auth = c.get('auth');
+  const orgId = resolveScopedOrgId(auth, c.req.param('orgId'));
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+
+  const data = await db
+    .select({
+      id: portalUsers.id,
+      email: portalUsers.email,
+      name: portalUsers.name,
+      lastLoginAt: portalUsers.lastLoginAt,
+    })
+    .from(portalUsers)
+    .where(and(eq(portalUsers.orgId, orgId), eq(portalUsers.authMethod, 'entra')))
+    .orderBy(asc(portalUsers.email));
+
+  return c.json({ data });
+});
+
+// ── Public consent-callback landing page ─────────────────────────────────────
+// Registered Redirect URI of the add-in app registration. Mutates NOTHING
+// (decision 7): consent state is derived from token exchanges, so unlike the
+// C2C callback (routes/c2c/m365Auth.ts:154) there is no cookie/state binding,
+// no token exchange, no DB write — just a human-readable confirmation.
+export const clientAiConsentCallbackRoute = new Hono();
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+clientAiConsentCallbackRoute.get('/consent/callback', (c) => {
+  const granted = (c.req.query('admin_consent') ?? '').toLowerCase() === 'true';
+  const error = c.req.query('error') ?? '';
+  const description = c.req.query('error_description') ?? '';
+  const title = granted ? 'Consent granted' : 'Consent not granted';
+  const detail = granted
+    ? 'You can close this window, return to Breeze, and click “I’ve granted consent” in the setup wizard.'
+    : escapeHtml(description || error || 'Microsoft did not report a granted consent. Close this window and retry from Breeze.');
+  const html = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>${title} — Breeze AI for Office</title>
+<style>body{font-family:system-ui,sans-serif;display:grid;place-items:center;min-height:100vh;margin:0;background:#0b0f17;color:#e5e7eb}main{max-width:28rem;padding:2rem;text-align:center}h1{font-size:1.25rem}p{color:#9ca3af;font-size:.9rem;line-height:1.5}</style>
+</head>
+<body><main><h1>${title}</h1><p>${detail}</p></main></body>
+</html>`;
+  return c.html(html, granted ? 200 : 400);
+});
+```
+
+- [ ] **Step 4: Mount — `admin.ts` and `index.ts`**
+
+Append to `apps/api/src/routes/clientAi/admin.ts` (after the policy routes; the group `use('*', authMiddleware)` + dark-gate at the top of the file apply to sub-routers mounted afterwards):
+
+```ts
+import { clientAiAdminOrgRoutes } from './adminOrgs';
+
+// ── Plan-4 dashboard sub-routers (inherit group auth + dark-gate above) ──────
+clientAiAdminRoutes.route('/', clientAiAdminOrgRoutes);
+```
+
+(Place the import with the other imports at the top of the file; the `.route` call at the very end.)
+
+In `apps/api/src/routes/clientAi/index.ts`, add the public callback route:
+
+```ts
+import { clientAiConsentCallbackRoute } from './adminOrgs';
+
+// Public Entra admin-consent landing page (no auth — informational only).
+clientAiRoutes.route('/', clientAiConsentCallbackRoute);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminOrgs.test.ts src/routes/clientAi/admin.test.ts`
+Expected: all PASS (admin.test.ts re-run proves the mount edit broke nothing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/adminOrgs.ts apps/api/src/routes/clientAi/adminOrgs.test.ts apps/api/src/routes/clientAi/admin.ts apps/api/src/routes/clientAi/index.ts
+git commit -m "feat(client-ai): admin org status list, consent-url helper + public consent callback" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Admin session audit routes — list, transcript, flag/unflag (TDD)
+
+The audit viewer's API (spec §9.3). Mirrors the technician flag/unflag handlers (`apps/api/src/routes/ai.ts:285-360` — decision 2) and the admin session list (`routes/ai.ts:883-906`), constrained to `type='excel_client'` with org/user/date/flagged filters and `organizations`/`portal_users` joins.
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/adminSessions.ts
+- Test: apps/api/src/routes/clientAi/adminSessions.test.ts
+- Modify: apps/api/src/routes/clientAi/admin.ts (mount)
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/routes/clientAi/adminSessions.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { dbSelectMock, dbUpdateMock, writeRouteAuditMock } = vi.hoisted(() => ({
+  dbSelectMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+  writeRouteAuditMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);
+    c.set('auth', {
+      scope: 'partner',
+      partnerId: 'f0f0f0f0-1111-4222-8333-444455556666',
+      orgId: null,
+      accessibleOrgIds: ['0c0c0c0c-1111-4222-8333-444455556666'],
+      canAccessOrg: (id: string) => id === '0c0c0c0c-1111-4222-8333-444455556666',
+      user: { id: 'ce11ce11-1111-4222-8333-444455556666', email: 'msp@example.com' },
+    });
+    return next();
+  }),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (c: any, next: any) => next()),
+}));
+
+vi.mock('../../config/env', () => ({
+  CLIENT_AI_ENTRA_CLIENT_ID: '00000000-aaaa-bbbb-cccc-000000000001',
+}));
+
+vi.mock('../../db', () => ({ db: { select: dbSelectMock, update: dbUpdateMock } }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
+
+import { clientAiAdminSessionRoutes, countRedactions } from './adminSessions';
+import { authMiddleware } from '../../middleware/auth';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const OTHER_ORG_ID = '9d9d9d9d-1111-4222-8333-444455556666';
+const SESSION_ID = '5e5e5e5e-1111-4222-8333-444455556666';
+const CLIENT_USER_ID = 'beefbeef-1111-4222-8333-444455556666';
+
+const SESSION_ROW = {
+  id: SESSION_ID,
+  orgId: ORG_ID,
+  orgName: 'Contoso Accounting',
+  clientUserId: CLIENT_USER_ID,
+  userEmail: 'finance.user@contoso.com',
+  title: 'Q3 budget review',
+  model: 'claude-sonnet-4-5-20250929',
+  status: 'closed',
+  type: 'excel_client',
+  turnCount: 6,
+  totalCostCents: 12.5,
+  totalInputTokens: 4000,
+  totalOutputTokens: 900,
+  flaggedAt: null,
+  flaggedBy: null,
+  flagReason: null,
+  createdAt: new Date('2026-06-10T09:00:00Z'),
+  lastActivityAt: new Date('2026-06-10T09:20:00Z'),
+};
+
+function chain(rows: unknown[]) {
+  const c: Record<string, unknown> = {};
+  const self = vi.fn(() => c);
+  for (const m of ['from', 'where', 'orderBy', 'groupBy', 'leftJoin', 'limit', 'offset']) {
+    c[m] = self;
+  }
+  c.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return c;
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/client-ai/admin', clientAiAdminSessionRoutes);
+  return app;
+}
+
+const AUTHED = { Authorization: 'Bearer token', 'Content-Type': 'application/json' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbUpdateMock.mockImplementation(() => ({
+    set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+  }));
+});
+
+describe('GET /client-ai/admin/sessions', () => {
+  it('returns rows + pagination (query 1 = rows, query 2 = count)', async () => {
+    let call = 0;
+    dbSelectMock.mockImplementation(() => {
+      call++;
+      return call === 1 ? chain([SESSION_ROW]) : chain([{ n: 1 }]);
+    });
+    const res = await buildApp().request('/client-ai/admin/sessions?flagged=false', {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({
+      id: SESSION_ID,
+      orgName: 'Contoso Accounting',
+      userEmail: 'finance.user@contoso.com',
+      turnCount: 6,
+      totalCostCents: 12.5,
+    });
+    expect(body.data[0].startedAt).toBeDefined();
+    expect(body.pagination).toMatchObject({ total: 1, limit: 50, offset: 0 });
+  });
+
+  it('404s an orgId filter outside the caller scope (no existence oracle)', async () => {
+    const res = await buildApp().request(
+      `/client-ai/admin/sessions?orgId=${OTHER_ORG_ID}`,
+      { headers: AUTHED }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('400s an unparsable date filter', async () => {
+    const res = await buildApp().request('/client-ai/admin/sessions?from=not-a-date', {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /client-ai/admin/sessions/:id', () => {
+  it('returns transcript with redaction counts and tool trail', async () => {
+    let call = 0;
+    dbSelectMock.mockImplementation(() => {
+      call++;
+      if (call === 1) return chain([SESSION_ROW]);
+      if (call === 2)
+        return chain([
+          {
+            id: 'm1',
+            role: 'user',
+            content: 'Card [REDACTED:creditCard] and [REDACTED:creditCard], ssn [REDACTED:ssn]',
+            contentBlocks: null,
+            toolName: null,
+            toolInput: null,
+            toolOutput: null,
+            createdAt: new Date(),
+          },
+        ]);
+      return chain([
+        {
+          id: 't1',
+          toolName: 'write_range',
+          toolInput: { range: 'B2:B4' },
+          status: 'completed',
+          approvedBy: null,
+          approvedAt: new Date(),
+          errorMessage: null,
+          durationMs: 240,
+          createdAt: new Date(),
+          completedAt: new Date(),
+        },
+      ]);
+    });
+    const res = await buildApp().request(`/client-ai/admin/sessions/${SESSION_ID}`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.session.id).toBe(SESSION_ID);
+    expect(body.messages[0].redactionCounts).toEqual({ creditCard: 2, ssn: 1 });
+    expect(body.toolExecutions[0].toolName).toBe('write_range');
+  });
+
+  it('404s when the session does not exist / is not excel_client', async () => {
+    dbSelectMock.mockImplementation(() => chain([]));
+    const res = await buildApp().request(`/client-ai/admin/sessions/${SESSION_ID}`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('404s a session in an inaccessible org (belt-and-braces over RLS)', async () => {
+    dbSelectMock.mockImplementation(() => chain([{ ...SESSION_ROW, orgId: OTHER_ORG_ID }]));
+    const res = await buildApp().request(`/client-ai/admin/sessions/${SESSION_ID}`, {
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('flag / unflag', () => {
+  it('POST flags with a reason and audits', async () => {
+    dbSelectMock.mockImplementation(() => chain([SESSION_ROW]));
+    const res = await buildApp().request(
+      `/client-ai/admin/sessions/${SESSION_ID}/flag`,
+      { method: 'POST', headers: AUTHED, body: JSON.stringify({ reason: 'PII concern' }) }
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(dbUpdateMock).toHaveBeenCalled();
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: ORG_ID,
+        action: 'client_ai.session.flag',
+        resourceType: 'ai_session',
+        resourceId: SESSION_ID,
+      })
+    );
+  });
+
+  it('POST accepts an empty body', async () => {
+    dbSelectMock.mockImplementation(() => chain([SESSION_ROW]));
+    const res = await buildApp().request(
+      `/client-ai/admin/sessions/${SESSION_ID}/flag`,
+      { method: 'POST', headers: AUTHED }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('DELETE unflags and audits', async () => {
+    dbSelectMock.mockImplementation(() =>
+      chain([{ ...SESSION_ROW, flaggedAt: new Date(), flagReason: 'old' }])
+    );
+    const res = await buildApp().request(
+      `/client-ai/admin/sessions/${SESSION_ID}/flag`,
+      { method: 'DELETE', headers: AUTHED }
+    );
+    expect(res.status).toBe(200);
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'client_ai.session.unflag' })
+    );
+  });
+
+  it('404s flagging a missing session', async () => {
+    dbSelectMock.mockImplementation(() => chain([]));
+    const res = await buildApp().request(
+      `/client-ai/admin/sessions/${SESSION_ID}/flag`,
+      { method: 'POST', headers: AUTHED }
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('countRedactions', () => {
+  it('counts markers per type and tolerates null', () => {
+    expect(countRedactions(null)).toEqual({});
+    expect(countRedactions('[REDACTED:iban] x [REDACTED:iban] [REDACTED:apiKey]')).toEqual({
+      iban: 2,
+      apiKey: 1,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminSessions.test.ts`
+Expected: FAIL with module-not-found for `./adminSessions`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/api/src/routes/clientAi/adminSessions.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, asc, count, desc, eq, gte, isNotNull, isNull, lte, type SQL } from 'drizzle-orm';
+import { db } from '../../db';
+import { aiSessions, aiMessages, aiToolExecutions } from '../../db/schema';
+import { organizations } from '../../db/schema/orgs';
+import { portalUsers } from '../../db/schema/portal';
+import { requireMfa, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { resolveScopedOrgId } from '../c2c/helpers';
+import { adminSessionListQuerySchema, flagSessionSchema } from './schemas';
+
+/**
+ * AI for Office — client-session audit viewer endpoints (spec §9.3).
+ * excel_client sessions ONLY; technician sessions stay on /ai/admin/*.
+ *
+ * Flag/unflag mirrors the technician handlers (routes/ai.ts:285-360) — those
+ * are inline db.updates with no shared service, so there is nothing to call
+ * (Plan-4 decision 2). Same MFA gate, audit actions namespaced client_ai.*.
+ *
+ * Redaction badges (Plan-4 decision 3): ai_messages stores the redacted form
+ * (spec §6 "redact before logging"), so redaction-event metadata is DERIVED
+ * by counting [REDACTED:type] markers — no dependency on a Plan-3 metadata
+ * format that does not exist yet.
+ */
+
+export const clientAiAdminSessionRoutes = new Hono();
+
+const requireOrgsRead = requirePermission(
+  PERMISSIONS.ORGS_READ.resource,
+  PERMISSIONS.ORGS_READ.action
+);
+const requireOrgsWrite = requirePermission(
+  PERMISSIONS.ORGS_WRITE.resource,
+  PERMISSIONS.ORGS_WRITE.action
+);
+
+export const REDACTION_MARKER_REGEX = /\[REDACTED:([A-Za-z0-9_-]+)\]/g;
+
+export function countRedactions(text: string | null | undefined): Record<string, number> {
+  const counts: Record<string, number> = {};
+  if (!text) return counts;
+  for (const match of text.matchAll(REDACTION_MARKER_REGEX)) {
+    const key = match[1]!;
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+type SessionAuth = {
+  canAccessOrg?: (orgId: string) => boolean;
+  user?: { id: string };
+};
+
+const sessionSelection = {
+  id: aiSessions.id,
+  orgId: aiSessions.orgId,
+  orgName: organizations.name,
+  clientUserId: aiSessions.clientUserId,
+  userEmail: portalUsers.email,
+  title: aiSessions.title,
+  model: aiSessions.model,
+  status: aiSessions.status,
+  turnCount: aiSessions.turnCount,
+  totalCostCents: aiSessions.totalCostCents,
+  totalInputTokens: aiSessions.totalInputTokens,
+  totalOutputTokens: aiSessions.totalOutputTokens,
+  flaggedAt: aiSessions.flaggedAt,
+  flaggedBy: aiSessions.flaggedBy,
+  flagReason: aiSessions.flagReason,
+  createdAt: aiSessions.createdAt,
+  lastActivityAt: aiSessions.lastActivityAt,
+};
+
+// ── GET /sessions — filtered, paginated list ─────────────────────────────────
+clientAiAdminSessionRoutes.get(
+  '/sessions',
+  requireOrgsRead,
+  zValidator('query', adminSessionListQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const q = c.req.valid('query');
+
+    const conditions: SQL[] = [eq(aiSessions.type, 'excel_client')];
+    if (q.orgId) {
+      const orgId = resolveScopedOrgId(auth, q.orgId);
+      if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+      conditions.push(eq(aiSessions.orgId, orgId));
+    }
+    if (q.clientUserId) conditions.push(eq(aiSessions.clientUserId, q.clientUserId));
+    if (q.from) conditions.push(gte(aiSessions.createdAt, new Date(q.from)));
+    if (q.to) conditions.push(lte(aiSessions.createdAt, new Date(q.to)));
+    if (q.flagged === 'true') conditions.push(isNotNull(aiSessions.flaggedAt));
+    if (q.flagged === 'false') conditions.push(isNull(aiSessions.flaggedAt));
+
+    const where = and(...conditions);
+
+    const rows = await db
+      .select(sessionSelection)
+      .from(aiSessions)
+      .leftJoin(organizations, eq(aiSessions.orgId, organizations.id))
+      .leftJoin(portalUsers, eq(aiSessions.clientUserId, portalUsers.id))
+      .where(where)
+      .orderBy(desc(aiSessions.createdAt))
+      .limit(q.limit)
+      .offset(q.offset);
+
+    const [totalRow] = await db.select({ n: count() }).from(aiSessions).where(where);
+
+    return c.json({
+      data: rows.map((r) => ({
+        id: r.id,
+        orgId: r.orgId,
+        orgName: r.orgName ?? null,
+        clientUserId: r.clientUserId,
+        userEmail: r.userEmail ?? null,
+        title: r.title,
+        startedAt: r.createdAt,
+        lastActivityAt: r.lastActivityAt,
+        turnCount: r.turnCount,
+        totalCostCents: r.totalCostCents,
+        flaggedAt: r.flaggedAt,
+        flagReason: r.flagReason,
+        status: r.status,
+      })),
+      pagination: { total: Number(totalRow?.n ?? 0), limit: q.limit, offset: q.offset },
+    });
+  }
+);
+
+/** Fetch one excel_client session the caller can access, else null. */
+async function getClientSession(auth: SessionAuth, sessionId: string) {
+  const [row] = await db
+    .select(sessionSelection)
+    .from(aiSessions)
+    .leftJoin(organizations, eq(aiSessions.orgId, organizations.id))
+    .leftJoin(portalUsers, eq(aiSessions.clientUserId, portalUsers.id))
+    .where(and(eq(aiSessions.id, sessionId), eq(aiSessions.type, 'excel_client')))
+    .limit(1);
+  if (!row) return null;
+  // RLS already scopes the SELECT; this is the belt-and-braces app-layer
+  // check the technician routes also perform via getSession(sessionId, auth).
+  if (auth.canAccessOrg && !auth.canAccessOrg(row.orgId)) return null;
+  return row;
+}
+
+// ── GET /sessions/:id — full transcript ──────────────────────────────────────
+clientAiAdminSessionRoutes.get('/sessions/:id', requireOrgsRead, async (c) => {
+  const auth = c.get('auth') as SessionAuth;
+  const session = await getClientSession(auth, c.req.param('id'));
+  if (!session) return c.json({ error: 'Session not found' }, 404);
+
+  const messages = await db
+    .select({
+      id: aiMessages.id,
+      role: aiMessages.role,
+      content: aiMessages.content,
+      contentBlocks: aiMessages.contentBlocks,
+      toolName: aiMessages.toolName,
+      toolInput: aiMessages.toolInput,
+      toolOutput: aiMessages.toolOutput,
+      createdAt: aiMessages.createdAt,
+    })
+    .from(aiMessages)
+    .where(eq(aiMessages.sessionId, session.id))
+    .orderBy(asc(aiMessages.createdAt));
+
+  const toolExecutions = await db
+    .select({
+      id: aiToolExecutions.id,
+      toolName: aiToolExecutions.toolName,
+      toolInput: aiToolExecutions.toolInput,
+      status: aiToolExecutions.status,
+      approvedBy: aiToolExecutions.approvedBy,
+      approvedAt: aiToolExecutions.approvedAt,
+      errorMessage: aiToolExecutions.errorMessage,
+      durationMs: aiToolExecutions.durationMs,
+      createdAt: aiToolExecutions.createdAt,
+      completedAt: aiToolExecutions.completedAt,
+    })
+    .from(aiToolExecutions)
+    .where(eq(aiToolExecutions.sessionId, session.id))
+    .orderBy(asc(aiToolExecutions.createdAt));
+
+  return c.json({
+    session,
+    messages: messages.map((m) => ({ ...m, redactionCounts: countRedactions(m.content) })),
+    toolExecutions,
+  });
+});
+
+// ── POST /sessions/:id/flag ───────────────────────────────────────────────────
+clientAiAdminSessionRoutes.post(
+  '/sessions/:id/flag',
+  requireOrgsWrite,
+  requireMfa(),
+  zValidator('json', flagSessionSchema),
+  async (c) => {
+    const auth = c.get('auth') as SessionAuth;
+    const session = await getClientSession(auth, c.req.param('id'));
+    if (!session) return c.json({ error: 'Session not found' }, 404);
+
+    const body = c.req.valid('json') ?? {};
+
+    await db
+      .update(aiSessions)
+      .set({
+        flaggedAt: new Date(),
+        flaggedBy: auth.user?.id ?? null,
+        flagReason: body.reason ?? null,
+      })
+      .where(eq(aiSessions.id, session.id));
+
+    writeRouteAudit(c, {
+      orgId: session.orgId,
+      action: 'client_ai.session.flag',
+      resourceType: 'ai_session',
+      resourceId: session.id,
+      details: { reason: body.reason ?? null },
+    });
+
+    return c.json({ success: true });
+  }
+);
+
+// ── DELETE /sessions/:id/flag ─────────────────────────────────────────────────
+clientAiAdminSessionRoutes.delete(
+  '/sessions/:id/flag',
+  requireOrgsWrite,
+  requireMfa(),
+  async (c) => {
+    const auth = c.get('auth') as SessionAuth;
+    const session = await getClientSession(auth, c.req.param('id'));
+    if (!session) return c.json({ error: 'Session not found' }, 404);
+
+    await db
+      .update(aiSessions)
+      .set({ flaggedAt: null, flaggedBy: null, flagReason: null })
+      .where(eq(aiSessions.id, session.id));
+
+    writeRouteAudit(c, {
+      orgId: session.orgId,
+      action: 'client_ai.session.unflag',
+      resourceType: 'ai_session',
+      resourceId: session.id,
+    });
+
+    return c.json({ success: true });
+  }
+);
+```
+
+Note: the empty-body POST works because `flagSessionSchema` is `.optional()` — same shape as the technician route's `zValidator('json', z.object({...}).optional())` (`routes/ai.ts:291`). If `zValidator` rejects a missing JSON body on this Hono version, mirror ai.ts exactly (it already handles this in production).
+
+- [ ] **Step 4: Mount in `admin.ts`**
+
+```ts
+import { clientAiAdminSessionRoutes } from './adminSessions';
+// ...
+clientAiAdminRoutes.route('/', clientAiAdminSessionRoutes);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminSessions.test.ts`
+Expected: 12 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/adminSessions.ts apps/api/src/routes/clientAi/adminSessions.test.ts apps/api/src/routes/clientAi/admin.ts
+git commit -m "feat(client-ai): admin session audit routes — list, transcript, flag/unflag" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Admin usage report + CSV export (TDD)
+
+Spec §8/§9.4: aggregate `client_ai_usage` monthly buckets per org/user, JSON for the dashboard table and `text/csv` for the MSP's invoicing artifact. CSV building follows `apps/api/src/routes/tickets/export.ts` (`csvRow` from `services/spreadsheetExport.ts` — formula-neutralized, quoted cells); the export is audited like `routes/auditLogs.ts:790-803`.
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/adminUsage.ts
+- Test: apps/api/src/routes/clientAi/adminUsage.test.ts
+- Modify: apps/api/src/routes/clientAi/admin.ts (mount)
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/routes/clientAi/adminUsage.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { dbSelectMock, writeRouteAuditMock } = vi.hoisted(() => ({
+  dbSelectMock: vi.fn(),
+  writeRouteAuditMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);
+    c.set('auth', {
+      scope: 'partner',
+      partnerId: 'f0f0f0f0-1111-4222-8333-444455556666',
+      orgId: null,
+      accessibleOrgIds: ['0c0c0c0c-1111-4222-8333-444455556666'],
+      user: { id: 'ce11ce11-1111-4222-8333-444455556666', email: 'msp@example.com' },
+    });
+    return next();
+  }),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (c: any, next: any) => next()),
+}));
+
+vi.mock('../../config/env', () => ({
+  CLIENT_AI_ENTRA_CLIENT_ID: '00000000-aaaa-bbbb-cccc-000000000001',
+}));
+
+vi.mock('../../db', () => ({ db: { select: dbSelectMock } }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
+
+import { clientAiAdminUsageRoutes } from './adminUsage';
+import { authMiddleware } from '../../middleware/auth';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const OTHER_ORG_ID = '9d9d9d9d-1111-4222-8333-444455556666';
+
+const USAGE_ROWS = [
+  {
+    periodKey: '2026-05',
+    orgId: ORG_ID,
+    orgName: 'Contoso Accounting',
+    clientUserId: 'beefbeef-1111-4222-8333-444455556666',
+    userEmail: 'finance.user@contoso.com',
+    inputTokens: 10000,
+    outputTokens: 2000,
+    totalCostCents: 150.4,
+    sessionCount: 4,
+    messageCount: 40,
+  },
+  {
+    periodKey: '2026-06',
+    orgId: ORG_ID,
+    orgName: 'Contoso Accounting',
+    clientUserId: 'cafecafe-1111-4222-8333-444455556666',
+    userEmail: 'ap.clerk@contoso.com',
+    inputTokens: 5000,
+    outputTokens: 1000,
+    totalCostCents: 75.1,
+    sessionCount: 2,
+    messageCount: 18,
+  },
+];
+
+function chain(rows: unknown[]) {
+  const c: Record<string, unknown> = {};
+  const self = vi.fn(() => c);
+  for (const m of ['from', 'where', 'orderBy', 'groupBy', 'leftJoin', 'limit', 'offset']) {
+    c[m] = self;
+  }
+  c.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return c;
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/client-ai/admin', clientAiAdminUsageRoutes);
+  return app;
+}
+
+const AUTHED = { Authorization: 'Bearer token' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbSelectMock.mockImplementation(() => chain(USAGE_ROWS));
+});
+
+describe('GET /client-ai/admin/usage', () => {
+  it('400s a missing/invalid month range', async () => {
+    expect((await buildApp().request('/client-ai/admin/usage', { headers: AUTHED })).status).toBe(400);
+    expect(
+      (
+        await buildApp().request('/client-ai/admin/usage?from=2026-06-01&to=2026-06', {
+          headers: AUTHED,
+        })
+      ).status
+    ).toBe(400);
+  });
+
+  it('returns per-user rows and computed totals', async () => {
+    const res = await buildApp().request(
+      '/client-ai/admin/usage?from=2026-05&to=2026-06',
+      { headers: AUTHED }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rows).toHaveLength(2);
+    expect(body.rows[0]).toMatchObject({
+      month: '2026-05',
+      orgName: 'Contoso Accounting',
+      userEmail: 'finance.user@contoso.com',
+      costCents: 150.4,
+    });
+    expect(body.totals).toMatchObject({
+      messageCount: 58,
+      sessionCount: 6,
+      inputTokens: 15000,
+      outputTokens: 3000,
+      costCents: 225.5,
+    });
+  });
+
+  it('404s an orgId outside the caller scope', async () => {
+    const res = await buildApp().request(
+      `/client-ai/admin/usage?from=2026-05&to=2026-06&orgId=${OTHER_ORG_ID}`,
+      { headers: AUTHED }
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /client-ai/admin/usage.csv', () => {
+  it('streams text/csv with the pinned column order and audits the export', async () => {
+    const res = await buildApp().request(
+      '/client-ai/admin/usage.csv?from=2026-05&to=2026-06',
+      { headers: AUTHED }
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/csv');
+    expect(res.headers.get('Content-Disposition')).toContain('client-ai-usage-2026-05-to-2026-06.csv');
+    const text = await res.text();
+    const lines = text.split('\n');
+    expect(lines[0]).toBe('month,org_name,user_email,messages,sessions,input_tokens,output_tokens,cost_cents');
+    expect(lines[1]).toContain('"2026-05"');
+    expect(lines[1]).toContain('"finance.user@contoso.com"');
+    expect(lines).toHaveLength(3);
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'client_ai.usage.export',
+        details: expect.objectContaining({ rowCount: 2, from: '2026-05', to: '2026-06' }),
+      })
+    );
+  });
+
+  it('CSV cells are formula-neutralized (spreadsheetExport)', async () => {
+    dbSelectMock.mockImplementation(() =>
+      chain([{ ...USAGE_ROWS[0], userEmail: '=HYPERLINK("evil")' }])
+    );
+    const res = await buildApp().request(
+      '/client-ai/admin/usage.csv?from=2026-05&to=2026-06',
+      { headers: AUTHED }
+    );
+    const text = await res.text();
+    expect(text).toContain(`"'=HYPERLINK(""evil"")"`);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminUsage.test.ts`
+Expected: FAIL with module-not-found for `./adminUsage`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/api/src/routes/clientAi/adminUsage.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, asc, eq, gte, lte, type SQL } from 'drizzle-orm';
+import { db } from '../../db';
+import { clientAiUsage } from '../../db/schema/clientAi';
+import { organizations } from '../../db/schema/orgs';
+import { portalUsers } from '../../db/schema/portal';
+import { requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { csvRow } from '../../services/spreadsheetExport';
+import { resolveScopedOrgId } from '../c2c/helpers';
+import { adminUsageQuerySchema } from './schemas';
+
+/**
+ * AI for Office — usage & billing report (spec §8, §9.4). Reads the
+ * client_ai_usage monthly buckets (org × user × month) the Plan-2 session
+ * loop writes; the CSV is the MSP's resale-invoicing artifact, so its column
+ * order is a pinned contract. CSV building follows routes/tickets/export.ts
+ * (csvRow — quoted + formula-neutralized cells); exports are audited like
+ * routes/auditLogs.ts GET /export.
+ */
+
+export const clientAiAdminUsageRoutes = new Hono();
+
+const requireOrgsRead = requirePermission(
+  PERMISSIONS.ORGS_READ.resource,
+  PERMISSIONS.ORGS_READ.action
+);
+
+const CSV_HEADERS = [
+  'month',
+  'org_name',
+  'user_email',
+  'messages',
+  'sessions',
+  'input_tokens',
+  'output_tokens',
+  'cost_cents',
+];
+
+type UsageQuery = { from: string; to: string; orgId?: string };
+
+async function loadUsageRows(q: UsageQuery) {
+  // period_key is 'YYYY-MM' for monthly rows — lexicographic range == calendar
+  // range (same trick as the ai_cost_usage bucket pattern).
+  const conditions: SQL[] = [
+    eq(clientAiUsage.period, 'monthly'),
+    gte(clientAiUsage.periodKey, q.from),
+    lte(clientAiUsage.periodKey, q.to),
+  ];
+  if (q.orgId) conditions.push(eq(clientAiUsage.orgId, q.orgId));
+
+  const rows = await db
+    .select({
+      periodKey: clientAiUsage.periodKey,
+      orgId: clientAiUsage.orgId,
+      orgName: organizations.name,
+      clientUserId: clientAiUsage.clientUserId,
+      userEmail: portalUsers.email,
+      inputTokens: clientAiUsage.inputTokens,
+      outputTokens: clientAiUsage.outputTokens,
+      totalCostCents: clientAiUsage.totalCostCents,
+      sessionCount: clientAiUsage.sessionCount,
+      messageCount: clientAiUsage.messageCount,
+    })
+    .from(clientAiUsage)
+    .leftJoin(organizations, eq(clientAiUsage.orgId, organizations.id))
+    .leftJoin(portalUsers, eq(clientAiUsage.clientUserId, portalUsers.id))
+    .where(and(...conditions))
+    .orderBy(asc(clientAiUsage.periodKey), asc(organizations.name), asc(portalUsers.email));
+
+  return rows.map((r) => ({
+    month: r.periodKey,
+    orgId: r.orgId,
+    orgName: r.orgName ?? null,
+    clientUserId: r.clientUserId,
+    userEmail: r.userEmail ?? null,
+    messageCount: Number(r.messageCount ?? 0),
+    sessionCount: Number(r.sessionCount ?? 0),
+    inputTokens: Number(r.inputTokens ?? 0),
+    outputTokens: Number(r.outputTokens ?? 0),
+    // totalCostCents is REAL (fractional cents accumulate) — round to 2dp.
+    costCents: Math.round(Number(r.totalCostCents ?? 0) * 100) / 100,
+  }));
+}
+
+function checkOrgAccess(
+  c: { get: (k: 'auth') => Parameters<typeof resolveScopedOrgId>[0] },
+  orgId: string | undefined
+): boolean {
+  if (!orgId) return true;
+  return resolveScopedOrgId(c.get('auth'), orgId) !== null;
+}
+
+// ── GET /usage — JSON report ──────────────────────────────────────────────────
+clientAiAdminUsageRoutes.get(
+  '/usage',
+  requireOrgsRead,
+  zValidator('query', adminUsageQuerySchema),
+  async (c) => {
+    const q = c.req.valid('query');
+    if (!checkOrgAccess(c as never, q.orgId)) {
+      return c.json({ error: 'Organization not found' }, 404);
+    }
+
+    const rows = await loadUsageRows(q);
+    const totals = rows.reduce(
+      (acc, r) => ({
+        messageCount: acc.messageCount + r.messageCount,
+        sessionCount: acc.sessionCount + r.sessionCount,
+        inputTokens: acc.inputTokens + r.inputTokens,
+        outputTokens: acc.outputTokens + r.outputTokens,
+        costCents: Math.round((acc.costCents + r.costCents) * 100) / 100,
+      }),
+      { messageCount: 0, sessionCount: 0, inputTokens: 0, outputTokens: 0, costCents: 0 }
+    );
+
+    return c.json({ rows, totals });
+  }
+);
+
+// ── GET /usage.csv — the invoicing artifact ──────────────────────────────────
+clientAiAdminUsageRoutes.get(
+  '/usage.csv',
+  requireOrgsRead,
+  zValidator('query', adminUsageQuerySchema),
+  async (c) => {
+    const q = c.req.valid('query');
+    if (!checkOrgAccess(c as never, q.orgId)) {
+      return c.json({ error: 'Organization not found' }, 404);
+    }
+
+    const rows = await loadUsageRows(q);
+
+    writeRouteAudit(c, {
+      orgId: q.orgId ?? null,
+      action: 'client_ai.usage.export',
+      resourceType: 'client_ai_usage',
+      details: { from: q.from, to: q.to, orgId: q.orgId ?? null, rowCount: rows.length },
+    });
+
+    const lines = [CSV_HEADERS.join(',')];
+    for (const r of rows) {
+      lines.push(
+        csvRow([
+          r.month,
+          r.orgName ?? '',
+          r.userEmail ?? '',
+          r.messageCount,
+          r.sessionCount,
+          r.inputTokens,
+          r.outputTokens,
+          r.costCents,
+        ])
+      );
+    }
+
+    c.header('Content-Type', 'text/csv');
+    c.header(
+      'Content-Disposition',
+      `attachment; filename="client-ai-usage-${q.from}-to-${q.to}.csv"`
+    );
+    return c.body(lines.join('\n'));
+  }
+);
+```
+
+- [ ] **Step 4: Mount in `admin.ts`**
+
+```ts
+import { clientAiAdminUsageRoutes } from './adminUsage';
+// ...
+clientAiAdminRoutes.route('/', clientAiAdminUsageRoutes);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminUsage.test.ts`
+Expected: 6 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/adminUsage.ts apps/api/src/routes/clientAi/adminUsage.test.ts apps/api/src/routes/clientAi/admin.ts
+git commit -m "feat(client-ai): usage report endpoint + audited CSV export" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Admin template CRUD (TDD)
+
+Spec §9.5/§10. Org-scoped rows (`org_id` set) and partner-wide rows (`org_id NULL`, `partner_id` set) on `client_ai_prompt_templates` (Plan 1 migration §5, dual-axis RLS). Partner-wide writes require partner/system scope with a `partnerId` — org-scope callers get a clean 403 instead of the RLS 42501 that bit `custom_field_definitions` (memory: `rls_dual_axis_contract_test_blindspot`).
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/adminTemplates.ts
+- Test: apps/api/src/routes/clientAi/adminTemplates.test.ts
+- Modify: apps/api/src/routes/clientAi/admin.ts (mount)
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/routes/clientAi/adminTemplates.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { dbSelectMock, dbInsertMock, dbUpdateMock, dbDeleteMock, writeRouteAuditMock, authState } =
+  vi.hoisted(() => ({
+    dbSelectMock: vi.fn(),
+    dbInsertMock: vi.fn(),
+    dbUpdateMock: vi.fn(),
+    dbDeleteMock: vi.fn(),
+    writeRouteAuditMock: vi.fn(),
+    authState: {
+      scope: 'partner' as string,
+      partnerId: 'f0f0f0f0-1111-4222-8333-444455556666' as string | null,
+    },
+  }));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);
+    c.set('auth', {
+      scope: authState.scope,
+      partnerId: authState.partnerId,
+      orgId: authState.scope === 'organization' ? '0c0c0c0c-1111-4222-8333-444455556666' : null,
+      accessibleOrgIds: ['0c0c0c0c-1111-4222-8333-444455556666'],
+      user: { id: 'ce11ce11-1111-4222-8333-444455556666', email: 'msp@example.com' },
+    });
+    return next();
+  }),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (c: any, next: any) => next()),
+}));
+
+vi.mock('../../config/env', () => ({
+  CLIENT_AI_ENTRA_CLIENT_ID: '00000000-aaaa-bbbb-cccc-000000000001',
+}));
+
+vi.mock('../../db', () => ({
+  db: { select: dbSelectMock, insert: dbInsertMock, update: dbUpdateMock, delete: dbDeleteMock },
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
+
+import { clientAiAdminTemplateRoutes } from './adminTemplates';
+import { authMiddleware } from '../../middleware/auth';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const OTHER_ORG_ID = '9d9d9d9d-1111-4222-8333-444455556666';
+const PARTNER_ID = 'f0f0f0f0-1111-4222-8333-444455556666';
+const TEMPLATE_ID = '7e7e7e7e-1111-4222-8333-444455556666';
+
+const PARTNER_ROW = {
+  id: TEMPLATE_ID,
+  orgId: null,
+  partnerId: PARTNER_ID,
+  orgName: null,
+  name: 'Quarterly variance walkthrough',
+  description: null,
+  promptBody: 'Explain the variance between the selected columns.',
+  category: 'finance',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function chain(rows: unknown[]) {
+  const c: Record<string, unknown> = {};
+  const self = vi.fn(() => c);
+  for (const m of ['from', 'where', 'orderBy', 'groupBy', 'leftJoin', 'limit', 'offset']) {
+    c[m] = self;
+  }
+  c.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return c;
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/client-ai/admin', clientAiAdminTemplateRoutes);
+  return app;
+}
+
+const AUTHED = { Authorization: 'Bearer token', 'Content-Type': 'application/json' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.scope = 'partner';
+  authState.partnerId = PARTNER_ID;
+  dbSelectMock.mockImplementation(() => chain([PARTNER_ROW]));
+  dbInsertMock.mockImplementation(() => ({
+    values: vi.fn((v: Record<string, unknown>) => ({
+      returning: vi.fn(() => Promise.resolve([{ ...PARTNER_ROW, ...v }])),
+    })),
+  }));
+  dbUpdateMock.mockImplementation(() => ({
+    set: vi.fn((v: Record<string, unknown>) => ({
+      where: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([{ ...PARTNER_ROW, ...v }])),
+      })),
+    })),
+  }));
+  dbDeleteMock.mockImplementation(() => ({
+    where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([PARTNER_ROW])) })),
+  }));
+});
+
+describe('GET /client-ai/admin/templates', () => {
+  it('lists all RLS-visible templates with orgName', async () => {
+    const res = await buildApp().request('/client-ai/admin/templates', { headers: AUTHED });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({ id: TEMPLATE_ID, partnerId: PARTNER_ID, orgId: null });
+  });
+
+  it('404s an orgId filter outside the caller scope', async () => {
+    const res = await buildApp().request(
+      `/client-ai/admin/templates?orgId=${OTHER_ORG_ID}`,
+      { headers: AUTHED }
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /client-ai/admin/templates', () => {
+  it('creates a partner-wide row when orgId is null and audits', async () => {
+    const res = await buildApp().request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ name: 'New', promptBody: 'Body', orgId: null }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.template).toMatchObject({ orgId: null, partnerId: PARTNER_ID });
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'client_ai.template.create',
+        resourceType: 'client_ai_prompt_template',
+        details: expect.objectContaining({ scope: 'partner' }),
+      })
+    );
+  });
+
+  it('creates an org-scoped row when orgId is provided', async () => {
+    const res = await buildApp().request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ name: 'Org one', promptBody: 'Body', orgId: ORG_ID }),
+    });
+    expect(res.status).toBe(201);
+    expect((await res.json()).template).toMatchObject({ orgId: ORG_ID, partnerId: null });
+  });
+
+  it('404s an org-scoped create for an inaccessible org', async () => {
+    const res = await buildApp().request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ name: 'X', promptBody: 'Y', orgId: OTHER_ORG_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('403s a partner-wide create from organization scope (clean error, not RLS 42501)', async () => {
+    authState.scope = 'organization';
+    authState.partnerId = null;
+    const res = await buildApp().request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ name: 'X', promptBody: 'Y', orgId: null }),
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'partner_scope_required' });
+  });
+
+  it('400s a strict-schema violation', async () => {
+    const res = await buildApp().request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: AUTHED,
+      body: JSON.stringify({ name: 'X', promptBody: 'Y', surprise: 1 }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('PUT /client-ai/admin/templates/:id', () => {
+  it('updates fields on an existing row and audits', async () => {
+    const res = await buildApp().request(`/client-ai/admin/templates/${TEMPLATE_ID}`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).template.name).toBe('Renamed');
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'client_ai.template.update', resourceId: TEMPLATE_ID })
+    );
+  });
+
+  it('404s a missing row', async () => {
+    dbSelectMock.mockImplementation(() => chain([]));
+    const res = await buildApp().request(`/client-ai/admin/templates/${TEMPLATE_ID}`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /client-ai/admin/templates/:id', () => {
+  it('deletes and audits', async () => {
+    const res = await buildApp().request(`/client-ai/admin/templates/${TEMPLATE_ID}`, {
+      method: 'DELETE',
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'client_ai.template.delete', resourceId: TEMPLATE_ID })
+    );
+  });
+
+  it('404s when nothing was deleted', async () => {
+    dbDeleteMock.mockImplementation(() => ({
+      where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) })),
+    }));
+    const res = await buildApp().request(`/client-ai/admin/templates/${TEMPLATE_ID}`, {
+      method: 'DELETE',
+      headers: AUTHED,
+    });
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminTemplates.test.ts`
+Expected: FAIL with module-not-found for `./adminTemplates`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/api/src/routes/clientAi/adminTemplates.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { asc, eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { clientAiPromptTemplates } from '../../db/schema/clientAi';
+import { organizations } from '../../db/schema/orgs';
+import { requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { resolveScopedOrgId } from '../c2c/helpers';
+import { templateBodySchema, templateUpdateSchema, templateListQuerySchema } from './schemas';
+
+/**
+ * AI for Office — prompt-template manager (spec §9.5, §10).
+ *
+ * client_ai_prompt_templates is dual-axis: org rows (org_id set, partner_id
+ * NULL) and partner-wide rows (org_id NULL, partner_id set). Partner-wide
+ * writes REQUIRE a partner/system caller carrying partnerId; org-scope
+ * callers get a clean 403 partner_scope_required instead of bubbling the RLS
+ * 42501 — the exact custom_field_definitions failure mode (2026-06-11-i).
+ * The end-to-end breeze_app proof for the partner-axis write path lives in
+ * __tests__/integration/client-ai-template-routes.integration.test.ts (Task 7).
+ *
+ * Scope is immutable after create (templateUpdateSchema has no orgId) — move
+ * a template by delete + recreate. Keeps the dual-axis invariants trivial.
+ */
+
+export const clientAiAdminTemplateRoutes = new Hono();
+
+const requireOrgsRead = requirePermission(
+  PERMISSIONS.ORGS_READ.resource,
+  PERMISSIONS.ORGS_READ.action
+);
+const requireOrgsWrite = requirePermission(
+  PERMISSIONS.ORGS_WRITE.resource,
+  PERMISSIONS.ORGS_WRITE.action
+);
+
+type TemplateAuth = {
+  scope: 'system' | 'partner' | 'organization';
+  partnerId: string | null;
+  user?: { id: string };
+};
+
+const templateSelection = {
+  id: clientAiPromptTemplates.id,
+  orgId: clientAiPromptTemplates.orgId,
+  partnerId: clientAiPromptTemplates.partnerId,
+  orgName: organizations.name,
+  name: clientAiPromptTemplates.name,
+  description: clientAiPromptTemplates.description,
+  promptBody: clientAiPromptTemplates.promptBody,
+  category: clientAiPromptTemplates.category,
+  createdAt: clientAiPromptTemplates.createdAt,
+  updatedAt: clientAiPromptTemplates.updatedAt,
+};
+
+// ── GET /templates ────────────────────────────────────────────────────────────
+clientAiAdminTemplateRoutes.get(
+  '/templates',
+  requireOrgsRead,
+  zValidator('query', templateListQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const q = c.req.valid('query');
+
+    if (q.orgId && !resolveScopedOrgId(auth, q.orgId)) {
+      return c.json({ error: 'Organization not found' }, 404);
+    }
+
+    // RLS bounds visibility (own partner rows + accessible-org rows); the
+    // optional filters narrow within that.
+    let rows = await db
+      .select(templateSelection)
+      .from(clientAiPromptTemplates)
+      .leftJoin(organizations, eq(clientAiPromptTemplates.orgId, organizations.id))
+      .orderBy(asc(clientAiPromptTemplates.name));
+
+    if (q.orgId) rows = rows.filter((r) => r.orgId === q.orgId);
+    if (q.scope === 'partner') rows = rows.filter((r) => r.orgId === null);
+    if (q.scope === 'org') rows = rows.filter((r) => r.orgId !== null);
+
+    return c.json({ data: rows });
+  }
+);
+
+// ── POST /templates ───────────────────────────────────────────────────────────
+clientAiAdminTemplateRoutes.post(
+  '/templates',
+  requireOrgsWrite,
+  zValidator('json', templateBodySchema),
+  async (c) => {
+    const auth = c.get('auth') as TemplateAuth & Parameters<typeof resolveScopedOrgId>[0];
+    const body = c.req.valid('json');
+    const targetOrgId = body.orgId ?? null;
+
+    let values: typeof clientAiPromptTemplates.$inferInsert;
+    if (targetOrgId) {
+      const orgId = resolveScopedOrgId(auth, targetOrgId);
+      if (!orgId) return c.json({ error: 'Organization not found' }, 404);
+      values = {
+        orgId,
+        partnerId: null,
+        name: body.name,
+        description: body.description ?? null,
+        promptBody: body.promptBody,
+        category: body.category ?? null,
+        createdBy: auth.user?.id ?? null,
+      };
+    } else {
+      // Partner-wide row: org_id NULL + partner_id set. Gate BEFORE the
+      // insert so org-scope callers see 403, not an RLS 42501 surprise.
+      if (auth.scope === 'organization' || !auth.partnerId) {
+        return c.json({ error: 'partner_scope_required' }, 403);
+      }
+      values = {
+        orgId: null,
+        partnerId: auth.partnerId,
+        name: body.name,
+        description: body.description ?? null,
+        promptBody: body.promptBody,
+        category: body.category ?? null,
+        createdBy: auth.user?.id ?? null,
+      };
+    }
+
+    const [row] = await db.insert(clientAiPromptTemplates).values(values).returning();
+    if (!row) return c.json({ error: 'Failed to create template' }, 500);
+
+    writeRouteAudit(c, {
+      orgId: row.orgId ?? null,
+      action: 'client_ai.template.create',
+      resourceType: 'client_ai_prompt_template',
+      resourceId: row.id,
+      resourceName: row.name,
+      details: { scope: row.orgId ? 'org' : 'partner' },
+    });
+
+    return c.json({ template: row }, 201);
+  }
+);
+
+// ── PUT /templates/:id ────────────────────────────────────────────────────────
+clientAiAdminTemplateRoutes.put(
+  '/templates/:id',
+  requireOrgsWrite,
+  zValidator('json', templateUpdateSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const body = c.req.valid('json');
+
+    // RLS scopes the read: a row outside the caller's tenancy is a plain 404.
+    const [existing] = await db
+      .select(templateSelection)
+      .from(clientAiPromptTemplates)
+      .leftJoin(organizations, eq(clientAiPromptTemplates.orgId, organizations.id))
+      .where(eq(clientAiPromptTemplates.id, id))
+      .limit(1);
+    if (!existing) return c.json({ error: 'Template not found' }, 404);
+
+    const set: Partial<typeof clientAiPromptTemplates.$inferInsert> = { updatedAt: new Date() };
+    if (body.name !== undefined) set.name = body.name;
+    if (body.description !== undefined) set.description = body.description ?? null;
+    if (body.promptBody !== undefined) set.promptBody = body.promptBody;
+    if (body.category !== undefined) set.category = body.category ?? null;
+
+    const [row] = await db
+      .update(clientAiPromptTemplates)
+      .set(set)
+      .where(eq(clientAiPromptTemplates.id, id))
+      .returning();
+    if (!row) return c.json({ error: 'Template not found' }, 404);
+
+    writeRouteAudit(c, {
+      orgId: row.orgId ?? null,
+      action: 'client_ai.template.update',
+      resourceType: 'client_ai_prompt_template',
+      resourceId: id,
+      resourceName: row.name,
+      details: { changedKeys: Object.keys(set).filter((k) => k !== 'updatedAt') },
+    });
+
+    return c.json({ template: row });
+  }
+);
+
+// ── DELETE /templates/:id ─────────────────────────────────────────────────────
+clientAiAdminTemplateRoutes.delete('/templates/:id', requireOrgsWrite, async (c) => {
+  const id = c.req.param('id');
+
+  const [row] = await db
+    .delete(clientAiPromptTemplates)
+    .where(eq(clientAiPromptTemplates.id, id))
+    .returning();
+  if (!row) return c.json({ error: 'Template not found' }, 404);
+
+  writeRouteAudit(c, {
+    orgId: row.orgId ?? null,
+    action: 'client_ai.template.delete',
+    resourceType: 'client_ai_prompt_template',
+    resourceId: id,
+    resourceName: row.name,
+  });
+
+  return c.json({ success: true });
+});
+```
+
+(Implementation note: the list route filters `orgId`/`scope` in JS after the RLS-bounded select instead of composing `where` — the visible set is small (templates, not telemetry) and it keeps the Drizzle mock trivial. If template counts ever matter, push the filters into SQL.)
+
+- [ ] **Step 4: Mount in `admin.ts`**
+
+```ts
+import { clientAiAdminTemplateRoutes } from './adminTemplates';
+// ...
+clientAiAdminRoutes.route('/', clientAiAdminTemplateRoutes);
+```
+
+After this task, the full mount block at the end of `apps/api/src/routes/clientAi/admin.ts` reads:
+
+```ts
+// ── Plan-4 dashboard sub-routers (inherit group auth + dark-gate above) ──────
+clientAiAdminRoutes.route('/', clientAiAdminOrgRoutes);
+clientAiAdminRoutes.route('/', clientAiAdminSessionRoutes);
+clientAiAdminRoutes.route('/', clientAiAdminUsageRoutes);
+clientAiAdminRoutes.route('/', clientAiAdminTemplateRoutes);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/adminTemplates.test.ts`
+Expected: 12 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/adminTemplates.ts apps/api/src/routes/clientAi/adminTemplates.test.ts apps/api/src/routes/clientAi/admin.ts
+git commit -m "feat(client-ai): admin template CRUD with org + partner-wide scopes" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Client-facing GET /client-ai/templates (TDD)
+
+The add-in's template picker source (spec §10, §11 — Plan 5 consumes this). Auth via Plan 1's `clientAiAuthMiddleware` + `requireClientAiEnabledMiddleware` (`apps/api/src/middleware/clientAiAuth.ts`). **Read decision 4 before touching this:** the middleware's DB context has `accessiblePartnerIds: []`, so the partner-wide rows require a narrowly re-scoped read.
+
+**Files:**
+- Create: apps/api/src/routes/clientAi/templates.ts
+- Test: apps/api/src/routes/clientAi/templates.test.ts
+- Modify: apps/api/src/routes/clientAi/index.ts (mount)
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/api/src/routes/clientAi/templates.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { dbSelectMock, withDbAccessContextMock, runOutsideDbContextMock, capturedContexts } =
+  vi.hoisted(() => {
+    const captured: unknown[] = [];
+    return {
+      dbSelectMock: vi.fn(),
+      withDbAccessContextMock: vi.fn((ctx: unknown, fn: () => unknown) => {
+        captured.push(ctx);
+        return fn();
+      }),
+      runOutsideDbContextMock: vi.fn((fn: () => unknown) => fn()),
+      capturedContexts: captured,
+    };
+  });
+
+vi.mock('../../db', () => ({
+  db: { select: dbSelectMock },
+  withDbAccessContext: withDbAccessContextMock,
+  runOutsideDbContext: runOutsideDbContextMock,
+}));
+
+vi.mock('../../middleware/clientAiAuth', () => ({
+  clientAiAuthMiddleware: vi.fn((c: any, next: any) => {
+    if (!c.req.header('authorization')) return c.json({ error: 'unauthorized' }, 401);
+    c.set('clientAiAuth', {
+      clientUserId: 'beefbeef-1111-4222-8333-444455556666',
+      orgId: '0c0c0c0c-1111-4222-8333-444455556666',
+      email: 'finance.user@contoso.com',
+      name: 'Finance User',
+      token: 'tok',
+    });
+    return next();
+  }),
+  requireClientAiEnabledMiddleware: vi.fn((_c: any, next: any) => next()),
+}));
+
+import { clientAiTemplateRoutes } from './templates';
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const PARTNER_ID = 'f0f0f0f0-1111-4222-8333-444455556666';
+
+function chain(rows: unknown[]) {
+  const c: Record<string, unknown> = {};
+  const self = vi.fn(() => c);
+  for (const m of ['from', 'where', 'orderBy', 'groupBy', 'leftJoin', 'limit', 'offset']) {
+    c[m] = self;
+  }
+  c.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return c;
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.route('/client-ai', clientAiTemplateRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedContexts.length = 0;
+  let call = 0;
+  dbSelectMock.mockImplementation(() => {
+    call++;
+    if (call === 1) return chain([{ partnerId: PARTNER_ID }]); // org row lookup
+    return chain([
+      {
+        id: 't-org',
+        name: 'Org template',
+        description: null,
+        category: 'finance',
+        promptBody: 'Org body',
+      },
+      {
+        id: 't-partner',
+        name: 'Partner template',
+        description: 'For all orgs',
+        category: null,
+        promptBody: 'Partner body',
+      },
+    ]);
+  });
+});
+
+describe('GET /client-ai/templates', () => {
+  it('401s without a session', async () => {
+    const res = await buildApp().request('/client-ai/templates');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the pinned bare-array shape with promptBody mapped to body', async () => {
+    const res = await buildApp().request('/client-ai/templates', {
+      headers: { Authorization: 'Bearer tok' },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[1]).toEqual({
+      id: 't-partner',
+      name: 'Partner template',
+      description: 'For all orgs',
+      category: null,
+      body: 'Partner body',
+    });
+    expect(body[0]).not.toHaveProperty('promptBody');
+  });
+
+  it('re-scopes the template read with the org partner axis (decision 4)', async () => {
+    await buildApp().request('/client-ai/templates', {
+      headers: { Authorization: 'Bearer tok' },
+    });
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+    expect(capturedContexts).toHaveLength(1);
+    expect(capturedContexts[0]).toEqual({
+      scope: 'organization',
+      orgId: ORG_ID,
+      accessibleOrgIds: [ORG_ID],
+      accessiblePartnerIds: [PARTNER_ID],
+      userId: null,
+    });
+  });
+
+  it('still serves org-scoped templates when the org row has no partner (defensive)', async () => {
+    let call = 0;
+    dbSelectMock.mockImplementation(() => {
+      call++;
+      if (call === 1) return chain([]); // org row not visible — should not happen, fail safe
+      return chain([
+        { id: 't-org', name: 'Org template', description: null, category: null, promptBody: 'X' },
+      ]);
+    });
+    const res = await buildApp().request('/client-ai/templates', {
+      headers: { Authorization: 'Bearer tok' },
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json())[0].id).toBe('t-org');
+    expect((capturedContexts[0] as { accessiblePartnerIds: string[] }).accessiblePartnerIds).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/templates.test.ts`
+Expected: FAIL with module-not-found for `./templates`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/api/src/routes/clientAi/templates.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { asc, eq, or } from 'drizzle-orm';
+import { db, runOutsideDbContext, withDbAccessContext } from '../../db';
+import { clientAiPromptTemplates } from '../../db/schema/clientAi';
+import { organizations } from '../../db/schema/orgs';
+import {
+  clientAiAuthMiddleware,
+  requireClientAiEnabledMiddleware,
+} from '../../middleware/clientAiAuth';
+
+/**
+ * AI for Office — client-facing template list (spec §10/§11). Consumed by the
+ * Plan-5 add-in's empty-chat template picker. Response shape is PINNED:
+ * a bare JSON array of { id, name, description, category, body }.
+ *
+ * RLS subtlety (Plan-4 decision 4): clientAiAuthMiddleware opens an
+ * org-scoped DB context with accessiblePartnerIds: [], under which
+ * partner-wide template rows (org_id NULL, dual-axis policy) are INVISIBLE —
+ * breeze_has_partner_access([]) is always false. And withDbAccessContext is a
+ * no-op when a context is already open (db/index.ts:103-105). So:
+ *   1. Read the org's partner_id INSIDE the middleware context (the org's own
+ *      row is readable: organizations is id-keyed shape 2).
+ *   2. runOutsideDbContext + a fresh context that adds ONLY the org's own
+ *      partner to the partner axis, for the single template SELECT, with an
+ *      explicit WHERE (org row OR own-partner row) layered on top of RLS.
+ * This grants the client principal the partner axis for exactly one read-only
+ * statement — it does NOT broaden the middleware context. The inner context
+ * briefly uses a second pooled connection while the outer request transaction
+ * is open; both are short reads (#1105 concerns long holds, not this).
+ */
+
+export const clientAiTemplateRoutes = new Hono();
+
+clientAiTemplateRoutes.get(
+  '/templates',
+  clientAiAuthMiddleware,
+  requireClientAiEnabledMiddleware,
+  async (c) => {
+    const auth = c.get('clientAiAuth');
+
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, auth.orgId))
+      .limit(1);
+    const partnerId = org?.partnerId ?? null;
+
+    const orgCondition = eq(clientAiPromptTemplates.orgId, auth.orgId);
+    const where = partnerId
+      ? or(orgCondition, eq(clientAiPromptTemplates.partnerId, partnerId))
+      : orgCondition;
+
+    const rows = await runOutsideDbContext(() =>
+      withDbAccessContext(
+        {
+          scope: 'organization',
+          orgId: auth.orgId,
+          accessibleOrgIds: [auth.orgId],
+          accessiblePartnerIds: partnerId ? [partnerId] : [],
+          userId: null,
+        },
+        () =>
+          db
+            .select({
+              id: clientAiPromptTemplates.id,
+              name: clientAiPromptTemplates.name,
+              description: clientAiPromptTemplates.description,
+              category: clientAiPromptTemplates.category,
+              promptBody: clientAiPromptTemplates.promptBody,
+            })
+            .from(clientAiPromptTemplates)
+            .where(where)
+            .orderBy(asc(clientAiPromptTemplates.name))
+      )
+    );
+
+    return c.json(
+      rows.map((r) => ({
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        category: r.category,
+        body: r.promptBody,
+      }))
+    );
+  }
+);
+```
+
+- [ ] **Step 4: Mount in `index.ts`**
+
+`apps/api/src/routes/clientAi/index.ts` gains:
+
+```ts
+import { clientAiTemplateRoutes } from './templates';
+
+// Client-facing (add-in) routes — clientAiAuthMiddleware inside.
+clientAiRoutes.route('/', clientAiTemplateRoutes);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/routes/clientAi/templates.test.ts`
+Expected: 4 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/clientAi/templates.ts apps/api/src/routes/clientAi/templates.test.ts apps/api/src/routes/clientAi/index.ts
+git commit -m "feat(client-ai): client-facing template list with re-scoped partner-axis read" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Route-level dual-axis RLS integration test (real DB)
+
+Spec §10 warning + pinned contract: prove the **route's** partner-wide insert works as `breeze_app`. Plan 1 Task 5 proved the raw SQL path (`client-ai-templates-rls.integration.test.ts`); this proves the full route → Drizzle → RLS path, which is exactly where `custom_field_definitions` regressed (route wrote partner-wide rows the policies couldn't accept → 42501/500; memory note `rls_dual_axis_contract_test_blindspot`). The real `authMiddleware` needs JWTs/users, so the middleware module is mocked to set the auth context AND open the same partner-scope `withDbAccessContext` the real one does (`middleware/auth.ts:440-447`) — the route, Drizzle layer, RLS GUCs, and policies are all real.
+
+**Files:**
+- Create: apps/api/src/__tests__/integration/client-ai-template-routes.integration.test.ts
+
+- [ ] **Step 1: Write the test**
+
+```ts
+/**
+ * client_ai_prompt_templates ROUTE-level dual-axis proof (spec §10 warning).
+ *
+ * Drives the real adminTemplates routes against the real docker postgres as
+ * breeze_app: a partner-wide POST (org_id NULL) must succeed under the
+ * dual-axis policies of 2026-06-12-b-client-ai-foundation.sql, and the
+ * created row must be invisible to a different partner. The rls-coverage
+ * contract test provably cannot catch a missing partner axis; only this
+ * functional path can (custom_field_definitions lesson, 2026-06-11-i).
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+
+let activeAuthContext: {
+  scope: 'partner';
+  partnerId: string;
+  accessibleOrgIds: string[];
+} | null = null;
+
+vi.mock('../../middleware/auth', async () => {
+  const { withDbAccessContext } = await import('../../db');
+  return {
+    authMiddleware: (c: any, next: any) => {
+      if (!activeAuthContext) return c.json({ error: 'Unauthorized' }, 401);
+      c.set('auth', {
+        scope: activeAuthContext.scope,
+        partnerId: activeAuthContext.partnerId,
+        orgId: null,
+        accessibleOrgIds: activeAuthContext.accessibleOrgIds,
+        user: { id: null, email: 'integration@test' },
+      });
+      // Same context shape the real authMiddleware opens (middleware/auth.ts:440-447).
+      return withDbAccessContext(
+        {
+          scope: 'partner',
+          orgId: null,
+          accessibleOrgIds: activeAuthContext.accessibleOrgIds,
+          accessiblePartnerIds: [activeAuthContext.partnerId],
+          userId: null,
+        },
+        () => next()
+      );
+    },
+    requirePermission: () => (_c: any, next: any) => next(),
+    requireMfa: () => (_c: any, next: any) => next(),
+  };
+});
+
+vi.mock('../../config/env', () => ({
+  CLIENT_AI_ENTRA_CLIENT_ID: '00000000-aaaa-bbbb-cccc-000000000001',
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+  writeAuditEvent: vi.fn(),
+}));
+
+import { db, withDbAccessContext } from '../../db';
+import { clientAiPromptTemplates } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const created: string[] = [];
+
+afterEach(async () => {
+  if (created.length === 0) return;
+  await withDbAccessContext(
+    { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null },
+    async () => {
+      for (const id of created) {
+        await db.delete(clientAiPromptTemplates).where(eq(clientAiPromptTemplates.id, id));
+      }
+    }
+  );
+  created.length = 0;
+});
+
+beforeEach(() => {
+  activeAuthContext = null;
+});
+
+async function buildApp() {
+  // Import AFTER mocks are registered.
+  const { clientAiAdminTemplateRoutes } = await import('../../routes/clientAi/adminTemplates');
+  const { authMiddleware } = await import('../../middleware/auth');
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/client-ai/admin', clientAiAdminTemplateRoutes);
+  return app;
+}
+
+const JSON_HEADERS = { Authorization: 'Bearer x', 'Content-Type': 'application/json' };
+
+describe('adminTemplates routes against real RLS (breeze_app)', () => {
+  it('POST creates a partner-wide template (org_id NULL) — the §10 write path', async () => {
+    const partner = await createPartner();
+    activeAuthContext = { scope: 'partner', partnerId: partner.id, accessibleOrgIds: [] };
+
+    const app = await buildApp();
+    const res = await app.request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        name: 'Partner-wide variance template',
+        promptBody: 'Explain the variance in the selection.',
+        orgId: null,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.template.orgId).toBeNull();
+    expect(body.template.partnerId).toBe(partner.id);
+    created.push(body.template.id);
+
+    // And the list sees it back through the same partner scope.
+    const list = await app.request('/client-ai/admin/templates', { headers: JSON_HEADERS });
+    const listBody = await list.json();
+    expect(listBody.data.map((t: { id: string }) => t.id)).toContain(body.template.id);
+  });
+
+  it('a different partner cannot see the row (RLS, not app filtering)', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+
+    activeAuthContext = { scope: 'partner', partnerId: partnerA.id, accessibleOrgIds: [] };
+    let app = await buildApp();
+    const createRes = await app.request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ name: 'A-only', promptBody: 'x', orgId: null }),
+    });
+    const { template } = await createRes.json();
+    created.push(template.id);
+
+    activeAuthContext = { scope: 'partner', partnerId: partnerB.id, accessibleOrgIds: [] };
+    app = await buildApp();
+    const list = await app.request('/client-ai/admin/templates', { headers: JSON_HEADERS });
+    const listBody = await list.json();
+    expect(listBody.data.map((t: { id: string }) => t.id)).not.toContain(template.id);
+
+    const update = await app.request(`/client-ai/admin/templates/${template.id}`, {
+      method: 'PUT',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ name: 'hijacked' }),
+    });
+    expect(update.status).toBe(404); // RLS-invisible == not found
+  });
+
+  it('POST creates an org-scoped template under the org axis', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    activeAuthContext = { scope: 'partner', partnerId: partner.id, accessibleOrgIds: [org.id] };
+
+    const app = await buildApp();
+    const res = await app.request('/client-ai/admin/templates', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ name: 'Org template', promptBody: 'y', orgId: org.id }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.template.orgId).toBe(org.id);
+    expect(body.template.partnerId).toBeNull();
+    created.push(body.template.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run against the docker test stack**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm test:docker:up
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run --config vitest.integration.config.ts src/__tests__/integration/client-ai-template-routes.integration.test.ts
+```
+
+Expected: 3 tests PASS. If the partner-wide POST returns 500 with a 42501 cause, the dual-axis policies are broken — stop and fix the Plan-1 migration situation before shipping anything.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/client-ai-template-routes.integration.test.ts
+git commit -m "test(client-ai): route-level partner-wide template insert proof as breeze_app" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Web dashboard tasks (Tasks 8–14)
+
+Conventions for every web task below — all verified against the real codebase, cite-checked file:line:
+
+- **Fetch:** `fetchWithAuth` from `../../stores/auth` (`apps/web/src/stores/auth.ts:406`). It Bearer-authenticates, retries once on 401 via refresh cookie, and **auto-injects `?orgId=`** from the org store (deviation 10) — the Plan-4 admin endpoints tolerate that as a filter.
+- **Mutations:** every POST/PUT/DELETE goes through `runAction` (`apps/web/src/lib/runAction.ts`), `onUnauthorized: () => void navigateTo('/login', { replace: true })` (the `OrgPortalSettingsEditor.tsx:68-88` idiom). Catch with the exported standard handler `handleActionError(err, fallback)` (`runAction.ts:87-90`) — it implements the CLAUDE.md pattern verbatim (401 ActionError → return, non-ActionError → fallback toast, other ActionErrors already toasted).
+- **GET loads:** plain `fetchWithAuth` + `res.ok` checks with a load-error card + Retry (the `AiUsagePage.tsx`/`BillablesExportCard.tsx` idiom) — `runAction` is for mutations.
+- **Dialogs:** `Dialog` / `ConfirmDialog` from `../shared/Dialog` / `../shared/ConfirmDialog` (no Drawer component exists in this codebase — the wizard and transcript viewer are Dialogs).
+- **Tables/badges:** thead `bg-muted/40` + uppercase tracking-wide header row, `rounded-full` chip badges — copied from `AiUsagePage.tsx:368-421` and `HuntressIntegration.tsx:75-85`.
+- **Toasts:** `showToast` from `../shared/Toast` (`{ message, type: 'success' | 'error' | 'warning' | 'undo' }`).
+- **Hash state:** `window.location.hash` only (never query params) — `DeviceDetails.tsx:147-166` for plain tabs, `OrganizationsPage.tsx:46/187` for ids in the hash. This plan's scheme: `#orgs` (default) / `#sessions` / `#usage` / `#templates` / `#policy/<orgId>`.
+- **data-testid on every interactive/asserted element** (`ai-office-*` prefix) — e2e suites are testid-only per `e2e-tests/README.md`.
+- **Tests:** Vitest + jsdom + `@testing-library/react`, colocated `*.test.tsx`, `vi.mock('../../stores/auth')` + `vi.mock('../shared/Toast')` + `vi.mock('@/lib/navigation')`, `makeJsonResponse` helper — copied from `OrgPortalSettingsEditor.test.tsx`. Per deviation 8, components are **implement-then-test** in the same task (API tasks above were strict TDD; this is the explored web norm).
+- **WS-A guard:** each component with mutating calls is added to `TARGET_GLOBS` in `apps/web/src/lib/__tests__/no-silent-mutations.test.ts:30-53` in the task that creates it. UsageTab is GET-only (CSV export) and is not adopted.
+- Every pnpm/vitest command carries the Node pin prefix.
+
+---
+
+### Task 8: OrgsTab — org status table + onboarding wizard
+
+Spec §9.1. Consumes Task 2's `GET /client-ai/admin/orgs` + `GET /orgs/:orgId/consent-url`, and Plan 1's `PUT/DELETE /orgs/:orgId/tenant-mapping` + `PUT /orgs/:orgId/policy`. The wizard is a 4-step Dialog: tenant mapping (pre-filled from `suggestedEntraTenantId` — the M365-connection reuse audit, Task 2) → admin-consent URL with copy button → enable toggle → static centralized-deployment instructions.
+
+**Files:**
+- Create: apps/web/src/components/clientAi/OrgsTab.tsx
+- Create: apps/web/src/components/clientAi/OrgsTab.test.tsx
+- Modify: apps/web/src/lib/__tests__/no-silent-mutations.test.ts (`TARGET_GLOBS`)
+
+- [ ] **Step 1: Write the component**
+
+`apps/web/src/components/clientAi/OrgsTab.tsx`:
+
+```tsx
+import { useCallback, useEffect, useState } from 'react';
+import {
+  CheckCircle2,
+  ClipboardCopy,
+  Clock,
+  ExternalLink,
+  Loader2,
+  Settings2,
+  SlidersHorizontal,
+  Unplug,
+} from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+import { Dialog } from '../shared/Dialog';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { runAction, handleActionError } from '@/lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+
+/**
+ * AI for Office — per-org provisioning status + onboarding wizard (spec §9.1).
+ * Reads GET /client-ai/admin/orgs (Plan-4 Task 2); the wizard writes Plan 1's
+ * tenant-mapping and policy endpoints. Status chip is driven by consentStatus
+ * exactly as Task 2 derives it: unknown → Not provisioned, pending → Consent
+ * pending, granted → Active. policyEnabled is a separate column — consent and
+ * the enable flip are independent facts.
+ */
+
+/** Row shape of GET /client-ai/admin/orgs (Plan-4 Task 2). */
+export interface OrgStatusRow {
+  orgId: string;
+  orgName: string;
+  mapped: boolean;
+  entraTenantId: string | null;
+  suggestedEntraTenantId: string | null;
+  consentStatus: 'unknown' | 'pending' | 'granted';
+  policyEnabled: boolean;
+  currentMonthCostCents: number;
+  currentMonthMessages: number;
+}
+
+interface OrgsTabProps {
+  /** Jump to the per-org policy editor (#policy/<orgId>, wired by AiForOfficePage). */
+  onOpenPolicy: (orgId: string) => void;
+}
+
+// Mirrors ENTRA_TENANT_GUID_REGEX (apps/api routes/clientAi/schemas.ts) — UX
+// pre-validation only; the server re-validates.
+const ENTRA_TENANT_GUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const formatCost = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+/** Spec §9.1 status chip: not provisioned / consent pending / active. */
+function StatusChip({ status }: { status: OrgStatusRow['consentStatus'] }) {
+  if (status === 'granted') {
+    return (
+      <span
+        data-testid="ai-office-status-active"
+        className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-400"
+      >
+        <CheckCircle2 className="h-3 w-3" /> Active
+      </span>
+    );
+  }
+  if (status === 'pending') {
+    return (
+      <span
+        data-testid="ai-office-status-pending"
+        className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
+      >
+        <Clock className="h-3 w-3" /> Consent pending
+      </span>
+    );
+  }
+  return (
+    <span
+      data-testid="ai-office-status-unprovisioned"
+      className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs text-slate-600 dark:border-slate-500/30 dark:bg-slate-500/10 dark:text-slate-400"
+    >
+      <Unplug className="h-3 w-3" /> Not provisioned
+    </span>
+  );
+}
+
+export default function OrgsTab({ onOpenPolicy }: OrgsTabProps) {
+  const [rows, setRows] = useState<OrgStatusRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [notEnabled, setNotEnabled] = useState(false);
+  const [wizardOrgId, setWizardOrgId] = useState<string | null>(null);
+  const [unmapOrg, setUnmapOrg] = useState<OrgStatusRow | null>(null);
+  const [unmapping, setUnmapping] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoadError(false);
+      const res = await fetchWithAuth('/client-ai/admin/orgs');
+      if (res.status === 404) {
+        // CLIENT_AI_ENTRA_CLIENT_ID dark-gate (Plan 1): the whole
+        // /client-ai/admin group 404s until the add-in app registration is
+        // configured on the API.
+        setNotEnabled(true);
+        return;
+      }
+      if (res.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { data: OrgStatusRow[] };
+      setRows(body.data ?? []);
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const confirmUnmap = async () => {
+    if (!unmapOrg || unmapping) return;
+    setUnmapping(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/client-ai/admin/orgs/${unmapOrg.orgId}/tenant-mapping`, {
+            method: 'DELETE',
+          }),
+        errorFallback: 'Failed to remove tenant mapping',
+        successMessage: `Tenant mapping removed for ${unmapOrg.orgName}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      setUnmapOrg(null);
+      await load();
+    } catch (err) {
+      handleActionError(err, 'Failed to remove tenant mapping');
+    } finally {
+      setUnmapping(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (notEnabled) {
+    return (
+      <div
+        className="rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+        data-testid="ai-office-not-enabled"
+      >
+        <p className="font-medium text-foreground">
+          Breeze AI for Office is not enabled on this instance.
+        </p>
+        <p className="mt-1">
+          Set <code className="rounded bg-muted px-1">CLIENT_AI_ENTRA_CLIENT_ID</code> (the Entra
+          add-in app registration) on the API and reload.
+        </p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div
+        className="rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+        data-testid="ai-office-orgs-load-error"
+      >
+        Failed to load organization status.{' '}
+        <button
+          type="button"
+          className="text-primary underline"
+          onClick={() => {
+            setLoading(true);
+            void load();
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const wizardRow = wizardOrgId ? (rows.find((r) => r.orgId === wizardOrgId) ?? null) : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border bg-card">
+        <div className="border-b px-6 py-4">
+          <h2 className="text-lg font-semibold">Client organizations</h2>
+          <p className="text-sm text-muted-foreground">
+            Provision the Excel AI assistant per client org: map the Entra tenant, grant admin
+            consent, enable the policy, deploy the add-in.
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-2">Organization</th>
+                <th className="px-4 py-2">Status</th>
+                <th className="px-4 py-2">AI enabled</th>
+                <th className="px-4 py-2">Entra tenant</th>
+                <th className="px-4 py-2 text-right">Cost (MTD)</th>
+                <th className="px-4 py-2 text-right">Messages (MTD)</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={row.orgId}
+                  className="border-b last:border-0 hover:bg-muted/20"
+                  data-testid={`ai-office-org-row-${row.orgId}`}
+                >
+                  <td className="px-4 py-2.5 font-medium">{row.orgName}</td>
+                  <td className="px-4 py-2.5">
+                    <StatusChip status={row.consentStatus} />
+                  </td>
+                  <td className="px-4 py-2.5">
+                    {row.policyEnabled ? (
+                      <span className="text-emerald-600 dark:text-emerald-400">Yes</span>
+                    ) : (
+                      <span className="text-muted-foreground">No</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-muted-foreground">
+                    {row.entraTenantId ?? '—'}
+                  </td>
+                  <td className="px-4 py-2.5 text-right">{formatCost(row.currentMonthCostCents)}</td>
+                  <td className="px-4 py-2.5 text-right">{row.currentMonthMessages}</td>
+                  <td className="px-4 py-2.5">
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setWizardOrgId(row.orgId)}
+                        className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                        data-testid={`ai-office-wizard-open-${row.orgId}`}
+                      >
+                        <Settings2 className="h-3.5 w-3.5" /> {row.mapped ? 'Manage' : 'Set up'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onOpenPolicy(row.orgId)}
+                        className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                        data-testid={`ai-office-policy-open-${row.orgId}`}
+                      >
+                        <SlidersHorizontal className="h-3.5 w-3.5" /> Policy
+                      </button>
+                      {row.mapped && (
+                        <button
+                          type="button"
+                          onClick={() => setUnmapOrg(row)}
+                          className="inline-flex items-center gap-1 rounded-md border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                          data-testid={`ai-office-unmap-${row.orgId}`}
+                        >
+                          <Unplug className="h-3.5 w-3.5" /> Unmap
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                    No organizations
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {wizardRow && (
+        <OnboardingWizard
+          row={wizardRow}
+          onClose={() => setWizardOrgId(null)}
+          onChanged={() => void load()}
+          onOpenPolicy={onOpenPolicy}
+        />
+      )}
+
+      <ConfirmDialog
+        open={unmapOrg !== null}
+        onClose={() => setUnmapOrg(null)}
+        onConfirm={() => void confirmUnmap()}
+        title="Remove tenant mapping"
+        message={
+          unmapOrg
+            ? `Users in ${unmapOrg.orgName}'s Entra tenant will no longer be able to sign in to the Excel assistant. The org policy and usage history are kept.`
+            : ''
+        }
+        confirmLabel="Remove mapping"
+        isLoading={unmapping}
+        confirmTestId="ai-office-unmap-confirm"
+      />
+    </div>
+  );
+}
+
+// ── Onboarding wizard (spec §9.1) ────────────────────────────────────────────
+
+type WizardStep = 1 | 2 | 3 | 4;
+
+function initialStep(row: OrgStatusRow): WizardStep {
+  if (!row.mapped) return 1;
+  if (row.consentStatus === 'pending') return 2;
+  if (!row.policyEnabled) return 3;
+  return 4;
+}
+
+interface ConsentInfo {
+  url: string;
+  tenantSegment: string;
+  redirectUri: string;
+}
+
+function OnboardingWizard({
+  row,
+  onClose,
+  onChanged,
+  onOpenPolicy,
+}: {
+  row: OrgStatusRow;
+  onClose: () => void;
+  onChanged: () => void;
+  onOpenPolicy: (orgId: string) => void;
+}) {
+  const [step, setStep] = useState<WizardStep>(() => initialStep(row));
+  const [tenantId, setTenantId] = useState(row.entraTenantId ?? row.suggestedEntraTenantId ?? '');
+  const [saving, setSaving] = useState(false);
+  const [consent, setConsent] = useState<ConsentInfo | null>(null);
+  const [consentError, setConsentError] = useState(false);
+
+  // Step 2 needs the admin-consent URL (GET /client-ai/admin/orgs/:orgId/consent-url, Task 2).
+  useEffect(() => {
+    if (step !== 2) return;
+    let cancelled = false;
+    setConsent(null);
+    setConsentError(false);
+    fetchWithAuth(`/client-ai/admin/orgs/${row.orgId}/consent-url`)
+      .then((r) =>
+        r.ok ? (r.json() as Promise<ConsentInfo>) : Promise.reject(new Error(`HTTP ${r.status}`))
+      )
+      .then((data) => {
+        if (!cancelled) setConsent(data);
+      })
+      .catch(() => {
+        if (!cancelled) setConsentError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [step, row.orgId]);
+
+  const tenantIdValid = ENTRA_TENANT_GUID_REGEX.test(tenantId.trim());
+
+  const saveMapping = async () => {
+    if (!tenantIdValid || saving) return;
+    setSaving(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/client-ai/admin/orgs/${row.orgId}/tenant-mapping`, {
+            method: 'PUT',
+            body: JSON.stringify({ entraTenantId: tenantId.trim() }),
+          }),
+        errorFallback: 'Failed to save tenant mapping',
+        successMessage: 'Tenant mapping saved',
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onChanged();
+      setStep(2);
+    } catch (err) {
+      // 409 tenant_already_mapped surfaces via runAction's error toast (the
+      // API's deliberately opaque message — it never reveals the owning org).
+      handleActionError(err, 'Failed to save tenant mapping');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const copyConsentUrl = async () => {
+    if (!consent) return;
+    try {
+      await navigator.clipboard.writeText(consent.url);
+      showToast({ type: 'success', message: 'Consent URL copied' });
+    } catch {
+      showToast({ type: 'error', message: 'Could not copy — select the URL manually' });
+    }
+  };
+
+  const enablePolicy = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/client-ai/admin/orgs/${row.orgId}/policy`, {
+            method: 'PUT',
+            body: JSON.stringify({ enabled: true }),
+          }),
+        errorFallback: 'Failed to enable AI for Office',
+        successMessage: `AI for Office enabled for ${row.orgName}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onChanged();
+      setStep(4);
+    } catch (err) {
+      handleActionError(err, 'Failed to enable AI for Office');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const steps: { n: WizardStep; label: string }[] = [
+    { n: 1, label: 'Tenant' },
+    { n: 2, label: 'Consent' },
+    { n: 3, label: 'Enable' },
+    { n: 4, label: 'Deploy' },
+  ];
+
+  return (
+    <Dialog open onClose={onClose} title={`Set up AI for Office — ${row.orgName}`} maxWidth="2xl" className="p-6">
+      <h2 className="text-lg font-semibold">Set up AI for Office — {row.orgName}</h2>
+      <div className="mt-3 flex items-center gap-2" data-testid="ai-office-wizard-steps">
+        {steps.map((s, i) => (
+          <div key={s.n} className="flex items-center gap-2">
+            {i > 0 && <div className="h-px w-6 bg-border" />}
+            <span
+              className={`inline-flex h-6 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium ${
+                step === s.n
+                  ? 'bg-primary text-primary-foreground'
+                  : step > s.n
+                    ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+                    : 'bg-muted text-muted-foreground'
+              }`}
+            >
+              {s.n}. {s.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {step === 1 && (
+        <div className="mt-5 space-y-3" data-testid="ai-office-wizard-step-1">
+          <p className="text-sm text-muted-foreground">
+            Map this org to its Microsoft Entra tenant (Directory ID). The mapping is the
+            tenant-isolation linchpin — every Excel sign-in from this tenant lands in this org.
+            {row.suggestedEntraTenantId && !row.entraTenantId
+              ? ' Pre-filled from the org’s existing Microsoft 365 connection.'
+              : ''}
+          </p>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Entra tenant ID</span>
+            <input
+              type="text"
+              value={tenantId}
+              onChange={(e) => setTenantId(e.target.value)}
+              placeholder="00000000-0000-0000-0000-000000000000"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
+              data-testid="ai-office-wizard-tenant-input"
+            />
+          </label>
+          {tenantId.trim() !== '' && !tenantIdValid && (
+            <p className="text-xs text-destructive">
+              Must be a GUID (Entra admin center → Overview → Tenant ID).
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void saveMapping()}
+              disabled={!tenantIdValid || saving}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+              data-testid="ai-office-wizard-save-mapping"
+            >
+              {saving ? 'Saving…' : 'Save & continue'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="mt-5 space-y-3" data-testid="ai-office-wizard-step-2">
+          <p className="text-sm text-muted-foreground">
+            A Microsoft 365 admin of the client tenant must grant admin consent to the Breeze AI
+            for Office app. Send them this link (or open it yourself if you hold Global Admin in
+            the client tenant):
+          </p>
+          {consentError && (
+            <p className="text-sm text-destructive">Failed to load the consent URL. Close and retry.</p>
+          )}
+          {!consent && !consentError && (
+            <p className="text-sm text-muted-foreground">
+              <Loader2 className="inline h-4 w-4 animate-spin" /> Loading consent URL…
+            </p>
+          )}
+          {consent && (
+            <>
+              <div className="flex items-center gap-2">
+                <code
+                  className="block flex-1 overflow-x-auto whitespace-nowrap rounded-md border bg-muted/40 px-3 py-2 text-xs"
+                  data-testid="ai-office-consent-url"
+                >
+                  {consent.url}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => void copyConsentUrl()}
+                  className="inline-flex items-center gap-1 rounded-md border px-2 py-2 text-xs hover:bg-muted"
+                  data-testid="ai-office-consent-copy"
+                  title="Copy URL"
+                >
+                  <ClipboardCopy className="h-4 w-4" />
+                </button>
+                <a
+                  href={consent.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-md border px-2 py-2 text-xs hover:bg-muted"
+                  title="Open in new tab"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                After granting, Microsoft redirects to a Breeze confirmation page. Consent shows as
+                granted here once the first user signs in from Excel — there is no live poll
+                against Microsoft (Plan-4 decision 1).
+              </p>
+            </>
+          )}
+          <div className="flex justify-between gap-2">
+            <button
+              type="button"
+              onClick={() => setStep(1)}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={() => setStep(3)}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground"
+              data-testid="ai-office-wizard-consent-done"
+            >
+              I&apos;ve granted consent
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="mt-5 space-y-3" data-testid="ai-office-wizard-step-3">
+          <p className="text-sm text-muted-foreground">
+            Enable the assistant for this org. This writes <code>enabled: true</code> to the org
+            policy with safe defaults (all users, read/write with end-user approval, DLP redaction
+            for financial/credential types). Tune everything in the policy editor afterwards.
+          </p>
+          <div className="flex justify-between gap-2">
+            <button
+              type="button"
+              onClick={() => setStep(2)}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={() => void enablePolicy()}
+              disabled={saving}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+              data-testid="ai-office-wizard-enable"
+            >
+              {saving ? 'Enabling…' : row.policyEnabled ? 'Already enabled — continue' : 'Enable AI for Office'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 4 && (
+        <div className="mt-5 space-y-3" data-testid="ai-office-wizard-step-4">
+          <p className="text-sm font-medium">Deploy the Excel add-in via Microsoft 365 centralized deployment</p>
+          <ol className="list-decimal space-y-1.5 pl-5 text-sm text-muted-foreground">
+            <li>
+              Sign in to the client tenant&apos;s{' '}
+              <span className="font-medium text-foreground">Microsoft 365 admin center</span> →
+              Settings → Integrated apps.
+            </li>
+            <li>
+              Choose <span className="font-medium text-foreground">Upload custom apps</span> →
+              Office add-in → provide the Breeze AI for Office manifest URL from your Breeze
+              instance.
+            </li>
+            <li>
+              Assign the add-in to everyone or to the user groups covered by this org&apos;s
+              access policy.
+            </li>
+            <li>
+              Deployment can take up to 24h to appear in users&apos; Excel ribbon (Home →
+              Add-ins).
+            </li>
+            <li>Users sign in automatically with their Microsoft work account — no extra credentials.</li>
+          </ol>
+          <div className="flex justify-between gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                onOpenPolicy(row.orgId);
+                onClose();
+              }}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+              data-testid="ai-office-wizard-open-policy"
+            >
+              Open policy editor
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground"
+              data-testid="ai-office-wizard-done"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Write the component tests**
+
+`apps/web/src/components/clientAi/OrgsTab.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrgsTab from './OrgsTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ORG_A = '0c0c0c0c-1111-4222-8333-444455556666'; // not provisioned (with suggestion)
+const ORG_B = '1d1d1d1d-1111-4222-8333-444455556666'; // consent pending
+const ORG_C = '2e2e2e2e-1111-4222-8333-444455556666'; // active
+const TID = '6f4f4f4f-1111-4222-8333-444455556666';
+
+const baseRow = {
+  mapped: false,
+  entraTenantId: null as string | null,
+  suggestedEntraTenantId: null as string | null,
+  consentStatus: 'unknown' as 'unknown' | 'pending' | 'granted',
+  policyEnabled: false,
+  currentMonthCostCents: 0,
+  currentMonthMessages: 0,
+};
+
+const ROWS = [
+  { ...baseRow, orgId: ORG_A, orgName: 'Unprovisioned Org', suggestedEntraTenantId: TID },
+  { ...baseRow, orgId: ORG_B, orgName: 'Pending Org', mapped: true, entraTenantId: TID, consentStatus: 'pending' as const },
+  {
+    ...baseRow,
+    orgId: ORG_C,
+    orgName: 'Active Org',
+    mapped: true,
+    entraTenantId: TID,
+    consentStatus: 'granted' as const,
+    policyEnabled: true,
+    currentMonthCostCents: 1234,
+    currentMonthMessages: 87,
+  },
+];
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+function mockApi() {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/client-ai/admin/orgs' && !init?.method) {
+      return makeJsonResponse({ data: ROWS });
+    }
+    if (url === `/client-ai/admin/orgs/${ORG_A}/tenant-mapping` && init?.method === 'PUT') {
+      return makeJsonResponse({
+        mapping: { id: 'm1', orgId: ORG_A, entraTenantId: TID, createdAt: '', updatedAt: '' },
+      });
+    }
+    if (url === `/client-ai/admin/orgs/${ORG_A}/consent-url` && !init?.method) {
+      return makeJsonResponse({
+        url: `https://login.microsoftonline.com/${TID}/adminconsent?client_id=x`,
+        tenantSegment: TID,
+        redirectUri: 'https://breeze.example/api/v1/client-ai/consent/callback',
+      });
+    }
+    if (url === `/client-ai/admin/orgs/${ORG_C}/tenant-mapping` && init?.method === 'DELETE') {
+      return makeJsonResponse({ mapping: null });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 500);
+  });
+}
+
+describe('OrgsTab', () => {
+  const onOpenPolicy = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the three onboarding status chips', async () => {
+    mockApi();
+    render(<OrgsTab onOpenPolicy={onOpenPolicy} />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-status-unprovisioned')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-office-status-pending')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-office-status-active')).toBeInTheDocument();
+    expect(screen.getByText('$12.34')).toBeInTheDocument(); // 1234 cents MTD
+  });
+
+  it('wizard step 1 pre-fills the suggested tenant and PUTs the exact mapping payload', async () => {
+    mockApi();
+    render(<OrgsTab onOpenPolicy={onOpenPolicy} />);
+    await waitFor(() => expect(screen.getByTestId(`ai-office-wizard-open-${ORG_A}`)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId(`ai-office-wizard-open-${ORG_A}`));
+    const input = screen.getByTestId('ai-office-wizard-tenant-input') as HTMLInputElement;
+    expect(input.value).toBe(TID); // pre-filled from suggestedEntraTenantId (M365 reuse audit)
+
+    fireEvent.click(screen.getByTestId('ai-office-wizard-save-mapping'));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'PUT')).toBe(true)
+    );
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT');
+    expect(String(putCall![0])).toBe(`/client-ai/admin/orgs/${ORG_A}/tenant-mapping`);
+    expect(JSON.parse(String(putCall![1]!.body))).toEqual({ entraTenantId: TID });
+
+    // Advances to step 2 and loads the consent URL
+    await waitFor(() => expect(screen.getByTestId('ai-office-wizard-step-2')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('ai-office-consent-url')).toBeInTheDocument());
+  });
+
+  it('unmap requires confirmation and DELETEs the mapping', async () => {
+    mockApi();
+    render(<OrgsTab onOpenPolicy={onOpenPolicy} />);
+    await waitFor(() => expect(screen.getByTestId(`ai-office-unmap-${ORG_C}`)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId(`ai-office-unmap-${ORG_C}`));
+    fireEvent.click(screen.getByTestId('ai-office-unmap-confirm'));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(true)
+    );
+    const delCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'DELETE');
+    expect(String(delCall![0])).toBe(`/client-ai/admin/orgs/${ORG_C}/tenant-mapping`);
+  });
+
+  it('shows the not-enabled notice when the admin group is dark-gated (404)', async () => {
+    fetchMock.mockResolvedValue(makeJsonResponse({ error: 'Breeze AI for Office is not enabled' }, false, 404));
+    render(<OrgsTab onOpenPolicy={onOpenPolicy} />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-not-enabled')).toBeInTheDocument());
+  });
+
+  it('Policy button hands the orgId to onOpenPolicy', async () => {
+    mockApi();
+    render(<OrgsTab onOpenPolicy={onOpenPolicy} />);
+    await waitFor(() => expect(screen.getByTestId(`ai-office-policy-open-${ORG_C}`)).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId(`ai-office-policy-open-${ORG_C}`));
+    expect(onOpenPolicy).toHaveBeenCalledWith(ORG_C);
+  });
+});
+```
+
+- [ ] **Step 3: Adopt into the WS-A guard**
+
+In `apps/web/src/lib/__tests__/no-silent-mutations.test.ts`, append to `TARGET_GLOBS` (before the closing `];`, after `'src/components/tickets/TicketPartsCard.tsx',`):
+
+```ts
+  'src/components/clientAi/OrgsTab.tsx',
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/components/clientAi/OrgsTab.test.tsx src/lib/__tests__/no-silent-mutations.test.ts
+```
+
+Expected: all PASS (the guard proves every mutating call in OrgsTab goes through `runAction`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/clientAi/OrgsTab.tsx apps/web/src/components/clientAi/OrgsTab.test.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(client-ai-web): org status table + 4-step onboarding wizard" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: PolicyEditor — full policy form + DLP rule builder with live regex test
+
+Spec §9.2. Edits every `client_ai_org_policies` knob through Plan 1's `GET/PUT /client-ai/admin/orgs/:orgId/policy` (`putPolicySchema` is **strict** — the payload below uses exactly its keys) and the user picker from Task 2's `GET /orgs/:orgId/users`. The DLP section writes the Task-1 `clientAiDlpConfigSchema` shape: `builtins` map over the six detectors + `customRules[{id,name,pattern,action}]`, with a live client-side regex test box (`new RegExp` in try/catch over a sample textarea — evaluated locally, never sent anywhere).
+
+**Files:**
+- Create: apps/web/src/components/clientAi/PolicyEditor.tsx
+- Create: apps/web/src/components/clientAi/PolicyEditor.test.tsx
+- Modify: apps/web/src/lib/__tests__/no-silent-mutations.test.ts (`TARGET_GLOBS`)
+
+- [ ] **Step 1: Write the component**
+
+`apps/web/src/components/clientAi/PolicyEditor.tsx`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, Loader2, Plus, Save, Trash2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+import { runAction, handleActionError } from '@/lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+
+/**
+ * AI for Office — per-org policy editor (spec §9.2). Reached via
+ * #policy/<orgId> from the OrgsTab. Endpoints (Plan 1 + Plan-4 Task 2):
+ *   GET /client-ai/admin/orgs/:orgId/policy  → { policy }
+ *   PUT /client-ai/admin/orgs/:orgId/policy  ← putPolicySchema (STRICT — keys below only)
+ *   GET /client-ai/admin/orgs/:orgId/users   → { data: entra portal users } (decision 9)
+ * The dlpConfig payload is the Plan-4 Task-1 clientAiDlpConfigSchema contract.
+ */
+
+type DlpAction = 'redact' | 'block' | 'log' | 'off';
+type DlpBuiltinKey = 'creditCard' | 'ssn' | 'iban' | 'apiKey' | 'email' | 'phone';
+type CustomRule = { id: string; name: string; pattern: string; action: DlpAction };
+
+const DLP_ACTIONS: { value: DlpAction; label: string }[] = [
+  { value: 'redact', label: 'Redact' },
+  { value: 'block', label: 'Block request' },
+  { value: 'log', label: 'Log only' },
+  { value: 'off', label: 'Off' },
+];
+
+// Mirrors CLIENT_AI_DLP_DEFAULT_BUILTINS (apps/api/src/routes/clientAi/schemas.ts,
+// Plan-4 Task 1): redact financial/credential types, email/phone off (spec §6).
+const DLP_BUILTINS: { key: DlpBuiltinKey; label: string; defaultAction: DlpAction }[] = [
+  { key: 'creditCard', label: 'Credit card numbers (Luhn-validated)', defaultAction: 'redact' },
+  { key: 'ssn', label: 'SSN / national IDs', defaultAction: 'redact' },
+  { key: 'iban', label: 'IBAN account numbers', defaultAction: 'redact' },
+  { key: 'apiKey', label: 'API keys & tokens', defaultAction: 'redact' },
+  { key: 'email', label: 'Email addresses', defaultAction: 'off' },
+  { key: 'phone', label: 'Phone numbers', defaultAction: 'off' },
+];
+
+// The models priced in apps/api/src/services/aiCostTracker.ts:17-18. Empty
+// selection = all available models (Plan-1 default allowedModels: []).
+const KNOWN_MODELS: { id: string; label: string }[] = [
+  { id: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5' },
+  { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
+];
+
+interface PolicyDto {
+  orgId: string;
+  enabled: boolean;
+  userAccess: 'all' | 'selected';
+  selectedUserIds: string[];
+  allowedProviders: string[];
+  allowedModels: string[];
+  writeMode: 'readwrite' | 'readonly';
+  dlpConfig: {
+    builtins?: Partial<Record<DlpBuiltinKey, DlpAction>>;
+    customRules?: CustomRule[];
+  } | null;
+  dailyBudgetCents: number | null;
+  monthlyBudgetCents: number | null;
+  perUserMessagesPerMinute: number;
+  orgMessagesPerHour: number;
+  retentionDays: number | null;
+  branding: { displayName?: string | null; logoUrl?: string | null } | null;
+}
+
+interface EntraUser {
+  id: string;
+  email: string;
+  name: string | null;
+  lastLoginAt: string | null;
+}
+
+function defaultBuiltins(): Record<DlpBuiltinKey, DlpAction> {
+  return Object.fromEntries(DLP_BUILTINS.map((b) => [b.key, b.defaultAction])) as Record<
+    DlpBuiltinKey,
+    DlpAction
+  >;
+}
+
+/** Live regex test (spec §9.2): compile client-side, count matches in the sample. */
+export function testPattern(
+  pattern: string,
+  sample: string
+): { ok: true; matches: number } | { ok: false; error: string } {
+  try {
+    const re = new RegExp(pattern, 'g');
+    return { ok: true, matches: sample ? (sample.match(re) ?? []).length : 0 };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Invalid pattern' };
+  }
+}
+
+export default function PolicyEditor({ orgId, onBack }: { orgId: string; onBack: () => void }) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [orgUsers, setOrgUsers] = useState<EntraUser[]>([]);
+
+  // Form state — buildPayload() below is the single source of the PUT body.
+  const [enabled, setEnabled] = useState(false);
+  const [userAccess, setUserAccess] = useState<'all' | 'selected'>('all');
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+  const [allowedModels, setAllowedModels] = useState<string[]>([]);
+  const [writeMode, setWriteMode] = useState<'readwrite' | 'readonly'>('readwrite');
+  const [builtins, setBuiltins] = useState<Record<DlpBuiltinKey, DlpAction>>(defaultBuiltins);
+  const [customRules, setCustomRules] = useState<CustomRule[]>([]);
+  const [dailyBudgetDollars, setDailyBudgetDollars] = useState('');
+  const [monthlyBudgetDollars, setMonthlyBudgetDollars] = useState('');
+  const [perUserPerMinute, setPerUserPerMinute] = useState('10');
+  const [orgPerHour, setOrgPerHour] = useState('500');
+  const [retentionDays, setRetentionDays] = useState('');
+  const [brandDisplayName, setBrandDisplayName] = useState('');
+  const [brandLogoUrl, setBrandLogoUrl] = useState('');
+  const [dlpSample, setDlpSample] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      setLoadError(false);
+      const [policyRes, usersRes] = await Promise.all([
+        fetchWithAuth(`/client-ai/admin/orgs/${orgId}/policy`),
+        fetchWithAuth(`/client-ai/admin/orgs/${orgId}/users`),
+      ]);
+      if (policyRes.status === 401 || usersRes.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      if (!policyRes.ok) throw new Error(`HTTP ${policyRes.status}`);
+      const { policy } = (await policyRes.json()) as { policy: PolicyDto };
+      setEnabled(policy.enabled);
+      setUserAccess(policy.userAccess);
+      setSelectedUserIds(policy.selectedUserIds ?? []);
+      setAllowedModels(policy.allowedModels ?? []);
+      setWriteMode(policy.writeMode);
+      const cfg = policy.dlpConfig ?? {};
+      setBuiltins({ ...defaultBuiltins(), ...(cfg.builtins ?? {}) });
+      setCustomRules(cfg.customRules ?? []);
+      setDailyBudgetDollars(
+        policy.dailyBudgetCents != null ? (policy.dailyBudgetCents / 100).toFixed(2) : ''
+      );
+      setMonthlyBudgetDollars(
+        policy.monthlyBudgetCents != null ? (policy.monthlyBudgetCents / 100).toFixed(2) : ''
+      );
+      setPerUserPerMinute(String(policy.perUserMessagesPerMinute));
+      setOrgPerHour(String(policy.orgMessagesPerHour));
+      setRetentionDays(policy.retentionDays != null ? String(policy.retentionDays) : '');
+      const branding = policy.branding ?? {};
+      setBrandDisplayName(branding.displayName ?? '');
+      setBrandLogoUrl(branding.logoUrl ?? '');
+      if (usersRes.ok) {
+        const usersBody = (await usersRes.json()) as { data: EntraUser[] };
+        setOrgUsers(usersBody.data ?? []);
+      }
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const ruleResults = useMemo(
+    () => new Map(customRules.map((r) => [r.id, testPattern(r.pattern, dlpSample)])),
+    [customRules, dlpSample]
+  );
+
+  const dollarsToCents = (v: string): number | null => {
+    const t = v.trim();
+    if (!t) return null;
+    const n = Number.parseFloat(t);
+    return Number.isFinite(n) && n >= 0 ? Math.round(n * 100) : null;
+  };
+  const toInt = (v: string, fallback: number): number => {
+    const n = Number.parseInt(v, 10);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+  };
+
+  /** Exactly putPolicySchema's keys (Plan 1; dlpConfig tightened by Plan-4 Task 1). */
+  const buildPayload = () => ({
+    enabled,
+    userAccess,
+    selectedUserIds: userAccess === 'selected' ? selectedUserIds : [],
+    allowedModels,
+    writeMode,
+    dlpConfig: {
+      builtins,
+      customRules: customRules.map((r) => ({
+        id: r.id,
+        name: r.name.trim(),
+        pattern: r.pattern,
+        action: r.action,
+      })),
+    },
+    dailyBudgetCents: dollarsToCents(dailyBudgetDollars),
+    monthlyBudgetCents: dollarsToCents(monthlyBudgetDollars),
+    perUserMessagesPerMinute: toInt(perUserPerMinute, 10),
+    orgMessagesPerHour: toInt(orgPerHour, 500),
+    retentionDays: retentionDays.trim() ? toInt(retentionDays, 1) : null,
+    branding: {
+      displayName: brandDisplayName.trim() || null,
+      logoUrl: brandLogoUrl.trim() || null,
+    },
+  });
+
+  const save = async () => {
+    if (saving) return;
+    // Client-side pre-validation of the DLP contract (the server schema
+    // rejects non-compiling patterns with a 400 — fail here with a clear toast).
+    for (const rule of customRules) {
+      if (!rule.name.trim()) {
+        showToast({ type: 'error', message: 'Every custom DLP rule needs a name' });
+        return;
+      }
+      const result = testPattern(rule.pattern, '');
+      if (!result.ok) {
+        showToast({
+          type: 'error',
+          message: `DLP rule "${rule.name}" has an invalid pattern — fix it before saving`,
+        });
+        return;
+      }
+    }
+    setSaving(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/client-ai/admin/orgs/${orgId}/policy`, {
+            method: 'PUT',
+            body: JSON.stringify(buildPayload()),
+          }),
+        errorFallback: 'Failed to save policy',
+        successMessage: 'Policy saved',
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+    } catch (err) {
+      handleActionError(err, 'Failed to save policy');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleModel = (id: string) =>
+    setAllowedModels((prev) => (prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id]));
+  const toggleUser = (id: string) =>
+    setSelectedUserIds((prev) => (prev.includes(id) ? prev.filter((u) => u !== id) : [...prev, id]));
+  const updateRule = (id: string, patch: Partial<CustomRule>) =>
+    setCustomRules((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  const addRule = () =>
+    setCustomRules((prev) => [...prev, { id: crypto.randomUUID(), name: '', pattern: '', action: 'redact' }]);
+  const removeRule = (id: string) => setCustomRules((prev) => prev.filter((r) => r.id !== id));
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div
+        className="rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+        data-testid="ai-office-policy-load-error"
+      >
+        Failed to load the org policy.{' '}
+        <button
+          type="button"
+          className="text-primary underline"
+          onClick={() => {
+            setLoading(true);
+            void load();
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6" data-testid="ai-office-policy-editor">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex items-center gap-1 rounded-md border px-2 py-1.5 text-sm hover:bg-muted"
+          data-testid="ai-office-policy-back"
+        >
+          <ArrowLeft className="h-4 w-4" /> Organizations
+        </button>
+        <div>
+          <h2 className="text-lg font-semibold">Org policy</h2>
+          <p className="text-sm text-muted-foreground">
+            Everything this client org&apos;s Excel assistant is allowed to do.
+          </p>
+        </div>
+      </div>
+
+      {/* General */}
+      <section className="rounded-lg border bg-card p-6">
+        <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          General
+        </h3>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Assistant</span>
+            <select
+              value={enabled ? 'true' : 'false'}
+              onChange={(e) => setEnabled(e.target.value === 'true')}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-enabled"
+            >
+              <option value="true">Enabled</option>
+              <option value="false">Disabled</option>
+            </select>
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Workbook access</span>
+            <select
+              value={writeMode}
+              onChange={(e) => setWriteMode(e.target.value as 'readwrite' | 'readonly')}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-writemode"
+            >
+              <option value="readwrite">Read &amp; write (writes approval-gated by the end user)</option>
+              <option value="readonly">Read only (write tools removed from the model)</option>
+            </select>
+          </label>
+          <div className="text-sm">
+            <span className="text-muted-foreground">Allowed models</span>
+            <div className="mt-1 space-y-1.5">
+              {KNOWN_MODELS.map((m) => (
+                <label key={m.id} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={allowedModels.includes(m.id)}
+                    onChange={() => toggleModel(m.id)}
+                    className="rounded border-border"
+                    data-testid={`ai-office-policy-model-${m.id}`}
+                  />
+                  {m.label}
+                </label>
+              ))}
+              <p className="text-xs text-muted-foreground">No selection = all available models.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* User access */}
+      <section className="rounded-lg border bg-card p-6">
+        <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          User access
+        </h3>
+        <label className="block max-w-xs text-sm">
+          <span className="text-muted-foreground">Who can use the assistant</span>
+          <select
+            value={userAccess}
+            onChange={(e) => setUserAccess(e.target.value as 'all' | 'selected')}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            data-testid="ai-office-policy-useraccess"
+          >
+            <option value="all">All users in the mapped tenant</option>
+            <option value="selected">Only selected users</option>
+          </select>
+        </label>
+        {userAccess === 'selected' && (
+          <div
+            className="mt-3 max-h-56 space-y-1.5 overflow-y-auto rounded-md border p-3"
+            data-testid="ai-office-policy-userlist"
+          >
+            {orgUsers.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                No users have signed in from Excel yet — users appear here after their first
+                sign-in. Until then, leave access on &quot;All users&quot;.
+              </p>
+            )}
+            {orgUsers.map((u) => (
+              <label key={u.id} className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={selectedUserIds.includes(u.id)}
+                  onChange={() => toggleUser(u.id)}
+                  className="rounded border-border"
+                  data-testid={`ai-office-policy-user-${u.id}`}
+                />
+                <span>{u.email}</span>
+                {u.name && <span className="text-xs text-muted-foreground">{u.name}</span>}
+              </label>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Budgets & rate limits */}
+      <section className="rounded-lg border bg-card p-6">
+        <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Budgets &amp; rate limits
+        </h3>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Daily budget ($)</span>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              value={dailyBudgetDollars}
+              onChange={(e) => setDailyBudgetDollars(e.target.value)}
+              placeholder="No limit"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-daily-budget"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Monthly budget ($)</span>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              value={monthlyBudgetDollars}
+              onChange={(e) => setMonthlyBudgetDollars(e.target.value)}
+              placeholder="No limit"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-monthly-budget"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Messages/min per user</span>
+            <input
+              type="number"
+              min="1"
+              max="600"
+              value={perUserPerMinute}
+              onChange={(e) => setPerUserPerMinute(e.target.value)}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-per-user-rate"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Messages/hour per org</span>
+            <input
+              type="number"
+              min="1"
+              value={orgPerHour}
+              onChange={(e) => setOrgPerHour(e.target.value)}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-org-rate"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Transcript retention (days)</span>
+            <input
+              type="number"
+              min="1"
+              max="3650"
+              value={retentionDays}
+              onChange={(e) => setRetentionDays(e.target.value)}
+              placeholder="Keep forever"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-retention"
+            />
+          </label>
+        </div>
+      </section>
+
+      {/* Branding */}
+      <section className="rounded-lg border bg-card p-6">
+        <h3 className="mb-1 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Branding
+        </h3>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Shown in the add-in footer: &quot;Governed by your IT provider&quot; — the white-label
+          hook (spec §11).
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Display name</span>
+            <input
+              type="text"
+              value={brandDisplayName}
+              onChange={(e) => setBrandDisplayName(e.target.value)}
+              placeholder="Your MSP name"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-brand-name"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Logo URL</span>
+            <input
+              type="url"
+              value={brandLogoUrl}
+              onChange={(e) => setBrandLogoUrl(e.target.value)}
+              placeholder="https://…/logo.png"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="ai-office-policy-brand-logo"
+            />
+          </label>
+        </div>
+      </section>
+
+      {/* DLP */}
+      <section className="rounded-lg border bg-card p-6">
+        <h3 className="mb-1 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Data loss prevention
+        </h3>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Every payload leaving Breeze for the model is scanned (spec §6). Redacted values are
+          stored redacted — the audit trail never keeps the sensitive form.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {DLP_BUILTINS.map((b) => (
+            <label key={b.key} className="block text-sm">
+              <span className="text-muted-foreground">{b.label}</span>
+              <select
+                value={builtins[b.key]}
+                onChange={(e) =>
+                  setBuiltins((prev) => ({ ...prev, [b.key]: e.target.value as DlpAction }))
+                }
+                className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                data-testid={`ai-office-policy-dlp-${b.key}`}
+              >
+                {DLP_ACTIONS.map((a) => (
+                  <option key={a.value} value={a.value}>
+                    {a.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ))}
+        </div>
+
+        <div className="mt-6">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-medium">Custom rules</h4>
+            <button
+              type="button"
+              onClick={addRule}
+              className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted"
+              data-testid="ai-office-policy-dlp-add-rule"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add rule
+            </button>
+          </div>
+          {customRules.length > 0 && (
+            <label className="mt-3 block text-sm">
+              <span className="text-muted-foreground">
+                Test sample (paste representative cell data — evaluated locally, never sent
+                anywhere)
+              </span>
+              <textarea
+                value={dlpSample}
+                onChange={(e) => setDlpSample(e.target.value)}
+                rows={3}
+                className="mt-1 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+                data-testid="ai-office-policy-dlp-sample"
+              />
+            </label>
+          )}
+          <div className="mt-3 space-y-3">
+            {customRules.map((rule, idx) => {
+              const result = ruleResults.get(rule.id);
+              return (
+                <div key={rule.id} className="rounded-md border p-3" data-testid={`ai-office-policy-dlp-rule-${idx}`}>
+                  <div className="grid gap-2 sm:grid-cols-[1fr_2fr_auto_auto]">
+                    <input
+                      type="text"
+                      value={rule.name}
+                      onChange={(e) => updateRule(rule.id, { name: e.target.value })}
+                      placeholder="Rule name"
+                      className="rounded-md border bg-background px-3 py-2 text-sm"
+                      data-testid={`ai-office-policy-dlp-rule-name-${idx}`}
+                    />
+                    <input
+                      type="text"
+                      value={rule.pattern}
+                      onChange={(e) => updateRule(rule.id, { pattern: e.target.value })}
+                      placeholder="Regular expression, e.g. PRJ-\d{4}"
+                      className="rounded-md border bg-background px-3 py-2 font-mono text-sm"
+                      data-testid={`ai-office-policy-dlp-rule-pattern-${idx}`}
+                    />
+                    <select
+                      value={rule.action}
+                      onChange={(e) => updateRule(rule.id, { action: e.target.value as DlpAction })}
+                      className="rounded-md border bg-background px-3 py-2 text-sm"
+                      data-testid={`ai-office-policy-dlp-rule-action-${idx}`}
+                    >
+                      {DLP_ACTIONS.filter((a) => a.value !== 'off').map((a) => (
+                        <option key={a.value} value={a.value}>
+                          {a.label}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => removeRule(rule.id)}
+                      className="rounded-md border px-2 py-2 text-destructive hover:bg-destructive/10"
+                      title="Remove rule"
+                      data-testid={`ai-office-policy-dlp-rule-remove-${idx}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                  {result && rule.pattern.trim() !== '' && (
+                    <p
+                      className={`mt-1.5 text-xs ${result.ok ? 'text-muted-foreground' : 'text-destructive'}`}
+                      data-testid={`ai-office-policy-dlp-rule-result-${idx}`}
+                    >
+                      {result.ok
+                        ? dlpSample
+                          ? `${result.matches} match${result.matches === 1 ? '' : 'es'} in the sample`
+                          : 'Pattern compiles — add a test sample above to see matches'
+                        : `Pattern error: ${result.error}`}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={saving}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          data-testid="ai-office-policy-save"
+        >
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          Save policy
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write the component tests**
+
+`apps/web/src/components/clientAi/PolicyEditor.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import PolicyEditor, { testPattern } from './PolicyEditor';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const USER_1 = 'beefbeef-1111-4222-8333-444455556666';
+
+// Plan-1 getOrgPolicy defaults (admin.test.ts fixture).
+const DEFAULT_POLICY = {
+  orgId: ORG_ID,
+  enabled: false,
+  userAccess: 'all',
+  selectedUserIds: [],
+  allowedProviders: ['anthropic'],
+  allowedModels: [],
+  writeMode: 'readwrite',
+  dlpConfig: {},
+  dailyBudgetCents: null,
+  monthlyBudgetCents: null,
+  perUserMessagesPerMinute: 10,
+  orgMessagesPerHour: 500,
+  retentionDays: null,
+  branding: {},
+};
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+function mockApi(policy: unknown = DEFAULT_POLICY) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === `/client-ai/admin/orgs/${ORG_ID}/policy` && !init?.method) {
+      return makeJsonResponse({ policy });
+    }
+    if (url === `/client-ai/admin/orgs/${ORG_ID}/policy` && init?.method === 'PUT') {
+      return makeJsonResponse({ policy });
+    }
+    if (url === `/client-ai/admin/orgs/${ORG_ID}/users` && !init?.method) {
+      return makeJsonResponse({
+        data: [{ id: USER_1, email: 'a@contoso.com', name: 'A', lastLoginAt: null }],
+      });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 500);
+  });
+}
+
+describe('PolicyEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves the exact putPolicySchema payload', async () => {
+    mockApi();
+    render(<PolicyEditor orgId={ORG_ID} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-policy-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('ai-office-policy-enabled'), { target: { value: 'true' } });
+    fireEvent.change(screen.getByTestId('ai-office-policy-writemode'), { target: { value: 'readonly' } });
+    fireEvent.click(screen.getByTestId('ai-office-policy-model-claude-sonnet-4-5-20250929'));
+    fireEvent.change(screen.getByTestId('ai-office-policy-monthly-budget'), { target: { value: '25.00' } });
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-ssn'), { target: { value: 'block' } });
+    fireEvent.click(screen.getByTestId('ai-office-policy-dlp-add-rule'));
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-rule-name-0'), { target: { value: 'Project codes' } });
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-rule-pattern-0'), { target: { value: 'PRJ-\\d{4}' } });
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-rule-action-0'), { target: { value: 'block' } });
+    fireEvent.change(screen.getByTestId('ai-office-policy-brand-name'), { target: { value: 'Lantern IT' } });
+    fireEvent.click(screen.getByTestId('ai-office-policy-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'PUT')).toBe(true)
+    );
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT');
+    expect(String(putCall![0])).toBe(`/client-ai/admin/orgs/${ORG_ID}/policy`);
+    const body = JSON.parse(String(putCall![1]!.body));
+    expect(body).toEqual({
+      enabled: true,
+      userAccess: 'all',
+      selectedUserIds: [],
+      allowedModels: ['claude-sonnet-4-5-20250929'],
+      writeMode: 'readonly',
+      dlpConfig: {
+        builtins: {
+          creditCard: 'redact',
+          ssn: 'block',
+          iban: 'redact',
+          apiKey: 'redact',
+          email: 'off',
+          phone: 'off',
+        },
+        customRules: [
+          { id: expect.any(String), name: 'Project codes', pattern: 'PRJ-\\d{4}', action: 'block' },
+        ],
+      },
+      dailyBudgetCents: null,
+      monthlyBudgetCents: 2500,
+      perUserMessagesPerMinute: 10,
+      orgMessagesPerHour: 500,
+      retentionDays: null,
+      branding: { displayName: 'Lantern IT', logoUrl: null },
+    });
+  });
+
+  it('sends selectedUserIds when access is "selected"', async () => {
+    mockApi();
+    render(<PolicyEditor orgId={ORG_ID} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-policy-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('ai-office-policy-useraccess'), { target: { value: 'selected' } });
+    fireEvent.click(screen.getByTestId(`ai-office-policy-user-${USER_1}`));
+    fireEvent.click(screen.getByTestId('ai-office-policy-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'PUT')).toBe(true)
+    );
+    const body = JSON.parse(
+      String(fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT')![1]!.body)
+    );
+    expect(body.userAccess).toBe('selected');
+    expect(body.selectedUserIds).toEqual([USER_1]);
+  });
+
+  it('blocks save and toasts when a custom rule pattern does not compile', async () => {
+    mockApi();
+    render(<PolicyEditor orgId={ORG_ID} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-policy-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('ai-office-policy-dlp-add-rule'));
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-rule-name-0'), { target: { value: 'Broken' } });
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-rule-pattern-0'), { target: { value: '(' } });
+    fireEvent.click(screen.getByTestId('ai-office-policy-save'));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }))
+    );
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'PUT')).toBe(false);
+  });
+
+  it('live regex test box shows match counts and compile errors', async () => {
+    mockApi();
+    render(<PolicyEditor orgId={ORG_ID} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-policy-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('ai-office-policy-dlp-add-rule'));
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-rule-pattern-0'), { target: { value: 'PRJ-\\d{4}' } });
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-sample'), {
+      target: { value: 'PRJ-0001 and PRJ-0002 but not PRJ-1' },
+    });
+    expect(screen.getByTestId('ai-office-policy-dlp-rule-result-0').textContent).toContain('2 matches');
+
+    fireEvent.change(screen.getByTestId('ai-office-policy-dlp-rule-pattern-0'), { target: { value: '(' } });
+    expect(screen.getByTestId('ai-office-policy-dlp-rule-result-0').textContent).toContain('Pattern error');
+  });
+
+  it('testPattern counts matches and reports compile errors', () => {
+    expect(testPattern('\\d+', 'a1 b22')).toEqual({ ok: true, matches: 2 });
+    expect(testPattern('([', 'x').ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Adopt into the WS-A guard**
+
+Append to `TARGET_GLOBS` in `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` (after the OrgsTab line from Task 8):
+
+```ts
+  'src/components/clientAi/PolicyEditor.tsx',
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/components/clientAi/PolicyEditor.test.tsx src/lib/__tests__/no-silent-mutations.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/clientAi/PolicyEditor.tsx apps/web/src/components/clientAi/PolicyEditor.test.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(client-ai-web): full org policy editor with DLP rule builder + live regex test" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: SessionsTab — client-session audit viewer with transcript drawer + flag/unflag
+
+Spec §9.3. Consumes Task 3's endpoints exactly: `GET /client-ai/admin/sessions` (filters `orgId`, `clientUserId`, `from`, `to`, `flagged`, `limit`, `offset` → `{data, pagination}`), `GET /sessions/:id` (`{session, messages[+redactionCounts], toolExecutions}`), `POST/DELETE /sessions/:id/flag`. Mirrors the technician flagged-sessions UI (`AiUsagePage.tsx:354-423` — flagged row accent, flag chip, flagged-only toggle) plus the transcript drill-in the technician UI doesn't have.
+
+**Files:**
+- Create: apps/web/src/components/clientAi/SessionsTab.tsx
+- Create: apps/web/src/components/clientAi/SessionsTab.test.tsx
+- Modify: apps/web/src/lib/__tests__/no-silent-mutations.test.ts (`TARGET_GLOBS`)
+
+- [ ] **Step 1: Write the component**
+
+`apps/web/src/components/clientAi/SessionsTab.tsx`:
+
+```tsx
+import { useCallback, useEffect, useState } from 'react';
+import { ChevronLeft, ChevronRight, Flag, FlagOff, Loader2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { Dialog } from '../shared/Dialog';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { runAction, handleActionError } from '@/lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+
+/**
+ * AI for Office — client-session audit viewer (spec §9.3). excel_client
+ * sessions only (the API constrains this — Plan-4 Task 3). Transcript shows
+ * redaction badges derived from redactionCounts (decision 3: counted
+ * [REDACTED:type] markers, since ai_messages stores the redacted form),
+ * workbook-context chips from tool inputs, and the tool approval trail from
+ * ai_tool_executions. Flag/unflag mirror the technician machinery with
+ * client_ai.* audit actions.
+ */
+
+const PAGE_SIZE = 50;
+
+/** Row shape of GET /client-ai/admin/sessions (Plan-4 Task 3). */
+interface SessionListRow {
+  id: string;
+  orgId: string;
+  orgName: string | null;
+  clientUserId: string | null;
+  userEmail: string | null;
+  title: string | null;
+  startedAt: string;
+  lastActivityAt: string | null;
+  turnCount: number;
+  totalCostCents: number;
+  flaggedAt: string | null;
+  flagReason: string | null;
+  status: string;
+}
+
+interface TranscriptMessage {
+  id: string;
+  role: string;
+  content: string | null;
+  contentBlocks: unknown;
+  toolName: string | null;
+  toolInput: unknown;
+  toolOutput: unknown;
+  createdAt: string;
+  /** Derived per message by the API: [REDACTED:type] marker counts. */
+  redactionCounts: Record<string, number>;
+}
+
+interface ToolExecution {
+  id: string;
+  toolName: string;
+  toolInput: unknown;
+  status: string;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  errorMessage: string | null;
+  durationMs: number | null;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+interface SessionDetailSession {
+  id: string;
+  orgId: string;
+  orgName: string | null;
+  clientUserId: string | null;
+  userEmail: string | null;
+  title: string | null;
+  model: string;
+  status: string;
+  turnCount: number;
+  totalCostCents: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  flaggedAt: string | null;
+  flaggedBy: string | null;
+  flagReason: string | null;
+  createdAt: string;
+  lastActivityAt: string | null;
+}
+
+interface SessionDetail {
+  session: SessionDetailSession;
+  messages: TranscriptMessage[];
+  toolExecutions: ToolExecution[];
+}
+
+const formatCost = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+const formatTime = (iso: string) => new Date(iso).toLocaleString();
+
+/** Workbook-context chips (spec §9.3): tool name + range/sheet from toolInput. */
+function workbookChips(m: TranscriptMessage): string[] {
+  const chips: string[] = [];
+  if (m.toolName) chips.push(m.toolName);
+  const input = m.toolInput as Record<string, unknown> | null;
+  if (input && typeof input.range === 'string') chips.push(input.range);
+  if (input && typeof input.sheet === 'string') chips.push(`Sheet: ${input.sheet}`);
+  return chips;
+}
+
+function ToolStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    completed:
+      'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-400',
+    approved:
+      'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-400',
+    pending:
+      'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400',
+    rejected:
+      'border-red-200 bg-red-50 text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-400',
+    failed:
+      'border-red-200 bg-red-50 text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-400',
+  };
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-xs ${styles[status] ?? 'border-slate-200 bg-slate-50 text-slate-600 dark:border-slate-500/30 dark:bg-slate-500/10 dark:text-slate-400'}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default function SessionsTab() {
+  // Filters
+  const [orgs, setOrgs] = useState<{ orgId: string; orgName: string }[]>([]);
+  const [orgUsers, setOrgUsers] = useState<{ id: string; email: string }[]>([]);
+  const [orgFilter, setOrgFilter] = useState('');
+  const [userFilter, setUserFilter] = useState('');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [flaggedOnly, setFlaggedOnly] = useState(false);
+  const [offset, setOffset] = useState(0);
+  // List
+  const [rows, setRows] = useState<SessionListRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  // Detail drawer
+  const [detailId, setDetailId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  // Flag/unflag
+  const [flagOpen, setFlagOpen] = useState(false);
+  const [flagReason, setFlagReason] = useState('');
+  const [unflagOpen, setUnflagOpen] = useState(false);
+  const [mutating, setMutating] = useState(false);
+
+  // Org names for the filter select (the Task-2 status endpoint already has them).
+  useEffect(() => {
+    void fetchWithAuth('/client-ai/admin/orgs')
+      .then((r) => (r.ok ? (r.json() as Promise<{ data?: { orgId: string; orgName: string }[] }>) : null))
+      .then((b) => {
+        if (b?.data) setOrgs(b.data.map(({ orgId, orgName }) => ({ orgId, orgName })));
+      })
+      .catch(() => {});
+  }, []);
+
+  // User filter options once an org is chosen (GET /orgs/:orgId/users, decision 9 —
+  // the API filter is clientUserId, a portal_users UUID, so free-text won't do).
+  useEffect(() => {
+    setOrgUsers([]);
+    setUserFilter('');
+    if (!orgFilter) return;
+    let cancelled = false;
+    void fetchWithAuth(`/client-ai/admin/orgs/${orgFilter}/users`)
+      .then((r) => (r.ok ? (r.json() as Promise<{ data?: { id: string; email: string }[] }>) : null))
+      .then((b) => {
+        if (!cancelled && b?.data) setOrgUsers(b.data);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [orgFilter]);
+
+  const loadSessions = useCallback(async () => {
+    try {
+      setLoading(true);
+      setLoadError(false);
+      const qs = new URLSearchParams({ limit: String(PAGE_SIZE), offset: String(offset) });
+      if (orgFilter) qs.set('orgId', orgFilter);
+      if (userFilter) qs.set('clientUserId', userFilter);
+      if (fromDate) qs.set('from', fromDate);
+      if (toDate) qs.set('to', `${toDate}T23:59:59.999Z`); // include the whole end day
+      if (flaggedOnly) qs.set('flagged', 'true');
+      const res = await fetchWithAuth(`/client-ai/admin/sessions?${qs.toString()}`);
+      if (res.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as {
+        data: SessionListRow[];
+        pagination: { total: number; limit: number; offset: number };
+      };
+      setRows(body.data ?? []);
+      setTotal(body.pagination?.total ?? 0);
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgFilter, userFilter, fromDate, toDate, flaggedOnly, offset]);
+
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  const loadDetail = useCallback(async (sessionId: string) => {
+    try {
+      setDetailLoading(true);
+      const res = await fetchWithAuth(`/client-ai/admin/sessions/${sessionId}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setDetail((await res.json()) as SessionDetail);
+    } catch {
+      setDetail(null);
+    } finally {
+      setDetailLoading(false);
+    }
+  }, []);
+
+  const openDetail = (sessionId: string) => {
+    setDetailId(sessionId);
+    setDetail(null);
+    void loadDetail(sessionId);
+  };
+  const closeDetail = () => {
+    setDetailId(null);
+    setDetail(null);
+  };
+
+  const flagSession = async () => {
+    if (!detailId || mutating) return;
+    setMutating(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/client-ai/admin/sessions/${detailId}/flag`, {
+            method: 'POST',
+            // flagSessionSchema: reason is string-or-absent (null is rejected).
+            body: JSON.stringify(flagReason.trim() ? { reason: flagReason.trim() } : {}),
+          }),
+        errorFallback: 'Failed to flag session',
+        successMessage: 'Session flagged',
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      setFlagOpen(false);
+      setFlagReason('');
+      await Promise.all([loadDetail(detailId), loadSessions()]);
+    } catch (err) {
+      handleActionError(err, 'Failed to flag session');
+    } finally {
+      setMutating(false);
+    }
+  };
+
+  const unflagSession = async () => {
+    if (!detailId || mutating) return;
+    setMutating(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/client-ai/admin/sessions/${detailId}/flag`, { method: 'DELETE' }),
+        errorFallback: 'Failed to unflag session',
+        successMessage: 'Session unflagged',
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      setUnflagOpen(false);
+      await Promise.all([loadDetail(detailId), loadSessions()]);
+    } catch (err) {
+      handleActionError(err, 'Failed to unflag session');
+    } finally {
+      setMutating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="text-xs">
+          Organization
+          <select
+            value={orgFilter}
+            onChange={(e) => {
+              setOrgFilter(e.target.value);
+              setOffset(0);
+            }}
+            className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm"
+            data-testid="ai-office-sessions-org"
+          >
+            <option value="">All organizations</option>
+            {orgs.map((o) => (
+              <option key={o.orgId} value={o.orgId}>
+                {o.orgName}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-xs">
+          User
+          <select
+            value={userFilter}
+            onChange={(e) => {
+              setUserFilter(e.target.value);
+              setOffset(0);
+            }}
+            disabled={!orgFilter}
+            className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm disabled:opacity-50"
+            data-testid="ai-office-sessions-user"
+          >
+            <option value="">All users</option>
+            {orgUsers.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.email}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-xs">
+          From
+          <input
+            type="date"
+            value={fromDate}
+            onChange={(e) => {
+              setFromDate(e.target.value);
+              setOffset(0);
+            }}
+            className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm"
+            data-testid="ai-office-sessions-from"
+          />
+        </label>
+        <label className="text-xs">
+          To
+          <input
+            type="date"
+            value={toDate}
+            onChange={(e) => {
+              setToDate(e.target.value);
+              setOffset(0);
+            }}
+            className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm"
+            data-testid="ai-office-sessions-to"
+          />
+        </label>
+        <label className="flex items-center gap-2 pb-1.5 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={flaggedOnly}
+            onChange={(e) => {
+              setFlaggedOnly(e.target.checked);
+              setOffset(0);
+            }}
+            className="rounded border-border"
+            data-testid="ai-office-sessions-flagged"
+          />
+          Flagged only
+        </label>
+      </div>
+
+      {/* Session table */}
+      <div className="rounded-lg border bg-card">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : loadError ? (
+          <div className="p-6 text-sm text-muted-foreground" data-testid="ai-office-sessions-load-error">
+            Failed to load sessions.{' '}
+            <button type="button" className="text-primary underline" onClick={() => void loadSessions()}>
+              Retry
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/40">
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <th className="px-4 py-2">Started</th>
+                  <th className="px-4 py-2">Organization</th>
+                  <th className="px-4 py-2">User</th>
+                  <th className="px-4 py-2">Title</th>
+                  <th className="px-4 py-2 text-right">Turns</th>
+                  <th className="px-4 py-2 text-right">Cost</th>
+                  <th className="px-4 py-2">Flagged</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((s) => (
+                  <tr
+                    key={s.id}
+                    onClick={() => openDetail(s.id)}
+                    className={`cursor-pointer border-b last:border-0 hover:bg-muted/20 ${s.flaggedAt ? 'border-l-2 border-l-amber-500' : ''}`}
+                    data-testid={`ai-office-session-row-${s.id}`}
+                  >
+                    <td className="px-4 py-2.5 text-xs text-muted-foreground">{formatTime(s.startedAt)}</td>
+                    <td className="px-4 py-2.5">{s.orgName ?? '—'}</td>
+                    <td className="px-4 py-2.5">{s.userEmail ?? '—'}</td>
+                    <td className="max-w-[220px] truncate px-4 py-2.5">{s.title || 'Untitled'}</td>
+                    <td className="px-4 py-2.5 text-right">{s.turnCount}</td>
+                    <td className="px-4 py-2.5 text-right">{formatCost(s.totalCostCents)}</td>
+                    <td className="px-4 py-2.5">
+                      {s.flaggedAt ? (
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full bg-amber-500/20 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-400"
+                          title={s.flagReason || 'Flagged'}
+                        >
+                          <Flag className="h-3 w-3" /> Flagged
+                        </span>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                      No client AI sessions match the filters
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {/* Pagination */}
+        {!loading && !loadError && total > 0 && (
+          <div className="flex items-center justify-between border-t px-4 py-2 text-xs text-muted-foreground">
+            <span>
+              {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                disabled={offset === 0}
+                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-50"
+                data-testid="ai-office-sessions-prev"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" /> Prev
+              </button>
+              <button
+                type="button"
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                disabled={offset + PAGE_SIZE >= total}
+                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-50"
+                data-testid="ai-office-sessions-next"
+              >
+                Next <ChevronRight className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Transcript drawer */}
+      {detailId && (
+        <Dialog
+          open
+          onClose={closeDetail}
+          title="Session transcript"
+          maxWidth="4xl"
+          alignTop
+          className="flex max-h-[90vh] flex-col p-6"
+        >
+          {detailLoading && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {!detailLoading && !detail && (
+            <p className="text-sm text-muted-foreground" data-testid="ai-office-session-detail-error">
+              Failed to load the session transcript.
+            </p>
+          )}
+          {detail && (
+            <>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold">{detail.session.title || 'Untitled session'}</h2>
+                  <p className="text-sm text-muted-foreground">
+                    {detail.session.orgName ?? '—'} · {detail.session.userEmail ?? '—'} ·{' '}
+                    {detail.session.model} · {formatCost(detail.session.totalCostCents)} ·{' '}
+                    {detail.session.totalInputTokens} in / {detail.session.totalOutputTokens} out
+                  </p>
+                  {detail.session.flagReason && (
+                    <p className="mt-1 text-sm text-amber-700 dark:text-amber-400" data-testid="ai-office-session-flag-reason">
+                      Flag reason: {detail.session.flagReason}
+                    </p>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  {detail.session.flaggedAt ? (
+                    <button
+                      type="button"
+                      onClick={() => setUnflagOpen(true)}
+                      className="inline-flex items-center gap-1 rounded-md border px-2 py-1.5 text-sm hover:bg-muted"
+                      data-testid="ai-office-session-unflag"
+                    >
+                      <FlagOff className="h-4 w-4" /> Unflag
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setFlagOpen(true)}
+                      className="inline-flex items-center gap-1 rounded-md border border-amber-500/50 px-2 py-1.5 text-sm text-amber-700 hover:bg-amber-500/10 dark:text-amber-400"
+                      data-testid="ai-office-session-flag"
+                    >
+                      <Flag className="h-4 w-4" /> Flag
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-4 flex-1 space-y-4 overflow-y-auto pr-1">
+                {/* Messages with redaction badges + workbook-context chips */}
+                <div className="space-y-2">
+                  {detail.messages.map((m) => {
+                    const redactions = Object.entries(m.redactionCounts ?? {});
+                    const chips = workbookChips(m);
+                    return (
+                      <div
+                        key={m.id}
+                        className={`rounded-md border p-3 ${m.role === 'user' ? 'bg-muted/30' : 'bg-card'}`}
+                      >
+                        <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                          <span className="font-semibold uppercase tracking-wide">{m.role}</span>
+                          <span>{formatTime(m.createdAt)}</span>
+                          {chips.map((chip) => (
+                            <span
+                              key={chip}
+                              className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-400"
+                            >
+                              {chip}
+                            </span>
+                          ))}
+                          {redactions.map(([type, count]) => (
+                            <span
+                              key={type}
+                              className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
+                              data-testid={`ai-office-redaction-${type}`}
+                            >
+                              redacted: {type} ×{count}
+                            </span>
+                          ))}
+                        </div>
+                        {m.content && <p className="whitespace-pre-wrap text-sm">{m.content}</p>}
+                      </div>
+                    );
+                  })}
+                  {detail.messages.length === 0 && (
+                    <p className="text-sm text-muted-foreground">No messages stored for this session.</p>
+                  )}
+                </div>
+
+                {/* Tool approval trail */}
+                {detail.toolExecutions.length > 0 && (
+                  <div>
+                    <h4 className="mb-2 text-sm font-semibold">Tool approval trail</h4>
+                    <div className="space-y-2">
+                      {detail.toolExecutions.map((t) => (
+                        <div key={t.id} className="rounded-md border p-3 text-sm" data-testid={`ai-office-tool-exec-${t.id}`}>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-mono text-xs">{t.toolName}</span>
+                            <ToolStatusBadge status={t.status} />
+                            {typeof (t.toolInput as { range?: unknown } | null)?.range === 'string' && (
+                              <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+                                {(t.toolInput as { range: string }).range}
+                              </span>
+                            )}
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            requested {formatTime(t.createdAt)}
+                            {t.approvedAt && ` · approved ${formatTime(t.approvedAt)}`}
+                            {t.completedAt &&
+                              ` · ${t.status === 'rejected' ? 'rejected' : 'applied'} ${formatTime(t.completedAt)}`}
+                            {t.durationMs != null && ` · ${t.durationMs}ms`}
+                          </p>
+                          {t.errorMessage && (
+                            <p className="mt-1 text-xs text-destructive">{t.errorMessage}</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </Dialog>
+      )}
+
+      {/* Flag dialog (reason prompt) */}
+      <Dialog open={flagOpen} onClose={() => setFlagOpen(false)} title="Flag session" maxWidth="md" className="p-6">
+        <h3 className="text-lg font-semibold">Flag session</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Flagging marks the session for follow-up and is recorded in the audit log.
+        </p>
+        <label className="mt-3 block text-sm">
+          <span className="text-muted-foreground">Reason (optional)</span>
+          <textarea
+            value={flagReason}
+            onChange={(e) => setFlagReason(e.target.value)}
+            rows={3}
+            maxLength={1000}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            data-testid="ai-office-flag-reason"
+          />
+        </label>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => setFlagOpen(false)}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void flagSession()}
+            disabled={mutating}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+            data-testid="ai-office-flag-confirm"
+          >
+            {mutating ? 'Flagging…' : 'Flag session'}
+          </button>
+        </div>
+      </Dialog>
+
+      {/* Unflag confirm */}
+      <ConfirmDialog
+        open={unflagOpen}
+        onClose={() => setUnflagOpen(false)}
+        onConfirm={() => void unflagSession()}
+        title="Unflag session"
+        message="Remove the flag from this session? The flag/unflag history stays in the audit log."
+        confirmLabel="Unflag"
+        variant="warning"
+        isLoading={mutating}
+        confirmTestId="ai-office-unflag-confirm"
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write the component tests**
+
+`apps/web/src/components/clientAi/SessionsTab.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SessionsTab from './SessionsTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const SESSION_ID = '5e5e5e5e-1111-4222-8333-444455556666';
+
+const LIST_ROW = {
+  id: SESSION_ID,
+  orgId: ORG_ID,
+  orgName: 'Contoso Accounting',
+  clientUserId: 'beefbeef-1111-4222-8333-444455556666',
+  userEmail: 'finance.user@contoso.com',
+  title: 'Q3 budget review',
+  startedAt: '2026-06-10T09:00:00Z',
+  lastActivityAt: '2026-06-10T09:20:00Z',
+  turnCount: 6,
+  totalCostCents: 12.5,
+  flaggedAt: null,
+  flagReason: null,
+  status: 'closed',
+};
+
+const DETAIL = {
+  session: {
+    ...LIST_ROW,
+    model: 'claude-sonnet-4-5-20250929',
+    totalInputTokens: 4000,
+    totalOutputTokens: 900,
+    flaggedBy: null,
+    createdAt: '2026-06-10T09:00:00Z',
+  },
+  messages: [
+    {
+      id: 'm1',
+      role: 'user',
+      content: 'Card [REDACTED:creditCard] please summarize',
+      contentBlocks: null,
+      toolName: null,
+      toolInput: null,
+      toolOutput: null,
+      createdAt: '2026-06-10T09:00:01Z',
+      redactionCounts: { creditCard: 1 },
+    },
+  ],
+  toolExecutions: [
+    {
+      id: 't1',
+      toolName: 'write_range',
+      toolInput: { range: 'B2:B4' },
+      status: 'completed',
+      approvedBy: null,
+      approvedAt: '2026-06-10T09:05:00Z',
+      errorMessage: null,
+      durationMs: 240,
+      createdAt: '2026-06-10T09:04:00Z',
+      completedAt: '2026-06-10T09:05:01Z',
+    },
+  ],
+};
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+function mockApi() {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/client-ai/admin/orgs' && !init?.method) {
+      return makeJsonResponse({
+        data: [{ orgId: ORG_ID, orgName: 'Contoso Accounting' }],
+      });
+    }
+    if (url.startsWith('/client-ai/admin/sessions?') && !init?.method) {
+      return makeJsonResponse({
+        data: [LIST_ROW],
+        pagination: { total: 1, limit: 50, offset: 0 },
+      });
+    }
+    if (url === `/client-ai/admin/sessions/${SESSION_ID}` && !init?.method) {
+      return makeJsonResponse(DETAIL);
+    }
+    if (url === `/client-ai/admin/sessions/${SESSION_ID}/flag` && init?.method === 'POST') {
+      return makeJsonResponse({ success: true });
+    }
+    if (url === `/client-ai/admin/sessions/${SESSION_ID}/flag` && init?.method === 'DELETE') {
+      return makeJsonResponse({ success: true });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 500);
+  });
+}
+
+describe('SessionsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists sessions and shows the transcript with redaction badges + tool trail', async () => {
+    mockApi();
+    render(<SessionsTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-session-row-${SESSION_ID}`)).toBeInTheDocument()
+    );
+    expect(screen.getByText('finance.user@contoso.com')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId(`ai-office-session-row-${SESSION_ID}`));
+    await waitFor(() =>
+      expect(screen.getByTestId('ai-office-redaction-creditCard')).toBeInTheDocument()
+    );
+    expect(screen.getByTestId('ai-office-redaction-creditCard').textContent).toContain('×1');
+    expect(screen.getByTestId('ai-office-tool-exec-t1')).toBeInTheDocument();
+    expect(screen.getByText('B2:B4')).toBeInTheDocument();
+  });
+
+  it('flags a session with a reason (exact POST payload)', async () => {
+    mockApi();
+    render(<SessionsTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-session-row-${SESSION_ID}`)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByTestId(`ai-office-session-row-${SESSION_ID}`));
+    await waitFor(() => expect(screen.getByTestId('ai-office-session-flag')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('ai-office-session-flag'));
+    fireEvent.change(screen.getByTestId('ai-office-flag-reason'), {
+      target: { value: 'PII concern' },
+    });
+    fireEvent.click(screen.getByTestId('ai-office-flag-confirm'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(true)
+    );
+    const postCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(String(postCall![0])).toBe(`/client-ai/admin/sessions/${SESSION_ID}/flag`);
+    expect(JSON.parse(String(postCall![1]!.body))).toEqual({ reason: 'PII concern' });
+  });
+
+  it('unflags a flagged session through the confirm dialog', async () => {
+    // Same mock surface as mockApi(), but the session is flagged so the
+    // Unflag button renders.
+    const flaggedDetail = {
+      ...DETAIL,
+      session: { ...DETAIL.session, flaggedAt: '2026-06-11T00:00:00Z', flagReason: 'old' },
+    };
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/client-ai/admin/orgs' && !init?.method)
+        return makeJsonResponse({ data: [{ orgId: ORG_ID, orgName: 'Contoso Accounting' }] });
+      if (url.startsWith('/client-ai/admin/sessions?') && !init?.method)
+        return makeJsonResponse({
+          data: [{ ...LIST_ROW, flaggedAt: '2026-06-11T00:00:00Z', flagReason: 'old' }],
+          pagination: { total: 1, limit: 50, offset: 0 },
+        });
+      if (url === `/client-ai/admin/sessions/${SESSION_ID}` && !init?.method)
+        return makeJsonResponse(flaggedDetail);
+      if (url === `/client-ai/admin/sessions/${SESSION_ID}/flag` && init?.method === 'DELETE')
+        return makeJsonResponse({ success: true });
+      return makeJsonResponse({ error: 'unexpected' }, false, 500);
+    });
+
+    render(<SessionsTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-session-row-${SESSION_ID}`)).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId(`ai-office-session-row-${SESSION_ID}`));
+    await waitFor(() => expect(screen.getByTestId('ai-office-session-unflag')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('ai-office-session-unflag'));
+    fireEvent.click(screen.getByTestId('ai-office-unflag-confirm'));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(true)
+    );
+  });
+
+  it('flagged-only filter adds flagged=true to the list query', async () => {
+    mockApi();
+    render(<SessionsTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId('ai-office-sessions-flagged')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('ai-office-sessions-flagged'));
+    await waitFor(() => {
+      const listCalls = fetchMock.mock.calls.filter(([u]) =>
+        String(u).startsWith('/client-ai/admin/sessions?')
+      );
+      expect(String(listCalls[listCalls.length - 1]![0])).toContain('flagged=true');
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Adopt into the WS-A guard**
+
+Append to `TARGET_GLOBS` in `apps/web/src/lib/__tests__/no-silent-mutations.test.ts`:
+
+```ts
+  'src/components/clientAi/SessionsTab.tsx',
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/components/clientAi/SessionsTab.test.tsx src/lib/__tests__/no-silent-mutations.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/clientAi/SessionsTab.tsx apps/web/src/components/clientAi/SessionsTab.test.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(client-ai-web): session audit viewer with transcript drawer + flag/unflag" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: UsageTab — per-org/per-user usage report + CSV export
+
+Spec §8/§9.4. Consumes Task 4's `GET /client-ai/admin/usage?from&to[&orgId]` (`{rows, totals}`) and `GET /client-ai/admin/usage.csv`. Native `<input type="month">` produces exactly the `YYYY-MM` strings `adminUsageQuerySchema` requires. The CSV download is the **`BillablesExportCard.tsx:30-55` blob pattern verbatim** (fetchWithAuth → blob → `URL.createObjectURL` → synthetic `<a download>` click → revoke) — a GET, so no `runAction`, with explicit error toasts like the precedent. Table groups rows per org with expandable per-user rows and a totals footer.
+
+**Files:**
+- Create: apps/web/src/components/clientAi/UsageTab.tsx
+- Create: apps/web/src/components/clientAi/UsageTab.test.tsx
+
+- [ ] **Step 1: Write the component**
+
+`apps/web/src/components/clientAi/UsageTab.tsx`:
+
+```tsx
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, Download, Loader2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+import { navigateTo } from '@/lib/navigation';
+
+/**
+ * AI for Office — usage & billing report (spec §8, §9.4). The CSV is the MSP's
+ * resale-invoicing artifact (Plan-4 Task 4 pins its column order server-side).
+ * GET-only component: list + CSV export, no mutations — deliberately NOT in
+ * the no-silent-mutations TARGET_GLOBS.
+ */
+
+/** Row/totals shapes of GET /client-ai/admin/usage (Plan-4 Task 4). */
+interface UsageRow {
+  month: string;
+  orgId: string;
+  orgName: string | null;
+  clientUserId: string | null;
+  userEmail: string | null;
+  messageCount: number;
+  sessionCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+}
+
+interface UsageTotals {
+  messageCount: number;
+  sessionCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+}
+
+function currentMonthKey(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+const formatCost = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+const formatTokens = (n: number) =>
+  n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${(n / 1_000).toFixed(1)}K` : String(n);
+
+interface OrgGroup {
+  orgId: string;
+  orgName: string | null;
+  rows: UsageRow[];
+  subtotal: UsageTotals;
+}
+
+export default function UsageTab() {
+  const [from, setFrom] = useState(currentMonthKey());
+  const [to, setTo] = useState(currentMonthKey());
+  const [orgFilter, setOrgFilter] = useState('');
+  const [orgs, setOrgs] = useState<{ orgId: string; orgName: string }[]>([]);
+  const [rows, setRows] = useState<UsageRow[]>([]);
+  const [totals, setTotals] = useState<UsageTotals | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [expandedOrgs, setExpandedOrgs] = useState<Set<string>>(new Set());
+
+  const rangeValid = from !== '' && to !== '' && from <= to;
+
+  useEffect(() => {
+    void fetchWithAuth('/client-ai/admin/orgs')
+      .then((r) => (r.ok ? (r.json() as Promise<{ data?: { orgId: string; orgName: string }[] }>) : null))
+      .then((b) => {
+        if (b?.data) setOrgs(b.data.map(({ orgId, orgName }) => ({ orgId, orgName })));
+      })
+      .catch(() => {});
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!rangeValid) return;
+    try {
+      setLoading(true);
+      setLoadError(false);
+      const qs = new URLSearchParams({ from, to });
+      if (orgFilter) qs.set('orgId', orgFilter);
+      const res = await fetchWithAuth(`/client-ai/admin/usage?${qs.toString()}`);
+      if (res.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { rows: UsageRow[]; totals: UsageTotals };
+      setRows(body.rows ?? []);
+      setTotals(body.totals ?? null);
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [from, to, orgFilter, rangeValid]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const groups = useMemo<OrgGroup[]>(() => {
+    const byOrg = new Map<string, OrgGroup>();
+    for (const r of rows) {
+      let g = byOrg.get(r.orgId);
+      if (!g) {
+        g = {
+          orgId: r.orgId,
+          orgName: r.orgName,
+          rows: [],
+          subtotal: { messageCount: 0, sessionCount: 0, inputTokens: 0, outputTokens: 0, costCents: 0 },
+        };
+        byOrg.set(r.orgId, g);
+      }
+      g.rows.push(r);
+      g.subtotal.messageCount += r.messageCount;
+      g.subtotal.sessionCount += r.sessionCount;
+      g.subtotal.inputTokens += r.inputTokens;
+      g.subtotal.outputTokens += r.outputTokens;
+      g.subtotal.costCents = Math.round((g.subtotal.costCents + r.costCents) * 100) / 100;
+    }
+    return [...byOrg.values()];
+  }, [rows]);
+
+  const toggleOrg = (orgId: string) =>
+    setExpandedOrgs((prev) => {
+      const next = new Set(prev);
+      if (next.has(orgId)) {
+        next.delete(orgId);
+      } else {
+        next.add(orgId);
+      }
+      return next;
+    });
+
+  // CSV export — the BillablesExportCard.tsx blob-download pattern. The
+  // filename matches the route's Content-Disposition (Plan-4 Task 4).
+  const downloadCsv = async () => {
+    if (downloading || !rangeValid) return;
+    setDownloading(true);
+    try {
+      const qs = new URLSearchParams({ from, to });
+      if (orgFilter) qs.set('orgId', orgFilter);
+      const res = await fetchWithAuth(`/client-ai/admin/usage.csv?${qs.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        showToast({
+          type: 'error',
+          message: (body as { error?: string } | null)?.error ?? 'Export failed',
+        });
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `client-ai-usage-${from}-to-${to}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      showToast({ type: 'error', message: 'Export failed' });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Range + filter bar */}
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="text-xs">
+          From month
+          <input
+            type="month"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm"
+            data-testid="ai-office-usage-from"
+          />
+        </label>
+        <label className="text-xs">
+          To month
+          <input
+            type="month"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm"
+            data-testid="ai-office-usage-to"
+          />
+        </label>
+        <label className="text-xs">
+          Organization
+          <select
+            value={orgFilter}
+            onChange={(e) => setOrgFilter(e.target.value)}
+            className="mt-0.5 block rounded-md border bg-background px-2 py-1.5 text-sm"
+            data-testid="ai-office-usage-org"
+          >
+            <option value="">All organizations</option>
+            {orgs.map((o) => (
+              <option key={o.orgId} value={o.orgId}>
+                {o.orgName}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={() => void downloadCsv()}
+          disabled={downloading || !rangeValid}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+          data-testid="ai-office-usage-export"
+        >
+          <Download className="h-4 w-4" />
+          {downloading ? 'Exporting…' : 'Export CSV'}
+        </button>
+        {!rangeValid && (
+          <span className="pb-1.5 text-xs text-destructive">From month must be ≤ to month</span>
+        )}
+      </div>
+
+      {/* Report table */}
+      <div className="rounded-lg border bg-card">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : loadError ? (
+          <div className="p-6 text-sm text-muted-foreground" data-testid="ai-office-usage-load-error">
+            Failed to load the usage report.{' '}
+            <button type="button" className="text-primary underline" onClick={() => void load()}>
+              Retry
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/40">
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <th className="px-4 py-2">Organization / user</th>
+                  <th className="px-4 py-2">Month</th>
+                  <th className="px-4 py-2 text-right">Messages</th>
+                  <th className="px-4 py-2 text-right">Sessions</th>
+                  <th className="px-4 py-2 text-right">Tokens (in/out)</th>
+                  <th className="px-4 py-2 text-right">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {groups.map((g) => {
+                  const expanded = expandedOrgs.has(g.orgId);
+                  return (
+                    <Fragment key={g.orgId}>
+                      <tr
+                        onClick={() => toggleOrg(g.orgId)}
+                        className="cursor-pointer border-b font-medium hover:bg-muted/20"
+                        data-testid={`ai-office-usage-org-${g.orgId}`}
+                      >
+                        <td className="px-4 py-2.5">
+                          <span className="inline-flex items-center gap-1.5">
+                            {expanded ? (
+                              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                            ) : (
+                              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                            )}
+                            {g.orgName ?? g.orgId}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2.5 text-xs text-muted-foreground">
+                          {g.rows.length} row{g.rows.length === 1 ? '' : 's'}
+                        </td>
+                        <td className="px-4 py-2.5 text-right">{g.subtotal.messageCount}</td>
+                        <td className="px-4 py-2.5 text-right">{g.subtotal.sessionCount}</td>
+                        <td className="px-4 py-2.5 text-right">
+                          {formatTokens(g.subtotal.inputTokens)} / {formatTokens(g.subtotal.outputTokens)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right">{formatCost(g.subtotal.costCents)}</td>
+                      </tr>
+                      {expanded &&
+                        g.rows.map((r) => (
+                          <tr
+                            key={`${r.orgId}-${r.clientUserId}-${r.month}`}
+                            className="border-b bg-muted/10 last:border-0"
+                            data-testid="ai-office-usage-user-row"
+                          >
+                            <td className="px-4 py-2 pl-12 text-muted-foreground">
+                              {r.userEmail ?? r.clientUserId ?? '—'}
+                            </td>
+                            <td className="px-4 py-2 text-xs text-muted-foreground">{r.month}</td>
+                            <td className="px-4 py-2 text-right">{r.messageCount}</td>
+                            <td className="px-4 py-2 text-right">{r.sessionCount}</td>
+                            <td className="px-4 py-2 text-right">
+                              {formatTokens(r.inputTokens)} / {formatTokens(r.outputTokens)}
+                            </td>
+                            <td className="px-4 py-2 text-right">{formatCost(r.costCents)}</td>
+                          </tr>
+                        ))}
+                    </Fragment>
+                  );
+                })}
+                {groups.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                      No usage recorded in this range
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+              {totals && groups.length > 0 && (
+                <tfoot>
+                  <tr className="border-t bg-muted/30 font-semibold" data-testid="ai-office-usage-totals">
+                    <td className="px-4 py-2.5" colSpan={2}>
+                      Total
+                    </td>
+                    <td className="px-4 py-2.5 text-right">{totals.messageCount}</td>
+                    <td className="px-4 py-2.5 text-right">{totals.sessionCount}</td>
+                    <td className="px-4 py-2.5 text-right">
+                      {formatTokens(totals.inputTokens)} / {formatTokens(totals.outputTokens)}
+                    </td>
+                    <td className="px-4 py-2.5 text-right">{formatCost(totals.costCents)}</td>
+                  </tr>
+                </tfoot>
+              )}
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write the component tests**
+
+`apps/web/src/components/clientAi/UsageTab.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UsageTab from './UsageTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+
+const USAGE_ROWS = [
+  {
+    month: '2026-06',
+    orgId: ORG_ID,
+    orgName: 'Contoso Accounting',
+    clientUserId: 'beefbeef-1111-4222-8333-444455556666',
+    userEmail: 'finance.user@contoso.com',
+    messageCount: 40,
+    sessionCount: 4,
+    inputTokens: 10000,
+    outputTokens: 2000,
+    costCents: 150,
+  },
+  {
+    month: '2026-06',
+    orgId: ORG_ID,
+    orgName: 'Contoso Accounting',
+    clientUserId: 'cafecafe-1111-4222-8333-444455556666',
+    userEmail: 'ap.clerk@contoso.com',
+    messageCount: 18,
+    sessionCount: 2,
+    inputTokens: 5000,
+    outputTokens: 1000,
+    costCents: 75,
+  },
+];
+
+const TOTALS = {
+  messageCount: 58,
+  sessionCount: 6,
+  inputTokens: 15000,
+  outputTokens: 3000,
+  costCents: 225,
+};
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+function mockApi() {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/client-ai/admin/orgs' && !init?.method) {
+      return makeJsonResponse({ data: [{ orgId: ORG_ID, orgName: 'Contoso Accounting' }] });
+    }
+    if (url.startsWith('/client-ai/admin/usage.csv?') && !init?.method) {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        blob: vi.fn().mockResolvedValue(new Blob(['month,org_name'], { type: 'text/csv' })),
+        json: vi.fn(),
+      } as unknown as Response;
+    }
+    if (url.startsWith('/client-ai/admin/usage?') && !init?.method) {
+      return makeJsonResponse({ rows: USAGE_ROWS, totals: TOTALS });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 500);
+  });
+}
+
+describe('UsageTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom has no createObjectURL — stub the pair the download path uses.
+    URL.createObjectURL = vi.fn(() => 'blob:fake');
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  it('renders org groups with subtotals and the totals footer', async () => {
+    mockApi();
+    render(<UsageTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-usage-org-${ORG_ID}`)).toBeInTheDocument()
+    );
+    // Org subtotal row: 58 messages, $2.25 total cost (225 cents)
+    expect(screen.getByTestId(`ai-office-usage-org-${ORG_ID}`).textContent).toContain('58');
+    expect(screen.getByTestId('ai-office-usage-totals').textContent).toContain('$2.25');
+  });
+
+  it('expands an org group to per-user rows', async () => {
+    mockApi();
+    render(<UsageTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-usage-org-${ORG_ID}`)).toBeInTheDocument()
+    );
+    expect(screen.queryAllByTestId('ai-office-usage-user-row')).toHaveLength(0);
+    fireEvent.click(screen.getByTestId(`ai-office-usage-org-${ORG_ID}`));
+    expect(screen.getAllByTestId('ai-office-usage-user-row')).toHaveLength(2);
+    expect(screen.getByText('finance.user@contoso.com')).toBeInTheDocument();
+    expect(screen.getByText('ap.clerk@contoso.com')).toBeInTheDocument();
+  });
+
+  it('re-queries when the month range changes (YYYY-MM params)', async () => {
+    mockApi();
+    render(<UsageTab />);
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([u]) => String(u).startsWith('/client-ai/admin/usage?'))).toBe(true)
+    );
+    fireEvent.change(screen.getByTestId('ai-office-usage-from'), { target: { value: '2026-01' } });
+    await waitFor(() => {
+      const usageCalls = fetchMock.mock.calls.filter(([u]) =>
+        String(u).startsWith('/client-ai/admin/usage?')
+      );
+      expect(String(usageCalls[usageCalls.length - 1]![0])).toContain('from=2026-01');
+    });
+  });
+
+  it('Export CSV hits usage.csv and triggers a blob download', async () => {
+    mockApi();
+    render(<UsageTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId('ai-office-usage-export')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('ai-office-usage-export'));
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([u]) => String(u).startsWith('/client-ai/admin/usage.csv?'))
+      ).toBe(true)
+    );
+    await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:fake');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/components/clientAi/UsageTab.test.tsx
+```
+
+Expected: 4 tests PASS. (UsageTab has no mutating fetches — CSV export is a GET — so it is intentionally not added to `TARGET_GLOBS`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/clientAi/UsageTab.tsx apps/web/src/components/clientAi/UsageTab.test.tsx
+git commit -m "feat(client-ai-web): usage report with per-user drill-down + CSV export" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: TemplatesTab — prompt template CRUD
+
+Spec §9.5/§10. Consumes Task 5's endpoints exactly: `GET /client-ai/admin/templates` → `{data}`, `POST /templates` (`templateBodySchema`: `orgId: null` ⇒ partner-wide/all-orgs row) → `201 {template}`, `PUT /templates/:id` (`templateUpdateSchema` — **no orgId key**; scope is immutable after create), `DELETE /templates/:id` → `{success:true}`. A 403 `partner_scope_required` on an all-orgs create from org scope surfaces via runAction's error toast.
+
+**Files:**
+- Create: apps/web/src/components/clientAi/TemplatesTab.tsx
+- Create: apps/web/src/components/clientAi/TemplatesTab.test.tsx
+- Modify: apps/web/src/lib/__tests__/no-silent-mutations.test.ts (`TARGET_GLOBS`)
+
+- [ ] **Step 1: Write the component**
+
+`apps/web/src/components/clientAi/TemplatesTab.tsx`:
+
+```tsx
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, Pencil, Plus, Trash2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { Dialog } from '../shared/Dialog';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { runAction, handleActionError } from '@/lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+
+/**
+ * AI for Office — prompt template manager (spec §9.5, §10). Templates surface
+ * in the add-in's empty-chat picker (Plan-4 Task 6 client route). Scope:
+ * orgId NULL = partner-wide ("All orgs") row, else org-scoped. Scope is
+ * immutable after create (templateUpdateSchema has no orgId — Plan-4 Task 5;
+ * move a template by delete + recreate).
+ */
+
+/** Row shape of GET /client-ai/admin/templates (Plan-4 Task 5). */
+interface TemplateRow {
+  id: string;
+  orgId: string | null;
+  partnerId: string | null;
+  orgName: string | null;
+  name: string;
+  description: string | null;
+  promptBody: string;
+  category: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+type EditorState = { mode: 'closed' } | { mode: 'create' } | { mode: 'edit'; template: TemplateRow };
+
+function ScopeBadge({ row }: { row: TemplateRow }) {
+  if (row.orgId === null) {
+    return (
+      <span
+        className="inline-flex items-center rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 text-xs text-violet-700 dark:border-violet-500/30 dark:bg-violet-500/10 dark:text-violet-400"
+        data-testid="ai-office-template-scope-partner"
+      >
+        All orgs
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs text-slate-600 dark:border-slate-500/30 dark:bg-slate-500/10 dark:text-slate-400"
+      data-testid="ai-office-template-scope-org"
+    >
+      {row.orgName ?? 'Org'}
+    </span>
+  );
+}
+
+export default function TemplatesTab() {
+  const [rows, setRows] = useState<TemplateRow[]>([]);
+  const [orgs, setOrgs] = useState<{ orgId: string; orgName: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [editor, setEditor] = useState<EditorState>({ mode: 'closed' });
+  const [deleting, setDeleting] = useState<TemplateRow | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoadError(false);
+      const res = await fetchWithAuth('/client-ai/admin/templates');
+      if (res.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { data: TemplateRow[] };
+      setRows(body.data ?? []);
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Org options for the create-dialog scope selector.
+  useEffect(() => {
+    void fetchWithAuth('/client-ai/admin/orgs')
+      .then((r) => (r.ok ? (r.json() as Promise<{ data?: { orgId: string; orgName: string }[] }>) : null))
+      .then((b) => {
+        if (b?.data) setOrgs(b.data.map(({ orgId, orgName }) => ({ orgId, orgName })));
+      })
+      .catch(() => {});
+  }, []);
+
+  const confirmDelete = async () => {
+    if (!deleting || deleteBusy) return;
+    setDeleteBusy(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/client-ai/admin/templates/${deleting.id}`, { method: 'DELETE' }),
+        errorFallback: 'Failed to delete template',
+        successMessage: `Template "${deleting.name}" deleted`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      setDeleting(null);
+      await load();
+    } catch (err) {
+      handleActionError(err, 'Failed to delete template');
+    } finally {
+      setDeleteBusy(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div
+        className="rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+        data-testid="ai-office-templates-load-error"
+      >
+        Failed to load templates.{' '}
+        <button
+          type="button"
+          className="text-primary underline"
+          onClick={() => {
+            setLoading(true);
+            void load();
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border bg-card">
+        <div className="flex items-center justify-between border-b px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold">Prompt templates</h2>
+            <p className="text-sm text-muted-foreground">
+              Shown in the add-in&apos;s empty-chat picker. &quot;All orgs&quot; templates reach
+              every client org; org templates only theirs.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setEditor({ mode: 'create' })}
+            className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground"
+            data-testid="ai-office-template-create"
+          >
+            <Plus className="h-4 w-4" /> New template
+          </button>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-2">Name</th>
+                <th className="px-4 py-2">Scope</th>
+                <th className="px-4 py-2">Category</th>
+                <th className="px-4 py-2">Updated</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={row.id}
+                  className="border-b last:border-0 hover:bg-muted/20"
+                  data-testid={`ai-office-template-row-${row.id}`}
+                >
+                  <td className="px-4 py-2.5">
+                    <p className="font-medium">{row.name}</p>
+                    {row.description && (
+                      <p className="max-w-[360px] truncate text-xs text-muted-foreground">{row.description}</p>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <ScopeBadge row={row} />
+                  </td>
+                  <td className="px-4 py-2.5 text-muted-foreground">{row.category ?? '—'}</td>
+                  <td className="px-4 py-2.5 text-xs text-muted-foreground">
+                    {new Date(row.updatedAt).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setEditor({ mode: 'edit', template: row })}
+                        className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                        data-testid={`ai-office-template-edit-${row.id}`}
+                      >
+                        <Pencil className="h-3.5 w-3.5" /> Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleting(row)}
+                        className="inline-flex items-center gap-1 rounded-md border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                        data-testid={`ai-office-template-delete-${row.id}`}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" /> Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-muted-foreground">
+                    No templates yet — create the first one
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {editor.mode !== 'closed' && (
+        <TemplateEditorDialog
+          state={editor}
+          orgs={orgs}
+          onClose={() => setEditor({ mode: 'closed' })}
+          onSaved={() => {
+            setEditor({ mode: 'closed' });
+            void load();
+          }}
+        />
+      )}
+
+      <ConfirmDialog
+        open={deleting !== null}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => void confirmDelete()}
+        title="Delete template"
+        message={
+          deleting
+            ? `Delete "${deleting.name}"? It disappears from the add-in's template picker immediately.`
+            : ''
+        }
+        confirmLabel="Delete"
+        isLoading={deleteBusy}
+        confirmTestId="ai-office-template-delete-confirm"
+      />
+    </div>
+  );
+}
+
+// ── Create/edit dialog ────────────────────────────────────────────────────────
+
+function TemplateEditorDialog({
+  state,
+  orgs,
+  onClose,
+  onSaved,
+}: {
+  state: Exclude<EditorState, { mode: 'closed' }>;
+  orgs: { orgId: string; orgName: string }[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const editing = state.mode === 'edit' ? state.template : null;
+  const [name, setName] = useState(editing?.name ?? '');
+  const [description, setDescription] = useState(editing?.description ?? '');
+  const [category, setCategory] = useState(editing?.category ?? '');
+  const [body, setBody] = useState(editing?.promptBody ?? '');
+  // 'partner' or an orgId. Immutable in edit mode (templateUpdateSchema has no
+  // orgId — Plan-4 Task 5).
+  const [scope, setScope] = useState<string>(editing ? (editing.orgId ?? 'partner') : 'partner');
+  const [saving, setSaving] = useState(false);
+
+  const valid = name.trim().length > 0 && body.trim().length > 0;
+
+  const save = async () => {
+    if (!valid || saving) return;
+    setSaving(true);
+    try {
+      if (editing) {
+        // templateUpdateSchema: name/description/promptBody/category only.
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/client-ai/admin/templates/${editing.id}`, {
+              method: 'PUT',
+              body: JSON.stringify({
+                name: name.trim(),
+                description: description.trim() ? description.trim() : null,
+                promptBody: body,
+                category: category.trim() ? category.trim() : null,
+              }),
+            }),
+          errorFallback: 'Failed to update template',
+          successMessage: 'Template updated',
+          onUnauthorized: () => void navigateTo('/login', { replace: true }),
+        });
+      } else {
+        // templateBodySchema: orgId null ⇒ partner-wide row. A 403
+        // partner_scope_required (org-scope caller) surfaces via the toast.
+        await runAction({
+          request: () =>
+            fetchWithAuth('/client-ai/admin/templates', {
+              method: 'POST',
+              body: JSON.stringify({
+                name: name.trim(),
+                description: description.trim() ? description.trim() : null,
+                promptBody: body,
+                category: category.trim() ? category.trim() : null,
+                orgId: scope === 'partner' ? null : scope,
+              }),
+            }),
+          errorFallback: 'Failed to create template',
+          successMessage: 'Template created',
+          onUnauthorized: () => void navigateTo('/login', { replace: true }),
+        });
+      }
+      onSaved();
+    } catch (err) {
+      handleActionError(err, editing ? 'Failed to update template' : 'Failed to create template');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      title={editing ? 'Edit template' : 'New template'}
+      maxWidth="3xl"
+      className="p-6"
+    >
+      <h2 className="text-lg font-semibold">{editing ? 'Edit template' : 'New template'}</h2>
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <label className="block text-sm">
+          <span className="text-muted-foreground">Name</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={200}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            data-testid="ai-office-template-name"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-muted-foreground">Category</span>
+          <input
+            type="text"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            maxLength={100}
+            placeholder="e.g. finance"
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            data-testid="ai-office-template-category"
+          />
+        </label>
+        <label className="block text-sm sm:col-span-2">
+          <span className="text-muted-foreground">Description</span>
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={2000}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            data-testid="ai-office-template-description"
+          />
+        </label>
+        <label className="block text-sm sm:col-span-2">
+          <span className="text-muted-foreground">Prompt body</span>
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={6}
+            maxLength={20000}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
+            data-testid="ai-office-template-body"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-muted-foreground">Scope</span>
+          <select
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            disabled={editing !== null}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-60"
+            data-testid="ai-office-template-scope"
+          >
+            <option value="partner">All organizations (partner-wide)</option>
+            {orgs.map((o) => (
+              <option key={o.orgId} value={o.orgId}>
+                {o.orgName}
+              </option>
+            ))}
+          </select>
+          {editing !== null && (
+            <span className="mt-1 block text-xs text-muted-foreground">
+              Scope can&apos;t change after creation — delete and recreate to move it.
+            </span>
+          )}
+        </label>
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={!valid || saving}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+          data-testid="ai-office-template-save"
+        >
+          {saving ? 'Saving…' : editing ? 'Save changes' : 'Create template'}
+        </button>
+      </div>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Write the component tests**
+
+`apps/web/src/components/clientAi/TemplatesTab.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TemplatesTab from './TemplatesTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
+const PARTNER_ID = 'f0f0f0f0-1111-4222-8333-444455556666';
+const TEMPLATE_ID = '7e7e7e7e-1111-4222-8333-444455556666';
+const ORG_TEMPLATE_ID = '8f8f8f8f-1111-4222-8333-444455556666';
+
+const PARTNER_ROW = {
+  id: TEMPLATE_ID,
+  orgId: null,
+  partnerId: PARTNER_ID,
+  orgName: null,
+  name: 'Quarterly variance walkthrough',
+  description: 'Explains variance between columns',
+  promptBody: 'Explain the variance between the selected columns.',
+  category: 'finance',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const ORG_ROW = {
+  ...PARTNER_ROW,
+  id: ORG_TEMPLATE_ID,
+  orgId: ORG_ID,
+  partnerId: null,
+  orgName: 'Contoso Accounting',
+  name: 'Contoso month-end checklist',
+};
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+function mockApi() {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === '/client-ai/admin/templates' && !init?.method) {
+      return makeJsonResponse({ data: [PARTNER_ROW, ORG_ROW] });
+    }
+    if (url === '/client-ai/admin/templates' && init?.method === 'POST') {
+      return makeJsonResponse({ template: { ...PARTNER_ROW, id: 'new-id' } }, true, 201);
+    }
+    if (url === `/client-ai/admin/templates/${TEMPLATE_ID}` && init?.method === 'PUT') {
+      return makeJsonResponse({ template: { ...PARTNER_ROW, name: 'Renamed' } });
+    }
+    if (url === `/client-ai/admin/templates/${TEMPLATE_ID}` && init?.method === 'DELETE') {
+      return makeJsonResponse({ success: true });
+    }
+    if (url === '/client-ai/admin/orgs' && !init?.method) {
+      return makeJsonResponse({ data: [{ orgId: ORG_ID, orgName: 'Contoso Accounting' }] });
+    }
+    return makeJsonResponse({ error: 'unexpected' }, false, 500);
+  });
+}
+
+describe('TemplatesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders scope badges: All orgs for partner-wide, org name for org-scoped', async () => {
+    mockApi();
+    render(<TemplatesTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-template-row-${TEMPLATE_ID}`)).toBeInTheDocument()
+    );
+    expect(screen.getByTestId('ai-office-template-scope-partner').textContent).toBe('All orgs');
+    expect(screen.getByTestId('ai-office-template-scope-org').textContent).toBe('Contoso Accounting');
+  });
+
+  it('creates a partner-wide template (exact POST payload)', async () => {
+    mockApi();
+    render(<TemplatesTab />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-template-create')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('ai-office-template-create'));
+    fireEvent.change(screen.getByTestId('ai-office-template-name'), { target: { value: 'New' } });
+    fireEvent.change(screen.getByTestId('ai-office-template-body'), { target: { value: 'Body' } });
+    // Scope select defaults to 'partner' — leave it.
+    fireEvent.click(screen.getByTestId('ai-office-template-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(true)
+    );
+    const postCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(String(postCall![0])).toBe('/client-ai/admin/templates');
+    expect(JSON.parse(String(postCall![1]!.body))).toEqual({
+      name: 'New',
+      description: null,
+      promptBody: 'Body',
+      category: null,
+      orgId: null,
+    });
+  });
+
+  it('creates an org-scoped template when an org is chosen', async () => {
+    mockApi();
+    render(<TemplatesTab />);
+    await waitFor(() => expect(screen.getByTestId('ai-office-template-create')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('ai-office-template-create'));
+    fireEvent.change(screen.getByTestId('ai-office-template-name'), { target: { value: 'Org one' } });
+    fireEvent.change(screen.getByTestId('ai-office-template-body'), { target: { value: 'Body' } });
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId('ai-office-template-scope') as HTMLSelectElement).options.length
+      ).toBeGreaterThan(1)
+    );
+    fireEvent.change(screen.getByTestId('ai-office-template-scope'), { target: { value: ORG_ID } });
+    fireEvent.click(screen.getByTestId('ai-office-template-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(true)
+    );
+    const body = JSON.parse(
+      String(fetchMock.mock.calls.find(([, init]) => init?.method === 'POST')![1]!.body)
+    );
+    expect(body.orgId).toBe(ORG_ID);
+  });
+
+  it('edits without an orgId key (scope is immutable) and the scope select is disabled', async () => {
+    mockApi();
+    render(<TemplatesTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-template-edit-${TEMPLATE_ID}`)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByTestId(`ai-office-template-edit-${TEMPLATE_ID}`));
+    expect((screen.getByTestId('ai-office-template-scope') as HTMLSelectElement).disabled).toBe(true);
+    fireEvent.change(screen.getByTestId('ai-office-template-name'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('ai-office-template-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'PUT')).toBe(true)
+    );
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT');
+    expect(String(putCall![0])).toBe(`/client-ai/admin/templates/${TEMPLATE_ID}`);
+    const body = JSON.parse(String(putCall![1]!.body));
+    expect(body).not.toHaveProperty('orgId');
+    expect(body.name).toBe('Renamed');
+  });
+
+  it('deletes through the confirm dialog', async () => {
+    mockApi();
+    render(<TemplatesTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId(`ai-office-template-delete-${TEMPLATE_ID}`)).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId(`ai-office-template-delete-${TEMPLATE_ID}`));
+    fireEvent.click(screen.getByTestId('ai-office-template-delete-confirm'));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(true)
+    );
+    const delCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'DELETE');
+    expect(String(delCall![0])).toBe(`/client-ai/admin/templates/${TEMPLATE_ID}`);
+  });
+});
+```
+
+- [ ] **Step 3: Adopt into the WS-A guard**
+
+Append to `TARGET_GLOBS` in `apps/web/src/lib/__tests__/no-silent-mutations.test.ts`. After this task the full clientAi block reads:
+
+```ts
+  'src/components/clientAi/OrgsTab.tsx',
+  'src/components/clientAi/PolicyEditor.tsx',
+  'src/components/clientAi/SessionsTab.tsx',
+  'src/components/clientAi/TemplatesTab.tsx',
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/components/clientAi/TemplatesTab.test.tsx src/lib/__tests__/no-silent-mutations.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/clientAi/TemplatesTab.tsx apps/web/src/components/clientAi/TemplatesTab.test.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(client-ai-web): prompt template manager with org/partner scopes" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Page shell — hash-tab island, Astro page, sidebar nav entry
+
+Wires the five tab components built in Tasks 8–12 into one island. Hash routing follows `DeviceDetails.tsx:147-166` (state-from-hash + `hashchange` listener) with the `OrganizationsPage.tsx`-style id-in-hash for `#policy/<orgId>`. The Astro page mirrors `pam.astro` exactly. The nav entry goes into the "AI & Fleet" section of `Sidebar.tsx` behind a new `partnerScopeOnly` flag that mirrors the existing `platformAdminOnly` flag (`Sidebar.tsx:79-89, 421-422`) and the partner-branding fetch's `getJwtClaims().scope` gate (`Sidebar.tsx:306-308`) — client-side UX nicety only; the server re-checks everything.
+
+**Files:**
+- Create: apps/web/src/components/clientAi/AiForOfficePage.tsx
+- Create: apps/web/src/components/clientAi/AiForOfficePage.test.tsx
+- Create: apps/web/src/pages/ai-for-office.astro
+- Modify: apps/web/src/components/layout/Sidebar.tsx
+
+- [ ] **Step 1: Write the island shell**
+
+`apps/web/src/components/clientAi/AiForOfficePage.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import OrgsTab from './OrgsTab';
+import PolicyEditor from './PolicyEditor';
+import SessionsTab from './SessionsTab';
+import UsageTab from './UsageTab';
+import TemplatesTab from './TemplatesTab';
+
+/**
+ * AI for Office — MSP admin surface shell (spec §9). Tab state lives in
+ * window.location.hash (#orgs default, #sessions, #usage, #templates,
+ * #policy/<orgId>) per the DeviceDetails.tsx hash-tab convention — never
+ * query params. Deep links and reloads land on the right tab.
+ */
+
+const SIMPLE_TABS = ['orgs', 'sessions', 'usage', 'templates'] as const;
+type SimpleTab = (typeof SIMPLE_TABS)[number];
+
+export type TabState = { tab: SimpleTab } | { tab: 'policy'; orgId: string };
+
+export function getStateFromHash(): TabState {
+  if (typeof window === 'undefined') return { tab: 'orgs' };
+  const hash = window.location.hash.replace('#', '');
+  if (hash.startsWith('policy/')) {
+    const orgId = hash.slice('policy/'.length);
+    if (orgId) return { tab: 'policy', orgId };
+  }
+  if ((SIMPLE_TABS as readonly string[]).includes(hash)) return { tab: hash as SimpleTab };
+  return { tab: 'orgs' };
+}
+
+const TAB_DEFS: { id: SimpleTab; label: string }[] = [
+  { id: 'orgs', label: 'Organizations' },
+  { id: 'sessions', label: 'Sessions' },
+  { id: 'usage', label: 'Usage' },
+  { id: 'templates', label: 'Templates' },
+];
+
+export default function AiForOfficePage() {
+  const [state, setState] = useState<TabState>(getStateFromHash);
+
+  useEffect(() => {
+    const onHashChange = () => setState(getStateFromHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  const switchTab = (tab: SimpleTab) => {
+    window.location.hash = tab;
+    setState({ tab });
+  };
+
+  const openPolicy = (orgId: string) => {
+    window.location.hash = `policy/${orgId}`;
+    setState({ tab: 'policy', orgId });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">AI for Office</h1>
+        <p className="text-muted-foreground">
+          Governed AI assistant in your clients&apos; Excel — provisioning, policy, audit, usage
+          and templates
+        </p>
+      </div>
+
+      <div className="border-b">
+        <nav className="-mb-px flex gap-4">
+          {TAB_DEFS.map((t) => {
+            const active = state.tab === t.id || (t.id === 'orgs' && state.tab === 'policy');
+            return (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => switchTab(t.id)}
+                className={`border-b-2 px-1 pb-2 text-sm font-medium transition-colors ${
+                  active
+                    ? 'border-primary text-foreground'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
+                }`}
+                data-testid={`ai-office-tab-${t.id}`}
+              >
+                {t.label}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+
+      {state.tab === 'orgs' && <OrgsTab onOpenPolicy={openPolicy} />}
+      {state.tab === 'policy' && (
+        <PolicyEditor orgId={state.orgId} onBack={() => switchTab('orgs')} />
+      )}
+      {state.tab === 'sessions' && <SessionsTab />}
+      {state.tab === 'usage' && <UsageTab />}
+      {state.tab === 'templates' && <TemplatesTab />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create the Astro page**
+
+`apps/web/src/pages/ai-for-office.astro` (mirrors `pam.astro`):
+
+```astro
+---
+import DashboardLayout from '../layouts/DashboardLayout.astro';
+import AiForOfficePage from '../components/clientAi/AiForOfficePage';
+---
+
+<DashboardLayout title="AI for Office">
+  <AiForOfficePage client:load />
+</DashboardLayout>
+```
+
+- [ ] **Step 3: Register the nav entry in Sidebar.tsx**
+
+Three small edits to `apps/web/src/components/layout/Sidebar.tsx`:
+
+**(a)** Add `FileSpreadsheet` to the lucide-react import block (alphabetically near `FileCode`/`FileText`):
+
+```ts
+  FileSpreadsheet,
+```
+
+**(b)** Extend the `NavItem` type (after the existing `platformAdminOnly` member, ~line 88):
+
+```ts
+  // Hidden when the JWT decodes to a non-partner scope (AI for Office is an
+  // MSP-admin surface). Client-side UX nicety only — same rationale as the
+  // partner-branding fetch below; undecodable tokens fall through to visible
+  // and the server re-checks everything.
+  partnerScopeOnly?: boolean;
+```
+
+**(c)** Add the item to the `ai-fleet` section's `items` (after `AI Workspace`, ~line 119):
+
+```ts
+      { name: 'AI for Office', href: '/ai-for-office', icon: FileSpreadsheet, partnerScopeOnly: true },
+```
+
+**(d)** Gate it in `renderNavItem`. Directly below the existing `platformAdminOnly` guard (`if (item.platformAdminOnly && !isPlatformAdmin) return null;`, ~line 422) add:
+
+```ts
+    if (item.partnerScopeOnly) {
+      const { scope } = getJwtClaims();
+      if (scope !== null && scope !== 'partner') return null;
+    }
+```
+
+(`getJwtClaims` is already imported in Sidebar.tsx from `../../lib/authScope` — no new import needed.)
+
+- [ ] **Step 4: Write the shell tests**
+
+`apps/web/src/components/clientAi/AiForOfficePage.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub the five tab islands — each has its own test file; here we only test
+// the hash routing shell.
+vi.mock('./OrgsTab', () => ({
+  default: ({ onOpenPolicy }: { onOpenPolicy: (id: string) => void }) => (
+    <button data-testid="stub-orgs" onClick={() => onOpenPolicy('ORG-1')}>
+      orgs
+    </button>
+  ),
+}));
+vi.mock('./PolicyEditor', () => ({
+  default: ({ orgId, onBack }: { orgId: string; onBack: () => void }) => (
+    <div data-testid="stub-policy">
+      <span data-testid="stub-policy-org">{orgId}</span>
+      <button data-testid="stub-policy-back" onClick={onBack}>
+        back
+      </button>
+    </div>
+  ),
+}));
+vi.mock('./SessionsTab', () => ({ default: () => <div data-testid="stub-sessions" /> }));
+vi.mock('./UsageTab', () => ({ default: () => <div data-testid="stub-usage" /> }));
+vi.mock('./TemplatesTab', () => ({ default: () => <div data-testid="stub-templates" /> }));
+
+import AiForOfficePage, { getStateFromHash } from './AiForOfficePage';
+
+describe('AiForOfficePage', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/ai-for-office');
+  });
+
+  it('defaults to the orgs tab', () => {
+    render(<AiForOfficePage />);
+    expect(screen.getByTestId('stub-orgs')).toBeInTheDocument();
+  });
+
+  it('reads the initial tab from the hash', () => {
+    window.location.hash = '#sessions';
+    render(<AiForOfficePage />);
+    expect(screen.getByTestId('stub-sessions')).toBeInTheDocument();
+  });
+
+  it('switches tabs on click and writes the hash', () => {
+    render(<AiForOfficePage />);
+    fireEvent.click(screen.getByTestId('ai-office-tab-usage'));
+    expect(screen.getByTestId('stub-usage')).toBeInTheDocument();
+    expect(window.location.hash).toBe('#usage');
+    fireEvent.click(screen.getByTestId('ai-office-tab-templates'));
+    expect(screen.getByTestId('stub-templates')).toBeInTheDocument();
+    expect(window.location.hash).toBe('#templates');
+  });
+
+  it('routes #policy/<orgId> deep links to the policy editor', () => {
+    window.location.hash = '#policy/ORG-9';
+    render(<AiForOfficePage />);
+    expect(screen.getByTestId('stub-policy-org').textContent).toBe('ORG-9');
+  });
+
+  it('OrgsTab → policy editor → back round-trip updates the hash', () => {
+    render(<AiForOfficePage />);
+    fireEvent.click(screen.getByTestId('stub-orgs')); // calls onOpenPolicy('ORG-1')
+    expect(screen.getByTestId('stub-policy-org').textContent).toBe('ORG-1');
+    expect(window.location.hash).toBe('#policy/ORG-1');
+    fireEvent.click(screen.getByTestId('stub-policy-back'));
+    expect(screen.getByTestId('stub-orgs')).toBeInTheDocument();
+    expect(window.location.hash).toBe('#orgs');
+  });
+
+  it('getStateFromHash falls back to orgs for junk hashes', () => {
+    window.location.hash = '#nonsense';
+    expect(getStateFromHash()).toEqual({ tab: 'orgs' });
+    window.location.hash = '#policy/';
+    expect(getStateFromHash()).toEqual({ tab: 'orgs' });
+  });
+});
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run src/components/clientAi/AiForOfficePage.test.tsx
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/clientAi/AiForOfficePage.tsx apps/web/src/components/clientAi/AiForOfficePage.test.tsx apps/web/src/pages/ai-for-office.astro apps/web/src/components/layout/Sidebar.tsx
+git commit -m "feat(client-ai-web): AI for Office page shell with hash tabs + partner-gated nav entry" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Final verification — type-check, full test sweep, manual smoke
+
+No new code. Proves the whole plan hangs together before the PR. (Verification-before-completion: run every command and read the output — no claims without evidence.)
+
+- [ ] **Step 1: Type-check apps/web (CI parity)**
+
+CI runs `astro check` for web (`.github/workflows/ci.yml:95-97`):
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec astro check
+```
+
+Expected: zero errors in `src/components/clientAi/**`, `src/pages/ai-for-office.astro`, and `src/components/layout/Sidebar.tsx`. If the baseline isn't clean, compare against a stash run (`git stash && pnpm exec astro check && git stash pop`) — only NEW errors are yours.
+
+- [ ] **Step 2: Type-check apps/api**
+
+```bash
+cd /Users/toddhebebrand/breeze
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec tsc --noEmit --project apps/api/tsconfig.json
+```
+
+Expected: only the known pre-existing errors in `agents.test.ts` and `apiKeyAuth.test.ts` — nothing in `routes/clientAi/**`.
+
+- [ ] **Step 3: Run the full web sweep for this plan (affected files only — the full parallel suite is known-flaky)**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/web
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run \
+  src/components/clientAi/AiForOfficePage.test.tsx \
+  src/components/clientAi/OrgsTab.test.tsx \
+  src/components/clientAi/PolicyEditor.test.tsx \
+  src/components/clientAi/SessionsTab.test.tsx \
+  src/components/clientAi/UsageTab.test.tsx \
+  src/components/clientAi/TemplatesTab.test.tsx \
+  src/lib/__tests__/no-silent-mutations.test.ts \
+  src/lib/runAction.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Re-run the API sweep for this plan**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/api
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm vitest run \
+  src/routes/clientAi/schemas.test.ts \
+  src/routes/clientAi/admin.test.ts \
+  src/routes/clientAi/auth.test.ts \
+  src/routes/clientAi/adminOrgs.test.ts \
+  src/routes/clientAi/adminSessions.test.ts \
+  src/routes/clientAi/adminUsage.test.ts \
+  src/routes/clientAi/adminTemplates.test.ts \
+  src/routes/clientAi/templates.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Manual smoke checklist (dev stack)**
+
+Bring up the dev stack (`docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up --build -d`) with `CLIENT_AI_ENTRA_CLIENT_ID` set on the API, log in as a **partner-scope** user, open `/ai-for-office`, and verify:
+
+1. **Nav gating** — "AI for Office" appears under AI & Fleet for the partner user; log in as an org-scope user and confirm it's hidden.
+2. **Dark gate** — with `CLIENT_AI_ENTRA_CLIENT_ID` unset, the Organizations tab shows the "not enabled" notice (no spinner-forever, no error toast storm).
+3. **#orgs (default)** — status chips render per org; "Set up" walks all four wizard steps against a test org: tenant GUID save (try a non-GUID → inline validation; try a tenant mapped to another org → "tenant_already_mapped" toast), consent URL copy button puts the URL on the clipboard, enable step flips the policy (org row shows AI enabled: Yes after Done), deployment instructions render. Unmap prompts for confirmation and clears the tenant column.
+4. **#policy/<orgId>** — deep-link by pasting the URL with the hash: editor loads, every section renders; add a custom DLP rule, paste sample text, watch the live match count; break the pattern (`(`) and confirm save is blocked with a toast; save a budget in dollars and re-open to see it round-trip (cents conversion).
+5. **#sessions** — filters narrow the list (org → user select populates; flagged-only); clicking a row opens the transcript with redaction badges, workbook chips, and the tool trail; flag with a reason → amber row accent + reason tooltip in the list; unflag via confirm.
+6. **#usage** — month range defaults to the current month; org rows expand to per-user rows; totals row matches the CSV: Export CSV downloads `client-ai-usage-<from>-to-<to>.csv` and the columns read `month,org_name,user_email,messages,sessions,input_tokens,output_tokens,cost_cents`.
+7. **#templates** — create an "All orgs" template and an org-scoped one (badges differ); edit shows the scope select disabled; delete asks for confirmation; the org-scoped template appears for that org's client via `GET /client-ai/templates` (curl with a Plan-1 client session token, or defer to the Plan-5 add-in test).
+8. **Hash routing** — reload on each tab lands on the same tab; browser Back from #policy/<orgId> returns to #orgs (hashchange listener).
+
+- [ ] **Step 6: Confirm a clean tree**
+
+```bash
+cd /Users/toddhebebrand/breeze && git status --short
+```
+
+Expected: empty (every task committed its own files). If the smoke pass forced fixes, commit them as `fix(client-ai-web): <what> (post-smoke)` with the Co-Authored-By trailer before opening the PR.

--- a/docs/superpowers/plans/2026-06-12-ai-for-office-5-excel-addin.md
+++ b/docs/superpowers/plans/2026-06-12-ai-for-office-5-excel-addin.md
@@ -1,0 +1,5200 @@
+# Breeze AI for Office — Plan 5: Excel Add-in
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the client-facing Excel add-in: a new `apps/office-addin/` task-pane app that signs users in via Office SSO (MSAL popup fallback), exchanges the Entra token for a Breeze client-AI session, streams chat over fetch-based SSE, executes the 9 workbook tools client-side via Office.js, gates every mutating tool behind a write-preview Apply/Reject card, and carries the context chip, template picker, and MSP-brandable footer from spec §11.
+
+**Architecture:** A standalone Vite + React app in the pnpm workspace (`apps/*` glob — no workspace-file change). Office.js loads from the Microsoft CDN in `taskpane.html`; the React island renders after `Office.onReady`. Auth is a two-hop chain: `OfficeRuntime.auth.getAccessToken` (silent SSO) → `@azure/msal-browser` popup fallback → `POST /client-ai/auth/exchange` → in-memory + sessionStorage Breeze session token with single-flight re-exchange on 401. The chat loop is a framework-free `ChatController` (testable without React) that consumes the session SSE stream, auto-executes read tools through an Office.js executor registry, and parks mutating `tool_request`s in an approval queue that the `WritePreviewCard` resolves via `POST .../tool-results`. All Office.js access is funneled through `Excel.run`, which a hand-rolled mock replaces wholesale in vitest.
+
+**Tech Stack:** Vite 8, React 19.2, TypeScript 5.7, Tailwind CSS 3.4, @azure/msal-browser 4, @types/office-js, office-addin-dev-certs (https dev server), Vitest 4 + jsdom
+
+**Spec:** docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md
+**Depends on:** Plans 1–4 (server); independently developable against mocks after Plan 2's API is stable
+---
+
+## Pinned server contracts (the ONLY API surface this plan touches)
+
+Workers implement against these shapes verbatim — no other doc is needed. Sources: Plan 1 (`docs/superpowers/plans/2026-06-12-ai-for-office-1-foundation.md`, Task 9 — implemented and authoritative) and the spec §5 protocol pins for the Plan-2 session loop (see Deviations D1 for the reconciliation rule).
+
+### 1. Auth exchange — `POST /client-ai/auth/exchange` (Plan 1, authoritative)
+
+Request: `{ "accessToken": "<Entra ID access token>" }` (no auth header — pre-auth route).
+
+200 response (Plan 1 Task 9, `auth.ts` lines ~2330-2335 of that plan):
+
+```json
+{
+  "accessToken": "<48-char Breeze session token>",
+  "expiresInSeconds": 86400,
+  "user": { "id": "<portal_users uuid>", "email": "user@contoso.com", "name": "Finance User" }
+}
+```
+
+`user.name` may be `null`. **There is no `org` or `branding` field in Plan 1's response** — see Deviation D2; the client types them as optional so a later server addition is picked up with zero client changes.
+
+Error responses — always `{ "error": "<code>" }`:
+
+| Status | `error` code | Add-in behavior |
+|---|---|---|
+| 400 | (zod detail) | treat as `unknown` failure |
+| 401 | `invalid_token` | retry sign-in from scratch |
+| 404 | `tenant_not_provisioned` | "not provisioned by your IT provider" screen |
+| 404 | `not_enabled` | same screen family (server lacks `CLIENT_AI_ENTRA_CLIENT_ID`) |
+| 403 | `disabled` | "disabled for your organization" screen |
+| 403 | `user_not_permitted` | "no access" screen |
+| 403 | `account_inactive` | "account inactive" screen |
+| 403 | `provisioning_failed` | generic failure, allow retry |
+| 429 | `rate_limited` | toastable error, allow retry |
+| 503 | `service_unavailable` | toastable error, allow retry |
+
+### 2. Session loop (Plan 2 surface — prompt-pinned, see D1)
+
+All requests carry `Authorization: Bearer <Breeze session token>`. On any 401 the client re-runs the exchange once (single-flight) and retries.
+
+- `POST /client-ai/sessions` body `{}` → `200 { "sessionId": "<uuid>" }`
+- `POST /client-ai/sessions/:id/messages` body:
+  ```json
+  {
+    "content": "What does column B total to?",
+    "workbookContext": {
+      "kind": "selection",
+      "address": "Sheet1!B2:F40",
+      "sheetName": "Sheet1",
+      "cells": [["Region", "Q1"], ["EMEA", 1200]]
+    }
+  }
+  ```
+  `workbookContext` optional; `kind` ∈ `selection | sheet | none`; `address`/`sheetName`/`cells` all optional (cells omitted when over the context cap). Returns 200 on accept; budget/rate rejections come back as 4xx `{ error }` (e.g. `budget_exceeded`, `rate_limited` — spec §4 pre-flight).
+- `GET /client-ai/sessions/:id/events` — SSE (`text/event-stream`). The add-in uses **fetch + ReadableStream parsing** so the `Authorization` header works (`EventSource` can't set headers); a `?token=` query-param fallback exists server-side but the header path is primary. Frames follow the technician-AI convention (`apps/api/src/routes/ai.ts:433`): `event: <type>` + `data: <JSON including "type">` — the client discriminates on the JSON `type` field and ignores unknown types. Event vocabulary (subset of `AiStreamEvent`, `packages/shared/src/types/ai.ts:104-119`, plus the client-execution event):
+
+  | `type` | Payload fields | Meaning |
+  |---|---|---|
+  | `message_start` | `messageId` | assistant turn begins |
+  | `content_delta` | `delta` | streaming text chunk |
+  | `tool_request` | `toolUseId`, `toolName`, `input`, `mutating` | **execute in the add-in** (spec §5 protocol step 1) |
+  | `tool_result` | `toolUseId`, `output`, `isError` | server echo after resolution (informational) |
+  | `message_end` | `inputTokens`, `outputTokens` | assistant turn done |
+  | `error` | `message` | loop error, user-readable |
+  | `done` | — | session loop idle |
+
+- `POST /client-ai/sessions/:id/tool-results` body `{ "toolUseId": "...", "status": "success" | "error" | "rejected", "output": <any JSON> }` → 200. Server timeouts (spec §5): 60s reads, 5min pending write approvals — a late result after timeout 4xxes; the client surfaces but does not retry.
+- `GET /client-ai/templates` → `200 [{ "id", "name", "description", "category", "body" }]` (`description`/`category` nullable). The client also tolerates the repo's `{ data: [...] }` envelope convention.
+
+### CORS prerequisite (deployment, not code)
+
+The API's CORS allowlist is env-driven (`CORS_ALLOWED_ORIGINS`, `apps/api/src/index.ts:256-307`; `Authorization` is already in `allowHeaders`). The add-in origin must be added: `https://localhost:3000` for dev, the production add-in host for prod. This is a deploy-time `.env` change, not a code change in this plan — verified in the manual checklist (Task 11, item 0).
+
+## Deviations & open questions (decided during planning)
+
+1. **D1 — Plan 2 does not exist yet.** The task prompt said to mirror `2026-06-12-ai-for-office-2-session-loop.md`; that file is not in the repo at planning time. The event vocabulary above is therefore pinned **here**, derived from the existing `AiStreamEvent` union that the spec says Plan 2 reuses (`SessionEventBus` pattern, spec §4) plus the prompt-pinned `tool_request` shape. **Reconciliation rule:** when Plan 2 is written/implemented, its SSE events MUST either adopt this table or this plan's `apps/office-addin/src/api/types.ts` (a single file — the only place event names appear) must be updated before integration testing. Unknown event types are skipped by the client, so additive Plan-2 events are safe.
+2. **D2 — No `branding`/`org` in the exchange response.** Plan 1's implemented response is `{ accessToken, expiresInSeconds, user }` only. The spec §11 footer needs `branding.displayName`/`logoUrl` from org policy. The client types `org?` and `branding?` as optional on `ExchangeResponse` and the footer falls back to "Governed by your IT provider" when absent. **Open question for Plan 2/4 owners:** add `branding` (and optionally `org`) to the exchange 200 body — it's a one-line join on `client_ai_org_policies.branding` the route already loads via `getOrgPolicy`. Zero add-in changes needed when it lands.
+3. **D3 — No `@breeze/shared` dependency.** The `/client-ai` wire contracts are not in `packages/shared` today (Plan 1 defined its zod schemas API-locally in `apps/api/src/routes/clientAi/schemas.ts`). The add-in defines its wire types locally in `src/api/types.ts` rather than importing `@breeze/shared` — there is nothing relevant to import, and skipping the dependency keeps the add-in's Vite/tsconfig free of the alias plumbing `apps/web` needs. If a later plan centralizes the client-AI contracts in `packages/shared`, adopt them via the same tsconfig-`paths` + vitest-`alias` pattern `apps/web` uses (`apps/web/tsconfig.json:6`, `apps/web/vitest.config.ts:10-13`).
+4. **D4 — SSO API choice.** v1 uses the classic Office SSO API (`OfficeRuntime.auth.getAccessToken`, wired to the manifest's `WebApplicationInfo`) with an MSAL **popup** fallback, exactly as spec §3 describes. Migrating the fallback to NAA (`createNestablePublicClientApplication`) is a drop-in swap inside `src/auth/entraToken.ts` later; it changes no other file.
+5. **D5 — `insert_formula` applies the same formula text to every cell** of the target range (Office.js does not rewrite relative references on assignment). Single-cell targets behave exactly as expected; for per-row formulas the model should call `insert_formula` per cell or use `write_range`. The tool description Plan 2 registers server-side should say so.
+6. **D6 — No component-test framework.** The prompt's required unit-test list (SSE parser, dispatcher routing, executors, auth ordering, diff builder) is all framework-free logic; `@testing-library/react` is intentionally not added. React components are verified by `tsc`, the production build, and the manual checklist (Playwright cannot drive Excel — spec §13).
+
+## Verification notes for workers
+
+- Node pin: prefix every pnpm/vitest/node command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict).
+- After creating `apps/office-addin/package.json`, run `pnpm install` from the repo root once — the `apps/*` workspace glob picks the new app up automatically; **no `pnpm-workspace.yaml` change**.
+- All add-in tests are new files in a new app — no interaction with the known-flaky parallel API suite. `pnpm --filter @breeze/office-addin test -- --run` is the whole verification surface.
+- If a pinned devDependency version doesn't resolve (the `office-addin-*` packages move majors), fall back to `pnpm --filter @breeze/office-addin add -D <pkg>@latest` — this plan only uses their stable surfaces (`getHttpsServerOptions`, `office-addin-manifest validate`, the `office-addin-dev-certs install` CLI).
+- HTTPS dev certs: first `pnpm dev` run may prompt for the OS keychain (cert install). Run `pnpm --filter @breeze/office-addin run certs` once interactively if the non-interactive prompt fails.
+- Never commit `manifest.xml` (generated), `.env`, or `public/assets/*.png` (generated) — the app `.gitignore` created in Task 1 covers them. The CLAUDE.md no-internal-infra rule applies: templates and `.env.example` carry placeholders only.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/office-addin/package.json` | Create | App manifest: scripts, deps (React 19.2, msal-browser 4, vite 8, vitest 4) |
+| `apps/office-addin/tsconfig.json` | Create | Strict TS, `office-js` + `vite/client` + `vitest/globals` types |
+| `apps/office-addin/vite.config.ts` | Create | React plugin, https via office-addin-dev-certs, port 3000, taskpane.html input |
+| `apps/office-addin/vitest.config.ts` | Create | jsdom, globals, setup file |
+| `apps/office-addin/tailwind.config.js` + `postcss.config.js` | Create | Tailwind 3 (same approach as apps/helper) |
+| `apps/office-addin/taskpane.html` | Create | Task-pane entry; Office.js CDN script tag |
+| `apps/office-addin/src/index.css` | Create | Tailwind directives |
+| `apps/office-addin/src/main.tsx` | Create | `Office.onReady` → React root |
+| `apps/office-addin/src/config.ts` | Create | `VITE_API_BASE_URL` / `VITE_CLIENT_AI_ENTRA_CLIENT_ID` env access |
+| `apps/office-addin/scripts/make-icons.mjs` | Create | Generates placeholder ribbon icons (valid PNGs, no binary in git) |
+| `apps/office-addin/scripts/generate-manifest.mjs` | Create | `manifest.template.xml` + env → `manifest.xml` |
+| `apps/office-addin/manifest.template.xml` | Create | Task-pane manifest with SSO `WebApplicationInfo`, placeholder tokens |
+| `apps/office-addin/.env.example` + `.gitignore` | Create | Generic placeholders; ignore generated artifacts |
+| `apps/office-addin/src/lib/address.ts` (+ `.test.ts`) | Create | A1-notation parsing/printing shared by tools, preview, mock |
+| `apps/office-addin/src/__tests__/setup.ts` | Create | Installs Excel/Office globals per test |
+| `apps/office-addin/src/__tests__/officeMock.ts` (+ `officeMock.test.ts`) | Create | Full Office.js Excel mock (workbook/worksheet/range/sync batching) |
+| `apps/office-addin/src/api/types.ts` | Create | Wire types incl. `ClientAiStreamEvent` (the D1 single-source file) |
+| `apps/office-addin/src/api/sse.ts` (+ `.test.ts`) | Create | Fetch-SSE ReadableStream parser |
+| `apps/office-addin/src/api/client.ts` (+ `.test.ts`) | Create | Typed bearer client, 401 single-flight re-auth, `streamEvents` |
+| `apps/office-addin/src/auth/entraToken.ts` (+ `.test.ts`) | Create | Office SSO → MSAL popup fallback |
+| `apps/office-addin/src/auth/session.ts` (+ `.test.ts`) | Create | Exchange call, error mapping, memory+sessionStorage store, refresh |
+| `apps/office-addin/src/tools/helpers.ts` | Create | Input validation + sheet resolution + caps |
+| `apps/office-addin/src/tools/getWorkbookOverview.ts` (+ `.test.ts`) | Create | Tool: `get_workbook_overview` |
+| `apps/office-addin/src/tools/readSelection.ts` | Create | Tool: `read_selection` |
+| `apps/office-addin/src/tools/readRange.ts` (+ `.test.ts`) | Create | Tool: `read_range` |
+| `apps/office-addin/src/tools/searchWorkbook.ts` (+ `.test.ts`) | Create | Tool: `search_workbook` |
+| `apps/office-addin/src/tools/writeRange.ts` (+ `.test.ts`) | Create | Tool: `write_range` |
+| `apps/office-addin/src/tools/insertFormula.ts` | Create | Tool: `insert_formula` |
+| `apps/office-addin/src/tools/createSheet.ts` | Create | Tool: `create_sheet` |
+| `apps/office-addin/src/tools/formatRange.ts` | Create | Tool: `format_range` |
+| `apps/office-addin/src/tools/createTable.ts` | Create | Tool: `create_table` |
+| `apps/office-addin/src/tools/dispatcher.ts` (+ `.test.ts`) | Create | Executor registry, mutating set, `executeTool` |
+| `apps/office-addin/src/approval/buildPreview.ts` (+ `.test.ts`) | Create | Before/after diff builder (≤200 cells) + summary fallback |
+| `apps/office-addin/src/approval/approvalStore.ts` (+ `.test.ts`) | Create | Pending-approval queue; Apply executes + posts, Reject posts without executing |
+| `apps/office-addin/src/chat/chatController.ts` (+ `.test.ts`) | Create | SSE consumption, tool routing, approval queue, tool-result posting |
+| `apps/office-addin/src/chat/captureContext.ts` | Create | Selection/sheet context capture for outgoing messages |
+| `apps/office-addin/src/hooks/useSelectionAddress.ts` | Create | Live selection address via `DocumentSelectionChanged` |
+| `apps/office-addin/src/components/WritePreviewCard.tsx` | Create | Apply/Reject preview card |
+| `apps/office-addin/src/components/ChatThread.tsx` | Create | Message list + streaming cursor + approval cards |
+| `apps/office-addin/src/components/Composer.tsx` | Create | Input, send, context chip + per-message toggle |
+| `apps/office-addin/src/components/TemplatePicker.tsx` | Create | Empty-state template picker |
+| `apps/office-addin/src/components/BrandingFooter.tsx` | Create | MSP-brandable footer |
+| `apps/office-addin/src/components/SignInScreen.tsx` + `BlockedScreen.tsx` | Create | Auth screens incl. "not provisioned" |
+| `apps/office-addin/src/components/ChatPane.tsx` | Create | Wires controller + composer + templates |
+| `apps/office-addin/src/App.tsx` | Create (Task 1 stub, Task 10 real) | Auth phase machine |
+| `apps/office-addin/README.md` | Create | Dev setup: certs, scripts, env, sideload pointers |
+
+---
+
+### Task 1: Scaffold — workspace app, Vite, Tailwind, entry html (verification, no TDD)
+
+**Files:**
+- Create: apps/office-addin/package.json
+- Create: apps/office-addin/tsconfig.json
+- Create: apps/office-addin/vite.config.ts
+- Create: apps/office-addin/vitest.config.ts
+- Create: apps/office-addin/tailwind.config.js
+- Create: apps/office-addin/postcss.config.js
+- Create: apps/office-addin/taskpane.html
+- Create: apps/office-addin/src/index.css
+- Create: apps/office-addin/src/main.tsx
+- Create: apps/office-addin/src/App.tsx (placeholder — replaced in Task 12)
+- Create: apps/office-addin/src/config.ts
+- Create: apps/office-addin/scripts/make-icons.mjs
+- Create: apps/office-addin/.env.example
+- Create: apps/office-addin/.gitignore
+
+- [ ] **Step 1: Create `apps/office-addin/package.json`**
+
+```json
+{
+  "name": "@breeze/office-addin",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "predev": "node scripts/make-icons.mjs && node scripts/generate-manifest.mjs",
+    "dev": "vite",
+    "prebuild": "node scripts/make-icons.mjs",
+    "build": "tsc --noEmit && vite build && node scripts/generate-manifest.mjs",
+    "test": "vitest",
+    "certs": "office-addin-dev-certs install",
+    "manifest": "node scripts/generate-manifest.mjs",
+    "validate-manifest": "office-addin-manifest validate manifest.xml"
+  },
+  "dependencies": {
+    "@azure/msal-browser": "^4.0.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/office-js": "^1.0.460",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "autoprefixer": "^10.5.0",
+    "jsdom": "^29.1.1",
+    "office-addin-dev-certs": "^2.0.0",
+    "office-addin-manifest": "^2.0.0",
+    "postcss": "^8.5.15",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.2",
+    "vite": "^8.0.12",
+    "vitest": "^4.1.8"
+  }
+}
+```
+
+(React/TS/Tailwind/vitest versions mirror `apps/web/package.json`; vite + plugin-react mirror `apps/helper/package.json`. `generate-manifest.mjs` arrives in Task 2 — `predev`/`build` will fail on it until then, which is fine; Step 8 verifies with `vite build` directly.)
+
+- [ ] **Step 2: Create `apps/office-addin/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "types": ["office-js", "vite/client", "vitest/globals"]
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 3: Create `apps/office-addin/vite.config.ts`**
+
+```ts
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Office hosts refuse to load task panes over plain http (except localhost in
+// some hosts, but Excel on the web always requires https). office-addin-dev-certs
+// installs a locally-trusted CA + localhost cert (~/.office-addin-dev-certs) and
+// getHttpsServerOptions() returns { ca, key, cert } for Vite. Set
+// ADDIN_NO_HTTPS=1 to opt out (plain-browser debugging only).
+export default defineConfig(async () => {
+  let https: { ca: Buffer; key: Buffer; cert: Buffer } | undefined;
+  if (!process.env.ADDIN_NO_HTTPS) {
+    const { getHttpsServerOptions } = await import('office-addin-dev-certs');
+    https = await getHttpsServerOptions();
+  }
+  return {
+    plugins: [react()],
+    server: { port: 3000, strictPort: true, https },
+    build: {
+      outDir: 'dist',
+      rollupOptions: {
+        input: { taskpane: fileURLToPath(new URL('./taskpane.html', import.meta.url)) },
+      },
+    },
+  };
+});
+```
+
+- [ ] **Step 4: Create `apps/office-addin/vitest.config.ts`**
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['src/__tests__/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    passWithNoTests: true,
+  },
+});
+```
+
+(`src/__tests__/setup.ts` is created in Task 4; until then `vitest` is not run.)
+
+- [ ] **Step 5: Create Tailwind + PostCSS configs and the entry CSS**
+
+`apps/office-addin/tailwind.config.js`:
+
+```js
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./taskpane.html', './src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+};
+```
+
+`apps/office-addin/postcss.config.js`:
+
+```js
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+```
+
+`apps/office-addin/src/index.css`:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+- [ ] **Step 6: Create `taskpane.html`, `src/main.tsx`, placeholder `src/App.tsx`, `src/config.ts`**
+
+`apps/office-addin/taskpane.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Breeze AI</title>
+    <!-- Office.js MUST load from the Microsoft CDN (host requirement) and must
+         not be bundled. It loads before the module script so Office.onReady is
+         defined when main.tsx runs. -->
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+`apps/office-addin/src/main.tsx`:
+
+```tsx
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './index.css';
+
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('taskpane.html is missing #root');
+const root = createRoot(rootEl);
+
+function render(): void {
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}
+
+// Inside Excel, wait for the host handshake; in a plain browser tab (dev
+// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — render anyway.
+if (typeof Office !== 'undefined' && typeof Office.onReady === 'function') {
+  void Office.onReady(() => render());
+} else {
+  render();
+}
+```
+
+`apps/office-addin/src/App.tsx` (placeholder — Task 12 replaces it):
+
+```tsx
+export function App() {
+  return (
+    <div className="flex h-screen items-center justify-center text-sm text-gray-500">
+      Breeze AI — scaffold OK
+    </div>
+  );
+}
+```
+
+`apps/office-addin/src/config.ts`:
+
+```ts
+/**
+ * Build-time configuration. Values come from Vite env (apps/office-addin/.env,
+ * gitignored — see .env.example). Defaults target local dev against the API
+ * dev server (apps/api listens on 3001; apps/web/astro.config.mjs uses the
+ * same default).
+ */
+export const API_BASE_URL: string =
+  ((import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001').replace(/\/$/, '');
+
+/** Entra app registration client ID — must equal the API's CLIENT_AI_ENTRA_CLIENT_ID (Plan 1 Task 6). */
+export const ENTRA_CLIENT_ID: string =
+  (import.meta.env.VITE_CLIENT_AI_ENTRA_CLIENT_ID as string | undefined) ?? '';
+```
+
+- [ ] **Step 7: Create `scripts/make-icons.mjs`, `.env.example`, `.gitignore`**
+
+`apps/office-addin/scripts/make-icons.mjs` (the manifest needs 16/32/64/80px icons; generating valid solid-color PNGs at build time keeps binaries out of git):
+
+```js
+#!/usr/bin/env node
+// Generates placeholder ribbon icons into public/assets/ as valid PNGs
+// (hand-built chunks: IHDR + zlib IDAT + IEND). Replace with real brand
+// icons later by dropping files at the same paths.
+import { deflateSync } from 'node:zlib';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const outDir = path.join(root, 'public', 'assets');
+mkdirSync(outDir, { recursive: true });
+
+function crc32(buf) {
+  let c = ~0;
+  for (let i = 0; i < buf.length; i++) {
+    c ^= buf[i];
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  }
+  return ~c >>> 0;
+}
+
+function chunk(type, data) {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length);
+  const body = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(body));
+  return Buffer.concat([len, body, crc]);
+}
+
+function png(size, [r, g, b]) {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(size, 0); // width
+  ihdr.writeUInt32BE(size, 4); // height
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // color type: truecolor RGB
+  // bytes 10-12 (compression/filter/interlace) stay 0
+  const row = Buffer.alloc(1 + size * 3); // filter byte 0 + RGB pixels
+  for (let x = 0; x < size; x++) {
+    row[1 + x * 3] = r;
+    row[2 + x * 3] = g;
+    row[3 + x * 3] = b;
+  }
+  const raw = Buffer.concat(Array.from({ length: size }, () => row));
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+const BREEZE_BLUE = [37, 99, 235];
+for (const size of [16, 32, 64, 80]) {
+  writeFileSync(path.join(outDir, `icon-${size}.png`), png(size, BREEZE_BLUE));
+}
+console.log(`[make-icons] wrote icon-16/32/64/80.png to ${outDir}`);
+```
+
+`apps/office-addin/.env.example` (generic placeholders only — CLAUDE.md no-internal-infra rule):
+
+```bash
+# Breeze API origin the add-in calls. Local dev default shown.
+VITE_API_BASE_URL=http://localhost:3001
+# Entra app registration (multi-tenant) client ID. MUST match the API's
+# CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).
+VITE_CLIENT_AI_ENTRA_CLIENT_ID=
+# Where the built add-in is hosted; used by generate-manifest. Dev default shown.
+ADDIN_BASE_URL=https://localhost:3000
+# Optional overrides for generate-manifest:
+# ADDIN_MANIFEST_ID=          # GUID identifying the add-in to Office (stable per environment)
+# ADDIN_SUPPORT_URL=https://your-domain.example.com/support
+```
+
+`apps/office-addin/.gitignore`:
+
+```
+node_modules
+dist
+manifest.xml
+public/assets/
+.env
+```
+
+- [ ] **Step 8: Verify — install, icons, type-check, build, dev server**
+
+```bash
+cd /Users/toddhebebrand/breeze
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm install
+cd apps/office-addin
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH node scripts/make-icons.mjs
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vite build
+ls dist/taskpane.html dist/assets public/assets/icon-32.png
+```
+
+Expected: install links `@breeze/office-addin` into the workspace; tsc clean; vite build emits `dist/taskpane.html`; icons exist. Then smoke the dev server (https cert install may prompt once):
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vite --port 3000 &
+sleep 3 && curl -sk https://localhost:3000/taskpane.html | grep -c 'office.js'
+kill %1
+```
+
+Expected: grep prints `1` (taskpane served with the CDN script tag). If cert installation needs interactivity, run `ADDIN_NO_HTTPS=1 npx vite --port 3000` and curl `http://localhost:3000/taskpane.html` instead, then fix certs via `pnpm run certs` before Task 13.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin pnpm-lock.yaml
+git commit -m "feat(office-addin): scaffold Vite+React task-pane app in workspace" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Manifest template + env-driven generator (verification, no TDD)
+
+The manifest is XML the M365 admin center / sideload consumes. It is environment-specific (dev localhost vs production host), so the repo tracks a **template** with `{{TOKEN}}` placeholders and a generator script; the generated `manifest.xml` is gitignored.
+
+**Entra app registration prerequisites (one-time, outside this repo — record in the PR description):** the multi-tenant app `CLIENT_AI_ENTRA_CLIENT_ID` needs (a) an SPA redirect URI `https://localhost:3000/taskpane.html` (plus the production equivalent), (b) an Application ID URI of the form `api://<host>/<client-id>` matching each hosting origin (dev: `api://localhost:3000/<client-id>`), (c) an exposed delegated scope `access_as_user`, and (d) the Microsoft Office client application `ea5a67f6-b6f3-4338-b240-c655ddc3cc8e` pre-authorized for that scope (this single ID covers all Office application endpoints). Without (d), silent SSO always falls back to the MSAL popup.
+
+**Files:**
+- Create: apps/office-addin/manifest.template.xml
+- Create: apps/office-addin/scripts/generate-manifest.mjs
+
+- [ ] **Step 1: Create `apps/office-addin/manifest.template.xml`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
+           xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides"
+           xsi:type="TaskPaneApp">
+  <Id>{{ADDIN_ID}}</Id>
+  <Version>0.1.0</Version>
+  <ProviderName>Breeze</ProviderName>
+  <DefaultLocale>en-US</DefaultLocale>
+  <DisplayName DefaultValue="Breeze AI"/>
+  <Description DefaultValue="AI assistant for Excel, governed by your IT provider."/>
+  <IconUrl DefaultValue="{{BASE_URL}}/assets/icon-32.png"/>
+  <HighResolutionIconUrl DefaultValue="{{BASE_URL}}/assets/icon-64.png"/>
+  <SupportUrl DefaultValue="{{SUPPORT_URL}}"/>
+  <AppDomains>
+    <AppDomain>{{API_BASE_URL}}</AppDomain>
+    <AppDomain>https://login.microsoftonline.com</AppDomain>
+  </AppDomains>
+  <Hosts>
+    <Host Name="Workbook"/>
+  </Hosts>
+  <DefaultSettings>
+    <SourceLocation DefaultValue="{{BASE_URL}}/taskpane.html"/>
+  </DefaultSettings>
+  <Permissions>ReadWriteDocument</Permissions>
+  <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
+    <Hosts>
+      <Host xsi:type="Workbook">
+        <DesktopFormFactor>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="Breeze.Group">
+                <Label resid="Breeze.GroupLabel"/>
+                <Icon>
+                  <bt:Image size="16" resid="Breeze.Icon16"/>
+                  <bt:Image size="32" resid="Breeze.Icon32"/>
+                  <bt:Image size="80" resid="Breeze.Icon80"/>
+                </Icon>
+                <Control xsi:type="Button" id="Breeze.TaskpaneButton">
+                  <Label resid="Breeze.TaskpaneButton.Label"/>
+                  <Supertip>
+                    <Title resid="Breeze.TaskpaneButton.Label"/>
+                    <Description resid="Breeze.TaskpaneButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Breeze.Icon16"/>
+                    <bt:Image size="32" resid="Breeze.Icon32"/>
+                    <bt:Image size="80" resid="Breeze.Icon80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>Breeze.Taskpane</TaskpaneId>
+                    <SourceLocation resid="Breeze.Taskpane.Url"/>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+    </Hosts>
+    <Resources>
+      <bt:Images>
+        <bt:Image id="Breeze.Icon16" DefaultValue="{{BASE_URL}}/assets/icon-16.png"/>
+        <bt:Image id="Breeze.Icon32" DefaultValue="{{BASE_URL}}/assets/icon-32.png"/>
+        <bt:Image id="Breeze.Icon80" DefaultValue="{{BASE_URL}}/assets/icon-80.png"/>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="Breeze.Taskpane.Url" DefaultValue="{{BASE_URL}}/taskpane.html"/>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="Breeze.GroupLabel" DefaultValue="Breeze AI"/>
+        <bt:String id="Breeze.TaskpaneButton.Label" DefaultValue="Breeze AI"/>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="Breeze.TaskpaneButton.Tooltip" DefaultValue="Open the Breeze AI assistant for this workbook."/>
+      </bt:LongStrings>
+    </Resources>
+    <WebApplicationInfo>
+      <Id>{{CLIENT_AI_ENTRA_CLIENT_ID}}</Id>
+      <Resource>api://{{BASE_HOST}}/{{CLIENT_AI_ENTRA_CLIENT_ID}}</Resource>
+      <Scopes>
+        <Scope>openid</Scope>
+        <Scope>profile</Scope>
+        <Scope>access_as_user</Scope>
+      </Scopes>
+    </WebApplicationInfo>
+  </VersionOverrides>
+</OfficeApp>
+```
+
+- [ ] **Step 2: Create `apps/office-addin/scripts/generate-manifest.mjs`**
+
+```js
+#!/usr/bin/env node
+// Renders manifest.template.xml -> manifest.xml from env / .env / CLI flags.
+//   node scripts/generate-manifest.mjs [--base-url https://localhost:3000] [--out manifest.xml]
+// Precedence: process.env > .env file > defaults. Fails loudly on unreplaced tokens.
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function loadDotEnv(file) {
+  if (!existsSync(file)) return {};
+  const out = {};
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    if (line.trim().startsWith('#')) continue;
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const env = { ...loadDotEnv(path.join(root, '.env')), ...process.env };
+const args = process.argv.slice(2);
+const argValue = (flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const baseUrl = (argValue('--base-url') ?? env.ADDIN_BASE_URL ?? 'https://localhost:3000').replace(/\/$/, '');
+const apiBaseUrl = (env.VITE_API_BASE_URL ?? 'http://localhost:3001').replace(/\/$/, '');
+const clientId = env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ?? env.CLIENT_AI_ENTRA_CLIENT_ID ?? '00000000-0000-0000-0000-000000000000';
+// Stable add-in identity GUID. Override per environment (dev vs prod must differ
+// or Office caches collide across hosts).
+const addinId = env.ADDIN_MANIFEST_ID ?? 'b7f3a9d2-4c61-4e0a-9f4e-2d8a51c0a9b3';
+const supportUrl = env.ADDIN_SUPPORT_URL ?? 'https://breezermm.com';
+const baseHost = new URL(baseUrl).host;
+
+if (clientId === '00000000-0000-0000-0000-000000000000') {
+  console.warn('[generate-manifest] WARNING: VITE_CLIENT_AI_ENTRA_CLIENT_ID is not set — SSO will not work with the placeholder GUID.');
+}
+
+const template = readFileSync(path.join(root, 'manifest.template.xml'), 'utf8');
+const output = template
+  .replaceAll('{{ADDIN_ID}}', addinId)
+  .replaceAll('{{BASE_URL}}', baseUrl)
+  .replaceAll('{{BASE_HOST}}', baseHost)
+  .replaceAll('{{API_BASE_URL}}', apiBaseUrl)
+  .replaceAll('{{SUPPORT_URL}}', supportUrl)
+  .replaceAll('{{CLIENT_AI_ENTRA_CLIENT_ID}}', clientId);
+
+const leftover = output.match(/{{[A-Z_]+}}/g);
+if (leftover) {
+  console.error(`[generate-manifest] Unreplaced placeholders: ${[...new Set(leftover)].join(', ')}`);
+  process.exit(1);
+}
+
+const outPath = path.join(root, argValue('--out') ?? 'manifest.xml');
+writeFileSync(outPath, output);
+console.log(`[generate-manifest] wrote ${outPath} (base: ${baseUrl}, clientId: ${clientId.slice(0, 8)}…)`);
+```
+
+- [ ] **Step 3: Verify — generate and validate**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/office-addin
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH node scripts/generate-manifest.mjs
+grep -c '{{' manifest.xml || true            # expected: 0 (no output from grep -c means grep exited 1 → zero matches)
+grep -c 'api://localhost:3000' manifest.xml  # expected: 1
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx office-addin-manifest validate manifest.xml
+```
+
+Expected: zero unreplaced tokens; the `WebApplicationInfo` resource targets the dev host; the validator passes (warnings about the placeholder client-id GUID are acceptable at this stage — it validates GUID shape, not existence).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/manifest.template.xml apps/office-addin/scripts/generate-manifest.mjs
+git commit -m "feat(office-addin): manifest template + env-driven generator with SSO WebApplicationInfo" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: A1-notation address utilities (TDD)
+
+Shared by the tool executors (search hit addresses), the preview diff builder (per-cell addresses), and the Office.js mock (range geometry). Pure functions — the easiest TDD on the critical path, done first.
+
+**Files:**
+- Create: apps/office-addin/src/lib/address.ts
+- Test: apps/office-addin/src/lib/address.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/office-addin/src/lib/address.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { columnLetter, parseAddress, parseColumn, rangeAddress, stripSheet } from './address';
+
+describe('columnLetter / parseColumn', () => {
+  it('round-trips single and multi letter columns', () => {
+    expect(columnLetter(0)).toBe('A');
+    expect(columnLetter(25)).toBe('Z');
+    expect(columnLetter(26)).toBe('AA');
+    expect(columnLetter(27)).toBe('AB');
+    expect(columnLetter(701)).toBe('ZZ');
+    expect(columnLetter(702)).toBe('AAA');
+    for (const i of [0, 25, 26, 51, 701, 702, 16383]) {
+      expect(parseColumn(columnLetter(i))).toBe(i);
+    }
+  });
+});
+
+describe('parseAddress', () => {
+  it('parses a bare cell', () => {
+    expect(parseAddress('B2')).toEqual({ sheet: null, startRow: 1, startCol: 1, endRow: 1, endCol: 1 });
+  });
+
+  it('parses a range with sheet prefix', () => {
+    expect(parseAddress('Sheet1!B2:F40')).toEqual({ sheet: 'Sheet1', startRow: 1, startCol: 1, endRow: 39, endCol: 5 });
+  });
+
+  it('parses a quoted sheet name and absolute refs', () => {
+    expect(parseAddress("'Q3 Budget'!$A$1:$C$3")).toEqual({ sheet: 'Q3 Budget', startRow: 0, startCol: 0, endRow: 2, endCol: 2 });
+  });
+
+  it('throws on garbage', () => {
+    expect(() => parseAddress('not-an-address')).toThrow(/Unsupported address/);
+    expect(() => parseAddress('')).toThrow(/Unsupported address/);
+  });
+});
+
+describe('rangeAddress / stripSheet', () => {
+  it('prints single cells without a colon', () => {
+    expect(rangeAddress(1, 1, 1, 1)).toBe('B2');
+  });
+
+  it('prints multi-cell ranges', () => {
+    expect(rangeAddress(1, 1, 39, 5)).toBe('B2:F40');
+  });
+
+  it('stripSheet drops the sheet prefix only', () => {
+    expect(stripSheet('Sheet1!B2:F40')).toBe('B2:F40');
+    expect(stripSheet('B2:F40')).toBe('B2:F40');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/lib/address.test.ts`
+Expected: FAIL — cannot resolve `./address`. (vitest setupFiles does not exist yet; if vitest complains about the missing setup file, create an empty `src/__tests__/setup.ts` now — Task 4 fills it in.)
+
+- [ ] **Step 3: Write the implementation** — `apps/office-addin/src/lib/address.ts`:
+
+```ts
+/**
+ * A1-notation helpers. Rows/columns are 0-based internally; printed addresses
+ * are 1-based like Excel. Only rectangular A1 references are supported (no
+ * R1C1, no whole-column "A:A" shorthand) — that is all the tool protocol uses.
+ */
+
+export type ParsedAddress = {
+  sheet: string | null;
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+};
+
+export function columnLetter(index: number): string {
+  let n = index + 1;
+  let out = '';
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    out = String.fromCharCode(65 + rem) + out;
+    n = Math.floor((n - 1) / 26);
+  }
+  return out;
+}
+
+export function parseColumn(letters: string): number {
+  let n = 0;
+  for (const ch of letters) n = n * 26 + (ch.toUpperCase().charCodeAt(0) - 64);
+  return n - 1;
+}
+
+const CELL_RE = /^\$?([A-Za-z]{1,3})\$?(\d+)$/;
+
+export function parseAddress(address: string): ParsedAddress {
+  let sheet: string | null = null;
+  let ref = address;
+  const bang = address.lastIndexOf('!');
+  if (bang !== -1) {
+    sheet = address.slice(0, bang).replace(/^'(.*)'$/, '$1');
+    ref = address.slice(bang + 1);
+  }
+  const [first, second, extra] = ref.split(':');
+  if (extra !== undefined) throw new Error(`Unsupported address: ${address}`);
+  const m1 = first !== undefined ? CELL_RE.exec(first) : null;
+  if (!m1) throw new Error(`Unsupported address: ${address}`);
+  const startCol = parseColumn(m1[1]!);
+  const startRow = parseInt(m1[2]!, 10) - 1;
+  if (second === undefined) return { sheet, startRow, startCol, endRow: startRow, endCol: startCol };
+  const m2 = CELL_RE.exec(second);
+  if (!m2) throw new Error(`Unsupported address: ${address}`);
+  const endCol = parseColumn(m2[1]!);
+  const endRow = parseInt(m2[2]!, 10) - 1;
+  return {
+    sheet,
+    startRow: Math.min(startRow, endRow),
+    startCol: Math.min(startCol, endCol),
+    endRow: Math.max(startRow, endRow),
+    endCol: Math.max(startCol, endCol),
+  };
+}
+
+/** 0-based start row/col + extent → "B2" or "B2:F40". */
+export function rangeAddress(startRow: number, startCol: number, rows: number, cols: number): string {
+  const start = `${columnLetter(startCol)}${startRow + 1}`;
+  if (rows === 1 && cols === 1) return start;
+  return `${start}:${columnLetter(startCol + cols - 1)}${startRow + rows}`;
+}
+
+export function stripSheet(address: string): string {
+  const bang = address.lastIndexOf('!');
+  return bang === -1 ? address : address.slice(bang + 1);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/lib/address.test.ts`
+Expected: 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/lib
+git commit -m "feat(office-addin): A1-notation address utilities" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Contract reconciliation — Plan 2 now exists (supersedes the §2 event table above)
+
+> Written when Tasks 4+ were planned: `docs/superpowers/plans/2026-06-12-ai-for-office-2-session-loop.md` now exists in the repo, which resolves Deviation D1 in Plan 2's favor. The "Session loop" table in *Pinned server contracts §2* above (message_start/content_delta/tool_result/message_end/error/done, "data JSON includes type") is **obsolete — do not implement it**. Tasks 4–11 below implement the contracts as Plan 2 actually pins them:
+
+- **SSE event names** (`CLIENT_AI_SSE_EVENTS`, Plan 2 Task 9, `apps/api/src/routes/clientAi/sse.ts`). Frames are `event: <name>` + `data: <JSON>`; the data JSON does **not** repeat the type — the client discriminates on the SSE `event:` field and skips unknown names (additive server events stay safe):
+
+  | `event:` | data payload |
+  |---|---|
+  | `message_delta` | `{ "text": string }` |
+  | `tool_request` | `{ "toolUseId", "toolName", "input", "mutating" }` |
+  | `tool_completed` | `{ "toolUseId", "toolName", "status": "success"\|"error"\|"rejected"\|"timeout", "redactions": [{rule,count,location}], "blockReason": string\|null }` |
+  | `turn_complete` | `{ "usage": { "inputTokens", "outputTokens", "costCents" } \| null }` |
+  | `session_error` | `{ "message": string }` |
+  | `ping` | `{}` every 25s (server keepalive) |
+
+- `POST /client-ai/sessions` body `{}` → **201** `{ "sessionId": "<uuid>" }` (not 200 — client accepts any 2xx).
+- `POST /client-ai/sessions/:id/messages` body `{ content: string (1..20000), workbookContext?: { kind: 'selection'|'sheet'|'none', address?: ≤100 chars, sheetName?: ≤255 chars, cells?: CellValue[][] (≤5000 rows × ≤500 cols, strings ≤32767 chars) } }` → **202** `{ "accepted": true }`; the turn streams over the persistent `GET /events` channel. Budget/rate rejections are 4xx `{ error }` (`budget_exceeded`, `rate_limited`, …).
+- `GET /client-ai/sessions/:id/events` — SSE; fetch + `Authorization` header primary, GET-only `?token=` exists server-side as the EventSource fallback (this client never uses it). **The events GET creates the active server session if absent**, so connecting right after create has no race.
+- `POST /client-ai/sessions/:id/tool-results` body `{ toolUseId, status: 'success'|'error'|'rejected', output?: any }` → 200. Late results after server timeout (60s reads / 300s writes) 4xx; surface, don't retry.
+- `GET /client-ai/sessions/:id` → `{ session: { id, status, title, model, turnCount, totalInputTokens, totalOutputTokens, totalCostCents, createdAt, lastActivityAt }, messages: [{ id, role, content, contentBlocks, toolName, toolInput, toolOutput, toolUseId, createdAt }] }` (history is stored already-redacted; render as-is).
+- `POST /client-ai/sessions/:id/close` → `{ success: true }`.
+- `GET /client-ai/templates` → **bare JSON array** `[{ id, name, description, category, body }]` (Plan 4 pins the bare array deliberately; the client still tolerates a `{ data: [...] }` envelope defensively).
+- Exchange (Plan 1) is unchanged from §1 above: 200 `{ accessToken, expiresInSeconds, user: { id, email, name } }`, audience = bare `CLIENT_AI_ENTRA_CLIENT_ID` GUID, no `org`/`branding` yet (D2 stands — typed optional client-side).
+
+---
+
+### Task 4: Office.js test mock (TDD — the mock gets its own spec test)
+
+The foundation for every tool/preview/context test: a hand-rolled fake of the Office.js proxy-object model. `Excel.run` executes the callback against a fake context whose ranges queue writes, record `load()` calls, and only expose property reads after `context.sync()` — the same lifecycle discipline the real API enforces, so tests catch missing `load`/`sync` bugs.
+
+**Files:**
+- Create: apps/office-addin/src/__tests__/officeMock.ts
+- Create: apps/office-addin/src/__tests__/setup.ts
+- Test: apps/office-addin/src/__tests__/officeMock.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/office-addin/src/__tests__/officeMock.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getOfficeMock } from './officeMock';
+
+describe('officeMock — Excel.run lifecycle', () => {
+  it('queues writes until sync and reads values back after load+sync', async () => {
+    await Excel.run(async (context) => {
+      const range = context.workbook.worksheets.getActiveWorksheet().getRange('B2:C3');
+      range.values = [
+        ['Region', 'Q1'],
+        ['EMEA', 1200],
+      ];
+      range.load(['values', 'address']);
+      await context.sync();
+      expect(range.address).toBe('Sheet1!B2:C3');
+      expect(range.values).toEqual([
+        ['Region', 'Q1'],
+        ['EMEA', 1200],
+      ]);
+    });
+    expect(getOfficeMock().getValues('Sheet1', 'B2:C3')).toEqual([
+      ['Region', 'Q1'],
+      ['EMEA', 1200],
+    ]);
+  });
+
+  it('throws when reading a property before context.sync()', async () => {
+    await Excel.run(async (context) => {
+      const range = context.workbook.worksheets.getActiveWorksheet().getRange('A1');
+      range.load('values');
+      expect(() => range.values).toThrow(/PropertyNotLoaded/);
+      await context.sync();
+      expect(range.values).toEqual([['']]);
+    });
+  });
+
+  it('computes the used range with sheet-qualified addresses', async () => {
+    getOfficeMock().setValues('Sheet1', 'B2', [
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+    await Excel.run(async (context) => {
+      const used = context.workbook.worksheets.getActiveWorksheet().getUsedRangeOrNullObject();
+      used.load(['address', 'values']);
+      await context.sync();
+      expect(used.isNullObject).toBe(false);
+      expect(used.address).toBe('Sheet1!B2:C3');
+    });
+  });
+
+  it('returns a null object for the used range of an empty sheet', async () => {
+    getOfficeMock().addSheet('Empty');
+    await Excel.run(async (context) => {
+      const used = context.workbook.worksheets.getItemOrNullObject('Empty').getUsedRangeOrNullObject();
+      used.load('address');
+      await context.sync();
+      expect(used.isNullObject).toBe(true);
+    });
+  });
+
+  it('getRow(0) of a used range exposes the header row', async () => {
+    getOfficeMock().setValues('Sheet1', 'A1', [
+      ['Name', 'Total'],
+      ['x', 1],
+    ]);
+    await Excel.run(async (context) => {
+      const used = context.workbook.worksheets.getActiveWorksheet().getUsedRangeOrNullObject();
+      const header = used.getRow(0);
+      header.load('values');
+      await context.sync();
+      expect(header.values).toEqual([['Name', 'Total']]);
+    });
+  });
+
+  it('worksheet collection: items, add, getItemOrNullObject', async () => {
+    getOfficeMock().addSheet('Data');
+    await Excel.run(async (context) => {
+      const worksheets = context.workbook.worksheets;
+      worksheets.load('items/name');
+      await context.sync();
+      expect(worksheets.items.map((s) => s.name)).toEqual(['Sheet1', 'Data']);
+      const missing = worksheets.getItemOrNullObject('Nope');
+      await context.sync();
+      expect(missing.isNullObject).toBe(true);
+      const added = worksheets.add('Report');
+      await context.sync();
+      expect(added.name).toBe('Report');
+      expect(getOfficeMock().hasSheet('Report')).toBe(true);
+    });
+  });
+
+  it('selection: getSelectedRange reflects state and select() fires handlers', async () => {
+    const mock = getOfficeMock();
+    const seen: string[] = [];
+    Office.context.document.addHandlerAsync(
+      Office.EventType.DocumentSelectionChanged,
+      () => seen.push('changed'),
+      () => undefined,
+    );
+    mock.select('Sheet1!B2:F40');
+    expect(seen).toEqual(['changed']);
+    await Excel.run(async (context) => {
+      const range = context.workbook.getSelectedRange();
+      range.load(['address', 'rowCount', 'columnCount']);
+      await context.sync();
+      expect(range.address).toBe('Sheet1!B2:F40');
+      expect(range.rowCount).toBe(39);
+      expect(range.columnCount).toBe(5);
+    });
+  });
+
+  it('records load and sync calls for assertions', async () => {
+    const mock = getOfficeMock();
+    await Excel.run(async (context) => {
+      const range = context.workbook.worksheets.getActiveWorksheet().getRange('A1:B2');
+      range.load('values');
+      await context.sync();
+    });
+    expect(mock.loadCalls.length).toBeGreaterThan(0);
+    expect(mock.syncCount).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/__tests__/officeMock.test.ts`
+Expected: FAIL — `./officeMock` does not exist (and vitest may first complain the setup file `src/__tests__/setup.ts` is missing; create it in Step 3 along with the mock).
+
+- [ ] **Step 3: Write the mock** — `apps/office-addin/src/__tests__/officeMock.ts`:
+
+```ts
+/**
+ * Hand-rolled Office.js mock (jsdom). Installed fresh per test by
+ * src/__tests__/setup.ts; tests seed and inspect workbook state via
+ * getOfficeMock().
+ *
+ * Faithfulness contract (the parts of the real proxy-object model the tools
+ * rely on, deliberately enforced so missing load()/sync() bugs fail tests):
+ *  - property reads on a Range THROW until a context.sync() has hydrated them
+ *  - property writes (range.values = ...) are queued and applied at sync()
+ *  - *OrNullObject lookups expose isNullObject; null objects propagate
+ *  - Excel.run() performs one trailing sync after the callback returns
+ * Documented leniencies (do NOT rely on these in src/ production code):
+ *  - Worksheet.name is always readable without load()
+ *  - worksheets.getItem() throws immediately instead of at sync
+ */
+import { vi } from 'vitest';
+import { parseAddress, rangeAddress, stripSheet } from '../lib/address';
+
+export type CellValue = string | number | boolean | null;
+type Rect = { startRow: number; startCol: number; rows: number; cols: number };
+
+const key = (row: number, col: number): string => `${row},${col}`;
+
+function rectOf(address: string): Rect {
+  const p = parseAddress(stripSheet(address));
+  return {
+    startRow: p.startRow,
+    startCol: p.startCol,
+    rows: p.endRow - p.startRow + 1,
+    cols: p.endCol - p.startCol + 1,
+  };
+}
+
+export class MockSheetState {
+  cells = new Map<string, CellValue>();
+  formulas = new Map<string, string>();
+  formats = new Map<string, Record<string, unknown>>();
+
+  constructor(public name: string) {}
+
+  setValues(anchor: string, values: CellValue[][]): void {
+    const { startRow, startCol } = parseAddress(stripSheet(anchor));
+    values.forEach((row, r) =>
+      row.forEach((value, c) => this.cells.set(key(startRow + r, startCol + c), value)),
+    );
+  }
+
+  getValues(rect: Rect): CellValue[][] {
+    return Array.from({ length: rect.rows }, (_, r) =>
+      Array.from(
+        { length: rect.cols },
+        (_, c) => this.cells.get(key(rect.startRow + r, rect.startCol + c)) ?? '',
+      ),
+    );
+  }
+
+  getFormulas(rect: Rect): string[][] {
+    return Array.from({ length: rect.rows }, (_, r) =>
+      Array.from({ length: rect.cols }, (_, c) => {
+        const k = key(rect.startRow + r, rect.startCol + c);
+        return this.formulas.get(k) ?? String(this.cells.get(k) ?? '');
+      }),
+    );
+  }
+
+  mergeFormat(rect: Rect, patch: Record<string, unknown>): void {
+    for (let r = 0; r < rect.rows; r++) {
+      for (let c = 0; c < rect.cols; c++) {
+        const k = key(rect.startRow + r, rect.startCol + c);
+        this.formats.set(k, { ...this.formats.get(k), ...patch });
+      }
+    }
+  }
+
+  /** Effective format of a single cell, e.g. formatAt('B2'). */
+  formatAt(cellAddress: string): Record<string, unknown> | undefined {
+    const p = parseAddress(stripSheet(cellAddress));
+    return this.formats.get(key(p.startRow, p.startCol));
+  }
+
+  usedRect(): Rect | null {
+    let minR = Infinity;
+    let minC = Infinity;
+    let maxR = -1;
+    let maxC = -1;
+    for (const k of [...this.cells.keys(), ...this.formulas.keys()]) {
+      const [r, c] = k.split(',').map(Number) as [number, number];
+      if (r < minR) minR = r;
+      if (c < minC) minC = c;
+      if (r > maxR) maxR = r;
+      if (c > maxC) maxC = c;
+    }
+    if (maxR === -1) return null;
+    return { startRow: minR, startCol: minC, rows: maxR - minR + 1, cols: maxC - minC + 1 };
+  }
+}
+
+export class MockWorkbookState {
+  sheets: MockSheetState[] = [new MockSheetState('Sheet1')];
+  activeSheetName = 'Sheet1';
+  /** Sheet-qualified selection, e.g. 'Sheet1!B2:F40'. */
+  selectionAddress = 'Sheet1!A1';
+  tables: Array<{ name: string; address: string; hasHeaders: boolean }> = [];
+  loadCalls: Array<{ target: string; props: unknown }> = [];
+  syncCount = 0;
+  selectionHandlers: Array<() => void> = [];
+
+  sheet(name: string): MockSheetState {
+    const found = this.sheets.find((s) => s.name === name);
+    if (!found) throw new Error(`ItemNotFound: ${name}`);
+    return found;
+  }
+
+  hasSheet(name: string): boolean {
+    return this.sheets.some((s) => s.name === name);
+  }
+
+  addSheet(name: string): MockSheetState {
+    if (this.hasSheet(name)) throw new Error(`InvalidArgument: sheet "${name}" already exists`);
+    const sheet = new MockSheetState(name);
+    this.sheets.push(sheet);
+    return sheet;
+  }
+
+  setValues(sheetName: string, anchor: string, values: CellValue[][]): void {
+    this.sheet(sheetName).setValues(anchor, values);
+  }
+
+  getValues(sheetName: string, address: string): CellValue[][] {
+    return this.sheet(sheetName).getValues(rectOf(address));
+  }
+
+  select(address: string): void {
+    this.selectionAddress = address.includes('!')
+      ? address
+      : `${this.activeSheetName}!${address}`;
+    this.fireSelectionChanged();
+  }
+
+  fireSelectionChanged(): void {
+    for (const handler of [...this.selectionHandlers]) handler();
+  }
+}
+
+type Syncable = { _sync(): void };
+
+class MockContext {
+  private tracked: Syncable[] = [];
+  readonly workbook: MockWorkbook;
+
+  constructor(readonly state: MockWorkbookState) {
+    this.workbook = new MockWorkbook(this);
+  }
+
+  track<T extends Syncable>(obj: T): T {
+    this.tracked.push(obj);
+    return obj;
+  }
+
+  sync = async (): Promise<void> => {
+    this.state.syncCount += 1;
+    for (const obj of [...this.tracked]) obj._sync();
+  };
+}
+
+class MockRange implements Syncable {
+  isNullObject: boolean;
+  readonly format: { fill: { color: string }; font: { bold: boolean; italic: boolean; color: string } };
+  private hydrated = false;
+  private pendingValues: CellValue[][] | null = null;
+  private pendingFormulas: string[][] | null = null;
+  private pendingNumberFormat: string[][] | null = null;
+  private pendingFormat: Record<string, unknown> = {};
+  private _values: CellValue[][] = [];
+  private _formulas: string[][] = [];
+  private _address = '';
+
+  constructor(
+    private ctx: MockContext,
+    private sheetState: MockSheetState | null,
+    private rect: Rect | null,
+  ) {
+    this.isNullObject = sheetState === null || rect === null;
+    const setterObj = <T extends object>(map: Record<string, string>): T => {
+      const obj = {} as T;
+      for (const [prop, formatKey] of Object.entries(map)) {
+        Object.defineProperty(obj, prop, {
+          set: (v: unknown) => {
+            this.pendingFormat[formatKey] = v;
+          },
+        });
+      }
+      return obj;
+    };
+    this.format = {
+      fill: setterObj<{ color: string }>({ color: 'fillColor' }),
+      font: setterObj<{ bold: boolean; italic: boolean; color: string }>({
+        bold: 'bold',
+        italic: 'italic',
+        color: 'fontColor',
+      }),
+    };
+    ctx.track(this);
+  }
+
+  load(props: unknown): this {
+    const target = this.isNullObject
+      ? 'range:null'
+      : `range:${this.sheetState!.name}!${rangeAddress(this.rect!.startRow, this.rect!.startCol, this.rect!.rows, this.rect!.cols)}`;
+    this.ctx.state.loadCalls.push({ target, props });
+    return this;
+  }
+
+  getRow(index: number): MockRange {
+    if (this.isNullObject) return new MockRange(this.ctx, null, null);
+    const r = this.rect!;
+    if (index < 0 || index >= r.rows) throw new Error('InvalidArgument: row index out of range');
+    return new MockRange(this.ctx, this.sheetState, {
+      startRow: r.startRow + index,
+      startCol: r.startCol,
+      rows: 1,
+      cols: r.cols,
+    });
+  }
+
+  private read<T>(prop: string, value: T): T {
+    if (!this.hydrated)
+      throw new Error(`PropertyNotLoaded: Range.${prop} read before context.sync()`);
+    return value;
+  }
+
+  get values(): CellValue[][] {
+    return this.read('values', this._values);
+  }
+  set values(v: CellValue[][]) {
+    this.pendingValues = v;
+  }
+
+  get formulas(): string[][] {
+    return this.read('formulas', this._formulas);
+  }
+  set formulas(v: string[][]) {
+    this.pendingFormulas = v;
+  }
+
+  set numberFormat(v: string[][]) {
+    this.pendingNumberFormat = v;
+  }
+
+  get address(): string {
+    return this.read('address', this._address);
+  }
+  get rowCount(): number {
+    return this.read('rowCount', this.rect?.rows ?? 0);
+  }
+  get columnCount(): number {
+    return this.read('columnCount', this.rect?.cols ?? 0);
+  }
+
+  _sync(): void {
+    if (this.isNullObject) {
+      this.hydrated = true;
+      return;
+    }
+    const sheet = this.sheetState!;
+    const rect = this.rect!;
+    if (this.pendingValues) {
+      if (
+        this.pendingValues.length !== rect.rows ||
+        (this.pendingValues[0]?.length ?? 0) !== rect.cols
+      ) {
+        throw new Error(
+          `InvalidArgument: values is ${this.pendingValues.length}x${this.pendingValues[0]?.length ?? 0} but the range is ${rect.rows}x${rect.cols}`,
+        );
+      }
+      this.pendingValues.forEach((row, r) =>
+        row.forEach((v, c) => {
+          const k = key(rect.startRow + r, rect.startCol + c);
+          sheet.cells.set(k, v);
+          sheet.formulas.delete(k);
+        }),
+      );
+      this.pendingValues = null;
+    }
+    if (this.pendingFormulas) {
+      this.pendingFormulas.forEach((row, r) =>
+        row.forEach((f, c) => {
+          const k = key(rect.startRow + r, rect.startCol + c);
+          sheet.formulas.set(k, f);
+          sheet.cells.set(k, f); // mock: the "calculated value" mirrors the formula text
+        }),
+      );
+      this.pendingFormulas = null;
+    }
+    if (this.pendingNumberFormat) {
+      sheet.mergeFormat(rect, { numberFormat: this.pendingNumberFormat[0]?.[0] ?? '' });
+      this.pendingNumberFormat = null;
+    }
+    if (Object.keys(this.pendingFormat).length > 0) {
+      sheet.mergeFormat(rect, this.pendingFormat);
+      this.pendingFormat = {};
+    }
+    this._values = sheet.getValues(rect);
+    this._formulas = sheet.getFormulas(rect);
+    this._address = `${sheet.name}!${rangeAddress(rect.startRow, rect.startCol, rect.rows, rect.cols)}`;
+    this.hydrated = true;
+  }
+}
+
+class MockWorksheet implements Syncable {
+  isNullObject: boolean;
+
+  constructor(
+    private ctx: MockContext,
+    private sheetState: MockSheetState | null,
+  ) {
+    this.isNullObject = sheetState === null;
+    ctx.track(this);
+  }
+
+  /** Leniency: readable without load(). */
+  get name(): string {
+    return this.sheetState?.name ?? '';
+  }
+
+  load(props: unknown): this {
+    this.ctx.state.loadCalls.push({ target: `worksheet:${this.name || 'null'}`, props });
+    return this;
+  }
+
+  getRange(address: string): MockRange {
+    if (!this.sheetState) throw new Error('ItemNotFound: getRange on a null worksheet');
+    return new MockRange(this.ctx, this.sheetState, rectOf(address));
+  }
+
+  getUsedRange(): MockRange {
+    return this.getUsedRangeOrNullObject();
+  }
+
+  getUsedRangeOrNullObject(): MockRange {
+    if (!this.sheetState) return new MockRange(this.ctx, null, null);
+    const rect = this.sheetState.usedRect();
+    return rect
+      ? new MockRange(this.ctx, this.sheetState, rect)
+      : new MockRange(this.ctx, null, null);
+  }
+
+  _sync(): void {
+    /* name is always readable; nothing to hydrate */
+  }
+}
+
+class MockWorksheetCollection implements Syncable {
+  private _items: MockWorksheet[] | null = null;
+
+  constructor(private ctx: MockContext) {
+    ctx.track(this);
+  }
+
+  load(props: unknown): this {
+    this.ctx.state.loadCalls.push({ target: 'worksheets', props });
+    return this;
+  }
+
+  get items(): MockWorksheet[] {
+    if (!this._items)
+      throw new Error('PropertyNotLoaded: WorksheetCollection.items read before context.sync()');
+    return this._items;
+  }
+
+  getActiveWorksheet(): MockWorksheet {
+    return new MockWorksheet(this.ctx, this.ctx.state.sheet(this.ctx.state.activeSheetName));
+  }
+
+  /** Leniency: throws immediately instead of at sync. */
+  getItem(name: string): MockWorksheet {
+    return new MockWorksheet(this.ctx, this.ctx.state.sheet(name));
+  }
+
+  getItemOrNullObject(name: string): MockWorksheet {
+    const found = this.ctx.state.sheets.find((s) => s.name === name) ?? null;
+    return new MockWorksheet(this.ctx, found);
+  }
+
+  add(name: string): MockWorksheet {
+    return new MockWorksheet(this.ctx, this.ctx.state.addSheet(name));
+  }
+
+  _sync(): void {
+    this._items = this.ctx.state.sheets.map((s) => new MockWorksheet(this.ctx, s));
+  }
+}
+
+class MockTable {
+  constructor(public name: string) {}
+  load(_props: unknown): this {
+    return this;
+  }
+  set style(_v: string) {
+    /* accepted, not modelled */
+  }
+}
+
+class MockTableCollection {
+  constructor(private ctx: MockContext) {}
+
+  add(address: string, hasHeaders: boolean): MockTable {
+    const state = this.ctx.state;
+    const sheetName = parseAddress(address).sheet ?? state.activeSheetName;
+    state.sheet(sheetName); // validates the sheet exists
+    const name = `Table${state.tables.length + 1}`;
+    state.tables.push({ name, address, hasHeaders });
+    return new MockTable(name);
+  }
+}
+
+class MockWorkbook {
+  readonly worksheets: MockWorksheetCollection;
+  readonly tables: MockTableCollection;
+
+  constructor(private ctx: MockContext) {
+    this.worksheets = new MockWorksheetCollection(ctx);
+    this.tables = new MockTableCollection(ctx);
+  }
+
+  getSelectedRange(): MockRange {
+    const address = this.ctx.state.selectionAddress;
+    const sheetName = parseAddress(address).sheet ?? this.ctx.state.activeSheetName;
+    return new MockRange(this.ctx, this.ctx.state.sheet(sheetName), rectOf(address));
+  }
+}
+
+let current: MockWorkbookState | null = null;
+
+export function installOfficeMock(): MockWorkbookState {
+  const state = new MockWorkbookState();
+  current = state;
+  const g = globalThis as Record<string, unknown>;
+  g.Excel = {
+    run: async <T>(callback: (context: unknown) => Promise<T>): Promise<T> => {
+      const context = new MockContext(state);
+      const result = await callback(context);
+      await context.sync(); // Excel.run always performs a trailing sync
+      return result;
+    },
+  };
+  g.Office = {
+    onReady: (cb?: (info: { host: string; platform: string }) => void) => {
+      const info = { host: 'Excel', platform: 'Mock' };
+      cb?.(info);
+      return Promise.resolve(info);
+    },
+    EventType: { DocumentSelectionChanged: 'documentSelectionChanged' },
+    context: {
+      document: {
+        addHandlerAsync: (
+          _type: string,
+          handler: () => void,
+          done?: (result: { status: string }) => void,
+        ) => {
+          state.selectionHandlers.push(handler);
+          done?.({ status: 'succeeded' });
+        },
+      },
+    },
+  };
+  g.OfficeRuntime = { auth: { getAccessToken: vi.fn(async () => 'mock-entra-access-token') } };
+  return state;
+}
+
+export function getOfficeMock(): MockWorkbookState {
+  if (!current)
+    throw new Error('installOfficeMock() has not run — is src/__tests__/setup.ts configured?');
+  return current;
+}
+```
+
+And `apps/office-addin/src/__tests__/setup.ts`:
+
+```ts
+import { beforeEach } from 'vitest';
+import { installOfficeMock } from './officeMock';
+
+beforeEach(() => {
+  installOfficeMock();
+  sessionStorage.clear();
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/__tests__/officeMock.test.ts`
+Expected: 8 tests PASS. Also re-run the address suite to confirm the setup file didn't break it: `npx vitest run src/lib/address.test.ts` (8 PASS).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/__tests__
+git commit -m "test(office-addin): Office.js Excel mock with load/sync lifecycle enforcement" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Auth — Office SSO → MSAL fallback → Breeze exchange (TDD)
+
+Two modules: `entraToken.ts` (silent `OfficeRuntime.auth.getAccessToken({ allowSignInPrompt: false })` → `@azure/msal-browser` popup fallback) and `session.ts` (the `POST /client-ai/auth/exchange` call, error-code → block-kind mapping, memory + sessionStorage store, single-flight re-exchange for 401s). Plus the `BlockedScreen` component the error kinds map onto (presentational — verified by tsc per D6).
+
+The MSAL scope is `api://<host>/<CLIENT_AI_ENTRA_CLIENT_ID>/access_as_user` — the same Application ID URI the manifest's `WebApplicationInfo` declares (Task 2). The Entra app registration must be configured for **v2.0 access tokens** (`requestedAccessTokenVersion: 2`) so the token's `aud` is the bare client-id GUID, which is exactly what Plan 1's `verifyEntraIdToken` pins (`audience: CLIENT_AI_ENTRA_CLIENT_ID`). Record this alongside the Task 2 registration prerequisites.
+
+**Files:**
+- Create: apps/office-addin/src/auth/entraToken.ts
+- Create: apps/office-addin/src/auth/session.ts
+- Create: apps/office-addin/src/components/BlockedScreen.tsx
+- Test: apps/office-addin/src/auth/entraToken.test.ts
+- Test: apps/office-addin/src/auth/session.test.ts
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/office-addin/src/auth/entraToken.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { getEntraTokenInteractive, getEntraTokenSilent, type EntraTokenDeps } from './entraToken';
+
+function deps(overrides: Partial<EntraTokenDeps> = {}): EntraTokenDeps {
+  return {
+    getSsoToken: vi.fn(async () => 'sso-token'),
+    getMsalToken: vi.fn(async () => 'msal-token'),
+    ...overrides,
+  };
+}
+
+describe('getEntraTokenInteractive — fallback ordering', () => {
+  it('returns the Office SSO token without touching MSAL when SSO succeeds', async () => {
+    const d = deps();
+    await expect(getEntraTokenInteractive(d)).resolves.toBe('sso-token');
+    expect(d.getMsalToken).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the MSAL popup when Office SSO fails', async () => {
+    const d = deps({ getSsoToken: vi.fn(async () => Promise.reject(new Error('13001'))) });
+    await expect(getEntraTokenInteractive(d)).resolves.toBe('msal-token');
+    expect(d.getMsalToken).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getEntraTokenSilent', () => {
+  it('never opens MSAL — rejects when SSO fails', async () => {
+    const d = deps({ getSsoToken: vi.fn(async () => Promise.reject(new Error('13001'))) });
+    await expect(getEntraTokenSilent(d)).rejects.toThrow('13001');
+    expect(d.getMsalToken).not.toHaveBeenCalled();
+  });
+});
+```
+
+`apps/office-addin/src/auth/session.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AuthBlockedError,
+  InvalidEntraTokenError,
+  __resetSessionForTests,
+  clearSession,
+  getSessionToken,
+  getStoredSession,
+  reExchange,
+  signIn,
+} from './session';
+import type { EntraTokenDeps } from './entraToken';
+
+const OK_BODY = {
+  accessToken: 'breeze-session-token-48ch',
+  expiresInSeconds: 86400,
+  user: { id: 'u-1', email: 'finance.user@contoso.com', name: 'Finance User' },
+};
+
+function entra(token = 'entra-token'): EntraTokenDeps {
+  return { getSsoToken: vi.fn(async () => token), getMsalToken: vi.fn(async () => token) };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  __resetSessionForTests();
+});
+
+describe('signIn', () => {
+  it('exchanges the Entra token and stores the session in memory + sessionStorage', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, OK_BODY));
+    const session = await signIn({ interactive: false }, { entra: entra(), fetchImpl });
+    expect(session.user.email).toBe('finance.user@contoso.com');
+    expect(getSessionToken()).toBe('breeze-session-token-48ch');
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/client-ai/auth/exchange');
+    expect(JSON.parse(init.body as string)).toEqual({ accessToken: 'entra-token' });
+    expect(sessionStorage.getItem('breeze-client-ai-session')).toContain('breeze-session-token-48ch');
+  });
+
+  it('maps exchange error codes to block kinds', async () => {
+    const cases: Array<[number, string, string]> = [
+      [404, 'tenant_not_provisioned', 'not_provisioned'],
+      [404, 'not_enabled', 'not_provisioned'],
+      [403, 'disabled', 'disabled'],
+      [403, 'user_not_permitted', 'user_not_permitted'],
+      [403, 'account_inactive', 'account_inactive'],
+      [403, 'provisioning_failed', 'retryable'],
+      [429, 'rate_limited', 'retryable'],
+      [503, 'service_unavailable', 'retryable'],
+    ];
+    for (const [status, code, kind] of cases) {
+      __resetSessionForTests();
+      const fetchImpl = vi.fn(async () => jsonResponse(status, { error: code }));
+      const err = await signIn({ interactive: false }, { entra: entra(), fetchImpl }).catch(
+        (e: unknown) => e,
+      );
+      expect(err, code).toBeInstanceOf(AuthBlockedError);
+      expect((err as AuthBlockedError).kind, code).toBe(kind);
+      expect((err as AuthBlockedError).errorCode, code).toBe(code);
+    }
+  });
+
+  it('on 401 invalid_token clears state and retries once with a fresh Entra token', async () => {
+    const entraDeps = entra();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, { error: 'invalid_token' }))
+      .mockResolvedValueOnce(jsonResponse(200, OK_BODY));
+    const session = await signIn({ interactive: false }, { entra: entraDeps, fetchImpl });
+    expect(session.user.id).toBe('u-1');
+    expect(entraDeps.getSsoToken).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates InvalidEntraTokenError when the retry also 401s', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(401, { error: 'invalid_token' }));
+    await expect(
+      signIn({ interactive: false }, { entra: entra(), fetchImpl }),
+    ).rejects.toBeInstanceOf(InvalidEntraTokenError);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('reExchange', () => {
+  it('is single-flight: concurrent callers share one exchange', async () => {
+    let resolveFetch!: (r: Response) => void;
+    const fetchImpl = vi.fn(
+      () => new Promise<Response>((resolve) => (resolveFetch = resolve)),
+    );
+    const p1 = reExchange({ entra: entra(), fetchImpl });
+    const p2 = reExchange({ entra: entra(), fetchImpl });
+    resolveFetch(jsonResponse(200, OK_BODY));
+    const [s1, s2] = await Promise.all([p1, p2]);
+    expect(s1.sessionToken).toBe(s2.sessionToken);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('session store', () => {
+  it('restores from sessionStorage and rejects expired entries', () => {
+    sessionStorage.setItem(
+      'breeze-client-ai-session',
+      JSON.stringify({
+        sessionToken: 'tok',
+        expiresAt: Date.now() + 60_000,
+        user: OK_BODY.user,
+        org: null,
+        branding: null,
+      }),
+    );
+    expect(getStoredSession()?.sessionToken).toBe('tok');
+    __resetSessionForTests();
+    sessionStorage.setItem(
+      'breeze-client-ai-session',
+      JSON.stringify({
+        sessionToken: 'tok',
+        expiresAt: Date.now() - 1,
+        user: OK_BODY.user,
+        org: null,
+        branding: null,
+      }),
+    );
+    expect(getStoredSession()).toBeNull();
+  });
+
+  it('clearSession wipes memory and sessionStorage', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, OK_BODY));
+    await signIn({ interactive: false }, { entra: entra(), fetchImpl });
+    clearSession();
+    expect(getSessionToken()).toBeNull();
+    expect(sessionStorage.getItem('breeze-client-ai-session')).toBeNull();
+  });
+});
+```
+
+(`__resetSessionForTests` clears the in-memory cache WITHOUT touching sessionStorage — `clearSession` does both; the restore test needs them separate.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/auth`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/office-addin/src/auth/entraToken.ts`:
+
+```ts
+/**
+ * Entra ID access-token acquisition (spec §3):
+ *   1. Office SSO — OfficeRuntime.auth.getAccessToken({ allowSignInPrompt: false }).
+ *      Works when the MSP centrally deployed the add-in and pre-authorized the
+ *      Office client app (Task 2 prerequisite d). Silent, no UI ever.
+ *   2. MSAL popup fallback — first-run consent / sideload / SSO error path.
+ *      Popups must originate from a user gesture, so the silent boot path
+ *      (App.tsx) uses getEntraTokenSilent and only the sign-in button uses
+ *      getEntraTokenInteractive.
+ * D4: swapping the fallback to NAA (createNestablePublicClientApplication)
+ * later only touches this file.
+ */
+import { ENTRA_CLIENT_ID } from '../config';
+
+export type EntraTokenDeps = {
+  getSsoToken: () => Promise<string>;
+  getMsalToken: () => Promise<string>;
+};
+
+/** Scope on the add-in's own app registration (matches the manifest's WebApplicationInfo Resource). */
+export function msalScopes(): string[] {
+  return [`api://${window.location.host}/${ENTRA_CLIENT_ID}/access_as_user`];
+}
+
+async function officeSsoToken(): Promise<string> {
+  const officeRuntime = (
+    globalThis as {
+      OfficeRuntime?: { auth?: { getAccessToken?: (opts: object) => Promise<string> } };
+    }
+  ).OfficeRuntime;
+  if (!officeRuntime?.auth?.getAccessToken) throw new Error('Office SSO unavailable');
+  return officeRuntime.auth.getAccessToken({ allowSignInPrompt: false });
+}
+
+let msalInstancePromise: Promise<
+  import('@azure/msal-browser').PublicClientApplication
+> | null = null;
+
+function getMsalInstance() {
+  if (!msalInstancePromise) {
+    msalInstancePromise = (async () => {
+      const { PublicClientApplication } = await import('@azure/msal-browser');
+      const pca = new PublicClientApplication({
+        auth: {
+          clientId: ENTRA_CLIENT_ID,
+          authority: 'https://login.microsoftonline.com/organizations',
+          redirectUri: `${window.location.origin}/taskpane.html`,
+        },
+        cache: { cacheLocation: 'sessionStorage' },
+      });
+      await pca.initialize();
+      return pca;
+    })();
+  }
+  return msalInstancePromise;
+}
+
+async function msalPopupToken(): Promise<string> {
+  const pca = await getMsalInstance();
+  const scopes = msalScopes();
+  const account = pca.getAllAccounts()[0];
+  if (account) {
+    try {
+      const silent = await pca.acquireTokenSilent({ scopes, account });
+      return silent.accessToken;
+    } catch {
+      /* fall through to the popup */
+    }
+  }
+  const popup = await pca.acquireTokenPopup({ scopes });
+  return popup.accessToken;
+}
+
+export const defaultEntraTokenDeps: EntraTokenDeps = {
+  getSsoToken: officeSsoToken,
+  getMsalToken: msalPopupToken,
+};
+
+/** Silent only — never opens UI. Throws when Office SSO is unavailable or fails. */
+export async function getEntraTokenSilent(
+  deps: EntraTokenDeps = defaultEntraTokenDeps,
+): Promise<string> {
+  return deps.getSsoToken();
+}
+
+/** Full chain: silent Office SSO, then MSAL popup. Call from a user gesture. */
+export async function getEntraTokenInteractive(
+  deps: EntraTokenDeps = defaultEntraTokenDeps,
+): Promise<string> {
+  try {
+    return await deps.getSsoToken();
+  } catch {
+    return deps.getMsalToken();
+  }
+}
+```
+
+`apps/office-addin/src/auth/session.ts`:
+
+```ts
+/**
+ * Breeze client-AI session: POST /client-ai/auth/exchange (Plan 1, authoritative
+ * — see Pinned server contracts §1). Stores { sessionToken, user, org?, branding? }
+ * in memory + sessionStorage; reExchange() is the single-flight 401 recovery
+ * path the API client (Task 6) calls.
+ */
+import { API_BASE_URL } from '../config';
+import {
+  defaultEntraTokenDeps,
+  getEntraTokenInteractive,
+  getEntraTokenSilent,
+  type EntraTokenDeps,
+} from './entraToken';
+
+export type ExchangeUser = { id: string; email: string; name: string | null };
+/** Not sent by Plan 1 yet (Deviation D2) — typed optional so a later server addition needs zero client changes. */
+export type ExchangeOrg = { id: string; name?: string | null };
+export type ExchangeBranding = { displayName?: string | null; logoUrl?: string | null };
+
+export type ExchangeResponse = {
+  accessToken: string;
+  expiresInSeconds: number;
+  user: ExchangeUser;
+  org?: ExchangeOrg;
+  branding?: ExchangeBranding;
+};
+
+export type AuthBlockKind =
+  | 'not_provisioned'
+  | 'disabled'
+  | 'user_not_permitted'
+  | 'account_inactive'
+  | 'retryable';
+
+export class AuthBlockedError extends Error {
+  constructor(
+    public kind: AuthBlockKind,
+    public errorCode: string,
+  ) {
+    super(`client-ai auth blocked: ${errorCode}`);
+    this.name = 'AuthBlockedError';
+  }
+}
+
+/** The exchange 401'd (stale/garbled Entra token). signIn retries once; then this propagates. */
+export class InvalidEntraTokenError extends Error {
+  constructor() {
+    super('Entra token rejected by the exchange');
+    this.name = 'InvalidEntraTokenError';
+  }
+}
+
+export type ClientSession = {
+  sessionToken: string;
+  expiresAt: number; // epoch ms
+  user: ExchangeUser;
+  org: ExchangeOrg | null;
+  branding: ExchangeBranding | null;
+};
+
+const STORAGE_KEY = 'breeze-client-ai-session';
+let current: ClientSession | null = null;
+
+export function getStoredSession(): ClientSession | null {
+  if (current && Date.now() < current.expiresAt) return current;
+  current = null;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ClientSession;
+    if (typeof parsed.sessionToken !== 'string' || Date.now() >= parsed.expiresAt) return null;
+    current = parsed;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function getSessionToken(): string | null {
+  return getStoredSession()?.sessionToken ?? null;
+}
+
+export function clearSession(): void {
+  current = null;
+  sessionStorage.removeItem(STORAGE_KEY);
+}
+
+/** Test-only: drops the in-memory cache WITHOUT touching sessionStorage. */
+export function __resetSessionForTests(): void {
+  current = null;
+}
+
+function storeSession(res: ExchangeResponse): ClientSession {
+  const session: ClientSession = {
+    sessionToken: res.accessToken,
+    expiresAt: Date.now() + res.expiresInSeconds * 1000,
+    user: res.user,
+    org: res.org ?? null,
+    branding: res.branding ?? null,
+  };
+  current = session;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  } catch {
+    /* storage may be unavailable in some webviews — in-memory still works */
+  }
+  return session;
+}
+
+/** Plan 1 error-code table → screen family (Pinned server contracts §1). */
+const BLOCK_KINDS: Record<string, AuthBlockKind> = {
+  tenant_not_provisioned: 'not_provisioned',
+  not_enabled: 'not_provisioned',
+  disabled: 'disabled',
+  user_not_permitted: 'user_not_permitted',
+  account_inactive: 'account_inactive',
+  provisioning_failed: 'retryable',
+  rate_limited: 'retryable',
+  service_unavailable: 'retryable',
+};
+
+async function exchangeOnce(entraToken: string, fetchImpl: typeof fetch): Promise<ClientSession> {
+  const res = await fetchImpl(`${API_BASE_URL}/client-ai/auth/exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accessToken: entraToken }),
+  });
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    /* non-JSON error body */
+  }
+  if (res.ok) return storeSession(body as ExchangeResponse);
+  const code =
+    body && typeof body === 'object' && typeof (body as { error?: unknown }).error === 'string'
+      ? (body as { error: string }).error
+      : `http_${res.status}`;
+  if (res.status === 401) throw new InvalidEntraTokenError();
+  throw new AuthBlockedError(BLOCK_KINDS[code] ?? 'retryable', code);
+}
+
+export type SignInDeps = { entra?: EntraTokenDeps; fetchImpl?: typeof fetch };
+
+export async function signIn(
+  opts: { interactive: boolean },
+  deps: SignInDeps = {},
+): Promise<ClientSession> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const entraDeps = deps.entra ?? defaultEntraTokenDeps;
+  const getToken = opts.interactive ? getEntraTokenInteractive : getEntraTokenSilent;
+  const entraToken = await getToken(entraDeps);
+  try {
+    return await exchangeOnce(entraToken, fetchImpl);
+  } catch (err) {
+    if (err instanceof InvalidEntraTokenError) {
+      // Stale cached Entra token: clear everything and retry once from scratch.
+      clearSession();
+      const freshToken = await getToken(entraDeps);
+      return exchangeOnce(freshToken, fetchImpl);
+    }
+    throw err;
+  }
+}
+
+let reExchangeInFlight: Promise<ClientSession> | null = null;
+
+/** Single-flight silent re-auth for API-level 401s (Task 6 apiFetch). */
+export function reExchange(deps: SignInDeps = {}): Promise<ClientSession> {
+  if (!reExchangeInFlight) {
+    clearSession();
+    reExchangeInFlight = signIn({ interactive: false }, deps).finally(() => {
+      reExchangeInFlight = null;
+    });
+  }
+  return reExchangeInFlight;
+}
+```
+
+`apps/office-addin/src/components/BlockedScreen.tsx`:
+
+```tsx
+import type { AuthBlockKind } from '../auth/session';
+
+const COPY: Record<AuthBlockKind, { title: string; body: string }> = {
+  not_provisioned: {
+    title: 'Not set up yet',
+    body: 'Breeze AI has not been provisioned for your organization. Contact your IT provider to enable it.',
+  },
+  disabled: {
+    title: 'Disabled',
+    body: 'Breeze AI is currently disabled for your organization. Contact your IT provider.',
+  },
+  user_not_permitted: {
+    title: 'No access',
+    body: 'Your account does not have access to Breeze AI. Contact your IT provider.',
+  },
+  account_inactive: {
+    title: 'Account inactive',
+    body: 'Your account is inactive. Contact your IT provider.',
+  },
+  retryable: {
+    title: 'Temporarily unavailable',
+    body: 'Something went wrong talking to Breeze. Try again in a moment.',
+  },
+};
+
+export function BlockedScreen({ kind, onRetry }: { kind: AuthBlockKind; onRetry?: () => void }) {
+  const copy = COPY[kind];
+  return (
+    <div
+      className="flex h-screen flex-col items-center justify-center gap-2 p-6 text-center"
+      data-testid={`blocked-${kind}`}
+    >
+      <div className="text-base font-semibold text-gray-800">{copy.title}</div>
+      <p className="text-sm text-gray-500">{copy.body}</p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-2 rounded-md border border-gray-300 px-4 py-1.5 text-sm text-gray-700"
+          data-testid="blocked-retry"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/auth`
+Expected: 10 tests PASS (3 entraToken + 7 session). Then `npx tsc --noEmit` — clean (BlockedScreen has no test; tsc is its gate, D6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/auth apps/office-addin/src/components/BlockedScreen.tsx
+git commit -m "feat(office-addin): Office SSO -> MSAL fallback -> Breeze exchange with block-kind mapping" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: API client + fetch-SSE parser (TDD)
+
+Three files: `types.ts` (the D1 single-source wire types, now mirroring Plan 2's `CLIENT_AI_SSE_EVENTS` exactly — see the Contract reconciliation section), `sse.ts` (a spec-correct SSE parser over `fetch` ReadableStream + TextDecoder, because `EventSource` cannot send the `Authorization` header), and `client.ts` (typed wrappers with bearer auth, single-flight 401 re-exchange, and `streamEvents` with reconnect-on-drop + history resync).
+
+**Files:**
+- Create: apps/office-addin/src/api/types.ts
+- Create: apps/office-addin/src/api/sse.ts
+- Create: apps/office-addin/src/api/client.ts
+- Test: apps/office-addin/src/api/sse.test.ts
+- Test: apps/office-addin/src/api/client.test.ts
+
+- [ ] **Step 1: Create `apps/office-addin/src/api/types.ts`** (pure types — no test of its own; consumed everywhere):
+
+```ts
+/**
+ * /client-ai wire types. THE single place event names/payloads appear (D1).
+ * SSE names mirror Plan 2's CLIENT_AI_SSE_EVENTS (apps/api/src/routes/clientAi/sse.ts)
+ * — the data JSON does NOT repeat the type; the client discriminates on the
+ * SSE `event:` field (see Contract reconciliation).
+ */
+
+export type CellValue = string | number | boolean | null;
+
+export type DlpRedaction = { rule: string; count: number; location: string };
+export type TurnUsage = { inputTokens: number; outputTokens: number; costCents: number };
+
+export type ToolResultStatus = 'success' | 'error' | 'rejected';
+export type ToolCompletedStatus = ToolResultStatus | 'timeout';
+
+export const CLIENT_AI_SSE_EVENTS = [
+  'message_delta',
+  'tool_request',
+  'tool_completed',
+  'turn_complete',
+  'session_error',
+  'ping',
+] as const;
+
+export type ClientAiStreamEvent =
+  | { type: 'message_delta'; text: string }
+  | {
+      type: 'tool_request';
+      toolUseId: string;
+      toolName: string;
+      input: Record<string, unknown>;
+      mutating: boolean;
+    }
+  | {
+      type: 'tool_completed';
+      toolUseId: string;
+      toolName: string;
+      status: ToolCompletedStatus;
+      redactions: DlpRedaction[];
+      blockReason: string | null;
+    }
+  | { type: 'turn_complete'; usage: TurnUsage | null }
+  | { type: 'session_error'; message: string }
+  | { type: 'ping' };
+
+export type WorkbookContextKind = 'selection' | 'sheet' | 'none';
+
+/** Per-message context chip payload (Plan 2 workbookContextSchema). */
+export type WorkbookContext = {
+  kind: WorkbookContextKind;
+  address?: string;
+  sheetName?: string;
+  cells?: CellValue[][];
+};
+
+export type SendMessageBody = { content: string; workbookContext?: WorkbookContext };
+
+export type ToolResultBody = { toolUseId: string; status: ToolResultStatus; output?: unknown };
+
+export type ClientAiTemplate = {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string | null;
+  body: string;
+};
+
+export type SessionSummary = {
+  id: string;
+  status: string;
+  title: string | null;
+  model: string;
+  turnCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostCents: number;
+  createdAt: string;
+  lastActivityAt: string | null;
+};
+
+export type SessionMessage = {
+  id: string;
+  role: string;
+  content: string | null;
+  contentBlocks: unknown;
+  toolName: string | null;
+  toolInput: unknown;
+  toolOutput: unknown;
+  toolUseId: string | null;
+  createdAt: string;
+};
+
+export type SessionHistory = { session: SessionSummary; messages: SessionMessage[] };
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`apps/office-addin/src/api/sse.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { parseSseStream, type SseFrame } from './sse';
+
+const encoder = new TextEncoder();
+
+function streamFrom(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(chunks: string[]): Promise<SseFrame[]> {
+  const frames: SseFrame[] = [];
+  for await (const frame of parseSseStream(streamFrom(chunks))) frames.push(frame);
+  return frames;
+}
+
+describe('parseSseStream', () => {
+  it('parses a single event frame', async () => {
+    const frames = await collect(['event: message_delta\ndata: {"text":"hi"}\n\n']);
+    expect(frames).toEqual([{ event: 'message_delta', data: '{"text":"hi"}' }]);
+  });
+
+  it('handles events split across arbitrary chunk boundaries', async () => {
+    const frames = await collect([
+      'event: mess',
+      'age_delta\nda',
+      'ta: {"text":"x',
+      'y"}\n',
+      '\nevent: ping\ndata: {}\n\n',
+    ]);
+    expect(frames).toEqual([
+      { event: 'message_delta', data: '{"text":"xy"}' },
+      { event: 'ping', data: '{}' },
+    ]);
+  });
+
+  it('joins multi-line data with newlines', async () => {
+    const frames = await collect(['event: message_delta\ndata: line1\ndata: line2\n\n']);
+    expect(frames).toEqual([{ event: 'message_delta', data: 'line1\nline2' }]);
+  });
+
+  it('accepts CRLF line endings', async () => {
+    const frames = await collect(['event: ping\r\ndata: {}\r\n\r\n']);
+    expect(frames).toEqual([{ event: 'ping', data: '{}' }]);
+  });
+
+  it('ignores comments and unknown fields', async () => {
+    const frames = await collect([
+      ': keepalive comment\nid: 42\nretry: 5000\nevent: ping\ndata: {}\n\n',
+    ]);
+    expect(frames).toEqual([{ event: 'ping', data: '{}' }]);
+  });
+
+  it("defaults the event name to 'message' when no event line is present", async () => {
+    const frames = await collect(['data: {"a":1}\n\n']);
+    expect(frames).toEqual([{ event: 'message', data: '{"a":1}' }]);
+  });
+
+  it('flushes a final frame when the stream ends without a trailing blank line', async () => {
+    const frames = await collect(['event: session_error\ndata: {"message":"boom"}']);
+    expect(frames).toEqual([{ event: 'session_error', data: '{"message":"boom"}' }]);
+  });
+});
+```
+
+`apps/office-addin/src/api/client.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ApiError,
+  createSession,
+  decodeStreamFrame,
+  getTemplates,
+  sendMessage,
+  streamEvents,
+} from './client';
+import { clearSession, getSessionToken, reExchange } from '../auth/session';
+import type { ClientAiStreamEvent } from './types';
+
+vi.mock('../auth/session', async () => {
+  const actual = await vi.importActual<typeof import('../auth/session')>('../auth/session');
+  return {
+    ...actual,
+    getSessionToken: vi.fn(() => 'breeze-token'),
+    reExchange: vi.fn(async () => ({}) as never),
+    clearSession: vi.fn(),
+  };
+});
+
+const getSessionTokenMock = vi.mocked(getSessionToken);
+const reExchangeMock = vi.mocked(reExchange);
+const clearSessionMock = vi.mocked(clearSession);
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const encoder = new TextEncoder();
+
+function sseResponse(frames: string, opts: { keepOpen?: boolean } = {}): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(frames));
+      if (!opts.keepOpen) controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+}
+
+beforeEach(() => {
+  getSessionTokenMock.mockReturnValue('breeze-token');
+  reExchangeMock.mockClear();
+  clearSessionMock.mockClear();
+});
+
+describe('apiFetch wrappers', () => {
+  it('attaches the Authorization bearer header and returns the sessionId (201)', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(201, { sessionId: 'sess-1' }));
+    await expect(createSession(fetchImpl as unknown as typeof fetch)).resolves.toBe('sess-1');
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/client-ai/sessions');
+    expect((init.headers as Headers).get('Authorization')).toBe('Bearer breeze-token');
+    expect((init.headers as Headers).get('Content-Type')).toBe('application/json');
+  });
+
+  it('on 401 runs the single-flight re-exchange and retries once', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, { error: 'invalid_token' }))
+      .mockResolvedValueOnce(jsonResponse(201, { sessionId: 'sess-2' }));
+    await expect(createSession(fetchImpl as unknown as typeof fetch)).resolves.toBe('sess-2');
+    expect(reExchangeMock).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates a 401 that survives the re-exchange and clears the session', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(401, { error: 'invalid_token' }));
+    const err = await createSession(fetchImpl as unknown as typeof fetch).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+    expect(clearSessionMock).toHaveBeenCalled();
+  });
+
+  it('surfaces server rejection codes (budget_exceeded) as ApiError', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(403, { error: 'budget_exceeded' }));
+    const err = await sendMessage('sess-1', { content: 'hi' }, fetchImpl as unknown as typeof fetch).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).code).toBe('budget_exceeded');
+  });
+
+  it('getTemplates accepts both the pinned bare array and a {data:[...]} envelope', async () => {
+    const template = { id: 't1', name: 'T', description: null, category: null, body: 'B' };
+    const bare = vi.fn(async () => jsonResponse(200, [template]));
+    await expect(getTemplates(bare as unknown as typeof fetch)).resolves.toEqual([template]);
+    const wrapped = vi.fn(async () => jsonResponse(200, { data: [template] }));
+    await expect(getTemplates(wrapped as unknown as typeof fetch)).resolves.toEqual([template]);
+  });
+});
+
+describe('decodeStreamFrame', () => {
+  it('types known events, passes ping without payload, and skips unknown names', () => {
+    expect(decodeStreamFrame({ event: 'message_delta', data: '{"text":"hi"}' })).toEqual({
+      type: 'message_delta',
+      text: 'hi',
+    });
+    expect(decodeStreamFrame({ event: 'ping', data: '{}' })).toEqual({ type: 'ping' });
+    expect(decodeStreamFrame({ event: 'turn_complete', data: '{"usage":null}' })).toEqual({
+      type: 'turn_complete',
+      usage: null,
+    });
+    expect(decodeStreamFrame({ event: 'some_future_event', data: '{}' })).toBeNull();
+  });
+});
+
+describe('streamEvents', () => {
+  it('reconnects after a dropped stream with backoff and calls onReconnect', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(sseResponse('event: message_delta\ndata: {"text":"a"}\n\n'))
+      .mockResolvedValueOnce(
+        sseResponse('event: message_delta\ndata: {"text":"b"}\n\n', { keepOpen: true }),
+      );
+    const events: ClientAiStreamEvent[] = [];
+    const onReconnect = vi.fn();
+    const handle = streamEvents(
+      'sess-1',
+      { onEvent: (e) => events.push(e), onReconnect },
+      fetchImpl as unknown as typeof fetch,
+      [10], // test-only backoff schedule
+    );
+    await vi.waitFor(() => expect(events).toHaveLength(2));
+    expect(events.map((e) => (e.type === 'message_delta' ? e.text : ''))).toEqual(['a', 'b']);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    handle.stop();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/api`
+Expected: FAIL — `./sse` / `./client` not found.
+
+- [ ] **Step 4: Write the implementation**
+
+`apps/office-addin/src/api/sse.ts`:
+
+```ts
+/**
+ * SSE parser over a fetch ReadableStream. EventSource cannot set the
+ * Authorization header, so the add-in consumes GET /events with fetch and
+ * parses frames manually (the server's GET-only ?token= fallback exists for
+ * EventSource clients; this client never uses it).
+ *
+ * Implements the SSE wire format subset the server emits: `event:` + one or
+ * more `data:` lines per frame, blank-line dispatch, `:` comments and
+ * `id:`/`retry:` fields ignored, CRLF tolerated, frames may be split across
+ * arbitrary chunk boundaries.
+ */
+
+export type SseFrame = { event: string; data: string };
+
+export async function* parseSseStream(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<SseFrame, void, undefined> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let eventName = '';
+  let dataLines: string[] = [];
+
+  const flush = (): SseFrame | null => {
+    if (dataLines.length === 0) {
+      eventName = '';
+      return null;
+    }
+    const frame = { event: eventName || 'message', data: dataLines.join('\n') };
+    eventName = '';
+    dataLines = [];
+    return frame;
+  };
+
+  const handleLine = (rawLine: string): SseFrame | null => {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    if (line === '') return flush();
+    if (line.startsWith(':')) return null; // comment / keepalive
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? '' : line.slice(colon + 1);
+    if (value.startsWith(' ')) value = value.slice(1);
+    if (field === 'event') eventName = value;
+    else if (field === 'data') dataLines.push(value);
+    // id: / retry: / anything else — ignored
+    return null;
+  };
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        const frame = handleLine(line);
+        if (frame) yield frame;
+      }
+    }
+    buffer += decoder.decode();
+    if (buffer.length > 0) {
+      const frame = handleLine(buffer);
+      if (frame) yield frame;
+    }
+    const last = flush();
+    if (last) yield last;
+  } finally {
+    reader.releaseLock();
+  }
+}
+```
+
+`apps/office-addin/src/api/client.ts`:
+
+```ts
+/**
+ * Typed /client-ai API client. Every request carries the Breeze session token;
+ * a 401 triggers ONE single-flight re-exchange (auth/session.ts) + retry.
+ * Contracts: Contract reconciliation section of this plan (Plan 2 / Plan 4 pins).
+ */
+import { API_BASE_URL } from '../config';
+import { AuthBlockedError, clearSession, getSessionToken, reExchange } from '../auth/session';
+import { parseSseStream } from './sse';
+import {
+  CLIENT_AI_SSE_EVENTS,
+  type ClientAiStreamEvent,
+  type ClientAiTemplate,
+  type SendMessageBody,
+  type SessionHistory,
+  type ToolResultBody,
+} from './types';
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+  ) {
+    super(`client-ai request failed: ${status} ${code}`);
+    this.name = 'ApiError';
+  }
+}
+
+type FetchLike = typeof fetch;
+
+export async function apiFetch(
+  path: string,
+  init: RequestInit = {},
+  fetchImpl: FetchLike = fetch,
+): Promise<Response> {
+  const doFetch = async (): Promise<Response> => {
+    const token = getSessionToken();
+    if (!token) throw new ApiError(401, 'no_session');
+    const headers = new Headers(init.headers);
+    headers.set('Authorization', `Bearer ${token}`);
+    if (init.body !== undefined && !headers.has('Content-Type'))
+      headers.set('Content-Type', 'application/json');
+    return fetchImpl(`${API_BASE_URL}${path}`, { ...init, headers });
+  };
+  let res = await doFetch();
+  if (res.status === 401) {
+    await reExchange(); // throws AuthBlockedError when access was revoked
+    res = await doFetch();
+    if (res.status === 401) {
+      clearSession();
+      throw new ApiError(401, 'unauthorized');
+    }
+  }
+  return res;
+}
+
+async function readJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function expectOk(res: Response): Promise<unknown> {
+  const body = await readJson(res);
+  if (!res.ok) {
+    const code =
+      body && typeof body === 'object' && typeof (body as { error?: unknown }).error === 'string'
+        ? (body as { error: string }).error
+        : `http_${res.status}`;
+    throw new ApiError(res.status, code);
+  }
+  return body;
+}
+
+/** POST /client-ai/sessions {} → 201 { sessionId } */
+export async function createSession(fetchImpl?: FetchLike): Promise<string> {
+  const body = (await expectOk(
+    await apiFetch('/client-ai/sessions', { method: 'POST', body: '{}' }, fetchImpl),
+  )) as { sessionId: string };
+  return body.sessionId;
+}
+
+/** POST /client-ai/sessions/:id/messages → 202 { accepted: true }; the turn streams over GET /events. */
+export async function sendMessage(
+  sessionId: string,
+  message: SendMessageBody,
+  fetchImpl?: FetchLike,
+): Promise<void> {
+  await expectOk(
+    await apiFetch(
+      `/client-ai/sessions/${sessionId}/messages`,
+      { method: 'POST', body: JSON.stringify(message) },
+      fetchImpl,
+    ),
+  );
+}
+
+/** POST /client-ai/sessions/:id/tool-results — resolves a parked tool_request server-side. */
+export async function postToolResult(
+  sessionId: string,
+  result: ToolResultBody,
+  fetchImpl?: FetchLike,
+): Promise<void> {
+  await expectOk(
+    await apiFetch(
+      `/client-ai/sessions/${sessionId}/tool-results`,
+      { method: 'POST', body: JSON.stringify(result) },
+      fetchImpl,
+    ),
+  );
+}
+
+/** GET /client-ai/templates → bare array (Plan 4 pin); {data:[...]} tolerated defensively. */
+export async function getTemplates(fetchImpl?: FetchLike): Promise<ClientAiTemplate[]> {
+  const body = await expectOk(await apiFetch('/client-ai/templates', {}, fetchImpl));
+  if (Array.isArray(body)) return body as ClientAiTemplate[];
+  if (body && typeof body === 'object' && Array.isArray((body as { data?: unknown }).data))
+    return (body as { data: ClientAiTemplate[] }).data;
+  return [];
+}
+
+/** GET /client-ai/sessions/:id → { session, messages } (already-redacted history). */
+export async function getSession(sessionId: string, fetchImpl?: FetchLike): Promise<SessionHistory> {
+  return (await expectOk(await apiFetch(`/client-ai/sessions/${sessionId}`, {}, fetchImpl))) as SessionHistory;
+}
+
+/** POST /client-ai/sessions/:id/close — best-effort teardown. */
+export async function closeSession(sessionId: string, fetchImpl?: FetchLike): Promise<void> {
+  await expectOk(
+    await apiFetch(`/client-ai/sessions/${sessionId}/close`, { method: 'POST', body: '{}' }, fetchImpl),
+  );
+}
+
+const KNOWN_EVENTS = new Set<string>(CLIENT_AI_SSE_EVENTS);
+
+/** SSE frame → typed event. Unknown event names → null (additive server events are safe). */
+export function decodeStreamFrame(frame: { event: string; data: string }): ClientAiStreamEvent | null {
+  if (!KNOWN_EVENTS.has(frame.event)) return null;
+  if (frame.event === 'ping') return { type: 'ping' };
+  let payload: unknown;
+  try {
+    payload = JSON.parse(frame.data);
+  } catch {
+    return null;
+  }
+  if (payload === null || typeof payload !== 'object') return null;
+  return { type: frame.event, ...(payload as object) } as ClientAiStreamEvent;
+}
+
+export type StreamHandle = { stop: () => void };
+
+export type StreamCallbacks = {
+  onEvent: (event: ClientAiStreamEvent) => void;
+  /** Fires after a successful REconnect — re-GET history and reconcile (the gap may have streamed events). */
+  onReconnect?: () => void | Promise<void>;
+  /** Auth permanently lost (re-exchange failed / blocked) — stop and surface. */
+  onPermanentError?: (err: unknown) => void;
+};
+
+const DEFAULT_BACKOFF_MS = [1000, 2000, 4000, 8000, 15000];
+
+/**
+ * Persistent GET /events consumer. fetch + Authorization header (primary path;
+ * the server's ?token= GET fallback is for EventSource clients only).
+ * Reconnects forever with capped backoff until stop() — server pings (25s)
+ * keep healthy connections alive, so a dropped read means real network loss.
+ */
+export function streamEvents(
+  sessionId: string,
+  callbacks: StreamCallbacks,
+  fetchImpl: FetchLike = fetch,
+  backoffMs: number[] = DEFAULT_BACKOFF_MS,
+): StreamHandle {
+  const controller = new AbortController();
+  let attempt = 0;
+  let connectedBefore = false;
+
+  const loop = async (): Promise<void> => {
+    for (;;) {
+      if (controller.signal.aborted) return;
+      try {
+        const res = await apiFetch(
+          `/client-ai/sessions/${sessionId}/events`,
+          { signal: controller.signal, headers: { Accept: 'text/event-stream' } },
+          fetchImpl,
+        );
+        if (!res.ok || !res.body) throw new ApiError(res.status, `http_${res.status}`);
+        if (connectedBefore) await callbacks.onReconnect?.();
+        connectedBefore = true;
+        for await (const frame of parseSseStream(res.body)) {
+          attempt = 0; // healthy traffic resets the backoff
+          const event = decodeStreamFrame(frame);
+          if (event) callbacks.onEvent(event);
+        }
+        // server closed the stream — fall through and reconnect
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        if (err instanceof AuthBlockedError || (err instanceof ApiError && err.status === 401)) {
+          callbacks.onPermanentError?.(err);
+          return;
+        }
+        // transient (network drop, 5xx) — fall through to backoff
+      }
+      if (controller.signal.aborted) return;
+      const delay = backoffMs[Math.min(attempt, backoffMs.length - 1)]!;
+      attempt += 1;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  };
+
+  void loop();
+  return { stop: () => controller.abort() };
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/api`
+Expected: 14 tests PASS (7 sse + 7 client).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/api
+git commit -m "feat(office-addin): typed client-ai API client + fetch-SSE parser with reconnect/backoff" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Tool executors — all 9 workbook tools + dispatcher (TDD)
+
+The client-side halves of Plan 2's `CLIENT_TOOL_REGISTRY` (spec §5). Every executor funnels through `Excel.run`; inputs are validated before any Office.js call so bad model input fails fast with a model-readable message. The dispatcher routes `tool_request` events: non-mutating → execute + POST the result; mutating → park in the approval queue ONLY (Task 8 resolves them). `request.mutating` from the server is OR-ed with the local `MUTATING_TOOLS` set as defense-in-depth — a server bug can never auto-execute a write.
+
+**Files:**
+- Create: apps/office-addin/src/tools/helpers.ts
+- Create: apps/office-addin/src/tools/getWorkbookOverview.ts
+- Create: apps/office-addin/src/tools/readSelection.ts
+- Create: apps/office-addin/src/tools/readRange.ts
+- Create: apps/office-addin/src/tools/writeRange.ts
+- Create: apps/office-addin/src/tools/insertFormula.ts
+- Create: apps/office-addin/src/tools/createSheet.ts
+- Create: apps/office-addin/src/tools/formatRange.ts
+- Create: apps/office-addin/src/tools/createTable.ts
+- Create: apps/office-addin/src/tools/searchWorkbook.ts
+- Create: apps/office-addin/src/tools/dispatcher.ts
+- Test: apps/office-addin/src/tools/getWorkbookOverview.test.ts
+- Test: apps/office-addin/src/tools/readRange.test.ts
+- Test: apps/office-addin/src/tools/writeRange.test.ts
+- Test: apps/office-addin/src/tools/searchWorkbook.test.ts
+- Test: apps/office-addin/src/tools/dispatcher.test.ts
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/office-addin/src/tools/getWorkbookOverview.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { getWorkbookOverview } from './getWorkbookOverview';
+
+describe('get_workbook_overview', () => {
+  it('returns sheet names, used ranges, and first-row headers', async () => {
+    const mock = getOfficeMock();
+    mock.setValues('Sheet1', 'B2', [
+      ['Region', 'Q1', 'Q2'],
+      ['EMEA', 1200, 1300],
+    ]);
+    mock.addSheet('Notes');
+    const result = (await getWorkbookOverview({})) as {
+      sheets: Array<{ name: string; usedRange: string | null; headers: unknown[] }>;
+    };
+    expect(result.sheets).toEqual([
+      { name: 'Sheet1', usedRange: 'Sheet1!B2:D3', headers: ['Region', 'Q1', 'Q2'] },
+      { name: 'Notes', usedRange: null, headers: [] },
+    ]);
+  });
+
+  it('caps headers at 50 columns', async () => {
+    const mock = getOfficeMock();
+    mock.setValues('Sheet1', 'A1', [Array.from({ length: 60 }, (_, i) => `h${i}`)]);
+    const result = (await getWorkbookOverview({})) as {
+      sheets: Array<{ headers: unknown[] }>;
+    };
+    expect(result.sheets[0]!.headers).toHaveLength(50);
+  });
+});
+```
+
+`apps/office-addin/src/tools/readRange.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { readRange } from './readRange';
+import { ToolInputError } from './helpers';
+
+describe('read_range', () => {
+  it('reads values with the sheet-qualified address', async () => {
+    getOfficeMock().setValues('Sheet1', 'B2', [
+      ['a', 1],
+      ['b', 2],
+    ]);
+    await expect(readRange({ address: 'B2:C3' })).resolves.toEqual({
+      address: 'Sheet1!B2:C3',
+      rowCount: 2,
+      columnCount: 2,
+      values: [
+        ['a', 1],
+        ['b', 2],
+      ],
+    });
+  });
+
+  it('rejects an unknown sheet with a model-readable error', async () => {
+    await expect(readRange({ address: 'A1', sheetName: 'Nope' })).rejects.toThrow(
+      /No worksheet named "Nope"/,
+    );
+  });
+
+  it('rejects ranges over the 50k-cell cap before touching Office.js', async () => {
+    await expect(readRange({ address: 'A1:ZZ10000' })).rejects.toBeInstanceOf(ToolInputError);
+  });
+});
+```
+
+`apps/office-addin/src/tools/writeRange.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { writeRange } from './writeRange';
+
+describe('write_range', () => {
+  it('writes a matrix anchored at a single cell and reports the written range', async () => {
+    await expect(
+      writeRange({
+        address: 'B2',
+        values: [
+          ['Region', 'Q1'],
+          ['EMEA', 1200],
+        ],
+      }),
+    ).resolves.toEqual({ address: 'Sheet1!B2:C3', rowsWritten: 2, columnsWritten: 2 });
+    expect(getOfficeMock().getValues('Sheet1', 'B2:C3')).toEqual([
+      ['Region', 'Q1'],
+      ['EMEA', 1200],
+    ]);
+  });
+
+  it('writes into an exactly-matching multi-cell range', async () => {
+    await expect(
+      writeRange({ address: 'A1:B1', values: [['x', 'y']] }),
+    ).resolves.toMatchObject({ address: 'Sheet1!A1:B1' });
+    expect(getOfficeMock().getValues('Sheet1', 'A1:B1')).toEqual([['x', 'y']]);
+  });
+
+  it('rejects a dimension mismatch against a multi-cell target', async () => {
+    await expect(writeRange({ address: 'A1:C1', values: [['only', 'two']] })).rejects.toThrow(
+      /values is 1x2 but A1:C1 is 1x3/,
+    );
+  });
+});
+```
+
+`apps/office-addin/src/tools/searchWorkbook.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { searchWorkbook } from './searchWorkbook';
+import { SEARCH_RESULT_CAP } from './helpers';
+
+type SearchResult = {
+  query: string;
+  results: Array<{ sheet: string; address: string; value: unknown }>;
+  truncated: boolean;
+};
+
+describe('search_workbook', () => {
+  it('finds case-insensitive substring matches across all sheets with cell addresses', async () => {
+    const mock = getOfficeMock();
+    mock.setValues('Sheet1', 'A1', [['Total Revenue', 'misc']]);
+    mock.addSheet('Data');
+    mock.setValues('Data', 'C5', [['quarterly TOTALS']]);
+    const result = (await searchWorkbook({ query: 'total' })) as SearchResult;
+    expect(result.results).toEqual([
+      { sheet: 'Sheet1', address: 'A1', value: 'Total Revenue' },
+      { sheet: 'Data', address: 'C5', value: 'quarterly TOTALS' },
+    ]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('scopes the search to sheetName when provided', async () => {
+    const mock = getOfficeMock();
+    mock.setValues('Sheet1', 'A1', [['match here']]);
+    mock.addSheet('Data');
+    mock.setValues('Data', 'A1', [['match there']]);
+    const result = (await searchWorkbook({ query: 'match', sheetName: 'Data' })) as SearchResult;
+    expect(result.results).toEqual([{ sheet: 'Data', address: 'A1', value: 'match there' }]);
+  });
+
+  it('caps results at SEARCH_RESULT_CAP and sets truncated', async () => {
+    const mock = getOfficeMock();
+    mock.setValues(
+      'Sheet1',
+      'A1',
+      Array.from({ length: SEARCH_RESULT_CAP + 5 }, () => ['needle']),
+    );
+    const result = (await searchWorkbook({ query: 'needle' })) as SearchResult;
+    expect(result.results).toHaveLength(SEARCH_RESULT_CAP);
+    expect(result.truncated).toBe(true);
+  });
+});
+```
+
+`apps/office-addin/src/tools/dispatcher.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { MUTATING_TOOLS, TOOL_EXECUTORS, dispatchToolRequest, executeTool } from './dispatcher';
+import type { ToolRequest } from './dispatcher';
+
+function deps() {
+  return { postToolResult: vi.fn(async () => undefined), enqueueApproval: vi.fn() };
+}
+
+function request(overrides: Partial<ToolRequest>): ToolRequest {
+  return {
+    type: 'tool_request',
+    toolUseId: 'tu-1',
+    toolName: 'read_range',
+    input: {},
+    mutating: false,
+    ...overrides,
+  };
+}
+
+describe('registry shape', () => {
+  it('registers exactly the 9 spec §5 tools; 5 are mutating', () => {
+    expect(Object.keys(TOOL_EXECUTORS).sort()).toEqual([
+      'create_sheet',
+      'create_table',
+      'format_range',
+      'get_workbook_overview',
+      'insert_formula',
+      'read_range',
+      'read_selection',
+      'search_workbook',
+      'write_range',
+    ]);
+    expect([...MUTATING_TOOLS].sort()).toEqual([
+      'create_sheet',
+      'create_table',
+      'format_range',
+      'insert_formula',
+      'write_range',
+    ]);
+  });
+});
+
+describe('dispatchToolRequest', () => {
+  it('auto-executes non-mutating tools and posts the success result', async () => {
+    getOfficeMock().setValues('Sheet1', 'A1', [['v']]);
+    const d = deps();
+    await dispatchToolRequest(request({ input: { address: 'A1' } }), d);
+    expect(d.enqueueApproval).not.toHaveBeenCalled();
+    expect(d.postToolResult).toHaveBeenCalledWith({
+      toolUseId: 'tu-1',
+      status: 'success',
+      output: { address: 'Sheet1!A1', rowCount: 1, columnCount: 1, values: [['v']] },
+    });
+  });
+
+  it('parks mutating tools in the approval queue WITHOUT executing or posting', async () => {
+    const d = deps();
+    const req = request({ toolName: 'write_range', mutating: true, input: { address: 'A1', values: [['x']] } });
+    await dispatchToolRequest(req, d);
+    expect(d.enqueueApproval).toHaveBeenCalledWith(req);
+    expect(d.postToolResult).not.toHaveBeenCalled();
+    expect(getOfficeMock().getValues('Sheet1', 'A1')).toEqual([['']]); // nothing written
+  });
+
+  it('treats a locally-known mutating tool as mutating even if the server flag lies', async () => {
+    const d = deps();
+    await dispatchToolRequest(
+      request({ toolName: 'write_range', mutating: false, input: { address: 'A1', values: [['x']] } }),
+      d,
+    );
+    expect(d.enqueueApproval).toHaveBeenCalledTimes(1);
+    expect(d.postToolResult).not.toHaveBeenCalled();
+  });
+
+  it('posts status:error when the executor throws', async () => {
+    const d = deps();
+    await dispatchToolRequest(request({ input: { address: 'A1', sheetName: 'Nope' } }), d);
+    expect(d.postToolResult).toHaveBeenCalledWith({
+      toolUseId: 'tu-1',
+      status: 'error',
+      output: { error: expect.stringContaining('No worksheet named "Nope"') },
+    });
+  });
+
+  it('posts status:error for an unknown tool', async () => {
+    const d = deps();
+    await dispatchToolRequest(request({ toolName: 'launch_missiles' }), d);
+    expect(d.postToolResult).toHaveBeenCalledWith({
+      toolUseId: 'tu-1',
+      status: 'error',
+      output: { error: 'Unknown tool: launch_missiles' },
+    });
+  });
+});
+
+describe('executeTool', () => {
+  it('never throws — failures come back as { status: "error" }', async () => {
+    await expect(executeTool('read_range', {})).resolves.toMatchObject({ status: 'error' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/tools`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/office-addin/src/tools/helpers.ts`:
+
+```ts
+/**
+ * Shared tool plumbing: input validation (model input is untrusted), sheet
+ * resolution, and payload caps. Caps mirror the server side: 50k cells is the
+ * DLP engine's fail-closed limit (Plan 3) — anything bigger would be refused
+ * there anyway, so fail fast here with a message the model can act on.
+ */
+import { parseAddress, stripSheet } from '../lib/address';
+import type { CellValue } from '../api/types';
+
+export const MAX_TOOL_CELLS = 50_000;
+export const SEARCH_RESULT_CAP = 200;
+export const OVERVIEW_HEADER_CAP = 50;
+
+export class ToolInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolInputError';
+  }
+}
+
+export function requireString(input: Record<string, unknown>, key: string): string {
+  const value = input[key];
+  if (typeof value !== 'string' || value.length === 0)
+    throw new ToolInputError(`${key} must be a non-empty string`);
+  return value;
+}
+
+export function optionalString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') throw new ToolInputError(`${key} must be a string`);
+  return value;
+}
+
+export function requireCellMatrix(input: Record<string, unknown>, key: string): CellValue[][] {
+  const value = input[key];
+  if (!Array.isArray(value) || value.length === 0 || !value.every((row) => Array.isArray(row)))
+    throw new ToolInputError(`${key} must be a non-empty 2D array`);
+  const matrix = value as unknown[][];
+  const width = matrix[0]!.length;
+  if (width === 0 || !matrix.every((row) => row.length === width))
+    throw new ToolInputError(`${key} must be rectangular (every row the same length)`);
+  for (const row of matrix) {
+    for (const cell of row) {
+      if (
+        cell !== null &&
+        typeof cell !== 'string' &&
+        typeof cell !== 'number' &&
+        typeof cell !== 'boolean'
+      )
+        throw new ToolInputError(`${key} cells must be string | number | boolean | null`);
+    }
+  }
+  return matrix as CellValue[][];
+}
+
+export function assertCellCap(rows: number, cols: number, what: string): void {
+  if (rows * cols > MAX_TOOL_CELLS)
+    throw new ToolInputError(
+      `${what} covers ${rows * cols} cells — over the ${MAX_TOOL_CELLS}-cell limit. Use a narrower range.`,
+    );
+}
+
+export function addressDims(address: string): { rows: number; cols: number } {
+  const p = parseAddress(stripSheet(address));
+  return { rows: p.endRow - p.startRow + 1, cols: p.endCol - p.startCol + 1 };
+}
+
+/** Explicit sheetName > sheet embedded in the address > active sheet. */
+export async function resolveSheet(
+  context: Excel.RequestContext,
+  sheetName: string | undefined,
+  address?: string,
+): Promise<Excel.Worksheet> {
+  const fromAddress = address?.includes('!') ? parseAddress(address).sheet : null;
+  const name = sheetName ?? fromAddress ?? null;
+  if (!name) return context.workbook.worksheets.getActiveWorksheet();
+  const sheet = context.workbook.worksheets.getItemOrNullObject(name);
+  await context.sync();
+  if (sheet.isNullObject) throw new ToolInputError(`No worksheet named "${name}"`);
+  return sheet;
+}
+```
+
+`apps/office-addin/src/tools/getWorkbookOverview.ts`:
+
+```ts
+import { OVERVIEW_HEADER_CAP } from './helpers';
+import type { CellValue } from '../api/types';
+
+/** Sheet names + used ranges + first-row headers — the model's map of the workbook. */
+export async function getWorkbookOverview(_input: Record<string, unknown>): Promise<unknown> {
+  return Excel.run(async (context) => {
+    const collection = context.workbook.worksheets;
+    collection.load('items/name');
+    await context.sync();
+    const scans = collection.items.map((sheet) => {
+      const used = sheet.getUsedRangeOrNullObject();
+      used.load('address');
+      const headerRow = used.getRow(0); // header row only — never hydrate the whole used range
+      headerRow.load('values');
+      return { sheet, used, headerRow };
+    });
+    await context.sync();
+    const sheets = scans.map(({ sheet, used, headerRow }) => {
+      if (used.isNullObject) return { name: sheet.name, usedRange: null, headers: [] as CellValue[] };
+      const headers = ((headerRow.values[0] ?? []) as CellValue[]).slice(0, OVERVIEW_HEADER_CAP);
+      return { name: sheet.name, usedRange: used.address, headers };
+    });
+    return { sheets };
+  });
+}
+```
+
+`apps/office-addin/src/tools/readSelection.ts`:
+
+```ts
+import { assertCellCap } from './helpers';
+
+/** Reads the user's current selection. Two-phase: dims first, values only when under the cap. */
+export async function readSelection(_input: Record<string, unknown>): Promise<unknown> {
+  return Excel.run(async (context) => {
+    const range = context.workbook.getSelectedRange();
+    range.load(['address', 'rowCount', 'columnCount']);
+    await context.sync();
+    assertCellCap(range.rowCount, range.columnCount, `Selection ${range.address}`);
+    range.load('values');
+    await context.sync();
+    return {
+      address: range.address,
+      rowCount: range.rowCount,
+      columnCount: range.columnCount,
+      values: range.values,
+    };
+  });
+}
+```
+
+`apps/office-addin/src/tools/readRange.ts`:
+
+```ts
+import { stripSheet } from '../lib/address';
+import { addressDims, assertCellCap, optionalString, requireString, resolveSheet } from './helpers';
+
+export async function readRange(input: Record<string, unknown>): Promise<unknown> {
+  const address = requireString(input, 'address');
+  const sheetName = optionalString(input, 'sheetName');
+  const { rows, cols } = addressDims(address);
+  assertCellCap(rows, cols, `Range ${address}`);
+  return Excel.run(async (context) => {
+    const sheet = await resolveSheet(context, sheetName, address);
+    const range = sheet.getRange(stripSheet(address));
+    range.load(['address', 'values', 'rowCount', 'columnCount']);
+    await context.sync();
+    return {
+      address: range.address,
+      rowCount: range.rowCount,
+      columnCount: range.columnCount,
+      values: range.values,
+    };
+  });
+}
+```
+
+`apps/office-addin/src/tools/writeRange.ts`:
+
+```ts
+import { parseAddress, rangeAddress, stripSheet } from '../lib/address';
+import {
+  addressDims,
+  assertCellCap,
+  optionalString,
+  requireCellMatrix,
+  requireString,
+  resolveSheet,
+  ToolInputError,
+} from './helpers';
+
+/**
+ * MUTATING — only ever invoked through the approval store (Task 8).
+ * A single-cell address acts as an anchor: the full matrix writes from there.
+ * A multi-cell address must match the matrix dimensions exactly.
+ */
+export async function writeRange(input: Record<string, unknown>): Promise<unknown> {
+  const address = requireString(input, 'address');
+  const sheetName = optionalString(input, 'sheetName');
+  const values = requireCellMatrix(input, 'values');
+  const { rows, cols } = addressDims(address);
+  const isAnchor = rows === 1 && cols === 1;
+  if (!isAnchor && (rows !== values.length || cols !== values[0]!.length))
+    throw new ToolInputError(
+      `values is ${values.length}x${values[0]!.length} but ${stripSheet(address)} is ${rows}x${cols}`,
+    );
+  assertCellCap(values.length, values[0]!.length, `Write to ${address}`);
+  return Excel.run(async (context) => {
+    const sheet = await resolveSheet(context, sheetName, address);
+    const parsed = parseAddress(stripSheet(address));
+    const target = rangeAddress(parsed.startRow, parsed.startCol, values.length, values[0]!.length);
+    const range = sheet.getRange(target);
+    range.values = values;
+    range.load('address');
+    await context.sync();
+    return { address: range.address, rowsWritten: values.length, columnsWritten: values[0]!.length };
+  });
+}
+```
+
+`apps/office-addin/src/tools/insertFormula.ts`:
+
+```ts
+import { stripSheet } from '../lib/address';
+import { addressDims, assertCellCap, optionalString, requireString, resolveSheet, ToolInputError } from './helpers';
+
+/**
+ * MUTATING. D5: Office.js assigns the SAME formula text to every cell of the
+ * target range (no relative-reference rewriting on assignment) — single-cell
+ * targets behave exactly as expected; per-row formulas need one call per cell.
+ */
+export async function insertFormula(input: Record<string, unknown>): Promise<unknown> {
+  const address = requireString(input, 'address');
+  const formula = requireString(input, 'formula');
+  const sheetName = optionalString(input, 'sheetName');
+  if (!formula.startsWith('=')) throw new ToolInputError('formula must start with "="');
+  const { rows, cols } = addressDims(address);
+  assertCellCap(rows, cols, `Formula fill of ${address}`);
+  return Excel.run(async (context) => {
+    const sheet = await resolveSheet(context, sheetName, address);
+    const range = sheet.getRange(stripSheet(address));
+    range.formulas = Array.from({ length: rows }, () => Array.from({ length: cols }, () => formula));
+    range.load('address');
+    await context.sync();
+    return { address: range.address, formula, cellCount: rows * cols };
+  });
+}
+```
+
+`apps/office-addin/src/tools/createSheet.ts`:
+
+```ts
+import { requireString, ToolInputError } from './helpers';
+
+/** MUTATING. */
+export async function createSheet(input: Record<string, unknown>): Promise<unknown> {
+  const name = requireString(input, 'name');
+  if (name.length > 31 || /[\\/?*[\]:]/.test(name))
+    throw new ToolInputError('Invalid sheet name (max 31 chars; no \\ / ? * [ ] :)');
+  return Excel.run(async (context) => {
+    const existing = context.workbook.worksheets.getItemOrNullObject(name);
+    await context.sync();
+    if (!existing.isNullObject) throw new ToolInputError(`A sheet named "${name}" already exists`);
+    const sheet = context.workbook.worksheets.add(name);
+    sheet.load('name');
+    await context.sync();
+    return { name: sheet.name, created: true };
+  });
+}
+```
+
+`apps/office-addin/src/tools/formatRange.ts`:
+
+```ts
+import { stripSheet } from '../lib/address';
+import { addressDims, assertCellCap, optionalString, requireString, resolveSheet, ToolInputError } from './helpers';
+
+type FormatInput = {
+  bold?: boolean;
+  italic?: boolean;
+  fontColor?: string;
+  fillColor?: string;
+  numberFormat?: string;
+};
+
+/** MUTATING. Applies a whitelisted subset of formatting to a range. */
+export async function formatRange(input: Record<string, unknown>): Promise<unknown> {
+  const address = requireString(input, 'address');
+  const sheetName = optionalString(input, 'sheetName');
+  const raw = input.format;
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw))
+    throw new ToolInputError('format must be an object');
+  const format = raw as FormatInput;
+  const { rows, cols } = addressDims(address);
+  assertCellCap(rows, cols, `Format of ${address}`);
+  return Excel.run(async (context) => {
+    const sheet = await resolveSheet(context, sheetName, address);
+    const range = sheet.getRange(stripSheet(address));
+    const applied: string[] = [];
+    if (typeof format.bold === 'boolean') {
+      range.format.font.bold = format.bold;
+      applied.push('bold');
+    }
+    if (typeof format.italic === 'boolean') {
+      range.format.font.italic = format.italic;
+      applied.push('italic');
+    }
+    if (typeof format.fontColor === 'string') {
+      range.format.font.color = format.fontColor;
+      applied.push('fontColor');
+    }
+    if (typeof format.fillColor === 'string') {
+      range.format.fill.color = format.fillColor;
+      applied.push('fillColor');
+    }
+    if (typeof format.numberFormat === 'string') {
+      range.numberFormat = Array.from({ length: rows }, () =>
+        Array.from({ length: cols }, () => format.numberFormat!),
+      );
+      applied.push('numberFormat');
+    }
+    if (applied.length === 0)
+      throw new ToolInputError(
+        'format contained no supported keys (bold, italic, fontColor, fillColor, numberFormat)',
+      );
+    range.load('address');
+    await context.sync();
+    return { address: range.address, applied };
+  });
+}
+```
+
+`apps/office-addin/src/tools/createTable.ts`:
+
+```ts
+import { stripSheet } from '../lib/address';
+import { optionalString, requireString, resolveSheet } from './helpers';
+
+/** MUTATING. */
+export async function createTable(input: Record<string, unknown>): Promise<unknown> {
+  const address = requireString(input, 'address');
+  const sheetName = optionalString(input, 'sheetName');
+  const hasHeaders = input.hasHeaders === undefined ? true : input.hasHeaders === true;
+  return Excel.run(async (context) => {
+    const sheet = await resolveSheet(context, sheetName, address);
+    sheet.load('name');
+    await context.sync();
+    const qualified = `${sheet.name}!${stripSheet(address)}`;
+    const table = context.workbook.tables.add(qualified, hasHeaders);
+    table.load('name');
+    await context.sync();
+    return { name: table.name, address: qualified, hasHeaders };
+  });
+}
+```
+
+`apps/office-addin/src/tools/searchWorkbook.ts`:
+
+```ts
+import { parseAddress, rangeAddress, stripSheet } from '../lib/address';
+import { optionalString, requireString, resolveSheet, SEARCH_RESULT_CAP } from './helpers';
+import type { CellValue } from '../api/types';
+
+/** Case-insensitive substring scan over used ranges, capped at SEARCH_RESULT_CAP hits. */
+export async function searchWorkbook(input: Record<string, unknown>): Promise<unknown> {
+  const query = requireString(input, 'query');
+  const sheetName = optionalString(input, 'sheetName');
+  const needle = query.toLowerCase();
+  return Excel.run(async (context) => {
+    let sheets: Excel.Worksheet[];
+    if (sheetName) {
+      sheets = [await resolveSheet(context, sheetName)];
+    } else {
+      const collection = context.workbook.worksheets;
+      collection.load('items/name');
+      await context.sync();
+      sheets = collection.items;
+    }
+    const scans = sheets.map((sheet) => {
+      sheet.load('name');
+      const used = sheet.getUsedRangeOrNullObject();
+      used.load(['address', 'values']);
+      return { sheet, used };
+    });
+    await context.sync();
+    const results: Array<{ sheet: string; address: string; value: CellValue }> = [];
+    let truncated = false;
+    outer: for (const { sheet, used } of scans) {
+      if (used.isNullObject) continue;
+      const origin = parseAddress(stripSheet(used.address));
+      const values = used.values as CellValue[][];
+      for (let r = 0; r < values.length; r++) {
+        const row = values[r]!;
+        for (let c = 0; c < row.length; c++) {
+          const value = row[c]!;
+          if (value === null || value === '') continue;
+          if (String(value).toLowerCase().includes(needle)) {
+            if (results.length >= SEARCH_RESULT_CAP) {
+              truncated = true;
+              break outer;
+            }
+            results.push({
+              sheet: sheet.name,
+              address: rangeAddress(origin.startRow + r, origin.startCol + c, 1, 1),
+              value,
+            });
+          }
+        }
+      }
+    }
+    return { query, results, truncated };
+  });
+}
+```
+
+`apps/office-addin/src/tools/dispatcher.ts`:
+
+```ts
+/**
+ * tool_request router (spec §5 protocol step 2):
+ *   non-mutating → execute via Office.js, POST the result immediately.
+ *   mutating     → park in the approval queue ONLY (Task 8's ApprovalStore
+ *                  executes on Apply / posts 'rejected' on Reject).
+ * executeTool never throws — executor failures become { status: 'error' }
+ * results so the model can react (the server's 60s read timeout is the
+ * backstop, not the happy path).
+ */
+import type { ClientAiStreamEvent, ToolResultBody } from '../api/types';
+import { getWorkbookOverview } from './getWorkbookOverview';
+import { readSelection } from './readSelection';
+import { readRange } from './readRange';
+import { writeRange } from './writeRange';
+import { insertFormula } from './insertFormula';
+import { createSheet } from './createSheet';
+import { formatRange } from './formatRange';
+import { createTable } from './createTable';
+import { searchWorkbook } from './searchWorkbook';
+
+export type ToolExecutor = (input: Record<string, unknown>) => Promise<unknown>;
+
+export const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
+  get_workbook_overview: getWorkbookOverview,
+  read_selection: readSelection,
+  read_range: readRange,
+  write_range: writeRange,
+  insert_formula: insertFormula,
+  create_sheet: createSheet,
+  format_range: formatRange,
+  create_table: createTable,
+  search_workbook: searchWorkbook,
+};
+
+export const MUTATING_TOOLS = new Set([
+  'write_range',
+  'insert_formula',
+  'create_sheet',
+  'format_range',
+  'create_table',
+]);
+
+export type ToolRequest = Extract<ClientAiStreamEvent, { type: 'tool_request' }>;
+
+export async function executeTool(
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<{ status: 'success' | 'error'; output: unknown }> {
+  const executor = TOOL_EXECUTORS[toolName];
+  if (!executor) return { status: 'error', output: { error: `Unknown tool: ${toolName}` } };
+  try {
+    return { status: 'success', output: await executor(input) };
+  } catch (err) {
+    return { status: 'error', output: { error: err instanceof Error ? err.message : String(err) } };
+  }
+}
+
+export type DispatcherDeps = {
+  postToolResult: (result: ToolResultBody) => Promise<void>;
+  enqueueApproval: (request: ToolRequest) => void | Promise<void>;
+};
+
+export async function dispatchToolRequest(request: ToolRequest, deps: DispatcherDeps): Promise<void> {
+  // Defense-in-depth: the server flag is OR-ed with the local set so a server
+  // bug can never auto-execute a write.
+  const mutating = request.mutating || MUTATING_TOOLS.has(request.toolName);
+  if (mutating) {
+    await deps.enqueueApproval(request);
+    return;
+  }
+  const { status, output } = await executeTool(request.toolName, request.input);
+  await deps.postToolResult({ toolUseId: request.toolUseId, status, output });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/tools`
+Expected: 16 tests PASS (2 overview + 3 readRange + 3 writeRange + 3 search + 5 dispatcher). Then `npx tsc --noEmit` — clean (covers the 4 executors without dedicated tests: readSelection, insertFormula, createSheet, formatRange, createTable are additionally exercised through Task 8's approval tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/tools
+git commit -m "feat(office-addin): 9 Office.js workbook tool executors + mutating-aware dispatcher" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Approval store + write-preview card (TDD)
+
+Spec §5 write approval: mutating tool requests park in a pending queue; a preview is built by reading the CURRENT target values for a before/after diff (≤200 cells renders a full grid; above that, a one-line summary). Apply → execute via Office.js then POST success/error; Reject → POST `status: 'rejected'` WITHOUT executing. The store is framework-free (immutable snapshots + subscribe, `useSyncExternalStore`-compatible); `WritePreviewCard` is the presentational card (tsc-gated per D6).
+
+**Files:**
+- Create: apps/office-addin/src/approval/buildPreview.ts
+- Create: apps/office-addin/src/approval/approvalStore.ts
+- Create: apps/office-addin/src/components/WritePreviewCard.tsx
+- Test: apps/office-addin/src/approval/buildPreview.test.ts
+- Test: apps/office-addin/src/approval/approvalStore.test.ts
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/office-addin/src/approval/buildPreview.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { buildWritePreview, PREVIEW_GRID_CELL_CAP } from './buildPreview';
+
+describe('buildWritePreview', () => {
+  it('builds a before/after grid with changedCount for small write_range inputs', async () => {
+    getOfficeMock().setValues('Sheet1', 'B2', [
+      ['old', 'same'],
+    ]);
+    const preview = await buildWritePreview('write_range', {
+      address: 'B2',
+      values: [['new', 'same']],
+    });
+    expect(preview).toEqual({
+      kind: 'grid',
+      toolName: 'write_range',
+      target: 'Sheet1!B2:C2',
+      before: [['old', 'same']],
+      after: [['new', 'same']],
+      changedCount: 1,
+    });
+  });
+
+  it('falls back to a summary line above the grid cap', async () => {
+    const rows = 30;
+    const cols = 10; // 300 cells > 200
+    expect(rows * cols).toBeGreaterThan(PREVIEW_GRID_CELL_CAP);
+    const preview = await buildWritePreview('write_range', {
+      address: 'A1',
+      values: Array.from({ length: rows }, () => Array.from({ length: cols }, () => 'x')),
+    });
+    expect(preview.kind).toBe('summary');
+    expect(preview.target).toBe('A1');
+    expect((preview as { description: string }).description).toContain('300 cells');
+  });
+
+  it('previews insert_formula as a grid of the formula text', async () => {
+    getOfficeMock().setValues('Sheet1', 'D1', [[5]]);
+    const preview = await buildWritePreview('insert_formula', {
+      address: 'D1',
+      formula: '=SUM(A1:C1)',
+    });
+    expect(preview).toMatchObject({
+      kind: 'grid',
+      target: 'Sheet1!D1',
+      before: [[5]],
+      after: [['=SUM(A1:C1)']],
+      changedCount: 1,
+    });
+  });
+
+  it('summarizes create_sheet / format_range / create_table', async () => {
+    const sheet = await buildWritePreview('create_sheet', { name: 'Report' });
+    expect(sheet).toMatchObject({ kind: 'summary', target: 'Report' });
+    const fmt = await buildWritePreview('format_range', {
+      address: 'A1:B2',
+      format: { bold: true },
+    });
+    expect(fmt).toMatchObject({ kind: 'summary', target: 'A1:B2' });
+    expect((fmt as { description: string }).description).toContain('bold');
+    const table = await buildWritePreview('create_table', { address: 'A1:C10' });
+    expect(table).toMatchObject({ kind: 'summary', target: 'A1:C10' });
+  });
+});
+```
+
+`apps/office-addin/src/approval/approvalStore.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { ApprovalStore } from './approvalStore';
+import type { ToolRequest } from '../tools/dispatcher';
+
+function writeRequest(toolUseId = 'tu-w1'): ToolRequest {
+  return {
+    type: 'tool_request',
+    toolUseId,
+    toolName: 'write_range',
+    input: { address: 'B2', values: [['hello']] },
+    mutating: true,
+  };
+}
+
+function makeStore() {
+  const postToolResult = vi.fn(async () => undefined);
+  const store = new ApprovalStore({ postToolResult });
+  return { store, postToolResult };
+}
+
+describe('ApprovalStore', () => {
+  it('enqueue builds a preview, exposes an immutable snapshot, and notifies subscribers', async () => {
+    const { store } = makeStore();
+    const seen: number[] = [];
+    store.subscribe(() => seen.push(store.getPending().length));
+    const before = store.getPending();
+    await store.enqueue(writeRequest());
+    expect(store.getPending()).toHaveLength(1);
+    expect(store.getPending()).not.toBe(before); // new snapshot reference
+    expect(store.getPending()[0]).toMatchObject({
+      toolUseId: 'tu-w1',
+      toolName: 'write_range',
+      preview: { kind: 'grid', target: 'Sheet1!B2' },
+    });
+    expect(seen).toEqual([1]);
+  });
+
+  it('apply executes the tool and posts the success result', async () => {
+    const { store, postToolResult } = makeStore();
+    await store.enqueue(writeRequest());
+    await store.apply('tu-w1');
+    expect(getOfficeMock().getValues('Sheet1', 'B2')).toEqual([['hello']]);
+    expect(postToolResult).toHaveBeenCalledWith({
+      toolUseId: 'tu-w1',
+      status: 'success',
+      output: { address: 'Sheet1!B2', rowsWritten: 1, columnsWritten: 1 },
+    });
+    expect(store.getPending()).toHaveLength(0);
+  });
+
+  it('apply posts status:error when execution fails', async () => {
+    const { store, postToolResult } = makeStore();
+    await store.enqueue({
+      type: 'tool_request',
+      toolUseId: 'tu-w2',
+      toolName: 'create_sheet',
+      input: { name: 'Sheet1' }, // already exists → executor error
+      mutating: true,
+    });
+    await store.apply('tu-w2');
+    expect(postToolResult).toHaveBeenCalledWith({
+      toolUseId: 'tu-w2',
+      status: 'error',
+      output: { error: expect.stringContaining('already exists') },
+    });
+  });
+
+  it('reject posts status:rejected WITHOUT executing', async () => {
+    const { store, postToolResult } = makeStore();
+    await store.enqueue(writeRequest('tu-w3'));
+    await store.reject('tu-w3');
+    expect(getOfficeMock().getValues('Sheet1', 'B2')).toEqual([['']]); // untouched
+    expect(postToolResult).toHaveBeenCalledWith({
+      toolUseId: 'tu-w3',
+      status: 'rejected',
+      output: { reason: 'User rejected the change' },
+    });
+    expect(store.getPending()).toHaveLength(0);
+  });
+
+  it('enqueue with unbuildable input posts an immediate error instead of a broken card', async () => {
+    const { store, postToolResult } = makeStore();
+    await store.enqueue({
+      type: 'tool_request',
+      toolUseId: 'tu-w4',
+      toolName: 'write_range',
+      input: { address: 'not-an-address', values: [['x']] },
+      mutating: true,
+    });
+    expect(store.getPending()).toHaveLength(0);
+    expect(postToolResult).toHaveBeenCalledWith({
+      toolUseId: 'tu-w4',
+      status: 'error',
+      output: { error: expect.stringContaining('Unsupported address') },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/approval`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/office-addin/src/approval/buildPreview.ts`:
+
+```ts
+/**
+ * Write-preview builder (spec §5): reads the CURRENT target values so the
+ * Apply/Reject card can show a real before/after diff. ≤200 cells renders the
+ * full grid; above that a summary line (reading thousands of cells to draw an
+ * unreadable table helps nobody).
+ */
+import { parseAddress, rangeAddress, stripSheet } from '../lib/address';
+import { addressDims, optionalString, requireCellMatrix, requireString, resolveSheet } from '../tools/helpers';
+import type { CellValue } from '../api/types';
+
+export const PREVIEW_GRID_CELL_CAP = 200;
+
+export type WritePreview =
+  | {
+      kind: 'grid';
+      toolName: string;
+      target: string;
+      before: CellValue[][];
+      after: CellValue[][];
+      changedCount: number;
+    }
+  | { kind: 'summary'; toolName: string; target: string; description: string };
+
+async function readCurrent(
+  sheetName: string | undefined,
+  address: string,
+  rows: number,
+  cols: number,
+): Promise<{ qualified: string; values: CellValue[][] }> {
+  return Excel.run(async (context) => {
+    const sheet = await resolveSheet(context, sheetName, address);
+    const parsed = parseAddress(stripSheet(address));
+    const range = sheet.getRange(rangeAddress(parsed.startRow, parsed.startCol, rows, cols));
+    range.load(['address', 'values']);
+    await context.sync();
+    return { qualified: range.address, values: range.values as CellValue[][] };
+  });
+}
+
+function diffCount(before: CellValue[][], after: CellValue[][]): number {
+  let changed = 0;
+  for (let r = 0; r < after.length; r++) {
+    for (let c = 0; c < after[r]!.length; c++) {
+      if ((before[r]?.[c] ?? '') !== after[r]![c]) changed++;
+    }
+  }
+  return changed;
+}
+
+export async function buildWritePreview(
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<WritePreview> {
+  switch (toolName) {
+    case 'write_range': {
+      const address = requireString(input, 'address');
+      const sheetName = optionalString(input, 'sheetName');
+      const after = requireCellMatrix(input, 'values');
+      const rows = after.length;
+      const cols = after[0]!.length;
+      if (rows * cols > PREVIEW_GRID_CELL_CAP)
+        return {
+          kind: 'summary',
+          toolName,
+          target: address,
+          description: `Write ${rows}×${cols} cells (${rows * cols} cells) starting at ${address}`,
+        };
+      const { qualified, values: before } = await readCurrent(sheetName, address, rows, cols);
+      return { kind: 'grid', toolName, target: qualified, before, after, changedCount: diffCount(before, after) };
+    }
+    case 'insert_formula': {
+      const address = requireString(input, 'address');
+      const sheetName = optionalString(input, 'sheetName');
+      const formula = requireString(input, 'formula');
+      const { rows, cols } = addressDims(address);
+      if (rows * cols > PREVIEW_GRID_CELL_CAP)
+        return {
+          kind: 'summary',
+          toolName,
+          target: address,
+          description: `Fill ${address} (${rows * cols} cells) with the formula ${formula}`,
+        };
+      const after: CellValue[][] = Array.from({ length: rows }, () =>
+        Array.from({ length: cols }, () => formula),
+      );
+      const { qualified, values: before } = await readCurrent(sheetName, address, rows, cols);
+      return { kind: 'grid', toolName, target: qualified, before, after, changedCount: diffCount(before, after) };
+    }
+    case 'create_sheet': {
+      const name = requireString(input, 'name');
+      return { kind: 'summary', toolName, target: name, description: `Create a new sheet named "${name}"` };
+    }
+    case 'format_range': {
+      const address = requireString(input, 'address');
+      const format = input.format;
+      const keys =
+        format && typeof format === 'object' && !Array.isArray(format)
+          ? Object.keys(format as object).join(', ')
+          : '';
+      return {
+        kind: 'summary',
+        toolName,
+        target: address,
+        description: `Apply formatting (${keys || 'none'}) to ${address}`,
+      };
+    }
+    case 'create_table': {
+      const address = requireString(input, 'address');
+      return { kind: 'summary', toolName, target: address, description: `Create a table over ${address}` };
+    }
+    default:
+      return { kind: 'summary', toolName, target: '', description: `Run ${toolName}` };
+  }
+}
+```
+
+`apps/office-addin/src/approval/approvalStore.ts`:
+
+```ts
+/**
+ * Pending mutating-tool queue. The dispatcher (Task 7) enqueues; the
+ * WritePreviewCard resolves via apply()/reject(). Snapshots are immutable and
+ * subscribe() fires on every change — useSyncExternalStore-compatible.
+ */
+import { buildWritePreview, type WritePreview } from './buildPreview';
+import { executeTool, type ToolRequest } from '../tools/dispatcher';
+import type { ToolResultBody } from '../api/types';
+
+export type PendingApproval = {
+  toolUseId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  preview: WritePreview;
+  requestedAt: number;
+};
+
+export type ApprovalDeps = {
+  postToolResult: (result: ToolResultBody) => Promise<void>;
+  /** Injectable for tests; defaults to the real Office.js executor. */
+  execute?: typeof executeTool;
+};
+
+export class ApprovalStore {
+  private queue: readonly PendingApproval[] = [];
+  private listeners = new Set<() => void>();
+
+  constructor(private deps: ApprovalDeps) {}
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify(): void {
+    for (const listener of [...this.listeners]) listener();
+  }
+
+  getPending(): readonly PendingApproval[] {
+    return this.queue;
+  }
+
+  async enqueue(request: ToolRequest): Promise<void> {
+    let preview: WritePreview;
+    try {
+      preview = await buildWritePreview(request.toolName, request.input);
+    } catch (err) {
+      // Malformed input (bad address etc.): tell the model now instead of
+      // rendering a broken card the user can't reason about.
+      await this.deps.postToolResult({
+        toolUseId: request.toolUseId,
+        status: 'error',
+        output: { error: err instanceof Error ? err.message : String(err) },
+      });
+      return;
+    }
+    this.queue = [
+      ...this.queue,
+      {
+        toolUseId: request.toolUseId,
+        toolName: request.toolName,
+        input: request.input,
+        preview,
+        requestedAt: Date.now(),
+      },
+    ];
+    this.notify();
+  }
+
+  private take(toolUseId: string): PendingApproval | null {
+    const found = this.queue.find((p) => p.toolUseId === toolUseId) ?? null;
+    if (found) {
+      this.queue = this.queue.filter((p) => p.toolUseId !== toolUseId);
+      this.notify();
+    }
+    return found;
+  }
+
+  /** Apply → execute via Office.js, then report success/error to the server. */
+  async apply(toolUseId: string): Promise<void> {
+    const pending = this.take(toolUseId);
+    if (!pending) return;
+    const run = this.deps.execute ?? executeTool;
+    const { status, output } = await run(pending.toolName, pending.input);
+    await this.deps.postToolResult({ toolUseId, status, output });
+  }
+
+  /** Reject → report 'rejected' WITHOUT executing anything. */
+  async reject(toolUseId: string, reason = 'User rejected the change'): Promise<void> {
+    const pending = this.take(toolUseId);
+    if (!pending) return;
+    await this.deps.postToolResult({ toolUseId, status: 'rejected', output: { reason } });
+  }
+}
+```
+
+`apps/office-addin/src/components/WritePreviewCard.tsx`:
+
+```tsx
+import type { PendingApproval } from '../approval/approvalStore';
+import type { CellValue } from '../api/types';
+
+function cellText(value: CellValue | undefined): string {
+  return value === null || value === undefined || value === '' ? '' : String(value);
+}
+
+export function WritePreviewCard({
+  approval,
+  onApply,
+  onReject,
+  busy,
+}: {
+  approval: PendingApproval;
+  onApply: () => void;
+  onReject: () => void;
+  busy?: boolean;
+}) {
+  const { preview } = approval;
+  return (
+    <div
+      className="my-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm"
+      data-testid="write-preview-card"
+    >
+      <div className="mb-1 font-semibold text-amber-900">
+        {approval.toolName} → {preview.target}
+      </div>
+      {preview.kind === 'summary' ? (
+        <p className="mb-2 text-amber-900">{preview.description}</p>
+      ) : (
+        <div className="mb-2">
+          <div className="max-h-48 overflow-auto">
+            <table className="w-full border-collapse text-xs">
+              <tbody>
+                {preview.after.map((row, r) => (
+                  <tr key={r}>
+                    {row.map((after, c) => {
+                      const before = preview.before[r]?.[c];
+                      const changed = (before ?? '') !== after;
+                      return (
+                        <td
+                          key={c}
+                          className={`border border-amber-200 px-1 py-0.5 ${changed ? 'bg-amber-100' : ''}`}
+                        >
+                          {changed && cellText(before) !== '' ? (
+                            <>
+                              <span className="text-gray-400 line-through">{cellText(before)}</span>{' '}
+                            </>
+                          ) : null}
+                          <span className={changed ? 'font-medium text-amber-900' : 'text-gray-600'}>
+                            {cellText(after)}
+                          </span>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-1 text-xs text-amber-700">{preview.changedCount} cell(s) will change</div>
+        </div>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onApply}
+          className="rounded bg-emerald-600 px-3 py-1 text-white disabled:opacity-50"
+          data-testid="approval-apply"
+        >
+          Apply
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onReject}
+          className="rounded border border-gray-300 px-3 py-1 text-gray-700 disabled:opacity-50"
+          data-testid="approval-reject"
+        >
+          Reject
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/approval`
+Expected: 9 tests PASS (4 buildPreview + 5 approvalStore). Then `npx tsc --noEmit` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/approval apps/office-addin/src/components/WritePreviewCard.tsx
+git commit -m "feat(office-addin): approval queue + before/after write-preview with Apply/Reject" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Chat UI — controller, context chip, thread, templates, branding (TDD on the controller)
+
+Spec §11. Per D6, ALL behavior lives in the framework-free `ChatController` (thread state, delta accumulation, banners, draft/template insertion, tool routing into the dispatcher/approval store, history resync) and `captureContext.ts` — both fully unit-tested in jsdom. The React components are thin renderers over controller snapshots (`useSyncExternalStore`) and are gated by tsc + the production build + the Task 11 manual checklist.
+
+Lifecycle: the session is created **lazily on the first send** (`ensureSession`), which also opens the persistent SSE stream — Plan 2's events-GET creates the server-side session, so there is no race.
+
+**Files:**
+- Create: apps/office-addin/src/chat/chatController.ts
+- Create: apps/office-addin/src/chat/captureContext.ts
+- Create: apps/office-addin/src/hooks/useSelectionAddress.ts
+- Create: apps/office-addin/src/components/ChatThread.tsx
+- Create: apps/office-addin/src/components/Composer.tsx
+- Create: apps/office-addin/src/components/TemplatePicker.tsx
+- Create: apps/office-addin/src/components/BrandingFooter.tsx
+- Create: apps/office-addin/src/components/ChatPane.tsx
+- Test: apps/office-addin/src/chat/chatController.test.ts
+
+- [ ] **Step 1: Write the failing test** — `apps/office-addin/src/chat/chatController.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { ChatController, type ChatApi } from './chatController';
+import { captureWorkbookContext } from './captureContext';
+import { getOfficeMock } from '../__tests__/officeMock';
+import { ApiError } from '../api/client';
+import type { WorkbookContext } from '../api/types';
+
+function stubApi(overrides: Partial<ChatApi> = {}): ChatApi {
+  return {
+    createSession: vi.fn(async () => 'sess-1'),
+    sendMessage: vi.fn(async () => undefined),
+    postToolResult: vi.fn(async () => undefined),
+    streamEvents: vi.fn(() => ({ stop: vi.fn() })),
+    getSession: vi.fn(async () => ({
+      session: {
+        id: 'sess-1',
+        status: 'active',
+        title: null,
+        model: 'm',
+        turnCount: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCostCents: 0,
+        createdAt: '',
+        lastActivityAt: null,
+      },
+      messages: [],
+    })),
+    ...overrides,
+  };
+}
+
+const SELECTION_CONTEXT: WorkbookContext = {
+  kind: 'selection',
+  address: 'Sheet1!B2:C3',
+  sheetName: 'Sheet1',
+  cells: [
+    ['Region', 'Q1'],
+    ['EMEA', 1200],
+  ],
+};
+
+describe('ChatController — streaming', () => {
+  it('accumulates message_delta text and finalizes one assistant message on turn_complete', () => {
+    const controller = new ChatController({ api: stubApi() });
+    controller.handleEvent({ type: 'message_delta', text: 'Hello ' });
+    controller.handleEvent({ type: 'message_delta', text: 'world' });
+    expect(controller.getState().streamingText).toBe('Hello world');
+    controller.handleEvent({
+      type: 'turn_complete',
+      usage: { inputTokens: 10, outputTokens: 5, costCents: 1 },
+    });
+    const state = controller.getState();
+    expect(state.streamingText).toBe('');
+    expect(state.busy).toBe(false);
+    expect(state.usage).toEqual({ inputTokens: 10, outputTokens: 5, costCents: 1 });
+    expect(state.thread.filter((m) => m.kind === 'assistant')).toEqual([
+      expect.objectContaining({ kind: 'assistant', text: 'Hello world' }),
+    ]);
+  });
+
+  it('session_error raises the error banner and clears busy', () => {
+    const controller = new ChatController({ api: stubApi() });
+    controller.handleEvent({ type: 'session_error', message: 'loop exploded' });
+    expect(controller.getState().banner).toEqual({ kind: 'error', text: 'loop exploded' });
+    expect(controller.getState().busy).toBe(false);
+  });
+
+  it('tool_completed appends an activity row with the redaction count and raises a block banner', () => {
+    const controller = new ChatController({ api: stubApi() });
+    controller.handleEvent({
+      type: 'tool_completed',
+      toolUseId: 'tu-1',
+      toolName: 'read_range',
+      status: 'success',
+      redactions: [
+        { rule: 'creditCard', count: 2, location: 'cell[0][0]' },
+        { rule: 'ssn', count: 1, location: 'cell[1][1]' },
+      ],
+      blockReason: null,
+    });
+    expect(controller.getState().thread.at(-1)).toMatchObject({
+      kind: 'tool',
+      toolName: 'read_range',
+      status: 'success',
+      redactions: 3,
+    });
+    controller.handleEvent({
+      type: 'tool_completed',
+      toolUseId: 'tu-2',
+      toolName: 'read_range',
+      status: 'error',
+      redactions: [],
+      blockReason: 'dlp_blocked:creditCard',
+    });
+    expect(controller.getState().banner?.kind).toBe('blocked');
+    expect(controller.getState().banner?.text).toContain('dlp_blocked:creditCard');
+  });
+});
+
+describe('ChatController — send', () => {
+  it('lazily creates the session, opens the stream once, and posts the pinned message body', async () => {
+    const api = stubApi();
+    const controller = new ChatController({ api, captureContext: async () => SELECTION_CONTEXT });
+    await controller.send('What does column B total to?');
+    await controller.send('And C?');
+    expect(api.createSession).toHaveBeenCalledTimes(1); // the busy guard makes the 2nd send a no-op
+    expect(api.streamEvents).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledWith('sess-1', {
+      content: 'What does column B total to?',
+      workbookContext: SELECTION_CONTEXT,
+    });
+    expect(controller.getState().thread[0]).toMatchObject({
+      kind: 'user',
+      text: 'What does column B total to?',
+    });
+    expect(controller.getState().busy).toBe(true);
+  });
+
+  it('surfaces budget rejections as a banner and clears busy', async () => {
+    const api = stubApi({
+      sendMessage: vi.fn(async () => {
+        throw new ApiError(403, 'budget_exceeded');
+      }),
+    });
+    const controller = new ChatController({ api, captureContext: async () => undefined });
+    await controller.send('hi');
+    expect(controller.getState().busy).toBe(false);
+    expect(controller.getState().banner?.text).toContain('budget');
+  });
+
+  it('routes mutating tool_requests into the approval queue without posting', async () => {
+    const api = stubApi();
+    const controller = new ChatController({ api, captureContext: async () => undefined });
+    await controller.send('write something'); // establishes sessionId
+    controller.handleEvent({
+      type: 'tool_request',
+      toolUseId: 'tu-w1',
+      toolName: 'write_range',
+      input: { address: 'B2', values: [['x']] },
+      mutating: true,
+    });
+    await vi.waitFor(() => expect(controller.approvals.getPending()).toHaveLength(1));
+    expect(api.postToolResult).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChatController — draft & templates', () => {
+  it('insertTemplate fills an empty draft and appends to a non-empty one', () => {
+    const controller = new ChatController({ api: stubApi() });
+    controller.insertTemplate('Summarize this sheet.');
+    expect(controller.getState().draft).toBe('Summarize this sheet.');
+    controller.insertTemplate('Then list outliers.');
+    expect(controller.getState().draft).toBe('Summarize this sheet.\n\nThen list outliers.');
+  });
+});
+
+describe('captureWorkbookContext', () => {
+  it("'selection' captures the pinned payload shape from the live selection", async () => {
+    const mock = getOfficeMock();
+    mock.setValues('Sheet1', 'B2', [
+      ['Region', 'Q1'],
+      ['EMEA', 1200],
+    ]);
+    mock.select('Sheet1!B2:C3');
+    await expect(captureWorkbookContext('selection')).resolves.toEqual(SELECTION_CONTEXT);
+  });
+
+  it("'sheet' captures the used range of the active sheet; 'none' sends kind only", async () => {
+    const mock = getOfficeMock();
+    mock.setValues('Sheet1', 'A1', [['x', 'y']]);
+    await expect(captureWorkbookContext('sheet')).resolves.toEqual({
+      kind: 'sheet',
+      sheetName: 'Sheet1',
+      address: 'Sheet1!A1:B1',
+      cells: [['x', 'y']],
+    });
+    await expect(captureWorkbookContext('none')).resolves.toEqual({ kind: 'none' });
+  });
+});
+```
+
+**Note on the double-send assertion:** the second `controller.send('And C?')` is a no-op because `busy` is still true from the first turn — that is the intended guard (one in-flight turn per pane). The assertions verify the session/stream were only set up once for the successful send.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/chat`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the framework-free modules**
+
+`apps/office-addin/src/chat/captureContext.ts`:
+
+```ts
+/**
+ * Context chip payload (spec §11): the user controls data egress per message.
+ *   selection → address + values of the current selection
+ *   sheet     → used range of the active sheet
+ *   none      → { kind: 'none' } (explicit choice, recorded server-side)
+ * Over CONTEXT_CELL_CAP cells, `cells` is omitted (address/sheetName only) —
+ * the model can still pull narrower data through read tools.
+ */
+import { parseAddress } from '../lib/address';
+import type { CellValue, WorkbookContext, WorkbookContextKind } from '../api/types';
+
+export const CONTEXT_CELL_CAP = 10_000;
+
+export async function captureWorkbookContext(
+  kind: WorkbookContextKind,
+): Promise<WorkbookContext | undefined> {
+  if (kind === 'none') return { kind: 'none' };
+  if (kind === 'selection') {
+    return Excel.run(async (context) => {
+      const range = context.workbook.getSelectedRange();
+      range.load(['address', 'values', 'rowCount', 'columnCount']);
+      await context.sync();
+      const sheetName = parseAddress(range.address).sheet ?? undefined;
+      const payload: WorkbookContext = {
+        kind: 'selection',
+        address: range.address,
+        ...(sheetName ? { sheetName } : {}),
+      };
+      if (range.rowCount * range.columnCount <= CONTEXT_CELL_CAP)
+        payload.cells = range.values as CellValue[][];
+      return payload;
+    });
+  }
+  return Excel.run(async (context) => {
+    const sheet = context.workbook.worksheets.getActiveWorksheet();
+    sheet.load('name');
+    const used = sheet.getUsedRangeOrNullObject();
+    used.load(['address', 'values', 'rowCount', 'columnCount']);
+    await context.sync();
+    if (used.isNullObject) return { kind: 'sheet', sheetName: sheet.name };
+    const payload: WorkbookContext = { kind: 'sheet', sheetName: sheet.name, address: used.address };
+    if (used.rowCount * used.columnCount <= CONTEXT_CELL_CAP)
+      payload.cells = used.values as CellValue[][];
+    return payload;
+  });
+}
+```
+
+`apps/office-addin/src/chat/chatController.ts`:
+
+```ts
+/**
+ * Framework-free chat state machine (D6): owns the thread, streaming buffer,
+ * banners, composer draft, and tool routing. React renders snapshots via
+ * subscribe()/getState() (useSyncExternalStore). The session is created
+ * lazily on the first send; the SSE stream opens in the same step.
+ */
+import {
+  ApiError,
+  createSession,
+  getSession,
+  postToolResult,
+  sendMessage,
+  streamEvents,
+  type StreamCallbacks,
+  type StreamHandle,
+} from '../api/client';
+import { dispatchToolRequest, type ToolRequest } from '../tools/dispatcher';
+import { ApprovalStore } from '../approval/approvalStore';
+import { captureWorkbookContext } from './captureContext';
+import type {
+  ClientAiStreamEvent,
+  SendMessageBody,
+  SessionHistory,
+  ToolCompletedStatus,
+  ToolResultBody,
+  TurnUsage,
+  WorkbookContext,
+  WorkbookContextKind,
+} from '../api/types';
+
+export type ChatApi = {
+  createSession: () => Promise<string>;
+  sendMessage: (sessionId: string, body: SendMessageBody) => Promise<void>;
+  postToolResult: (sessionId: string, result: ToolResultBody) => Promise<void>;
+  streamEvents: (sessionId: string, callbacks: StreamCallbacks) => StreamHandle;
+  getSession: (sessionId: string) => Promise<SessionHistory>;
+};
+
+const realApi: ChatApi = { createSession, sendMessage, postToolResult, streamEvents, getSession };
+
+export type ThreadMessage =
+  | { kind: 'user'; id: number; text: string; context?: WorkbookContext }
+  | { kind: 'assistant'; id: number; text: string }
+  | {
+      kind: 'tool';
+      id: number;
+      toolName: string;
+      status: ToolCompletedStatus;
+      redactions: number;
+      blockReason: string | null;
+    };
+
+export type ChatState = {
+  thread: ThreadMessage[];
+  streamingText: string;
+  busy: boolean;
+  banner: { kind: 'error' | 'blocked'; text: string } | null;
+  draft: string;
+  contextKind: WorkbookContextKind;
+  usage: TurnUsage | null;
+};
+
+const ERROR_BANNERS: Record<string, string> = {
+  budget_exceeded:
+    "Your organization's AI budget for this period has been reached. Contact your IT provider.",
+  rate_limited: 'You are sending messages too quickly. Wait a moment and try again.',
+  no_session: 'Not signed in. Reload the task pane.',
+};
+
+function bannerText(err: unknown): string {
+  if (err instanceof ApiError) return ERROR_BANNERS[err.code] ?? `Request failed (${err.code}).`;
+  return err instanceof Error ? err.message : 'Something went wrong.';
+}
+
+export type ChatControllerDeps = {
+  api?: ChatApi;
+  captureContext?: (kind: WorkbookContextKind) => Promise<WorkbookContext | undefined>;
+};
+
+export class ChatController {
+  readonly approvals: ApprovalStore;
+  private state: ChatState = {
+    thread: [],
+    streamingText: '',
+    busy: false,
+    banner: null,
+    draft: '',
+    contextKind: 'selection',
+    usage: null,
+  };
+  private listeners = new Set<() => void>();
+  private sessionId: string | null = null;
+  private stream: StreamHandle | null = null;
+  private nextId = 1;
+  private api: ChatApi;
+  private capture: (kind: WorkbookContextKind) => Promise<WorkbookContext | undefined>;
+
+  constructor(deps: ChatControllerDeps = {}) {
+    this.api = deps.api ?? realApi;
+    this.capture = deps.captureContext ?? captureWorkbookContext;
+    this.approvals = new ApprovalStore({
+      postToolResult: async (result) => {
+        if (!this.sessionId) throw new Error('No active session for tool result');
+        await this.api.postToolResult(this.sessionId, result);
+      },
+    });
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getState(): ChatState {
+    return this.state;
+  }
+
+  private update(patch: Partial<ChatState>): void {
+    this.state = { ...this.state, ...patch };
+    for (const listener of [...this.listeners]) listener();
+  }
+
+  setDraft(text: string): void {
+    this.update({ draft: text });
+  }
+
+  /** Template picker → composer (spec §10: templates land in the input, not auto-sent). */
+  insertTemplate(body: string): void {
+    this.update({ draft: this.state.draft ? `${this.state.draft}\n\n${body}` : body });
+  }
+
+  setContextKind(kind: WorkbookContextKind): void {
+    this.update({ contextKind: kind });
+  }
+
+  dismissBanner(): void {
+    this.update({ banner: null });
+  }
+
+  private async ensureSession(): Promise<string> {
+    if (this.sessionId) return this.sessionId;
+    this.sessionId = await this.api.createSession();
+    this.stream = this.api.streamEvents(this.sessionId, {
+      onEvent: (event) => this.handleEvent(event),
+      onReconnect: () => this.resync(),
+      onPermanentError: () =>
+        this.update({
+          busy: false,
+          banner: { kind: 'error', text: 'Connection to Breeze lost. Reload the task pane.' },
+        }),
+    });
+    return this.sessionId;
+  }
+
+  async send(content?: string): Promise<void> {
+    const text = (content ?? this.state.draft).trim();
+    if (!text || this.state.busy) return;
+    let workbookContext: WorkbookContext | undefined;
+    try {
+      workbookContext = await this.capture(this.state.contextKind);
+    } catch {
+      workbookContext = undefined; // context capture must never block sending
+    }
+    this.update({
+      thread: [
+        ...this.state.thread,
+        { kind: 'user', id: this.nextId++, text, ...(workbookContext ? { context: workbookContext } : {}) },
+      ],
+      draft: '',
+      busy: true,
+      banner: null,
+    });
+    try {
+      const sessionId = await this.ensureSession();
+      await this.api.sendMessage(sessionId, {
+        content: text,
+        ...(workbookContext ? { workbookContext } : {}),
+      });
+    } catch (err) {
+      this.update({ busy: false, banner: { kind: 'error', text: bannerText(err) } });
+    }
+  }
+
+  /** Moves any streamed text into the thread, optionally appending one more item. */
+  private flushStreaming(extra?: ThreadMessage): void {
+    const thread = [...this.state.thread];
+    if (this.state.streamingText)
+      thread.push({ kind: 'assistant', id: this.nextId++, text: this.state.streamingText });
+    if (extra) thread.push(extra);
+    this.update({ thread, streamingText: '' });
+  }
+
+  handleEvent(event: ClientAiStreamEvent): void {
+    switch (event.type) {
+      case 'message_delta':
+        this.update({ streamingText: this.state.streamingText + event.text });
+        break;
+      case 'turn_complete':
+        this.flushStreaming();
+        this.update({ busy: false, usage: event.usage });
+        break;
+      case 'tool_request':
+        void this.handleToolRequest(event);
+        break;
+      case 'tool_completed': {
+        this.flushStreaming({
+          kind: 'tool',
+          id: this.nextId++,
+          toolName: event.toolName,
+          status: event.status,
+          redactions: event.redactions.reduce((n, r) => n + r.count, 0),
+          blockReason: event.blockReason,
+        });
+        if (event.blockReason)
+          this.update({
+            banner: {
+              kind: 'blocked',
+              text: `Blocked by your IT provider's data policy (${event.blockReason}).`,
+            },
+          });
+        break;
+      }
+      case 'session_error':
+        this.update({ busy: false, banner: { kind: 'error', text: event.message } });
+        break;
+      case 'ping':
+        break; // server keepalive — nothing to do
+    }
+  }
+
+  private async handleToolRequest(request: ToolRequest): Promise<void> {
+    const sessionId = this.sessionId;
+    if (!sessionId) return; // events only flow on an open stream, which implies a session
+    await dispatchToolRequest(request, {
+      postToolResult: (result) => this.api.postToolResult(sessionId, result),
+      enqueueApproval: (req) => this.approvals.enqueue(req),
+    });
+  }
+
+  /** After an SSE reconnect: replace the local thread with server history (already redacted). */
+  private async resync(): Promise<void> {
+    if (!this.sessionId) return;
+    try {
+      const history = await this.api.getSession(this.sessionId);
+      const thread: ThreadMessage[] = [];
+      for (const m of history.messages) {
+        if (m.toolName) {
+          thread.push({
+            kind: 'tool',
+            id: this.nextId++,
+            toolName: m.toolName,
+            status: 'success',
+            redactions: 0,
+            blockReason: null,
+          });
+        } else if (m.role === 'user') {
+          thread.push({ kind: 'user', id: this.nextId++, text: m.content ?? '' });
+        } else if (m.content) {
+          thread.push({ kind: 'assistant', id: this.nextId++, text: m.content });
+        }
+      }
+      this.update({ thread, streamingText: '' });
+    } catch {
+      // keep the local thread when the history fetch fails — better stale than empty
+    }
+  }
+
+  dispose(): void {
+    this.stream?.stop();
+    this.stream = null;
+  }
+}
+```
+
+`apps/office-addin/src/hooks/useSelectionAddress.ts`:
+
+```ts
+/**
+ * Live sheet-qualified selection address via DocumentSelectionChanged.
+ * No removeHandlerAsync on unmount: the hook lives in the always-mounted
+ * Composer; the `disposed` flag guards late setState.
+ */
+import { useEffect, useState } from 'react';
+
+export function useSelectionAddress(): string | null {
+  const [address, setAddress] = useState<string | null>(null);
+  useEffect(() => {
+    let disposed = false;
+    const refresh = () => {
+      void Excel.run(async (context) => {
+        const range = context.workbook.getSelectedRange();
+        range.load('address');
+        await context.sync();
+        if (!disposed) setAddress(range.address);
+      }).catch(() => undefined);
+    };
+    refresh();
+    const officeGlobal = (globalThis as { Office?: typeof Office }).Office;
+    officeGlobal?.context?.document?.addHandlerAsync(
+      officeGlobal.EventType.DocumentSelectionChanged,
+      refresh,
+      () => undefined,
+    );
+    return () => {
+      disposed = true;
+    };
+  }, []);
+  return address;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/apps/office-addin && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/chat`
+Expected: 9 tests PASS.
+
+- [ ] **Step 5: Write the React components** (tsc-gated, D6)
+
+`apps/office-addin/src/components/ChatThread.tsx`:
+
+```tsx
+import type { ChatState, ThreadMessage } from '../chat/chatController';
+import type { PendingApproval } from '../approval/approvalStore';
+import { WritePreviewCard } from './WritePreviewCard';
+
+const TOOL_STATUS_LABEL: Record<string, string> = {
+  success: 'ran',
+  error: 'failed',
+  rejected: 'rejected',
+  timeout: 'timed out',
+};
+
+function ToolRow({ item }: { item: Extract<ThreadMessage, { kind: 'tool' }> }) {
+  return (
+    <div className="my-1 flex items-center gap-2 text-xs text-gray-500" data-testid="tool-activity">
+      <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono">{item.toolName}</span>
+      <span>{TOOL_STATUS_LABEL[item.status] ?? item.status}</span>
+      {item.redactions > 0 && (
+        <span
+          className="rounded bg-purple-100 px-1.5 py-0.5 text-purple-700"
+          data-testid="redaction-badge"
+        >
+          {item.redactions} redacted
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function ChatThread({
+  state,
+  approvals,
+  onApply,
+  onReject,
+  onDismissBanner,
+}: {
+  state: ChatState;
+  approvals: readonly PendingApproval[];
+  onApply: (toolUseId: string) => void;
+  onReject: (toolUseId: string) => void;
+  onDismissBanner: () => void;
+}) {
+  return (
+    <div className="flex-1 space-y-2 overflow-y-auto p-3">
+      {state.thread.map((item) =>
+        item.kind === 'user' ? (
+          <div key={item.id} className="ml-6 whitespace-pre-wrap rounded-lg bg-blue-600 p-2 text-sm text-white">
+            {item.text}
+          </div>
+        ) : item.kind === 'assistant' ? (
+          <div key={item.id} className="mr-6 whitespace-pre-wrap rounded-lg bg-gray-100 p-2 text-sm text-gray-900">
+            {item.text}
+          </div>
+        ) : (
+          <ToolRow key={item.id} item={item} />
+        ),
+      )}
+      {state.streamingText && (
+        <div
+          className="mr-6 whitespace-pre-wrap rounded-lg bg-gray-100 p-2 text-sm text-gray-900"
+          data-testid="streaming-message"
+        >
+          {state.streamingText}
+          <span className="animate-pulse">▍</span>
+        </div>
+      )}
+      {approvals.map((approval) => (
+        <WritePreviewCard
+          key={approval.toolUseId}
+          approval={approval}
+          onApply={() => onApply(approval.toolUseId)}
+          onReject={() => onReject(approval.toolUseId)}
+        />
+      ))}
+      {state.banner && (
+        <div
+          className={`flex items-start justify-between gap-2 rounded-md border p-2 text-xs ${
+            state.banner.kind === 'blocked'
+              ? 'border-purple-300 bg-purple-50 text-purple-800'
+              : 'border-red-300 bg-red-50 text-red-700'
+          }`}
+          data-testid="chat-banner"
+        >
+          <span>{state.banner.text}</span>
+          <button type="button" onClick={onDismissBanner} className="font-semibold" aria-label="Dismiss">
+            ×
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+`apps/office-addin/src/components/Composer.tsx`:
+
+```tsx
+import { useSelectionAddress } from '../hooks/useSelectionAddress';
+import { parseAddress, stripSheet } from '../lib/address';
+import type { WorkbookContextKind } from '../api/types';
+
+const CONTEXT_OPTIONS: Array<{ value: WorkbookContextKind; label: string }> = [
+  { value: 'selection', label: 'Selection' },
+  { value: 'sheet', label: 'Whole sheet' },
+  { value: 'none', label: 'No workbook data' },
+];
+
+export function Composer({
+  draft,
+  busy,
+  contextKind,
+  onDraftChange,
+  onContextKindChange,
+  onSend,
+}: {
+  draft: string;
+  busy: boolean;
+  contextKind: WorkbookContextKind;
+  onDraftChange: (text: string) => void;
+  onContextKindChange: (kind: WorkbookContextKind) => void;
+  onSend: () => void;
+}) {
+  const selection = useSelectionAddress();
+  const sheetName = selection ? parseAddress(selection).sheet : null;
+  const chip =
+    contextKind === 'none'
+      ? 'No workbook data'
+      : contextKind === 'sheet'
+        ? sheetName
+          ? `Sheet: ${sheetName}`
+          : 'Whole sheet'
+        : selection
+          ? `Selection ${stripSheet(selection)}`
+          : 'Selection';
+  return (
+    <div className="border-t border-gray-200 p-2">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-700" data-testid="context-chip">
+          {chip}
+        </span>
+        <select
+          className="ml-auto rounded border border-gray-200 text-xs"
+          value={contextKind}
+          onChange={(e) => onContextKindChange(e.target.value as WorkbookContextKind)}
+          data-testid="context-select"
+        >
+          {CONTEXT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <form
+        className="flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSend();
+        }}
+      >
+        <textarea
+          value={draft}
+          onChange={(e) => onDraftChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              onSend();
+            }
+          }}
+          rows={2}
+          placeholder="Ask about this workbook…"
+          className="flex-1 resize-none rounded border border-gray-300 p-2 text-sm"
+          data-testid="composer-input"
+        />
+        <button
+          type="submit"
+          disabled={busy || !draft.trim()}
+          className="self-end rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-50"
+          data-testid="composer-send"
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}
+```
+
+`apps/office-addin/src/components/TemplatePicker.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { getTemplates } from '../api/client';
+import type { ClientAiTemplate } from '../api/types';
+
+/** Empty-state template picker (spec §10): click inserts the body into the composer. */
+export function TemplatePicker({ onPick }: { onPick: (body: string) => void }) {
+  const [templates, setTemplates] = useState<ClientAiTemplate[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    let disposed = false;
+    getTemplates()
+      .then((items) => {
+        if (!disposed) {
+          setTemplates(items);
+          setLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (!disposed) setLoaded(true); // templates are sugar — never block chat on them
+      });
+    return () => {
+      disposed = true;
+    };
+  }, []);
+  if (!loaded || templates.length === 0) return null;
+  return (
+    <div className="p-3">
+      <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+        Templates from your IT provider
+      </div>
+      <div className="space-y-1">
+        {templates.map((template) => (
+          <button
+            key={template.id}
+            type="button"
+            onClick={() => onPick(template.body)}
+            className="block w-full rounded-md border border-gray-200 p-2 text-left text-sm hover:border-blue-400"
+            data-testid={`template-${template.id}`}
+          >
+            <div className="font-medium text-gray-800">{template.name}</div>
+            {template.description && <div className="text-xs text-gray-500">{template.description}</div>}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+`apps/office-addin/src/components/BrandingFooter.tsx`:
+
+```tsx
+import type { ExchangeBranding } from '../auth/session';
+
+/** spec §11 white-label hook. branding is absent until the server adds it (D2) — graceful fallback. */
+export function BrandingFooter({ branding }: { branding: ExchangeBranding | null }) {
+  const name = branding?.displayName?.trim() || 'your IT provider';
+  return (
+    <div
+      className="flex items-center justify-center gap-1.5 border-t border-gray-100 py-1.5 text-[11px] text-gray-400"
+      data-testid="branding-footer"
+    >
+      {branding?.logoUrl ? (
+        <img src={branding.logoUrl} alt="" className="h-3.5 w-3.5 rounded-sm object-contain" />
+      ) : null}
+      <span>Powered by {name}</span>
+    </div>
+  );
+}
+```
+
+`apps/office-addin/src/components/ChatPane.tsx`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { ChatController } from '../chat/chatController';
+import { ChatThread } from './ChatThread';
+import { Composer } from './Composer';
+import { TemplatePicker } from './TemplatePicker';
+import { BrandingFooter } from './BrandingFooter';
+import type { ClientSession } from '../auth/session';
+
+export function ChatPane({ session }: { session: ClientSession }) {
+  const controller = useMemo(() => new ChatController(), []);
+  useEffect(() => () => controller.dispose(), [controller]);
+
+  const state = useSyncExternalStore(
+    useCallback((cb: () => void) => controller.subscribe(cb), [controller]),
+    () => controller.getState(),
+  );
+  const approvals = useSyncExternalStore(
+    useCallback((cb: () => void) => controller.approvals.subscribe(cb), [controller]),
+    () => controller.approvals.getPending(),
+  );
+
+  const empty = state.thread.length === 0 && !state.streamingText;
+
+  return (
+    <div className="flex h-screen flex-col">
+      {empty && <TemplatePicker onPick={(body) => controller.insertTemplate(body)} />}
+      <ChatThread
+        state={state}
+        approvals={approvals}
+        onApply={(id) => void controller.approvals.apply(id)}
+        onReject={(id) => void controller.approvals.reject(id)}
+        onDismissBanner={() => controller.dismissBanner()}
+      />
+      <Composer
+        draft={state.draft}
+        busy={state.busy}
+        contextKind={state.contextKind}
+        onDraftChange={(text) => controller.setDraft(text)}
+        onContextKindChange={(kind) => controller.setContextKind(kind)}
+        onSend={() => void controller.send()}
+      />
+      <BrandingFooter branding={session.branding} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Verify the whole app still type-checks and the suite is green**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/office-addin
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run
+```
+
+Expected: tsc clean; full suite green (address 8, officeMock 8, auth 10, api 14, tools 16, approval 9, chat 9 ≈ 74 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/chat apps/office-addin/src/hooks apps/office-addin/src/components
+git commit -m "feat(office-addin): chat controller + streamed thread, context chip, templates, branding footer" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: App shell — auth state machine, sign-in/blocked screens, README (verification, no TDD)
+
+Replaces the Task 1 placeholder `App.tsx` with the real phase machine: `loading` → silent SSO attempt → (`signin` screen with MSAL-popup button | `blocked` screens | `ready` → ChatPane). The silent boot path NEVER opens a popup (browsers block popups outside user gestures); the popup only fires from the sign-in button. The session itself is created lazily on the first message (Task 9), so a signed-in pane that never chats costs nothing server-side.
+
+**Files:**
+- Modify: apps/office-addin/src/App.tsx (replace the Task 1 placeholder)
+- Create: apps/office-addin/src/components/SignInScreen.tsx
+- Create: apps/office-addin/README.md
+
+- [ ] **Step 1: Create `apps/office-addin/src/components/SignInScreen.tsx`**
+
+```tsx
+export function SignInScreen({ failed, onSignIn }: { failed: boolean; onSignIn: () => void }) {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-3 p-6 text-center">
+      <div className="text-base font-semibold text-gray-800">Breeze AI</div>
+      <p className="text-sm text-gray-500">
+        Sign in with your work account to use the AI assistant for this workbook.
+      </p>
+      {failed && (
+        <p className="text-xs text-red-600" data-testid="signin-error">
+          Sign-in didn&apos;t complete. Try again.
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={onSignIn}
+        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white"
+        data-testid="signin-button"
+      >
+        Sign in with Microsoft
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Replace `apps/office-addin/src/App.tsx`** (Task 1 placeholder) with:
+
+```tsx
+/**
+ * Auth phase machine (spec §3 + §11):
+ *   loading → silent Office SSO → ready
+ *                              ↘ blocked (not_provisioned / disabled / no-access / inactive / retryable)
+ *                              ↘ signin (silent failed; button triggers SSO→MSAL-popup chain)
+ * A stored unexpired session short-circuits straight to ready.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AuthBlockedError,
+  getStoredSession,
+  signIn,
+  type AuthBlockKind,
+  type ClientSession,
+} from './auth/session';
+import { BlockedScreen } from './components/BlockedScreen';
+import { SignInScreen } from './components/SignInScreen';
+import { ChatPane } from './components/ChatPane';
+
+type Phase =
+  | { name: 'loading' }
+  | { name: 'signin'; failed: boolean }
+  | { name: 'blocked'; kind: AuthBlockKind }
+  | { name: 'ready'; session: ClientSession };
+
+export function App() {
+  const [phase, setPhase] = useState<Phase>({ name: 'loading' });
+
+  useEffect(() => {
+    const restored = getStoredSession();
+    if (restored) {
+      setPhase({ name: 'ready', session: restored });
+      return;
+    }
+    let cancelled = false;
+    // Silent path only — popups are blocked outside user gestures.
+    signIn({ interactive: false })
+      .then((session) => {
+        if (!cancelled) setPhase({ name: 'ready', session });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof AuthBlockedError) setPhase({ name: 'blocked', kind: err.kind });
+        else setPhase({ name: 'signin', failed: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const interactiveSignIn = useCallback(() => {
+    setPhase({ name: 'loading' });
+    signIn({ interactive: true })
+      .then((session) => setPhase({ name: 'ready', session }))
+      .catch((err: unknown) => {
+        if (err instanceof AuthBlockedError) setPhase({ name: 'blocked', kind: err.kind });
+        else setPhase({ name: 'signin', failed: true });
+      });
+  }, []);
+
+  switch (phase.name) {
+    case 'loading':
+      return (
+        <div className="flex h-screen items-center justify-center text-sm text-gray-400">
+          Connecting to Breeze…
+        </div>
+      );
+    case 'signin':
+      return <SignInScreen failed={phase.failed} onSignIn={interactiveSignIn} />;
+    case 'blocked':
+      return (
+        <BlockedScreen
+          kind={phase.kind}
+          onRetry={phase.kind === 'retryable' ? interactiveSignIn : undefined}
+        />
+      );
+    case 'ready':
+      return <ChatPane session={phase.session} />;
+  }
+}
+```
+
+- [ ] **Step 3: Create `apps/office-addin/README.md`**
+
+````markdown
+# Breeze AI for Office — Excel add-in
+
+Task-pane add-in delivering the governed Breeze AI assistant to MSP client
+end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md`.
+
+## Prerequisites
+
+- Node 22 (`nvm use 22.20.0`) and `pnpm install` from the repo root.
+- HTTPS dev certs (Office hosts require https):
+
+  ```bash
+  pnpm run certs   # office-addin-dev-certs install — one-time, may prompt for the OS keychain
+  ```
+
+- `.env` (copy `.env.example`): `VITE_API_BASE_URL`, `VITE_CLIENT_AI_ENTRA_CLIENT_ID`
+  (must equal the API's `CLIENT_AI_ENTRA_CLIENT_ID`), `ADDIN_BASE_URL`.
+- The API's `CORS_ALLOWED_ORIGINS` must include this app's origin
+  (`https://localhost:3000` for dev).
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `pnpm dev` | Generates icons + `manifest.xml`, serves the pane at `https://localhost:3000` |
+| `pnpm build` | Type-check + production build into `dist/` + manifest |
+| `pnpm test` | Vitest (jsdom + the Office.js mock in `src/__tests__/officeMock.ts`) |
+| `pnpm manifest` | Re-render `manifest.xml` from `manifest.template.xml` + env |
+| `pnpm validate-manifest` | `office-addin-manifest validate manifest.xml` |
+
+## Sideloading the generated `manifest.xml`
+
+- **Excel on the web:** Insert ▸ Add-ins ▸ More Add-ins ▸ MY ADD-INS ▸ Upload My Add-in.
+- **Excel desktop (macOS):** copy `manifest.xml` to
+  `~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/` and restart Excel
+  (the add-in appears under Insert ▸ My Add-ins ▸ Developer Add-ins).
+- **Excel desktop (Windows):** add a shared-folder catalog pointing at the
+  directory containing `manifest.xml` (File ▸ Options ▸ Trust Center ▸ Trusted
+  Add-in Catalogs), then Insert ▸ My Add-ins ▸ SHARED FOLDER.
+- Production distribution is M365 **centralized deployment** by the MSP (spec §2).
+
+## Entra app registration
+
+Silent SSO needs the registration described in the plan (Task 2 prerequisites):
+SPA redirect URI `<origin>/taskpane.html`, Application ID URI
+`api://<host>/<client-id>`, delegated scope `access_as_user`, the Office client
+app `ea5a67f6-b6f3-4338-b240-c655ddc3cc8e` pre-authorized, and **v2.0 access
+tokens** (`requestedAccessTokenVersion: 2`). Without pre-authorization, the
+add-in falls back to the MSAL popup — functional, just not silent.
+````
+
+- [ ] **Step 4: Verify — type-check, full suite, production build**
+
+```bash
+cd /Users/toddhebebrand/breeze/apps/office-addin
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH node scripts/make-icons.mjs
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vite build
+ls dist/taskpane.html
+```
+
+Expected: tsc clean, suite green (~74 tests), build emits `dist/taskpane.html`. Smoke the dev server once more as in Task 1 Step 8 if anything around the entry changed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/office-addin/src/App.tsx apps/office-addin/src/components/SignInScreen.tsx apps/office-addin/README.md
+git commit -m "feat(office-addin): auth phase machine, sign-in/blocked screens, README" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Manual test checklist (no code)
+
+Playwright cannot drive Excel (spec §13) — the in-host behavior is verified by hand against a Plan 1–4 capable API. Work through the numbered list in order on BOTH hosts where marked; record results in the PR description. Prep: a dev Entra tenant mapped via `client_ai_tenant_mappings`, a second unmapped tenant, an org policy you can toggle (`enabled`, `writeMode`, a DLP block rule), and at least one prompt template row.
+
+- [ ] **0. CORS prerequisite** — add the add-in origin (`https://localhost:3000`) to the API's `CORS_ALLOWED_ORIGINS` and restart it. Sanity: a browser-tab fetch from the pane origin to `GET <api>/health` succeeds.
+- [ ] **1. Sideload — Excel desktop** — `pnpm dev`, sideload `manifest.xml` (README instructions). Ribbon shows the Breeze AI button; the pane opens and renders past "Connecting to Breeze…".
+- [ ] **2. Sideload — Excel on the web** — upload the same manifest. Pane loads over https with no mixed-content/CORS console errors.
+- [ ] **3. Silent SSO** — in a tenant with admin consent + the Office client app pre-authorized: open the pane → lands directly in chat with **no** sign-in UI. Verify a `client_ai.auth.exchange` success audit row.
+- [ ] **4. MSAL popup fallback** — in a consented tenant WITHOUT Office-client pre-authorization (or a fresh sideload where `getAccessToken` 13012s): pane shows the sign-in screen; the button opens the MSAL popup; completing it lands in chat.
+- [ ] **5. Unprovisioned tenant** — sign in from the unmapped tenant: "Not set up yet" screen (`tenant_not_provisioned`), no chat UI.
+- [ ] **6. Disabled org** — set the org policy `enabled=false`: pane shows the "Disabled" screen on next sign-in/exchange.
+- [ ] **7. Read Q&A on selection** — select a numeric range, context chip shows `Selection <range>`, ask "what do these total to?" → tool activity rows appear for read tools, the streamed answer references the selected data.
+- [ ] **8. Sheet-context toggle** — switch the context select to "Whole sheet": chip shows `Sheet: <name>`; send a message and verify (server logs / session viewer) the message carried `workbookContext.kind='sheet'` with used-range cells.
+- [ ] **9. Write apply** — ask for a small edit ("put 'Reviewed' in D1"): write-preview card shows the before/after diff; Apply → the cell changes in the grid, the model receives the success result and confirms.
+- [ ] **10. Write reject** — repeat with Reject: the workbook is untouched, the model acknowledges the rejection (`status:'rejected'` tool result), no retry loop.
+- [ ] **11. Readonly org** — set `writeMode='readonly'`: ask for a write → NO `tool_request` for mutating tools ever arrives (Plan 2 removes write tools from the toolset); the model answers in text only; no approval card renders.
+- [ ] **12. Template insert** — with an empty thread, the template picker lists the seeded template; clicking inserts its body into the composer (not auto-sent).
+- [ ] **13. DLP block banner** — add a `block`-action DLP rule (e.g. credit cards), put a matching value in a cell, ask the model to read it: `tool_completed` arrives with `blockReason`, the purple "Blocked by your IT provider's data policy" banner renders, and the redaction badge appears on redact-action rules.
+- [ ] **14. 401 mid-session re-exchange** — delete the Breeze session token key from Redis while the pane is open, then send a message: the single-flight re-exchange runs silently (one new exchange audit row) and the message succeeds with no visible interruption.
+- [ ] **15. Network-loss reconnect** — kill the API (or drop the network) mid-turn, restore within ~30s: the stream reconnects with backoff, history resyncs via `GET /sessions/:id` (no duplicated/garbled thread), and chat continues.
+- [ ] **16. Idle ping keepalive** — leave the pane idle 3+ minutes: `ping` frames keep the SSE connection alive (network tab), no error banner, and the next message streams without reconnecting.
+
+---
+
+## Execution order & parallelism notes
+
+Tasks 4 → 7 → 8 → 9 are a strict chain (mock → tools → approvals → controller). Task 5 (auth) and Task 6 (API client) only depend on Tasks 1–3 and can run in parallel with Task 4/7 — except `client.ts` imports `auth/session.ts`, so Task 5 lands before Task 6. Task 10 needs everything; Task 11 needs Plans 1–4 deployed somewhere reachable.

--- a/e2e-tests/release-checklist-v0.70-results.md
+++ b/e2e-tests/release-checklist-v0.70-results.md
@@ -1,0 +1,274 @@
+# Release Checklist v0.70 — Manual Playwright Test Results
+
+**Tested by:** Claude (Opus 4.8)
+**Date:** 2026-06-11 (Round 1) · **2026-06-12 (Round 2 — PRs #1264–#1276)**
+**Environment:** Local Docker (`http://localhost`), web+api+postgres+redis all healthy
+**Login:** admin@breeze.local
+
+Legend: ✅ PASS · ❌ FAIL · ⚠️ PARTIAL/ISSUE · ⏭️ SKIPPED (not testable locally) · 💡 UI/UX note
+
+---
+
+## Round 2 — 2026-06-12 (PRs #1264–#1276, images rebuilt from current `main`)
+
+**Setup:** pulled the 2 trailing merges (#1265 passkey MFA, #1266 patch split), `pnpm install` (new `@simplewebauthn` deps), rebuilt `breeze-api:dev`/`breeze-web:dev`, recreated containers. Migrations auto-applied: `avatar-bytea-columns`, `device-pending-reboot`, `user-passkeys`, `huntress-partner-mapping`. There is a **live agent heartbeating** this round.
+
+### New unit tests (all green)
+- **Web:** 13 new/changed files, **88 tests pass** (passkeys store/login/profile, useBulkActions, PatchCompliance, DevicePatchStatusTab, DeviceUserIdleStat, DeviceList, Huntress, PatchTab, PatchAppRulesSection, installCommands).
+- **API:** 18 new/changed files, **403 tests pass** (auth.passkeys, services/passkeys, users/avatar, patches compliance/index/appOptions, devices/patches, patchApprovalEvaluator, configPolicyPatching, huntressClient, filterEngine, tickets/parts, timeEntries, agents/sessions+heartbeat, patchJobExecutor, aiToolsTicketing).
+- **Go agent:** collectors / patching (reboot_detect) / sessionbroker (idle) — all `ok` with `-race`.
+- **Shared:** timeEntries + inline-settings validators, **62 tests pass**.
+
+### 🐛 Bug found & fixed this round
+- **❌→✅ #1273 list "Reboot pending" badge never rendered (real shipping bug).** The device **list** API (`routes/devices/core.ts`) SELECTed `pendingReboot` (line 526) but the response mapper (lines ~610–652) rebuilt each row field-by-field and **dropped `pendingReboot`** — identical failure mode to the #862 agent-silent badge. Verified end-to-end: seeded `pending_reboot=true` → **detail page badge rendered, list badge did not**, and `GET /devices` omitted the field entirely. **Fix:** added `pendingReboot: d.pendingReboot,` to the list mapper. Re-verified: list now shows "e2e-macos.local … Down **Reboot pending**". **Regression test** added to `core.list-response-shape.test.ts` (the file that already guards this exact bug class) — extended both rows + a dedicated assertion; 81/81 device-core tests pass. *(Detail page already worked because it returns the full row; the `system.rebootRequired` advanced filter already worked because `filterEngine` queries the column directly.)*
+
+### Playwright verification (browser, live session)
+
+| PR | Item | Result | Evidence |
+|---|---|---|---|
+| #1268 | Login React #418 hydration | ✅ | Clean `/login` load → **0 console errors** (was #418). Form (not placeholder) renders on first client paint. |
+| #1268 | Deletion-requests badge 403 | ✅ | Authenticated dashboard → **0 console errors** (was a 403-per-page). `isPlatformAdmin:false` for this admin → "Deletion requests" nav item hidden, badge fetch never fires. |
+| #1268/#1059 | Avatar upload (now DB bytea) | ✅ | UI upload (blob preview → "Upload") → `POST /users/me/avatar` **200** (was 500 EACCES); stored **70 B `image/png` bytea**; `GET avatar` 200; **zero EACCES** in logs. Headline must-fix resolved. |
+| #1272 | User Idle stat on device detail | ✅ | "User Idle" stat renders beside "Logged-in User"; graceful `—` for the offline device (documented fallback). Numeric value needs an online agent reporting `idleMinutes`. |
+| #1273 | Pending Reboot — detail + list | ✅ | After fix above: `device-pending-reboot-badge` "Reboot pending" on detail **and** list row. |
+| #1270 | EDR events in automation builder | ✅ | Trigger=Event → Event Type dropdown lists all **6** new options (Huntress Created/Updated/Agent Offline, SentinelOne Threat Detected/Device Isolated/Threat Action Completed). |
+| #1266 | Approved vs Pending-Approval split | ✅ | Patch Compliance: "3 have pending patches · **3 pending approval** · 1 critical"; "Pending Patches (3)" + "3rd-Party Pending" filter labels present. |
+| #1269 | Third-party patch source mgmt | ✅ | Policy → Patches tab → **Patch Sources** with "OS updates" + "Third-party applications" + "At least one patch source must be selected" guard. |
+| #1275 | Policy auto-approve + app rules | ✅ | `auto-approve-toggle` reveals severity checkboxes (Critical/Important/Moderate/Low) + Deferral days; **Application Rules** section + `app-rules-add` present. |
+| #1265 | Passkey MFA (static UI) | ✅ | `/settings/profile` Passkeys section + "Add passkey" render. Full WebAuthn add/login ceremony needs a Playwright virtual authenticator (CDP) — not exercised. |
+| #1271 | Partial-connectivity install cmds | ✅ (unit) | Logic covered by passing `installCommands.test.ts` (mktemp + `sudo bash --server --token`; Windows `$ErrorActionPreference='Stop'` + MZ-magic / `$LASTEXITCODE`). Add-Device modal not driven this pass. |
+| #1264 | Huntress integration | ⚠️ | Page header renders ("Connect **one partner-level** Huntress account…") but the form body didn't mount in admin/org scope. **Note:** commit `63869a39` re-scoped Huntress to **partner-level**, superseding #1264's per-org key/secret wording in the checklist — needs a re-check under partner scope. |
+| #1276 | Ticketing Phase 3 (time/parts) | ⏭️ | Backend-only; no UI shipped yet (deferred to a follow-up frontend PR). API covered by unit/integration tests. |
+| #1246/#1248/#1249 | PAM agent/AI tools | ⏭️ | Agent-side / Tauri Helper / AI-tool flows — not web-Playwright testable. |
+
+**Round-2 notes:**
+- 💡 Pre-existing console noise persists and is **not** from these PRs: the always-mounted `docs.breezermm.com` iframe emits CSP-report-only violations on every page (5 on `/automations/new`, 2 elsewhere). Cosmetic.
+- ℹ️ Footer/`/health` still report **0.63.5** — cosmetic dev-image version label; live migrations confirm current code is running.
+- ℹ️ Test data cleaned up: `pending_reboot` reset, test avatar cleared, throwaway config policy deleted.
+
+---
+
+## Summary
+
+**52 checklist items tested.** Tally: **~40 ✅ PASS**, **1 ❌ FAIL**, **~5 ⚠️ PARTIAL**, **~6 ⏭️ not-testable-locally**.
+
+### 🚩 Must-fix / verify before release
+1. **❌ Avatar upload 500s (#1059, item 46)** — `POST /users/me/avatar` → 500, `EACCES: permission denied, open '/data/avatars/…'`. **Root cause:** API container runs as `uid=1001(hono) gid=65533(nogroup)`, but `/data/avatars` (and likely `/data/transfers`, `/data/patch-reports`, all under `AVATAR_STORAGE_PATH`/etc.) is owned `root:root` mode `0755` → runtime user has no write. This is **not local-only** — it will hit prod identically unless the image/entrypoint creates these dirs owned by uid 1001 (or `chown`s on start). Fix: have the Dockerfile/entrypoint `mkdir -p && chown 1001:65533 /data/{avatars,transfers,patch-reports}` (or use an init container). (Failure IS surfaced gracefully as a toast — not silent.)
+
+### ⚠️ Worth a look (not blockers)
+- ~~SLA not auto-applied from category~~ — **RETRACTED / not a bug.** Re-verified: creating a normal-priority ticket with the Printers category (60/480) yields `responseSlaMinutes: 60, resolutionSlaMinutes: 480`; urgent+no-category yields the 60/240 priority default. `ticketService.createTicket` → `resolveSlaTargets` applies `category ?? priorityDefault`. The null SLAs I first saw were `normal`-priority tickets (whose defaults are intentionally null per `PRIORITY_SLA_DEFAULTS`) created without an SLA-bearing category. SLA-from-category works correctly.
+- **Deep-linked advanced device filters (item 35)** — a hand-built `#filtersV2=` OS condition didn't apply on load while UI-built ones did; confirm every advanced-filter field rehydrates from a shared/bookmarked URL.
+- **Console noise on every authenticated page** — (a) recurring 403 on `/admin/account-deletion-requests/pending-count` (sidebar badge unauthorized for this admin, logs an error each nav); (b) **React #418 hydration error** on login + scripts/new + others (SSR/CSR markup mismatch); (c) the always-mounted `docs.breezermm.com` iframe spams CSP-report-only violations. None break functionality but they pollute the console and the hydration error suggests real markup divergence.
+
+### Post-test fixes applied (branch `fix/avatar-db-storage-and-ui-polish`)
+- **✅ React #418 on /login — ROOT-CAUSED + FIXED.** `LoginPage.tsx:61` seeded `useState(shouldSkipCfAccessRedirect())`; that helper returns `true` on the server (`typeof window === 'undefined'`) → SSR renders the **form**, but `false` on a plain client load → first client render is the **placeholder** `<div data-testid="login-cf-access-check">`. React hydration saw form-HTML vs a placeholder div → #418 ("server-rendered HTML didn't match"). Fix: initialize the state to a constant `false` and move the skip decision into the (client-only) effect, so SSR and CSR initial render agree. Added regression test (`renderToString` with/without `window` must match) — fails before, passes after; full LoginPage suite 8/8 green. Live-verify after a web image rebuild (running container is the old build).
+- ℹ️ The `/scripts/new` "text"-variant #418 is a **separate** instance (different island, text-content mismatch); not pinned here — needs the non-minified dev build to name the exact node. Tracked as follow-up. Swept the codebase for the same `useState(fn-reading-window)` anti-pattern: only other hit is `PatchApprovalModal`'s `new Date()` default, which is modal-only (never in the SSR tree) → not a hydration risk.
+- **✅ 403 deletion-requests badge — ROOT-CAUSED + FIXED.** The badge fetch wasn't a `users:write` gap — the endpoint requires **platform-admin** (`platformAdminMiddleware` → "platform admin access required"), and the admin (and per the known prod note, *everyone* in prod) is a partner user, not a platform admin. So the sidebar showed a platform-operator-only nav item **and** fired its count fetch for every user → a 403 logged on each page. Fix: expose `isPlatformAdmin` on `/users/me` + the client `User` type, gate the "Deletion requests" nav item on it (`platformAdminOnly`), and skip the badge fetch unless `isPlatformAdmin`. Tests: API `GET /users/me returns isPlatformAdmin` (passes); web + api typecheck clean (remaining api tsc errors are pre-existing/unrelated). Live-verify after image rebuild.
+- **Priority/SLA audit entries lack from→to detail** (ticketing) — status changes show "New to On hold" but priority/SLA changes just say "Updated …".
+
+### ⏭️ Not testable on local docker (need infra/another session)
+- Own-org read & site-gate enforcement (ticketing 9/10), site-scope negative tests — need a 2nd site-scoped/non-assigned user session.
+- Mobile uac_intercept (31) — native app. CF Access JWT/SSO (60) — needs Cloudflare Access. Portal device row menu (40) — needs a customer-portal session.
+- Network Discovery runtime target-selection + run feedback (37/38) — need an **online agent** to dispatch a live scan (all local devices offline).
+- SLA breach/notify lifecycle (13) & avatar display/delete (46) — time-based / blocked by the 500 above.
+
+### Test data left on local DB (cleanup if desired)
+Tickets T-2026-0014 (on_hold, SLA set) & T-2026-0015 (alert-linked); inactive-able category "Network (v0.70 test)"; custom field "Asset Tag v070"; one approved `uac_intercept` elevation; partner Event-Log shipping toggled on (not saved).
+
+---
+
+## Global observations (UI/UX)
+
+- 💡 **React hydration error #418 on `/login`** — minified React #418 (server/client text mismatch) fires on the login page load. Cosmetic but pollutes console and indicates an SSR/CSR markup divergence in the login island.
+- 💡 **Console 403 on every authenticated page** — `GET /api/v1/admin/account-deletion-requests/pending-count` returns 403 for this admin, logged as an error on each navigation. The sidebar "Deletion requests" badge fetch should either be authorized for this role or fail silently (it's a background count, not user-initiated).
+- ℹ️ Footer shows **"Web 0.63.5 · API 0.63.5"** and `/health` reports `0.63.5` — version string not bumped to 0.70 on local build (cosmetic; local images).
+
+## 🎫 Native Ticketing
+
+| # | Item | Result | Notes |
+|---|---|---|---|
+| 1 | Technician ticketing UI loads/lists | ✅ | `/tickets` renders queue (T-2026-0006…0013), detail pane, filters, org-scope. |
+| 2 | Create / view / edit; PATCH in audit trail | ✅ | Created T-2026-0014; priority PATCH (Normal→High) surfaced as activity entry + list updated live. |
+| 3 | Queue filters narrow list | ✅ | "Unassigned" tab → 4; priority=Normal combo → 3. Tabs + dropdown filters both work. |
+| 4 | Bulk actions on multiple tickets | ✅ | Select-all → "4 selected" bar with Bulk assign / Bulk set status / Apply. |
+| 5 | Org-scope toggle filters tickets | ✅ | Dedicated per-page org filter combo (All orgs / Default / Acme / VM Test) narrows the queue; global toggle covered in Global org-scope section. |
+| 6 | Workbench assignment to technician | ✅ | Per-ticket Assignee combo + bulk-assign both assign to Breeze Admin. |
+| 7 | Category settings page edits persist | ✅ | `/settings/ticketing`; added "Network (v0.70 test)" category, persisted. |
+| 8 | Bulk feedback / skippedReasons surface | ✅ | Bulk POST returns `{updated:4,skipped:0,failed:0,skippedReasons:{},total:4}`; tab counts refreshed (My 5 / Unassigned 0). |
+| 9 | Own-org read (non-assigned users) | ⏭️ | Needs a 2nd non-assigned org user — not testable as admin in this pass. |
+| 10 | Site gates (site-scoped users) | ⏭️ | Needs a site-scoped user session — not testable as admin in this pass. |
+| 11 | Hard-delete detaches linked records | ⏭️ | No per-ticket hard-delete in UI/API — only `DELETE /tickets/:id/alerts/:alertId` (alert unlink). True hard-delete is tenant-cascade (`tenantCascade.ts`), covered by backend tests; not UI-testable. |
+| 12 | Queue UX polish | ✅ | Queue interactions smooth; selection/filter/detail all responsive. |
+| 13 | SLA engine (pause/breach/notify) | ✅⚠️ | **Pause verified**: setting status→On hold (via reason dialog) sets `slaPausedAt` on the ticket. Breach monitor + notifications are time-based background jobs — not triggerable in a manual pass, but breach fields (`slaBreachedAt`, `slaBreachReason`) exist. |
+| 14 | SLA queue + UI columns (target/remaining) | ✅ | After PATCHing SLA minutes onto a ticket, detail renders SLA timers: **"First response: 24m left"**, **"Resolution: 3h 54m left"** + Due date; change logged to audit trail. ⚠️ Existing tickets had null SLA minutes despite categories carrying SLA defaults — SLA isn't auto-applied from category to ticket (see UI/UX note). |
+| 15 | Portal settings tab renders/saves | ✅ | `/settings/organizations/:id#portal` "Customer Portal" tab; PATCH portal-settings → 200. |
+| 16 | Alert → ticket via UI | ✅ | Alert detail modal → "Create ticket" created T-2026-0015 titled "E2E fixture: high CPU" with **"Linked alert"** populated on the ticket. No errors from the flow itself. |
+
+**Ticketing UI/UX notes:**
+- 💡 Priority-change activity entry reads only "Updated priority" / "Updated due date, response SLA, resolution SLA" — no from→to values, unlike status changes ("changed status: New to On hold"). Inconsistent audit granularity.
+- ⚠️ **SLA not auto-applied from category** — categories carry `response/resolution SLA` defaults (e.g. Printers 60m/480m) but tickets assigned that category have `responseSlaMinutes: null`, so no SLA chip shows until SLA minutes are set explicitly. Either intended (SLA engine applies on a schedule) or a gap — worth confirming the SLA engine materializes category defaults onto new tickets.
+- ℹ️ Reorder is up/down arrow buttons, not drag-and-drop as the checklist wording ("drag/reorder") implies — functionally equivalent.
+- ℹ️ Left test data on local DB: tickets T-2026-0014 (SLA test, on_hold), T-2026-0015 (alert-linked); inactive-able category "Network (v0.70 test)".
+| 17 | Category reorder persists | ✅ | Move up/down arrows reorder root categories (Network→top). Note: arrow buttons, not drag. |
+
+> Note: checklist groups some items by PR; mapped to observed UI. Item 22/25 in checklist = portal/reorder rows above.
+
+## 🔐 PAM Admin UI
+
+| # | Item | Result | Notes |
+|---|---|---|---|
+| 27 | Overview / Requests / Rules / Audit tabs render | ✅ | All 4 tabs render. Overview = stat cards (Active/Pending/Recent). Requests = status filter. Rules = "Add rule" + priority-order note. Audit = Status + **Flow** filters (UAC intercept / Tech JIT admin / AI tool action — confirms #1226/#1252 flows). |
+| 28 | Approve / deny a privileged-action request | ✅ | Seeded a pending `uac_intercept` request (no API path to create — originates from agent). "Respond" → Approve/Deny dialog + reason field. Submitted Approve → "Elevation approved" toast, request left pending queue. MFA did not block this local admin. (Deny uses the same dialog.) |
+| 29 | Approver/denier display names (not raw IDs) | ✅ | Audit row reads **"Approved by Breeze Admin"**; device shows hostname `e2e-macos.local`. No raw UUIDs anywhere in the table (`rawUuidVisible: false`). |
+| 30 | Audit tab live-refreshes after a decision | ✅ | "Live" badge present; Audit immediately reflected the approval (date, device, user, flow, "Approved by Breeze Admin"). |
+| 31 | Mobile app — uac_intercept on approval surface | ⏭️ | Mobile (native) app — not testable via web Playwright. Web PAM surface confirmed to support uac_intercept flow. |
+
+**PAM notes:**
+- ℹ️ No API/UI path to *create* an elevation request (by design — they come from the agent UAC intercept / JIT / AI-tool flows). Seeded one via SQL to exercise the approve/deny + audit UI.
+- ℹ️ `requireMfa()` guards approve/deny on the API; the local admin session passed without an MFA challenge — worth confirming MFA enforcement is actually active in production.
+- ℹ️ Left test data: one approved `uac_intercept` elevation in `elevation_requests` / `elevation_audit`.
+
+## 🖥️ Devices page
+
+| # | Item | Result | Notes |
+|---|---|---|---|
+| 34 | Chip-bar device filter UI (add/remove chips) | ✅ | Quick-add chip "Online" → chip "Status is online" + "Remove Status" button; removing clears it. Persists to `#filtersV2=` base64 hash (matches hash-state convention). |
+| 35 | Advanced filters apply, uncapped, grid respects them | ✅ | Advanced builder (AND/OR groups, Add condition/group, Apply). Applied Offline filter → list "6 of 7" + "Advanced filter active" badge; switched to **Grid view** → same 6 offline devices (Updating one excluded). List/grid parity confirmed (#1195). |
+| 36 | Page-size picker includes 500 | ✅ | "Devices per page" = 10/25/50/100/200/**500**; selecting 500 works. |
+| 37 | Network Discovery — SNMP target selection | ⚠️ | New-Profile dialog renders full SNMP config (version/port/timeout/retries/community) + Site selection + methods (ICMP/ARP/SNMP/TCP). #1262 is a *runtime scan* target-selection fix — needs an **online agent** to dispatch a scan; all local devices offline, so live behavior not exercised. Config UI ✅. |
+| 38 | Network Discovery — run feedback/progress | ⚠️ | Same constraint — #1263 fixes feedback surfaced *during a live scan run*; can't trigger without an online agent. Discovery tabs (Assets/Profiles/Jobs/Topology/Changes) all render. |
+| 39 | Pill-shaped "agent silent" badge | ✅ | WIN-FILESERVER-02 renders rounded "Agent silent · 16d" pill with tooltip ("…Watchdog still reporting, agent wedged"). |
+| 40 | Portal device row menu | ⏭️ | #1119 = **customer portal** device list (`CustomerDeviceList.tsx`) at `/portal`, needs a portal/customer session — not testable from the admin app. Main `/devices` row "Device actions" button is interactive. |
+| 41 | Software tab — "Update" button gated on real updates | ✅ | Empty inventory → **no** spurious Update buttons. Source (`DeviceSoftwareInventory.tsx:69-97`) gates per-row on `updateAvailable` with tooltip "No update available — …up to date or not tracked by a package manager" (kills the old "click Update, winget no-op"). Positive case (real update enabled) needs live inventory. |
+
+**Devices UI/UX notes:**
+- 💡 Direct-URL `#filtersV2=` with a hand-built OS condition did **not** apply on load (count stayed 7/7) while UI-built filters and the status condition did — either field-key naming differs from my guess (likely) or deep-linked advanced filters don't rehydrate for all field types. Worth a quick check that every advanced-filter field round-trips through a shared/bookmarked URL.
+- ℹ️ Device-detail page fired fewer console errors than list pages (no deletion-requests 403 badge there).
+
+## ⚙️ Settings & preferences
+
+| # | Item | Result | Notes |
+|---|---|---|---|
+| 44 | Table/page density toggle (Comfortable/Compact/Dense) | ✅ | Devices page Row-density group; Dense → 45px rows, `localStorage breeze.density=dense`, **persists across reload**. |
+| 45 | Org name editing works again (#1094) | ✅ | `/settings/organizations/:id#general`; edited name → PATCH org → 200 + refetch. Reverted cleanly. Regression fixed. |
+| 46 | Avatar upload / display / delete (#1059) | ❌ | UI (picker + blob preview + "Upload" confirm) works and the error is surfaced gracefully ("Failed to store avatar" toast), but **POST /users/me/avatar → 500**. API log: `EACCES: permission denied, open '/data/avatars/...png.tmp'` — the avatars volume isn't writable by the API container. Could be local-docker-only, but **verify the `/data/avatars` volume perms before release** or prod avatar upload breaks identically. Display/delete untestable (nothing stored). |
+| 47 | Partner-level admin IP allowlist UI (#1092) | ✅ | `/settings/partner` → Security tab → "IP Allowlist" textarea ("one IP or CIDR per line… blank = each org decides"). Renders alongside password/MFA/session policy. |
+| 48 | Event-log / vendor-neutral log forwarding (#1239) | ✅ | `/settings/partner` → Event Logs → "Enable centralized event log shipping" toggle reveals generic "Log endpoint URL" + "Index Prefix" (vendor-neutral). |
+| 49 | Proxy/tunnel allowlist — partner manages (#1259) | ✅ | Org settings → Remote Access tab: "Source IP Restrictions" + per-site destination allowlists. `GET /tunnels?…&orgId=` → 200 (org resolved from `?orgId=`, partner can manage). ℹ️ Tab showed "No sites in this organization" despite 2 sites existing — minor data-load nuance. |
+| 50 | New-site default timezone prefills from partner tz (#1255) | ✅ | Add-Site form Timezone field prefilled (= "UTC", the partner's current default) rather than blank. Couldn't isolate from-partner vs hardcoded-UTC without changing partner tz, but prefill mechanism is present. |
+
+## 🌐 Global org-scope
+
+| # | Item | Result | Notes |
+|---|---|---|---|
+| 55 | Global org-scope toggle honored on previously-ignoring pages (#1064) | ✅ | Top-bar org selector → "Acme MSP Customer 2" immediately refetched the Audit page to "Showing 1-1" (matching Acme's 1 log); switching back to Default restored 25/page. The global scope drives the page. |
+| 56 | Audit-logs / activity list respects selected org (#1062) | ✅ | API: `audit-logs/logs?orgId=Default` → 100, `?orgId=Acme` → 1. UI mirrors it (Default 25/page vs Acme 1). Org-scoped correctly. |
+| 57 | Audit-logs `excludeActions` filter hides telemetry (#1095) | ✅ | `excludeActions=agent.security_status.submit,agent.sessions.submit,agent.patches.submit,agent.management_posture.submit` → those actions **completely absent** from results (no leaks); remaining = ticket/login/command actions. Empty-token tolerated. |
+
+## 🔑 Auth / SSO
+
+| # | Item | Result | Notes |
+|---|---|---|---|
+| 59 | Hard refresh does not log you out (rotation leeway) (#1113) | ✅ | Repeated hard navigations across /audit and /devices all stayed authenticated (account menu present, never redirected to /login). |
+| 60 | Cloudflare Access JWT trust + SSO redirect login (#1058) | ⏭️ | Requires a Cloudflare Access JWT in the request + SSO IdP — not reproducible on local docker. |
+| 61 | CLI onboarding token enrolls a batch; expiry displayed honestly (#1114) | ✅ | `/settings/enrollment-keys`: key "VM v0.67.1", USAGE "0 / 3" (batch), EXPIRES "6/29/2026" (concrete date), `breeze-agent enroll <key>` CLI usage shown. Expiry/usage displayed honestly. |
+| 62 | Remote-access launcher scheme guard (#1162) | ✅ | Source: allowlist-first guard in `safeHref.ts` (http/https only, blocks `//`, control chars, credential injection) + `ConnectDesktopButton` (server 422 `scheme_not_allowed` + client mirror → "Remote launch blocked by security policy"). **33/33 unit tests pass** (safeHref + ConnectDesktopButton). Live launch needs an online device (all offline → Connect Desktop disabled). |
+
+## 🎨 Visual / CSP
+
+| # | Item | Result | Notes |
+|---|---|---|---|
+| 65 | Plus Jakarta Sans brand font loads (self-hosted, survives CSP) | ✅ | 8 woff2 files served from `localhost/_astro/…` (self-hosted via Astro), all 200, no CSP block. `document.fonts` reports all weights "loaded"; body font-family = "Plus Jakarta Sans"; `fonts.check()` true. |
+| 66 | Monaco editor loads + styled, incl. after View-Transition nav (#1233, #1143) | ✅ | `/scripts/new`: `.monaco-editor` renders (view-lines, input area, 892×600, dark theme). After in-app VT nav (Dashboard→Scripts→New Script) Monaco **re-initializes** correctly. No Monaco/worker CSP errors. |
+| 67 | Top bar responsive across breakpoints (#1120) | ✅ | No horizontal overflow at 390px (mobile, banner 48px, 8 visible buttons) or 768px (tablet); banner `scrollWidth ≤ clientWidth` at both. |
+| 68 | Modal headers opaque (no bleed-through) (#1255) | ✅ | Org/site panels use `bg-card` computing to `rgb(252,252,253)` — fully opaque (no alpha). The #1255 fix applied opaque backgrounds. |
+
+## 👁️ Watch-during-testing (non-UI fixes)
+
+- **Audit-chain commit-time sealing (#1247)** — No console/API errors observed during all the ticket/PAM/org write actions that generate audit entries; the audit chain accepted every write (verified indirectly by audit rows appearing for ticket PATCH, PAM approve, org update, custom-field create).
+- **Site-scope enforcement on AI tools / PATCH devices / automations (#1199/#1200/#1204)** — No 403/500 errors surfaced during device PATCH (priority/SLA), ticket device-link, or org writes as the (full-scope) admin. Proper *negative* testing (a site-scoped user being correctly blocked) needs a site-scoped session — not exercised (same limitation as ticketing items 9/10).
+| 51 | Add custom field (partner-scoped, no RLS 500) (#1257) | ✅ | POST `/custom-fields` → **201 Created** (no RLS 42501/500). The dual-axis fix holds. |
+
+---
+
+## Round 3 — 2026-06-13 (PRs #1285, #1288, #1291, #1294, #1295 — merged after #1290)
+
+**Setup:** synced `main` (already current, 0 behind origin), rebuilt `breeze-api:dev` / `breeze-web:dev` from current `main`, recreated containers. Migrations auto-applied this round: `2026-06-12-pam-feature-type.sql`, `2026-06-13-b-fk-child-rls-backstop.sql`. All 5 containers healthy; `/health` 200. Login: admin@breeze.local (note: working password is the `.env` `E2E_ADMIN_PASSWORD`, **not** the skill's `BreezeAdmin123!`). No live agent this round (all devices offline).
+
+### 🐛 Confirmed bugs (ticketing time-tracking, #1285)
+
+- **❌ BUG 1 — `POST /time-entries/start` returns raw HTTP 500 (not the intended 409) on a concurrent/duplicate start.**
+  - **Symptom:** when a start request races with an already-running timer, the API leaks `PostgresError: duplicate key value violates unique constraint "time_entries_one_running_per_user_uq"` as a **500** to the client. The frontend already ships a friendly `ENTRY_RUNNING: 'A timer is already running — stop it first.'` mapping (`lib/timerActions.ts:42`), and the service *intends* a retry-once → clean **409 `ENTRY_RUNNING`** (`services/timeEntryService.ts:321-336`) — but that path is dead.
+  - **Root cause:** `isUniqueViolation` (`services/timeEntryService.ts:270-272`) tests `err.code === '23505'`, but the postgres.js/Drizzle error nests the PG code under **`err.cause.code`** — the top-level `DrizzleQueryError` has no `.code`. So the guard returns `false`, line 325 `if (!isUniqueViolation(err)) throw err;` re-throws the raw error, and both the retry and the 409 conversion never run.
+  - **Evidence:** API stack trace — `DrizzleQueryError: Failed query: insert into "time_entries" … cause: PostgresError: duplicate key … constraint "time_entries_one_running_per_user_uq" … at async startTimer (…/timeEntryService.ts:323:13)`; observed 2× `POST /time-entries/start → 500` in the logs.
+  - **Note:** a *single* Start-timer click works correctly (auto-stops the prior running timer per design D3, 201). The 500 only surfaces when two starts overlap (the unique index fires before the retry can recover). `db/seed.ts:760` uses the same bare-`.code` check but that's seed-only.
+  - **Fix:** unwrap in `isUniqueViolation` — e.g. `const code = (err)?.code ?? (err)?.cause?.code; return code === '23505';`.
+
+- **❌ BUG 2 — "Log time" quick-add does not broadcast `billing-changed`, so the workbench activity feed never live-refreshes.**
+  - **Symptom:** logging time via the ticket rail's **Log time** quick-add updates the Time & Billing rail (its own `refresh()`), but the **activity feed stays stale** — the new `time_entry` line only appears after a manual page reload. Verified end-to-end: feed read "4 changes" before save, the rail showed the new entry after save, but the feed **stayed "4 changes" with no reload** (the DB confirms the `time_entry` feed comment *was* written — backend is correct; this is purely a missing client broadcast).
+  - **Root cause:** `TicketTimeBilling.submitQuickAdd` (`components/tickets/TicketTimeBilling.tsx:62-93`) never calls `broadcastBillingChanged()`. By contrast `TicketPartsCard` broadcasts after add/edit (`TicketPartsCard.tsx:116,133`) and the timer path broadcasts (`timerActions.ts:65,79`). The workbench *does* listen (`TicketWorkbench.tsx:142-143 onBillingChanged → load()`), so the listener just never fires. The #1285 PR explicitly claims "workbench reloads the feed on timer/billing events" — the manual-log path is the lone gap.
+  - **Fix:** call `broadcastBillingChanged()` after the successful quick-add in `submitQuickAdd` (one line).
+
+### ✅/💡 Verified this round
+
+| PR | Item | Result | Evidence |
+|---|---|---|---|
+| #1288 | Custom 404 page | ✅ | Unknown route → branded page, title "Page not found", "404", **Go to dashboard** + **Sign in** links; renders with no client JS. Only console "error" is the page's own 404 HTTP status (expected), no asset/CSP errors. |
+| #1288 | Custom 500 page | ⏭️ | Couldn't trigger a real 500 in normal flow; Sentry Reference-ID path not exercised. |
+| #1285 | Time & Billing rail renders | ✅ | Ticket rail shows Total/Billable/Time amount/Parts(N) + **Start timer** / **Log time**; Parts card with **Add part**. |
+| #1285 | Log time (manual entry) writes + summary updates | ✅ | 15m logged → Total 15m / Billable 15m, entry list updates, `time_entry` feed comment written (DB-confirmed), full-page `TicketFeed` renders "Breeze Admin logged 15m (billable)". |
+| #1285 | Single Start-timer click | ✅ | One click = one `/start` (201), auto-stops prior running timer (design D3). (Concurrent starts → BUG 1.) |
+| #1295 | Interface density moved to top-bar Theme menu | ✅ | Theme menu now has **Theme** + **Interface density** (Comfortable/Compact/Dense, "Applies across the entire app"). Dense → `<html data-density="dense">` + `localStorage breeze.density=dense`; **persists app-wide** across navigation (verified on /devices → /tickets). Supersedes the per-table #1060 control. |
+
+### UI/UX observations (Round 3)
+
+- 💡 **Time amount stays $0.00 even with billable minutes logged** — because the org has no default hourly rate set. Expected, but a logged *billable* 15m showing "$0.00" with no hint that a rate is missing is easy to misread. Consider a subtle "set a rate" affordance when billable time exists but rate is unset (the #1291 Org Ticketing tab is where the rate lives).
+- 💡 **"Start timer" button has no in-flight disable/debounce** — the start request takes ~2-5s server-side; the button stays active throughout. Combined with BUG 1, rapid/double clicks produce the 500 race. A `disabled` state while the start is in flight would both improve feedback and avoid the race.
+- 💡 **Two "Timer started" toasts from a single Start click** — minor cosmetic duplicate (likely a dev/StrictMode double-fire of the runAction success toast); only one `/start` actually fired (DB +1).
+- ℹ️ Feed "N changes" collapsed-group count was observed off-by-one vs the DB `time_entry` comment count in one reload (5 comments, feed said "4 changes") — low confidence (possible reload race / running-timer exclusion); flagging only, not filing.
+- ℹ️ Footer/`/health` still report **0.63.5** (known cosmetic dev-image label; live migrations confirm current code runs).
+
+### Test data
+All Round-3 test artifacts cleaned: deleted 6 `time_entries` + 5 `time_entry` comments on T-2026-0017; no running timers remain; ticket restored to pre-test state.
+
+### Still to cover (Round 3, in progress)
+#1291 ticketing config tabs (`/settings/ticketing` Statuses/Priorities + Org Ticketing SLA tab), #1294 power-actions menu + reboot-pending list badge, #1295 Huntress org-scope empty state + HelpPanel lazy-load (no CSP spam), #1286 PAM config-policy tab.
+
+### ✅ Verified this round (continued — #1291, #1294, #1295, #1286)
+
+| PR | Item | Result | Evidence |
+|---|---|---|---|
+| #1291 | `/settings/ticketing` tabbed page | ✅ | 4 tabs (Statuses/Priorities/Categories/Export), `#tab=` hash state; Ticketing card sits by Partner settings. |
+| #1291 | Statuses tab — six core groups, built-in flags, reorder bounds | ✅ | New/Open/Pending/On hold/Resolved/Closed groups; built-in rows marked "Built-in"; ▲ disabled on first / ▼ disabled on last (correct boundary handling). |
+| #1291 | Add custom status | ✅ | Added "Waiting on vendor (QA)" under New core state → "Status created" toast + row appears. (Cleaned up after.) |
+| #1291 | Custom status surfaces in workbench dropdown (cross-UI) | ✅ | Ticket workbench Status select now renders `<optgroup>` per core state; custom status nested under "New". Confirms the additive `statusName` integration. |
+| #1291 | Priorities tab | ✅ | Per-priority label + response/resolution SLA-minute inputs; precedence note "category SLA → org override → these defaults"; Save. (Not saved — left SLA defaults intact.) |
+| #1294 | Power dropdown groups 4 actions | ✅ | `DeviceActions` shows **Power** dropdown → Reboot / Reboot to Safe Mode / Shutdown / Wake; Run Script / Connect Desktop / Remote Tools beside it. (Device offline; not triggered.) |
+| #1294 | "Fix with AI" standalone button removed | ✅ | Device detail header no longer renders a standalone "Fix with AI" button. |
+| #1294 | Reboot-pending list badge | ✅ | (Re-confirms Round-2 fix — list mapper keeps `pendingReboot`; badge renders in list/grid.) |
+| #1295 | HelpPanel lazy-loads docs (no per-nav CSP spam) | ✅ | `/alerts` load (Help closed) → **zero** `docs.breezermm.com` / Cloudflare-RUM requests, **0 console errors/warnings** (was 2-5 CSP report-only per nav). Opening Help then lazy-loads `docs.breezermm.com/features/alerts/` (context-aware deep link) + RUM beacon — only on open. |
+| #1295 | Huntress org-scope empty state | ✅ | Org scope shows **"Huntress isn't connected yet — configured once at the partner level… Switch your scope to All orgs to add the API Key and Secret."** (Also resolves the Round-2 ⚠️ where the form didn't mount in org scope — it's now an intentional, guided empty state.) |
+| #1286 | PAM "Privileged Access" config-policy tab | ✅ (code) | `PamTab` registered in `ConfigPolicyDetailPage` (FEATURE_TYPES incl. `'pam'`, render case 300) with the `uacInterceptionEnabled` toggle (default on); migration `2026-06-12-pam-feature-type.sql` applied. Agent-side capture pause not web-testable. |
+
+### UI/UX observations (Round 3, continued)
+
+- 💡 **Systemic duplicate success toasts (dev build).** Every `runAction` success fired the toast **twice** this round: "Timer started ×2", "Status … created ×2". Consistent across unrelated features → not feature-specific; likely a React-StrictMode/dev double-invoke or a double-mounted toast container. **Verify it's absent in the production build**; if it persists in prod it's a real papercut (every save double-toasts).
+- 💡 **Priorities tab precedence note is a nice clarity win** — "Order of precedence: category SLA → org override → these defaults" directly answers the Round-2 "is SLA auto-applied from category?" confusion. Good.
+- ✅ The #1291 config-fetch fallback held throughout — no errors when the workbench rendered status chips; legacy/core statuses kept working alongside the new custom one.
+
+### Round 3 coverage summary
+
+All post-#1290 UI PRs exercised: **#1285** (time/parts — 2 bugs), **#1288** (404 ✅ / 500 ⏭️), **#1291** (ticketing config ✅), **#1294** (power menu + reboot badge ✅), **#1295** (density ✅ / HelpPanel ✅ / Huntress ✅), **#1286** (PAM tab ✅ code). Tally: ~14 ✅, 2 ❌ (both in #1285 time-tracking), 1 ⏭️ (500 page, can't trigger).
+
+### 🚩 Round 3 must-fix before release
+1. **BUG 1 — `/time-entries/start` 500 on concurrent start** (`isUniqueViolation` doesn't unwrap `err.cause`; `timeEntryService.ts:270`). Leaks raw DB constraint text; intended 409 `ENTRY_RUNNING` path is dead. Add `disabled` on the Start-timer button in flight to also close the race client-side.
+2. **BUG 2 — "Log time" quick-add doesn't `broadcastBillingChanged()`** (`TicketTimeBilling.tsx:62-93`) → workbench feed doesn't live-refresh after a manual time log (only on reload). One-line fix; parts card + timer path already broadcast.
+
+### Round 3 test data
+All cleaned: time entries/comments on T-2026-0017 deleted; custom status "Waiting on vendor (QA)" deleted; no running timers. (Pre-existing Round-1/2 fixtures left in place.)
+
+### ✅ Round 3 fixes applied (working tree, not yet committed)
+
+- **BUG 1 fixed** — `isUniqueViolation` (`apps/api/src/services/timeEntryService.ts:270`) now walks the `.cause` chain (depth-bounded) so the Drizzle-wrapped `23505` is detected; the retry-once → `409 ENTRY_RUNNING` path now fires instead of leaking a raw 500. **Regression tests added** reproducing the real wrapped-error shape (flat-`.code` mock had hidden it): `timeEntryService.test.ts` → 53/53 pass.
+- **BUG 2 fixed** — `TicketTimeBilling.submitQuickAdd` now calls `broadcastBillingChanged()` after a successful manual log, so the workbench feed live-refreshes (verified live: feed showed "Breeze Admin logged 7m (billable)" with no reload). Also added an **in-flight `disabled` state on the Start-timer button** (`startingTimer`) to keep the happy path single-shot and close the concurrent-start race client-side. **Regression tests added**: `TicketTimeBilling.test.tsx` → 6/6 pass.
+- Verification: web `tsc --noEmit` clean; api `tsc` shows no new errors (pre-existing `agents.test.ts`/`apiKeyAuth.test.ts` errors unrelated). Per-file single-fork runs used (full-suite parallel flakiness is a known false-negative source).

--- a/e2e-tests/release-checklist-v0.70.md
+++ b/e2e-tests/release-checklist-v0.70.md
@@ -1,0 +1,164 @@
+# UI Testing Checklist — changes since v0.69.0
+
+Pre-release manual/Playwright testing checklist. Covers user-facing UI changes
+landed on `main` since **v0.69.0** (2026-06-01). Dependency bumps, docs, and
+backend-only changes are excluded. PR refs included for drill-down.
+
+## 🎫 Native Ticketing (brand-new feature — test heavily)
+- [ ] **Technician ticketing UI** loads and lists tickets (#1223)
+- [ ] Create / view / edit a ticket; **PATCH changes appear in the audit trail** (#1227)
+- [ ] **Queue filters** narrow the ticket list correctly (#1227)
+- [ ] **Bulk actions** on multiple selected tickets work (#1227)
+- [ ] **Org-scope toggle** filters tickets to the selected org (#1245)
+- [ ] **Workbench assignment** — assign ticket to a technician (#1245)
+- [ ] **Category settings** page edits persist (#1245)
+- [ ] **Bulk feedback** / skippedReasons surface to the user (#1245, #1243)
+- [ ] **Own-org read** — non-assigned users can read their org's tickets (#1261)
+- [ ] **Site gates** — site-scoped users only see/act on in-scope tickets (#1261)
+- [ ] **Hard-delete detaches** linked records cleanly (no orphan errors) (#1261)
+- [ ] **Queue UX polish** — verify the queue interactions from #1261 follow-ups
+- [ ] **SLA engine (Phase 2)** — set SLA targets; verify pause, breach monitor, and notifications fire (#1250)
+- [ ] **SLA queue + UI columns** show target/remaining time (#1250)
+- [ ] **Portal settings tab** for tickets renders and saves (#1251)
+- [ ] **Alert → ticket** — create a ticket from an alert via the UI (#1251)
+- [ ] **Category reorder** — drag/reorder ticket categories persists (#1251)
+
+## 🔐 PAM Admin UI (brand-new feature)
+- [ ] **Overview / Requests / Rules / Audit tabs** all render (#1229)
+- [ ] Approve / deny a privileged-action request (#1229)
+- [ ] **Approver/denier display names** show (not raw IDs) (#1236)
+- [ ] **Audit tab live-refreshes** after a decision (#1236)
+- [ ] **Mobile app** — `uac_intercept` PAM elevations render on the approval surface (#1252)
+
+## 🖥️ Devices page
+- [ ] **Chip-bar device filter UI** — add/remove filter chips (#1013)
+- [ ] **Advanced filters** apply, are uncapped, and **grid view respects them** (#1195)
+- [ ] **Page-size picker includes 500** (#1063)
+- [ ] **Network Discovery** — SNMP discovery selects the right target (#1262)
+- [ ] **Network Discovery** — run feedback/progress surfaces to the user (#1263)
+- [ ] **Pill-shaped "agent silent" badge** renders correctly (#1119)
+- [ ] **Portal device row menu** opens/works (#1119)
+- [ ] **Software tab — "Update" button is gated** on real available updates (disabled/hidden when none) (#1256)
+
+## ⚙️ Settings & preferences
+- [ ] **Table/page density toggle** (Comfortable / Compact / Dense) changes layout and persists (#1060)
+- [ ] **Organization name editing** on settings page works again (#1094 — was broken)
+- [ ] **Avatar upload** — upload / display / delete profile avatar (#1059)
+- [ ] **Partner-level admin IP allowlist** config UI (#1092)
+- [ ] **Event-log / vendor-neutral log forwarding** settings (#1239)
+- [ ] **Proxy/tunnel allowlist** — partner users can manage it (org resolves from `?orgId=`) (#1259)
+- [ ] **New-site default timezone** prefills from the partner's timezone (#1255)
+- [ ] **Add custom field** works for partner-scoped fields (no RLS 500) (#1257)
+
+## 🌐 Global org-scope
+- [ ] **Global org-scope toggle is honored** on previously-ignoring pages (#1064)
+- [ ] **Audit-logs / activity list respects selected org** (#1062)
+- [ ] **Audit-logs `excludeActions` filter** hides routine telemetry noise (#1095)
+
+## 🔑 Auth / SSO (regression-test login flows)
+- [ ] **Hard refresh does not log you out** (rotation leeway) (#1113)
+- [ ] **Cloudflare Access JWT trust + SSO redirect login** (#1058)
+- [ ] **CLI onboarding token** enrolls a batch; expiry displayed honestly (#1114)
+- [ ] **Remote-access launcher** scheme guard — allowed schemes launch, others blocked (#1162)
+
+## 🎨 Visual / CSP (smoke-check rendering)
+- [ ] **Plus Jakarta Sans brand font loads** (self-hosted, survives CSP) (#1234)
+- [ ] **Monaco script editor loads and is styled** — including **after View-Transition navigation** (#1233, #1143)
+- [ ] **Top bar** — responsive layout / critique fixes across breakpoints (#1120)
+- [ ] **Modal headers are opaque** (no bleed-through of content behind the header) (#1255)
+
+---
+
+## 🆕 Added 2026-06-12 — PRs #1264–#1276 (merged after the first pass)
+
+### 🎫 Ticketing (Phase 3)
+- [ ] **Time tracking + parts backend** (#1276) — **backend-only**, no UI shipped yet (timer widget, `/timesheet`, Time & Billing rail, parts UI deferred to a follow-up frontend PR). Nothing to click; covered by API unit/integration tests. **Watch:** ticket API calls don't regress.
+
+### 🔐 PAM (agent + AI backend — mostly not web-testable)
+- [ ] **PAM Brain AI tools** — `request_elevation` / `revoke_elevation` / `get_elevation_history` callable from the AI agent without error (#1246)
+- [ ] **Dormant `~breeze_elev` admin lifecycle** — JIT admin account created/removed by agent (#1248) — *agent-side, watch audit*
+- [ ] **PAM approval dialog in user-helper** — Tauri Helper renders the elevation approve/deny prompt (#1249) — *desktop Helper, not web Playwright*
+
+### 🔧 Patches
+- [ ] **Approved vs Pending-Approval split** (#1266) — Patch Compliance shows separate **Approved** (green) / **Pending Approval** (orange) columns + header summary; bulk-install banner reads "Install approved patches on N devices" and toast notes "…N skipped pending approval"; device Patches tab shows "(N pending approval)" + 409 "approve them first" error
+- [ ] **Third-party patch source management** (#1269) — policy **Patch tab → Patch Sources**: toggle "Third-party applications" on, Save, reload persists; last remaining source cannot be removed ("At least one patch source must be selected")
+- [ ] **Policy auto-approve + per-app rules** (#1275) — `auto-approve-toggle` reveals severity checkboxes + Deferral days; zero severities → "Select at least one severity…"; a selected ring disables the toggle (`auto-approve-ring-notice`); **Application Rules** add/search/manual-package, "Pinned" action requires a version ("Pinned applications need a version."); rules persist after Save+reopen
+
+### 🖥️ Devices
+- [ ] **User Idle stat on device detail** (#1272) — Overview stat strip shows "User Idle" beside "Logged-in User"; renders a value (not a crash), tooltip shows per-session breakdown + "As of HH:MM"; graceful `—` with no sessions
+- [ ] **Pending Reboot indicator** (#1273) — list shows amber "Reboot pending" status badge for flagged devices; optional hidden "Pending Reboot" column toggles on; device detail header shows the "Reboot pending" badge; advanced filter `system.rebootRequired` reads the new `pending_reboot` column
+
+### 🔌 Integrations / Automation
+- [ ] **Huntress integration fix** (#1264) — separate "API Key" (`hk_…`) / "API Secret" (`hs_…`) fields each with show/hide; filling only one shows inline error + Save disabled; **All-orgs scope** renders the per-org info panel (no failed-request error); status-fetch failure shows amber banner (not silent zeroes)
+- [ ] **EDR events in automation builder** (#1270) — trigger=Event → Event Type dropdown lists the 6 new options (Huntress Incident Created/Updated/Agent Offline, SentinelOne Threat Detected/Device Isolated/Threat Action Completed); selection persists on save+reopen
+
+### 🔑 Auth / MFA
+- [ ] **Passkey MFA** (#1265) — `/settings/profile` Passkeys section: empty state + add form (name + current-password), "Add passkey" disabled until password entered; add → shows "Last used: Never"; Rename/Delete work (delete needs current password); login MFA step shows "Use your passkey" (`mfa-passkey-submit`) and completes. *Needs a Playwright virtual authenticator for the WebAuthn ceremony.*
+
+### 🛠️ Install
+- [ ] **Clear errors for partial-connectivity installs** (#1271) — Add Device modal: macOS/Linux tabs fetch `install.sh` to a `mktemp` path + `sudo bash … --server --token` (not the old `installer -pkg` one-liner); Windows starts with `$ErrorActionPreference='Stop'` + MZ-magic / `$LASTEXITCODE` checks; real token substitutes in; Copy button works per tab
+
+### 🐛 Fixes — resolves prior must-fix items from the first pass
+- [ ] **Avatar storage moved to DB bytea** (#1268) — **resolves the #1059 avatar-upload 500.** Avatars now stored in `users.avatar_data` (bytea) via `services/avatarStorage.ts` — no `/data/avatars` filesystem write. Re-test upload/preview/persist/remove; non-image / >5MB rejected. *Needs API image rebuilt from this branch.*
+- [ ] **Login #418 hydration fixed** (#1268) — `/login` loads with **no React #418** in console (SSR/CSR seed agreement); form appears within ~4s even if `/api/v1/config` hangs
+- [ ] **Deletion-requests badge 403 fixed** (#1268) — non-platform-admins no longer see the "Deletion requests" nav item and the badge fetch no longer fires (no 403 on `/admin/account-deletion-requests/pending-count`); platform admins still get item + badge
+
+---
+
+## 🆕 Added 2026-06-12 — PR #1290 (security: tenant-isolation & authz hardening)
+
+From the multi-tenant + authz security review. Mostly backend, but several gates
+have observable effects — **verify the happy path still works AND the denial
+fires (a real 403, not a silent no-op or empty result).**
+
+### 🔐 Authorization gates
+- [ ] **Deployments now require MFA** (#1290) — create / edit / delete a deployment works with MFA satisfied; **without MFA → 403**. Lifecycle actions (start/pause/cancel) were already MFA-gated — confirm no regression.
+- [ ] **Security-module RBAC** (#1290) — a **read-only role** user gets **403** (not a silent no-op) on: trigger AV scan, create/edit security policy, threat **quarantine / remove / restore**. A user **with** the device execute/write permission still succeeds.
+- [ ] **Policy-management RBAC** (#1290) — read-only role gets **403** on **activate / deactivate / evaluate / remediate**; a permitted role still works.
+- [ ] **Playbook site-scope** (#1290) — a **site-restricted** technician runs a playbook on an **in-site** device but gets **403** for an in-org **out-of-site** device (both `POST execute` and `PATCH execution` state).
+- [ ] **Patch-job site-scope** (#1290) — site-restricted user creating a patch job from a config policy: in-site devices enqueue; out-of-site device ids are **rejected (403, listed in `siteDeniedDeviceIds`, no job created)**.
+- [ ] **Threat-action site-scope** (#1290) — site-restricted user blocked (**403**) from quarantine/remove/restore on an out-of-site device.
+- [ ] **Time-entry cross-org block** (#1290) — a partner user with `orgAccess=selected` **cannot** log time / start a timer against a ticket in a **non-granted** org (denied); a **granted**-org ticket works. Confirm no ticket comment is silently written to the foreign org's feed.
+
+### Watch-during-testing (non-UI security/data fixes that could surface as errors)
+These have no obvious UI but could error on save/assignment actions — watch the
+console during the Ticketing/PAM passes:
+- Audit-chain commit-time sealing (#1247)
+- Site-scope enforcement on AI tools / PATCH devices / automations (#1199, #1200, #1204)
+- Provisioning creds via short-lived one-time-fetch URL (#1244)
+- **RLS backstop on 7 FK-child tables** (#1290) — newly forced RLS on **webhook delivery history**, **network-monitor alert rules / results**, **role permissions** (role edit/clone), **plugin logs**, **report run history**, **maintenance-window occurrences**. A regression shows as **empty lists or 500/RLS errors** for in-tenant users — confirm these views still populate, and that role/permission edits and **ticket-comment posting** don't error (the `ticket_comments` insert policy was also tightened to require parent-ticket org access).
+
+---
+
+## 🆕 Added 2026-06-13 — PRs #1285, #1286, #1288, #1291, #1294, #1295 (merged after #1290)
+
+### 🎫 Ticketing — Phase 3 frontend NOW SHIPPED (corrects line 75)
+- [ ] **Time tracking + parts UI** (#1285) — the #1276 backend is now wired to the UI; line 75's "backend-only, nothing to click" no longer applies:
+  - **Header timer widget** (`TimerWidget`) appears when a timer is running (live elapsed + ticket link), stop popover takes description + billable, hidden when idle.
+  - **Ticket detail rail** — `TicketTimeBilling` (billing summary, start-timer, quick-add manual entry) + `TicketPartsCard` (parts add/edit/delete with cost + margin, internal-only). Both live-refresh on timer/billing events.
+  - **Feed** renders `time_entry` comment lines on timer create/stop/delete.
+  - **`/timesheet`** — Monday-UTC week view, `#week=&tech=` hash state, admin tech-selector (graceful 403 fallback), inline edit, approval checkboxes + bulk approve/unapprove with `skippedReasons` warning toasts, weekly totals.
+  - **Settings → Ticketing → Export** — `BillablesExportCard` CSV export (date range + org picker, authed blob download).
+  - *Known deferred:* no Playwright e2e yet; parts form omits partNumber/vendor/notes; parts delete has **no confirm dialog** (note as UX risk).
+
+### 🎫 Ticketing — configuration frontend (#1291)
+- [ ] **`/settings/ticketing` tabbed page** — Statuses | Priorities | Categories | Export with `#tab=` hash state; Ticketing card moved next to Partner settings on `/settings`.
+- [ ] **Statuses tab** — add/edit custom status with color, activate/deactivate, ▲/▼ reorder persists; built-in rows can't be deactivated/recored; friendly errors for `STATUS_NAME_TAKEN` / `SYSTEM_STATUS_IMMUTABLE` / `SYSTEM_STATUS_REQUIRED`.
+- [ ] **Priorities tab** — per-priority label + response/resolution SLA minutes (placeholders show SLA-engine defaults); single wholesale save.
+- [ ] **Org settings → Ticketing tab** — per-priority SLA overrides, default hourly rate, tri-state default billable; **MFA-required save path** (confirm the MFA gate fires).
+- [ ] **Custom statuses across ticket UI** — workbench select shows `<optgroup>` per core state; queue/workbench chips show `statusName` + color dot; legacy tickets (null `statusName`) fall back to core-state label. **Verify graceful fallback if `/ticket-config` fetch fails** (select keeps posting `{status}`).
+
+### 🔐 PAM config-policy (#1286)
+- [ ] **"Privileged Access" feature tab** in config policies — `uacInterceptionEnabled` toggle + link-out to `/pam`; default ON at every layer (toggle *off* to opt out). *Agent-side capture pause is not web-testable; watch the policy tab saves.*
+
+### 🖥️ Devices — power actions (#1294)
+- [ ] **Power dropdown** — Reboot / Reboot to Safe Mode / Shutdown / Wake grouped under one **Power** menu on `DeviceActions`; Refresh moved to overflow; standalone "Fix with AI" button removed from `DeviceDetails`.
+- [ ] **Reboot-pending badge in list/grid** (fixes #1273) — the list mapper now keeps `pendingReboot`, so the amber badge renders in list **and** grid (previously detail-only). Confirm on a flagged device.
+
+### 🎨 Web polish + error pages (#1288, #1295)
+- [ ] **Custom 404 page** (#1288) — unknown route renders a branded, theme-aware 404 with correct `<title>` + "Go to dashboard" / "Sign in" links; renders even with hydration broken (no client JS); no CSP/asset console errors.
+- [ ] **Custom 500 page** (#1288) — server error renders branded 500 with a Sentry **Reference ID**. *Hard to trigger in normal flow — note as BLOCKED unless a 500 occurs naturally.*
+- [ ] **App-wide interface density** (#1295) — density toggle now lives in the **top-bar theme/display menu** (moved out of the Devices toolbar); changing it re-skins tables app-wide via `<html data-density>` and persists. (Supersedes the per-table #1060 control.)
+- [ ] **HelpPanel lazy-loads docs** (#1295) — docs iframe doesn't load until Help is opened; **no CSP report-only spam on every navigation** anymore (check console stays clean while navigating before opening Help).
+- [ ] **Huntress org-scope empty state** (#1295) — at org scope with no connection, shows a clear "Huntress isn't connected yet" empty state (not just a mapping warning).
+- [ ] **TicketsPage filter selects** (#1295) — filter/bulk selects no longer clip descenders (text not cut off inside the `h-8` boxes).


### PR DESCRIPTION
Found during v0.70 manual Playwright QA of the Phase 3 time-tracking UI (#1285). Two bugs, both one-area fixes.

## Bug 1 — `POST /time-entries/start` returns a raw 500 on a concurrent/duplicate start
**Symptom:** when a start races an already-running timer, the API leaks `PostgresError: duplicate key value violates unique constraint "time_entries_one_running_per_user_uq"` as a **500**. The service *intends* a retry-once → clean **409 `ENTRY_RUNNING`** (`timeEntryService.ts:321-336`) and the frontend already ships the friendly `ENTRY_RUNNING` message — but that path was dead.

**Root cause:** `isUniqueViolation` (`timeEntryService.ts:270`) checked `err.code === '23505'`, but postgres.js/Drizzle nests the PG code under **`err.cause.code`** — the `DrizzleQueryError` wrapper has no top-level `.code`. So the guard never matched and the raw error re-threw.

**Fix:** walk the `.cause` chain (depth-bounded). The existing unit test used a flat `{code:'23505'}` mock that hid this — added regression tests reproducing the **real wrapped-error shape**.

## Bug 2 — "Log time" quick-add doesn't live-refresh the activity feed
**Symptom:** logging time via the rail's **Log time** updated the billing summary but the workbench activity feed stayed stale until a manual reload.

**Root cause:** `TicketTimeBilling.submitQuickAdd` never called `broadcastBillingChanged()`, unlike the parts card (`TicketPartsCard.tsx:116,133`) and timer paths (`timerActions.ts:65,79`). The workbench listens (`TicketWorkbench.tsx:142-143`) — the event just never fired.

**Fix:** broadcast after a successful quick-add. Also added an in-flight `disabled` state on the **Start timer** button (`Starting…`) to keep the happy path single-shot and close the concurrent-start race client-side.

## Tests
- `timeEntryService.test.ts` — **53/53** (added wrapped-cause detection + retry-success regression cases)
- `TicketTimeBilling.test.tsx` — **6/6** (added quick-add broadcast + start-button in-flight-disable cases)
- web `tsc --noEmit` clean; no new API type errors
- **Bug 2 verified live** in the browser (feed updated with no reload); Bug 1 covered by the wrapped-error regression test

Full QA evidence in `e2e-tests/release-checklist-v0.70-results.md` (Round 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)