### PR TITLE
test(web): partial CSP script-src drift guard — initial-SSR scripts only (refs #1232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,11 +316,14 @@ jobs:
       - name: Build Web
         run: pnpm build --filter=@breeze/web
 
-      # Guard against CSP script-src hash drift (#1232): boots the freshly-built
-      # server bundle and asserts every emitted inline <script> hash is covered
-      # by the served script-src. Catches stale hand-pinned hashes in
-      # astro.config.mjs before they break Astro/React hydration in production.
-      - name: Check CSP hash drift
+      # Partial guard against CSP script-src hash drift (#1232): boots the
+      # freshly-built server bundle and asserts every inline <script> hash in the
+      # *initial SSR HTML* is covered by the served script-src. Catches drift in
+      # Astro's build-time auto-hashed scripts. NOTE: it does NOT cover the two
+      # hand-pinned <ClientRouter> runtime-swap hashes in astro.config.mjs (that
+      # script is injected during client-side navigation, never in a GET) — the
+      # remaining real fix is tracked on #1232.
+      - name: Check CSP hash drift (partial)
         run: pnpm --filter @breeze/web run check:csp
 
       - name: Upload Web artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,13 @@ jobs:
       - name: Build Web
         run: pnpm build --filter=@breeze/web
 
+      # Guard against CSP script-src hash drift (#1232): boots the freshly-built
+      # server bundle and asserts every emitted inline <script> hash is covered
+      # by the served script-src. Catches stale hand-pinned hashes in
+      # astro.config.mjs before they break Astro/React hydration in production.
+      - name: Check CSP hash drift
+        run: pnpm --filter @breeze/web run check:csp
+
       - name: Upload Web artifact
         uses: actions/upload-artifact@v7
         with:

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -72,6 +72,11 @@ export default defineConfig({
         // It is constant per Astro version; if you bump astro, re-verify and
         // update.  Hash-chasing here is a known-fragile workaround --
         // longer-term we should migrate to a nonce-based CSP.
+        //
+        // Drift guard (#1232): `pnpm --filter @breeze/web run check:csp` boots
+        // the built server and fails if any emitted inline <script> hash is
+        // missing from the served script-src.  CI runs it in the build-web job,
+        // so a stale pin here breaks CI instead of breaking hydration in prod.
         resources: [
           "'self'",
           'https://static.cloudflareinsights.com',

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -73,10 +73,16 @@ export default defineConfig({
         // update.  Hash-chasing here is a known-fragile workaround --
         // longer-term we should migrate to a nonce-based CSP.
         //
-        // Drift guard (#1232): `pnpm --filter @breeze/web run check:csp` boots
-        // the built server and fails if any emitted inline <script> hash is
-        // missing from the served script-src.  CI runs it in the build-web job,
-        // so a stale pin here breaks CI instead of breaking hydration in prod.
+        // Partial drift guard (#1232): `pnpm --filter @breeze/web run check:csp`
+        // boots the built server and fails if any inline <script> in the
+        // *initial SSR HTML* has a hash missing from the served script-src.  CI
+        // runs it in the build-web job.  IMPORTANT: it does NOT cover the two
+        // hand-pins below — the <ClientRouter> swap script is injected at
+        // runtime during client-side navigation, never in an initial GET, so a
+        // fetch-based guard can't see it (it reports these pins as UNVERIFIED).
+        // Deleting either pin here will NOT fail the guard but WILL break view
+        // transitions in the browser.  The real fix is to eliminate these
+        // runtime hand-pins via a nonce-based CSP — see #1232.
         resources: [
           "'self'",
           'https://static.cloudflareinsights.com',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "prod:docker": "pnpm run build:prod && pnpm run preview:docker",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
+    "check:csp": "node --experimental-strip-types scripts/check-csp-hash-drift.ts",
     "lint": "eslint src",
     "clean": "rm -rf dist .astro"
   },

--- a/apps/web/scripts/check-csp-hash-drift.ts
+++ b/apps/web/scripts/check-csp-hash-drift.ts
@@ -85,7 +85,11 @@ export function extractDirective(csp: string, name: string): string {
 /** Inline <script> bodies (no `src`, non-empty) from a rendered HTML document. */
 export function inlineScriptBodies(html: string): string[] {
   const bodies: string[] = [];
-  const re = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  // Tolerate whitespace in the closing tag (`</script >`, `</script\n>`). Without
+  // `\s*`, a non-greedy `[\s\S]*?` would run past such a close to the next
+  // `</script>`, yielding a wrong body + wrong hash → a false-positive drift
+  // failure that blocks CI on a perfectly good build (flagged by CodeQL).
+  const re = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
   let match: RegExpExecArray | null;
   while ((match = re.exec(html)) !== null) {
     const attrs = match[1];

--- a/apps/web/scripts/check-csp-hash-drift.ts
+++ b/apps/web/scripts/check-csp-hash-drift.ts
@@ -1,21 +1,44 @@
 /**
- * CSP script-src hash drift guard (issue #1232).
+ * CSP script-src regression guard (partial — issue #1232).
  *
  * The web app emits inline <script> blocks at build time (Astro's hydration
- * bootstrap, the <ClientRouter> view-transition swap script — issue #618 — and
- * the per-island loader).  Their sha256 hashes are pinned in the `script-src`
- * directive: Astro auto-hashes most of them, and `astro.config.mjs` hand-pins
- * two more under `scriptDirective.resources`.  When those hand-pinned hashes
- * drift from the scripts the build actually emits (typically after an Astro
- * version bump), the browser blocks the inline script and React fails to
- * hydrate (React #418), but nothing in CI catches it because the build still
- * succeeds.
+ * bootstrap and the per-island loader).  Their sha256 hashes are pinned in the
+ * `script-src` directive: Astro 6's `security.csp` auto-hashes the ones it can
+ * see at build time, and `astro.config.mjs` hand-pins a couple more under
+ * `scriptDirective.resources`.  When a pinned hash drifts from the script the
+ * build actually emits (typically after an Astro version bump), the browser
+ * blocks the inline script and React fails to hydrate (React #418), but the
+ * build still succeeds, so nothing in CI catches it.
  *
- * This guard boots the freshly-built server bundle, fetches a set of
- * server-rendered routes, and for every inline <script> in the rendered HTML
- * asserts that its sha256 hash is present in the served `script-src`.  It is
- * deliberately black-box (no Astro-internal reverse engineering) so it stays
- * correct across Astro versions — it tests the exact thing the browser tests.
+ * SCOPE — what this guard does and does NOT cover (read before trusting it):
+ *
+ *   COVERS: every inline <script> present in the *initial server-rendered HTML*
+ *   of the probed routes.  It boots the freshly-built server bundle, fetches
+ *   those routes, sha256-hashes each inline script, and asserts the hash is in
+ *   the served `script-src`.  This catches drift in Astro's build-time
+ *   auto-hashed scripts and in any hand-pin that backs an initial-SSR script.
+ *
+ *   DOES NOT COVER: the <ClientRouter> view-transition *swap* script (issue
+ *   #618).  That script is injected at runtime via `insertAdjacentHTML` during
+ *   client-side navigation (see astro/dist/transitions/router.js) — it never
+ *   appears in an initial GET response, so a pure fetch-based guard can never
+ *   observe it.  The hand-pinned `scriptDirective.resources` hashes that exist
+ *   *only* to cover that runtime swap script are therefore NOT verified here.
+ *   Removing such a pin from astro.config.mjs would still pass this guard while
+ *   breaking view transitions in a real browser.  Closing that gap needs either
+ *   a browser-driven navigation in the guard (heavy — no Playwright in the build
+ *   job) or eliminating the runtime hand-pins via a nonce-based CSP.  Tracked as
+ *   the remaining real fix on #1232; this guard is the partial backstop.
+ *
+ * To keep that limitation honest rather than silent, the guard cross-checks the
+ * hand-pinned hashes in astro.config.mjs against what it actually observed: any
+ * pin it could NOT exercise from an initial-SSR script is reported as
+ * UNVERIFIED (not a failure — it may legitimately back the runtime swap script),
+ * and any pin not present in the served script-src at all is a hard failure.
+ *
+ * It is deliberately black-box (no Astro-internal reverse engineering) so the
+ * SSR-coverage half stays correct across Astro versions — it tests the exact
+ * thing the browser tests on first paint.
  *
  * Run after `pnpm --filter @breeze/web build`:
  *   node --experimental-strip-types scripts/check-csp-hash-drift.ts
@@ -24,11 +47,12 @@
  */
 import { createHash } from 'node:crypto';
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const WEB_ROOT = join(import.meta.dirname, '..');
 const SERVER_ENTRY = join(WEB_ROOT, 'dist', 'server', 'entry.mjs');
+const ASTRO_CONFIG = join(WEB_ROOT, 'astro.config.mjs');
 
 /**
  * Server-rendered routes that emit inline scripts without requiring auth.
@@ -71,6 +95,29 @@ export function inlineScriptBodies(html: string): string[] {
     bodies.push(body);
   }
   return bodies;
+}
+
+/**
+ * sha256 hashes hand-pinned in `scriptDirective.resources` of astro.config.mjs.
+ * These are the manually-maintained supplements (not Astro's auto-hashes) that
+ * #1232 flags as drift-prone.  We parse them textually so the guard can report
+ * which pins it was actually able to verify against an emitted inline script.
+ */
+export function handPinnedScriptHashes(configSource: string): string[] {
+  // Narrow to the scriptDirective.resources array, then pull sha256 tokens.
+  const start = configSource.indexOf('scriptDirective');
+  const slice = start === -1 ? configSource : configSource.slice(start);
+  const resourcesIdx = slice.indexOf('resources');
+  const region = resourcesIdx === -1 ? slice : slice.slice(resourcesIdx);
+  const hashes: string[] = [];
+  const re = /sha256-[A-Za-z0-9+/]+=*/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(region)) !== null) {
+    // Stop once we leave the resources array (next directive block).
+    if (region.slice(0, match.index).includes('styleDirective')) break;
+    hashes.push(match[0]);
+  }
+  return Array.from(new Set(hashes));
 }
 
 async function waitForServer(baseUrl: string, timeoutMs: number): Promise<void> {
@@ -131,6 +178,8 @@ async function main(): Promise<number> {
   let routesWithHtml = 0;
   /** Hashes the build actually emitted inline, across all probed routes. */
   const emittedHashes = new Set<string>();
+  /** The served `script-src` token list per route, for the hand-pin cross-check. */
+  const servedScriptSrcByRoute = new Map<string, string>();
 
   try {
     for (const route of ROUTES) {
@@ -161,6 +210,7 @@ async function main(): Promise<number> {
       }
 
       const scriptSrc = extractDirective(csp, 'script-src');
+      servedScriptSrcByRoute.set(route, scriptSrc);
       for (const body of inline) {
         totalInlineScripts += 1;
         const hash = sha256Base64(body);
@@ -204,10 +254,45 @@ async function main(): Promise<number> {
     return 1;
   }
 
+  // Cross-check the hand-pinned hashes against what we actually observed, so the
+  // guard's coverage gap is reported rather than silently passed over.  A pin
+  // that the served script-src no longer contains at all is a hard failure (a
+  // genuinely dead/typo'd pin); a pin we could not tie to any initial-SSR inline
+  // script is reported as UNVERIFIED — it may legitimately back the runtime
+  // <ClientRouter> swap script, which this fetch-based guard cannot exercise.
+  let configSource = '';
+  try {
+    configSource = readFileSync(ASTRO_CONFIG, 'utf8');
+  } catch {
+    // If the config can't be read we simply skip the cross-check.
+  }
+  const handPins = configSource ? handPinnedScriptHashes(configSource) : [];
+  const servedScriptSrcs = Array.from(servedScriptSrcByRoute.values());
+  const unverifiedPins: string[] = [];
+  for (const pin of handPins) {
+    const emittedFromSsr = emittedHashes.has(`sha256-${pin.replace(/^sha256-/, '')}`);
+    const servedSomewhere = servedScriptSrcs.some((s) => s.includes(pin));
+    if (!servedSomewhere) {
+      console.error(
+        `[csp-drift] hand-pinned hash 'sha256-…' (${pin}) is NOT in any served ` +
+          `script-src — it is dead config. Remove it from astro.config.mjs or fix the pin.`
+      );
+      return 1;
+    }
+    if (!emittedFromSsr) unverifiedPins.push(pin);
+  }
+
   console.log(
-    `[csp-drift] OK — ${totalInlineScripts} inline script(s) across ${routesWithHtml} route(s); ` +
-      `all ${emittedHashes.size} unique hash(es) covered by script-src.`
+    `[csp-drift] OK (partial) — ${totalInlineScripts} inline script(s) across ${routesWithHtml} ` +
+      `route(s); all ${emittedHashes.size} initial-SSR hash(es) covered by script-src.`
   );
+  if (unverifiedPins.length > 0) {
+    console.log(
+      `[csp-drift] NOTE — ${unverifiedPins.length} hand-pinned hash(es) could not be verified ` +
+        `against an initial-SSR inline script (likely the <ClientRouter> runtime swap script, ` +
+        `which this guard cannot exercise — see #1232): ${unverifiedPins.join(', ')}`
+    );
+  }
   return 0;
 }
 

--- a/apps/web/scripts/check-csp-hash-drift.ts
+++ b/apps/web/scripts/check-csp-hash-drift.ts
@@ -1,0 +1,226 @@
+/**
+ * CSP script-src hash drift guard (issue #1232).
+ *
+ * The web app emits inline <script> blocks at build time (Astro's hydration
+ * bootstrap, the <ClientRouter> view-transition swap script — issue #618 — and
+ * the per-island loader).  Their sha256 hashes are pinned in the `script-src`
+ * directive: Astro auto-hashes most of them, and `astro.config.mjs` hand-pins
+ * two more under `scriptDirective.resources`.  When those hand-pinned hashes
+ * drift from the scripts the build actually emits (typically after an Astro
+ * version bump), the browser blocks the inline script and React fails to
+ * hydrate (React #418), but nothing in CI catches it because the build still
+ * succeeds.
+ *
+ * This guard boots the freshly-built server bundle, fetches a set of
+ * server-rendered routes, and for every inline <script> in the rendered HTML
+ * asserts that its sha256 hash is present in the served `script-src`.  It is
+ * deliberately black-box (no Astro-internal reverse engineering) so it stays
+ * correct across Astro versions — it tests the exact thing the browser tests.
+ *
+ * Run after `pnpm --filter @breeze/web build`:
+ *   node --experimental-strip-types scripts/check-csp-hash-drift.ts
+ *
+ * Exit code 0 = no drift, 1 = drift / coverage failure.
+ */
+import { createHash } from 'node:crypto';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WEB_ROOT = join(import.meta.dirname, '..');
+const SERVER_ENTRY = join(WEB_ROOT, 'dist', 'server', 'entry.mjs');
+
+/**
+ * Server-rendered routes that emit inline scripts without requiring auth.
+ * `/` exercises the full app layout (3 inline scripts incl. the ClientRouter
+ * swap script); the public auth pages exercise the lighter auth layout.  Each
+ * route must return HTML — a redirect or non-HTML response is skipped, but at
+ * least one route must yield inline scripts or the guard fails closed (a build
+ * that stopped emitting any inline script would otherwise pass vacuously).
+ */
+const ROUTES = ['/', '/login', '/register-partner', '/forgot-password', '/reset-password'];
+
+const HOST = '127.0.0.1';
+const PORT = 41232; // fixed, uncommon port; the guard owns this process
+
+export function sha256Base64(body: string): string {
+  return `sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}`;
+}
+
+/** Extract the token list of the first matching directive from a CSP string. */
+export function extractDirective(csp: string, name: string): string {
+  for (const entry of csp.split(';')) {
+    const trimmed = entry.trim();
+    if (trimmed.toLowerCase().startsWith(`${name.toLowerCase()} `)) {
+      return trimmed.slice(name.length).trim();
+    }
+  }
+  return '';
+}
+
+/** Inline <script> bodies (no `src`, non-empty) from a rendered HTML document. */
+export function inlineScriptBodies(html: string): string[] {
+  const bodies: string[] = [];
+  const re = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    const attrs = match[1];
+    const body = match[2];
+    if (/\bsrc\s*=/.test(attrs)) continue; // external script, hash not applicable
+    if (!body.trim()) continue; // empty/whitespace-only
+    bodies.push(body);
+  }
+  return bodies;
+}
+
+async function waitForServer(baseUrl: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${baseUrl}/login`, { redirect: 'manual' });
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+  throw new Error(`server did not come up within ${timeoutMs}ms`);
+}
+
+async function main(): Promise<number> {
+  if (!existsSync(SERVER_ENTRY)) {
+    console.error(
+      `[csp-drift] missing ${SERVER_ENTRY}.\n` +
+        `Run \`pnpm --filter @breeze/web build\` before this guard.`
+    );
+    return 1;
+  }
+
+  const baseUrl = `http://${HOST}:${PORT}`;
+  const server: ChildProcess = spawn(process.execPath, [SERVER_ENTRY], {
+    cwd: WEB_ROOT,
+    env: { ...process.env, NODE_ENV: 'production', HOST, PORT: String(PORT) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let serverLog = '';
+  server.stdout?.on('data', (d) => (serverLog += d.toString()));
+  server.stderr?.on('data', (d) => (serverLog += d.toString()));
+
+  const shutdown = (): Promise<void> =>
+    new Promise((resolve) => {
+      if (server.exitCode !== null || server.signalCode !== null) return resolve();
+      server.once('exit', () => resolve());
+      server.kill('SIGTERM');
+      setTimeout(() => {
+        if (server.exitCode === null) server.kill('SIGKILL');
+        resolve();
+      }, 3000);
+    });
+
+  try {
+    await waitForServer(baseUrl, 30_000);
+  } catch (err) {
+    console.error(`[csp-drift] ${(err as Error).message}`);
+    if (serverLog.trim()) console.error(`[csp-drift] server output:\n${serverLog}`);
+    await shutdown();
+    return 1;
+  }
+
+  const drifts: string[] = [];
+  let totalInlineScripts = 0;
+  let routesWithHtml = 0;
+  /** Hashes the build actually emitted inline, across all probed routes. */
+  const emittedHashes = new Set<string>();
+
+  try {
+    for (const route of ROUTES) {
+      let res: Response;
+      try {
+        res = await fetch(`${baseUrl}${route}`, { redirect: 'manual' });
+      } catch (err) {
+        drifts.push(`${route}: request failed — ${(err as Error).message}`);
+        continue;
+      }
+
+      const contentType = res.headers.get('content-type') ?? '';
+      if (!contentType.includes('text/html')) {
+        // Redirects and non-HTML responses carry no inline scripts to check.
+        continue;
+      }
+      routesWithHtml += 1;
+
+      const csp = res.headers.get('content-security-policy');
+      const html = await res.text();
+      const inline = inlineScriptBodies(html);
+
+      if (!csp) {
+        if (inline.length > 0) {
+          drifts.push(`${route}: rendered ${inline.length} inline script(s) but sent no Content-Security-Policy header`);
+        }
+        continue;
+      }
+
+      const scriptSrc = extractDirective(csp, 'script-src');
+      for (const body of inline) {
+        totalInlineScripts += 1;
+        const hash = sha256Base64(body);
+        emittedHashes.add(hash);
+        if (!scriptSrc.includes(`'${hash}'`) && !scriptSrc.includes(hash)) {
+          const preview = body.replace(/\s+/g, ' ').trim().slice(0, 70);
+          drifts.push(
+            `${route}: inline script (${body.length} bytes) hash ${hash} NOT in script-src — ` +
+              `add it (or fix the stale pin) in astro.config.mjs scriptDirective.resources. ` +
+              `Script starts: ${preview}…`
+          );
+        }
+      }
+    }
+  } finally {
+    await shutdown();
+  }
+
+  // Fail closed: a build that emits no inline scripts on any probed route means
+  // either the probe routes broke or Astro changed its emission model — either
+  // way the guard can no longer detect drift, so treat it as a failure.
+  if (routesWithHtml === 0) {
+    console.error('[csp-drift] no probed route returned HTML; cannot verify CSP coverage.');
+    return 1;
+  }
+  if (totalInlineScripts === 0) {
+    console.error(
+      '[csp-drift] probed routes rendered no inline scripts. ' +
+        'If Astro stopped emitting inline scripts this guard is obsolete; ' +
+        'otherwise the probe routes regressed. Investigate before bypassing.'
+    );
+    return 1;
+  }
+
+  if (drifts.length > 0) {
+    console.error(`[csp-drift] DRIFT DETECTED — ${drifts.length} issue(s):`);
+    for (const d of drifts) console.error(`  - ${d}`);
+    console.error(
+      '\nThe browser will block these inline scripts, breaking Astro/React hydration (React #418).'
+    );
+    return 1;
+  }
+
+  console.log(
+    `[csp-drift] OK — ${totalInlineScripts} inline script(s) across ${routesWithHtml} route(s); ` +
+      `all ${emittedHashes.size} unique hash(es) covered by script-src.`
+  );
+  return 0;
+}
+
+// Only boot the server + probe when invoked as a CLI. Importing this module
+// (e.g. from the unit test that exercises the pure helpers above) must not run.
+const invokedDirectly =
+  typeof process.argv[1] === 'string' && import.meta.filename === process.argv[1];
+
+if (invokedDirectly) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error('[csp-drift] unexpected failure:', err);
+      process.exit(1);
+    });
+}

--- a/apps/web/src/__tests__/check-csp-hash-drift.test.ts
+++ b/apps/web/src/__tests__/check-csp-hash-drift.test.ts
@@ -43,6 +43,14 @@ describe('inlineScriptBodies', () => {
     const html = `<script>${body}</script>`;
     expect(inlineScriptBodies(html)).toEqual([body]);
   });
+
+  it('matches closing tags with whitespace and does not run past them', () => {
+    // `</script >` / `</script\n>` are valid closes. A regex that only matched
+    // `</script>` would skip the first close and capture everything up to the
+    // next one — a wrong body, a wrong hash, and a false-positive drift failure.
+    const html = `<script>first();</script >\n<script>second();</script\n>`;
+    expect(inlineScriptBodies(html)).toEqual(['first();', 'second();']);
+  });
 });
 
 describe('extractDirective', () => {

--- a/apps/web/src/__tests__/check-csp-hash-drift.test.ts
+++ b/apps/web/src/__tests__/check-csp-hash-drift.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractDirective,
+  inlineScriptBodies,
+  sha256Base64,
+} from '../../scripts/check-csp-hash-drift';
+
+// Unit coverage for the pure parsing/hashing helpers that back the CSP hash
+// drift guard (#1232). The full build-and-boot guard runs in CI
+// (`pnpm --filter @breeze/web run check:csp`); these tests pin the logic that
+// decides which scripts get hashed and how a served script-src is parsed.
+
+describe('inlineScriptBodies', () => {
+  it('collects bodies of inline scripts that have no src', () => {
+    const html = `
+      <html><head>
+        <script type="module" src="/_astro/ClientRouter.x.js"></script>
+        <script>console.log('a');</script>
+        <script type="module">console.log('b');</script>
+      </head></html>`;
+    expect(inlineScriptBodies(html)).toEqual(["console.log('a');", "console.log('b');"]);
+  });
+
+  it('ignores external scripts even when they have a body-like attribute', () => {
+    const html = `<script src="/x.js" data-onload="init()"></script>`;
+    expect(inlineScriptBodies(html)).toEqual([]);
+  });
+
+  it('ignores empty and whitespace-only inline scripts', () => {
+    const html = `<script></script><script>   \n  </script><script>real();</script>`;
+    expect(inlineScriptBodies(html)).toEqual(['real();']);
+  });
+
+  it('preserves the exact bytes so the hash matches what the browser sees', () => {
+    // The hash is over the verbatim text content, including leading/trailing
+    // whitespace inside the tag — must not be trimmed.
+    const body = '  let x = 1;  ';
+    const html = `<script>${body}</script>`;
+    expect(inlineScriptBodies(html)).toEqual([body]);
+  });
+});
+
+describe('extractDirective', () => {
+  const csp =
+    "default-src 'self'; script-src 'self' 'sha256-AAA=' https://cdn.example.com; style-src 'self'";
+
+  it('returns the token list of the named directive', () => {
+    expect(extractDirective(csp, 'script-src')).toBe(
+      "'self' 'sha256-AAA=' https://cdn.example.com"
+    );
+  });
+
+  it('is case-insensitive on the directive name', () => {
+    expect(extractDirective(csp, 'Script-Src')).toBe(
+      "'self' 'sha256-AAA=' https://cdn.example.com"
+    );
+  });
+
+  it('returns an empty string for an absent directive', () => {
+    expect(extractDirective(csp, 'connect-src')).toBe('');
+  });
+
+  it('does not confuse a prefix directive with a granular one', () => {
+    const withGranular = "script-src 'self'; script-src-attr 'none'";
+    expect(extractDirective(withGranular, 'script-src')).toBe("'self'");
+    expect(extractDirective(withGranular, 'script-src-attr')).toBe("'none'");
+  });
+});
+
+describe('sha256Base64', () => {
+  it('produces the CSP sha256-<base64> form the browser computes', () => {
+    // Empty-string sha256 is a known vector; this is the value Chrome reports.
+    expect(sha256Base64('')).toBe('sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=');
+  });
+
+  it('round-trips: a script hashed here is found in a script-src containing it', () => {
+    const body = "(()=>{console.log('hydrate')})()";
+    const hash = sha256Base64(body);
+    const scriptSrc = `'self' '${hash}'`;
+    expect(scriptSrc.includes(`'${hash}'`)).toBe(true);
+  });
+});

--- a/apps/web/src/__tests__/check-csp-hash-drift.test.ts
+++ b/apps/web/src/__tests__/check-csp-hash-drift.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
   extractDirective,
+  handPinnedScriptHashes,
   inlineScriptBodies,
   sha256Base64,
 } from '../../scripts/check-csp-hash-drift';
 
-// Unit coverage for the pure parsing/hashing helpers that back the CSP hash
-// drift guard (#1232). The full build-and-boot guard runs in CI
+// Unit coverage for the pure parsing/hashing helpers that back the partial CSP
+// hash drift guard (#1232). The full build-and-boot guard runs in CI
 // (`pnpm --filter @breeze/web run check:csp`); these tests pin the logic that
-// decides which scripts get hashed and how a served script-src is parsed.
+// decides which scripts get hashed, how a served script-src is parsed, and how
+// the hand-pinned hashes are read back out of astro.config.mjs for the
+// verified/unverified cross-check. NOTE: the guard only covers inline scripts in
+// the *initial* SSR HTML — it cannot exercise the <ClientRouter> runtime swap
+// script, so the two runtime hand-pins are reported UNVERIFIED, not asserted.
 
 describe('inlineScriptBodies', () => {
   it('collects bodies of inline scripts that have no src', () => {
@@ -64,6 +69,51 @@ describe('extractDirective', () => {
     const withGranular = "script-src 'self'; script-src-attr 'none'";
     expect(extractDirective(withGranular, 'script-src')).toBe("'self'");
     expect(extractDirective(withGranular, 'script-src-attr')).toBe("'none'");
+  });
+});
+
+describe('handPinnedScriptHashes', () => {
+  // A trimmed shape of astro.config.mjs scriptDirective/styleDirective.
+  const config = `
+    security: {
+      csp: {
+        scriptDirective: {
+          resources: [
+            "'self'",
+            'https://static.cloudflareinsights.com',
+            "'sha256-dr7co1YqmJP1+caEJBfXkM/oHRwOVAknT+gDygo8nD0='",
+            "'sha256-6wgjuQN80bYuvy8C2/v+mFX1HAEgrfvSs+beElRyx+8='"
+          ]
+        },
+        styleDirective: {
+          resources: ["'self'", "'sha256-STYLEHASHdoNotPickThis0000000000000000000='"]
+        }
+      }
+    }`;
+
+  it('extracts only the sha256 hashes inside scriptDirective.resources', () => {
+    expect(handPinnedScriptHashes(config)).toEqual([
+      'sha256-dr7co1YqmJP1+caEJBfXkM/oHRwOVAknT+gDygo8nD0=',
+      'sha256-6wgjuQN80bYuvy8C2/v+mFX1HAEgrfvSs+beElRyx+8=',
+    ]);
+  });
+
+  it('does not pick up hashes from a later styleDirective', () => {
+    expect(handPinnedScriptHashes(config)).not.toContain(
+      'sha256-STYLEHASHdoNotPickThis0000000000000000000='
+    );
+  });
+
+  it('returns an empty list when there are no hand-pinned hashes', () => {
+    const noHashes = `scriptDirective: { resources: ["'self'", 'https://cdn.example.com'] }`;
+    expect(handPinnedScriptHashes(noHashes)).toEqual([]);
+  });
+
+  it('de-duplicates a hash pinned more than once', () => {
+    const dupe = `scriptDirective: { resources: [
+      "'sha256-AAAA='", "'sha256-AAAA='"
+    ] }`;
+    expect(handPinnedScriptHashes(dupe)).toEqual(['sha256-AAAA=']);
   });
 });
 


### PR DESCRIPTION
## Problem

Hand-pinned `sha256` hashes in `apps/web/astro.config.mjs` (`scriptDirective.resources`) drift from the inline scripts the build/runtime actually emits, typically after an Astro version bump. When that happens the browser blocks the inline script and React fails to hydrate (**React #418**), but the build still succeeds, so nothing in CI catches it (#1232).

## What this PR is (and is NOT)

This is a **partial** regression backstop, **not** a full fix for #1232. Be honest about the boundary:

- **Covers:** every inline `<script>` in the **initial server-rendered HTML** of a set of public routes. The guard boots the freshly-built server bundle, fetches those routes, `sha256`-hashes each inline script, and asserts the hash is in the served `script-src`. This genuinely catches drift in Astro 6 `security.csp` build-time auto-hashed scripts.
- **Does NOT cover** the `<ClientRouter>` view-transition **swap** script (#618). That script is injected at runtime via `insertAdjacentHTML` during client-side navigation (`astro/dist/transitions/router.js`) — it **never** appears in an initial GET response, so a fetch-based guard can't observe it. The two hand-pinned hashes (`sha256-dr7co1Yq…`, `sha256-6wgjuQN8…`) exist **only** to cover that runtime script.

**Empirical proof of the gap:** deleting the `sha256-dr7co1Yq…` pin from `astro.config.mjs` and rebuilding **still passes** the guard. That is exactly the real drift vector #1232 reports, and a fetch-based guard cannot close it.

I also checked the robust alternative: Astro 6's stable `security.csp` build-time hashing (`trackScriptHashes`) iterates `inlinedScripts` / client chunks / `settings.scripts` but does **not** hash the runtime swap script either, so the hand-pins **cannot** be eliminated by leaning on Astro's auto-hashing. Eliminating them needs a **nonce-based** CSP — the remaining real fix, tracked on #1232.

## What changed

- `apps/web/scripts/check-csp-hash-drift.ts` — the partial guard. Now also parses the hand-pins out of `astro.config.mjs` (`handPinnedScriptHashes`) and cross-checks them: a pin absent from the served `script-src` is a hard failure (dead/typo'd config); a pin not tied to any initial-SSR script is reported **UNVERIFIED** (likely the runtime swap script) rather than silently assumed good.
- `apps/web/src/__tests__/check-csp-hash-drift.test.ts` — unit coverage for the pure helpers incl. the new `handPinnedScriptHashes` (**24 tests**).
- `.github/workflows/ci.yml` — runs the guard in `build-web`, labelled "(partial)".
- `apps/web/astro.config.mjs` — comment now states plainly that the two runtime hand-pins are **not** verified by the guard and that deleting one passes CI but breaks view transitions.

## Verification

- Self-consistent build passes:
  `[csp-drift] OK (partial) — 11 inline script(s) across 5 route(s); all 3 initial-SSR hash(es) covered by script-src.`
  `[csp-drift] NOTE — 2 hand-pinned hash(es) could not be verified … (likely the <ClientRouter> runtime swap script): sha256-dr7co1Yq…, sha256-6wgjuQN8…`
- **Tests:** `pnpm --filter @breeze/web exec vitest run src/lib/csp.test.ts src/middleware.test.ts src/__tests__/check-csp-hash-drift.test.ts` → **24 passed**.

## Remaining real fix (does NOT close #1232)

Migrate the two runtime inline-script hand-pins to a **nonce-based** CSP (per-request nonce stamped by `apps/web/src/middleware.ts` on Astro's inline scripts), which eliminates the drift class entirely. App-wide change needing cross-page browser verification — out of scope here. See the explainer comment on #1232.

Refs #1232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)