### PR TITLE
fix(agent): honor software-update version pin on macOS and Linux (#993)

### DIFF
--- a/agent/internal/remote/tools/software_update.go
+++ b/agent/internal/remote/tools/software_update.go
@@ -24,10 +24,16 @@ type updateAttempt = uninstallAttempt
 //
 //   - Windows: winget `--version <v>` (already supported).
 //   - Linux:   package managers that accept an exact-version selector
-//     (apt `pkg=ver`, dnf/yum `pkg-ver`, zypper `pkg=ver`) honor the pin.
-//     Managers that cannot install an arbitrary repo version (pacman) are
-//     excluded from a pinned upgrade, and if no version-capable manager is
-//     present the attempt fails with "no supported update command".
+//     (apt `pkg=ver`, dnf/yum `pkg-ver`, zypper `pkg=ver`) honor the pin,
+//     including downgrades to an OLDER pinned build (apt `--allow-downgrades`,
+//     dnf/yum `downgrade`, zypper `--oldpackage`). After the attempt the
+//     installed version is re-queried (dpkg-query/rpm) and the pin is rejected
+//     loudly unless it actually matches — apt/dnf/yum report success-equivalents
+//     like "already the newest version" when the pin is older, so the attempt
+//     succeeding is not proof the pin held (#993). Managers that cannot install
+//     an arbitrary repo version (pacman) are excluded from a pinned upgrade, and
+//     if no version-capable manager is present the attempt fails with "no
+//     supported update command".
 //   - macOS:   Homebrew cannot upgrade a cask/formula to an arbitrary prior
 //     version, so a pinned macOS update is rejected up front with an explicit
 //     "version pinning unsupported" error rather than silently jumping to the
@@ -174,7 +180,21 @@ func updateSoftwareLinux(name, version string) error {
 		return fmt.Errorf("refusing to update protected package %q", name)
 	}
 
-	return runUpdateAttempts(name, buildLinuxUpdateAttempts(name, version))
+	if err := runUpdateAttempts(name, buildLinuxUpdateAttempts(name, version)); err != nil {
+		return err
+	}
+
+	// A pin is a control constraint: the attempt "succeeding" is not enough,
+	// because apt/dnf/yum emit "is already the newest version" / "nothing to
+	// do" when the pin is OLDER than what's installed — and runUpdateAttempts
+	// maps those success-equivalents to nil. Without this post-check the pin
+	// would be silently dropped, which is the exact #993 bug class on Linux.
+	// So when a version is pinned we VERIFY the installed version matches and
+	// fail loudly otherwise. No pin → nothing to verify.
+	if version != "" {
+		return verifyLinuxPinnedVersion(name, version, queryInstalledLinuxVersion)
+	}
+	return nil
 }
 
 // buildLinuxUpdateAttempts returns the ordered package-manager attempts for a
