### PR TITLE
fix(agent): reliable /run/breeze at boot via RuntimeDirectory= (#1297)

### DIFF
--- a/agent/cmd/breeze-agent/systemd_unit.go
+++ b/agent/cmd/breeze-agent/systemd_unit.go
@@ -11,7 +11,10 @@ import (
 // startup reconcile rewrites any on-disk unit older than this.
 // Version 1 is the legacy unversioned/hardened unit (any unit without a marker
 // is treated as pre-v2).
-const currentUnitVersion = 2
+// Version 3 adds RuntimeDirectory=breeze so systemd recreates /run/breeze on
+// every boot, independent of the tmpfiles.d snippet (issue #1297). Hosts still
+// on v2 pick this up on the next agent start via reconcileServiceUnitIfNeeded.
+const currentUnitVersion = 3
 
 const unitVersionPrefix = "# breeze-unit-version:"
 
@@ -27,11 +30,21 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
-# breeze-unit-version: 2
+# breeze-unit-version: 3
 Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
+
+# RuntimeDirectory makes systemd create /run/breeze (root:root 0770) before
+# every ExecStart and remove it on stop. /run is tmpfs and wiped on reboot;
+# this guarantees the IPC socket directory exists at boot WITHOUT depending on
+# the tmpfiles.d snippet being present (issue #1297 / regression of #502). The
+# agent re-chowns it to root:breeze at runtime so the user helper can connect.
+# NOTE: RuntimeDirectory is NOT a sandbox directive — it does not restrict
+# child processes — so it does not violate the unsandboxed invariant below.
+RuntimeDirectory=breeze
+RuntimeDirectoryMode=0770
 # 30s cooldown spreads respawn across a fleet that crashes simultaneously
 # (e.g. correlated network blip). Combined with StartLimitBurst=5 over
 # StartLimitIntervalSec=60, a misbehaving host backs off entirely instead

--- a/agent/cmd/breeze-agent/systemd_unit.go
+++ b/agent/cmd/breeze-agent/systemd_unit.go
@@ -14,7 +14,12 @@ import (
 // Version 3 adds RuntimeDirectory=breeze so systemd recreates /run/breeze on
 // every boot, independent of the tmpfiles.d snippet (issue #1297). Hosts still
 // on v2 pick this up on the next agent start via reconcileServiceUnitIfNeeded.
-const currentUnitVersion = 3
+// Version 4 adds RuntimeDirectoryPreserve=yes so an agent restart on a
+// partially-upgraded host does NOT remove /run/breeze out from under a still-
+// hardened breeze-watchdog (which would re-wedge it at 226/NAMESPACE), and
+// corrects a comment that wrongly claimed the agent re-chowns the directory to
+// root:breeze at runtime (it relaxes it to 0755 instead).
+const currentUnitVersion = 4
 
 const unitVersionPrefix = "# breeze-unit-version:"
 
@@ -30,21 +35,28 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
-# breeze-unit-version: 3
+# breeze-unit-version: 4
 Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
 
 # RuntimeDirectory makes systemd create /run/breeze (root:root 0770) before
-# every ExecStart and remove it on stop. /run is tmpfs and wiped on reboot;
-# this guarantees the IPC socket directory exists at boot WITHOUT depending on
-# the tmpfiles.d snippet being present (issue #1297 / regression of #502). The
-# agent re-chowns it to root:breeze at runtime so the user helper can connect.
+# every ExecStart. /run is tmpfs and wiped on reboot; this guarantees the IPC
+# socket directory exists at boot WITHOUT depending on the tmpfiles.d snippet
+# being present (issue #1297 / regression of #502). The running agent's broker
+# relaxes the directory to 0755 (world-traversable) at runtime so the per-user
+# helper can traverse it to the socket; the socket itself is 0660 and gated by
+# peer-credential + binary-path verification.
+# RuntimeDirectoryPreserve=yes keeps /run/breeze across a single unit's
+# stop/restart so a restart of this unit does NOT remove the directory out from
+# under a still-running, still-hardened breeze-watchdog (which binds it via
+# ReadWritePaths and would otherwise wedge at 226/NAMESPACE).
 # NOTE: RuntimeDirectory is NOT a sandbox directive — it does not restrict
 # child processes — so it does not violate the unsandboxed invariant below.
 RuntimeDirectory=breeze
 RuntimeDirectoryMode=0770
+RuntimeDirectoryPreserve=yes
 # 30s cooldown spreads respawn across a fleet that crashes simultaneously
 # (e.g. correlated network blip). Combined with StartLimitBurst=5 over
 # StartLimitIntervalSec=60, a misbehaving host backs off entirely instead

--- a/agent/cmd/breeze-agent/systemd_unit_test.go
+++ b/agent/cmd/breeze-agent/systemd_unit_test.go
@@ -50,6 +50,11 @@ func TestUnitNeedsReconcile(t *testing.T) {
 		{"equal -> skip", "# breeze-unit-version: 2\n", 2, false},
 		{"newer -> skip (no downgrade)", "# breeze-unit-version: 3\n", 2, false},
 		{"garbage -> reconcile", "# breeze-unit-version: x\n", 2, true},
+		// v3 adds RuntimeDirectory=breeze (#1297): a host still on the v2 unit
+		// (which lacks RuntimeDirectory) must reconcile up to v3 so /run/breeze
+		// is recreated at boot independent of the tmpfiles.d snippet.
+		{"v2 on disk -> reconcile to v3", "# breeze-unit-version: 2\n", 3, true},
+		{"v3 on disk -> skip", "# breeze-unit-version: 3\n", 3, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -142,6 +147,23 @@ func TestUnitIsNotReHardened(t *testing.T) {
 	}
 	if v, _ := parseUnitVersion(linuxUnit); v != currentUnitVersion {
 		t.Errorf("linuxUnit marker version != currentUnitVersion (%d)", currentUnitVersion)
+	}
+}
+
+// TestUnitDeclaresRuntimeDirectory guards the #1297 fix: the agent unit must
+// declare RuntimeDirectory=breeze so systemd recreates /run/breeze before every
+// ExecStart. /run is tmpfs and wiped on reboot; without this a host whose
+// tmpfiles.d snippet is missing wedges at 226/NAMESPACE on the next reboot
+// (regression of #502). RuntimeDirectory is not a sandbox directive, so it does
+// not conflict with TestUnitIsNotReHardened.
+func TestUnitDeclaresRuntimeDirectory(t *testing.T) {
+	if !strings.Contains(linuxUnit, "RuntimeDirectory=breeze") {
+		t.Error("linuxUnit must declare RuntimeDirectory=breeze so systemd recreates " +
+			"/run/breeze at boot independent of the tmpfiles.d snippet (#1297)")
+	}
+	if !strings.Contains(linuxUnit, "RuntimeDirectoryMode=0770") {
+		t.Error("linuxUnit must declare RuntimeDirectoryMode=0770 so the breeze group " +
+			"can traverse /run/breeze to the IPC socket")
 	}
 }
 

--- a/agent/cmd/breeze-agent/systemd_unit_test.go
+++ b/agent/cmd/breeze-agent/systemd_unit_test.go
@@ -55,6 +55,11 @@ func TestUnitNeedsReconcile(t *testing.T) {
 		// is recreated at boot independent of the tmpfiles.d snippet.
 		{"v2 on disk -> reconcile to v3", "# breeze-unit-version: 2\n", 3, true},
 		{"v3 on disk -> skip", "# breeze-unit-version: 3\n", 3, false},
+		// v4 adds RuntimeDirectoryPreserve=yes (#1297 follow-up): a host on the
+		// v3 unit (which lacks it) must reconcile up to v4 so an agent restart
+		// no longer removes /run/breeze out from under the hardened watchdog.
+		{"v3 on disk -> reconcile to v4", "# breeze-unit-version: 3\n", 4, true},
+		{"v4 on disk -> skip", "# breeze-unit-version: 4\n", 4, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -164,6 +169,29 @@ func TestUnitDeclaresRuntimeDirectory(t *testing.T) {
 	if !strings.Contains(linuxUnit, "RuntimeDirectoryMode=0770") {
 		t.Error("linuxUnit must declare RuntimeDirectoryMode=0770 so the breeze group " +
 			"can traverse /run/breeze to the IPC socket")
+	}
+}
+
+// TestUnitDeclaresRuntimeDirectoryPreserve guards the #1297 follow-up: on a
+// partially-upgraded host the still-hardened breeze-watchdog binds /run/breeze
+// via ReadWritePaths, so an agent restart must NOT remove the directory out
+// from under it. RuntimeDirectoryPreserve defaults to 'no' (remove on stop), so
+// the directive must be set explicitly.
+func TestUnitDeclaresRuntimeDirectoryPreserve(t *testing.T) {
+	if !strings.Contains(linuxUnit, "RuntimeDirectoryPreserve=yes") {
+		t.Error("linuxUnit must declare RuntimeDirectoryPreserve=yes so an agent restart " +
+			"does not remove /run/breeze out from under a still-hardened watchdog (#1297)")
+	}
+}
+
+// TestUnitDoesNotClaimRuntimeChown guards against the false comment that was
+// corrected: the agent does NOT re-chown /run/breeze to root:breeze at runtime
+// (broker_unix.go setupSocket relaxes it to 0755, never chowns). If a future
+// edit re-introduces that claim without the implementation, this catches it.
+func TestUnitDoesNotClaimRuntimeChown(t *testing.T) {
+	if strings.Contains(linuxUnit, "re-chowns it to root:breeze") {
+		t.Error("linuxUnit comment claims the agent re-chowns /run/breeze to root:breeze at " +
+			"runtime, but setupSocket only chmods it to 0755 — the comment is false (#1297)")
 	}
 }
 

--- a/agent/cmd/breeze-watchdog/service_cmd_linux.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_linux.go
@@ -35,6 +35,18 @@ Restart=always
 # cover an agent crash, but 5s was unnecessarily aggressive.
 RestartSec=15
 
+# RuntimeDirectory makes systemd create /run/breeze before this unit's mount
+# namespace is built. The watchdog stays sandboxed (ProtectSystem=strict +
+# ReadWritePaths=/var/run/breeze below), so without this it hit the SAME
+# 226/NAMESPACE wedge as the pre-#1197 agent: /run is tmpfs, wiped on reboot,
+# and a missing tmpfiles.d snippet left /run/breeze absent, so the bind mount
+# for ReadWritePaths failed and the watchdog could not start. systemd reference-
+# counts the directory across breeze-agent + breeze-watchdog, so the directory
+# survives as long as either unit is active (issue #1297). RuntimeDirectory is
+# not a sandbox restriction, so it does not relax the hardening below.
+RuntimeDirectory=breeze
+RuntimeDirectoryMode=0770
+
 # Security hardening
 ProtectSystem=strict
 ProtectHome=read-only

--- a/agent/cmd/breeze-watchdog/service_cmd_linux.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_linux.go
@@ -44,8 +44,13 @@ RestartSec=15
 # counts the directory across breeze-agent + breeze-watchdog, so the directory
 # survives as long as either unit is active (issue #1297). RuntimeDirectory is
 # not a sandbox restriction, so it does not relax the hardening below.
+# RuntimeDirectoryPreserve=yes keeps /run/breeze across a single unit's
+# stop/restart so a restart of THIS unit does not remove the directory out from
+# under a still-running breeze-agent on a partially-upgraded host (RemoveOnStop
+# defaults to 'no'/remove, which would re-wedge the agent at 226/NAMESPACE).
 RuntimeDirectory=breeze
 RuntimeDirectoryMode=0770
+RuntimeDirectoryPreserve=yes
 
 # Security hardening
 ProtectSystem=strict

--- a/agent/cmd/breeze-watchdog/service_cmd_linux_test.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_linux_test.go
@@ -30,6 +30,13 @@ func TestWatchdogUnitDeclaresRuntimeDirectory(t *testing.T) {
 	if !strings.Contains(watchdogUnit, "RuntimeDirectoryMode=0770") {
 		t.Error("watchdogUnit must declare RuntimeDirectoryMode=0770 to match the agent unit")
 	}
+	// RuntimeDirectoryPreserve defaults to 'no' (remove on stop). Without it, a
+	// watchdog restart on a partially-upgraded host would remove /run/breeze out
+	// from under a still-running breeze-agent, re-wedging it at 226/NAMESPACE.
+	if !strings.Contains(watchdogUnit, "RuntimeDirectoryPreserve=yes") {
+		t.Error("watchdogUnit must declare RuntimeDirectoryPreserve=yes so a watchdog restart " +
+			"does not remove /run/breeze out from under a still-running agent (#1297)")
+	}
 }
 
 // TestWatchdogUnitStillReferencesRunBreeze documents the invariant that makes the

--- a/agent/cmd/breeze-watchdog/service_cmd_linux_test.go
+++ b/agent/cmd/breeze-watchdog/service_cmd_linux_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWatchdogUnitDeclaresRuntimeDirectory guards the #1297 fix on the watchdog.
+//
+// Unlike the agent (which is intentionally unsandboxed since #1197), the
+// watchdog stays hardened: ProtectSystem=strict + ReadWritePaths=/var/run/breeze.
+// systemd builds that mount namespace by bind-mounting every ReadWritePaths
+// entry, which REQUIRES the path to already exist. /run is tmpfs and wiped on
+// reboot, so on a host whose tmpfiles.d snippet was never installed /run/breeze
+// is absent at boot and the watchdog fails sandbox setup with 226/NAMESPACE —
+// the same wedge the agent hit before #1197. With both the agent and the
+// watchdog wedged, nothing on the host can self-heal.
+//
+// RuntimeDirectory=breeze makes systemd create /run/breeze BEFORE building the
+// namespace, eliminating that dependency. systemd reference-counts the runtime
+// directory across breeze-agent + breeze-watchdog, so it persists while either
+// unit is active.
+func TestWatchdogUnitDeclaresRuntimeDirectory(t *testing.T) {
+	if !strings.Contains(watchdogUnit, "RuntimeDirectory=breeze") {
+		t.Error("watchdogUnit must declare RuntimeDirectory=breeze so systemd creates " +
+			"/run/breeze before its hardened mount namespace is built (#1297)")
+	}
+	if !strings.Contains(watchdogUnit, "RuntimeDirectoryMode=0770") {
+		t.Error("watchdogUnit must declare RuntimeDirectoryMode=0770 to match the agent unit")
+	}
+}
+
+// TestWatchdogUnitStillReferencesRunBreeze documents the invariant that makes the
+// RuntimeDirectory directive load-bearing: as long as the watchdog keeps
+// /var/run/breeze in ReadWritePaths, that path MUST be guaranteed to exist at
+// boot. If a future change drops the ReadWritePaths entry, the RuntimeDirectory
+// requirement could be revisited — but until then they must travel together.
+func TestWatchdogUnitStillReferencesRunBreeze(t *testing.T) {
+	if strings.Contains(watchdogUnit, "ReadWritePaths=") &&
+		strings.Contains(watchdogUnit, "/var/run/breeze") &&
+		!strings.Contains(watchdogUnit, "RuntimeDirectory=breeze") {
+		t.Error("watchdogUnit binds /var/run/breeze via ReadWritePaths but no longer " +
+			"declares RuntimeDirectory=breeze — it will wedge at 226/NAMESPACE on reboot (#1297)")
+	}
+}

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -52,15 +52,22 @@ elif [ -f "breeze-watchdog" ]; then
     chmod 755 /usr/local/bin/breeze-watchdog
 fi
 
-# Install watchdog systemd unit if not already present
+# (Re)install the watchdog systemd unit on EVERY install/upgrade.
+#
+# `breeze-watchdog service install` always rewrites the unit file (and runs
+# daemon-reload + enable). Re-running it on an existing host is how unit changes
+# — e.g. the RuntimeDirectory=breeze / RuntimeDirectoryPreserve=yes additions
+# for #1297 — reach already-deployed watchdogs. The old "rewrite only when
+# absent, else just restart" path silently skipped those edits, so an upgraded
+# host kept its stale watchdog unit and stayed one reboot away from a
+# 226/NAMESPACE wedge. `service install` is idempotent, so always calling it is
+# safe. It stops the service while writing the unit but does not start it, so we
+# (re)start explicitly afterward.
 if [ -f "/usr/local/bin/breeze-watchdog" ]; then
-    if [ ! -f "/etc/systemd/system/breeze-watchdog.service" ]; then
-        echo "Registering watchdog service..."
-        /usr/local/bin/breeze-watchdog service install
-    else
-        echo "Restarting watchdog service..."
-        systemctl restart breeze-watchdog || true
-    fi
+    echo "Registering watchdog service..."
+    /usr/local/bin/breeze-watchdog service install
+    echo "Starting watchdog service..."
+    systemctl restart breeze-watchdog || true
 fi
 
 # Install systemd unit

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -104,17 +104,19 @@ if ! getent group breeze &>/dev/null; then
 fi
 
 # Install tmpfiles.d snippet so /run/breeze is recreated on every boot.
-# /run is tmpfs-backed and wiped across reboots; without this the service
-# fails sandbox setup (ProtectSystem=strict + ReadWritePaths=/var/run/breeze)
-# and does not auto-start after reboot. Runs AFTER groupadd because the
-# snippet references the breeze group for ownership.
+# /run is tmpfs-backed and wiped across reboots. The breeze-agent.service and
+# breeze-watchdog.service units now declare RuntimeDirectory=breeze, so systemd
+# recreates /run/breeze before each ExecStart even without this snippet — that
+# is the primary, self-contained fix for #1297. The snippet remains as defense-
+# in-depth so /run/breeze also exists for tooling that runs before the units
+# start. Runs AFTER groupadd because the snippet references the breeze group.
 TMPFILES_SRC="$SCRIPT_DIR/../../service/tmpfiles.d/breeze-agent.conf"
 TMPFILES_DST="/usr/lib/tmpfiles.d/breeze-agent.conf"
 if [ -f "$TMPFILES_SRC" ]; then
     cp "$TMPFILES_SRC" "$TMPFILES_DST"
     chmod 644 "$TMPFILES_DST"
     if ! systemd-tmpfiles --create "$TMPFILES_DST"; then
-        echo "Warning: systemd-tmpfiles --create failed; /run/breeze will be created on next boot" >&2
+        echo "Warning: systemd-tmpfiles --create failed; relying on RuntimeDirectory=breeze in the unit to recreate /run/breeze on next start" >&2
     fi
     echo "tmpfiles.d snippet installed (recreates /run/breeze on reboot)."
 fi
@@ -124,6 +126,16 @@ IPC_DIR="/var/run/breeze"
 mkdir -p "$IPC_DIR"
 chown root:breeze "$IPC_DIR"
 chmod 770 "$IPC_DIR"
+
+# Verify /run/breeze exists post-install. With RuntimeDirectory=breeze on both
+# units this is normally redundant, but a failed mkdir/chown above (e.g. a
+# read-only /run) would otherwise ship a host one reboot away from a silent
+# 226/NAMESPACE wedge (#1297 / #502). Fail loudly instead of warn-and-continue.
+if [ ! -d "$IPC_DIR" ]; then
+    echo "Error: $IPC_DIR does not exist after install — the service will fail to start." >&2
+    echo "       Check that /run is writable and re-run the installer." >&2
+    exit 1
+fi
 
 # Add all logged-in users to the breeze group
 for user in $(who | awk '{print $1}' | sort -u); do

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -7,11 +7,21 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
-# breeze-unit-version: 2
+# breeze-unit-version: 3
 Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
+
+# RuntimeDirectory makes systemd create /run/breeze (root:root 0770) before
+# every ExecStart and remove it on stop. /run is tmpfs and wiped on reboot;
+# this guarantees the IPC socket directory exists at boot WITHOUT depending on
+# the tmpfiles.d snippet being present (issue #1297 / regression of #502). The
+# agent re-chowns it to root:breeze at runtime so the user helper can connect.
+# NOTE: RuntimeDirectory is NOT a sandbox directive — it does not restrict
+# child processes — so it does not violate the unsandboxed invariant below.
+RuntimeDirectory=breeze
+RuntimeDirectoryMode=0770
 # 30s cooldown spreads respawn across a fleet that crashes simultaneously
 # (e.g. correlated network blip). Combined with StartLimitBurst=5 over
 # StartLimitIntervalSec=60, a misbehaving host backs off entirely instead

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -7,21 +7,28 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
-# breeze-unit-version: 3
+# breeze-unit-version: 4
 Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
 Restart=on-failure
 
 # RuntimeDirectory makes systemd create /run/breeze (root:root 0770) before
-# every ExecStart and remove it on stop. /run is tmpfs and wiped on reboot;
-# this guarantees the IPC socket directory exists at boot WITHOUT depending on
-# the tmpfiles.d snippet being present (issue #1297 / regression of #502). The
-# agent re-chowns it to root:breeze at runtime so the user helper can connect.
+# every ExecStart. /run is tmpfs and wiped on reboot; this guarantees the IPC
+# socket directory exists at boot WITHOUT depending on the tmpfiles.d snippet
+# being present (issue #1297 / regression of #502). The running agent's broker
+# relaxes the directory to 0755 (world-traversable) at runtime so the per-user
+# helper can traverse it to the socket; the socket itself is 0660 and gated by
+# peer-credential + binary-path verification.
+# RuntimeDirectoryPreserve=yes keeps /run/breeze across a single unit's
+# stop/restart so a restart of this unit does NOT remove the directory out from
+# under a still-running, still-hardened breeze-watchdog (which binds it via
+# ReadWritePaths and would otherwise wedge at 226/NAMESPACE).
 # NOTE: RuntimeDirectory is NOT a sandbox directive — it does not restrict
 # child processes — so it does not violate the unsandboxed invariant below.
 RuntimeDirectory=breeze
 RuntimeDirectoryMode=0770
+RuntimeDirectoryPreserve=yes
 # 30s cooldown spreads respawn across a fleet that crashes simultaneously
 # (e.g. correlated network blip). Combined with StartLimitBurst=5 over
 # StartLimitIntervalSec=60, a misbehaving host backs off entirely instead


### PR DESCRIPTION
## Problem

Linux agents wedge on reboot with `226/NAMESPACE` because `/run/breeze` is missing. `/run` is tmpfs and **wiped on every reboot**; the directory was only recreated by the tmpfiles.d snippet shipped in #503. Hosts that:

- upgraded only the binary (never re-ran the installer), or
- hit a `systemd-tmpfiles --create` failure at install time (the installer only warned and continued),

never received the snippet → they regress to the #502 behavior and **one reboot silently kills the agent** with no logs (the binary never executes). #1197's in-process self-heal (`reconcileServiceUnitIfNeeded`) **cannot rescue an already-wedged host**, because that host never starts the agent → never auto-updates → never reconciles.

## Root cause it also surfaced

The **watchdog** unit (`breeze-watchdog.service`) is still hardened — `ProtectSystem=strict` + `ReadWritePaths=... /var/run/breeze ...`. systemd builds that mount namespace by bind-mounting each `ReadWritePaths` entry, which requires the path to exist. So the watchdog had the **identical** `226/NAMESPACE` wedge. With both the agent and the watchdog dead on reboot, nothing on the host could self-heal.

## Fix — make `/run/breeze` creation independent of the tmpfiles snippet

- **`breeze-agent.service` (v2 → v4):** add `RuntimeDirectory=breeze` + `RuntimeDirectoryMode=0770` + `RuntimeDirectoryPreserve=yes`. systemd recreates `/run/breeze` before every `ExecStart`. `currentUnitVersion` bumped so existing hosts that *can* still start pick it up via the existing startup reconcile. `RuntimeDirectory` is **not** a sandbox directive, so the intentionally-unsandboxed invariant (`TestUnitIsNotReHardened`) is preserved. Static unit kept byte-identical to the embedded const.
- **`breeze-watchdog.service`:** add the same `RuntimeDirectory=breeze` + `RuntimeDirectoryPreserve=yes`. systemd reference-counts the runtime dir across `breeze-agent` + `breeze-watchdog`, so it survives as long as either unit is active. The watchdog stays hardened.
- **`RuntimeDirectoryPreserve=yes` on both units:** `RuntimeDirectoryPreserve` defaults to remove-on-stop. On a partially-upgraded host, restarting *one* unit would tear `/run/breeze` out from under the *other* still-hardened unit and re-wedge it at `226/NAMESPACE`. Setting it on both units keeps the directory alive across a single unit's stop/restart.
- **`install-linux.sh`:** keep the tmpfiles snippet as defense-in-depth, and **verify `/run/breeze` exists post-install** — hard error instead of warn-and-continue. Also **always (re)install the watchdog systemd unit on every install/upgrade** (`breeze-watchdog service install` is idempotent and always rewrites the unit). The previous "rewrite only when absent, else just restart" branch never reached an already-deployed host, so the `RuntimeDirectory` edits would never have landed on the wedged population on a re-run of the installer.

## What changed

- `agent/cmd/breeze-agent/systemd_unit.go` — embedded `linuxUnit` v4 + `RuntimeDirectory` + `RuntimeDirectoryPreserve`; corrected a false comment that claimed the agent re-chowns `/run/breeze` to `root:breeze` at runtime (it does not — `broker_unix.go setupSocket()` chmods the dir to 0755, never chowns)
- `agent/service/systemd/breeze-agent.service` — static copy (byte-identical)
- `agent/cmd/breeze-watchdog/service_cmd_linux.go` — embedded `watchdogUnit` + `RuntimeDirectory` + `RuntimeDirectoryPreserve`
- `agent/scripts/install/install-linux.sh` — post-install `/run/breeze` verification + always re-install watchdog unit on upgrade
- `agent/cmd/breeze-agent/systemd_unit_test.go` — `TestUnitDeclaresRuntimeDirectory` + `TestUnitDeclaresRuntimeDirectoryPreserve` + `TestUnitDoesNotClaimRuntimeChown` + v3→v4 reconcile cases
- `agent/cmd/breeze-watchdog/service_cmd_linux_test.go` — watchdog `RuntimeDirectory` + `RuntimeDirectoryPreserve` regression guards

## Tests

`cd agent && go test -race -run 'TestParseUnitVersion|TestUnitNeedsReconcile|TestReconcileTransientArgs|TestStaticUnitMatchesEmbedded|TestUnitIsNotReHardened|TestUnitDeclaresRuntimeDirectory|TestUnitDeclaresRuntimeDirectoryPreserve|TestUnitDoesNotClaimRuntimeChown' ./cmd/breeze-agent/` → **ok / PASS** (incl. byte-identical static-unit check and the new RuntimeDirectory/Preserve assertions).

Watchdog test is linux-tagged (can't execute on the darwin dev host); verified it **builds + vets clean** for `GOOS=linux` (`go test -c`, `go vet`). Both `breeze-agent` and `breeze-watchdog` build clean for `GOOS=linux GOARCH=amd64`.

**On-target verification still recommended:** actual reboot-survival on a stock systemd host (install on a host with no tmpfiles snippet, reboot, confirm both units start and the IPC socket comes up; also confirm a single unit's restart on a partially-upgraded host no longer removes `/run/breeze`). Could not be exercised in this environment.

## Notes for reviewers / fleet rollout

This permanently removes the failure mode for any host that can still start (it reconciles the unit to v4 on next start, and re-running the installer now always rewrites the watchdog unit). Hosts **already** wedged at `226/NAMESPACE` on the legacy hardened unit still need the one-time manual unblock from the issue (`mkdir /run/breeze` + restart), since they never run the new binary — that is inherent to the catch-22 and called out in #1297.

Closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)