### PR TITLE
enhance(web): normalize device OS labels

### DIFF
--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -24,7 +24,8 @@ import {
   Ticket,
 } from 'lucide-react';
 import { formatUptime } from '../../lib/utils';
-import type { Device, DeviceStatus, OSType } from './DeviceList';
+import type { Device, DeviceStatus } from './DeviceList';
+import { formatDeviceSummaryOs } from './osDisplay';
 import DeviceActions from './DeviceActions';
 import DeviceInfoTab from './DeviceInfoTab';
 import DeviceHardwareInventory from './DeviceHardwareInventory';
@@ -102,24 +103,6 @@ const statusLabels: Record<DeviceStatus, string> = {
   updating: 'Updating',
   pending: 'Pending'
 };
-
-const osLabels: Record<OSType, string> = {
-  windows: 'Windows',
-  macos: 'macOS',
-  linux: 'Linux'
-};
-
-function formatOsVersion(os: OSType, osVersion: string): string {
-  if (!osVersion) return osLabels[os];
-  let v = osVersion;
-  // Strip redundant "Microsoft Windows" prefix since osLabels already shows "Windows"
-  v = v.replace(/^Microsoft Windows\s*/i, '');
-  // Strip kernel name prefix (e.g. "darwin 26.3.1" → "26.3.1")
-  v = v.replace(/^(darwin|linux)\s*/i, '');
-  // Strip build/version numbers (e.g. "10.0.26200.7623 Build 26200.7623")
-  v = v.replace(/\s*\d+\.\d+\.\d+[\d.]*\s*(Build\s*[\d.]+)?/i, '').trim();
-  return v ? `${osLabels[os]} ${v}` : osLabels[os];
-}
 
 function formatLastSeen(dateString: string, timezone?: string): string {
   const date = new Date(dateString);
@@ -223,7 +206,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
                 )}
               </div>
               <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
-                <span>{formatOsVersion(device.os, device.osVersion)}</span>
+                <span>{formatDeviceSummaryOs(device.os, device.osVersion)}</span>
                 <span>Agent v{device.agentVersion}</span>
                 <span>{device.siteName}</span>
               </div>

--- a/apps/web/src/components/devices/DeviceInfoTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.test.tsx
@@ -50,6 +50,67 @@ function mockInitialLoad(displayName: string | null) {
   });
 }
 
