### PR TITLE
fix(web): in-flight feedback on alert acknowledge via runAction

### DIFF
--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AlertsPage from './AlertsPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+// The device filter bar issues its own fetches; stub it out so the page's
+// alert/device fetches are the only traffic under test.
+vi.mock('../filters/DeviceFilterBar', () => ({
+  DeviceFilterBar: () => null
+}));
+
+// Pin the org-scope selectors so the page doesn't try to read a real store.
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { orgScope: string; currentOrgId: string | null }) => unknown) =>
+    selector({ orgScope: 'current', currentOrgId: 'org-1' })
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ALERT_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const activeAlert = {
+  id: ALERT_ID,
+  title: 'High CPU on SRV-01',
+  message: 'CPU above 95% for 5 minutes',
+  severity: 'critical',
+  status: 'active',
+  deviceId: 'device-1',
+  deviceName: 'SRV-01',
+  triggeredAt: new Date().toISOString()
+};
+
+/** A promise we can resolve from the test body to simulate a slow ack. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('AlertsPage — acknowledge in-flight feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows an in-flight spinner on the acked row while the request is pending, then a success toast', async () => {
+    const ackDeferred = deferred<Response>();
+
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [activeAlert] }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === `/alerts/${ALERT_ID}/acknowledge` && method === 'POST') {
+        // Deliberately do NOT resolve yet — this models the ~19s ack.
+        return ackDeferred.promise;
+      }
+      return Promise.resolve(makeJsonResponse({ error: 'unexpected' }, false, 404));
+    });
+
+    render(<AlertsPage />);
+
+    // Wait for the alert row to render.
+    const ackButton = await screen.findByRole('button', { name: /Acknowledge: High CPU on SRV-01/i });
+    const row = ackButton.closest('tr')!;
+
+    // Click Ack — the request is now in flight (deferred, unresolved).
+    fireEvent.click(ackButton);
+
+    // While in flight, the row must surface a spinner and hide the action buttons.
+    await waitFor(() => {
+      expect(within(row).queryByRole('button', { name: /Acknowledge:/i })).not.toBeInTheDocument();
+    });
+    expect(row.querySelector('.animate-spin')).toBeInTheDocument();
+
+    // No success toast yet — the request hasn't returned.
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+
+    // Resolve the ack.
+    ackDeferred.resolve(makeJsonResponse({ success: true }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    });
+  });
+
+  it('disables the AlertDetails Acknowledge button and shows a spinner while the request is pending', async () => {
+    const ackDeferred = deferred<Response>();
+
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [activeAlert] }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === `/alerts/${ALERT_ID}` && method === 'GET') {
+        // Detail-panel fetch (status/notification history).
+        return Promise.resolve(makeJsonResponse({ statusHistory: [], notificationHistory: [] }));
+      }
+      if (url === `/alerts/${ALERT_ID}/acknowledge` && method === 'POST') {
+        return ackDeferred.promise;
+      }
+      return Promise.resolve(makeJsonResponse({ error: 'unexpected' }, false, 404));
+    });
+
+    render(<AlertsPage />);
+
+    // Open the slide-over by clicking the row (the title cell).
+    const titleCell = await screen.findByText('High CPU on SRV-01');
+    fireEvent.click(titleCell);
+
+    // The detail panel's Acknowledge button (full word, distinct from the row "Ack").
+    const dialog = await screen.findByRole('dialog');
+    const detailAck = within(dialog).getByRole('button', { name: /^Acknowledge$/i });
+    expect(detailAck).not.toBeDisabled();
+
+    fireEvent.click(detailAck);
+
+    // In flight: button disabled + spinner present in the dialog footer.
+    await waitFor(() => expect(detailAck).toBeDisabled());
+    expect(dialog.querySelector('.animate-spin')).toBeInTheDocument();
+
+    ackDeferred.resolve(makeJsonResponse({ success: true }));
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    });
+  });
+
+  it('surfaces an error toast when the acknowledge request fails', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [activeAlert] }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === `/alerts/${ALERT_ID}/acknowledge` && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: 'unexpected' }, false, 404));
+    });
+
+    render(<AlertsPage />);
+    const ackButton = await screen.findByRole('button', { name: /Acknowledge: High CPU on SRV-01/i });
+    fireEvent.click(ackButton);
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+});

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -11,6 +11,7 @@ import type { FilterConditionGroup } from '@breeze/shared';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
+import { runAction, ActionError } from '../../lib/runAction';
 
 type Device = { id: string; name: string };
 
@@ -102,6 +103,9 @@ export default function AlertsPage() {
     let cancelled = false;
     (async () => {
       try {
+        // runaction-exempt: read-only filter preview (POST carries the filter
+        // body but mutates nothing). Failure is handled inline by falling back
+        // to the unfiltered list; a toast here would be noise.
         const res = await fetchWithAuth('/filters/preview', {
           method: 'POST',
           body: JSON.stringify({ conditions: deviceFilter, limit: 100 })
@@ -140,16 +144,19 @@ export default function AlertsPage() {
   };
 
   const handleAcknowledge = async (alert: Alert) => {
+    // setSubmitting/setSubmittingId drive the in-flight spinner + disabled state
+    // (row spinner in AlertList, disabled Ack button in AlertDetails). The
+    // acknowledge round-trip can be slow, so this feedback must show the whole
+    // time the request is in flight — not just after it returns (#1300).
     setSubmitting(true);
     setSubmittingId(alert.id);
     try {
-      const response = await fetchWithAuth(`/alerts/${alert.id}/acknowledge`, {
-        method: 'POST'
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/${alert.id}/acknowledge`, { method: 'POST' }),
+        errorFallback: 'Failed to acknowledge alert',
+        successMessage: 'Alert acknowledged',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to acknowledge alert');
-      }
 
       setAlerts(prev => prev.map(a =>
         a.id === alert.id ? { ...a, status: 'acknowledged' as const, acknowledgedAt: new Date().toISOString() } : a
@@ -162,11 +169,12 @@ export default function AlertsPage() {
         );
       }
 
-      showToast({ message: 'Alert acknowledged', type: 'success' });
       fetchAlerts();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to acknowledge alert';
-      showToast({ message: msg, type: 'error' });
+      // runAction already toasted any ActionError (and 401 → login redirect).
+      if (!(err instanceof ActionError)) {
+        showToast({ message: 'Failed to acknowledge alert', type: 'error' });
+      }
     } finally {
       setSubmitting(false);
       setSubmittingId(null);
@@ -177,25 +185,26 @@ export default function AlertsPage() {
     setSubmitting(true);
     setSubmittingId(alert.id);
     try {
-      const response = await fetchWithAuth(`/alerts/${alert.id}/resolve`, {
-        method: 'POST',
-        body: JSON.stringify({ note })
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/${alert.id}/resolve`, {
+          method: 'POST',
+          body: JSON.stringify({ note })
+        }),
+        errorFallback: 'Failed to resolve alert',
+        successMessage: 'Alert resolved',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to resolve alert');
-      }
 
       setAlerts(prev => prev.map(a =>
         a.id === alert.id ? { ...a, status: 'resolved' as const, resolvedAt: new Date().toISOString() } : a
       ));
 
-      showToast({ message: 'Alert resolved', type: 'success' });
       handleCloseDetail();
       fetchAlerts();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to resolve alert';
-      showToast({ message: msg, type: 'error' });
+      if (!(err instanceof ActionError)) {
+        showToast({ message: 'Failed to resolve alert', type: 'error' });
+      }
     } finally {
       setSubmitting(false);
       setSubmittingId(null);
@@ -224,8 +233,12 @@ export default function AlertsPage() {
       duration: 5000,
     });
 
-    // Fire the actual request
+    // Fire the actual request.
     try {
+      // runaction-exempt: optimistic-with-undo handler — it shows its outcome
+      // inline (the optimistic row mutation + the undo toast above, and an
+      // explicit revert + error toast on failure below). Routing through
+      // runAction would double-toast and fight the optimistic flow.
       const response = await fetchWithAuth(`/alerts/${alert.id}/suppress`, {
         method: 'POST'
       });
@@ -246,23 +259,23 @@ export default function AlertsPage() {
   const executeBulkAction = async (action: string, selectedAlerts: Alert[]) => {
     setSubmitting(true);
     try {
-      const response = await fetchWithAuth('/alerts/bulk', {
-        method: 'POST',
-        body: JSON.stringify({
-          action,
-          alertIds: selectedAlerts.map(a => a.id)
-        })
+      await runAction({
+        request: () => fetchWithAuth('/alerts/bulk', {
+          method: 'POST',
+          body: JSON.stringify({
+            action,
+            alertIds: selectedAlerts.map(a => a.id)
+          })
+        }),
+        errorFallback: `Failed to ${action} alerts`,
+        successMessage: `${selectedAlerts.length} alert${selectedAlerts.length > 1 ? 's' : ''} ${action}d`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        throw new Error(`Failed to ${action} alerts`);
-      }
-
-      showToast({ message: `${selectedAlerts.length} alert${selectedAlerts.length > 1 ? 's' : ''} ${action}d`, type: 'success' });
       await fetchAlerts();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : `Failed to ${action} alerts`;
-      showToast({ message: msg, type: 'error' });
+      if (!(err instanceof ActionError)) {
+        showToast({ message: `Failed to ${action} alerts`, type: 'error' });
+      }
     } finally {
       setSubmitting(false);
       setPendingBulk(null);

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -29,6 +29,7 @@ const REPO_ROOT = resolve(WEB_ROOT, '../../..');
 // to silent mutations. Grows as more handlers migrate (see the backlog).
 const TARGET_GLOBS = [
   'src/components/alerts/NotificationChannelsPage.tsx',
+  'src/components/alerts/AlertsPage.tsx',
   'src/components/settings/PartnerSettingsPage.tsx',
   'src/components/patches/PatchesPage.tsx',
   'src/components/settings/RolesPage.tsx',
@@ -244,7 +245,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(25);
+    expect(absoluteFiles.length).toBe(26);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/runActionAllowlist.ts
+++ b/apps/web/src/lib/runActionAllowlist.ts
@@ -28,6 +28,6 @@ export const RUN_ACTION_MIGRATION_BACKLOG: ReadonlyArray<string> = [
   'apps/web/src/components/alerts/AlertRulesPage.tsx',
   'apps/web/src/components/alerts/AlertTemplateEditor.tsx',
   'apps/web/src/components/alerts/AlertTemplateList.tsx',
-  'apps/web/src/components/alerts/AlertsPage.tsx',
+  // AlertsPage.tsx migrated to runAction (#1300) — now in TARGET_GLOBS.
   'apps/web/src/components/alerts/CorrelatedAlertGroups.tsx',
 ];


### PR DESCRIPTION
## Summary
Acknowledging an active alert can take ~19s server-side, during which the action looked dead — only the row mutating after the round-trip signaled success (borderline silent-mutation, the #720 defect class). The `AlertsPage` acknowledge handler used a raw `fetchWithAuth` and sat on the `runAction` migration backlog, so its success/failure feedback wasn't guaranteed.

This adds reliable in-flight + outcome feedback on the acknowledge action (and the resolve/bulk handlers that share the path), via the existing `runAction` pattern.

## What changed
- **Migrate `AlertsPage` `handleAcknowledge` / `handleResolve` / `executeBulkAction` to `runAction`** — the outcome (success toast, error toast, HTTP-200 `{success:false}` treated as failure, 401 → login redirect) is now always surfaced regardless of latency.
- **Keep the in-flight feedback** that the spinner relies on: `submitting` / `submittingId` still drive the `AlertList` row spinner (action buttons swapped for a `Loader2`, row gets `opacity-60 pointer-events-none`) and the disabled `AlertDetails` Acknowledge button with its own spinner. So the button is visibly pending the whole time the request is in flight.
- **`runaction-exempt` markers** on the optimistic-with-undo `handleSuppress` (it shows its outcome inline via the undo toast + explicit revert) and on the read-only `/filters/preview` POST (carries a filter body but mutates nothing).
- **Move `AlertsPage.tsx` off `RUN_ACTION_MIGRATION_BACKLOG`** into the `no-silent-mutations` `TARGET_GLOBS` (count 25 → 26), per the backlog comment's "migrate opportunistically and move each into TARGET_GLOBS as it's done."

## Latency investigation (out of scope for the fix here)
The ~19s is the route's awaited `publishEvent('alert.acknowledged')` in `apps/api/src/routes/alerts/alerts.ts` — `eventBus.publishEvent` does a Redis `xadd` + two `publish` calls and then `invokeLocalHandlers`, which `await`s every local `*`-subscriber **serially** before the HTTP response returns. On a dev image with cold Redis paths this explains the multi-second wait (matches QA's "event published ~8s in, response ~11s after"). Deferring/parallelizing that fan-out is a separate perf change; this PR makes the UI honest about the wait either way.

## Tests
New `apps/web/src/components/alerts/AlertsPage.test.tsx`:
- row spinner shows + Ack button hidden while the ack request is in flight (deferred promise), success toast after it resolves;
- `AlertDetails` Acknowledge button disabled + spinner while in flight;
- error toast (no success toast) on a failed ack.

`no-silent-mutations` guard now scans `AlertsPage.tsx`.

```
pnpm --filter @breeze/web exec vitest run \
  src/components/alerts/AlertsPage.test.tsx \
  src/components/alerts/CreateTicketFromAlertDialog.test.tsx \
  src/lib/__tests__/no-silent-mutations.test.ts
```
Result: 3 files, 54 tests passed.

Closes #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)