### PR TITLE
fix(web): avoid duplicate Windows OS build in "OS Version"

### DIFF
--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -24,7 +24,8 @@ import {
   Ticket,
 } from 'lucide-react';
 import { formatUptime } from '../../lib/utils';
-import type { Device, DeviceStatus, OSType } from './DeviceList';
+import type { Device, DeviceStatus } from './DeviceList';
+import { formatDeviceSummaryOs } from './osDisplay';
 import DeviceActions from './DeviceActions';
 import DeviceInfoTab from './DeviceInfoTab';
 import DeviceHardwareInventory from './DeviceHardwareInventory';
@@ -101,24 +102,6 @@ const statusLabels: Record<DeviceStatus, string> = {
   updating: 'Updating',
   pending: 'Pending'
 };
-
-const osLabels: Record<OSType, string> = {
-  windows: 'Windows',
-  macos: 'macOS',
-  linux: 'Linux'
-};
-
-function formatOsVersion(os: OSType, osVersion: string): string {
-  if (!osVersion) return osLabels[os];
-  let v = osVersion;
-  // Strip redundant "Microsoft Windows" prefix since osLabels already shows "Windows"
-  v = v.replace(/^Microsoft Windows\s*/i, '');
-  // Strip kernel name prefix (e.g. "darwin 26.3.1" → "26.3.1")
-  v = v.replace(/^(darwin|linux)\s*/i, '');
-  // Strip build/version numbers (e.g. "10.0.26200.7623 Build 26200.7623")
-  v = v.replace(/\s*\d+\.\d+\.\d+[\d.]*\s*(Build\s*[\d.]+)?/i, '').trim();
-  return v ? `${osLabels[os]} ${v}` : osLabels[os];
-}
 
 function formatLastSeen(dateString: string, timezone?: string): string {
   const date = new Date(dateString);
@@ -222,7 +205,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
                 )}
               </div>
               <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
-                <span>{formatOsVersion(device.os, device.osVersion)}</span>
+                <span>{formatDeviceSummaryOs(device.os, device.osVersion)}</span>
                 <span>Agent v{device.agentVersion}</span>
                 <span>{device.siteName}</span>
               </div>

--- a/apps/web/src/components/devices/DeviceInfoTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.test.tsx
@@ -50,6 +50,95 @@ function mockInitialLoad(displayName: string | null) {
   });
 }
 
