### PR TITLE
feat(web): surface partner ticketing config on the Partner settings hub (#1327)

### DIFF
--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -19,6 +19,18 @@ vi.mock('../shared/Toast', () => ({
   showToast: vi.fn(),
 }));
 
+// Stub the embedded ticketing sub-tab group — we only assert that the Partner
+// hub mounts it on the Ticketing tab, not the (separately tested) sub-tab
+// behaviour. The stub records the `syncHash` prop so we can assert the hub
+// disables hash-sync to avoid colliding with its own top-level tab hash.
+const ticketingTabsProps: Array<{ syncHash?: boolean }> = [];
+vi.mock('./TicketingSettingsTabs', () => ({
+  default: (props: { syncHash?: boolean }) => {
+    ticketingTabsProps.push(props);
+    return <div data-testid="stub-ticketing-settings-tabs">TicketingTabsStub</div>;
+  },
+}));
+
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 const useOrgStoreMock = vi.mocked(useOrgStore);
 const showToastMock = vi.mocked(showToast);
@@ -86,6 +98,7 @@ describe('runPartnerSave', () => {
 describe('PartnerSettingsPage language control', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.location.hash = '';
     useOrgStoreMock.mockReturnValue({ currentPartnerId: 'partner-1', isLoading: false } as never);
   });
 
@@ -127,6 +140,7 @@ describe('PartnerSettingsPage language control', () => {
 describe('PartnerSettingsPage Company tab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.location.hash = '';
     useOrgStoreMock.mockReturnValue({ currentPartnerId: 'partner-1', isLoading: false } as never);
   });
 
@@ -209,5 +223,73 @@ describe('PartnerSettingsPage Company tab', () => {
     const body = JSON.parse((patchCall![1] as RequestInit).body as string);
     expect(body.name).toBe('Acme MSP Inc.');
     expect(body.settings.address.city).toBe('Denver');
+  });
+});
+
+describe('PartnerSettingsPage Ticketing tab', () => {
+  const partnerResponse = {
+    id: 'partner-1',
+    name: 'Acme MSP',
+    slug: 'acme',
+    type: 'partner',
+    plan: 'pro',
+    createdAt: '2026-02-09T00:00:00.000Z',
+    settings: {
+      timezone: 'UTC',
+      dateFormat: 'MM/DD/YYYY',
+      timeFormat: '12h',
+      language: 'en',
+      businessHours: { preset: 'business' },
+      contact: {},
+      address: {},
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    ticketingTabsProps.length = 0;
+    useOrgStoreMock.mockReturnValue({ currentPartnerId: 'partner-1', isLoading: false } as never);
+  });
+
+  it('exposes a Ticketing tab in the tab bar', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(partnerResponse));
+
+    render(<PartnerSettingsPage />);
+
+    await screen.findByText('Partner Settings');
+    expect(screen.getByRole('button', { name: /^ticketing$/i })).not.toBeNull();
+    // Not the active tab by default, so the embedded tabs are not mounted yet.
+    expect(screen.queryByTestId('stub-ticketing-settings-tabs')).toBeNull();
+  });
+
+  it('mounts the ticketing sub-tabs (hash-sync disabled) when the tab is clicked', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(partnerResponse));
+
+    render(<PartnerSettingsPage />);
+
+    await screen.findByText('Partner Settings');
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^ticketing$/i }));
+
+    expect(screen.getByTestId('stub-ticketing-settings-tabs')).not.toBeNull();
+    // The hub owns the top-level tab hash, so the embedded group must NOT sync it.
+    expect(ticketingTabsProps.at(-1)).toMatchObject({ syncHash: false });
+    // Clicking the tab keeps the URL deep-linkable.
+    expect(window.location.hash).toBe('#ticketing');
+    // The inheritance banner is partner-config-only and must be hidden here.
+    expect(screen.queryByText(/enforced across all organizations/i)).toBeNull();
+  });
+
+  it('deep-links #ticketing straight to the Ticketing tab on mount', async () => {
+    window.location.hash = '#ticketing';
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(partnerResponse));
+
+    render(<PartnerSettingsPage />);
+
+    expect(await screen.findByTestId('stub-ticketing-settings-tabs')).not.toBeNull();
   });
 });

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   Save,
 } from 'lucide-react';
