### PR TITLE
feat(auth): observability + status detail for inactive-tenant auth denials (#719)

### DIFF
--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -127,6 +127,9 @@ import { loginRoutes } from './login';
 import { db } from '../../db';
 import { createTokenPair } from '../../services';
 import { enforceIpAllowlist } from '../../services/ipAllowlist';
+import { recordFailedLogin } from '../../services/anomalyMetrics';
+import { TenantInactiveError } from '../../services/tenantStatus';
+import { resolveCurrentUserTokenContext } from './helpers';
 
 function selectChain(rows: unknown[]) {
   return {
@@ -228,5 +231,72 @@ describe('POST /login — IP allowlist', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { user: { isPlatformAdmin?: boolean } };
     expect(body.user.isPlatformAdmin).toBe(false);
+  });
+});
+
+// #719 residual 2: inactive-account and inactive-tenant login denials must
+// emit an anomaly-metric signal (so a spike is alertable) WITHOUT changing the
+// generic 401 the client sees (so nothing leaks for enumeration).
+describe('POST /login — inactive-tenant observability signal (#719)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env.E2E_MODE = 'true';
+    vi.mocked(enforceIpAllowlist).mockResolvedValue({ decision: 'allow' });
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+  });
+
+  it('counts an inactive-account denial as account_inactive and still returns a generic 401', async () => {
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'sus@msp.com',
+      name: 'Suspended User',
+      passwordHash: 'password-hash',
+      status: 'suspended',
+      mfaEnabled: false,
+      mfaSecret: null,
+      mfaMethod: null,
+      phoneNumber: null,
+      avatarUrl: null,
+    }]) as any);
+
+    const res = await postLogin({ email: 'sus@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    // Generic body — no account/tenant status leaks.
+    expect(body).toMatchObject({ error: 'Invalid email or password' });
+    expect(JSON.stringify(body)).not.toContain('suspended');
+    expect(recordFailedLogin).toHaveBeenCalledWith('account_inactive');
+    expect(createTokenPair).not.toHaveBeenCalled();
+  });
+
+  it('counts an inactive-tenant denial as tenant_inactive and still returns a generic 401', async () => {
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'trapped@msp.com',
+      name: 'Trapped User',
+      passwordHash: 'password-hash',
+      status: 'active',
+      mfaEnabled: false,
+      mfaSecret: null,
+      mfaMethod: null,
+      phoneNumber: null,
+      avatarUrl: null,
+    }]) as any);
+    // The user is active, but their tenant (partner/org) is not — the context
+    // resolver throws TenantInactiveError, which the handler maps to a generic
+    // 401 plus the tenant_inactive metric.
+    vi.mocked(resolveCurrentUserTokenContext).mockRejectedValueOnce(
+      new TenantInactiveError('Partner is not active'),
+    );
+
+    const res = await postLogin({ email: 'trapped@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body).toMatchObject({ error: 'Invalid email or password' });
+    expect(recordFailedLogin).toHaveBeenCalledWith('tenant_inactive');
+    expect(createTokenPair).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -75,6 +75,14 @@ vi.mock('../../middleware/auth', () => ({
   authMiddleware: vi.fn((_c: unknown, next: () => unknown) => next()),
 }));
 
+// NOTE: auditUserLoginFailure is NOT a bare vi.fn() here. The real helper
+// (apps/api/src/routes/auth/helpers.ts) feeds the anomaly metric by calling
+// recordFailedLogin() exactly once internally. If we stubbed it out, the
+// login handler could re-add its own recordFailedLogin() call on the same
+// path and we'd never notice the double-count. The mock below mirrors the
+// real helper's SINGLE internal emission, so the "called exactly once"
+// assertions in the inactive-tenant/account tests will fail if anyone
+// reintroduces a redundant recordFailedLogin() in login.ts (#719 regression).
 vi.mock('./helpers', () => ({
   getClientIP: vi.fn(() => '203.0.113.10'),
   getClientRateLimitKey: vi.fn(() => 'test-client'),
@@ -95,7 +103,13 @@ vi.mock('./helpers', () => ({
     orgId: null,
     scope: 'partner',
   })),
-  auditUserLoginFailure: vi.fn(),
+  auditUserLoginFailure: vi.fn(
+    async (_c: unknown, opts: { reason: string }) => {
+      // Faithful stand-in for the real helper's single internal emission.
+      const { recordFailedLogin } = await import('../../services/anomalyMetrics');
+      recordFailedLogin(opts.reason);
+    },
+  ),
   auditLogin: vi.fn(),
   userRequiresSetup: vi.fn(() => false),
 }));
@@ -268,6 +282,10 @@ describe('POST /login — inactive-tenant observability signal (#719)', () => {
     expect(body).toMatchObject({ error: 'Invalid email or password' });
     expect(JSON.stringify(body)).not.toContain('suspended');
     expect(recordFailedLogin).toHaveBeenCalledWith('account_inactive');
+    // Exactly once — a single inactive-account attempt must not double-count.
+    // The metric is emitted ONLY via auditUserLoginFailure's internal
+    // recordFailedLogin call; login.ts must not add its own (#719 regression).
+    expect(recordFailedLogin).toHaveBeenCalledTimes(1);
     expect(createTokenPair).not.toHaveBeenCalled();
   });
 
@@ -297,6 +315,10 @@ describe('POST /login — inactive-tenant observability signal (#719)', () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body).toMatchObject({ error: 'Invalid email or password' });
     expect(recordFailedLogin).toHaveBeenCalledWith('tenant_inactive');
+    // Exactly once — a single inactive-tenant attempt must not double-count.
+    // The metric is emitted ONLY via auditUserLoginFailure's internal
+    // recordFailedLogin call; login.ts must not add its own (#719 regression).
+    expect(recordFailedLogin).toHaveBeenCalledTimes(1);
     expect(createTokenPair).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -340,6 +340,10 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
       result: 'denied',
       details: { accountStatus: user.status, method: 'password' }
     });
