### PR TITLE
feat(agent/pam): wire ETW detection → dialog → decision → actuate (#1253)

### DIFF
--- a/agent/cmd/breeze-agent/etwlua_start_windows.go
+++ b/agent/cmd/breeze-agent/etwlua_start_windows.go
@@ -40,9 +40,16 @@ func startETWLua(ctx context.Context, hb *heartbeat.Heartbeat) <-chan struct{} {
 		close(done)
 		return done
 	}
+	// The local PAM elevation flow (dialog → actuate) needs the user-helper
+	// session broker. When it's absent (e.g. an interactive agent with no
+	// user-helper), pass a nil PamRunner so etwlua stays detection-only.
+	var pam etwlua.PamRunner
+	if hb.SessionBroker() != nil {
+		pam = hb
+	}
 	go func() {
 		defer close(done)
-		if err := etwlua.Start(ctx, sub, hb); err != nil {
+		if err := etwlua.Start(ctx, sub, hb, pam); err != nil {
 			log.Warn("etwlua Start returned error", "error", err.Error())
 		}
 	}()

--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -38,8 +38,9 @@
 // scripts hitting the same MSI). Without dedupe a single legitimate
 // admin-prompt can produce 5+ events. We key dedupe on
 // sha256(exe_path) + ":" + subject_username with a 30s window using the
-// existing ipc.RateLimiter — matches what Track 1's server-side dedupe
-// will also do, so the wire is clean.
+// existing ipc.RateLimiter. The server runs its own independent dedupe on
+// ingest; the keys and windows are not guaranteed identical, so this is
+// agent-side noise suppression, not a parity contract with the server.
 //
 // Offline-queue rationale. The agent often runs on laptops behind captive
 // portals or VPNs that drop briefly. The intercept event itself is short-
@@ -308,13 +309,24 @@ func handleEvent(ctx context.Context, ev Event, limiter *ipc.RateLimiter, hb Hea
 		"path", ev.TargetExecutablePath,
 	)
 
-	// Drive the local elevation flow. The dedupe above already prevents
-	// stacked dialogs for re-fired ETW events on one prompt. Note this only
-	// fires for live posts: events replayed later via Queue.Drain discard the
-	// outcome and deliberately skip the flow — a drained event is a stale
-	// prompt whose consent.exe dialog is long gone, so actuating it is wrong.
+	// Drive the local elevation flow. The dedupe above prevents stacked dialogs
+	// for re-fired ETW events that arrive *before* the flow starts, but the
+	// window is re-asserted at flow-end (below) to also cover flows that run
+	// longer than dedupeWindow. Note this only fires for live posts: events
+	// replayed later via Queue.Drain discard the outcome and deliberately skip
+	// the flow — a drained event is a stale prompt whose consent.exe dialog is
+	// long gone, so actuating it is wrong.
 	if pam != nil && outcome.RequestID != "" && outcome.Status != "ignored" {
 		pam.RunPamFlow(ctx, ev, outcome)
+		// RunPamFlow can block on the PAM dialog up to ~90s — longer than the
+		// 30s dedupeWindow — so the arrival entry recorded above may have
+		// expired by now. Re-record the key so the dedupe window restarts from
+		// flow-end: the sliding-window limiter prunes the stale arrival entry
+		// and records this moment, so a buffered re-fire drained within
+		// dedupeWindow of flow-end is suppressed, while a genuine retry after
+		// the window still gets through. Result discarded — we're recording,
+		// not gating.
+		_ = limiter.Allow(key)
 	}
 
 	// Opportunistic drain on every successful post — quickly catches up

--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -38,9 +38,10 @@
 // scripts hitting the same MSI). Without dedupe a single legitimate
 // admin-prompt can produce 5+ events. We key dedupe on
 // sha256(exe_path) + ":" + subject_username with a 30s window using the
-// existing ipc.RateLimiter. The server runs its own independent dedupe on
-// ingest; the keys and windows are not guaranteed identical, so this is
-// agent-side noise suppression, not a parity contract with the server.
+// existing ipc.RateLimiter. This is purely agent-side noise suppression —
+// the server applies its own per-device rate limit on ingest but does not
+// coalesce duplicates (it inserts a fresh row per accepted request), so
+// there is no parity contract and the keys/windows are unrelated.
 //
 // Offline-queue rationale. The agent often runs on laptops behind captive
 // portals or VPNs that drop briefly. The intercept event itself is short-
@@ -121,6 +122,16 @@ type Event struct {
 	ObservedAt time.Time `json:"observed_at"`
 }
 
+// ElevationStatus is the server's ingest decision for a uac_intercept request.
+type ElevationStatus string
+
+const (
+	ElevationPending      ElevationStatus = "pending"
+	ElevationAutoApproved ElevationStatus = "auto_approved"
+	ElevationDenied       ElevationStatus = "denied"
+	ElevationIgnored      ElevationStatus = "ignored"
+)
+
 // ElevationOutcome is the server's synchronous ingest decision for a posted
 // uac_intercept elevation request, parsed from the POST response body
 // {"id":"<uuid>","status":"<status>"}. Status is one of "pending",
@@ -128,7 +139,7 @@ type Event struct {
 // server suppressed the request (status "ignored", id null).
 type ElevationOutcome struct {
 	RequestID string
-	Status    string
+	Status    ElevationStatus
 }
 
 // Subscriber abstracts the ETW event source. Real Windows builds use
@@ -316,16 +327,17 @@ func handleEvent(ctx context.Context, ev Event, limiter *ipc.RateLimiter, hb Hea
 	// replayed later via Queue.Drain discard the outcome and deliberately skip
 	// the flow — a drained event is a stale prompt whose consent.exe dialog is
 	// long gone, so actuating it is wrong.
-	if pam != nil && outcome.RequestID != "" && outcome.Status != "ignored" {
+	if pam != nil && outcome.RequestID != "" && outcome.Status != ElevationIgnored {
 		pam.RunPamFlow(ctx, ev, outcome)
 		// RunPamFlow can block on the PAM dialog up to ~90s — longer than the
 		// 30s dedupeWindow — so the arrival entry recorded above may have
-		// expired by now. Re-record the key so the dedupe window restarts from
-		// flow-end: the sliding-window limiter prunes the stale arrival entry
-		// and records this moment, so a buffered re-fire drained within
-		// dedupeWindow of flow-end is suppressed, while a genuine retry after
-		// the window still gets through. Result discarded — we're recording,
-		// not gating.
+		// expired by now. Re-record the key so a re-fired *live* ETW event
+		// arriving right after the flow completes is suppressed. This only
+		// effectively restarts the window from flow-end when the flow OUTLASTS
+		// dedupeWindow; for a short flow the arrival entry is still live and
+		// this Allow is a no-op (the window stays anchored at arrival) — still
+		// correct, just unnecessary. A genuine retry after the window still
+		// gets through. Result discarded — we're recording, not gating.
 		_ = limiter.Allow(key)
 	}
 

--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -120,6 +120,16 @@ type Event struct {
 	ObservedAt time.Time `json:"observed_at"`
 }
 
+// ElevationOutcome is the server's synchronous ingest decision for a posted
+// uac_intercept elevation request, parsed from the POST response body
+// {"id":"<uuid>","status":"<status>"}. Status is one of "pending",
+// "auto_approved", "denied", or "ignored". RequestID is empty when the
+// server suppressed the request (status "ignored", id null).
+type ElevationOutcome struct {
+	RequestID string
+	Status    string
+}
+
 // Subscriber abstracts the ETW event source. Real Windows builds use
 // etwSession from etwlua_windows.go; tests pass a fake.
 type Subscriber interface {
@@ -137,7 +147,10 @@ type Subscriber interface {
 // create a cycle once heartbeat imports etwlua for the SendElevationRequest
 // handler).
 type HeartbeatPoster interface {
-	SendElevationRequest(req Event) error
+	// SendElevationRequest posts the detected prompt and returns the
+	// server's ingest decision. A non-nil error means the post failed
+	// (network/5xx) and the event should be queued for retry.
+	SendElevationRequest(req Event) (ElevationOutcome, error)
 	// IsUACInterceptionEnabled reports the server-resolved 'pam' config
 	// policy state. While false, handleEvent drops events entirely (no
 	// post, no offline queue) and the periodic queue drain is paused.
@@ -259,7 +272,7 @@ func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queu
 		return
 	}
 
-	if err := hb.SendElevationRequest(ev); err != nil {
+	if _, err := hb.SendElevationRequest(ev); err != nil {
 		log.Warn("etwlua: post failed, queueing",
 			"user", ev.SubjectUsername,
 			"path", ev.TargetExecutablePath,

--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -157,6 +157,21 @@ type HeartbeatPoster interface {
 	IsUACInterceptionEnabled() bool
 }
 
+// PamRunner drives the local elevation flow (dialog → decision →
+// actuate/deny) for one detected UAC prompt, using the server's ingest
+// decision. It is the single edge from etwlua into the session broker +
+// actuator, kept behind an interface so etwlua stays unit-testable without
+// a live broker or Windows. A nil PamRunner disables the flow (detection +
+// post only) — used on non-Windows builds and when the broker is absent.
+//
+// Implementations must be non-blocking-forever: bound the dialog round-trip
+// to consent.exe's lifetime. RunPamFlow is called synchronously from the
+// event loop; UAC prompts are modal and serial, so one in-flight flow at a
+// time is correct.
+type PamRunner interface {
+	RunPamFlow(ctx context.Context, ev Event, outcome ElevationOutcome)
+}
+
 // ErrNotPrivileged is returned by Start when the process is not running as
 // SYSTEM/Administrator. Callers should log+continue rather than crash.
 var ErrNotPrivileged = errors.New("etwlua: process not running with admin/SYSTEM privileges; ETW subscribe skipped")
@@ -190,7 +205,7 @@ const drainTickInterval = 60 * time.Second
 // containers — IsRunningAsRoot returns true there).
 //
 // Start does not spawn its own goroutine; callers should `go etwlua.Start(...)`.
-func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster) error {
+func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster, pam PamRunner) error {
 	if !privilege.IsRunningAsRoot() {
 		log.Warn(ErrNotPrivileged.Error())
 		return ErrNotPrivileged
@@ -226,7 +241,7 @@ func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster) error {
 			if ev.ObservedAt.IsZero() {
 				ev.ObservedAt = time.Now().UTC()
 			}
-			handleEvent(ev, limiter, hb, q)
+			handleEvent(ctx, ev, limiter, hb, q, pam)
 
 		case <-ticker.C:
 			if q != nil && hb.IsUACInterceptionEnabled() {
@@ -244,7 +259,7 @@ func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster) error {
 
 // handleEvent is the per-event hot path, extracted so tests can exercise it
 // without spinning up the full Start loop.
-func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queue) {
+func handleEvent(ctx context.Context, ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queue, pam PamRunner) {
 	if !hb.IsUACInterceptionEnabled() {
 		dropCounter.Add(1)
 		if dropLogged.CompareAndSwap(false, true) {
@@ -272,7 +287,8 @@ func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queu
 		return
 	}
 
-	if _, err := hb.SendElevationRequest(ev); err != nil {
+	outcome, err := hb.SendElevationRequest(ev)
+	if err != nil {
 		log.Warn("etwlua: post failed, queueing",
 			"user", ev.SubjectUsername,
 			"path", ev.TargetExecutablePath,
@@ -291,6 +307,13 @@ func handleEvent(ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queu
 		"user", ev.SubjectUsername,
 		"path", ev.TargetExecutablePath,
 	)
+
+	// Drive the local elevation flow. The dedupe above already prevents
+	// stacked dialogs for re-fired ETW events on one prompt.
+	if pam != nil && outcome.RequestID != "" && outcome.Status != "ignored" {
+		pam.RunPamFlow(ctx, ev, outcome)
+	}
+
 	// Opportunistic drain on every successful post — quickly catches up
 	// after a network blip.
 	// Mirror the ticker-drain gate: both drain sites must check the policy flag.

--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -309,7 +309,10 @@ func handleEvent(ctx context.Context, ev Event, limiter *ipc.RateLimiter, hb Hea
 	)
 
 	// Drive the local elevation flow. The dedupe above already prevents
-	// stacked dialogs for re-fired ETW events on one prompt.
+	// stacked dialogs for re-fired ETW events on one prompt. Note this only
+	// fires for live posts: events replayed later via Queue.Drain discard the
+	// outcome and deliberately skip the flow — a drained event is a stale
+	// prompt whose consent.exe dialog is long gone, so actuating it is wrong.
 	if pam != nil && outcome.RequestID != "" && outcome.Status != "ignored" {
 		pam.RunPamFlow(ctx, ev, outcome)
 	}

--- a/agent/internal/etwlua/etwlua_test.go
+++ b/agent/internal/etwlua/etwlua_test.go
@@ -18,7 +18,8 @@ type fakeHB struct {
 	received []Event
 	failNext atomic.Int32 // number of next posts to fail
 	failErr  error
-	disabled atomic.Bool // simulates uacInterceptionEnabled=false from the server
+	disabled atomic.Bool      // simulates uacInterceptionEnabled=false from the server
+	outcome  ElevationOutcome // returned on a successful post; zero value by default
 }
 
 func (f *fakeHB) IsUACInterceptionEnabled() bool {
@@ -36,7 +37,7 @@ func (f *fakeHB) SendElevationRequest(req Event) (ElevationOutcome, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.received = append(f.received, req)
-	return ElevationOutcome{}, nil
+	return f.outcome, nil
 }
 
 func (f *fakeHB) Received() []Event {
@@ -44,6 +45,27 @@ func (f *fakeHB) Received() []Event {
 	defer f.mu.Unlock()
 	out := make([]Event, len(f.received))
 	copy(out, f.received)
+	return out
+}
+
+// fakePamRunner records every outcome RunPamFlow is invoked with so tests can
+// assert the etwlua → broker edge fires exactly when expected.
+type fakePamRunner struct {
+	mu       sync.Mutex
+	outcomes []ElevationOutcome
+}
+
+func (f *fakePamRunner) RunPamFlow(_ context.Context, _ Event, outcome ElevationOutcome) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.outcomes = append(f.outcomes, outcome)
+}
+
+func (f *fakePamRunner) Calls() []ElevationOutcome {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]ElevationOutcome, len(f.outcomes))
+	copy(out, f.outcomes)
 	return out
 }
 
@@ -82,7 +104,7 @@ func TestHandleEventDedupesWithinWindow(t *testing.T) {
 	ev := sampleEvent("alice", `C:\Program Files\Foo\foo.exe`)
 
 	for i := 0; i < 5; i++ {
-		handleEvent(ev, limiter, hb, nil)
+		handleEvent(context.Background(), ev, limiter, hb, nil, nil)
 	}
 
 	if got := len(hb.Received()); got != 1 {
@@ -94,9 +116,9 @@ func TestHandleEventDifferentKeysBothPost(t *testing.T) {
 	hb := &fakeHB{}
 	limiter := ipc.NewRateLimiter(1, dedupeWindow)
 
-	handleEvent(sampleEvent("alice", `C:\foo.exe`), limiter, hb, nil)
-	handleEvent(sampleEvent("bob", `C:\foo.exe`), limiter, hb, nil)
-	handleEvent(sampleEvent("alice", `C:\bar.exe`), limiter, hb, nil)
+	handleEvent(context.Background(), sampleEvent("alice", `C:\foo.exe`), limiter, hb, nil, nil)
+	handleEvent(context.Background(), sampleEvent("bob", `C:\foo.exe`), limiter, hb, nil, nil)
+	handleEvent(context.Background(), sampleEvent("alice", `C:\bar.exe`), limiter, hb, nil, nil)
 
 	if got := len(hb.Received()); got != 3 {
 		t.Fatalf("expected 3 distinct posts, got %d", got)
@@ -114,7 +136,7 @@ func TestHandleEventPostFailureEnqueues(t *testing.T) {
 	limiter := ipc.NewRateLimiter(1, dedupeWindow)
 
 	ev := sampleEvent("alice", `C:\foo.exe`)
-	handleEvent(ev, limiter, hb, q)
+	handleEvent(context.Background(), ev, limiter, hb, q, nil)
 
 	n, err := q.Len()
 	if err != nil {
@@ -140,7 +162,7 @@ func TestHandleEventOpportunisticDrainAfterSuccess(t *testing.T) {
 
 	limiter := ipc.NewRateLimiter(1, dedupeWindow)
 	live := sampleEvent("alice", `C:\live.exe`)
-	handleEvent(live, limiter, hb, q)
+	handleEvent(context.Background(), live, limiter, hb, q, nil)
 
 	received := hb.Received()
 	if len(received) != 2 {
@@ -166,7 +188,7 @@ func TestHandleEventDroppedWhenInterceptionDisabled(t *testing.T) {
 	limiter := ipc.NewRateLimiter(1, dedupeWindow)
 
 	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
-	handleEvent(ev, limiter, hb, nil)
+	handleEvent(context.Background(), ev, limiter, hb, nil, nil)
 	if got := len(hb.Received()); got != 0 {
 		t.Fatalf("expected 0 posts while interception disabled, got %d", got)
 	}
@@ -177,7 +199,7 @@ func TestHandleEventDroppedWhenInterceptionDisabled(t *testing.T) {
 	// dedupe window before a disable would still be deduped — the guard
 	// guarantees drops are free, not that re-enables always post.)
 	hb.disabled.Store(false)
-	handleEvent(ev, limiter, hb, nil)
+	handleEvent(context.Background(), ev, limiter, hb, nil, nil)
 	if got := len(hb.Received()); got != 1 {
 		t.Fatalf("expected 1 post after re-enable, got %d", got)
 	}
@@ -201,9 +223,9 @@ func TestHandleEventDropCounterAndReenableReset(t *testing.T) {
 	ev2 := sampleEvent("bob", `C:\Windows\System32\cmd.exe`)
 	ev3 := sampleEvent("carol", `C:\foo.exe`)
 
-	handleEvent(ev1, limiter, hb, nil)
-	handleEvent(ev2, limiter, hb, nil)
-	handleEvent(ev3, limiter, hb, nil)
+	handleEvent(context.Background(), ev1, limiter, hb, nil, nil)
+	handleEvent(context.Background(), ev2, limiter, hb, nil, nil)
+	handleEvent(context.Background(), ev3, limiter, hb, nil, nil)
 
 	if got := dropCounter.Load(); got != 3 {
 		t.Fatalf("expected dropCounter=3 after 3 disabled drops, got %d", got)
@@ -218,7 +240,7 @@ func TestHandleEventDropCounterAndReenableReset(t *testing.T) {
 	// Re-enable and send a new (unique) event — this should post and reset drop state.
 	hb.disabled.Store(false)
 	evNew := sampleEvent("dave", `C:\unique.exe`)
-	handleEvent(evNew, limiter, hb, nil)
+	handleEvent(context.Background(), evNew, limiter, hb, nil, nil)
 
 	if got := len(hb.Received()); got != 1 {
 		t.Fatalf("expected 1 post after re-enable, got %d", got)
@@ -243,7 +265,7 @@ func TestStartReturnsOnContextCancel(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- Start(ctx, sub, hb)
+		done <- Start(ctx, sub, hb, nil)
 	}()
 
 	// Inject one event so we exercise the dispatch path before cancelling.
@@ -262,5 +284,76 @@ func TestStartReturnsOnContextCancel(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("Start did not return after context cancel")
+	}
+}
+
+// TestHandleEventInvokesPamRunnerOnSuccess verifies that after a successful
+// post returning an actionable outcome, the PamRunner is invoked exactly once
+// with that outcome.
+func TestHandleEventInvokesPamRunnerOnSuccess(t *testing.T) {
+	hb := &fakeHB{outcome: ElevationOutcome{RequestID: "r1", Status: "auto_approved"}}
+	limiter := ipc.NewRateLimiter(1, dedupeWindow)
+	pam := &fakePamRunner{}
+
+	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+	handleEvent(context.Background(), ev, limiter, hb, nil, pam)
+
+	if got := len(hb.Received()); got != 1 {
+		t.Fatalf("expected 1 post, got %d", got)
+	}
+	calls := pam.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected PamRunner invoked once, got %d", len(calls))
+	}
+	if calls[0].RequestID != "r1" || calls[0].Status != "auto_approved" {
+		t.Fatalf("PamRunner got wrong outcome: %+v", calls[0])
+	}
+}
+
+// TestHandleEventSkipsPamRunnerWhenIgnored verifies the runner is NOT invoked
+// when the server suppressed the request (status "ignored", empty RequestID).
+func TestHandleEventSkipsPamRunnerWhenIgnored(t *testing.T) {
+	hb := &fakeHB{outcome: ElevationOutcome{RequestID: "", Status: "ignored"}}
+	limiter := ipc.NewRateLimiter(1, dedupeWindow)
+	pam := &fakePamRunner{}
+
+	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+	handleEvent(context.Background(), ev, limiter, hb, nil, pam)
+
+	if got := len(hb.Received()); got != 1 {
+		t.Fatalf("expected 1 post (post still happens), got %d", got)
+	}
+	if got := len(pam.Calls()); got != 0 {
+		t.Fatalf("expected PamRunner NOT invoked for ignored outcome, got %d calls", got)
+	}
+}
+
+// TestHandleEventSkipsPamRunnerWhenNil verifies a nil PamRunner is a no-op
+// (detection + post only) and does not panic.
+func TestHandleEventSkipsPamRunnerWhenNil(t *testing.T) {
+	hb := &fakeHB{outcome: ElevationOutcome{RequestID: "r2", Status: "pending"}}
+	limiter := ipc.NewRateLimiter(1, dedupeWindow)
+
+	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+	handleEvent(context.Background(), ev, limiter, hb, nil, nil)
+
+	if got := len(hb.Received()); got != 1 {
+		t.Fatalf("expected 1 post with nil runner, got %d", got)
+	}
+}
+
+// TestHandleEventDoesNotInvokeRunnerOnPostFailure verifies the runner is NOT
+// invoked when the post fails (the event is queued instead).
+func TestHandleEventDoesNotInvokeRunnerOnPostFailure(t *testing.T) {
+	hb := &fakeHB{outcome: ElevationOutcome{RequestID: "r3", Status: "auto_approved"}}
+	hb.failNext.Store(1)
+	limiter := ipc.NewRateLimiter(1, dedupeWindow)
+	pam := &fakePamRunner{}
+
+	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+	handleEvent(context.Background(), ev, limiter, hb, nil, pam)
+
+	if got := len(pam.Calls()); got != 0 {
+		t.Fatalf("expected PamRunner NOT invoked on post failure, got %d calls", got)
 	}
 }

--- a/agent/internal/etwlua/etwlua_test.go
+++ b/agent/internal/etwlua/etwlua_test.go
@@ -25,18 +25,18 @@ func (f *fakeHB) IsUACInterceptionEnabled() bool {
 	return !f.disabled.Load()
 }
 
-func (f *fakeHB) SendElevationRequest(req Event) error {
+func (f *fakeHB) SendElevationRequest(req Event) (ElevationOutcome, error) {
 	if remaining := f.failNext.Load(); remaining > 0 {
 		f.failNext.Add(-1)
 		if f.failErr != nil {
-			return f.failErr
+			return ElevationOutcome{}, f.failErr
 		}
-		return errors.New("fakeHB: forced failure")
+		return ElevationOutcome{}, errors.New("fakeHB: forced failure")
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.received = append(f.received, req)
-	return nil
+	return ElevationOutcome{}, nil
 }
 
 func (f *fakeHB) Received() []Event {

--- a/agent/internal/etwlua/etwlua_test.go
+++ b/agent/internal/etwlua/etwlua_test.go
@@ -368,8 +368,8 @@ func TestHandleEventDoesNotInvokeRunnerOnPostFailure(t *testing.T) {
 // TestHandleEventReassertsDedupeAfterLongFlow proves the post-flow re-record:
 // RunPamFlow can block longer than the dedupe window (a real PAM dialog waits
 // up to ~90s, the window is 30s). Without re-recording the dedupe key at
-// flow-end, the original arrival entry expires during the flow and a buffered
-// re-fire drained right after sails past the now-stale window and triggers a
+// flow-end, the original arrival entry expires during the flow and a live event
+// re-fired right after sails past the now-stale window and triggers a
 // redundant second flow. We use a short window and a flow that outlasts it: the
 // second handleEvent for the same key must be deduped by the flow-end re-record.
 func TestHandleEventReassertsDedupeAfterLongFlow(t *testing.T) {

--- a/agent/internal/etwlua/etwlua_test.go
+++ b/agent/internal/etwlua/etwlua_test.go
@@ -53,9 +53,16 @@ func (f *fakeHB) Received() []Event {
 type fakePamRunner struct {
 	mu       sync.Mutex
 	outcomes []ElevationOutcome
+	// delay simulates a long-running flow (e.g. a blocking PAM dialog). When
+	// longer than the dedupe window it lets a test prove the post-flow re-record
+	// restarts the dedupe window from flow-end.
+	delay time.Duration
 }
 
 func (f *fakePamRunner) RunPamFlow(_ context.Context, _ Event, outcome ElevationOutcome) {
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.outcomes = append(f.outcomes, outcome)
@@ -355,5 +362,33 @@ func TestHandleEventDoesNotInvokeRunnerOnPostFailure(t *testing.T) {
 
 	if got := len(pam.Calls()); got != 0 {
 		t.Fatalf("expected PamRunner NOT invoked on post failure, got %d calls", got)
+	}
+}
+
+// TestHandleEventReassertsDedupeAfterLongFlow proves the post-flow re-record:
+// RunPamFlow can block longer than the dedupe window (a real PAM dialog waits
+// up to ~90s, the window is 30s). Without re-recording the dedupe key at
+// flow-end, the original arrival entry expires during the flow and a buffered
+// re-fire drained right after sails past the now-stale window and triggers a
+// redundant second flow. We use a short window and a flow that outlasts it: the
+// second handleEvent for the same key must be deduped by the flow-end re-record.
+func TestHandleEventReassertsDedupeAfterLongFlow(t *testing.T) {
+	const window = 60 * time.Millisecond
+	hb := &fakeHB{outcome: ElevationOutcome{RequestID: "r-long", Status: "auto_approved"}}
+	limiter := ipc.NewRateLimiter(1, window)
+	// Flow outlasts the window: the arrival entry recorded at line 282 will have
+	// expired by the time the flow returns, so the post-flow re-record is the
+	// only thing that can suppress an immediate re-fire.
+	pam := &fakePamRunner{delay: 2 * window}
+
+	ev := sampleEvent("alice", `C:\Windows\System32\mmc.exe`)
+
+	// First event: posts, runs the (long) flow, and on return re-records the key.
+	handleEvent(context.Background(), ev, limiter, hb, nil, pam)
+	// Immediate re-fire of the SAME key: must be deduped by the flow-end record.
+	handleEvent(context.Background(), ev, limiter, hb, nil, pam)
+
+	if got := len(pam.Calls()); got != 1 {
+		t.Fatalf("expected RunPamFlow invoked once (re-fire deduped by flow-end re-record), got %d", got)
 	}
 }

--- a/agent/internal/etwlua/queue.go
+++ b/agent/internal/etwlua/queue.go
@@ -118,7 +118,7 @@ func (q *Queue) Drain(hb HeartbeatPoster) (int, error) {
 			posted++
 			continue
 		}
-		if err := hb.SendElevationRequest(ev); err != nil {
+		if _, err := hb.SendElevationRequest(ev); err != nil {
 			// Keep this and everything after; stop draining.
 			kept = append(kept, events[i:]...)
 			break

--- a/agent/internal/heartbeat/handlers_actuate.go
+++ b/agent/internal/heartbeat/handlers_actuate.go
@@ -95,8 +95,9 @@ func handleActuateElevation(h *Heartbeat, cmd Command) tools.CommandResult {
 }
 
 // actuateElevation runs the dormant-admin promote → consent.exe type →
-// guaranteed-demote pipeline and returns the actuator result. Shared by the
-// remote actuate_elevation command handler and the local etwlua-driven flow.
+// guaranteed-demote pipeline and returns the actuator result. Called by the
+// remote actuate_elevation command handler, and (Task 5) by the local
+// etwlua-driven flow — the receiver is on *Heartbeat so RunPamFlow can share it.
 func (h *Heartbeat) actuateElevation(ctx context.Context, requestID string, timeoutMs int) pamactuator.Result {
 	manager := newElevationAccountManager()
 	cred, err := manager.Promote(ctx)

--- a/agent/internal/heartbeat/handlers_actuate.go
+++ b/agent/internal/heartbeat/handlers_actuate.go
@@ -99,6 +99,13 @@ func handleActuateElevation(h *Heartbeat, cmd Command) tools.CommandResult {
 // remote actuate_elevation command handler, and (Task 5) by the local
 // etwlua-driven flow — the receiver is on *Heartbeat so RunPamFlow can share it.
 func (h *Heartbeat) actuateElevation(ctx context.Context, requestID string, timeoutMs int) pamactuator.Result {
+	// Serialize the whole promote→Trigger→demote critical section against any
+	// concurrent denyConsent (or a second actuateElevation): two goroutines
+	// driving SendInput/SetThreadDesktop against the same live consent.exe
+	// would corrupt input injection. See Heartbeat.pamActuateMu.
+	h.pamActuateMu.Lock()
+	defer h.pamActuateMu.Unlock()
+
 	manager := newElevationAccountManager()
 	cred, err := manager.Promote(ctx)
 	if err != nil {

--- a/agent/internal/heartbeat/handlers_actuate.go
+++ b/agent/internal/heartbeat/handlers_actuate.go
@@ -60,7 +60,7 @@ var newActuator = pamactuator.New
 // newElevationAccountManager is test-swappable for handler safety tests.
 var newElevationAccountManager = elevaccount.New
 
-func handleActuateElevation(_ *Heartbeat, cmd Command) tools.CommandResult {
+func handleActuateElevation(h *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
 
 	payload, err := parseActuatePayload(cmd.Payload)
@@ -78,36 +78,7 @@ func handleActuateElevation(_ *Heartbeat, cmd Command) tools.CommandResult {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*timeout)
 	defer cancel()
 
-	manager := newElevationAccountManager()
-	cred, err := manager.Promote(ctx)
-	if err != nil {
-		out := actuateResult{
-			ElevationRequestID: payload.ElevationRequestID,
-			Success:            false,
-			Reason:             promoteFailureReason(err),
-			Message:            err.Error(),
-		}
-		return tools.NewSuccessResult(out, time.Since(start).Milliseconds())
-	}
-	defer func() {
-		demoteCtx, demoteCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer demoteCancel()
-		if err := manager.Demote(demoteCtx); err != nil {
-			log.Warn("actuate_elevation: demote failed",
-				"elevationRequestId", payload.ElevationRequestID,
-				"error", err.Error(),
-			)
-		}
-	}()
-	defer zeroCredential(&cred)
-
-	act := newActuator()
-	res := act.Trigger(ctx, pamactuator.Request{
-		ElevationRequestID: payload.ElevationRequestID,
-		Username:           cred.Username,
-		Password:           cred.Password,
-		TimeoutMs:          payload.TimeoutMs,
-	})
+	res := h.actuateElevation(ctx, payload.ElevationRequestID, payload.TimeoutMs)
 
 	out := actuateResult{
 		ElevationRequestID: payload.ElevationRequestID,
@@ -121,6 +92,40 @@ func handleActuateElevation(_ *Heartbeat, cmd Command) tools.CommandResult {
 	// of the firmup: the server is the one deciding retry/escalate based
 	// on the Reason code, not the agent.
 	return tools.NewSuccessResult(out, time.Since(start).Milliseconds())
+}
+
+// actuateElevation runs the dormant-admin promote → consent.exe type →
+// guaranteed-demote pipeline and returns the actuator result. Shared by the
+// remote actuate_elevation command handler and the local etwlua-driven flow.
+func (h *Heartbeat) actuateElevation(ctx context.Context, requestID string, timeoutMs int) pamactuator.Result {
+	manager := newElevationAccountManager()
+	cred, err := manager.Promote(ctx)
+	if err != nil {
+		return pamactuator.Result{
+			Success:       false,
+			Reason:        promoteFailureReason(err),
+			DetailMessage: err.Error(),
+		}
+	}
+	defer func() {
+		demoteCtx, demoteCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer demoteCancel()
+		if err := manager.Demote(demoteCtx); err != nil {
+			log.Warn("actuate_elevation: demote failed",
+				"elevationRequestId", requestID,
+				"error", err.Error(),
+			)
+		}
+	}()
+	defer zeroCredential(&cred)
+
+	act := newActuator()
+	return act.Trigger(ctx, pamactuator.Request{
+		ElevationRequestID: requestID,
+		Username:           cred.Username,
+		Password:           cred.Password,
+		TimeoutMs:          timeoutMs,
+	})
 }
 
 // parseActuatePayload validates the incoming payload. Required fields:

--- a/agent/internal/heartbeat/handlers_actuate.go
+++ b/agent/internal/heartbeat/handlers_actuate.go
@@ -73,7 +73,7 @@ func handleActuateElevation(h *Heartbeat, cmd Command) tools.CommandResult {
 	// itself enforces its own deadline; this ctx is the belt-and-braces.
 	timeout := time.Duration(payload.TimeoutMs) * time.Millisecond
 	if timeout <= 0 {
-		timeout = 8 * time.Second
+		timeout = defaultActuateTimeoutMs * time.Millisecond
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*timeout)
 	defer cancel()

--- a/agent/internal/heartbeat/handlers_actuate_test.go
+++ b/agent/internal/heartbeat/handlers_actuate_test.go
@@ -44,7 +44,10 @@ func (a fakeActuator) Trigger(ctx context.Context, req pamactuator.Request) pama
 
 func (a fakeActuator) Dismiss(ctx context.Context) pamactuator.Result {
 	if a.dismiss == nil {
-		return pamactuator.Result{Success: true, Reason: "ok"}
+		// Fail-safe default matching the production non-windows stub, so a
+		// deny-path test that forgets to wire `dismiss` fails loud instead of
+		// silently reporting a successful dismissal.
+		return pamactuator.Result{Success: false, Reason: "unsupported_platform"}
 	}
 	return a.dismiss(ctx)
 }

--- a/agent/internal/heartbeat/handlers_actuate_test.go
+++ b/agent/internal/heartbeat/handlers_actuate_test.go
@@ -98,7 +98,7 @@ func TestHandleActuateElevationUsesLocalCredentialAndDemotes(t *testing.T) {
 		}}
 	})
 
-	result := handleActuateElevation(nil, Command{
+	result := handleActuateElevation(&Heartbeat{}, Command{
 		ID:   "cmd-1",
 		Type: tools.CmdActuateElevation,
 		Payload: map[string]any{
@@ -154,7 +154,7 @@ func TestHandleActuateElevationDemotesWhenActuatorPanics(t *testing.T) {
 		}
 	}()
 
-	_ = handleActuateElevation(nil, Command{
+	_ = handleActuateElevation(&Heartbeat{}, Command{
 		ID:   "cmd-1",
 		Type: tools.CmdActuateElevation,
 		Payload: map[string]any{
@@ -174,7 +174,7 @@ func TestHandleActuateElevationPromoteFailureReturnsStructuredResult(t *testing.
 		}}
 	})
 
-	result := handleActuateElevation(nil, Command{
+	result := handleActuateElevation(&Heartbeat{}, Command{
 		ID:   "cmd-1",
 		Type: tools.CmdActuateElevation,
 		Payload: map[string]any{

--- a/agent/internal/heartbeat/handlers_actuate_test.go
+++ b/agent/internal/heartbeat/handlers_actuate_test.go
@@ -35,10 +35,18 @@ func (m *fakeElevationManager) Demote(context.Context) error {
 
 type fakeActuator struct {
 	trigger func(context.Context, pamactuator.Request) pamactuator.Result
+	dismiss func(context.Context) pamactuator.Result
 }
 
 func (a fakeActuator) Trigger(ctx context.Context, req pamactuator.Request) pamactuator.Result {
 	return a.trigger(ctx, req)
+}
+
+func (a fakeActuator) Dismiss(ctx context.Context) pamactuator.Result {
+	if a.dismiss == nil {
+		return pamactuator.Result{Success: true, Reason: "ok"}
+	}
+	return a.dismiss(ctx)
 }
 
 func TestParseActuatePayloadAcceptsSlimGoSignal(t *testing.T) {

--- a/agent/internal/heartbeat/handlers_elevation.go
+++ b/agent/internal/heartbeat/handlers_elevation.go
@@ -25,10 +25,10 @@ import (
 // interface; IsUACInterceptionEnabled lives in heartbeat.go. Together they
 // satisfy the full interface so etwlua doesn't need to import the heartbeat
 // package.
-func (h *Heartbeat) SendElevationRequest(req etwlua.Event) error {
+func (h *Heartbeat) SendElevationRequest(req etwlua.Event) (etwlua.ElevationOutcome, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return fmt.Errorf("marshal elevation request: %w", err)
+		return etwlua.ElevationOutcome{}, fmt.Errorf("marshal elevation request: %w", err)
 	}
 
 	url := fmt.Sprintf("%s/api/v1/agents/%s/elevation-requests", h.config.ServerURL, h.config.AgentID)
@@ -42,13 +42,24 @@ func (h *Heartbeat) SendElevationRequest(req etwlua.Event) error {
 
 	resp, err := httputil.Do(ctx, h.httpClient(), "POST", url, body, headers, h.retryCfg)
 	if err != nil {
-		return fmt.Errorf("post elevation request: %w", err)
+		return etwlua.ElevationOutcome{}, fmt.Errorf("post elevation request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("elevation-requests returned status %d: %s", resp.StatusCode, string(errBody))
+		return etwlua.ElevationOutcome{}, fmt.Errorf("elevation-requests returned status %d: %s", resp.StatusCode, string(errBody))
 	}
-	return nil
+
+	// The post succeeded. Parse the server's ingest decision from the body
+	// {"id":"<uuid>","status":"<status>"}. A malformed or empty body is not
+	// fatal — the request was accepted, so we return whatever parsed (possibly
+	// zero values) and ignore the unmarshal error.
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var decoded struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	_ = json.Unmarshal(respBody, &decoded)
+	return etwlua.ElevationOutcome{RequestID: decoded.ID, Status: decoded.Status}, nil
 }

--- a/agent/internal/heartbeat/handlers_elevation.go
+++ b/agent/internal/heartbeat/handlers_elevation.go
@@ -1,6 +1,7 @@
 package heartbeat
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -60,6 +61,13 @@ func (h *Heartbeat) SendElevationRequest(req etwlua.Event) (etwlua.ElevationOutc
 		ID     string `json:"id"`
 		Status string `json:"status"`
 	}
-	_ = json.Unmarshal(respBody, &decoded)
-	return etwlua.ElevationOutcome{RequestID: decoded.ID, Status: decoded.Status}, nil
+	if uerr := json.Unmarshal(respBody, &decoded); uerr != nil && len(bytes.TrimSpace(respBody)) > 0 {
+		// The request was accepted (2xx) but the ingest-decision body did not
+		// parse. Non-fatal — we still return a zero-value outcome and nil error
+		// so the event is not re-queued — but warn so a server-contract drift is
+		// observable instead of the local PAM flow silently never starting.
+		log.Warn("elevation-requests: accepted but ingest-decision body unparseable; local PAM flow will be skipped",
+			"statusCode", resp.StatusCode, "error", uerr.Error())
+	}
+	return etwlua.ElevationOutcome{RequestID: decoded.ID, Status: etwlua.ElevationStatus(decoded.Status)}, nil
 }

--- a/agent/internal/heartbeat/handlers_elevation_test.go
+++ b/agent/internal/heartbeat/handlers_elevation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/etwlua"
+	"github.com/breeze-rmm/agent/internal/httputil"
 )
 
 func sampleElevationEvent() etwlua.Event {
@@ -52,10 +53,15 @@ func TestSendElevationRequestParsesIngestDecision(t *testing.T) {
 
 // TestSendElevationRequestErrorsOnServerError exercises the retry-exhaustion
 // path: 500 is a retryable status (httputil.isRetryableStatus), so httputil.Do
-// burns all DefaultRetryConfig retries (~7s of real backoff) and finally returns
-// a non-nil error. SendElevationRequest then hits the post-Do error branch
-// (handlers_elevation.go:44-46). It does NOT cover the non-2xx status branch —
-// see TestSendElevationRequestErrorsOnNonRetryableStatus for that.
+// makes its attempts and finally returns a non-nil error. SendElevationRequest
+// then hits the post-Do error branch (handlers_elevation.go:44-46). It does NOT
+// cover the non-2xx status branch — see
+// TestSendElevationRequestErrorsOnNonRetryableStatus for that.
+//
+// We pin MaxRetries:0 so the test makes a single attempt and returns in ~ms
+// instead of burning DefaultRetryConfig's ~7s of real backoff (1+2+4s). The
+// retryable-500 error branch is identical with 0 retries — Do still returns a
+// non-nil error after the lone attempt — so the assertion is unchanged.
 func TestSendElevationRequestErrorsOnServerError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -68,10 +74,18 @@ func TestSendElevationRequestErrorsOnServerError(t *testing.T) {
 		ServerURL: ts.URL,
 		AuthToken: "token",
 	}, "test", nil, nil)
+	h.retryCfg = httputil.RetryConfig{MaxRetries: 0}
 
+	start := time.Now()
 	_, err := h.SendElevationRequest(sampleElevationEvent())
+	elapsed := time.Since(start)
+
 	if err == nil {
 		t.Fatal("SendElevationRequest returned nil error on 500, want non-nil")
+	}
+	// With MaxRetries:0 there is no backoff sleep, so this must return fast.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("500 with MaxRetries:0 took %s, want fast (no backoff)", elapsed)
 	}
 }
 

--- a/agent/internal/heartbeat/handlers_elevation_test.go
+++ b/agent/internal/heartbeat/handlers_elevation_test.go
@@ -3,6 +3,7 @@ package heartbeat
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +50,12 @@ func TestSendElevationRequestParsesIngestDecision(t *testing.T) {
 	}
 }
 
+// TestSendElevationRequestErrorsOnServerError exercises the retry-exhaustion
+// path: 500 is a retryable status (httputil.isRetryableStatus), so httputil.Do
+// burns all DefaultRetryConfig retries (~7s of real backoff) and finally returns
+// a non-nil error. SendElevationRequest then hits the post-Do error branch
+// (handlers_elevation.go:44-46). It does NOT cover the non-2xx status branch —
+// see TestSendElevationRequestErrorsOnNonRetryableStatus for that.
 func TestSendElevationRequestErrorsOnServerError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -65,5 +72,81 @@ func TestSendElevationRequestErrorsOnServerError(t *testing.T) {
 	_, err := h.SendElevationRequest(sampleElevationEvent())
 	if err == nil {
 		t.Fatal("SendElevationRequest returned nil error on 500, want non-nil")
+	}
+}
+
+// TestSendElevationRequestErrorsOnNonRetryableStatus covers the non-2xx status
+// branch (handlers_elevation.go:49-52). 403 is NOT a retryable status, so
+// httputil.Do returns the response immediately (no retries, no backoff sleep)
+// and SendElevationRequest builds the "elevation-requests returned status %d"
+// error itself. This is the fast counterpart to the 500 retry-exhaustion test.
+func TestSendElevationRequestErrorsOnNonRetryableStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"nope"}`))
+	}))
+	defer ts.Close()
+
+	h := NewWithVersion(&config.Config{
+		AgentID:   "agent-1",
+		ServerURL: ts.URL,
+		AuthToken: "token",
+	}, "test", nil, nil)
+
+	start := time.Now()
+	_, err := h.SendElevationRequest(sampleElevationEvent())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("SendElevationRequest returned nil error on 403, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Fatalf("error %q does not mention status code 403", err.Error())
+	}
+	// 403 must short-circuit without burning retry backoff. DefaultRetryConfig's
+	// first retry alone sleeps ~1s, so anything over a few hundred ms means we
+	// wrongly retried.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("non-retryable 403 took %s, want fast (no retries)", elapsed)
+	}
+}
+
+// TestSendElevationRequestMalformedBodyIsNonFatal locks in the deliberate
+// non-fatal-unmarshal decision (handlers_elevation.go:54-64): a 201 with a junk
+// or empty body must still return err == nil and a zero-value ElevationOutcome,
+// because the request was accepted regardless of the body we can parse back.
+func TestSendElevationRequestMalformedBodyIsNonFatal(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"junk", "this is not json"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer ts.Close()
+
+			h := NewWithVersion(&config.Config{
+				AgentID:   "agent-1",
+				ServerURL: ts.URL,
+				AuthToken: "token",
+			}, "test", nil, nil)
+
+			outcome, err := h.SendElevationRequest(sampleElevationEvent())
+			if err != nil {
+				t.Fatalf("SendElevationRequest returned error on malformed 201 body: %v", err)
+			}
+			if outcome.RequestID != "" {
+				t.Fatalf("RequestID = %q, want empty (zero value)", outcome.RequestID)
+			}
+			if outcome.Status != "" {
+				t.Fatalf("Status = %q, want empty (zero value)", outcome.Status)
+			}
+		})
 	}
 }

--- a/agent/internal/heartbeat/handlers_elevation_test.go
+++ b/agent/internal/heartbeat/handlers_elevation_test.go
@@ -1,0 +1,69 @@
+package heartbeat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/etwlua"
+)
+
+func sampleElevationEvent() etwlua.Event {
+	return etwlua.Event{
+		SubjectUsername:      "CORP\\alice",
+		TargetExecutablePath: `C:\Windows\System32\cmd.exe`,
+		TargetExecutableHash: "deadbeef",
+		PID:                  4321,
+		ObservedAt:           time.Now().UTC(),
+	}
+}
+
+func TestSendElevationRequestParsesIngestDecision(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"req-123","status":"auto_approved"}`))
+	}))
+	defer ts.Close()
+
+	h := NewWithVersion(&config.Config{
+		AgentID:   "agent-1",
+		ServerURL: ts.URL,
+		AuthToken: "token",
+	}, "test", nil, nil)
+
+	outcome, err := h.SendElevationRequest(sampleElevationEvent())
+	if err != nil {
+		t.Fatalf("SendElevationRequest returned error: %v", err)
+	}
+	if outcome.RequestID != "req-123" {
+		t.Fatalf("RequestID = %q, want %q", outcome.RequestID, "req-123")
+	}
+	if outcome.Status != "auto_approved" {
+		t.Fatalf("Status = %q, want %q", outcome.Status, "auto_approved")
+	}
+}
+
+func TestSendElevationRequestErrorsOnServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer ts.Close()
+
+	h := NewWithVersion(&config.Config{
+		AgentID:   "agent-1",
+		ServerURL: ts.URL,
+		AuthToken: "token",
+	}, "test", nil, nil)
+
+	_, err := h.SendElevationRequest(sampleElevationEvent())
+	if err == nil {
+		t.Fatal("SendElevationRequest returned nil error on 500, want non-nil")
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -165,6 +165,10 @@ type Heartbeat struct {
 	helperFinder     func(targetSession string) *sessionbroker.Session
 	spawnHelper      func(targetSession string) error
 	killStaleHelpers func(staleKey string)
+	// pamFindSession / pamRequestDialog default to the real broker methods in
+	// RunPamFlow when nil; overridden in pam_flow_test.go.
+	pamFindSession   func(capability, targetWinSession string) *sessionbroker.Session
+	pamRequestDialog func(session *sessionbroker.Session, id string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error)
 	wsDesktopStart   func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
 	desktopOwners    sync.Map // desktop session ID -> helper session ID
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -169,6 +169,12 @@ type Heartbeat struct {
 	// RunPamFlow when nil; overridden in pam_flow_test.go.
 	pamFindSession   func(capability, targetWinSession string) *sessionbroker.Session
 	pamRequestDialog func(session *sessionbroker.Session, id string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error)
+	// pamActuateMu serializes consent.exe actuation/dismissal so the local
+	// etwlua flow (RunPamFlow) and the remote actuate_elevation command never
+	// drive SendInput/SetThreadDesktop against the same live consent.exe prompt
+	// concurrently (e.g. an await_remote technician approval firing
+	// actuate_elevation while a re-fired ETW event re-enters RunPamFlow).
+	pamActuateMu sync.Mutex
 	wsDesktopStart   func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
 	desktopOwners    sync.Map // desktop session ID -> helper session ID
 

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -94,15 +94,18 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 		// remote handler (handlers_actuate.go). Deriving from ctx (not
 		// context.Background) preserves agent-shutdown cancellation while
 		// adding a flow-scoped timeout so a stuck desktop can't pin the
-		// etwlua loop goroutine forever.
-		actCtx, cancel := context.WithTimeout(ctx, 2*defaultActuateTimeoutMs*time.Millisecond)
-		res := h.actuateElevation(actCtx, outcome.RequestID, defaultActuateTimeoutMs)
-		cancel()
-		if res.Success {
-			log.Info("pam: local actuation complete", "elevationRequestId", outcome.RequestID, "success", true, "reason", res.Reason)
-		} else {
-			log.Warn("pam: local actuation failed", "elevationRequestId", outcome.RequestID, "reason", res.Reason, "message", res.DetailMessage)
-		}
+		// etwlua loop goroutine forever. Wrapped in a closure so defer cancel
+		// releases the timer even if actuateElevation panics (recovered above).
+		func() {
+			actCtx, cancel := context.WithTimeout(ctx, 2*defaultActuateTimeoutMs*time.Millisecond)
+			defer cancel()
+			res := h.actuateElevation(actCtx, outcome.RequestID, defaultActuateTimeoutMs)
+			if res.Success {
+				log.Info("pam: local actuation complete", "elevationRequestId", outcome.RequestID, "success", true, "reason", res.Reason)
+			} else {
+				log.Warn("pam: local actuation failed", "elevationRequestId", outcome.RequestID, "reason", res.Reason, "message", res.DetailMessage)
+			}
+		}()
 	case sessionbroker.PamActionDeny:
 		h.denyConsent(ctx, outcome.RequestID, dialog.Reason)
 	case sessionbroker.PamActionAwaitRemote:

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -29,6 +29,19 @@ const (
 // path resolves remotely: the server issues an actuate_elevation command once
 // a technician approves.
 func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etwlua.ElevationOutcome) {
+	// RunPamFlow runs on the etwlua loop goroutine and reaches raw SendInput
+	// syscalls via the actuator — unlike the remote actuate path, there is no
+	// worker-pool recover() above it. A syscall panic here would crash the
+	// whole agent. Contain it: the credential-zeroing/demote defers inside
+	// actuateElevation still run during unwinding, so this is purely
+	// availability hardening, not a correctness shortcut.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("pam: panic in RunPamFlow; elevation flow aborted",
+				"elevationRequestId", outcome.RequestID, "panic", r)
+		}
+	}()
+
 	switch outcome.Status {
 	case "denied":
 		h.denyConsent(ctx, outcome.RequestID, "policy_denied") // policy hard-deny, no dialog
@@ -77,8 +90,19 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 
 	switch sessionbroker.ComposePamDecision(verdict, dialog, nil) {
 	case sessionbroker.PamActionActuate:
-		res := h.actuateElevation(ctx, outcome.RequestID, defaultActuateTimeoutMs)
-		log.Info("pam: local actuation complete", "elevationRequestId", outcome.RequestID, "success", res.Success, "reason", res.Reason)
+		// Bound the local actuation with a per-flow ceiling, mirroring the
+		// remote handler (handlers_actuate.go). Deriving from ctx (not
+		// context.Background) preserves agent-shutdown cancellation while
+		// adding a flow-scoped timeout so a stuck desktop can't pin the
+		// etwlua loop goroutine forever.
+		actCtx, cancel := context.WithTimeout(ctx, 2*defaultActuateTimeoutMs*time.Millisecond)
+		res := h.actuateElevation(actCtx, outcome.RequestID, defaultActuateTimeoutMs)
+		cancel()
+		if res.Success {
+			log.Info("pam: local actuation complete", "elevationRequestId", outcome.RequestID, "success", true, "reason", res.Reason)
+		} else {
+			log.Warn("pam: local actuation failed", "elevationRequestId", outcome.RequestID, "reason", res.Reason, "message", res.DetailMessage)
+		}
 	case sessionbroker.PamActionDeny:
 		h.denyConsent(ctx, outcome.RequestID, dialog.Reason)
 	case sessionbroker.PamActionAwaitRemote:
@@ -88,10 +112,21 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 
 // denyConsent cancels the live consent.exe prompt and logs the denial.
 func (h *Heartbeat) denyConsent(ctx context.Context, requestID, reason string) {
+	// Serialize the Dismiss against any concurrent actuateElevation so the two
+	// never drive SendInput against the same prompt at once. See pamActuateMu.
+	h.pamActuateMu.Lock()
 	res := newActuator().Dismiss(ctx)
-	log.Info("pam: denied elevation, dismissed consent prompt",
-		"elevationRequestId", requestID, "reason", reason,
-		"dismiss_success", res.Success, "dismiss_reason", res.Reason)
+	h.pamActuateMu.Unlock()
+
+	if res.Success {
+		log.Info("pam: denied elevation, dismissed consent prompt",
+			"elevationRequestId", requestID, "reason", reason,
+			"dismiss_success", true, "dismiss_reason", res.Reason)
+	} else {
+		log.Warn("pam: deny enforcement FAILED — consent.exe may still be live",
+			"elevationRequestId", requestID, "reason", reason,
+			"dismiss_reason", res.Reason, "dismiss_message", res.DetailMessage)
+	}
 }
 
 // buildPamRequestDialog maps a detected ETW event onto the dialog payload.
@@ -103,6 +138,11 @@ func buildPamRequestDialog(ev etwlua.Event) ipc.PamRequestDialog {
 		Hash:           ev.TargetExecutableHash,
 		SubjectUser:    ev.SubjectUsername,
 		CommandLine:    ev.CommandLine,
+		// TimeoutSeconds is informational only today: the authoritative
+		// round-trip timeout is enforced broker-side via the pamDialogTimeout
+		// arg to RequestPamApproval, and the user-helper MessageBox does not
+		// currently self-dismiss on this value. Populated for a future helper
+		// self-timeout — do not rely on it for enforcement.
 		TimeoutSeconds: int(pamDialogTimeout.Seconds()),
 	}
 }

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -43,13 +43,13 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 	}()
 
 	switch outcome.Status {
-	case "denied":
+	case etwlua.ElevationDenied:
 		h.denyConsent(ctx, outcome.RequestID, "policy_denied") // policy hard-deny, no dialog
 		return
-	case "auto_approved", "pending":
+	case etwlua.ElevationAutoApproved, etwlua.ElevationPending:
 		// fall through to the dialog gate
 	default:
-		log.Debug("pam: no local flow for status", "status", outcome.Status, "elevationRequestId", outcome.RequestID)
+		log.Debug("pam: no local flow for status", "status", string(outcome.Status), "elevationRequestId", outcome.RequestID)
 		return
 	}
 
@@ -80,12 +80,22 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 	dialog, err := ask(session, outcome.RequestID, buildPamRequestDialog(ev), pamDialogTimeout)
 	if err != nil {
 		log.Warn("pam: dialog round-trip error; treating as deny", "elevationRequestId", outcome.RequestID, "error", err.Error())
-		dialog = ipc.PamDialogResult{Approved: false, DismissedByUser: true}
+		dialog = ipc.PamDialogResult{Approved: false, DismissedByUser: true, Reason: "dialog_roundtrip_error"}
 	}
 
-	verdict := sessionbroker.PamPolicyEndUserAllowed
-	if outcome.Status == "pending" {
+	var verdict string
+	switch outcome.Status {
+	case etwlua.ElevationAutoApproved:
+		verdict = sessionbroker.PamPolicyEndUserAllowed
+	case etwlua.ElevationPending:
 		verdict = sessionbroker.PamPolicyRequireApproval
+	default:
+		// Unreachable today (the switch above only lets these two through),
+		// but fail closed if a new fall-through status is ever added upstream:
+		// never actuate on a status we don't recognize.
+		log.Warn("pam: unexpected status at verdict mapping; denying", "status", string(outcome.Status), "elevationRequestId", outcome.RequestID)
+		h.denyConsent(ctx, outcome.RequestID, "unexpected_status")
+		return
 	}
 
 	switch sessionbroker.ComposePamDecision(verdict, dialog, nil) {
@@ -121,11 +131,16 @@ func (h *Heartbeat) denyConsent(ctx context.Context, requestID, reason string) {
 	res := newActuator().Dismiss(ctx)
 	h.pamActuateMu.Unlock()
 
-	if res.Success {
+	switch {
+	case res.Success:
 		log.Info("pam: denied elevation, dismissed consent prompt",
-			"elevationRequestId", requestID, "reason", reason,
-			"dismiss_success", true, "dismiss_reason", res.Reason)
-	} else {
+			"elevationRequestId", requestID, "reason", reason, "dismiss_reason", res.Reason)
+	case res.Reason == "no_consent_window":
+		// Prompt already gone (user closed it, self-timeout, or a prior dismiss) —
+		// the deny is satisfied, not a failure.
+		log.Info("pam: deny — consent prompt already closed",
+			"elevationRequestId", requestID, "reason", reason)
+	default:
 		log.Warn("pam: deny enforcement FAILED — consent.exe may still be live",
 			"elevationRequestId", requestID, "reason", reason,
 			"dismiss_reason", res.Reason, "dismiss_message", res.DetailMessage)
@@ -136,11 +151,11 @@ func (h *Heartbeat) denyConsent(ctx context.Context, requestID, reason string) {
 // Reason/IntentSummary are left empty (AI intent summary is Phase 2).
 func buildPamRequestDialog(ev etwlua.Event) ipc.PamRequestDialog {
 	return ipc.PamRequestDialog{
-		ExePath:        ev.TargetExecutablePath,
-		Signer:         ev.TargetExecutableSigner,
-		Hash:           ev.TargetExecutableHash,
-		SubjectUser:    ev.SubjectUsername,
-		CommandLine:    ev.CommandLine,
+		ExePath:     ev.TargetExecutablePath,
+		Signer:      ev.TargetExecutableSigner,
+		Hash:        ev.TargetExecutableHash,
+		SubjectUser: ev.SubjectUsername,
+		CommandLine: ev.CommandLine,
 		// TimeoutSeconds is informational only today: the authoritative
 		// round-trip timeout is enforced broker-side via the pamDialogTimeout
 		// arg to RequestPamApproval, and the user-helper MessageBox does not

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -9,6 +9,9 @@ import (
 	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
 
+// Compile-time check that *Heartbeat satisfies the etwlua PamRunner contract.
+var _ etwlua.PamRunner = (*Heartbeat)(nil)
+
 const (
 	// pamDialogTimeout bounds the broker round-trip to comfortably under
 	// consent.exe's idle lifetime (~120s default). Timeout → deny+dismiss
@@ -34,6 +37,15 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 		// fall through to the dialog gate
 	default:
 		log.Debug("pam: no local flow for status", "status", outcome.Status, "elevationRequestId", outcome.RequestID)
+		return
+	}
+
+	// Defensive: the PamRunner contract (see etwlua.PamRunner) says the caller
+	// passes a nil runner when the broker is absent. Guard anyway so a wiring
+	// slip can't panic the ETW hot path — only the dialog path needs the broker.
+	if h.pamFindSession == nil && h.sessionBroker == nil {
+		log.Warn("pam: no session broker available; skipping elevation flow",
+			"elevationRequestId", outcome.RequestID)
 		return
 	}
 

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -1,0 +1,96 @@
+package heartbeat
+
+import (
+	"context"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/etwlua"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+const (
+	// pamDialogTimeout bounds the broker round-trip to comfortably under
+	// consent.exe's idle lifetime (~120s default). Timeout → deny+dismiss
+	// (RequestPamApproval already returns that on timeout).
+	pamDialogTimeout = 90 * time.Second
+	// defaultActuateTimeoutMs is the per-actuation consent.exe wait, matching
+	// the remote handler's fallback.
+	defaultActuateTimeoutMs = 8000
+)
+
+// RunPamFlow implements etwlua.PamRunner. Given the server's ingest decision
+// for a detected UAC prompt, it shows the user-desktop PAM dialog (when the
+// status warrants it), composes the decision, and either actuates locally
+// (end-user-allowed) or dismisses consent.exe (deny). The require-approval
+// path resolves remotely: the server issues an actuate_elevation command once
+// a technician approves.
+func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etwlua.ElevationOutcome) {
+	switch outcome.Status {
+	case "denied":
+		h.denyConsent(ctx, outcome.RequestID, "policy_denied") // policy hard-deny, no dialog
+		return
+	case "auto_approved", "pending":
+		// fall through to the dialog gate
+	default:
+		log.Debug("pam: no local flow for status", "status", outcome.Status, "elevationRequestId", outcome.RequestID)
+		return
+	}
+
+	find := h.pamFindSession
+	if find == nil {
+		find = h.sessionBroker.FindCapableSession
+	}
+	session := find(ipc.ScopePam, "")
+	if session == nil {
+		log.Warn("pam: no capable user-helper session; cannot show dialog, consent.exe will time out",
+			"elevationRequestId", outcome.RequestID)
+		return
+	}
+
+	ask := h.pamRequestDialog
+	if ask == nil {
+		ask = h.sessionBroker.RequestPamApproval
+	}
+	dialog, err := ask(session, outcome.RequestID, buildPamRequestDialog(ev), pamDialogTimeout)
+	if err != nil {
+		log.Warn("pam: dialog round-trip error; treating as deny", "elevationRequestId", outcome.RequestID, "error", err.Error())
+		dialog = ipc.PamDialogResult{Approved: false, DismissedByUser: true}
+	}
+
+	verdict := sessionbroker.PamPolicyEndUserAllowed
+	if outcome.Status == "pending" {
+		verdict = sessionbroker.PamPolicyRequireApproval
+	}
+
+	switch sessionbroker.ComposePamDecision(verdict, dialog, nil) {
+	case sessionbroker.PamActionActuate:
+		res := h.actuateElevation(ctx, outcome.RequestID, defaultActuateTimeoutMs)
+		log.Info("pam: local actuation complete", "elevationRequestId", outcome.RequestID, "success", res.Success, "reason", res.Reason)
+	case sessionbroker.PamActionDeny:
+		h.denyConsent(ctx, outcome.RequestID, dialog.Reason)
+	case sessionbroker.PamActionAwaitRemote:
+		log.Info("pam: awaiting remote technician approval; server will issue actuate_elevation", "elevationRequestId", outcome.RequestID)
+	}
+}
+
+// denyConsent cancels the live consent.exe prompt and logs the denial.
+func (h *Heartbeat) denyConsent(ctx context.Context, requestID, reason string) {
+	res := newActuator().Dismiss(ctx)
+	log.Info("pam: denied elevation, dismissed consent prompt",
+		"elevationRequestId", requestID, "reason", reason,
+		"dismiss_success", res.Success, "dismiss_reason", res.Reason)
+}
+
+// buildPamRequestDialog maps a detected ETW event onto the dialog payload.
+// Reason/IntentSummary are left empty (AI intent summary is Phase 2).
+func buildPamRequestDialog(ev etwlua.Event) ipc.PamRequestDialog {
+	return ipc.PamRequestDialog{
+		ExePath:        ev.TargetExecutablePath,
+		Signer:         ev.TargetExecutableSigner,
+		Hash:           ev.TargetExecutableHash,
+		SubjectUser:    ev.SubjectUsername,
+		CommandLine:    ev.CommandLine,
+		TimeoutSeconds: int(pamDialogTimeout.Seconds()),
+	}
+}

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -20,24 +20,35 @@ func TestRunPamFlow(t *testing.T) {
 	dismissed := ipc.PamDialogResult{Approved: false, DismissedByUser: true}
 
 	cases := []struct {
-		name          string
-		status        string
-		dialog        ipc.PamDialogResult
+		name   string
+		status etwlua.ElevationStatus
+		dialog ipc.PamDialogResult
 		// returnErr, when non-nil, is returned by the pamRequestDialog seam to
 		// simulate a broker round-trip failure. RunPamFlow must coerce that to
 		// deny+dismiss regardless of the (ignored) dialog result.
-		returnErr     error
-		noSession     bool
+		returnErr error
+		noSession bool
 		// noBroker builds the heartbeat with nil swappable fields (pamFindSession,
 		// pamRequestDialog) AND a nil sessionBroker, reproducing production wiring
 		// where the broker is absent. Proves RunPamFlow never panics in that shape.
-		noBroker      bool
+		noBroker bool
 		// wantDialog asserts whether the broker dialog round-trip was reached.
 		wantDialog    bool
 		wantTriggered bool
 		wantDismissed bool
 		// wantActuated asserts the promote→demote credential pipeline ran.
 		wantActuated bool
+		// promoteErr, when non-nil, makes the fake elevation manager's Promote
+		// fail. actuateElevation returns early (no Trigger, no deferred Demote),
+		// proving RunPamFlow tolerates a failed actuation cleanly.
+		promoteErr error
+		// wantPromoteAttempt asserts Promote was called exactly once even though
+		// the actuation did not complete (used with promoteErr).
+		wantPromoteAttempt bool
+		// dismissResult, when non-nil, overrides the fake actuator's Dismiss
+		// return so the deny-path logging switch can be exercised against the
+		// benign "no_consent_window" and the genuine-failure reasons.
+		dismissResult *pamactuator.Result
 	}{
 		{
 			name:          "policy hard-deny dismisses without dialog",
@@ -142,6 +153,49 @@ func TestRunPamFlow(t *testing.T) {
 			wantDismissed: false,
 			wantActuated:  false,
 		},
+		{
+			// FIX I: auto-approved + user-approved, but the credential Promote
+			// fails (e.g. ErrUnsupportedPlatform). actuateElevation returns the
+			// failure early — Trigger is never reached as success, no Demote runs,
+			// and no spurious dismiss occurs. Proves the local flow tolerates a
+			// failed actuation cleanly without panicking.
+			name:               "auto-approved promote failure tolerated, no dismiss",
+			status:             "auto_approved",
+			dialog:             approved,
+			promoteErr:         elevaccount.ErrUnsupportedPlatform,
+			wantDialog:         true,
+			wantTriggered:      false, // Promote fails before Trigger
+			wantDismissed:      false, // actuate path never dismisses
+			wantActuated:       false, // promote→demote pipeline did not complete
+			wantPromoteAttempt: true,  // Promote attempted exactly once
+		},
+		{
+			// FIX B: deny path where Dismiss reports the prompt was already gone.
+			// no_consent_window is the desired deny end-state, not a failure — the
+			// flow must not panic and must still have invoked Dismiss. (The only
+			// observable difference vs a hard failure is log level.)
+			name:          "deny with dismiss no_consent_window is benign",
+			status:        "denied",
+			dialog:        approved, // ignored — denied short-circuits
+			dismissResult: &pamactuator.Result{Success: false, Reason: "no_consent_window"},
+			wantDialog:    false,
+			wantTriggered: false,
+			wantDismissed: true,
+			wantActuated:  false,
+		},
+		{
+			// FIX B: deny path where Dismiss genuinely failed (send_input_failed).
+			// This is the real "enforcement FAILED" case; the flow must still not
+			// panic and must have invoked Dismiss.
+			name:          "deny with dismiss send_input_failed does not panic",
+			status:        "denied",
+			dialog:        approved, // ignored
+			dismissResult: &pamactuator.Result{Success: false, Reason: "send_input_failed"},
+			wantDialog:    false,
+			wantTriggered: false,
+			wantDismissed: true,
+			wantActuated:  false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -157,13 +211,17 @@ func TestRunPamFlow(t *testing.T) {
 					},
 					dismiss: func(context.Context) pamactuator.Result {
 						dismissed = true
+						if tc.dismissResult != nil {
+							return *tc.dismissResult
+						}
 						return pamactuator.Result{Success: true, Reason: "dismissed"}
 					},
 				}
 			})
 
 			manager := &fakeElevationManager{
-				cred: elevaccount.Credential{Username: "~breeze_elev", Password: "x"},
+				cred:       elevaccount.Credential{Username: "~breeze_elev", Password: "x"},
+				promoteErr: tc.promoteErr,
 			}
 			swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
 
@@ -220,10 +278,14 @@ func TestRunPamFlow(t *testing.T) {
 				t.Errorf("dialogCalled = %v, want %v", dialogCalled, tc.wantDialog)
 			}
 
-			// The actuate path runs Promote then a deferred Demote.
+			// The actuate path runs Promote then a deferred Demote. When Promote
+			// fails (promoteErr), actuateElevation returns before registering the
+			// Demote defer, so Promote is attempted once but Demote never runs.
 			wantPromote, wantDemote := 0, 0
 			if tc.wantActuated {
 				wantPromote, wantDemote = 1, 1
+			} else if tc.wantPromoteAttempt {
+				wantPromote = 1 // promote attempted, then failed → no Demote
 			}
 			if manager.promoteSeen != wantPromote {
 				t.Errorf("Promote called %d times, want %d", manager.promoteSeen, wantPromote)

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -2,6 +2,9 @@ package heartbeat
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +23,10 @@ func TestRunPamFlow(t *testing.T) {
 		name          string
 		status        string
 		dialog        ipc.PamDialogResult
+		// returnErr, when non-nil, is returned by the pamRequestDialog seam to
+		// simulate a broker round-trip failure. RunPamFlow must coerce that to
+		// deny+dismiss regardless of the (ignored) dialog result.
+		returnErr     error
 		noSession     bool
 		// noBroker builds the heartbeat with nil swappable fields (pamFindSession,
 		// pamRequestDialog) AND a nil sessionBroker, reproducing production wiring
@@ -112,15 +119,40 @@ func TestRunPamFlow(t *testing.T) {
 			wantDismissed: true,
 			wantActuated:  false,
 		},
+		{
+			// Broker round-trip error must fail safe: even an APPROVED dialog
+			// is overridden to deny+dismiss (pam_flow.go dialog-error branch).
+			name:          "dialog round-trip error coerces to deny+dismiss",
+			status:        "auto_approved",
+			dialog:        approved, // overridden by the error path
+			returnErr:     errors.New("broker pipe closed"),
+			wantDialog:    true, // the ask(...) seam was reached (and errored)
+			wantTriggered: false,
+			wantDismissed: true,
+			wantActuated:  false,
+		},
+		{
+			// Unknown/future status hits the inert default branch: no dialog,
+			// no actuation, no dismissal.
+			name:          "unknown status is inert (default branch)",
+			status:        "some_future_status",
+			dialog:        approved, // ignored
+			wantDialog:    false,
+			wantTriggered: false,
+			wantDismissed: false,
+			wantActuated:  false,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var triggered, dismissed bool
+			var gotRequest pamactuator.Request
 			swapActuatorForTest(t, func() pamactuator.Actuator {
 				return fakeActuator{
-					trigger: func(context.Context, pamactuator.Request) pamactuator.Result {
+					trigger: func(_ context.Context, req pamactuator.Request) pamactuator.Result {
 						triggered = true
+						gotRequest = req
 						return pamactuator.Result{Success: true, Reason: "ok"}
 					},
 					dismiss: func(context.Context) pamactuator.Result {
@@ -136,6 +168,8 @@ func TestRunPamFlow(t *testing.T) {
 			swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
 
 			var dialogCalled bool
+			var gotDialog ipc.PamRequestDialog
+			var gotDialogTimeout time.Duration
 			// noBroker reproduces production wiring: both swappable seams nil
 			// AND a nil sessionBroker. The defensive guard in RunPamFlow must
 			// keep this from dereferencing the nil broker.
@@ -150,18 +184,22 @@ func TestRunPamFlow(t *testing.T) {
 					}
 					return &sessionbroker.Session{}
 				}
-				h.pamRequestDialog = func(_ *sessionbroker.Session, _ string, _ ipc.PamRequestDialog, _ time.Duration) (ipc.PamDialogResult, error) {
+				h.pamRequestDialog = func(_ *sessionbroker.Session, _ string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error) {
 					dialogCalled = true
-					return tc.dialog, nil
+					gotDialog = req
+					gotDialogTimeout = timeout
+					return tc.dialog, tc.returnErr
 				}
 			}
 
+			// Distinct, recognizable field values so a transposition (e.g.
+			// Signer↔Hash) in buildPamRequestDialog fails the mapping assertion.
 			ev := etwlua.Event{
-				SubjectUsername:        "CORP\\\\alice",
-				TargetExecutablePath:   `C:\Windows\regedit.exe`,
-				TargetExecutableHash:   "abc123",
-				TargetExecutableSigner: "Microsoft Windows",
-				CommandLine:            `regedit.exe`,
+				SubjectUsername:        "CORP\\subjectuser",
+				TargetExecutablePath:   `C:\path\to\target.exe`,
+				TargetExecutableHash:   "hash-deadbeef",
+				TargetExecutableSigner: "signer-Acme Corp",
+				CommandLine:            `target.exe --do-thing`,
 			}
 			outcome := etwlua.ElevationOutcome{RequestID: "req-1", Status: tc.status}
 
@@ -193,6 +231,142 @@ func TestRunPamFlow(t *testing.T) {
 			if manager.demoteSeen != wantDemote {
 				t.Errorf("Demote called %d times, want %d", manager.demoteSeen, wantDemote)
 			}
+
+			// FIX 3: whenever the dialog round-trip succeeds, assert the full
+			// ETW-event → PamRequestDialog field mapping. This guards a
+			// security-sensitive, compiler-invisible mapping (a Signer↔Hash
+			// transposition would silently mislabel the prompt to the user).
+			if tc.wantDialog && tc.returnErr == nil {
+				if gotDialog.ExePath != ev.TargetExecutablePath {
+					t.Errorf("dialog ExePath = %q, want %q", gotDialog.ExePath, ev.TargetExecutablePath)
+				}
+				if gotDialog.Signer != ev.TargetExecutableSigner {
+					t.Errorf("dialog Signer = %q, want %q", gotDialog.Signer, ev.TargetExecutableSigner)
+				}
+				if gotDialog.Hash != ev.TargetExecutableHash {
+					t.Errorf("dialog Hash = %q, want %q", gotDialog.Hash, ev.TargetExecutableHash)
+				}
+				if gotDialog.SubjectUser != ev.SubjectUsername {
+					t.Errorf("dialog SubjectUser = %q, want %q", gotDialog.SubjectUser, ev.SubjectUsername)
+				}
+				if gotDialog.CommandLine != ev.CommandLine {
+					t.Errorf("dialog CommandLine = %q, want %q", gotDialog.CommandLine, ev.CommandLine)
+				}
+				if gotDialog.TimeoutSeconds != 90 {
+					t.Errorf("dialog TimeoutSeconds = %d, want 90", gotDialog.TimeoutSeconds)
+				}
+				if gotDialogTimeout != pamDialogTimeout {
+					t.Errorf("dialog round-trip timeout = %v, want %v", gotDialogTimeout, pamDialogTimeout)
+				}
+			}
+
+			// FIX 7: on the actuate path, the actuator must receive the right
+			// Request — the same elevation request ID and the default timeout.
+			if tc.wantActuated {
+				if gotRequest.ElevationRequestID != outcome.RequestID {
+					t.Errorf("actuator Request.ElevationRequestID = %q, want %q", gotRequest.ElevationRequestID, outcome.RequestID)
+				}
+				if gotRequest.TimeoutMs != defaultActuateTimeoutMs {
+					t.Errorf("actuator Request.TimeoutMs = %d, want %d", gotRequest.TimeoutMs, defaultActuateTimeoutMs)
+				}
+			}
 		})
+	}
+}
+
+// TestActuateAndDenyMutuallyExclusive proves pamActuateMu serializes consent.exe
+// actuation against dismissal: a remote actuate_elevation (actuateElevation) and
+// a re-fired local deny (denyConsent) must never drive SendInput against the same
+// prompt concurrently. The fake trigger/dismiss closures flip a shared `inside`
+// flag on entry, sleep to widen the overlap window, and fail the test if they
+// observe another invocation already inside the critical section. Run with -race.
+func TestActuateAndDenyMutuallyExclusive(t *testing.T) {
+	var inside atomic.Bool
+	var violation atomic.Bool
+
+	// guarded wraps a fake actuator op: assert nobody else is inside, hold the
+	// section briefly to widen the race window, then clear the flag.
+	guarded := func() {
+		if !inside.CompareAndSwap(false, true) {
+			violation.Store(true) // someone else was already inside
+		}
+		time.Sleep(2 * time.Millisecond)
+		inside.Store(false)
+	}
+
+	swapActuatorForTest(t, func() pamactuator.Actuator {
+		return fakeActuator{
+			trigger: func(context.Context, pamactuator.Request) pamactuator.Result {
+				guarded()
+				return pamactuator.Result{Success: true, Reason: "ok"}
+			},
+			dismiss: func(context.Context) pamactuator.Result {
+				guarded()
+				return pamactuator.Result{Success: true, Reason: "dismissed"}
+			},
+		}
+	})
+	swapElevationManagerForTest(t, func() elevaccount.AccountManager {
+		return &fakeElevationManager{cred: elevaccount.Credential{Username: "~breeze_elev", Password: "x"}}
+	})
+
+	h := &Heartbeat{}
+
+	const iterations = 40
+	var wg sync.WaitGroup
+	for i := 0; i < iterations; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			h.actuateElevation(context.Background(), "req-actuate", defaultActuateTimeoutMs)
+		}()
+		go func() {
+			defer wg.Done()
+			h.denyConsent(context.Background(), "req-deny", "policy_denied")
+		}()
+	}
+	wg.Wait()
+
+	if violation.Load() {
+		t.Fatal("detected concurrent consent.exe actuation/dismissal — pamActuateMu is not serializing")
+	}
+}
+
+// TestRunPamFlowSurvivesActuatorPanic proves the defer/recover at the top of
+// RunPamFlow contains a syscall-level panic on the local actuate path (which
+// runs on the etwlua loop goroutine, unprotected by the worker-pool recover).
+// The credential-zeroing/demote defers in actuateElevation still run during
+// unwinding; this is purely availability hardening.
+func TestRunPamFlowSurvivesActuatorPanic(t *testing.T) {
+	manager := &fakeElevationManager{cred: elevaccount.Credential{Username: "~breeze_elev", Password: "x"}}
+	swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
+	swapActuatorForTest(t, func() pamactuator.Actuator {
+		return fakeActuator{
+			trigger: func(context.Context, pamactuator.Request) pamactuator.Result {
+				panic("simulated SendInput syscall panic")
+			},
+			dismiss: func(context.Context) pamactuator.Result {
+				return pamactuator.Result{Success: true, Reason: "dismissed"}
+			},
+		}
+	})
+
+	h := &Heartbeat{}
+	h.pamFindSession = func(capability, _ string) *sessionbroker.Session {
+		return &sessionbroker.Session{}
+	}
+	h.pamRequestDialog = func(_ *sessionbroker.Session, _ string, _ ipc.PamRequestDialog, _ time.Duration) (ipc.PamDialogResult, error) {
+		return ipc.PamDialogResult{Approved: true}, nil
+	}
+
+	ev := etwlua.Event{TargetExecutablePath: `C:\Windows\regedit.exe`}
+	outcome := etwlua.ElevationOutcome{RequestID: "req-panic", Status: "auto_approved"}
+
+	// Must NOT panic out of RunPamFlow.
+	h.RunPamFlow(context.Background(), ev, outcome)
+
+	// The deferred Demote in actuateElevation must still have run during unwinding.
+	if manager.demoteSeen != 1 {
+		t.Fatalf("Demote called %d times after panic, want 1 (deferred cleanup must run)", manager.demoteSeen)
 	}
 }

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -1,0 +1,154 @@
+package heartbeat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/elevaccount"
+	"github.com/breeze-rmm/agent/internal/etwlua"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/pamactuator"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+func TestRunPamFlow(t *testing.T) {
+	approved := ipc.PamDialogResult{Approved: true}
+	dismissed := ipc.PamDialogResult{Approved: false, DismissedByUser: true}
+
+	cases := []struct {
+		name          string
+		status        string
+		dialog        ipc.PamDialogResult
+		noSession     bool
+		wantTriggered bool
+		wantDismissed bool
+		// wantActuated asserts the promote→demote credential pipeline ran.
+		wantActuated bool
+	}{
+		{
+			name:          "policy hard-deny dismisses without dialog",
+			status:        "denied",
+			dialog:        approved, // ignored — denied short-circuits before the dialog
+			wantTriggered: false,
+			wantDismissed: true,
+			wantActuated:  false,
+		},
+		{
+			name:          "auto-approved + user-approved actuates",
+			status:        "auto_approved",
+			dialog:        approved,
+			wantTriggered: true,
+			wantDismissed: false,
+			wantActuated:  true,
+		},
+		{
+			name:          "auto-approved + user-dismissed denies",
+			status:        "auto_approved",
+			dialog:        dismissed,
+			wantTriggered: false,
+			wantDismissed: true,
+			wantActuated:  false,
+		},
+		{
+			name:          "pending + user-approved awaits remote",
+			status:        "pending",
+			dialog:        approved,
+			wantTriggered: false,
+			wantDismissed: false,
+			wantActuated:  false,
+		},
+		{
+			name:          "pending + user-dismissed denies",
+			status:        "pending",
+			dialog:        dismissed,
+			wantTriggered: false,
+			wantDismissed: true,
+			wantActuated:  false,
+		},
+		{
+			name:          "auto-approved but no capable session shows nothing",
+			status:        "auto_approved",
+			dialog:        approved,
+			noSession:     true,
+			wantTriggered: false,
+			wantDismissed: false,
+			wantActuated:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var triggered, dismissed bool
+			swapActuatorForTest(t, func() pamactuator.Actuator {
+				return fakeActuator{
+					trigger: func(context.Context, pamactuator.Request) pamactuator.Result {
+						triggered = true
+						return pamactuator.Result{Success: true, Reason: "ok"}
+					},
+					dismiss: func(context.Context) pamactuator.Result {
+						dismissed = true
+						return pamactuator.Result{Success: true, Reason: "dismissed"}
+					},
+				}
+			})
+
+			manager := &fakeElevationManager{
+				cred: elevaccount.Credential{Username: "~breeze_elev", Password: "x"},
+			}
+			swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
+
+			var dialogCalled bool
+			h := &Heartbeat{
+				pamFindSession: func(capability, targetWinSession string) *sessionbroker.Session {
+					if capability != ipc.ScopePam {
+						t.Fatalf("FindCapableSession capability = %q, want %q", capability, ipc.ScopePam)
+					}
+					if tc.noSession {
+						return nil
+					}
+					return &sessionbroker.Session{}
+				},
+				pamRequestDialog: func(_ *sessionbroker.Session, _ string, _ ipc.PamRequestDialog, _ time.Duration) (ipc.PamDialogResult, error) {
+					dialogCalled = true
+					return tc.dialog, nil
+				},
+			}
+
+			ev := etwlua.Event{
+				SubjectUsername:        "CORP\\\\alice",
+				TargetExecutablePath:   `C:\Windows\regedit.exe`,
+				TargetExecutableHash:   "abc123",
+				TargetExecutableSigner: "Microsoft Windows",
+				CommandLine:            `regedit.exe`,
+			}
+			outcome := etwlua.ElevationOutcome{RequestID: "req-1", Status: tc.status}
+
+			h.RunPamFlow(context.Background(), ev, outcome)
+
+			if triggered != tc.wantTriggered {
+				t.Errorf("triggered = %v, want %v", triggered, tc.wantTriggered)
+			}
+			if dismissed != tc.wantDismissed {
+				t.Errorf("dismissed = %v, want %v", dismissed, tc.wantDismissed)
+			}
+
+			// The "denied" status must short-circuit before the dialog is shown.
+			if tc.status == "denied" && dialogCalled {
+				t.Errorf("policy hard-deny showed the dialog; should short-circuit")
+			}
+
+			// The actuate path runs Promote then a deferred Demote.
+			wantPromote, wantDemote := 0, 0
+			if tc.wantActuated {
+				wantPromote, wantDemote = 1, 1
+			}
+			if manager.promoteSeen != wantPromote {
+				t.Errorf("Promote called %d times, want %d", manager.promoteSeen, wantPromote)
+			}
+			if manager.demoteSeen != wantDemote {
+				t.Errorf("Demote called %d times, want %d", manager.demoteSeen, wantDemote)
+			}
+		})
+	}
+}

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -21,6 +21,12 @@ func TestRunPamFlow(t *testing.T) {
 		status        string
 		dialog        ipc.PamDialogResult
 		noSession     bool
+		// noBroker builds the heartbeat with nil swappable fields (pamFindSession,
+		// pamRequestDialog) AND a nil sessionBroker, reproducing production wiring
+		// where the broker is absent. Proves RunPamFlow never panics in that shape.
+		noBroker      bool
+		// wantDialog asserts whether the broker dialog round-trip was reached.
+		wantDialog    bool
 		wantTriggered bool
 		wantDismissed bool
 		// wantActuated asserts the promote→demote credential pipeline ran.
@@ -30,6 +36,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "policy hard-deny dismisses without dialog",
 			status:        "denied",
 			dialog:        approved, // ignored — denied short-circuits before the dialog
+			wantDialog:    false,
 			wantTriggered: false,
 			wantDismissed: true,
 			wantActuated:  false,
@@ -38,6 +45,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "auto-approved + user-approved actuates",
 			status:        "auto_approved",
 			dialog:        approved,
+			wantDialog:    true,
 			wantTriggered: true,
 			wantDismissed: false,
 			wantActuated:  true,
@@ -46,6 +54,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "auto-approved + user-dismissed denies",
 			status:        "auto_approved",
 			dialog:        dismissed,
+			wantDialog:    true,
 			wantTriggered: false,
 			wantDismissed: true,
 			wantActuated:  false,
@@ -54,6 +63,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "pending + user-approved awaits remote",
 			status:        "pending",
 			dialog:        approved,
+			wantDialog:    true,
 			wantTriggered: false,
 			wantDismissed: false,
 			wantActuated:  false,
@@ -62,6 +72,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "pending + user-dismissed denies",
 			status:        "pending",
 			dialog:        dismissed,
+			wantDialog:    true,
 			wantTriggered: false,
 			wantDismissed: true,
 			wantActuated:  false,
@@ -71,8 +82,34 @@ func TestRunPamFlow(t *testing.T) {
 			status:        "auto_approved",
 			dialog:        approved,
 			noSession:     true,
+			wantDialog:    false, // early return precedes the dialog round-trip
 			wantTriggered: false,
 			wantDismissed: false,
+			wantActuated:  false,
+		},
+		{
+			// Production wiring: sessionBroker is nil (only built when
+			// UserHelperEnabled/IsService/IsHeadless), yet etwlua can still
+			// fire. The defensive guard must skip the dialog path without panic.
+			name:          "auto-approved with nil broker skips without panic",
+			status:        "auto_approved",
+			dialog:        approved,
+			noBroker:      true,
+			wantDialog:    false,
+			wantTriggered: false,
+			wantDismissed: false,
+			wantActuated:  false,
+		},
+		{
+			// denied returns via denyConsent (Actuator.Dismiss, no broker)
+			// BEFORE the nil-broker guard, so it must still dismiss cleanly.
+			name:          "denied with nil broker still dismisses without panic",
+			status:        "denied",
+			dialog:        approved, // ignored
+			noBroker:      true,
+			wantDialog:    false,
+			wantTriggered: false,
+			wantDismissed: true,
 			wantActuated:  false,
 		},
 	}
@@ -99,8 +136,12 @@ func TestRunPamFlow(t *testing.T) {
 			swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
 
 			var dialogCalled bool
-			h := &Heartbeat{
-				pamFindSession: func(capability, targetWinSession string) *sessionbroker.Session {
+			// noBroker reproduces production wiring: both swappable seams nil
+			// AND a nil sessionBroker. The defensive guard in RunPamFlow must
+			// keep this from dereferencing the nil broker.
+			h := &Heartbeat{}
+			if !tc.noBroker {
+				h.pamFindSession = func(capability, targetWinSession string) *sessionbroker.Session {
 					if capability != ipc.ScopePam {
 						t.Fatalf("FindCapableSession capability = %q, want %q", capability, ipc.ScopePam)
 					}
@@ -108,11 +149,11 @@ func TestRunPamFlow(t *testing.T) {
 						return nil
 					}
 					return &sessionbroker.Session{}
-				},
-				pamRequestDialog: func(_ *sessionbroker.Session, _ string, _ ipc.PamRequestDialog, _ time.Duration) (ipc.PamDialogResult, error) {
+				}
+				h.pamRequestDialog = func(_ *sessionbroker.Session, _ string, _ ipc.PamRequestDialog, _ time.Duration) (ipc.PamDialogResult, error) {
 					dialogCalled = true
 					return tc.dialog, nil
-				},
+				}
 			}
 
 			ev := etwlua.Event{
@@ -133,9 +174,12 @@ func TestRunPamFlow(t *testing.T) {
 				t.Errorf("dismissed = %v, want %v", dismissed, tc.wantDismissed)
 			}
 
-			// The "denied" status must short-circuit before the dialog is shown.
-			if tc.status == "denied" && dialogCalled {
-				t.Errorf("policy hard-deny showed the dialog; should short-circuit")
+			// The dialog round-trip must only be reached when expected: denied
+			// short-circuits before it, and the no-session early return precedes
+			// the ask(...) call. (With a nil broker the seam is never installed,
+			// so dialogCalled stays false trivially.)
+			if dialogCalled != tc.wantDialog {
+				t.Errorf("dialogCalled = %v, want %v", dialogCalled, tc.wantDialog)
 			}
 
 			// The actuate path runs Promote then a deferred Demote.

--- a/agent/internal/pamactuator/actuator.go
+++ b/agent/internal/pamactuator/actuator.go
@@ -88,6 +88,12 @@ type Actuator interface {
 	// goroutine; the impl locks an OS thread internally before touching
 	// the secure desktop.
 	Trigger(ctx context.Context, req Request) Result
+
+	// Dismiss cancels the live consent.exe prompt by sending Escape on the
+	// input desktop (deny path). Returns Reason "ok" on a confirmed close,
+	// "no_consent_window" if none was found, or a desktop-attach failure
+	// reason mirroring Trigger.
+	Dismiss(ctx context.Context) Result
 }
 
 // New returns the platform-default Actuator. On non-Windows this returns

--- a/agent/internal/pamactuator/actuator.go
+++ b/agent/internal/pamactuator/actuator.go
@@ -71,7 +71,8 @@ type Result struct {
 	// Reason is a short stable code suitable for switch statements on
 	// the server side. One of: "ok", "no_consent_window", "desktop_open_failed",
 	// "set_thread_desktop_failed", "send_input_failed", "consent_did_not_close",
-	// "unsupported_platform".
+	// "unsupported_platform". Dismiss returns from this same code set (it shares
+	// Trigger's desktop-attach / input / close-verification failure reasons).
 	Reason string
 
 	// DetailMessage is a free-form human-readable string for logs. Never
@@ -91,8 +92,10 @@ type Actuator interface {
 
 	// Dismiss cancels the live consent.exe prompt by sending Escape on the
 	// input desktop (deny path). Returns Reason "ok" on a confirmed close,
-	// "no_consent_window" if none was found, or a desktop-attach failure
-	// reason mirroring Trigger.
+	// "no_consent_window" if none was found, or one of Trigger's failure
+	// reasons for desktop-attach / input / close-verification failures
+	// ("desktop_open_failed", "set_thread_desktop_failed", "send_input_failed",
+	// "consent_did_not_close", "unsupported_platform").
 	Dismiss(ctx context.Context) Result
 }
 

--- a/agent/internal/pamactuator/actuator_other.go
+++ b/agent/internal/pamactuator/actuator_other.go
@@ -19,3 +19,11 @@ func (*noopActuator) Trigger(_ context.Context, _ Request) Result {
 		DetailMessage: "pamactuator: not implemented for this platform",
 	}
 }
+
+func (*noopActuator) Dismiss(_ context.Context) Result {
+	return Result{
+		Success:       false,
+		Reason:        "unsupported_platform",
+		DetailMessage: "pamactuator: not implemented for this platform",
+	}
+}

--- a/agent/internal/pamactuator/actuator_test.go
+++ b/agent/internal/pamactuator/actuator_test.go
@@ -65,6 +65,23 @@ func TestNoopActuatorIsNonBlocking(t *testing.T) {
 	}
 }
 
+// TestDismissUnsupportedOnNonWindows guards the deny-path stub: on
+// non-Windows hosts Dismiss must report "unsupported_platform" so the
+// Track 6 deny flow can record the outcome rather than block.
+func TestDismissUnsupportedOnNonWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no-op stub only compiled on non-Windows")
+	}
+
+	res := New().Dismiss(context.Background())
+	if res.Success {
+		t.Fatal("Dismiss should not succeed on non-windows")
+	}
+	if res.Reason != "unsupported_platform" {
+		t.Fatalf("reason = %q, want unsupported_platform", res.Reason)
+	}
+}
+
 // TestRequestZeroValuesAreSafe sanity-checks that a zero-valued Request
 // doesn't make the stub panic. The Windows impl applies a default 8000ms
 // timeout when TimeoutMs<=0; the stub doesn't need to but must not crash.

--- a/agent/internal/pamactuator/actuator_windows.go
+++ b/agent/internal/pamactuator/actuator_windows.go
@@ -144,6 +144,77 @@ func (a *windowsActuator) Trigger(ctx context.Context, req Request) Result {
 	}
 }
 
+// Dismiss cancels the live consent.exe prompt by sending Escape on the
+// input desktop (deny path). It mirrors Trigger's secure-desktop attach
+// scaffolding — lock the OS thread, OpenInputDesktop, SetThreadDesktop,
+// poll for the consent window — then presses Escape instead of typing
+// credentials and waits for the window to close. There is no Request
+// here (the deny path carries no credential), so it uses the same default
+// 8000ms window Trigger falls back to when TimeoutMs<=0.
+func (a *windowsActuator) Dismiss(ctx context.Context) Result {
+	// SetThreadDesktop is per-thread; stay on the same OS thread for the
+	// duration so the desktop binding doesn't follow a reparked goroutine.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	hDesk, _, openErr := winProcOpenInputDesktop.Call(0, 0, uintptr(winDesktopGenericAll))
+	if hDesk == 0 {
+		slog.Warn("pamactuator: OpenInputDesktop failed (dismiss)",
+			"error", openErr.Error(),
+		)
+		return Result{
+			Success:       false,
+			Reason:        "desktop_open_failed",
+			DetailMessage: "OpenInputDesktop returned 0: " + openErr.Error(),
+		}
+	}
+	defer winProcCloseDesktop.Call(hDesk)
+
+	if ret, _, setErr := winProcSetThreadDesktop.Call(hDesk); ret == 0 {
+		slog.Warn("pamactuator: SetThreadDesktop failed (dismiss)",
+			"error", setErr.Error(),
+		)
+		return Result{
+			Success:       false,
+			Reason:        "set_thread_desktop_failed",
+			DetailMessage: "SetThreadDesktop returned 0: " + setErr.Error(),
+		}
+	}
+
+	deadline := time.Now().Add(8000 * time.Millisecond)
+
+	hwnd := waitForConsent(ctx, deadline)
+	if hwnd == 0 {
+		return Result{
+			Success:       false,
+			Reason:        "no_consent_window",
+			DetailMessage: "consent.exe did not appear within the timeout window",
+		}
+	}
+
+	if err := pressVK(vkEscape); err != nil {
+		return Result{
+			Success:       false,
+			Reason:        "send_input_failed",
+			DetailMessage: "Escape: " + err.Error(),
+		}
+	}
+
+	if !waitForConsentClose(ctx, hwnd, deadline) {
+		return Result{
+			Success:       false,
+			Reason:        "consent_did_not_close",
+			DetailMessage: "consent.exe still present after Escape",
+		}
+	}
+
+	return Result{
+		Success:       true,
+		Reason:        "ok",
+		DetailMessage: "consent.exe closed after Escape (deny)",
+	}
+}
+
 // waitForConsent polls for the consent.exe window until it appears, the
 // context cancels, or the deadline passes. Returns 0 on timeout/cancel.
 func waitForConsent(ctx context.Context, deadline time.Time) uintptr {

--- a/agent/internal/pamactuator/actuator_windows.go
+++ b/agent/internal/pamactuator/actuator_windows.go
@@ -46,6 +46,11 @@ const pollInterval = 100 * time.Millisecond
 // causes occasional dropped characters on slower VMs.
 const settleDelay = 25 * time.Millisecond
 
+// defaultConsentTimeoutMs is the fallback consent.exe wait window used when a
+// Request carries no TimeoutMs (Trigger) and for the deny path (Dismiss, which
+// has no Request at all).
+const defaultConsentTimeoutMs = 8000
+
 func (a *windowsActuator) Trigger(ctx context.Context, req Request) Result {
 	// SetThreadDesktop is per-thread; the rest of the actuator must stay on
 	// the same OS thread or the desktop binding goes with the original
@@ -81,7 +86,7 @@ func (a *windowsActuator) Trigger(ctx context.Context, req Request) Result {
 
 	timeoutMs := req.TimeoutMs
 	if timeoutMs <= 0 {
-		timeoutMs = 8000
+		timeoutMs = defaultConsentTimeoutMs
 	}
 	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
 
@@ -181,7 +186,7 @@ func (a *windowsActuator) Dismiss(ctx context.Context) Result {
 		}
 	}
 
-	deadline := time.Now().Add(8000 * time.Millisecond)
+	deadline := time.Now().Add(defaultConsentTimeoutMs * time.Millisecond)
 
 	hwnd := waitForConsent(ctx, deadline)
 	if hwnd == 0 {

--- a/agent/internal/pamactuator/wininput.go
+++ b/agent/internal/pamactuator/wininput.go
@@ -97,8 +97,9 @@ func typeRune(r rune) error {
 	return nil
 }
 
-// pressVK sends a vk-down then vk-up pair. Used for Tab/Enter only; user
-// content goes through typeRune so layout-independent Unicode is used.
+// pressVK sends a vk-down then vk-up pair. Used for control keys
+// (Tab/Enter/Escape); user content goes through typeRune so
+// layout-independent Unicode is used.
 func pressVK(vk uint16) error {
 	down := winInput{inputType: inputKeyboard}
 	down.ki.wVk = vk

--- a/agent/internal/pamactuator/wininput.go
+++ b/agent/internal/pamactuator/wininput.go
@@ -34,6 +34,7 @@ const (
 const (
 	vkTab    = 0x09
 	vkReturn = 0x0D
+	vkEscape = 0x1B
 )
 
 // keybdInput mirrors the Win32 KEYBDINPUT struct. Layout matches the

--- a/docs/superpowers/plans/2026-06-14-pam-etw-wire-detect-actuate.md
+++ b/docs/superpowers/plans/2026-06-14-pam-etw-wire-detect-actuate.md
@@ -1,0 +1,1007 @@
+# PAM: Wire ETW Detection → Dialog → Decision → Actuate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Issue:** LanternOps/breeze#1253 — `[Agent] PAM: wire ETW detection → dialog → decision → actuate (the etwlua trigger)`
+**Deferred from:** #1152 (Tasks 4–5 of `docs/superpowers/plans/2026-06-09-pam-dialog-user-helper.md`).
+**Pairs with:** #1150 (dormant admin), #960 (actuator), #1163 (remote-approval / `actuate_elevation` command), #1254 (mobile bridge — separate issue).
+
+**Goal:** When the ETW subscriber detects a UAC prompt, drive the already-built pieces (PAM dialog, decision composer, dormant-admin promote/demote, consent.exe actuator) into a single working local elevation flow: **detect → dialog → decide → actuate-or-deny**.
+
+**Architecture:** `etwlua.handleEvent` already POSTs each detected prompt to the API, which synchronously runs the policy/rule decisioning and returns `{id, status}` (`status ∈ pending | auto_approved | denied | ignored`). Today the agent discards that body. We (1) parse it into an `ElevationOutcome`, (2) add a nil-safe `PamRunner` interface — the single, mockable edge from `etwlua` into the session broker + actuator — and (3) implement that runner on `*heartbeat.Heartbeat` (which already holds the broker, actuator, and dormant-admin manager). The runner maps the server status to `ComposePamDecision`'s verdict, shows the dialog, and on the resulting `PamAction` either actuates (promote → type creds onto consent.exe → demote) or dismisses consent.exe (new Escape path). The `await_remote` branch does nothing locally — the existing `actuate_elevation` server command (#1163) actuates when a technician approves.
+
+**Tech Stack:** Go 1.x, `internal/etwlua` (detection), `internal/sessionbroker` (dialog round-trip + `ComposePamDecision`), `internal/heartbeat` (orchestrator + HTTP), `internal/pamactuator` (consent.exe SendInput), `internal/elevaccount` (`~breeze_elev` promote/demote), `internal/ipc` (message types + `RateLimiter`). Go standard `testing`, table-driven, `go test -race ./...`. Windows-only runtime; cross-platform code is unit-tested, the live path needs VM verification (CI gap #1000).
+
+---
+
+## EXISTS vs GREENFIELD
+
+- **EXISTS (wire together, do not rebuild):**
+  - `etwlua.handleEvent` dedupe + POST + offline queue (`internal/etwlua/etwlua.go:234`).
+  - Server returns the decision: `POST /api/v1/agents/:id/elevation-requests` responds `{ "id": "...", "status": "pending"|"auto_approved"|"denied"|"ignored" }` (`apps/api/src/routes/agents/elevationRequests.ts`, response at line ~416 / ignored at ~264). **No server change required.**
+  - Broker round-trip `Broker.RequestPamApproval(session, id, ipc.PamRequestDialog, timeout) (ipc.PamDialogResult, error)` — timeout/nil-session → `{Approved:false, DismissedByUser:true}` (`internal/sessionbroker/broker.go:1119`).
+  - Session selection `Broker.FindCapableSession(capability, targetWinSession string) *Session` — `ipc.ScopePam` only matches user-role helpers (`broker.go:878`).
+  - Pure decision `sessionbroker.ComposePamDecision(policyVerdict string, dialog ipc.PamDialogResult, remoteApproved *bool) PamAction` → `PamActionActuate | PamActionDeny | PamActionAwaitRemote` (`internal/sessionbroker/pam_decision.go:18`, tested in `pam_decision_test.go`). It compares `policyVerdict` against the literals `"end-user-allowed"` and `"require-approval"`.
+  - Dormant admin `elevaccount.New() AccountManager` with `Promote(ctx) (Credential, error)` / `Demote(ctx) error` (`internal/elevaccount/elevaccount.go:45`, windows impl at `elevaccount_windows.go:109`).
+  - Actuator `pamactuator.New() Actuator` with `Trigger(ctx, Request) Result` (`internal/pamactuator/actuator.go:82`, windows impl `actuator_windows.go:49`). `wininput.go` already defines `typeRune`, `pressVK`, `findConsentWindow`, `isWindowAlive`, and VK consts `vkTab=0x09`, `vkReturn=0x0D`.
+  - Remote actuation handler `actuate_elevation` already exists (`internal/heartbeat/handlers_actuate.go:63`) and the `*Heartbeat` already owns `sessionBroker *sessionbroker.Broker` (`heartbeat.go:161`) plus the swappable test seams `newActuator = pamactuator.New` and `newElevationAccountManager = elevaccount.New`.
+- **GREENFIELD (this plan builds):**
+  1. Parsing the POST response into `etwlua.ElevationOutcome` (the agent currently throws the body away).
+  2. The `etwlua.PamRunner` interface seam + threading it through `Start`/`handleEvent` (nil-safe).
+  3. The orchestrator `(*Heartbeat).RunPamFlow` that maps status → verdict → dialog → `PamAction` → actuate/deny/await.
+  4. The consent.exe **denial** path: `vkEscape` const + `Actuator.Dismiss(ctx) Result` (only the approve path exists today).
+  5. Refactoring the actuate core out of `handleActuateElevation` into a shared `(*Heartbeat).actuateElevation` so the remote command and the local flow share one code path (DRY).
+
+## Status → verdict mapping (the one design decision)
+
+| Server `status` | Dialog shown? | `ComposePamDecision` verdict | Then |
+|---|---|---|---|
+| `ignored` | no | — | do nothing (filtered before the runner is called) |
+| `denied` | no | — | `denyConsent` immediately (policy hard-deny) |
+| `auto_approved` | yes (end-user consent gate) | `"end-user-allowed"` | approve→actuate, deny→denyConsent |
+| `pending` | yes | `"require-approval"` | approve→`await_remote` (server actuates via `actuate_elevation`), deny→denyConsent |
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `agent/internal/etwlua/etwlua.go` | `ElevationOutcome` type; `HeartbeatPoster.SendElevationRequest` return change; `PamRunner` interface; thread `ctx`+`pam` through `Start`/`handleEvent` | Modify |
+| `agent/internal/etwlua/queue.go` | `Drain` call site discards new return value | Modify (1 line) |
+| `agent/internal/etwlua/etwlua_test.go` | Update `fakeHB`; add `fakePamRunner` + runner-invocation tests | Modify |
+| `agent/internal/heartbeat/handlers_elevation.go` | Parse `{id,status}` → return `etwlua.ElevationOutcome` | Modify |
+| `agent/internal/heartbeat/handlers_elevation_test.go` | Test response parsing | Create (or extend if present) |
+| `agent/internal/heartbeat/pam_flow.go` | `RunPamFlow`, `buildPamRequestDialog`, `denyConsent`, `actuateElevation`, constants | Create |
+| `agent/internal/heartbeat/pam_flow_test.go` | Table test for `RunPamFlow` status→action mapping | Create |
+| `agent/internal/heartbeat/handlers_actuate.go` | `handleActuateElevation` delegates to shared `actuateElevation` | Modify |
+| `agent/internal/pamactuator/actuator.go` | Add `Dismiss(ctx) Result` to the `Actuator` interface | Modify |
+| `agent/internal/pamactuator/actuator_windows.go` | Implement `Dismiss` (open desktop → Escape consent.exe) | Modify |
+| `agent/internal/pamactuator/actuator_other.go` | Stub `Dismiss` → `{Success:false, Reason:"unsupported_platform"}` | Modify |
+| `agent/internal/pamactuator/wininput.go` | Add `vkEscape = 0x1B` | Modify |
+| `agent/cmd/breeze-agent/etwlua_start_windows.go` | Pass `hb` as the `PamRunner` arg | Modify |
+
+---
+
+## Task 1 — Parse the server decision into `ElevationOutcome`
+
+**Files:**
+- Modify: `agent/internal/etwlua/etwlua.go` (add type + change `HeartbeatPoster`)
+- Modify: `agent/internal/heartbeat/handlers_elevation.go:28-54`
+- Modify: `agent/internal/etwlua/queue.go` (the one `hb.SendElevationRequest` call in `Drain`)
+- Test: `agent/internal/heartbeat/handlers_elevation_test.go`
+
+- [ ] **Step 1: Add the `ElevationOutcome` type and change the interface in `etwlua.go`**
+
+Add near the `Event` type (after line ~121) in `agent/internal/etwlua/etwlua.go`:
+
+```go
+// ElevationOutcome is the server's synchronous ingest decision for a posted
+// uac_intercept elevation request, parsed from the POST response body
+// {"id":"<uuid>","status":"<status>"}. Status is one of "pending",
+// "auto_approved", "denied", or "ignored". RequestID is empty when the
+// server suppressed the request (status "ignored", id null).
+type ElevationOutcome struct {
+	RequestID string
+	Status    string
+}
+```
+
+Change the `HeartbeatPoster` interface method (currently `SendElevationRequest(req Event) error`):
+
+```go
+type HeartbeatPoster interface {
+	// SendElevationRequest posts the detected prompt and returns the
+	// server's ingest decision. A non-nil error means the post failed
+	// (network/5xx) and the event should be queued for retry.
+	SendElevationRequest(req Event) (ElevationOutcome, error)
+	IsUACInterceptionEnabled() bool
+}
+```
+
+- [ ] **Step 2: Write the failing parse test**
+
+Create/extend `agent/internal/heartbeat/handlers_elevation_test.go`:
+
+```go
+package heartbeat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/etwlua"
+)
+
+func TestSendElevationRequestParsesDecision(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"req-123","status":"auto_approved"}`))
+	}))
+	defer srv.Close()
+
+	h := newTestHeartbeat(t, srv.URL) // see note below
+	out, err := h.SendElevationRequest(etwlua.Event{TargetExecutablePath: `C:\x.exe`, SubjectUsername: "alice"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.RequestID != "req-123" || out.Status != "auto_approved" {
+		t.Fatalf("got %+v, want {req-123 auto_approved}", out)
+	}
+}
+
+func TestSendElevationRequestErrorOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	h := newTestHeartbeat(t, srv.URL)
+	if _, err := h.SendElevationRequest(etwlua.Event{}); err == nil {
+		t.Fatal("expected error on 500")
+	}
+}
+```
+
+Note: reuse the existing heartbeat test constructor if one exists in this package (grep `func newTestHeartbeat` / how other `handlers_*_test.go` build a `*Heartbeat` with a `config.ServerURL`, `httpClient`, `retryCfg`). If none exists, build the minimal `*Heartbeat{config: ..., ...}` the same way the nearest existing handler test does. Do not invent new helper signatures.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/heartbeat/ -run TestSendElevationRequest -v`
+Expected: FAIL — `SendElevationRequest` still returns a single value / does not compile.
+
+- [ ] **Step 4: Implement the parse in `handlers_elevation.go`**
+
+Replace the body of `SendElevationRequest` (lines 28-54). New signature + parse the success body:
+
+```go
+func (h *Heartbeat) SendElevationRequest(req etwlua.Event) (etwlua.ElevationOutcome, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return etwlua.ElevationOutcome{}, fmt.Errorf("marshal elevation request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/agents/%s/elevation-requests", h.config.ServerURL, h.config.AgentID)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {h.authHeader()},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := httputil.Do(ctx, h.httpClient(), "POST", url, body, headers, h.retryCfg)
+	if err != nil {
+		return etwlua.ElevationOutcome{}, fmt.Errorf("post elevation request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return etwlua.ElevationOutcome{}, fmt.Errorf("elevation-requests returned status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	// Parse the server's ingest decision. A malformed/empty body is not
+	// fatal — the post succeeded; we just have no local flow to drive.
+	var decoded struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = json.Unmarshal(respBody, &decoded)
+	return etwlua.ElevationOutcome{RequestID: decoded.ID, Status: decoded.Status}, nil
+}
+```
+
+- [ ] **Step 5: Fix the `Drain` call site in `queue.go`**
+
+`Queue.Drain` re-posts queued events via `hb.SendElevationRequest`. Drained events are post-hoc (the consent.exe prompt is long gone) so the outcome is discarded. Find the call in `agent/internal/etwlua/queue.go` and change:
+
+```go
+// before:  if err := hb.SendElevationRequest(ev); err != nil {
+// after:
+if _, err := hb.SendElevationRequest(ev); err != nil {
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd agent && go test ./internal/heartbeat/ -run TestSendElevationRequest -v && go build ./...`
+Expected: PASS, and the whole module still builds (the `etwlua` callers compile against the new signature only after Task 2 — if `go build ./...` flags `etwlua`/`cmd` here, that is expected; complete Task 2 before the final build). To keep this task self-contained, build just the two packages: `go build ./internal/heartbeat/ ./internal/etwlua/` — `etwlua` will fail to build until Step 7.
+
+- [ ] **Step 7: Make `etwlua` compile against the new interface (minimal)**
+
+In `etwlua.go` `handleEvent`, the existing call `if err := hb.SendElevationRequest(ev); err != nil {` must become `if _, err := hb.SendElevationRequest(ev); err != nil {` (Task 2 adds the real use of the outcome). This keeps the package compiling.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd agent && git add internal/etwlua/etwlua.go internal/etwlua/queue.go internal/heartbeat/handlers_elevation.go internal/heartbeat/handlers_elevation_test.go
+git commit -m "feat(agent/pam): parse server ingest decision into ElevationOutcome"
+```
+
+---
+
+## Task 2 — `PamRunner` interface seam + thread through `Start`/`handleEvent`
+
+**Files:**
+- Modify: `agent/internal/etwlua/etwlua.go` (`PamRunner` type; `Start` + `handleEvent` signatures)
+- Modify: `agent/internal/etwlua/etwlua_test.go` (update `fakeHB`; add `fakePamRunner`; update `Start`/`handleEvent` call sites)
+
+- [ ] **Step 1: Add the `PamRunner` interface in `etwlua.go`**
+
+After the `HeartbeatPoster` interface:
+
+```go
+// PamRunner drives the local elevation flow (dialog → decision →
+// actuate/deny) for one detected UAC prompt, using the server's ingest
+// decision. It is the single edge from etwlua into the session broker +
+// actuator, kept behind an interface so etwlua stays unit-testable without
+// a live broker or Windows. A nil PamRunner disables the flow (detection +
+// post only) — used on non-Windows builds and when the broker is absent.
+//
+// Implementations must be non-blocking-forever: bound the dialog round-trip
+// to consent.exe's lifetime. RunPamFlow is called synchronously from the
+// event loop; UAC prompts are modal and serial, so one in-flight flow at a
+// time is correct.
+type PamRunner interface {
+	RunPamFlow(ctx context.Context, ev Event, outcome ElevationOutcome)
+}
+```
+
+Add the `context` import if not already present.
+
+- [ ] **Step 2: Write failing tests in `etwlua_test.go`**
+
+First update the existing `fakeHB` (lines ~16-48) so `SendElevationRequest` matches the new interface — return a configurable outcome:
+
+```go
+type fakeHB struct {
+	mu        sync.Mutex
+	posts     []etwlua.Event
+	postErr   error
+	outcome   etwlua.ElevationOutcome // returned on success
+	enabled   bool
+}
+
+func (f *fakeHB) SendElevationRequest(ev etwlua.Event) (etwlua.ElevationOutcome, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.posts = append(f.posts, ev)
+	if f.postErr != nil {
+		return etwlua.ElevationOutcome{}, f.postErr
+	}
+	return f.outcome, nil
+}
+
+func (f *fakeHB) IsUACInterceptionEnabled() bool { return f.enabled }
+```
+
+(Preserve any existing fields/methods the current `fakeHB` has — only add `outcome` and change the `SendElevationRequest` return. Update every existing test that constructs `fakeHB{...}` to set `enabled: true` if it relied on the old default, and to call the new `handleEvent` signature from Step 4.)
+
+Add a fake runner and tests:
+
+```go
+type fakePamRunner struct {
+	mu    sync.Mutex
+	calls []etwlua.ElevationOutcome
+}
+
+func (f *fakePamRunner) RunPamFlow(_ context.Context, _ etwlua.Event, out etwlua.ElevationOutcome) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, out)
+}
+
+func TestHandleEventInvokesPamRunnerOnSuccess(t *testing.T) {
+	hb := &fakeHB{enabled: true, outcome: etwlua.ElevationOutcome{RequestID: "r1", Status: "auto_approved"}}
+	pam := &fakePamRunner{}
+	limiter := ipc.NewRateLimiter(1, time.Minute)
+	etwlua.HandleEventForTest(context.Background(), etwlua.Event{TargetExecutablePath: "a", SubjectUsername: "u"}, limiter, hb, nil, pam)
+	if len(pam.calls) != 1 || pam.calls[0].RequestID != "r1" || pam.calls[0].Status != "auto_approved" {
+		t.Fatalf("runner calls = %+v, want one {r1 auto_approved}", pam.calls)
+	}
+}
+
+func TestHandleEventSkipsPamRunnerWhenIgnored(t *testing.T) {
+	hb := &fakeHB{enabled: true, outcome: etwlua.ElevationOutcome{RequestID: "", Status: "ignored"}}
+	pam := &fakePamRunner{}
+	etwlua.HandleEventForTest(context.Background(), etwlua.Event{}, ipc.NewRateLimiter(1, time.Minute), hb, nil, pam)
+	if len(pam.calls) != 0 {
+		t.Fatalf("runner should not fire for ignored, got %+v", pam.calls)
+	}
+}
+
+func TestHandleEventSkipsPamRunnerWhenNil(t *testing.T) {
+	hb := &fakeHB{enabled: true, outcome: etwlua.ElevationOutcome{RequestID: "r1", Status: "pending"}}
+	// nil runner must not panic
+	etwlua.HandleEventForTest(context.Background(), etwlua.Event{}, ipc.NewRateLimiter(1, time.Minute), hb, nil, nil)
+}
+
+func TestHandleEventDoesNotInvokeRunnerOnPostFailure(t *testing.T) {
+	hb := &fakeHB{enabled: true, postErr: errors.New("boom")}
+	pam := &fakePamRunner{}
+	etwlua.HandleEventForTest(context.Background(), etwlua.Event{}, ipc.NewRateLimiter(1, time.Minute), hb, nil, pam)
+	if len(pam.calls) != 0 {
+		t.Fatalf("runner should not fire on post failure, got %+v", pam.calls)
+	}
+}
+```
+
+`handleEvent` is unexported; expose a thin test shim in `etwlua.go` (export-for-test pattern, same package would be simpler but the existing tests use `package etwlua_test` — keep that). Add to `etwlua.go`:
+
+```go
+// HandleEventForTest exposes handleEvent for black-box tests in this
+// package. Not for production use.
+func HandleEventForTest(ctx context.Context, ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queue, pam PamRunner) {
+	handleEvent(ctx, ev, limiter, hb, q, pam)
+}
+```
+
+(If the existing tests are white-box `package etwlua`, call `handleEvent` directly instead and skip the shim.)
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd agent && go test ./internal/etwlua/ -run TestHandleEvent -v`
+Expected: FAIL — `handleEvent`/`HandleEventForTest` don't take `ctx`/`pam` yet.
+
+- [ ] **Step 4: Change `handleEvent` and `Start` signatures**
+
+In `etwlua.go`, change `handleEvent` to accept `ctx` and `pam` and invoke the runner after a successful post:
+
+```go
+func handleEvent(ctx context.Context, ev Event, limiter *ipc.RateLimiter, hb HeartbeatPoster, q *Queue, pam PamRunner) {
+	// ... unchanged: interception-disabled gate, re-enable log, dedupe ...
+
+	outcome, err := hb.SendElevationRequest(ev)
+	if err != nil {
+		log.Warn("etwlua: post failed, queueing",
+			"user", ev.SubjectUsername, "path", ev.TargetExecutablePath, "error", err.Error())
+		if q != nil {
+			if qerr := q.Enqueue(ev); qerr != nil {
+				log.Error("etwlua: enqueue failed; event dropped", "error", qerr.Error())
+			}
+		}
+		return
+	}
+
+	log.Debug("etwlua: event posted", "user", ev.SubjectUsername, "path", ev.TargetExecutablePath)
+
+	// Drive the local elevation flow. The dedupe above already prevents
+	// stacked dialogs for re-fired ETW events on one prompt.
+	if pam != nil && outcome.RequestID != "" && outcome.Status != "ignored" {
+		pam.RunPamFlow(ctx, ev, outcome)
+	}
+
+	if q != nil && hb.IsUACInterceptionEnabled() {
+		if _, derr := q.Drain(hb); derr != nil {
+			log.Debug("etwlua: opportunistic drain failed", "error", derr.Error())
+		}
+	}
+}
+```
+
+Change `Start` to accept and pass `pam`:
+
+```go
+func Start(ctx context.Context, sub Subscriber, hb HeartbeatPoster, pam PamRunner) error {
+	// ... unchanged setup ...
+	for {
+		select {
+		case <-ctx.Done():
+			// ...
+		case ev, ok := <-sub.Events():
+			// ... unchanged zero-time fill ...
+			handleEvent(ctx, ev, limiter, hb, q, pam)
+		case <-ticker.C:
+			// ... unchanged ...
+		}
+	}
+}
+```
+
+Update the existing `TestStartReturnsOnContextCancel` to pass `nil` for the new `pam` arg.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd agent && go test ./internal/etwlua/ -race -v`
+Expected: PASS (all existing + 4 new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd agent && git add internal/etwlua/etwlua.go internal/etwlua/etwlua_test.go
+git commit -m "feat(agent/pam): add nil-safe PamRunner seam to the etwlua hot path"
+```
+
+---
+
+## Task 3 — Consent.exe denial path: `vkEscape` + `Actuator.Dismiss`
+
+**Files:**
+- Modify: `agent/internal/pamactuator/wininput.go` (add `vkEscape`)
+- Modify: `agent/internal/pamactuator/actuator.go` (interface)
+- Modify: `agent/internal/pamactuator/actuator_windows.go` (impl)
+- Modify: `agent/internal/pamactuator/actuator_other.go` (stub)
+- Test: `agent/internal/pamactuator/actuator_test.go` (cross-platform stub behavior)
+
+- [ ] **Step 1: Add `vkEscape` in `wininput.go`**
+
+In the const block (currently `vkTab = 0x09`, `vkReturn = 0x0D`):
+
+```go
+const (
+	vkTab    = 0x09
+	vkReturn = 0x0D
+	vkEscape = 0x1B
+)
+```
+
+- [ ] **Step 2: Write the failing stub test**
+
+In `agent/internal/pamactuator/actuator_test.go` (this runs on the dev/CI host, which is non-Windows → exercises the `_other` stub):
+
+```go
+//go:build !windows
+
+package pamactuator
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDismissUnsupportedOnNonWindows(t *testing.T) {
+	res := New().Dismiss(context.Background())
+	if res.Success {
+		t.Fatal("Dismiss should not succeed on non-windows")
+	}
+	if res.Reason != "unsupported_platform" {
+		t.Fatalf("reason = %q, want unsupported_platform", res.Reason)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/pamactuator/ -run TestDismiss -v`
+Expected: FAIL — `Dismiss` not defined on the `Actuator` interface.
+
+- [ ] **Step 4: Add `Dismiss` to the interface in `actuator.go`**
+
+```go
+type Actuator interface {
+	// Trigger types the dormant-admin credential onto the live consent.exe
+	// prompt (approve path).
+	Trigger(ctx context.Context, req Request) Result
+	// Dismiss cancels the live consent.exe prompt by sending Escape on the
+	// input desktop (deny path). Returns Reason "ok" on a confirmed close,
+	// "no_consent_window" if none was found, or a desktop-attach failure
+	// reason mirroring Trigger.
+	Dismiss(ctx context.Context) Result
+}
+```
+
+- [ ] **Step 5: Implement the non-Windows stub in `actuator_other.go`**
+
+```go
+func (a *otherActuator) Dismiss(_ context.Context) Result {
+	return Result{Success: false, Reason: "unsupported_platform", DetailMessage: "consent dismissal only supported on Windows"}
+}
+```
+
+(Match the receiver type name used by the existing `Trigger` stub in this file.)
+
+- [ ] **Step 6: Implement `Dismiss` in `actuator_windows.go`**
+
+Mirror `Trigger`'s desktop-attach scaffolding (lines ~49-95), then send Escape instead of typing creds:
+
+```go
+func (a *windowsActuator) Dismiss(ctx context.Context) Result {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	hDesk, err := openInputDesktop()
+	if err != nil {
+		return Result{Success: false, Reason: "desktop_open_failed", DetailMessage: err.Error()}
+	}
+	defer closeDesktop(hDesk)
+
+	if err := setThreadDesktop(hDesk); err != nil {
+		return Result{Success: false, Reason: "set_thread_desktop_failed", DetailMessage: err.Error()}
+	}
+
+	hwnd, ok := waitForConsent(ctx) // reuse the existing poll helper
+	if !ok {
+		return Result{Success: false, Reason: "no_consent_window", DetailMessage: "consent.exe window not found"}
+	}
+
+	if err := pressVK(vkEscape); err != nil {
+		return Result{Success: false, Reason: "send_input_failed", DetailMessage: err.Error()}
+	}
+
+	if !waitForConsentClose(ctx, hwnd) {
+		return Result{Success: false, Reason: "consent_did_not_close", DetailMessage: "consent.exe still open after Escape"}
+	}
+	return Result{Success: true, Reason: "ok"}
+}
+```
+
+Use the **exact** names of the existing private helpers in this file (`openInputDesktop`/`OpenInputDesktop`, `closeDesktop`, `setThreadDesktop`/`SetThreadDesktop`, `waitForConsent`, `waitForConsentClose`). Read the file first and match them — do not introduce new helper names. If `waitForConsent`/`waitForConsentClose` take different args (e.g. a timeout rather than ctx), match their real signatures.
+
+- [ ] **Step 7: Run tests + Windows build**
+
+Run: `cd agent && go test ./internal/pamactuator/ -v && GOOS=windows go build ./internal/pamactuator/`
+Expected: PASS; Windows cross-compile succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd agent && git add internal/pamactuator/
+git commit -m "feat(agent/pam): add consent.exe Dismiss (Escape) deny path to actuator"
+```
+
+---
+
+## Task 4 — Refactor the actuate core into a shared `(*Heartbeat).actuateElevation`
+
+**Files:**
+- Modify: `agent/internal/heartbeat/handlers_actuate.go` (extract helper; `handleActuateElevation` delegates)
+- Test: existing `handlers_actuate` tests must stay green (no new test needed; this is a pure refactor verified by existing coverage)
+
+- [ ] **Step 1: Confirm the existing tests pass (baseline)**
+
+Run: `cd agent && go test ./internal/heartbeat/ -run Actuate -v`
+Expected: PASS (record which tests run; they are the regression guard for this refactor).
+
+- [ ] **Step 2: Extract the shared helper**
+
+Add to `handlers_actuate.go`:
+
+```go
+// actuateElevation runs the dormant-admin promote → consent.exe type →
+// guaranteed-demote pipeline and returns the actuator result. Shared by the
+// remote actuate_elevation command handler and the local etwlua-driven flow.
+func (h *Heartbeat) actuateElevation(ctx context.Context, requestID string, timeoutMs int) pamactuator.Result {
+	manager := newElevationAccountManager()
+	cred, err := manager.Promote(ctx)
+	if err != nil {
+		return pamactuator.Result{
+			Success:       false,
+			Reason:        promoteFailureReason(err),
+			DetailMessage: err.Error(),
+		}
+	}
+	defer func() {
+		demoteCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if derr := manager.Demote(demoteCtx); derr != nil {
+			log.Warn("actuate_elevation: demote failed", "elevationRequestId", requestID, "error", derr.Error())
+		}
+	}()
+	defer zeroCredential(&cred)
+
+	return newActuator().Trigger(ctx, pamactuator.Request{
+		ElevationRequestID: requestID,
+		Username:           cred.Username,
+		Password:           cred.Password,
+		TimeoutMs:          timeoutMs,
+	})
+}
+```
+
+- [ ] **Step 3: Rewrite `handleActuateElevation` to delegate**
+
+Replace the promote/defer-demote/trigger body (lines ~80-118) with a call to the helper, preserving the existing context-bounding and result mapping:
+
+```go
+func handleActuateElevation(h *Heartbeat, cmd Command) tools.CommandResult {
+	start := time.Now()
+
+	payload, err := parseActuatePayload(cmd.Payload)
+	if err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
+	timeout := time.Duration(payload.TimeoutMs) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 8 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*timeout)
+	defer cancel()
+
+	res := h.actuateElevation(ctx, payload.ElevationRequestID, payload.TimeoutMs)
+
+	out := actuateResult{
+		ElevationRequestID: payload.ElevationRequestID,
+		Success:            res.Success,
+		Reason:             res.Reason,
+		Message:            res.DetailMessage,
+	}
+	return tools.NewSuccessResult(out, time.Since(start).Milliseconds())
+}
+```
+
+Note: the prior handler returned the promote-failure as a `NewSuccessResult` (completed-with-failure). The helper now folds promote failure into `res` (Success:false, Reason from `promoteFailureReason`), and the handler wraps `res` in `NewSuccessResult` — so the server still always sees a JSON body. Behavior preserved. (`handleActuateElevation` ignores its `*Heartbeat` param today via `_`; switch it to `h` so it can call the method.)
+
+- [ ] **Step 4: Run the regression tests**
+
+Run: `cd agent && go test ./internal/heartbeat/ -run Actuate -race -v`
+Expected: PASS — same tests as Step 1, unchanged behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd agent && git add internal/heartbeat/handlers_actuate.go
+git commit -m "refactor(agent/pam): share actuate core between remote command and local flow"
+```
+
+---
+
+## Task 5 — The orchestrator `(*Heartbeat).RunPamFlow`
+
+**Files:**
+- Create: `agent/internal/heartbeat/pam_flow.go`
+- Create: `agent/internal/heartbeat/pam_flow_test.go`
+- Modify: `agent/internal/heartbeat/heartbeat.go` (add two swappable test-seam fields to the struct)
+
+- [ ] **Step 1: Add swappable dialog seams to the `Heartbeat` struct**
+
+In `heartbeat.go`, beside `helperFinder` (line 165), add two nil-able fields (lazy defaults are applied in `RunPamFlow`, so no init-block change is required):
+
+```go
+	helperFinder     func(targetSession string) *sessionbroker.Session
+	// pamFindSession / pamRequestDialog default to the real broker methods
+	// in RunPamFlow when nil; overridden in pam_flow_test.go.
+	pamFindSession   func(capability, targetWinSession string) *sessionbroker.Session
+	pamRequestDialog func(session *sessionbroker.Session, id string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error)
+```
+
+- [ ] **Step 2: Write the failing table test in `pam_flow_test.go`**
+
+```go
+package heartbeat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/elevaccount"
+	"github.com/breeze-rmm/agent/internal/etwlua"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/pamactuator"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+// fakeActuator records which path fired.
+type fakeActuator struct{ triggered, dismissed bool }
+
+func (f *fakeActuator) Trigger(_ context.Context, _ pamactuator.Request) pamactuator.Result {
+	f.triggered = true
+	return pamactuator.Result{Success: true, Reason: "ok"}
+}
+func (f *fakeActuator) Dismiss(_ context.Context) pamactuator.Result {
+	f.dismissed = true
+	return pamactuator.Result{Success: true, Reason: "ok"}
+}
+
+type fakeAccount struct{ promoted, demoted bool }
+
+func (f *fakeAccount) EnsureProvisioned() error { return nil }
+func (f *fakeAccount) Promote(_ context.Context) (elevaccount.Credential, error) {
+	f.promoted = true
+	return elevaccount.Credential{Username: "~breeze_elev", Password: "pw"}, nil
+}
+func (f *fakeAccount) Demote(_ context.Context) error { f.demoted = true; return nil }
+
+func TestRunPamFlow(t *testing.T) {
+	approve := ipc.PamDialogResult{Approved: true}
+	deny := ipc.PamDialogResult{Approved: false, DismissedByUser: true}
+
+	cases := []struct {
+		name           string
+		status         string
+		dialog         ipc.PamDialogResult
+		noSession      bool
+		wantTriggered  bool
+		wantDismissed  bool
+	}{
+		{"policy denied → dismiss, no dialog", "denied", approve, false, false, true},
+		{"auto_approved + approve → actuate", "auto_approved", approve, false, true, false},
+		{"auto_approved + user deny → dismiss", "auto_approved", deny, false, false, true},
+		{"pending + approve → await (nothing)", "pending", approve, false, false, false},
+		{"pending + user deny → dismiss", "pending", deny, false, false, true},
+		{"no capable session → nothing", "auto_approved", approve, true, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			act := &fakeActuator{}
+			acct := &fakeAccount{}
+			restoreAct := swapActuatorForTest(func() pamactuator.Actuator { return act })
+			defer restoreAct()
+			restoreAcct := swapAccountForTest(func() elevaccount.AccountManager { return acct })
+			defer restoreAcct()
+
+			h := &Heartbeat{
+				pamFindSession: func(string, string) *sessionbroker.Session {
+					if tc.noSession {
+						return nil
+					}
+					return &sessionbroker.Session{}
+				},
+				pamRequestDialog: func(*sessionbroker.Session, string, ipc.PamRequestDialog, time.Duration) (ipc.PamDialogResult, error) {
+					return tc.dialog, nil
+				},
+			}
+
+			h.RunPamFlow(context.Background(), etwlua.Event{TargetExecutablePath: `C:\x.exe`}, etwlua.ElevationOutcome{RequestID: "r1", Status: tc.status})
+
+			if act.triggered != tc.wantTriggered {
+				t.Errorf("triggered = %v, want %v", act.triggered, tc.wantTriggered)
+			}
+			if act.dismissed != tc.wantDismissed {
+				t.Errorf("dismissed = %v, want %v", act.dismissed, tc.wantDismissed)
+			}
+			if tc.wantTriggered && (!acct.promoted || !acct.demoted) {
+				t.Errorf("actuate must promote(%v) and demote(%v)", acct.promoted, acct.demoted)
+			}
+		})
+	}
+}
+```
+
+This test references `swapActuatorForTest` / `swapAccountForTest`. The mapping mentioned `swapActuatorForTest` already exists for `newActuator`; if `swapAccountForTest` does not exist, add the trivial swap helpers next to the `newActuator`/`newElevationAccountManager` vars:
+
+```go
+func swapActuatorForTest(fn func() pamactuator.Actuator) func() {
+	prev := newActuator
+	newActuator = fn
+	return func() { newActuator = prev }
+}
+func swapAccountForTest(fn func() elevaccount.AccountManager) func() {
+	prev := newElevationAccountManager
+	newElevationAccountManager = fn
+	return func() { newElevationAccountManager = prev }
+}
+```
+
+(If `swapActuatorForTest` already exists, reuse it and only add `swapAccountForTest`.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/heartbeat/ -run TestRunPamFlow -v`
+Expected: FAIL — `RunPamFlow` not defined.
+
+- [ ] **Step 4: Implement `pam_flow.go`**
+
+```go
+package heartbeat
+
+import (
+	"context"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/etwlua"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+const (
+	// These literals must match sessionbroker.ComposePamDecision's expected
+	// policyVerdict values (pam_decision.go). Do not change without changing both.
+	pamVerdictEndUserAllowed  = "end-user-allowed"
+	pamVerdictRequireApproval = "require-approval"
+
+	// pamDialogTimeout bounds the broker round-trip to comfortably under
+	// consent.exe's idle lifetime (~120s default). Timeout → deny+dismiss.
+	pamDialogTimeout = 90 * time.Second
+
+	// defaultActuateTimeoutMs is the per-actuation consent.exe wait (mirrors
+	// the remote handler's 8s default).
+	defaultActuateTimeoutMs = 8000
+)
+
+// RunPamFlow implements etwlua.PamRunner. Given the server's ingest decision
+// for a detected UAC prompt, it shows the user-desktop PAM dialog (when the
+// status warrants it), composes the decision, and either actuates locally
+// (end-user-allowed) or dismisses consent.exe (deny). The require-approval
+// path resolves remotely: the server issues an actuate_elevation command
+// (handlers_actuate.go) once a technician approves.
+func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etwlua.ElevationOutcome) {
+	switch outcome.Status {
+	case "denied":
+		// Policy hard-deny — no dialog; cancel the prompt immediately.
+		h.denyConsent(ctx, outcome.RequestID, "policy_denied")
+		return
+	case "auto_approved", "pending":
+		// fall through to the dialog gate
+	default:
+		log.Debug("pam: no local flow for status", "status", outcome.Status, "elevationRequestId", outcome.RequestID)
+		return
+	}
+
+	find := h.pamFindSession
+	if find == nil {
+		find = h.sessionBroker.FindCapableSession
+	}
+	session := find(ipc.ScopePam, "")
+	if session == nil {
+		log.Warn("pam: no capable user-helper session; cannot show dialog, consent.exe will time out",
+			"elevationRequestId", outcome.RequestID)
+		return
+	}
+
+	ask := h.pamRequestDialog
+	if ask == nil {
+		ask = h.sessionBroker.RequestPamApproval
+	}
+	dialog, err := ask(session, outcome.RequestID, buildPamRequestDialog(ev), pamDialogTimeout)
+	if err != nil {
+		// RequestPamApproval already returns deny+dismiss on error, but be defensive.
+		log.Warn("pam: dialog round-trip error; treating as deny", "elevationRequestId", outcome.RequestID, "error", err.Error())
+		dialog = ipc.PamDialogResult{Approved: false, DismissedByUser: true}
+	}
+
+	verdict := pamVerdictEndUserAllowed
+	if outcome.Status == "pending" {
+		verdict = pamVerdictRequireApproval
+	}
+
+	switch sessionbroker.ComposePamDecision(verdict, dialog, nil) {
+	case sessionbroker.PamActionActuate:
+		res := h.actuateElevation(ctx, outcome.RequestID, defaultActuateTimeoutMs)
+		log.Info("pam: local actuation complete",
+			"elevationRequestId", outcome.RequestID, "success", res.Success, "reason", res.Reason)
+	case sessionbroker.PamActionDeny:
+		h.denyConsent(ctx, outcome.RequestID, dialog.Reason)
+	case sessionbroker.PamActionAwaitRemote:
+		log.Info("pam: awaiting remote technician approval; server will issue actuate_elevation",
+			"elevationRequestId", outcome.RequestID)
+	}
+}
+
+// denyConsent cancels the live consent.exe prompt and logs the denial.
+// Server-side audit of the local decision is a follow-up (no agent→server
+// outcome endpoint exists yet; the remote/mobile mirror is #1254).
+func (h *Heartbeat) denyConsent(ctx context.Context, requestID, reason string) {
+	res := newActuator().Dismiss(ctx)
+	log.Info("pam: denied elevation, dismissed consent prompt",
+		"elevationRequestId", requestID, "reason", reason,
+		"dismiss_success", res.Success, "dismiss_reason", res.Reason)
+}
+
+// buildPamRequestDialog maps a detected ETW event onto the dialog payload.
+// Reason/IntentSummary are left empty (AI intent summary is Phase 2).
+func buildPamRequestDialog(ev etwlua.Event) ipc.PamRequestDialog {
+	return ipc.PamRequestDialog{
+		ExePath:     ev.TargetExecutablePath,
+		Signer:      ev.TargetExecutableSigner,
+		Hash:        ev.TargetExecutableHash,
+		SubjectUser: ev.SubjectUsername,
+		CommandLine: ev.CommandLine,
+	}
+}
+```
+
+Before writing, **read `internal/ipc/message.go`** to confirm the exact `PamRequestDialog` field names (`ExePath`, `Signer`, `Hash`, `SubjectUser`, `CommandLine`, `Reason`, `IntentSummary`) and `PamDialogResult` (`Approved`, `Reason`, `DismissedByUser`), and confirm `ipc.ScopePam` is the const name. Adjust field names to match reality if they differ.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd agent && go test ./internal/heartbeat/ -run TestRunPamFlow -race -v`
+Expected: PASS (all 6 table cases).
+
+- [ ] **Step 6: Full package test + Windows build**
+
+Run: `cd agent && go test ./internal/heartbeat/ -race && GOOS=windows go build ./...`
+Expected: PASS; Windows cross-compile succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd agent && git add internal/heartbeat/pam_flow.go internal/heartbeat/pam_flow_test.go internal/heartbeat/heartbeat.go
+git commit -m "feat(agent/pam): RunPamFlow orchestrator — dialog → decision → actuate/deny"
+```
+
+---
+
+## Task 6 — Wire the runner at agent startup
+
+**Files:**
+- Modify: `agent/cmd/breeze-agent/etwlua_start_windows.go:28-50`
+
+- [ ] **Step 1: Pass `hb` as the `PamRunner`**
+
+`*heartbeat.Heartbeat` now satisfies both `etwlua.HeartbeatPoster` and `etwlua.PamRunner`. Update the `Start` call in `startETWLua`:
+
+```go
+	go func() {
+		defer close(done)
+		if err := etwlua.Start(ctx, sub, hb, hb); err != nil { // hb is both poster and runner
+			log.Warn("etwlua Start returned error", "error", err.Error())
+		}
+	}()
+```
+
+- [ ] **Step 2: Verify the non-Windows path still compiles**
+
+If a non-Windows `startETWLua` stub or any other `etwlua.Start` caller exists, ensure it passes a `PamRunner` (or `nil`). Grep:
+
+Run: `cd agent && grep -rn "etwlua.Start(" cmd/ internal/`
+For each call site, ensure arity matches the new 4-arg signature (pass `nil` where there is no runner).
+
+- [ ] **Step 3: Build both targets**
+
+Run: `cd agent && go build ./... && GOOS=windows go build ./...`
+Expected: both succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd agent && git add cmd/breeze-agent/etwlua_start_windows.go
+git commit -m "feat(agent/pam): wire RunPamFlow into etwlua startup"
+```
+
+---
+
+## Task 7 — Full suite + cross-compile gate
+
+- [ ] **Step 1: Race the touched packages**
+
+Run: `cd agent && go test -race ./internal/etwlua/ ./internal/heartbeat/ ./internal/pamactuator/ ./internal/sessionbroker/`
+Expected: PASS.
+
+- [ ] **Step 2: Windows cross-compile (the runtime target)**
+
+Run: `cd agent && GOOS=windows GOARCH=amd64 go build ./...`
+Expected: success — this is the only compile-time check CI gives us for the Windows path (runtime gap is #1000).
+
+- [ ] **Step 3: `go vet`**
+
+Run: `cd agent && go vet ./internal/etwlua/ ./internal/heartbeat/ ./internal/pamactuator/`
+Expected: clean.
+
+- [ ] **Step 4: Commit any fixups**
+
+```bash
+cd agent && git add -A && git commit -m "test(agent/pam): green race + windows cross-compile for etwlua wiring" || echo "nothing to commit"
+```
+
+---
+
+## Manual VM verification (Windows — gated, not CI; tracks #1000)
+
+Run on a throwaway Windows VM with the agent installed as a SYSTEM service and a user logged into the interactive console (so a `pam`-scoped user helper is connected). For each, watch agent diagnostic logs (`component=pam` / `etwlua`).
+
+- [ ] **Auto-approved path:** Configure a PAM rule/software-policy that auto-approves a chosen signed exe. Trigger its UAC prompt. Expect: Breeze dialog appears on the user desktop within ~1s → click Approve → `~breeze_elev` is promoted → creds typed onto consent.exe → consent closes (app elevates) → `~breeze_elev` demoted. Confirm the account is disabled again afterward (`net user ~breeze_elev`).
+- [ ] **End-user deny:** Same rule; click Deny on the Breeze dialog. Expect: consent.exe is dismissed via Escape (prompt closes, app does not elevate); log shows `dismiss_success=true`.
+- [ ] **Policy hard-deny:** Configure a blocklist rule for an exe. Trigger it. Expect: **no** Breeze dialog; consent.exe dismissed immediately; log `reason=policy_denied`.
+- [ ] **Require-approval / await_remote:** Configure a rule with no auto-decision (→ `pending`). Trigger it, approve the Breeze dialog. Expect: log `awaiting remote technician approval`; consent.exe stays up; approve from the web/mobile surface (#1159) → server sends `actuate_elevation` → promote/type/demote completes. (This exercises the seam with #1254's server-side mobile bridge once that lands.)
+- [ ] **Dedupe:** Trigger the same exe twice within 30s. Expect: a single dialog (re-fired ETW events deduped), no stacked dialogs.
+- [ ] **No helper connected:** Lock the workstation / no console user. Trigger a prompt. Expect: log `no capable user-helper session`; agent does not crash; consent.exe times out on its own.
+
+---
+
+## Risks / watch-items
+
+- **Blocking the ETW loop:** `RunPamFlow` is called synchronously from `handleEvent`. UAC is modal and serial, and the dialog round-trip is bounded by `pamDialogTimeout` (90s) and the actuator's own deadline, so the loop cannot pin forever. If real-world UAC bursts prove this too coarse, move the call to a single-flight goroutine — but do **not** allow concurrent flows (one consent.exe at a time).
+- **consent.exe lifetime vs await_remote:** the default UAC idle timeout is ~120s. The `pending` path depends on a technician approving within that window; otherwise consent.exe self-dismisses and the later `actuate_elevation` finds no window (`no_consent_window`). This is inherent, not a bug — note it in docs (#1161).
+- **Verdict literal coupling:** `pamVerdictEndUserAllowed`/`pamVerdictRequireApproval` must stay byte-identical to `ComposePamDecision`'s expected strings. A unit test indirectly guards this (a mismatch makes `auto_approved + approve` fail to actuate); keep the table test.
+- **`ipc.PamRequestDialog`/`PamDialogResult` field names** — verify against `ipc/message.go` before writing Task 5; the names above come from the #1152 plan, not a fresh read.
+- **No agent→server outcome audit** for the local decision yet. The dormant-admin promote/demote already audit-log agent-side; mirroring the *decision* to the server row is deferred (pairs with #1254). Don't invent an endpoint here.
+- **Windows-only runtime, CI blind** (#1000): everything cross-platform is unit-tested; the live path is only proven by the VM checklist above.
+
+---
+
+## Self-review checklist
+
+- [ ] Dialog renders on the user's interactive desktop via the `pam`-scoped user helper (`FindCapableSession(ipc.ScopePam, "")`), never SYSTEM/secure desktop.
+- [ ] `denied` status skips the dialog; `ignored` never reaches the runner (filtered in `handleEvent`).
+- [ ] `auto_approved`→`end-user-allowed`, `pending`→`require-approval`; verdict literals match `ComposePamDecision`.
+- [ ] `await_remote` does nothing locally — the existing `actuate_elevation` command is the remote actuation path; no new server command invented.
+- [ ] `etwlua`→broker edge is behind the `PamRunner` interface; `etwlua` tests use `fakePamRunner`, no live broker.
+- [ ] RateLimiter dedupe (unchanged, 30s) prevents stacked dialogs per prompt.
+- [ ] Actuate core is shared between the remote command and local flow (`actuateElevation`); demotion is still guaranteed via `defer`.
+- [ ] No server-side change (the POST already returns `{id,status}`).
+- [ ] `go test -race` green on all four packages; `GOOS=windows go build ./...` succeeds.


### PR DESCRIPTION
## Summary

Implements **#1253** — the keystone that connects the already-shipped PAM building blocks into a working local Windows elevation flow: **detect → dialog → decide → actuate-or-deny**. Until now, ETW UAC detection, the PAM dialog, the decision composer, the dormant-admin lifecycle, and the consent.exe actuator all existed independently and nothing fired them end-to-end.

**No server change** — the `POST /elevation-requests` handler already returns its ingest decision as `{id, status}`; the agent just parses it now and drives the flow off `status`.

## What's wired

`etwlua.handleEvent` (after the existing dedupe + POST) → `(*Heartbeat).RunPamFlow`:

| Server `status` | Flow |
|---|---|
| `ignored` / empty | skipped (filtered at the etwlua gate) |
| `denied` | dismiss consent.exe (Escape), **no dialog** — policy hard-deny |
| `auto_approved` | show user-desktop dialog → approve → promote `~breeze_elev` → type creds → demote; deny → dismiss |
| `pending` | show dialog → approve → `await_remote` (the **existing** `actuate_elevation` server command actuates when a tech approves); deny → dismiss |

Key pieces: parse `{id,status}`→`ElevationOutcome`; a nil-safe `etwlua.PamRunner` seam (keeps `etwlua` unit-testable, broker-gated at startup); a new consent.exe **deny** path (`vkEscape` + `Actuator.Dismiss`); a shared `actuateElevation` used by both the local flow and the remote command; verdict mapping via the exported `sessionbroker.PamPolicy*` consts.

## Review

Built task-by-task (TDD) with per-task spec + code-quality review, then a multi-dimension adversarial review (7 dimensions → 27 findings → 14 confirmed, each verified by a refutation pass). **All confirmed fix-now findings are resolved**, including two genuinely important ones:

- **Actuation race:** the local etwlua flow and the remote `actuate_elevation` command could drive SendInput at the same consent.exe concurrently → added a `pamActuateMu` serializing the promote/type/demote and dismiss critical sections (verified non-reentrant, no deadlock; `-race` test).
- **Dedupe vs flow duration:** the 30s dedupe could expire during a ≤90s blocking flow → re-assert dedupe at flow-end.

Plus: `recover()` guard on the local flow (raw-syscall path), per-flow context ceiling, Warn-level logging for failed deny/actuation, and `buildPamRequestDialog` field-mapping test coverage.

## Test plan

- [x] `go test -race ./internal/etwlua/ ./internal/heartbeat/ ./internal/pamactuator/ ./internal/sessionbroker/` — all pass
- [x] `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` — both clean
- [x] `go vet` — clean
- [ ] **Manual Windows VM verification (required before merge — CI-blind, see #1000):** the live detect→dialog→actuate/deny path has only been compiled, never run. Run the checklist in `docs/superpowers/plans/2026-06-14-pam-etw-wire-detect-actuate.md`: auto_approved→actuate, end-user deny→Escape, policy hard-deny→Escape (no dialog), pending→await_remote→server `actuate_elevation`, dedupe (one dialog per prompt), no-helper-session→consent times out.

## Known follow-ups (deferred by design)

- **User-facing "awaiting tech approval" notice** on the `await_remote` path is only logged today (the notify primitive exists; pairs with the #1254 mobile/web UX).
- **Synchronous flow blocks the ETW loop** for the dialog round-trip; under a multi-user/RDS burst (>64 distinct prompts in one ~90s window) distinct events could be dropped. Fallback is a single-flight goroutine — tracked for a hardening follow-up.
- **Agent→server outcome audit** of the local decision is deferred (pairs with #1254); no outcome endpoint exists yet.

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)