### PR TITLE
feat(agent): surface failed systemd unit auto-heal to the fleet (#1201)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -508,6 +508,13 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 		"agentId", cfg.AgentID,
 	)
 
+	// Surface a failed systemd unit auto-heal (reconcileServiceUnitIfNeeded /
+	// the reconcile-unit subcommand) to the fleet now that the log shipper is
+	// up — those failure paths run before the shipper or in a transient unit
+	// whose journal is GC'd, so they'd otherwise be invisible (#1201). No-op
+	// off Linux and when there's nothing recorded.
+	startReconcileFailureReporter()
+
 	// Load mTLS client certificate if configured
 	var tlsCfg *tls.Config
 	if cfg.MtlsCertPEM != "" {

--- a/agent/cmd/breeze-agent/reconcile_status_linux.go
+++ b/agent/cmd/breeze-agent/reconcile_status_linux.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// reconcileStatusPath records the outcome of the most recent failed systemd
+// unit auto-heal so the running agent can surface it to the fleet. It lives
+// under the agent data dir (a var, not const, so tests can point it elsewhere).
+//
+// Why a file: the heal failure can originate in two processes — the agent
+// itself (reconcileServiceUnitIfNeeded, before the log shipper is up) and the
+// transient `reconcile-unit` subcommand spawned under PID 1 (whose stderr lands
+// in a --collect'd transient-unit journal that's GC'd). Neither path can ship a
+// log directly, so they drop a breadcrumb here and the running agent ships it
+// once its log shipper is initialized. See issue #1201.
+var reconcileStatusPath = filepath.Join(linuxDataDir, "reconcile-status")
+
+const (
+	reconcileStatusPrefix       = "failed\t"
+	reconcileReportWindow       = 3 * time.Minute
+	reconcileReportPollInterval = 10 * time.Second
+)
+
+// recordReconcileFailure persists a heal-failure reason. Best-effort: if we
+// can't write it, the failure still surfaced to journald via the caller's
+// stderr warning — this only adds the fleet-visible signal on top.
+func recordReconcileFailure(reason string) {
+	_ = os.MkdirAll(linuxDataDir, 0o755)
+	line := reconcileStatusPrefix + strings.ReplaceAll(strings.TrimSpace(reason), "\n", " ") +
+		"\t" + time.Now().UTC().Format(time.RFC3339)
+	if err := os.WriteFile(reconcileStatusPath, []byte(line+"\n"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not record reconcile-status breadcrumb: %v\n", err)
+	}
+}
+
+// clearReconcileStatus removes a stale failure breadcrumb after a later success.
+func clearReconcileStatus() {
+	if err := os.Remove(reconcileStatusPath); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Warning: could not clear reconcile-status breadcrumb: %v\n", err)
+	}
+}
+
+// readReconcileFailure returns the recorded failure reason, if any.
+func readReconcileFailure() (reason string, ok bool) {
+	data, err := os.ReadFile(reconcileStatusPath)
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(line, reconcileStatusPrefix) {
+		return "", false
+	}
+	fields := strings.Split(strings.TrimPrefix(line, reconcileStatusPrefix), "\t")
+	if len(fields) == 0 || strings.TrimSpace(fields[0]) == "" {
+		return "", false
+	}
+	return fields[0], true
+}
+
+// startReconcileFailureReporter ships a recorded heal failure to the fleet
+// (agent_logs) once the log shipper is up. It polls briefly rather than reading
+// once: the transient reconcile subcommand runs a few seconds after the agent
+// launches it, and in the worst case (unit rewritten but `systemctl restart`
+// failed) the old, still-sandboxed agent keeps running — so a one-shot check
+// would race the subcommand. The window is bounded so we never poll forever; by
+// then the heal has either succeeded (breadcrumb cleared) or been reported.
+func startReconcileFailureReporter() {
+	go func() {
+		deadline := time.Now().Add(reconcileReportWindow)
+		for {
+			if reason, ok := readReconcileFailure(); ok {
+				log.Error(
+					"systemd unit auto-heal failed; remote terminal/scripts may hit privilege "+
+						"errors until 'sudo breeze-agent service install' is run",
+					"component", "service-reconcile",
+					"reason", reason,
+				)
+				clearReconcileStatus()
+				return
+			}
+			if time.Now().After(deadline) {
+				return
+			}
+			time.Sleep(reconcileReportPollInterval)
+		}
+	}()
+}

--- a/agent/cmd/breeze-agent/reconcile_status_linux_test.go
+++ b/agent/cmd/breeze-agent/reconcile_status_linux_test.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withTempStatusPath(t *testing.T) {
+	t.Helper()
+	orig := reconcileStatusPath
+	reconcileStatusPath = filepath.Join(t.TempDir(), "reconcile-status")
+	t.Cleanup(func() { reconcileStatusPath = orig })
+}
+
+func TestReconcileStatusRoundTrip(t *testing.T) {
+	withTempStatusPath(t)
+
+	if reason, ok := readReconcileFailure(); ok {
+		t.Fatalf("expected no failure recorded initially, got %q", reason)
+	}
+
+	recordReconcileFailure("reconcile subcommand: restart: Job failed")
+	reason, ok := readReconcileFailure()
+	if !ok {
+		t.Fatal("expected a recorded failure after recordReconcileFailure")
+	}
+	if reason != "reconcile subcommand: restart: Job failed" {
+		t.Fatalf("unexpected reason %q", reason)
+	}
+
+	clearReconcileStatus()
+	if _, ok := readReconcileFailure(); ok {
+		t.Fatal("expected no failure after clearReconcileStatus")
+	}
+	// clear is idempotent — a second clear on an absent file must not error/panic.
+	clearReconcileStatus()
+}
+
+func TestReconcileStatusSanitizesNewlines(t *testing.T) {
+	withTempStatusPath(t)
+
+	recordReconcileFailure("line one\nline two")
+	reason, ok := readReconcileFailure()
+	if !ok {
+		t.Fatal("expected a recorded failure")
+	}
+	// Newlines collapse to spaces so the single-line, tab-delimited breadcrumb
+	// (reason \t timestamp) can't be corrupted by a multi-line reason.
+	if strings.ContainsAny(reason, "\n\t") {
+		t.Fatalf("reason must be a single tab-free line, got %q", reason)
+	}
+	if reason != "line one line two" {
+		t.Fatalf("expected newlines collapsed to spaces, got %q", reason)
+	}
+}
+
+func TestReadReconcileFailureIgnoresForeignContent(t *testing.T) {
+	withTempStatusPath(t)
+
+	if err := os.WriteFile(reconcileStatusPath, []byte("ok\tnothing wrong\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if reason, ok := readReconcileFailure(); ok {
+		t.Fatalf("expected non-failure content to be ignored, got %q", reason)
+	}
+}

--- a/agent/cmd/breeze-agent/reconcile_status_other.go
+++ b/agent/cmd/breeze-agent/reconcile_status_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package main
+
+// startReconcileFailureReporter is a no-op off Linux. The systemd unit
+// auto-heal and its failure-surfacing (issue #1201) are Linux-only;
+// recordReconcileFailure / clearReconcileStatus are referenced solely from the
+// Linux service path and are not defined here.
+func startReconcileFailureReporter() {}

--- a/agent/cmd/breeze-agent/service_cmd_linux.go
+++ b/agent/cmd/breeze-agent/service_cmd_linux.go
@@ -77,6 +77,7 @@ func reconcileServiceUnitIfNeeded() {
 					"Warning: could not read %s to check for an outdated systemd unit: %v. "+
 						"If the remote terminal/scripts hit privilege errors, run: "+
 						"sudo breeze-agent service install\n", linuxUnitDst, err)
+				recordReconcileFailure(fmt.Sprintf("could not read unit file %s: %v", linuxUnitDst, err))
 			}
 			return
 		}