+    // #719 residual 2: feed the anomaly metric so repeated inactive-account /
+    // inactive-tenant login denials are alertable. Server-side counter only —
+    // the response stays a generic 401, so this leaks nothing to the client.
+    recordFailedLogin('account_inactive');
     await floorPromise;
     return c.json(genericAuthError(), 401);
   }
@@ -351,14 +355,21 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
     await assertPasswordAuthAllowedBySso(context);
   } catch (err) {
     if (!(err instanceof TenantInactiveError) && !(err instanceof SsoPasswordAuthRequiredError)) throw err;
+    const inactiveTenant = err instanceof TenantInactiveError;
     void auditUserLoginFailure(c, {
       userId: user.id,
       email: user.email,
       name: user.name,
-      reason: err instanceof SsoPasswordAuthRequiredError ? 'sso_required' : 'tenant_inactive',
+      reason: inactiveTenant ? 'tenant_inactive' : 'sso_required',
       result: 'denied',
       details: { method: 'password' }
     });
+    // #719 residual 2: count inactive-tenant login denials so a sudden spike
+    // (e.g. a billing-state change trapping a cohort of users) is alertable.
+    // Metric only — the client still gets the generic 401.
+    if (inactiveTenant) {
+      recordFailedLogin('tenant_inactive');
+    }
     await floorPromise;
     return c.json(genericAuthError(), 401);
   }

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -332,6 +332,11 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
   // used for invalid creds, but keep the rich audit trail (status, reason)
   // so ops can still see why a real user was bounced.
   if (user.status !== 'active') {
+    // #719 residual 2: auditUserLoginFailure feeds the anomaly metric
+    // (recordFailedLogin) internally, so repeated inactive-account login
+    // denials are alertable WITHOUT double-counting. Server-side counter
+    // only — the response stays a generic 401, so this leaks nothing to
+    // the client.
     void auditUserLoginFailure(c, {
       userId: user.id,
       email: user.email,
@@ -340,10 +345,6 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
       result: 'denied',
       details: { accountStatus: user.status, method: 'password' }
     });
-    // #719 residual 2: feed the anomaly metric so repeated inactive-account /
-    // inactive-tenant login denials are alertable. Server-side counter only —
-    // the response stays a generic 401, so this leaks nothing to the client.
-    recordFailedLogin('account_inactive');
     await floorPromise;
     return c.json(genericAuthError(), 401);
   }
