### PR TITLE
feat(timezone): partner-tz default + shared resolver (#1318 phase 1)

### DIFF
--- a/apps/api/migrations/2026-06-13-c-partner-timezone-column.sql
+++ b/apps/api/migrations/2026-06-13-c-partner-timezone-column.sql
@@ -1,0 +1,38 @@
+-- First-class partner timezone (issue #1318).
+--
+-- Today the partner timezone lives only as a free-form, unvalidated key inside
+-- the `partners.settings` JSONB blob, and nothing in the tz resolution chain
+-- ever consults it. This promotes it to a real `partners.timezone` column so it
+-- can be joined cheaply in `resolveDeviceTimezone` and constrained, while the
+-- legacy `settings.timezone` key stays the UI write target (non-destructive —
+-- we do NOT remove it here).
+--
+-- `partners` is a partner-axis tenant-scoped table that is already RLS-enabled +
+-- forced with policies, so adding a plain column needs no new RLS policy (same
+-- reasoning as 2026-06-09-users-disabled-reason.sql / 2026-06-11-j-device-
+-- pending-reboot.sql). Idempotent: ADD COLUMN IF NOT EXISTS + a NULL-guarded
+-- backfill, so re-applying is a no-op.
+
+ALTER TABLE partners
+  ADD COLUMN IF NOT EXISTS timezone varchar(64) NOT NULL DEFAULT 'UTC';
+
+-- Backfill the column from the existing JSONB key for partners that set one,
+-- but only where the column is still at its 'UTC' default (so re-running, or a
+-- later explicit column write, is never clobbered). The settings value is only
+-- copied when it is a non-empty string; invalid IANA strings are left for the
+-- application-layer resolver to skip rather than silently rewriting them here.
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  UPDATE partners
+  SET timezone = settings->>'timezone'
+  WHERE timezone = 'UTC'
+    AND settings ? 'timezone'
+    AND coalesce(settings->>'timezone', '') <> ''
+    AND settings->>'timezone' <> 'UTC';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'backfilled partners.timezone from settings.timezone for % partner(s)', n;
+  END IF;
+END $$;

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -16,6 +16,11 @@ export const partners = pgTable('partners', {
   status: partnerStatusEnum('status').notNull().default('active'),
   maxOrganizations: integer('max_organizations'),
   maxDevices: integer('max_devices'),
+  // First-class partner timezone (issue #1318). The canonical default that a tz
+  // field resolves to when no more-specific scope (explicit/site/org) is set.
+  // Kept in sync with the legacy `settings.timezone` JSONB key, which remains
+  // the UI write target until the full call-site migration lands.
+  timezone: varchar('timezone', { length: 64 }).notNull().default('UTC'),
   settings: jsonb('settings').default({}),
   ssoConfig: jsonb('sso_config'),
   billingEmail: varchar('billing_email', { length: 255 }),

--- a/apps/api/src/jobs/patchSchedulerWorker.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Unit coverage for loadDeviceSchedulingContexts' partner-timezone resolution
+// (#1318). The scheduling context is what drives which partner-local clock a
+// device's patch window is evaluated against, so the explicit -> site -> org ->
+// partner -> UTC precedence (and its fallback when the partner row is absent)
+// must hold. We mock only the `db` select chain and the side-effect-heavy
+// service imports so the real shared `resolveEffectiveTimezone` precedence runs.
+
+let mockRows: Array<Record<string, unknown>> = [];
+
+// loadDeviceSchedulingContexts query shape:
+//   from(devices).innerJoin(organizations).leftJoin(partners).leftJoin(sites)
+//     .where(inArray(devices.id, deviceIds))
+// The partners join is a LEFT join (#1318 review): under org scope the partner
+// row is RLS-invisible, and an inner join would drop the device row entirely.
+// The chain resolves to the rows array at the final .where() (no .limit()).
+vi.mock('../db', () => {
+  const where = vi.fn(() => Promise.resolve(mockRows));
+  const leftJoinSites = vi.fn(() => ({ where }));
+  const leftJoinPartners = vi.fn(() => ({ leftJoin: leftJoinSites }));
+  const innerJoinOrgs = vi.fn(() => ({ leftJoin: leftJoinPartners }));
+  const from = vi.fn(() => ({ innerJoin: innerJoinOrgs }));
+  const select = vi.fn(() => ({ from }));
+  return {
+    db: { select },
+    withSystemDbAccessContext: <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+// Thin schema stub — the worker imports many tables but the unit under test
+// only references them as opaque column handles passed to the mocked db chain.
+vi.mock('../db/schema', () => ({
+  configurationPolicies: {},
+  configPolicyFeatureLinks: {},
+  configPolicyAssignments: {},
+  patchJobs: {},
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  deviceGroupMemberships: {},
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId', settings: 'organizations.settings' },
+  partners: { id: 'partners.id', timezone: 'partners.timezone', settings: 'partners.settings' },
+  sites: { id: 'sites.id', timezone: 'sites.timezone' },
+}));
+
+// Side-effect-heavy imports the module pulls in at load time — stub so importing
+// the worker doesn't spin up Redis/BullMQ or the full resolver graph.
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../services/featureConfigResolver', () => ({ checkDeviceMaintenanceWindow: vi.fn() }));
+vi.mock('./patchJobExecutor', () => ({ enqueuePatchJob: vi.fn() }));
+vi.mock('../services/patchJobSnapshot', () => ({ buildPatchesSnapshot: vi.fn() }));
+vi.mock('../services/configPolicyPatching', () => ({
+  backfillMissingPatchSettings: vi.fn(),
+  listAllPatchInventory: vi.fn(),
+  loadPolicyLocalPatchConfig: vi.fn(),
+  summarizePatchInventory: vi.fn(),
+}));
+vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
+
+import { __testOnly } from './patchSchedulerWorker';
+
+const { loadDeviceSchedulingContexts } = __testOnly;
+
+describe('loadDeviceSchedulingContexts (#1318 partner tz)', () => {
+  beforeEach(() => {
+    mockRows = [];
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty array without querying when no device ids are given', async () => {
+    expect(await loadDeviceSchedulingContexts([])).toEqual([]);
+  });
+
+  it('applies the partner timezone column when site and org are unset (partner visible)', async () => {
+    mockRows = [
+      {
+        deviceId: 'dev-1',
+        orgId: 'org-1',
+        siteTimezone: null,
+        orgSettings: {},
+        partnerTimezone: 'Europe/London',
+        partnerSettings: {},
+      },
+    ];
+    const [ctx] = await loadDeviceSchedulingContexts(['dev-1']);
+    expect(ctx).toMatchObject({ deviceId: 'dev-1', orgId: 'org-1', timezone: 'Europe/London' });
+  });
+
+  it('reads the legacy partner settings.timezone key when the column is still default UTC', async () => {
+    mockRows = [
+      {
+        deviceId: 'dev-1',
+        orgId: 'org-1',
+        siteTimezone: null,
+        orgSettings: {},
+        partnerTimezone: 'UTC',
+        partnerSettings: { timezone: 'Asia/Tokyo' },
+      },
+    ];
+    const [ctx] = await loadDeviceSchedulingContexts(['dev-1']);
+    expect(ctx?.timezone).toBe('Asia/Tokyo');
+  });
+
+  it('prefers site over org over partner (precedence)', async () => {
+    mockRows = [
+      {
+        deviceId: 'dev-1',
+        orgId: 'org-1',
+        siteTimezone: 'America/Chicago',
+        orgSettings: { timezone: 'America/Denver' },
+        partnerTimezone: 'America/Los_Angeles',
+        partnerSettings: {},
+      },
+    ];
+    const [ctx] = await loadDeviceSchedulingContexts(['dev-1']);
+    expect(ctx?.timezone).toBe('America/Chicago');
+  });
+
+  it('falls back to the org tz when the partner row is absent (RLS-invisible left join)', async () => {
+    // Under a hypothetical org-scoped read the leftJoin yields null partner
+    // columns. The device row must survive (left, not inner join) and resolve
+    // through site -> org. An inner join would drop the device entirely.
+    mockRows = [
+      {
+        deviceId: 'dev-1',
+        orgId: 'org-1',
+        siteTimezone: null,
+        orgSettings: { timezone: 'America/Denver' },
+        partnerTimezone: null,
+        partnerSettings: null,
+      },
+    ];
+    const [ctx] = await loadDeviceSchedulingContexts(['dev-1']);
+    expect(ctx?.timezone).toBe('America/Denver');
+  });
+
+  it('falls back to UTC when nothing (incl. partner) resolves', async () => {
+    mockRows = [
+      {
+        deviceId: 'dev-1',
+        orgId: 'org-1',
+        siteTimezone: null,
+        orgSettings: {},
+        partnerTimezone: 'UTC',
+        partnerSettings: {},
+      },
+    ];
+    const [ctx] = await loadDeviceSchedulingContexts(['dev-1']);
+    expect(ctx?.timezone).toBe('UTC');
+  });
+
+  it('coerces a garbage stored tz to UTC via normalizeTimezone', async () => {
+    mockRows = [
+      {
+        deviceId: 'dev-1',
+        orgId: 'org-1',
+        siteTimezone: 'Not/AZone',
+        orgSettings: {},
+        partnerTimezone: 'UTC',
+        partnerSettings: {},
+      },
+    ];
+    const [ctx] = await loadDeviceSchedulingContexts(['dev-1']);
+    expect(ctx?.timezone).toBe('UTC');
+  });
+});

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -15,9 +15,11 @@ import {
   devices,
   deviceGroupMemberships,
   organizations,
+  partners,
   sites,
 } from '../db/schema';
 import { and, eq, gte, inArray } from 'drizzle-orm';
+import { resolveEffectiveTimezone } from '@breeze/shared';
 import { getBullMQConnection } from '../services/redis';
 import { checkDeviceMaintenanceWindow } from '../services/featureConfigResolver';
 import { enqueuePatchJob } from './patchJobExecutor';
@@ -86,6 +88,15 @@ function parseOrgTimezone(settings: unknown): string | null {
   if (!settings || typeof settings !== 'object') return null;
   const timezone = (settings as Record<string, unknown>).timezone;
   return typeof timezone === 'string' && timezone.length > 0 ? timezone : null;
+}
+
+// Partner tz with the column as source of truth and the legacy
+// `settings.timezone` JSONB key as a non-destructive fallback (issue #1318).
+function parsePartnerTimezone(column: string | null | undefined, settings: unknown): string | null {
+  if (typeof column === 'string' && column.length > 0 && column !== 'UTC') return column;
+  const fromSettings = parseOrgTimezone(settings);
+  if (fromSettings) return fromSettings;
+  return typeof column === 'string' && column.length > 0 ? column : null;
 }
 
 function normalizeTimezone(timezone: string | null | undefined): string {
@@ -233,16 +244,28 @@ async function loadDeviceSchedulingContexts(deviceIds: string[]): Promise<Device
       orgId: devices.orgId,
       siteTimezone: sites.timezone,
       orgSettings: organizations.settings,
+      partnerTimezone: partners.timezone,
+      partnerSettings: partners.settings,
     })
     .from(devices)
     .innerJoin(organizations, eq(devices.orgId, organizations.id))
+    .innerJoin(partners, eq(organizations.partnerId, partners.id))
     .leftJoin(sites, eq(devices.siteId, sites.id))
     .where(inArray(devices.id, deviceIds));
 
   return rows.map((row) => ({
     deviceId: row.deviceId,
     orgId: row.orgId,
-    timezone: normalizeTimezone(row.siteTimezone || parseOrgTimezone(row.orgSettings) || 'UTC'),
+    // explicit (n/a) -> site -> org -> partner -> UTC (issue #1318). The
+    // resolver IANA-validates each candidate, so normalizeTimezone here just
+    // guards the (already-valid) result for the older call shape.
+    timezone: normalizeTimezone(
+      resolveEffectiveTimezone({
+        siteTz: row.siteTimezone,
+        orgTz: parseOrgTimezone(row.orgSettings),
+        partnerTz: parsePartnerTimezone(row.partnerTimezone, row.partnerSettings),
+      }),
+    ),
   }));
 }
 

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -19,7 +19,7 @@ import {
   sites,
 } from '../db/schema';
 import { and, eq, gte, inArray } from 'drizzle-orm';
-import { resolveEffectiveTimezone } from '@breeze/shared';
+import { resolveEffectiveTimezone, canonicalizeTimezone } from '@breeze/shared';
 import { getBullMQConnection } from '../services/redis';
 import { checkDeviceMaintenanceWindow } from '../services/featureConfigResolver';
 import { enqueuePatchJob } from './patchJobExecutor';
@@ -92,11 +92,14 @@ function parseOrgTimezone(settings: unknown): string | null {
 
 // Partner tz with the column as source of truth and the legacy
 // `settings.timezone` JSONB key as a non-destructive fallback (issue #1318).
+// canonicalizeTimezone folds a non-canonical stored 'utc' to the 'UTC' sentinel
+// so it is treated as "still at the default" rather than an explicit choice.
 function parsePartnerTimezone(column: string | null | undefined, settings: unknown): string | null {
-  if (typeof column === 'string' && column.length > 0 && column !== 'UTC') return column;
+  const canonicalColumn = canonicalizeTimezone(column);
+  if (canonicalColumn !== null && canonicalColumn !== 'UTC') return canonicalColumn;
   const fromSettings = parseOrgTimezone(settings);
   if (fromSettings) return fromSettings;
-  return typeof column === 'string' && column.length > 0 ? column : null;
+  return canonicalColumn;
 }
 
 function normalizeTimezone(timezone: string | null | undefined): string {
@@ -259,6 +262,13 @@ async function loadDeviceSchedulingContexts(deviceIds: string[]): Promise<Device
     // explicit (n/a) -> site -> org -> partner -> UTC (issue #1318). The
     // resolver IANA-validates each candidate, so normalizeTimezone here just
     // guards the (already-valid) result for the older call shape.
+    //
+    // BEHAVIORAL CHANGE (intended): adding the `partner` branch means an
+    // existing device under a partner that has set a non-UTC tz now has its
+    // patch window evaluated in partner-LOCAL time instead of UTC — so its
+    // scheduled patch occurrence effectively shifts on upgrade. This is the
+    // explicit intent of #1318 (partner tz is the default), not a regression.
+    // Partners left at the 'UTC' default are unaffected.
     timezone: normalizeTimezone(
       resolveEffectiveTimezone({
         siteTz: row.siteTimezone,

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -252,7 +252,14 @@ async function loadDeviceSchedulingContexts(deviceIds: string[]): Promise<Device
     })
     .from(devices)
     .innerJoin(organizations, eq(devices.orgId, organizations.id))
-    .innerJoin(partners, eq(organizations.partnerId, partners.id))
+    // leftJoin (not inner) on partners: the partners SELECT RLS policy is
+    // breeze_has_partner_access(id), which is FALSE for an org-scoped request,
+    // so an inner join would drop the entire device row when the partner row is
+    // RLS-invisible. This worker runs under system scope (partners visible), but
+    // a left join is the correct, defensive shape: if the partner row is ever
+    // invisible the device still gets a context, with partnerTimezone null so
+    // resolveEffectiveTimezone falls through site -> org -> UTC (#1318).
+    .leftJoin(partners, eq(organizations.partnerId, partners.id))
     .leftJoin(sites, eq(devices.siteId, sites.id))
     .where(inArray(devices.id, deviceIds));
 
@@ -532,3 +539,9 @@ export async function shutdownPatchSchedulerWorker(): Promise<void> {
     schedulerQueue = null;
   }
 }
+
+// Exported for unit tests of the partner-tz scheduling-context resolution
+// (#1318). Internal helper, not part of the worker's public surface.
+export const __testOnly = {
+  loadDeviceSchedulingContexts,
+};

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -418,6 +418,42 @@ describe('org routes', () => {
       expect(capturedUpdateData.timezone).toBe('UTC');
     });
 
+    // #1318: updatePartnerSchema uses `settings: z.any()`, so an invalid IANA
+    // settings.timezone is NOT caught by zod here (unlike /partners/me). It must
+    // be rejected with a 400 rather than silently persisted into the JSONB while
+    // the column write is skipped — that is the column<->settings desync this PR
+    // exists to prevent.
+    it('rejects an invalid IANA settings.timezone on a system-scope write (no JSONB desync)', async () => {
+      const currentPartner = { id: 'partner-1', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
+            limit: vi.fn().mockResolvedValue([currentPartner])
+          })
+        })
+      } as any);
+
+      const setSpy = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([currentPartner])
+        })
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+      const res = await app.request('/orgs/partners/partner-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { timezone: 'Mars/Olympus_Mons' } })
+      });
+
+      expect(res.status).toBe(400);
+      // The garbage tz must never reach the DB: no update should be issued.
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
     it('revokes tenant access (including the agent fleet) when a partner is suspended', async () => {
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1923,6 +1923,57 @@ describe('org routes', () => {
       expect(capturedUpdateData.settings.notifications).toEqual({ emailEnabled: true });
     });
 
+    // #1318: a valid tz in settings is mirrored to the first-class
+    // `partners.timezone` column so resolveEffectiveTimezone can read it.
+    it('mirrors settings.timezone into the partners.timezone column', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
+            limit: vi.fn().mockResolvedValue([currentPartner])
+          })
+        })
+      } as any);
+
+      let capturedUpdateData: any;
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockImplementation((data: any) => {
+          capturedUpdateData = data;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ ...currentPartner, settings: data.settings }])
+            })
+          };
+        })
+      } as any);
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { timezone: 'America/New_York' } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(capturedUpdateData.timezone).toBe('America/New_York');
+      expect(capturedUpdateData.settings.timezone).toBe('America/New_York');
+    });
+
+    it('rejects an invalid IANA timezone in partner settings', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { timezone: 'Mars/Olympus_Mons' } })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
     it('accepts a fully populated address in settings', async () => {
       setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
       const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: {} };

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -341,6 +341,83 @@ describe('org routes', () => {
       expect(body.name).toBe('Updated');
     });
 
+    // #1318: a system-scoped wholesale settings write must mirror
+    // settings.timezone into the first-class `partners.timezone` column the same
+    // way PATCH /partners/me does, or resolveEffectiveTimezone (which reads the
+    // column first) would silently desync.
+    it('mirrors settings.timezone into the partners.timezone column on a system-scope write', async () => {
+      const currentPartner = { id: 'partner-1', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
+            limit: vi.fn().mockResolvedValue([currentPartner])
+          })
+        })
+      } as any);
+
+      let capturedUpdateData: any;
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockImplementation((data: any) => {
+          capturedUpdateData = data;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ ...currentPartner, settings: data.settings }])
+            })
+          };
+        })
+      } as any);
+
+      const res = await app.request('/orgs/partners/partner-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { timezone: 'America/New_York' } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(capturedUpdateData.timezone).toBe('America/New_York');
+      expect(capturedUpdateData.settings.timezone).toBe('America/New_York');
+    });
+
+    // #1318 cosmetic: a lowercase 'utc' settings value canonicalizes to the
+    // 'UTC' sentinel so the column never holds a non-canonical default.
+    it('canonicalizes a lowercase utc settings tz to the UTC sentinel in the column', async () => {
+      const currentPartner = { id: 'partner-1', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
+            limit: vi.fn().mockResolvedValue([currentPartner])
+          })
+        })
+      } as any);
+
+      let capturedUpdateData: any;
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockImplementation((data: any) => {
+          capturedUpdateData = data;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ ...currentPartner, settings: data.settings }])
+            })
+          };
+        })
+      } as any);
+
+      const res = await app.request('/orgs/partners/partner-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { timezone: 'utc' } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(capturedUpdateData.timezone).toBe('UTC');
+    });
+
     it('revokes tenant access (including the agent fleet) when a partner is suspended', async () => {
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -20,7 +20,7 @@ import {
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
-import { isAllowedLauncherScheme } from '@breeze/shared';
+import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone } from '@breeze/shared';
 import type { IpAllowlistStatus } from '@breeze/shared';
 import { isValidIpOrCidr } from '../services/ipMatch';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
@@ -120,18 +120,8 @@ const listSitesSchema = z.object({
   limit: z.string().optional()
 });
 
-// Intl.supportedValuesOf('timeZone') omits UTC, GMT, and the Etc/* zones, so
-// a Set-membership check against that list rejects 'UTC' (the default).
-// Constructing Intl.DateTimeFormat throws RangeError on unknown zones and
-// accepts everything Intl recognizes, including those omissions.
-function isValidIanaTimezone(tz: string): boolean {
-  try {
-    new Intl.DateTimeFormat('en-US', { timeZone: tz });
-    return true;
-  } catch {
-    return false;
-  }
-}
+// IANA timezone validation lives in @breeze/shared (`isValidIanaTimezone`) so
+// the API route, workers, and web all share one implementation (issue #1318).
 
 // Stored as-is into a JSONB column; `.passthrough()` keeps unknown keys for
 // forward compatibility. Email format is policed when present so downstream
@@ -542,9 +532,13 @@ orgRoutes.patch('/partners/me', requireScope('partner'), requirePartner, require
   // Keep the first-class `partners.timezone` column in sync with the legacy
   // `settings.timezone` JSONB key the UI writes (issue #1318). The column is the
   // source of truth for `resolveEffectiveTimezone`; the validator above already
-  // guarantees a valid IANA zone here.
+  // guarantees a valid IANA zone here, and canonicalizeTimezone folds any UTC
+  // casing ('utc' -> 'UTC') so the sentinel comparison in the resolver holds.
   if (typeof body.settings?.timezone === 'string' && body.settings.timezone.length > 0) {
-    updateData.timezone = body.settings.timezone;
+    const canonicalTz = canonicalizeTimezone(body.settings.timezone);
+    if (canonicalTz !== null) {
+      updateData.timezone = canonicalTz;
+    }
   }
 
   const [partner] = await db
@@ -619,6 +613,20 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
           currentPartner.settings,
           updates.settings as Record<string, unknown>,
         );
+      }
+
+      // Keep the first-class `partners.timezone` column in sync with the
+      // settings.timezone JSONB key on this system-scoped wholesale write — the
+      // same mirroring PATCH /partners/me does (issue #1318). Without this, a
+      // platform-admin settings write would update the JSONB key but leave the
+      // column stale, and resolveEffectiveTimezone reads the column first, so
+      // the partner-tz default would silently desync. canonicalizeTimezone
+      // folds 'utc' -> 'UTC' and rejects garbage (returns null -> skip).
+      // Read the value BEFORE encryption (settings is plaintext here).
+      const rawTz = (updates.settings as Record<string, unknown>).timezone;
+      const canonicalTz = canonicalizeTimezone(rawTz);
+      if (canonicalTz !== null) {
+        updates.timezone = canonicalTz;
       }
     }
     // Encrypt secret-bearing fields in partners.settings before writing.

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -620,12 +620,27 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
       // same mirroring PATCH /partners/me does (issue #1318). Without this, a
       // platform-admin settings write would update the JSONB key but leave the
       // column stale, and resolveEffectiveTimezone reads the column first, so
