### PR TITLE
docs(pam): admin guide + security model + API reference (#1161)

### DIFF
--- a/apps/api/src/data/docsIndex.json
+++ b/apps/api/src/data/docsIndex.json
@@ -1914,7 +1914,12 @@
       "Audit",
       "The Windows UAC Approval Flow",
       "How Just-in-Time Admin Works",
-      "Enabling and Disabling UAC Interception"
+      "Enabling and Disabling UAC Interception",
+      "Per-organization and per-device overrides",
+      "Operational notes",
+      "Exporting the audit trail for compliance",
+      "Running alongside other RMM or security agents",
+      "Platform support"
     ],
     "section": "features"
   },
@@ -3260,6 +3265,26 @@
     "section": "reference"
   },
   {
+    "path": "/reference/pam-api/",
+    "title": "PAM API",
+    "description": "REST reference for the Privileged Access Management endpoints -- elevation requests, approvals, revocation, rules, and the actuation surface.",
+    "headings": [
+      "Authentication and authorization",
+      "Elevation requests",
+      "List elevation requests",
+      "List active elevations",
+      "Respond (approve / deny)",
+      "Revoke",
+      "Rules",
+      "Create / update a rule",
+      "Preview a rule",
+      "Device actuation",
+      "Agent ingest",
+      "Configuration policy: enabling UAC capture"
+    ],
+    "section": "reference"
+  },
+  {
     "path": "/reference/partner-management/",
     "title": "Partner Management",
     "description": "Partner self-registration, multi-tenant partner hierarchy, feature flag controls, and partner administration.",
@@ -3577,6 +3602,26 @@
       "C1 — Confidentiality",
       "Vulnerability Disclosure",
       "Security Controls Summary"
+    ],
+    "section": "security"
+  },
+  {
+    "path": "/security/pam/",
+    "title": "Privileged Access Management Security Model",
+    "description": "Trust boundaries, elevation primitives, the dormant-admin pattern, separation of duties, and the audit guarantees behind Breeze just-in-time elevation -- for security teams evaluating PAM.",
+    "headings": [
+      "What PAM is for",
+      "Trust boundaries",
+      "Elevation primitives",
+      "The dormant-admin pattern",
+      "Secure-desktop credential injection (Flavor A)",
+      "Single-use actuation",
+      "Separation of duties",
+      "Decisioning chain and fail-safe behavior",
+      "Offline rule enforcement and staleness",
+      "Audit guarantees",
+      "What PAM does and does not protect against",
+      "Platform-evolution and liability notes"
     ],
     "section": "security"
   },

--- a/apps/docs/src/content/docs/features/pam.mdx
+++ b/apps/docs/src/content/docs/features/pam.mdx
@@ -9,6 +9,8 @@ import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Privileged Access Management (PAM) lets you take admin rights *away* from everyday user accounts and hand them back only when they're actually needed -- for a few minutes, on one machine, with a recorded decision behind it. Instead of standing local-administrator membership that sits on every endpoint waiting to be abused, a user requests elevation in the moment, an approver says yes or no, and the access disappears on its own when the window closes.
 
+This page is the operator's guide. For the trust model behind PAM -- how credentials are minted on the endpoint and never transmitted, what PAM does and does not defend against -- see the [PAM Security Model](/security/pam/). For the REST endpoints, see the [PAM API](/reference/pam-api/).
+
 Open **Privileged Access** from the Security section of the left sidebar to work the console.
 
 PAM covers three kinds of elevation, all of which land in the same queue:
@@ -166,3 +168,45 @@ Whether a device captures UAC prompts at all is controlled through a **Configura
 <Aside type="note">
   The Configuration Policy toggle **only** controls whether devices capture elevation prompts. It does **not** govern the rule chain. PAM elevation rules -- the auto-approve / deny / require-approval logic, the request queue, and the audit history -- are scoped to the **organization and site** and managed in the Privileged Access console. Closest-wins policy precedence deliberately does *not* apply to rule chains: a device-level policy must never silently shadow an organization's security baseline rules.
 </Aside>
+
+### Per-organization and per-device overrides
+
+Because UAC capture is a Configuration Policy feature, you turn it on or off at any level of the hierarchy and let the closest assignment win:
+
+- **Disable for one organization** -- assign a policy with **Capture Windows UAC elevation prompts** turned off to that organization. Every device under it stops surfacing new UAC elevation requests, unless a closer (site, group, or device) assignment re-enables it.
+- **Disable for one device** -- assign the "off" policy directly to that device (or a device group). A device-level assignment is the closest match, so it wins over the organization baseline.
+- **Re-enable a narrower scope** -- because the toggle is independent at every level, you can disable capture org-wide but turn it back on for a single high-touch site or device by assigning an "on" policy there.
+
+Disabling capture is the safe "kill switch" for the UAC-intercept flow on a scope: the agent simply stops reporting new prompts, native UAC behaves exactly as Windows ships it, and existing approved windows finish out their timers. It does not delete rules or audit history.
+
+---
+
+## Operational notes
+
+### Exporting the audit trail for compliance
+
+The **Audit** tab is the permanent, immutable record of every elevation decision. To produce a report:
+
+<Steps>
+
+1. Open **Privileged Access** and select the **Audit** tab.
+
+2. Filter by status, flow type, and date range to scope the report (for example, all approvals in the previous quarter).
+
+3. Export the filtered set to **CSV**.
+
+</Steps>
+
+Each row names the decider -- the approver or denier by name for human decisions, or the software policy / PAM rule that made an automatic call -- alongside the device, requesting user, target, and timestamps. Auto-decided and human-decided requests appear on the same ledger, so a single export shows the complete decision history with no gaps.
+
+### Running alongside other RMM or security agents
+
+PAM's UAC-intercept flow interacts with whatever else is installed on the endpoint, because it works with the live Windows `consent.exe` prompt. Before enabling capture broadly on a fleet that also runs another vendor's agent, validate the interaction on a pilot group.
+
+<Aside type="caution">
+  There is a documented, production-breaking interaction between the **N-able N-Central agent** and `consent.exe` on idle or locked machines: UAC prompts accept credentials and then hang for **4-5 minutes** because of a deadlock in N-able's signature-verification hooks (Microsoft Q&A 5733506). This is an N-able issue addressed by their `Framework.dll` hotfixes, but any UAC-touching code -- including Breeze PAM -- shares the same surface. If your customers run N-Central concurrently, test PAM against it before turning capture on org-wide, and keep the [per-scope disable](#per-organization-and-per-device-overrides) switch in mind as an immediate mitigation.
+</Aside>
+
+### Platform support
+
+The UAC-intercept flow, the just-in-time admin window, and the dormant-admin credential lifecycle are **Windows-only**. Tech JIT admin and AI tool-action governance are platform-independent at the approval layer, but the on-device elevation primitives apply to Windows endpoints.