+import TicketingSettingsTabs from './TicketingSettingsTabs';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { getJwtClaims } from '../../lib/authScope';
@@ -37,7 +38,7 @@ import type {
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
 
-type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'aiBudgets' | 'remoteAccess';
+type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'aiBudgets' | 'remoteAccess' | 'ticketing';
 
 type Partner = {
   id: string;
@@ -59,7 +60,24 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: 'branding', label: 'Branding' },
   { key: 'aiBudgets', label: 'AI Budgets' },
   { key: 'remoteAccess', label: 'Remote' },
+  { key: 'ticketing', label: 'Ticketing' },
 ];
+
+const VALID_TAB_KEYS = TABS.map(t => t.key);
+
+/**
+ * Map a top-level URL hash to a partner settings tab. The Ticketing tab is
+ * deep-linkable via `/settings/partner#ticketing` (the old `/settings/ticketing`
+ * route redirects here), so honor that fragment on first render. Other fragments
+ * fall back to the default Company tab. The nested ticketing sub-tab `#tab=…`
+ * fragment is intentionally NOT used here — the embedded TicketingSettingsTabs
+ * keeps its own local state so the two hash schemes don't collide.
+ */
+function getTabFromHash(): TabKey | null {
+  if (typeof window === 'undefined') return null;
+  const hash = window.location.hash.replace('#', '');
+  return (VALID_TAB_KEYS as string[]).includes(hash) ? (hash as TabKey) : null;
+}
 
 const TIMEZONES = [
   'UTC', 'America/New_York', 'America/Chicago', 'America/Denver',
@@ -208,6 +226,21 @@ export default function PartnerSettingsPage() {
     setLoading(false); // JWT confirms non-partner scope; show access denied
   }, [currentPartnerId, contextLoading, fetchPartner, setPartnerContext]);
 
