### PR TITLE
fix(installer): require --token in install.sh, demote --enrollment-secret to supplement

### DIFF
--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -210,10 +210,17 @@ describe('GET /install.sh — generated installer script', () => {
     ).toHaveLength(2);
   });
 
-  it('requires a token OR an enrollment secret, not unconditionally the secret', async () => {
+  it('requires the enrollment token, treating --enrollment-secret as a supplement', async () => {
     const script = await fetchScript();
-    expect(script).toContain('Pass --token TOKEN or --enrollment-secret SECRET');
-    // The old unconditional secret check must be gone.
+    // The token is mandatory end-to-end (agent `enroll` takes it as a required
+    // positional arg; the server resolves the org/site from it). The validation
+    // must gate on the token alone, NOT on "token OR secret" — a secret-only
+    // invocation used to pass here and then die at the last step with cobra's
+    // "accepts 1 arg(s), received 0".
+    expect(script).toContain('An enrollment token is required. Pass --token TOKEN');
+    // The old token-OR-secret acceptance must be gone.
+    expect(script).not.toContain('-z "$BREEZE_ENROLL_TOKEN" && -z "$BREEZE_ENROLLMENT_SECRET"');
+    expect(script).not.toContain('An enrollment credential is required');
     expect(script).not.toContain('BREEZE_ENROLLMENT_SECRET is required');
   });
 
@@ -375,23 +382,46 @@ describe('install.sh functional pre-flight behavior', () => {
     }
   });
 
-  it('rejects a missing enrollment credential with guidance', async () => {
+  it('rejects a missing enrollment token with guidance', async () => {
     const { code, output } = await runScript(['--server', 'http://127.0.0.1:1']);
     expect(code).not.toBe(0);
-    expect(output).toContain('Pass --token TOKEN or --enrollment-secret SECRET');
+    expect(output).toContain('An enrollment token is required. Pass --token TOKEN');
   });
 
-  it('accepts --enrollment-secret alone (legacy flow) past credential validation', async () => {
+  it('rejects a secret-only invocation at validation (issue #1274), before installing anything', async () => {
+    // The bug: --enrollment-secret without --token passed the script's own
+    // credential check, installed the agent, and then died at the very last
+    // step with cobra's "accepts 1 arg(s), received 0" — because the agent's
+    // `enroll` requires the enrollment key as a positional arg and the server
+    // resolves the org/site from it. The fix makes the script fail fast at the
+    // first step (validation), never reaching the connectivity pre-flight or
+    // download.
     const { code, output } = await runScript([
       '--server',
       'http://127.0.0.1:1',
       '--enrollment-secret',
       'sec',
     ]);
-    // Dies at the connectivity pre-flight (nothing listening), proving the
-    // token-OR-secret check let the secret-only invocation through.
     expect(code).not.toBe(0);
-    expect(output).not.toContain('enrollment credential is required');
+    expect(output).toContain('An enrollment token is required. Pass --token TOKEN');
+    // Must die at validation, NOT proceed to connectivity/download.
+    expect(output).not.toContain('Checking connectivity');
+    expect(output).not.toContain('Cannot reach the Breeze server');
+  });
+
+  it('accepts --token plus --enrollment-secret together past credential validation', async () => {
+    const { code, output } = await runScript([
+      '--server',
+      'http://127.0.0.1:1',
+      '--token',
+      'tok',
+      '--enrollment-secret',
+      'sec',
+    ]);
+    // The supplementary secret is allowed alongside the required token; the run
+    // proceeds to the connectivity pre-flight and dies there (nothing listening).
+    expect(code).not.toBe(0);
+    expect(output).not.toContain('An enrollment token is required');
     expect(output).toContain('Cannot reach the Breeze server');
   });
 

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -315,15 +315,19 @@ function generateInstallScript(serverUrl: string): string {
 #     --server ${serverUrl} \\
 #     --token YOUR_ENROLLMENT_TOKEN
 #
-# Or with an org enrollment secret:
+# The enrollment token is REQUIRED — it identifies the org/site to enroll into.
+# An org enrollment secret (--enrollment-secret) is an OPTIONAL extra gate that
+# the server can require IN ADDITION to the token; it is never a substitute for
+# it. Pass both when your server is configured with AGENT_ENROLLMENT_SECRET:
 #   curl -fsSL ${serverUrl}/api/v1/agents/install.sh | sudo bash -s -- \\
 #     --server ${serverUrl} \\
+#     --token YOUR_ENROLLMENT_TOKEN \\
 #     --enrollment-secret YOUR_SECRET
 #
 # Or with environment variables — pass them through sudo, since a plain
 # \`export\` is stripped by sudo's env_reset:
 #   curl -fsSL ${serverUrl}/api/v1/agents/install.sh | \\
-#     sudo BREEZE_SERVER="${serverUrl}" BREEZE_ENROLLMENT_SECRET="YOUR_SECRET" bash
+#     sudo BREEZE_SERVER="${serverUrl}" BREEZE_ENROLL_TOKEN="YOUR_ENROLLMENT_TOKEN" bash
 # ============================================
 
 set -euo pipefail
@@ -370,8 +374,14 @@ if [[ -z "\$BREEZE_SERVER" ]]; then
   fatal "BREEZE_SERVER is required. Pass --server URL or export BREEZE_SERVER."
 fi
 
-if [[ -z "\$BREEZE_ENROLL_TOKEN" && -z "\$BREEZE_ENROLLMENT_SECRET" ]]; then
-  fatal "An enrollment credential is required. Pass --token TOKEN or --enrollment-secret SECRET (or pass BREEZE_ENROLL_TOKEN / BREEZE_ENROLLMENT_SECRET through sudo)."
+# The enrollment token is mandatory end-to-end: the agent's \`enroll\` command
+# takes it as a required positional arg, and the server resolves the org/site
+# from it. --enrollment-secret is only a supplementary gate, never a standalone
+# credential — accepting it alone here used to pass validation and then die at
+# the very last step with cobra's "accepts 1 arg(s), received 0". Fail at the
+# first step instead, with actionable guidance.
+if [[ -z "\$BREEZE_ENROLL_TOKEN" ]]; then
+  fatal "An enrollment token is required. Pass --token TOKEN (or BREEZE_ENROLL_TOKEN through sudo). Generate one from the Add Device dialog. --enrollment-secret is an optional extra gate, not a replacement for the token."
 fi
 
 # Strip trailing slash from server URL
@@ -558,7 +568,7 @@ if [[ "\$OS" == "darwin" ]]; then
   fi
 
   if ! "\$INSTALL_DIR/\$BINARY_NAME" "\${ENROLL_ARGS[@]}"; then
-    fatal "Enrollment failed. Check the server URL and enrollment secret."
+    fatal "Enrollment failed. Check the server URL and that the enrollment token is valid and not expired (plus the enrollment secret, if your server requires one)."
   fi
   success "Agent enrolled successfully"
 

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -553,9 +553,9 @@ if [[ "\$OS" == "darwin" ]]; then
   # Enroll agent
   info "Enrolling agent with Breeze server..."
   ENROLL_ARGS=(enroll)
-  if [[ -n "\$BREEZE_ENROLL_TOKEN" ]]; then
-    ENROLL_ARGS+=("\$BREEZE_ENROLL_TOKEN")
-  fi
+  # The token is mandatory and already validated above as non-empty, so append
+  # it unconditionally — there is no token-less enroll path.
+  ENROLL_ARGS+=("\$BREEZE_ENROLL_TOKEN")
   ENROLL_ARGS+=(--server "\$BREEZE_SERVER")
   if [[ -n "\$BREEZE_ENROLLMENT_SECRET" ]]; then
     ENROLL_ARGS+=(--enrollment-secret "\$BREEZE_ENROLLMENT_SECRET")
@@ -653,9 +653,9 @@ success "Config directory ready"
 # ----- Enroll agent -----
 info "Enrolling agent with Breeze server..."
 ENROLL_ARGS=(enroll)
-if [[ -n "\$BREEZE_ENROLL_TOKEN" ]]; then
-  ENROLL_ARGS+=("\$BREEZE_ENROLL_TOKEN")
-fi
+# The token is mandatory and already validated above as non-empty, so append
+# it unconditionally — there is no token-less enroll path.
+ENROLL_ARGS+=("\$BREEZE_ENROLL_TOKEN")
 ENROLL_ARGS+=(--server "\$BREEZE_SERVER")
 if [[ -n "\$BREEZE_ENROLLMENT_SECRET" ]]; then
   ENROLL_ARGS+=(--enrollment-secret "\$BREEZE_ENROLLMENT_SECRET")
@@ -668,7 +668,7 @@ if [[ -n "\$BREEZE_DEVICE_ROLE" ]]; then
 fi
 
 if ! "\$INSTALL_DIR/\$BINARY_NAME" "\${ENROLL_ARGS[@]}"; then
-  fatal "Enrollment failed. Check the server URL and enrollment secret."
+  fatal "Enrollment failed. Check the server URL and that the enrollment token is valid and not expired (plus the enrollment secret, if your server requires one)."
 fi
 success "Agent enrolled successfully"
 

--- a/apps/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/src/content/docs/getting-started/quickstart.mdx
@@ -98,8 +98,20 @@ Download and install the Breeze agent on a device:
 
 ```bash
 # On the target device:
+# The enrollment token is REQUIRED — grab it from the Add Device dialog.
 curl -fsSL https://localhost/api/v1/agents/install.sh | \
   BREEZE_SERVER=https://localhost \
+  BREEZE_ENROLL_TOKEN=<your-enrollment-token> \
+  bash
+```
+
+If your server is configured with an org enrollment secret, pass it as an
+**optional** extra gate alongside the token (never instead of it):
+
+```bash
+curl -fsSL https://localhost/api/v1/agents/install.sh | \
+  BREEZE_SERVER=https://localhost \
+  BREEZE_ENROLL_TOKEN=<your-enrollment-token> \
   BREEZE_ENROLLMENT_SECRET=<your-enrollment-secret> \
   bash
 ```


### PR DESCRIPTION
## Summary

`install.sh` (served at `GET /api/v1/agents/install.sh`) accepted `--enrollment-secret` without `--token` and documented a secret-only invocation — but that path **never worked**. It passed the script's own credential validation, downloaded and installed the agent, then died at the very last step with cobra's:

```
Error: accepts 1 arg(s), received 0
```

This is the same late-cryptic-failure class PR #1271 set out to eliminate, surfaced by test-coverage review on that PR.

## Root cause

The enrollment **key/token is mandatory end-to-end**, but install.sh treated it as optional:

- **Agent CLI:** `enroll` is `cobra.ExactArgs(1)` — the positional enrollment key is required; `--enrollment-secret` is only a supplementary flag (`agent/cmd/breeze-agent/main.go:171,216`).
- **API:** `POST /agents/enroll` resolves the org/site by looking the key up in `enrollment_keys` and cannot proceed without it; the secret is an additional gate, not an alternative credential (`apps/api/src/routes/agents/enrollment.ts`).
- **install.sh:** validation accepted token **OR** secret and built `ENROLL_ARGS=(enroll --server URL --enrollment-secret SECRET)` with **zero positional args** when no token was given.

So no secret-only invocation has ever been able to enroll.

## What changed (Option 1 from the issue — recommended)

- Make `--token` **required** in install.sh; fail at validation (first step) instead of post-install (last step).
- Demote `--enrollment-secret` to the optional supplement it actually is (still appended when provided, in both the darwin and linux branches).
- Rewrote the script header docs: removed the broken secret-only example, kept token + optional secret, and fixed the env-var example to use `BREEZE_ENROLL_TOKEN`.
- Updated the fatal credential message and the enrollment-failure guidance so the script, agent CLI, and API tell one consistent story.

## Tests

Updated `download.test.ts`:
- The previously-locked "accepts `--enrollment-secret` alone (legacy flow)" test now asserts the secret-only invocation is **rejected at validation** before installing anything (the #1274 regression guard).
- New test: `--token` + `--enrollment-secret` together proceed past validation (supplement is still allowed).
- The header-doc and "requires the enrollment token" assertions were updated to the new story.

These tests run the real generated script through `bash` (plus a `bash -n` syntax check), so they exercise the actual installer behavior.

```
pnpm --filter @breeze/api exec vitest run src/routes/agents/download.test.ts
```

Result: **22 passed (22)**.

Closes #1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)