### PR TITLE
feat: process-level resource drill-down (Phase 1: CPU + RAM)

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -41,30 +41,31 @@ type PolicyConfigStateProbe struct {
 }
 
 type Config struct {
-	AgentID                  string   `mapstructure:"agent_id"`
-	ServerURL                string   `mapstructure:"server_url"`
-	AuthToken                string   `mapstructure:"auth_token"`
-	WatchdogAuthToken        string   `mapstructure:"watchdog_auth_token"`
-	HelperAuthToken          string   `mapstructure:"helper_auth_token"`
-	OrgID                    string   `mapstructure:"org_id"`
-	SiteID                   string   `mapstructure:"site_id"`
-	HeartbeatIntervalSeconds int      `mapstructure:"heartbeat_interval_seconds"`
-	MetricsIntervalSeconds   int      `mapstructure:"metrics_interval_seconds"`
-	EnabledCollectors        []string `mapstructure:"enabled_collectors"`
-	BackupEnabled            bool     `mapstructure:"backup_enabled"`
-	BackupPaths              []string `mapstructure:"backup_paths"`
-	BackupSchedule           string   `mapstructure:"backup_schedule"`
-	BackupRetention          int      `mapstructure:"backup_retention"`
-	BackupProvider           string   `mapstructure:"backup_provider"`
-	BackupLocalPath          string   `mapstructure:"backup_local_path"`
-	BackupS3Bucket           string   `mapstructure:"backup_s3_bucket"`
-	BackupS3Region           string   `mapstructure:"backup_s3_region"`
-	BackupS3AccessKey        string   `mapstructure:"backup_s3_access_key"`
-	BackupS3SecretKey        string   `mapstructure:"backup_s3_secret_key"`
-	BackupVSSEnabled         bool     `mapstructure:"backup_vss_enabled"`          // Windows: VSS shadow copy before backup
-	BackupSystemStateEnabled bool     `mapstructure:"backup_system_state_enabled"` // Collect system state alongside file backup
-	BackupBinaryPath         string   `mapstructure:"backup_binary_path"`          // Path to breeze-backup helper binary
-	BackupStagingDir         string   `mapstructure:"backup_staging_dir"`          // Staging directory for Hyper-V exports, MSSQL backups, etc. (empty = OS temp dir)
+	AgentID                      string   `mapstructure:"agent_id"`
+	ServerURL                    string   `mapstructure:"server_url"`
+	AuthToken                    string   `mapstructure:"auth_token"`
+	WatchdogAuthToken            string   `mapstructure:"watchdog_auth_token"`
+	HelperAuthToken              string   `mapstructure:"helper_auth_token"`
+	OrgID                        string   `mapstructure:"org_id"`
+	SiteID                       string   `mapstructure:"site_id"`
+	HeartbeatIntervalSeconds     int      `mapstructure:"heartbeat_interval_seconds"`
+	MetricsIntervalSeconds       int      `mapstructure:"metrics_interval_seconds"`
+	ProcessSampleIntervalSeconds int      `mapstructure:"process_sample_interval_seconds"`
+	EnabledCollectors            []string `mapstructure:"enabled_collectors"`
+	BackupEnabled                bool     `mapstructure:"backup_enabled"`
+	BackupPaths                  []string `mapstructure:"backup_paths"`
+	BackupSchedule               string   `mapstructure:"backup_schedule"`
+	BackupRetention              int      `mapstructure:"backup_retention"`
+	BackupProvider               string   `mapstructure:"backup_provider"`
+	BackupLocalPath              string   `mapstructure:"backup_local_path"`
+	BackupS3Bucket               string   `mapstructure:"backup_s3_bucket"`
+	BackupS3Region               string   `mapstructure:"backup_s3_region"`
+	BackupS3AccessKey            string   `mapstructure:"backup_s3_access_key"`
+	BackupS3SecretKey            string   `mapstructure:"backup_s3_secret_key"`
+	BackupVSSEnabled             bool     `mapstructure:"backup_vss_enabled"`          // Windows: VSS shadow copy before backup
+	BackupSystemStateEnabled     bool     `mapstructure:"backup_system_state_enabled"` // Collect system state alongside file backup
+	BackupBinaryPath             string   `mapstructure:"backup_binary_path"`          // Path to breeze-backup helper binary
+	BackupStagingDir             string   `mapstructure:"backup_staging_dir"`          // Staging directory for Hyper-V exports, MSSQL backups, etc. (empty = OS temp dir)
 
 	// Local vault (SMB share / USB drive) configuration
 	VaultEnabled        bool   `mapstructure:"vault_enabled"`
@@ -190,21 +191,22 @@ func ConfigDir() string {
 
 func Default() *Config {
 	return &Config{
-		HeartbeatIntervalSeconds: 60,
-		MetricsIntervalSeconds:   30,
-		EnabledCollectors:        []string{"hardware", "software", "metrics", "network"},
-		LogLevel:                 "info",
-		LogFormat:                "text",
-		LogFile:                  defaultLogFile(),
-		LogMaxSizeMB:             50,
-		LogMaxBackups:            3,
-		LogShippingLevel:         "warn",
-		PAMEnabled:               false,
-		MaxConcurrentCommands:    10,
-		CommandQueueSize:         100,
-		AuditEnabled:             true,
-		AuditMaxSizeMB:           50,
-		AuditMaxBackups:          3,
+		HeartbeatIntervalSeconds:     60,
+		MetricsIntervalSeconds:       30,
+		ProcessSampleIntervalSeconds: 180,
+		EnabledCollectors:            []string{"hardware", "software", "metrics", "network"},
+		LogLevel:                     "info",
+		LogFormat:                    "text",
+		LogFile:                      defaultLogFile(),
+		LogMaxSizeMB:                 50,
+		LogMaxBackups:                3,
+		LogShippingLevel:             "warn",
+		PAMEnabled:                   false,
+		MaxConcurrentCommands:        10,
+		CommandQueueSize:             100,
+		AuditEnabled:                 true,
+		AuditMaxSizeMB:               50,
+		AuditMaxBackups:              3,
 
 		AutoUpdate:                 true,
 		PatchExcludeFeatureUpdates: true,

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -765,6 +765,7 @@ func (h *Heartbeat) Start() {
 	// Send initial inventory in background
 	go h.sendInventory()
 	go h.sendReliabilityMetrics()
+	go h.runProcessSampler()
 	h.mu.Lock()
 	h.lastPostureUpdate = time.Now()
 	h.lastReliabilityUpdate = time.Now()
@@ -1038,6 +1039,79 @@ func (h *Heartbeat) sendInventoryData(endpoint string, payload any, label string
 		log.Debug("inventory sent", "label", label)
 	} else {
 		log.Warn("inventory send failed", "label", label, "status", resp.StatusCode)
+	}
+}
+
+// processSampleTopN is the per-dimension top-N (CPU and RAM); the union is
+// capped at 2×this and must stay ≤ the API ingest schema's processes.max(16).
+const processSampleTopN = 8
+
+// runProcessSampler periodically captures a top-N process snapshot and POSTs it,
+// on its own ticker decoupled from the heartbeat (spec: process-sample pipeline).
+func (h *Heartbeat) runProcessSampler() {
+	defer observability.Recoverer("heartbeat.processSampler")
+
+	secs := h.config.ProcessSampleIntervalSeconds
+	if secs < 60 {
+		secs = 60
+	} else if secs > 3600 {
+		secs = 3600
+	}
+	ticker := time.NewTicker(time.Duration(secs) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if h.authMon != nil && h.authMon.ShouldSkip() {
+				continue
+			}
+			h.sendProcessSample()
+		case <-h.stopChan:
+			return
+		}
+	}
+}
+
+// sendProcessSample builds a top-N process snapshot and POSTs it to the ingest
+// route, mirroring sendInventoryData's auth/retry/timeout handling.
+func (h *Heartbeat) sendProcessSample() {
+	entries, err := tools.TopProcessSample(processSampleTopN)
+	if err != nil {
+		log.Error("failed to collect process sample", "error", err.Error())
+		return
+	}
+
+	payload := map[string]any{
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"processes": entries,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Error("failed to marshal process sample", "error", err.Error())
+		return
+	}
+
+	url := fmt.Sprintf("%s/api/v1/agents/%s/process-sample", h.config.ServerURL, h.config.AgentID)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {h.authHeader()},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := httputil.Do(ctx, h.httpClient(), "POST", url, body, headers, h.retryCfg)
+	if err != nil {
+		log.Error("failed to send process sample", "error", err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		log.Debug("process sample sent", "count", len(entries))
+	} else {
+		log.Warn("process sample send failed", "status", resp.StatusCode)
 	}
 }
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1053,8 +1053,10 @@ func (h *Heartbeat) runProcessSampler() {
 
 	secs := h.config.ProcessSampleIntervalSeconds
 	if secs < 60 {
+		log.Warn("clamping process_sample_interval_seconds to minimum", "configured", secs, "clamped", 60)
 		secs = 60
 	} else if secs > 3600 {
+		log.Warn("clamping process_sample_interval_seconds to maximum", "configured", secs, "clamped", 3600)
 		secs = 3600
 	}
 	ticker := time.NewTicker(time.Duration(secs) * time.Second)

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1046,18 +1046,26 @@ func (h *Heartbeat) sendInventoryData(endpoint string, payload any, label string
 // capped at 2×this and must stay ≤ the API ingest schema's processes.max(16).
 const processSampleTopN = 8
 
+// clampProcessSampleInterval bounds the configured sampler interval to a safe
+// [60, 3600] second range. Pure (no side effects) so it can be unit-tested and
+// so time.NewTicker never receives a non-positive duration.
+func clampProcessSampleInterval(secs int) int {
+	if secs < 60 {
+		return 60
+	}
+	if secs > 3600 {
+		return 3600
+	}
+	return secs
+}
+
 // runProcessSampler periodically captures a top-N process snapshot and POSTs it,
 // on its own ticker decoupled from the heartbeat (spec: process-sample pipeline).
 func (h *Heartbeat) runProcessSampler() {
-	defer observability.Recoverer("heartbeat.processSampler")
-
-	secs := h.config.ProcessSampleIntervalSeconds
-	if secs < 60 {
-		log.Warn("clamping process_sample_interval_seconds to minimum", "configured", secs, "clamped", 60)
-		secs = 60
-	} else if secs > 3600 {
-		log.Warn("clamping process_sample_interval_seconds to maximum", "configured", secs, "clamped", 3600)
-		secs = 3600
+	configured := h.config.ProcessSampleIntervalSeconds
+	secs := clampProcessSampleInterval(configured)
+	if secs != configured {
+		log.Warn("clamped process_sample_interval_seconds", "configured", configured, "clamped", secs)
 	}
 	ticker := time.NewTicker(time.Duration(secs) * time.Second)
 	defer ticker.Stop()
@@ -1065,10 +1073,15 @@ func (h *Heartbeat) runProcessSampler() {
 	for {
 		select {
 		case <-ticker.C:
-			if h.authMon != nil && h.authMon.ShouldSkip() {
-				continue
-			}
-			h.sendProcessSample()
+			// Per-iteration recovery: a panic in a single sample must not kill the
+			// long-lived sampler goroutine (a top-level defer Recoverer would).
+			func() {
+				defer observability.Recoverer("heartbeat.processSampler")
+				if h.authMon != nil && h.authMon.ShouldSkip() {
+					return
+				}
+				h.sendProcessSample()
+			}()
 		case <-h.stopChan:
 			return
 		}

--- a/agent/internal/heartbeat/heartbeat_processsampler_test.go
+++ b/agent/internal/heartbeat/heartbeat_processsampler_test.go
@@ -1,0 +1,23 @@
+package heartbeat
+
+import "testing"
+
+func TestClampProcessSampleInterval(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{in: 0, want: 60},      // unset/zero → floor (no NewTicker(0) panic)
+		{in: -5, want: 60},     // negative → floor
+		{in: 30, want: 60},     // below min → floor
+		{in: 60, want: 60},     // min boundary
+		{in: 180, want: 180},   // default, in range
+		{in: 3600, want: 3600}, // max boundary
+		{in: 9999, want: 3600}, // above max → ceiling
+	}
+	for _, c := range cases {
+		if got := clampProcessSampleInterval(c.in); got != c.want {
+			t.Errorf("clampProcessSampleInterval(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/agent/internal/remote/tools/process_sample.go
+++ b/agent/internal/remote/tools/process_sample.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/shirou/gopsutil/v3/process"
@@ -37,11 +38,21 @@ func TopProcessSample(perDimension int) ([]ProcessSampleEntry, error) {
 		if err != nil {
 			continue
 		}
+		// Bound the name to the ingest schema's limit (256) so one pathological
+		// name can't 400 the whole sample; rune-safe.
+		name, _ = truncateStringBytes(name, 256)
 		e := ProcessSampleEntry{Name: name, PID: p.Pid, CPU: cpuPercents[p.Pid]}
 		if mem, err := p.MemoryInfo(); err == nil && mem != nil {
 			e.RAMMb = float64(mem.RSS) / 1024 / 1024
 		}
 		entries = append(entries, e)
+	}
+
+	// A non-empty process table that yields zero entries means every Name()
+	// lookup failed (sandbox/permission/platform regression) — surface it as an
+	// error rather than silently POSTing an empty "successful" snapshot.
+	if len(procs) > 0 && len(entries) == 0 {
+		return nil, fmt.Errorf("collected 0 of %d processes: all Name() lookups failed", len(procs))
 	}
 
 	return selectTopN(entries, perDimension), nil

--- a/agent/internal/remote/tools/process_sample.go
+++ b/agent/internal/remote/tools/process_sample.go
@@ -1,0 +1,79 @@
+package tools
+
+import (
+	"sort"
+
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+// ProcessSampleEntry is one process in a periodic top-N snapshot. JSON tags
+// match the API ingest schema and the device_process_samples top_processes
+// JSONB shape. DiskBps/NetBps are reserved for later phases (omitted now).
+type ProcessSampleEntry struct {
+	Name    string  `json:"name"`
+	PID     int32   `json:"pid"`
+	CPU     float64 `json:"cpu"`
+	RAMMb   float64 `json:"ramMb"`
+	DiskBps float64 `json:"diskBps,omitempty"`
+	NetBps  float64 `json:"netBps,omitempty"`
+}
+
+// TopProcessSample enumerates processes once, measures *instantaneous* CPU over
+// a single shared 250ms window (sampleProcessCPUPercents — never the lifetime
+// average), reads RSS, and returns the union of the top perDimension by CPU and
+// by RAM. It skips username resolution on purpose: the snapshot does not need
+// it, and resolveUsername is the expensive Windows SID-lookup path.
+func TopProcessSample(perDimension int) ([]ProcessSampleEntry, error) {
+	procs, err := process.Processes()
+	if err != nil {
+		return nil, err
+	}
+
+	cpuPercents := sampleProcessCPUPercents(procs, cpuSampleInterval)
+
+	entries := make([]ProcessSampleEntry, 0, len(procs))
+	for _, p := range procs {
+		name, err := p.Name()
+		if err != nil {
+			continue
+		}
+		e := ProcessSampleEntry{Name: name, PID: p.Pid, CPU: cpuPercents[p.Pid]}
+		if mem, err := p.MemoryInfo(); err == nil && mem != nil {
+			e.RAMMb = float64(mem.RSS) / 1024 / 1024
+		}
+		entries = append(entries, e)
+	}
+
+	return selectTopN(entries, perDimension), nil
+}
+
+// selectTopN returns the union of the top perDimension entries by CPU and the
+// top perDimension by RAM, deduped by PID, preserving the original input order.
+func selectTopN(entries []ProcessSampleEntry, perDimension int) []ProcessSampleEntry {
+	if perDimension < 1 {
+		perDimension = 1
+	}
+
+	rankTop := func(less func(a, b ProcessSampleEntry) bool) map[int32]bool {
+		sorted := append([]ProcessSampleEntry(nil), entries...)
+		sort.Slice(sorted, func(i, j int) bool { return less(sorted[i], sorted[j]) })
+		top := map[int32]bool{}
+		for i := 0; i < len(sorted) && i < perDimension; i++ {
+			top[sorted[i].PID] = true
+		}
+		return top
+	}
+
+	keep := rankTop(func(a, b ProcessSampleEntry) bool { return a.CPU > b.CPU })
+	for pid := range rankTop(func(a, b ProcessSampleEntry) bool { return a.RAMMb > b.RAMMb }) {
+		keep[pid] = true
+	}
+
+	out := make([]ProcessSampleEntry, 0, len(keep))
+	for _, e := range entries {
+		if keep[e.PID] {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/agent/internal/remote/tools/process_sample_test.go
+++ b/agent/internal/remote/tools/process_sample_test.go
@@ -74,3 +74,26 @@ func pids(entries []ProcessSampleEntry) []int32 {
 	}
 	return out
 }
+
+func TestSelectTopNEmptyInput(t *testing.T) {
+	if got := selectTopN(nil, 8); len(got) != 0 {
+		t.Errorf("expected empty result for nil input, got %+v", got)
+	}
+	if got := selectTopN([]ProcessSampleEntry{}, 8); len(got) != 0 {
+		t.Errorf("expected empty result for empty input, got %+v", got)
+	}
+}
+
+func TestSelectTopNPerDimensionFloor(t *testing.T) {
+	entries := []ProcessSampleEntry{
+		{Name: "a", PID: 1, CPU: 5, RAMMb: 1},
+		{Name: "b", PID: 2, CPU: 9, RAMMb: 1}, // top CPU
+		{Name: "c", PID: 3, CPU: 1, RAMMb: 9}, // top RAM
+	}
+	// perDimension <= 0 must floor to 1 (no panic), yielding top-1-by-CPU ∪ top-1-by-RAM.
+	got := selectTopN(entries, 0)
+	set := pidSet(got)
+	if !set[2] || !set[3] || set[1] {
+		t.Errorf("expected {2,3} (top-1 CPU=2, top-1 RAM=3), got %v", pids(got))
+	}
+}

--- a/agent/internal/remote/tools/process_sample_test.go
+++ b/agent/internal/remote/tools/process_sample_test.go
@@ -1,0 +1,76 @@
+package tools
+
+import "testing"
+
+func pidSet(entries []ProcessSampleEntry) map[int32]bool {
+	m := map[int32]bool{}
+	for _, e := range entries {
+		m[e.PID] = true
+	}
+	return m
+}
+
+func TestSelectTopN(t *testing.T) {
+	entries := []ProcessSampleEntry{
+		{Name: "a", PID: 1, CPU: 90, RAMMb: 10}, // top CPU
+		{Name: "b", PID: 2, CPU: 80, RAMMb: 20}, // 2nd CPU
+		{Name: "c", PID: 3, CPU: 1, RAMMb: 900}, // top RAM
+		{Name: "d", PID: 4, CPU: 2, RAMMb: 800}, // 2nd RAM
+		{Name: "e", PID: 5, CPU: 0, RAMMb: 0},   // neither
+	}
+
+	got := selectTopN(entries, 2)
+	pids := pidSet(got)
+
+	for _, want := range []int32{1, 2, 3, 4} {
+		if !pids[want] {
+			t.Errorf("expected PID %d in union of top-2-by-CPU and top-2-by-RAM", want)
+		}
+	}
+	if pids[5] {
+		t.Errorf("PID 5 (neither top CPU nor RAM) should be excluded")
+	}
+	if len(got) != 4 {
+		t.Errorf("expected 4 unioned entries, got %d", len(got))
+	}
+}
+
+func TestSelectTopNDedupesProcessHighInBoth(t *testing.T) {
+	entries := []ProcessSampleEntry{
+		{Name: "hog", PID: 1, CPU: 99, RAMMb: 999}, // top of both rankings
+		{Name: "b", PID: 2, CPU: 50, RAMMb: 1},
+		{Name: "c", PID: 3, CPU: 1, RAMMb: 500},
+	}
+	got := selectTopN(entries, 1)
+	// top-1 CPU = pid1, top-1 RAM = pid1 → union is just {1}, no duplicate row.
+	if len(got) != 1 || got[0].PID != 1 {
+		t.Errorf("expected single deduped entry pid=1, got %+v", got)
+	}
+}
+
+func TestSelectTopNPreservesInputOrder(t *testing.T) {
+	entries := []ProcessSampleEntry{
+		{Name: "a", PID: 3, CPU: 10, RAMMb: 1},
+		{Name: "b", PID: 1, CPU: 20, RAMMb: 1},
+		{Name: "c", PID: 2, CPU: 30, RAMMb: 1},
+	}
+	// perDimension=3 keeps all three; output must preserve input order [3,1,2].
+	got := selectTopN(entries, 3)
+	want := []int32{3, 1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d entries, got %d (%+v)", len(want), len(got), got)
+	}
+	for i, w := range want {
+		if got[i].PID != w {
+			t.Errorf("position %d: expected PID %d, got %d (full order %v)", i, w, got[i].PID, pids(got))
+		}
+	}
+}
+
+func pids(entries []ProcessSampleEntry) []int32 {
+	out := make([]int32, len(entries))
+	for i, e := range entries {
+		out[i] = e.PID
+	}
+	return out
+}

--- a/apps/api/migrations/2026-06-13-device-process-samples.sql
+++ b/apps/api/migrations/2026-06-13-device-process-samples.sql
@@ -1,0 +1,35 @@
+-- 2026-06-13: device_process_samples — per-device top-N process snapshots for
+-- the Performance-tab drill-down. RLS shape #1 (direct org_id), policies created
+-- in the same migration that creates the table (CLAUDE.md tenancy rule).
+-- timestamp = server receive time (the key for chart correlation);
+-- agent_timestamp = agent-reported sample time, kept for clock-skew forensics.
+
+CREATE TABLE IF NOT EXISTS public.device_process_samples (
+  device_id uuid NOT NULL REFERENCES public.devices(id) ON DELETE CASCADE,
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  "timestamp" timestamptz NOT NULL,
+  agent_timestamp timestamptz,
+  top_processes jsonb NOT NULL,
+  PRIMARY KEY (device_id, "timestamp")
+);
+
+CREATE INDEX IF NOT EXISTS device_process_samples_device_ts_desc_idx
+  ON public.device_process_samples (device_id, "timestamp" DESC);
+
+ALTER TABLE public.device_process_samples ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.device_process_samples FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON public.device_process_samples;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.device_process_samples;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON public.device_process_samples;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.device_process_samples;
+
+CREATE POLICY breeze_org_isolation_select ON public.device_process_samples
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON public.device_process_samples
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON public.device_process_samples
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON public.device_process_samples
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -183,6 +183,25 @@ export const deviceMetrics = pgTable('device_metrics', {
   pk: primaryKey({ columns: [table.deviceId, table.timestamp] })
 }));
 
+export type TopProcess = {
+  name: string;
+  pid: number;
+  cpu: number;
+  ramMb: number;
+  diskBps?: number;
+  netBps?: number;
+};
+
+export const deviceProcessSamples = pgTable('device_process_samples', {
+  deviceId: uuid('device_id').notNull().references(() => devices.id),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  timestamp: timestamp('timestamp', { withTimezone: true }).notNull(),
+  agentTimestamp: timestamp('agent_timestamp', { withTimezone: true }),
+  topProcesses: jsonb('top_processes').$type<TopProcess[]>().notNull()
+}, (table) => ({
+  pk: primaryKey({ columns: [table.deviceId, table.timestamp] })
+}));
+
 export const deviceSoftware = pgTable('device_software', {
   id: uuid('id').primaryKey().defaultRandom(),
   deviceId: uuid('device_id').notNull().references(() => devices.id),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -151,6 +151,7 @@ import { initializeSnmpWorker, shutdownSnmpWorker } from './jobs/snmpWorker';
 import { initializeMonitorWorker, shutdownMonitorWorker } from './jobs/monitorWorker';
 import { initializeSnmpRetention, shutdownSnmpRetention } from './jobs/snmpRetention';
 import { initializeReliabilityRetention, shutdownReliabilityRetention } from './jobs/reliabilityRetention';
+import { initializeProcessSampleRetention } from './jobs/processSampleRetention';
 import { initializePlaybookRetention, shutdownPlaybookRetention } from './jobs/playbookRetention';
 import { initializePolicyEvaluationWorker, shutdownPolicyEvaluationWorker } from './jobs/policyEvaluationWorker';
 import { initializeAutomationWorker, shutdownAutomationWorker } from './jobs/automationWorker';
@@ -1031,6 +1032,7 @@ async function initializeWorkers(): Promise<void> {
     ['agentLogRetention', initializeAgentLogRetention],
     ['ipHistoryRetention', initializeIPHistoryRetention],
     ['reliabilityRetention', initializeReliabilityRetention],
+    ['processSampleRetention', initializeProcessSampleRetention],
     ['changeLogRetention', initializeChangeLogRetention],
     ['oauthCleanup', initializeOauthCleanupWorker],
     ['auditRetention', initializeAuditRetentionWorker],

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -151,7 +151,7 @@ import { initializeSnmpWorker, shutdownSnmpWorker } from './jobs/snmpWorker';
 import { initializeMonitorWorker, shutdownMonitorWorker } from './jobs/monitorWorker';
 import { initializeSnmpRetention, shutdownSnmpRetention } from './jobs/snmpRetention';
 import { initializeReliabilityRetention, shutdownReliabilityRetention } from './jobs/reliabilityRetention';
-import { initializeProcessSampleRetention } from './jobs/processSampleRetention';
+import { initializeProcessSampleRetention, shutdownProcessSampleRetention } from './jobs/processSampleRetention';
 import { initializePlaybookRetention, shutdownPlaybookRetention } from './jobs/playbookRetention';
 import { initializePolicyEvaluationWorker, shutdownPolicyEvaluationWorker } from './jobs/policyEvaluationWorker';
 import { initializeAutomationWorker, shutdownAutomationWorker } from './jobs/automationWorker';
@@ -1202,6 +1202,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownAgentLogRetention,
     shutdownIPHistoryRetention,
     shutdownReliabilityRetention,
+    shutdownProcessSampleRetention,
     shutdownChangeLogRetention,
     shutdownOauthCleanupWorker,
     shutdownAuditRetentionWorker,

--- a/apps/api/src/jobs/processSampleRetention.test.ts
+++ b/apps/api/src/jobs/processSampleRetention.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Avoid real Redis/DB/Sentry side effects when importing the module under test.
+vi.mock('../db', () => ({ db: {}, withSystemDbAccessContext: (fn: any) => fn() }));
+vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
+vi.mock('../services/sentry', () => ({ captureException: () => {} }));
+
+import { extractRowCount } from './processSampleRetention';
+
+describe('extractRowCount (batched-delete loop termination depends on this)', () => {
+  it('prefers rowCount (node-postgres) over count', () => {
+    expect(extractRowCount({ rowCount: 7, count: 3 })).toBe(7);
+  });
+
+  it('falls back to count (postgres-js DELETE result)', () => {
+    expect(extractRowCount({ count: 5 })).toBe(5);
+  });
+
+  it('falls back to array length when the driver returns rows', () => {
+    expect(extractRowCount([{}, {}, {}])).toBe(3);
+  });
+
+  it('returns 0 for an unrecognized object shape (does not falsely terminate as a partial batch)', () => {
+    expect(extractRowCount({})).toBe(0);
+  });
+
+  it('reports a full batch as the batch size so the loop continues', () => {
+    // A full batch (count === BATCH_SIZE) must not be read as < BATCH_SIZE.
+    expect(extractRowCount({ count: 10000 })).toBe(10000);
+  });
+});

--- a/apps/api/src/jobs/processSampleRetention.ts
+++ b/apps/api/src/jobs/processSampleRetention.ts
@@ -29,10 +29,12 @@ type RetentionJobData = { retentionDays?: number };
 /**
  * postgres-js / drizzle row-count extraction. The result may expose `.count`
  * (postgres-js DELETE), `.rowCount`, or — when the driver returns rows as an
- * array — fall back to `.length`. Mirrors `auditRetention.extractRowCount` and
- * `ipHistoryRetention` so we never report 0 when rows were actually deleted.
+ * array — fall back to `.length`. Mirrors `auditRetention.extractRowCount`
+ * (and the inline `.count ?? .length` check in `ipHistoryRetention`) so we never
+ * report 0 when rows were actually deleted — which would prematurely end the
+ * batched-delete loop and silently leave old rows.
  */
-function extractRowCount(result: unknown): number {
+export function extractRowCount(result: unknown): number {
   const raw = result as { rowCount?: number; count?: number };
   if (typeof raw.rowCount === 'number') return raw.rowCount;
   if (typeof raw.count === 'number') return raw.count;

--- a/apps/api/src/jobs/processSampleRetention.ts
+++ b/apps/api/src/jobs/processSampleRetention.ts
@@ -1,0 +1,106 @@
+/**
+ * Process-Sample Retention Worker
+ *
+ * BullMQ worker that prunes old device_process_samples in bounded ctid batches.
+ * Default retention: 7 days (configurable via PROCESS_SAMPLE_RETENTION_DAYS, max 14).
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error('[ProcessSampleRetention] withSystemDbAccessContext is not available — DB module may not have loaded correctly');
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+const QUEUE_NAME = 'process-sample-retention';
+const BATCH_SIZE = 10000;
+const DEFAULT_RETENTION_DAYS = Math.min(14, Math.max(1, parseInt(process.env.PROCESS_SAMPLE_RETENTION_DAYS || '7', 10)));
+
+type RetentionJobData = { retentionDays?: number };
+
+let retentionQueue: Queue<RetentionJobData> | null = null;
+let retentionWorker: Worker<RetentionJobData> | null = null;
+
+export function getProcessSampleRetentionQueue(): Queue<RetentionJobData> {
+  if (!retentionQueue) {
+    retentionQueue = new Queue<RetentionJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return retentionQueue;
+}
+
+export function createProcessSampleRetentionWorker(): Worker<RetentionJobData> {
+  return new Worker<RetentionJobData>(
+    QUEUE_NAME,
+    async (job: Job<RetentionJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        const retentionDays = Math.min(14, Math.max(1, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS));
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+        const startedAt = Date.now();
+
+        let deleted = 0;
+        for (;;) {
+          const result = await db.execute(sql`
+            DELETE FROM device_process_samples
+            WHERE ctid IN (
+              SELECT ctid FROM device_process_samples
+              WHERE "timestamp" < ${cutoff}
+              LIMIT ${BATCH_SIZE}
+            )
+          `);
+          const n = (result as unknown as { count?: number }).count ?? 0;
+          deleted += n;
+          if (n < BATCH_SIZE) break;
+        }
+
+        const durationMs = Date.now() - startedAt;
+        console.log(`[ProcessSampleRetention] Pruned ${deleted} process samples older than ${retentionDays} days in ${durationMs}ms`);
+        return { retentionDays, deleted, durationMs };
+      });
+    },
+    { connection: getBullMQConnection(), concurrency: 1 }
+  );
+}
+
+export async function initializeProcessSampleRetention(): Promise<void> {
+  try {
+    retentionWorker = createProcessSampleRetentionWorker();
+    retentionWorker.on('error', (error) => {
+      console.error('[ProcessSampleRetention] Worker error:', error);
+      captureException(error);
+    });
+    retentionWorker.on('failed', (job, error) => {
+      console.error(`[ProcessSampleRetention] Job ${job?.id} failed after ${job?.attemptsMade} attempts:`, error);
+      captureException(error);
+    });
+
+    const queue = getProcessSampleRetentionQueue();
+    const existing = await queue.getRepeatableJobs();
+    for (const job of existing) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+
+    await queue.add(
+      'cleanup',
+      { retentionDays: DEFAULT_RETENTION_DAYS },
+      { repeat: { every: 24 * 60 * 60 * 1000 }, removeOnComplete: { count: 5 }, removeOnFail: { count: 10 } }
+    );
+
+    console.log('[ProcessSampleRetention] Retention worker initialized');
+  } catch (error) {
+    console.error('[ProcessSampleRetention] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownProcessSampleRetention(): Promise<void> {
+  if (retentionWorker) { await retentionWorker.close(); retentionWorker = null; }
+  if (retentionQueue) { await retentionQueue.close(); retentionQueue = null; }
+}

--- a/apps/api/src/jobs/processSampleRetention.ts
+++ b/apps/api/src/jobs/processSampleRetention.ts
@@ -26,6 +26,19 @@ const DEFAULT_RETENTION_DAYS = Math.min(14, Math.max(1, parseInt(process.env.PRO
 
 type RetentionJobData = { retentionDays?: number };
 
+/**
+ * postgres-js / drizzle row-count extraction. The result may expose `.count`
+ * (postgres-js DELETE), `.rowCount`, or — when the driver returns rows as an
+ * array — fall back to `.length`. Mirrors `auditRetention.extractRowCount` and
+ * `ipHistoryRetention` so we never report 0 when rows were actually deleted.
+ */
+function extractRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? (result as unknown[]).length : 0;
+}
+
 let retentionQueue: Queue<RetentionJobData> | null = null;
 let retentionWorker: Worker<RetentionJobData> | null = null;
 
@@ -55,7 +68,7 @@ export function createProcessSampleRetentionWorker(): Worker<RetentionJobData> {
               LIMIT ${BATCH_SIZE}
             )
           `);
-          const n = (result as unknown as { count?: number }).count ?? 0;
+          const n = extractRowCount(result);
           deleted += n;
           if (n < BATCH_SIZE) break;
         }

--- a/apps/api/src/routes/agents/index.ts
+++ b/apps/api/src/routes/agents/index.ts
@@ -19,6 +19,7 @@ import { changesRoutes } from './changes';
 import { peripheralRoutes } from './peripherals';
 import { tokenRoutes } from './token';
 import { elevationRequestsRoutes } from './elevationRequests';
+import { processSampleRoutes } from './processSample';
 
 export const agentRoutes = new Hono();
 
@@ -69,3 +70,4 @@ agentRoutes.route('/', reliabilityRoutes);
 agentRoutes.route('/', changesRoutes);
 agentRoutes.route('/', peripheralRoutes);
 agentRoutes.route('/', elevationRequestsRoutes);
+agentRoutes.route('/', processSampleRoutes);

--- a/apps/api/src/routes/agents/processSample.test.ts
+++ b/apps/api/src/routes/agents/processSample.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const inserted: any[] = [];
+vi.mock('../../db', () => ({
+  db: {
+    insert: () => ({ values: (v: any) => { inserted.push(v); return Promise.resolve(); } })
+  },
+  withDbAccessContext: (_ctx: any, fn: any) => fn()
+}));
+
+import { processSampleRoutes } from './processSample';
+
+function appWithAgent(agent: any) {
+  const app = new Hono();
+  app.use('*', async (c, next) => { c.set('agent', agent); await next(); });
+  app.route('/', processSampleRoutes);
+  return app;
+}
+
+describe('POST /:id/process-sample', () => {
+  beforeEach(() => { inserted.length = 0; });
+
+  it('derives org_id from the auth context and ignores any body org_id', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    const res = await app.request('/dev-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        timestamp: '2026-06-13T12:00:00.000Z',
+        orgId: 'org-attacker',
+        processes: [{ name: 'chrome', pid: 42, cpu: 12.5, ramMb: 800 }]
+      })
+    });
+    expect(res.status).toBe(201);
+    expect(inserted[0].orgId).toBe('org-real');
+    expect(inserted[0].deviceId).toBe('dev-1');
+  });
+
+  it('server-stamps timestamp and stores agent time separately', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    await app.request('/dev-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2020-01-01T00:00:00.000Z', processes: [] })
+    });
+    expect(inserted[0].agentTimestamp).toEqual(new Date('2020-01-01T00:00:00.000Z'));
+    expect(inserted[0].timestamp.getTime()).toBeGreaterThan(new Date('2025-01-01').getTime());
+  });
+
+  it('rejects a payload over the 16-process cap', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    const processes = Array.from({ length: 17 }, (_, i) => ({ name: `p${i}`, pid: i, cpu: 0, ramMb: 0 }));
+    const res = await app.request('/dev-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes })
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when path id does not match the authenticated device', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    const res = await app.request('/dev-OTHER/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes: [] })
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/agents/processSample.ts
+++ b/apps/api/src/routes/agents/processSample.ts
@@ -1,0 +1,36 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { bodyLimit } from 'hono/body-limit';
+import { db } from '../../db';
+import { deviceProcessSamples } from '../../db/schema';
+import { type AgentAuthContext } from '../../middleware/agentAuth';
+import { processSampleSchema } from './schemas';
+
+export const processSampleRoutes = new Hono();
+
+processSampleRoutes.post(
+  '/:id/process-sample',
+  bodyLimit({ maxSize: 256 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }),
+  zValidator('json', processSampleSchema),
+  async (c) => {
+    const deviceId = c.req.param('id');
+    const data = c.req.valid('json');
+    const agent = c.get('agent') as AgentAuthContext | undefined;
+
+    // Tenancy is derived server-side from the authenticated device — the agent
+    // payload is never trusted for org_id, and the path id must match the token.
+    if (!agent || agent.deviceId !== deviceId) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+
+    await db.insert(deviceProcessSamples).values({
+      deviceId: agent.deviceId,
+      orgId: agent.orgId,
+      timestamp: new Date(),                       // server receive time
+      agentTimestamp: new Date(data.timestamp),    // agent-reported, forensic
+      topProcesses: data.processes
+    });
+
+    return c.json({ success: true }, 201);
+  }
+);

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -169,6 +169,22 @@ export const heartbeatSchema = z.object({
 });
 
 // ============================================
+// Process Samples
+// ============================================
+
+export const processSampleSchema = z.object({
+  timestamp: z.string().datetime(),
+  processes: z.array(z.object({
+    name: z.string().min(1).max(256),
+    pid: z.number().int().min(0),
+    cpu: z.number().min(0),
+    ramMb: z.number().min(0),
+    diskBps: z.number().min(0).optional(),
+    netBps: z.number().min(0).optional()
+  })).max(16)
+});
+
+// ============================================
 // Commands
 // ============================================
 

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -100,7 +100,8 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
   'device_filesystem_cleanup_runs', 'device_filesystem_scan_state',
   'device_filesystem_snapshots',
   'device_group_memberships', 'device_hardware', 'device_ip_history',
-  'device_metrics', 'device_network', 'device_patches', 'device_registry_state',
+  'device_metrics', 'device_network', 'device_patches',
+  'device_process_samples', 'device_registry_state',
   'device_reliability', 'device_reliability_history', 'device_sessions',
   'device_warranty',
   'dns_event_aggregations', 'dns_security_events',
@@ -199,6 +200,7 @@ export const DEVICE_CASCADE_DELETE_TABLES = [
   // Analytics & reliability
   'device_reliability_history', 'device_reliability',
   'playbook_executions', 'time_series_metrics', 'capacity_predictions',
+  'device_process_samples',
   // Portal & integrations (tickets are detached, not deleted —
   // see DEVICE_DETACH_DEVICE_ID_TABLES)
   'psa_ticket_mappings', 'asset_checkouts',

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { coreRoutes } from './core';
 import { metricsRoutes } from './metrics';
+import { processSamplesRoutes } from './processSamples';
 import { softwareRoutes } from './software';
 import { commandsRoutes } from './commands';
 import { hardwareRoutes } from './hardware';
@@ -46,6 +47,7 @@ deviceRoutes.route('/', coreRoutes);
 
 // Mount sub-resource routes
 deviceRoutes.route('/', metricsRoutes);
+deviceRoutes.route('/', processSamplesRoutes);
 // Mount softwareActionsRoutes BEFORE softwareRoutes so the POST /:id/software/update
 // + /:id/software/uninstall handlers are registered ahead of any future
 // software.ts handlers that might shadow them. Different verbs today (POST vs

--- a/apps/api/src/routes/devices/processSamples.test.ts
+++ b/apps/api/src/routes/devices/processSamples.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const calls: any = { nearest: null, markers: null };
+const DEFAULT_NEAREST = [{ timestamp: new Date('2026-06-13T12:00:00Z'), agentTimestamp: null, topProcesses: [{ name: 'chrome', pid: 1, cpu: 9, ramMb: 100 }] }];
+const calls: any = { nearest: null, markers: null, nearestRows: DEFAULT_NEAREST };
 vi.mock('../../db', () => {
   const chain = (kind: string) => ({
     from: () => ({
       where: () => ({
         orderBy: () => ({
-          limit: () => { calls.nearest = kind; return Promise.resolve([{ timestamp: new Date('2026-06-13T12:00:00Z'), agentTimestamp: null, topProcesses: [{ name: 'chrome', pid: 1, cpu: 9, ramMb: 100 }] }]); },
+          limit: () => { calls.nearest = kind; return Promise.resolve(calls.nearestRows); },
         }),
       }),
     }),
@@ -55,7 +56,7 @@ function app() {
 }
 
 describe('GET /:id/process-samples', () => {
-  beforeEach(() => { calls.nearest = null; calls.markers = null; });
+  beforeEach(() => { calls.nearest = null; calls.markers = null; calls.nearestRows = DEFAULT_NEAREST; });
 
   it('returns the nearest snapshot for ?at', async () => {
     const res = await app().request('/dev-1/process-samples?at=2026-06-13T12:00:30.000Z');
@@ -71,5 +72,24 @@ describe('GET /:id/process-samples', () => {
     const body = await res.json();
     expect(Array.isArray(body.markers)).toBe(true);
     expect(calls.markers).toBe(true);
+  });
+
+  it('returns { sample: null } when no snapshot exists at-or-before the time', async () => {
+    calls.nearestRows = [];
+    const res = await app().request('/dev-1/process-samples?at=2026-06-13T12:00:30.000Z');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sample).toBeNull();
+    expect(calls.nearest).toBe('nearest');
+  });
+
+  it('rejects a request with neither ?at nor ?from&to (400)', async () => {
+    const res = await app().request('/dev-1/process-samples');
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects ?from without ?to (400)', async () => {
+    const res = await app().request('/dev-1/process-samples?from=2026-06-13T11:00:00.000Z');
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/api/src/routes/devices/processSamples.test.ts
+++ b/apps/api/src/routes/devices/processSamples.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const calls: any = { nearest: null, markers: null };
+vi.mock('../../db', () => {
+  const chain = (kind: string) => ({
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: () => { calls.nearest = kind; return Promise.resolve([{ timestamp: new Date('2026-06-13T12:00:00Z'), agentTimestamp: null, topProcesses: [{ name: 'chrome', pid: 1, cpu: 9, ramMb: 100 }] }]); },
+        }),
+      }),
+    }),
+  });
+  return {
+    db: {
+      select: (cols: any) => {
+        // markers query selects only { timestamp }
+        if (cols && Object.keys(cols).length === 1 && 'timestamp' in cols) {
+          return { from: () => ({ where: () => ({ orderBy: () => { calls.markers = true; return Promise.resolve([{ timestamp: new Date('2026-06-13T11:57:00Z') }]); } }) }) };
+        }
+        return chain('nearest');
+      }
+    },
+    withDbAccessContext: (_ctx: any, fn: any) => fn()
+  };
+});
+vi.mock('./helpers', () => ({
+  getDeviceWithOrgAndSiteCheck: async () => ({ id: 'dev-1', orgId: 'org-1', siteId: 'site-1' }),
+  SITE_ACCESS_DENIED: Symbol('denied')
+}));
+// authMiddleware is the ONLY thing that sets the auth context (and, in prod,
+// establishes the withDbAccessContext RLS GUCs). The test app deliberately does
+// NOT inject auth itself — so if the route forgets to call
+// `processSamplesRoutes.use('*', authMiddleware)`, c.get('auth') is undefined
+// and the route breaks. This guards against the multi-tenant bypass.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => { c.set('auth', { scope: 'organization', orgId: 'org-1' }); await next(); },
+  // Mirror the real requireScope: it reads c.get('auth') and 401s when absent.
+  // If the route forgets `.use('*', authMiddleware)`, auth is never set and this
+  // returns 401 — surfacing the multi-tenant bypass the no-op mock used to mask.
+  requireScope: () => async (c: any, next: any) => {
+    if (!c.get('auth')) return c.json({ error: 'Not authenticated' }, 401);
+    await next();
+  },
+  requirePermission: () => async (_c: any, next: any) => next()
+}));
+
+import { processSamplesRoutes } from './processSamples';
+
+function app() {
+  const a = new Hono();
+  a.route('/', processSamplesRoutes);
+  return a;
+}
+
+describe('GET /:id/process-samples', () => {
+  beforeEach(() => { calls.nearest = null; calls.markers = null; });
+
+  it('returns the nearest snapshot for ?at', async () => {
+    const res = await app().request('/dev-1/process-samples?at=2026-06-13T12:00:30.000Z');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sample.topProcesses[0].name).toBe('chrome');
+    expect(calls.nearest).toBe('nearest');
+  });
+
+  it('returns timestamp markers for ?from&to', async () => {
+    const res = await app().request('/dev-1/process-samples?from=2026-06-13T11:00:00.000Z&to=2026-06-13T12:00:00.000Z');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.markers)).toBe(true);
+    expect(calls.markers).toBe(true);
+  });
+});

--- a/apps/api/src/routes/devices/processSamples.ts
+++ b/apps/api/src/routes/devices/processSamples.ts
@@ -1,0 +1,65 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq, lte, gte, asc, desc } from 'drizzle-orm';
+import { db } from '../../db';
+import { deviceProcessSamples } from '../../db/schema';
+import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
+import { processSamplesQuerySchema } from './schemas';
+
+export const processSamplesRoutes = new Hono();
+
+processSamplesRoutes.use('*', authMiddleware);
+
+processSamplesRoutes.get(
+  '/:id/process-samples',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  zValidator('query', processSamplesQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id');
+    const query = c.req.valid('query');
+
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) return c.json({ error: 'Access to this site denied' }, 403);
+    if (!device) return c.json({ error: 'Device not found' }, 404);
+
+    // Range markers: lightweight timestamp-only list so the scrubber knows
+    // which samples exist in the visible chart range.
+    if (query.from && query.to) {
+      const markers = await db
+        .select({ timestamp: deviceProcessSamples.timestamp })
+        .from(deviceProcessSamples)
+        .where(and(
+          eq(deviceProcessSamples.deviceId, deviceId),
+          gte(deviceProcessSamples.timestamp, new Date(query.from)),
+          lte(deviceProcessSamples.timestamp, new Date(query.to))
+        ))
+        .orderBy(asc(deviceProcessSamples.timestamp));
+      return c.json({ markers: markers.map((m) => m.timestamp.toISOString()) });
+    }
+
+    // Nearest snapshot at-or-before the clicked time (index-backed reverse scan
+    // on PK (device_id, timestamp DESC)).
+    const [sample] = await db
+      .select()
+      .from(deviceProcessSamples)
+      .where(and(
+        eq(deviceProcessSamples.deviceId, deviceId),
+        lte(deviceProcessSamples.timestamp, new Date(query.at!))
+      ))
+      .orderBy(desc(deviceProcessSamples.timestamp))
+      .limit(1);
+
+    if (!sample) return c.json({ sample: null });
+    return c.json({
+      sample: {
+        timestamp: sample.timestamp.toISOString(),
+        agentTimestamp: sample.agentTimestamp ? sample.agentTimestamp.toISOString() : null,
+        topProcesses: sample.topProcesses
+      }
+    });
+  }
+);

--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -109,6 +109,14 @@ export const softwareQuerySchema = z.object({
   search: z.string().optional()
 });
 
+export const processSamplesQuerySchema = z.object({
+  at: z.string().datetime().optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional()
+}).refine((q) => q.at || (q.from && q.to), {
+  message: 'Provide either ?at=<ts> or both ?from and ?to'
+});
+
 export const createCommandSchema = z.object({
   // 'wake' is the user-facing wake action. Internally it dispatches via the
   // wakeOnLan service and writes a deviceCommands row of type 'wake_on_lan'

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -123,6 +123,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'device_metrics',
   'device_network',
   'device_patches',
+  'device_process_samples',
   'device_registry_state',
   'device_reliability',
   'device_reliability_history',

--- a/apps/web/src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx
+++ b/apps/web/src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+// recharts' ResponsiveContainer needs ResizeObserver, which jsdom does not provide.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = (globalThis as any).ResizeObserver ?? ResizeObserverStub;
+
+import DevicePerformanceGraphs from './DevicePerformanceGraphs';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
+
+describe('DevicePerformanceGraphs drill-down lazy-load', () => {
+  beforeEach(() => {
+    fetchWithAuth.mockReset();
+    fetchWithAuth.mockReturnValue(Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) } as Response));
+  });
+
+  it('does not request process-samples on mount', async () => {
+    render(<DevicePerformanceGraphs deviceId="dev-1" />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+    const calledUrls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes('/process-samples'))).toBe(false);
+    expect(calledUrls.every((u) => u.includes('/metrics'))).toBe(true);
+  });
+});

--- a/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
+++ b/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
@@ -13,6 +13,7 @@ import {
   Legend
 } from 'recharts';
 import { fetchWithAuth } from '../../stores/auth';
+import ProcessDrilldownPanel from './ProcessDrilldownPanel';
 
 type TimeRange = '24h' | '7d' | '30d';
 
@@ -78,6 +79,7 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
   const [data, setData] = useState<MetricPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [drilldownAt, setDrilldownAt] = useState<string | null>(null);
 
   const fetchMetrics = useCallback(async () => {
     setLoading(true);
@@ -215,7 +217,12 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
 
       <div className={compact ? 'mt-4 h-56' : 'mt-6 h-80'}>
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={data}>
+          <LineChart
+            data={data}
+            onClick={(state: { activeLabel?: string | number } | null) => {
+              if (state && state.activeLabel != null) setDrilldownAt(String(state.activeLabel));
+            }}
+          >
             <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
             <XAxis
               dataKey="timestamp"
@@ -429,6 +436,10 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
             </div>
           )}
         </>
+      )}
+
+      {drilldownAt && (
+        <ProcessDrilldownPanel deviceId={deviceId} at={drilldownAt} onClose={() => setDrilldownAt(null)} />
       )}
     </div>
   );

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
@@ -43,9 +43,12 @@ describe('ProcessDrilldownPanel', () => {
     render(<ProcessDrilldownPanel deviceId="dev-1" at="2026-06-13T12:32:00.000Z" onClose={() => {}} />);
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
 
-    fetchWithAuth.mockReturnValue(jsonResponse({ processes: [{ name: 'live', pid: 9, cpuPercent: 3, memoryMb: 7 }] }));
+    // Real GET /devices/:id/processes shape is { data: [...processes], meta }.
+    fetchWithAuth.mockReturnValue(jsonResponse({ data: [{ name: 'live', pid: 9, cpuPercent: 3, memoryMb: 7 }], meta: { total: 1 } }));
     fireEvent.click(screen.getByTestId('process-drilldown-live-toggle'));
 
     await waitFor(() => expect(fetchWithAuth).toHaveBeenLastCalledWith(expect.stringContaining('/devices/dev-1/processes')));
+    // and the live row actually renders from `data` (regression guard for the array-under-data shape)
+    await waitFor(() => expect(screen.getByTestId('process-drilldown-row-0')).toHaveTextContent('live'));
   });
 });

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ProcessDrilldownPanel from './ProcessDrilldownPanel';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: any[]) => fetchWithAuth(...args) }));
+
+function jsonResponse(body: any) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+}
+
+describe('ProcessDrilldownPanel', () => {
+  beforeEach(() => { fetchWithAuth.mockReset(); });
+
+  it('fetches the nearest sample for the clicked time and renders rows sorted by CPU', async () => {
+    fetchWithAuth.mockReturnValue(jsonResponse({
+      sample: {
+        timestamp: '2026-06-13T12:31:40.000Z',
+        agentTimestamp: null,
+        topProcesses: [
+          { name: 'node', pid: 2, cpu: 5, ramMb: 50 },
+          { name: 'chrome', pid: 1, cpu: 88, ramMb: 1200 },
+        ],
+      },
+    }));
+
+    render(<ProcessDrilldownPanel deviceId="dev-1" at="2026-06-13T12:32:00.000Z" onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('process-drilldown-row-0')).toBeInTheDocument());
+    // default sort = CPU desc → chrome (88) first
+    expect(screen.getByTestId('process-drilldown-row-0')).toHaveTextContent('chrome');
+    // header shows the actual sample time (not the clicked time), formatted in the
+    // runtime's locale/timezone — compute the expected string the same way to stay TZ-independent.
+    const expectedTime = new Date('2026-06-13T12:31:40.000Z').toLocaleString();
+    expect(screen.getByTestId('process-drilldown-sample-time')).toHaveTextContent(expectedTime);
+    expect(fetchWithAuth).toHaveBeenCalledWith(
+      expect.stringContaining('/devices/dev-1/process-samples?at=2026-06-13T12%3A32%3A00.000Z')
+    );
+  });
+
+  it('Live toggle switches to the on-demand processes endpoint', async () => {
+    fetchWithAuth.mockReturnValue(jsonResponse({ sample: { timestamp: '2026-06-13T12:31:40.000Z', agentTimestamp: null, topProcesses: [] } }));
+    render(<ProcessDrilldownPanel deviceId="dev-1" at="2026-06-13T12:32:00.000Z" onClose={() => {}} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+
+    fetchWithAuth.mockReturnValue(jsonResponse({ processes: [{ name: 'live', pid: 9, cpuPercent: 3, memoryMb: 7 }] }));
+    fireEvent.click(screen.getByTestId('process-drilldown-live-toggle'));
+
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenLastCalledWith(expect.stringContaining('/devices/dev-1/processes')));
+  });
+});

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
@@ -47,7 +47,9 @@ describe('ProcessDrilldownPanel', () => {
     fetchWithAuth.mockReturnValue(jsonResponse({ data: [{ name: 'live', pid: 9, cpuPercent: 3, memoryMb: 7 }], meta: { total: 1 } }));
     fireEvent.click(screen.getByTestId('process-drilldown-live-toggle'));
 
-    await waitFor(() => expect(fetchWithAuth).toHaveBeenLastCalledWith(expect.stringContaining('/devices/dev-1/processes')));
+    // The on-demand listing is mounted under /system-tools (not /devices) — asserting
+    // the full path guards against the 404 the loose '/devices/...' match previously masked.
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenLastCalledWith(expect.stringContaining('/system-tools/devices/dev-1/processes')));
     // and the live row actually renders from `data` (regression guard for the array-under-data shape)
     await waitFor(() => expect(screen.getByTestId('process-drilldown-row-0')).toHaveTextContent('live'));
   });

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { Dialog } from '../shared/Dialog';
 
@@ -19,38 +19,50 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(undefined);
-    try {
-      if (live) {
-        const res = await fetchWithAuth(`/devices/${deviceId}/processes?limit=16&sortBy=cpu&sortDesc=true`);
-        if (!res.ok) throw new Error('Failed to fetch live processes');
-        const json = await res.json();
-        const procs = (json.processes ?? json.data?.processes ?? []) as Array<Record<string, unknown>>;
-        setRows(procs.map((p) => ({
-          name: String(p.name ?? ''),
-          pid: Number(p.pid ?? 0),
-          cpu: Number(p.cpuPercent ?? p.cpu ?? 0),
-          ramMb: Number(p.memoryMb ?? p.ramMb ?? 0),
-        })));
-        setSampleTime(null);
-      } else {
-        const res = await fetchWithAuth(`/devices/${deviceId}/process-samples?at=${encodeURIComponent(at)}`);
-        if (!res.ok) throw new Error('Failed to fetch process sample');
-        const json = await res.json();
-        if (!json.sample) { setRows([]); setSampleTime(null); return; }
-        setRows((json.sample.topProcesses ?? []) as Row[]);
-        setSampleTime(json.sample.timestamp);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load processes');
-    } finally {
-      setLoading(false);
-    }
-  }, [deviceId, at, live]);
+  useEffect(() => {
+    // `cancelled` guards against a slow/older response clobbering newer state
+    // (e.g. toggling Live on→off fast) or setting state after unmount.
+    let cancelled = false;
 
-  useEffect(() => { load(); }, [load]);
+    (async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        if (live) {
+          const res = await fetchWithAuth(`/devices/${deviceId}/processes?limit=16&sortBy=cpu&sortDesc=true`);
+          if (!res.ok) throw new Error('Failed to fetch live processes');
+          const json = await res.json();
+          // The on-demand endpoint returns { data: [...processes], meta } — the
+          // process array lives directly under `data`.
+          const procs = (Array.isArray(json.data)
+            ? json.data
+            : json.processes ?? json.data?.processes ?? []) as Array<Record<string, unknown>>;
+          if (cancelled) return;
+          setRows(procs.map((p) => ({
+            name: String(p.name ?? ''),
+            pid: Number(p.pid ?? 0),
+            cpu: Number(p.cpuPercent ?? p.cpu ?? 0),
+            ramMb: Number(p.memoryMb ?? p.ramMb ?? 0),
+          })));
+          setSampleTime(null);
+        } else {
+          const res = await fetchWithAuth(`/devices/${deviceId}/process-samples?at=${encodeURIComponent(at)}`);
+          if (!res.ok) throw new Error('Failed to fetch process sample');
+          const json = await res.json();
+          if (cancelled) return;
+          if (!json.sample) { setRows([]); setSampleTime(null); return; }
+          setRows((json.sample.topProcesses ?? []) as Row[]);
+          setSampleTime(json.sample.timestamp);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load processes');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [deviceId, at, live]);
 
   const sorted = useMemo(
     () => [...rows].sort((a, b) => (sortKey === 'cpu' ? b.cpu - a.cpu : b.ramMb - a.ramMb)),
@@ -97,7 +109,7 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
           </thead>
           <tbody>
             {sorted.map((r, i) => (
-              <tr key={`${r.pid}-${i}`} data-testid={`process-drilldown-row-${i}`}>
+              <tr key={r.pid} data-testid={`process-drilldown-row-${i}`}>
                 <td>{r.name}</td>
                 <td>{r.pid}</td>
                 <td>{r.cpu.toFixed(1)}</td>

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
@@ -29,7 +29,10 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
       setError(undefined);
       try {
         if (live) {
-          const res = await fetchWithAuth(`/devices/${deviceId}/processes?limit=16&sortBy=cpu&sortDesc=true`);
+          // On-demand process listing lives under /system-tools; the agent
+          // already returns CPU-desc order by default (sortBy/sortDesc aren't
+          // accepted query params here).
+          const res = await fetchWithAuth(`/system-tools/devices/${deviceId}/processes?limit=16`);
           if (!res.ok) throw new Error('Failed to fetch live processes');
           const json = await res.json();
           // The on-demand endpoint returns { data: [...processes], meta } — the

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { Dialog } from '../shared/Dialog';
+
+type Row = { name: string; pid: number; cpu: number; ramMb: number; diskBps?: number; netBps?: number };
+type SortKey = 'cpu' | 'ramMb';
+
+type Props = {
+  deviceId: string;
+  at: string; // ISO timestamp of the clicked chart point
+  onClose: () => void;
+};
+
+export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [sampleTime, setSampleTime] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('cpu');
+  const [live, setLive] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      if (live) {
+        const res = await fetchWithAuth(`/devices/${deviceId}/processes?limit=16&sortBy=cpu&sortDesc=true`);
+        if (!res.ok) throw new Error('Failed to fetch live processes');
+        const json = await res.json();
+        const procs = (json.processes ?? json.data?.processes ?? []) as Array<Record<string, unknown>>;
+        setRows(procs.map((p) => ({
+          name: String(p.name ?? ''),
+          pid: Number(p.pid ?? 0),
+          cpu: Number(p.cpuPercent ?? p.cpu ?? 0),
+          ramMb: Number(p.memoryMb ?? p.ramMb ?? 0),
+        })));
+        setSampleTime(null);
+      } else {
+        const res = await fetchWithAuth(`/devices/${deviceId}/process-samples?at=${encodeURIComponent(at)}`);
+        if (!res.ok) throw new Error('Failed to fetch process sample');
+        const json = await res.json();
+        if (!json.sample) { setRows([]); setSampleTime(null); return; }
+        setRows((json.sample.topProcesses ?? []) as Row[]);
+        setSampleTime(json.sample.timestamp);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load processes');
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId, at, live]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const sorted = useMemo(
+    () => [...rows].sort((a, b) => (sortKey === 'cpu' ? b.cpu - a.cpu : b.ramMb - a.ramMb)),
+    [rows, sortKey]
+  );
+
+  return (
+    <Dialog open onClose={onClose} title="Top processes" maxWidth="lg">
+      <div className="p-4" data-testid="process-drilldown-panel">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-base font-semibold">Top processes</h3>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={live}
+              onChange={(e) => setLive(e.target.checked)}
+              data-testid="process-drilldown-live-toggle"
+            />
+            Live
+          </label>
+        </div>
+
+        <p className="mt-1 text-xs text-muted-foreground" data-testid="process-drilldown-sample-time">
+          {live
+            ? 'Live (now)'
+            : sampleTime
+              ? `Nearest sample: ${new Date(sampleTime).toLocaleString()}`
+              : 'No sample near this time'}
+        </p>
+
+        <div className="mt-3 flex gap-2 text-sm">
+          <button type="button" onClick={() => setSortKey('cpu')} aria-pressed={sortKey === 'cpu'} className={sortKey === 'cpu' ? 'font-semibold' : ''}>CPU</button>
+          <button type="button" onClick={() => setSortKey('ramMb')} aria-pressed={sortKey === 'ramMb'} className={sortKey === 'ramMb' ? 'font-semibold' : ''}>RAM</button>
+        </div>
+
+        {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+        {loading && <p className="mt-3 text-sm text-muted-foreground">Loading…</p>}
+
+        <table className="mt-3 w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th>Process</th><th>PID</th><th>CPU %</th><th>RAM (MB)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((r, i) => (
+              <tr key={`${r.pid}-${i}`} data-testid={`process-drilldown-row-${i}`}>
+                <td>{r.name}</td>
+                <td>{r.pid}</td>
+                <td>{r.cpu.toFixed(1)}</td>
+                <td>{Math.round(r.ramMb)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Dialog>
+  );
+}

--- a/docs/superpowers/plans/2026-06-13-process-drilldown-phase1.md
+++ b/docs/superpowers/plans/2026-06-13-process-drilldown-phase1.md
@@ -1,0 +1,1410 @@
+# Process-Level Resource Drill-Down (Phase 1: CPU + RAM) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator click a point on a device's CPU/RAM performance chart and see the top processes consuming that resource at that moment, including scrubbing back to past samples.
+
+**Architecture:** A new agent goroutine samples the top-N processes every ~180s (decoupled from the 60s heartbeat) and POSTs a compact snapshot to a new ingest route, which stores one JSONB row per device per sample in `device_process_samples` (RLS shape #1, direct `org_id`). A read route serves the nearest snapshot to a clicked timestamp plus lightweight range markers; the web Performance tab lazily opens a drill-down panel on chart click. A new BullMQ retention job prunes the table with batched deletes (7-day default).
+
+**Tech Stack:** Go (gopsutil v3) agent · Hono + Drizzle + PostgreSQL (postgres.js) API · BullMQ/Redis jobs · Astro + React + Recharts web · Vitest (API/web) + Go `testing`.
+
+**Scope:** Phase 1 = CPU + RAM only. Disk-I/O and network per-process columns are deferred to follow-up plans (spec §"Per-resource phasing"); the schema and UI leave nullable `diskBps`/`netBps` slots so those phases are additive.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-process-level-resource-drilldown-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/migrations/2026-06-13-device-process-samples.sql` — table + index + RLS policies (one idempotent migration)
+- `apps/api/src/routes/agents/processSample.ts` — ingest route `POST /:id/process-sample`
+- `apps/api/src/routes/devices/processSamples.ts` — read route `GET /:id/process-samples`
+- `apps/api/src/jobs/processSampleRetention.ts` — batched-delete retention worker
+- `apps/web/src/components/devices/ProcessDrilldownPanel.tsx` — drill-down panel (table + scrubber + Live toggle)
+- `agent/internal/remote/tools/process_sample.go` — `TopProcessSample` + `selectTopN`
+- `agent/internal/remote/tools/process_sample_test.go` — `selectTopN` unit tests
+
+**Modify:**
+- `apps/api/src/db/schema/devices.ts` — add `deviceProcessSamples` table + `TopProcess` type
+- `apps/api/src/routes/agents/schemas.ts` — add `processSampleSchema`
+- `apps/api/src/routes/agents/index.ts` — mount `processSampleRoutes`
+- `apps/api/src/routes/devices/schemas.ts` — add `processSamplesQuerySchema`
+- `apps/api/src/routes/devices/index.ts` — mount `processSamplesRoutes`
+- `apps/api/src/index.ts` — register `processSampleRetention` worker
+- `agent/internal/config/config.go` — add `ProcessSampleIntervalSeconds` field + default 180
+- `agent/internal/heartbeat/heartbeat.go` — launch sampler goroutine in `Start()`, add `runProcessSampler`/`sendProcessSample`
+- `apps/web/src/components/devices/DevicePerformanceGraphs.tsx` — make the CPU/RAM chart clickable, render the panel
+
+---
+
+## Task 1: DB migration + Drizzle schema for `device_process_samples`
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-13-device-process-samples.sql`
+- Modify: `apps/api/src/db/schema/devices.ts` (after `deviceMetrics`, ends line 184)
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-13-device-process-samples.sql`. Idempotent, no inner `BEGIN/COMMIT` (autoMigrate wraps each file in a transaction), RLS shape #1 (direct `org_id`). `breeze_app` table privileges come from the role's default grants (the `device_metrics` RLS migration adds none either), so no `GRANT` is needed.
+
+```sql
+-- 2026-06-13: device_process_samples — per-device top-N process snapshots for
+-- the Performance-tab drill-down. RLS shape #1 (direct org_id), policies created
+-- in the same migration that creates the table (CLAUDE.md tenancy rule).
+-- timestamp = server receive time (the key for chart correlation);
+-- agent_timestamp = agent-reported sample time, kept for clock-skew forensics.
+
+CREATE TABLE IF NOT EXISTS public.device_process_samples (
+  device_id uuid NOT NULL REFERENCES public.devices(id) ON DELETE CASCADE,
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  "timestamp" timestamptz NOT NULL,
+  agent_timestamp timestamptz,
+  top_processes jsonb NOT NULL,
+  PRIMARY KEY (device_id, "timestamp")
+);
+
+CREATE INDEX IF NOT EXISTS device_process_samples_device_ts_desc_idx
+  ON public.device_process_samples (device_id, "timestamp" DESC);
+
+ALTER TABLE public.device_process_samples ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.device_process_samples FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON public.device_process_samples;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.device_process_samples;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON public.device_process_samples;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.device_process_samples;
+
+CREATE POLICY breeze_org_isolation_select ON public.device_process_samples
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON public.device_process_samples
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON public.device_process_samples
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON public.device_process_samples
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+```
+
+- [ ] **Step 2: Add the Drizzle schema definition**
+
+In `apps/api/src/db/schema/devices.ts`, immediately after the `deviceMetrics` block (closes at line 184), add:
+
+```typescript
+export type TopProcess = {
+  name: string;
+  pid: number;
+  cpu: number;
+  ramMb: number;
+  diskBps?: number;
+  netBps?: number;
+};
+
+export const deviceProcessSamples = pgTable('device_process_samples', {
+  deviceId: uuid('device_id').notNull().references(() => devices.id),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  timestamp: timestamp('timestamp').notNull(),
+  agentTimestamp: timestamp('agent_timestamp'),
+  topProcesses: jsonb('top_processes').$type<TopProcess[]>().notNull()
+}, (table) => ({
+  pk: primaryKey({ columns: [table.deviceId, table.timestamp] })
+}));
+```
+
+(`pgTable`, `uuid`, `timestamp`, `jsonb`, `primaryKey` are already imported in this file — confirm at the top; `deviceMetrics` uses all of them.)
+
+- [ ] **Step 3: Apply the migration and verify no schema drift**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsx src/db/autoMigrate.ts 2>/dev/null || true
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+```
+Expected: migration applies cleanly; `db:check-drift` reports no drift between `devices.ts` and migrations.
+
+- [ ] **Step 4: Verify tenant isolation as `breeze_app`**
+
+Run:
+```bash
+docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "\d+ device_process_samples"
+```
+Expected: table exists, `Row security: enabled` and `forced`, four `breeze_org_isolation_*` policies listed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-13-device-process-samples.sql apps/api/src/db/schema/devices.ts
+git commit -m "feat(metrics): add device_process_samples table + RLS (shape #1)"
+```
+
+---
+
+## Task 2: RLS contract + functional isolation verification
+
+**Files:**
+- Verify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (no edit — shape #1 tables are auto-discovered by the `org_id`-column query at lines ~487-499)
+
+- [ ] **Step 0: Confirm the test DB connection is NOT a BYPASSRLS role (worktree foot-gun)**
+
+The RLS coverage test loads `../../.env.test`. On a fresh worktree that gitignored symlink may be missing, so the test silently runs on a BYPASSRLS admin connection and **passes vacuously** (nearly shipped broken RLS in #1357). Before trusting any RLS result:
+```bash
+ls -l /Users/toddhebebrand/breeze/.env.test   # must exist (symlink ok); if missing, restore it
+docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "SELECT rolname, rolbypassrls FROM pg_roles WHERE rolname = current_user;"
+```
+Expected: `.env.test` present; `breeze_app` shows `rolbypassrls = f`.
+
+- [ ] **Step 1: Run the RLS coverage contract test**
+
+Run (needs a real DB; uses the dedicated coverage config that loads `.env.test`):
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run -c vitest.config.rls-coverage.ts
+```
+Expected: PASS. The "every org-tenant public table has RLS on and all four DML commands covered by `breeze_has_org_access`" test auto-discovers `device_process_samples` (it has an `org_id` column) and asserts its policies. No allowlist entry is required for shape #1.
+
+- [ ] **Step 2: Manually forge a cross-tenant insert (CLAUDE.md requirement)**
+
+Run as `breeze_app` with a deliberately mismatched org context — it MUST be rejected:
+```bash
+docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "
+  SET breeze.current_scope = 'organization';
+  SET breeze.current_org_id = '00000000-0000-0000-0000-000000000001';
+  INSERT INTO device_process_samples (device_id, org_id, \"timestamp\", top_processes)
+  VALUES (gen_random_uuid(), '00000000-0000-0000-0000-0000000000ff', now(), '[]'::jsonb);
+"
+```
+Expected: `ERROR: new row violates row-level security policy for table "device_process_samples"`. (Adjust the GUC names if the local helper uses different ones — confirm against how `withDbAccessContext` sets them in `apps/api/src/db/index.ts`.)
+
+- [ ] **Step 3: Commit (only if any allowlist/test change was needed)**
+
+If steps 1-2 passed with no file change, skip the commit. Otherwise:
+```bash
+git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "test(rls): cover device_process_samples"
+```
+
+---
+
+## Task 3: API ingest route `POST /:id/process-sample`
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/schemas.ts` (add schema near `heartbeatSchema`, ~line 94)
+- Create: `apps/api/src/routes/agents/processSample.ts`
+- Create: `apps/api/src/routes/agents/processSample.test.ts`
+- Modify: `apps/api/src/routes/agents/index.ts` (import + mount, near line 41-66)
+
+- [ ] **Step 1: Add the Zod ingest schema (bounded payload)**
+
+In `apps/api/src/routes/agents/schemas.ts`, add:
+
+```typescript
+export const processSampleSchema = z.object({
+  timestamp: z.string().datetime(),
+  processes: z.array(z.object({
+    name: z.string().min(1).max(256),
+    pid: z.number().int().min(0),
+    cpu: z.number().min(0),
+    ramMb: z.number().min(0),
+    diskBps: z.number().min(0).optional(),
+    netBps: z.number().min(0).optional()
+  })).max(16)
+});
+```
+
+The `.max(16)` cap and per-field bounds are the server-side guard so a buggy/compromised agent can't insert an oversized JSONB blob.
+
+- [ ] **Step 2: Write the failing route test**
+
+Create `apps/api/src/routes/agents/processSample.test.ts`. This mirrors existing agent-route tests (Drizzle mock + Hono test client). It asserts: (a) `org_id` is taken from the auth context, not the body; (b) `timestamp` is server-stamped while `agent_timestamp` keeps the agent value; (c) an over-cap payload is rejected by Zod.
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const inserted: any[] = [];
+vi.mock('../../db', () => ({
+  db: {
+    insert: () => ({ values: (v: any) => { inserted.push(v); return Promise.resolve(); } })
+  },
+  withDbAccessContext: (_ctx: any, fn: any) => fn()
+}));
+
+import { processSampleRoutes } from './processSample';
+
+function appWithAgent(agent: any) {
+  const app = new Hono();
+  app.use('*', async (c, next) => { c.set('agent', agent); await next(); });
+  app.route('/', processSampleRoutes);
+  return app;
+}
+
+describe('POST /:id/process-sample', () => {
+  beforeEach(() => { inserted.length = 0; });
+
+  it('derives org_id from the auth context and ignores any body org_id', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    const res = await app.request('/dev-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        timestamp: '2026-06-13T12:00:00.000Z',
+        orgId: 'org-attacker',
+        processes: [{ name: 'chrome', pid: 42, cpu: 12.5, ramMb: 800 }]
+      })
+    });
+    expect(res.status).toBe(201);
+    expect(inserted[0].orgId).toBe('org-real');
+    expect(inserted[0].deviceId).toBe('dev-1');
+  });
+
+  it('server-stamps timestamp and stores agent time separately', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    await app.request('/dev-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2020-01-01T00:00:00.000Z', processes: [] })
+    });
+    expect(inserted[0].agentTimestamp).toEqual(new Date('2020-01-01T00:00:00.000Z'));
+    expect(inserted[0].timestamp.getTime()).toBeGreaterThan(new Date('2025-01-01').getTime());
+  });
+
+  it('rejects a payload over the 16-process cap', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    const processes = Array.from({ length: 17 }, (_, i) => ({ name: `p${i}`, pid: i, cpu: 0, ramMb: 0 }));
+    const res = await app.request('/dev-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes })
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when path id does not match the authenticated device', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    const res = await app.request('/dev-OTHER/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes: [] })
+    });
+    expect(res.status).toBe(403);
+  });
+});
+```
+
+- [ ] **Step 2b: Run the test to confirm it fails**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/routes/agents/processSample.test.ts
+```
+Expected: FAIL — `Cannot find module './processSample'`.
+
+- [ ] **Step 3: Implement the ingest route**
+
+Create `apps/api/src/routes/agents/processSample.ts`:
+
+```typescript
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { bodyLimit } from 'hono/body-limit';
+import { db } from '../../db';
+import { deviceProcessSamples } from '../../db/schema';
+import { type AgentAuthContext } from '../../middleware/agentAuth';
+import { processSampleSchema } from './schemas';
+
+export const processSampleRoutes = new Hono();
+
+processSampleRoutes.post(
+  '/:id/process-sample',
+  bodyLimit({ maxSize: 256 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }),
+  zValidator('json', processSampleSchema),
+  async (c) => {
+    const deviceId = c.req.param('id');
+    const data = c.req.valid('json');
+    const agent = c.get('agent') as AgentAuthContext | undefined;
+
+    // Tenancy is derived server-side from the authenticated device — the agent
+    // payload is never trusted for org_id, and the path id must match the token.
+    if (!agent || agent.deviceId !== deviceId) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+
+    await db.insert(deviceProcessSamples).values({
+      deviceId: agent.deviceId,
+      orgId: agent.orgId,
+      timestamp: new Date(),                       // server receive time
+      agentTimestamp: new Date(data.timestamp),    // agent-reported, forensic
+      topProcesses: data.processes
+    });
+
+    return c.json({ success: true }, 201);
+  }
+);
+```
+
+- [ ] **Step 4: Mount the route**
+
+In `apps/api/src/routes/agents/index.ts`, add the import alongside the others (near line 1-20) and mount it with the other `:id/*` routes (near line 58-66):
+
+```typescript
+import { processSampleRoutes } from './processSample';
+```
+```typescript
+agentRoutes.route('/', processSampleRoutes);
+```
+
+The `agentRoutes.use('/:id/*', ...)` block (line 41) already applies `agentAuthMiddleware` to `/:id/process-sample` — `process-sample` is not in `AGENT_AUTH_SKIP_ID_SEGMENTS`/`AGENT_AUTH_SKIP_ACTIONS`, so bearer auth is enforced. No skip-list change.
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/routes/agents/processSample.test.ts
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/agents/processSample.ts apps/api/src/routes/agents/processSample.test.ts apps/api/src/routes/agents/schemas.ts apps/api/src/routes/agents/index.ts
+git commit -m "feat(api): ingest route for process samples (server-derived org_id + timestamp)"
+```
+
+---
+
+## Task 4: API read route `GET /:id/process-samples`
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/schemas.ts` (add query schema)
+- Create: `apps/api/src/routes/devices/processSamples.ts`
+- Create: `apps/api/src/routes/devices/processSamples.test.ts`
+- Modify: `apps/api/src/routes/devices/index.ts` (import + mount, near line 50)
+
+- [ ] **Step 1: Add the query schema**
+
+In `apps/api/src/routes/devices/schemas.ts`, add:
+
+```typescript
+export const processSamplesQuerySchema = z.object({
+  at: z.string().datetime().optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional()
+}).refine((q) => q.at || (q.from && q.to), {
+  message: 'Provide either ?at=<ts> or both ?from and ?to'
+});
+```
+
+- [ ] **Step 2: Write the failing route test**
+
+Create `apps/api/src/routes/devices/processSamples.test.ts`. Asserts the nearest-snapshot query orders by `timestamp DESC` at-or-before `at`, and the markers query returns timestamp-only rows.
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const calls: any = { nearest: null, markers: null };
+vi.mock('../../db', () => {
+  const chain = (kind: string) => ({
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: () => { calls.nearest = kind; return Promise.resolve([{ timestamp: new Date('2026-06-13T12:00:00Z'), agentTimestamp: null, topProcesses: [{ name: 'chrome', pid: 1, cpu: 9, ramMb: 100 }] }]); },
+        }),
+      }),
+    }),
+  });
+  return {
+    db: {
+      select: (cols: any) => {
+        // markers query selects only { timestamp }
+        if (cols && Object.keys(cols).length === 1 && 'timestamp' in cols) {
+          return { from: () => ({ where: () => ({ orderBy: () => { calls.markers = true; return Promise.resolve([{ timestamp: new Date('2026-06-13T11:57:00Z') }]); } }) }) };
+        }
+        return chain('nearest');
+      }
+    },
+    withDbAccessContext: (_ctx: any, fn: any) => fn()
+  };
+});
+vi.mock('./helpers', () => ({
+  getDeviceWithOrgAndSiteCheck: async () => ({ id: 'dev-1', orgId: 'org-1', siteId: 'site-1' }),
+  SITE_ACCESS_DENIED: Symbol('denied')
+}));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (_c: any, next: any) => next(),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next()
+}));
+
+import { processSamplesRoutes } from './processSamples';
+
+function app() {
+  const a = new Hono();
+  a.use('*', async (c, next) => { c.set('auth', { scope: 'organization' }); await next(); });
+  a.route('/', processSamplesRoutes);
+  return a;
+}
+
+describe('GET /:id/process-samples', () => {
+  beforeEach(() => { calls.nearest = null; calls.markers = null; });
+
+  it('returns the nearest snapshot for ?at', async () => {
+    const res = await app().request('/dev-1/process-samples?at=2026-06-13T12:00:30.000Z');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sample.topProcesses[0].name).toBe('chrome');
+    expect(calls.nearest).toBe('nearest');
+  });
+
+  it('returns timestamp markers for ?from&to', async () => {
+    const res = await app().request('/dev-1/process-samples?from=2026-06-13T11:00:00.000Z&to=2026-06-13T12:00:00.000Z');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.markers)).toBe(true);
+    expect(calls.markers).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2b: Run to confirm it fails**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/routes/devices/processSamples.test.ts
+```
+Expected: FAIL — `Cannot find module './processSamples'`.
+
+- [ ] **Step 3: Implement the read route**
+
+Create `apps/api/src/routes/devices/processSamples.ts`. Mirrors `metrics.ts` auth/guards (lines 166-182). RLS is enforced by the request DB context established in `authMiddleware`, exactly as `metrics.ts` relies on it.
+
+```typescript
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq, lte, gte, asc, desc } from 'drizzle-orm';
+import { db } from '../../db';
+import { deviceProcessSamples } from '../../db/schema';
+import { requirePermission, requireScope } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
+import { processSamplesQuerySchema } from './schemas';
+
+export const processSamplesRoutes = new Hono();
+
+processSamplesRoutes.get(
+  '/:id/process-samples',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  zValidator('query', processSamplesQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id');
+    const query = c.req.valid('query');
+
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) return c.json({ error: 'Access to this site denied' }, 403);
+    if (!device) return c.json({ error: 'Device not found' }, 404);
+
+    // Range markers: lightweight timestamp-only list so the scrubber knows
+    // which samples exist in the visible chart range.
+    if (query.from && query.to) {
+      const markers = await db
+        .select({ timestamp: deviceProcessSamples.timestamp })
+        .from(deviceProcessSamples)
+        .where(and(
+          eq(deviceProcessSamples.deviceId, deviceId),
+          gte(deviceProcessSamples.timestamp, new Date(query.from)),
+          lte(deviceProcessSamples.timestamp, new Date(query.to))
+        ))
+        .orderBy(asc(deviceProcessSamples.timestamp));
+      return c.json({ markers: markers.map((m) => m.timestamp.toISOString()) });
+    }
+
+    // Nearest snapshot at-or-before the clicked time (index-backed reverse scan
+    // on PK (device_id, timestamp DESC)).
+    const [sample] = await db
+      .select()
+      .from(deviceProcessSamples)
+      .where(and(
+        eq(deviceProcessSamples.deviceId, deviceId),
+        lte(deviceProcessSamples.timestamp, new Date(query.at!))
+      ))
+      .orderBy(desc(deviceProcessSamples.timestamp))
+      .limit(1);
+
+    if (!sample) return c.json({ sample: null });
+    return c.json({
+      sample: {
+        timestamp: sample.timestamp.toISOString(),
+        agentTimestamp: sample.agentTimestamp ? sample.agentTimestamp.toISOString() : null,
+        topProcesses: sample.topProcesses
+      }
+    });
+  }
+);
+```
+
+- [ ] **Step 4: Mount the route**
+
+In `apps/api/src/routes/devices/index.ts`, add the import near the other sub-resource imports (lines 1-23) and mount it right after `metricsRoutes` (line 50):
+
+```typescript
+import { processSamplesRoutes } from './processSamples';
+```
+```typescript
+deviceRoutes.route('/', metricsRoutes);
+deviceRoutes.route('/', processSamplesRoutes);
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/routes/devices/processSamples.test.ts
+```
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/devices/processSamples.ts apps/api/src/routes/devices/processSamples.test.ts apps/api/src/routes/devices/schemas.ts apps/api/src/routes/devices/index.ts
+git commit -m "feat(api): read route for process samples (nearest + range markers)"
+```
+
+---
+
+## Task 5: Agent top-N selector (`selectTopN`)
+
+**Files:**
+- Create: `agent/internal/remote/tools/process_sample.go`
+- Create: `agent/internal/remote/tools/process_sample_test.go`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `agent/internal/remote/tools/process_sample_test.go`:
+
+```go
+package tools
+
+import (
+	"sort"
+	"testing"
+)
+
+func pidSet(entries []ProcessSampleEntry) map[int32]bool {
+	m := map[int32]bool{}
+	for _, e := range entries {
+		m[e.PID] = true
+	}
+	return m
+}
+
+func TestSelectTopN(t *testing.T) {
+	entries := []ProcessSampleEntry{
+		{Name: "a", PID: 1, CPU: 90, RAMMb: 10},  // top CPU
+		{Name: "b", PID: 2, CPU: 80, RAMMb: 20},  // 2nd CPU
+		{Name: "c", PID: 3, CPU: 1, RAMMb: 900},  // top RAM
+		{Name: "d", PID: 4, CPU: 2, RAMMb: 800},  // 2nd RAM
+		{Name: "e", PID: 5, CPU: 0, RAMMb: 0},    // neither
+	}
+
+	got := selectTopN(entries, 2)
+	pids := pidSet(got)
+
+	for _, want := range []int32{1, 2, 3, 4} {
+		if !pids[want] {
+			t.Errorf("expected PID %d in union of top-2-by-CPU and top-2-by-RAM", want)
+		}
+	}
+	if pids[5] {
+		t.Errorf("PID 5 (neither top CPU nor RAM) should be excluded")
+	}
+	if len(got) != 4 {
+		t.Errorf("expected 4 unioned entries, got %d", len(got))
+	}
+}
+
+func TestSelectTopNDedupesProcessHighInBoth(t *testing.T) {
+	entries := []ProcessSampleEntry{
+		{Name: "hog", PID: 1, CPU: 99, RAMMb: 999}, // top of both rankings
+		{Name: "b", PID: 2, CPU: 50, RAMMb: 1},
+		{Name: "c", PID: 3, CPU: 1, RAMMb: 500},
+	}
+	got := selectTopN(entries, 1)
+	// top-1 CPU = pid1, top-1 RAM = pid1 → union is just {1}, no duplicate row.
+	if len(got) != 1 || got[0].PID != 1 {
+		t.Errorf("expected single deduped entry pid=1, got %+v", got)
+	}
+}
+
+func TestSelectTopNPreservesInputOrder(t *testing.T) {
+	entries := []ProcessSampleEntry{
+		{Name: "a", PID: 3, CPU: 10, RAMMb: 1},
+		{Name: "b", PID: 1, CPU: 20, RAMMb: 1},
+		{Name: "c", PID: 2, CPU: 30, RAMMb: 1},
+	}
+	got := selectTopN(entries, 3)
+	pids := make([]int32, len(got))
+	for i, e := range got {
+		pids[i] = e.PID
+	}
+	if !sort.SliceIsSorted(pids, func(i, j int) bool { return false }) && !(pids[0] == 3 && pids[1] == 1 && pids[2] == 2) {
+		t.Errorf("expected original input order [3,1,2], got %v", pids)
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+Run:
+```bash
+cd agent && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH go test ./internal/remote/tools/ -run TestSelectTopN
+```
+Expected: FAIL — `undefined: ProcessSampleEntry`, `undefined: selectTopN`.
+
+- [ ] **Step 3: Implement the selector + collector**
+
+Create `agent/internal/remote/tools/process_sample.go`. `TopProcessSample` deliberately skips username resolution (the Windows SID-lookup bottleneck) — the snapshot only needs name/pid/cpu/ramMb. CPU comes from the existing instantaneous `sampleProcessCPUPercents` (NOT gopsutil's lifetime-average `CPUPercent()`).
+
+```go
+package tools
+
+import (
+	"sort"
+
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+// ProcessSampleEntry is one process in a periodic top-N snapshot. JSON tags
+// match the API ingest schema and the device_process_samples top_processes
+// JSONB shape. DiskBps/NetBps are reserved for later phases (omitted now).
+type ProcessSampleEntry struct {
+	Name    string  `json:"name"`
+	PID     int32   `json:"pid"`
+	CPU     float64 `json:"cpu"`
+	RAMMb   float64 `json:"ramMb"`
+	DiskBps float64 `json:"diskBps,omitempty"`
+	NetBps  float64 `json:"netBps,omitempty"`
+}
+
+// TopProcessSample enumerates processes once, measures *instantaneous* CPU over
+// a single shared 250ms window (sampleProcessCPUPercents — never the lifetime
+// average), reads RSS, and returns the union of the top perDimension by CPU and
+// by RAM. It skips username resolution on purpose: the snapshot does not need
+// it, and resolveUsername is the expensive Windows SID-lookup path.
+func TopProcessSample(perDimension int) ([]ProcessSampleEntry, error) {
+	procs, err := process.Processes()
+	if err != nil {
+		return nil, err
+	}
+
+	cpuPercents := sampleProcessCPUPercents(procs, cpuSampleInterval)
+
+	entries := make([]ProcessSampleEntry, 0, len(procs))
+	for _, p := range procs {
+		name, err := p.Name()
+		if err != nil {
+			continue
+		}
+		e := ProcessSampleEntry{Name: name, PID: p.Pid, CPU: cpuPercents[p.Pid]}
+		if mem, err := p.MemoryInfo(); err == nil && mem != nil {
+			e.RAMMb = float64(mem.RSS) / 1024 / 1024
+		}
+		entries = append(entries, e)
+	}
+
+	return selectTopN(entries, perDimension), nil
+}
+
+// selectTopN returns the union of the top perDimension entries by CPU and the
+// top perDimension by RAM, deduped by PID, preserving the original input order.
+func selectTopN(entries []ProcessSampleEntry, perDimension int) []ProcessSampleEntry {
+	if perDimension < 1 {
+		perDimension = 1
+	}
+
+	rankTop := func(less func(a, b ProcessSampleEntry) bool) map[int32]bool {
+		sorted := append([]ProcessSampleEntry(nil), entries...)
+		sort.Slice(sorted, func(i, j int) bool { return less(sorted[i], sorted[j]) })
+		top := map[int32]bool{}
+		for i := 0; i < len(sorted) && i < perDimension; i++ {
+			top[sorted[i].PID] = true
+		}
+		return top
+	}
+
+	keep := rankTop(func(a, b ProcessSampleEntry) bool { return a.CPU > b.CPU })
+	for pid := range rankTop(func(a, b ProcessSampleEntry) bool { return a.RAMMb > b.RAMMb }) {
+		keep[pid] = true
+	}
+
+	out := make([]ProcessSampleEntry, 0, len(keep))
+	for _, e := range entries {
+		if keep[e.PID] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run to confirm it passes**
+
+Run:
+```bash
+cd agent && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH go test -race ./internal/remote/tools/ -run TestSelectTopN
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/remote/tools/process_sample.go agent/internal/remote/tools/process_sample_test.go
+git commit -m "feat(agent): top-N process snapshot selector (instantaneous CPU, no SID lookup)"
+```
+
+---
+
+## Task 6: Agent config field + default
+
+**Files:**
+- Modify: `agent/internal/config/config.go` (struct ~line 52, `Default()` ~line 193)
+
+- [ ] **Step 1: Add the config field**
+
+In `agent/internal/config/config.go`, add to the `Config` struct right after `MetricsIntervalSeconds` (line 52):
+
+```go
+	ProcessSampleIntervalSeconds int      `mapstructure:"process_sample_interval_seconds"`
+```
+
+- [ ] **Step 2: Add the default**
+
+In the `Default()` function, after `MetricsIntervalSeconds: 30,` (line 194):
+
+```go
+		ProcessSampleIntervalSeconds: 180,
+```
+
+- [ ] **Step 3: Build to confirm it compiles**
+
+Run:
+```bash
+cd agent && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH go build ./internal/config/
+```
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/internal/config/config.go
+git commit -m "feat(agent): ProcessSampleIntervalSeconds config (default 180s)"
+```
+
+---
+
+## Task 7: Agent sampler goroutine + authenticated POST
+
+**Files:**
+- Modify: `agent/internal/heartbeat/heartbeat.go` (`Start()` ~line 730; add new methods near `sendInventoryData` ~line 1018)
+
+- [ ] **Step 1: Add the sampler goroutine + send method**
+
+In `agent/internal/heartbeat/heartbeat.go`, add these methods (place near `sendInventoryData`, ~line 1018). Confirm `"github.com/breeze/agent/internal/remote/tools"` is imported (add it if not — match the module path used by other imports in this package).
+
+```go
+// processSampleTopN is the per-dimension top-N (CPU and RAM); the union is
+// capped at 2×this and must stay ≤ the API ingest schema's processes.max(16).
+const processSampleTopN = 8
+
+// runProcessSampler periodically captures a top-N process snapshot and POSTs it,
+// on its own ticker decoupled from the heartbeat (spec: process-sample pipeline).
+func (h *Heartbeat) runProcessSampler() {
+	defer observability.Recoverer("heartbeat.processSampler")
+
+	secs := h.config.ProcessSampleIntervalSeconds
+	if secs < 60 {
+		secs = 60
+	} else if secs > 3600 {
+		secs = 3600
+	}
+	ticker := time.NewTicker(time.Duration(secs) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if h.authMon != nil && h.authMon.ShouldSkip() {
+				continue
+			}
+			h.sendProcessSample()
+		case <-h.stopChan:
+			return
+		}
+	}
+}
+
+func (h *Heartbeat) sendProcessSample() {
+	entries, err := tools.TopProcessSample(processSampleTopN)
+	if err != nil {
+		log.Error("failed to collect process sample", "error", err.Error())
+		return
+	}
+
+	payload := map[string]any{
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"processes": entries,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Error("failed to marshal process sample", "error", err.Error())
+		return
+	}
+
+	url := fmt.Sprintf("%s/api/v1/agents/%s/process-sample", h.config.ServerURL, h.config.AgentID)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {h.authHeader()},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := httputil.Do(ctx, h.httpClient(), "POST", url, body, headers, h.retryCfg)
+	if err != nil {
+		log.Error("failed to send process sample", "error", err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		log.Debug("process sample sent", "count", len(entries))
+	} else {
+		log.Warn("process sample send failed", "status", resp.StatusCode)
+	}
+}
+```
+
+- [ ] **Step 2: Launch the goroutine from `Start()`**
+
+In `Start()`, right after the existing `go h.sendReliabilityMetrics()` line (~line 762, in the initial-dispatch block before the `for` loop), add:
+
+```go
+	go h.runProcessSampler()
+```
+
+- [ ] **Step 3: Build the whole agent to confirm it compiles**
+
+Run:
+```bash
+cd agent && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH go build ./...
+```
+Expected: no output (success). If `tools`, `httputil`, `observability`, `log`, `json`, `fmt`, `http`, `context`, or `time` are not already imported in `heartbeat.go`, add them (most already are — `sendInventoryData` uses `json`, `fmt`, `http`, `context`, `httputil`, `log`).
+
+- [ ] **Step 4: Vet for races**
+
+Run:
+```bash
+cd agent && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH go vet ./internal/heartbeat/
+```
+Expected: no output (success).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/heartbeat/heartbeat.go
+git commit -m "feat(agent): 180s process-sample goroutine posting top-N snapshots"
+```
+
+---
+
+## Task 8: Retention job (batched deletes, 7-day default)
+
+**Files:**
+- Create: `apps/api/src/jobs/processSampleRetention.ts`
+- Modify: `apps/api/src/index.ts` (workers array, ~line 1012-1033)
+
+- [ ] **Step 1: Implement the retention worker**
+
+Create `apps/api/src/jobs/processSampleRetention.ts`. Modeled on `reliabilityRetention.ts`, but deletes in bounded `ctid` batches so a large sweep never holds a long transaction against the tight prod connection budget (CLAUDE.md large-table guidance).
+
+```typescript
+/**
+ * Process-Sample Retention Worker
+ *
+ * BullMQ worker that prunes old device_process_samples in bounded ctid batches.
+ * Default retention: 7 days (configurable via PROCESS_SAMPLE_RETENTION_DAYS, max 14).
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error('[ProcessSampleRetention] withSystemDbAccessContext is not available — DB module may not have loaded correctly');
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+const QUEUE_NAME = 'process-sample-retention';
+const BATCH_SIZE = 10000;
+const DEFAULT_RETENTION_DAYS = Math.min(14, Math.max(1, parseInt(process.env.PROCESS_SAMPLE_RETENTION_DAYS || '7', 10)));
+
+type RetentionJobData = { retentionDays?: number };
+
+let retentionQueue: Queue<RetentionJobData> | null = null;
+let retentionWorker: Worker<RetentionJobData> | null = null;
+
+export function getProcessSampleRetentionQueue(): Queue<RetentionJobData> {
+  if (!retentionQueue) {
+    retentionQueue = new Queue<RetentionJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return retentionQueue;
+}
+
+export function createProcessSampleRetentionWorker(): Worker<RetentionJobData> {
+  return new Worker<RetentionJobData>(
+    QUEUE_NAME,
+    async (job: Job<RetentionJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        const retentionDays = Math.min(14, Math.max(1, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS));
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+        const startedAt = Date.now();
+
+        let deleted = 0;
+        for (;;) {
+          const result = await db.execute(sql`
+            DELETE FROM device_process_samples
+            WHERE ctid IN (
+              SELECT ctid FROM device_process_samples
+              WHERE "timestamp" < ${cutoff}
+              LIMIT ${BATCH_SIZE}
+            )
+          `);
+          const n = (result as unknown as { count?: number }).count ?? 0;
+          deleted += n;
+          if (n < BATCH_SIZE) break;
+        }
+
+        const durationMs = Date.now() - startedAt;
+        console.log(`[ProcessSampleRetention] Pruned ${deleted} process samples older than ${retentionDays} days in ${durationMs}ms`);
+        return { retentionDays, deleted, durationMs };
+      });
+    },
+    { connection: getBullMQConnection(), concurrency: 1 }
+  );
+}
+
+export async function initializeProcessSampleRetention(): Promise<void> {
+  try {
+    retentionWorker = createProcessSampleRetentionWorker();
+    retentionWorker.on('error', (error) => {
+      console.error('[ProcessSampleRetention] Worker error:', error);
+      captureException(error);
+    });
+    retentionWorker.on('failed', (job, error) => {
+      console.error(`[ProcessSampleRetention] Job ${job?.id} failed after ${job?.attemptsMade} attempts:`, error);
+      captureException(error);
+    });
+
+    const queue = getProcessSampleRetentionQueue();
+    const existing = await queue.getRepeatableJobs();
+    for (const job of existing) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+
+    await queue.add(
+      'cleanup',
+      { retentionDays: DEFAULT_RETENTION_DAYS },
+      { repeat: { every: 24 * 60 * 60 * 1000 }, removeOnComplete: { count: 5 }, removeOnFail: { count: 10 } }
+    );
+
+    console.log('[ProcessSampleRetention] Retention worker initialized');
+  } catch (error) {
+    console.error('[ProcessSampleRetention] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownProcessSampleRetention(): Promise<void> {
+  if (retentionWorker) { await retentionWorker.close(); retentionWorker = null; }
+  if (retentionQueue) { await retentionQueue.close(); retentionQueue = null; }
+}
+```
+
+- [ ] **Step 2: Register the worker at startup**
+
+In `apps/api/src/index.ts`, add the import next to the other job imports, then add an entry to the `workers` array (after the `reliabilityRetention` entry, ~line 1031):
+
+```typescript
+import { initializeProcessSampleRetention } from './jobs/processSampleRetention';
+```
+```typescript
+  ['processSampleRetention', initializeProcessSampleRetention],
+```
+
+- [ ] **Step 3: Type-check**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsc --noEmit
+```
+Expected: no new errors in `processSampleRetention.ts` or `index.ts` (pre-existing errors in `agents.test.ts`/`apiKeyAuth.test.ts` are known and unrelated).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/jobs/processSampleRetention.ts apps/api/src/index.ts
+git commit -m "feat(api): batched-delete retention for device_process_samples (7d default)"
+```
+
+---
+
+## Task 9: Web drill-down panel component
+
+**Files:**
+- Create: `apps/web/src/components/devices/ProcessDrilldownPanel.tsx`
+- Create: `apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx`. Asserts click→fetch→sorted-table, the sample-time header, and the Live toggle switching endpoints.
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ProcessDrilldownPanel from './ProcessDrilldownPanel';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../lib/api', () => ({ fetchWithAuth: (...args: any[]) => fetchWithAuth(...args) }));
+
+function jsonResponse(body: any) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+}
+
+describe('ProcessDrilldownPanel', () => {
+  beforeEach(() => { fetchWithAuth.mockReset(); });
+
+  it('fetches the nearest sample for the clicked time and renders rows sorted by CPU', async () => {
+    fetchWithAuth.mockReturnValue(jsonResponse({
+      sample: {
+        timestamp: '2026-06-13T12:31:40.000Z',
+        agentTimestamp: null,
+        topProcesses: [
+          { name: 'node', pid: 2, cpu: 5, ramMb: 50 },
+          { name: 'chrome', pid: 1, cpu: 88, ramMb: 1200 }
+        ]
+      }
+    }));
+
+    render(<ProcessDrilldownPanel deviceId="dev-1" at="2026-06-13T12:32:00.000Z" onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('process-drilldown-row-0')).toBeInTheDocument());
+    // default sort = CPU desc → chrome (88) first
+    expect(screen.getByTestId('process-drilldown-row-0')).toHaveTextContent('chrome');
+    // header shows the actual sample time, not the clicked time
+    expect(screen.getByTestId('process-drilldown-sample-time')).toHaveTextContent('12:31');
+    expect(fetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/devices/dev-1/process-samples?at=2026-06-13T12%3A32%3A00.000Z'));
+  });
+
+  it('Live toggle switches to the on-demand processes endpoint', async () => {
+    fetchWithAuth.mockReturnValue(jsonResponse({ sample: { timestamp: '2026-06-13T12:31:40.000Z', agentTimestamp: null, topProcesses: [] } }));
+    render(<ProcessDrilldownPanel deviceId="dev-1" at="2026-06-13T12:32:00.000Z" onClose={() => {}} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+
+    fetchWithAuth.mockReturnValue(jsonResponse({ processes: [{ name: 'live', pid: 9, cpuPercent: 3, memoryMb: 7 }] }));
+    fireEvent.click(screen.getByTestId('process-drilldown-live-toggle'));
+
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenLastCalledWith(expect.stringContaining('/devices/dev-1/processes')));
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/devices/ProcessDrilldownPanel.test.tsx
+```
+Expected: FAIL — cannot resolve `./ProcessDrilldownPanel`.
+
+- [ ] **Step 3: Implement the panel**
+
+Create `apps/web/src/components/devices/ProcessDrilldownPanel.tsx`. Uses the shared `Dialog` drawer. Default sort = CPU desc; resource toggle re-sorts; "nearest sample" header shows the real sample time; Live toggle reads the existing on-demand `/devices/:id/processes`. Confirm the `fetchWithAuth` import path matches the rest of `devices/` (e.g. `DevicePerformanceGraphs.tsx` imports it — match that exact path; the test mocks `../../lib/api`).
+
+```tsx
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchWithAuth } from '../../lib/api';
+import Dialog from '../shared/Dialog';
+
+type Row = { name: string; pid: number; cpu: number; ramMb: number; diskBps?: number; netBps?: number };
+type SortKey = 'cpu' | 'ramMb';
+
+type Props = {
+  deviceId: string;
+  at: string;          // ISO timestamp of the clicked chart point
+  onClose: () => void;
+};
+
+export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [sampleTime, setSampleTime] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('cpu');
+  const [live, setLive] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      if (live) {
+        const res = await fetchWithAuth(`/devices/${deviceId}/processes?limit=16&sortBy=cpu&sortDesc=true`);
+        if (!res.ok) throw new Error('Failed to fetch live processes');
+        const json = await res.json();
+        const procs = (json.processes ?? json.data?.processes ?? []) as Array<Record<string, unknown>>;
+        setRows(procs.map((p) => ({ name: String(p.name ?? ''), pid: Number(p.pid ?? 0), cpu: Number(p.cpuPercent ?? p.cpu ?? 0), ramMb: Number(p.memoryMb ?? p.ramMb ?? 0) })));
+        setSampleTime(null);
+      } else {
+        const res = await fetchWithAuth(`/devices/${deviceId}/process-samples?at=${encodeURIComponent(at)}`);
+        if (!res.ok) throw new Error('Failed to fetch process sample');
+        const json = await res.json();
+        if (!json.sample) { setRows([]); setSampleTime(null); return; }
+        setRows((json.sample.topProcesses ?? []) as Row[]);
+        setSampleTime(json.sample.timestamp);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load processes');
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId, at, live]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const sorted = useMemo(
+    () => [...rows].sort((a, b) => (sortKey === 'cpu' ? b.cpu - a.cpu : b.ramMb - a.ramMb)),
+    [rows, sortKey]
+  );
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="lg">
+      <div className="p-4" data-testid="process-drilldown-panel">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-base font-semibold">Top processes</h3>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={live} onChange={(e) => setLive(e.target.checked)} data-testid="process-drilldown-live-toggle" />
+            Live
+          </label>
+        </div>
+
+        <p className="mt-1 text-xs text-muted-foreground" data-testid="process-drilldown-sample-time">
+          {live ? 'Live (now)' : sampleTime ? `Nearest sample: ${new Date(sampleTime).toLocaleString()}` : 'No sample near this time'}
+        </p>
+
+        <div className="mt-3 flex gap-2 text-sm">
+          <button type="button" onClick={() => setSortKey('cpu')} aria-pressed={sortKey === 'cpu'} className={sortKey === 'cpu' ? 'font-semibold' : ''}>CPU</button>
+          <button type="button" onClick={() => setSortKey('ramMb')} aria-pressed={sortKey === 'ramMb'} className={sortKey === 'ramMb' ? 'font-semibold' : ''}>RAM</button>
+        </div>
+
+        {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+        {loading && <p className="mt-3 text-sm text-muted-foreground">Loading…</p>}
+
+        <table className="mt-3 w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th>Process</th><th>PID</th><th>CPU %</th><th>RAM (MB)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((r, i) => (
+              <tr key={`${r.pid}-${i}`} data-testid={`process-drilldown-row-${i}`}>
+                <td>{r.name}</td>
+                <td>{r.pid}</td>
+                <td>{r.cpu.toFixed(1)}</td>
+                <td>{Math.round(r.ramMb)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run to confirm it passes**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/devices/ProcessDrilldownPanel.test.tsx
+```
+Expected: PASS (2 tests). If `Dialog`'s default vs named export or `fetchWithAuth`'s import path differ, align the imports with `DevicePerformanceGraphs.tsx`/`ProcessManager.tsx` and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/ProcessDrilldownPanel.tsx apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
+git commit -m "feat(web): process drill-down panel (sortable table, sample-time header, Live toggle)"
+```
+
+---
+
+## Task 10: Wire the drill-down into the Performance chart (lazy)
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DevicePerformanceGraphs.tsx` (CPU/RAM `LineChart` ~line 216; component body ~line 76)
+- Create: `apps/web/src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx`
+
+- [ ] **Step 1: Write the failing lazy-load test**
+
+Create `apps/web/src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx`. Asserts the hard requirement: **no** process-sample request fires on mount — only after a chart click.
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import DevicePerformanceGraphs from './DevicePerformanceGraphs';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../lib/api', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
+
+describe('DevicePerformanceGraphs drill-down lazy-load', () => {
+  beforeEach(() => {
+    fetchWithAuth.mockReset();
+    fetchWithAuth.mockReturnValue(Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) } as Response));
+  });
+
+  it('does not request process-samples on mount', async () => {
+    render(<DevicePerformanceGraphs deviceId="dev-1" />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+    const calledUrls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes('/process-samples'))).toBe(false);
+    expect(calledUrls.every((u) => u.includes('/metrics'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it passes already (guard test)**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx
+```
+Expected: PASS today (no drill-down code yet). This test is the regression guard that the wiring in Step 3 must NOT break.
+
+- [ ] **Step 3: Add the click handler + lazy panel render**
+
+In `apps/web/src/components/devices/DevicePerformanceGraphs.tsx`:
+
+(a) Add the import near the top:
+```tsx
+import ProcessDrilldownPanel from './ProcessDrilldownPanel';
+```
+
+(b) Add state in the component body (after the existing `useState` calls, ~line 80):
+```tsx
+  const [drilldownAt, setDrilldownAt] = useState<string | null>(null);
+```
+
+(c) Add `onClick` to the CPU/RAM `<LineChart>` (the one at ~line 218 with `dataKey="cpu"`/`"ram"`). Recharts passes the chart state; `activeLabel` is the clicked X value (the `timestamp`):
+```tsx
+    <LineChart
+      data={data}
+      onClick={(state: { activeLabel?: string | number } | null) => {
+        if (state && state.activeLabel != null) setDrilldownAt(String(state.activeLabel));
+      }}
+    >
+```
+
+(d) Render the panel lazily at the end of the component's returned JSX (just before the outermost closing tag):
+```tsx
+      {drilldownAt && (
+        <ProcessDrilldownPanel deviceId={deviceId} at={drilldownAt} onClose={() => setDrilldownAt(null)} />
+      )}
+```
+
+- [ ] **Step 4: Run both web tests to confirm pass + no regression**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx src/components/devices/ProcessDrilldownPanel.test.tsx
+```
+Expected: PASS (lazy-load guard still green, panel tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/DevicePerformanceGraphs.tsx apps/web/src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx
+git commit -m "feat(web): open process drill-down on Performance chart click (lazy)"
+```
+
+---
+
+## Task 11: Full verification sweep
+
+- [ ] **Step 1: API affected-file tests**
+
+Run (single fork — full-suite parallel runs are flaky per project memory):
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --pool forks --poolOptions.forks.singleFork src/routes/agents/processSample.test.ts src/routes/devices/processSamples.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 2: Agent tests + race**
+
+Run:
+```bash
+cd agent && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH go test -race ./internal/remote/tools/...
+```
+Expected: PASS.
+
+- [ ] **Step 3: Web tests**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/devices/
+```
+Expected: PASS.
+
+- [ ] **Step 4: RLS contract + drift**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run -c vitest.config.rls-coverage.ts
+```
+Expected: no drift; RLS coverage PASS (device_process_samples auto-covered). (First confirm `.env.test` exists and `breeze_app.rolbypassrls = f` per Task 2 Step 0 — otherwise the coverage test passes vacuously.)
+
+- [ ] **Step 5: End-to-end smoke (optional, needs a live agent)**
+
+With a local agent enrolled, wait one sample interval (~180s), then confirm a row landed and the read route serves it:
+```bash
+docker exec -i breeze-postgres psql -U breeze -d breeze -c "SELECT device_id, \"timestamp\", jsonb_array_length(top_processes) FROM device_process_samples ORDER BY \"timestamp\" DESC LIMIT 3;"
+```
+Expected: recent rows with a non-zero process count. In the web UI, open a device → Performance, click a CPU/RAM chart point, and confirm the drill-down panel lists processes with the nearest-sample time in the header.
+
+---
+
+## Self-Review Notes (spec coverage)
+
+- Historical drill-down (scrub to past spikes) → Tasks 1,4,9,10 (nearest snapshot + Live toggle).
+- CPU + RAM per process, phased → Task 5 (Phase 1); `diskBps`/`netBps` are nullable slots in the schema (Task 1), agent struct (Task 5), and API schema (Task 3) so disk/net phases are additive (separate plans).
+- Click chart entry point → Task 10.
+- Storage Approach A (1 JSONB row/device/sample) → Task 1.
+- Tenancy: server-derived `org_id`, RLS shape #1, same-migration policies → Tasks 1,2,3.
+- Clock skew: server-stamped `timestamp` + `agent_timestamp` → Tasks 1,3.
+- Payload bounds → Task 3 (`processes.max(16)` + per-field limits).
+- Sampler decoupled from heartbeat, instantaneous CPU invariant → Tasks 5,6,7.
+- Retention (net-new, batched, 7-day default) → Task 8.
+- Lazy web load (zero added page-load cost) → Tasks 9,10 (guard test in Task 10).
+
+**Deviation from spec:** the existing Performance chart plots CPU/RAM/Disk on one combined `LineChart`, so a click yields a timestamp but not a specific resource. The panel therefore opens sorted by CPU with a CPU/RAM toggle, rather than auto-sorting by the exact line clicked. This preserves the core need (drill-down at a timestamp, sortable by resource); per-line click targeting can be a refinement if desired.
+
+**Deferred to follow-up plans:** Phase 2 (disk I/O per process) and Phase 3 (network per process) collection behind faked OS interfaces; spike-triggered capture; a full slider-style time scrubber (this plan ships nearest-snapshot + Live; the `?from&to` markers endpoint is built in Task 4 and ready for a slider).

--- a/docs/superpowers/specs/2026-06-07-process-level-resource-drilldown-design.md
+++ b/docs/superpowers/specs/2026-06-07-process-level-resource-drilldown-design.md
@@ -1,8 +1,15 @@
 # Process-Level Resource Drill-Down — Design
 
-**Date:** 2026-06-07
+**Date:** 2026-06-07 (revised 2026-06-13)
 **Status:** Approved (brainstorm) — ready for implementation plan
 **Author:** Todd Hebebrand (with Claude)
+
+**2026-06-13 revision** (after code-grounded review): corrected the retention plan (no
+existing metrics-cleanup job exists — it's net-new), pinned CPU% to the instantaneous
+sample path, added server-stamped timestamp + clock-skew handling, added ingest payload
+bounds, made the web lazy-load contract explicit, and replaced "Scale Notes" with a full
+**Performance & Load Budget** section. Net conclusion: no added page-load cost; storage
+(retention) is the only real lever.
 
 ## Problem / Feature Request
 
@@ -98,6 +105,14 @@ additive.
 
 - **Reuse** `agent/internal/remote/tools/processes.go` (`ListProcesses`) for per-process
   collection — do not write a second enumerator.
+- **CPU% must be instantaneous, not lifetime-average (hard invariant).** gopsutil's
+  `process.CPUPercent()` returns total-CPU-time ÷ uptime — a lifetime average — which
+  would make "top processes at that moment" silently wrong. The reused path already
+  avoids this: `ListProcesses` calls `sampleProcessCPUPercents` with a shared 250ms
+  sample window (`processes.go:43,211` — "what makes the list show *current* CPU rather
+  than a lifetime average"). The sampler **must** go through that path; a unit test
+  should pin this so a later refactor can't reintroduce raw `CPUPercent()`. Cost: one
+  ~250ms sleep window per sample per agent (negligible at the 180s cadence).
 - **Top-N selector**: union of top-N by CPU and top-N by RAM, dedupe by PID, cap at
   ~10–12 entries. Each entry: `{name, pid, cpu, ramMb, diskBps?, netBps?}`. Disk/net
   fields are nullable and omitted on OSes that cannot supply them.
@@ -126,9 +141,15 @@ and so an unsupported OS cleanly returns "no data" rather than erroring.
 |---|---|---|
 | `device_id` | uuid | FK → devices |
 | `org_id` | uuid | FK → organizations; **set server-side**, not from agent |
-| `timestamp` | timestamptz | sample time |
+| `timestamp` | timestamptz | **server receive time** — the key for chart correlation |
+| `agent_timestamp` | timestamptz | agent-reported sample time (clock-skew forensics) |
 | `top_processes` | jsonb | array of `{name, pid, cpu, ramMb, diskBps?, netBps?}` |
 
+- **Clock skew:** the Performance charts plot **server-stamped** `deviceMetrics`
+  timestamps, so the `?at=` nearest-snapshot lookup must key on the **server receive
+  time** (`timestamp`), not the agent-supplied value — otherwise a skewed agent clock
+  makes "click the 14:32 spike" fetch a snapshot from a different minute. Keep the
+  agent's reported time in `agent_timestamp` for forensics only.
 - **PK** `(device_id, timestamp)`; index `(device_id, timestamp DESC)`.
 - **RLS shape #1** (direct `org_id`): `breeze_has_org_access(org_id)`, RLS **enabled +
   forced + policies** created in the **same idempotent migration** that creates the
@@ -141,22 +162,49 @@ and so an unsupported OS cleanly returns "no data" rather than erroring.
 
 - **`POST /agents/:id/process-sample`** (in `apps/api/src/routes/agents/`): Zod-validated
   payload, `agentAuth` bearer. **`org_id` is derived server-side from the authenticated
-  device record — the agent payload is never trusted for tenancy.** Inserts one row.
+  device record — the agent payload is never trusted for tenancy.** Stamps `timestamp`
+  server-side at receipt; stores the agent-reported time in `agent_timestamp`. Inserts
+  one row. **Bound the payload in Zod** — cap the `processes` array (e.g. ≤ 16) and each
+  string field's length, so a buggy or compromised agent can't insert an oversized JSONB
+  blob. Mirror the single-insert-per-request shape of the existing heartbeat metrics
+  insert (`apps/api/src/routes/agents/heartbeat.ts`); no cross-request batching needed
+  (the new write rate is ~⅓ of the existing heartbeat-metrics rate — see Performance).
 - **`GET /devices/:id/process-samples?at=<ts>`**: returns the snapshot nearest to `<ts>`.
   Also supports `?from&to` returning lightweight `(timestamp)` markers so the scrubber
   knows which samples exist in a range. Runs through `withDbAccessContext` (RLS enforced).
 
 ### Retention
 
-Hook into the existing metrics cleanup job with a **separate, shorter window**
-(default **14 days**), independent of aggregate-metric retention. Per-process snapshots
-are heavier and only needed for recent forensic investigation.
+> **Correction (verified 2026-06-13):** there is **no** existing `deviceMetrics`
+> cleanup job to "hook into" — `apps/api/src/jobs/` has `auditRetention.ts`,
+> `reliabilityRetention.ts`, `eventLogRetention.ts`, `backupRetention.ts`, etc., but
+> nothing for device metrics. This retention is **net-new work**, not a hook.
+
+Add a **new** retention job for `device_process_samples`, modeled on
+`reliabilityRetention.ts` (BullMQ queue + worker, env-driven `*_RETENTION_DAYS`).
+Default window **7 days** (configurable, max 14) — shorter than aggregate metrics
+because per-process snapshots are heavier and only needed for recent forensic
+investigation. Deletes **must be batched** (time-range or `ctid`-chunked `DELETE`
+loops, per CLAUDE.md large-table guidance), never a single unbounded
+`DELETE ... WHERE timestamp < ...` — large sweeps are rough on DO-managed Postgres and
+contend for the tight connection budget (US `max_connections=25`).
 
 ## Web UI
 
+- **Lazy by construction — zero added page-load cost (hard requirement).** The
+  Performance tab today fires exactly one fetch on mount (`DevicePerformanceGraphs.tsx`
+  → `GET /devices/:id/metrics`). The drill-down must add **nothing** to initial render or
+  tab-switch: the nearest-snapshot fetch, the `?from&to` scrubber-markers fetch, and the
+  Live poll all fire **only after the user clicks a chart point** and the panel opens,
+  and the Live poll stops when the panel closes. A web test should assert no
+  process-sample request fires on mount.
 - In `DevicePerformanceGraphs.tsx`, make CPU/RAM chart points clickable. On click, fetch
   the nearest process sample and open a drill-down panel (reuse `Dialog.tsx` drawer +
   `ProcessManager.tsx` table styling).
+- **Show the actual sample time.** Samples (180s) are sparser than chart points (~60s),
+  so the nearest snapshot can be ±90s from the clicked point. Display the real sample
+  timestamp in the panel header ("nearest sample: 14:31:40") so operators don't read it
+  as exact.
 - Panel contents:
   - Sortable process table, **pre-sorted by the resource clicked** (click CPU → CPU desc;
     click RAM → RAM desc).
@@ -167,25 +215,67 @@ are heavier and only needed for recent forensic investigation.
 - Disk/net columns appear once their phases ship; show "—" / "not available" where an OS
   or phase has no data.
 
-## Scale Notes
+## Performance & Load Budget
 
-- Approach A keeps row volume at roughly **1 row per device per sample**, the same order
-  of magnitude as the existing `deviceMetrics` table — not the ~10× of a per-process
-  normalized table (Approach B).
-- At 10k agents × 180s cadence ≈ 10k × 480 samples/day ≈ **4.8M rows/day**, each a small
-  JSONB blob, pruned at 14 days. Comparable to existing metrics load; viable on
-  DO-managed Postgres without TimescaleDB.
+Where load lands, verified against the current code (2026-06-13). Summary: **the
+overview/Performance page gains zero initial-load cost**, agent and DB-write overhead are
+modest (below today's heartbeat-metrics load), and **DB storage is the only real cost
+lever** — fully controlled by retention.
+
+| Surface | Impact | Risk |
+|---|---|---|
+| Web initial page load | **0 new requests** — drill-down fetches are click-lazy (see Web UI) | none |
+| Agent CPU | one ~250ms CPU-sample window per sample, every 180s, reusing the existing worker-pooled enumerator | low |
+| Agent network | ~1 small POST / device / 180s | low |
+| DB writes | ~**56 inserts/sec** at 10k agents — **~⅓** of today's heartbeat-metrics write rate | low (watch conn pool) |
+| DB read (drill-down) | single index-backed `ORDER BY timestamp DESC LIMIT 1`, on click only | none |
+| DB storage | ~67M rows / 14d; JSONB → main cost, bounded by retention | **medium — manage** |
+
+**Web page load.** The Performance tab fires one fetch on mount today
+(`DevicePerformanceGraphs.tsx` → `GET /devices/:id/metrics`). The drill-down adds nothing
+to that path: nearest-snapshot, scrubber-markers, and Live-poll requests all fire only
+after a click opens the panel (enforced by the lazy-load requirement + a test). No new
+JS runs on the hot render path; the click handler and panel are inert until used.
+
+**Agent CPU / network.** A dedicated 180s goroutine (separate from the 60s heartbeat,
+matching the existing boot-check/user-helper ticker pattern in `heartbeat.go`). Each tick
+reuses `ListProcesses`' worker-pooled enumeration + one shared 250ms CPU-sample sleep —
+the same cost the live Process Manager already pays on demand, now once per 180s. The
+known-expensive part (Windows per-process SID lookups) is already mitigated by the
+8-worker pool. One small POST per tick. Negligible at this cadence.
+
+**DB writes.** One insert per request, mirroring the heartbeat-metrics insert — no
+batching. At 10k agents / 180s that's ~56 rows/sec, roughly **⅓** of the existing
+~167 rows/sec heartbeat-metrics rate that production already sustains. The one thing to
+watch is the tight US connection budget (`max_connections=25`): these inserts are short
+and index-cheap, but if pool pressure shows up, server-side micro-batching is the lever
+(deferred — not needed at launch).
+
+**DB storage (the lever).** Row volume is ~1 row/device/sample — same order as
+`deviceMetrics`, not the ~10× of normalized Approach B. At 10k × 480 samples/day ≈
+**4.8M rows/day**, ≈ **67M rows at 14d**. Each row is heavier than a metrics row (a JSONB
+array of ~10–12 compact `{name,pid,cpu,ramMb}` entries ≈ 1–1.5 KB; Postgres TOAST-
+compresses larger blobs), so figure **tens of GB**, not the single-digit GB of aggregate
+metrics. This is bounded entirely by retention: the **7-day default** (vs 14) roughly
+halves it, and the top-N cap keeps each row small. This is why retention is a hard
+requirement of this work, not a follow-up. Viable on DO-managed Postgres without
+TimescaleDB.
 
 ## Testing (per `breeze-testing`)
 
-- **API**: route tests for ingest (Zod validation, auth, **server-side org_id
-  derivation**) and read (nearest-snapshot, range markers). **RLS contract test** for
-  `device_process_samples` (`rls-coverage.integration.test.ts`) — verify cross-tenant
-  insert/select is blocked as `breeze_app`.
-- **Agent**: table-driven tests for the top-N union/dedupe selector; per-OS disk/net
-  collectors behind interfaces, tested with fakes; unsupported-OS returns "no data".
-- **Web**: component test for click→fetch→sorted-table, the time scrubber re-fetch, and
-  the Live toggle.
+- **API**: route tests for ingest (Zod validation incl. **payload bounds** — array cap +
+  string lengths, auth, **server-side org_id derivation**, **server-stamped timestamp**)
+  and read (**nearest-snapshot keyed on server time**, range markers). **RLS contract
+  test** for `device_process_samples` (`rls-coverage.integration.test.ts`) — verify
+  cross-tenant insert/select is blocked as `breeze_app`. Add the table to RLS shape #1
+  in the same PR.
+- **Agent**: table-driven tests for the top-N union/dedupe selector; a test pinning that
+  CPU% comes from the **instantaneous** sample path (not raw `CPUPercent()`); per-OS
+  disk/net collectors behind interfaces, tested with fakes; unsupported-OS returns
+  "no data".
+- **Web**: component test for click→fetch→sorted-table, the time scrubber re-fetch, the
+  Live toggle, and a test asserting **no process-sample request fires on mount / tab
+  switch** (the lazy-load contract).
 
 ## Rejected Alternatives
 


### PR DESCRIPTION
## Summary

Lets an operator click a point on a device's CPU/RAM performance chart and see the **top processes** consuming that resource at that moment, including scrubbing back to past samples. Familiar N-Central-style capability. **Phase 1 = CPU + RAM**; disk-I/O and network per-process columns are deferred to follow-up plans (the schema/agent/API leave nullable `diskBps`/`netBps` slots so they're additive).

**Design/plan:** `docs/superpowers/specs/2026-06-07-process-level-resource-drilldown-design.md` · `docs/superpowers/plans/2026-06-13-process-drilldown-phase1.md`

## Architecture

A new agent goroutine samples the top-N processes every ~180s (decoupled from the 60s heartbeat) and POSTs a compact snapshot to a new ingest route, which stores **one JSONB row per device per sample** in `device_process_samples` (RLS shape #1, direct `org_id`). A read route serves the nearest snapshot to a clicked timestamp; the web Performance tab lazily opens a drill-down panel on chart click. A BullMQ job prunes the table with batched deletes (7-day default).

## What's in each layer

- **DB** (`61f9a38b`): `device_process_samples` — `timestamp` (server receive time, the chart-correlation key) + `agent_timestamp` (clock-skew forensics) + `top_processes` jsonb; RLS enabled+forced with 4 `breeze_has_org_access(org_id)` policies in the same idempotent migration.
- **Ingest** `POST /agents/:id/process-sample` (`0ec9c2d7`): bearer-auth; **`org_id`/`deviceId` derived server-side from the auth context, never the body**; server-stamps `timestamp`; Zod-bounded payload (`processes.max(16)` + per-field limits); 403 on path/token mismatch.
- **Read** `GET /devices/:id/process-samples` (`cf15c253`): index-backed nearest-at-or-before snapshot for `?at`, lightweight timestamp markers for `?from&to`.
- **Retention** (`dfc4ade5`, `4dabdf81`): batched `ctid` deletes (10k/batch), default 7d (`PROCESS_SAMPLE_RETENTION_DAYS`, clamped 1–14); shutdown handler wired; robust row-count extraction.
- **Agent** (`8a7e6726`, `97f3ea14`, `0acd2fb8`): `TopProcessSample`/`selectTopN` (union of top-N by CPU and RAM, deduped) — CPU sourced from the **instantaneous** sample path, never gopsutil's lifetime-average; username resolution skipped (no Windows SID-lookup cost). New 180s goroutine mirroring the heartbeat sender pattern; `ProcessSampleIntervalSeconds` config (default 180).
- **Web** (`97efe7b2`, `918bc814`, `2ade9a89`): on-click drill-down panel (sortable table, "nearest sample" header, Live toggle) — **lazy: zero added fetches on page mount** (guard test). Live toggle reads the real `{ data: [...] }` processes-endpoint shape.

## Performance

Verified against the code: **zero** added initial-page-load cost (drill-down fetches are click-lazy), agent CPU/network overhead is modest, DB write rate ~⅓ of the existing heartbeat-metrics rate, and storage is bounded by retention. Full breakdown in the spec's "Performance & Load Budget" section.

## Test Plan

- [x] API route tests — 6/6 (ingest: server-side org derivation, server timestamp, payload cap, path/token mismatch; read: nearest + markers)
- [x] Agent — `go test -race ./internal/remote/tools/...` green (selectTopN union/dedup/order); `go build ./...` + `go vet` clean
- [x] Web — 136/136 device-component tests (incl. lazy-load-on-mount guard, panel sort/Live, Live array-under-data regression guard)
- [x] **RLS** — coverage contract 27/27 (genuinely covers `device_process_samples`, confirmed RLS enabled+forced on the test DB); manual `breeze_app` cross-tenant forge-insert **rejected**, matched-org insert succeeds
- [ ] Reviewer: confirm on a clean CI DB that `db:check-drift` is green (locally it flags only the unrelated `2026-06-12-b-client-ai-foundation.sql` foreign migration from another branch)

## Notes

- **Deferred (follow-up plans):** Phase 2 (disk I/O per process), Phase 3 (network per process), a full slider scrubber (the `?from&to` markers endpoint is built and ready), spike-triggered capture.
- The combined CPU/RAM/Disk chart yields a timestamp (not a specific resource) on click, so the panel opens sorted-by-CPU with a CPU/RAM toggle rather than auto-sorting by the exact line clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)