### PR TITLE
feat(web): added profile theming section & font selection

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -575,6 +575,74 @@ describe('user routes', () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it.each([
+      ['theme', 'sepia', /Invalid theme value/i],
+      ['density', 'tiny', /Invalid density value/i],
+      ['font', 'comic-sans', /Invalid font value/i],
+    ])('rejects invalid %s appearance preference', async (key, value, message) => {
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ preferences: { [key]: value } })
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(message);
+    });
+
+    it('merges partial preference updates instead of clobbering existing keys', async () => {
+      const existingPreferences = {
+        theme: 'dark',
+        density: 'compact',
+        customKey: 'preserve-me'
+      };
+      const mergedPreferences = {
+        ...existingPreferences,
+        font: 'system'
+      };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              email: 'test@example.com',
+              passwordHash: 'hash',
+              preferences: existingPreferences
+            }])
+          })
+        })
+      } as any);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'user-123',
+            email: 'test@example.com',
+            name: 'Test User',
+            avatarUrl: null,
+            status: 'active',
+            mfaEnabled: false,
+            preferences: mergedPreferences
+          }])
+        })
+      });
+      vi.mocked(db.update).mockReturnValue({
+        set: setMock
+      } as any);
+
+      const res = await app.request('/users/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ preferences: { font: 'system' } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(setMock).toHaveBeenCalledWith(expect.objectContaining({
+        preferences: mergedPreferences
+      }));
+      const body = await res.json();
+      expect(body.preferences).toEqual(mergedPreferences);
+    });
   });
 
   describe('PATCH /users/me audit coverage (SOC2)', () => {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -471,6 +471,24 @@ const updateMeSchema = z
   })
   .strict();
 
+function isPreferenceRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validatePreferenceEnum(
+  prefs: Record<string, unknown>,
+  key: string,
+  validValues: readonly string[],
+  label: string
+): string | null {
+  if (!(key in prefs)) return null;
+  const value = prefs[key];
+  if (typeof value !== 'string' || !validValues.includes(value)) {
+    return `Invalid ${key} value. Must be ${label}.`;
+  }
+  return null;
+}
+
 userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
   const auth = c.get('auth');
   const body = c.req.valid('json');
@@ -478,7 +496,11 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
   // Load the caller's own row once: needed to detect a real email change and to
   // choose the right step-up factor (local password vs MFA).
   const [self] = await db
-    .select({ email: users.email, passwordHash: users.passwordHash })
+    .select({
+      email: users.email,
+      passwordHash: users.passwordHash,
+      preferences: users.preferences
+    })
     .from(users)
     .where(eq(users.id, auth.user.id))
     .limit(1);
@@ -510,14 +532,32 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
         return c.json({ error: 'preferences payload too large (64KB max)' }, 400);
       }
       const prefs = body.preferences as Record<string, unknown>;
-      const validThemes = ['light', 'dark', 'system'];
-      if (
-        typeof prefs.theme === 'string'
-        && !validThemes.includes(prefs.theme)
-      ) {
-        return c.json({ error: 'Invalid theme value. Must be light, dark, or system.' }, 400);
+      const validationError =
+        validatePreferenceEnum(
+          prefs,
+          'theme',
+          ['light', 'dark', 'system'],
+          'light, dark, or system'
+        )
+        ?? validatePreferenceEnum(
+          prefs,
+          'density',
+          ['comfortable', 'compact', 'dense'],
+          'comfortable, compact, or dense'
+        )
+        ?? validatePreferenceEnum(prefs, 'font', ['breeze', 'system'], 'breeze or system');
+      if (validationError) {
+        return c.json({ error: validationError }, 400);
       }
-      updates.preferences = prefs;
+      const mergedPreferences = {
+        ...(isPreferenceRecord(self.preferences) ? self.preferences : {}),
+        ...prefs
+      };
+      const mergedSerialized = JSON.stringify(mergedPreferences);
+      if (mergedSerialized.length > 64 * 1024) {
+        return c.json({ error: 'preferences payload too large (64KB max)' }, 400);
+      }
+      updates.preferences = mergedPreferences;
     } else if (body.preferences === null) {
       updates.preferences = undefined;
     }

--- a/apps/web/public/theme-bootstrap.js
+++ b/apps/web/public/theme-bootstrap.js
@@ -20,14 +20,24 @@
     document.documentElement.setAttribute('data-density', d);
   }
 
+  function applyFont() {
+    var f = localStorage.getItem('breeze.font');
+    if (f !== 'system') {
+      f = 'breeze';
+    }
+    document.documentElement.setAttribute('data-font', f);
+  }
+
   applyTheme();
   applyDensity();