@@ -88,6 +89,8 @@ func reconcileServiceUnitIfNeeded() {
 				"Warning: breeze-agent systemd unit is outdated (pre-v%d) and systemd-run is "+
 					"unavailable to auto-heal it. The remote terminal/scripts may hit privilege "+
 					"errors (e.g. apt). Fix: sudo breeze-agent service install\n", currentUnitVersion)
+			recordReconcileFailure(fmt.Sprintf(
+				"systemd-run unavailable to auto-heal outdated unit (pre-v%d)", currentUnitVersion))
 			return
 		}
 		// TRANSIENT SERVICE, deliberately NOT --scope: a scope child is forked
@@ -104,6 +107,7 @@ func reconcileServiceUnitIfNeeded() {
 			fmt.Fprintf(os.Stderr,
 				"Warning: failed to auto-heal outdated systemd unit via systemd-run: %s. "+
 					"Fix: sudo breeze-agent service install\n", strings.TrimSpace(string(out)))
+			recordReconcileFailure(fmt.Sprintf("systemd-run launch failed: %s", strings.TrimSpace(string(out))))
 		}
 	})
 }
@@ -419,9 +423,11 @@ var serviceReconcileUnitCmd = &cobra.Command{
 		// so the next startup won't re-attempt the restart — the relaxed sandbox
 		// then applies on the following natural service restart rather than now.
 		if err := os.WriteFile(linuxUnitDst, []byte(linuxUnit), 0644); err != nil {
+			recordReconcileFailure(fmt.Sprintf("reconcile subcommand: write unit: %v", err))
 			return fmt.Errorf("write unit: %w", err)
 		}
 		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+			recordReconcileFailure(fmt.Sprintf("reconcile subcommand: daemon-reload: %s", strings.TrimSpace(string(out))))
 			return fmt.Errorf("daemon-reload: %w: %s", err, strings.TrimSpace(string(out)))
 		}
 		fmt.Printf("Reconciled %s to unit version %d; restarting service.\n", linuxUnitDst, currentUnitVersion)
