### PR TITLE
fix(web): strip embedded Windows build from OS Version display (#1302)

### DIFF
--- a/apps/web/src/components/devices/DeviceCard.tsx
+++ b/apps/web/src/components/devices/DeviceCard.tsx
@@ -3,7 +3,7 @@ import { Monitor, MoreVertical, Terminal, RotateCcw, FileCode, Settings, Trash2 
 import type { Device, DeviceStatus, OSType } from './DeviceList';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatLastSeen } from '@/lib/formatTime';
-import { asRecord, toPercentNullable } from '@/lib/deviceUtils';
+import { asRecord, toPercentNullable, formatOsVersionForDisplay } from '@/lib/deviceUtils';
 
 type DeviceCardProps = {
   device: Device;
@@ -169,7 +169,7 @@ export default function DeviceCard({ device, timezone, onClick, onAction }: Devi
               <span className={`h-2 w-2 rounded-full ${statusColors[device.status]}`} aria-hidden="true" />
               <span className="sr-only">{device.status.charAt(0).toUpperCase() + device.status.slice(1)}</span>
             </div>
-            <p className="text-xs text-muted-foreground">{device.osVersion}</p>
+            <p className="text-xs text-muted-foreground">{formatOsVersionForDisplay(device.osVersion, '')}</p>
           </div>
         </div>
         <div className="relative">

--- a/apps/web/src/components/devices/DeviceInfoTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.test.tsx
@@ -237,3 +237,41 @@ describe('DeviceInfoTab — role + custom-field mutations also use runAction', (
     });
   });
 });
+
+describe('DeviceInfoTab — OS Version display (issue #1302)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('strips the embedded build from a Windows OS Version, keeping it only in OS Build', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/devices/${deviceId}` && method === 'GET') {
+        return makeJsonResponse({
+          hostname: 'TST-LAPTOP-01',
+          osType: 'windows',
+          osVersion: 'Microsoft Windows 11 Pro 10.0.22631 Build 22631',
+          osBuild: '22631',
+          tags: [],
+          status: 'online',
+        });
+      }
+      if (url === '/custom-fields') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<DeviceInfoTab deviceId={deviceId} />);
+    await screen.findByText('TST-LAPTOP-01');
+
+    // OS Version row shows the clean marketing name, NOT the embedded build.
+    const osVersionRow = screen.getByText('OS Version').closest('div') as HTMLElement;
+    expect(osVersionRow).toHaveTextContent('Microsoft Windows 11 Pro');
+    expect(osVersionRow).not.toHaveTextContent('22631');
+    expect(osVersionRow).not.toHaveTextContent(/Build/i);
+
+    // OS Build row still carries the build number.
+    const osBuildRow = screen.getByText('OS Build').closest('div') as HTMLElement;
+    expect(osBuildRow).toHaveTextContent('22631');
+  });
+});

--- a/apps/web/src/components/devices/DeviceInfoTab.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.tsx
@@ -5,6 +5,7 @@ import MacOSPermissionsCard from './MacOSPermissionsCard';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatUptime } from '../../lib/utils';
 import { runAction, ActionError } from '../../lib/runAction';
