### PR TITLE
feat(observability): contextless-write guard + unified worker error reporting (#1379)

### DIFF
--- a/apps/api/src/db/contextlessWriteGuard.test.ts
+++ b/apps/api/src/db/contextlessWriteGuard.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the sentry service so the proxy guard's captureMessage call is
+// observable and never touches a real (uninitialized) SDK.
+vi.mock('../services/sentry', () => ({
+  captureMessage: vi.fn(),
+}));
+
+import { captureMessage } from '../services/sentry';
+import { db, hasDbAccessContext } from './index';
+
+describe('contextless-write guard on proxiedDb (#1375/#1379)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('precondition: no active DB access context in a bare test', () => {
+    expect(hasDbAccessContext()).toBe(false);
+  });
+
+  it('warns + reports when accessing .update outside a context', () => {
+    // Merely accessing the proxy getter fires the guard (we never execute
+    // the query, so no DB connection is required).
+    void db.update;
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+
+    const firstCall = (captureMessage as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const [message, level, extra] = firstCall;
+    expect(message).toContain('.update()');
+    expect(message).toContain('#1375');
+    expect(level).toBe('warning');
+    expect(extra).toHaveProperty('stack');
+  });
+
+  it('warns + reports for .insert and .delete too', () => {
+    void db.insert;
+    void db.delete;
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(captureMessage).toHaveBeenCalledTimes(2);
+    const calls = (captureMessage as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toContain('.insert()');
+    expect(calls[1]![0]).toContain('.delete()');
+  });
+
+  it('does NOT warn for read methods like .select', () => {
+    void db.select;
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -8,6 +8,7 @@ import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
+import { captureMessage } from '../services/sentry';
 
 // Prefer DATABASE_URL_APP (the unprivileged breeze_app role) so RLS policies
 // are actually enforced. Fall back to DATABASE_URL for backward compatibility
@@ -163,8 +164,33 @@ export const runOutsideDbContext: RunOutsideDbContextFn = <T>(fn: () => T): T =>
   return dbContextStorage.exit(fn);
 };
 
+// Write methods that, when invoked on the bare pool (no active RLS access
+// context), silently match 0 rows under the forced-RLS `breeze_app` role
+// instead of erroring (#1375). We instrument these to surface the
+// missing-context bug to logs + Sentry.
+const CONTEXTLESS_WRITE_GUARD_METHODS = new Set<PropertyKey>(['insert', 'update', 'delete']);
+
 const proxiedDb = new Proxy(baseDb, {
   get(_target, prop) {
+    // Contextless-write guard (#1375 / #1379). A DB write issued from a path
+    // with no `withDbAccessContext`/`withSystemDbAccessContext` wrapper runs
+    // on the bare pool as `breeze_app` with no RLS GUCs set, so forced RLS
+    // matches 0 rows and the write silently no-ops — no error, no rows.
+    //
+    // This is warn-only (no throw) on purpose: it's a conservative,
+    // prod-safe rollout. There ARE intentional contextless writers we must
+    // not break — the agent-WS `device_commands` path is system-scoped, and
+    // the separate audit-admin pool (auditAdminPool.ts) bypasses this proxy
+    // entirely — so a hard throw would cause false-positive crashes. The
+    // throw-in-CI escalation is deferred to a follow-up PR in #1379.
+    if (CONTEXTLESS_WRITE_GUARD_METHODS.has(prop) && !hasDbAccessContext()) {
+      const message =
+        `DB write .${String(prop)}() ran with no RLS access context — `
+        + `wrap in withDbAccessContext/withSystemDbAccessContext (#1375)`;
+      console.warn(message);
+      captureMessage(message, 'warning', { stack: new Error().stack });
+    }
+
     const activeDb = getCurrentDb() as unknown as Record<PropertyKey, unknown>;
     const value = activeDb[prop];
     if (typeof value === 'function') {

--- a/apps/api/src/jobs/agentLogRetention.ts
+++ b/apps/api/src/jobs/agentLogRetention.ts
@@ -10,6 +10,7 @@ import * as dbModule from '../db';
 import { agentLogs } from '../db/schema';
 import { lt } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -77,6 +78,7 @@ let retentionWorker: Worker<RetentionJobData> | null = null;
 export async function initializeAgentLogRetention(): Promise<void> {
   try {
     retentionWorker = createAgentLogRetentionWorker();
+    attachWorkerObservability(retentionWorker, 'agentLogRetention');
 
     retentionWorker.on('error', (error) => {
       console.error('[AgentLogRetention] Worker error:', error);

--- a/apps/api/src/jobs/alertWorker.ts
+++ b/apps/api/src/jobs/alertWorker.ts
@@ -17,6 +17,7 @@ import {
   checkAutoResolveFromConfigPolicy,
 } from '../services/alertService';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -445,6 +446,7 @@ export async function initializeAlertWorkers(): Promise<void> {
   try {
     // Create worker
     alertWorker = createAlertWorker();
+    attachWorkerObservability(alertWorker, 'alertWorker');
 
     // Set up error handler
     alertWorker.on('error', (error) => {

--- a/apps/api/src/jobs/automationWorker.ts
+++ b/apps/api/src/jobs/automationWorker.ts
@@ -30,6 +30,7 @@ import {
 } from '../services/featureConfigResolver';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -880,6 +881,7 @@ function subscribeToAutomationEvents(): void {
 
 export async function initializeAutomationWorker(): Promise<void> {
   automationWorker = createAutomationWorker();
+  attachWorkerObservability(automationWorker, 'automationWorker');
 
   automationWorker.on('error', (error) => {
     console.error('[AutomationWorker] Worker error:', error);

--- a/apps/api/src/jobs/backupSlaWorker.ts
+++ b/apps/api/src/jobs/backupSlaWorker.ts
@@ -17,6 +17,7 @@ import {
 } from '../db/schema';
 import { eq, and, sql, isNull, desc, inArray } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 import { getEventBus } from '../services/eventBus';
 import { resolveAllBackupAssignedDevices } from '../services/featureConfigResolver';
 
@@ -389,6 +390,7 @@ let slaWorkerInstance: Worker<SlaJobData> | null = null;
 export async function initializeBackupSlaWorker(): Promise<void> {
   try {
     slaWorkerInstance = createSlaWorker();
+    attachWorkerObservability(slaWorkerInstance, 'backupSlaWorker');
 
     slaWorkerInstance.on('error', (error) => {
       console.error('[SlaWorker] Worker error:', error);

--- a/apps/api/src/jobs/backupVerificationJobs.ts
+++ b/apps/api/src/jobs/backupVerificationJobs.ts
@@ -1,6 +1,7 @@
 import { Job, Queue, Worker } from 'bullmq';
 import * as dbModule from '../db';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 import {
   ensurePostBackupIntegrityChecks,
   recalculateReadinessScores,
@@ -132,6 +133,7 @@ export async function initializeBackupVerificationJobs(): Promise<void> {
   }
 
   backupVerificationWorker = createBackupVerificationWorker();
+  attachWorkerObservability(backupVerificationWorker, 'backupVerificationWorker');
   backupVerificationWorker.on('error', (error) => {
     console.error('[BackupVerificationJobs] Worker error:', error);
   });

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -40,6 +40,7 @@ import { getDueOccurrenceKey } from '../routes/backup/helpers';
 import { applyBackupCommandResultToJob } from '../services/backupResultPersistence';
 import { markBackupJobFailedIfInFlight } from '../services/backupResultPersistence';
 import { createScheduledBackupJobIfAbsent } from '../services/backupJobCreation';
+import { attachWorkerObservability } from './workerObservability';
 import { assertQueueJobName, parseQueueJobData } from '../services/bullmqValidation';
 import {
   backupQueueJobDataSchema,
@@ -641,6 +642,7 @@ let backupWorkerInstance: Worker<BackupQueueJobData> | null = null;
 export async function initializeBackupWorker(): Promise<void> {
   try {
     backupWorkerInstance = createBackupWorker();
+    attachWorkerObservability(backupWorkerInstance, 'backupWorker');
 
     backupWorkerInstance.on('error', (error) => {
       console.error('[BackupWorker] Worker error:', error);

--- a/apps/api/src/jobs/browserSecurityJobs.ts
+++ b/apps/api/src/jobs/browserSecurityJobs.ts
@@ -4,6 +4,7 @@ import * as dbModule from '../db';
 import { browserExtensions, browserPolicies, browserPolicyViolations, devices } from '../db/schema';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -142,6 +143,7 @@ export async function initializeBrowserSecurityJobs(): Promise<void> {
       concurrency: 1,
     }
   );
+  attachWorkerObservability(evalWorker, 'browserSecurityEvalWorker');
 
   evalWorker.on('error', (error) => {
     console.error('[BrowserSecurityJobs] Worker error:', error);

--- a/apps/api/src/jobs/c2cBackupWorker.ts
+++ b/apps/api/src/jobs/c2cBackupWorker.ts
@@ -17,6 +17,7 @@ import {
 } from '../db/schema';
 import { and, eq, sql } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 import {
   closeC2cQueue,
   enqueueC2cSync,
@@ -331,6 +332,7 @@ let c2cWorkerInstance: Worker<C2cJobData> | null = null;
 export async function initializeC2cBackupWorker(): Promise<void> {
   try {
     c2cWorkerInstance = createC2cWorker();
+    attachWorkerObservability(c2cWorkerInstance, 'c2cBackupWorker');
 
     c2cWorkerInstance.on('error', (error) => {
       console.error('[C2CBackupWorker] Worker error:', error);

--- a/apps/api/src/jobs/cveEnrichmentWorker.ts
+++ b/apps/api/src/jobs/cveEnrichmentWorker.ts
@@ -8,6 +8,7 @@ import {
   OsvServerError,
 } from '../services/osvClient';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 
@@ -178,6 +179,7 @@ export async function initializeCveEnrichmentWorker(): Promise<void> {
 
   try {
     enrichmentWorker = createCveEnrichmentWorker();
+    attachWorkerObservability(enrichmentWorker, 'cveEnrichmentWorker');
 
     enrichmentWorker.on('error', (error) => {
       console.error('[CveEnrichment] Worker error:', error);

--- a/apps/api/src/jobs/discoveryWorker.ts
+++ b/apps/api/src/jobs/discoveryWorker.ts
@@ -24,6 +24,7 @@ import { eq, and, or, sql, inArray, type SQL } from 'drizzle-orm';
 import { normalizeMac, buildApprovalDecision } from '../services/assetApproval';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 import { sendCommandToAgent, isAgentConnected, type AgentCommand } from '../routes/agentWs';
 import { isCronDue } from '../services/automationRuntime';
 import { lookupMacVendor, inferAssetTypeFromVendor } from '../services/macVendorLookup';
@@ -1296,6 +1297,7 @@ let discoveryWorkerInstance: Worker<DiscoveryJobData> | null = null;
 export async function initializeDiscoveryWorker(): Promise<void> {
   try {
     discoveryWorkerInstance = createDiscoveryWorker();
+    attachWorkerObservability(discoveryWorkerInstance, 'discoveryWorker');
 
     discoveryWorkerInstance.on('error', (error) => {
       console.error('[DiscoveryWorker] Worker error:', error);

--- a/apps/api/src/jobs/drExecutionWorker.ts
+++ b/apps/api/src/jobs/drExecutionWorker.ts
@@ -3,6 +3,7 @@ import { getBullMQConnection } from '../services/redis';
 import { withSystemDbAccessContext } from '../db';
 import { reconcileDrExecution } from '../services/drExecutionService';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 import { assertQueueJobName, parseQueueJobData } from '../services/bullmqValidation';
 import {
   drExecutionQueueJobDataSchema,
@@ -100,6 +101,7 @@ export async function enqueueDrExecutionReconcile(executionId: string, delayMs =
 
 export async function initializeDrExecutionWorker(): Promise<void> {
   drExecutionWorkerInstance = createDrExecutionWorker();
+  attachWorkerObservability(drExecutionWorkerInstance, 'drExecutionWorker');
 
   drExecutionWorkerInstance.on('error', (error) => {
     console.error('[DrExecutionWorker] Worker error:', error);

--- a/apps/api/src/jobs/eventLogRetention.ts
+++ b/apps/api/src/jobs/eventLogRetention.ts
@@ -12,6 +12,7 @@ import { deviceEventLogs } from '../db/schema';
 import { and, eq, lt } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { getOrgEventLogRetentionDays } from '../routes/agents/helpers';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -88,6 +89,7 @@ let retentionWorker: Worker<RetentionJobData> | null = null;
 export async function initializeEventLogRetention(): Promise<void> {
   try {
     retentionWorker = createEventLogRetentionWorker();
+    attachWorkerObservability(retentionWorker, 'eventLogRetention');
 
     retentionWorker.on('error', (error) => {
       console.error('[EventLogRetention] Worker error:', error);

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -22,6 +22,7 @@ import {
   type QueueActorMeta,
   withQueueMeta,
 } from './queueSchemas';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -576,6 +577,7 @@ let monitorWorkerInstance: Worker<MonitorJobData> | null = null;
 export async function initializeMonitorWorker(): Promise<void> {
   try {
     monitorWorkerInstance = createMonitorWorker();
+    attachWorkerObservability(monitorWorkerInstance, 'monitorWorker');
 
     monitorWorkerInstance.on('error', (error) => {
       console.error('[MonitorWorker] Worker error:', error);

--- a/apps/api/src/jobs/offlineDetector.ts
+++ b/apps/api/src/jobs/offlineDetector.ts
@@ -14,6 +14,7 @@ import { publishEvent } from '../services/eventBus';
 import { createAlert } from '../services/alertService';
 import { interpolateTemplate } from '../services/alertConditions';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -449,6 +450,7 @@ export async function initializeOfflineDetector(): Promise<void> {
   try {
     // Create worker
     offlineWorker = createOfflineWorker();
+    attachWorkerObservability(offlineWorker, 'offlineDetector');
 
     // Set up error handler
     offlineWorker.on('error', (error) => {

--- a/apps/api/src/jobs/patchComplianceReportWorker.ts
+++ b/apps/api/src/jobs/patchComplianceReportWorker.ts
@@ -7,6 +7,7 @@ import { Job, Queue, Worker } from 'bullmq';
 import * as dbModule from '../db';
 import { devicePatches, devices, patchComplianceReports, patches, patchSourceEnum, patchSeverityEnum } from '../db/schema';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -338,6 +339,7 @@ export async function initializePatchComplianceReportWorker(): Promise<void> {
   }
 
   patchComplianceReportWorker = createPatchComplianceReportWorker();
+  attachWorkerObservability(patchComplianceReportWorker, 'patchComplianceReportWorker');
   patchComplianceReportWorker.on('error', (error) => {
     console.error('[PatchComplianceReportWorker] Worker error:', error);
   });

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -21,6 +21,7 @@ import {
 import { and, eq, gte, inArray } from 'drizzle-orm';
 import { resolveEffectiveTimezone, canonicalizeTimezone } from '@breeze/shared';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 import { checkDeviceMaintenanceWindow } from '../services/featureConfigResolver';
 import { enqueuePatchJob } from './patchJobExecutor';
 import { buildPatchesSnapshot } from '../services/patchJobSnapshot';
@@ -528,6 +529,7 @@ export async function initializePatchSchedulerWorker(): Promise<void> {
   });
 
   schedulerWorker = createSchedulerWorker();
+  attachWorkerObservability(schedulerWorker, 'patchSchedulerWorker');
 
   schedulerWorker.on('error', (error) => {
     console.error('[PatchScheduler] Worker error:', error);

--- a/apps/api/src/jobs/peripheralJobs.ts
+++ b/apps/api/src/jobs/peripheralJobs.ts
@@ -6,6 +6,7 @@ import { publishEvent } from '../services/eventBus';
 import { CommandTypes, queueCommand, queueCommandForExecution } from '../services/commandQueue';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -335,7 +336,9 @@ export async function schedulePeripheralPolicyDistribution(
 
 export async function initializePeripheralJobs(): Promise<void> {
   anomalyWorker = createPeripheralAnomalyWorker();
+  attachWorkerObservability(anomalyWorker, 'peripheralAnomalyWorker');
   policyDistributionWorker = createPeripheralPolicyDistributionWorker();
+  attachWorkerObservability(policyDistributionWorker, 'peripheralPolicyDistributionWorker');
 
   anomalyWorker.on('error', (error) => {
     console.error('[PeripheralJobs] Anomaly worker error:', error);

--- a/apps/api/src/jobs/policyEvaluationWorker.ts
+++ b/apps/api/src/jobs/policyEvaluationWorker.ts
@@ -9,6 +9,7 @@ import { and, eq } from 'drizzle-orm';
 import * as dbModule from '../db';
 import { automationPolicies } from '../db/schema';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 import { evaluatePolicy, scanAndEvaluateConfigPolicyCompliance } from '../services/policyEvaluationService';
 
 const { db } = dbModule;
@@ -191,6 +192,7 @@ export function createPolicyEvaluationWorker(): Worker<PolicyEvaluationJobData> 
 
 export async function initializePolicyEvaluationWorker(): Promise<void> {
   policyEvaluationWorker = createPolicyEvaluationWorker();
+  attachWorkerObservability(policyEvaluationWorker, 'policyEvaluationWorker');
 
   policyEvaluationWorker.on('error', (error) => {
     console.error('[PolicyEvaluationWorker] Worker error:', error);

--- a/apps/api/src/jobs/recoveryBootMediaWorker.ts
+++ b/apps/api/src/jobs/recoveryBootMediaWorker.ts
@@ -1,5 +1,6 @@
 import { Job, Queue, Worker } from 'bullmq';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 import { withSystemDbAccessContext } from '../db';
 import { isReusableState } from '../services/bullmqUtils';
 import { buildRecoveryBootMediaArtifact } from '../services/recoveryBootMediaService';
@@ -93,6 +94,7 @@ export async function enqueueRecoveryBootMediaBuild(artifactId: string): Promise
 
 export async function initializeRecoveryBootMediaWorker(): Promise<void> {
   recoveryBootMediaWorkerInstance = createRecoveryBootMediaWorker();
+  attachWorkerObservability(recoveryBootMediaWorkerInstance, 'recoveryBootMediaWorker');
 
   recoveryBootMediaWorkerInstance.on('error', (error) => {
     console.error('[RecoveryBootMediaWorker] Worker error:', error);

--- a/apps/api/src/jobs/recoveryMediaWorker.ts
+++ b/apps/api/src/jobs/recoveryMediaWorker.ts
@@ -3,6 +3,7 @@ import { getBullMQConnection } from '../services/redis';
 import { withSystemDbAccessContext } from '../db';
 import { isReusableState } from '../services/bullmqUtils';
 import { buildRecoveryMediaArtifact } from '../services/recoveryMediaService';
+import { attachWorkerObservability } from './workerObservability';
 import { assertQueueJobName, parseQueueJobData } from '../services/bullmqValidation';
 import {
   recoveryMediaQueueJobDataSchema,
@@ -93,6 +94,7 @@ export async function enqueueRecoveryMediaBuild(artifactId: string): Promise<str
 
 export async function initializeRecoveryMediaWorker(): Promise<void> {
   recoveryMediaWorkerInstance = createRecoveryMediaWorker();
+  attachWorkerObservability(recoveryMediaWorkerInstance, 'recoveryMediaWorker');
 
   recoveryMediaWorkerInstance.on('error', (error) => {
     console.error('[RecoveryMediaWorker] Worker error:', error);

--- a/apps/api/src/jobs/securityPostureWorker.ts
+++ b/apps/api/src/jobs/securityPostureWorker.ts
@@ -6,6 +6,7 @@ import { devices } from '../db/schema';
 import { publishEvent } from '../services/eventBus';
 import { getBullMQConnection } from '../services/redis';
 import { computeAndPersistOrgSecurityPosture } from '../services/securityPosture';
+import { attachWorkerObservability } from './workerObservability';
 import { isReusableState } from '../services/bullmqUtils';
 
 const { db } = dbModule;
@@ -240,6 +241,7 @@ async function scheduleSecurityPostureScan(): Promise<void> {
 
 export async function initializeSecurityPostureWorker(): Promise<void> {
   securityPostureWorker = createSecurityPostureWorker();
+  attachWorkerObservability(securityPostureWorker, 'securityPostureWorker');
   securityPostureWorker.on('error', (error) => {
     console.error('[SecurityPostureWorker] Worker error:', error);
   });

--- a/apps/api/src/jobs/sensitiveDataJobs.ts
+++ b/apps/api/src/jobs/sensitiveDataJobs.ts
@@ -5,6 +5,7 @@ import * as dbModule from '../db';
 import { deviceCommands, devices, sensitiveDataPolicies, sensitiveDataScans } from '../db/schema';
 import { CommandTypes, queueCommandForExecution } from '../services/commandQueue';
 import { isCronDue } from '../services/automationRuntime';
+import { attachWorkerObservability } from './workerObservability';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 
@@ -517,6 +518,7 @@ async function schedulePolicyWorker(): Promise<void> {
 
 export async function initializeSensitiveDataWorkers(): Promise<void> {
   sensitiveDataWorker = createSensitiveDataWorker();
+  attachWorkerObservability(sensitiveDataWorker, 'sensitiveDataWorker');
   sensitiveDataWorker.on('error', (error) => {
     console.error('[SensitiveDataWorker] Worker error:', error);
   });

--- a/apps/api/src/jobs/snmpRetention.ts
+++ b/apps/api/src/jobs/snmpRetention.ts
@@ -10,6 +10,7 @@ import * as dbModule from '../db';
 import { snmpMetrics } from '../db/schema';
 import { lt } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -65,6 +66,7 @@ let retentionWorker: Worker<RetentionJobData> | null = null;
 export async function initializeSnmpRetention(): Promise<void> {
   try {
     retentionWorker = createSnmpRetentionWorker();
+    attachWorkerObservability(retentionWorker, 'snmpRetention');
 
     retentionWorker.on('error', (error) => {
       console.error('[SnmpRetention] Worker error:', error);

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -11,6 +11,7 @@ import { snmpDevices, snmpMetrics, snmpTemplates, devices } from '../db/schema';
 import { eq, and, or, sql } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 import { sendCommandToAgent, isAgentConnected, type AgentCommand } from '../routes/agentWs';
 import { decryptSnmpSecret } from '../services/snmpSecrets';
 
@@ -415,6 +416,7 @@ let snmpWorkerInstance: Worker<SnmpJobData> | null = null;
 export async function initializeSnmpWorker(): Promise<void> {
   try {
     snmpWorkerInstance = createSnmpWorker();
+    attachWorkerObservability(snmpWorkerInstance, 'snmpWorker');
 
     snmpWorkerInstance.on('error', (error) => {
       console.error('[SnmpWorker] Worker error:', error);

--- a/apps/api/src/jobs/userRiskJobs.ts
+++ b/apps/api/src/jobs/userRiskJobs.ts
@@ -11,6 +11,7 @@ import {
   publishUserRiskScoreEvents
 } from '../services/userRiskScoring';
 import { isReusableState } from '../services/bullmqUtils';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -253,6 +254,7 @@ async function scheduleUserRiskScan(): Promise<void> {
 
 export async function initializeUserRiskJobs(): Promise<void> {
   userRiskWorker = createUserRiskWorker();
+  attachWorkerObservability(userRiskWorker, 'userRiskWorker');
   userRiskWorker.on('error', (error) => {
     console.error('[UserRiskJobs] Worker error:', error);
   });

--- a/apps/api/src/jobs/userRiskRetention.ts
+++ b/apps/api/src/jobs/userRiskRetention.ts
@@ -10,6 +10,7 @@ import { sql } from 'drizzle-orm';
 
 import * as dbModule from '../db';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -94,6 +95,7 @@ export function createUserRiskRetentionWorker(): Worker<RetentionJobData> {
 
 export async function initializeUserRiskRetention(): Promise<void> {
   retentionWorker = createUserRiskRetentionWorker();
+  attachWorkerObservability(retentionWorker, 'userRiskRetention');
   retentionWorker.on('error', (error) => {
     console.error('[UserRiskRetention] Worker error:', error);
   });

--- a/apps/api/src/jobs/workerObservability.test.ts
+++ b/apps/api/src/jobs/workerObservability.test.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'node:events';
+import type { Worker } from 'bullmq';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the sentry service so we can assert capture without an initialized SDK.
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+// Mock @sentry/node's withScope to a passthrough that invokes the callback
+// with a no-op scope, so the `failed` handler's tag/context calls don't throw.
+vi.mock('@sentry/node', () => ({
+  withScope: (fn: (scope: unknown) => void) =>
+    fn({ setTag: vi.fn(), setContext: vi.fn() }),
+}));
+
+import { captureException } from '../services/sentry';
+import { attachWorkerObservability } from './workerObservability';
+
+function makeFakeWorker(): Worker {
+  // A bare EventEmitter satisfies the .on(...) surface we exercise.
+  return new EventEmitter() as unknown as Worker;
+}
+
+describe('attachWorkerObservability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports failed jobs to Sentry with the job error', () => {
+    const worker = makeFakeWorker();
+    attachWorkerObservability(worker, 'testWorker');
+
+    const err = new Error('boom');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    (worker as unknown as EventEmitter).emit('failed', { id: 'job-1', name: 'doThing' }, err);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(err);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('reports worker-level errors to Sentry', () => {
+    const worker = makeFakeWorker();
+    attachWorkerObservability(worker, 'testWorker');
+
+    const err = new Error('worker exploded');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    (worker as unknown as EventEmitter).emit('error', err);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(err);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('tolerates a failed event with an undefined job', () => {
+    const worker = makeFakeWorker();
+    attachWorkerObservability(worker, 'testWorker');
+
+    const err = new Error('no job');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() =>
+      (worker as unknown as EventEmitter).emit('failed', undefined, err)
+    ).not.toThrow();
+    expect(captureException).toHaveBeenCalledWith(err);
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/api/src/jobs/workerObservability.ts
+++ b/apps/api/src/jobs/workerObservability.ts
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/node';
+import type { Worker } from 'bullmq';
+import { captureException } from '../services/sentry';
+
+/**
+ * Attaches unified error + failed-job reporting to a BullMQ worker (#1379).
+ *
+ * Many workers historically only `console.error`'d on `error`/`failed`, so
+ * job failures were invisible in Sentry — a class of silent failure this
+ * wires up. Purely additive: callers keep any existing `.on('error')` /
+ * `.on('failed')` handlers; this just adds Sentry capture alongside.
+ */
+export function attachWorkerObservability(worker: Worker, name: string): void {
+  worker.on('error', (e) => {
+    console.error(`[${name}] worker error:`, e);
+    captureException(e);
+  });
+
+  worker.on('failed', (job, err) => {
+    console.error(`[${name}] job ${job?.id} failed:`, err);
+    Sentry.withScope((scope) => {
+      scope.setTag('worker', name);
+      scope.setTag('jobId', job?.id);
+      scope.setContext('job', { name: job?.name });
+      captureException(err);
+    });
+  });
+}

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -61,6 +61,22 @@ export function captureException(err: unknown, c?: Context): void {
   });
 }
 
+export function captureMessage(
+  message: string,
+  level: 'info' | 'warning' | 'error' = 'warning',
+  extra?: Record<string, unknown>
+): void {
+  if (!initialized) {
+    return;
+  }
+
+  Sentry.withScope((scope) => {
+    scope.setLevel(level);
+    scope.setExtras(extra ?? {});
+    Sentry.captureMessage(message);
+  });
+}
+
 export async function flushSentry(timeoutMs = 2000): Promise<void> {
   if (!initialized) {
     return;


### PR DESCRIPTION
First observability PR for the API (tracking #1379). Ships the two highest-value, low-risk pieces that make silent failures visible. No behavior change in the happy path.

## 1. Contextless-write guard (#1375 bug class)
DB writes on the bare `db` from paths with **no** RLS access context silently match 0 rows under forced RLS as `breeze_app` — no error, no rows (the #1375 footgun).

The `proxiedDb` getter in `db/index.ts` now detects when `prop` is `insert`/`update`/`delete` **and** `hasDbAccessContext() === false`. It:
- builds a message: `DB write .<prop>() ran with no RLS access context — wrap in withDbAccessContext/withSystemDbAccessContext (#1375)`
- always `console.warn`s it
- reports via the new `captureMessage(message, 'warning', { stack })`
- then proceeds normally — **does NOT throw** and **does NOT block** the call.

**Warn-only by design** (conservative, prod-safe): there are intentional contextless writers — the agent-WS `device_commands` path is system-scoped, and the separate audit-admin pool bypasses this proxy entirely — so a hard throw would false-positive. `execute` is intentionally **not** guarded (used by the context-setter and migrations). The throw-in-CI escalation is deferred (see below).

Adds `captureMessage(message, level, extra)` to `services/sentry.ts` (no-op when Sentry uninitialized; uses `Sentry.withScope` → `setLevel`/`setExtras`).

## 2. Unified BullMQ worker error reporting
New `jobs/workerObservability.ts` exports `attachWorkerObservability(worker, name)`, wiring `worker.on('error')` and `worker.on('failed')` to Sentry (`captureException`), tagging `worker` + `jobId` and a `job` context. Applied to every worker that previously only `console.error`'d (or had no handler). Purely additive — existing handlers are preserved, and workers that **already** route to Sentry were left untouched (no double-capture).

### Workers wired (26 files, 27 worker instances)
automationWorker, snmpWorker, policyEvaluationWorker, softwareComplianceWorker*, softwareRemediationWorker*, backupSlaWorker, cveEnrichmentWorker, c2cBackupWorker, patchComplianceReportWorker, recoveryBootMediaWorker, eventLogRetention, agentLogRetention, alertWorker, backupVerificationJobs, backupWorker, browserSecurityJobs (evalWorker), discoveryWorker, drExecutionWorker, monitorWorker, offlineDetector, patchSchedulerWorker, peripheralJobs (anomalyWorker + policyDistributionWorker), recoveryMediaWorker, securityPostureWorker, sensitiveDataJobs, snmpRetention, userRiskJobs, userRiskRetention.

\* softwareComplianceWorker / softwareRemediationWorker already captured to Sentry and were **not** re-wired (avoided in the final set). `deploymentWorker.ts` was deliberately **skipped** — it is being modified in open PR #1376 to avoid a merge conflict.

## Tests
- `jobs/workerObservability.test.ts` — fake EventEmitter worker; asserts `failed`/`error` emit → `captureException`, plus undefined-job tolerance.
- `db/contextlessWriteGuard.test.ts` — asserts `.insert`/`.update`/`.delete` getter access outside a context fires `console.warn` + `captureMessage` (mocked), and `.select` does not. No real DB connection required.

## Validation
- `npx tsc --noEmit`: 0 new errors (only the two known pre-existing failures in `agents.test.ts` / `apiKeyAuth.test.ts` remain).
- New tests: 7 passed. Spot-checked 15 touched worker test files: all green.

## Deferred to follow-up PRs in #1379
throw-in-CI escalation, tenant-context middleware, Sentry `beforeSend`, `uncaughtException` handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)