### PR TITLE
fix(web): in-app Help docs iframe works on self-hosted/custom domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -281,6 +281,17 @@ GRAFANA_ADMIN_PASSWORD=changeme
 DASHBOARD_URL=https://breeze.yourdomain.com
 PUBLIC_APP_URL=https://breeze.yourdomain.com
 
+# Self-hosted documentation origin for the in-app Help panel (the slide-out docs
+# iframe). Leave UNSET to use the hosted Breeze docs (which are only embeddable
+# on Breeze-owned domains). Set this to the origin of a docs site you control and
+# have configured to allow framing from your app domain (i.e. its frame-ancestors
+# / X-Frame-Options permits PUBLIC_APP_URL). When set, the app rebases docs links
+# onto this origin, widens the CSP frame-src to it, and treats your custom app
+# origin as embed-eligible so the Help panel renders inline instead of falling
+# back to "open in a new tab". Build-time constant — changing it requires a web
+# rebuild.
+# PUBLIC_DOCS_URL=https://docs.yourdomain.com
+
 # --------------------------------------------
 # Proxy Configuration
 # --------------------------------------------

--- a/apps/web/src/lib/docsEmbed.test.ts
+++ b/apps/web/src/lib/docsEmbed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isDocsEmbeddableOrigin } from './docsEmbed';
+import { configuredDocsOrigin, isDocsEmbeddableOrigin } from './docsEmbed';
 
 describe('isDocsEmbeddableOrigin', () => {
   it('allows Breeze-hosted https origins', () => {
@@ -19,5 +19,47 @@ describe('isDocsEmbeddableOrigin', () => {
     expect(isDocsEmbeddableOrigin('https://example.com')).toBe(false);
     expect(isDocsEmbeddableOrigin('https://localhost:4321')).toBe(false);
     expect(isDocsEmbeddableOrigin('not-a-url')).toBe(false);
+  });
+
+  it('rejects a custom app origin when no docs origin is configured', () => {
+    expect(isDocsEmbeddableOrigin('https://rmm.example.com', {})).toBe(false);
+    expect(isDocsEmbeddableOrigin('https://rmm.example.com', { PUBLIC_DOCS_URL: '' })).toBe(false);
+  });
+
+  it('allows a self-hosted app origin once PUBLIC_DOCS_URL is configured', () => {
+    const env = { PUBLIC_DOCS_URL: 'https://docs.example.com' };
+    // The operator stood up their own docs origin and authorized framing — the
+    // custom app origin (https or plain http) is now embed-eligible.
+    expect(isDocsEmbeddableOrigin('https://rmm.example.com', env)).toBe(true);
+    expect(isDocsEmbeddableOrigin('http://rmm.internal', env)).toBe(true);
+  });
+
+  it('still rejects non-http(s) origins even with PUBLIC_DOCS_URL set', () => {
+    const env = { PUBLIC_DOCS_URL: 'https://docs.example.com' };
+    expect(isDocsEmbeddableOrigin('ftp://rmm.example.com', env)).toBe(false);
+    expect(isDocsEmbeddableOrigin('not-a-url', env)).toBe(false);
+  });
+
+  it('ignores an invalid PUBLIC_DOCS_URL', () => {
+    expect(isDocsEmbeddableOrigin('https://rmm.example.com', { PUBLIC_DOCS_URL: 'not a url' })).toBe(false);
+    expect(isDocsEmbeddableOrigin('https://rmm.example.com', { PUBLIC_DOCS_URL: 'mailto:a@b.c' })).toBe(false);
+  });
+});
+
+describe('configuredDocsOrigin', () => {
+  it('returns the bare origin of a valid PUBLIC_DOCS_URL', () => {
+    expect(configuredDocsOrigin({ PUBLIC_DOCS_URL: 'https://docs.example.com/help/' })).toBe(
+      'https://docs.example.com',
+    );
+    expect(configuredDocsOrigin({ PUBLIC_DOCS_URL: 'http://docs.internal:8080/x' })).toBe(
+      'http://docs.internal:8080',
+    );
+  });
+
+  it('returns null when unset or invalid', () => {
+    expect(configuredDocsOrigin({})).toBeNull();
+    expect(configuredDocsOrigin({ PUBLIC_DOCS_URL: '   ' })).toBeNull();
+    expect(configuredDocsOrigin({ PUBLIC_DOCS_URL: 'not a url' })).toBeNull();
+    expect(configuredDocsOrigin({ PUBLIC_DOCS_URL: 'mailto:a@b.c' })).toBeNull();
   });
 });

--- a/apps/web/src/lib/docsEmbed.ts
+++ b/apps/web/src/lib/docsEmbed.ts
@@ -14,16 +14,75 @@ const ALLOWED_HTTP_HOSTS = new Set([
   'tauri.localhost',
 ]);
 
-export function isDocsEmbeddableOrigin(origin: string): boolean {
+export type DocsEmbedEnv = { PUBLIC_DOCS_URL?: string | undefined };
+
+/**
+ * Self-hosted / custom-domain deployments serve the app from an origin we can't
+ * enumerate ahead of time (e.g. `https://rmm.example.com`), so the hard-coded
+ * allowlist above would always disable the embedded docs panel and force the
+ * new-tab fallback — even for operators who've correctly stood up their own
+ * docs origin and authorized framing from their app.
+ *
+ * `PUBLIC_DOCS_URL` is the single deployment knob for "I run my own docs site."
+ * Setting it already widens the CSP `frame-src` directive to that origin
+ * (see `resolveFrameSrcDirective` in `csp.ts`). When it's present we treat the
+ * *current app origin* as embed-eligible too, so the two halves of the embed
+ * path (the CSP header and this client gate) stay in lock-step. Operators who
+ * leave it unset keep the conservative Breeze-only allowlist and the graceful
+ * new-tab fallback.
+ *
+ * The env map is injected so the gate is unit-testable; production callers fall
+ * back to `import.meta.env`.
+ */
+function readEnv(env?: DocsEmbedEnv): DocsEmbedEnv {
+  if (env) return env;
+  try {
+    return import.meta.env as unknown as DocsEmbedEnv;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * The origin (scheme + host + port) of a self-hosted docs site configured via
+ * `PUBLIC_DOCS_URL`, or `null` when unset/invalid. Returning the bare origin
+ * (not the full URL) lets callers rebase docs paths onto it and lets the
+ * `isDocsUrl` security gate add it as a second trusted origin without ever
+ * widening to a lookalike host.
+ */
+export function configuredDocsOrigin(env?: DocsEmbedEnv): string | null {
+  const raw = readEnv(env).PUBLIC_DOCS_URL?.trim();
+  if (!raw) return null;
+  try {
+    const { protocol, origin } = new URL(raw);
+    if (protocol !== 'http:' && protocol !== 'https:') return null;
+    return origin;
+  } catch {
+    return null;
+  }
+}
+
+function hasConfiguredDocsOrigin(env: DocsEmbedEnv): boolean {
+  return configuredDocsOrigin(env) !== null;
+}
+
+export function isDocsEmbeddableOrigin(origin: string, env?: DocsEmbedEnv): boolean {
   try {
     const { protocol, hostname } = new URL(origin);
 
     if (protocol === 'https:') {
-      return ALLOWED_HTTPS_HOSTS.has(hostname) || ALLOWED_HTTPS_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+      if (ALLOWED_HTTPS_HOSTS.has(hostname) || ALLOWED_HTTPS_SUFFIXES.some((suffix) => hostname.endsWith(suffix))) {
+        return true;
+      }
+      // Self-hosted opt-in: a configured docs origin signals the operator
+      // controls both the app and the docs site and has authorized framing.
+      return hasConfiguredDocsOrigin(readEnv(env));
     }
 
     if (protocol === 'http:') {
-      return ALLOWED_HTTP_HOSTS.has(hostname);
+      // Local dev hosts are always embeddable. A plain-http custom origin is
+      // only honored when the operator opted in via PUBLIC_DOCS_URL.
+      return ALLOWED_HTTP_HOSTS.has(hostname) || hasConfiguredDocsOrigin(readEnv(env));
     }
 
     return false;

--- a/apps/web/src/lib/safeHref.test.ts
+++ b/apps/web/src/lib/safeHref.test.ts
@@ -96,4 +96,22 @@ describe('isDocsUrl', () => {
     // DOCS_BASE_URL is https; the http variant is a different origin.
     expect(isDocsUrl('http://docs.breezermm.com/agents/install')).toBe(false);
   });
+
+  it('trusts a self-hosted docs origin supplied via PUBLIC_DOCS_URL', () => {
+    const selfHosted = 'https://docs.example.com';
+    expect(isDocsUrl('https://docs.example.com/getting-started/', selfHosted)).toBe(true);
+    // The canonical hosted origin remains trusted alongside the self-hosted one.
+    expect(isDocsUrl(`${DOCS_BASE_URL}/agents/install`, selfHosted)).toBe(true);
+  });
+
+  it('keeps rejecting lookalikes of the self-hosted docs origin (exact origin match)', () => {
+    const selfHosted = 'https://docs.example.com';
+    expect(isDocsUrl('https://docs.example.com.evil.com/phish', selfHosted)).toBe(false);
+    expect(isDocsUrl('https://docs.example.com@evil.com/x', selfHosted)).toBe(false);
+    expect(isDocsUrl('http://docs.example.com/x', selfHosted)).toBe(false); // scheme differs
+  });
+
+  it('rejects an arbitrary origin when no self-hosted docs origin is configured', () => {
+    expect(isDocsUrl('https://docs.example.com/x', null)).toBe(false);
+  });
 });

--- a/apps/web/src/lib/safeHref.ts
+++ b/apps/web/src/lib/safeHref.ts
@@ -1,22 +1,35 @@
 import { DOCS_BASE_URL } from '@breeze/shared';
+import { configuredDocsOrigin } from './docsEmbed';
 
 const SAFE_LINK_PROTOCOLS = new Set(['http:', 'https:']);
 
 /**
  * True only when `url` parses as an absolute URL whose origin (scheme + host +
- * port) strictly equals the docs origin. This is an ORIGIN check, not a string
- * prefix check: lookalikes such as `https://docs.breezermm.com.evil.com/x`,
+ * port) strictly equals a trusted docs origin. This is an ORIGIN check, not a
+ * string prefix check: lookalikes such as `https://docs.breezermm.com.evil.com/x`,
  * `https://docs.breezermm.com@evil.com/x`, or `https://docs.breezermm.comevil.com`
  * are rejected even though they share the `DOCS_BASE_URL` string prefix.
+ *
+ * The canonical hosted docs origin (`DOCS_BASE_URL`) is always trusted. A
+ * self-hosted deployment may add exactly one more trusted origin via
+ * `PUBLIC_DOCS_URL`; that origin is still matched exactly (no suffix/prefix
+ * widening), so the lookalike protection holds for custom domains too.
  *
  * Used to decide whether a value is safe to treat as a trusted in-app docs link
  * (e.g. consumed as an `<iframe src>` / passed to `window.open`). Returns false
  * for unparseable, scheme-relative, null, or undefined values.
+ * `selfHostedDocsOrigin` is injectable for tests; production callers fall back
+ * to `PUBLIC_DOCS_URL`.
  */
-export function isDocsUrl(url: string | null | undefined): boolean {
+export function isDocsUrl(
+  url: string | null | undefined,
+  selfHostedDocsOrigin: string | null = configuredDocsOrigin(),
+): boolean {
   if (!url) return false;
   try {
-    return new URL(url).origin === new URL(DOCS_BASE_URL).origin;
+    const origin = new URL(url).origin;
+    if (origin === new URL(DOCS_BASE_URL).origin) return true;
+    return selfHostedDocsOrigin !== null && origin === selfHostedDocsOrigin;
   } catch {
     return false;
   }

--- a/apps/web/src/stores/helpStore.test.ts
+++ b/apps/web/src/stores/helpStore.test.ts
@@ -9,7 +9,7 @@ vi.mock('./aiStore', () => ({
 }));
 
 import { getDocsForPath, DOCS_BASE_URL } from '@breeze/shared';
-import { useHelpStore } from './helpStore';
+import { rebaseDocsUrl, useHelpStore } from './helpStore';
 
 const setPathname = (pathname: string) => {
   Object.defineProperty(window, 'location', {
@@ -74,5 +74,31 @@ describe('help store open() href hardening', () => {
     expect(state.isOpen).toBe(true);
     expect(state.docsUrl).toBe(expected.url);
     expect(state.label).toBe(expected.label);
+  });
+});
+
+describe('rebaseDocsUrl (self-hosted docs origin)', () => {
+  const selfHosted = 'https://docs.example.com';
+
+  it('is a no-op when no docs origin is configured', () => {
+    const canonical = `${DOCS_BASE_URL}/features/device-groups/`;
+    expect(rebaseDocsUrl(canonical, null)).toBe(canonical);
+  });
+
+  it('swaps the canonical docs origin for the configured one, keeping path/query/hash', () => {
+    expect(rebaseDocsUrl(`${DOCS_BASE_URL}/features/device-groups/?x=1#frag`, selfHosted)).toBe(
+      'https://docs.example.com/features/device-groups/?x=1#frag',
+    );
+    expect(rebaseDocsUrl(DOCS_BASE_URL, selfHosted)).toBe('https://docs.example.com/');
+  });
+
+  it('leaves a non-canonical-origin url untouched', () => {
+    // Already a self-hosted (or unrelated) origin — nothing to rebase.
+    expect(rebaseDocsUrl('https://docs.example.com/x', selfHosted)).toBe('https://docs.example.com/x');
+    expect(rebaseDocsUrl('https://unrelated.example/x', selfHosted)).toBe('https://unrelated.example/x');
+  });
+
+  it('returns the input unchanged for an unparseable url', () => {
+    expect(rebaseDocsUrl('not a url', selfHosted)).toBe('not a url');
   });
 });

--- a/apps/web/src/stores/helpStore.ts
+++ b/apps/web/src/stores/helpStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { getDocsForPath, DOCS_BASE_URL } from '@breeze/shared';
 import { isDocsUrl } from '@/lib/safeHref';
+import { configuredDocsOrigin } from '@/lib/docsEmbed';
 
 interface HelpState {
   isOpen: boolean;
@@ -12,9 +13,29 @@ interface HelpState {
   close: () => void;
 }
 
+/**
+ * Rebase a docs URL built from the canonical `DOCS_BASE_URL` onto a self-hosted
+ * docs origin when `PUBLIC_DOCS_URL` is configured. The docs path map lives in
+ * `@breeze/shared` and is hard-coded to the hosted origin; self-hosters serve
+ * the same content at their own origin, so we keep the resolved path/query/hash
+ * and only swap the origin. Returns the input unchanged when no docs origin is
+ * configured or the swap can't be performed.
+ */
+export function rebaseDocsUrl(url: string, docsOrigin: string | null = configuredDocsOrigin()): string {
+  if (!docsOrigin) return url;
+  try {
+    const canonical = new URL(DOCS_BASE_URL).origin;
+    const parsed = new URL(url);
+    if (parsed.origin !== canonical) return url;
+    return `${docsOrigin}${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+}
+
 export const useHelpStore = create<HelpState>((set) => ({
   isOpen: false,
-  docsUrl: DOCS_BASE_URL,
+  docsUrl: rebaseDocsUrl(DOCS_BASE_URL),
   label: 'Documentation',
 
   toggle: () => {
@@ -32,16 +53,19 @@ export const useHelpStore = create<HelpState>((set) => ({
       .then(({ useAiStore }) => useAiStore.getState().close())
       .catch((err) => console.warn('[HelpStore] Failed to close AI panel:', err));
 
-    // Only a url whose ORIGIN exactly matches the docs site may be written into
-    // docsUrl, which is consumed as an <iframe src>. This is an origin check
+    // Only a url whose ORIGIN exactly matches a trusted docs site may be written
+    // into docsUrl, which is consumed as an <iframe src>. This is an origin check
     // (via isDocsUrl), not a string-prefix match, so docs-lookalike hosts such
-    // as docs.breezermm.com.evil.com are rejected. Any untrusted value falls
-    // back to the safe contextual docs page for the current path.
+    // as docs.breezermm.com.evil.com are rejected. isDocsUrl trusts both the
+    // canonical hosted origin and a self-hosted origin from PUBLIC_DOCS_URL, so
+    // a caller-supplied self-hosted docs link is accepted as-is. Any untrusted
+    // value falls back to the safe contextual docs page for the current path,
+    // rebased onto the self-hosted docs origin when one is configured.
     if (isDocsUrl(url)) {
       set({ isOpen: true, docsUrl: url, label: 'Documentation' });
     } else {
       const { url: resolved, label } = getDocsForPath(window.location.pathname);
-      set({ isOpen: true, docsUrl: resolved, label });
+      set({ isOpen: true, docsUrl: rebaseDocsUrl(resolved), label });
     }
   },
 


### PR DESCRIPTION
## Problem
The in-app Help panel (`HelpPanel.tsx`) embeds the docs site in an `<iframe>`. On a self-hosted or custom app domain (e.g. `https://rmm.example.com`) the panel silently disabled the iframe and fell back to "open in a new tab", because:

1. `isDocsEmbeddableOrigin()` (`apps/web/src/lib/docsEmbed.ts`) allowlisted only Breeze-owned domains, so any custom app origin returned `false` → `canEmbedDocs = false`.
2. The iframe `src` (via `DOCS_BASE_URL`) was hard-wired to the hosted docs origin, which won't allow framing from a custom app domain anyway.

The CSP layer (`csp.ts`) already honored `PUBLIC_DOCS_URL` to widen `frame-src` — but the rest of the embed path ignored it.

## What changed
Honor the existing `PUBLIC_DOCS_URL` deployment knob across the whole embed path. When an operator sets it (signalling they run their own docs origin and have authorized framing from their app):

- **`docsEmbed.ts`** — new `configuredDocsOrigin()`; `isDocsEmbeddableOrigin()` now treats the custom app origin as embed-eligible when `PUBLIC_DOCS_URL` is set (env injectable for tests; falls back to `import.meta.env`). Still rejects non-http(s) origins and invalid config.
- **`safeHref.ts`** — `isDocsUrl()` trusts the canonical docs origin **and** the self-hosted origin from `PUBLIC_DOCS_URL`. Still an **exact origin match**, so lookalike hosts (`docs.example.com.evil.com`, `…@evil.com`, scheme mismatches) stay rejected on custom domains too.
- **`helpStore.ts`** — new `rebaseDocsUrl()`; resolved docs paths are rebased onto the configured docs origin so the iframe points at the operator's own docs site (path/query/hash preserved).
- **`.env.example`** — document `PUBLIC_DOCS_URL` with a generic placeholder (`https://docs.yourdomain.com`), no internal infra.

Leaving `PUBLIC_DOCS_URL` unset preserves the prior Breeze-only behavior and the graceful new-tab fallback — zero change for the hosted product.

## Note on infra half
Embedding still requires the operator's **docs site** to permit framing from their app origin (its `frame-ancestors` / `X-Frame-Options`). That's deployment config on the docs host, outside this repo; this PR makes the app side honor it.

## Tests
`pnpm --filter @breeze/web exec vitest run src/lib/docsEmbed.test.ts src/lib/safeHref.test.ts src/stores/helpStore.test.ts src/components/help/HelpPanel.test.tsx src/lib/csp.test.ts`
→ **5 files, 63 tests passed.** New cases cover the self-hosted opt-in, invalid-config handling, lookalike rejection on custom origins, and `rebaseDocsUrl` origin-swap.

Closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)