+describe('DeviceInfoTab — OS version display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('omits redundant macOS text from the OS Version row', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/devices/${deviceId}` && method === 'GET') {
+        return makeJsonResponse({
+          hostname: 'MACBOOK-PRO',
+          displayName: null,
+          osType: 'macos',
+          osVersion: 'darwin 26.5.1',
+          osBuild: '25.5.0',
+          architecture: 'amd64',
+          tags: [],
+          status: 'online',
+        });
+      }
+      if (url === '/custom-fields') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<DeviceInfoTab deviceId={deviceId} />);
+
+    await screen.findByText('Operating System');
+    expect(screen.getByText('macOS')).toBeInTheDocument();
+    expect(screen.getByText('26.5.1')).toBeInTheDocument();
+    expect(screen.queryByText('macOS 26.5.1')).toBeNull();
+  });
+
+  it('capitalizes Linux distro names in the OS Version row', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/devices/${deviceId}` && method === 'GET') {
+        return makeJsonResponse({
+          hostname: 'RAMPHEX-PI-P52',
+          displayName: null,
+          osType: 'linux',
+          osVersion: 'raspbian 13.5',
+          osBuild: '6.18.33+rpt-rpi-v8',
+          architecture: 'arm64',
+          tags: [],
+          status: 'online',
+        });
+      }
+      if (url === '/custom-fields') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<DeviceInfoTab deviceId={deviceId} />);
+
+    await screen.findByText('Operating System');
+    expect(screen.getByText('Raspbian 13.5')).toBeInTheDocument();
+    expect(screen.queryByText('raspbian 13.5')).toBeNull();
+  });
+});
+
 describe('DeviceInfoTab — display name inline edit', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/devices/DeviceInfoTab.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.tsx
@@ -12,6 +12,7 @@ import {
   getDeviceRoleSourceLabel,
   getDeviceRoleSourceColor,
 } from '@/lib/deviceRoles';
+import { formatDeviceDetailOsVersion } from './osDisplay';
 
 type DeviceInfoTabProps = {
   deviceId: string;
@@ -95,12 +96,6 @@ const osTypeLabels: Record<string, string> = {
 function formatOsType(raw: string | null | undefined): string {
   if (!raw) return '—';
   return osTypeLabels[raw.toLowerCase()] ?? raw;
-}
-
-function formatOsVersionForDisplay(raw: string | null | undefined): string {
-  if (!raw) return '—';
-  // Strip kernel name prefix (e.g. "darwin 26.3.1" → "26.3.1")
-  return raw.replace(/^(darwin|linux)\s+/i, '');
 }
 
 function formatDesktopAccessMode(mode: DesktopAccessState['mode'] | undefined): string {
@@ -590,7 +585,7 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
 
       <Section title="Operating System" icon={<Info className="h-4 w-4 text-muted-foreground" />}>
         <InfoRow label="OS Type" value={formatOsType(info?.osType)} />
-        <InfoRow label="OS Version" value={formatOsVersionForDisplay(info?.osVersion)} />
+        <InfoRow label="OS Version" value={formatDeviceDetailOsVersion(info?.osType, info?.osVersion) || '—'} />
         <InfoRow label="OS Build" value={info?.osBuild ?? '—'} />
         <InfoRow label="Architecture" value={info?.architecture ?? '—'} />
       </Section>

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -31,6 +31,42 @@ const baseDevice: Device = {
   tags: [],
 };
 
+describe('DeviceList — OS version display', () => {
+  beforeEach(() => {
+    window.localStorage?.clear();
+  });
+
+  it('shows macOS instead of the Darwin kernel name in the OS Version column', () => {
+    const device: Device = {
+      ...baseDevice,
+      os: 'macos',
+      osVersion: 'darwin 26.5.1',
+    };
+
+    render(<DeviceList devices={[device]} />);
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+    fireEvent.click(screen.getByLabelText('OS Version'));
+
+    expect(screen.getByText('macOS 26.5.1')).toBeInTheDocument();
+    expect(screen.queryByText('darwin 26.5.1')).toBeNull();
+  });
+
+  it('capitalizes Linux distro names in the OS Version column', () => {
+    const device: Device = {
+      ...baseDevice,
+      os: 'linux',
+      osVersion: 'raspbian 13.5',
+    };
+
+    render(<DeviceList devices={[device]} />);
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+    fireEvent.click(screen.getByLabelText('OS Version'));
+
+    expect(screen.getByText('Raspbian 13.5')).toBeInTheDocument();
+    expect(screen.queryByText('raspbian 13.5')).toBeNull();
+  });
+});
+
 describe('DeviceList — agent-silent (watchdog OK) badge (#800 web-UI gap)', () => {
   it('renders the amber badge when mainAgentSilentSince is set AND watchdog is reporting', () => {
     const device: Device = {

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -27,6 +27,7 @@ import {
   type Density,
 } from '@/lib/density';
 import { OSIcon } from './osIcons';
+import { formatDeviceOsVersion } from './osDisplay';
 
 export type DeviceStatus = 'online' | 'offline' | 'maintenance' | 'decommissioned' | 'quarantined' | 'updating' | 'pending';
 export type OSType = 'windows' | 'macos' | 'linux';
@@ -226,7 +227,7 @@ const sortValue: Record<ColumnId, (d: Device) => string | number | null> = {
   organization: d => d.orgName || null,
   site: d => d.siteName || null,
   os: d => osLabels[d.os],
-  osVersion: d => d.osVersion || null,
+  osVersion: d => formatDeviceOsVersion(d.os, d.osVersion) || null,
   osBuild: d => d.osBuild || null,
   architecture: d => d.architecture || null,
   role: d => getDeviceRoleLabel(d.deviceRole ?? 'unknown'),
@@ -667,7 +668,7 @@ export default function DeviceList({
       header: () => sortHeader('osVersion', 'OS Version', 'Sort by OS version'),
       cell: (device) => (
         <td key="osVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
-          {device.osVersion || dash}
+          {formatDeviceOsVersion(device.os, device.osVersion) || dash}
         </td>
       ),
     },

--- a/apps/web/src/components/devices/osDisplay.test.ts
+++ b/apps/web/src/components/devices/osDisplay.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDeviceDetailOsVersion, formatDeviceOsVersion, formatDeviceSummaryOs } from './osDisplay';
+
+describe('device OS display formatting', () => {
+  it('leaves Windows OS versions untouched', () => {
+    expect(
+      formatDeviceOsVersion('windows', 'Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655'),
+    ).toBe('Microsoft Windows 11 Home 10.0.26200.8655 Build 26200.8655');
+  });
+
+  it('only treats Darwin as macOS when the OS type is macos', () => {
+    expect(formatDeviceOsVersion('macos', 'darwin 26.5.1')).toBe('macOS 26.5.1');
+    expect(formatDeviceOsVersion('macos', 'darwin')).toBe('macOS');
+    expect(formatDeviceOsVersion('darwin', 'darwin 26.5.1')).toBe('darwin 26.5.1');
+  });
+
+  it('omits the redundant macOS label for detail OS version rows', () => {
+    expect(formatDeviceDetailOsVersion('macos', 'darwin 26.5.1')).toBe('26.5.1');
+    expect(formatDeviceDetailOsVersion('macos', 'macOS 26.5.1')).toBe('26.5.1');
+  });
+
+  it('capitalizes Linux distro names in OS versions', () => {
+    expect(formatDeviceOsVersion('linux', 'raspbian 13.5')).toBe('Raspbian 13.5');
+    expect(formatDeviceOsVersion('linux', 'bazzite 44')).toBe('Bazzite 44');
+    expect(formatDeviceOsVersion('linux', 'debian 13.5')).toBe('Debian 13.5');
+    expect(formatDeviceOsVersion('linux', 'almalinux 9.4')).toBe('AlmaLinux 9.4');
+    expect(formatDeviceOsVersion('linux', 'amazon linux 2023')).toBe('Amazon Linux 2023');
+    expect(formatDeviceOsVersion('linux', 'linux mint 22')).toBe('Linux Mint 22');
+    expect(formatDeviceOsVersion('linux', 'linuxmint 22')).toBe('Linux Mint 22');
+    expect(formatDeviceOsVersion('linux', 'cachyos 2025.06')).toBe('CachyOS 2025.06');
+    expect(formatDeviceOsVersion('linux', 'elementary os 8')).toBe('elementary OS 8');
+    expect(formatDeviceOsVersion('linux', 'kde neon 6')).toBe('KDE neon 6');
+    expect(formatDeviceOsVersion('linux', 'nixos 24.11')).toBe('NixOS 24.11');
+    expect(formatDeviceOsVersion('linux', 'oracle linux 9.5')).toBe('Oracle Linux 9.5');
+    expect(formatDeviceOsVersion('linux', 'proxmox ve 8.3')).toBe('Proxmox VE 8.3');
+    expect(formatDeviceOsVersion('linux', 'raspberry pi os 13')).toBe('Raspberry Pi OS 13');
+    expect(formatDeviceOsVersion('linux', 'red hat enterprise linux 9.5')).toBe(
+      'Red Hat Enterprise Linux 9.5',
+    );
+    expect(formatDeviceOsVersion('linux', 'rocky 9.4')).toBe('Rocky Linux 9.4');
+    expect(formatDeviceOsVersion('linux', 'sles 15.6')).toBe('SLES 15.6');
+    expect(formatDeviceOsVersion('linux', 'suse linux enterprise server 15.6')).toBe(
+      'SUSE Linux Enterprise Server 15.6',
+    );
+    expect(formatDeviceOsVersion('linux', 'truenas scale 24.10')).toBe('TrueNAS SCALE 24.10');
+    expect(formatDeviceOsVersion('linux', 'unraid 7.0')).toBe('Unraid 7.0');
+    expect(formatDeviceOsVersion('linux', 'pop!_os 22.04')).toBe('Pop!_OS 22.04');
+  });
+
+  it('includes the OS type in the device summary when the version does not already name it', () => {
+    expect(formatDeviceSummaryOs('linux', 'raspbian 13.5')).toBe('Linux Raspbian 13.5');
+    expect(formatDeviceSummaryOs('macos', 'darwin 26.5.1')).toBe('macOS 26.5.1');
+    expect(formatDeviceSummaryOs('windows', '11 Pro')).toBe('Windows 11 Pro');
+  });
+
+  it('does not duplicate OS family names in the device summary', () => {
+    expect(formatDeviceSummaryOs('windows', 'Microsoft Windows 11 Pro')).toBe('Microsoft Windows 11 Pro');
+    expect(formatDeviceSummaryOs('macos', 'Mac OS X 10.15.7')).toBe('Mac OS X 10.15.7');
+    expect(formatDeviceSummaryOs('linux', 'almalinux 9.4')).toBe('AlmaLinux 9.4');
+    expect(formatDeviceSummaryOs('linux', 'amazon linux 2023')).toBe('Amazon Linux 2023');
+    expect(formatDeviceSummaryOs('linux', 'linux mint 22')).toBe('Linux Mint 22');
+    expect(formatDeviceSummaryOs('linux', 'oracle linux 9.5')).toBe('Oracle Linux 9.5');
+    expect(formatDeviceSummaryOs('linux', 'rocky 9.4')).toBe('Rocky Linux 9.4');
+    expect(formatDeviceSummaryOs('linux', 'suse linux enterprise server 15.6')).toBe(
+      'SUSE Linux Enterprise Server 15.6',
+    );
+  });
+});

--- a/apps/web/src/components/devices/osDisplay.ts
+++ b/apps/web/src/components/devices/osDisplay.ts
@@ -1,0 +1,162 @@
+const osTypeLabels: Record<string, string> = {
+  windows: 'Windows',
+  macos: 'macOS',
+  linux: 'Linux',
+};
+
+const linuxNameOverrides: Record<string, string> = {
+  'alma linux': 'AlmaLinux',
+  almalinux: 'AlmaLinux',
+  'amazon linux': 'Amazon Linux',
+  amazonlinux: 'Amazon Linux',
+  arch: 'Arch',
+  bazzite: 'Bazzite',
+  cachyos: 'CachyOS',
+  centos: 'CentOS',
+  debian: 'Debian',
+  'elementary os': 'elementary OS',
+  elementaryos: 'elementary OS',
+  endeavouros: 'EndeavourOS',
+  fedora: 'Fedora',
+  garuda: 'Garuda',
+  kali: 'Kali',
+  'kde neon': 'KDE neon',
+  kdeneon: 'KDE neon',
+  linux: 'Linux',
+  'linux lite': 'Linux Lite',
+  linuxlite: 'Linux Lite',
+  'linux mint': 'Linux Mint',
+  linuxmint: 'Linux Mint',
+  manjaro: 'Manjaro',
+  nixos: 'NixOS',
+  nobara: 'Nobara',
+  opensuse: 'openSUSE',
+  'oracle linux': 'Oracle Linux',
+  oraclelinux: 'Oracle Linux',
+  os: 'OS',
+  'pop os': 'Pop!_OS',
+  popos: 'Pop!_OS',
+  'proxmox ve': 'Proxmox VE',
+  proxmox: 'Proxmox VE',
+  proxmoxve: 'Proxmox VE',
+  'raspberry pi os': 'Raspberry Pi OS',
+  raspberrypios: 'Raspberry Pi OS',
+  raspbian: 'Raspbian',
+  'red hat enterprise linux': 'Red Hat Enterprise Linux',
+  redhat: 'Red Hat',
+  redhatenterpriselinux: 'Red Hat Enterprise Linux',
+  rhel: 'RHEL',
+  rocky: 'Rocky Linux',
+  'rocky linux': 'Rocky Linux',
+  sles: 'SLES',
+  steamos: 'SteamOS',
+  suse: 'SUSE',
+  'suse linux enterprise server': 'SUSE Linux Enterprise Server',
+  suselinuxenterpriseserver: 'SUSE Linux Enterprise Server',
+  'truenas scale': 'TrueNAS SCALE',
+  truenasscale: 'TrueNAS SCALE',
+  ubuntu: 'Ubuntu',
+  unraid: 'Unraid',
+  zorin: 'Zorin',
+};
+
+const linuxPrefixedDistros = new Set(['lite', 'mint']);
+
+function normalizeLinuxNameKey(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/[!]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeLinuxName(value: string): string {
+  const key = normalizeLinuxNameKey(value);
+  const compactKey = key.replace(/\s+/g, '');
+  const override = linuxNameOverrides[key] ?? linuxNameOverrides[compactKey];
+  if (override) return override;
+
+  return value
+    .split(/([ _-])/)
+    .map((part) => {
+      if (part === ' ' || part === '_' || part === '-') return part === '_' ? ' ' : part;
+      const partKey = normalizeLinuxNameKey(part);
+      return linuxNameOverrides[partKey] ?? `${part.charAt(0).toUpperCase()}${part.slice(1)}`;
+    })
+    .join('');
+}
+
+function normalizeLinuxDistroName(value: string): string {
+  const withoutKernelPrefix = value.replace(/^linux\s+([a-z][a-z0-9!_]*)/i, (match, nextToken: string) => {
+    return linuxPrefixedDistros.has(normalizeLinuxNameKey(nextToken)) ? match : nextToken;
+  }).trim();
+
+  return withoutKernelPrefix.replace(/^[a-z][a-z0-9!_]*(?:[ _-][a-z][a-z0-9!_]*)*/i, (name) =>
+    normalizeLinuxName(name)
+  );
+}
+
+function versionNamesWindows(version: string): boolean {
+  return /windows/i.test(version);
+}
+
+function versionNamesMacos(version: string): boolean {
+  return /(?:macos|mac\s+os(?:\s+x)?|os\s+x)/i.test(version);
+}
+
+function versionNamesLinux(version: string): boolean {
+  return /linux/i.test(version);
+}
+
+export function formatDeviceOsVersion(
+  osType: string | null | undefined,
+  osVersion: string | null | undefined,
+): string {
+  const type = osType?.toLowerCase() ?? '';
+  const raw = osVersion?.trim() ?? '';
+  if (!raw) return '';
+
+  if (type === 'macos') {
+    if (/^macos\b/i.test(raw)) return raw.replace(/^macos\b/i, 'macOS');
+    if (versionNamesMacos(raw)) return raw;
+
+    if (/^darwin(?:\s+|$)/i.test(raw)) {
+      const withoutDarwin = raw.replace(/^darwin(?:\s+|$)/i, '').trim();
+      return withoutDarwin ? `macOS ${withoutDarwin}` : 'macOS';
+    }
+
+    return `macOS ${raw}`;
+  }
+
+  if (type === 'linux') {
+    return normalizeLinuxDistroName(raw);
+  }
+
+  return raw;
+}
+
+export function formatDeviceDetailOsVersion(
+  osType: string | null | undefined,
+  osVersion: string | null | undefined,
+): string {
+  const formatted = formatDeviceOsVersion(osType, osVersion);
+  if (osType?.toLowerCase() !== 'macos') return formatted;
+
+  return formatted.replace(/^macOS\s*/i, '').trim();
+}
+
+export function formatDeviceSummaryOs(
+  osType: string | null | undefined,
+  osVersion: string | null | undefined,
+): string {
+  const type = osType?.toLowerCase() ?? '';
+  const label = osTypeLabels[type] ?? osType ?? '';
+  const version = formatDeviceOsVersion(osType, osVersion);
+
+  if (!version) return label || 'Unknown OS';
+  if (type === 'windows') return versionNamesWindows(version) ? version : `Windows ${version}`;
+  if (type === 'macos') return versionNamesMacos(version) ? version : `macOS ${version}`;
+  if (type === 'linux') return versionNamesLinux(version) ? version : `Linux ${version}`;
+  return label ? `${label} ${version}` : version;
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it brief (1-3 bullets). -->

- Normalizes device OS labels across the device list, device header, and device details OS section. (Previously discussed in #1303)
- Displays Darwin-based macOS versions as macOS, preserves Windows version/build text, and improves Linux distro casing/branding.
- Adds regression coverage for OS label formatting across list/detail views.

## Type of Change

<!-- Check the one that applies: -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other: <!-- describe -->

## Testing

<!-- How did you verify this works? -->

- [ ] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [x] Manual testing (describe below)

Focused checks run:

- `pnpm --filter @breeze/web exec vitest run src/components/devices/osDisplay.test.ts src/components/devices/DeviceList.test.tsx src/components/devices/DeviceInfoTab.test.tsx`
- `pnpm --filter @breeze/web lint`
- `pnpm --filter @breeze/web exec tsc --noEmit`
- `git diff --check`

Manual validation: built and deployed a GHCR web test image, then confirmed OS labels render cleanly for Windows, macOS, and Linux device examples.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included