### PR TITLE
test(api): catch-block wiring coverage for SSRF sync errors — DNS + SentinelOne (#1035 item 2)

### DIFF
--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -444,7 +444,12 @@ async function processSyncAll(): Promise<{ queued: number }> {
   return { queued: dueIntegrations.length };
 }
 
-async function processSyncIntegration(data: SyncIntegrationJobData): Promise<{
+// Exported for focused catch-block coverage (#1035 item 2): a unit test mocks
+// the provider to throw a DnsProviderHttpError carrying a distinctive upstream
+// body marker and asserts the SSRF read-oracle invariant — the tenant-visible
+// `lastSyncError` column gets only the body-free status line while the full
+// (redacted) body lands in the server-side log.
+export async function processSyncIntegration(data: SyncIntegrationJobData): Promise<{
   integrationId: string;
   fetched: number;
   inserted: number;
@@ -653,7 +658,10 @@ async function processSyncIntegration(data: SyncIntegrationJobData): Promise<{
   }
 }
 
-async function processPolicySync(data: SyncPolicyJobData): Promise<{
+// Exported for focused catch-block coverage (#1035 item 2) — same invariant as
+// processSyncIntegration, but for the policy-sync path's tenant-visible
+// `dns_policies.syncError` column.
+export async function processPolicySync(data: SyncPolicyJobData): Promise<{
   policyId: string;
   added: number;
   removed: number;

--- a/apps/api/src/jobs/dnsSyncJob_syncError.test.ts
+++ b/apps/api/src/jobs/dnsSyncJob_syncError.test.ts
@@ -1,0 +1,221 @@
+/**
+ * DNS sync catch-block wiring — SSRF read-oracle invariant (#1035 item 2,
+ * follow-up to #1025).
+ *
+ * The pure helpers (`tenantVisibleSyncError`, `logSyncFailureServerSide`) are
+ * unit-tested in dnsSyncJob.test.ts, but nothing proved the *catch blocks* in
+ * `processSyncIntegration` / `processPolicySync` actually call them correctly.
+ * A regression that swapped the tenant-visible column write back to
+ * `redactLogMessage(error.responseBody)` (the pre-#1025 behavior) would have
+ * passed every existing test, re-opening the partial-read oracle for
+ * tenant-controlled Pi-hole / AdGuard endpoints.
+ *
+ * These tests drive the (now exported) processors with a chainable DB mock and
+ * a provider stubbed to throw a `DnsProviderHttpError` carrying a distinctive
+ * upstream-body marker, then assert:
+ *   (a) the value written to the tenant column (`lastSyncError` / `syncError`)
+ *       contains the body-free status line and NEVER the upstream body marker;
+ *   (b) the full (redacted) body IS captured in the server-side console.error.
+ *
+ * Pure unit test — runs in the standard `test-api` CI job (no live DB needed).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Distinctive markers planted in the upstream response body. Neither may ever
+// reach the tenant-visible DB column; the secret-shaped one must additionally
+// be redacted even in the server-side log.
+const UPSTREAM_BODY_MARKER = 'UPSTREAM_PIHOLE_BODY_MARKER_must_not_reach_tenant';
+const UPSTREAM_BODY_SECRET = 'auth=SUPERSECRETPIHOLEKEY';
+
+// Capture every payload passed to `db.update(...).set(<payload>)` so we can
+// inspect what would be persisted to the tenant-visible columns.
+const setCalls: Array<Record<string, unknown>> = [];
+
+const mockDb = {
+  // SELECT chain — `processSyncIntegration` does `.select().from().where().limit()`
+  // and `processPolicySync` does `.select().from().innerJoin().where().limit()`.
+  select: vi.fn(),
+  insert: vi.fn(),
+  delete: vi.fn(),
+  update: vi.fn(),
+};
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: undefined,
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+}));
+
+// Keep the REAL DnsProviderHttpError (the processors use `instanceof`), but stub
+// the factory so we can make the provider throw on demand.
+const createDnsProviderMock = vi.fn();
+vi.mock('../services/dnsProviders', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/dnsProviders')>();
+  return {
+    ...actual,
+    createDnsProvider: createDnsProviderMock,
+  };
+});
+
+// The decrypt step runs before the provider is built — make it a no-op pass-through.
+vi.mock('../services/secretCrypto', () => ({
+  decryptForColumn: (_table: string, _column: string, value: unknown) => value ?? 'decrypted',
+}));
+
+// Event-bus publish is best-effort and irrelevant to the error path.
+vi.mock('../services/eventBus', () => ({
+  publishEvent: vi.fn().mockResolvedValue(undefined),
+  EVENT_TYPES: { DNS_THREAT_BLOCKED: 'dns.threat.blocked' },
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+
+const { processSyncIntegration, processPolicySync } = await import('./dnsSyncJob');
+const { DnsProviderHttpError } = await import('../services/dnsProviders');
+
+/** A single-result SELECT chain returning `rows`. */
+function selectReturning(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  for (const method of ['from', 'where', 'innerJoin']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.limit = vi.fn().mockResolvedValue(rows);
+  return chain;
+}
+
+function makeUpdateMock() {
+  return vi.fn().mockImplementation(() => ({
+    set: vi.fn().mockImplementation((payload: Record<string, unknown>) => {
+      setCalls.push(payload);
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setCalls.length = 0;
+  mockDb.update.mockImplementation(makeUpdateMock());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('processSyncIntegration catch block — tenant-visible lastSyncError is body-free (#1035)', () => {
+  it('stores only the HTTP status line, never the upstream body, and logs the redacted body server-side', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // SELECT the integration row.
+    mockDb.select.mockReturnValue(
+      selectReturning([
+        {
+          id: 'int-1',
+          orgId: 'org-1',
+          provider: 'pihole',
+          apiKey: 'enc-key',
+          apiSecret: null,
+          isActive: true,
+          config: {},
+          lastSync: null,
+        },
+      ]),
+    );
+
+    // The provider's syncEvents throws an upstream HTTP error whose body carries
+    // a secret + a distinctive marker — the read-oracle payload.
+    createDnsProviderMock.mockReturnValue({
+      syncEvents: vi.fn().mockRejectedValue(
+        new DnsProviderHttpError(
+          502,
+          'Bad Gateway',
+          `${UPSTREAM_BODY_MARKER} ${UPSTREAM_BODY_SECRET}`,
+        ),
+      ),
+    });
+
+    await expect(
+      processSyncIntegration({ type: 'sync-integration', integrationId: 'int-1' }),
+    ).rejects.toBeInstanceOf(DnsProviderHttpError);
+
+    // The catch block must have written the error status to the tenant column.
+    const errorUpdate = setCalls.find((payload) => payload.lastSyncStatus === 'error');
+    expect(errorUpdate).toBeDefined();
+    const stored = String(errorUpdate!.lastSyncError);
+
+    // (a) status line present, upstream body absent.
+    expect(stored).toBe('HTTP 502 Bad Gateway');
+    expect(stored).not.toContain(UPSTREAM_BODY_MARKER);
+    expect(stored).not.toContain('SUPERSECRETPIHOLEKEY');
+
+    // (b) the full (redacted) body lands in the server-side log only.
+    const logged = errorSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n');
+    expect(logged).toContain(UPSTREAM_BODY_MARKER);
+    expect(logged).toContain('[REDACTED]');
+    // ...and the secret is NOT echoed verbatim even server-side.
+    expect(logged).not.toContain('SUPERSECRETPIHOLEKEY');
+  });
+
+  it('redacts a transport-error secret (Pi-hole ?auth=<key>) in the stored column', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockDb.select.mockReturnValue(
+      selectReturning([
+        { id: 'int-2', orgId: 'org-1', provider: 'pihole', apiKey: 'k', apiSecret: null, isActive: true, config: {}, lastSync: null },
+      ]),
+    );
+    createDnsProviderMock.mockReturnValue({
+      syncEvents: vi.fn().mockRejectedValue(
+        new Error('connect ECONNREFUSED https://pihole.local/admin/api.php?auth=SUPERSECRETPIHOLEKEY'),
+      ),
+    });
+
+    await expect(
+      processSyncIntegration({ type: 'sync-integration', integrationId: 'int-2' }),
+    ).rejects.toThrow();
+
+    const stored = String(setCalls.find((p) => p.lastSyncStatus === 'error')!.lastSyncError);
+    expect(stored).not.toContain('SUPERSECRETPIHOLEKEY');
+    expect(stored).toContain('[REDACTED]');
+  });
+});
+
+describe('processPolicySync catch block — tenant-visible syncError is body-free (#1035)', () => {
+  it('stores only the HTTP status line in dns_policies.syncError, never the upstream body', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // SELECT the policy joined to its integration.
+    mockDb.select.mockReturnValue(
+      selectReturning([
+        {
+          policy: { id: 'pol-1', type: 'blocklist', domains: [{ domain: 'evil.example.com' }] },
+          integration: { id: 'int-1', orgId: 'org-1', provider: 'adguard_home', apiKey: 'k', apiSecret: 's', config: {} },
+        },
+      ]),
+    );
+
+    // addBlocklistDomain throws an upstream HTTP error with the marker body.
+    createDnsProviderMock.mockReturnValue({
+      addBlocklistDomain: vi.fn().mockRejectedValue(
+        new DnsProviderHttpError(403, 'Forbidden', `${UPSTREAM_BODY_MARKER} ${UPSTREAM_BODY_SECRET}`),
+      ),
+      removeBlocklistDomain: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(
+      processPolicySync({ type: 'sync-policy', policyId: 'pol-1' }),
+    ).rejects.toBeInstanceOf(DnsProviderHttpError);
+
+    const errorUpdate = setCalls.find((payload) => payload.syncStatus === 'error');
+    expect(errorUpdate).toBeDefined();
+    const stored = String(errorUpdate!.syncError);
+
+    expect(stored).toBe('HTTP 403 Forbidden');
+    expect(stored).not.toContain(UPSTREAM_BODY_MARKER);
+    expect(stored).not.toContain('SUPERSECRETPIHOLEKEY');
+
+    const logged = errorSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n');
+    expect(logged).toContain(UPSTREAM_BODY_MARKER);
+    expect(logged).toContain('[REDACTED]');
+  });
+});

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -579,7 +579,14 @@ async function syncThreatsForIntegration(
   };
 }
 
-async function processSyncIntegration(data: SyncIntegrationJobData) {
+// Exported for focused catch-block coverage (#1035 item 2): a unit test mocks
+// the S1 client to throw a SentinelOneHttpError carrying a distinctive upstream
+// body marker and asserts that the tenant-visible `s1_integrations.lastSyncError`
+// column receives only the body-free status line (no marker), while the full
+// (redacted) body is logged server-side. A regression swapping the column write
+// back to `redactLogMessage(error.responseBody)` would otherwise pass every
+// existing helper-level test.
+export async function processSyncIntegration(data: SyncIntegrationJobData) {
   const [integration] = await db
     .select({
       id: s1Integrations.id,

--- a/apps/api/src/jobs/s1Sync_syncError.test.ts
+++ b/apps/api/src/jobs/s1Sync_syncError.test.ts
@@ -1,0 +1,179 @@
+/**
+ * SentinelOne sync catch-block wiring — SSRF read-oracle invariant (#1035 item
+ * 2, follow-up to #1025).
+ *
+ * The helpers (`truncateError`, `logSyncFailureServerSide`) are unit-tested in
+ * s1Sync.test.ts, but nothing proved the *catch block* in `processSyncIntegration`
+ * actually calls them correctly. A regression swapping the tenant-visible
+ * `s1_integrations.lastSyncError` write back to `redactLogMessage(error.responseBody)`
+ * would have passed every existing test, re-opening the partial-read oracle.
+ *
+ * This drives the (now exported) processor with a chainable DB mock and an S1
+ * client stubbed to throw a `SentinelOneHttpError` carrying a distinctive
+ * upstream-body marker, then asserts:
+ *   (a) the value written to `lastSyncError` is the body-free status line and
+ *       NEVER contains the upstream body marker;
+ *   (b) the full (redacted) body IS captured in the server-side console.error.
+ *
+ * Pure unit test — runs in the standard `test-api` CI job (no live DB needed).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SentinelOneHttpError } from '../services/sentinelOne/client';
+
+const UPSTREAM_BODY_MARKER = 'UPSTREAM_S1_BODY_MARKER_must_not_reach_tenant';
+const UPSTREAM_BODY_SECRET = 'Authorization: Bearer s1_leaked_token';
+
+// Capture every `db.update(...).set(<payload>)` payload.
+const setCalls: Array<Record<string, unknown>> = [];
+
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: undefined,
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+}));
+
+vi.mock('../services/secretCrypto', () => ({
+  decryptForColumn: () => 'decrypted-token',
+}));
+
+// Stub the S1 client so listAgents throws an upstream HTTP error, but keep the
+// REAL SentinelOneHttpError (processSyncIntegration / logSyncFailureServerSide
+// use `instanceof`) and S1_THREAT_ACTIONS. A real mock class is used so `new
+// SentinelOneClient(...)` constructs correctly (a vi.fn() impl returning an
+// object does not behave as a constructor here).
+const listAgentsMock = vi.fn();
+vi.mock('../services/sentinelOne/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/sentinelOne/client')>();
+  class MockSentinelOneClient {
+    listAgents = listAgentsMock;
+    listThreats = vi.fn().mockResolvedValue({ results: [], truncated: false });
+    getActivityStatus = vi.fn();
+  }
+  return {
+    ...actual,
+    SentinelOneClient: MockSentinelOneClient,
+  };
+});
+
+vi.mock('../services/sentinelOne/metrics', () => ({
+  recordS1ActionDispatch: vi.fn(),
+  recordS1ActionPollTransition: vi.fn(),
+  recordS1SyncRun: vi.fn(),
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn().mockResolvedValue(undefined) }));
+
+const { processSyncIntegration } = await import('./s1Sync');
+
+/** A single-result SELECT chain returning `rows`. */
+function selectReturning(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  for (const method of ['from', 'where', 'innerJoin', 'leftJoin']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.limit = vi.fn().mockResolvedValue(rows);
+  // Some selects in the sync path are awaited directly (no .limit()); make the
+  // chain itself thenable so `await db.select()...where()` resolves to [].
+  chain.then = (resolve: (value: unknown[]) => unknown) => resolve(rows);
+  return chain;
+}
+
+function makeUpdateMock() {
+  return vi.fn().mockImplementation(() => ({
+    set: vi.fn().mockImplementation((payload: Record<string, unknown>) => {
+      setCalls.push(payload);
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setCalls.length = 0;
+  mockDb.update.mockImplementation(makeUpdateMock());
+  // syncAgentsForIntegration runs mapSiteOrgIds / mapDeviceCandidatesByOrg first
+  // (both empty), then listAgents throws. Default every SELECT to empty rows;
+  // the integration lookup is overridden per-test.
+  mockDb.select.mockReturnValue(selectReturning([]));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('s1 processSyncIntegration catch block — lastSyncError is body-free (#1035)', () => {
+  function primeIntegrationLookup() {
+    // First .select() is the integration row; the rest (site mappings, device
+    // candidates) come back empty via the default mock.
+    mockDb.select
+      .mockReturnValueOnce(
+        selectReturning([
+          {
+            id: 'int-1',
+            orgId: 'org-1',
+            managementUrl: 'https://example.sentinelone.net',
+            apiTokenEncrypted: 'enc',
+            isActive: true,
+            lastSyncAt: null,
+          },
+        ]),
+      )
+      .mockReturnValue(selectReturning([]));
+  }
+
+  it('stores only the status line, never the upstream body, and logs the redacted body server-side', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    primeIntegrationLookup();
+
+    listAgentsMock.mockRejectedValue(
+      new SentinelOneHttpError(
+        'GET',
+        '/web/api/v2.1/agents',
+        500,
+        `${UPSTREAM_BODY_MARKER} ${UPSTREAM_BODY_SECRET}`,
+      ),
+    );
+
+    await expect(
+      processSyncIntegration({ type: 'sync-integration', integrationId: 'int-1', syncAgents: true, syncThreats: false }),
+    ).rejects.toBeInstanceOf(SentinelOneHttpError);
+
+    const errorUpdate = setCalls.find((payload) => payload.lastSyncStatus === 'error');
+    expect(errorUpdate).toBeDefined();
+    const stored = String(errorUpdate!.lastSyncError);
+
+    // (a) body-free status line; upstream body + header secret absent.
+    expect(stored).toBe('SentinelOne API GET /web/api/v2.1/agents failed (500)');
+    expect(stored).not.toContain(UPSTREAM_BODY_MARKER);
+    expect(stored).not.toContain('s1_leaked_token');
+
+    // (b) the (redacted) body is captured server-side only.
+    const logged = errorSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n');
+    expect(logged).toContain(UPSTREAM_BODY_MARKER);
+    expect(logged).toContain('[REDACTED]');
+    expect(logged).not.toContain('s1_leaked_token');
+  });
+
+  it('redacts a header-shaped secret from a non-HTTP transport error in the stored column', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    primeIntegrationLookup();
+    listAgentsMock.mockRejectedValue(new Error('socket hangup Authorization: Bearer s1_leaked_token'));
+
+    await expect(
+      processSyncIntegration({ type: 'sync-integration', integrationId: 'int-1', syncAgents: true, syncThreats: false }),
+    ).rejects.toThrow();
+
+    const stored = String(setCalls.find((p) => p.lastSyncStatus === 'error')!.lastSyncError);
+    expect(stored).not.toContain('s1_leaked_token');
+    expect(stored).toContain('[REDACTED]');
+  });
+});

--- a/apps/api/src/services/sentinelOne/actions_dispatchError.test.ts
+++ b/apps/api/src/services/sentinelOne/actions_dispatchError.test.ts
@@ -1,0 +1,167 @@
+/**
+ * SentinelOne action-dispatch catch-block wiring — SSRF read-oracle invariant
+ * (#1035 item 2, follow-up to #1025).
+ *
+ * actions.test.ts proves the helpers (`truncateError`,
+ * `logActionDispatchFailureServerSide`) in isolation, but nothing drove
+ * `executeS1IsolationForOrg` / `executeS1ThreatActionForOrg` to prove the catch
+ * block wires them together correctly. The catch site builds the tenant-visible
+ * `s1_actions.error` text and the dispatch result `warning`; a regression that
+ * fed `error.responseBody` into that text (instead of the body-free `.message`)
+ * would have passed every existing test, leaking an upstream-body read oracle
+ * for a tenant-supplied/look-alike S1 console.
+ *
+ * These tests mock the provider-dispatch functions to throw a
+ * `SentinelOneHttpError` carrying a distinctive upstream-body marker, capture
+ * the row written to `s1_actions` (and the returned `warning`), and assert:
+ *   (a) the persisted `error` / `warning` carries the body-free status line and
+ *       NEVER the upstream body marker;
+ *   (b) the full (redacted) body IS captured in the server-side console.error.
+ *
+ * Pure unit test — runs in the standard `test-api` CI job (no live DB needed).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SentinelOneHttpError } from './client';
+
+const UPSTREAM_BODY_MARKER = 'UPSTREAM_S1_ACTION_BODY_MARKER_must_not_reach_tenant';
+const UPSTREAM_BODY_SECRET = 'Authorization: Bearer s1_action_leaked_token';
+
+// Capture every row array passed to `db.insert(...).values(<rows>)`.
+const insertedRows: Array<Record<string, unknown>> = [];
+
+const selectQueue: unknown[][] = [];
+
+const mockDb = {
+  select: vi.fn(() => {
+    const rows = selectQueue.shift() ?? [];
+    const chain: Record<string, unknown> = {};
+    for (const method of ['from', 'where', 'innerJoin', 'leftJoin']) {
+      chain[method] = vi.fn().mockReturnValue(chain);
+    }
+    chain.limit = vi.fn().mockResolvedValue(rows);
+    chain.then = (resolve: (value: unknown[]) => unknown) => resolve(rows);
+    return chain;
+  }),
+  insert: vi.fn(() => ({
+    values: vi.fn((rows: Array<Record<string, unknown>>) => {
+      insertedRows.push(...rows);
+      return {
+        returning: vi.fn().mockResolvedValue(
+          rows.map((_row, i) => ({ id: `action-${i}`, deviceId: (rows[i]!.deviceId as string | null) ?? null })),
+        ),
+      };
+    }),
+  })),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('../../db', () => ({
+  db: mockDb,
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+  withDbAccessContext: <T>(_ctx: unknown, fn: () => T): T => fn(),
+  withSystemDbAccessContext: <T>(fn: () => T): T => fn(),
+}));
+
+const dispatchS1IsolationMock = vi.fn();
+const dispatchS1ThreatActionMock = vi.fn();
+vi.mock('../../jobs/s1Sync', () => ({
+  dispatchS1Isolation: dispatchS1IsolationMock,
+  dispatchS1ThreatAction: dispatchS1ThreatActionMock,
+  scheduleS1ActionPoll: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../sentry', () => ({ captureException: vi.fn() }));
+
+const { executeS1IsolationForOrg, executeS1ThreatActionForOrg } = await import('./actions');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertedRows.length = 0;
+  selectQueue.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function s1HttpError(method: 'POST' | 'GET', path: string, status: number) {
+  return new SentinelOneHttpError(method, path, status, `${UPSTREAM_BODY_MARKER} ${UPSTREAM_BODY_SECRET}`);
+}
+
+describe('executeS1IsolationForOrg catch block — body-free error/warning (#1035)', () => {
+  it('persists a body-free error to s1_actions and logs the redacted body server-side', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // (1) accessible devices, (2) agent mappings.
+    selectQueue.push([{ id: 'dev-1' }]);
+    selectQueue.push([{ deviceId: 'dev-1', s1AgentId: 's1-agent-1' }]);
+
+    dispatchS1IsolationMock.mockRejectedValue(
+      s1HttpError('POST', '/web/api/v2.1/agents/actions/disconnect', 502),
+    );
+
+    const result = await executeS1IsolationForOrg({
+      orgId: 'org-1',
+      integrationId: 'int-1',
+      requestedBy: 'user-1',
+      deviceIds: ['dev-1'],
+      isolate: true,
+    });
+
+    // Dispatch failed → 502 but the records are still persisted (ok:true, 502).
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(502);
+
+    // (a) the row written to s1_actions.error is body-free.
+    const persistedError = String(insertedRows[0]!.error);
+    expect(persistedError).toContain('SentinelOne action dispatch failed');
+    expect(persistedError).toContain('failed (502)');
+    expect(persistedError).not.toContain(UPSTREAM_BODY_MARKER);
+    expect(persistedError).not.toContain('s1_action_leaked_token');
+
+    // ...and the same goes for the tenant-facing warning in the result payload.
+    const warning = String((result as { data: { warning?: string } }).data.warning);
+    expect(warning).not.toContain(UPSTREAM_BODY_MARKER);
+
+    // (b) the full (redacted) body is captured server-side only.
+    const logged = errorSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n');
+    expect(logged).toContain(UPSTREAM_BODY_MARKER);
+    expect(logged).toContain('[REDACTED]');
+    expect(logged).not.toContain('s1_action_leaked_token');
+  });
+});
+
+describe('executeS1ThreatActionForOrg catch block — body-free error/warning (#1035)', () => {
+  it('persists a body-free error to s1_actions and logs the redacted body server-side', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // (1) matched threats.
+    selectQueue.push([{ id: 'threat-uuid-1', s1ThreatId: 's1-threat-1', deviceId: 'dev-9' }]);
+
+    dispatchS1ThreatActionMock.mockRejectedValue(
+      s1HttpError('POST', '/web/api/v2.1/threats/mitigate/kill', 500),
+    );
+
+    const result = await executeS1ThreatActionForOrg({
+      orgId: 'org-2',
+      integrationId: 'int-2',
+      requestedBy: 'user-2',
+      action: 'kill',
+      threatIds: ['s1-threat-1'],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(502);
+
+    const persistedError = String(insertedRows[0]!.error);
+    expect(persistedError).toContain('SentinelOne action dispatch failed');
+    expect(persistedError).toContain('failed (500)');
+    expect(persistedError).not.toContain(UPSTREAM_BODY_MARKER);
+    expect(persistedError).not.toContain('s1_action_leaked_token');
+
+    const logged = errorSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n');
+    expect(logged).toContain(UPSTREAM_BODY_MARKER);
+    expect(logged).toContain('[REDACTED]');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up test debt from the SSRF-hardening PR (#1025). Item 1 (the `c2c_connections` m365 tenant-GUID `CHECK`) already shipped in #1187; this closes the **item-2** gap from #1035: the sync / action-dispatch catch blocks were only proven *transitively* via helper unit tests (`tenantVisibleSyncError`, `truncateError`, `logSyncFailureServerSide`, `logActionDispatchFailureServerSide`). Nothing drove the actual catch blocks, so a regression that fed the upstream `error.responseBody` into a tenant-visible column (the exact pre-#1025 behavior) would have passed every existing test — re-opening the partial-read SSRF oracle for tenant-controlled Pi-hole / AdGuard / look-alike S1 endpoints.

## What this adds

Three focused unit tests that drive the **real catch blocks** with a provider stubbed to throw an HTTP error carrying a distinctive upstream-body marker, asserting:
- **(a)** the tenant-visible column / dispatch warning receives only the body-free status line and **never** the upstream body marker;
- **(b)** the full (redacted) body **is** captured in the server-side `console.error`.

| Test file | Covers | Tenant column |
|---|---|---|
| `apps/api/src/jobs/dnsSyncJob_syncError.test.ts` | `processSyncIntegration`, `processPolicySync` | `dns_filter_integrations.lastSyncError`, `dns_policies.syncError` |
| `apps/api/src/jobs/s1Sync_syncError.test.ts` | `processSyncIntegration` | `s1_integrations.lastSyncError` |
| `apps/api/src/services/sentinelOne/actions_dispatchError.test.ts` | `executeS1IsolationForOrg`, `executeS1ThreatActionForOrg` | `s1_actions.error` + result `warning` |

The two DNS processors and the S1 sync processor were module-private; they are now **exported** (additive only, `tsc --noEmit` clean — 0 errors across the API package) so the catch blocks can be tested directly. The S1 action-dispatch functions were already exported.

**Each assertion is mutation-verified:** re-introducing the `responseBody` leak (`redactLogMessage(error.responseBody)`) in the catch block fails the body-marker assertion in every suite. The secret-shaped marker also confirms `redactLogMessage` still fires (`[REDACTED]`) on the server-side log.

## Phase 1 — done vs deferred

- **Done (item 2):** DNS + SentinelOne sync error wiring catch-block coverage (this PR).
- **Already done (item 1):** c2c m365 tenant-GUID `CHECK` behavior — #1187.
- **Deferred (item 3, explicitly "optional, lower value" in #1035):** an end-to-end SSRF block + reflection read-back smoke test (tenant-supplied internal URL refused at request time → body-free `lastSyncError` on read-back via `GET /dns-security/integrations`). That mostly re-tests the `safeFetch` seam already covered by `urlSafety.test.ts` + each integration's client tests, and needs the live-DB integration harness; left for a separate change.

## Testing

Pure unit tests (mocked DB + mocked provider/client) — they run in the standard **test-api** CI job, no live-DB harness needed.

```
pnpm --filter @breeze/api exec vitest run \
  src/jobs/dnsSyncJob.test.ts src/jobs/dnsSyncJob_syncError.test.ts \
  src/jobs/s1Sync.test.ts src/jobs/s1Sync_syncError.test.ts \
  src/services/sentinelOne/actions.test.ts src/services/sentinelOne/actions_dispatchError.test.ts
→ 6 files, 42 tests passing
```

`npx tsc --noEmit` (apps/api): 0 errors.

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)