### PR TITLE
fix(audit): green main's Integration Tests + complete #1351 erasure wiring

### DIFF
--- a/apps/api/src/__tests__/integration/audit-chain-anchor.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-chain-anchor.integration.test.ts
@@ -55,8 +55,10 @@ async function readHead(orgId: string): Promise<HeadRow> {
     SELECT head_chain_seq, head_chain_checksum, entry_count
     FROM audit_chain_read_head(${orgId}::uuid)
   `)) as unknown as HeadRow[];
-  // entry_count is a pg bigint → returned as a string; coerce so numeric assertions hold.
-  return { ...rows[0]!, entry_count: Number(rows[0]!.entry_count) };
+  // head_chain_seq / entry_count are pg bigints → returned as strings; coerce
+  // so numeric assertions (toBe / toBeGreaterThan) hold.
+  const r = rows[0]!;
+  return { ...r, head_chain_seq: Number(r.head_chain_seq), entry_count: Number(r.entry_count) };
 }
 
 async function writeAnchor(orgId: string): Promise<AnchorRow> {
@@ -65,7 +67,8 @@ async function writeAnchor(orgId: string): Promise<AnchorRow> {
       SELECT anchor_seq, head_chain_seq, entry_count, signed
       FROM audit_chain_anchor_head(${orgId}::uuid)
     `)) as unknown as AnchorRow[];
-    return { ...rows[0]!, entry_count: Number(rows[0]!.entry_count) };
+    const r = rows[0]!;
+    return { ...r, anchor_seq: Number(r.anchor_seq), head_chain_seq: Number(r.head_chain_seq), entry_count: Number(r.entry_count) };
   });
 }
 
@@ -74,7 +77,11 @@ async function verifyAnchor(orgId: string): Promise<DivergenceRow[]> {
     SELECT reason, anchored_head_seq, live_head_seq
     FROM audit_chain_verify_anchor(${orgId}::uuid)
   `)) as unknown as DivergenceRow[];
-  return rows;
+  return rows.map((r) => ({
+    ...r,
+    anchored_head_seq: Number(r.anchored_head_seq),
+    live_head_seq: Number(r.live_head_seq),
+  }));
 }
 
 interface SignedAnchorRow {
@@ -107,7 +114,8 @@ async function writeSignedAnchor(
         ${expectedEntryCount}::bigint
       )
     `)) as unknown as SignedAnchorRow[];
-    return rows[0]!;
+    const r = rows[0]!;
+    return { ...r, anchor_seq: Number(r.anchor_seq), head_chain_seq: Number(r.head_chain_seq) };
   });
 }
 

--- a/apps/api/src/__tests__/integration/audit-chain-anchor.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-chain-anchor.integration.test.ts
@@ -55,7 +55,8 @@ async function readHead(orgId: string): Promise<HeadRow> {
     SELECT head_chain_seq, head_chain_checksum, entry_count
     FROM audit_chain_read_head(${orgId}::uuid)
   `)) as unknown as HeadRow[];
-  return rows[0]!;
+  // entry_count is a pg bigint → returned as a string; coerce so numeric assertions hold.
+  return { ...rows[0]!, entry_count: Number(rows[0]!.entry_count) };
 }
 
 async function writeAnchor(orgId: string): Promise<AnchorRow> {
@@ -64,7 +65,7 @@ async function writeAnchor(orgId: string): Promise<AnchorRow> {
       SELECT anchor_seq, head_chain_seq, entry_count, signed
       FROM audit_chain_anchor_head(${orgId}::uuid)
     `)) as unknown as AnchorRow[];
-    return rows[0]!;
+    return { ...rows[0]!, entry_count: Number(rows[0]!.entry_count) };
   });
 }
 
@@ -277,7 +278,7 @@ describe('audit_chain_anchors external anchor', () => {
     expect(
       (updateErr as { cause?: { message?: string } })?.cause?.message ??
         String(updateErr),
-    ).toMatch(/append-only/i);
+    ).toMatch(/append-only|permission denied/i); // both layers (grant REVOKE + trigger) enforce immutability for breeze_app
 
     // DELETE must also be rejected (no retention GUC set).
     let deleteErr: unknown;
@@ -294,7 +295,7 @@ describe('audit_chain_anchors external anchor', () => {
     expect(
       (deleteErr as { cause?: { message?: string } })?.cause?.message ??
         String(deleteErr),
-    ).toMatch(/append-only/i);
+    ).toMatch(/append-only|permission denied/i); // both layers (grant REVOKE + trigger) enforce immutability for breeze_app
 
     // The anchor row is still present and unchanged.
     const remaining = (await getTestDb().execute(sql`

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -73,6 +73,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'audit_baseline_apply_approvals',
   'audit_baseline_results',
   'audit_baselines',
+  'audit_chain_anchors',
   'audit_log_chain',
   'audit_logs',
   'audit_policy_states',
@@ -280,7 +281,7 @@ const ASSOCIATED_SYSTEM_SCOPED_TABLES: ReadonlyArray<{
  * to DELETE. These are gated by the audit_log_immutable trigger and
  * the per-role DELETE grant established in migration 2026-05-25-i.
  */
-const AUDIT_ADMIN_REQUIRED_TABLES: ReadonlySet<string> = new Set<string>(['audit_logs', 'audit_log_chain']);
+const AUDIT_ADMIN_REQUIRED_TABLES: ReadonlySet<string> = new Set<string>(['audit_logs', 'audit_log_chain', 'audit_chain_anchors']);
 
 interface FkEdge {
   // SQL aliases are snake_case (postgres-js does not auto-camelCase).


### PR DESCRIPTION
**Root cause:** #1351 (#916) merged with main's `Integration Tests` job red. Four defects, all in the audit-anchor work:

1. **`audit_chain_anchors` missing from `ORG_CASCADE_DELETE_ORDER`** (it has `org_id`) → `tenantCascade.integration.test.ts` contract failed.
2. **Missing from `AUDIT_ADMIN_REQUIRED_TABLES`** — it's append-only (breeze_app `REVOKE DELETE` + immutability trigger) like `audit_log_chain`, so GDPR erasure must delete it as `breeze_audit_admin` or it would fail `permission denied`. Latent runtime bug, not just a test gap.
3. **`entry_count` count assertions** (`'3' to be 3`) — pg bigint returns as a string; coerce in `readHead`/`writeAnchor`.
4. **`/append-only/i` vs `permission denied`** — on main the grant REVOKE blocks UPDATE/DELETE before the trigger fires, so the error text differs; broaden both assertions (either proves immutability for breeze_app).

**Why:** unblocks main (and #1282/#1283/#1356, which all inherit the red Integration Tests). Found during local integration testing of the merged batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)