### PR TITLE
perf(ticketing): kill the per-action refetch cascade in the queue UI

### DIFF
--- a/apps/web/src/components/tickets/TicketQueueList.test.tsx
+++ b/apps/web/src/components/tickets/TicketQueueList.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TicketQueueList from './TicketQueueList';
+import type { TicketSummary } from './ticketConfig';
+
+const makeTicket = (overrides: Partial<TicketSummary> & { id: string }): TicketSummary => ({
+  internalNumber: 'T-1',
+  subject: 'A ticket',
+  status: 'open',
+  priority: 'normal',
+  source: 'portal',
+  orgId: 'org-1',
+  orgName: 'Acme',
+  deviceId: null,
+  deviceHostname: null,
+  assignedTo: null,
+  assigneeName: null,
+  categoryId: null,
+  dueDate: null,
+  slaBreachedAt: null,
+  firstResponseAt: null,
+  createdAt: new Date('2026-06-01T10:00:00Z').toISOString(),
+  updatedAt: new Date('2026-06-01T10:00:00Z').toISOString(),
+  ...overrides
+});
+
+describe('TicketQueueList loading skeleton', () => {
+  it('shows the skeleton only on a cold load (loading with no rows yet)', () => {
+    render(<TicketQueueList tickets={[]} selectedId={null} onSelect={vi.fn()} loading />);
+    expect(screen.getByTestId('tickets-queue-loading')).toBeInTheDocument();
+  });
+
+  it('keeps showing existing rows during a background reconcile (loading but rows present)', () => {
+    render(
+      <TicketQueueList
+        tickets={[makeTicket({ id: 'tk-1', subject: 'Stays visible' })]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        loading
+      />
+    );
+    // A background refresh must not blank the list with the skeleton.
+    expect(screen.queryByTestId('tickets-queue-loading')).toBeNull();
+    expect(screen.getByTestId('ticket-row-tk-1')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/tickets/TicketQueueList.tsx
+++ b/apps/web/src/components/tickets/TicketQueueList.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { cn } from '@/lib/utils';
 import SlaChip from './SlaChip';
 import { statusConfig, priorityConfig, type TicketSummary } from './ticketConfig';
@@ -24,10 +25,13 @@ function timeAgo(iso: string): string {
   return `${Math.floor(mins / (60 * 24))}d ago`;
 }
 
-export default function TicketQueueList({ tickets, selectedId, onSelect, loading, config = null, onClearFilters, bulkSelectedIds, onToggleSelect }: Props) {
+function TicketQueueList({ tickets, selectedId, onSelect, loading, config = null, onClearFilters, bulkSelectedIds, onToggleSelect }: Props) {
   const anyBulkSelected = (bulkSelectedIds?.size ?? 0) > 0;
 
-  if (loading) {
+  // Skeleton only on a cold load (no rows yet). A background reconcile after a
+  // mutation keeps `loading` true briefly — blanking the populated list with the
+  // skeleton on every action is the visible "flash" that made the queue feel slow.
+  if (loading && tickets.length === 0) {
     return (
       <div className="divide-y" data-testid="tickets-queue-loading">
         {Array.from({ length: 8 }).map((_, i) => (
@@ -126,3 +130,8 @@ export default function TicketQueueList({ tickets, selectedId, onSelect, loading
     </ul>
   );
 }
+
+// Memoized: the parent (TicketsPage) re-renders on unrelated state (search box,
+// bulk menu, reconcile timers); without this the whole list (up to 100 rows)
+// re-renders on every keystroke and every background refresh.
+export default memo(TicketQueueList);

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -646,6 +646,85 @@ describe('TicketWorkbench host-supplied assignees prop', () => {
   });
 });
 
+describe('TicketWorkbench optimistic updates & background reconcile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchConfigMock.mockResolvedValue(null);
+  });
+
+  /**
+   * First detail GET resolves immediately; mutations succeed; the post-mutation
+   * reconcile GET stays pending until released. Lets us assert the optimistic
+   * value renders BEFORE the reconcile lands, and that no skeleton/aria-busy
+   * appears during a background reconcile.
+   */
+  function mockWithHeldReconcile(initial: TicketDetail) {
+    let releaseReload: (() => void) | null = null;
+    let ticketGets = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/users') return makeJsonResponse({ data: [] });
+      if ((!init?.method || init.method === 'GET') && url === `/tickets/${initial.id}`) {
+        ticketGets += 1;
+        if (ticketGets === 1) return makeJsonResponse({ data: initial });
+        // Reconcile returns the UNCHANGED ticket — if the UI were reconcile-driven
+        // (not optimistic) the select would revert once this resolves.
+        return new Promise<Response>((resolve) => {
+          releaseReload = () => resolve(makeJsonResponse({ data: initial }));
+        });
+      }
+      return makeJsonResponse({ success: true });
+    });
+    return { release: () => releaseReload?.() };
+  }
+
+  it('reflects a status change immediately and reconciles in the background (no skeleton, not aria-busy)', async () => {
+    mockWithHeldReconcile(makeTicket({ status: 'open' }));
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'closed' } });
+
+    // Optimistic: the controlled select shows the new value before the reconcile GET resolves.
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-workbench-status')).toHaveValue('closed');
+    });
+    // Background reconcile must not blank the pane with the skeleton or mark it busy.
+    expect(screen.queryByTestId('ticket-workbench-loading')).toBeNull();
+    expect(screen.getByTestId('ticket-workbench')).not.toHaveAttribute('aria-busy');
+  });
+
+  it('reflects a priority change immediately (optimistic, before reconcile)', async () => {
+    const { release } = mockWithHeldReconcile(makeTicket({ priority: 'normal' }));
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-priority'), { target: { value: 'high' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-workbench-priority')).toHaveValue('high');
+    });
+    expect(screen.getByTestId('ticket-workbench')).not.toHaveAttribute('aria-busy');
+    release(); // the held reconcile (unchanged ticket) must NOT revert the optimistic value
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-workbench-priority')).toHaveValue('high');
+    });
+  });
+
+  it('notifies the host of the optimistic row patch via onTicketPatched', async () => {
+    mockWithHeldReconcile(makeTicket({ status: 'open' }));
+    const onTicketPatched = vi.fn();
+    render(<TicketWorkbench ticketId="tk-1" onTicketPatched={onTicketPatched} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'closed' } });
+
+    await waitFor(() => {
+      expect(onTicketPatched).toHaveBeenCalledWith('tk-1', expect.objectContaining({ status: 'closed' }));
+    });
+  });
+});
+
 // ─── Custom statuses (config path) ───────────────────────────────────────────
 
 const makeConfig = (overrides: Partial<TicketConfig> = {}): TicketConfig => ({

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -17,7 +17,11 @@ import { onTimerChanged, onBillingChanged } from '../../lib/timerActions';
 
 interface Props {
   ticketId: string;
-  onChanged?: () => void;       // queue refresh hook
+  onChanged?: () => void;       // queue refresh hook (debounced background reconcile)
+  // Optimistic row patch: lets the host update the matching queue row in place
+  // the instant a mutation lands, so the list reflects the change without waiting
+  // for (or paying for) a full list refetch. `onChanged` still reconciles after.
+  onTicketPatched?: (id: string, patch: Partial<TicketDetail>) => void;
   expanded?: boolean;            // full-page mode
   resolveRequestToken?: number;  // increments when the page-level `e` shortcut asks to open the resolve form
   refreshToken?: number;         // bumped by bulk actions in the queue after they mutate tickets
@@ -31,7 +35,7 @@ interface Props {
 const STATUS_OPTIONS: TicketStatus[] = ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'];
 const PRIORITY_OPTIONS: TicketPriority[] = ['urgent', 'high', 'normal', 'low'];
 
-export default function TicketWorkbench({ ticketId, onChanged, expanded, resolveRequestToken, refreshToken, assignees: assigneesProp }: Props) {
+export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, expanded, resolveRequestToken, refreshToken, assignees: assigneesProp }: Props) {
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -54,13 +58,20 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
   const assigneesProvided = assigneesProp !== undefined;
   const assignees = assigneesProvided ? assigneesProp : fetchedAssignees;
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(undefined);
-    setErrorKind(undefined);
+  // `background: true` reconciles after a mutation without the loading flag — no
+  // skeleton, no aria-busy, and a failed reconcile is swallowed so it can't wipe
+  // out an already-applied optimistic update or surface a spurious error pane.
+  const load = useCallback(async (opts?: { background?: boolean }) => {
+    const background = opts?.background ?? false;
+    if (!background) {
+      setLoading(true);
+      setError(undefined);
+      setErrorKind(undefined);
+    }
     try {
       const res = await fetchWithAuth(`/tickets/${ticketId}`);
       if (res.status === 404 || res.status === 403) {
+        if (background) return; // keep the current view; a reconcile 404 isn't a load failure
         setTicket(null);
         setError('Ticket not found. It may have been deleted, or you may not have access to it.');
         setErrorKind('not-found');
@@ -70,10 +81,11 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
       const body = await res.json();
       setTicket(body.data);
     } catch (e) {
+      if (background) return; // swallow — the mutation already succeeded
       setError(e instanceof Error ? e.message : 'Ticket failed to load.');
       setErrorKind('load');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   }, [ticketId]);
 
@@ -145,9 +157,22 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     return () => { unsubTimer(); unsubBilling(); };
   }, [load]);
 
+  // Shared post-mutation path: paint the change locally for instant feedback,
+  // tell the host to patch its queue row, then reconcile in the background. The
+  // controlled selects bind to `ticket.*`, so without the optimistic patch they
+  // snap back to the old value until the reconcile GET lands — the visible lag.
+  const afterMutation = useCallback((optimistic?: Partial<TicketDetail>) => {
+    if (optimistic) {
+      setTicket((t) => (t ? { ...t, ...optimistic } : t));
+      onTicketPatched?.(ticketId, optimistic);
+    }
+    void load({ background: true });
+    onChanged?.();
+  }, [ticketId, load, onChanged, onTicketPatched]);
+
   // Returns true on success, false on a swallowed ActionError — callers with
   // form state (resolve/pending) must only close/clear when the POST landed.
-  const mutate = useCallback(async (path: string, body: unknown, success: string): Promise<boolean> => {
+  const mutate = useCallback(async (path: string, body: unknown, success: string, optimistic?: Partial<TicketDetail>): Promise<boolean> => {
     try {
       await runAction({
         request: () => fetchWithAuth(`/tickets/${ticketId}${path}`, { method: 'POST', body: JSON.stringify(body) }),
@@ -155,14 +180,13 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
         successMessage: success,
         onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
-      await load();
-      onChanged?.();
+      afterMutation(optimistic);
       return true;
     } catch (err) {
       if (!(err instanceof ActionError)) throw err;
       return false; // already toasted by runAction
     }
-  }, [ticketId, load, onChanged]);
+  }, [ticketId, afterMutation]);
 
   // Assemble a draft invoice from this ticket's billable work, then jump to it.
   const createInvoice = useCallback(async () => {
@@ -189,7 +213,8 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     setPendingStatusId(null);
     if (status === 'resolved') { setResolveOpen(true); return; }
     if (status === 'pending' || status === 'on_hold') { setPendingOpen(status); return; }
-    await mutate('/status', { status }, 'Status updated');
+    // Core path clears any custom-status decoration the row may have carried.
+    await mutate('/status', { status }, 'Status updated', { status, statusName: null, statusColor: null });
   }, [mutate]);
 
   // Config path: option values are custom-status row ids; the chosen row's
@@ -205,13 +230,14 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
       return;
     }
     setPendingStatusId(null);
-    await mutate('/status', { statusId }, 'Status updated');
+    await mutate('/status', { statusId }, 'Status updated', { status: row.coreStatus, statusName: row.name, statusColor: row.color ?? null });
   }, [config, mutate]);
 
   const submitResolve = useCallback(async () => {
     if (!resolutionNote.trim()) return;
     const target = pendingStatusId ? { statusId: pendingStatusId } : { status: 'resolved' as const };
-    const ok = await mutate('/status', { ...target, resolutionNote: resolutionNote.trim() }, 'Ticket resolved');
+    const note = resolutionNote.trim();
+    const ok = await mutate('/status', { ...target, resolutionNote: note }, 'Ticket resolved', { status: 'resolved', resolutionNote: note });
     if (!ok) return; // keep the form open and the typed note intact on failure
     setResolveOpen(false);
     setResolutionNote('');
@@ -222,7 +248,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
     if (!pendingOpen) return;
     const reason = pendingReason.trim();
     const target = pendingStatusId ? { statusId: pendingStatusId } : { status: pendingOpen };
-    const ok = await mutate('/status', { ...target, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated');
+    const ok = await mutate('/status', { ...target, ...(reason ? { pendingReason: reason } : {}) }, 'Status updated', { status: pendingOpen, pendingReason: reason || null });
     if (!ok) return; // keep the form open and the typed reason intact on failure
     setPendingOpen(null);
     setPendingReason('');
@@ -235,9 +261,10 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
       errorFallback: 'Reply failed. Retry.',
       onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
     });
-    await load();
-    onChanged?.();
-  }, [ticketId, load, onChanged]);
+    // The new comment can only come from the server; reconcile in the background
+    // so the composer releases the instant the POST lands (the feed fills in next).
+    afterMutation();
+  }, [ticketId, afterMutation]);
 
   // Skeleton only on the first load of a ticket. Refreshes (send, status
   // change, refreshToken bump) keep the tree mounted so composer state —
@@ -335,11 +362,12 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
           <select
             value={ticket.priority}
             onChange={(e) => {
+              const priority = e.target.value as TicketPriority;
               void runAction({
-                request: () => fetchWithAuth(`/tickets/${ticketId}`, { method: 'PATCH', body: JSON.stringify({ priority: e.target.value }) }),
+                request: () => fetchWithAuth(`/tickets/${ticketId}`, { method: 'PATCH', body: JSON.stringify({ priority }) }),
                 errorFallback: 'Priority update failed. Retry.',
                 onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
-              }).then(() => { void load(); onChanged?.(); }).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+              }).then(() => afterMutation({ priority })).catch((err) => { if (!(err instanceof ActionError)) throw err; });
             }}
             className={cn('rounded-md border px-2 py-1 text-xs font-medium', priorityConfig[ticket.priority].color)}
             data-testid="ticket-workbench-priority"
