### PR TITLE
fix(ticketing): config-settings hydration mismatch + shared pg unique-violation unwrap

### DIFF
--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -4,6 +4,7 @@ import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
+import { isPgUniqueViolation } from '../../utils/pgErrors';
 import {
   getConfigPolicy,
   assignPolicy,
@@ -86,8 +87,8 @@ assignmentRoutes.post(
       });
 
       return c.json(assignment, 201);
-    } catch (err: any) {
-      if (err?.code === '23505') {
+    } catch (err: unknown) {
+      if (isPgUniqueViolation(err)) {
         return c.json({ error: 'This policy is already assigned to this target at this level' }, 409);
       }
       throw err;

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -5,6 +5,7 @@ import { hasSatisfiedMfa, requirePermission, requireScope } from '../../middlewa
 import { backupInlineSettingsSchema, patchInlineSettingsSchema } from '@breeze/shared/validators';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
+import { isPgUniqueViolation } from '../../utils/pgErrors';
 import {
   getConfigPolicy,
   addFeatureLink,
@@ -126,8 +127,8 @@ featureLinkRoutes.post(
       });
 
       return c.json(link, 201);
-    } catch (err: any) {
-      if (err?.code === '23505') {
+    } catch (err: unknown) {
+      if (isPgUniqueViolation(err)) {
         return c.json({ error: `Feature type "${data.featureType}" already linked to this policy` }, 409);
       }
       throw err;

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -11,6 +11,7 @@ import {
 } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { enqueueBaselineScan } from '../jobs/networkBaselineWorker';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 import {
   normalizeBaselineAlertSettings,
   normalizeBaselineScanSchedule
@@ -305,8 +306,7 @@ networkBaselineRoutes.post(
 
       return c.json(mapBaselineRow(created), 201);
     } catch (error) {
-      const pgError = error as { code?: string };
-      if (pgError.code === '23505') {
+      if (isPgUniqueViolation(error)) {
         return c.json({ error: 'Baseline already exists for this org/site/subnet' }, 409);
       }
       throw error;

--- a/apps/api/src/routes/networkKnownGuests.ts
+++ b/apps/api/src/routes/networkKnownGuests.ts
@@ -6,6 +6,7 @@ import { db } from '../db';
 import { networkKnownGuests } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 
 export const networkKnownGuestsRoutes = new Hono();
 const requireKnownGuestRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
@@ -64,7 +65,7 @@ networkKnownGuestsRoutes.post(
 
       return c.json({ data: guest }, 201);
     } catch (err: unknown) {
-      if (typeof err === 'object' && err !== null && (err as Record<string, unknown>).code === '23505') {
+      if (isPgUniqueViolation(err)) {
         return c.json({ error: 'This MAC address is already in your known guests list' }, 409);
       }
       throw err;

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -1,4 +1,5 @@
 import { db } from '../db';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 import { configurationPolicies, configPolicyFeatureLinks, configPolicyAssignments, automationPolicyCompliance } from '../db/schema';
 import { eq, and, desc, isNull, isNotNull, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
@@ -233,8 +234,8 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
           message: `Policy "${policy.name}" assigned to ${input.level} ${input.targetId}`,
           assignmentId: assignment.id,
         });
-      } catch (err: any) {
-        if (err?.code === '23505') {
+      } catch (err: unknown) {
+        if (isPgUniqueViolation(err)) {
           return JSON.stringify({ error: 'This policy is already assigned to this target at this level' });
         }
         throw err;
@@ -602,8 +603,8 @@ For link-only types, set featurePolicyId instead of inlineSettings:
             input.inlineSettings ?? null
           );
           return JSON.stringify({ success: true, featureLink: link });
-        } catch (err: any) {
-          if (err?.code === '23505') {
+        } catch (err: unknown) {
+          if (isPgUniqueViolation(err)) {
             return JSON.stringify({ error: `Feature type "${featureType}" already exists on this policy. Use update action instead.` });
           }
           throw err;

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -8,6 +8,7 @@
 
 import type Anthropic from '@anthropic-ai/sdk';
 import { db } from '../db';
+import { pgErrorCode } from '../utils/pgErrors';
 import {
   automationPolicies,
   automationPolicyCompliance,
@@ -84,7 +85,7 @@ function safeHandler(toolName: string, fn: FleetHandler): FleetHandler {
       return await fn(input, auth);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Internal error';
-      const code = (err as { code?: string }).code;
+      const code = pgErrorCode(err);
       console.error(`[fleet:${toolName}]`, input.action, message, err);
 
       // Surface specific DB constraint errors instead of generic "Operation failed"

--- a/apps/api/src/services/aiToolsNetwork.ts
+++ b/apps/api/src/services/aiToolsNetwork.ts
@@ -11,6 +11,7 @@
 
 import { isIP } from 'node:net';
 import { db } from '../db';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 import {
   devices,
   deviceIpHistory,
@@ -340,8 +341,7 @@ export function registerNetworkTools(aiTools: Map<string, AiTool>): void {
 
         return JSON.stringify({ success: true, baselineId: created.id, action: 'created' });
       } catch (error) {
-        const pgError = error as { code?: string };
-        if (pgError.code === '23505') {
+        if (isPgUniqueViolation(error)) {
           return JSON.stringify({ error: 'Baseline already exists for this org/site/subnet' });
         }
         throw error;

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -7,6 +7,7 @@
  */
 
 import { db } from '../db';
+import { pgErrorCode } from '../utils/pgErrors';
 import { patchPolicies } from '../db/schema/patches';
 import { softwarePolicies } from '../db/schema/softwarePolicies';
 import { peripheralPolicies } from '../db/schema/peripheralControl';
@@ -33,7 +34,7 @@ function safeHandler(toolName: string, fn: Handler): Handler {
       return await fn(input, auth);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Internal error';
-      const code = (err as { code?: string }).code;
+      const code = pgErrorCode(err);
       console.error(`[policy-prereq:${toolName}]`, input.action, message, err);
       if (code === '23503') return JSON.stringify({ error: 'Referenced record not found.' });
       if (code === '23505') return JSON.stringify({ error: 'Duplicate entry — a record with this name already exists.' });

--- a/apps/api/src/services/ticketConfigService.test.ts
+++ b/apps/api/src/services/ticketConfigService.test.ts
@@ -144,13 +144,15 @@ describe('createTicketStatus', () => {
   });
 
   it('maps a 23505 unique violation to STATUS_NAME_TAKEN 409', async () => {
-    dbMocks.insertErrors.push(Object.assign(new Error('dup'), { code: '23505' }));
+    dbMocks.insertErrors.push(Object.assign(new Error('dup'), { code: '23505', constraint: 'ticket_statuses_partner_name_uq' }));
     await expect(createTicketStatus(PARTNER, { name: 'New', coreStatus: 'new' }))
       .rejects.toMatchObject({ status: 409, code: 'STATUS_NAME_TAKEN' });
   });
 
-  it('maps a constraint-name violation to STATUS_NAME_TAKEN', async () => {
-    dbMocks.insertErrors.push(new Error('violates ticket_statuses_partner_name_uq'));
+  it('maps a constraint-name violation surfaced only in the message to STATUS_NAME_TAKEN', async () => {
+    // postgres.js sets code 23505 but some wrappers drop the discrete .constraint
+    // field — the helper then falls back to scanning the message.
+    dbMocks.insertErrors.push(Object.assign(new Error('violates unique constraint "ticket_statuses_partner_name_uq"'), { code: '23505' }));
     await expect(createTicketStatus(PARTNER, { name: 'New', coreStatus: 'new' }))
       .rejects.toMatchObject({ code: 'STATUS_NAME_TAKEN' });
   });
@@ -213,7 +215,7 @@ describe('updateTicketStatus', () => {
     vi.mocked(db.update).mockImplementationOnce(() => ({
       set: vi.fn(() => ({
         where: vi.fn(() => ({
-          returning: vi.fn(() => Promise.reject(Object.assign(new Error('dup'), { code: '23505' }))),
+          returning: vi.fn(() => Promise.reject(Object.assign(new Error('dup'), { code: '23505', constraint: 'ticket_statuses_partner_name_uq' }))),
         })),
       })),
     }) as any);

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -4,6 +4,7 @@ import { eq, and, asc, inArray } from 'drizzle-orm';
 import { ticketStatuses, ticketPrioritySettings, orgTicketSettings } from '../db/schema';
 import { ticketStatusEnum } from '../db/schema/portal';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 import type {
   CreateTicketStatusInput, UpdateTicketStatusInput, PrioritySettingsInput,
   OrgTicketSettingsInput, TicketPriorityValue
@@ -284,19 +285,12 @@ export class TicketConfigServiceError extends Error {
 const PRIORITIES: TicketPriorityValue[] = ['low', 'normal', 'high', 'urgent'];
 
 function isUniqueNameViolation(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const code = (err as { code?: unknown }).code;
-  const constraint = (err as { constraint?: unknown }).constraint;
-  const message = (err as { message?: unknown }).message;
-  // When the driver surfaces a constraint name, only treat it as a name collision
-  // if it specifically targets the name uniqueness index. Other 23505s (e.g.
-  // ticket_statuses_partner_core_status_system_uq) must propagate as-is.
-  if (typeof constraint === 'string') {
-    return constraint === 'ticket_statuses_partner_name_uq';
-  }
-  // No constraint field from the driver: fall back on code + message scan.
-  if (code === '23505') return true;
-  return typeof message === 'string' && message.includes('ticket_statuses_partner_name_uq');
+  // Only the name-uniqueness index counts as a name collision; other 23505s
+  // (e.g. ticket_statuses_partner_core_status_system_uq) must propagate as-is.
+  // isPgUniqueViolation unwraps the DrizzleQueryError `.cause` — a bare
+  // `err.code` check missed every wrapped insert and leaked a 500 (BUG: dup
+  // status name returned 500 instead of STATUS_NAME_TAKEN).
+  return isPgUniqueViolation(err, 'ticket_statuses_partner_name_uq');
 }
 
 type PriorityConfig = {

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -3,6 +3,7 @@ import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { timeEntries, ticketParts, tickets, ticketCategories, organizations, users, ticketComments } from '../db/schema';
 import { emitTimeEntryEvent } from './timeEntryEvents';
 import { getOrgBillingDefaults } from './ticketConfigService';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 import type { CreateTimeEntryInput, UpdateTimeEntryInput, TicketPartInput, BillingStatus } from '@breeze/shared';
 
 export type TimeEntryServiceErrorCode =
@@ -267,17 +268,9 @@ async function stopRunningEntry(
   return rows[0] ?? null;
 }
 
-function isUniqueViolation(err: unknown): boolean {
-  // postgres.js raises a PostgresError with code '23505', but Drizzle wraps it
-  // in a DrizzleQueryError whose own `.code` is undefined — the PG code lives on
-  // `.cause`. Walk the cause chain so the retry/409 path actually fires.
-  let cur: unknown = err;
-  for (let depth = 0; cur && typeof cur === 'object' && depth < 5; depth++) {
-    if ((cur as { code?: string }).code === '23505') return true;
-    cur = (cur as { cause?: unknown }).cause;
-  }
-  return false;
-}
+// Unwraps the DrizzleQueryError `.cause` so the retry/409 path actually fires
+// (a bare `err.code` check missed every wrapped insert). See utils/pgErrors.
+const isUniqueViolation = (err: unknown): boolean => isPgUniqueViolation(err);
 
 export async function startTimer(input: { ticketId?: string; description?: string }, actor: TimeEntryActor) {
   let partnerId = actor.partnerId;

--- a/apps/api/src/utils/pgErrors.test.ts
+++ b/apps/api/src/utils/pgErrors.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { isPgUniqueViolation } from './pgErrors';
+
+// postgres.js surfaces the index as `constraint_name` (the real shape we hit in prod)
+const pgErr = (constraint?: string) =>
+  Object.assign(new Error('duplicate key value violates unique constraint' + (constraint ? ` "${constraint}"` : '')), {
+    code: '23505',
+    ...(constraint ? { constraint_name: constraint } : {})
+  });
+
+// node-postgres surfaces it as `constraint`
+const pgErrNodePg = (constraint: string) =>
+  Object.assign(new Error(`duplicate key value violates unique constraint "${constraint}"`), { code: '23505', constraint });
+
+// DrizzleQueryError shape: generic message, no top-level code, real error on .cause
+const drizzleWrap = (cause: unknown) => Object.assign(new Error('Failed query: insert into "t" ...'), { cause });
+
+describe('isPgUniqueViolation', () => {
+  it('detects a top-level (unwrapped) 23505', () => {
+    expect(isPgUniqueViolation(pgErr())).toBe(true);
+  });
+
+  it('detects a 23505 wrapped in a DrizzleQueryError cause (no top-level code)', () => {
+    expect(isPgUniqueViolation(drizzleWrap(pgErr()))).toBe(true);
+  });
+
+  it('returns false for non-unique errors and non-objects', () => {
+    expect(isPgUniqueViolation(Object.assign(new Error('x'), { code: '23503' }))).toBe(false);
+    expect(isPgUniqueViolation(null)).toBe(false);
+    expect(isPgUniqueViolation('boom')).toBe(false);
+  });
+
+  it('matches a specific constraint when provided (wrapped, postgres.js constraint_name)', () => {
+    expect(isPgUniqueViolation(drizzleWrap(pgErr('ticket_statuses_partner_name_uq')), 'ticket_statuses_partner_name_uq')).toBe(true);
+  });
+
+  it('matches a specific constraint via node-postgres `constraint` field too', () => {
+    expect(isPgUniqueViolation(drizzleWrap(pgErrNodePg('ticket_statuses_partner_name_uq')), 'ticket_statuses_partner_name_uq')).toBe(true);
+  });
+
+  it('does NOT match a different constraint (other 23505s propagate)', () => {
+    expect(isPgUniqueViolation(drizzleWrap(pgErr('ticket_statuses_partner_core_status_system_uq')), 'ticket_statuses_partner_name_uq')).toBe(false);
+  });
+
+  it('falls back to message scan when the constraint name is not a discrete field', () => {
+    const noConstraintField = Object.assign(new Error('… unique constraint "ticket_statuses_partner_name_uq"'), { code: '23505' });
+    expect(isPgUniqueViolation(noConstraintField, 'ticket_statuses_partner_name_uq')).toBe(true);
+  });
+});

--- a/apps/api/src/utils/pgErrors.ts
+++ b/apps/api/src/utils/pgErrors.ts
@@ -1,0 +1,49 @@
+/**
+ * Detect a Postgres unique-violation (SQLSTATE 23505) from a thrown error.
+ *
+ * postgres.js raises a `PostgresError` with `.code === '23505'` (and a
+ * `.constraint`), but Drizzle wraps it in a `DrizzleQueryError` whose own
+ * `.code`/`.constraint` are undefined — the real fields live on `.cause`.
+ * Checks that only read the top-level `err.code` therefore miss every
+ * Drizzle-issued insert/update and leak a raw 500 instead of mapping the
+ * conflict to a friendly error. This walks the `.cause` chain so both shapes
+ * are handled.
+ *
+ * @param constraint  When given, only matches that specific unique index.
+ *   If the driver surfaced a constraint name we compare it exactly; if it
+ *   didn't (some wrappers drop it), we fall back to scanning the error message
+ *   for the constraint name.
+ */
+export function isPgUniqueViolation(err: unknown, constraint?: string): boolean {
+  let cur: unknown = err;
+  for (let depth = 0; cur && typeof cur === 'object' && depth < 5; depth++) {
+    const e = cur as { code?: unknown; constraint?: unknown; constraint_name?: unknown; message?: unknown };
+    if (e.code === '23505') {
+      if (!constraint) return true;
+      // postgres.js surfaces the index as `constraint_name`; node-postgres uses
+      // `constraint`. Fall back to a message scan only if neither is present.
+      const name = typeof e.constraint_name === 'string' ? e.constraint_name
+        : typeof e.constraint === 'string' ? e.constraint : undefined;
+      if (name !== undefined) return name === constraint;
+      return typeof e.message === 'string' && e.message.includes(constraint);
+    }
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
+ * Returns the Postgres SQLSTATE (e.g. '23505', '23503', '22P02') from a thrown
+ * error, unwrapping the DrizzleQueryError `.cause` chain. Use for error mappers
+ * that branch on several codes; for a simple unique check prefer
+ * {@link isPgUniqueViolation}. Returns undefined if no SQLSTATE is found.
+ */
+export function pgErrorCode(err: unknown): string | undefined {
+  let cur: unknown = err;
+  for (let depth = 0; cur && typeof cur === 'object' && depth < 5; depth++) {
+    const code = (cur as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return undefined;
+}

--- a/apps/web/src/components/settings/TicketingSettingsPage.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.tsx
@@ -31,7 +31,11 @@ function hashFor(tab: Tab): string {
 }
 
 export default function TicketingSettingsPage() {
-  const [activeTab, setActiveTab] = useState<Tab>(parseHash);
+  // Seed the SSR-safe default ('statuses') so the first client render matches the
+  // server (which has no hash); the deep-linked #tab= is applied in the mount
+  // effect below. Reading the hash directly into useState caused a hydration
+  // mismatch on `/settings/ticketing#tab=export` (same class as the login #418).
+  const [activeTab, setActiveTab] = useState<Tab>('statuses');
 
   const switchTab = (tab: Tab) => {
     history.replaceState(null, '', hashFor(tab));
@@ -39,6 +43,7 @@ export default function TicketingSettingsPage() {
   };
 
   useEffect(() => {
+    setActiveTab(parseHash());
     const onHashChange = () => setActiveTab(parseHash());
     window.addEventListener('hashchange', onHashChange);
     return () => window.removeEventListener('hashchange', onHashChange);

--- a/e2e-tests/release-checklist-v0.70-results.md
+++ b/e2e-tests/release-checklist-v0.70-results.md
@@ -272,3 +272,94 @@ All cleaned: time entries/comments on T-2026-0017 deleted; custom status "Waitin
 - **BUG 1 fixed** — `isUniqueViolation` (`apps/api/src/services/timeEntryService.ts:270`) now walks the `.cause` chain (depth-bounded) so the Drizzle-wrapped `23505` is detected; the retry-once → `409 ENTRY_RUNNING` path now fires instead of leaking a raw 500. **Regression tests added** reproducing the real wrapped-error shape (flat-`.code` mock had hidden it): `timeEntryService.test.ts` → 53/53 pass.
 - **BUG 2 fixed** — `TicketTimeBilling.submitQuickAdd` now calls `broadcastBillingChanged()` after a successful manual log, so the workbench feed live-refreshes (verified live: feed showed "Breeze Admin logged 7m (billable)" with no reload). Also added an **in-flight `disabled` state on the Start-timer button** (`startingTimer`) to keep the happy path single-shot and close the concurrent-start race client-side. **Regression tests added**: `TicketTimeBilling.test.tsx` → 6/6 pass.
 - Verification: web `tsc --noEmit` clean; api `tsc` shows no new errors (pre-existing `agents.test.ts`/`apiKeyAuth.test.ts` errors unrelated). Per-file single-fork runs used (full-suite parallel flakiness is a known false-negative source).
+
+---
+
+## Round 4 — 2026-06-13 (gap-closing: #1285 parts/timesheet/export, #1291 org SLA + statuses, avatar re-verify, core workflows, #1290 authz negatives)
+
+### ✅ #3 Avatar upload re-verify (#1268) — RESOLVES the Round-1 ❌ must-fix
+Post-rebuild, the full lifecycle works on DB-bytea storage (no filesystem EACCES):
+- **Upload**: pick PNG → blob preview → **Upload** → `POST /users/me/avatar` **200** (was 500 EACCES); stored **70-byte `avatar_data` bytea** (+ `avatar_mime`); `GET /users/:id/avatar` **200**.
+- **Remove**: `DELETE /users/me/avatar` **200**; `avatar_data` cleared to null.
+- Picker `accept="image/png,image/jpeg,image/webp"` + "Max 5 MB" copy present (server-side >5MB/non-image rejection covered by the `users/avatar` unit tests from Round 2). **The headline Round-1 blocker is closed.**
+
+### #1 — Parts / Timesheet / Billables export (#1285)
+
+| Item | Result | Evidence |
+|---|---|---|
+| Parts — add | ✅ | qty 2 @ $100, cost $60 → card "$200.00 · 2 × $100.00 · **$80.00** margin" (200 revenue − 120 cost = 80 ✓); billing rail live-updated to **Parts (1) / $200.00** (parts card *does* broadcast billing-changed). |
+| Parts — delete | ⚠️ | Deletes **instantly with no confirm dialog** (matches the PR's deferred note). Single mis-click permanently removes a costed part — minor but real risk on a billing surface. |
+| /timesheet — render + nav | ✅ | Tech selector (My timesheet / Breeze Admin), Monday-UTC week ("Week of June 8"), prev/next/this-week, per-day rows, weekly total. |
+| /timesheet — bulk approve | ✅ | Select entry → "Approve selected" → `POST /time-entries/bulk-approve` **200**; entry flipped `is_approved=t` + approver set; timesheet refetched. "Unapprove" present for the reverse path. |
+| Billables CSV export | ✅ | Settings→Ticketing→Export → `GET /tickets/export/billables.csv` **200**, valid header `type,date,organization,ticket,description,technician,quantity,rate,amount,billing_status,approved`; date-bounded (today's rows excluded by To=Jun 12, as expected). |
+
+### 🐛 BUG 3 — hydration mismatch on `/settings/ticketing` deep-linked with `#tab=` (#1291)
+- **Symptom:** loading `/settings/ticketing#tab=export` (or any non-default tab) throws a **React hydration mismatch** (#418-class) in console; React discards the SSR tree and regenerates client-side. Plain `/settings/ticketing` (no hash) is clean.
+- **Root cause:** `TicketingSettingsPage.tsx:34` seeds `useState<Tab>(parseHash)`; `parseHash()` returns `'statuses'` on the server (no `window`) but the hash-derived tab on the client → the first client render disagrees with SSR (`aria-selected`, class, and which panel mounts). Same anti-pattern as the login #418 fixed in #1268.
+- **Fix:** seed `activeTab` to the SSR-safe default `'statuses'` and apply `parseHash()` inside the mount `useEffect` (which already exists at line 41), so initial client render matches SSR. (Accept a one-frame flash to the correct tab — standard for hash-driven SSR state.)
+
+### ℹ️ Perf note
+- `POST /time-entries/start` and `/time-entries/bulk-approve` each took **~5s** server-side (dev build). Consistent across the time-tracking write endpoints. Likely dev-image overhead (tsx, cold paths) but **worth confirming prod latency** — slow writes with no spinner invite the double-click that triggered the BUG 1 start-race.
+
+### #2 — Statuses edge cases + Org Ticketing SLA tab (#1291)
+
+| Item | Result | Evidence |
+|---|---|---|
+| Status — add custom | ✅ | "QA Custom Status" created + listed under its core group. |
+| Status — deactivate/reactivate | ✅ | Deactivate → row shows **Inactive** + toggle flips to **Activate**; built-in rows have no deactivate control. |
+| Status — duplicate name | ❌ **BUG 4** | Adding a 2nd "QA Custom Status" → `POST /ticket-config/statuses` **500** (`duplicate key … ticket_statuses_partner_name_uq`) and **no toast at all** — instead of the friendly `STATUS_NAME_TAKEN`. Silent failure to the user. |
+| Org → Ticketing tab renders | ✅ | 8 per-priority SLA inputs (urgent/high/normal/low × response/resolution, placeholders = partner defaults), `org-ticket-rate`, tri-state billable (Inherit/Billable/Non-billable), "Save ticket settings". |
+| Org → Ticketing save | ✅ | Set rate 150 → `PATCH …/ticket-settings` **200**, `default_hourly_rate=150.00` persisted. (Reset after.) |
+| MFA-required save path | ⚠️ | Save succeeded **without an MFA challenge** — the local admin has no MFA enrolled (same as the Round-2 PAM observation). The gate's *enforcement* still needs verifying with an MFA-enabled user. |
+
+### 🐛 BUG 4 — duplicate ticket-status name returns raw 500, not `STATUS_NAME_TAKEN` (#1291) — SAME CLASS AS BUG 1
+- **Root cause:** `ticketConfigService.ts:286-300 isUniqueNameViolation` reads `err.code` / `err.constraint` / `err.message` off the **top-level** error, but Drizzle nests them under `err.cause` (wrapper message is just "Failed query: insert into ticket_statuses …", no constraint name). So the guard returns false and the raw 500 propagates instead of the structured 409 `STATUS_NAME_TAKEN` the UI maps to a friendly message.
+- **This is systemic.** The same bare `err.code === '23505'` (no `.cause` unwrap) appears at ~10 sites — confirmed-broken at `timeEntryService` (BUG 1, fixed) and `ticketConfigService` (BUG 4); **suspected** at: `routes/networkKnownGuests.ts:67`, `routes/networkBaselines.ts:309`, `routes/configurationPolicies/assignments.ts:90` + `featureLinks.ts:130`, `services/aiToolsConfigPolicy.ts:237,606`, `services/aiToolsNetwork.ts:344`, `services/aiToolsPolicyPrereqs.ts:39`, `services/aiToolsFleet.ts:92`. (`db/seed.ts:760` is seed-only.)
+- **Recommended fix:** a shared `pgUniqueViolation(err, constraint?)` util that walks the `.cause` chain (generalize the BUG-1 fix), and refactor all sites onto it. Removes the divergent local checks and the whole bug class at once.
+
+### #4 — Alerts / Scripts / Cmd+K core workflows
+
+| Item | Result | Evidence |
+|---|---|---|
+| Alerts — acknowledge | ✅⚠️ | `POST /alerts/:id/acknowledge` **200**, alert → `acknowledged`, Ack button removed from the row. **But: the request took ~19s and showed no toast/spinner** — only the button vanishing (after the round-trip) signals success. Borderline silent-mutation + a real latency concern. (Restored the alert to active after.) |
+| Notification channel — create | ✅ | New Channel modal (all 7 types: Email/Slack/Teams/PagerDuty/Webhook/SMS/Pushover, templates, routing rules). Created an Email channel → `POST /alerts/channels` 200, listed. |
+| Notification channel — Test | ✅ | "Test" → `POST /alerts/channels/:id/test` **200**, `last_test_status=success`, row shows "Last test: Just now". (Deleted the test channel after.) |
+| Scripts — library | ✅ | `/scripts` renders library + "New Script" + "Import from Library" + category/language filters (PowerShell/Bash/Python/CMD). Monaco editor confirmed in Round 2; full create→run→output needs the multi-step flow (a live agent is now connected — runnable in a follow-up). |
+| Cmd+K global search | ✅ | Search palette → typed "WIN" → DEVICES section with correctly-filtered matches (E2E Windows Test Device, File Server, WIN-DHQNR1F8LO2…), arrow/Enter navigation hints. |
+
+### ⚠️ UX/perf — alert acknowledge latency + no feedback
+`POST /alerts/:id/acknowledge` took **~19s** (vs ~5s on ticketing writes, sub-second on the channel test) with **no toast or spinner** the entire time. The EventBus published `alert.acknowledged` ~8s in, response ~11s after that — something in the ack path (event handlers? a blocking notify attempt?) is slow. No notification channels were configured, so it isn't channel dispatch. **Worth profiling the acknowledge path** — and adding an in-flight spinner + success toast regardless, so the action doesn't look dead for 19s. (May be partly dev-build overhead; confirm in prod.)
+
+### #5 — Authz / site-scope negatives (#1290) — API-level (seeded users, real tokens)
+
+Seeded 3 users (shared admin password): read-only **Partner Viewer**, **selected-org** technician (Default only), and a **site-restricted** Org Technician. Logged in via `/auth/login`, asserted with their real bearer tokens. All seed data removed after.
+
+| Test | Expected | Actual | Verdict |
+|---|---|---|---|
+| Security **AV scan** (`POST /security/scan/:dev`), read-only viewer | 403 | **403** "Permission denied" | ✅ RBAC enforced (needs `devices:execute`) |
+| Same, **admin** (control) | not-403 | **202** Accepted | ✅ gate doesn't over-block |
+| **Deployment create** (`POST /deployments`), read-only viewer | 403 | **403** "Permission denied" | ✅ RBAC enforced (needs `devices:write`) |
+| **time-entries** (`POST /time-entries`), admin `org_access=all` (control) | 2xx | **201** | ✅ endpoint works for partner-scope |
+| **time-entries**, `org_access=selected` user (granted + non-granted org) | denied | **403 both** | ✅ denied (see note) |
+
+**Solidly verified:** the read-only RBAC gates from #1290 (security AV scan, deployment create) return real **403s**, with an admin positive control proving they don't over-block. Cross-org access for a selected-org user is **denied** on the partner-scoped time-entries route.
+
+**Characterized, not independently isolated in this harness (covered by the PR's integration tests):**
+- **MFA gate** (`requireMfa()` on deployments): code returns `403 "MFA required"`, but locally `force_mfa` is **off** — admin (no MFA enrolled) passed the gate and reached validation (400). So the MFA *enforcement* path can't be exercised without enabling `force_mfa` for the partner. (Consistent with the Round-2/PAM and #2 org-save observations.)
+- **time-entries org-axis** (`TICKET_ORG_DENIED`): the route requires `requireScope('partner','system')`, which an `org_access=selected` partner user doesn't satisfy → they're 403'd on *both* granted and non-granted org tickets (denied either way = safe), so the service-level org-axis `404` branch isn't reachable via this route+user. The org-axis isolation itself is covered by the #1290 integration tests.
+- **Playbook / patch-job / threat-action site-scope:** not run — the same selected/site-scoped permission-resolution nuances (and needing devices pinned to specific sites) make a clean in-site-pass / out-of-site-403 harness more setup than this pass allowed. Covered by the PR's site-scope integration tests; recommend a dedicated multi-user fixture to verify end-to-end in-app.
+
+### Round 4 summary
+**Verified:** avatar lifecycle (#1268 resolved); parts add/delete + margin + live-summary; /timesheet + bulk approve; billables CSV export; status add/deactivate; org ticketing SLA save; alerts ack; notification channel create + Test; scripts library; Cmd+K; #1290 read-only RBAC 403s (AV scan, deployment).
+**New bugs:** **BUG 3** (ticketing-settings `#tab=` hydration mismatch, #1291) · **BUG 4** (duplicate status name → raw 500 not `STATUS_NAME_TAKEN`; **systemic** `err.cause` unwrap gap at ~10 sites, #1291).
+**UX/perf flags:** parts delete has no confirm dialog; alert acknowledge ~19s with no spinner/toast; duplicate-toast on runAction successes (dev); ticketing write endpoints ~5s (dev).
+
+---
+
+## Round 4 fixes applied — BUG 3 + BUG 4 (branch: fix/ticketing-config-hydration-and-pg-unique-unwrap)
+
+- **BUG 3 (hydration) — FIXED + live-verified.** `TicketingSettingsPage.tsx` now seeds the SSR-safe default tab and applies the `#tab=` hash in the mount effect. `/settings/ticketing#tab=export` now loads with **0 console errors** (was a hydration mismatch) and the Export tab is correctly selected. Web tsc + 12 TicketingSettingsPage tests pass.
+- **BUG 4 (systemic 23505 unwrap) — FIXED.** New shared `apps/api/src/utils/pgErrors.ts` (`isPgUniqueViolation`, `pgErrorCode`) walks the DrizzleQueryError `.cause` chain and matches the constraint via **`constraint_name`** (postgres.js) *or* `constraint` (node-pg), with a message-scan fallback. Refactored 10 call sites onto it: `ticketConfigService`, `timeEntryService`, `routes/networkKnownGuests`, `routes/networkBaselines`, `routes/configurationPolicies/{assignments,featureLinks}`, `services/aiToolsConfigPolicy` (×2), `services/aiToolsNetwork` (unique), and `services/aiТoolsPolicyPrereqs` + `services/aiToolsFleet` (multi-code mappers via `pgErrorCode`, which also fixes their `23503`/`22P02` mapping).
+  - **Key correction found during fix:** the real postgres.js error carries the index name on **`constraint_name`**, not `constraint` — the first cut of the helper relied on a fragile message-scan; now it checks both fields.
+  - **Verification:** 94 API tests pass (new `pgErrors.test.ts` covers wrapped/unwrapped/constraint_name/node-pg/message-fallback; `ticketConfigService` + `timeEntryService` regression cases updated to the realistic wrapped shape). An **in-container tsx probe confirmed `isPgUniqueViolation(realError, name) === true`** against the exact production `DrizzleQueryError{cause: PostgresError{code:'23505', constraint_name:…}}` shape.
+  - ⚠️ **Dev-env note:** the live HTTP path still returned 500 because the dev API's `tsx watch` would not reload the change — a known macOS `:cached` bind-mount + persistent `node_modules/.cache` mtime-cache issue (same reason the avatar fix needed an image rebuild). Verified via unit tests + in-container probe instead; the fix is correct and will run on a clean build/deploy.


### PR DESCRIPTION
Two bugs from v0.70 manual QA of the ticketing configuration UI (#1291).

## BUG 3 — hydration mismatch on `/settings/ticketing#tab=…`
Deep-linking a non-default tab threw a React #418-class hydration mismatch (SSR rendered the default `statuses` tab; the client read the hash and selected another) → React discarded and regenerated the tree.
**Fix:** `TicketingSettingsPage` seeds the SSR-safe default and applies the `#tab=` hash in the mount effect (same pattern as the login #418 in #1268). **Verified live:** `#tab=export` now loads with 0 console errors, Export tab selected.

## BUG 4 — duplicate status name → raw 500 (systemic `err.cause` unwrap gap)
Adding a duplicate-named status returned HTTP **500** leaking `duplicate key … ticket_statuses_partner_name_uq` with no toast, instead of the friendly `STATUS_NAME_TAKEN`. Root cause is **systemic**: ~10 sites checked `err.code === '23505'` on the top-level error, but postgres.js/Drizzle nests the code — and the index name as **`constraint_name`** (not `constraint`) — under `err.cause`. Every wrapped insert slipped past the guard. (Same class as the timer-start 500 fixed in #1296.)

**Fix:** new shared `apps/api/src/utils/pgErrors.ts`:
- `isPgUniqueViolation(err, constraint?)` — walks the `.cause` chain; matches the constraint via `constraint_name` (postgres.js) or `constraint` (node-pg), message-scan fallback.
- `pgErrorCode(err)` — unwrapped SQLSTATE for multi-code mappers.

Refactored all ~10 sites onto them (`ticketConfigService`, `timeEntryService`, `networkKnownGuests`, `networkBaselines`, `configurationPolicies/{assignments,featureLinks}`, `aiToolsConfigPolicy` ×2, `aiToolsNetwork`, `aiToolsPolicyPrereqs`, `aiToolsFleet`). The two AI-tool mappers also get correct `23503`/`22P02` handling via `pgErrorCode`.

## Tests
- **94 API tests** pass — new `pgErrors.test.ts` (wrapped / `constraint_name` / node-pg `constraint` / message-fallback / different-constraint), plus `ticketConfigService` + `timeEntryService` regression cases updated to the realistic wrapped error shape.
- web `tsc` clean; **12 `TicketingSettingsPage` tests** pass.
- BUG 4 helper additionally confirmed via an **in-container runtime probe** against the exact production `DrizzleQueryError{cause: PostgresError{code:'23505', constraint_name:…}}` shape (the dev `tsx watch` wouldn't hot-reload the change on the macOS bind mount — same reason the avatar fix needed a rebuild; correct on a clean build/deploy).

Full QA evidence: `e2e-tests/release-checklist-v0.70-results.md` (Round 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)