### PR TITLE
fix(web): de-dupe identical toasts to kill duplicate success toasts (#1301)

### DIFF
--- a/apps/web/src/components/shared/Toast.test.tsx
+++ b/apps/web/src/components/shared/Toast.test.tsx
@@ -142,6 +142,72 @@ describe('ToastContainer', () => {
     expect(toast).toHaveTextContent('heads up');
   });
 
+  it('collapses two identical success toasts fired in quick succession into one (#1301 double-toast papercut)', () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      showToast({ type: 'success', message: 'Timer started' });
+      showToast({ type: 'success', message: 'Timer started' });
+    });
+
+    // A double-emit (double-mounted container / view-transition overlap / a
+    // caller firing twice) must surface exactly one toast, not two.
+    const toasts = screen.getAllByTestId('toast');
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toHaveTextContent('Timer started');
+  });
+
+  it('does NOT collapse toasts with different messages or types fired together', () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      showToast({ type: 'success', message: 'Status created' });
+      showToast({ type: 'success', message: 'Status updated' }); // different message
+      showToast({ type: 'error', message: 'Status created' }); // same message, different type
+    });
+
+    const toasts = screen.getAllByTestId('toast');
+    expect(toasts).toHaveLength(3);
+  });
+
+  it('re-shows an identical toast once the dedupe window has elapsed (legitimate repeat action)', () => {
+    vi.useFakeTimers();
+    try {
+      render(<ToastContainer />);
+
+      act(() => {
+        showToast({ type: 'success', message: 'Saved' });
+      });
+      expect(screen.getAllByTestId('toast')).toHaveLength(1);
+
+      // Advance past the dedupe window (and the duplicate inside it is dropped).
+      act(() => {
+        showToast({ type: 'success', message: 'Saved' }); // within window → dropped
+        vi.advanceTimersByTime(1001);
+        showToast({ type: 'success', message: 'Saved' }); // after window → shown again
+      });
+
+      // First toast hasn't auto-dismissed yet (5000ms), so both the original and
+      // the post-window repeat are present — two toasts, not one.
+      expect(screen.getAllByTestId('toast')).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('never collapses undo toasts — each targets a distinct row with its own onUndo', () => {
+    render(<ToastContainer />);
+    const onUndoA = vi.fn();
+    const onUndoB = vi.fn();
+
+    act(() => {
+      showToast({ type: 'undo', message: 'Decommissioning...', onUndo: onUndoA });
+      showToast({ type: 'undo', message: 'Decommissioning...', onUndo: onUndoB });
+    });
+
+    expect(screen.getAllByTestId('toast')).toHaveLength(2);
+  });
+
   it('auto-dismisses after the default 5000ms', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { AlertTriangle, CheckCircle, X, Undo2, XCircle } from 'lucide-react';
 
 interface ToastData {
@@ -8,6 +8,16 @@ interface ToastData {
   onUndo?: () => void;
   duration?: number;
 }
+
+// Identical toasts (same type+message) emitted within this window collapse into
+// one. This kills the "double success toast" papercut (#1301) regardless of the
+// emit source — a double-mounted/view-transition-overlapped container, a
+// StrictMode double-invoke, or a caller that fires twice — without suppressing
+// legitimately-repeated actions (e.g. clicking "Save" again seconds later, which
+// users expect to re-confirm). Undo toasts are never collapsed: they carry a
+// distinct per-invocation onUndo callback, so two "Decommissioning…" toasts
+// genuinely target two different rows and must both stay actionable.
+const DEDUPE_WINDOW_MS = 1000;
 
 let addToastFn: ((toast: Omit<ToastData, 'id'>) => void) | null = null;
 const pendingToasts: Array<Omit<ToastData, 'id'>> = [];
@@ -28,8 +38,32 @@ export function _resetToastQueueForTests() {
 
 export default function ToastContainer() {
   const [toasts, setToasts] = useState<ToastData[]>([]);
+  // Tracks the last time each (type|message) key was shown, so we can collapse a
+  // burst of identical toasts. A ref (not state) keeps this out of the render
+  // cycle and survives across addToast calls without re-subscribing the effect.
+  const recentToastsRef = useRef<Map<string, number>>(new Map());
 
   const addToast = useCallback((toast: Omit<ToastData, 'id'>) => {
+    // Undo toasts always render — each carries a unique onUndo for a distinct
+    // target row and must stay individually actionable.
+    if (toast.type !== 'undo') {
+      const key = `${toast.type}|${toast.message}`;
+      const now = Date.now();
+      const last = recentToastsRef.current.get(key);
+      if (last !== undefined && now - last < DEDUPE_WINDOW_MS) {
+        recentToastsRef.current.set(key, now);
+        return; // identical toast already shown moments ago — drop the duplicate
+      }
+      recentToastsRef.current.set(key, now);
+      // Opportunistically prune stale keys so the map can't grow unbounded over a
+      // long-lived session.
+      if (recentToastsRef.current.size > 50) {
+        for (const [k, t] of recentToastsRef.current) {
+          if (now - t >= DEDUPE_WINDOW_MS) recentToastsRef.current.delete(k);
+        }
+      }
+    }
+
     const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     setToasts(prev => [...prev, { ...toast, id }]);
     setTimeout(() => {


### PR DESCRIPTION
## Summary

Successful `runAction` mutations surfaced their success toast **twice** — observed systemically across unrelated features in the v0.70 QA sweep ("Timer started ×2", "Status created ×2"), while only **one** underlying request actually fired (DB +1). This is a low-severity but pervasive papercut: every save double-toasts.

## Root cause

`runAction` (`apps/web/src/lib/runAction.ts`) calls `showToast` **exactly once** on the success path, so it is not the double-emitter. The duplication originates above it at the toast host — the most prod-plausible mechanism is a double-mounted / view-transition-overlapped `ToastContainer` (the dashboard mounts it `client:load transition:persist`), and the same symptom would also arise from a StrictMode double-invoke or a caller firing twice. The codebase has no `StrictMode` wrapper, so dev-only StrictMode is ruled out; the fix is made robust to all of these.

## What changed

- `apps/web/src/components/shared/Toast.tsx` — `ToastContainer.addToast` now collapses identical `(type|message)` toasts that arrive within a 1s window (`DEDUPE_WINDOW_MS`). The window is tracked in a per-container `useRef<Map>` (out of the render cycle, opportunistically pruned so it can't grow unbounded). This kills the duplicate uniformly regardless of emit source.
  - **Undo toasts are never collapsed** — each carries a distinct per-invocation `onUndo` for a different target row and must stay individually actionable.
  - Legitimately repeated actions still re-confirm: an identical toast fired *after* the window elapses shows again.
- `apps/web/src/components/shared/Toast.test.tsx` — added coverage: collapse two identical toasts into one; do NOT collapse different message/type; re-show after the window elapses; never collapse undo toasts.

## Test command + result

```
pnpm --filter @breeze/web exec vitest run src/components/shared/Toast.test.tsx
# Test Files  1 passed (1) — Tests  12 passed (12)

pnpm --filter @breeze/web exec vitest run src/lib/runAction.test.ts
# Test Files  1 passed (1) — Tests  14 passed (14)
```

Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)