### PR TITLE
test(monitoring): de-flake TestApplyConfigRestopsAndRestarts

### DIFF
--- a/agent/internal/monitoring/monitor_lifecycle_test.go
+++ b/agent/internal/monitoring/monitor_lifecycle_test.go
@@ -8,6 +8,31 @@ import (
 
 // --- Lifecycle integration tests ---
 
+// waitForCallCount polls until the supplied counter reaches `want` (or more)
+// within a generous deadline, then returns the observed count. The immediate
+// check kicked off by ApplyConfig/Start runs asynchronously in the loop
+// goroutine, so a fixed real-clock sleep races that goroutine — on a busy CI
+// runner the check may not have fired yet when the sleep elapses (issue #1267).
+// Polling lets timing pressure only slow the test, never fail it.
+func waitForCallCount(t *testing.T, mu *sync.Mutex, callCount *int, want int) int {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		count := *callCount
+		mu.Unlock()
+
+		if count >= want {
+			return count
+		}
+		if time.Now().After(deadline) {
+			return count
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestMonitorRunsImmediateCheckOnStart(t *testing.T) {
 	var mu sync.Mutex
 	var callCount int
@@ -26,13 +51,9 @@ func TestMonitorRunsImmediateCheckOnStart(t *testing.T) {
 	}
 
 	m.ApplyConfig(cfg)
-	// Give the immediate check time to fire
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the async immediate check to fire instead of racing a fixed sleep.
+	count := waitForCallCount(t, &mu, &callCount, 1)
 	m.Stop()
-
-	mu.Lock()
-	count := callCount
-	mu.Unlock()
 
 	if count < 1 {
 		t.Fatalf("callCount = %d, want >= 1 (immediate check should have fired)", count)
@@ -56,7 +77,9 @@ func TestApplyConfigRestopsAndRestarts(t *testing.T) {
 		},
 	}
 	m.ApplyConfig(cfg1)
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the first ApplyConfig's immediate check before re-applying, so the
+	// second config can't clobber the first check before it runs.
+	waitForCallCount(t, &mu, &callCount, 1)
 
 	// Re-apply with different config — should stop and restart
 	cfg2 := MonitorConfig{
@@ -66,12 +89,9 @@ func TestApplyConfigRestopsAndRestarts(t *testing.T) {
 		},
 	}
 	m.ApplyConfig(cfg2)
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the second ApplyConfig's immediate check (total >= 2).
+	count := waitForCallCount(t, &mu, &callCount, 2)
 	m.Stop()
-
-	mu.Lock()
-	count := callCount
-	mu.Unlock()
 
 	// Should have fired at least twice (one immediate check per ApplyConfig)
 	if count < 2 {


### PR DESCRIPTION
## Summary

`TestApplyConfigRestopsAndRestarts` (and its sibling `TestMonitorRunsImmediateCheckOnStart`) raced a fixed ~100ms real-clock sleep against the async immediate check that `ApplyConfig`/`Start` kicks off in the monitor loop goroutine. On a busy CI runner the immediate check could miss the sleep window, leaving `callCount` below the expected threshold and failing the test — with no underlying product defect (see #1267: the failing PR had zero Go changes and a re-run went green).

## What changed

- Added a `waitForCallCount` polling helper in `agent/internal/monitoring/monitor_lifecycle_test.go` that waits up to a generous 2s deadline for the callback counter to reach a target, polling every 5ms.
- Replaced the fixed `time.Sleep(100ms)` waits in both lifecycle tests with this helper. In `TestApplyConfigRestopsAndRestarts` we now wait for the first `ApplyConfig`'s immediate check (count >= 1) before re-applying — guaranteeing the second config can't clobber the first check before it runs — then wait for the second check (count >= 2).
- Timing pressure can now only slow the test, never fail it.

This is a test-only change; no production code was touched.

## Test command + result

```
cd agent && go test -race -run 'TestApplyConfigRestopsAndRestarts|TestMonitorRunsImmediateCheckOnStart' -count=20 ./internal/monitoring/...
# ok  github.com/breeze-rmm/agent/internal/monitoring

cd agent && go test -race -run TestApplyConfigRestopsAndRestarts -count=50 ./internal/monitoring/...
# ok  (exit 0)

cd agent && go test -race ./internal/monitoring/...
# ok  (full package green)
```

`go vet` and `gofmt` are clean.

Closes #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)