### PR TITLE
feat(events): emit siteId on live-event payloads so site-restricted users get in-site events

### DIFF
--- a/apps/api/src/jobs/offlineDetector.ts
+++ b/apps/api/src/jobs/offlineDetector.ts
@@ -207,7 +207,7 @@ async function processMarkOffline(data: MarkOfflineJobData): Promise<{
     .set({ status: 'offline' })
     .where(eq(devices.id, data.deviceId));
 
-  // Publish device.offline event
+  // Publish device.offline event — carry siteId for site-restricted users
   await publishEvent(
     'device.offline',
     data.orgId,
@@ -217,7 +217,8 @@ async function processMarkOffline(data: MarkOfflineJobData): Promise<{
       displayName: device.displayName,
       lastSeenAt: data.lastSeenAt
     },
-    'offline-detector'
+    'offline-detector',
+    { siteId: device.siteId }
   );
 
   console.log(`[OfflineDetector] Marked device ${data.deviceId} as offline`);

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1473,7 +1473,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
       if (agentDb) {
         try {
           const [deviceInfo] = await runWithAgentDbAccess(async () =>
-            db.select({ id: devices.id, hostname: devices.hostname, agentVersion: devices.agentVersion })
+            db.select({ id: devices.id, siteId: devices.siteId, hostname: devices.hostname, agentVersion: devices.agentVersion })
               .from(devices)
               .where(eq(devices.agentId, agentId))
               .limit(1)
@@ -1484,7 +1484,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
               hostname: deviceInfo.hostname,
               agentVersion: deviceInfo.agentVersion,
               status: 'online',
-            }, 'agent-ws').catch(err => {
+            }, 'agent-ws', { siteId: deviceInfo.siteId }).catch(err => {
               console.error('[AgentWs] Failed to publish device.online:', err);
               captureException(err);
             });
@@ -1960,7 +1960,7 @@ onClose: async (_event: unknown, ws: WSContext) => {
           await runWithAgentDbAccess(async () => {
             try {
               const [current] = await db
-                .select({ id: devices.id, status: devices.status, hostname: devices.hostname })
+                .select({ id: devices.id, siteId: devices.siteId, status: devices.status, hostname: devices.hostname })
                 .from(devices)
                 .where(eq(devices.agentId, agentId))
                 .limit(1);
@@ -1976,7 +1976,7 @@ onClose: async (_event: unknown, ws: WSContext) => {
               publishEvent('device.offline', agentDb.orgId, {
                 deviceId: current.id,
                 hostname: current.hostname,
-              }, 'agent-ws').catch(err => {
+              }, 'agent-ws', { siteId: current.siteId }).catch(err => {
                 console.error('[AgentWs] Failed to publish device.offline:', err);
                 captureException(err);
               });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -190,7 +190,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         silenceDurationSeconds: device.lastSeenAt
           ? Math.round((now.getTime() - device.lastSeenAt.getTime()) / 1000)
           : null,
-      }, 'heartbeat-watchdog-branch', { priority: 'high' }).catch((err) => {
+      }, 'heartbeat-watchdog-branch', { priority: 'high', siteId: device.siteId }).catch((err) => {
         console.error('[heartbeat] device.main_agent_silent publish failed:', err);
       });
     }
@@ -375,7 +375,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       deviceId: device.id,
       fields: ['agentVersion'],
       agentVersion: data.agentVersion,
-    }, 'heartbeat').catch(err => {
+    }, 'heartbeat', { siteId: device.siteId }).catch(err => {
       console.error('[Heartbeat] Failed to publish device.updated:', err);
       captureException(err);
     });
@@ -738,7 +738,8 @@ heartbeatRoutes.put('/:id/monitoring-results', bodyLimit({ maxSize: 1024 * 1024,
             'monitoring.check_failed',
             device.orgId,
             { deviceId: device.id, name: result.name, watchType: result.watchType, status: result.status, consecutiveFailures: count },
-            'agent-monitoring'
+            'agent-monitoring',
+            { siteId: device.siteId }
           );
         } catch (err) {
           console.warn(`[monitoring] Redis failure counter error for ${device.id}/${result.name}:`, err);
@@ -755,7 +756,8 @@ heartbeatRoutes.put('/:id/monitoring-results', bodyLimit({ maxSize: 1024 * 1024,
               'monitoring.check_recovered',
               device.orgId,
               { deviceId: device.id, name: result.name, watchType: result.watchType, previousFailures: Number(prevCount) },
-              'agent-monitoring'
+              'agent-monitoring',
+              { siteId: device.siteId }
             );
           }
         } catch (err) {

--- a/apps/api/src/routes/agents/sessions.ts
+++ b/apps/api/src/routes/agents/sessions.ts
@@ -30,6 +30,7 @@ sessionsRoutes.put('/:id/sessions', zValidator('json', submitSessionsSchema), as
     .select({
       id: devices.id,
       orgId: devices.orgId,
+      siteId: devices.siteId,
       hostname: devices.hostname,
     })
     .from(devices)
@@ -162,7 +163,8 @@ sessionsRoutes.put('/:id/sessions', zValidator('json', submitSessionsSchema), as
           activityState: event.activityState ?? null,
           timestamp: event.timestamp ?? now.toISOString(),
         },
-        'agent'
+        'agent',
+        { siteId: device.siteId }
       );
     } catch (err) {
       console.error(`[agents] failed to publish ${eventType} for ${device.id}:`, err);

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -25,6 +25,7 @@ import { evaluateConditions, evaluateAutoResolveConditions, interpolateTemplate 
 import { isCooldownActive, setCooldown, isConfigPolicyRuleCooling, markConfigPolicyRuleCooldown, recordStateTransition, isFlapping } from './alertCooldown';
 import { resolveAlertRulesForDevice, resolveMaintenanceConfigForDevice, isInMaintenanceWindow } from './featureConfigResolver';
 import { publishEvent } from './eventBus';
+import { resolveDeviceSiteId } from './deviceSiteResolver';
 
 // Types for alert creation
 export interface CreateAlertParams {
@@ -149,7 +150,8 @@ export async function createAlert(params: CreateAlertParams): Promise<string | n
   // Phase 6b: Auto-correlate with other recent alerts on the same device
   await autoCorrelateAlert(newAlert.id, deviceId, orgId);
 
-  // Publish event
+  // Publish event — attach the device's site so site-restricted users see it
+  const siteId = await resolveDeviceSiteId(deviceId);
   await publishEvent(
     'alert.triggered',
     orgId,
@@ -161,7 +163,8 @@ export async function createAlert(params: CreateAlertParams): Promise<string | n
       title,
       message
     },
-    'alert-service'
+    'alert-service',
+    { siteId }
   );
 
   console.log(`[AlertService] Created alert ${newAlert.id} for rule=${ruleId} device=${deviceId}`);
@@ -321,7 +324,8 @@ export async function resolveAlert(
     }
   }
 
-  // Publish event
+  // Publish event — attach the device's site so site-restricted users see it
+  const siteId = await resolveDeviceSiteId(alert.deviceId);
   await publishEvent(
     'alert.resolved',
     alert.orgId,
@@ -331,7 +335,8 @@ export async function resolveAlert(
       deviceId: alert.deviceId,
       resolutionNote
     },
-    'alert-service'
+    'alert-service',
+    { siteId }
   );
 
   console.log(`[AlertService] Resolved alert ${alertId}`);
@@ -673,7 +678,7 @@ export async function evaluateDeviceAlertsFromPolicy(deviceId: string): Promise<
           // Phase 6b: Auto-correlate with other recent alerts on the same device
           await autoCorrelateAlert(newAlert.id, deviceId, device.orgId);
 
-          // 11. Publish event
+          // 11. Publish event — carry siteId so site-restricted users get it
           await publishEvent(
             'alert.triggered',
             device.orgId,
@@ -687,7 +692,8 @@ export async function evaluateDeviceAlertsFromPolicy(deviceId: string): Promise<
               message,
               source: 'config_policy',
             },
-            'alert-service'
+            'alert-service',
+            { siteId: device.siteId }
           );
 
           console.log(`[AlertService] Created config policy alert ${newAlert.id} for cpar=${rule.id} device=${deviceId}`);

--- a/apps/api/src/services/deviceSiteResolver.test.ts
+++ b/apps/api/src/services/deviceSiteResolver.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Chainable Drizzle-style select mock: select().from().where().limit() → rows.
+// `limitResult` is what the final `.limit(1)` resolves to.
+const limitMock = vi.fn();
+
+vi.mock('../db', () => {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit: (...args: unknown[]) => limitMock(...args),
+  };
+  return {
+    db: {
+      select: vi.fn(() => chain),
+    },
+  };
+});
+
+vi.mock('../db/schema', () => ({
+  devices: { id: 'devices.id', siteId: 'devices.site_id' },
+}));
+
+describe('deviceSiteResolver', () => {
+  let resolveDeviceSiteId: typeof import('./deviceSiteResolver')['resolveDeviceSiteId'];
+  let _clearDeviceSiteCache: typeof import('./deviceSiteResolver')['_clearDeviceSiteCache'];
+  let _primeDeviceSiteCache: typeof import('./deviceSiteResolver')['_primeDeviceSiteCache'];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    limitMock.mockReset();
+    const mod = await import('./deviceSiteResolver');
+    resolveDeviceSiteId = mod.resolveDeviceSiteId;
+    _clearDeviceSiteCache = mod._clearDeviceSiteCache;
+    _primeDeviceSiteCache = mod._primeDeviceSiteCache;
+    _clearDeviceSiteCache();
+  });
+
+  it('returns undefined for a null/undefined/empty deviceId without hitting the DB', async () => {
+    expect(await resolveDeviceSiteId(undefined)).toBeUndefined();
+    expect(await resolveDeviceSiteId(null)).toBeUndefined();
+    expect(await resolveDeviceSiteId('')).toBeUndefined();
+    expect(limitMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves siteId via a single PK lookup and caches it (second call skips the DB)', async () => {
+    limitMock.mockResolvedValueOnce([{ siteId: 'site-a' }]);
+
+    expect(await resolveDeviceSiteId('dev-1')).toBe('site-a');
+    expect(limitMock).toHaveBeenCalledTimes(1);
+
+    // Cached — no second DB round-trip.
+    expect(await resolveDeviceSiteId('dev-1')).toBe('site-a');
+    expect(limitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a "not found" result as undefined (no repeated lookups for unknown devices)', async () => {
+    limitMock.mockResolvedValueOnce([]);
+
+    expect(await resolveDeviceSiteId('ghost')).toBeUndefined();
+    expect(await resolveDeviceSiteId('ghost')).toBeUndefined();
+    expect(limitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open to undefined when the DB lookup throws (event still publishes org-level)', async () => {
+    limitMock.mockRejectedValueOnce(new Error('db down'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(await resolveDeviceSiteId('dev-err')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('serves a primed cache entry without any DB call', async () => {
+    _primeDeviceSiteCache('dev-primed', 'site-z');
+
+    expect(await resolveDeviceSiteId('dev-primed')).toBe('site-z');
+    expect(limitMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/deviceSiteResolver.ts
+++ b/apps/api/src/services/deviceSiteResolver.ts
@@ -1,0 +1,99 @@
+/**
+ * deviceSiteResolver
+ *
+ * Resolves a device's `siteId` for event-publish-time site attribution.
+ *
+ * Why this exists
+ * ---------------
+ * The events-WS layer (`routes/eventWs.ts`) must deliver in-site live events to
+ * site-restricted users (the app-layer SITE-scope axis). The WS dispatch path is
+ * synchronous and cannot do a DB lookup per event, so the `siteId` has to be on
+ * the wire at publish time (issue #1280, follow-up to #1278). Most device-scoped
+ * publishers (alert.triggered, session.login, device.offline, …) only carry a
+ * `deviceId`, so they need a cheap deviceId → siteId resolution at publish time.
+ *
+ * A device's site assignment changes rarely (only on an explicit move), so a
+ * short-lived in-process cache keeps this off the hot path without serving stale
+ * site attribution for any meaningful window. A cache miss falls back to a single
+ * indexed primary-key lookup. Resolution never throws — a failure yields
+ * `undefined` (org-level / no attribution), which the WS filter treats as
+ * fail-closed for site-restricted users and is a no-op for unrestricted users.
+ */
+
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { devices } from '../db/schema';
+
+const CACHE_TTL_MS = 60 * 1000; // 1 minute — site assignment changes are rare
+const MAX_CACHE_ENTRIES = 50_000; // bound memory on large fleets
+
+interface CacheEntry {
+  siteId: string | undefined;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function getCached(deviceId: string): CacheEntry | undefined {
+  const entry = cache.get(deviceId);
+  if (!entry) return undefined;
+  if (Date.now() >= entry.expiresAt) {
+    cache.delete(deviceId);
+    return undefined;
+  }
+  return entry;
+}
+
+function setCached(deviceId: string, siteId: string | undefined): void {
+  // Cheap size bound: when full, evict the oldest insertion (Map preserves
+  // insertion order). Avoids unbounded growth without a full LRU.
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(deviceId, { siteId, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/**
+ * Resolve a device's `siteId` for event publishing. Returns `undefined` when the
+ * device is unknown or the lookup fails — never throws.
+ */
+export async function resolveDeviceSiteId(
+  deviceId: string | null | undefined,
+): Promise<string | undefined> {
+  if (!deviceId) return undefined;
+
+  const cached = getCached(deviceId);
+  if (cached) return cached.siteId;
+
+  try {
+    const [row] = await db
+      .select({ siteId: devices.siteId })
+      .from(devices)
+      .where(eq(devices.id, deviceId))
+      .limit(1);
+
+    const siteId = row?.siteId ?? undefined;
+    setCached(deviceId, siteId);
+    return siteId;
+  } catch (err) {
+    // Fail open to "no attribution": the event still publishes (org-level), it
+    // just won't reach site-restricted users until a later event carries siteId.
+    console.warn(
+      '[deviceSiteResolver] failed to resolve siteId for device',
+      deviceId,
+      err instanceof Error ? err.message : err,
+    );
+    return undefined;
+  }
+}
+
+/** @internal Test-only: clear the in-process cache. */
+export function _clearDeviceSiteCache(): void {
+  cache.clear();
+}
+
+/** @internal Test-only: prime the cache directly (avoids a DB round-trip). */
+export function _primeDeviceSiteCache(deviceId: string, siteId: string | undefined): void {
+  setCached(deviceId, siteId);
+}

--- a/apps/api/src/services/eventBus.test.ts
+++ b/apps/api/src/services/eventBus.test.ts
@@ -202,6 +202,77 @@ describe('eventBus service', () => {
     expect(event.payload.domain).toBe('malware.example.com');
   });
 
+  // ---------------------------------------------------------------------
+  // siteId attribution on the published event (#1280 — eventWs follow-up).
+  // The events-WS site filter (routes/eventWs.ts) delivers in-site live
+  // events to site-restricted users by reading the TOP-LEVEL `siteId` off the
+  // published BreezeEvent. These assert publish() puts it there from options.
+  // ---------------------------------------------------------------------
+
+  function lastPublishedEvent(): Record<string, unknown> {
+    const xaddMock = mockRedis.xadd as ReturnType<typeof vi.fn>;
+    const lastCall = xaddMock.mock.calls[xaddMock.mock.calls.length - 1]!;
+    const eventJson = lastCall[lastCall.length - 1] as string;
+    return JSON.parse(eventJson) as Record<string, unknown>;
+  }
+
+  it('puts options.siteId on the published event as a top-level field (#1280)', async () => {
+    const { publishEvent, EVENT_TYPES } = eventBusModule;
+
+    await publishEvent(
+      EVENT_TYPES.ALERT_TRIGGERED,
+      'org-1',
+      { deviceId: 'dev-1', alertId: 'a-1' },
+      'unit-test',
+      { siteId: 'site-a' },
+    );
+
+    const event = lastPublishedEvent();
+    expect(event.siteId).toBe('site-a');
+    // payload is left untouched — siteId lives at the top level where the
+    // WS filter reads it first.
+    expect((event.payload as Record<string, unknown>).siteId).toBeUndefined();
+  });
+
+  it('omits siteId entirely when no site context is provided (org-level event)', async () => {
+    const { publishEvent, EVENT_TYPES } = eventBusModule;
+
+    await publishEvent(EVENT_TYPES.USER_LOGIN, 'org-1', { userId: 'u-1' }, 'unit-test');
+
+    const event = lastPublishedEvent();
+    expect('siteId' in event).toBe(false);
+  });
+
+  it('normalises an empty-string siteId to "no attribution" (never matches a blank id)', async () => {
+    const { publishEvent, EVENT_TYPES } = eventBusModule;
+
+    await publishEvent(
+      EVENT_TYPES.DEVICE_OFFLINE,
+      'org-1',
+      { deviceId: 'dev-1' },
+      'unit-test',
+      { siteId: '' },
+    );
+
+    const event = lastPublishedEvent();
+    expect('siteId' in event).toBe(false);
+  });
+
+  it('treats a null siteId option as no attribution', async () => {
+    const { publishEvent, EVENT_TYPES } = eventBusModule;
+
+    await publishEvent(
+      EVENT_TYPES.DEVICE_OFFLINE,
+      'org-1',
+      { deviceId: 'dev-1' },
+      'unit-test',
+      { siteId: null },
+    );
+
+    const event = lastPublishedEvent();
+    expect('siteId' in event).toBe(false);
+  });
+
   it('should unsubscribe handlers', async () => {
     const { getEventBus, EVENT_TYPES } = eventBusModule;
     const bus = getEventBus();

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -110,6 +110,18 @@ export interface BreezeEvent<T = Record<string, unknown>> {
   id: string;
   type: EventType;
   orgId: string;
+  /**
+   * Site this event is attributable to, when known. Used by the events WS
+   * layer to deliver in-site events to site-restricted users (the app-layer
+   * SITE-scope axis; RLS only enforces ORG). See `buildSiteFilter` in
+   * `routes/eventWs.ts`, which fails closed when no `siteId` is present.
+   *
+   * Omitted for genuinely org-level events with no site context. The WS filter
+   * treats a missing `siteId` as "not deliverable to a site-restricted user"
+   * (fail-closed) — unrestricted users are unaffected either way. Device-scoped
+   * publishers should set this whenever the device's site is cheaply available.
+   */
+  siteId?: string;
   source: string;
   priority: EventPriority;
   payload: T;
@@ -126,6 +138,13 @@ export interface PublishOptions {
   correlationId?: string;
   causationId?: string;
   userId?: string;
+  /**
+   * Site this event is attributable to. Surfaces as a top-level `siteId` on the
+   * published `BreezeEvent` so the events-WS site filter can deliver it to
+   * site-restricted users. Pass it whenever the originating device's site is
+   * known. `null`/`undefined` ⇒ org-level (no site attribution).
+   */
+  siteId?: string | null;
 }
 
 export type EventHandler<T = Record<string, unknown>> = (event: BreezeEvent<T>) => Promise<void>;
@@ -191,10 +210,16 @@ class EventBus {
     const eventId = randomUUID();
     const streamKey = `${STREAM_PREFIX}:${orgId}`;
 
+    // Normalise an empty-string siteId to "no attribution" so the WS filter
+    // never matches against a blank id.
+    const siteId =
+      typeof options.siteId === 'string' && options.siteId.length > 0 ? options.siteId : undefined;
+
     const event: BreezeEvent<T> = {
       id: eventId,
       type,
       orgId,
+      ...(siteId ? { siteId } : {}),
       source,
       priority: options.priority || 'normal',
       payload,
@@ -515,7 +540,8 @@ class EventBus {
         priority: event.priority,
         correlationId: event.metadata.correlationId,
         causationId: event.id, // Original event becomes causation
-        userId: event.metadata.userId
+        userId: event.metadata.userId,
+        siteId: event.siteId, // preserve site attribution on retry
       }
     );
 

--- a/apps/api/src/services/eventDispatcher.test.ts
+++ b/apps/api/src/services/eventDispatcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { matchesEventType, getEventDispatcher, shutdownEventDispatcher } from './eventDispatcher';
+import { buildSiteFilter } from '../routes/eventWs';
 
 vi.mock('./redis', () => ({
   resolveRedisUrl: () => 'redis://localhost:6379',
@@ -257,6 +258,116 @@ describe('EventDispatcher', () => {
 
     dispatcher.unregister('org-1', throwingClient);
     dispatcher.unregister('org-1', plainClient);
+  });
+
+  // -------------------------------------------------------------------
+  // End-to-end (#1280): a site-restricted client built with the REAL
+  // `buildSiteFilter` (from eventWs.ts) receives in-site events and not
+  // out-of-site ones, driven through the real `dispatch()` with
+  // publish-shaped BreezeEvent messages carrying a TOP-LEVEL `siteId` (the
+  // shape `publishEvent({ siteId })` now produces). This closes the loop
+  // from publish → wire → dispatch filter that the issue asks to verify.
+  // -------------------------------------------------------------------
+
+  it('site-restricted client (real buildSiteFilter) gets in-site events, drops out-of-site (#1280)', () => {
+    const dispatcher = getEventDispatcher();
+    const restrictedWs = mockWs();
+    const unrestrictedWs = mockWs();
+
+    const restricted = {
+      ws: restrictedWs,
+      userId: 'site-user',
+      subscribedTypes: new Set(['*']),
+      filter: buildSiteFilter(['site-a']), // restricted to site-a
+    };
+    const unrestricted = {
+      ws: unrestrictedWs,
+      userId: 'org-admin',
+      subscribedTypes: new Set(['*']),
+      filter: buildSiteFilter(undefined), // full org access — undefined filter
+    };
+    dispatcher.register('org-1', restricted);
+    dispatcher.register('org-1', unrestricted);
+
+    // Publish-shaped event: siteId is a TOP-LEVEL field (as publishEvent emits).
+    const inSite = JSON.stringify({
+      id: 'e1',
+      type: 'alert.triggered',
+      orgId: 'org-1',
+      siteId: 'site-a',
+      source: 'alert-service',
+      priority: 'normal',
+      payload: { alertId: 'a1', deviceId: 'd1' },
+      metadata: { timestamp: '2026-06-13T00:00:00Z' },
+    });
+    (dispatcher as any).dispatch('org-1', inSite);
+
+    // Restricted client receives the in-site event; admin receives it too.
+    expect(restrictedWs.send).toHaveBeenCalledTimes(1);
+    expect(unrestrictedWs.send).toHaveBeenCalledTimes(1);
+
+    restrictedWs.send.mockClear();
+    unrestrictedWs.send.mockClear();
+
+    // Out-of-site event (different site).
+    const outOfSite = JSON.stringify({
+      id: 'e2',
+      type: 'alert.triggered',
+      orgId: 'org-1',
+      siteId: 'site-b',
+      source: 'alert-service',
+      priority: 'normal',
+      payload: { alertId: 'a2', deviceId: 'd2' },
+      metadata: { timestamp: '2026-06-13T00:00:01Z' },
+    });
+    (dispatcher as any).dispatch('org-1', outOfSite);
+
+    // Restricted client does NOT receive it; admin still does.
+    expect(restrictedWs.send).not.toHaveBeenCalled();
+    expect(unrestrictedWs.send).toHaveBeenCalledTimes(1);
+
+    dispatcher.unregister('org-1', restricted);
+    dispatcher.unregister('org-1', unrestricted);
+  });
+
+  it('org-level event with no siteId is withheld from site-restricted clients, delivered to admins (#1280)', () => {
+    const dispatcher = getEventDispatcher();
+    const restrictedWs = mockWs();
+    const unrestrictedWs = mockWs();
+
+    const restricted = {
+      ws: restrictedWs,
+      userId: 'site-user',
+      subscribedTypes: new Set(['*']),
+      filter: buildSiteFilter(['site-a']),
+    };
+    const unrestricted = {
+      ws: unrestrictedWs,
+      userId: 'org-admin',
+      subscribedTypes: new Set(['*']),
+      filter: buildSiteFilter(undefined),
+    };
+    dispatcher.register('org-1', restricted);
+    dispatcher.register('org-1', unrestricted);
+
+    // Genuinely org-level event — no siteId on the wire (e.g. user.login).
+    const orgLevel = JSON.stringify({
+      id: 'e3',
+      type: 'user.login',
+      orgId: 'org-1',
+      source: 'auth',
+      priority: 'normal',
+      payload: { userId: 'u1' },
+      metadata: { timestamp: '2026-06-13T00:00:02Z' },
+    });
+    (dispatcher as any).dispatch('org-1', orgLevel);
+
+    // Fail-closed policy: site-restricted user is withheld; admin still gets it.
+    expect(restrictedWs.send).not.toHaveBeenCalled();
+    expect(unrestrictedWs.send).toHaveBeenCalledTimes(1);
+
+    dispatcher.unregister('org-1', restricted);
+    dispatcher.unregister('org-1', unrestricted);
   });
 
   it('unsubscribes from Redis when last client for org disconnects', () => {


### PR DESCRIPTION
Follow-up to #1278 (finding #8 of the 2026-06-12 multi-tenant security review).

## Problem
#1278 added a fail-closed, per-client site filter to the events WS (`buildSiteFilter` in `routes/eventWs.ts`): a site-restricted user only receives an event we can positively attribute to one of their allowed sites. But **no publisher emitted `siteId`**, so site-restricted users received **no live events at all** — safe versus the prior leak, but a degraded live feed.

## Fix
Put `siteId` on the wire at publish time so `buildSiteFilter` resumes in-site delivery with **no further eventWs change**.

**Infrastructure**
- `siteId` is now a first-class **top-level** field on `BreezeEvent` and a `PublishOptions.siteId` option (`services/eventBus.ts`). Empty-string / `null` normalise to "no attribution"; preserved across DLQ retry. The WS filter already reads top-level `siteId` first.
- New `services/deviceSiteResolver.ts`: a shared, short-TTL-cached `deviceId → siteId` resolver for publishers that hold only a `deviceId`. Fails open to `undefined` (org-level) and never throws — a resolution failure just means the event publishes org-level (fail-closed for site-restricted users, no-op for unrestricted).

**Publishers wired with siteId**
- `alert.triggered` / `alert.resolved` (`alertService.ts`) — via resolver; config-policy `alert.triggered` uses the device record already loaded.
- `session.login` / `session.logout` (`agents/sessions.ts`).
- `device.online`, `device.offline` (`agentWs.ts` connect/disconnect) + `device.offline` (`jobs/offlineDetector.ts`).
- `device.updated`, `device.main_agent_silent`, `monitoring.check_failed` / `monitoring.check_recovered` (`agents/heartbeat.ts`).

**Org-level events** (e.g. `user.login`) carry no `siteId` and remain **fail-closed** for site-restricted users (withheld) — explicit and tested. Unrestricted users are unaffected throughout.

## Tests
- `eventBus.test.ts` — top-level `siteId` emission, omission for org-level events, empty-string/null normalisation.
- `deviceSiteResolver.test.ts` — cache hit/miss, not-found caching, fail-open on DB error, no DB call for empty `deviceId`.
- `eventDispatcher.test.ts` — **end-to-end** through the real `dispatch()` + the real `buildSiteFilter`: a site-restricted client receives in-site events, drops out-of-site events, and is withheld org-level events; an org admin receives all.

Run:
\`\`\`
pnpm --filter @breeze/api exec vitest run \
  src/services/eventBus.test.ts \
  src/services/deviceSiteResolver.test.ts \
  src/services/eventDispatcher.test.ts \
  src/routes/eventWs.test.ts \
  src/routes/agents/sessions.test.ts \
  src/routes/agents/heartbeat.test.ts \
  src/routes/agentWs.test.ts \
  src/jobs/offlineDetector.test.ts
\`\`\`
Result: all green (eventBus/dispatcher/resolver 35; eventWs+sessions+offlineDetector 33; heartbeat+agentWs 56). `tsc --noEmit` for `@breeze/api`: 0 errors.

## Phase-1 follow-up
This covers the marquee live-feed publishers. The remaining device-scoped publishers (peripheral-control, CIS/compliance, incident, sensitive-data command-result handlers) are a trivial follow-up now that the `siteId` option and the resolver exist.

Closes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)