@@ -355,21 +356,19 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
     await assertPasswordAuthAllowedBySso(context);
   } catch (err) {
     if (!(err instanceof TenantInactiveError) && !(err instanceof SsoPasswordAuthRequiredError)) throw err;
-    const inactiveTenant = err instanceof TenantInactiveError;
+    // #719 residual 2: auditUserLoginFailure feeds the anomaly metric
+    // (recordFailedLogin) internally, so a sudden spike in inactive-tenant
+    // denials (e.g. a billing-state change trapping a cohort of users) is
+    // alertable WITHOUT double-counting. Metric only — the client still
+    // gets the generic 401.
     void auditUserLoginFailure(c, {
       userId: user.id,
       email: user.email,
       name: user.name,
-      reason: inactiveTenant ? 'tenant_inactive' : 'sso_required',
+      reason: err instanceof SsoPasswordAuthRequiredError ? 'sso_required' : 'tenant_inactive',
       result: 'denied',
       details: { method: 'password' }
     });
-    // #719 residual 2: count inactive-tenant login denials so a sudden spike
-    // (e.g. a billing-state change trapping a cohort of users) is alertable.
-    // Metric only — the client still gets the generic 401.
-    if (inactiveTenant) {
-      recordFailedLogin('tenant_inactive');
-    }
     await floorPromise;
     return c.json(genericAuthError(), 401);
   }