+  applyFont();
 
   if (!window.__themeSwap) {
     window.__themeSwap = true;
     document.addEventListener('astro:after-swap', function () {
       applyTheme();
       applyDensity();
+      applyFont();
       var main = document.querySelector('main');
       if (main) main.scrollTop = 0;
     });

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -35,11 +35,21 @@ import { useFeaturesStore } from '../../stores/featuresStore';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '../../lib/navigation';
 import { useAvatarBlobUrl } from '../../lib/avatarBlobCache';
-import { readDensity, writeDensity, subscribeDensity, type Density } from '../../lib/density';
+import {
+  readDensity,
+  readThemePreference,
+  subscribeDensity,
+  subscribeTheme,
+  writeDensity,
+  writeThemePreference,
+  type Density,
+  type ThemePreference,
+} from '../../lib/appearance';
+import { saveUserPreferences } from '../../lib/userPreferences';
 
 export default function Header() {
   const [mounted, setMounted] = useState(false);
-  const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('light');
+  const [theme, setTheme] = useState<ThemePreference>('system');
   // Interface density: account-wide preference (breeze.density) shared with
   // any table that opts in. The control lives in this theme/display submenu;
   // changing it re-skins the whole app via <html data-density> (globals.css).
@@ -69,14 +79,13 @@ export default function Header() {
   // Mark as mounted after hydration to avoid SSR/client mismatch
   useEffect(() => {
     setMounted(true);
-    const raw = localStorage.getItem('theme');
-    const stored = (raw === 'light' || raw === 'dark' || raw === 'system') ? raw : null;
-    setTheme(stored || 'system');
+    setTheme(readThemePreference());
     // Hydrate density from storage and stay in sync if another component
     // (e.g. a table toolbar) ever flips it.
     setDensity(readDensity());
   }, []);
 
+  useEffect(() => subscribeTheme(setTheme), []);
   useEffect(() => subscribeDensity(setDensity), []);
 
   useEffect(() => {
@@ -169,26 +178,14 @@ export default function Header() {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [showUserMenu]);
 
-  const applyTheme = (next: 'light' | 'dark' | 'system') => {
+  const applyTheme = (next: ThemePreference) => {
     setTheme(next);
     setShowThemeMenu(false);
-
-    const resolved = next === 'system'
-      ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-      : next;
-
-    if (resolved === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-    localStorage.setItem('theme', next);
+    writeThemePreference(next);
 
     if (isAuthenticated) {
-      fetchWithAuth('/users/me', {
-        method: 'PATCH',
-        body: JSON.stringify({ preferences: { theme: next } })
-      }).catch((err) => console.warn('[theme] Failed to persist preference:', err));
+      saveUserPreferences({ theme: next }, 'Failed to save theme preference')
+        .catch((err) => console.warn('[theme] Failed to persist preference:', err));
     }
   };
 
@@ -197,6 +194,10 @@ export default function Header() {
   // (subscribeDensity above keeps this menu's checkmark in sync).
   const applyDensity = (next: Density) => {
     writeDensity(next);
+    if (isAuthenticated) {
+      saveUserPreferences({ density: next }, 'Failed to save density preference')
+        .catch((err) => console.warn('[density] Failed to persist preference:', err));
+    }
   };
 
   // Listen for OS theme changes when in system mode
@@ -204,11 +205,7 @@ export default function Header() {
     if (theme !== 'system') return;
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = (e: MediaQueryListEvent) => {
-      if (e.matches) {
-        document.documentElement.classList.add('dark');
-      } else {
-        document.documentElement.classList.remove('dark');
-      }
+      document.documentElement.classList.toggle('dark', e.matches);
     };
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ProfilePage from './ProfilePage';
 import { fetchWithAuth } from '../../stores/auth';
+import { writeDensity, writeFontPreference, writeThemePreference } from '@/lib/appearance';
 
 vi.mock('../../stores/auth', () => ({
   createPasskeyCredential: vi.fn(),
@@ -223,6 +224,59 @@ describe('ProfilePage theming settings', () => {
         });
       }
       return undefined as unknown as Response;
+    });
+  });
+
+  it('renders theming below the passkeys section', async () => {
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: false
+        }}
+      />
+    );
+
+    await screen.findByText('No passkeys are registered for this account.');
+    const addPasskeyButton = screen.getByRole('button', { name: 'Add passkey' });
+    const themingHeading = screen.getByRole('heading', { name: 'Theming' });
+
+    expect(
+      addPasskeyButton.compareDocumentPosition(themingHeading) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('reflects appearance changes made outside the profile page', async () => {
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: false,
+          preferences: {
+            theme: 'light',
+            density: 'comfortable',
+            font: 'breeze'
+          }
+        }}
+      />
+    );
+
+    await screen.findByText('No passkeys are registered for this account.');
+
+    act(() => {
+      writeThemePreference('dark');
+      writeDensity('dense');
+      writeFontPreference('system');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Dark/i })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: /Dense/i })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByText('OS interface font').closest('button')).toHaveAttribute('aria-pressed', 'true');
     });
   });
 

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -31,9 +31,37 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
     json: vi.fn().mockResolvedValue(payload)
   }) as unknown as Response;
 
