### PR TITLE
feat(web): add Monitoring + Backup left-nav sections

### DIFF
--- a/apps/web/src/components/layout/Sidebar.nav.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.nav.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+
+// Mock the stores so importing Sidebar.tsx (which the navSections export lives
+// in) doesn't pull in real auth/ui store side effects.
+import { vi } from 'vitest';
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: { getState: () => ({ tokens: null }) },
+}));
+vi.mock('../../stores/uiStore', () => ({
+  useUiStore: vi.fn(() => ({ isMobileMenuOpen: false, closeMobileMenu: vi.fn() })),
+}));
+
+import { navSections } from './Sidebar';
+
+function section(id: string) {
+  const s = navSections.find((sec) => sec.id === id);
+  if (!s) throw new Error(`section "${id}" not found`);
+  return s;
+}
+
+function hrefsOf(id: string) {
+  return section(id).items.map((i) => i.href);
+}
+
+describe('navSections structure (#1321, #1324)', () => {
+  it('has a dedicated Monitoring section with Network Monitor + Network Discovery, in that order', () => {
+    const monitoring = section('monitoring');
+    expect(monitoring.label).toBe('Monitoring');
+    expect(hrefsOf('monitoring')).toEqual(['/monitoring', '/discovery']);
+
+    const names = monitoring.items.map((i) => i.name);
+    expect(names).toEqual(['Network Monitor', 'Network Discovery']);
+  });
+
+  it('has a dedicated Backup section with Backup, Cloud Backup, Disaster Recovery, in that order', () => {
+    const backup = section('backup');
+    expect(backup.label).toBe('Backup');
+    expect(hrefsOf('backup')).toEqual(['/backup', '/c2c', '/dr']);
+
+    const names = backup.items.map((i) => i.name);
+    expect(names).toEqual(['Backup', 'Cloud Backup', 'Disaster Recovery']);
+  });
+
+  it('removed Network Monitor from Security (now lives only under Monitoring)', () => {
+    expect(hrefsOf('security')).not.toContain('/monitoring');
+    // Security still leads with its own Security item.
+    expect(section('security').items[0].href).toBe('/security');
+  });
+
+  it('removed Network Discovery and all backup items from Operations', () => {
+    const ops = hrefsOf('operations');
+    expect(ops).not.toContain('/discovery');
+    expect(ops).not.toContain('/backup');
+    expect(ops).not.toContain('/c2c');
+    expect(ops).not.toContain('/dr');
+    // Operations retains its non-backup items.
+    expect(ops).toEqual([
+      '/software',
+      '/software-inventory',
+      '/configuration-policies',
+      '/integrations',
+    ]);
+  });
+
+  it('each moved href appears in exactly one section (no duplicate membership)', () => {
+    const allHrefs = navSections.flatMap((s) => s.items.map((i) => i.href));
+    for (const href of ['/monitoring', '/discovery', '/backup', '/c2c', '/dr']) {
+      const count = allHrefs.filter((h) => h === href).length;
+      expect(count, `${href} should appear exactly once across all sections`).toBe(1);
+    }
+  });
+
+  it('orders sections AI & Fleet -> Monitoring -> Security -> Operations -> Backup -> Reporting -> Settings', () => {
+    expect(navSections.map((s) => s.id)).toEqual([
+      'ai-fleet',
+      'monitoring',
+      'security',
+      'operations',
+      'backup',
+      'reporting',
+      'settings',
+    ]);
+  });
+});

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -110,7 +110,8 @@ interface NavSection {
   items: NavItem[];
 }
 
-const navSections: NavSection[] = [
+// Exported for structural nav tests (see Sidebar.nav.test.tsx).
+export const navSections: NavSection[] = [
   {
     id: 'ai-fleet',
     label: 'AI & Fleet',
@@ -121,11 +122,19 @@ const navSections: NavSection[] = [
     ],
   },
   {
+    id: 'monitoring',
+    label: 'Monitoring',
+    icon: Activity,
+    items: [
+      { name: 'Network Monitor', href: '/monitoring', icon: Activity },
+      { name: 'Network Discovery', href: '/discovery', icon: Network },
+    ],
+  },
+  {
     id: 'security',
     label: 'Security',
     icon: ShieldCheck,
     items: [
-      { name: 'Network Monitor', href: '/monitoring', icon: Activity },
       { name: 'Security', href: '/security', icon: ShieldCheck },
       { name: 'DNS Security', href: '/dns-security', icon: Network },
       { name: 'PAM', href: '/pam', icon: KeyRound },
@@ -141,14 +150,20 @@ const navSections: NavSection[] = [
     label: 'Operations',
     icon: Layers,
     items: [
-      { name: 'Network Discovery', href: '/discovery', icon: Network },
       { name: 'Software Library', href: '/software', icon: Package },
       { name: 'Software Policies', href: '/software-inventory', icon: Package },
       { name: 'Config Policies', href: '/configuration-policies', icon: Layers },
+      { name: 'Integrations', href: '/integrations', icon: Plug },
+    ],
+  },
+  {
+    id: 'backup',
+    label: 'Backup',
+    icon: HardDrive,
+    items: [
       { name: 'Backup', href: '/backup', icon: HardDrive },
       { name: 'Cloud Backup', href: '/c2c', icon: Cloud },
       { name: 'Disaster Recovery', href: '/dr', icon: ShieldEllipsis },
-      { name: 'Integrations', href: '/integrations', icon: Plug },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Two related left-nav information-architecture changes, both pure data-driven moves inside `navSections` in `apps/web/src/components/layout/Sidebar.tsx`:

- **#1321 — Monitoring section:** Network Monitor (`/monitoring`) and Network Discovery (`/discovery`) previously lived ~15 items apart in two different sections (Security and Operations). They're now colocated under a new **Monitoring** section, placed after AI & Fleet and before Security.
- **#1324 — Backup section:** The three data-protection items (Backup `/backup`, Cloud Backup `/c2c`, Disaster Recovery `/dr`) were buried in Operations next to unrelated items. They're now grouped under their own dedicated **Backup** section, placed after Operations.

## What changed

- Added `monitoring` `NavSection` (`Network Monitor`, `Network Discovery`).
- Removed `Network Monitor` from `security` (Security now leads with its own Security item).
- Removed `Network Discovery` from `operations`.
- Added `backup` `NavSection` (`Backup`, `Cloud Backup`, `Disaster Recovery`).
- Removed the three backup items from `operations` (Operations retains Software Library, Software Policies, Config Policies, Integrations).
- Exported `navSections` (mirrors the existing `VersionSpan` export-for-test pattern) and added `Sidebar.nav.test.tsx`.

All `href`/`icon`/`name`/gating preserved verbatim. No new permissions or feature flags. Section collapse-state persistence and auto-expand-on-active-route work automatically for the new section ids (`monitoring`, `backup`) — no logic changes needed.

Final section order: AI & Fleet → Monitoring → Security → Operations → Backup → Reporting → Settings.

## Tests

New `Sidebar.nav.test.tsx` asserts: both new sections exist with the right label/items in the right order; Network Monitor is gone from Security and Network Discovery + backup items are gone from Operations; each moved href appears in exactly one section; and the overall section ordering.

Command:
```
pnpm --filter @breeze/web exec vitest run \
  src/components/layout/Sidebar.nav.test.tsx \
  src/components/layout/Sidebar.staleness.test.tsx
```
Result: **2 files passed, 11 tests passed** (6 new nav + 5 existing staleness — the latter confirms the `navSections` export change didn't break the existing `VersionSpan` import).

Closes #1321
Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)