### PR TITLE
fix(agents): honor Org > General agent update policy in heartbeat

### DIFF
--- a/apps/api/src/routes/agents/agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeAgentUpdatePolicy,
+  parseMaintenanceWindow,
+  isWithinMaintenanceWindow,
+  shouldSendAgentUpgrade,
+} from './agentUpdatePolicy';
+
+// All Dates below are UTC. 2026-06-14 is a Sunday.
+const SUN_0300 = new Date('2026-06-14T03:00:00Z'); // Sunday 03:00 UTC
+const SUN_0500 = new Date('2026-06-14T05:00:00Z'); // Sunday 05:00 UTC
+const MON_0300 = new Date('2026-06-15T03:00:00Z'); // Monday 03:00 UTC
+
+describe('normalizeAgentUpdatePolicy', () => {
+  it('passes through known policies', () => {
+    expect(normalizeAgentUpdatePolicy('auto')).toBe('auto');
+    expect(normalizeAgentUpdatePolicy('staged')).toBe('staged');
+    expect(normalizeAgentUpdatePolicy('manual')).toBe('manual');
+  });
+
+  it('defaults unknown/absent values to staged (permissive when no window set)', () => {
+    expect(normalizeAgentUpdatePolicy(undefined)).toBe('staged');
+    expect(normalizeAgentUpdatePolicy(null)).toBe('staged');
+    expect(normalizeAgentUpdatePolicy('')).toBe('staged');
+    expect(normalizeAgentUpdatePolicy('bogus')).toBe('staged');
+    expect(normalizeAgentUpdatePolicy(42)).toBe('staged');
+  });
+});
+
+describe('parseMaintenanceWindow', () => {
+  it('parses a day-prefixed window', () => {
+    expect(parseMaintenanceWindow('Sun 02:00-04:00')).toEqual({ day: 0, startMin: 120, endMin: 240 });
+  });
+
+  it('parses a daily (no day) window', () => {
+    expect(parseMaintenanceWindow('02:00-04:00')).toEqual({ day: null, startMin: 120, endMin: 240 });
+  });
+
+  it('is case-insensitive and tolerates spacing', () => {
+    expect(parseMaintenanceWindow('  mON  22:30 - 23:45 ')).toEqual({ day: 1, startMin: 1350, endMin: 1425 });
+  });
+
+  it('returns null for empty / non-string / malformed input', () => {
+    expect(parseMaintenanceWindow('')).toBeNull();
+    expect(parseMaintenanceWindow('   ')).toBeNull();
+    expect(parseMaintenanceWindow(null)).toBeNull();
+    expect(parseMaintenanceWindow(undefined)).toBeNull();
+    expect(parseMaintenanceWindow('sometime soon')).toBeNull();
+    expect(parseMaintenanceWindow('Xyz 02:00-04:00')).toBeNull(); // bad day
+    expect(parseMaintenanceWindow('25:00-26:00')).toBeNull(); // bad hour
+    expect(parseMaintenanceWindow('02:00-02:00')).toBeNull(); // zero-length
+  });
+});
+
+describe('isWithinMaintenanceWindow', () => {
+  it('returns true (no restriction) when window is absent or malformed', () => {
+    expect(isWithinMaintenanceWindow(null, SUN_0300)).toBe(true);
+    expect(isWithinMaintenanceWindow('', SUN_0300)).toBe(true);
+    expect(isWithinMaintenanceWindow('garbage', SUN_0300)).toBe(true);
+  });
+
+  it('respects same-day day-prefixed windows', () => {
+    expect(isWithinMaintenanceWindow('Sun 02:00-04:00', SUN_0300)).toBe(true);
+    expect(isWithinMaintenanceWindow('Sun 02:00-04:00', SUN_0500)).toBe(false); // after window
+    expect(isWithinMaintenanceWindow('Sun 02:00-04:00', MON_0300)).toBe(false); // wrong day
+  });
+
+  it('treats day-less windows as daily', () => {
+    expect(isWithinMaintenanceWindow('02:00-04:00', SUN_0300)).toBe(true);
+    expect(isWithinMaintenanceWindow('02:00-04:00', MON_0300)).toBe(true);
+    expect(isWithinMaintenanceWindow('02:00-04:00', SUN_0500)).toBe(false);
+  });
+
+  it('handles windows that wrap past midnight (daily)', () => {
+    // 22:00-02:00 daily: 23:00 in, 01:00 in, 03:00 out
+    expect(isWithinMaintenanceWindow('22:00-02:00', new Date('2026-06-14T23:00:00Z'))).toBe(true);
+    expect(isWithinMaintenanceWindow('22:00-02:00', new Date('2026-06-15T01:00:00Z'))).toBe(true);
+    expect(isWithinMaintenanceWindow('22:00-02:00', new Date('2026-06-15T03:00:00Z'))).toBe(false);
+  });
+
+  it('handles day-prefixed windows that wrap past midnight', () => {
+    // Sat 22:00-02:00: covers Sat 22:00+ and Sun 00:00-02:00
+    expect(isWithinMaintenanceWindow('Sat 22:00-02:00', new Date('2026-06-13T23:00:00Z'))).toBe(true); // Sat
+    expect(isWithinMaintenanceWindow('Sat 22:00-02:00', new Date('2026-06-14T01:00:00Z'))).toBe(true); // Sun
+    expect(isWithinMaintenanceWindow('Sat 22:00-02:00', new Date('2026-06-14T03:00:00Z'))).toBe(false); // Sun, too late
+    expect(isWithinMaintenanceWindow('Sat 22:00-02:00', new Date('2026-06-13T20:00:00Z'))).toBe(false); // Sat, too early
+  });
+});
+
+describe('shouldSendAgentUpgrade', () => {
+  it('manual never allows auto-upgrade, even inside a window', () => {
+    expect(shouldSendAgentUpgrade({ policy: 'manual', maintenanceWindow: null }, SUN_0300))
+      .toEqual({ allow: false, reason: 'manual-approval' });
+    expect(shouldSendAgentUpgrade({ policy: 'manual', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0300))
+      .toEqual({ allow: false, reason: 'manual-approval' });
+  });
+
+  it('auto upgrades anytime when no window is set', () => {
+    expect(shouldSendAgentUpgrade({ policy: 'auto', maintenanceWindow: null }, SUN_0500))
+      .toEqual({ allow: true, reason: 'allowed' });
+  });
+
+  it('auto and staged respect a configured window', () => {
+    expect(shouldSendAgentUpgrade({ policy: 'auto', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0300))
+      .toEqual({ allow: true, reason: 'allowed' });
+    expect(shouldSendAgentUpgrade({ policy: 'auto', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0500))
+      .toEqual({ allow: false, reason: 'outside-maintenance-window' });
+    expect(shouldSendAgentUpgrade({ policy: 'staged', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0300))
+      .toEqual({ allow: true, reason: 'allowed' });
+    expect(shouldSendAgentUpgrade({ policy: 'staged', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0500))
+      .toEqual({ allow: false, reason: 'outside-maintenance-window' });
+  });
+
+  it('staged with no window behaves like auto-anytime (non-breaking default)', () => {
+    expect(shouldSendAgentUpgrade({ policy: 'staged', maintenanceWindow: null }, SUN_0500))
+      .toEqual({ allow: true, reason: 'allowed' });
+  });
+});

--- a/apps/api/src/routes/agents/agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.test.ts
@@ -40,6 +40,11 @@ describe('parseMaintenanceWindow', () => {
     expect(parseMaintenanceWindow('  mON  22:30 - 23:45 ')).toEqual({ day: 1, startMin: 1350, endMin: 1425 });
   });
 
+  it('accepts single-digit hours (regex allows \\d{1,2}, UI may not zero-pad)', () => {
+    expect(parseMaintenanceWindow('2:00-4:00')).toEqual({ day: null, startMin: 120, endMin: 240 });
+    expect(parseMaintenanceWindow('Sun 2:00-4:00')).toEqual({ day: 0, startMin: 120, endMin: 240 });
+  });
+
   it('returns null for empty / non-string / malformed input', () => {
     expect(parseMaintenanceWindow('')).toBeNull();
     expect(parseMaintenanceWindow('   ')).toBeNull();

--- a/apps/api/src/routes/agents/agentUpdatePolicy.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.ts
@@ -1,0 +1,134 @@
+/**
+ * Agent update policy resolution (pure logic).
+ *
+ * The org-level "Agent update policy" (Org > General) governs whether the
+ * heartbeat handler is allowed to hand an agent an `upgradeTo` target:
+ *
+ *   - `manual`  → never auto-upgrade; upgrades happen only via explicit admin action
+ *   - `auto`    → upgrade whenever a newer version exists
+ *   - `staged`  → same as `auto`, but only while inside the configured
+ *                 maintenance window (when one is set)
+ *
+ * In addition, a configured `maintenanceWindow` suppresses upgrades outside the
+ * window for both `auto` and `staged`. A device with no maintenance window set
+ * may upgrade at any time (this preserves the historical behaviour for orgs
+ * that never configured the policy).
+ *
+ * Timezone note: the org `maintenanceWindow` is a free-form string with no
+ * timezone component (e.g. "Sun 02:00-04:00"), so it is evaluated against UTC
+ * server time. Malformed windows fail open (no time restriction) so a typo
+ * never permanently blocks updates.
+ *
+ * This module is pure and side-effect free so it can be unit tested without a
+ * database. The DB read lives in `getOrgAgentUpdatePolicy` (helpers.ts).
+ */
+
+export type AgentUpdatePolicy = 'auto' | 'staged' | 'manual';
+
+export interface AgentUpdateSettings {
+  policy: AgentUpdatePolicy;
+  maintenanceWindow: string | null;
+}
+
+export interface AgentUpdateGate {
+  allow: boolean;
+  reason: 'allowed' | 'manual-approval' | 'outside-maintenance-window';
+}
+
+const DAY_OF_WEEK: Record<string, number> = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+
+interface ParsedWindow {
+  /** UTC day-of-week the window starts on (0=Sun), or null for "any day" (daily). */
+  day: number | null;
+  /** Minutes-since-midnight the window opens. */
+  startMin: number;
+  /** Minutes-since-midnight the window closes. */
+  endMin: number;
+}
+
+/**
+ * Coerce an arbitrary stored value into a known policy. Unknown / absent values
+ * default to `staged` to match the UI default; combined with an absent
+ * maintenance window this is permissive (upgrade anytime), which preserves the
+ * pre-existing behaviour for orgs that never set the policy.
+ */
+export function normalizeAgentUpdatePolicy(raw: unknown): AgentUpdatePolicy {
+  if (raw === 'auto' || raw === 'staged' || raw === 'manual') return raw;
+  return 'staged';
+}
+
+/**
+ * Parse a maintenance window string of the form "Sun 02:00-04:00" (optional
+ * 3-letter day prefix; "02:00-04:00" means daily). Returns null when the input
+ * is empty or malformed — callers treat null as "no time restriction".
+ */
+export function parseMaintenanceWindow(raw: string | null | undefined): ParsedWindow | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const m = trimmed.match(/^(?:([A-Za-z]{3})\s+)?(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/);
+  if (!m) return null;
+
+  const [, dayStr, sh, sm, eh, em] = m;
+  let day: number | null = null;
+  if (dayStr) {
+    const d = DAY_OF_WEEK[dayStr.toLowerCase()];
+    if (d === undefined) return null;
+    day = d;
+  }
+
+  const startH = Number(sh), startM = Number(sm), endH = Number(eh), endM = Number(em);
+  if (startH > 23 || endH > 23 || startM > 59 || endM > 59) return null;
+
+  const startMin = startH * 60 + startM;
+  const endMin = endH * 60 + endM;
+  if (startMin === endMin) return null; // zero-length window is meaningless
+
+  return { day, startMin, endMin };
+}
+
+/**
+ * Whether `now` (evaluated in UTC) falls inside the maintenance window. A null /
+ * empty / malformed window means "no restriction" → always true (fail open).
+ * Windows that wrap past midnight (start > end) are supported.
+ */
+export function isWithinMaintenanceWindow(raw: string | null | undefined, now: Date): boolean {
+  const parsed = parseMaintenanceWindow(raw);
+  if (!parsed) return true;
+
+  const nowMin = now.getUTCHours() * 60 + now.getUTCMinutes();
+  const nowDay = now.getUTCDay();
+  const { day, startMin, endMin } = parsed;
+
+  if (startMin < endMin) {
+    // Same-day window, e.g. 02:00-04:00.
+    if (day !== null && day !== nowDay) return false;
+    return nowMin >= startMin && nowMin < endMin;
+  }
+
+  // Wraps past midnight, e.g. 22:00-02:00 → [start,24:00) today + [00:00,end) tomorrow.
+  if (day === null) {
+    return nowMin >= startMin || nowMin < endMin;
+  }
+  const nextDay = (day + 1) % 7;
+  if (nowDay === day) return nowMin >= startMin;
+  if (nowDay === nextDay) return nowMin < endMin;
+  return false;
+}
+
+/**
+ * Decide whether the heartbeat handler may hand the agent an upgrade target
+ * right now, given the org's update settings.
+ */
+export function shouldSendAgentUpgrade(settings: AgentUpdateSettings, now: Date): AgentUpdateGate {
+  if (settings.policy === 'manual') {
+    return { allow: false, reason: 'manual-approval' };
+  }
+  if (!isWithinMaintenanceWindow(settings.maintenanceWindow, now)) {
+    return { allow: false, reason: 'outside-maintenance-window' };
+  }
+  return { allow: true, reason: 'allowed' };
+}

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1048,4 +1048,126 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     const body = await resp.json() as { upgradeTo?: string | null };
     expect(body.upgradeTo).toBe('0.66.0');
   });
+
+  // A dev-push build (dev-*) must never be auto-upgraded back to a release,
+  // regardless of policy. This pins the precedence of the dev-build short
+  // circuit relative to the `updateGateAllows` branch (heartbeat.ts:508-511).
+  it('dev- agent build is never upgraded even under auto policy', async () => {
+    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: 'dev-local', metrics: minimalHeartbeatBody.metrics }),
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------
+// The same gate also governs the helper and watchdog upgrade channels, and
+// must NOT block bootstrap (first-install of a component a device is missing).
+// These channels live in separate `if` blocks from the agent upgrade, so they
+// get their own coverage — without it a refactor could silently drop the gate
+// from one channel (re-introducing the bug this PR fixes) or, conversely,
+// start gating bootstrap (stranding devices that never receive a component).
+// ---------------------------------------------------------------------
+
+describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => {
+  // Device already running a (non-dev) watchdog, so the watchdog path takes the
+  // gated version-to-version branch rather than the ungated bootstrap branch.
+  const deviceWithWatchdog = {
+    id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+    architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: '0.65.0',
+    lastSeenAt: new Date(), mainAgentSilentSince: null,
+  };
+  // Fresh device missing both helper and watchdog — both take the bootstrap
+  // branch, which must fire regardless of policy.
+  const deviceNeedingBootstrap = {
+    id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+    architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: null,
+    lastSeenAt: new Date(), mainAgentSilentSince: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    updateMock.mockReset();
+    insertMock.mockReset();
+    runOutsideDbContextMock.mockClear();
+    getActiveTrustKeysetMock.mockReset();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+  });
+
+  // Reports an installed helperVersion so the helper path takes the gated
+  // version-to-version branch (not the ungated `!data.helperVersion` bootstrap).
+  async function postWithInstalledComponents(deviceRow: typeof deviceWithWatchdog) {
+    const { compareAgentVersions } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1); // latest > reported, all components
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        role: 'agent', agentVersion: '0.65.10', helperVersion: '0.65.0',
+        metrics: minimalHeartbeatBody.metrics,
+      }),
+    });
+  }
+
+  it('manual policy → withholds helper and watchdog version-to-version upgrades', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+
+    const resp = await postWithInstalledComponents(deviceWithWatchdog);
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { helperUpgradeTo?: string | null; watchdogUpgradeTo?: string | null };
+    expect(body.helperUpgradeTo).toBeFalsy();
+    expect(body.watchdogUpgradeTo).toBeFalsy();
+  });
+
+  it('auto policy → offers helper and watchdog version-to-version upgrades', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+
+    const resp = await postWithInstalledComponents(deviceWithWatchdog);
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { helperUpgradeTo?: string | null; watchdogUpgradeTo?: string | null };
+    expect(body.helperUpgradeTo).toBe('0.66.0');
+    expect(body.watchdogUpgradeTo).toBe('0.66.0');
+  });
+
+  it('manual policy → STILL bootstraps a missing helper and watchdog (bootstrap is ungated)', async () => {
+    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceNeedingBootstrap]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    // No helperVersion in the body → helper bootstrap branch; watchdogVersion
+    // null on the device → watchdog bootstrap branch. Both must fire under manual.
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.65.10', metrics: minimalHeartbeatBody.metrics }),
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as {
+      upgradeTo?: string | null; helperUpgradeTo?: string | null; watchdogUpgradeTo?: string | null;
+    };
+    expect(body.upgradeTo).toBeFalsy(); // agent version-to-version IS gated → withheld
+    expect(body.helperUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite manual
+    expect(body.watchdogUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite manual
+  });
 });

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -95,6 +95,9 @@ vi.mock('./helpers', () => ({
   buildMonitoringConfigUpdate: vi.fn(() => undefined),
   buildHelperConfigUpdate: vi.fn(() => undefined),
   buildPamConfigUpdate: vi.fn(async () => ({ uacInterceptionEnabled: false })),
+  // Permissive default (staged + no window = upgrade anytime) so the upgrade
+  // gating is transparent to tests that don't care about the org policy.
+  getOrgAgentUpdatePolicy: vi.fn(async () => ({ policy: 'staged', maintenanceWindow: null })),
 }));
 
 vi.mock('../../services/auditEvents', () => ({
@@ -953,5 +956,96 @@ describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () =>
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.uacInterceptionEnabled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Org > General > Agent update policy: the heartbeat handler must gate the
+// agent `upgradeTo` it hands back based on the org's resolved policy. Before
+// this wiring the setting was stored but never consulted (agents ignored it).
+// ---------------------------------------------------------------------
+
+describe('POST /agents/:id/heartbeat — org agent update policy gating', () => {
+  const deviceRow = {
+    id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+    architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: null,
+    lastSeenAt: new Date(), mainAgentSilentSince: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    updateMock.mockReset();
+    insertMock.mockReset();
+    runOutsideDbContextMock.mockClear();
+    getActiveTrustKeysetMock.mockReset();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+  });
+
+  async function postAgentHeartbeat() {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.65.10', metrics: minimalHeartbeatBody.metrics }),
+    });
+  }
+
+  it('manual policy → withholds agent upgradeTo even when a newer version exists', async () => {
+    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1); // latest > reported
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    const resp = await postAgentHeartbeat();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBeFalsy();
+  });
+
+  it('auto policy with no maintenance window → offers agent upgradeTo when newer exists', async () => {
+    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    const resp = await postAgentHeartbeat();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBe('0.66.0');
+  });
+
+  it('staged policy outside the maintenance window → withholds agent upgradeTo', async () => {
+    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    // A window on a different UTC day than "now" guarantees we're outside it.
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const otherDay = days[(new Date().getUTCDay() + 3) % 7];
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'staged', maintenanceWindow: `${otherDay} 02:00-04:00` });
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    const resp = await postAgentHeartbeat();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBeFalsy();
+  });
+
+  it('fails open (offers upgrade) when the policy lookup throws', async () => {
+    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    const resp = await postAgentHeartbeat();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBe('0.66.0');
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -21,7 +21,9 @@ import {
   buildMonitoringConfigUpdate,
   buildHelperConfigUpdate,
   buildPamConfigUpdate,
+  getOrgAgentUpdatePolicy,
 } from './helpers';
+import { shouldSendAgentUpgrade } from './agentUpdatePolicy';
 import { processDeviceIPHistoryUpdate } from '../../services/deviceIpHistory';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
 import { publishEvent } from '../../services/eventBus';
@@ -462,6 +464,26 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     console.error(`[agents] failed to build policy probe config update for ${agentId}:`, err);
   }
 
+  // Org > General > Agent update policy. Governs whether we may hand the agent
+  // (or its helper/watchdog) an auto-upgrade target right now. `manual` blocks
+  // all auto-upgrades; `auto`/`staged` honour the maintenance window when set.
+  // Bootstrap installs (a component not yet present) are intentionally NOT
+  // gated below — a device must be able to finish installing regardless.
+  // Fails open: if the lookup throws we behave as before (upgrades allowed).
+  let updateGateAllows = true;
+  try {
+    const updateSettings = await getOrgAgentUpdatePolicy(device.orgId);
+    const gate = shouldSendAgentUpgrade(updateSettings, new Date());
+    updateGateAllows = gate.allow;
+    if (!gate.allow) {
+      console.log(
+        `[agents] auto-upgrade withheld for ${agentId} by org update policy (${gate.reason})`,
+      );
+    }
+  } catch (err) {
+    console.error(`[agents] failed to resolve agent update policy for ${agentId}:`, err);
+  }
+
   let upgradeTo: string | null = null;
   const normalizedArch = normalizeAgentArchitecture(device.architecture);
   if (normalizedArch) {
@@ -486,7 +508,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         // on the agent side; the server also refrains from sending upgradeTo.
         if (data.agentVersion.startsWith('dev-')) {
           // no-op: leave upgradeTo null so agent stays on the dev build
-        } else {
+        } else if (updateGateAllows) {
           const cmp = compareAgentVersions(latestVersion.version, data.agentVersion);
           if (cmp > 0) {
             upgradeTo = latestVersion.version;
@@ -519,8 +541,11 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
 
 if (latestHelper) {
         // If agent reports no helper version, always upgrade (bootstraps first install
-        // or recovers from broken helper that never wrote its status file)
-        if (!data.helperVersion || compareAgentVersions(latestHelper.version, data.helperVersion) > 0) {
+        // or recovers from broken helper that never wrote its status file) — bootstrap
+        // is NOT subject to the org update policy. Version-to-version upgrades are.
+        if (!data.helperVersion) {
+          helperUpgradeTo = latestHelper.version;
+        } else if (updateGateAllows && compareAgentVersions(latestHelper.version, data.helperVersion) > 0) {
           helperUpgradeTo = latestHelper.version;
         }
       }
@@ -547,14 +572,16 @@ if (latestHelper) {
         .limit(1);
 
       if (latestWatchdog && device.watchdogVersion) {
-        if (!device.watchdogVersion.startsWith('dev-')) {
+        // Version-to-version upgrade is subject to the org update policy.
+        if (updateGateAllows && !device.watchdogVersion.startsWith('dev-')) {
           const cmp = compareAgentVersions(latestWatchdog.version, device.watchdogVersion);
           if (cmp > 0) {
             watchdogUpgradeTo = latestWatchdog.version;
           }
         }
       } else if (latestWatchdog && !device.watchdogVersion) {
-        // Watchdog not yet installed — signal to agent to install it
+        // Watchdog not yet installed — signal to agent to install it. Bootstrap
+        // installs are NOT gated by the org update policy.
         watchdogUpgradeTo = latestWatchdog.version;
       }
     } catch (err) {

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for getOrgAgentUpdatePolicy — the DB read that resolves the org-level
+ * "Agent update policy" (Org > General) from organizations.settings.defaults.
+ *
+ * The pure gating logic lives in agentUpdatePolicy.ts (tested separately); this
+ * file pins the JSONB extraction + normalization seam that the heartbeat tests
+ * mock away: nested settings.defaults lookup, isObject guards at both levels,
+ * unknown-policy fallback to `staged`, and whitespace-trim-to-null of the
+ * maintenance window. That seam is the one most likely to silently break (a
+ * renamed key → permissive default) on a settings-schema change.
+ *
+ * helpers.ts has a large import graph, so the mock harness below mirrors
+ * helpers.pam.test.ts: a single-call db.select queue plus stubs for everything
+ * the module references at load time.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.hoisted() must run before any import.
+// ---------------------------------------------------------------------------
+const { dbMock } = vi.hoisted(() => {
+  let nextResult: unknown[] = [];
+
+  const makeSelectChain = () => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(nextResult)),
+    };
+    chain.then = (resolve: any, reject: any) => Promise.resolve(nextResult).then(resolve, reject);
+    return chain;
+  };
+
+  const dbMock = {
+    select: vi.fn(() => makeSelectChain()),
+    _setResult(rows: unknown[]) {
+      nextResult = rows;
+    },
+  };
+
+  return { dbMock };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks (must come before any import of the module under test)
+// ---------------------------------------------------------------------------
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: dbMock,
+}));
+
+vi.mock('../../db/schema', () => ({
+  organizations: { id: 'orgs.id', settings: 'orgs.settings' },
+  // Stub out everything else helpers.ts references so the module loads.
+  devices: {},
+  deviceGroupMemberships: {},
+  configPolicyAssignments: {},
+  configurationPolicies: {},
+  configPolicyFeatureLinks: {},
+  softwarePolicies: {},
+  softwareComplianceStatus: {},
+  deviceCommands: { $inferSelect: {} },
+  deviceDisks: {},
+  deviceFilesystemSnapshots: {},
+  automationPolicies: {},
+  cisBaselines: {},
+  cisBaselineResults: {},
+  cisRemediationActions: {},
+  securityStatus: {},
+  securityThreats: {},
+  securityScans: {},
+  sensitiveDataFindings: {},
+  sensitiveDataScans: {},
+  sites: {},
+  users: {},
+  deviceGroups: {},
+  configPolicyMonitoringSettings: {},
+  configPolicyMonitoringWatches: {},
+  configPolicyEventLogSettings: {},
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: vi.fn() }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/commandQueue', () => ({ queueCommandForExecution: vi.fn() }));
+vi.mock('../../services/cisHardening', () => ({ parseCisCollectorOutput: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../services/cloudflareMtls', () => ({ CloudflareMtlsService: vi.fn() }));
+vi.mock('../../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit: vi.fn() }));
+vi.mock('../../services/filesystemAnalysis', () => ({
+  getFilesystemScanState: vi.fn(),
+  mergeFilesystemAnalysisPayload: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  readCheckpointPendingDirectories: vi.fn(),
+  readHotDirectories: vi.fn(),
+  saveFilesystemSnapshot: vi.fn(),
+  upsertFilesystemScanState: vi.fn(),
+}));
+vi.mock('../metrics', () => ({
+  recordSoftwareRemediationDecision: vi.fn(),
+  recordSensitiveDataFinding: vi.fn(),
+  recordSensitiveDataRemediationDecision: vi.fn(),
+}));
+vi.mock('../../jobs/softwareComplianceWorker', () => ({
+  scheduleSoftwareComplianceCheck: vi.fn(),
+}));
+vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => true) }));
+
+// ---------------------------------------------------------------------------
+// Import under test — AFTER all mocks are installed.
+// ---------------------------------------------------------------------------
+import { getOrgAgentUpdatePolicy } from './helpers';
+
+const ORG_ID = '00000000-0000-4000-8000-000000000001';
+
+describe('getOrgAgentUpdatePolicy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads a fully configured policy + maintenance window', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 'Sun 02:00-04:00' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: 'Sun 02:00-04:00',
+    });
+  });
+
+  it('trims a maintenance window and passes through auto/staged', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: '  02:00-04:00  ' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'auto', maintenanceWindow: '02:00-04:00',
+    });
+  });
+
+  it('normalizes a whitespace-only window to null', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'staged', maintenanceWindow: '   ' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: null,
+    });
+  });
+
+  it('normalizes a non-string window to null', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 42 } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: null,
+    });
+  });
+
+  it('falls back to the permissive default (staged + null) for an unknown policy', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'bogus' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: null,
+    });
+  });
+
+  it('defaults when defaults sub-object is absent', async () => {
+    dbMock._setResult([{ settings: { somethingElse: true } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: null,
+    });
+  });
+
+  it('defaults when settings is absent / non-object', async () => {
+    dbMock._setResult([{ settings: null }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: null,
+    });
+  });
+
+  it('defaults when the org row is missing entirely', async () => {
+    dbMock._setResult([]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: null,
+    });
+  });
+});

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -53,6 +53,10 @@ import { CloudflareMtlsService } from '../../services/cloudflareMtls';
 import { isAllowedPolicyConfigProbe } from './policyProbeSafety';
 import { PAM_DEFAULTS, parsePamSettings, type PamSettings } from './pamSettings';
 import {
+  normalizeAgentUpdatePolicy,
+  type AgentUpdateSettings,
+} from './agentUpdatePolicy';
+import {
   type SecurityProviderValue,
   type SecurityStatusPayload,
   type PolicyRegistryProbeUpdate,
@@ -1994,6 +1998,28 @@ export function generateApiKey(): string {
 // ============================================
 // mTLS
 // ============================================
+
+/**
+ * Read the org-level agent update policy from `organizations.settings.defaults`
+ * (Org > General). Returns a normalized policy plus the raw maintenance-window
+ * string; the gating decision lives in `shouldSendAgentUpgrade`. Unconfigured
+ * orgs resolve to a permissive default (staged + no window = upgrade anytime).
+ */
+export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdateSettings> {
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  const settings = isObject(org?.settings) ? org.settings : {};
+  const defaults = isObject(settings.defaults) ? settings.defaults : {};
+  const policy = normalizeAgentUpdatePolicy(defaults.agentUpdatePolicy);
+  const maintenanceWindow =
+    typeof defaults.maintenanceWindow === 'string' && defaults.maintenanceWindow.trim()
+      ? defaults.maintenanceWindow.trim()
+      : null;
+  return { policy, maintenanceWindow };
+}
 
 export async function getOrgHelperSettings(orgId: string): Promise<{ enabled: boolean }> {
   const [org] = await db


### PR DESCRIPTION
## Problem

Ramphex (Discord) reported that agents don't obey **Org > General > Agent update policy**. They're right — and not in a subtle way.

`agentUpdatePolicy` (`auto`/`staged`/`manual`) and its companion `maintenanceWindow` are stored/validated/edited in `organizations.settings.defaults`, but **nothing ever reads them**. A repo-wide grep shows every reference is UI, the Zod validator, or a type — zero reads in the decision path.

The heartbeat handler (`apps/api/src/routes/agents/heartbeat.ts`) computes `upgradeTo` purely by comparing the device's version against the latest `agentVersions` row. The Go agent then acts on `upgradeTo` based only on its **local** `config.AutoUpdate` flag. The org policy is decorative.

## Fix

Wire the policy into the heartbeat handler (server-side only — no agent/protocol change; the agent already no-ops on empty `upgradeTo`):

- **`manual`** → never auto-send `upgradeTo` (upgrades only via explicit admin action)
- **`auto` / `staged`** → allowed, but suppressed outside the configured `maintenanceWindow` when one is set (no window = upgrade anytime)

### What's new
- `agentUpdatePolicy.ts` — pure, unit-tested gate: policy normalization + maintenance-window parsing (optional day prefix, daily windows, midnight-wrapping, UTC). Malformed windows **fail open** so a typo never permanently blocks updates.
- `getOrgAgentUpdatePolicy(orgId)` in `helpers.ts` — DB read following the existing `getOrg*Settings` pattern.
- Gating applied to **agent, helper, and watchdog version upgrades**.

### Deliberately NOT gated
- **Bootstrap installs** (a component not yet present) — a device must always be able to finish installing.
- **#1104 wedged-agent watchdog recovery** — that path only fires when the main agent is silent/wedged; gating self-heal behind `manual` could strand agents with no recovery.

### Non-breaking
Unconfigured orgs resolve to a permissive default (`staged` + no window = upgrade anytime), and the lookup fails open — so existing deployments see no behavior change.

## Testing
- `agentUpdatePolicy.test.ts` — 15 pure-logic cases (parsing, windows, gate semantics)
- 4 new heartbeat integration cases: manual withholds, auto offers, staged-outside-window withholds, fail-open on lookup error
- Full agents route suite green: **261 tests**; `tsc --noEmit` clean

## Known limitations / follow-ups
- Partner-level `agentUpdatePolicy` (the Partner Defaults tab) is **not** inherited when an org leaves its policy unset — only the org's own setting is read. Org-level was the reported issue; partner inheritance can be a follow-up.
- Maintenance window is evaluated in **UTC** (the stored string carries no timezone). Worth surfacing in the UI or adding an org timezone later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)