### PR TITLE
fix(agent): separate Windows OS version and build (#1302)

### DIFF
--- a/agent/internal/collectors/hardware.go
+++ b/agent/internal/collectors/hardware.go
@@ -48,8 +48,12 @@ func (c *HardwareCollector) CollectSystemInfo() (*SystemInfo, error) {
 	hostInfo, err := host.Info()
 	if err == nil {
 		info.OSType = normalizeOSType(hostInfo.OS)
-		info.OSVersion = hostInfo.Platform + " " + hostInfo.PlatformVersion
-		info.OSBuild = hostInfo.KernelVersion
+		info.OSVersion, info.OSBuild = normalizeOSVersionBuild(
+			info.OSType, hostInfo.Platform, hostInfo.PlatformVersion, hostInfo.KernelVersion)
+		// Platform-specific enrichment (Windows: registry feature label +
+		// authoritative build). No-op on other platforms. Best-effort —
+		// failures leave the gopsutil-derived values untouched.
+		enrichOSInfo(info)
 	}
 
 	// Resolve hostname via the fallback chain (os.Hostname → platform
@@ -80,6 +84,70 @@ func normalizeOSType(os string) string {
 		return "macos"
 	}
 	return os
+}
+
+// normalizeOSVersionBuild derives a clean, separated OS version and build
+// string from gopsutil's host.Info fields.
+//
+// On Linux/macOS gopsutil already separates these cleanly: PlatformVersion is
+// the distro/OS version (e.g. "12.12", "15.7.7") and KernelVersion is the
+// build (e.g. "6.8.12-1-pve"). On Windows, however, gopsutil packs the full
+// build into BOTH PlatformVersion and KernelVersion (e.g.
+// "10.0.26200.8457 Build 26200.8457"), so the naive
+// "Platform + ' ' + PlatformVersion" duplicated the build into the version
+// column and left both fields verbose (issue #1302). Platform on Windows is
+// already the clean product name including the correct major release
+// ("Microsoft Windows 11 Pro" — gopsutil resolves the Win11-reports-10
+// registry quirk), so we use it verbatim as the version and extract just the
+// build.UBR for the build column.
+//
+// This is a pure function (no syscalls) so it is fully unit-testable and
+// produces correct output even when the Windows registry enrichment in
+// enrichOSInfo is unavailable.
+func normalizeOSVersionBuild(osType, platform, platformVersion, kernelVersion string) (osVersion, osBuild string) {
+	platform = strings.TrimSpace(platform)
+	platformVersion = strings.TrimSpace(platformVersion)
+	kernelVersion = strings.TrimSpace(kernelVersion)
+
+	if osType == "windows" {
+		// Version = product name only (build-free). Build = the canonical
+		// "<CurrentBuildNumber>.<UBR>" extracted from the gopsutil string.
+		build := platformVersion
+		if build == "" {
+			build = kernelVersion
+		}
+		return platform, extractWindowsBuild(build)
+	}
+
+	// Non-Windows: preserve gopsutil's already-clean separation.
+	osVersion = strings.TrimSpace(platform + " " + platformVersion)
+	return osVersion, kernelVersion
+}
+
+// extractWindowsBuild reduces a gopsutil Windows version string to the
+// canonical "<build>.<UBR>" form admins recognize. Inputs seen in the wild:
+//   - "10.0.26200.8457 Build 26200.8457" -> "26200.8457"
+//   - "10.0.26200.8457"                  -> "26200.8457"
+//   - "26200.8457"                       -> "26200.8457"
+//
+// Anything unrecognized is returned trimmed and unchanged so we never lose
+// information.
+func extractWindowsBuild(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	// Prefer the explicit "Build <x>" token (case-insensitive); take the last.
+	if idx := strings.LastIndex(strings.ToLower(v), "build "); idx >= 0 {
+		if tail := strings.TrimSpace(v[idx+len("build "):]); tail != "" {
+			return tail
+		}
+	}
+	// Else strip a leading NT major.minor ("10.0.") from a dotted quad.
+	if strings.HasPrefix(v, "10.0.") {
+		return strings.TrimPrefix(v, "10.0.")
+	}
+	return v
 }
 
 func (c *HardwareCollector) CollectHardware() (*HardwareInfo, error) {

--- a/agent/internal/collectors/hardware_other.go
+++ b/agent/internal/collectors/hardware_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package collectors
+
+// enrichOSInfo is a no-op on non-Windows platforms; gopsutil already reports a
+// clean, separated OS version and build there (see normalizeOSVersionBuild).
+func enrichOSInfo(info *SystemInfo) {}

--- a/agent/internal/collectors/hardware_test.go
+++ b/agent/internal/collectors/hardware_test.go
@@ -1,0 +1,131 @@
+package collectors
+
+import "testing"
+
+func TestNormalizeOSVersionBuild(t *testing.T) {
+	tests := []struct {
+		name            string
+		osType          string
+		platform        string
+		platformVersion string
+		kernelVersion   string
+		wantVersion     string
+		wantBuild       string
+	}{
+		{
+			name:            "windows 11 strips embedded build from version (#1302)",
+			osType:          "windows",
+			platform:        "Microsoft Windows 11 Pro",
+			platformVersion: "10.0.26200.8457 Build 26200.8457",
+			kernelVersion:   "10.0.26200.8457 Build 26200.8457",
+			wantVersion:     "Microsoft Windows 11 Pro",
+			wantBuild:       "26200.8457",
+		},
+		{
+			name:            "windows 10 enterprise",
+			osType:          "windows",
+			platform:        "Microsoft Windows 10 Enterprise",
+			platformVersion: "10.0.19045.6456 Build 19045.6456",
+			kernelVersion:   "10.0.19045.6456 Build 19045.6456",
+			wantVersion:     "Microsoft Windows 10 Enterprise",
+			wantBuild:       "19045.6456",
+		},
+		{
+			name:            "windows server keeps server/datacenter keywords for role classification",
+			osType:          "windows",
+			platform:        "Microsoft Windows Server 2022 Datacenter",
+			platformVersion: "10.0.20348.2966 Build 20348.2966",
+			kernelVersion:   "10.0.20348.2966 Build 20348.2966",
+			wantVersion:     "Microsoft Windows Server 2022 Datacenter",
+			wantBuild:       "20348.2966",
+		},
+		{
+			name:            "windows version without Build token falls back to dotted-quad strip",
+			osType:          "windows",
+			platform:        "Microsoft Windows 11 Pro",
+			platformVersion: "10.0.22631.4317",
+			kernelVersion:   "10.0.22631.4317",
+			wantVersion:     "Microsoft Windows 11 Pro",
+			wantBuild:       "22631.4317",
+		},
+		{
+			name:            "windows already-clean build is preserved",
+			osType:          "windows",
+			platform:        "Microsoft Windows 11 Pro",
+			platformVersion: "26100.4061",
+			kernelVersion:   "26100.4061",
+			wantVersion:     "Microsoft Windows 11 Pro",
+			wantBuild:       "26100.4061",
+		},
+		{
+			name:            "windows empty version yields empty build, never panics",
+			osType:          "windows",
+			platform:        "Microsoft Windows 11 Pro",
+			platformVersion: "",
+			kernelVersion:   "",
+			wantVersion:     "Microsoft Windows 11 Pro",
+			wantBuild:       "",
+		},
+		{
+			name:            "linux keeps clean version + kernel build untouched",
+			osType:          "linux",
+			platform:        "debian",
+			platformVersion: "12.12",
+			kernelVersion:   "6.17.13-2-pve",
+			wantVersion:     "debian 12.12",
+			wantBuild:       "6.17.13-2-pve",
+		},
+		{
+			name:            "macos keeps clean version + kernel build untouched",
+			osType:          "macos",
+			platform:        "darwin",
+			platformVersion: "15.7.7",
+			kernelVersion:   "24.6.0",
+			wantVersion:     "darwin 15.7.7",
+			wantBuild:       "24.6.0",
+		},
+		{
+			name:            "non-windows with empty platformVersion does not leave trailing space",
+			osType:          "linux",
+			platform:        "alpine",
+			platformVersion: "",
+			kernelVersion:   "6.6.0",
+			wantVersion:     "alpine",
+			wantBuild:       "6.6.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVersion, gotBuild := normalizeOSVersionBuild(tt.osType, tt.platform, tt.platformVersion, tt.kernelVersion)
+			if gotVersion != tt.wantVersion {
+				t.Errorf("osVersion = %q, want %q", gotVersion, tt.wantVersion)
+			}
+			if gotBuild != tt.wantBuild {
+				t.Errorf("osBuild = %q, want %q", gotBuild, tt.wantBuild)
+			}
+		})
+	}
+}
+
+func TestExtractWindowsBuild(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"10.0.26200.8457 Build 26200.8457", "26200.8457"},
+		{"10.0.19045.6456 Build 19045.6456", "19045.6456"},
+		{"10.0.22631.4317", "22631.4317"},
+		{"26100.4061", "26100.4061"},
+		{"  10.0.26200.8457 Build 26200.8457  ", "26200.8457"},
+		{"", ""},
+		// "Build" with an empty tail must not collapse to empty — fall through
+		// to the trimmed original rather than lose the value.
+		{"Build ", "Build"},
+	}
+	for _, tt := range tests {
+		if got := extractWindowsBuild(tt.in); got != tt.want {
+			t.Errorf("extractWindowsBuild(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/agent/internal/collectors/hardware_windows.go
+++ b/agent/internal/collectors/hardware_windows.go
@@ -3,9 +3,12 @@
 package collectors
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 const wmicTimeout = 15 * time.Second
@@ -26,6 +29,49 @@ func wmicGet(args []string, property string) string {
 		}
 	}
 	return ""
+}
+
+// enrichOSInfo refines the OS version/build on Windows using the authoritative
+// registry source (HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion):
+//
+//   - DisplayVersion (e.g. "25H2") is appended to the product name so the
+//     version reads "Microsoft Windows 11 Pro 25H2" — the feature-update label
+//     admins actually track, mirroring how Linux shows "debian 12.12".
+//   - OSBuild is set to "<CurrentBuildNumber>.<UBR>" (e.g. "26200.8457"), the
+//     canonical build string.
+//
+// It is strictly best-effort: any missing key or read error leaves the
+// gopsutil-derived values (already correct after normalizeOSVersionBuild) in
+// place. We deliberately do NOT read ProductName here — on Windows 11 it still
+// reports "Windows 10", whereas gopsutil's Platform correctly resolves "11".
+func enrichOSInfo(info *SystemInfo) {
+	if info == nil {
+		return
+	}
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		slog.Debug("os enrich: open CurrentVersion failed", "error", err.Error())
+		return
+	}
+	defer k.Close()
+
+	if display, _, derr := k.GetStringValue("DisplayVersion"); derr == nil {
+		if display = strings.TrimSpace(display); display != "" &&
+			info.OSVersion != "" && !strings.Contains(info.OSVersion, display) {
+			info.OSVersion = info.OSVersion + " " + display
+		}
+	}
+
+	if build, _, berr := k.GetStringValue("CurrentBuildNumber"); berr == nil {
+		if build = strings.TrimSpace(build); build != "" {
+			if ubr, _, uerr := k.GetIntegerValue("UBR"); uerr == nil {
+				info.OSBuild = fmt.Sprintf("%s.%d", build, ubr)
+			} else {
+				info.OSBuild = build
+			}
+		}
+	}
 }
 
 func collectPlatformHardware(hw *HardwareInfo) {


### PR DESCRIPTION
Closes #1302.

## Problem
Windows agents reported the OS build embedded inside the version string, so the **OS Version** and **OS Build** columns showed the same verbose value. Live examples from the fleet:

| field | before |
|---|---|
| os_version | `Microsoft Windows 11 Pro 10.0.26200.8457 Build 26200.8457` |
| os_build | `10.0.26200.8457 Build 26200.8457` |

Linux/macOS were unaffected (gopsutil separates `PlatformVersion` and `KernelVersion` cleanly there — e.g. `debian 12.12` / `6.17.13-2-pve`).

## Root cause
`CollectSystemInfo` set `OSVersion = Platform + " " + PlatformVersion`, but on Windows gopsutil packs the full build into **both** `PlatformVersion` and `KernelVersion`.

## Fix
- **`normalizeOSVersionBuild()`** — a pure, fully unit-tested helper. On Windows, OSVersion is the build-free product name (gopsutil's `Platform` already resolves the Win11-reports-"10" registry quirk correctly), and OSBuild is the canonical `<build>.<UBR>` extracted from the gopsutil string. Non-Windows behavior is preserved byte-for-byte.
- **`enrichOSInfo()`** (Windows, best-effort) — reads `HKLM\…\CurrentVersion` for the feature-update label (`DisplayVersion`, e.g. `25H2`) and the authoritative `CurrentBuildNumber`.`UBR`. Deliberately does **not** read `ProductName` (it still reports "Windows 10" on Windows 11). No-op stub on non-Windows.

The core fix is independent of the registry enrichment — output is correct even if the registry read fails.

| field | after |
|---|---|
| os_version | `Microsoft Windows 11 Pro 25H2` |
| os_build | `26200.8457` |

`classify.go` role detection keys on "server"/"datacenter" in OSVersion; the product name retains those (`Microsoft Windows Server 2022 Datacenter`), and the existing `classify_test.go` fixtures already use the clean build-free form, so this aligns the runtime with what the tests assumed.

## Verification
- **End-to-end on a real Windows 11 box**: the live `CollectSystemInfo()` now returns version `Microsoft Windows 11 Pro 25H2`, build `26200.8457` (measured against the raw gopsutil + registry values on the same host).
- New table-driven tests: `normalizeOSVersionBuild` (Win10/11/Server, no-"Build"-token, already-clean, empty, Linux, macOS) and `extractWindowsBuild`.
- `go test -race ./internal/collectors/` green; `go vet`, `gofmt`, cross-builds for windows/linux/darwin, and `govulncheck` (0 affecting) all clean via local OrbStack.