--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -7,6 +7,7 @@ const {
   updateWhereMock,
   getEligibilityMock,
   getEligibilityForUserMock,
+  recordFailedLoginMock,
 } = vi.hoisted(() => ({
   sendPasswordResetMock: vi.fn(async () => undefined),
   setexMock: vi.fn(async () => 'OK'),
@@ -14,6 +15,7 @@ const {
   updateWhereMock: vi.fn(async () => undefined),
   getEligibilityMock: vi.fn(),
   getEligibilityForUserMock: vi.fn(),
+  recordFailedLoginMock: vi.fn(),
 }));
 
 vi.mock('../../db', () => ({
@@ -59,6 +61,10 @@ vi.mock('../../services/email', () => ({
 vi.mock('../../services/passwordResetEligibility', () => ({
   getPasswordResetEligibility: getEligibilityMock,
   getPasswordResetEligibilityForUser: getEligibilityForUserMock,
+}));
+
+vi.mock('../../services/anomalyMetrics', () => ({
+  recordFailedLogin: recordFailedLoginMock,
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -133,6 +139,7 @@ describe('password reset eligibility (#719)', () => {
     updateWhereMock.mockReset();
     getEligibilityMock.mockReset();
     getEligibilityForUserMock.mockReset();
+    recordFailedLoginMock.mockReset();
   });
 
   describe('POST /forgot-password', () => {
@@ -163,12 +170,15 @@ describe('password reset eligibility (#719)', () => {
           userId: 'u-pending',
         }),
       );
+      // A successful (allowed) reset must NOT pollute the inactive-tenant signal.
+      expect(recordFailedLoginMock).not.toHaveBeenCalled();
     });
 
     it('refuses reset for users in suspended partners (generic 200, no email sent)', async () => {
       getEligibilityMock.mockResolvedValue({
         allowed: false,
         reason: 'tenant_inactive',
+        detail: 'partner:suspended',
         userId: 'u-suspended',
         email: 'sus@x.com',
       });
@@ -176,8 +186,11 @@ describe('password reset eligibility (#719)', () => {
       const res = await postJson('/forgot-password', { email: 'sus@x.com' });
 
       expect(res.status).toBe(200);
-      const body = await res.json() as { success: boolean };
+      const body = await res.json() as { success: boolean; error?: string };
       expect(body.success).toBe(true);
+      // Anti-enumeration: the blocking partner status NEVER appears in the
+      // response body.
+      expect(JSON.stringify(body)).not.toContain('suspended');
       expect(sendPasswordResetMock).not.toHaveBeenCalled();
       expect(setexMock).not.toHaveBeenCalled();
       expect(writeAuthAudit).toHaveBeenCalledWith(
@@ -187,8 +200,12 @@ describe('password reset eligibility (#719)', () => {
           result: 'denied',
           reason: 'tenant_inactive',
           userId: 'u-suspended',
+          // #719 residual 1: specific status recorded server-side for ops.
+          details: { detail: 'partner:suspended' },
         }),
       );
+      // #719 residual 2: inactive-tenant reset attempts feed the anomaly metric.
+      expect(recordFailedLoginMock).toHaveBeenCalledWith('reset_tenant_inactive');
     });
 
     it('refuses reset for unknown emails (generic 200, no email sent, no audit)', async () => {
@@ -205,6 +222,9 @@ describe('password reset eligibility (#719)', () => {
       // No audit log for unknown users — defeats enumeration via audit-trail
       // exposure or write-volume side-channels.
       expect(writeAuthAudit).not.toHaveBeenCalled();
+      // And no metric — an unknown email must be indistinguishable from a
+      // known-but-inactive one in every observable channel.
+      expect(recordFailedLoginMock).not.toHaveBeenCalled();
     });
 
     it('refuses reset for SSO-enforced org users', async () => {
@@ -228,6 +248,9 @@ describe('password reset eligibility (#719)', () => {
           userId: 'u-sso',
         }),
       );
+      // Only tenant_inactive feeds the inactive-tenant signal — sso_required
+      // is a separate, intentional policy and must not inflate it.
+      expect(recordFailedLoginMock).not.toHaveBeenCalled();
     });
 
     it('refuses reset for disabled users', async () => {
@@ -290,6 +313,7 @@ describe('password reset eligibility (#719)', () => {
       getEligibilityForUserMock.mockResolvedValue({
         allowed: false,
         reason: 'tenant_inactive',
+        detail: 'partner:suspended',
         userId: 'u-suspended',
       });
 
@@ -302,6 +326,7 @@ describe('password reset eligibility (#719)', () => {
       const body = await res.json() as { error: string };
       // Generic message — never leaks partner-status.
       expect(body.error).toBe('Invalid or expired reset token');
+      expect(JSON.stringify(body)).not.toContain('suspended');
       expect(updateWhereMock).not.toHaveBeenCalled();
       expect(writeAuthAudit).toHaveBeenCalledWith(
         expect.anything(),
@@ -310,8 +335,12 @@ describe('password reset eligibility (#719)', () => {
           result: 'denied',
           reason: 'tenant_inactive',
           userId: 'u-suspended',
+          details: { detail: 'partner:suspended' },
         }),
       );
+      // #719 residual 2: a tenant flipping inactive mid-flow is exactly the
+      // trap class we want alertable.
+      expect(recordFailedLoginMock).toHaveBeenCalledWith('reset_tenant_inactive');
     });
 
     it('returns 403 when org enforces SSO', async () => {

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -19,6 +19,7 @@ import {
   getPasswordResetEligibility,
   getPasswordResetEligibilityForUser,
 } from '../../services/passwordResetEligibility';
+import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { nanoid } from 'nanoid';
 import { createHash } from 'crypto';
 import { ENABLE_2FA, forgotPasswordSchema, resetPasswordSchema, changePasswordSchema } from './schemas';
@@ -129,14 +130,24 @@ passwordRoutes.post('/forgot-password', zValidator('json', forgotPasswordSchema)
     console.warn('[auth] Password reset requested for non-existent account');
   } else if (eligibility.userId) {
     // Known user, blocked for policy reasons (SSO required / tenant
-    // inactive / user disabled). Log the denial for ops visibility.
+    // inactive / user disabled). Log the denial for ops visibility. The
+    // `detail` (e.g. `partner:suspended`) is recorded server-side only —
+    // never in the HTTP response (#719 residual 1).
     writeAuthAudit(c, {
       action: 'user.password.reset.requested',
       result: 'denied',
       reason: eligibility.reason,
       userId: eligibility.userId,
       email: eligibility.email,
+      details: eligibility.detail ? { detail: eligibility.detail } : undefined,
     });
+    // #719 residual 2: feed the anomaly metric so a spike of inactive-tenant
+    // reset attempts is alertable. Reuses the existing failed-login counter
+    // (breeze_failed_logins_total) — the metric is server-side only and never
+    // leaves an enumeration trail in any response.
+    if (eligibility.reason === 'tenant_inactive') {
+      recordFailedLogin('reset_tenant_inactive');
+    }
   }
 
   // Always return success
@@ -185,7 +196,14 @@ passwordRoutes.post('/reset-password', zValidator('json', resetPasswordSchema), 
       result: 'denied',
       reason: eligibility.reason,
       userId,
+      details: eligibility.detail ? { detail: eligibility.detail } : undefined,
     });
+    // #719 residual 2: a tenant that flipped inactive between token-issue and
+    // token-consume is exactly the "trap class" we want visibility on. Count
+    // it (server-side metric only).
+    if (eligibility.reason === 'tenant_inactive') {
+      recordFailedLogin('reset_tenant_inactive');
+    }
     // For all other ineligible reasons (tenant_inactive, user_disabled,
     // unknown_user) surface the same generic error as an expired token
     // — never leak partner-status to the client.

--- a/apps/api/src/services/passwordResetEligibility.test.ts
+++ b/apps/api/src/services/passwordResetEligibility.test.ts
@@ -117,6 +117,10 @@ describe('getPasswordResetEligibility', () => {
 
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe('tenant_inactive');
+    // #719 residual 1: the specific blocking status is recorded server-side
+    // so the audit trail distinguishes a deliberate suspension from a benign
+    // pending signup.
+    expect(result.detail).toBe('partner:suspended');
   });
 
   it('blocks reset for churned partner', async () => {
@@ -129,9 +133,10 @@ describe('getPasswordResetEligibility', () => {
 
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe('tenant_inactive');
+    expect(result.detail).toBe('partner:churned');
   });
 
-  it('blocks reset for soft-deleted partner', async () => {
+  it('blocks reset for soft-deleted partner (detail maps to missing, not the raw status)', async () => {
     setupSelects(
       [{ id: 'u-1', email: 'gone@acme.com', status: 'active', partnerId: 'p-1', orgId: null }],
       [{ status: 'active', deletedAt: new Date('2026-01-01') }],
@@ -141,6 +146,9 @@ describe('getPasswordResetEligibility', () => {
 
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe('tenant_inactive');
+    // Soft-deleted collapses to `missing` so a purged-vs-soft-deleted partner
+    // can't be distinguished from the audit detail.
+    expect(result.detail).toBe('partner:missing');
   });
 
   it('blocks reset for disabled users', async () => {
@@ -165,6 +173,7 @@ describe('getPasswordResetEligibility', () => {
 
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe('tenant_inactive');
+    expect(result.detail).toBe('org:suspended');
   });
 
   it('blocks reset for SSO-enforced org users', async () => {

--- a/apps/api/src/services/passwordResetEligibility.ts
+++ b/apps/api/src/services/passwordResetEligibility.ts
@@ -14,6 +14,20 @@ export interface ResetEligibility {
   reason?: ResetIneligibleReason;
   userId?: string;
   email?: string;
+  /**
+   * Server-side-only diagnostic detail for the blocking condition (#719
+   * residual 1). For a `tenant_inactive` denial this is the SPECIFIC tenant
+   * status that blocked the reset — `partner:suspended`, `partner:churned`,
+   * `partner:missing`, `org:suspended`, `org:churned`, `org:missing` — so an
+   * operator reading the audit trail can tell a benign self-service `pending`
+   * signup (now ALLOWED) apart from a deliberate `suspended`/`churned` cutoff,
+   * and so the observability signal can be sliced by status.
+   *
+   * MUST NOT be surfaced in any HTTP response body — doing so would turn the
+   * reset flow into an account-enumeration / tenant-status oracle. Callers use
+   * it for audit logging and anomaly metrics only.
+   */
+  detail?: string;
 }
 
 interface UserLookupRow {
@@ -119,7 +133,13 @@ async function evaluateEligibility(user: UserLookupRow): Promise<ResetEligibilit
       .limit(1);
 
     if (!partner || partner.deletedAt || !RESET_ALLOWED_PARTNER_STATUSES.has(partner.status as string)) {
-      return { allowed: false, reason: 'tenant_inactive', userId: user.id, email: user.email };
+      // `detail` records the specific blocking status for the audit trail /
+      // anomaly metric (#719 residual 1). Soft-deleted and not-found both map
+      // to `missing` so a purged-vs-soft-deleted partner can't be told apart.
+      const detail = !partner || partner.deletedAt
+        ? 'partner:missing'
+        : `partner:${partner.status}`;
+      return { allowed: false, reason: 'tenant_inactive', detail, userId: user.id, email: user.email };
     }
   }
 
@@ -131,7 +151,10 @@ async function evaluateEligibility(user: UserLookupRow): Promise<ResetEligibilit
       .limit(1);
 
     if (!org || org.deletedAt || RESET_BLOCKED_ORG_STATUSES.has(org.status as string)) {
-      return { allowed: false, reason: 'tenant_inactive', userId: user.id, email: user.email };
+      const detail = !org || org.deletedAt
+        ? 'org:missing'
+        : `org:${org.status}`;
+      return { allowed: false, reason: 'tenant_inactive', detail, userId: user.id, email: user.email };
     }
   }
 


### PR DESCRIPTION
## Summary

Residual scope for #719, after the acute regression already closed via #774 (`pending` partners can now password-reset). The two follow-ups called out in the issue thread — both implemented in a strictly non-enumerating way.

### 1. Distinguish `pending` vs `suspended`/`churned` (server-side audit only)
`getPasswordResetEligibility` now returns a `detail` for a `tenant_inactive` denial: `partner:suspended`, `partner:churned`, `partner:missing`, `org:suspended`, `org:churned`, `org:missing`. This lands in the auth-audit `details` so an operator can tell a benign self-service `pending` signup (now allowed) apart from a deliberate `suspended`/`churned` cutoff.

- Soft-deleted/not-found collapse to `missing` (no purged-vs-soft-deleted distinction).
- The field is documented as **forbidden from any HTTP response** — surfacing it would make the reset flow a tenant-status oracle. Tests assert no status string appears in any response body.

### 2. Observability signal for repeated inactive-tenant denials
Wired the existing anomaly recorder (`breeze_failed_logins_total`) into the previously audit-only denial branches:
- `login` → `account_inactive` and `tenant_inactive`
- `forgot-password` / `reset-password` → `reset_tenant_inactive`

Server-side counter only — every client response stays the same generic 401/200/400, so this adds zero enumeration surface. `reason` is a bounded label, so no cardinality concern. This makes a spike (e.g. a billing-state change trapping a cohort) alertable.

**Review fix (double-count):** on the login path the metric is emitted **exactly once** — `auditUserLoginFailure` already calls `recordFailedLogin()` internally (`helpers.ts:567`), so the inactive-account / inactive-tenant branches no longer add a second direct `recordFailedLogin()`. The kept (internal) emission also passes the resolved `orgId`, so it is strictly better-instrumented. `login.test.ts` no longer fully stubs `auditUserLoginFailure`; it mirrors the helper's single internal emission and asserts `recordFailedLogin` is called exactly once per attempt — reintroducing the double-count now fails the suite. The rate-limit branches (`rate_limited_ip` / `rate_limited_account`) keep their standalone direct calls (no paired audit on those paths).

## Security notes
- No status or account-existence information added to any response body.
- `/forgot-password` and `/reset-password` still return generic 200/400; unknown-user and inactive-tenant remain indistinguishable to a network attacker.
- Metric only fires on `tenant_inactive` — not on allowed, unknown, sso_required, or disabled paths (asserted).
- No schema / RLS / migration changes.

## Done vs deferred
- Done: residual (1) audit-status differentiation; residual (2) anomaly signal across login + reset flows; double-count fix on the login path; tests.
- Not in scope (already shipped earlier): the user-facing post-login `pending` vs `suspended`/`churned` copy already exists in `AccountInactiveScreen.tsx`; the `pending`-allows-reset acute fix shipped via #774.

## Tests
`pnpm --filter @breeze/api exec vitest run src/services/passwordResetEligibility.test.ts src/routes/auth/password.test.ts src/routes/auth/login.test.ts` → **29 passed**.

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)