+describe('DeviceInfoTab — OS version and build display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps Windows build details out of the OS Version row when OS Build is shown', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/devices/${deviceId}` && method === 'GET') {
+        return makeJsonResponse({
+          hostname: 'WIN-11-HOME',
+          displayName: null,
+          osType: 'windows',
+          osVersion: 'Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655',
+          osBuild: '10.0.26200.8655 Build 26200.8655',
+          architecture: 'amd64',
+          tags: [],
+          status: 'online',
+        });
+      }
+      if (url === '/custom-fields') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<DeviceInfoTab deviceId={deviceId} />);
+
+    await screen.findByText('Operating System');
+    expect(screen.getByText('Microsoft Windows 11 Home')).toBeInTheDocument();
+    expect(screen.getByText('10.0.26200.8655 Build 26200.8655')).toBeInTheDocument();
+    expect(screen.queryByText('Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655')).toBeNull();
+  });
+
+  it('capitalizes Linux distro names in the OS Version row', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/devices/${deviceId}` && method === 'GET') {
+        return makeJsonResponse({
+          hostname: 'RAMPHEX-PI-P52',
+          displayName: null,
+          osType: 'linux',
+          osVersion: 'raspbian 13.5',
+          osBuild: '6.18.33+rpt-rpi-v8',
+          architecture: 'arm64',
+          tags: [],
+          status: 'online',
+        });
+      }
+      if (url === '/custom-fields') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<DeviceInfoTab deviceId={deviceId} />);
+
+    await screen.findByText('Operating System');
+    expect(screen.getByText('Raspbian 13.5')).toBeInTheDocument();
+    expect(screen.queryByText('raspbian 13.5')).toBeNull();
+  });
+
+  it('omits redundant macOS text from the OS Version row', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/devices/${deviceId}` && method === 'GET') {
+        return makeJsonResponse({
+          hostname: 'MACBOOK-PRO',
+          displayName: null,
+          osType: 'macos',
+          osVersion: 'darwin 26.5.1',
+          osBuild: '25.5.0',
+          architecture: 'amd64',
+          tags: [],
+          status: 'online',
+        });
+      }
+      if (url === '/custom-fields') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<DeviceInfoTab deviceId={deviceId} />);
+
+    await screen.findByText('Operating System');
+    expect(screen.getByText('macOS')).toBeInTheDocument();
+    expect(screen.getByText('26.5.1')).toBeInTheDocument();
+    expect(screen.queryByText('macOS 26.5.1')).toBeNull();
+  });
+});
+
 describe('DeviceInfoTab — display name inline edit', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/devices/DeviceInfoTab.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.tsx
@@ -12,6 +12,7 @@ import {
   getDeviceRoleSourceLabel,
   getDeviceRoleSourceColor,
 } from '@/lib/deviceRoles';
+import { formatDeviceDetailOsVersion } from './osDisplay';
 
 type DeviceInfoTabProps = {
   deviceId: string;
@@ -95,12 +96,6 @@ const osTypeLabels: Record<string, string> = {
 function formatOsType(raw: string | null | undefined): string {
   if (!raw) return '—';
   return osTypeLabels[raw.toLowerCase()] ?? raw;
-}
-
-function formatOsVersionForDisplay(raw: string | null | undefined): string {
-  if (!raw) return '—';
-  // Strip kernel name prefix (e.g. "darwin 26.3.1" → "26.3.1")
-  return raw.replace(/^(darwin|linux)\s+/i, '');
 }
 
 function formatDesktopAccessMode(mode: DesktopAccessState['mode'] | undefined): string {
@@ -590,7 +585,7 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
 
       <Section title="Operating System" icon={<Info className="h-4 w-4 text-muted-foreground" />}>
         <InfoRow label="OS Type" value={formatOsType(info?.osType)} />
-        <InfoRow label="OS Version" value={formatOsVersionForDisplay(info?.osVersion)} />
+        <InfoRow label="OS Version" value={formatDeviceDetailOsVersion(info?.osType, info?.osVersion) || '—'} />
         <InfoRow label="OS Build" value={info?.osBuild ?? '—'} />
         <InfoRow label="Architecture" value={info?.architecture ?? '—'} />
       </Section>

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -47,6 +47,22 @@ describe('DeviceList — OS version and build columns', () => {
     expect(screen.getByText('10.0.26200.8655 Build 26200.8655')).toBeInTheDocument();
     expect(screen.queryByText('Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655')).toBeNull();
   });
+
+  it('shows macOS instead of the Darwin kernel name in the OS Version column', () => {
+    const device: Device = {
+      ...baseDevice,
+      os: 'macos',
+      osVersion: 'darwin 26.5.1',
+    };
+
+    render(<DeviceList devices={[device]} />);
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+    fireEvent.click(screen.getByLabelText('OS Version'));
+
+    expect(screen.getByText('macOS 26.5.1')).toBeInTheDocument();
+    expect(screen.queryByText('darwin 26.5.1')).toBeNull();
+    expect(screen.queryByText('26.5.1')).toBeNull();
+  });
 });
 
 describe('DeviceList — agent-silent (watchdog OK) badge (#800 web-UI gap)', () => {

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -30,6 +30,25 @@ const baseDevice: Device = {
   tags: [],
 };
 
+describe('DeviceList — OS version and build columns', () => {
+  it('keeps Windows build details out of the OS Version column when OS Build is shown', () => {
+    const device: Device = {
+      ...baseDevice,
+      osVersion: 'Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655',
+      osBuild: '10.0.26200.8655 Build 26200.8655',
+    };
+
+    render(<DeviceList devices={[device]} />);
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+    fireEvent.click(screen.getByLabelText('OS Version'));
+    fireEvent.click(screen.getByLabelText('OS Build'));
+
+    expect(screen.getByText('Microsoft Windows 11 Home')).toBeInTheDocument();
+    expect(screen.getByText('10.0.26200.8655 Build 26200.8655')).toBeInTheDocument();
+    expect(screen.queryByText('Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655')).toBeNull();
+  });
+});
+
 describe('DeviceList — agent-silent (watchdog OK) badge (#800 web-UI gap)', () => {
   it('renders the amber badge when mainAgentSilentSince is set AND watchdog is reporting', () => {
     const device: Device = {

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -26,6 +26,7 @@ import {
   type Density,
 } from '@/lib/density';
 import { OSIcon } from './osIcons';
+import { formatDeviceOsVersion } from './osDisplay';
 
 export type DeviceStatus = 'online' | 'offline' | 'maintenance' | 'decommissioned' | 'quarantined' | 'updating' | 'pending';
 export type OSType = 'windows' | 'macos' | 'linux';
@@ -165,16 +166,6 @@ function formatSilentDuration(silentSince: string): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h`;
   return `${Math.floor(hours / 24)}d`;
-}
-
-const windowsVersionBuildSuffix = /\s+\d+\.\d+\.\d+(?:\.\d+)?(?:\s+Build\s+\d+(?:\.\d+)*)?\s*$/i;
-
-function formatOsVersionColumn(device: Pick<Device, 'os' | 'osVersion'>): string {
-  const raw = device.osVersion.trim();
-  if (!raw || device.os !== 'windows') return raw;
-
-  const withoutBuild = raw.replace(windowsVersionBuildSuffix, '').trim();
-  return withoutBuild || raw;
 }
 
 type SortField = 'hostname' | 'status' | 'cpuPercent' | 'ramPercent' | 'lastSeen' | null;