-      // the partner-tz default would silently desync. canonicalizeTimezone
-      // folds 'utc' -> 'UTC' and rejects garbage (returns null -> skip).
+      // the partner-tz default would silently desync.
+      //
+      // updatePartnerSchema uses `settings: z.any()`, so unlike /partners/me
+      // there is no zod IANA refine here. Validate the tz on the system path
+      // too: an invalid value (e.g. 'Mars/Olympus_Mons') must be REJECTED, not
+      // silently dropped — otherwise canonicalizeTimezone(null) skips the column
+      // write while the garbage persists in the JSONB, the exact column<->
+      // settings desync #1318 exists to prevent. canonicalizeTimezone folds any
+      // UTC casing ('utc' -> 'UTC') and returns null for a non-IANA value.
       // Read the value BEFORE encryption (settings is plaintext here).
-      const rawTz = (updates.settings as Record<string, unknown>).timezone;
-      const canonicalTz = canonicalizeTimezone(rawTz);
-      if (canonicalTz !== null) {
+      const settingsObj = updates.settings as Record<string, unknown>;
+      const rawTz = settingsObj.timezone;
+      if (rawTz !== undefined && rawTz !== null) {
+        const canonicalTz = canonicalizeTimezone(rawTz);
+        if (canonicalTz === null) {
+          return c.json({ error: 'Invalid IANA timezone in settings.timezone' }, 400);
+        }
+        // Write the canonical form back into settings so the JSONB and the
+        // column hold the identical value (e.g. 'utc' is normalized to 'UTC' in
+        // both places, never one casing in JSONB and another in the column).
+        settingsObj.timezone = canonicalTz;
         updates.timezone = canonicalTz;
       }
     }

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -307,7 +307,9 @@ const dayScheduleSchema = z.object({
 });
 
 const partnerSettingsSchema = z.object({
-  timezone: z.string().optional(),
+  // Partner tz is the canonical default for every downstream tz field (#1318),
+  // so police it as a real IANA zone on write (was previously unvalidated).
+  timezone: z.string().refine(isValidIanaTimezone, 'Invalid IANA timezone').optional(),
   dateFormat: z.enum(['MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY-MM-DD']).optional(),
   timeFormat: z.enum(['12h', '24h']).optional(),
   language: z.literal('en').optional(),
@@ -536,6 +538,14 @@ orgRoutes.patch('/partners/me', requireScope('partner'), requirePartner, require
 
   if (body.name) updateData.name = body.name;
   if (body.billingEmail) updateData.billingEmail = body.billingEmail;
+
+  // Keep the first-class `partners.timezone` column in sync with the legacy
+  // `settings.timezone` JSONB key the UI writes (issue #1318). The column is the
+  // source of truth for `resolveEffectiveTimezone`; the validator above already
+  // guarantees a valid IANA zone here.
+  if (typeof body.settings?.timezone === 'string' && body.settings.timezone.length > 0) {
+    updateData.timezone = body.settings.timezone;
+  }
 
   const [partner] = await db
     .update(partners)

--- a/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
+++ b/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
@@ -108,6 +108,12 @@ vi.mock('../db/schema', () => ({
     partnerId: 'organizations.partnerId',
     settings: 'organizations.settings',
   },
+  // resolveDeviceTimezone joins partners for the #1318 partner-tz fallback.
+  partners: {
+    id: 'partners.id',
+    timezone: 'partners.timezone',
+    settings: 'partners.settings',
+  },
   deviceGroupMemberships: {
     deviceId: 'deviceGroupMemberships.deviceId',
     groupId: 'deviceGroupMemberships.groupId',

--- a/apps/api/src/services/featureConfigResolver.timezone.test.ts
+++ b/apps/api/src/services/featureConfigResolver.timezone.test.ts
@@ -6,13 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mockRow: Record<string, unknown> | undefined;
 
+// Join chain mirrors resolveDeviceTimezone's query exactly:
+//   from(devices).innerJoin(organizations).leftJoin(partners).leftJoin(sites)
+//     .where(...).limit(1)
+// The partners join is a LEFT join (#1318 review) so an RLS-invisible partner
+// row under org scope leaves the device row intact instead of dropping it.
 vi.mock('../db', () => {
   const limit = vi.fn(() => Promise.resolve(mockRow ? [mockRow] : []));
   const where = vi.fn(() => ({ limit }));
-  const leftJoin = vi.fn(() => ({ where }));
-  const innerJoin2 = vi.fn(() => ({ leftJoin }));
-  const innerJoin1 = vi.fn(() => ({ innerJoin: innerJoin2 }));
-  const from = vi.fn(() => ({ innerJoin: innerJoin1 }));
+  const leftJoinSites = vi.fn(() => ({ where }));
+  const leftJoinPartners = vi.fn(() => ({ leftJoin: leftJoinSites }));
+  const innerJoinOrgs = vi.fn(() => ({ leftJoin: leftJoinPartners }));
+  const from = vi.fn(() => ({ innerJoin: innerJoinOrgs }));
   const select = vi.fn(() => ({ from }));
   return { db: { select } };
 });
@@ -96,6 +101,30 @@ describe('resolveDeviceTimezone (#1318 partner fallback)', () => {
       partnerSettings: { timezone: 'Asia/Tokyo' },
     };
     expect(await resolveDeviceTimezone('dev-1')).toBe('Asia/Tokyo');
+  });
+
+  it('org-scoped (partner RLS-invisible): still resolves the org tz, not UTC', async () => {
+    // Under an org-scoped request the partners SELECT policy is false, so the
+    // leftJoin yields null partner columns. The device row must survive (left
+    // join, not inner) and resolve through site -> org. An inner join here would
+    // drop the row entirely and regress to 'UTC'.
+    mockRow = {
+      siteTimezone: null,
+      orgSettings: { timezone: 'America/Denver' },
+      partnerTimezone: null,
+      partnerSettings: null,
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('America/Denver');
+  });
+
+  it('org-scoped (partner RLS-invisible): still resolves the site tz, not UTC', async () => {
+    mockRow = {
+      siteTimezone: 'America/Chicago',
+      orgSettings: {},
+      partnerTimezone: null,
+      partnerSettings: null,
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('America/Chicago');
   });
 
   it('returns UTC as the last resort when nothing resolves', async () => {

--- a/apps/api/src/services/featureConfigResolver.timezone.test.ts
+++ b/apps/api/src/services/featureConfigResolver.timezone.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// resolveDeviceTimezone (#1318) must consult the partner timezone, falling
+// through explicit -> site -> org -> partner -> UTC. We mock only the `db`
+// select chain so the real shared `resolveEffectiveTimezone` precedence runs.
+
+let mockRow: Record<string, unknown> | undefined;
+
+vi.mock('../db', () => {
+  const limit = vi.fn(() => Promise.resolve(mockRow ? [mockRow] : []));
+  const where = vi.fn(() => ({ limit }));
+  const leftJoin = vi.fn(() => ({ where }));
+  const innerJoin2 = vi.fn(() => ({ leftJoin }));
+  const innerJoin1 = vi.fn(() => ({ innerJoin: innerJoin2 }));
+  const from = vi.fn(() => ({ innerJoin: innerJoin1 }));
+  const select = vi.fn(() => ({ from }));
+  return { db: { select } };
+});
+
+// The resolver imports many schema tables; a thin stub keeps the module load
+// cheap without pulling the full Drizzle schema graph into the test.
+vi.mock('../db/schema', () => ({
+  configurationPolicies: {},
+  configPolicyFeatureLinks: {},
+  configPolicyAssignments: {},
+  configPolicyAlertRules: {},
+  configPolicyAutomations: {},
+  configPolicyComplianceRules: {},
+  configPolicyPatchSettings: {},
+  configPolicyMaintenanceSettings: {},
+  configPolicyBackupSettings: {},
+  configPolicySensitiveDataSettings: {},
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId', settings: 'organizations.settings' },
+  partners: { id: 'partners.id', timezone: 'partners.timezone', settings: 'partners.settings' },
+  deviceGroupMemberships: {},
+  sites: { id: 'sites.id', timezone: 'sites.timezone' },
+  softwarePolicies: {},
+}));
+
+import { resolveDeviceTimezone } from './featureConfigResolver';
+
+describe('resolveDeviceTimezone (#1318 partner fallback)', () => {
+  beforeEach(() => {
+    mockRow = undefined;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prefers the site timezone when set', async () => {
+    mockRow = {
+      siteTimezone: 'America/Chicago',
+      orgSettings: { timezone: 'America/Denver' },
+      partnerTimezone: 'America/Los_Angeles',
+      partnerSettings: {},
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('America/Chicago');
+  });
+
+  it('falls back to the org timezone when site is unset', async () => {
+    mockRow = {
+      siteTimezone: null,
+      orgSettings: { timezone: 'America/Denver' },
+      partnerTimezone: 'America/Los_Angeles',
+      partnerSettings: {},
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('America/Denver');
+  });
+
+  it('falls back to the partner column when site and org are unset', async () => {
+    mockRow = {
+      siteTimezone: null,
+      orgSettings: {},
+      partnerTimezone: 'Europe/London',
+      partnerSettings: {},
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('Europe/London');
+  });
+
+  it('reads the legacy partner settings.timezone key when the column is still default UTC', async () => {
+    mockRow = {
+      siteTimezone: null,
+      orgSettings: {},
+      partnerTimezone: 'UTC',
+      partnerSettings: { timezone: 'Asia/Tokyo' },
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('Asia/Tokyo');
+  });
+
+  it('returns UTC as the last resort when nothing resolves', async () => {
+    mockRow = {
+      siteTimezone: null,
+      orgSettings: {},
+      partnerTimezone: 'UTC',
+      partnerSettings: {},
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('UTC');
+  });
+
+  it('returns UTC when the device row is missing', async () => {
+    mockRow = undefined;
+    expect(await resolveDeviceTimezone('missing')).toBe('UTC');
+  });
+});

--- a/apps/api/src/services/featureConfigResolver.timezone.test.ts
+++ b/apps/api/src/services/featureConfigResolver.timezone.test.ts
@@ -88,6 +88,16 @@ describe('resolveDeviceTimezone (#1318 partner fallback)', () => {
     expect(await resolveDeviceTimezone('dev-1')).toBe('Asia/Tokyo');
   });
 
+  it('treats a non-canonical lowercase utc column as the default and consults the legacy settings key', async () => {
+    mockRow = {
+      siteTimezone: null,
+      orgSettings: {},
+      partnerTimezone: 'utc',
+      partnerSettings: { timezone: 'Asia/Tokyo' },
+    };
+    expect(await resolveDeviceTimezone('dev-1')).toBe('Asia/Tokyo');
+  });
+
   it('returns UTC as the last resort when nothing resolves', async () => {
     mockRow = {
       siteTimezone: null,

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -384,7 +384,17 @@ export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
     })
     .from(devices)
     .innerJoin(organizations, eq(devices.orgId, organizations.id))
-    .innerJoin(partners, eq(organizations.partnerId, partners.id))
+    // leftJoin (not inner) on partners: the partners SELECT RLS policy is
+    // breeze_has_partner_access(id), which is FALSE for an ORG-scoped request
+    // (computeAccessiblePartnerIds returns [] for org scope). An inner join
+    // would make the partner row RLS-invisible and drop the ENTIRE device row,
+    // sending resolveDeviceTimezone down its missing-row branch -> 'UTC', a
+    // regression of the prior site->org->UTC behavior. With a left join the
+    // device row survives, partnerTimezone is simply null, and
+    // resolveEffectiveTimezone falls through site -> org -> UTC. For
+    // system/partner-scoped requests the partner row is visible and contributes
+    // to the chain as intended (#1318).
+    .leftJoin(partners, eq(organizations.partnerId, partners.id))
     .leftJoin(sites, eq(devices.siteId, sites.id))
     .where(eq(devices.id, deviceId))
     .limit(1);

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -11,11 +11,13 @@ import {
   configPolicyBackupSettings,
   devices,
   organizations,
+  partners,
   deviceGroupMemberships,
   sites,
   softwarePolicies,
 } from '../db/schema';
 import { and, eq, sql, inArray, asc, SQL } from 'drizzle-orm';
+import { resolveEffectiveTimezone } from '@breeze/shared';
 import type { AuthContext } from '../middleware/auth';
 import type { TokenPayload } from './jwt';
 
@@ -345,14 +347,40 @@ export interface ResolvedPatchConfigDetails {
   resolvedTimezone: string;
 }
 
+// Reads the partner timezone with the column as the source of truth and the
+// legacy `settings.timezone` JSONB key as a non-destructive fallback (the column
+// is backfilled from that key but the UI still writes the key today — see
+// issue #1318 / migration 2026-06-13-c).
+function partnerTimezoneFrom(
+  column: string | null | undefined,
+  settings: unknown,
+): string | null {
+  if (typeof column === 'string' && column.length > 0 && column !== 'UTC') {
+    return column;
+  }
+  const fromSettings =
+    settings && typeof settings === 'object'
+      ? (settings as Record<string, unknown>).timezone
+      : null;
+  if (typeof fromSettings === 'string' && fromSettings.length > 0) {
+    return fromSettings;
+  }
+  // Column defaults to 'UTC'; surface it so the resolver can use it as a
+  // genuine (if last-resort) candidate rather than treating it as unset.
+  return typeof column === 'string' && column.length > 0 ? column : null;
+}
+
 export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
   const [row] = await db
     .select({
-      timezone: sites.timezone,
+      siteTimezone: sites.timezone,
       orgSettings: organizations.settings,
+      partnerTimezone: partners.timezone,
+      partnerSettings: partners.settings,
     })
     .from(devices)
     .innerJoin(organizations, eq(devices.orgId, organizations.id))
+    .innerJoin(partners, eq(organizations.partnerId, partners.id))
     .leftJoin(sites, eq(devices.siteId, sites.id))
     .where(eq(devices.id, deviceId))
     .limit(1);
@@ -362,7 +390,12 @@ export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
       ? (row.orgSettings as Record<string, unknown>).timezone
       : null;
 
-  return row?.timezone || (typeof orgTimezone === 'string' && orgTimezone.length > 0 ? orgTimezone : 'UTC');
+  // explicit (n/a for a device — devices have no own tz) -> site -> org -> partner -> UTC
+  return resolveEffectiveTimezone({
+    siteTz: row?.siteTimezone,
+    orgTz: typeof orgTimezone === 'string' ? orgTimezone : null,
+    partnerTz: partnerTimezoneFrom(row?.partnerTimezone, row?.partnerSettings),
+  });
 }
 
 export async function resolvePatchConfigDetailsForDevice(

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -17,7 +17,7 @@ import {
   softwarePolicies,
 } from '../db/schema';
 import { and, eq, sql, inArray, asc, SQL } from 'drizzle-orm';
-import { resolveEffectiveTimezone } from '@breeze/shared';
+import { resolveEffectiveTimezone, canonicalizeTimezone } from '@breeze/shared';
 import type { AuthContext } from '../middleware/auth';
 import type { TokenPayload } from './jwt';
 
@@ -355,8 +355,12 @@ function partnerTimezoneFrom(
   column: string | null | undefined,
   settings: unknown,
 ): string | null {
-  if (typeof column === 'string' && column.length > 0 && column !== 'UTC') {
-    return column;
+  // Canonicalize the column so a non-canonical stored 'utc' (e.g. a row that
+  // predates the canonicalize-on-write fix) folds to the 'UTC' sentinel and is
+  // correctly treated as "still at the default" rather than an explicit choice.
+  const canonicalColumn = canonicalizeTimezone(column);
+  if (canonicalColumn !== null && canonicalColumn !== 'UTC') {
+    return canonicalColumn;
   }
   const fromSettings =
     settings && typeof settings === 'object'
@@ -367,7 +371,7 @@ function partnerTimezoneFrom(
   }
   // Column defaults to 'UTC'; surface it so the resolver can use it as a
   // genuine (if last-resort) candidate rather than treating it as unset.
-  return typeof column === 'string' && column.length > 0 ? column : null;
+  return canonicalColumn;
 }
 
 export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
@@ -391,6 +395,16 @@ export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
       : null;
 
   // explicit (n/a for a device — devices have no own tz) -> site -> org -> partner -> UTC
+  //
+  // BEHAVIORAL CHANGE (issue #1318, intended): the historical chain stopped at
+  // site -> org -> UTC with no partner branch, so any device whose site/org had
+  // no tz resolved to UTC. Inserting `partner` between org and the UTC floor
+  // means an existing device under a partner that has set a non-UTC
+  // `partners.timezone` now resolves patch/backup/maintenance schedules in
+  // partner-LOCAL time instead of UTC. Patch/maintenance windows for those
+  // devices effectively shift on upgrade — this is the explicit intent of
+  // #1318 (default to the partner tz), NOT a regression. Partners left at the
+  // 'UTC' default are unaffected (UTC stays the resolved value).
   return resolveEffectiveTimezone({
     siteTz: row?.siteTimezone,
     orgTz: typeof orgTimezone === 'string' ? orgTimezone : null,

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -45,6 +45,8 @@ type Partner = {
   slug: string;
   type: string;
   plan: string;
+  // First-class partner timezone column (#1318); the canonical tz default.
+  timezone?: string;
   settings: PartnerSettings;
   createdAt: string;
 };
@@ -154,7 +156,9 @@ export default function PartnerSettingsPage() {
       setCompanyName(data.name || '');
 
       const settings = data.settings || {};
-      setTimezone(settings.timezone || 'UTC');
+      // Prefer the legacy JSONB key the UI has always written, then the new
+      // first-class `partners.timezone` column (#1318), then UTC.
+      setTimezone(settings.timezone || data.timezone || 'UTC');
       setDateFormat(settings.dateFormat || 'MM/DD/YYYY');
       setTimeFormat(settings.timeFormat || '12h');
       setBusinessHoursPreset(settings.businessHours?.preset || 'business');

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -21,6 +21,8 @@ export interface Partner {
   plan: PlanType;
   maxOrganizations: number | null;
   maxDevices: number | null;
+  /** First-class partner timezone (#1318); canonical tz default. */
+  timezone?: string;
   settings: Record<string, unknown>;
   ssoConfig: Record<string, unknown> | null;
   billingEmail: string;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './formatBytes';
 export * from './docsMapping';
 export * from './semverCompare';
+export * from './timezone';

--- a/packages/shared/src/utils/timezone.test.ts
+++ b/packages/shared/src/utils/timezone.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isValidIanaTimezone,
+  normalizeTimezone,
+  resolveEffectiveTimezone,
+  UTC_TIMEZONE,
+} from './timezone';
+
+describe('isValidIanaTimezone', () => {
+  it('accepts UTC, GMT, and Etc/* zones that Intl.supportedValuesOf omits', () => {
+    expect(isValidIanaTimezone('UTC')).toBe(true);
+    expect(isValidIanaTimezone('GMT')).toBe(true);
+    expect(isValidIanaTimezone('Etc/UTC')).toBe(true);
+    expect(isValidIanaTimezone('Etc/GMT+5')).toBe(true);
+  });
+
+  it('accepts canonical region zones', () => {
+    expect(isValidIanaTimezone('America/New_York')).toBe(true);
+    expect(isValidIanaTimezone('Europe/London')).toBe(true);
+    expect(isValidIanaTimezone('Australia/Sydney')).toBe(true);
+  });
+
+  it('rejects unknown, empty, and non-string values', () => {
+    expect(isValidIanaTimezone('Not/AZone')).toBe(false);
+    expect(isValidIanaTimezone('')).toBe(false);
+    expect(isValidIanaTimezone(undefined)).toBe(false);
+    expect(isValidIanaTimezone(null)).toBe(false);
+    expect(isValidIanaTimezone(42)).toBe(false);
+  });
+});
+
+describe('normalizeTimezone', () => {
+  it('returns the value when valid', () => {
+    expect(normalizeTimezone('America/Chicago')).toBe('America/Chicago');
+  });
+
+  it('falls back to UTC for invalid values', () => {
+    expect(normalizeTimezone('garbage')).toBe('UTC');
+    expect(normalizeTimezone('')).toBe('UTC');
+    expect(normalizeTimezone(null)).toBe('UTC');
+    expect(normalizeTimezone(undefined)).toBe('UTC');
+  });
+
+  it('honors a custom fallback when the primary is invalid', () => {
+    expect(normalizeTimezone(null, 'Europe/Berlin')).toBe('Europe/Berlin');
+  });
+
+  it('ignores an invalid custom fallback and uses UTC', () => {
+    expect(normalizeTimezone(null, 'not-a-zone')).toBe('UTC');
+  });
+});
+
+describe('resolveEffectiveTimezone', () => {
+  it('prefers an explicit value over every scope', () => {
+    expect(
+      resolveEffectiveTimezone({
+        explicit: 'America/New_York',
+        siteTz: 'America/Chicago',
+        orgTz: 'America/Denver',
+        partnerTz: 'America/Los_Angeles',
+      }),
+    ).toBe('America/New_York');
+  });
+
+  it('falls through explicit -> site -> org -> partner in order', () => {
+    expect(
+      resolveEffectiveTimezone({
+        siteTz: 'America/Chicago',
+        orgTz: 'America/Denver',
+        partnerTz: 'America/Los_Angeles',
+      }),
+    ).toBe('America/Chicago');
+
+    expect(
+      resolveEffectiveTimezone({
+        orgTz: 'America/Denver',
+        partnerTz: 'America/Los_Angeles',
+      }),
+    ).toBe('America/Denver');
+
+    expect(
+      resolveEffectiveTimezone({
+        partnerTz: 'America/Los_Angeles',
+      }),
+    ).toBe('America/Los_Angeles');
+  });
+
+  it('falls back to the partner tz when site and org are unset (issue #1318 core)', () => {
+    expect(
+      resolveEffectiveTimezone({
+        explicit: null,
+        siteTz: null,
+        orgTz: null,
+        partnerTz: 'Europe/London',
+      }),
+    ).toBe('Europe/London');
+  });
+
+  it('skips invalid candidates rather than short-circuiting to UTC', () => {
+    expect(
+      resolveEffectiveTimezone({
+        explicit: 'garbage',
+        siteTz: '',
+        orgTz: 'also-bad',
+        partnerTz: 'Asia/Tokyo',
+      }),
+    ).toBe('Asia/Tokyo');
+  });
+
+  it('returns UTC as the last resort when nothing resolves', () => {
+    expect(resolveEffectiveTimezone({})).toBe(UTC_TIMEZONE);
+    expect(
+      resolveEffectiveTimezone({
+        explicit: null,
+        siteTz: undefined,
+        orgTz: '',
+        partnerTz: 'nope',
+      }),
+    ).toBe('UTC');
+  });
+});

--- a/packages/shared/src/utils/timezone.test.ts
+++ b/packages/shared/src/utils/timezone.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canonicalizeTimezone,
   isValidIanaTimezone,
   normalizeTimezone,
   resolveEffectiveTimezone,
@@ -47,6 +48,27 @@ describe('normalizeTimezone', () => {
 
   it('ignores an invalid custom fallback and uses UTC', () => {
     expect(normalizeTimezone(null, 'not-a-zone')).toBe('UTC');
+  });
+});
+
+describe('canonicalizeTimezone', () => {
+  it('folds every casing of the UTC sentinel to the canonical "UTC"', () => {
+    expect(canonicalizeTimezone('utc')).toBe('UTC');
+    expect(canonicalizeTimezone('Utc')).toBe('UTC');
+    expect(canonicalizeTimezone('UTC')).toBe('UTC');
+  });
+
+  it('preserves canonical casing for region zones', () => {
+    expect(canonicalizeTimezone('America/New_York')).toBe('America/New_York');
+    expect(canonicalizeTimezone('Europe/London')).toBe('Europe/London');
+  });
+
+  it('returns null for invalid or non-string values', () => {
+    expect(canonicalizeTimezone('garbage')).toBeNull();
+    expect(canonicalizeTimezone('')).toBeNull();
+    expect(canonicalizeTimezone(null)).toBeNull();
+    expect(canonicalizeTimezone(undefined)).toBeNull();
+    expect(canonicalizeTimezone(42)).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/timezone.ts
+++ b/packages/shared/src/utils/timezone.ts
@@ -40,6 +40,19 @@ export function normalizeTimezone(
   return isValidIanaTimezone(fallback) ? fallback : UTC_TIMEZONE;
 }
 
+// Canonicalize a tz string on write. Intl treats UTC case-insensitively, so a
+// caller can persist 'utc' / 'Utc' — but the 'UTC' sentinel logic elsewhere
+// (e.g. `partnerTimezoneFrom`, which uses `column !== 'UTC'` to tell "still at
+// the default" from "explicitly set") does an exact string compare and would
+// mistake a stored 'utc' for a real, non-default candidate. Fold every casing
+// of the UTC sentinel back to the canonical 'UTC' so that comparison holds.
+// Returns null for a value that is not a valid IANA zone, so callers can reject
+// or skip it rather than persisting garbage.
+export function canonicalizeTimezone(tz: unknown): string | null {
+  if (!isValidIanaTimezone(tz)) return null;
+  return tz.toUpperCase() === UTC_TIMEZONE ? UTC_TIMEZONE : tz;
+}
+
 export interface EffectiveTimezoneInput {
   /** A tz explicitly stored on the entity (maintenance window, automation, …). */
   explicit?: string | null;

--- a/packages/shared/src/utils/timezone.ts
+++ b/packages/shared/src/utils/timezone.ts
@@ -1,0 +1,67 @@
+// Canonical timezone helpers shared by the API, workers, and web.
+//
+// Background (issue #1318): timezone (IANA tz string) fields are scattered
+// across many features and each one previously defaulted independently —
+// almost always to a hardcoded 'UTC'. This module centralizes two concerns:
+//
+//   1. IANA validation — the duplicated `Intl.DateTimeFormat` try/catch that
+//      lived in orgs.ts, discovery.ts, backup/helpers.ts, discoveryWorker.ts,
+//      and patchSchedulerWorker.ts.
+//   2. Default resolution order — explicit -> site -> org -> partner -> UTC,
+//      so the *partner* timezone becomes the base default instead of UTC.
+//
+// DST is handled correctly anywhere `Intl.DateTimeFormat` is used; never do
+// manual offset math against these strings.
+
+export const UTC_TIMEZONE = 'UTC';
+
+// `Intl.supportedValuesOf('timeZone')` omits UTC, GMT, and the Etc/* zones, so
+// a Set-membership check against that list would reject 'UTC' (the default).
+// Constructing `Intl.DateTimeFormat` throws RangeError on unknown zones and
+// accepts everything Intl recognizes, including those omissions.
+export function isValidIanaTimezone(tz: unknown): tz is string {
+  if (typeof tz !== 'string' || tz.length === 0) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Returns `tz` when it is a valid IANA zone, otherwise `fallback`. Use this to
+// replace the scattered `tz || 'UTC'` / `tz ?? 'UTC'` fallbacks so an invalid
+// stored value can never reach `Intl.DateTimeFormat` and throw at format time.
+export function normalizeTimezone(
+  tz: unknown,
+  fallback: string = UTC_TIMEZONE,
+): string {
+  if (isValidIanaTimezone(tz)) return tz;
+  return isValidIanaTimezone(fallback) ? fallback : UTC_TIMEZONE;
+}
+
+export interface EffectiveTimezoneInput {
+  /** A tz explicitly stored on the entity (maintenance window, automation, …). */
+  explicit?: string | null;
+  /** The device's site timezone (`sites.timezone`). */
+  siteTz?: string | null;
+  /** The organization timezone (today: `organizations.settings.timezone`). */
+  orgTz?: string | null;
+  /** The partner timezone (`partners.timezone`, falling back to its settings key). */
+  partnerTz?: string | null;
+}
+
+// Resolution order: explicit -> site -> org -> partner -> UTC.
+//
+// The change from the historical behavior (which stopped at site -> org -> UTC)
+// is inserting the partner timezone between org and the 'UTC' floor, making the
+// partner tz the canonical default and 'UTC' only a true last resort. Each
+// candidate is IANA-validated, so a garbage value at one level is skipped
+// rather than short-circuiting to UTC.
+export function resolveEffectiveTimezone(input: EffectiveTimezoneInput): string {
+  const candidates = [input.explicit, input.siteTz, input.orgTz, input.partnerTz];
+  for (const candidate of candidates) {
+    if (isValidIanaTimezone(candidate)) return candidate;
+  }
+  return UTC_TIMEZONE;
+}


### PR DESCRIPTION
## Summary

Normalize timezone defaulting (issue #1318) so a tz field resolves to the **partner's** timezone when no more-specific scope is set, instead of jumping straight to a hardcoded `'UTC'`. This is a coherent **phase-1 slice** — the issue inventories ~29 hardcoded-UTC call sites; this PR establishes the canonical seam (column + shared resolver) and wires the two highest-value resolution paths. Remaining call-site migration is a tracked follow-up.

## Behavioral change (release-note)

Inserting the partner timezone between `org` and the `UTC` floor changes resolution for **existing** devices, not just new ones. On upgrade:

- Partners that **have set a non-UTC timezone** (UI partner settings, or the legacy `settings.timezone` key, now mirrored to `partners.timezone`) will see existing **patch, backup, and maintenance windows shift from UTC to partner-local time**. A 02:00 patch window that previously fired at 02:00 UTC will fire at 02:00 in the partner's local zone.
- Partners **left at the `UTC` default are unaffected** — `UTC` stays the resolved value and nothing shifts.

This is **intended** per #1318 (partner tz becomes the canonical default); it is not a regression. The shift only reaches a device when its own site/org have no more-specific timezone set (those still win). The behavior is documented inline at both resolver insertion points (`featureConfigResolver.resolveDeviceTimezone`, `patchSchedulerWorker`).

## What changed

**Schema (`partners.timezone` first-class column)**
- Added `partners.timezone varchar(64) NOT NULL DEFAULT 'UTC'` (`db/schema/orgs.ts`) + idempotent date-prefixed migration `2026-06-13-c-partner-timezone-column.sql`.
- Migration `ADD COLUMN IF NOT EXISTS` and backfills from the legacy `settings.timezone` JSONB key with a `GET DIAGNOSTICS` row-count warning. **Non-destructive** — the JSONB key stays the UI write target; we never destructively migrate.
- `partners` is an already-RLS-forced partner-axis tenant table, so a plain column add needs no new policy (same precedent as `2026-06-09-users-disabled-reason` / `2026-06-11-j-device-pending-reboot`). No rls-coverage allowlist change needed.

**Shared resolver + validator (`packages/shared/src/utils/timezone.ts`)**
- `isValidIanaTimezone`, `normalizeTimezone(tz, fallback)`, `canonicalizeTimezone(tz)`, and `resolveEffectiveTimezone({explicit, siteTz, orgTz, partnerTz})` implementing **explicit → site → org → partner → UTC**. Each candidate is IANA-validated, so a garbage value at one level is skipped rather than short-circuiting to UTC. DST stays correct (always `Intl.DateTimeFormat`, never manual offset math).
- `canonicalizeTimezone` folds any UTC casing (`'utc'` → `'UTC'`) and rejects non-IANA values, keeping the `'UTC'` sentinel comparison (`column !== 'UTC'`) consistent on both write and read.

**API**
- `resolveDeviceTimezone()` (`services/featureConfigResolver.ts`) now joins `partners` and resolves through the shared resolver — previously site → org.settings → UTC with **no partner branch**. Reads the column as source of truth, falling back to the legacy `settings.timezone` key.
- Patch scheduler worker (`jobs/patchSchedulerWorker.ts`) resolves device tz the same way.
- **RLS-safe partner join (review fix):** both join paths use `leftJoin(partners)`, not `innerJoin`. The `partners` SELECT policy is `breeze_has_partner_access(id)`, which is **false for org-scoped requests** — an inner join would make the partner row RLS-invisible and drop the *entire* device row, sending `resolveDeviceTimezone` to its missing-row branch → `'UTC'` (a regression of the prior site→org resolution). With the left join the device row survives, `partnerTz` is simply null, and the resolver falls through site → org → UTC. System/partner scope still see the partner row and resolve partner tz as intended.
- Both partner-settings PATCH paths mirror `settings.timezone` into the new column: `PATCH /partners/me` (partner scope) and `PATCH /partners/:id` (**system scope**, previously left the column stale on a wholesale settings write).
- **System-scope tz validation (review fix):** `updatePartnerSchema` uses `settings: z.any()`, so an invalid IANA `settings.timezone` was not caught by zod. `PATCH /partners/:id` now **rejects an invalid tz with 400** and writes the canonical form back into `settings`, so the JSONB column and the `partners.timezone` column can never desync (the exact failure this work exists to prevent). `PATCH /partners/me` is IANA-validated by its zod schema.
- `orgs.ts` imports the shared `isValidIanaTimezone` instead of a local duplicate.

**Web**
- Partner-settings tz picker falls back to the resolved `partners.timezone` column when the JSONB key is absent.

## Deferred (phase-1 follow-ups)
- Migrate the remaining ~27 `|| 'UTC'` / `?? 'UTC'` call sites (maintenance, automations, backup, discovery, sensitive-data, quiet hours, PAM, email render, `partnerCreate`) onto `resolveEffectiveTimezone`.
- Consolidate the ~6 divergent web `TIMEZONE_LIST` arrays into one shared picker.
- Add validated IANA tz to the remaining shared validators.

## Tests
```
pnpm --filter @breeze/shared exec vitest run src/utils/timezone.test.ts        # 15/15
pnpm --filter @breeze/api exec vitest run \
  src/services/featureConfigResolver.timezone.test.ts \
  src/jobs/patchSchedulerWorker.test.ts \
  src/routes/orgs.test.ts src/db/autoMigrate.test.ts                            # 170/170
pnpm --filter @breeze/web exec vitest run src/components/settings/PartnerSettingsPage.test.tsx  # 7/7
```
Review-fix coverage added:
- `featureConfigResolver.timezone.test.ts`: org-scoped (partner-RLS-invisible) cases assert the device still resolves site/org tz, **not** `'UTC'`.
- `patchSchedulerWorker.test.ts` (**new** — was zero coverage): partner-tz precedence + fallback when the partner row is absent.
- `orgs.test.ts`: an invalid IANA `settings.timezone` on the system path is rejected with 400 and never reaches the DB.

Each new assertion was verified to **fail when its fix is reverted**. All green; `tsc --noEmit` clean for every touched file.

Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