+  // Deep-link support: open the tab named in the URL hash on mount (e.g.
+  // `/settings/partner#ticketing`, which the legacy `/settings/ticketing` route
+  // redirects to). Seeded SSR-safe via the 'company' default above; the hash is
+  // applied client-side here to avoid a hydration mismatch. Also tracks external
+  // hash changes (back/forward, in-app links).
+  useEffect(() => {
+    const applyHash = () => {
+      const tab = getTabFromHash();
+      if (tab) setActiveTab(tab);
+    };
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+    return () => window.removeEventListener('hashchange', applyHash);
+  }, []);
+
   const handleSave = async () => {
     setSaving(true);
     setError(undefined);
@@ -350,7 +383,11 @@ export default function PartnerSettingsPage() {
           <button
             key={tab.key}
             type="button"
-            onClick={() => setActiveTab(tab.key)}
+            onClick={() => {
+              setActiveTab(tab.key);
+              // Keep the URL hash in sync so the tab is bookmarkable / deep-linkable.
+              history.replaceState(null, '', `#${tab.key}`);
+            }}
             className={cn(
               'px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap',
               activeTab === tab.key
@@ -363,7 +400,7 @@ export default function PartnerSettingsPage() {
         ))}
       </div>
 
-      {activeTab !== 'regional' && activeTab !== 'company' && (
+      {activeTab !== 'regional' && activeTab !== 'company' && activeTab !== 'ticketing' && (
         <div className="rounded-md border bg-blue-50 dark:bg-blue-950/30 px-4 py-3 text-sm text-blue-700 dark:text-blue-300">
           Values you set here are enforced across all organizations. Leave fields empty to let each organization configure individually.
         </div>
@@ -544,6 +581,19 @@ export default function PartnerSettingsPage() {
       {activeTab === 'remoteAccess' && (
         <section className="rounded-lg border bg-card p-6 shadow-sm">
           <PartnerRemoteAccessTab data={remoteAccessData} onChange={setRemoteAccessData} />
+        </section>
+      )}
+
+      {/* Ticketing: partner-wide statuses, priority SLAs, categories, and billing
+          export. Each sub-tab persists independently, so the top-level "Save
+          Settings" button does not apply here. */}
+      {activeTab === 'ticketing' && (
+        <section className="space-y-2" data-testid="partner-ticketing-tab">
+          <p className="text-sm text-muted-foreground">
+            Configure ticket statuses, priority SLA defaults, categories, and billing exports.
+            These apply across all of your organizations.
+          </p>
+          <TicketingSettingsTabs syncHash={false} />
         </section>
       )}
     </div>

--- a/apps/web/src/components/settings/TicketingSettingsPage.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsPage.tsx
@@ -1,54 +1,6 @@
-import { useEffect, useState } from 'react';
-import { cn } from '@/lib/utils';
-import TicketCategoriesPage from './TicketCategoriesPage';
-import BillablesExportCard from './BillablesExportCard';
-import TicketStatusesTab from './TicketStatusesTab';
-import TicketPrioritiesTab from './TicketPrioritiesTab';
-
-const VALID_TABS = ['statuses', 'priorities', 'categories', 'export'] as const;
-type Tab = (typeof VALID_TABS)[number];
-
-const TABS: Array<{ id: Tab; label: string }> = [
-  { id: 'statuses', label: 'Statuses' },
-  { id: 'priorities', label: 'Priorities' },
-  { id: 'categories', label: 'Categories' },
-  { id: 'export', label: 'Export' }
-];
-
-function parseHash(): Tab {
-  if (typeof window === 'undefined') return 'statuses';
-  for (const part of window.location.hash.replace('#', '').split('&')) {
-    if (part.startsWith('tab=')) {
-      const value = part.slice('tab='.length);
-      if ((VALID_TABS as readonly string[]).includes(value)) return value as Tab;
-    }
-  }
-  return 'statuses';
-}
-
-function hashFor(tab: Tab): string {
-  return `#tab=${tab}`;
-}
+import TicketingSettingsTabs from './TicketingSettingsTabs';
 
 export default function TicketingSettingsPage() {
-  // Seed the SSR-safe default ('statuses') so the first client render matches the
-  // server (which has no hash); the deep-linked #tab= is applied in the mount
-  // effect below. Reading the hash directly into useState caused a hydration
-  // mismatch on `/settings/ticketing#tab=export` (same class as the login #418).
-  const [activeTab, setActiveTab] = useState<Tab>('statuses');
-
-  const switchTab = (tab: Tab) => {
-    history.replaceState(null, '', hashFor(tab));
-    setActiveTab(tab);
-  };
-
-  useEffect(() => {
-    setActiveTab(parseHash());
-    const onHashChange = () => setActiveTab(parseHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
-
   return (
     <div className="space-y-6" data-testid="ticketing-settings-page">
       <div>
@@ -58,42 +10,7 @@ export default function TicketingSettingsPage() {
         </p>
       </div>
 
-      <div role="tablist" className="flex gap-1 border-b" data-testid="ticketing-settings-tabs">
-        {TABS.map((t) => (
-          <button
-            key={t.id}
-            type="button"
-            role="tab"
-            aria-selected={activeTab === t.id}
-            onClick={() => switchTab(t.id)}
-            data-testid={`ticketing-tab-${t.id}`}
-            className={cn(
-              'border-b-2 px-4 py-2 text-sm font-medium transition-colors -mb-px',
-              activeTab === t.id
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            )}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-
-      {activeTab === 'statuses' && (
-        <div data-testid="ticketing-tab-panel-statuses">
-          <TicketStatusesTab />
-        </div>
-      )}
-
-      {activeTab === 'priorities' && (
-        <div data-testid="ticketing-tab-panel-priorities">
-          <TicketPrioritiesTab />
-        </div>
-      )}
-
-      {activeTab === 'categories' && <TicketCategoriesPage />}
-
-      {activeTab === 'export' && <BillablesExportCard />}
+      <TicketingSettingsTabs />
     </div>
   );
 }

--- a/apps/web/src/components/settings/TicketingSettingsTabs.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub child components — we test only the sub-tab group's switching behaviour.
+vi.mock('./TicketCategoriesPage', () => ({
+  default: () => <div data-testid="stub-ticket-categories-page">CategoriesStub</div>
+}));
+vi.mock('./BillablesExportCard', () => ({
+  default: () => <div data-testid="stub-billables-export-card">ExportStub</div>
+}));
+vi.mock('./TicketStatusesTab', () => ({
+  default: () => <div data-testid="stub-ticket-statuses-tab">StatusesStub</div>
+}));
+vi.mock('./TicketPrioritiesTab', () => ({
+  default: () => <div data-testid="stub-ticket-priorities-tab">PrioritiesStub</div>
+}));
+
+import TicketingSettingsTabs from './TicketingSettingsTabs';
+
+describe('TicketingSettingsTabs', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('renders all four sub-tabs and defaults to statuses', () => {
+    render(<TicketingSettingsTabs />);
+    expect(screen.getByTestId('ticketing-tab-statuses')).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-priorities')).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-categories')).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-export')).toBeInTheDocument();
+    expect(screen.getByTestId('ticketing-tab-panel-statuses')).toBeInTheDocument();
+  });
+
+  it('switches tabs and (by default) syncs the URL hash', () => {
+    render(<TicketingSettingsTabs />);
+    fireEvent.click(screen.getByTestId('ticketing-tab-categories'));
+    expect(screen.getByTestId('stub-ticket-categories-page')).toBeInTheDocument();
+    expect(window.location.hash).toBe('#tab=categories');
+  });
+
+  it('honors a #tab= deep link on mount', () => {
+    window.location.hash = '#tab=export';
+    render(<TicketingSettingsTabs />);
+    expect(screen.getByTestId('stub-billables-export-card')).toBeInTheDocument();
+  });
+
+  it('does NOT touch the URL hash when syncHash is false (embedded mode)', () => {
+    window.location.hash = '#ticketing';
+    render(<TicketingSettingsTabs syncHash={false} />);
+    fireEvent.click(screen.getByTestId('ticketing-tab-export'));
+    // Tab still switches locally...
+    expect(screen.getByTestId('stub-billables-export-card')).toBeInTheDocument();
+    // ...but the owning hub's top-level hash is left untouched.
+    expect(window.location.hash).toBe('#ticketing');
+  });
+
+  it('ignores #tab= deep links when syncHash is false', () => {
+    window.location.hash = '#tab=export';
+    render(<TicketingSettingsTabs syncHash={false} />);
+    // Embedded mode starts on the default statuses tab regardless of #tab=.
+    expect(screen.getByTestId('ticketing-tab-panel-statuses')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-billables-export-card')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import TicketCategoriesPage from './TicketCategoriesPage';
+import BillablesExportCard from './BillablesExportCard';
+import TicketStatusesTab from './TicketStatusesTab';
+import TicketPrioritiesTab from './TicketPrioritiesTab';
+
+const VALID_TABS = ['statuses', 'priorities', 'categories', 'export'] as const;
+type Tab = (typeof VALID_TABS)[number];
+
+const TABS: Array<{ id: Tab; label: string }> = [
+  { id: 'statuses', label: 'Statuses' },
+  { id: 'priorities', label: 'Priorities' },
+  { id: 'categories', label: 'Categories' },
+  { id: 'export', label: 'Export' }
+];
+
+function parseHash(): Tab {
+  if (typeof window === 'undefined') return 'statuses';
+  for (const part of window.location.hash.replace('#', '').split('&')) {
+    if (part.startsWith('tab=')) {
+      const value = part.slice('tab='.length);
+      if ((VALID_TABS as readonly string[]).includes(value)) return value as Tab;
+    }
+  }
+  return 'statuses';
+}
+
+function hashFor(tab: Tab): string {
+  return `#tab=${tab}`;
+}
+
+/**
+ * Reusable partner-wide ticketing config sub-tab group: Statuses / Priorities /
+ * Categories / Export. All four child components are already partner-scoped (no
+ * org context), so this renders identically whether mounted on the standalone
+ * `/settings/ticketing` page or embedded inside the Partner settings hub.
+ *
+ * Sub-tab selection is driven by a `#tab=` hash fragment so deep-links survive a
+ * page reload. The default is seeded SSR-safe ('statuses') and the deep-linked
+ * value is applied in the mount effect to avoid a hydration mismatch (same class
+ * as login #418).
+ *
+ * `syncHash` controls whether sub-tab clicks write back to the URL hash. The
+ * standalone page owns the whole hash so it syncs; when embedded under the
+ * Partner hub (which owns the top-level tab hash, e.g. `#ticketing`) we leave it
+ * off so the two don't fight over `window.location.hash`.
+ */
+export default function TicketingSettingsTabs({ syncHash = true }: { syncHash?: boolean }) {
+  const [activeTab, setActiveTab] = useState<Tab>('statuses');
+
+  const switchTab = (tab: Tab) => {
+    if (syncHash) history.replaceState(null, '', hashFor(tab));
+    setActiveTab(tab);
+  };
+
+  useEffect(() => {
+    if (!syncHash) return;
+    setActiveTab(parseHash());
+    const onHashChange = () => setActiveTab(parseHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, [syncHash]);
+
+  return (
+    <div className="space-y-6">
+      <div role="tablist" className="flex gap-1 border-b" data-testid="ticketing-settings-tabs">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === t.id}
+            onClick={() => switchTab(t.id)}
+            data-testid={`ticketing-tab-${t.id}`}
+            className={cn(
+              'border-b-2 px-4 py-2 text-sm font-medium transition-colors -mb-px',
+              activeTab === t.id
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'statuses' && (
+        <div data-testid="ticketing-tab-panel-statuses">
+          <TicketStatusesTab />
+        </div>
+      )}
+
+      {activeTab === 'priorities' && (
+        <div data-testid="ticketing-tab-panel-priorities">
+          <TicketPrioritiesTab />
+        </div>
+      )}
+
+      {activeTab === 'categories' && <TicketCategoriesPage />}
+
+      {activeTab === 'export' && <BillablesExportCard />}
+    </div>
+  );
+}

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -515,7 +515,7 @@ export default function TicketsPage() {
           </p>
           <div className="mt-3 flex gap-2">
             <a href="/tickets/new" className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90" data-testid="tickets-empty-create">Create ticket</a>
-            <a href="/settings/ticketing" className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted" data-testid="tickets-empty-settings">Ticketing settings</a>
+            <a href="/settings/partner#ticketing" className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted" data-testid="tickets-empty-settings">Ticketing settings</a>
           </div>
         </div>
       ) : error ? (

--- a/apps/web/src/pages/settings/index.astro
+++ b/apps/web/src/pages/settings/index.astro
@@ -14,7 +14,7 @@ import PartnerSettingsCard from '../../components/settings/PartnerSettingsCard';
       <PartnerSettingsCard client:load />
 
       <a
-        href="/settings/ticketing"
+        href="/settings/partner#ticketing"
         class="rounded-lg border bg-card p-6 shadow-sm transition hover:border-primary hover:shadow-md"
       >
         <div class="space-y-2">

--- a/apps/web/src/pages/settings/ticketing.astro
+++ b/apps/web/src/pages/settings/ticketing.astro
@@ -1,8 +1,6 @@
 ---
-import DashboardLayout from '../../layouts/DashboardLayout.astro';
-import TicketingSettingsPage from '../../components/settings/TicketingSettingsPage';
+// Ticketing config now lives on the Partner settings hub (issue #1327). Keep this
+// route as a permanent alias so existing bookmarks / in-app links land on the
+// new Ticketing tab instead of 404ing.
+return Astro.redirect('/settings/partner#ticketing', 301);
 ---
-
-<DashboardLayout title="Ticketing Settings">
-  <TicketingSettingsPage client:load />
-</DashboardLayout>


### PR DESCRIPTION
## What

Brings all partner-wide ticketing options onto the **Partner settings hub**, matching the Org page's integrated tabbed layout. The partner-wide ticketing config (statuses, priority SLAs, categories, billing export) **already existed and was already partner-scoped** — it just lived on an orphaned `/settings/ticketing` route never wired into the Partner settings page.

This is **Phase 1 / interpretation (a)** from the issue: web-only IA wiring, **no schema change**. Statuses/priorities/categories remain defined once per partner and shared by all child orgs; orgs keep their existing SLA + billing overrides.

## Changes

- **Extract** the four ticketing sub-tabs (Statuses / Priorities / Categories / Export) into a reusable `TicketingSettingsTabs` component with a `syncHash` prop.
- **Add a Ticketing tab** to `PartnerSettingsPage` that embeds it with `syncHash={false}` so the hub's top-level tab hash and the sub-tab `#tab=` hash don't collide. The tab is deep-linkable via `/settings/partner#ticketing`.
- **Redirect** the legacy `/settings/ticketing` route (301) to the new tab and point the settings index card + Tickets empty-state link at it. `TicketingSettingsPage` becomes a thin wrapper over the shared component (existing route/bookmarks still work).
- **Hide** the "enforced across all organizations" inheritance banner on the Ticketing tab — it's partner config, not inheritable defaults.

## organizations:read grant trap

The Export tab's org dropdown reuses the existing partner-scoped `/orgs/organizations` listing. No new `organizations:read` exposure: the component lived behind partner scope before and the new Partner page is also partner-scoped, and partner scope already has org-list access. Verified — no change to grants.

## Deferred (not in this PR)

Interpretation (b) — per-org **overridable** statuses/categories (dual-axis schema on `ticket_statuses` / `ticket_priority_settings` / `ticket_categories`, inheritance resolution, RLS allowlist updates, backfill migration). Tracked as a separate follow-up if per-org category/status customization is actually wanted.

## Tests

```
pnpm --filter @breeze/web exec vitest run \
  src/components/settings/TicketingSettingsPage.test.tsx \
  src/components/settings/TicketingSettingsTabs.test.tsx \
  src/components/settings/PartnerSettingsPage.test.tsx
```
=> **27 passed**. Covers: new Ticketing tab in the bar, mounting the sub-tabs on click with `syncHash=false`, `#ticketing` deep-link, banner hidden on the tab, and the extracted component's hash-sync / embedded-mode behaviour. Web typecheck clean on all touched files.

Closes #1327

🤖 Generated with [Claude Code](https://claude.com/claude-code)