--- a/apps/docs/src/content/docs/reference/pam-api.mdx
+++ b/apps/docs/src/content/docs/reference/pam-api.mdx
@@ -230,11 +230,15 @@ The preview is a pure per-rule match -- it does not replay priority shadowing or
 
 `POST /devices/:id/actuate-elevation` — organization/partner/system scope, `devices:execute`, MFA.
 
-Queues the agent "go" signal for a `consent.exe` prompt that is already waiting on the user's screen. The command payload carries **only** the elevation request id and a timeout -- the dormant-admin credential is minted locally by the agent and never crosses the wire.
+Queues the agent "go" signal for a `consent.exe` prompt that is already waiting on the user's screen. The command payload that reaches the agent carries **only** the elevation request id and a timeout -- the dormant-admin credential is minted locally by the agent and never crosses the wire.
 
 ```json
 { "elevationRequestId": "…", "timeoutMs": 8000 }
 ```
+
+<Aside type="note">
+  The request schema also accepts optional `username` and `password` fields, but they are **vestigial** -- the handler never reads them and never forwards them into the queued command, and they never appear in the audit log. A reader auditing the schema directly will see a `password` field; it is inert and exists only as a leftover of an earlier design. The credential is minted on the endpoint, not supplied over the API.
+</Aside>
 
 The route is single-use: it atomically transitions the request from `approved` to `actuating` in the same transaction that queues the command. A request that is not `approved`, or that another caller already claimed, is refused.
 