+import { formatOsVersionForDisplay } from '../../lib/deviceUtils';
 import {
   DEVICE_ROLES,
   getDeviceRoleLabel,
@@ -95,12 +96,6 @@ const osTypeLabels: Record<string, string> = {
 function formatOsType(raw: string | null | undefined): string {
   if (!raw) return '—';
   return osTypeLabels[raw.toLowerCase()] ?? raw;
-}
-
-function formatOsVersionForDisplay(raw: string | null | undefined): string {
-  if (!raw) return '—';
-  // Strip kernel name prefix (e.g. "darwin 26.3.1" → "26.3.1")
-  return raw.replace(/^(darwin|linux)\s+/i, '');
 }
 
 function formatDesktopAccessMode(mode: DesktopAccessState['mode'] | undefined): string {

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -6,6 +6,7 @@ import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { widthPercentClass, formatUptime } from '@/lib/utils';
 import { formatLastSeen } from '@/lib/formatTime';
 import { DEVICE_ROLES, getDeviceRoleLabel, getDeviceRoleIcon, type DeviceRole } from '@/lib/deviceRoles';
+import { formatOsVersionForDisplay } from '@/lib/deviceUtils';
 import {
   PAGE_SIZE_OPTIONS,
   readPageSizePreference,
@@ -541,7 +542,7 @@ export default function DeviceList({
       header: () => <th key="osVersion" className="px-3 py-3">OS Version</th>,
       cell: (device) => (
         <td key="osVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
-          {device.osVersion || dash}
+          {device.osVersion ? formatOsVersionForDisplay(device.osVersion) : dash}
         </td>
       ),
     },

--- a/apps/web/src/lib/deviceUtils.test.ts
+++ b/apps/web/src/lib/deviceUtils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { formatOsVersionForDisplay } from './deviceUtils';
+
+describe('formatOsVersionForDisplay', () => {
+  it('returns the fallback for empty / nullish input', () => {
+    expect(formatOsVersionForDisplay(undefined)).toBe('—');
+    expect(formatOsVersionForDisplay(null)).toBe('—');
+    expect(formatOsVersionForDisplay('')).toBe('—');
+    expect(formatOsVersionForDisplay('   ')).toBe('—');
+  });
+
+  it('honours a custom fallback', () => {
+    expect(formatOsVersionForDisplay(null, 'Unknown')).toBe('Unknown');
+  });
+
+  it('strips the embedded build from Windows 11 version strings (issue #1302)', () => {
+    expect(
+      formatOsVersionForDisplay('Microsoft Windows 11 Pro 10.0.22631 Build 22631'),
+    ).toBe('Microsoft Windows 11 Pro');
+  });
+
+  it('strips the embedded build from Windows 10 version strings', () => {
+    expect(
+      formatOsVersionForDisplay('Microsoft Windows 10 Pro 10.0.19045 Build 19045'),
+    ).toBe('Microsoft Windows 10 Pro');
+  });
+
+  it('strips a four-segment build version with Build suffix', () => {
+    expect(
+      formatOsVersionForDisplay('Microsoft Windows 11 Enterprise 10.0.26200.7623 Build 26200.7623'),
+    ).toBe('Microsoft Windows 11 Enterprise');
+  });
+
+  it('strips the embedded build when there is no redundant Build suffix', () => {
+    expect(
+      formatOsVersionForDisplay('Microsoft Windows Server 2022 Datacenter 10.0.20348'),
+    ).toBe('Microsoft Windows Server 2022 Datacenter');
+  });
+
+  it('leaves an already-clean Windows name untouched', () => {
+    expect(formatOsVersionForDisplay('Microsoft Windows 11 Pro')).toBe('Microsoft Windows 11 Pro');
+  });
+
+  it('falls back to the raw value when osVersion is just a bare build', () => {
+    expect(formatOsVersionForDisplay('10.0.20348')).toBe('10.0.20348');
+  });
+
+  it('preserves macOS marketing versions (no kernel prefix)', () => {
+    expect(formatOsVersionForDisplay('26.3.1')).toBe('26.3.1');
+    expect(formatOsVersionForDisplay('15.2')).toBe('15.2');
+  });
+
+  it('strips a darwin kernel prefix but keeps the version', () => {
+    expect(formatOsVersionForDisplay('darwin 26.3.1')).toBe('26.3.1');
+  });
+
+  it('strips a linux kernel prefix but keeps the distro version', () => {
+    expect(formatOsVersionForDisplay('linux 6.8.0')).toBe('6.8.0');
+  });
+
+  it('preserves a plain distro name + short version', () => {
+    expect(formatOsVersionForDisplay('Ubuntu 24.04')).toBe('Ubuntu 24.04');
+  });
+});

--- a/apps/web/src/lib/deviceUtils.ts
+++ b/apps/web/src/lib/deviceUtils.ts
@@ -26,3 +26,44 @@ export function toPercentNullable(value: unknown): number | null {
   if (!Number.isFinite(parsed)) return null;
   return Math.min(100, Math.max(0, Number(parsed.toFixed(2))));
 }
+
+/**
+ * Normalize a raw `osVersion` string for the "OS Version" display column/row.
+ *
+ * The agent reports `osVersion` as gopsutil's `Platform + " " + PlatformVersion`.
+ * On Windows, `PlatformVersion` embeds the build number (and often a redundant
+ * `Build NNNNN` suffix), so the raw string looks like
+ * `"Microsoft Windows 11 Pro 10.0.22631 Build 22631"`. That build also lives in
+ * the separate `osBuild` field, so showing it inside OS Version is duplicative
+ * (issue #1302). This strips the embedded Windows build artifacts, leaving the
+ * marketing name (e.g. `"Microsoft Windows 11 Pro"`).
+ *
+ * macOS/Linux versions are plain marketing versions (e.g. `"26.3.1"`) and are
+ * left intact aside from stripping a leading kernel name (`darwin`/`linux`).
+ *
+ * @param raw       the raw osVersion string
+ * @param fallback  value returned when `raw` is empty/whitespace (default "—")
+ */
+export function formatOsVersionForDisplay(
+  raw: string | null | undefined,
+  fallback = '—',
+): string {
+  if (!raw || !raw.trim()) return fallback;
+
+  // Strip kernel name prefix (e.g. "darwin 26.3.1" → "26.3.1").
+  let v = raw.replace(/^(darwin|linux)\s+/i, '').trim();
+
+  // Strip a trailing Windows build clause: an optional dotted build version
+  // (e.g. "10.0.22631", "10.0.26200.7623") optionally followed by a redundant
+  // "Build NNNNN[.NNNN]" suffix — or a standalone "Build NNNNN[.NNNN]". This
+  // intentionally requires the dotted number to have 3+ segments so plain
+  // macOS/Linux versions like "26.3.1" or "10.15" are preserved.
+  const stripped = v
+    .replace(/\s+\d+\.\d+\.\d+(?:\.\d+)*(?:\s+Build\s+[\d.]+)?\s*$/i, '')
+    .replace(/\s+Build\s+[\d.]+\s*$/i, '')
+    .trim();
+
+  // If stripping removed everything (e.g. osVersion was just a bare build like
+  // "10.0.20348"), fall back to the kernel-stripped value rather than blank.
+  return stripped || v;
+}


### PR DESCRIPTION
## Summary

Windows agents displayed the OS build embedded inside the **OS Version** column/row, duplicating what already shows in **OS Build**. Reported by the community (ramphex) — issue #1302.

**Root cause:** the agent reports `osVersion` as gopsutil's `Platform + " " + PlatformVersion`. On Windows, `PlatformVersion` embeds the build number (and often a redundant `Build NNNNN` suffix), so the raw string is e.g. `Microsoft Windows 11 Pro 10.0.22631 Build 22631`. The same build also lives in the separate `osBuild` field. macOS/Linux split the two cleanly because their `PlatformVersion` is a plain marketing version.

## What changed

- Added a shared `formatOsVersionForDisplay` helper to `apps/web/src/lib/deviceUtils.ts` that strips the embedded Windows build (the 3-4 segment dotted build version `10.0.22631[.7623]` and any trailing `Build NNNNN[.NNNN]`), leaving the marketing name `Microsoft Windows 11 Pro`. Plain macOS/Linux versions (`26.3.1`, `15.2`, `Ubuntu 24.04`) are preserved; only a leading `darwin`/`linux` kernel name is stripped (the prior behavior of the local helper).
- Wired it into:
  - `DeviceList.tsx` — Devices list **OS Version** column (was rendering `osVersion` raw).
  - `DeviceInfoTab.tsx` — Device > Details **OS Version** row (replaced the local helper that only handled the kernel prefix).
  - `DeviceCard.tsx` — device card subtitle.
- Added `deviceUtils.test.ts` for the helper and a DeviceInfoTab test asserting the Windows build is stripped from OS Version while remaining in OS Build.

Display-layer only — the underlying `osVersion` / `osBuild` data is unchanged.

## Testing

`pnpm --filter @breeze/web exec vitest run src/lib/deviceUtils.test.ts src/components/devices/DeviceInfoTab.test.tsx src/components/devices/DeviceList.test.tsx src/components/devices/DeviceCard.test.tsx`

Result: **4 files passed, 32 tests passed.**

Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)