### PR TITLE
feat(web): add delete control to Software Library catalog

### DIFF
--- a/apps/web/src/components/software/SoftwareCatalog.test.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SoftwareCatalog from './SoftwareCatalog';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+// DeploymentWizard / SoftwareVersionManager pull in their own fetches; stub them
+// out so this test exercises only the catalog delete flow.
+vi.mock('./DeploymentWizard', () => ({ default: () => null }));
+vi.mock('./SoftwareVersionManager', () => ({ default: () => null }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const ITEM = {
+  id: 'cat-1',
+  name: 'TestApp',
+  vendor: 'Acme',
+  category: 'utility',
+  description: 'A test package',
+  createdAt: '2026-06-14T00:00:00Z'
+};
+
+describe('SoftwareCatalog delete', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    showToast.mockReset();
+  });
+
+  it('deletes a package via DELETE /software/catalog/:id and removes it from the list', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: [ITEM] })) // GET /software/catalog
+      .mockResolvedValueOnce(jsonResponse({ success: true, id: ITEM.id })); // DELETE
+
+    render(<SoftwareCatalog />);
+    await waitFor(() => expect(screen.getByText('TestApp')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('TestApp'));
+
+    // Footer "Delete" opens the confirm modal.
+    const deleteButtons = await screen.findAllByRole('button', { name: /Delete/ });
+    fireEvent.click(deleteButtons[0]);
+
+    expect(await screen.findByText('Delete package?')).toBeInTheDocument();
+
+    // Confirm: the last "Delete" button is the one inside the confirm dialog.
+    const confirmButtons = screen.getAllByRole('button', { name: /^Delete$/ });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenLastCalledWith('/software/catalog/cat-1', { method: 'DELETE' })
+    );
+
+    // Success toast + item removed from the grid.
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' })));
+    await waitFor(() => expect(screen.queryByText('TestApp')).not.toBeInTheDocument());
+  });
+
+  it('does not call the API when the delete is cancelled', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [ITEM] }));
+
+    render(<SoftwareCatalog />);
+    await waitFor(() => expect(screen.getByText('TestApp')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('TestApp'));
+    const deleteButtons = await screen.findAllByRole('button', { name: /Delete/ });
+    fireEvent.click(deleteButtons[0]);
+    expect(await screen.findByText('Delete package?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByText('Delete package?')).not.toBeInTheDocument());
+    // Only the initial catalog GET happened — no DELETE.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Still present (in the card and the still-open detail modal).
+    expect(screen.getAllByText('TestApp').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/software/SoftwareCatalog.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.tsx
@@ -5,10 +5,12 @@ import {
   X,
   Rocket,
   Plus,
+  Trash2,
   Loader2
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
 import DeploymentWizard from './DeploymentWizard';
 import SoftwareVersionManager from './SoftwareVersionManager';
 
@@ -43,6 +45,8 @@ export default function SoftwareCatalog() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [saving, setSaving] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<SoftwareItem | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const [addForm, setAddForm] = useState({
     name: '',
     vendor: '',
@@ -134,6 +138,24 @@ export default function SoftwareCatalog() {
       setError(err instanceof Error ? err.message : 'Failed to add package');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleDeletePackage = async (item: SoftwareItem) => {
+    try {
+      setDeleting(true);
+      await runAction({
+        request: () => fetchWithAuth(`/software/catalog/${item.id}`, { method: 'DELETE' }),
+        errorFallback: 'Failed to delete package',
+        successMessage: `Deleted "${item.name}"`,
+      });
+      setCatalogItems(prev => prev.filter(i => i.id !== item.id));
+      setConfirmDelete(null);
+      setSelectedSoftware(prev => (prev?.id === item.id ? null : prev));
+    } catch (err) {
+      handleActionError(err, 'Failed to delete package');
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -342,7 +364,15 @@ export default function SoftwareCatalog() {
                     {selectedSoftware.description}
                   </div>
                 )}
-                <div className="mt-5 flex items-center justify-end">
+                <div className="mt-5 flex items-center justify-between">
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDelete(selectedSoftware)}
+                    className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-destructive/40 bg-background px-4 text-sm font-medium text-destructive hover:bg-destructive/10"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                  </button>
                   <button
                     type="button"
                     onClick={() => {
@@ -362,6 +392,46 @@ export default function SoftwareCatalog() {
                 <SoftwareVersionManager catalogId={selectedSoftware.id} />
               </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation modal */}
+      {confirmDelete && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-destructive/10">
+                <Trash2 className="h-5 w-5 text-destructive" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold">Delete package?</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  This removes <span className="font-medium text-foreground">{confirmDelete.name}</span> from
+                  the software library, along with all of its versions and stored installer references. This
+                  cannot be undone.
+                </p>
+              </div>
+            </div>
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(null)}
+                disabled={deleting}
+                className="inline-flex h-9 items-center justify-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDeletePackage(confirmDelete)}
+                disabled={deleting}
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-destructive px-4 text-sm font-semibold text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+              >
+                {deleting && <Loader2 className="h-4 w-4 animate-spin" />}
+                {deleting ? 'Deleting...' : 'Delete'}
+              </button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Problem

Surfaced in the #1377 follow-up discussion: a self-hosted user could create software packages but found no way to **delete** one from the Software Library. The backend `DELETE /api/v1/software/catalog/:id` endpoint (`apps/api/src/routes/software.ts`) already exists and works — it cascades the catalog item's versions, requires software-write permission + MFA, and writes a `software.catalog.delete` audit entry — but `SoftwareCatalog.tsx` never rendered a control wired to it, so deletion was an API-only operation.

## Change

- Add a **Delete** button to the catalog detail modal (Details tab), styled destructive.
- Clicking it opens a confirmation dialog that warns the removal is a **cascade** (the package, all its versions, and stored installer references) and is irreversible.
- The delete request goes through `runAction` (per the repo's mutation-feedback convention) so success and failure are always toasted. On success the package is removed from the list and any open modal for it closes.
- No backend change — this only wires the UI to the existing endpoint.

## Tests

`apps/web/src/components/software/SoftwareCatalog.test.tsx` (new): covers the delete-and-remove happy path (asserts `DELETE /software/catalog/:id`, success toast, item removed) and the cancel path (no API call, item retained).

## Local verification (pnpm 10.33.4)

- web `tsc --noEmit`: exit 0
- `eslint` on changed files: exit 0
- new `SoftwareCatalog.test.tsx`: 2/2 pass
- `no-silent-mutations` guard: 42/42 pass

(Other pre-existing failures in the full local web suite are unrelated to this change — they're in `stores/*`, `devices/filterUrl`, `integrations/Huntress`, etc., fail identically on clean `main`, and pass in `main` CI; a local Node-version environmental discrepancy. This PR touches only `SoftwareCatalog.{tsx,test.tsx}`.)
