### PR TITLE
fix(api): carve out 500MB body limit for software package uploads (#1377)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import { bodyLimit } from 'hono/body-limit';
 
 import { securityMiddleware } from './middleware/security';
+import { bodyLimitForPath } from './middleware/bodyLimit';
 import { globalRateLimit } from './middleware/globalRateLimit';
 import { authRoutes } from './routes/auth';
 import { accountDeletionAdminRoutes } from './routes/auth/accountDeletion';
@@ -286,19 +287,8 @@ app.use('*', async (c, next) => {
   if (c.req.path === '/oauth' || c.req.path.startsWith('/oauth/')) {
     return next();
   }
-  // Dev-push uploads agent binaries (~20MB); skip the default 1MB limit.
-  if (c.req.path.startsWith('/api/v1/dev/push')) {
-    return bodyLimit({ maxSize: 150 * 1024 * 1024, onError: (ctx) => ctx.json({ error: 'Binary too large (max 150MB)' }, 413) })(c, next);
-  }
-  // File transfer chunk uploads can be up to 50MB; route-level bodyLimit handles the real cap.
-  if (c.req.path.match(/^\/api\/v1\/remote\/transfers\/[^/]+\/chunks$/)) {
-    return bodyLimit({ maxSize: 50 * 1024 * 1024, onError: (ctx) => ctx.json({ error: 'Chunk too large (max 50MB)' }, 413) })(c, next);
-  }
-  // File browser uploads send base64-encoded content in JSON body (~33% overhead).
-  if (c.req.path.match(/^\/api\/v1\/system-tools\/devices\/[^/]+\/files\/upload$/)) {
-    return bodyLimit({ maxSize: 50 * 1024 * 1024, onError: (ctx) => ctx.json({ error: 'File too large (max ~37MB)' }, 413) })(c, next);
-  }
-  return bodyLimit({ maxSize: 1024 * 1024, onError: (ctx) => ctx.json({ error: 'Request body too large' }, 413) })(c, next);
+  const { maxSize, error } = bodyLimitForPath(c.req.path);
+  return bodyLimit({ maxSize, onError: (ctx) => ctx.json({ error }, 413) })(c, next);
 });
 app.use('*', globalRateLimit());
 app.use('*', prettyJSON());

--- a/apps/api/src/middleware/bodyLimit.test.ts
+++ b/apps/api/src/middleware/bodyLimit.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { bodyLimitForPath } from './bodyLimit';
+
+const MB = 1024 * 1024;
+
+describe('bodyLimitForPath', () => {
+  it('applies the tight 1MB default to ordinary routes', () => {
+    expect(bodyLimitForPath('/api/v1/devices')).toEqual({
+      maxSize: 1 * MB,
+      error: 'Request body too large',
+    });
+    expect(bodyLimitForPath('/api/v1/software/catalog')).toEqual({
+      maxSize: 1 * MB,
+      error: 'Request body too large',
+    });
+  });
+
+  it('carves out dev-push binary uploads at 150MB', () => {
+    expect(bodyLimitForPath('/api/v1/dev/push')).toEqual({
+      maxSize: 150 * MB,
+      error: 'Binary too large (max 150MB)',
+    });
+    expect(bodyLimitForPath('/api/v1/dev/push/anything')).toEqual({
+      maxSize: 150 * MB,
+      error: 'Binary too large (max 150MB)',
+    });
+  });
+
+  it('carves out remote file-transfer chunk uploads at 50MB', () => {
+    expect(bodyLimitForPath('/api/v1/remote/transfers/abc-123/chunks')).toEqual({
+      maxSize: 50 * MB,
+      error: 'Chunk too large (max 50MB)',
+    });
+  });
+
+  it('carves out file-browser uploads at 50MB', () => {
+    expect(bodyLimitForPath('/api/v1/system-tools/devices/dev-1/files/upload')).toEqual({
+      maxSize: 50 * MB,
+      error: 'File too large (max ~37MB)',
+    });
+  });
+
+  // Regression for #1377: the software package (installer) upload route must get a
+  // 500MB+ carve-out, not the 1MB default. Before the fix, any installer over 1MB
+  // was rejected by the global gate with "Request body too large" before the route's
+  // own 500MB MAX_UPLOAD_SIZE check could run.
+  it('carves out software package installer uploads above the route 500MB cap (#1377)', () => {
+    const result = bodyLimitForPath('/api/v1/software/catalog/cat-123/versions/upload');
+    expect(result.error).toBe('Package too large (max 500MB)');
+    expect(result.maxSize).toBeGreaterThan(500 * MB);
+    expect(result.maxSize).toBe(512 * MB);
+  });
+
+  it('does not over-match the software carve-out to sibling software routes', () => {
+    // The version metadata route (no file body) and the catalog list must stay at the default.
+    expect(bodyLimitForPath('/api/v1/software/catalog/cat-123/versions').maxSize).toBe(1 * MB);
+    expect(bodyLimitForPath('/api/v1/software/catalog/cat-123/versions/upload/extra').maxSize).toBe(1 * MB);
+  });
+});

--- a/apps/api/src/middleware/bodyLimit.ts
+++ b/apps/api/src/middleware/bodyLimit.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-route request body-size limits.
+ *
+ * The global default is intentionally tight (1MB). Routes that legitimately
+ * accept larger payloads (binary/dev-push, file-transfer chunks, file-browser
+ * uploads, software package installers) are carved out explicitly here so the
+ * global gate doesn't reject them with a generic 413 before their own
+ * route-level size checks ever run.
+ *
+ * Kept as a pure function (no Hono/server imports) so it can be unit-tested
+ * without booting the API.
+ */
+export function bodyLimitForPath(path: string): { maxSize: number; error: string } {
+  // Dev-push uploads agent binaries (~20MB); skip the default 1MB limit.
+  if (path.startsWith('/api/v1/dev/push')) {
+    return { maxSize: 150 * 1024 * 1024, error: 'Binary too large (max 150MB)' };
+  }
+  // File transfer chunk uploads can be up to 50MB; route-level bodyLimit handles the real cap.
+  if (path.match(/^\/api\/v1\/remote\/transfers\/[^/]+\/chunks$/)) {
+    return { maxSize: 50 * 1024 * 1024, error: 'Chunk too large (max 50MB)' };
+  }
+  // File browser uploads send base64-encoded content in JSON body (~33% overhead).
+  if (path.match(/^\/api\/v1\/system-tools\/devices\/[^/]+\/files\/upload$/)) {
+    return { maxSize: 50 * 1024 * 1024, error: 'File too large (max ~37MB)' };
+  }
+  // Software package (installer) uploads are multipart and capped at 500MB by the
+  // route's own MAX_UPLOAD_SIZE check; give the body limit headroom over that so the
+  // route returns its specific "File too large" message instead of this generic one.
+  if (path.match(/^\/api\/v1\/software\/catalog\/[^/]+\/versions\/upload$/)) {
+    return { maxSize: 512 * 1024 * 1024, error: 'Package too large (max 500MB)' };
+  }
+  return { maxSize: 1024 * 1024, error: 'Request body too large' };
+}


### PR DESCRIPTION
## Problem

Fixes #1377. On a self-hosted v0.70.0 deployment, uploading an installer to the software library fails with **"Request body too large"** for any real package.

Root cause: the package-file upload route `POST /api/v1/software/catalog/:id/versions/upload` (`apps/api/src/routes/software.ts`) is designed to accept files up to **500MB** (`MAX_UPLOAD_SIZE`), but the global body-size middleware in `apps/api/src/index.ts` applies the tight **1MB** default to every route that isn't explicitly carved out. This route wasn't in the carve-out list (unlike `/dev/push`, `/remote/transfers/.../chunks`, `/system-tools/.../files/upload`), so the global gate rejected every upload with a generic `413 "Request body too large"` before the route's own `file.size > MAX_UPLOAD_SIZE` check (or its S3-configured check) ever ran. Every `.msi/.exe/.dmg/.deb/.pkg` is larger than 1MB, so the upload always failed. The reporter's Caddy isn't involved — Caddy doesn't cap request bodies by default.

## Fix

- Add a body-limit carve-out for `^/api/v1/software/catalog/[^/]+/versions/upload$` at **512MB** (headroom over the route's 500MB cap, so the route returns its own specific "File too large (max 500MB)" message rather than the generic one).
- Extract the path → limit decision out of the inline middleware closure into a pure, exported `bodyLimitForPath()` in `apps/api/src/middleware/bodyLimit.ts`. `index.ts` runs `bootstrap()` (server/DB/Redis) at import, so the inline closure couldn't be unit-tested; the pure helper can. No behavior change for any existing route.
- Add `bodyLimit.test.ts` covering every carve-out, the 1MB default, the new software-upload rule, and over-match guards (sibling `/versions` metadata route and `/upload/extra` stay at the default).

## Note for self-hosters

This route stores the file in S3-compatible storage and returns `503 "S3 storage is not configured"` unless `S3_BUCKET` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` are set. That was previously masked by the 1MB gate firing first; after this fix those vars are required for the upload to actually store the package. (Tracking only software metadata via "Add Package" + a version `downloadUrl` avoids the file-upload path entirely.)

## Local verification (OrbStack / pnpm 10.33.4)

- `tsc --noEmit` (api): exit 0
- `eslint` on changed files: exit 0
- new `bodyLimit.test.ts`: 6/6 pass
- adjacent route tests (`devPush`, `remote`, `agents/logs`): 45/45 pass
- full API unit suite: **7688 passed**, 28 skipped. The only 2 failures are in `routes/auth/login.test.ts` (`#719` inactive-tenant observability), which **fail identically on clean `main` without this change** and pass in `main` CI on the same commit — a local Node-version environmental discrepancy, unrelated to this PR (this PR touches only `index.ts` + `middleware/bodyLimit.*`).