@@ -266,7 +270,7 @@ Request body (synthesized fields like `reason` are written server-side; the agen
 {
   "subject_username": "acme\\sarah",
   "target_executable_path": "C:\\Users\\sarah\\Downloads\\FirefoxSetup.exe",
-  "target_executable_hash": "<sha256>",
+  "target_executable_hash": "<agent-reported file hash>",
   "target_executable_signer": "Mozilla Corporation",
   "pid": 4812,
   "parent_image": "C:\\Windows\\explorer.exe",
@@ -274,6 +278,10 @@ Request body (synthesized fields like `reason` are written server-side; the agen
   "observed_at": "2026-06-13T14:02:11Z"
 }
 ```
+
+<Aside type="note">
+  `target_executable_hash` is a **free-form string of up to 128 characters** -- the ingest schema does not validate it as hex or pin it to a 64-character SHA-256 digest. It is the value the agent reports and is stored as-is for display and rule matching. By contrast, the rule-side [`matchHash`](#create--update-a-rule) criterion **is** strictly validated as a 64-character SHA-256 hex digest, so a rule can only match on a well-formed hash.
+</Aside>
 
 | Status | Meaning |
 |---|---|

--- a/apps/docs/src/content/docs/reference/pam-api.mdx
+++ b/apps/docs/src/content/docs/reference/pam-api.mdx
@@ -1,0 +1,297 @@
+---
+title: PAM API
+description: REST reference for the Privileged Access Management endpoints -- elevation requests, approvals, revocation, rules, and the actuation surface.
+sidebar:
+  label: PAM API
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This reference covers the Privileged Access Management (PAM) REST surface: the admin control plane under `/api/v1/pam`, the device actuation endpoint, and the agent-side ingest endpoint. For the administrative workflow these endpoints back, see [Privileged Access Management](/features/pam/); for the trust model, see the [PAM Security Model](/security/pam/).
+
+All paths are relative to the API base URL and version prefix (`/api/v1`). See the [API Overview](/reference/api/) for authentication, base URL, and common conventions.
+
+## Authentication and authorization
+
+The `/pam/*` control-plane endpoints require a JWT bearer token (or API key) and run under **organization, partner, or system** scope. Authorization maps to the device permission set:
+
+| Operation class | Permission | Extra gate |
+|---|---|---|
+| Read (list, active, rules) | `devices:read` | -- |
+| Rule create / update / delete | `devices:write` | MFA |
+| Approve / deny / revoke | `devices:execute` | MFA |
+
+Tenant isolation is enforced by row-level security on every query. Site-restricted technicians are additionally narrowed to their allowed sites: requests outside those sites are filtered from reads and rejected on writes with `403`.
+
+<Aside type="note">
+  Every mutating call records an entry in both the platform audit log and the dedicated elevation audit ledger. Approvals, denials, and revocations are attributed to the calling user by id.
+</Aside>
+
+---
+
+## Elevation requests
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/pam/elevation-requests` | List and filter elevation requests (Requests and Audit tabs). |
+| `GET` | `/pam/active` | List currently-active (unexpired, approved) elevations. |
+| `POST` | `/pam/elevation-requests/:id/respond` | Approve or deny a pending request. |
+| `POST` | `/pam/elevation-requests/:id/revoke` | Revoke an active elevation before it expires. |
+
+### List elevation requests
+
+`GET /pam/elevation-requests`
+
+Query parameters (all optional):
+
+| Param | Type | Notes |
+|---|---|---|
+| `status` | enum | `pending`, `approved`, `auto_approved`, `denied`, `expired`, `revoked`, `actuating` |
+| `flowType` | enum | `uac_intercept`, `tech_jit_admin`, `ai_tool_action` |
+| `deviceId` | uuid | Filter to one device |
+| `siteId` | uuid | Filter to one site (must be within the caller's site scope) |
+| `from` / `to` | ISO-8601 | Bound by request time |
+| `page` / `limit` | int | `limit` max 100, default 50 |
+
+Response:
+
+```json
+{
+  "success": true,
+  "requests": [
+    {
+      "id": "…",
+      "orgId": "…",
+      "deviceId": "…",
+      "deviceHostname": "WIN-ACCT-04",
+      "siteName": "HQ",
+      "flowType": "uac_intercept",
+      "status": "pending",
+      "subjectUsername": "acme\\sarah",
+      "targetExecutablePath": "C:\\Users\\sarah\\Downloads\\FirefoxSetup.exe",
+      "targetExecutableSigner": "Mozilla Corporation",
+      "requestedAt": "2026-06-13T14:02:11Z",
+      "approvedByName": null,
+      "deniedByName": null,
+      "revokedByName": null,
+      "matchedPolicyName": null,
+      "pamRuleId": null,
+      "pamRuleName": null,
+      "decisionSource": null
+    }
+  ],
+  "pagination": { "page": 1, "limit": 50, "total": 1 }
+}
+```
+
+`decisionSource` is derived: `software_policy`, `pam_rule`, `human`, or `null` (still pending). AI tool-action rows additionally carry `toolName`, `riskTier`, and `actionDigest`.
+
+### List active elevations
+
+`GET /pam/active`
+
+Returns up to 500 elevations whose status is `approved`, `auto_approved`, or `actuating` and whose `expiresAt` is in the future. No query parameters. Used to render the live "active windows" view with expiry countdowns.
+
+```json
+{ "success": true, "active": [ { "id": "…", "expiresAt": "2026-06-13T14:17:00Z", "…": "…" } ] }
+```
+
+### Respond (approve / deny)
+
+`POST /pam/elevation-requests/:id/respond` — requires `devices:execute` + MFA.
+
+Request body:
+
+```json
+{
+  "decision": "approve",
+  "reason": "Approved per change CHG-1042",
+  "durationMinutes": 30
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `decision` | enum | `approve` or `deny` (required) |
+| `reason` | string | Optional on approve, recommended on deny; max 2000 chars |
+| `durationMinutes` | int | Approval window, 1–1440 (24h max). Defaults to 15 |
+
+Only a `pending` request can be decided. The transition is an atomic compare-and-swap on `pending`, so concurrent decisions are safe.
+
+| Status | Meaning |
+|---|---|
+| `200` | `{ "success": true, "id": "…", "status": "approved" \| "denied" }` |
+| `400` | Invalid id or body |
+| `403` | Site access denied, or MFA not satisfied |
+| `404` | Request not found (or outside the caller's org) |
+| `409` | Request is no longer pending (lost the race), or a linked AI tool execution already timed out |
+
+<Aside>
+  For an `ai_tool_action` request, an approval is mirrored onto the linked AI tool execution inside the same transaction. If that execution already timed out, the whole decision is rolled back and the call returns `409` rather than recording a grant that can never take effect.
+</Aside>
+
+### Revoke
+
+`POST /pam/elevation-requests/:id/revoke` — requires `devices:execute` + MFA.
+
+Ends an active elevation early.
+
+```json
+{ "reason": "Maintenance window cancelled" }
+```
+
+`reason` is **required** (1–2000 chars). Only an active elevation (`approved`, `auto_approved`, or `actuating`) can be revoked; a stale or already-finished row returns `409`.
+
+```json
+{ "success": true, "id": "…", "status": "revoked" }
+```
+
+---
+
+## Rules
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/pam/rules` | List rules in priority order. |
+| `POST` | `/pam/rules` | Create a rule. |
+| `POST` | `/pam/rules/preview` | Dry-run draft criteria against request history. |
+| `PATCH` | `/pam/rules/:id` | Update a rule. |
+| `DELETE` | `/pam/rules/:id` | Delete a rule. |
+
+### Create / update a rule
+
+`POST /pam/rules` (create) and `PATCH /pam/rules/:id` (partial update) — require `devices:write` + MFA.
+
+```json
+{
+  "name": "Auto-approve signed Mozilla installers",
+  "verdict": "auto_approve",
+  "priority": 50,
+  "enabled": true,
+  "matchSigner": "Mozilla Corporation",
+  "approvalDurationMinutes": 30,
+  "siteId": null
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Required, 1–255 chars |
+| `verdict` | enum | `auto_approve`, `auto_deny`, `require_approval`, `ignore` |
+| `priority` | int | Lower runs first; default 100 |
+| `enabled` | bool | Default true |
+| `siteId` | uuid \| null | Narrow to one site; null = org-wide |
+| `matchSigner` | string | Code-signer (executable rule) |
+| `matchHash` | string | SHA-256 hex digest (executable rule) |
+| `matchPathGlob` | string | File-path glob (executable rule) |
+| `matchParentImage` | string | Parent process (executable rule) |
+| `matchUser` | string | Narrow by requesting user |
+| `matchAdGroup` | string | Narrow by AD group |
+| `matchToolName` | string | AI tool name (tool-action rule) |
+| `matchRiskTier` | int | Risk tier 0–4 (tool-action rule) |
+| `timeWindow` | object | `{ start, end, days?, timezone? }`, `HH:MM` 24h, days 0–6 (Sun–Sat) |
+| `approvalDurationMinutes` | int | 1–1440; null falls back to the org default |
+
+Rule-shape validation (enforced on create and on the merged result of an update):
+
+- A rule must carry **at least one identifying criterion** (signer/hash/path/parent/user/group/tool/tier). A rule scoped only by time window -- or nothing -- is rejected with `400`.
+- A rule is either **executable-shaped** (signer/hash/path/parent) or **tool-action-shaped** (tool name / risk tier). Mixing the two is rejected, because no single observation carries both.
+- `verdict: "ignore"` is not valid for tool-action rules -- a tool action must be decided.
+
+Create returns `201` with the full rule; update returns `200`.
+
+### Preview a rule
+
+`POST /pam/rules/preview` — requires `devices:write`.
+
+Dry-runs draft criteria against historical requests so you can see what a rule *would* have matched before saving it. Accepts the same criteria fields as a rule, plus `windowDays` (1–90, default 30) and an optional `flowType`.
+
+```json
+{
+  "success": true,
+  "totalMatched": 12,
+  "totalScanned": 480,
+  "windowDays": 30,
+  "truncated": false,
+  "statusBreakdown": { "pending": 2, "approved": 7, "auto_approved": 3, "denied": 0, "expired": 0, "revoked": 0, "actuating": 0 },
+  "sample": [ { "id": "…", "requestedAt": "…", "flowType": "uac_intercept", "status": "approved" } ]
+}
+```
+
+The preview is a pure per-rule match -- it does not replay priority shadowing or the software-policy bridge. Historical rows do not store AD groups, so any draft containing `matchAdGroup` reports zero matches.
+
+---
+
+## Device actuation
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/devices/:id/actuate-elevation` | Queue an `actuate_elevation` command for an approved UAC elevation. |
+
+`POST /devices/:id/actuate-elevation` — organization/partner/system scope, `devices:execute`, MFA.
+
+Queues the agent "go" signal for a `consent.exe` prompt that is already waiting on the user's screen. The command payload carries **only** the elevation request id and a timeout -- the dormant-admin credential is minted locally by the agent and never crosses the wire.
+
+```json
+{ "elevationRequestId": "…", "timeoutMs": 8000 }
+```
+
+The route is single-use: it atomically transitions the request from `approved` to `actuating` in the same transaction that queues the command. A request that is not `approved`, or that another caller already claimed, is refused.
+
+| Status | Meaning |
+|---|---|
+| `201` | Command queued; returns the command id and `elevationRequestId` |
+| `400` | Invalid body, or device decommissioned |
+| `403` | PAM actuator disabled, site access denied, or MFA not satisfied |
+| `404` | Device or elevation request not found |
+| `409` | Request not approved (`wrong_status`) or already being actuated (`race_lost`) |
+
+<Aside type="caution">
+  The actuator is **disabled by default in every environment** and must be explicitly enabled server-side once just-in-time credentials and agent-side re-validation are deployed. While disabled, this endpoint returns `403`.
+</Aside>
+
+---
+
+## Agent ingest
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/agents/:id/elevation-requests` | Agent reports an observed UAC consent prompt. |
+
+This endpoint is called **by the agent**, authenticated with the agent bearer token (not a user JWT), and is documented here for completeness. It records a UAC observation as an `elevation_requests` row with `flowType: uac_intercept`, runs the decisioning chain (software-policy bridge → PAM rules → pending), and emits the corresponding event and audit rows.
+
+Request body (synthesized fields like `reason` are written server-side; the agent only sends discovery data):
+
+```json
+{
+  "subject_username": "acme\\sarah",
+  "target_executable_path": "C:\\Users\\sarah\\Downloads\\FirefoxSetup.exe",
+  "target_executable_hash": "<sha256>",
+  "target_executable_signer": "Mozilla Corporation",
+  "pid": 4812,
+  "parent_image": "C:\\Windows\\explorer.exe",
+  "command_line": "…",
+  "observed_at": "2026-06-13T14:02:11Z"
+}
+```
+
+| Status | Meaning |
+|---|---|
+| `201` | `{ "id": "…", "status": "pending" \| "auto_approved" \| "denied" }` |
+| `200` | `{ "id": null, "status": "ignored" }` -- an `ignore` rule matched; no request row is created |
+| `413` | Body exceeds 32 KB |
+| `429` | Per-device rate limit exceeded (about 10 requests/second) |
+
+Decisioning fails safe: if either evaluator errors, the request is recorded as `pending` rather than auto-approved.
+
+---
+
+## Configuration policy: enabling UAC capture
+
+Whether a device captures UAC prompts at all is governed by the **`pam`** configuration-policy feature, resolved through the normal policy hierarchy (partner → org → site → group → device, closest-wins). The feature's inline settings shape is a single flag:
+
+```json
+{ "uacInterceptionEnabled": true }
+```
+
+`uacInterceptionEnabled` defaults to **true** at every level, so upgrades are behavior-preserving; admins opt a scope *out* by assigning a policy that turns it off. This toggle controls only whether devices *capture* elevation prompts -- it does not govern the rule chain, request queue, or audit history, which are scoped to the organization and site and managed in the Privileged Access console. See [Configuration Policies](/features/configuration-policies/) for how feature settings resolve.

--- a/apps/docs/src/content/docs/security/pam.mdx
+++ b/apps/docs/src/content/docs/security/pam.mdx
@@ -1,0 +1,185 @@
+---
+title: Privileged Access Management Security Model
+description: Trust boundaries, elevation primitives, the dormant-admin pattern, separation of duties, and the audit guarantees behind Breeze just-in-time elevation -- for security teams evaluating PAM.
+sidebar:
+  label: PAM Security Model
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This document describes the security model behind Breeze **Privileged Access Management (PAM)** -- the just-in-time elevation system that replaces standing local-administrator rights with short-lived, recorded grants. It is written for security teams assessing Breeze for compliance or risk review. For the day-to-day administrative workflow, see [Privileged Access Management](/features/pam/); for the REST surface, see [PAM API](/reference/pam-api/).
+
+PAM is a high-trust feature: it lets a Breeze operator grant local-administrator access on a managed endpoint. The model below explains exactly what is trusted, what is not, where credentials live, and what the system does -- and does not -- defend against.
+
+---
+
+## What PAM is for
+
+Endpoint PAM does one job: keep standard users standard, while making admin approvals fast enough that nobody works around the policy. Without it, the only choices are "make everyone a local admin" or "have the helpdesk remote in every time someone needs to install a printer driver." PAM removes standing privilege and replaces it with elevation that exists only for the moment it is needed and cleans itself up afterward.
+
+PAM governs three elevation flows, all recorded on one ledger:
+
+| Flow | What it elevates |
+|---|---|
+| **UAC intercept** (`uac_intercept`) | A Windows UAC consent prompt observed on a managed endpoint. |
+| **Tech JIT admin** (`tech_jit_admin`) | A technician-requested temporary local-admin grant on a device. |
+| **AI tool action** (`ai_tool_action`) | A privileged action proposed by the Breeze AI agent or Helper that requires a human to sign off before it runs. |
+
+---
+
+## Trust boundaries
+
+PAM spans three trust domains, each with a distinct identity and a distinct set of privileges. No domain can unilaterally grant elevation.
+
+| Domain | Identity | Holds | Cannot |
+|---|---|---|---|
+| **Endpoint agent** (Windows service) | Local `SYSTEM` | The dormant-admin account lifecycle and credential minting | Decide its own approvals; reach across tenants |
+| **Breeze control plane** (API) | Unprivileged DB role under row-level security | The request ledger, rule chain, and decisions | See or transmit any endpoint credential |
+| **Approver** (technician / mobile / Helper) | Authenticated user with MFA | The approve/deny/revoke decision | Approve a request they originated |
+
+The single most important property of this split: **the credential that satisfies a UAC prompt is minted on the endpoint, used on the endpoint, and destroyed on the endpoint.** It is never written to the agent's configuration file and never transmitted to the server. The control plane records *that* an elevation was approved; it never holds the secret that exercises it.
+
+<Aside type="caution">
+  Because Breeze has privileged access to every device it manages, PAM is held to the same standard as the rest of the platform: tenant isolation by forced PostgreSQL row-level security, an unprivileged application database role, MFA on every state-changing decision, and append-only audit. See the [Security Architecture](/security/overview/) overview for the platform-wide controls these inherit from.
+</Aside>
+
+---
+
+## Elevation primitives
+
+### The dormant-admin pattern
+
+On a managed Windows device, the agent maintains a single dormant local account named **`~breeze_elev`**. The leading tilde and a `SpecialAccounts\UserList` registry entry hide it from the logon screen and from Settings. At rest, the account is:
+
+- **Disabled** -- it cannot be logged into.
+- **Removed from the local Administrators group** -- it holds no privilege.
+- **Holding a 40-character random password** generated with a cryptographically secure RNG (`crypto/rand`), with guaranteed upper/lower/digit/symbol complexity and a 32-character floor.
+
+The account moves through exactly three states, each driven by the SYSTEM-context agent:
+
+1. **Provisioned (at rest).** The account exists, disabled, with no admin membership and a freshly randomized password. If the agent ever finds the account *in* the Administrators group when no elevation is active -- for example after a crash mid-window -- it strips the membership and re-randomizes the password to recover. This self-heal works "blind": it never needs the previous password.
+
+2. **Promoted (window open).** On an approved elevation the agent generates a *new* random password locally, enables the account, and adds it to the local Administrators group -- for exactly the approved duration. If any step of the promotion fails, the agent immediately demotes (best-effort, 10-second deadline) so a half-promoted account is never left behind.
+
+3. **Demoted (window closed).** When the timer expires, the elevation is revoked, or the work finishes, the agent removes the account from Administrators, re-randomizes its password, and disables it again.
+
+The net effect is admin access that is genuinely just-in-time: it exists only inside an approved window, holds a different password each time, and returns to a powerless state automatically.
+
+### Secure-desktop credential injection (Flavor A)
+
+On Windows, a UAC prompt (`consent.exe`) runs at high integrity on the secure desktop (`WINSTA0\WINLOGON`). Only Windows processes can natively reach that desktop, and `SendInput` from any process not already attached to it is silently dropped.
+
+Breeze satisfies the prompt the same way a person would -- by typing real credentials into the consent UI -- rather than by injecting a SYSTEM-side approval through a kernel hook. This is **Flavor A**:
+
+1. The agent runs as a Windows service under `SYSTEM`, which holds the privileges needed to open the input desktop.
+2. On an approved actuation, the agent mints the `~breeze_elev` credential locally and hands it, in process memory, to the actuator.
+3. The actuator pins its OS thread, opens the active input desktop, attaches the thread to it, waits for `consent.exe`, and types the username, Tab, password, and Enter via Unicode `SendInput`. The credential string lives only in process memory for the duration of the keystrokes and is cleared after use.
+4. The actuator waits for `consent.exe` to close, then reports a stable result code (`ok`, `no_consent_window`, `consent_did_not_close`, and so on) back to the control plane.
+
+This choice keeps the native Windows audit trail intact -- the standard logon event and `consent.exe` process record are preserved -- and avoids shipping a kernel driver, which would carry a far heavier signing and attack-surface burden.
+
+<Aside type="note">
+  The password is never present in the device command, the API request, the audit log, or any agent configuration file. The actuator's detail messages and log lines are explicitly constructed to exclude it.
+</Aside>
+
+### Single-use actuation
+
+A server-side actuation cannot be replayed. The actuator route's proof of approval is the elevation row's status being `approved`. To make that proof one-shot, the same database transaction that queues the agent command performs an atomic compare-and-swap of the row from `approved` to `actuating`, scoped by the device's organization. If the compare-and-swap returns zero rows -- because the row was not approved, or a concurrent request already claimed it -- the actuation is refused with `409`. Every outcome (success, lost race, wrong status) is written to the elevation audit ledger with its cause.
+
+The PAM actuator is additionally **disabled by default in every environment** and is only enabled via an explicit server-side flag once just-in-time credentials and agent-side target re-validation are deployed.
+
+---
+
+## Separation of duties
+
+The approver is always a separate identity from the requester:
+
+- A user **cannot approve their own elevation.**
+- An AI agent or Helper session **cannot sign off on the action it proposed** -- AI tool actions and unmatched UAC prompts always default to **pending**, waiting on a human. Automation can never quietly relax its own approval.
+- The mobile app guards self-approval (when a user's own phone approves a request for that same user) behind a deliberate 5-second hold-to-confirm, so a momentarily unlocked phone cannot rubber-stamp a self-issued request.
+
+Every approve, deny, and revoke is gated by:
+
+- **Permission** -- the caller must hold the device execute permission.
+- **Scope** -- organization, partner, or system scope, narrowed to the caller's allowed sites for site-restricted technicians.
+- **MFA** -- the decision endpoints require a multi-factor-satisfied session. A caller without MFA receives `403`.
+
+Decisions are made through a transactional compare-and-swap on the request's `pending` (or active) status, so when two approvers -- or an approver and the expiry reaper -- act on the same request at once, exactly one wins; a request can never be both approved and denied.
+
+---
+
+## Decisioning chain and fail-safe behavior
+
+When the agent reports a UAC observation, the control plane decides it before any human sees it:
+
+1. **Software-policy bridge.** The device's winning software policy is consulted first: an allowlist match auto-approves, a blocklist match denies.
+2. **PAM rules.** When no software policy binds, the org's enabled PAM rules run in priority order; the first match wins with its verdict (`auto_approve`, `auto_deny`, `require_approval`, or `ignore`).
+3. **Pending.** With no policy and no matching rule, the request is held pending for a human.
+
+This chain **fails safe**. If either evaluator errors, the request falls through to `pending` -- never to an auto-approval. Degrading a would-be blocklist denial to a pending row is preferable to dropping the observation, and an evaluator outage can never become a silent grant.
+
+A rule must carry at least one identifying criterion; a rule scoped only by time window (or nothing) is rejected at the API, because it would match every elevation in the org -- catastrophic for an auto-approve verdict.
+
+---
+
+## Offline rule enforcement and staleness
+
+The agent caches the PAM ruleset locally so it can keep enforcing while disconnected from the API. The cache is an **HMAC-SHA256-authenticated JSON envelope**:
+
+- The HMAC is the authoritative trust boundary. Tampering with the file on disk is detected on load, and a mismatch causes the agent to reject the rule body entirely.
+- The HMAC key lives in a separately permissioned `keys/` subdirectory, not alongside the cache file, so a single ACL regression on the data directory cannot expose both the envelope and the key needed to forge a new one. On Windows the cache is additionally locked to a SYSTEM-and-Administrators-only DACL; on Unix it is mode `0600` under a `0750` parent.
+
+Staleness is bounded by two thresholds keyed on the last successful sync:
+
+| Threshold | Behavior |
+|---|---|
+| **24 hours** (stale) | The agent keeps enforcing the cached rules but raises a staleness alert. |
+| **7 days** (refuse) | The agent refuses to hand back the cached ruleset at all. The policy layer must re-sync or fail closed rather than enforce ancient rules. |
+
+<Aside type="caution">
+  The staleness gate uses wall-clock time. A local-administrator attacker who can roll the system clock back can keep a stale envelope "fresh" indefinitely. The gate is designed to catch the *operational* failure mode -- "agent forgotten or connectivity broken for more than a week, rules need to fail closed" -- not to defend against an active local-admin adversary on the box. A monotonic last-seen-fresh watermark is tracked as a follow-up.
+</Aside>
+
+---
+
+## Audit guarantees
+
+Every elevation produces an immutable chain of events on a dedicated ledger, separate from -- and in addition to -- the platform audit log:
+
+- A `requested` event is written for every observation.
+- Auto-decisions add an `approved` / `denied` event attributed to the deciding software policy or PAM rule.
+- Human decisions add `approved`, `denied`, or `revoked` events attributed to the approver **by user**, with the supplied reason.
+- Actuation, session start/stop, and command execution land as their own event types.
+
+The ledger denormalizes the organization id and ties each audit row to its parent request with a **composite foreign key** `(elevation_request_id, org_id) -> elevation_requests(id, org_id)`. This is a structural guarantee that an audit row's tenant can never drift from its parent request's tenant, even under a logic bug. Because it inherits the platform's forced row-level security, an audit entry is only ever visible within its own tenant.
+
+The **Audit** tab of the Privileged Access console renders this ledger -- filterable by status, flow, and date range, and exportable to CSV for compliance reporting. Each entry names the decider, so there is never ambiguity about who (or what rule) granted access.
+
+---
+
+## What PAM does and does not protect against
+
+**PAM protects against:**
+
+- **Standing local-administrator sprawl.** Endpoints carry no permanently privileged user account; admin exists only inside approved windows.
+- **Credential exposure.** The elevation credential is minted, used, and destroyed on the endpoint and never transits the network or lands in a config file.
+- **Self-approval and automation self-grant.** Requester and approver are always distinct identities, enforced with MFA.
+- **Replay of an approval.** Single-use actuation makes an approved request non-replayable.
+- **Tenant cross-contamination.** Forced row-level security plus a composite-FK audit tie keep every request, rule, and audit entry inside its own organization.
+- **Silent failure of the decision engine.** Evaluator errors fail safe to pending, never to auto-approve.
+- **Enforcing dangerously old rules offline.** Cached rules alert at 24 hours and refuse past 7 days.
+
+**PAM does not protect against:**
+
+- **A compromised approver.** If an authenticated, MFA-satisfied operator approves a malicious request, PAM grants it. Mitigations are operational: approval reasons, requester history surfaced in the UI, per-tenant approval-rate limits, and anomaly alerting on approval-rate spikes. Treat approver accounts as the high-value identities they are.
+- **An existing local-administrator adversary on the endpoint.** The offline staleness gate and self-heal assume an attacker without prior SYSTEM/admin control. A box that is already fully compromised is outside PAM's threat model -- PAM is a privilege-*reduction* control, not endpoint EDR.
+- **Third-party agent-stack interactions.** UAC-touching code interacts with whatever else is installed. There is a documented production-breaking deadlock between the N-able N-Central agent and `consent.exe` on idle or locked machines that hangs UAC prompts for 4-5 minutes. Validate PAM against the agent stack your customers actually run before enabling it broadly. See the [admin guide's operational notes](/features/pam/#operational-notes).
+- **Non-Windows endpoints.** The dormant-admin lifecycle, secure-desktop injection, and UAC interception are Windows-only. On other platforms the elevation primitives are no-ops.
+
+---
+
+## Platform-evolution and liability notes
+
+- **Windows Administrator Protection / 24H2.** PAM's detection relies on the documented `Microsoft-Windows-LUA` ETW telemetry provider, which Microsoft extends (rather than replaces) for the Administrator Protection path. The injection path uses the supported SYSTEM-context route to the secure desktop.
+- **CVE-2026-20824 (Credential UI hardening, Jan 2026).** Microsoft tightened which processes can request `uiAccess` and added input-source validation. The hardening targeted remote-input tools (TeamViewer, AnyDesk, RDP); SYSTEM-context injection on the secure desktop was not named as impacted. Breeze tracks the trajectory and validates the path empirically each Windows release.
+- **E&O / SLA implications.** Because PAM lets the MSP grant administrator access, an erroneous or coerced approval can attribute blame to the MSP. This may warrant disclosure on the MSP's errors-and-omissions coverage and explicit carve-outs in MSP-customer SLAs. Flag PAM enablement in customer onboarding.

--- a/apps/docs/src/content/docs/security/pam.mdx
+++ b/apps/docs/src/content/docs/security/pam.mdx
@@ -35,7 +35,7 @@ PAM spans three trust domains, each with a distinct identity and a distinct set 
 |---|---|---|---|
 | **Endpoint agent** (Windows service) | Local `SYSTEM` | The dormant-admin account lifecycle and credential minting | Decide its own approvals; reach across tenants |
 | **Breeze control plane** (API) | Unprivileged DB role under row-level security | The request ledger, rule chain, and decisions | See or transmit any endpoint credential |
-| **Approver** (technician / mobile / Helper) | Authenticated user with MFA | The approve/deny/revoke decision | Approve a request they originated |
+| **Approver** (technician / mobile / Helper) | Authenticated user with MFA | The approve/deny/revoke decision | Relax automation's own verdict (AI/unmatched actions default to pending) |
 
 The single most important property of this split: **the credential that satisfies a UAC prompt is minted on the endpoint, used on the endpoint, and destroyed on the endpoint.** It is never written to the agent's configuration file and never transmitted to the server. The control plane records *that* an elevation was approved; it never holds the secret that exercises it.
 
@@ -92,11 +92,15 @@ The PAM actuator is additionally **disabled by default in every environment** an
 
 ## Separation of duties
 
-The approver is always a separate identity from the requester:
+The separation-of-duties property the system enforces today is **automation cannot self-grant**:
 
-- A user **cannot approve their own elevation.**
-- An AI agent or Helper session **cannot sign off on the action it proposed** -- AI tool actions and unmatched UAC prompts always default to **pending**, waiting on a human. Automation can never quietly relax its own approval.
-- The mobile app guards self-approval (when a user's own phone approves a request for that same user) behind a deliberate 5-second hold-to-confirm, so a momentarily unlocked phone cannot rubber-stamp a self-issued request.
+- An AI agent or Helper session **cannot sign off on the action it proposed** -- AI tool actions and unmatched UAC prompts always default to **pending**, waiting on a human (see [Decisioning chain and fail-safe behavior](#decisioning-chain-and-fail-safe-behavior)). Automation can never quietly relax its own approval, and an evaluator outage degrades to pending rather than to an auto-grant.
+
+<Aside type="caution">
+  **Human requester-vs-approver separation is not yet enforced.** The respond route does not compare the approving user against the requester, and the elevation flows that matter here (`uac_intercept`, `tech_jit_admin`) do not record an originating user identity at all (`subjectUserId` is `null` on every insert), so the control plane has nothing to compare against. Today, a user who holds `devices:execute` + MFA can approve a request -- including one tied to their own work. Treat requester/approver separation as an **operational** control: rely on approval reasons, the requester/device context surfaced in the UI, and anomaly alerting, not on a system-enforced block.
+
+  A self-approval gate is planned but **not active in production**. The mobile *hold-to-confirm* step-up (a deliberate 5-second hold when a user's own phone approves a request for that same user) lives on the separate Helper/mobile approval-request path and is keyed on an `isRecursive` flag. That flag's derivation currently returns `false` for all real traffic -- the requesting-client identity is not yet plumbed through the AI-agent/mobile-MCP path -- so the hold-to-confirm gate does not fire today. It will become active once the mobile-MCP step-up path lands.
+</Aside>
 
 Every approve, deny, and revoke is gated by:
 
@@ -163,7 +167,7 @@ The **Audit** tab of the Privileged Access console renders this ledger -- filter
 
 - **Standing local-administrator sprawl.** Endpoints carry no permanently privileged user account; admin exists only inside approved windows.
 - **Credential exposure.** The elevation credential is minted, used, and destroyed on the endpoint and never transits the network or lands in a config file.
-- **Self-approval and automation self-grant.** Requester and approver are always distinct identities, enforced with MFA.
+- **Automation self-grant.** AI tool actions and unmatched UAC prompts default to **pending** and wait on a human, so automation can never approve the action it proposed. (Note: human requester-vs-approver separation is *not* yet system-enforced -- see [Separation of duties](#separation-of-duties).)
 - **Replay of an approval.** Single-use actuation makes an approved request non-replayable.
 - **Tenant cross-contamination.** Forced row-level security plus a composite-FK audit tie keep every request, rule, and audit entry inside its own organization.
 - **Silent failure of the decision engine.** Evaluator errors fail safe to pending, never to auto-approve.
@@ -172,6 +176,7 @@ The **Audit** tab of the Privileged Access console renders this ledger -- filter
 **PAM does not protect against:**
 
 - **A compromised approver.** If an authenticated, MFA-satisfied operator approves a malicious request, PAM grants it. Mitigations are operational: approval reasons, requester history surfaced in the UI, per-tenant approval-rate limits, and anomaly alerting on approval-rate spikes. Treat approver accounts as the high-value identities they are.
+- **Human self-approval.** The respond route does not yet block a user from approving a request tied to their own work, and the elevation flows do not record an originating user identity, so there is no system-enforced requester-vs-approver split for human-decided requests today. The mobile hold-to-confirm gate that will cover this is not active in production yet. See [Separation of duties](#separation-of-duties).
 - **An existing local-administrator adversary on the endpoint.** The offline staleness gate and self-heal assume an attacker without prior SYSTEM/admin control. A box that is already fully compromised is outside PAM's threat model -- PAM is a privilege-*reduction* control, not endpoint EDR.
 - **Third-party agent-stack interactions.** UAC-touching code interacts with whatever else is installed. There is a documented production-breaking deadlock between the N-able N-Central agent and `consent.exe` on idle or locked machines that hangs UAC prompts for 4-5 minutes. Validate PAM against the agent stack your customers actually run before enabling it broadly. See the [admin guide's operational notes](/features/pam/#operational-notes).
 - **Non-Windows endpoints.** The dormant-admin lifecycle, secure-desktop injection, and UAC interception are Windows-only. On other platforms the elevation primitives are no-ops.

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -819,20 +819,64 @@
     {
       "pattern": "apps/api/src/routes/pam.ts",
       "docs": [
-        "features/pam.mdx"
+        "features/pam.mdx",
+        "reference/pam-api.mdx",
+        "security/pam.mdx"
       ]
     },
     {
       "pattern": "apps/api/src/routes/agents/elevationRequests.ts",
       "docs": [
-        "features/pam.mdx"
+        "features/pam.mdx",
+        "reference/pam-api.mdx",
+        "security/pam.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/devices/actuateElevation.ts",
+      "docs": [
+        "reference/pam-api.mdx",
+        "security/pam.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/elevations.ts",
+      "docs": [
+        "reference/pam-api.mdx",
+        "security/pam.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/pam.ts",
+      "docs": [
+        "reference/pam-api.mdx",
+        "security/pam.mdx"
+      ]
+    },
+    {
+      "pattern": "agent/internal/elevaccount/**",
+      "docs": [
+        "security/pam.mdx"
+      ]
+    },
+    {
+      "pattern": "agent/internal/pamactuator/**",
+      "docs": [
+        "security/pam.mdx"
+      ]
+    },
+    {
+      "pattern": "agent/internal/pam/**",
+      "docs": [
+        "security/pam.mdx"
       ]
     },
     {
       "pattern": "apps/api/src/routes/agents/pamSettings.ts",
       "docs": [
         "features/pam.mdx",
-        "features/configuration-policies.mdx"
+        "features/configuration-policies.mdx",
+        "reference/pam-api.mdx"
       ]
     },
     {


### PR DESCRIPTION
Adds the Privileged Access Management (PAM) documentation set requested in #1161. All content is sourced from the shipped implementation (not in-flight design), per the issue's sequencing note.

## Three deliverables

**1. PAM Security Model** — `apps/docs/src/content/docs/security/pam.mdx` (new, evaluator-facing, auto-registers in the autogenerated Security Architecture sidebar)
- Trust boundaries across the three domains (SYSTEM-context agent / unprivileged control plane / MFA'd approver) and the core property: the elevation credential is minted, used, and destroyed on the endpoint and never transits the wire or a config file.
- Elevation primitives: the `~breeze_elev` dormant-admin lifecycle (provisioned → promoted → demoted, crash self-heal, 40-char `crypto/rand` passwords), Flavor-A secure-desktop credential injection into `consent.exe`, and single-use actuation (atomic `approved → actuating` CAS).
- Separation of duties (no self-approval, no automation self-grant, MFA on every decision), fail-safe decisioning (errors fall through to pending), the offline HMAC-SHA256 rule cache with 24h-alert / 7-day-refuse staleness, and the append-only audit ledger with its composite-FK tenant tie.
- Explicit **does / does-not-protect** section, incl. compromised-approver, existing-local-admin, the N-able N-Central `consent.exe` deadlock, CVE-2026-20824, non-Windows scope, and E&O / SLA implications.

**2. PAM API Reference** — `apps/docs/src/content/docs/reference/pam-api.mdx` (new, auto-registers in the autogenerated Reference sidebar)
- The `/api/v1/pam/*` control plane: `GET /elevation-requests`, `GET /active`, `POST /…/respond`, `POST /…/revoke`, rules CRUD + `POST /rules/preview` — with methods, scopes, permissions (`devices:read`/`write`/`execute`), MFA gates, and request/response shapes incl. status codes.
- The device `POST /devices/:id/actuate-elevation` route (single-use, disabled-by-default) and the agent `POST /agents/:id/elevation-requests` ingest endpoint.
- The `pam` config-policy feature (`uacInterceptionEnabled`, default true).

**3. PAM Admin Guide** — `apps/docs/src/content/docs/features/pam.mdx` (extended the existing operator guide)
- Added per-organization / per-device enable-disable overrides (the "kill switch"), a CSV audit-export procedure, the N-able N-Central deadlock operational note, a platform-support note, and cross-links to the two new pages.

## How content was sourced
Read directly from the codebase: `routes/pam.ts`, `routes/agents/elevationRequests.ts`, `routes/devices/actuateElevation.ts`, `routes/agents/pamSettings.ts`, `db/schema/elevations.ts` + `pam.ts`, and `agent/internal/{elevaccount,pamactuator,pam}`. The security-model narrative, N-able deadlock, and CVE-2026-20824 note are cross-checked against Discussion #858 §5. No internal infrastructure details (IPs/hostnames/regions) are included.

## Verification
- `npx astro build` in `apps/docs` — green; both new pages render (`/security/pam/`, `/reference/pam-api/`) with no broken-link warnings.
- Rebuilt the docs search index (`scripts/build-docs-index.ts`); both new pages indexed.
- Updated `scripts/docs-review/mapping.json` with the new source→doc relationships.
- `pnpm test --filter=@breeze/shared docsMapping` — 40 passed.

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: security-model accuracy correction (commit d687494f)

A docs-review pass found the security model **over-claimed** the separation-of-duties guarantee. Corrected to match what the code actually enforces:

- **Dropped** the blanket "a user cannot approve their own elevation" / "requester and approver are always distinct" claims. The respond route (`routes/pam.ts /elevation-requests/:id/respond`) performs **no** requester-vs-approver comparison, and `uac_intercept` / `tech_jit_admin` inserts set `subjectUserId = null`, so no originating identity is even recorded to compare against. Reframed around the one genuine property the code *does* enforce — **automation cannot self-grant** (AI tool actions and unmatched UAC prompts default to `pending`).
- **Reframed** the mobile 5s hold-to-confirm self-approval gate as **planned / not yet active in production**: it lives on the separate `approval_requests` path and is keyed on `isRecursive`, whose `deriveIsRecursive()` returns `false` for all real traffic until the mobile-MCP step-up path is plumbed through. Added a matching entry to the "does not protect against" list.
- **PAM API:** noted the `username`/`password` fields on `actuate-elevation` are **vestigial** (accepted by the schema but never read or forwarded into the queued command).
- **PAM API:** clarified the agent-ingest `target_executable_hash` is a free-form `string` ≤128 chars (no hex/length validation); only the rule-side `matchHash` is strictly validated as a 64-char SHA-256 hex digest.

Docs build remains green (123 pages, no broken-link warnings); `docsIndex.json` unchanged (no heading changes).
