### PR TITLE
fix(api): stop invoice routers leaking auth onto public routes (#1383 main smoke regression)

### DIFF
--- a/apps/api/src/routes/invoices/assembly.ts
+++ b/apps/api/src/routes/invoices/assembly.ts
@@ -8,14 +8,17 @@ import { assembleDraftFromOrg, assembleDraftFromTicket } from '../../services/in
 import { invoiceActorFrom, handleServiceError } from './invoices';
 
 export const invoiceAssemblyRoutes = new Hono();
-// Mounted at top level (not under the invoices hub), so it must apply auth itself —
-// requireScope/requirePermission below depend on c.get('auth') being populated.
-invoiceAssemblyRoutes.use('*', authMiddleware);
+// Mounted at the api root via `api.route('/', ...)`, so auth is applied PER-ROUTE
+// below — NOT via `use('*', authMiddleware)`. A wildcard middleware on a router
+// mounted at '/' runs for every request that reaches it, including sibling routes
+// registered later (e.g. the public agent-binary download endpoint), which then
+// 401s. That was the #1383 regression. Each route already depends on c.get('auth'),
+// so authMiddleware simply leads each route's middleware chain.
 const scopes = requireScope('partner', 'system');
 const writePerm = requirePermission(PERMISSIONS.INVOICES_WRITE.resource, PERMISSIONS.INVOICES_WRITE.action);
 
 // Mounted at top level so the paths read /orgs/:orgId/invoices/assemble and /tickets/:ticketId/invoice
-invoiceAssemblyRoutes.post('/orgs/:orgId/invoices/assemble', scopes, writePerm,
+invoiceAssemblyRoutes.post('/orgs/:orgId/invoices/assemble', authMiddleware, scopes, writePerm,
   zValidator('param', z.object({ orgId: z.string().uuid() })),
   zValidator('json', assembleFromOrgSchema.omit({ orgId: true })),
   async (c) => {
@@ -23,7 +26,7 @@ invoiceAssemblyRoutes.post('/orgs/:orgId/invoices/assemble', scopes, writePerm,
       return c.json({ data: await assembleDraftFromOrg({ orgId, ...b }, invoiceActorFrom(c)) }); }
     catch (err) { return handleServiceError(c, err); }
   });
-invoiceAssemblyRoutes.post('/tickets/:ticketId/invoice', scopes, writePerm,
+invoiceAssemblyRoutes.post('/tickets/:ticketId/invoice', authMiddleware, scopes, writePerm,
   zValidator('param', z.object({ ticketId: z.string().uuid() })),
   async (c) => {
     try { return c.json({ data: await assembleDraftFromTicket(c.req.valid('param').ticketId, invoiceActorFrom(c)) }); }

--- a/apps/api/src/routes/invoices/authScope.test.ts
+++ b/apps/api/src/routes/invoices/authScope.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// Deterministic auth gate: 401 unless an Authorization header is present.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    if (!c.req.header('authorization')) {
+      return c.json({ error: 'Missing or invalid authorization header' }, 401);
+    }
+    return next();
+  },
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+}));
+
+// The invoice route handlers are never reached in these tests (auth blocks them),
+// but the modules import these — stub them so importing the routers is side-effect free.
+vi.mock('../../services/invoiceService', () => ({
+  assembleDraftFromOrg: vi.fn(),
+  assembleDraftFromTicket: vi.fn(),
+  updatePartnerBillingSettings: vi.fn(),
+  updateOrgBillingSettings: vi.fn(),
+}));
+vi.mock('./invoices', () => ({
+  invoiceActorFrom: vi.fn(),
+  handleServiceError: vi.fn(),
+}));
+
+import { invoiceAssemblyRoutes } from './assembly';
+import { invoiceSettingsRoutes } from './settings';
+
+// Regression for the #1383 main-smoke break: the invoice assembly/settings routers
+// are mounted at the api root via `api.route('/', ...)`. They must NOT install a
+// `use('*', authMiddleware)`, because a wildcard middleware on a router mounted at
+// '/' leaks onto every sibling route registered afterwards — including public ones
+// like the agent-binary download endpoint, which then returns 401.
+function buildApp() {
+  const app = new Hono();
+  app.route('/', invoiceAssemblyRoutes);
+  app.route('/', invoiceSettingsRoutes);
+  // A public route registered AFTER the invoice routers, mimicking how the real
+  // agent-versions download route mounts later in index.ts.
+  app.get('/agent-versions/:version/download', (c) => c.text('public-ok'));
+  return app;
+}
+
+describe('invoice routers do not leak auth onto sibling routes (#1383)', () => {
+  it('does not auth-gate a public route registered after the invoice routers', async () => {
+    const app = buildApp();
+    const res = await app.request('/agent-versions/0.65.9/download');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('public-ok');
+  });
+
+  it('still requires auth on the invoice assembly routes', async () => {
+    const app = buildApp();
+    const res = await app.request('/tickets/11111111-1111-4111-8111-111111111111/invoice', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('still requires auth on the billing-settings routes', async () => {
+    const app = buildApp();
+    const partner = await app.request('/partner/billing-settings', { method: 'PATCH' });
+    expect(partner.status).toBe(401);
+    const org = await app.request('/orgs/22222222-2222-4222-8222-222222222222/billing-settings', {
+      method: 'PATCH',
+    });
+    expect(org.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/invoices/settings.ts
+++ b/apps/api/src/routes/invoices/settings.ts
@@ -9,20 +9,21 @@ import { invoiceActorFrom, handleServiceError } from './invoices';
 
 // Mounted at the api root (not under the /invoices hub) so the paths read
 // /api/v1/partner/billing-settings and /api/v1/orgs/:orgId/billing-settings.
-// It applies authMiddleware itself, mirroring invoiceAssemblyRoutes.
+// Auth is applied PER-ROUTE (not via `use('*')`): mounted at '/', a wildcard
+// middleware would leak onto sibling/public routes registered later and 401 them
+// (the #1383 regression). authMiddleware leads each route's middleware chain.
 export const invoiceSettingsRoutes = new Hono();
-invoiceSettingsRoutes.use('*', authMiddleware);
 const scopes = requireScope('partner', 'system');
 const writePerm = requirePermission(PERMISSIONS.INVOICES_WRITE.resource, PERMISSIONS.INVOICES_WRITE.action);
 
-invoiceSettingsRoutes.patch('/partner/billing-settings', scopes, writePerm,
+invoiceSettingsRoutes.patch('/partner/billing-settings', authMiddleware, scopes, writePerm,
   zValidator('json', partnerBillingSettingsSchema),
   async (c) => {
     try { return c.json({ data: await updatePartnerBillingSettings(c.req.valid('json'), invoiceActorFrom(c)) }); }
     catch (err) { return handleServiceError(c, err); }
   });
 
-invoiceSettingsRoutes.patch('/orgs/:orgId/billing-settings', scopes, writePerm,
+invoiceSettingsRoutes.patch('/orgs/:orgId/billing-settings', authMiddleware, scopes, writePerm,
   zValidator('param', z.object({ orgId: z.string().uuid() })),
   zValidator('json', orgBillingSettingsSchema),
   async (c) => {


### PR DESCRIPTION
## Problem

The #1383 merge turned `main` smoke red (`smoke-binary-source-github` + `smoke-binary-source-local`). The public agent-binary download endpoint started returning 401:

```
GET /api/v1/agent-versions/0.65.9/download?... -> 401 {"error":"Missing or invalid authorization header"}
```

Agents fetch updates with no user JWT, so this endpoint must stay public. In production this would block agent binary downloads and self-updates fleet-wide.

## Root cause

`invoiceAssemblyRoutes` (`routes/invoices/assembly.ts`) and `invoiceSettingsRoutes` (`routes/invoices/settings.ts`) each installed `use('*', authMiddleware)` and are mounted at the **api root**:

```ts
// index.ts
api.route('/', invoiceAssemblyRoutes);   // :747
api.route('/', invoiceSettingsRoutes);   // :751
...
api.route('/agent-versions', agentVersionRoutes);   // :834  (public download lives here)
```

A `use('*')` on a router mounted at `/` registers middleware against `/*` and runs for every request that reaches it, including sibling routes registered later in `index.ts`. So the invoice auth blanket leaked onto the public `/agent-versions/.../download` route (and any other public route after `:751`).

## Fix

Apply `authMiddleware` **per-route** instead of via `use('*')`. Each route already carries its `requireScope` / `requirePermission` chain, so `authMiddleware` simply leads each chain. No behavior change for the invoice routes (still auth-gated); the blanket leak is gone.

Adds `routes/invoices/authScope.test.ts`: mounts both routers at `/`, registers a public route after them, and asserts the public route is reachable without auth while the invoice routes still 401 — a regression guard for this exact mount footgun.

## Local verification (pnpm 10.33.4)

- api `tsc --noEmit`: exit 0
- `eslint` on changed files: exit 0
- `authScope.test.ts` (new) + `invoices.test.ts` + `settings.test.ts`: 37/37 pass

The `smoke-binary-source-*` jobs — the exact checks that went red on `main` — should return green on this branch's CI.

Fixes the regression from #1383.