@@ -183,28 +203,42 @@ func updateSoftwareLinux(name, version string) error {
 //
 // Without a version pin every manager upgrades to the newest available, as
 // before. With a version pin we switch to each manager's exact-version selector
-// so the pin is actually honored rather than silently ignored (#993):
+// so the pin is actually honored rather than silently ignored (#993). Crucially,
+// the pin can be OLDER than the installed build (an intentional downgrade/hold),
+// which the plain upgrade/update verbs CANNOT perform, so each manager also gets
+// an explicit downgrade-capable attempt:
 //
-//   - apt-get: `install --only-upgrade pkg=version`
-//   - dnf:     `upgrade pkg-version` (also installs an exact NEVRA)
-//   - yum:     `update pkg-version`
-//   - zypper:  `install --oldpackage pkg=version` (--oldpackage permits a
-//     downgrade to the pinned version if the installed one is newer)
+//   - apt-get: `install --only-upgrade pkg=version`, then
+//     `install --allow-downgrades pkg=version` (the latter forces a downgrade to
+//     the pinned version when a newer build is installed).
+//   - dnf:     `upgrade pkg-version`, then `downgrade pkg-version`.
+//   - yum:     `update pkg-version`, then `downgrade pkg-version`.
+//   - zypper:  `install --oldpackage pkg=version` (--oldpackage already permits a
+//     downgrade to the pinned version in one shot).
 //
 // pacman is intentionally omitted from a pinned upgrade: it can only install the
 // single version currently in the synced repos, so it cannot honor an arbitrary
 // pin. When a version is requested and none of the version-capable managers are
 // present, runUpdateAttempts reports "no supported update command" — a loud
-// failure, never a silent upgrade to latest.
+// failure, never a silent upgrade to latest. (And even when an attempt reports
+// success, updateSoftwareLinux re-verifies the installed version — see #993.)
 func buildLinuxUpdateAttempts(name, version string) []updateAttempt {
 	if version != "" {
 		aptTarget := name + "=" + version
 		rpmTarget := name + "-" + version
 		zypperTarget := name + "=" + version
 		return []updateAttempt{
+			// Upgrade path (pin newer-than or equal-to installed) first, then the
+			// downgrade path (pin older-than installed). runUpdateAttempts tries
+			// each in order until one succeeds; the upgrade verb is a clean no-op
+			// when a downgrade is needed, so the downgrade attempt follows it.
 			{command: "apt-get", args: []string{"install", "--only-upgrade", "-y", aptTarget}},
+			{command: "apt-get", args: []string{"install", "--allow-downgrades", "-y", aptTarget}},
 			{command: "dnf", args: []string{"upgrade", "-y", rpmTarget}},
+			{command: "dnf", args: []string{"downgrade", "-y", rpmTarget}},
 			{command: "yum", args: []string{"update", "-y", rpmTarget}},
+			{command: "yum", args: []string{"downgrade", "-y", rpmTarget}},
+			// zypper --oldpackage handles both directions in a single invocation.
 			{command: "zypper", args: []string{"install", "-y", "--oldpackage", zypperTarget}},
 		}
 	}
@@ -219,6 +253,102 @@ func buildLinuxUpdateAttempts(name, version string) []updateAttempt {
 		// pacman -S is the upgrade-or-install verb on Arch.
 		{command: "pacman", args: []string{"-S", "--noconfirm", name}},
 	}
+}
+
+// linuxVersionQuery resolves the currently-installed version of a package via the
+// native package database (dpkg-query / rpm). Injected so the verification path
+// can be table-tested without a real package manager. Returns ("", nil) when the
+// package isn't found by any available tool, and a non-nil error only on an
+// unexpected tool failure.
+type linuxVersionQuery func(name string) (string, error)
+
+// verifyLinuxPinnedVersion confirms the installed version of name satisfies the
+// pinned version. The promise from #993 — "honored exactly or fails loudly,
+// never silently dropped" — only holds on Linux because of this check: the
+// package manager can report success (or a success-equivalent like "already the
+// newest version") while the installed version is NOT the pin.
+//
+// We can't query the installed version (no dpkg/rpm), so we cannot prove the pin
+// held — fail loudly rather than assume success.
+func verifyLinuxPinnedVersion(name, version string, query linuxVersionQuery) error {
+	installed, err := query(name)
+	if err != nil {
+		return fmt.Errorf("updated %q but could not verify it now reports pinned version %q: %v", name, version, err)
+	}
+	if installed == "" {
+		return fmt.Errorf("updated %q but could not determine its installed version to confirm the pin %q held", name, version)
+	}
+	if !installedVersionMatchesPin(installed, version) {
+		return fmt.Errorf("version pin not honored for %q: requested %q but %q is installed", name, version, installed)
+	}
+	return nil
+}
+
+// installedVersionMatchesPin reports whether the installed version string
+// satisfies the requested pin. Package managers decorate the version we asked
+// for — apt prefixes an epoch ("1:131.0"), rpm appends a release ("131.0-1.fc39")
+// — so an exact string compare would produce false "pin not honored" failures.
+// We accept the pin as an exact match, or as the version component once the apt
+// epoch and rpm release are stripped from the installed string.
+func installedVersionMatchesPin(installed, pin string) bool {
+	installed = strings.TrimSpace(installed)
+	pin = strings.TrimSpace(pin)
+	if installed == pin {
+		return true
+	}
+	normalized := installed
+	// Strip a leading apt/dpkg epoch ("1:131.0" -> "131.0").
+	if idx := strings.Index(normalized, ":"); idx >= 0 {
+		normalized = normalized[idx+1:]
+	}
+	if normalized == pin {
+		return true
+	}
+	// If the pin itself carries a release ("131.0-1"), the above covers it.
+	// Otherwise strip the rpm release suffix ("131.0-1.fc39" -> "131.0") only
+	// when the pin has no release of its own, so a release-bearing pin still
+	// requires an exact (epoch-stripped) match.
+	if !strings.Contains(pin, "-") {
+		if idx := strings.Index(normalized, "-"); idx >= 0 {
+			normalized = normalized[:idx]
+		}
+		if normalized == pin {
+			return true
+		}
+	}
+	return false
+}
+
+// queryInstalledLinuxVersion looks up the installed version of a package using
+// dpkg-query (Debian/Ubuntu) first, then rpm (RHEL/Fedora/SUSE). Returns
+// ("", nil) when neither tool is present or the package isn't installed.
+func queryInstalledLinuxVersion(name string) (string, error) {
+	if _, err := exec.LookPath("dpkg-query"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		out, err := exec.CommandContext(ctx, "dpkg-query", "-W", "-f=${Version}", name).Output()
+		cancel()
+		if err == nil {
+			if v := strings.TrimSpace(string(out)); v != "" {
+				return v, nil
+			}
+		}
+	}
+
+	if _, err := exec.LookPath("rpm"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		out, err := exec.CommandContext(ctx, "rpm", "-q", "--queryformat", "%{VERSION}-%{RELEASE}", name).Output()
+		cancel()
+		if err == nil {
+			v := strings.TrimSpace(string(out))
+			// rpm -q on a missing package exits non-zero (caught above) but be
+			// defensive against the "package X is not installed" text on stdout.
+			if v != "" && !strings.Contains(strings.ToLower(v), "not installed") {
+				return v, nil
+			}
+		}
+	}
+
+	return "", nil
 }
 
 func runUpdateAttempts(softwareName string, attempts []updateAttempt) error {

--- a/agent/internal/remote/tools/software_update.go
+++ b/agent/internal/remote/tools/software_update.go
@@ -15,11 +15,26 @@ import (
 // parallel type so the runner code can stay shared.
 type updateAttempt = uninstallAttempt
 
-// UpdateSoftware upgrades a named package to the latest version available via
-// the platform's native package manager. Like UninstallSoftware it accepts
-// {name, version?} payload; version is currently only used by winget on
-// Windows (passes through as --version target). On macOS and Linux version
-// is ignored — package managers always upgrade to the newest available.
+// UpdateSoftware upgrades a named package via the platform's native package
+// manager. Like UninstallSoftware it accepts {name, version?} payload.
+//
+// Version pinning (a non-empty version) is treated as a control/compliance
+// constraint, not a hint: every platform either honors the exact version or
+// fails loudly. It is never silently dropped (the bug in #993):
+//
+//   - Windows: winget `--version <v>` (already supported).
+//   - Linux:   package managers that accept an exact-version selector
+//     (apt `pkg=ver`, dnf/yum `pkg-ver`, zypper `pkg=ver`) honor the pin.
+//     Managers that cannot install an arbitrary repo version (pacman) are
+//     excluded from a pinned upgrade, and if no version-capable manager is
+//     present the attempt fails with "no supported update command".
+//   - macOS:   Homebrew cannot upgrade a cask/formula to an arbitrary prior
+//     version, so a pinned macOS update is rejected up front with an explicit
+//     "version pinning unsupported" error rather than silently jumping to the
+//     newest available.
+//
+// When no version is supplied behavior is unchanged: upgrade to the newest
+// available on every platform.
 //
 // This is intentionally NOT a download-arbitrary-payload path. Anything that
 // can't be expressed as a package-manager upgrade (e.g. an app installed by
@@ -66,9 +81,9 @@ func updateSoftwareOS(name, version, packageID string) error {
 	case "windows":
 		return updateSoftwareWindows(name, version, packageID)
 	case "darwin":
-		return updateSoftwareMacOS(name)
+		return updateSoftwareMacOS(name, version)
 	case "linux":
-		return updateSoftwareLinux(name)
+		return updateSoftwareLinux(name, version)
 	default:
 		return fmt.Errorf("software update unsupported on %s", runtime.GOOS)
 	}
@@ -126,7 +141,20 @@ func buildWindowsUpdateAttempts(name, version, packageID string) []updateAttempt
 	return attempts
 }
 
-func updateSoftwareMacOS(name string) error {
+// errMacOSVersionPinUnsupported is returned when a macOS update is asked to pin
+// an exact version. Homebrew has no first-class "upgrade to this specific prior
+// version" command for casks/formulae (`brew upgrade` always targets the latest
+// available), so honoring the pin is not possible. Failing loudly is preferable
+// to silently upgrading past the requested version (#993).
+var errMacOSVersionPinUnsupported = fmt.Errorf(
+	"version pinning is not supported for software updates on macOS (Homebrew always upgrades to the latest available); " +
+		"omit the version to upgrade to latest")
+
+func updateSoftwareMacOS(name, version string) error {
+	if version != "" {
+		return errMacOSVersionPinUnsupported
+	}
+
 	// brew upgrade on a cask name fails with "No available formula" before
 	// it tries the cask form, so try cask first. Plain formula second.
 	attempts := []updateAttempt{
@@ -137,7 +165,7 @@ func updateSoftwareMacOS(name string) error {
 	return runUpdateAttempts(name, attempts)
 }
 
-func updateSoftwareLinux(name string) error {
+func updateSoftwareLinux(name, version string) error {
 	// Reuse the protected-package guard from uninstall: upgrading
 	// systemd/glibc/kernel through this path is just as risky as
 	// removing them, and the typical breakage (interrupted boot,
@@ -146,7 +174,42 @@ func updateSoftwareLinux(name string) error {
 		return fmt.Errorf("refusing to update protected package %q", name)
 	}
 
-	attempts := []updateAttempt{
+	return runUpdateAttempts(name, buildLinuxUpdateAttempts(name, version))
+}
+
+// buildLinuxUpdateAttempts returns the ordered package-manager attempts for a
+// Linux update. The first whose binary is present and whose invocation succeeds
+// wins (see runUpdateAttempts).
+//
+// Without a version pin every manager upgrades to the newest available, as
+// before. With a version pin we switch to each manager's exact-version selector
+// so the pin is actually honored rather than silently ignored (#993):
+//
+//   - apt-get: `install --only-upgrade pkg=version`
+//   - dnf:     `upgrade pkg-version` (also installs an exact NEVRA)
+//   - yum:     `update pkg-version`
+//   - zypper:  `install --oldpackage pkg=version` (--oldpackage permits a
+//     downgrade to the pinned version if the installed one is newer)
+//
+// pacman is intentionally omitted from a pinned upgrade: it can only install the
+// single version currently in the synced repos, so it cannot honor an arbitrary
+// pin. When a version is requested and none of the version-capable managers are
+// present, runUpdateAttempts reports "no supported update command" — a loud
+// failure, never a silent upgrade to latest.
+func buildLinuxUpdateAttempts(name, version string) []updateAttempt {
+	if version != "" {
+		aptTarget := name + "=" + version
+		rpmTarget := name + "-" + version
+		zypperTarget := name + "=" + version
+		return []updateAttempt{
+			{command: "apt-get", args: []string{"install", "--only-upgrade", "-y", aptTarget}},
+			{command: "dnf", args: []string{"upgrade", "-y", rpmTarget}},
+			{command: "yum", args: []string{"update", "-y", rpmTarget}},
+			{command: "zypper", args: []string{"install", "-y", "--oldpackage", zypperTarget}},
+		}
+	}
+
+	return []updateAttempt{
 		// apt-get install --only-upgrade is the documented way to bump
 		// a single package; plain `upgrade` is whole-system.
 		{command: "apt-get", args: []string{"install", "--only-upgrade", "-y", name}},
@@ -156,8 +219,6 @@ func updateSoftwareLinux(name string) error {
 		// pacman -S is the upgrade-or-install verb on Arch.
 		{command: "pacman", args: []string{"-S", "--noconfirm", name}},
 	}
-
-	return runUpdateAttempts(name, attempts)
 }
 
 func runUpdateAttempts(softwareName string, attempts []updateAttempt) error {

--- a/agent/internal/remote/tools/software_update_test.go
+++ b/agent/internal/remote/tools/software_update_test.go
@@ -130,6 +130,149 @@ func TestBuildWindowsUpdateAttemptsNameFirstWithoutPackageID(t *testing.T) {
 	}
 }
 
+// argsContain reports whether the attempt's args contain the given value
+// anywhere (used for whole-token package specs like "pkg=1.2.3").
+func argsContain(a updateAttempt, value string) bool {
+	for _, arg := range a.args {
+		if arg == value {
+			return true
+		}
+	}
+	return false
+}
+
+// hasCommand reports whether any attempt uses the given package-manager binary.
+func hasCommand(attempts []updateAttempt, command string) bool {
+	for _, a := range attempts {
+		if a.command == command {
+			return true
+		}
+	}
+	return false
+}
+
+// findCommand returns the first attempt using the given binary (and whether it
+// was found).
+func findCommand(attempts []updateAttempt, command string) (updateAttempt, bool) {
+	for _, a := range attempts {
+		if a.command == command {
+			return a, true
+		}
+	}
+	return updateAttempt{}, false
+}
+
+func TestBuildLinuxUpdateAttemptsNoVersionUpgradesToLatest(t *testing.T) {
+	t.Parallel()
+	attempts := buildLinuxUpdateAttempts("firefox", "")
+
+	// Without a pin every supported manager — including pacman — is attempted,
+	// each targeting the bare package name (latest available).
+	for _, mgr := range []string{"apt-get", "dnf", "yum", "zypper", "pacman"} {
+		a, ok := findCommand(attempts, mgr)
+		if !ok {
+			t.Fatalf("expected an attempt for %s, got %+v", mgr, attempts)
+		}
+		if !argsContain(a, "firefox") {
+			t.Fatalf("expected %s attempt to target bare name 'firefox', got %v", mgr, a.args)
+		}
+		// No version-pinned spec should leak in.
+		for _, arg := range a.args {
+			if strings.Contains(arg, "firefox=") || strings.Contains(arg, "firefox-") {
+				t.Fatalf("unexpected version-pinned spec for %s: %v", mgr, a.args)
+			}
+		}
+	}
+}
+
+func TestBuildLinuxUpdateAttemptsVersionPinUsesExactSelector(t *testing.T) {
+	t.Parallel()
+	attempts := buildLinuxUpdateAttempts("firefox", "131.0")
+
+	cases := []struct {
+		command string
+		spec    string
+	}{
+		{"apt-get", "firefox=131.0"},
+		{"dnf", "firefox-131.0"},
+		{"yum", "firefox-131.0"},
+		{"zypper", "firefox=131.0"},
+	}
+	for _, tc := range cases {
+		a, ok := findCommand(attempts, tc.command)
+		if !ok {
+			t.Fatalf("expected a %s attempt for a version pin, got %+v", tc.command, attempts)
+		}
+		if !argsContain(a, tc.spec) {
+			t.Fatalf("expected %s to pin via %q, got %v", tc.command, tc.spec, a.args)
+		}
+	}
+
+	// zypper needs --oldpackage so the pin can downgrade past a newer installed
+	// version; otherwise the pin would be a no-op when a newer build is present.
+	if z, ok := findCommand(attempts, "zypper"); ok {
+		if !argsContain(z, "--oldpackage") {
+			t.Fatalf("expected zypper pin to include --oldpackage, got %v", z.args)
+		}
+	}
+}
+
+func TestBuildLinuxUpdateAttemptsVersionPinExcludesPacman(t *testing.T) {
+	t.Parallel()
+	// pacman cannot install an arbitrary repo version, so it must NOT appear in a
+	// pinned upgrade — otherwise it would silently jump to whatever the synced
+	// repos currently hold, defeating the pin (#993).
+	attempts := buildLinuxUpdateAttempts("firefox", "131.0")
+	if hasCommand(attempts, "pacman") {
+		t.Fatalf("did not expect pacman in a version-pinned upgrade, got %+v", attempts)
+	}
+}
+
+func TestUpdateSoftwareMacOSRejectsVersionPin(t *testing.T) {
+	t.Parallel()
+	// macOS cannot honor a pin (Homebrew always upgrades to latest), so it must
+	// fail loudly rather than silently upgrading past the pin (#993). The guard
+	// lives in updateSoftwareMacOS, so exercise it directly to stay
+	// platform-independent.
+	err := updateSoftwareMacOS("Firefox", "131.0")
+	if err == nil {
+		t.Fatal("expected an error when pinning a version on macOS, got nil")
+	}
+	if !strings.Contains(err.Error(), "version pinning is not supported") {
+		t.Fatalf("expected unsupported-pin error, got %q", err.Error())
+	}
+}
+
+func TestUpdateSoftwareMacOSAllowsLatestUpgrade(t *testing.T) {
+	t.Parallel()
+	// Without a pin, macOS must NOT hit the unsupported-version guard — it should
+	// fall through to building brew attempts. We can't run brew here, so on
+	// non-darwin we only assert the guard didn't reject; on darwin the call may
+	// fail later for lack of brew, which is fine as long as it isn't our pin
+	// error.
+	err := updateSoftwareMacOS("Firefox", "")
+	if err != nil && strings.Contains(err.Error(), "version pinning is not supported") {
+		t.Fatalf("did not expect the pin guard to fire without a version, got %q", err.Error())
+	}
+}
+
+// TestUpdateSoftwareMacOSPinSurfacedThroughPublicEntry confirms the rejection
+// reaches the public CommandResult on darwin (where updateSoftwareOS routes to
+// macOS). On other platforms updateSoftwareOS routes elsewhere, so skip.
+func TestUpdateSoftwareMacOSPinSurfacedThroughPublicEntry(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "darwin" {
+		t.Skipf("darwin-only routing test, current %s", runtime.GOOS)
+	}
+	result := UpdateSoftware(map[string]any{"name": "Firefox", "version": "131.0"})
+	if result.Status != "failed" {
+		t.Fatalf("expected failed status for macOS version pin, got %s", result.Status)
+	}
+	if !strings.Contains(result.Error, "version pinning is not supported") {
+		t.Fatalf("expected unsupported-pin error, got %q", result.Error)
+	}
+}
+
 func TestValidateSoftwarePackageID(t *testing.T) {
 	t.Parallel()
 	// Empty is allowed (the field is optional).

--- a/agent/internal/remote/tools/software_update_test.go
+++ b/agent/internal/remote/tools/software_update_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -227,6 +228,194 @@ func TestBuildLinuxUpdateAttemptsVersionPinExcludesPacman(t *testing.T) {
 		t.Fatalf("did not expect pacman in a version-pinned upgrade, got %+v", attempts)
 	}
 }
+
+// argsHaveFlag reports whether the attempt's args contain the given flag token
+// anywhere (e.g. "--allow-downgrades", "downgrade").
+func argsHaveFlag(a updateAttempt, flag string) bool {
+	for _, arg := range a.args {
+		if arg == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// findAttempt returns the first attempt matching command + a required arg token,
+// and whether it was found. Used to assert a specific verb (e.g. apt-get's
+// downgrade attempt) exists in addition to the upgrade attempt.
+func findAttempt(attempts []updateAttempt, command, requiredArg string) (updateAttempt, bool) {
+	for _, a := range attempts {
+		if a.command == command && argsHaveFlag(a, requiredArg) {
+			return a, true
+		}
+	}
+	return updateAttempt{}, false
+}
+
+func TestBuildLinuxUpdateAttemptsVersionPinIncludesDowngradePath(t *testing.T) {
+	t.Parallel()
+	// A pin can be OLDER than the installed build (an intentional downgrade/hold).
+	// The plain upgrade/update verbs can't perform that, so each manager must also
+	// offer a downgrade-capable attempt for the same pinned spec (#993).
+	attempts := buildLinuxUpdateAttempts("firefox", "131.0")
+
+	// apt-get: must have both --only-upgrade and --allow-downgrades for the pin.
+	if _, ok := findAttempt(attempts, "apt-get", "--only-upgrade"); !ok {
+		t.Fatalf("expected apt-get --only-upgrade pinned attempt, got %+v", attempts)
+	}
+	apt, ok := findAttempt(attempts, "apt-get", "--allow-downgrades")
+	if !ok {
+		t.Fatalf("expected apt-get --allow-downgrades pinned attempt, got %+v", attempts)
+	}
+	if !argsContain(apt, "firefox=131.0") {
+		t.Fatalf("expected apt-get downgrade to target firefox=131.0, got %v", apt.args)
+	}
+
+	// dnf/yum: must have both the upgrade/update verb and a downgrade verb.
+	for _, mgr := range []string{"dnf", "yum"} {
+		dn, ok := findAttempt(attempts, mgr, "downgrade")
+		if !ok {
+			t.Fatalf("expected %s downgrade pinned attempt, got %+v", mgr, attempts)
+		}
+		if !argsContain(dn, "firefox-131.0") {
+			t.Fatalf("expected %s downgrade to target firefox-131.0, got %v", mgr, dn.args)
+		}
+	}
+	if _, ok := findAttempt(attempts, "dnf", "upgrade"); !ok {
+		t.Fatalf("expected dnf upgrade pinned attempt, got %+v", attempts)
+	}
+	if _, ok := findAttempt(attempts, "yum", "update"); !ok {
+		t.Fatalf("expected yum update pinned attempt, got %+v", attempts)
+	}
+
+	// zypper --oldpackage handles both directions in one shot.
+	if _, ok := findAttempt(attempts, "zypper", "--oldpackage"); !ok {
+		t.Fatalf("expected zypper --oldpackage pinned attempt, got %+v", attempts)
+	}
+}
+
+func TestInstalledVersionMatchesPin(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		installed string
+		pin       string
+		want      bool
+	}{
+		{"exact match", "131.0", "131.0", true},
+		{"apt epoch prefix", "1:131.0", "131.0", true},
+		{"rpm release suffix", "131.0-1.fc39", "131.0", true},
+		{"apt epoch and rpm release", "2:131.0-1.el9", "131.0", true},
+		{"release-bearing pin exact", "131.0-1", "131.0-1", true},
+		{"release-bearing pin with epoch", "1:131.0-1", "131.0-1", true},
+		{"mismatch newer installed", "132.0", "131.0", false},
+		{"mismatch older installed", "130.0", "131.0", false},
+		{"release-bearing pin must not loosen", "131.0-2", "131.0-1", false},
+		{"prefix is not a match", "131.0.1", "131.0", false},
+		{"empty installed", "", "131.0", false},
+		{"whitespace trimmed", " 131.0 ", "131.0", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := installedVersionMatchesPin(tc.installed, tc.pin); got != tc.want {
+				t.Fatalf("installedVersionMatchesPin(%q, %q) = %v, want %v", tc.installed, tc.pin, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifyLinuxPinnedVersion(t *testing.T) {
+	t.Parallel()
+	const pin = "131.0"
+
+	cases := []struct {
+		name        string
+		query       linuxVersionQuery
+		wantErr     bool
+		errContains string
+	}{
+		{
+			// pin == installed: the upgrade/update verb already had it; verify passes.
+			name:    "pin equals installed",
+			query:   func(string) (string, error) { return "131.0", nil },
+			wantErr: false,
+		},
+		{
+			// pin > installed (an upgrade): after a successful upgrade the installed
+			// version is the pin; verify passes.
+			name:    "pin newer than installed, now applied",
+			query:   func(string) (string, error) { return "131.0", nil },
+			wantErr: false,
+		},
+		{
+			// pin < installed and the downgrade did NOT take (apt said "already the
+			// newest version", runUpdateAttempts mapped it to success): the installed
+			// version is still the newer build, so verify must FAIL loudly — this is
+			// the silent-drop hole #993 is about, on Linux.
+			name:        "pin older than installed, still newer installed",
+			query:       func(string) (string, error) { return "132.0", nil },
+			wantErr:     true,
+			errContains: "version pin not honored",
+		},
+		{
+			// pin < installed and the downgrade DID take: installed is now the pin.
+			name:    "pin older than installed, downgrade applied",
+			query:   func(string) (string, error) { return "131.0", nil },
+			wantErr: false,
+		},
+		{
+			// apt epoch decoration must not produce a false mismatch.
+			name:    "installed reports apt epoch",
+			query:   func(string) (string, error) { return "1:131.0", nil },
+			wantErr: false,
+		},
+		{
+			// rpm release decoration must not produce a false mismatch.
+			name:    "installed reports rpm release",
+			query:   func(string) (string, error) { return "131.0-1.fc39", nil },
+			wantErr: false,
+		},
+		{
+			// Can't determine the installed version → can't prove the pin held →
+			// fail loudly rather than assume success.
+			name:        "installed version unknown",
+			query:       func(string) (string, error) { return "", nil },
+			wantErr:     true,
+			errContains: "could not determine",
+		},
+		{
+			// Query tool error → fail loudly.
+			name:        "query error",
+			query:       func(string) (string, error) { return "", errTestQuery },
+			wantErr:     true,
+			errContains: "could not verify",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := verifyLinuxPinnedVersion("firefox", pin, tc.query)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("expected error to contain %q, got %q", tc.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+var errTestQuery = fmt.Errorf("dpkg-query exploded")
 
 func TestUpdateSoftwareMacOSRejectsVersionPin(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Problem

A software-update version pin was honored only on Windows (winget `--version`). `updateSoftwareMacOS` / `updateSoftwareLinux` ignored the `version` field and always upgraded to the newest available, so a pin submitted against a macOS or Linux endpoint **silently** upgraded past the requested version with no error or warning. Version pinning reads as a compliance/control feature, so a silent no-op could violate an intended hold (#993, follow-up to #974).

## What changed — `agent/internal/remote/tools/software_update.go`

A version pin is now treated as a control constraint on every platform — **honored exactly, or failed loudly. Never silently dropped.**

- **Linux**: when a version is supplied, build each manager's exact-version selector and, critically, a **downgrade-capable** attempt too, because a pin can be OLDER than the installed build (an intentional hold/rollback):
  - apt-get: `install --only-upgrade pkg=ver`, then `install --allow-downgrades pkg=ver`
  - dnf: `upgrade pkg-ver`, then `downgrade pkg-ver`
  - yum: `update pkg-ver`, then `downgrade pkg-ver`
  - zypper: `install --oldpackage pkg=ver` (one shot, both directions)

  After the attempt the installed version is **re-queried (dpkg-query / rpm) and the pin is rejected loudly unless it actually matches**. This closes a second silent-drop hole that the first pass missed: when the pin is older than installed, apt/dnf/yum emit "is already the newest version" / "nothing to do", which `runUpdateAttempts` maps to success — so the attempt "succeeding" is NOT proof the pin held. The version comparison is epoch/release-aware (apt `1:131.0`, rpm `131.0-1.fc39`) to avoid false mismatches. If the installed version can't be determined, the update fails rather than assuming success. `pacman` is excluded from a pinned upgrade (it can only install the synced-repo version, can't honor an arbitrary pin). If no version-capable manager is present, the attempt fails with "no supported update command" rather than jumping to latest.
- **macOS**: Homebrew has no first-class "upgrade to an arbitrary prior version" command (`brew upgrade` always targets latest), so a pinned macOS update is rejected up front with an explicit `version pinning is not supported for software updates on macOS` error instead of silently upgrading to latest.
- **No version supplied**: behavior unchanged on every platform (upgrade to latest, pacman still included on Linux).

## Tests

Adds table-driven Go tests: latest-upgrade path (all managers incl. pacman), pinned exact-version selectors per manager, the per-manager downgrade attempts, `--oldpackage` on zypper, pacman exclusion under a pin, the macOS rejection (direct call + public `UpdateSoftware` routing), epoch/release-aware version matching, and the post-update verification across pin<installed / pin==installed / pin>installed plus the unknown-version and query-error fail-loud paths.

```
cd agent && go test -race ./internal/remote/tools/...
ok  github.com/breeze-rmm/agent/internal/remote/tools
```

All package tests pass; `go vet` and `gofmt` clean.

## Notes / follow-ups

- Platform-specific package-manager invocations and the dpkg-query/rpm verification path are unit-tested at the attempt-build and verify layers (with an injected version query); the actual `brew`/`apt`/`dnf`/`zypper` execution and on-disk version readback still warrant on-target manual verification on real Debian/RHEL/SUSE hosts.
- The English-string success matching in `runUpdateAttempts` is now backstopped on Linux pins by the installed-version verification, so a success-equivalent message can no longer silently drop a pin.
- The API/UI could additionally disable the version field for macOS rows for a better UX, but the agent-side enforcement here is the complete, self-contained fix that closes the silent-no-op hole.

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)