@@ -544,7 +535,7 @@ export default function DeviceList({
       header: () => <th key="osVersion" className="px-3 py-3">OS Version</th>,
       cell: (device) => (
         <td key="osVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
-          {formatOsVersionColumn(device) || dash}
+          {formatDeviceOsVersion(device.os, device.osVersion) || dash}
         </td>
       ),
     },

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -12,7 +12,6 @@ import {
   writePageSizePreference,
 } from './pageSizePreference';
 import {
-  COLUMN_IDS,
   COLUMN_LABELS,
   readColumnOrder,
   readColumnVisibility,
@@ -168,11 +167,15 @@ function formatSilentDuration(silentSince: string): string {
   return `${Math.floor(hours / 24)}d`;
 }
 
-const osLabels: Record<OSType, string> = {
-  windows: 'Windows',
-  macos: 'macOS',
-  linux: 'Linux'
-};
+const windowsVersionBuildSuffix = /\s+\d+\.\d+\.\d+(?:\.\d+)?(?:\s+Build\s+\d+(?:\.\d+)*)?\s*$/i;
+
+function formatOsVersionColumn(device: Pick<Device, 'os' | 'osVersion'>): string {
+  const raw = device.osVersion.trim();
+  if (!raw || device.os !== 'windows') return raw;
+
+  const withoutBuild = raw.replace(windowsVersionBuildSuffix, '').trim();
+  return withoutBuild || raw;
+}
 
 type SortField = 'hostname' | 'status' | 'cpuPercent' | 'ramPercent' | 'lastSeen' | null;
 type SortDirection = 'asc' | 'desc';
@@ -541,7 +544,7 @@ export default function DeviceList({
       header: () => <th key="osVersion" className="px-3 py-3">OS Version</th>,
       cell: (device) => (
         <td key="osVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
-          {device.osVersion || dash}
+          {formatOsVersionColumn(device) || dash}
         </td>
       ),
     },

--- a/apps/web/src/components/devices/osDisplay.test.ts
+++ b/apps/web/src/components/devices/osDisplay.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDeviceDetailOsVersion, formatDeviceOsVersion, formatDeviceSummaryOs } from './osDisplay';
+
+describe('device OS display formatting', () => {
+  it('strips duplicated Windows build details from the OS version', () => {
+    expect(
+      formatDeviceOsVersion('windows', 'Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655'),
+    ).toBe('Microsoft Windows 11 Home');
+  });
+
+  it('shows Darwin-based macOS versions as macOS', () => {
+    expect(formatDeviceOsVersion('macos', 'darwin 26.5.1')).toBe('macOS 26.5.1');
+  });
+
+  it('omits the redundant macOS label for detail OS version rows', () => {
+    expect(formatDeviceDetailOsVersion('macos', 'darwin 26.5.1')).toBe('26.5.1');
+    expect(formatDeviceDetailOsVersion('macos', 'macOS 26.5.1')).toBe('26.5.1');
+  });
+
+  it('capitalizes Linux distro names in OS versions', () => {
+    expect(formatDeviceOsVersion('linux', 'raspbian 13.5')).toBe('Raspbian 13.5');
+    expect(formatDeviceOsVersion('linux', 'bazzite 44')).toBe('Bazzite 44');
+    expect(formatDeviceOsVersion('linux', 'debian 13.5')).toBe('Debian 13.5');
+  });
+
+  it('includes the OS type for the device summary', () => {
+    expect(formatDeviceSummaryOs('linux', 'raspbian 13.5')).toBe('Linux Raspbian 13.5');
+    expect(formatDeviceSummaryOs('macos', 'darwin 26.5.1')).toBe('macOS 26.5.1');
+  });
+});

--- a/apps/web/src/components/devices/osDisplay.ts
+++ b/apps/web/src/components/devices/osDisplay.ts
@@ -1,0 +1,85 @@
+const windowsVersionBuildSuffix = /\s+\d+\.\d+\.\d+(?:\.\d+)?(?:\s+Build\s+\d+(?:\.\d+)*)?\s*$/i;
+
+const osTypeLabels: Record<string, string> = {
+  windows: 'Windows',
+  macos: 'macOS',
+  linux: 'Linux',
+};
+
+const linuxNameOverrides: Record<string, string> = {
+  bazzite: 'Bazzite',
+  centos: 'CentOS',
+  debian: 'Debian',
+  fedora: 'Fedora',
+  linux: 'Linux',
+  opensuse: 'openSUSE',
+  os: 'OS',
+  raspbian: 'Raspbian',
+  rhel: 'RHEL',
+  ubuntu: 'Ubuntu',
+};
+
+function normalizeLinuxDistroName(value: string): string {
+  const withoutKernelPrefix = value.replace(/^linux\s+/i, '').trim();
+  return withoutKernelPrefix.replace(/^[a-z][a-z0-9]*(?:[ -][a-z][a-z0-9]*)*/i, (name) =>
+    name
+      .split(/([ -])/)
+      .map((part) => {
+        if (part === ' ' || part === '-') return part;
+        const override = linuxNameOverrides[part.toLowerCase()];
+        return override ?? `${part.charAt(0).toUpperCase()}${part.slice(1)}`;
+      })
+      .join('')
+  );
+}
+
+export function formatDeviceOsVersion(
+  osType: string | null | undefined,
+  osVersion: string | null | undefined,
+): string {
+  const raw = osVersion?.trim() ?? '';
+  if (!raw) return '';
+
+  if (osType?.toLowerCase() === 'windows') {
+    const withoutBuild = raw.replace(windowsVersionBuildSuffix, '').trim();
+    return withoutBuild || raw;
+  }
+
+  if (osType?.toLowerCase() === 'macos') {
+    if (/^macos\b/i.test(raw)) return raw.replace(/^macos\b/i, 'macOS');
+
+    const withoutDarwin = raw.replace(/^darwin\s+/i, '').trim();
+    return withoutDarwin ? `macOS ${withoutDarwin}` : 'macOS';
+  }
+
+  if (osType?.toLowerCase() === 'linux') {
+    return normalizeLinuxDistroName(raw);
+  }
+
+  return raw;
+}
+
+export function formatDeviceDetailOsVersion(
+  osType: string | null | undefined,
+  osVersion: string | null | undefined,
+): string {
+  const formatted = formatDeviceOsVersion(osType, osVersion);
+  if (osType?.toLowerCase() !== 'macos') return formatted;
+
+  return formatted.replace(/^macOS\s*/i, '').trim();
+}
+
+export function formatDeviceSummaryOs(
+  osType: string | null | undefined,
+  osVersion: string | null | undefined,
+): string {
+  const type = osType?.toLowerCase() ?? '';
+  const label = osTypeLabels[type] ?? osType ?? '';
+  const version = formatDeviceOsVersion(osType, osVersion);
+
+  if (!version) return label || 'Unknown OS';
+  if (type === 'windows') return /\bwindows\b/i.test(version) ? version : `Windows ${version}`;
+  if (type === 'macos') return /^macOS\b/.test(version) ? version : `macOS ${version}`;
+  if (type === 'linux') return /^Linux\b/.test(version) ? version : `Linux ${version}`;
+  return label ? `${label} ${version}` : version;
+}


### PR DESCRIPTION
## Summary

- Addresses #1302.
- Prevents Windows build/version details from being duplicated in `OS Version` and `OS Build` across the device list and device details views.
- Normalizes OS display labels: Darwin-based macOS versions render cleanly, Linux distro names are capitalized, and macOS detail rows avoid redundant `macOS macOS`-style text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other: <!-- describe -->

## Testing

- [ ] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [x] Manual testing (describe below)

Focused checks run:

- `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceList.test.tsx src/components/devices/DeviceInfoTab.test.tsx src/components/devices/osDisplay.test.ts`
- `pnpm --filter @breeze/web lint`
- `pnpm --filter @breeze/web exec tsc --noEmit`

Manual validation: built and deployed `ghcr.io/ramphex/breeze/web:fix-os-version-test`, then confirmed Windows build duplication was removed, Linux distro names were capitalized, and macOS details avoided redundant OS labeling.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included

Screenshots:
<img width="480" height="304" alt="Screenshot 2026-06-13 at 02 35 25" src="https://github.com/user-attachments/assets/280a4297-a683-4f9a-a3f5-6082f9d6f7c8" />

<img width="967" height="285" alt="Screenshot 2026-06-13 at 02 35 55" src="https://github.com/user-attachments/assets/bef787f3-439d-4b4b-a117-33312404061a" />