+function installLocalStorageStub() {
+  const values = new Map<string, string>();
+  const storage = {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+    clear: vi.fn(() => {
+      values.clear();
+    }),
+  };
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+}
+
 // Stub URL.createObjectURL / revokeObjectURL — jsdom doesn't provide them by
 // default, and the component calls them when a file is selected for preview.
 beforeEach(() => {
+  installLocalStorageStub();
+  document.documentElement.classList.remove('dark');
+  document.documentElement.removeAttribute('data-density');
+  document.documentElement.removeAttribute('data-font');
   globalThis.URL.createObjectURL = vi.fn(() => 'blob:fake');
   globalThis.URL.revokeObjectURL = vi.fn();
 });
@@ -175,6 +203,67 @@ describe('ProfilePage avatar settings', () => {
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull();
     });
+  });
+});
+
+describe('ProfilePage theming settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      if (String(url) === '/users/me') {
+        return makeJsonResponse({
+          preferences: {
+            theme: 'dark',
+            density: 'compact',
+            font: 'system'
+          }
+        });
+      }
+      return undefined as unknown as Response;
+    });
+  });
+
+  it('saves font selection with the existing theme and density preferences', async () => {
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: false,
+          preferences: {
+            theme: 'dark',
+            density: 'compact',
+            font: 'breeze'
+          }
+        }}
+      />
+    );
+
+    const systemFontButton = screen.getByText('OS interface font').closest('button');
+    expect(systemFontButton).not.toBeNull();
+    fireEvent.click(systemFontButton!);
+
+    await screen.findByText('Theming preferences saved.');
+
+    const preferenceCall = fetchWithAuthMock.mock.calls.find(
+      ([url]) => String(url) === '/users/me'
+    );
+    expect(preferenceCall).toBeDefined();
+    const [, init] = preferenceCall!;
+    expect(init?.method).toBe('PATCH');
+    expect(JSON.parse(String(init?.body))).toEqual({
+      preferences: {
+        theme: 'dark',
+        density: 'compact',
+        font: 'system'
+      }
+    });
+    expect(localStorage.getItem('breeze.font')).toBe('system');
+    expect(document.documentElement).toHaveAttribute('data-font', 'system');
   });
 });
 

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -742,11 +742,6 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         </button>
       </form>
 
-      <ThemingSettings
-        preferences={user?.preferences}
-        onSaved={(preferences) => setUser(prev => (prev ? { ...prev, preferences } : prev))}
-      />
-
       {/* Change Password */}
       <ChangePasswordForm
         onSubmit={handlePasswordChange}
@@ -919,6 +914,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
           </div>
         )}
       </div>
+
+      <ThemingSettings
+        preferences={user?.preferences}
+        onSaved={(preferences) => setUser(prev => (prev ? { ...prev, preferences } : prev))}
+      />
 
       {/* Onboarding */}
       <div className="rounded-lg border bg-card p-6 shadow-sm">

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -4,8 +4,9 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import ChangePasswordForm from './ChangePasswordForm';
 import MFASettings from './MFASettings';
+import ThemingSettings from './ThemingSettings';
 import { createPasskeyCredential, fetchWithAuth, useAuthStore } from '../../stores/auth';
-import type { PasskeyRegistrationOptions } from '../../stores/auth';
+import type { PasskeyRegistrationOptions, UserPreferences } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { useAvatarBlobUrl } from '@/lib/avatarBlobCache';
 
