### PR TITLE
fix(api): enqueue patch jobs outside the system DB transaction (#1105)

### DIFF
--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -276,9 +276,15 @@ async function hasExistingOccurrenceJob(
   });
 }
 
-async function scanAndCreateJobs(): Promise<{ created: number; scanned: number }> {
+async function scanAndCreateJobs(): Promise<{ created: number; scanned: number; enqueueJobIds: string[] }> {
   const now = new Date();
   let created = 0;
+  // Job ids to enqueue to Redis AFTER the system DB access-context transaction
+  // closes. Enqueuing inside it held the pooled connection idle-in-transaction
+  // across BullMQ/Redis round-trips — a contributor to the #1105 pool-poisoning
+  // pattern (txn around slow non-DB work). DB writes stay in the context; the
+  // Redis enqueue happens outside it (see the worker processor).
+  const enqueueJobIds: string[] = [];
 
   const patchPoliciesWithSchedules = await db
     .select({
@@ -394,7 +400,7 @@ async function scanAndCreateJobs(): Promise<{ created: number; scanned: number }
           .returning();
 
         if (job) {
-          await enqueuePatchJob(job.id);
+          enqueueJobIds.push(job.id);
           created += 1;
           console.log(
             `[PatchScheduler] Created job ${job.id} for config policy ${row.configPolicyId} (${eligibleDeviceIds.length} devices, ${group.timezone}, ${group.occurrenceKey})`
@@ -409,14 +415,14 @@ async function scanAndCreateJobs(): Promise<{ created: number; scanned: number }
     }
   }
 
-  return { created, scanned: patchPoliciesWithSchedules.length };
+  return { created, scanned: patchPoliciesWithSchedules.length, enqueueJobIds };
 }
 
 function createSchedulerWorker(): Worker {
   return new Worker(
     QUEUE_NAME,
     async (_job: Job) => {
-      return runWithSystemDbAccess(async () => {
+      const result = await runWithSystemDbAccess(async () => {
         try {
           return await scanAndCreateJobs();
         } catch (error: unknown) {
@@ -425,11 +431,31 @@ function createSchedulerWorker(): Worker {
               _configPolicyTableWarningLogged = true;
               console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
             }
-            return { created: 0, scanned: 0 };
+            return { created: 0, scanned: 0, enqueueJobIds: [] };
           }
           throw error;
         }
       });
+
+      // Enqueue OUTSIDE the system DB access-context transaction (#1105). All
+      // DB writes (incl. the patch_jobs inserts) committed when the context
+      // above returned; doing the Redis enqueue here keeps the pooled
+      // connection from sitting idle-in-transaction across BullMQ round-trips.
+      // A job that fails to enqueue is logged (its row already exists) and is
+      // skipped by the occurrence-idempotency guard on the next scan — same
+      // outcome as the prior in-transaction failure path.
+      for (const jobId of result.enqueueJobIds) {
+        try {
+          await enqueuePatchJob(jobId);
+        } catch (err) {
+          console.error(
+            `[PatchScheduler] Failed to enqueue patch job ${jobId}:`,
+            err instanceof Error ? err.message : err
+          );
+        }
+      }
+
+      return { created: result.created, scanned: result.scanned };
     },
     {
       connection: getBullMQConnection(),


### PR DESCRIPTION
Refs #1105 (the patch-scheduler instance of the pattern; the core architectural fix stays with the maintainer design proposal).

## Problem
`scanAndCreateJobs` ran the entire scan — **including the BullMQ/Redis `enqueuePatchJob` call** — inside the `withSystemDbAccessContext` transaction. That holds a pooled Postgres connection `idle in transaction` across Redis round-trips, the txn-around-slow-work pattern behind the #1105 pool-poisoning report (`idle_in_transaction_session_timeout` → `write CONNECTION_CLOSED postgres:5432` cascades). Todd's analysis on the issue explicitly called out the patch scheduler as *"a separate, real instance of the same pattern worth fixing independently."*

## Fix
`scanAndCreateJobs` now collects the created job ids and returns them; the worker enqueues them to Redis **after** the access-context transaction has committed and released the connection. All DB work (reads + the `patch_jobs` inserts) still runs inside the context.

- Enqueue failures are logged per-job (the row already exists; the occurrence-idempotency guard skips it on the next scan) — same outcome as the prior in-transaction failure path, but one bad enqueue no longer affects the others.
- No schema/behavior change to job creation or idempotency.

## Scope (deliberate)
This is **only** the worker-level instance. The broader root cause Todd traced — the per-request heartbeat handler wrapped in the RLS-GUC transaction (`withDbAccessContext`/`agentAuth`) — is an architectural change that needs an RLS-isolation design pass (careless changes leak GUCs across pooled connections = a tenant-isolation bug) and is intentionally **not** in this PR.

## Verification
`tsc --noEmit`, `eslint`, and the full `apps/api` jobs suite (248 tests) green locally via OrbStack. Structural relocation of the enqueue; no new behavior to unit-test beyond the existing suite.