### PR TITLE
fix(ticketing): theme-aware assignee select (white on dark theme)

### DIFF
--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -355,7 +355,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
                 if (next === (ticket.assignedTo ?? null)) return; // no-op guard: never write a bogus feed entry
                 void mutate('/assign', { assigneeId: next }, next ? 'Assigned' : 'Unassigned');
               }}
-              className="max-w-[180px] rounded-md border px-2 py-1 text-xs"
+              className="max-w-[180px] rounded-md border bg-background px-2 py-1 text-xs text-foreground"
               data-testid="ticket-workbench-assignee"
               aria-label="Assignee"
             >


### PR DESCRIPTION
## Problem
The assignee `<select>` in the ticket workbench rendered with a **white background on the dark theme**. It was the only `<select>` in the ticketing module missing `bg-background`, so the native control fell back to the browser default.

## Fix
Added `bg-background text-foreground` to `TicketWorkbench.tsx:337` to match the established convention used by every sibling control (status/priority use color configs; filters and composer already use `bg-background`).

## Scope
One-line className change, dark-theme only. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)