@@ -353,7 +381,11 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
               onChange={(e) => {
                 const next = e.target.value || null;
                 if (next === (ticket.assignedTo ?? null)) return; // no-op guard: never write a bogus feed entry
-                void mutate('/assign', { assigneeId: next }, next ? 'Assigned' : 'Unassigned');
+                const picked = next ? assignees?.find((u) => u.id === next) : null;
+                void mutate('/assign', { assigneeId: next }, next ? 'Assigned' : 'Unassigned', {
+                  assignedTo: next,
+                  assigneeName: picked ? (picked.name || picked.email) : null
+                });
               }}
               className="max-w-[180px] rounded-md border px-2 py-1 text-xs"
               data-testid="ticket-workbench-assignee"
@@ -370,7 +402,7 @@ export default function TicketWorkbench({ ticketId, onChanged, expanded, resolve
           ) : ticket.assignedTo ? (
             <button
               type="button"
-              onClick={() => void mutate('/assign', { assigneeId: null }, 'Unassigned')}
+              onClick={() => void mutate('/assign', { assigneeId: null }, 'Unassigned', { assignedTo: null, assigneeName: null })}
               className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
               data-testid="ticket-workbench-unassign"
             >

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -526,6 +526,29 @@ describe('TicketsPage', () => {
     expect(lastUrl).not.toContain('categoryId=');
   });
 
+  describe('search debounce', () => {
+    it('coalesces rapid keystrokes — the intermediate value never hits the network', async () => {
+      mockListApi([healthy]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      const before = ticketFetchUrls().length;
+
+      // Two changes within one tick (far inside the debounce window).
+      fireEvent.change(screen.getByTestId('tickets-search-input'), { target: { value: 'p' } });
+      fireEvent.change(screen.getByTestId('tickets-search-input'), { target: { value: 'pr' } });
+
+      // The final value fetches once the debounce settles…
+      await waitFor(() => {
+        expect(ticketFetchUrls().some((u) => u.includes('search=pr'))).toBe(true);
+      });
+      // …and the intermediate "p" was coalesced away (would fire per-keystroke without debounce).
+      expect(ticketFetchUrls().filter((u) => /[?&]search=p(&|$)/.test(u))).toHaveLength(0);
+      // Exactly one extra list fetch resulted from the burst (not two).
+      expect(ticketFetchUrls().length - before).toBe(1);
+    });
+  });
+
   describe('org-scope hygiene', () => {
     it('org-scoped session: does not fetch /orgs/organizations and hides the org filter select', async () => {
       mockGetJwtClaims.mockReturnValue({ scope: 'organization', orgId: 'org-1', partnerId: null });

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -107,6 +107,9 @@ export default function TicketsPage() {
   const [selectedNumber, setSelectedNumber] = useState<string | null>(() => parseHash().selection);
   const [sort, setSort] = useState<TicketSort>(() => parseHash().sort);
   const [search, setSearch] = useState('');
+  // Debounced twin of `search` — only this drives the list fetch, so typing
+  // doesn't fire a 100-row query per keystroke (the input itself stays instant).
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [orgFilter, setOrgFilter] = useState('');
   const [priorityFilter, setPriorityFilter] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('');
@@ -177,7 +180,7 @@ export default function TicketsPage() {
     setError(undefined);
     try {
       const params = new URLSearchParams(tabQuery(tab));
-      if (search) params.set('search', search);
+      if (debouncedSearch) params.set('search', debouncedSearch);
       if (orgFilter) params.set('orgId', orgFilter);
       if (priorityFilter) params.set('priority', priorityFilter);
       if (categoryFilter) params.set('categoryId', categoryFilter);
@@ -201,7 +204,7 @@ export default function TicketsPage() {
     } finally {
       if (seq === fetchSeq.current) setLoading(false);
     }
-  }, [tab, search, orgFilter, priorityFilter, categoryFilter, assigneeFilter, sort]);
+  }, [tab, debouncedSearch, orgFilter, priorityFilter, categoryFilter, assigneeFilter, sort]);
 
   const fetchStats = useCallback(async () => {
     try {
@@ -216,6 +219,31 @@ export default function TicketsPage() {
   }, []);
 
   useEffect(() => { void fetchTickets(); void fetchStats(); }, [fetchTickets, fetchStats]);
+
+  // Trailing debounce: commit the typed search to the fetch-driving value 300ms
+  // after the last keystroke. An empty box applies immediately (clearing search
+  // should feel instant). Cleared on every change so only the final value lands.
+  useEffect(() => {
+    if (search === '') { setDebouncedSearch(''); return; }
+    const id = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(id);
+  }, [search]);
+
+  // Patch a single queue row in place after a workbench mutation — instant list
+  // feedback without a full /tickets refetch (the heavy 100-row query that, on
+  // the connection-capped US droplet, also contended for DB connections).
+  const patchTicketRow = useCallback((id: string, patch: Partial<TicketSummary>) => {
+    setTickets((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  }, []);
+
+  // Debounced background reconcile after a mutation: coalesces bursts (rapid
+  // status/assignee changes) into one list+stats refresh instead of one per click.
+  const reconcileTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleReconcile = useCallback(() => {
+    if (reconcileTimer.current) clearTimeout(reconcileTimer.current);
+    reconcileTimer.current = setTimeout(() => { void fetchTickets(); void fetchStats(); }, 300);
+  }, [fetchTickets, fetchStats]);
+  useEffect(() => () => { if (reconcileTimer.current) clearTimeout(reconcileTimer.current); }, []);
 
   // Fetch ticket config once (module-cached). Failure leaves config null, so
   // chips and the bulk-status menu keep using the static core labels.
@@ -287,7 +315,8 @@ export default function TicketsPage() {
 
   const assignMe = useCallback(async () => {
     if (!selected) return;
-    const userId = useAuthStore.getState().user?.id;
+    const me = useAuthStore.getState().user;
+    const userId = me?.id;
     if (!userId) {
       showToast({ type: 'error', message: 'Assign failed. Retry.' });
       return;
@@ -299,13 +328,13 @@ export default function TicketsPage() {
         successMessage: 'Assigned to you',
         onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
-      void fetchTickets();
-      void fetchStats();
+      patchTicketRow(selected.id, { assignedTo: userId, assigneeName: me?.name ?? me?.email ?? null });
+      scheduleReconcile();
     } catch (err) {
       // ActionError is already toasted by runAction; surface anything else too.
       if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Assign failed. Retry.' });
     }
-  }, [selected, fetchTickets, fetchStats]);
+  }, [selected, patchTicketRow, scheduleReconcile]);
 
   const toggleBulkSelect = useCallback((id: string) => {
     setBulkSelectedIds((prev) => {
@@ -616,7 +645,7 @@ export default function TicketsPage() {
           </div>
           <div className="hidden min-w-0 flex-1 min-[1100px]:block">
             {selected ? (
-              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} refreshToken={paneRefresh} assignees={assignees} onChanged={() => { void fetchTickets(); void fetchStats(); }} />
+              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} refreshToken={paneRefresh} assignees={assignees} onTicketPatched={patchTicketRow} onChanged={scheduleReconcile} />
             ) : (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground" data-testid="tickets-no-selection">
                 <p>Select a ticket. Use j/k to move, Enter to expand.</p>


### PR DESCRIPTION
## Problem
Investigated the report that ticketing buttons/actions feel slow — reproduced on Docker **and** the US droplet, so it's frontend architecture, not infra.

Every ticket action ran a **serial, blocking cascade**:
`await POST` → `await` full ticket-detail GET → full **100-row** list refetch + stats refetch.

Two distinct costs:
1. **Perceived latency.** The controlled selects (status/priority/assignee) are bound to `ticket.*`, so on click they snapped *back* to the old value until the detail GET resolved (~400ms+), then jumped to the new value. The queue also flashed its loading skeleton on every action.
2. **Real DB load.** The redundant 100-row `/tickets?limit=100` query per action contends for connections — and per ops notes the US managed Postgres sits at its connection ceiling, so this amplifies under load.

## Fix (behaviour-preserving — same endpoints, same payloads)
- **Optimistic local patch** of the detail + the matching queue row on success → selects/chips update instantly. New `onTicketPatched` prop carries the patch to the list.
- **Background reconcile**: detail `load({ background: true })` runs without the loading flag (no skeleton / aria-busy), failures swallowed so they can't clobber the optimistic state. The button/composer release the instant the POST lands.
- **No more full-list refetch per single-ticket action** — the row is patched in place; the full list+stats reconcile is **debounced (300ms)** to coalesce bursts.
- **Search debounced (300ms)** — typing no longer fires a list query per keystroke (clearing still applies immediately).
- **TicketQueueList**: skeleton only on a cold load (no rows yet) + `React.memo` so the 100-row list doesn't re-render on every keystroke / reconcile.

## Tests
Added: optimistic-update + background-reconcile (`TicketWorkbench`), search-debounce coalescing (`TicketsPage`), skeleton-only-when-empty (`TicketQueueList`). Full `apps/web` suite green — **1498 tests, 189 files**.

## Note for review
User-facing UI change — worth a manual pass in the ticket queue (status/priority/assignee changes, comments, search typing) to confirm the instant-feedback feel. One deliberate behaviour nuance: a single-ticket change now reconciles list membership ~300ms later (debounced) rather than synchronously; the row updates optimistically in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)