### PR TITLE
fix(web): confirm before deleting a costed ticket part

### DIFF
--- a/apps/web/src/components/tickets/TicketPartsCard.test.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.test.tsx
@@ -40,10 +40,37 @@ describe('TicketPartsCard', () => {
     });
   });
 
-  it('deletes a part via /tickets/parts/:id', async () => {
+  it('requires confirmation before deleting — first Delete click does not call the API', async () => {
     render(<TicketPartsCard ticketId="tk-1" />);
     fireEvent.click(await screen.findByTestId('ticket-part-delete-p-1'));
+    // Confirm affordance appears; no DELETE request yet
+    expect(await screen.findByTestId('ticket-part-delete-confirm-p-1')).toBeTruthy();
+    expect(
+      fetchWithAuth.mock.calls.some(
+        (args) => args[0] === '/tickets/parts/p-1' && (args[1] as RequestInit)?.method === 'DELETE',
+      ),
+    ).toBe(false);
+  });
+
+  it('deletes a part via /tickets/parts/:id after confirming', async () => {
+    render(<TicketPartsCard ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-part-delete-p-1'));
+    fireEvent.click(await screen.findByTestId('ticket-part-delete-confirm-yes-p-1'));
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/tickets/parts/p-1', expect.objectContaining({ method: 'DELETE' })));
+  });
+
+  it('cancel dismisses the confirm without deleting', async () => {
+    render(<TicketPartsCard ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-part-delete-p-1'));
+    fireEvent.click(await screen.findByTestId('ticket-part-delete-confirm-cancel-p-1'));
+    await waitFor(() => expect(screen.queryByTestId('ticket-part-delete-confirm-p-1')).toBeNull());
+    expect(
+      fetchWithAuth.mock.calls.some(
+        (args) => args[0] === '/tickets/parts/p-1' && (args[1] as RequestInit)?.method === 'DELETE',
+      ),
+    ).toBe(false);
+    // Delete button is back
+    expect(screen.getByTestId('ticket-part-delete-p-1')).toBeTruthy();
   });
 
   it('edits a part — preserves costBasis as number, omits sparse fields', async () => {

--- a/apps/web/src/components/tickets/TicketPartsCard.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.tsx
@@ -23,6 +23,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
   const [costBasis, setCostBasis] = useState('');
   const [billable, setBillable] = useState(true);
   const [busy, setBusy] = useState(false);
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     const res = await fetchWithAuth(`/tickets/${ticketId}/parts`)
@@ -44,6 +45,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
     setUnitPrice('');
     setCostBasis('');
     setBillable(true);
+    setConfirmingDeleteId(null);
   }, [ticketId]);
 
   const resetForm = () => {
@@ -129,6 +131,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
         errorFallback: 'Failed to delete part',
         successMessage: 'Part deleted',
       });
+      setConfirmingDeleteId(null);
       await refresh();
       broadcastBillingChanged();
     } catch (err) {
@@ -180,24 +183,50 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
                     </span>
                   )}
                 </div>
-                <div className="mt-0.5 flex gap-1">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(part)}
-                    className="rounded px-1 py-0.5 text-xs hover:bg-muted"
-                    data-testid={`ticket-part-edit-${part.id}`}
+                {confirmingDeleteId === part.id ? (
+                  <div
+                    className="mt-0.5 flex items-center gap-1"
+                    data-testid={`ticket-part-delete-confirm-${part.id}`}
                   >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void deletePart(part.id)}
-                    className="rounded px-1 py-0.5 text-xs text-destructive hover:bg-muted"
-                    data-testid={`ticket-part-delete-${part.id}`}
-                  >
-                    Delete
-                  </button>
-                </div>
+                    <span className="text-destructive">Delete?</span>
+                    <span className="text-muted-foreground">·</span>
+                    <button
+                      type="button"
+                      onClick={() => void deletePart(part.id)}
+                      className="rounded px-1 py-0.5 text-xs font-medium text-destructive hover:bg-muted"
+                      data-testid={`ticket-part-delete-confirm-yes-${part.id}`}
+                    >
+                      Confirm
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingDeleteId(null)}
+                      className="rounded px-1 py-0.5 text-xs hover:bg-muted"
+                      data-testid={`ticket-part-delete-confirm-cancel-${part.id}`}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <div className="mt-0.5 flex gap-1">
+                    <button
+                      type="button"
+                      onClick={() => openEdit(part)}
+                      className="rounded px-1 py-0.5 text-xs hover:bg-muted"
+                      data-testid={`ticket-part-edit-${part.id}`}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingDeleteId(part.id)}
+                      className="rounded px-1 py-0.5 text-xs text-destructive hover:bg-muted"
+                      data-testid={`ticket-part-delete-${part.id}`}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
On a ticket's **Parts** card, clicking **Delete** on a line item removed it instantly — no confirmation, no undo. A single mis-click permanently deleted a part carrying cost/price/margin data on a billing surface (#1299, deferred from #1285).

## What changed
- `TicketPartsCard.tsx`: the row **Delete** button now opens a lightweight inline confirm (`Delete? · Confirm / Cancel`) instead of deleting immediately. Per the issue plan, this is intentionally inline rather than a heavy modal, since parts are deleted often during ticket work.
  - New `confirmingDeleteId` state drives the per-row confirm affordance.
  - The actual delete still flows through `runAction` (success/error toasts preserved).
  - Pending-confirm state resets on `ticketId` change and after a successful delete.
- `TicketPartsCard.test.tsx`: updated the delete test to confirm-then-delete, and added coverage that (a) the first Delete click does **not** hit the API, and (b) Cancel dismisses the confirm without deleting.

## Testing
```
pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketPartsCard.test.tsx
```
Result: 6 passed (6).

Closes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)