### PR TITLE
feat(patches): selectable page size + clickable header sorting

### DIFF
--- a/apps/api/src/routes/patches/helpers.ts
+++ b/apps/api/src/routes/patches/helpers.ts
@@ -2,9 +2,15 @@ import { sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { writeRouteAudit, type AuthContext } from '../../services/auditEvents';
 
+// Max rows the patches list endpoint will return in a single page. Raised from
+// 100 to 200 so the web patches table's "200" page-size option is actually
+// honored server-side (issue #1316). The patches catalog is a global vendor
+// list, so a 200-row page is a bounded, index-friendly scan.
+export const MAX_PAGE_LIMIT = 200;
+
 export function getPagination(query: { page?: string; limit?: string }) {
   const page = Math.max(1, Number.parseInt(query.page ?? '1', 10) || 1);
-  const limit = Math.min(100, Math.max(1, Number.parseInt(query.limit ?? '50', 10) || 50));
+  const limit = Math.min(MAX_PAGE_LIMIT, Math.max(1, Number.parseInt(query.limit ?? '50', 10) || 50));
   return { page, limit, offset: (page - 1) * limit };
 }
 

--- a/apps/api/src/routes/patches/helpers.ts
+++ b/apps/api/src/routes/patches/helpers.ts
@@ -2,10 +2,15 @@ import { sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { writeRouteAudit, type AuthContext } from '../../services/auditEvents';
 
-// Max rows the patches list endpoint will return in a single page. Raised from
+// Max rows a patches list endpoint will return in a single page. Raised from
 // 100 to 200 so the web patches table's "200" page-size option is actually
 // honored server-side (issue #1316). The patches catalog is a global vendor
 // list, so a 200-row page is a bounded, index-friendly scan.
+//
+// Blast radius: getPagination is shared, so this 200 cap also applies to
+// GET /patches/approvals (operations via patch_approvals) and GET /patches/jobs.
+// That is intentional and benign — both are tenant-scoped, indexed list queries
+// (filtered by org_id), so a higher page cap stays bounded and index-friendly.
 export const MAX_PAGE_LIMIT = 200;
 
 export function getPagination(query: { page?: string; limit?: string }) {

--- a/apps/api/src/routes/patches/index.test.ts
+++ b/apps/api/src/routes/patches/index.test.ts
@@ -30,6 +30,7 @@ vi.mock('drizzle-orm', () => {
     and: (...conditions: unknown[]) => ({ op: 'and', conditions }),
     eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
     inArray: (left: unknown, right: unknown) => ({ op: 'inArray', left, right }),
+    asc: (value: unknown) => ({ op: 'asc', value }),
     desc: (value: unknown) => ({ op: 'desc', value }),
     sql
   };
@@ -198,6 +199,35 @@ function selectPatchListResult(rows: unknown[]) {
   };
 }
 
+// Like selectPatchListResult but records the orderBy/limit/offset args so a test
+// can assert how sort + pagination params were translated into the query.
+function selectPatchListCapture(rows: unknown[], capture: {
+  orderBy?: unknown;
+  limit?: unknown;
+  offset?: unknown;
+}) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockImplementation((arg: unknown) => {
+          capture.orderBy = arg;
+          return {
+            limit: vi.fn().mockImplementation((lim: unknown) => {
+              capture.limit = lim;
+              return {
+                offset: vi.fn().mockImplementation((off: unknown) => {
+                  capture.offset = off;
+                  return Promise.resolve(rows);
+                })
+              };
+            })
+          };
+        })
+      })
+    })
+  };
+}
+
 function selectSourceCountsResult(rows: Array<{ source: string; count: number }> = []) {
   return {
     from: vi.fn().mockReturnValue({
@@ -337,6 +367,104 @@ describe('patch routes', () => {
     expect(body.data).toHaveLength(1);
     expect(body.data[0].cveIds).toEqual(['CVE-2024-1234']);
     expect(body.data[0].version).toBe('128.0.3');
+  });
+
+  it('defaults to newest-first (desc createdAt) when no sort params are supplied', async () => {
+    const capture: { orderBy?: unknown; limit?: unknown; offset?: unknown } = {};
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchListCapture([], capture) as any)
+      .mockReturnValueOnce(selectWhereResult([{ count: 0 }]) as any)
+      .mockReturnValueOnce(selectSourceCountsResult() as any);
+
+    const res = await app.request('/patches', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(capture.orderBy).toEqual({ op: 'desc', value: 'patches.createdAt' });
+  });
+
+  it('maps a whitelisted sortBy/sortDir to the matching column and direction', async () => {
+    const capture: { orderBy?: unknown; limit?: unknown; offset?: unknown } = {};
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchListCapture([], capture) as any)
+      .mockReturnValueOnce(selectWhereResult([{ count: 0 }]) as any)
+      .mockReturnValueOnce(selectSourceCountsResult() as any);
+
+    const res = await app.request('/patches?sortBy=title&sortDir=desc', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(capture.orderBy).toEqual({ op: 'desc', value: 'patches.title' });
+  });
+
+  it('defaults sort direction to asc when sortBy is given without sortDir', async () => {
+    const capture: { orderBy?: unknown; limit?: unknown; offset?: unknown } = {};
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchListCapture([], capture) as any)
+      .mockReturnValueOnce(selectWhereResult([{ count: 0 }]) as any)
+      .mockReturnValueOnce(selectSourceCountsResult() as any);
+
+    const res = await app.request('/patches?sortBy=severity', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(capture.orderBy).toEqual({ op: 'asc', value: 'patches.severity' });
+  });
+
+  it('rejects an unknown sortBy column with 400', async () => {
+    const res = await app.request('/patches?sortBy=dropTable', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid sortDir with 400', async () => {
+    const res = await app.request('/patches?sortBy=title&sortDir=sideways', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('honors a page size up to the raised 200 cap', async () => {
+    const capture: { orderBy?: unknown; limit?: unknown; offset?: unknown } = {};
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchListCapture([], capture) as any)
+      .mockReturnValueOnce(selectWhereResult([{ count: 0 }]) as any)
+      .mockReturnValueOnce(selectSourceCountsResult() as any);
+
+    const res = await app.request('/patches?limit=200', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(capture.limit).toBe(200);
+  });
+
+  it('clamps a limit above the 200 cap down to 200', async () => {
+    const capture: { orderBy?: unknown; limit?: unknown; offset?: unknown } = {};
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchListCapture([], capture) as any)
+      .mockReturnValueOnce(selectWhereResult([{ count: 0 }]) as any)
+      .mockReturnValueOnce(selectSourceCountsResult() as any);
+
+    const res = await app.request('/patches?limit=5000', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(capture.limit).toBe(200);
   });
 
   it('infers patch os from associated device when source is third_party', async () => {

--- a/apps/api/src/routes/patches/list.ts
+++ b/apps/api/src/routes/patches/list.ts
@@ -9,6 +9,17 @@ import { getPagination, inferPatchOs } from './helpers';
 
 // Whitelist mapping sort keys (validated by listPatchesSchema) to real columns.
 // Never pass raw user input into orderBy — only keys present here are honored.
+//
+// NOTE (sort divergence — read before wiring the web to these params):
+//   - `severity` here sorts ALPHABETICALLY (asc(patches.severity)). The web
+//     (PatchList.tsx severityRank/approvalRank) sorts by SEMANTIC priority
+//     (critical=0, important=1, moderate=2, low=3). Whoever later sends
+//     sortBy/sortDir from fetchPatches must reconcile these — either map the
+//     web's priority order onto a CASE expression here, or drop the client-side
+//     rank — or severity sort will silently change meaning.
+//   - The web also exposes `os` and `approvalStatus` as SortKeys with NO column
+//     in this map; they'd need server-side support (osTypes / patch_approvals
+//     join) before they can be pushed down.
 const PATCH_SORT_COLUMNS: Record<string, Column> = {
   title: patches.title,
   severity: patches.severity,
@@ -71,6 +82,13 @@ listRoutes.get(
     // the prior newest-first behavior when no sort params are supplied. The
     // `?? createdAt` fallback is defensive — query.sortBy is already constrained
     // to the whitelist keys by listPatchesSchema, so the lookup never misses.
+    //
+    // sortBy/sortDir are API-ready but NOT yet consumed by the web client: the
+    // patches page (apps/web/.../PatchesPage.tsx) fetches a fixed `limit=200`
+    // and sorts/paginates entirely client-side, so this server-side ordering is
+    // currently exercised only by direct API callers. Wiring the web to send
+    // these is a follow-up — see the severity-divergence NOTE on
+    // PATCH_SORT_COLUMNS above before doing so.
     const sortColumn = (query.sortBy && PATCH_SORT_COLUMNS[query.sortBy]) || patches.createdAt;
     const sortDirection = query.sortDir ?? (query.sortBy ? 'asc' : 'desc');
     const orderByClause = sortDirection === 'asc' ? asc(sortColumn) : desc(sortColumn);

--- a/apps/api/src/routes/patches/list.ts
+++ b/apps/api/src/routes/patches/list.ts
@@ -1,11 +1,21 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, sql, desc, type SQL } from 'drizzle-orm';
+import { and, eq, sql, asc, desc, type SQL, type Column } from 'drizzle-orm';
 import { requireScope } from '../../middleware/auth';
 import { db } from '../../db';
 import { patches, patchApprovals, devices, devicePatches } from '../../db/schema';
 import { listPatchesSchema, listSourcesSchema, patchIdParamSchema } from './schemas';
 import { getPagination, inferPatchOs } from './helpers';
+
+// Whitelist mapping sort keys (validated by listPatchesSchema) to real columns.
+// Never pass raw user input into orderBy — only keys present here are honored.
+const PATCH_SORT_COLUMNS: Record<string, Column> = {
+  title: patches.title,
+  severity: patches.severity,
+  source: patches.source,
+  releaseDate: patches.releaseDate,
+  createdAt: patches.createdAt
+};
 
 export const listRoutes = new Hono();
 
@@ -57,6 +67,14 @@ listRoutes.get(
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
+    // Resolve sort column/direction from the whitelisted map. Defaults preserve
+    // the prior newest-first behavior when no sort params are supplied. The
+    // `?? createdAt` fallback is defensive — query.sortBy is already constrained
+    // to the whitelist keys by listPatchesSchema, so the lookup never misses.
+    const sortColumn = (query.sortBy && PATCH_SORT_COLUMNS[query.sortBy]) || patches.createdAt;
+    const sortDirection = query.sortDir ?? (query.sortBy ? 'asc' : 'desc');
+    const orderByClause = sortDirection === 'asc' ? asc(sortColumn) : desc(sortColumn);
+
     // Get patches with optional approval status for the org
     const patchList = await db
       .select({
@@ -86,7 +104,7 @@ listRoutes.get(
       })
       .from(patches)
       .where(whereClause)
-      .orderBy(desc(patches.createdAt))
+      .orderBy(orderByClause)
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/patches/schemas.ts
+++ b/apps/api/src/routes/patches/schemas.ts
@@ -1,5 +1,15 @@
 import { z } from 'zod';
 
+// Whitelisted sortable columns for the patches list. Never feed raw user input
+// into orderBy — list.ts maps these keys to real columns (issue #1316).
+export const PATCH_SORT_KEYS = [
+  'title',
+  'severity',
+  'source',
+  'releaseDate',
+  'createdAt'
+] as const;
+
 export const listPatchesSchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional(),
@@ -7,7 +17,9 @@ export const listPatchesSchema = z.object({
   ringId: z.string().uuid().optional(),
   source: z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom']).optional(),
   severity: z.enum(['critical', 'important', 'moderate', 'low', 'unknown']).optional(),
-  os: z.enum(['windows', 'macos', 'linux']).optional()
+  os: z.enum(['windows', 'macos', 'linux']).optional(),
+  sortBy: z.enum(PATCH_SORT_KEYS).optional(),
+  sortDir: z.enum(['asc', 'desc']).optional()
 });
 
 export const patchIdParamSchema = z.object({

--- a/apps/web/src/components/patches/PatchList.test.tsx
+++ b/apps/web/src/components/patches/PatchList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import PatchList, { type Patch } from './PatchList';
@@ -14,6 +14,35 @@ function makePatch(overrides: Partial<Patch> = {}): Patch {
     approvalStatus: 'pending',
     ...overrides,
   };
+}
+
+// Build N patches with distinct, sortable titles (Patch 001 … Patch NNN).
+function makePatches(count: number): Patch[] {
+  return Array.from({ length: count }, (_, i) => {
+    const n = String(i + 1).padStart(3, '0');
+    return makePatch({
+      id: `00000000-0000-0000-0000-${n.padStart(12, '0')}`,
+      title: `Patch ${n}`,
+    });
+  });
+}
+
+// Body data rows (excludes the header row). Each row's second <td> holds the
+// patch title in a font-medium div.
+function bodyRows(): HTMLElement[] {
+  return screen.getAllByRole('row').slice(1);
+}
+
+function rowTitle(row: HTMLElement): string {
+  const cells = within(row).getAllByRole('cell');
+  // cells[0] = checkbox, cells[1] = title block.
+  const titleEl = cells[1]?.querySelector('.font-medium');
+  return titleEl?.textContent?.trim() ?? '';
+}
+
+// Titles rendered in the current page, in DOM order.
+function renderedTitles(): string[] {
+  return bodyRows().map(rowTitle);
 }
 
 describe('PatchList CVE chips', () => {
@@ -53,5 +82,106 @@ describe('PatchList CVE chips', () => {
 
     rerender(<PatchList patches={[missing]} />);
     expect(container.querySelector('[data-testid^="patch-row-"][data-testid*="-cve-"]')).toBeNull();
+  });
+});
+
+describe('PatchList page-size selector', () => {
+  it('defaults to 25 rows per page', () => {
+    render(<PatchList patches={makePatches(40)} />);
+    expect((screen.getByTestId('patch-page-size') as HTMLSelectElement).value).toBe('25');
+    expect(renderedTitles()).toHaveLength(25);
+  });
+
+  it('changes the number of visible rows when a larger page size is chosen', () => {
+    render(<PatchList patches={makePatches(120)} />);
+
+    expect(renderedTitles()).toHaveLength(25);
+
+    fireEvent.change(screen.getByTestId('patch-page-size'), { target: { value: '100' } });
+
+    expect(renderedTitles()).toHaveLength(100);
+  });
+
+  it('resets to page 1 when the page size changes', () => {
+    render(<PatchList patches={makePatches(60)} />);
+
+    // Move to page 2 (25 per page → 3 pages).
+    fireEvent.click(screen.getByText('Page 1 of 3').parentElement!.querySelectorAll('button')[1]);
+    expect(screen.getByText('Page 2 of 3')).toBeTruthy();
+
+    // Raising page size to 100 collapses to a single page starting at 1.
+    fireEvent.change(screen.getByTestId('patch-page-size'), { target: { value: '100' } });
+
+    expect(renderedTitles()[0]).toBe('Patch 001');
+    expect(renderedTitles()).toHaveLength(60);
+  });
+
+  it('offers 25, 50, 100, and 200 options', () => {
+    render(<PatchList patches={makePatches(5)} />);
+    const options = Array.from(
+      (screen.getByTestId('patch-page-size') as HTMLSelectElement).options
+    ).map(o => o.value);
+    expect(options).toEqual(['25', '50', '100', '200']);
+  });
+});
+
+describe('PatchList header sorting', () => {
+  it('sorts by Patch title ascending then descending on repeated header clicks', () => {
+    render(
+      <PatchList
+        patches={[
+          makePatch({ id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', title: 'Zeta Update' }),
+          makePatch({ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', title: 'Alpha Update' }),
+          makePatch({ id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', title: 'Mango Update' }),
+        ]}
+      />
+    );
+
+    // Unsorted: original order.
+    expect(renderedTitles()).toEqual(['Zeta Update', 'Alpha Update', 'Mango Update']);
+
+    fireEvent.click(screen.getByTestId('patch-sort-title'));
+    expect(renderedTitles()).toEqual(['Alpha Update', 'Mango Update', 'Zeta Update']);
+
+    fireEvent.click(screen.getByTestId('patch-sort-title'));
+    expect(renderedTitles()).toEqual(['Zeta Update', 'Mango Update', 'Alpha Update']);
+  });
+
+  it('sorts by severity using priority order (critical first) ascending', () => {
+    render(
+      <PatchList
+        patches={[
+          makePatch({ id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', title: 'Low One', severity: 'low' }),
+          makePatch({ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', title: 'Crit One', severity: 'critical' }),
+          makePatch({ id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', title: 'Mod One', severity: 'moderate' }),
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('patch-sort-severity'));
+    expect(renderedTitles()).toEqual(['Crit One', 'Mod One', 'Low One']);
+  });
+
+  it('marks the active sort header via aria-sort', () => {
+    render(<PatchList patches={makePatches(3)} />);
+
+    const titleHeader = screen.getByTestId('patch-sort-title').closest('th') as HTMLElement;
+    expect(titleHeader.getAttribute('aria-sort')).toBe('none');
+
+    fireEvent.click(screen.getByTestId('patch-sort-title'));
+    expect(titleHeader.getAttribute('aria-sort')).toBe('ascending');
+
+    fireEvent.click(screen.getByTestId('patch-sort-title'));
+    expect(titleHeader.getAttribute('aria-sort')).toBe('descending');
+  });
+
+  it('resets to page 1 when a new sort is applied', () => {
+    render(<PatchList patches={makePatches(60)} />);
+
+    fireEvent.click(screen.getByText('Page 1 of 3').parentElement!.querySelectorAll('button')[1]);
+    expect(screen.getByText('Page 2 of 3')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('patch-sort-title'));
+    expect(screen.getByText('Page 1 of 3')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/patches/PatchList.tsx
+++ b/apps/web/src/components/patches/PatchList.tsx
@@ -3,6 +3,9 @@ import {
   Search,
   ChevronLeft,
   ChevronRight,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
   CheckCircle,
   XCircle,
   Clock,
@@ -39,7 +42,8 @@ type PatchListProps = {
   onView?: (patch: Patch) => void;
   onBulkApprove?: (patchIds: string[]) => Promise<void>;
   onBulkDecline?: (patchIds: string[]) => Promise<void>;
-  pageSize?: number;
+  /** Initial rows-per-page; user can change it via the page-size selector. */
+  initialPageSize?: number;
   loading?: boolean;
   error?: string;
   onRetry?: () => void;
@@ -65,6 +69,48 @@ function formatDate(dateString: string): string {
   return date.toLocaleDateString();
 }
 
+type SortKey = 'title' | 'severity' | 'source' | 'os' | 'releaseDate' | 'approvalStatus';
+type SortDir = 'asc' | 'desc';
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
+const DEFAULT_PAGE_SIZE = 25;
+
+// Semantic ordering for severity / approval so a sort reflects priority rather
+// than raw alphabetical order of the enum value.
+const severityRank: Record<PatchSeverity, number> = {
+  critical: 0,
+  important: 1,
+  moderate: 2,
+  low: 3
+};
+
+const approvalRank: Record<PatchApprovalStatus, number> = {
+  pending: 0,
+  deferred: 1,
+  approved: 2,
+  declined: 3
+};
+
+function compareBySort(a: Patch, b: Patch, key: SortKey): number {
+  switch (key) {
+    case 'severity':
+      return severityRank[a.severity] - severityRank[b.severity];
+    case 'approvalStatus':
+      return approvalRank[a.approvalStatus] - approvalRank[b.approvalStatus];
+    case 'releaseDate': {
+      const at = new Date(a.releaseDate).getTime();
+      const bt = new Date(b.releaseDate).getTime();
+      const aValid = Number.isNaN(at) ? -Infinity : at;
+      const bValid = Number.isNaN(bt) ? -Infinity : bt;
+      return aValid - bValid;
+    }
+    default:
+      return String(a[key] ?? '').localeCompare(String(b[key] ?? ''), undefined, {
+        sensitivity: 'base'
+      });
+  }
+}
+
 export default function PatchList({
   patches,
   onReview,
@@ -72,7 +118,7 @@ export default function PatchList({
   onView,
   onBulkApprove,
   onBulkDecline,
-  pageSize = 8,
+  initialPageSize = DEFAULT_PAGE_SIZE,
   loading,
   error,
   onRetry
@@ -84,7 +130,25 @@ export default function PatchList({
   const [sourceFilter, setSourceFilter] = useState<string>('all');
   const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(initialPageSize);
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [bulkLoading, setBulkLoading] = useState(false);
+
+  // Clicking a header toggles direction when it's already the active sort,
+  // otherwise selects that column ascending. Resetting to page 1 keeps the
+  // user from landing on an out-of-range page after a re-sort.
+  const handleSort = useCallback((key: SortKey) => {
+    setSortKey(prevKey => {
+      if (prevKey === key) {
+        setSortDir(prevDir => (prevDir === 'asc' ? 'desc' : 'asc'));
+        return key;
+      }
+      setSortDir('asc');
+      return key;
+    });
+    setCurrentPage(1);
+  }, []);
 
   const availableSources = useMemo(() => {
     const sources = new Set(patches.map(patch => patch.source));
@@ -114,9 +178,16 @@ export default function PatchList({
     });
   }, [patches, query, severityFilter, statusFilter, osFilter, sourceFilter]);
 
-  const totalPages = Math.ceil(filteredPatches.length / pageSize);
+  const sortedPatches = useMemo(() => {
+    if (!sortKey) return filteredPatches;
+    const dirFactor = sortDir === 'asc' ? 1 : -1;
+    // Copy before sort so we don't mutate the memoized filtered array.
+    return [...filteredPatches].sort((a, b) => compareBySort(a, b, sortKey) * dirFactor);
+  }, [filteredPatches, sortKey, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(sortedPatches.length / pageSize));
   const startIndex = (currentPage - 1) * pageSize;
-  const paginatedPatches = filteredPatches.slice(startIndex, startIndex + pageSize);
+  const paginatedPatches = sortedPatches.slice(startIndex, startIndex + pageSize);
 
   const paginatedIds = useMemo(() => paginatedPatches.map(p => p.id), [paginatedPatches]);
   const { selectedIds, allPageSelected, somePageSelected, toggleSelect, toggleSelectAll, clearSelection } = usePatchSelection(paginatedIds);
@@ -373,12 +444,38 @@ export default function PatchList({
                     )}
                   </button>
                 </th>
-                <th className="px-4 py-3">Patch</th>
-                <th className="px-4 py-3">Severity</th>
-                <th className="px-4 py-3">Source</th>
-                <th className="px-4 py-3">OS</th>
-                <th className="px-4 py-3">Release</th>
-                <th className="px-4 py-3">Approval</th>
+                {([
+                  ['title', 'Patch'],
+                  ['severity', 'Severity'],
+                  ['source', 'Source'],
+                  ['os', 'OS'],
+                  ['releaseDate', 'Release'],
+                  ['approvalStatus', 'Approval']
+                ] as Array<[SortKey, string]>).map(([key, label]) => {
+                  const active = sortKey === key;
+                  const SortIcon = active
+                    ? sortDir === 'asc'
+                      ? ChevronUp
+                      : ChevronDown
+                    : ChevronsUpDown;
+                  return (
+                    <th key={key} className="px-4 py-3" aria-sort={active ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                      <button
+                        type="button"
+                        onClick={() => handleSort(key)}
+                        data-testid={`patch-sort-${key}`}
+                        className={cn(
+                          'group flex items-center gap-1 uppercase tracking-wide hover:text-foreground',
+                          active ? 'text-foreground' : 'text-muted-foreground'
+                        )}
+                        title={`Sort by ${label}`}
+                      >
+                        {label}
+                        <SortIcon className={cn('h-3.5 w-3.5', active ? 'opacity-100' : 'opacity-40 group-hover:opacity-70')} />
+                      </button>
+                    </th>
+                  );
+                })}
                 <th className="px-4 py-3 text-right">Actions</th>
               </tr>
             </thead>
@@ -502,29 +599,54 @@ export default function PatchList({
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
-          <span>
-            Page {currentPage} of {totalPages}
-          </span>
+      {!loading && !(error && patches.length === 0) && (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
-              disabled={currentPage === 1}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md border disabled:opacity-50"
+            <label htmlFor="patch-page-size" className="whitespace-nowrap">
+              Rows per page
+            </label>
+            <select
+              id="patch-page-size"
+              data-testid="patch-page-size"
+              value={pageSize}
+              onChange={event => {
+                setPageSize(Number(event.target.value));
+                setCurrentPage(1);
+              }}
+              className="h-8 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
             >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
-              disabled={currentPage === totalPages}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md border disabled:opacity-50"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
+              {PAGE_SIZE_OPTIONS.map(size => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
           </div>
+          {totalPages > 1 && (
+            <div className="flex items-center gap-3">
+              <span>
+                Page {currentPage} of {totalPages}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
+                  disabled={currentPage === 1}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border disabled:opacity-50"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
+                  disabled={currentPage === totalPages}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border disabled:opacity-50"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/patches/PatchList.tsx
+++ b/apps/web/src/components/patches/PatchList.tsx
@@ -77,6 +77,16 @@ const DEFAULT_PAGE_SIZE = 25;
 
 // Semantic ordering for severity / approval so a sort reflects priority rather
 // than raw alphabetical order of the enum value.
+//
+// WARNING (sort divergence): this client-side severity sort uses SEMANTIC
+// priority (critical=0 … low=3), whereas the API sorts severity ALPHABETICALLY
+// (asc(patches.severity) in routes/patches/list.ts). These currently never
+// disagree because the web does 100% client-side sort/paginate over a fixed
+// `limit=200` fetch and never sends sortBy/sortDir. Whoever later pushes
+// sorting down to the server (via fetchPatches) MUST reconcile the two or
+// severity ordering will silently change. Note also that `os` and
+// `approvalStatus` are SortKeys here with no matching column in the API's
+// PATCH_SORT_COLUMNS — they can't be pushed down without server-side support.
 const severityRank: Record<PatchSeverity, number> = {
   critical: 0,
   important: 1,

--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -36,7 +36,7 @@ describe('PatchesPage', () => {
         return makeJsonResponse({ data: [] });
       }
 
-      if (url === '/patches') {
+      if (url === '/patches?limit=200') {
         return makeJsonResponse({
           data: [
             {
@@ -105,7 +105,7 @@ describe('PatchesPage', () => {
         return makeJsonResponse({ data: [] });
       }
 
-      if (url === '/patches') {
+      if (url === '/patches?limit=200') {
         return makeJsonResponse({ data: [] });
       }
 
@@ -178,7 +178,7 @@ describe('PatchesPage', () => {
       const url = String(input);
 
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
 
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({
@@ -220,7 +220,7 @@ describe('PatchesPage', () => {
       const url = String(input);
 
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
 
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({ error: 'internal server error' }, false, 500);
@@ -254,7 +254,7 @@ describe('PatchesPage', () => {
       const url = String(input);
 
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
 
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({
@@ -291,7 +291,7 @@ describe('PatchesPage', () => {
       const url = String(input);
 
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
 
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({
@@ -340,7 +340,7 @@ describe('PatchesPage', () => {
       const url = String(input);
 
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
 
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({
@@ -377,7 +377,7 @@ describe('PatchesPage', () => {
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({
           data: [
@@ -432,7 +432,7 @@ describe('PatchesPage', () => {
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({
           data: Array.from({ length: 10 }, (_, i) => ({ id: `device-${i + 1}`, hostname: `W${i + 1}` })),
@@ -479,7 +479,7 @@ describe('PatchesPage', () => {
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
-      if (url === '/patches') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
       if (url === '/devices?limit=100&page=1') {
         return makeJsonResponse({
           data: Array.from({ length: 5 }, (_, i) => ({ id: `device-${i + 1}`, hostname: `W${i + 1}` })),

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -113,11 +113,13 @@ export default function PatchesPage() {
     try {
       setPatchesLoading(true);
       setPatchesError(undefined);
-      const params = new URLSearchParams();
-      if (selectedRingId) params.set('ringId', selectedRingId);
+      // Request a large page so the patches-table page-size selector (up to 200)
+      // is actually populated. The API caps limit at 200 and paginates/sorts the
+      // already-loaded array client-side (issue #1316). Ring-scoped patches use a
+      // dedicated endpoint that returns its own bounded set.
       const url = selectedRingId
         ? `/update-rings/${selectedRingId}/patches`
-        : '/patches';
+        : '/patches?limit=200';
       const response = await fetchWithAuth(url);
       if (!response.ok) {
         if (response.status === 401) { void navigateTo('/login', { replace: true }); return; }

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -113,10 +113,14 @@ export default function PatchesPage() {
     try {
       setPatchesLoading(true);
       setPatchesError(undefined);
-      // Request a large page so the patches-table page-size selector (up to 200)
-      // is actually populated. The API caps limit at 200 and paginates/sorts the
-      // already-loaded array client-side (issue #1316). Ring-scoped patches use a
-      // dedicated endpoint that returns its own bounded set.
+      // Fixed `limit=200` fetch: PatchList sorts AND paginates entirely
+      // client-side over this already-loaded array (issue #1316), so the
+      // page-size selector (up to 200) is fully populated. Caveat: for an org
+      // with >200 patches, only the loaded subset is sorted/searched — the rest
+      // are never fetched. Note: this never sends sortBy/sortDir, so the
+      // server-side sort added to the API (list.ts / schemas.ts) is NOT yet
+      // consumed by the web; wiring it up is a follow-up (see list.ts comment).
+      // Ring-scoped patches use a dedicated endpoint with its own bounded set.
       const url = selectedRingId
         ? `/update-rings/${selectedRingId}/patches`
         : '/patches?limit=200';


### PR DESCRIPTION
## Summary

Adds two UX improvements to the Patches table (`/patches?tab=patches`) requested by the product owner: a selectable rows-per-page control and clickable, sortable column headers — so an operator can show many patches at once and bulk-approve them efficiently.

**How it works (accuracy note):** the web does **client-side sort + pagination over a single 200-row fetch**. `fetchPatches` requests a fixed `/patches?limit=200` and `PatchList` sorts and paginates that already-loaded array entirely in the browser. For an org with **more than 200 patches, only the loaded subset is sorted/searched** — the remainder are never fetched. Server-side `sortBy`/`sortDir` params were added to the API but are **not yet consumed by the web** (the web never sends them); wiring the table to push sorting/paging down to the server is noted as a **follow-up**.

## What changed

**Web (`apps/web/src/components/patches/`)**
- `PatchList.tsx`
  - Page-size selector (25 / 50 / 100 / 200) near the pagination controls; resets to page 1 on change. Default page size is now 25 (was a fixed, never-overridden `pageSize=8`).
  - Clickable `<th>` headers for Patch, Severity, Source, OS, Release, Approval. Clicking toggles asc/desc, shows an up/down chevron, and sets `aria-sort`. Sorting is **client-side only**. Severity and Approval use a semantic priority order (critical-first) rather than raw alphabetical.
  - Replaced the fixed `pageSize` prop with an optional `initialPageSize`.
- `PatchesPage.tsx`
  - `fetchPatches` now requests `/patches?limit=200` so the page-size options are actually populated (previously only the API default 50 were ever loaded, then sliced 8-at-a-time client-side — patches beyond 50 never reached the table). It does **not** send `sortBy`/`sortDir`.

**API (`apps/api/src/routes/patches/`)**
- `schemas.ts`: `listPatchesSchema` gains `sortBy` (whitelisted enum) + `sortDir` (`asc`/`desc`). API-ready; not yet exercised by the web.
- `list.ts`: replaces the hardcoded `desc(patches.createdAt)` with a whitelist-mapped `orderBy` — no raw user input into `orderBy`; defaults preserve newest-first. **Caveat:** severity sorts **alphabetically** here vs the web's **semantic priority** rank — these must be reconciled before the web wires up server-side sort (documented in code comments).
- `helpers.ts`: `getPagination` limit cap raised 100 → 200 (`MAX_PAGE_LIMIT`) so a 200-row page is honored server-side. Because `getPagination` is shared, this **intentionally also lifts the cap on `GET /patches/approvals` and `GET /patches/jobs`** — both are tenant-scoped, indexed list queries, so the higher cap stays bounded and benign.

## Tests

- `PatchList.test.tsx`: page-size default/change/reset/options + header sort asc↔desc, severity priority order, `aria-sort`, page-reset-on-sort.
- `PatchesPage.test.tsx`: updated the `/patches` fetch expectation to `/patches?limit=200`.
- `patches/index.test.ts`: default sort, whitelisted `sortBy`/`sortDir` mapping, asc-default, rejected unknown column / invalid direction (400), 200-cap honored, over-cap clamped.

Command:
```
pnpm --filter @breeze/web exec vitest run src/components/patches/PatchList.test.tsx src/components/patches/PatchesPage.test.tsx
pnpm --filter @breeze/api exec vitest run src/routes/patches/index.test.ts
```
Result: web 21 passed (2 files), api 27 passed (1 file). Type-check clean on all changed files.

Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)