@@ -21,6 +22,7 @@ type User = {
   email: string;
   avatarUrl?: string;
   mfaEnabled?: boolean;
+  preferences?: UserPreferences;
 };
 
 type PasskeySummary = {
@@ -739,6 +741,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
           {isProfileLoading ? 'Saving...' : 'Save changes'}
         </button>
       </form>
+
+      <ThemingSettings
+        preferences={user?.preferences}
+        onSaved={(preferences) => setUser(prev => (prev ? { ...prev, preferences } : prev))}
+      />
 
       {/* Change Password */}
       <ChangePasswordForm

--- a/apps/web/src/components/settings/ThemingSettings.tsx
+++ b/apps/web/src/components/settings/ThemingSettings.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AlignJustify, Check, Monitor, Moon, Rows3, Rows4, Sun, Type } from 'lucide-react';
+import type { UserPreferences } from '../../stores/auth';
+import {
+  applyAppearancePreferences,
+  normalizeDensity,
+  normalizeFont,
+  normalizeTheme,
+  readDensity,
+  readFontPreference,
+  readThemePreference,
+  type Density,
+  type FontPreference,
+  type ThemePreference,
+} from '@/lib/appearance';
+import { saveUserPreferences } from '@/lib/userPreferences';
+
+const themeOptions = [
+  { value: 'light' as const, label: 'Light', Icon: Sun },
+  { value: 'dark' as const, label: 'Dark', Icon: Moon },
+  { value: 'system' as const, label: 'System', Icon: Monitor },
+];
+
+const densityOptions = [
+  { value: 'comfortable' as const, label: 'Comfortable', Icon: Rows3 },
+  { value: 'compact' as const, label: 'Compact', Icon: Rows4 },
+  { value: 'dense' as const, label: 'Dense', Icon: AlignJustify },
+];
+
+const fontOptions = [
+  { value: 'breeze' as const, label: 'Breeze default', description: 'Plus Jakarta Sans', Icon: Type },
+  { value: 'system' as const, label: 'System', description: 'OS interface font', Icon: Monitor },
+];
+
+function resolveAppearance(preferences?: UserPreferences | null): Required<UserPreferences> {
+  return {
+    theme: normalizeTheme(preferences?.theme) ?? readThemePreference(),
+    density: normalizeDensity(preferences?.density) ?? readDensity(),
+    font: normalizeFont(preferences?.font) ?? readFontPreference(),
+  };
+}
+
+type ThemingSettingsProps = {
+  preferences?: UserPreferences | null;
+  onSaved?: (preferences: UserPreferences) => void;
+};
+
+export default function ThemingSettings({ preferences, onSaved }: ThemingSettingsProps) {
+  const [themePreference, setThemePreference] = useState<ThemePreference>('system');
+  const [densityPreference, setDensityPreference] = useState<Density>('comfortable');
+  const [fontPreference, setFontPreference] = useState<FontPreference>('breeze');
+  const [appearanceError, setAppearanceError] = useState<string | undefined>();
+  const [appearanceSuccess, setAppearanceSuccess] = useState<string | undefined>();
+  const [isSavingAppearance, setIsSavingAppearance] = useState(false);
+
+  const syncAppearanceState = useCallback((nextPreferences?: UserPreferences | null) => {
+    const next = resolveAppearance(nextPreferences);
+    setThemePreference(next.theme);
+    setDensityPreference(next.density);
+    setFontPreference(next.font);
+  }, []);
+
+  useEffect(() => {
+    syncAppearanceState(preferences);
+  }, [preferences, syncAppearanceState]);
+
+  const handleAppearanceChange = async (
+    patch: Partial<Pick<Required<UserPreferences>, 'theme' | 'density' | 'font'>>
+  ) => {
+    const next: Required<UserPreferences> = {
+      theme: patch.theme ?? themePreference,
+      density: patch.density ?? densityPreference,
+      font: patch.font ?? fontPreference,
+    };
+
+    setThemePreference(next.theme);
+    setDensityPreference(next.density);
+    setFontPreference(next.font);
+    setAppearanceError(undefined);
+    setAppearanceSuccess(undefined);
+    applyAppearancePreferences(next);
+
+    try {
+      setIsSavingAppearance(true);
+      const saved = await saveUserPreferences(next, 'Failed to save theming preferences');
+      const resolved = resolveAppearance(saved);
+      setThemePreference(resolved.theme);
+      setDensityPreference(resolved.density);
+      setFontPreference(resolved.font);
+      onSaved?.(saved);
+      setAppearanceSuccess('Theming preferences saved.');
+    } catch (error) {
+      setAppearanceError(error instanceof Error ? error.message : 'Failed to save theming preferences');
+    } finally {
+      setIsSavingAppearance(false);
+    }
+  };
+
+  return (
+    <section className="space-y-6 rounded-lg border bg-card p-6 shadow-sm">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold">Theming</h2>
+        <p className="text-sm text-muted-foreground">Set your display preferences for this account.</p>
+      </div>
+
+      <div className="space-y-5">
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">Theme</legend>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {themeOptions.map(({ value, label, Icon }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => void handleAppearanceChange({ theme: value })}
+                aria-pressed={themePreference === value}
+                disabled={isSavingAppearance}
+                className={`flex h-10 items-center justify-center gap-2 rounded-md border px-3 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 ${
+                  themePreference === value ? 'border-primary bg-primary/10 text-primary' : 'bg-background'
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                <span>{label}</span>
+                {themePreference === value && <Check className="h-4 w-4" />}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">Interface density</legend>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {densityOptions.map(({ value, label, Icon }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => void handleAppearanceChange({ density: value })}
+                aria-pressed={densityPreference === value}
+                disabled={isSavingAppearance}
+                className={`flex h-10 items-center justify-center gap-2 rounded-md border px-3 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 ${
+                  densityPreference === value ? 'border-primary bg-primary/10 text-primary' : 'bg-background'
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                <span>{label}</span>
+                {densityPreference === value && <Check className="h-4 w-4" />}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">Font selection</legend>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {fontOptions.map(({ value, label, description, Icon }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => void handleAppearanceChange({ font: value })}
+                aria-pressed={fontPreference === value}
+                disabled={isSavingAppearance}
+                className={`flex min-h-14 items-center gap-3 rounded-md border px-3 py-2 text-left text-sm transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 ${
+                  fontPreference === value ? 'border-primary bg-primary/10 text-primary' : 'bg-background'
+                }`}
+              >
+                <Icon className="h-4 w-4 shrink-0" />
+                <span className="min-w-0 flex-1">
+                  <span className="block font-medium">{label}</span>
+                  <span className="block text-xs text-muted-foreground">{description}</span>
+                </span>
+                {fontPreference === value && <Check className="h-4 w-4 shrink-0" />}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+      </div>
+
+      {appearanceSuccess && (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600">
+          {appearanceSuccess}
+        </div>
+      )}
+      {appearanceError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {appearanceError}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/ThemingSettings.tsx
+++ b/apps/web/src/components/settings/ThemingSettings.tsx
@@ -9,6 +9,9 @@ import {
   readDensity,
   readFontPreference,
   readThemePreference,
+  subscribeDensity,
+  subscribeFont,
+  subscribeTheme,
   type Density,
   type FontPreference,
   type ThemePreference,
@@ -63,6 +66,18 @@ export default function ThemingSettings({ preferences, onSaved }: ThemingSetting
   useEffect(() => {
     syncAppearanceState(preferences);
   }, [preferences, syncAppearanceState]);
+
+  useEffect(() => {
+    const unsubscribeTheme = subscribeTheme(setThemePreference);
+    const unsubscribeDensity = subscribeDensity(setDensityPreference);
+    const unsubscribeFont = subscribeFont(setFontPreference);
+
+    return () => {
+      unsubscribeTheme();
+      unsubscribeDensity();
+      unsubscribeFont();
+    };
+  }, []);
 
   const handleAppearanceChange = async (
     patch: Partial<Pick<Required<UserPreferences>, 'theme' | 'density' | 'font'>>

--- a/apps/web/src/lib/appearance.ts
+++ b/apps/web/src/lib/appearance.ts
@@ -1,0 +1,199 @@
+export const THEME_OPTIONS = ['light', 'dark', 'system'] as const;
+export type ThemePreference = (typeof THEME_OPTIONS)[number];
+
+export const DENSITY_OPTIONS = ['comfortable', 'compact', 'dense'] as const;
+export type Density = (typeof DENSITY_OPTIONS)[number];
+
+export const FONT_OPTIONS = ['breeze', 'system'] as const;
+export type FontPreference = (typeof FONT_OPTIONS)[number];
+
+export type AppearancePreferences = {
+  theme?: ThemePreference;
+  density?: Density;
+  font?: FontPreference;
+};
+
+export const DEFAULT_THEME: ThemePreference = 'system';
+export const DEFAULT_DENSITY: Density = 'comfortable';
+export const DEFAULT_FONT: FontPreference = 'breeze';
+
+export const THEME_STORAGE_KEY = 'theme';
+export const DENSITY_STORAGE_KEY = 'breeze.density';
+export const FONT_STORAGE_KEY = 'breeze.font';
+
+export function isValidTheme(value: unknown): value is ThemePreference {
+  return typeof value === 'string' && (THEME_OPTIONS as readonly string[]).includes(value);
+}
+
+export function isValidDensity(value: unknown): value is Density {
+  return typeof value === 'string' && (DENSITY_OPTIONS as readonly string[]).includes(value);
+}
+
+export function isValidFont(value: unknown): value is FontPreference {
+  return typeof value === 'string' && (FONT_OPTIONS as readonly string[]).includes(value);
+}
+
+export function normalizeTheme(value: unknown): ThemePreference | undefined {
+  return isValidTheme(value) ? value : undefined;
+}
+
+export function normalizeDensity(value: unknown): Density | undefined {
+  return isValidDensity(value) ? value : undefined;
+}
+
+export function normalizeFont(value: unknown): FontPreference | undefined {
+  return isValidFont(value) ? value : undefined;
+}
+
+function readStorageValue(key: string): string | null {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeStorageValue(key: string, value: string): void {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Quota / SecurityError: ignore. The DOM-applied value still takes effect.
+  }
+}
+
+export function readThemePreference(): ThemePreference {
+  return normalizeTheme(readStorageValue(THEME_STORAGE_KEY)) ?? DEFAULT_THEME;
+}
+
+export function readDensity(): Density {
+  return normalizeDensity(readStorageValue(DENSITY_STORAGE_KEY)) ?? DEFAULT_DENSITY;
+}
+
+export function readFontPreference(): FontPreference {
+  return normalizeFont(readStorageValue(FONT_STORAGE_KEY)) ?? DEFAULT_FONT;
+}
+
+export function applyThemePreference(value: ThemePreference): void {
+  if (typeof document === 'undefined') return;
+  const resolved = value === 'system'
+    ? (typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+    : value;
+
+  document.documentElement.classList.toggle('dark', resolved === 'dark');
+}
+
+export function applyDensityAttribute(value: Density): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-density', value);
+}
+
+export function applyFontAttribute(value: FontPreference): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-font', value);
+}
+
+export function writeThemePreference(value: ThemePreference): void {
+  if (!isValidTheme(value)) return;
+  writeStorageValue(THEME_STORAGE_KEY, value);
+  applyThemePreference(value);
+  notifyTheme(value);
+}
+
+export function writeDensity(value: Density): void {
+  if (!isValidDensity(value)) return;
+  writeStorageValue(DENSITY_STORAGE_KEY, value);
+  applyDensityAttribute(value);
+  notifyDensity(value);
+}
+
+export function writeFontPreference(value: FontPreference): void {
+  if (!isValidFont(value)) return;
+  writeStorageValue(FONT_STORAGE_KEY, value);
+  applyFontAttribute(value);
+  notifyFont(value);
+}
+
+export function applyAppearancePreferences(preferences: AppearancePreferences): void {
+  if (preferences.theme) {
+    writeThemePreference(preferences.theme);
+  }
+  if (preferences.density) {
+    writeDensity(preferences.density);
+  }
+  if (preferences.font) {
+    writeFontPreference(preferences.font);
+  }
+}
+
+const themeSubscribers = new Set<(value: ThemePreference) => void>();
+const densitySubscribers = new Set<(value: Density) => void>();
+const fontSubscribers = new Set<(value: FontPreference) => void>();
+
+function notifyTheme(value: ThemePreference): void {
+  for (const fn of themeSubscribers) {
+    try {
+      fn(value);
+    } catch {
+      // Subscriber errors must not break setter.
+    }
+  }
+}
+
+function notifyDensity(value: Density): void {
+  for (const fn of densitySubscribers) {
+    try {
+      fn(value);
+    } catch {
+      // Subscriber errors must not break setter.
+    }
+  }
+}
+
+function notifyFont(value: FontPreference): void {
+  for (const fn of fontSubscribers) {
+    try {
+      fn(value);
+    } catch {
+      // Subscriber errors must not break setter.
+    }
+  }
+}
+
+export function subscribeTheme(fn: (value: ThemePreference) => void): () => void {
+  themeSubscribers.add(fn);
+  return () => {
+    themeSubscribers.delete(fn);
+  };
+}
+
+export function subscribeDensity(fn: (value: Density) => void): () => void {
+  densitySubscribers.add(fn);
+  return () => {
+    densitySubscribers.delete(fn);
+  };
+}
+
+export function subscribeFont(fn: (value: FontPreference) => void): () => void {
+  fontSubscribers.add(fn);
+  return () => {
+    fontSubscribers.delete(fn);
+  };
+}
+
+export function densityTableClasses(density: Density): string {
+  switch (density) {
+    case 'compact':
+      return '[&_td]:py-2 [&_th]:py-2';
+    case 'dense':
+      return '[&_td]:py-1.5 [&_th]:py-1.5 [&_td]:text-xs';
+    case 'comfortable':
+    default:
+      return '';
+  }
+}

--- a/apps/web/src/lib/density.ts
+++ b/apps/web/src/lib/density.ts
@@ -1,108 +1,12 @@
-// Per-user table density preference. Persisted in localStorage under a
-// single account-wide key (not per-table) so the choice applies anywhere
-// a table opts in. Mirrors the pageSizePreference / columnVisibility
-// pattern: SSR-safe getter, silent-fail setter, and a small subscribe
-// helper so unrelated component instances can re-render when one of
-// them changes the preference.
-
-export const DENSITY_OPTIONS = ['comfortable', 'compact', 'dense'] as const;
-export type Density = (typeof DENSITY_OPTIONS)[number];
-
-export const DEFAULT_DENSITY: Density = 'comfortable';
-export const DENSITY_STORAGE_KEY = 'breeze.density';
-
-export function isValidDensity(value: unknown): value is Density {
-  return typeof value === 'string' && (DENSITY_OPTIONS as readonly string[]).includes(value);
-}
-
-// readDensity returns the stored preference if present and recognized,
-// otherwise DEFAULT_DENSITY. SSR-safe: localStorage access during server
-// render or in Safari private mode (SecurityError on getItem) falls back
-// to the default.
-export function readDensity(): Density {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return DEFAULT_DENSITY;
-  }
-  try {
-    const raw = window.localStorage.getItem(DENSITY_STORAGE_KEY);
-    if (raw === null) return DEFAULT_DENSITY;
-    return isValidDensity(raw) ? raw : DEFAULT_DENSITY;
-  } catch {
-    return DEFAULT_DENSITY;
-  }
-}
-
-// writeDensity persists the chosen density. Silently swallows quota /
-// SecurityError errors — the choice still applies in component state,
-// only persistence across reload is lost. Notifies subscribers so other
-// table instances on the same page re-read and re-render. Also mirrors
-// the value to a data-density attribute on <html> so the page-level CSS
-// rules in globals.css can tighten outer padding, card padding, gaps,
-// header height, sidebar nav rows, and modal padding.
-export function writeDensity(value: Density): void {
-  if (!isValidDensity(value)) return;
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return;
-  try {
-    window.localStorage.setItem(DENSITY_STORAGE_KEY, value);
-  } catch {
-    // Quota / SecurityError — ignore.
-  }
-  applyDensityAttribute(value);
-  for (const fn of subscribers) {
-    try {
-      fn(value);
-    } catch {
-      // Subscriber errors must not break setter.
-    }
-  }
-}
-
-// applyDensityAttribute sets data-density on <html> so descendant CSS
-// rules can target it. theme-bootstrap.js also does this inline on
-// first paint to avoid FOUC; this function exists so subsequent
-// React-driven changes stay in sync.
-export function applyDensityAttribute(value: Density): void {
-  if (typeof document === 'undefined') return;
-  try {
-    document.documentElement.setAttribute('data-density', value);
-  } catch {
-    // Unusable DOM (jsdom edge cases) — ignore.
-  }
-}
-
-const subscribers = new Set<(value: Density) => void>();
-
-// subscribeDensity registers a listener invoked synchronously after a
-// successful writeDensity call in the same tab. Returns an unsubscribe
-// function. Does not cover cross-tab updates (would need a `storage`
-// event listener); v1 scope is the one-tab case.
-export function subscribeDensity(fn: (value: Density) => void): () => void {
-  subscribers.add(fn);
-  return () => {
-    subscribers.delete(fn);
-  };
-}
-
-// densityTableClasses returns the Tailwind utility string applied to the
-// <table> element. Uses arbitrary-variant child selectors so every td/th
-// inside the table picks up the override without touching individual
-// cell className strings. Comfortable matches the pre-feature defaults
-// (py-3, text-sm) so existing visual is unchanged.
-//
-// Padding scale (vertical):
-//   comfortable: py-3  (12px)  — existing
-//   compact:     py-2  (8px)   — ~33% less
-//   dense:       py-1.5 (6px) — ~50% less
-//
-// Font size only shrinks at dense to keep compact readable.
-export function densityTableClasses(density: Density): string {
-  switch (density) {
-    case 'compact':
-      return '[&_td]:py-2 [&_th]:py-2';
-    case 'dense':
-      return '[&_td]:py-1.5 [&_th]:py-1.5 [&_td]:text-xs';
-    case 'comfortable':
-    default:
-      return '';
-  }
-}
+export {
+  DENSITY_OPTIONS,
+  DEFAULT_DENSITY,
+  DENSITY_STORAGE_KEY,
+  applyDensityAttribute,
+  densityTableClasses,
+  isValidDensity,
+  readDensity,
+  subscribeDensity,
+  writeDensity,
+} from './appearance';
+export type { Density } from './appearance';

--- a/apps/web/src/lib/userPreferences.ts
+++ b/apps/web/src/lib/userPreferences.ts
@@ -1,0 +1,28 @@
+import { fetchWithAuth, useAuthStore, type UserPreferences } from '../stores/auth';
+import { runAction } from './runAction';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export async function saveUserPreferences(
+  patch: UserPreferences,
+  errorFallback = 'Failed to save preferences'
+): Promise<UserPreferences> {
+  const current = useAuthStore.getState().user?.preferences ?? {};
+  const next: UserPreferences = { ...current, ...patch };
+
+  const updated = await runAction<{ preferences?: unknown }>({
+    request: () => fetchWithAuth('/users/me', {
+      method: 'PATCH',
+      body: JSON.stringify({ preferences: next })
+    }),
+    errorFallback
+  });
+
+  const preferences = isRecord(updated.preferences)
+    ? (updated.preferences as UserPreferences)
+    : next;
+  useAuthStore.getState().updateUser({ preferences });
+  return preferences;
+}

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -9,9 +9,17 @@ import {
   type RegistrationResponseJSON
 } from '@simplewebauthn/browser';
 import { extractApiError } from '@/lib/apiError';
+import {
+  applyAppearancePreferences,
+  type Density,
+  type FontPreference,
+  type ThemePreference,
+} from '@/lib/appearance';
 
 export interface UserPreferences {
-  theme?: 'light' | 'dark' | 'system';
+  theme?: ThemePreference;
+  density?: Density;
+  font?: FontPreference;
 }
 
 export interface User {
@@ -780,21 +788,6 @@ export async function apiLogout(): Promise<void> {
   }
 }
 
-function applyThemePreference(theme: string | undefined): void {
-  if (!theme || typeof document === 'undefined') return;
-
-  const resolved = theme === 'system'
-    ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-    : theme;
-
-  if (resolved === 'dark') {
-    document.documentElement.classList.add('dark');
-  } else {
-    document.documentElement.classList.remove('dark');
-  }
-  localStorage.setItem('theme', theme);
-}
-
 export async function fetchAndApplyPreferences(): Promise<void> {
   try {
     const response = await fetchWithAuth('/users/me');
@@ -810,7 +803,7 @@ export async function fetchAndApplyPreferences(): Promise<void> {
     }
     if (data.preferences) {
       useAuthStore.getState().updateUser({ preferences: data.preferences });
-      applyThemePreference(data.preferences.theme);
+      applyAppearancePreferences(data.preferences);
     }
   } catch {
     // Non-critical — localStorage still has the cached theme

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -26,6 +26,8 @@ select {
 
 @layer base {
   :root {
+    --font-sans: "Plus Jakarta Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
     /* Warm off-white surfaces — not pure white */
     --background: 220 20% 98%;
     --foreground: 224 28% 14%;
@@ -59,6 +61,10 @@ select {
     --input: 220 16% 90%;
     --ring: 225 62% 48%;
     --radius: 0.5rem;
+  }
+
+  :root[data-font='system'] {
+    --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
 
   .dark {
@@ -8958,4 +8964,3 @@ select {
   padding-top: 0.25rem !important;
   padding-bottom: 0.25rem !important;
 }
-

--- a/apps/web/tailwind.config.mjs
+++ b/apps/web/tailwind.config.mjs
@@ -5,7 +5,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['"Plus Jakarta Sans"', 'system-ui', '-apple-system', 'sans-serif'],
+        sans: ['var(--font-sans)'],
       },
       colors: {
         border: 'hsl(var(--border))',


### PR DESCRIPTION
## Summary

- Adds a Theming section to Profile settings for theme, interface density, and font selection.
- Persists appearance preferences on the user profile and applies them across app load/header/profile surfaces.
- Keeps Profile Theming controls in sync with the header quick theme/density menu.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Testing

- [x] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests

Verified with:
- `pnpm lint`
- `pnpm --filter=@breeze/web exec vitest run src/components/settings/ProfilePage.test.tsx`
- `NODE_OPTIONS='--localstorage-file=/tmp/breeze-web-vitest-localstorage' CI=true pnpm test --filter=@breeze/web`
- `pnpm --filter=@breeze/web exec astro check`

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included

## Screenshot:
<img width="724" height="377" alt="Screenshot 2026-06-13 at 03 18 40" src="https://github.com/user-attachments/assets/c431ab26-2582-4a49-81c7-be3846675c68" />
