### PR TITLE
feat(web): pre-expand org switcher tree to the selected site

### DIFF
--- a/apps/web/src/components/layout/OrgSwitcher.test.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.test.tsx
@@ -213,3 +213,130 @@ describe('OrgSwitcher org change navigation', () => {
     expect(reloadMock).not.toHaveBeenCalled();
   });
 });
+
+// #1319: when a site is the active scope, opening the picker should land the
+// user on their current context — the ancestor org pre-expanded and the
+// selected site row visible/highlighted — instead of a flat list of collapsed
+// orgs.
+describe('OrgSwitcher pre-expand to selected site (#1319)', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    setOrganizationMock.mockReset();
+    setSiteMock.mockReset();
+    setOrgScopeMock.mockReset();
+    fetchOrganizationsMock.mockReset();
+    fetchSitesMock.mockReset();
+    waitForPendingRefreshMock.mockClear();
+    waitForPendingRefreshMock.mockResolvedValue(undefined);
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, pathname: '/devices', reload: vi.fn() }
+    });
+
+    mockStoreState = {
+      currentOrgId: 'org-a',
+      currentSiteId: 'site-a1',
+      orgScope: 'current',
+      organizations: [
+        { id: 'org-a', partnerId: 'p1', name: 'Org A', status: 'active', createdAt: '2024-01-01' },
+        { id: 'org-b', partnerId: 'p1', name: 'Org B', status: 'active', createdAt: '2024-01-01' }
+      ],
+      sites: [
+        { id: 'site-a1', orgId: 'org-a', name: 'HQ Site', deviceCount: 12, createdAt: '2024-01-01' },
+        { id: 'site-a2', orgId: 'org-a', name: 'Branch Site', deviceCount: 3, createdAt: '2024-01-01' }
+      ],
+      isLoading: false
+    };
+    mockStoreRef.current = mockStoreState;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation
+    });
+  });
+
+  function openDropdown() {
+    fireEvent.click(screen.getByTestId('org-switcher-trigger'));
+  }
+
+  it('auto-expands the ancestor org so the selected site is visible on open without a manual click', () => {
+    render(<OrgSwitcher />);
+
+    openDropdown();
+
+    // The selected site's row (and its sibling) are visible immediately — the
+    // user did NOT have to click the org row to expand it.
+    expect(screen.getByText('HQ Site')).toBeInTheDocument();
+    expect(screen.getByText('Branch Site')).toBeInTheDocument();
+    // The "All Sites" affordance only renders inside an expanded org, so its
+    // presence confirms the submenu mounted.
+    expect(screen.getByText('All Sites')).toBeInTheDocument();
+  });
+
+  it('does not throw even though jsdom stubs scrollIntoView (selected row scrolled into view)', () => {
+    // jsdom does not implement scrollIntoView; the component guards the call.
+    // Opening must not throw regardless of whether the stub exists.
+    expect(() => {
+      render(<OrgSwitcher />);
+      openDropdown();
+    }).not.toThrow();
+  });
+
+  it('does not auto-expand any org in All-orgs scope', () => {
+    mockStoreState.orgScope = 'all';
+    mockStoreRef.current = mockStoreState;
+
+    render(<OrgSwitcher />);
+
+    openDropdown();
+
+    // No submenu should be visible: sites stay hidden and there is no
+    // "All Sites" row until the user manually expands an org.
+    expect(screen.queryByText('HQ Site')).not.toBeInTheDocument();
+    expect(screen.queryByText('All Sites')).not.toBeInTheDocument();
+  });
+
+  it('leaves orgs collapsed when only an org (no site) is selected', () => {
+    mockStoreState.currentSiteId = null;
+    mockStoreRef.current = mockStoreState;
+
+    render(<OrgSwitcher />);
+
+    openDropdown();
+
+    // Org selected but no site → submenu stays collapsed.
+    expect(screen.queryByText('HQ Site')).not.toBeInTheDocument();
+    expect(screen.queryByText('All Sites')).not.toBeInTheDocument();
+  });
+
+  it('re-seeds expansion on each open so a manual collapse does not persist across opens', () => {
+    render(<OrgSwitcher />);
+
+    // First open: auto-expanded.
+    openDropdown();
+    expect(screen.getByText('HQ Site')).toBeInTheDocument();
+
+    // Manually collapse Org A by clicking its row, then close the dropdown.
+    const orgARow = screen
+      .getAllByRole('button')
+      .find(
+        (b) =>
+          b.getAttribute('data-testid') !== 'org-switcher-trigger' &&
+          b.textContent?.includes('Org A')
+      )!;
+    fireEvent.click(orgARow);
+    expect(screen.queryByText('HQ Site')).not.toBeInTheDocument();
+
+    // Re-open — should re-seed and expand again rather than respect the manual
+    // collapse from the prior session.
+    openDropdown(); // toggle closed
+    openDropdown(); // toggle open again
+    expect(screen.getByText('HQ Site')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/OrgSwitcher.tsx
+++ b/apps/web/src/components/layout/OrgSwitcher.tsx
@@ -75,7 +75,10 @@ function OrgMenuItem({
   onSelect,
   sites,
   currentSiteId,
-  onSelectSite
+  onSelectSite,
+  isExpanded,
+  onToggleSites,
+  selectedSiteRef
 }: {
   org: Organization;
   isSelected: boolean;
@@ -83,10 +86,18 @@ function OrgMenuItem({
   sites: Site[];
   currentSiteId: string | null;
   onSelectSite: (siteId: string | null) => void;
+  // Expansion state is owned by the parent OrgSwitcher so it can be seeded
+  // from the current selection when the dropdown opens (#1319). This item is
+  // purely presentational for expansion.
+  isExpanded: boolean;
+  onToggleSites: () => void;
+  // The parent passes a ref it attaches to whichever org's currently-selected
+  // site row is rendered, so it can scrollIntoView after the submenu mounts.
+  selectedSiteRef: (el: HTMLButtonElement | null) => void;
 }) {
-  const [showSites, setShowSites] = useState(false);
   const orgSites = sites.filter((site) => site.orgId === org.id);
   const hasSites = orgSites.length > 0;
+  const showSites = isExpanded && hasSites;
 
   return (
     <div className="relative">
@@ -94,7 +105,7 @@ function OrgMenuItem({
         onClick={() => {
           onSelect();
           if (hasSites) {
-            setShowSites(!showSites);
+            onToggleSites();
           }
         }}
         className={cn(
@@ -121,7 +132,7 @@ function OrgMenuItem({
       </button>
 
       {/* Sites submenu */}
-      {showSites && hasSites && (
+      {showSites && (
         <div className="ml-6 mt-1 border-l pl-2">
           <button
             onClick={() => onSelectSite(null)}
@@ -138,6 +149,7 @@ function OrgMenuItem({
           {orgSites.map((site) => (
             <button
               key={site.id}
+              ref={currentSiteId === site.id ? selectedSiteRef : undefined}
               onClick={() => onSelectSite(site.id)}
               className={cn(
                 'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted',
@@ -256,9 +268,16 @@ export default function OrgSwitcher() {
   // True from the moment a switch is initiated until the page reloads — shows a
   // spinner on the trigger and disables it so the bar never silently freezes.
   const [switching, setSwitching] = useState(false);
+  // Which org rows have their sites submenu expanded. Owned here (not per-item)
+  // so it can be seeded from the current selection when the dropdown opens
+  // (#1319) — a user whose scope is a site lands on it pre-expanded.
+  const [expandedOrgIds, setExpandedOrgIds] = useState<Set<string>>(new Set());
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  // Set by OrgMenuItem on whichever org renders the currently-selected site row,
+  // so the open effect can scroll it into view once the submenu has mounted.
+  const selectedSiteRef = useRef<HTMLButtonElement | null>(null);
 
   const {
     currentOrgId,
@@ -343,6 +362,33 @@ export default function OrgSwitcher() {
     return () => document.removeEventListener('keydown', handler);
   }, [isOpen]);
 
+  // Seed expansion + scroll-to-selection when the dropdown opens (#1319).
+  // When the active scope is a site, pre-expand its ancestor org (which is
+  // simply `currentOrgId` — sites are only fetched for the current org) so the
+  // user lands on their current context instead of a flat list of collapsed
+  // orgs. Re-seed on every open so re-opening reflects the live selection
+  // rather than stale manual toggles. In All-orgs scope there is no single
+  // "current" site, so don't auto-expand anything.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (orgScope === 'current' && currentSiteId && currentOrgId) {
+      setExpandedOrgIds(new Set([currentOrgId]));
+    } else {
+      setExpandedOrgIds(new Set());
+    }
+  }, [isOpen, orgScope, currentOrgId, currentSiteId]);
+
+  // After the submenu has mounted (next frame), scroll the selected site row
+  // into view so it's visible even on a long org list. jsdom stubs
+  // scrollIntoView as a no-op, so the guard keeps tests from throwing.
+  useEffect(() => {
+    if (!isOpen) return;
+    const raf = requestAnimationFrame(() => {
+      selectedSiteRef.current?.scrollIntoView?.({ block: 'nearest' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isOpen, expandedOrgIds, currentSiteId]);
+
   // Get current selections
   const currentOrg = organizations.find((org) => org.id === currentOrgId);
   const currentSite = sites.find((site) => site.id === currentSiteId);
@@ -419,6 +465,25 @@ export default function OrgSwitcher() {
                   key={org.id}
                   org={org}
                   isSelected={org.id === currentOrgId && orgScope === 'current'}
+                  isExpanded={expandedOrgIds.has(org.id)}
+                  onToggleSites={() =>
+                    setExpandedOrgIds((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(org.id)) {
+                        next.delete(org.id);
+                      } else {
+                        next.add(org.id);
+                      }
+                      return next;
+                    })
+                  }
+                  selectedSiteRef={(el) => {
+                    // Callback ref on the currently-selected site row. React
+                    // calls it with the element on mount and null on unmount;
+                    // tracking both keeps the parent from scrolling a detached
+                    // node after the org is collapsed.
+                    selectedSiteRef.current = el;
+                  }}
                   onSelect={async () => {
                     // Picking a specific org from the dropdown implies the
                     // user wants to narrow to that org, so auto-flip the


### PR DESCRIPTION
## Summary

In the org switcher dropdown, every org row used to start collapsed even when the user's active scope was a *site*. A user whose context is `Org A / HQ Site` opened the picker and saw a flat list of collapsed orgs, with no indication of where they currently were — they had to remember which org their site lived under, expand it, then scan for the selected site.

Now, when the dropdown opens and the active scope is a site, its ancestor org is pre-expanded, the selected site row is highlighted (existing behavior) and scrolled into view, so the user lands directly on their current context.

## What changed

- **Lifted expand state into `OrgSwitcher`.** Replaced the per-`OrgMenuItem` local `useState(showSites)` with a parent-owned `Set<string>` of expanded org ids. `OrgMenuItem` is now presentational for expansion: it takes `isExpanded` + `onToggleSites`. Clicking an org row still toggles its own sites submenu, unchanged.
- **Seed on open.** An effect keyed on `isOpen` / `orgScope` / `currentOrgId` / `currentSiteId` seeds `expandedOrgIds` with `currentOrgId` when scope is `current` and a site is selected. The ancestor org is simply `currentOrgId` (sites are only ever fetched for the current org), so no extra lookup or API call is needed. Re-seeds on every open so re-opening reflects the live selection, not stale manual toggles. In `All orgs` scope nothing auto-expands; with an org-only selection (no site) the row stays collapsed.
- **Scroll into view.** The selected site button gets a callback ref; a `requestAnimationFrame` after the submenu mounts calls `scrollIntoView({ block: 'nearest' })`, guarded for jsdom's no-op stub.
- No store changes — `currentOrgId` / `currentSiteId` already exist and are persisted.

## Test command + result

```
pnpm --filter @breeze/web exec vitest run src/components/layout/OrgSwitcher.test.tsx
```

14 passed (14) — 9 existing + 5 new covering: auto-expand makes the selected site visible on open without a manual click; opening does not throw under jsdom's `scrollIntoView` stub; no auto-expand in All-orgs scope; org-only selection stays collapsed; re-seed on each open (manual collapse does not persist across opens).

Front-end only; changes are scoped to `OrgSwitcher.tsx` + its test.

Closes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)