### PR TITLE
fix(api): token-based fallback for AI cost tracking ($0.00 bug)

### DIFF
--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -16,7 +16,10 @@ import { escapeLike } from '../utils/sql';
 import { AI_SYSTEM_PROMPT_BASE } from './aiAgentSystemPrompt';
 import { getActiveDeviceContext } from './brainDeviceContext';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+// Current model id so the Claude Agent SDK can price it natively. A stale id makes the
+// SDK report total_cost_usd: 0 → $0.00 cost tracking (issue #1326). Successor to the
+// previous default claude-sonnet-4-5-20250929, at the same $3/$15 per-MTok tier.
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 
 // ============================================
 // Session Management

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { calculateCostCents, recordUsageFromSdkResult } from './aiCostTracker';
+import { db } from '../db';
+
+// ============================================
+// Mocks
+// ============================================
+
+// `sql` is used as a tagged template that builds increment expressions like
+// `${aiSessions.totalCostCents} + ${costCents}`. We capture the interpolated
+// values so tests can read back the exact cost that was written.
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ _eq: args })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  desc: vi.fn((...args: unknown[]) => ({ _desc: args })),
+  isNotNull: vi.fn((...args: unknown[]) => ({ _isNotNull: args })),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({ _sql: strings, values }),
+    {},
+  ),
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    update: vi.fn(),
+    insert: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: {
+    id: 'id',
+    model: 'model',
+    totalInputTokens: 'totalInputTokens',
+    totalOutputTokens: 'totalOutputTokens',
+    totalCostCents: 'totalCostCents',
+    turnCount: 'turnCount',
+  },
+  aiCostUsage: {
+    orgId: 'orgId',
+    period: 'period',
+    periodKey: 'periodKey',
+    inputTokens: 'inputTokens',
+    outputTokens: 'outputTokens',
+    totalCostCents: 'totalCostCents',
+    messageCount: 'messageCount',
+    toolExecutionCount: 'toolExecutionCount',
+  },
+  aiBudgets: { orgId: 'orgId', dailyBudgetCents: 'dailyBudgetCents' },
+  organizations: { id: 'id', partnerId: 'partnerId' },
+}));
+
+vi.mock('./redis', () => ({ getRedis: vi.fn(() => ({})) }));
+vi.mock('./rate-limit', () => ({ rateLimiter: vi.fn() }));
+vi.mock('./effectiveSettings', () => ({ getEffectiveAiBudget: vi.fn() }));
+
+const mockDb = db as unknown as {
+  update: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * Wire up chainable db mocks. `capturedSessionSet` holds the object passed to
+ * `db.update(aiSessions).set({...})` — the cost recorded on the session row.
+ * `sessionModel` is returned by the session-model lookup `db.select(...).limit(1)`.
+ */
+function setupDbMocks(sessionModel: string | null) {
+  const capture: { sessionSet?: Record<string, unknown> } = {};
+
+  mockDb.update.mockReturnValue({
+    set: vi.fn((values: Record<string, unknown>) => {
+      capture.sessionSet = values;
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  });
+
+  mockDb.insert.mockReturnValue({
+    values: vi.fn(() => ({
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    })),
+  });
+
+  // db.select(...) is used both for the session-model lookup and for the
+  // anomaly-check budget/usage queries. Returning an empty array for the budget
+  // query short-circuits anomaly checks; returning the model row drives the
+  // token-pricing fallback.
+  mockDb.select.mockImplementation((cols?: Record<string, unknown>) => {
+    const isModelLookup = !!cols && 'model' in cols;
+    const result = isModelLookup && sessionModel ? [{ model: sessionModel }] : [];
+    return {
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue(result),
+        })),
+      })),
+    };
+  });
+
+  return capture;
+}
+
+/** Extract the numeric cost the function tried to add to the session row. */
+function recordedCostCents(captured: Record<string, unknown> | undefined): number {
+  const expr = captured?.totalCostCents as { values?: unknown[] } | undefined;
+  // sql`${col} + ${costCents}` → values = [colRef, costCents]
+  return Number(expr?.values?.[1]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.BILLING_SERVICE_URL;
+  delete process.env.BILLING_SERVICE_API_KEY;
+});
+
+// ============================================
+// calculateCostCents
+// ============================================
+
+describe('calculateCostCents', () => {
+  it('returns a non-zero cost for a current model with non-zero tokens', () => {
+    // claude-sonnet-4-6 is $3/$15 per MTok → 300/1500 cents per MTok.
+    // 1M in + 1M out = 300 + 1500 = 1800 cents.
+    expect(calculateCostCents('claude-sonnet-4-6', 1_000_000, 1_000_000)).toBe(1800);
+  });
+
+  it.each([
+    // [model, inputPerMTokCents, outputPerMTokCents]
+    ['claude-opus-4-8', 500, 2500],
+    ['claude-sonnet-4-6', 300, 1500],
+    ['claude-haiku-4-5', 100, 500],
+    ['claude-haiku-4-5-20251001', 100, 500],
+    ['claude-fable-5', 1000, 5000],
+    ['claude-sonnet-4-5-20250929', 300, 1500],
+  ])('prices %s from MODEL_PRICING (no DEFAULT fallthrough)', (model, inCents, outCents) => {
+    // 1M in / 1M out should equal exactly the per-MTok rates summed.
+    const expected = inCents + outCents;
+    expect(calculateCostCents(model, 1_000_000, 1_000_000)).toBe(expected);
+    // And it must be a non-zero, finite number.
+    expect(calculateCostCents(model, 1_000_000, 1_000_000)).toBeGreaterThan(0);
+  });
+
+  it('falls back to DEFAULT_PRICING and warns for an unknown model', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // DEFAULT_PRICING mirrors opus-tier 500/2500.
+    expect(calculateCostCents('some-unreleased-model', 1_000_000, 1_000_000)).toBe(3000);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('some-unreleased-model'));
+    warn.mockRestore();
+  });
+
+  it('returns 0 when there are no tokens', () => {
+    expect(calculateCostCents('claude-opus-4-8', 0, 0)).toBe(0);
+  });
+});
+
+// ============================================
+// recordUsageFromSdkResult — token-based fallback (issue #1326)
+// ============================================
+
+describe('recordUsageFromSdkResult', () => {
+  it('records a non-zero cost when total_cost_usd is 0 but tokens are present (uses result.model)', async () => {
+    const captured = setupDbMocks(null);
+
+    await recordUsageFromSdkResult('sess-1', 'org-1', {
+      total_cost_usd: 0,
+      usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+    });
+
+    // 1M/1M on sonnet-4-6 → 1800 cents, NOT 0.
+    expect(recordedCostCents(captured.sessionSet)).toBe(1800);
+  });
+
+  it('falls back to the session-row model when result.model is absent', async () => {
+    const captured = setupDbMocks('claude-opus-4-8');
+
+    await recordUsageFromSdkResult('sess-2', 'org-1', {
+      total_cost_usd: 0,
+      usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      num_turns: 1,
+      // no model — should be looked up from aiSessions row (opus-4-8 → 3000 cents)
+    });
+
+    expect(recordedCostCents(captured.sessionSet)).toBe(3000);
+  });
+
+  it('uses the SDK-reported cost verbatim when it is non-zero', async () => {
+    const captured = setupDbMocks('claude-sonnet-4-6');
+
+    await recordUsageFromSdkResult('sess-3', 'org-1', {
+      total_cost_usd: 0.1234, // $0.1234 → 12.34 cents
+      usage: { input_tokens: 5_000, output_tokens: 2_000 },
+      num_turns: 2,
+      model: 'claude-sonnet-4-6',
+    });
+
+    // Must record the exact SDK value, not a token-derived one.
+    expect(recordedCostCents(captured.sessionSet)).toBe(12.34);
+  });
+
+  it('records 0 cost when both SDK cost and tokens are zero', async () => {
+    const captured = setupDbMocks('claude-sonnet-4-6');
+
+    await recordUsageFromSdkResult('sess-4', 'org-1', {
+      total_cost_usd: 0,
+      usage: { input_tokens: 0, output_tokens: 0 },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+    });
+
+    expect(recordedCostCents(captured.sessionSet)).toBe(0);
+  });
+
+  it('skips recording when orgId is empty', async () => {
+    setupDbMocks('claude-sonnet-4-6');
+
+    await recordUsageFromSdkResult('sess-5', '', {
+      total_cost_usd: 0,
+      usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+    });
+
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -155,6 +155,25 @@ describe('calculateCostCents', () => {
   it('returns 0 when there are no tokens', () => {
     expect(calculateCostCents('claude-opus-4-8', 0, 0)).toBe(0);
   });
+
+  it('prices cache read (0.1x input) and cache creation (1.25x input) tokens', () => {
+    // sonnet-4-6 input rate = 300 cents/MTok.
+    // 1M cache-read  → 300 * 0.1  = 30 cents.
+    // 1M cache-write → 300 * 1.25 = 375 cents.
+    // No input/output tokens, so the total is purely the cache cost.
+    expect(calculateCostCents('claude-sonnet-4-6', 0, 0, 1_000_000, 0)).toBe(30);
+    expect(calculateCostCents('claude-sonnet-4-6', 0, 0, 0, 1_000_000)).toBe(375);
+  });
+
+  it('adds cache cost on top of input+output (cached request costs more)', () => {
+    // sonnet-4-6: 1M in + 1M out = 1800 cents (baseline, no cache).
+    const baseline = calculateCostCents('claude-sonnet-4-6', 1_000_000, 1_000_000);
+    // Same in/out plus 1M cache-read (+30) and 1M cache-write (+375) = 2205.
+    const withCache = calculateCostCents('claude-sonnet-4-6', 1_000_000, 1_000_000, 1_000_000, 1_000_000);
+    expect(baseline).toBe(1800);
+    expect(withCache).toBe(2205);
+    expect(withCache).toBeGreaterThan(baseline);
+  });
 });
 
 // ============================================
@@ -174,6 +193,54 @@ describe('recordUsageFromSdkResult', () => {
 
     // 1M/1M on sonnet-4-6 → 1800 cents, NOT 0.
     expect(recordedCostCents(captured.sessionSet)).toBe(1800);
+  });
+
+  it('includes cache tokens in the fallback cost (cached request priced higher than in+out alone)', async () => {
+    // First: in+out only → 1800 cents on sonnet-4-6 (1M/1M).
+    const baselineCapture = setupDbMocks(null);
+    await recordUsageFromSdkResult('sess-cache-base', 'org-1', {
+      total_cost_usd: 0,
+      usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+    });
+    expect(recordedCostCents(baselineCapture.sessionSet)).toBe(1800);
+
+    // Now the same in+out PLUS cache tokens. cache-read 1M (+30) and
+    // cache-write 1M (+375) must be added on top → 2205 cents.
+    const cachedCapture = setupDbMocks(null);
+    await recordUsageFromSdkResult('sess-cache', 'org-1', {
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_read_input_tokens: 1_000_000,
+        cache_creation_input_tokens: 1_000_000,
+      },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+    });
+    const cachedCost = recordedCostCents(cachedCapture.sessionSet);
+    expect(cachedCost).toBe(2205);
+    expect(cachedCost).toBeGreaterThan(1800);
+  });
+
+  it('prices a $0 result that only has cache tokens (no uncached in/out)', async () => {
+    // Fully-cached follow-up turn: input_tokens/output_tokens can be ~0 while the
+    // real spend is entirely cache reads. Must NOT record $0.
+    const captured = setupDbMocks(null);
+    await recordUsageFromSdkResult('sess-cache-only', 'org-1', {
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 1_000_000, // sonnet-4-6: 300 * 0.1 = 30 cents
+        cache_creation_input_tokens: 0,
+      },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+    });
+    expect(recordedCostCents(captured.sessionSet)).toBe(30);
   });
 
   it('falls back to the session-row model when result.model is absent', async () => {

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -12,13 +12,27 @@ import { getRedis } from './redis';
 import { rateLimiter } from './rate-limit';
 import { getEffectiveAiBudget } from './effectiveSettings';
 
-// Cost per million tokens (in cents)
+// Cost per million tokens, expressed in cents (USD * 100).
+// Source: official Anthropic pricing — https://platform.claude.com/docs/en/about-claude/models/overview
+// (input / output $/MTok): opus-4-8 $5/$25, sonnet-4-6 $3/$15, haiku-4-5 $1/$5, fable-5 $10/$50.
+// Verified 2026-06-13. Do NOT edit these without re-confirming against the official pricing page.
+// Both the dateless alias and the pinned dated snapshot are keyed where one exists, since callers
+// may pass either form (the SDK / DB sessions use the alias; legacy rows may carry the dated id).
 const MODEL_PRICING: Record<string, { inputPerMillion: number; outputPerMillion: number }> = {
-  'claude-sonnet-4-5-20250929': { inputPerMillion: 300, outputPerMillion: 1500 },
-  'claude-haiku-4-5-20251001': { inputPerMillion: 100, outputPerMillion: 500 }
+  // Current models
+  'claude-opus-4-8': { inputPerMillion: 500, outputPerMillion: 2500 },
+  'claude-sonnet-4-6': { inputPerMillion: 300, outputPerMillion: 1500 },
+  'claude-haiku-4-5': { inputPerMillion: 100, outputPerMillion: 500 },
+  'claude-haiku-4-5-20251001': { inputPerMillion: 100, outputPerMillion: 500 },
+  'claude-fable-5': { inputPerMillion: 1000, outputPerMillion: 5000 },
+  // Legacy / previously-default models still seen on older sessions
+  'claude-sonnet-4-5': { inputPerMillion: 300, outputPerMillion: 1500 },
+  'claude-sonnet-4-5-20250929': { inputPerMillion: 300, outputPerMillion: 1500 }
 };
 
-const DEFAULT_PRICING = { inputPerMillion: 300, outputPerMillion: 1500 };
+// Conservative last-resort pricing for an unrecognized model id. Mirrors the most
+// expensive current Opus-tier rate so we never silently undercount. Hitting this is logged.
+const DEFAULT_PRICING = { inputPerMillion: 500, outputPerMillion: 2500 };
 
 async function checkBillingCredits(orgId: string): Promise<string | null> {
   const billingUrl = process.env.BILLING_SERVICE_URL;
@@ -82,8 +96,35 @@ async function deductBillingCredits(orgId: string, costCents: number): Promise<v
   }
 }
 
+/**
+ * Look up the model id recorded on a session, used to price tokens when the SDK
+ * does not report a cost. Returns null if the session can't be found.
+ */
+async function getSessionModel(sessionId: string): Promise<string | null> {
+  try {
+    const [row] = await db
+      .select({ model: aiSessions.model })
+      .from(aiSessions)
+      .where(eq(aiSessions.id, sessionId))
+      .limit(1);
+    return row?.model ?? null;
+  } catch (err) {
+    console.error(`[AI] Failed to look up model for session=${sessionId}:`, err);
+    return null;
+  }
+}
+
 export function calculateCostCents(model: string, inputTokens: number, outputTokens: number): number {
-  const pricing = MODEL_PRICING[model] ?? DEFAULT_PRICING;
+  let pricing = MODEL_PRICING[model];
+  if (!pricing) {
+    pricing = DEFAULT_PRICING;
+    // Surface unrecognized models so we can add them to MODEL_PRICING rather than
+    // silently billing at the conservative default rate.
+    console.warn(
+      `[AI] No pricing entry for model "${model}" — falling back to DEFAULT_PRICING ` +
+      `($${(DEFAULT_PRICING.inputPerMillion / 100).toFixed(2)}/$${(DEFAULT_PRICING.outputPerMillion / 100).toFixed(2)} per MTok). Add it to MODEL_PRICING.`
+    );
+  }
   const inputCost = (inputTokens / 1_000_000) * pricing.inputPerMillion;
   const outputCost = (outputTokens / 1_000_000) * pricing.outputPerMillion;
   return Math.round((inputCost + outputCost) * 100) / 100;
@@ -254,7 +295,13 @@ export async function recordUsage(
 
 /**
  * Record usage from the Claude Agent SDK result message.
- * The SDK provides total_cost_usd and per-model token breakdowns.
+ *
+ * Cost comes from the SDK's self-reported `total_cost_usd` when it is present and
+ * non-zero. The SDK computes that from its own bundled model→price table, so a
+ * model id newer than that table makes it report `total_cost_usd: 0`. To avoid
+ * silently recording $0.00 in that case (issue #1326), we fall back to pricing the
+ * reported `input_tokens`/`output_tokens` ourselves via MODEL_PRICING. The model id
+ * is taken from `result.model` when available, otherwise looked up from the session row.
  */
 export async function recordUsageFromSdkResult(
   sessionId: string,
@@ -263,14 +310,38 @@ export async function recordUsageFromSdkResult(
     total_cost_usd: number;
     usage: { input_tokens: number; output_tokens: number };
     num_turns: number;
+    /** Model id the SDK ran with. Used to price tokens when total_cost_usd is 0. */
+    model?: string;
   }
 ): Promise<void> {
   if (!orgId) {
     console.warn(`[AI] Skipping recordUsageFromSdkResult — empty orgId for session=${sessionId}`);
     return;
   }
-  const costCents = Math.round(result.total_cost_usd * 100 * 100) / 100; // USD → cents, 2 decimal places
   const { input_tokens: inputTokens, output_tokens: outputTokens } = result.usage;
+
+  // Prefer the SDK's self-reported cost. Fall back to token-based pricing only when
+  // the SDK reports 0/missing cost but actually consumed tokens — this is the case
+  // that was silently producing $0.00 sessions (the SDK can't price a model id newer
+  // than its bundled table).
+  let costCents = Math.round(result.total_cost_usd * 100 * 100) / 100; // USD → cents, 2 decimal places
+  if (costCents <= 0 && (inputTokens > 0 || outputTokens > 0)) {
+    const model = result.model ?? (await getSessionModel(sessionId));
+    if (model) {
+      costCents = calculateCostCents(model, inputTokens, outputTokens);
+      console.warn(
+        `[AI] SDK reported total_cost_usd=${result.total_cost_usd} for session=${sessionId} ` +
+        `(${inputTokens} in / ${outputTokens} out tokens). Priced from MODEL_PRICING ` +
+        `for model "${model}" → ${costCents} cents.`
+      );
+    } else {
+      console.warn(
+        `[AI] SDK reported total_cost_usd=${result.total_cost_usd} for session=${sessionId} ` +
+        `with ${inputTokens} in / ${outputTokens} out tokens but no model id available — ` +
+        `cannot price tokens, recording 0 cents.`
+      );
+    }
+  }
   const now = new Date();
   const dailyKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
   const monthlyKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -34,6 +34,15 @@ const MODEL_PRICING: Record<string, { inputPerMillion: number; outputPerMillion:
 // expensive current Opus-tier rate so we never silently undercount. Hitting this is logged.
 const DEFAULT_PRICING = { inputPerMillion: 500, outputPerMillion: 2500 };
 
+// Prompt-caching price multipliers, applied to the model's base input rate.
+// Standard Anthropic convention: a cache READ is billed at 0.1x the input rate
+// (https://platform.claude.com/docs/en/build-with-claude/prompt-caching) and a
+// cache WRITE / creation (5-minute TTL) is billed at 1.25x the input rate. These
+// are reused across every model since Anthropic prices cache tokens as a fixed
+// fraction of the per-model input rate rather than as separate flat amounts.
+const CACHE_READ_INPUT_MULTIPLIER = 0.1;
+const CACHE_WRITE_INPUT_MULTIPLIER = 1.25;
+
 async function checkBillingCredits(orgId: string): Promise<string | null> {
   const billingUrl = process.env.BILLING_SERVICE_URL;
   const billingKey = process.env.BILLING_SERVICE_API_KEY;
@@ -114,7 +123,16 @@ async function getSessionModel(sessionId: string): Promise<string | null> {
   }
 }
 
-export function calculateCostCents(model: string, inputTokens: number, outputTokens: number): number {
+export function calculateCostCents(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  // Cache tokens are reported separately from `input_tokens` by the SDK usage
+  // object and are billed at different rates (see the multiplier constants).
+  // Default to 0 so callers that don't care about caching are unaffected.
+  cacheReadInputTokens = 0,
+  cacheCreationInputTokens = 0
+): number {
   let pricing = MODEL_PRICING[model];
   if (!pricing) {
     pricing = DEFAULT_PRICING;
@@ -127,7 +145,14 @@ export function calculateCostCents(model: string, inputTokens: number, outputTok
   }
   const inputCost = (inputTokens / 1_000_000) * pricing.inputPerMillion;
   const outputCost = (outputTokens / 1_000_000) * pricing.outputPerMillion;
-  return Math.round((inputCost + outputCost) * 100) / 100;
+  // Cache reads (~0.1x input) and cache writes/creation (~1.25x input) are priced
+  // off the per-model input rate. Omitting them undercounts cost for any cached
+  // request — the bulk of input tokens on multi-turn sessions land in the cache.
+  const cacheReadCost =
+    (cacheReadInputTokens / 1_000_000) * pricing.inputPerMillion * CACHE_READ_INPUT_MULTIPLIER;
+  const cacheWriteCost =
+    (cacheCreationInputTokens / 1_000_000) * pricing.inputPerMillion * CACHE_WRITE_INPUT_MULTIPLIER;
+  return Math.round((inputCost + outputCost + cacheReadCost + cacheWriteCost) * 100) / 100;
 }
 
 /**
@@ -308,7 +333,15 @@ export async function recordUsageFromSdkResult(
   orgId: string,
   result: {
     total_cost_usd: number;
-    usage: { input_tokens: number; output_tokens: number };
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      // Cache tokens are reported separately from input_tokens by the SDK usage
+      // object and are billed at different rates. Optional so older/partial usage
+      // payloads (and tests) don't have to supply them.
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
     num_turns: number;
     /** Model id the SDK ran with. Used to price tokens when total_cost_usd is 0. */
     model?: string;
@@ -318,20 +351,37 @@ export async function recordUsageFromSdkResult(
     console.warn(`[AI] Skipping recordUsageFromSdkResult — empty orgId for session=${sessionId}`);
     return;
   }
-  const { input_tokens: inputTokens, output_tokens: outputTokens } = result.usage;
+  const {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_read_input_tokens: cacheReadTokens = 0,
+    cache_creation_input_tokens: cacheCreationTokens = 0,
+  } = result.usage;
 
   // Prefer the SDK's self-reported cost. Fall back to token-based pricing only when
   // the SDK reports 0/missing cost but actually consumed tokens — this is the case
   // that was silently producing $0.00 sessions (the SDK can't price a model id newer
   // than its bundled table).
   let costCents = Math.round(result.total_cost_usd * 100 * 100) / 100; // USD → cents, 2 decimal places
-  if (costCents <= 0 && (inputTokens > 0 || outputTokens > 0)) {
+  if (
+    costCents <= 0 &&
+    (inputTokens > 0 || outputTokens > 0 || cacheReadTokens > 0 || cacheCreationTokens > 0)
+  ) {
     const model = result.model ?? (await getSessionModel(sessionId));
     if (model) {
-      costCents = calculateCostCents(model, inputTokens, outputTokens);
+      // Include cache read/creation tokens — pricing only input+output here would
+      // systematically undercount cost for cached requests (issue #1326 follow-up).
+      costCents = calculateCostCents(
+        model,
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens
+      );
       console.warn(
         `[AI] SDK reported total_cost_usd=${result.total_cost_usd} for session=${sessionId} ` +
-        `(${inputTokens} in / ${outputTokens} out tokens). Priced from MODEL_PRICING ` +
+        `(${inputTokens} in / ${outputTokens} out / ${cacheReadTokens} cache-read / ` +
+        `${cacheCreationTokens} cache-write tokens). Priced from MODEL_PRICING ` +
         `for model "${model}" → ${costCents} cents.`
       );
     } else {

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -715,6 +715,11 @@ export class StreamingSessionManager {
               usage: {
                 input_tokens: resultMsg.usage?.input_tokens ?? 0,
                 output_tokens: resultMsg.usage?.output_tokens ?? 0,
+                // Cache tokens are billed separately (read ~0.1x input, write ~1.25x
+                // input). Capture them so the token-based fallback doesn't undercount
+                // cost on cached requests when the SDK reports $0.
+                cache_read_input_tokens: resultMsg.usage?.cache_read_input_tokens ?? 0,
+                cache_creation_input_tokens: resultMsg.usage?.cache_creation_input_tokens ?? 0,
               },
               num_turns: resultMsg.num_turns ?? 0,
               // Model id for token-based cost fallback when the SDK reports $0.

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -223,6 +223,11 @@ export interface ActiveSession {
    * is always set, even for system/partner-scoped users who own the session.
    */
   readonly orgId: string;
+  /**
+   * Model id this session runs with (from the aiSessions row). Used to price
+   * tokens for cost tracking when the SDK fails to report total_cost_usd.
+   */
+  readonly model: string;
   sdkSessionId: string | null;
   query: Query;
   abortController: AbortController;
@@ -358,6 +363,7 @@ export class StreamingSessionManager {
     const session: ActiveSession = {
       breezeSessionId,
       orgId: dbSession.orgId,
+      model: dbSession.model,
       sdkSessionId: dbSession.sdkSessionId,
       query: null as unknown as Query, // set below
       abortController,
@@ -711,6 +717,8 @@ export class StreamingSessionManager {
                 output_tokens: resultMsg.usage?.output_tokens ?? 0,
               },
               num_turns: resultMsg.num_turns ?? 0,
+              // Model id for token-based cost fallback when the SDK reports $0.
+              model: session.model,
             };
 
             if (!resultMsg.usage || (!resultMsg.usage.input_tokens && !resultMsg.usage.output_tokens)) {


### PR DESCRIPTION
## Summary

AI cost tracking displayed **\$0.00 everywhere** because, on the default Claude Agent SDK path, cost came *exclusively* from the SDK's self-reported `total_cost_usd`. The SDK prices from its own bundled model→price table, so a model id newer than that table makes it report `total_cost_usd: 0`, and every session landed at \$0.00 with no recovery. The in-house `MODEL_PRICING` map that could have backstopped it was both stale (missing every current model) and dead (no non-test callers), and `DEFAULT_MODEL` was a stale id the SDK couldn't price natively.

## What changed

- **Token-based fallback** in `recordUsageFromSdkResult` (`aiCostTracker.ts`): when `total_cost_usd` is 0/missing but tokens are present, price the tokens via `MODEL_PRICING`. The model id comes from the SDK result (threaded through as `session.model`) or, if absent, a lookup of the `aiSessions` row. A valid non-zero `total_cost_usd` is still used verbatim.
- **Cache tokens are now priced in the fallback.** The SDK usage object reports uncached `input_tokens` separately from `cache_read_input_tokens` (~0.1x input rate) and `cache_creation_input_tokens` (~1.25x input rate), each billed separately. The original fallback priced only input + output, systematically **undercounting cached requests** (the bulk of input tokens on multi-turn sessions land in the cache). `calculateCostCents` now takes optional cache-read / cache-creation token counts and prices them off the per-model input rate using the standard Anthropic convention (read 0.1x, write 1.25x), documented inline. `streamingSessionManager` captures both counts from `resultMsg.usage`, and the fallback now also fires on fully-cached turns where only cache tokens are present (no more \$0 on cache-only turns). Base per-model rates are unchanged.
- **Refreshed `MODEL_PRICING`** with verified current rates sourced from the official Anthropic pricing page (`platform.claude.com/docs/.../models/overview`) — **not guessed**:
  - `claude-opus-4-8` — \$5 / \$25 per MTok
  - `claude-sonnet-4-6` — \$3 / \$15 per MTok
  - `claude-haiku-4-5` (+ dated `-20251001`) — \$1 / \$5 per MTok
  - `claude-fable-5` — \$10 / \$50 per MTok
  - Legacy ids kept; `DEFAULT_PRICING` now **logs a warning when hit** so unrecognized models are observable instead of silently billed at the default.
- **Bumped `DEFAULT_MODEL`** in `aiAgent.ts` from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6` (same \$3/\$15 tier, a current id the SDK can price natively).
- Threaded the session's `model` onto `ActiveSession` and into the SDK `usageData` so the fallback can price without a DB round-trip.

## Tests

`apps/api/src/services/aiCostTracker.test.ts` (18 cases): non-zero cost for each current model (no `DEFAULT_PRICING` fallthrough for shipping models), the **`total_cost_usd: 0` + tokens > 0 → non-zero cost** regression, verbatim SDK cost when non-zero, the session-row model fallback, zero-token/empty-org guards, and the new **cache-token pricing** cases — cache-read (0.1x) and cache-creation (1.25x) priced off the input rate, a cached request costing strictly more than input+output alone, and a \$0 cache-only turn that must not record \$0. All 4 cache cases were verified to fail when the cache pricing is reverted.

```
pnpm --filter @breeze/api exec vitest run src/services/aiCostTracker.test.ts
# Test Files  1 passed (1)
#      Tests  18 passed (18)
```

`npx tsc --noEmit` on `@breeze/api` reports 0 errors in the changed files.

## Notes

All pricing is sourced from official Anthropic docs, so no TODO/placeholder constant was needed. Cache multipliers follow the standard Anthropic convention (read 0.1x input, write 1.25x input). Model ids confirmed current: `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-fable-5`.

Closes #1326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