@@ -429,8 +435,14 @@ var serviceReconcileUnitCmd = &cobra.Command{
 		// the old agent; we run as a systemd-run transient service whose parent
 		// is PID 1 (not the agent), so this child survives to finish the restart.
 		if out, err := exec.Command("systemctl", "restart", linuxServiceName).CombinedOutput(); err != nil {
+			// The unit is v2 on disk but the live process is still sandboxed and
+			// won't re-attempt on its own — this is the silent worst case #1201
+			// exists to surface. The still-running old agent's reporter ships it.
+			recordReconcileFailure(fmt.Sprintf("reconcile subcommand: restart: %s", strings.TrimSpace(string(out))))
 			return fmt.Errorf("restart: %w: %s", err, strings.TrimSpace(string(out)))
 		}
+		// Heal succeeded — drop any stale failure breadcrumb from a prior attempt.
+		clearReconcileStatus()
 		return nil
 	},
 }


### PR DESCRIPTION
Closes #1201. Follow-up to #1197 (silent-failure review).

## Problem
When the startup auto-heal (`reconcileServiceUnitIfNeeded`) or its transient `reconcile-unit` subcommand fails, the host stays on the old sandboxed unit — remote terminal/scripts keep hitting privilege errors (e.g. `apt`) — but there is **no fleet-visible signal**. Two reasons:
1. The parent runs *before* the log shipper is initialized, so its `stderr` warnings reach journald only.
2. The repair runs as a `systemd-run` transient service whose errors land in a `--collect`'d transient-unit journal that's GC'd.

Worst case: unit rewritten to v2 on disk but `systemctl restart` failed → the live process stays sandboxed and `unitNeedsReconcile` returns false next boot, so it won't re-attempt until a natural restart. Recoverable, but silent in the meantime.

## Fix (observability only — heal/escape mechanism unchanged)
- Every failure path drops a one-line breadcrumb to `/var/lib/breeze/reconcile-status`:
  - **parent:** unit-read error, `systemd-run` missing, `systemd-run` launch error
  - **subcommand:** unit-write / `daemon-reload` / `restart` error
- A successful heal clears any stale breadcrumb.
- Once the log shipper is up, `startReconcileFailureReporter()` ships the recorded failure at **ERROR** (→ `agent_logs`, visible in the console without SSH) and clears it. It **polls briefly** rather than reading once, because the subcommand runs async under PID 1 and — in the restart-failure worst case — the old agent keeps running, so a one-shot read would race it. The poll window is bounded so it never runs forever. No-op off Linux.

Surfacing is log-based (no schema/API/web change). A device-level badge could be a follow-up if stronger console surfacing is wanted.

## Scope
Purely the failure-path observability the issue asks for. The sandbox relaxation and the systemd-run escape are untouched.

## Verification
**End-to-end on a real systemd host (OrbStack machine):**
- success path reconciled an outdated (pre-v2) unit to v2 and cleared a stale breadcrumb;
- a forced `systemctl restart` failure recorded the breadcrumb: `failed\treconcile subcommand: restart: Job for breeze-agent.service failed (simulated)\t<UTC ts>`.

Unit tests cover record/read/clear round-trip, newline sanitization, and foreign-content rejection. `gofmt`/`go vet` clean; cross-builds for linux/darwin/windows green; `govulncheck` 0 (no new deps).