### PR TITLE
feat(office-addin): runtime config.json — deployment-neutral add-in bundle

### DIFF
--- a/apps/excel-addin/.env.example
+++ b/apps/excel-addin/.env.example
@@ -1,4 +1,7 @@
 # Breeze API origin the add-in calls. Local dev default shown.
+# Runtime config: in production these values are served at /config.json (see
+# scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
+# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/excel-addin/.env.example
+++ b/apps/excel-addin/.env.example
@@ -1,7 +1,9 @@
 # Breeze API origin the add-in calls. Local dev default shown.
 # Runtime config: in production these values are served at /config.json (see
 # scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
-# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
+# are dev fallbacks — they fill any field /config.json leaves absent or empty.
+# (The committed public/config.json ships an empty entraClientId, so
+# VITE_CLIENT_AI_ENTRA_CLIENT_ID fills it for local SSO.)
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/excel-addin/README.md
+++ b/apps/excel-addin/README.md
@@ -52,7 +52,7 @@ add-in falls back to the MSAL popup — functional, just not silent.
 The JS bundle is deployment-neutral. At boot it fetches `/config.json`
 (`{ "apiBaseUrl": "...", "entraClientId": "..." }`) from its own origin. For
 local dev the committed `public/config.json` (localhost defaults) is served by
-Vite; the `VITE_*` env vars are only a fallback when `/config.json` is absent.
+Vite; the `VITE_*` env vars are dev fallbacks that fill any field `/config.json` leaves absent or empty (the committed `public/config.json` ships an empty `entraClientId`, so `VITE_CLIENT_AI_ENTRA_CLIENT_ID` fills it for local SSO).
 
 To produce a deployment's config:
 

--- a/apps/excel-addin/package.json
+++ b/apps/excel-addin/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "certs": "office-addin-dev-certs install",
     "manifest": "node scripts/generate-manifest.mjs",
+    "config": "node scripts/generate-config.mjs",
     "validate-manifest": "office-addin-manifest validate manifest.xml"
   },
   "dependencies": {

--- a/apps/excel-addin/public/config.json
+++ b/apps/excel-addin/public/config.json
@@ -1,0 +1,4 @@
+{
+  "apiBaseUrl": "http://localhost:3001",
+  "entraClientId": ""
+}

--- a/apps/excel-addin/scripts/generate-config.mjs
+++ b/apps/excel-addin/scripts/generate-config.mjs
@@ -34,15 +34,23 @@ const apiBaseUrl = (
   argValue('--api-base-url') ??
   env.VITE_API_BASE_URL ??
   'http://localhost:3001'
-).replace(/\/$/, '');
+).replace(/\/+$/, '');
 const clientId =
   argValue('--client-id') ??
   env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
   env.CLIENT_AI_ENTRA_CLIENT_ID ??
   '';
 
+const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/.test(apiBaseUrl);
+if (!clientId && !isLocalhost) {
+  console.error(
+    `[generate-config] ERROR: entraClientId is empty for a non-localhost apiBaseUrl (${apiBaseUrl}). ` +
+      'SSO cannot work — pass --client-id <guid> (or set VITE_CLIENT_AI_ENTRA_CLIENT_ID).',
+  );
+  process.exit(1);
+}
 if (!clientId) {
-  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+  console.warn('[generate-config] WARNING: entraClientId is empty (localhost dev) — SSO will not work until set.');
 }
 
 const outPath = path.join(root, argValue('--out') ?? 'public/config.json');

--- a/apps/excel-addin/scripts/generate-config.mjs
+++ b/apps/excel-addin/scripts/generate-config.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Writes public/config.json (served at /config.json) from env / .env / CLI flags.
+//   node scripts/generate-config.mjs [--api-base-url https://us.2breeze.app] [--client-id <guid>] [--out public/config.json]
+// Precedence: CLI flag > process.env > .env file > localhost default.
+// This is a DEPLOY-TIME utility. The committed public/config.json holds localhost
+// defaults so the shipped bundle stays deployment-neutral; each deployment runs
+// this (or serves its own config.json) with its real API origin + Entra client ID.
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function loadDotEnv(file) {
+  if (!existsSync(file)) return {};
+  const out = {};
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    if (line.trim().startsWith('#')) continue;
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const env = { ...loadDotEnv(path.join(root, '.env')), ...process.env };
+const args = process.argv.slice(2);
+const argValue = (flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const apiBaseUrl = (
+  argValue('--api-base-url') ??
+  env.VITE_API_BASE_URL ??
+  'http://localhost:3001'
+).replace(/\/$/, '');
+const clientId =
+  argValue('--client-id') ??
+  env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
+  env.CLIENT_AI_ENTRA_CLIENT_ID ??
+  '';
+
+if (!clientId) {
+  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+}
+
+const outPath = path.join(root, argValue('--out') ?? 'public/config.json');
+writeFileSync(outPath, `${JSON.stringify({ apiBaseUrl, entraClientId: clientId }, null, 2)}\n`);
+console.log(`[generate-config] wrote ${outPath} (api: ${apiBaseUrl}, clientId: ${clientId.slice(0, 8) || '∅'}…)`);

--- a/apps/excel-addin/src/main.tsx
+++ b/apps/excel-addin/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { App } from '@breeze/office-addin-core';
+import { App, bootAddin } from '@breeze/office-addin-core';
 import { excelHostAdapter } from './host/excel';
 import './index.css';
 
@@ -16,10 +16,15 @@ function render(): void {
   );
 }
 
+// bootAddin loads runtime config (/config.json) BEFORE the first render — App's
+// mount effect kicks off a silent sign-in that needs the API origin + Entra
+// client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
+const boot = (): void => void bootAddin(render);
+
 // Inside Excel, wait for the host handshake; in a plain browser tab (dev
-// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — render anyway.
+// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.
 if (typeof Office !== 'undefined' && typeof Office.onReady === 'function') {
-  void Office.onReady(() => render());
+  void Office.onReady(() => boot());
 } else {
-  render();
+  boot();
 }

--- a/apps/excel-addin/src/main.tsx
+++ b/apps/excel-addin/src/main.tsx
@@ -19,7 +19,14 @@ function render(): void {
 // bootAddin loads runtime config (/config.json) BEFORE the first render — App's
 // mount effect kicks off a silent sign-in that needs the API origin + Entra
 // client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
-const boot = (): void => void bootAddin(render);
+const boot = (): void => {
+  // boot() is the one path with no ErrorBoundary above it — surface a
+  // render-time throw instead of leaving a silent blank pane on a dropped
+  // promise rejection. (loadRuntimeConfig itself never throws.)
+  void bootAddin(render).catch((err: unknown) => {
+    console.error('[breeze] add-in failed to start', err);
+  });
+};
 
 // Inside Excel, wait for the host handshake; in a plain browser tab (dev
 // convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.

--- a/apps/outlook-addin/.env.example
+++ b/apps/outlook-addin/.env.example
@@ -1,4 +1,7 @@
 # Breeze API origin the add-in calls. Local dev default shown.
+# Runtime config: in production these values are served at /config.json (see
+# scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
+# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/outlook-addin/.env.example
+++ b/apps/outlook-addin/.env.example
@@ -1,7 +1,9 @@
 # Breeze API origin the add-in calls. Local dev default shown.
 # Runtime config: in production these values are served at /config.json (see
 # scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
-# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
+# are dev fallbacks — they fill any field /config.json leaves absent or empty.
+# (The committed public/config.json ships an empty entraClientId, so
+# VITE_CLIENT_AI_ENTRA_CLIENT_ID fills it for local SSO.)
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/outlook-addin/README.md
+++ b/apps/outlook-addin/README.md
@@ -49,7 +49,7 @@ add-in falls back to the MSAL popup — functional, just not silent.
 The JS bundle is deployment-neutral. At boot it fetches `/config.json`
 (`{ "apiBaseUrl": "...", "entraClientId": "..." }`) from its own origin. For
 local dev the committed `public/config.json` (localhost defaults) is served by
-Vite; the `VITE_*` env vars are only a fallback when `/config.json` is absent.
+Vite; the `VITE_*` env vars are dev fallbacks that fill any field `/config.json` leaves absent or empty (the committed `public/config.json` ships an empty `entraClientId`, so `VITE_CLIENT_AI_ENTRA_CLIENT_ID` fills it for local SSO).
 
 To produce a deployment's config:
 

--- a/apps/outlook-addin/README.md
+++ b/apps/outlook-addin/README.md
@@ -1,7 +1,7 @@
-# Breeze AI for Office — Excel add-in
+# Breeze AI for Office — Outlook add-in
 
 Task-pane add-in delivering the governed Breeze AI assistant to MSP client
-end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md`.
+end-users inside Outlook. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md`.
 
 ## Prerequisites
 
@@ -15,13 +15,13 @@ end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-o
 - `.env` (copy `.env.example`): `VITE_API_BASE_URL`, `VITE_CLIENT_AI_ENTRA_CLIENT_ID`
   (must equal the API's `CLIENT_AI_ENTRA_CLIENT_ID`), `ADDIN_BASE_URL`.
 - The API's `CORS_ALLOWED_ORIGINS` must include this app's origin
-  (`https://localhost:3000` for dev).
+  (`https://localhost:3004` for dev).
 
 ## Scripts
 
 | Script | What it does |
 | --- | --- |
-| `pnpm dev` | Generates icons + `manifest.xml`, serves the pane at `https://localhost:3000` |
+| `pnpm dev` | Generates icons + `manifest.xml`, serves the pane at `https://localhost:3004` |
 | `pnpm build` | Type-check + production build into `dist/` + manifest |
 | `pnpm test` | Vitest (jsdom + the Office.js mock in `src/__tests__/officeMock.ts`) |
 | `pnpm manifest` | Re-render `manifest.xml` from `manifest.template.xml` + env |
@@ -29,13 +29,10 @@ end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-o
 
 ## Sideloading the generated `manifest.xml`
 
-- **Excel on the web:** Insert ▸ Add-ins ▸ More Add-ins ▸ MY ADD-INS ▸ Upload My Add-in.
-- **Excel desktop (macOS):** copy `manifest.xml` to
-  `~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/` and restart Excel
-  (the add-in appears under Insert ▸ My Add-ins ▸ Developer Add-ins).
-- **Excel desktop (Windows):** add a shared-folder catalog pointing at the
-  directory containing `manifest.xml` (File ▸ Options ▸ Trust Center ▸ Trusted
-  Add-in Catalogs), then Insert ▸ My Add-ins ▸ SHARED FOLDER.
+- **Outlook on the web:** Settings ▸ Mail ▸ Customize actions / Get Add-ins ▸
+  My add-ins ▸ Custom Addins ▸ Add a custom add-in ▸ Add from file.
+- **Outlook desktop:** add the add-in from the same **Get Add-ins** dialog
+  (Outlook reads its manifest centrally, not from a per-host `wef/` folder).
 - Production distribution is M365 **centralized deployment** by the MSP (spec §2).
 
 ## Entra app registration

--- a/apps/outlook-addin/package.json
+++ b/apps/outlook-addin/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "certs": "office-addin-dev-certs install",
     "manifest": "node scripts/generate-manifest.mjs",
+    "config": "node scripts/generate-config.mjs",
     "validate-manifest": "office-addin-manifest validate manifest.xml"
   },
   "dependencies": {

--- a/apps/outlook-addin/public/config.json
+++ b/apps/outlook-addin/public/config.json
@@ -1,0 +1,4 @@
+{
+  "apiBaseUrl": "http://localhost:3001",
+  "entraClientId": ""
+}

--- a/apps/outlook-addin/scripts/generate-config.mjs
+++ b/apps/outlook-addin/scripts/generate-config.mjs
@@ -34,15 +34,23 @@ const apiBaseUrl = (
   argValue('--api-base-url') ??
   env.VITE_API_BASE_URL ??
   'http://localhost:3001'
-).replace(/\/$/, '');
+).replace(/\/+$/, '');
 const clientId =
   argValue('--client-id') ??
   env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
   env.CLIENT_AI_ENTRA_CLIENT_ID ??
   '';
 
+const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/.test(apiBaseUrl);
+if (!clientId && !isLocalhost) {
+  console.error(
+    `[generate-config] ERROR: entraClientId is empty for a non-localhost apiBaseUrl (${apiBaseUrl}). ` +
+      'SSO cannot work — pass --client-id <guid> (or set VITE_CLIENT_AI_ENTRA_CLIENT_ID).',
+  );
+  process.exit(1);
+}
 if (!clientId) {
-  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+  console.warn('[generate-config] WARNING: entraClientId is empty (localhost dev) — SSO will not work until set.');
 }
 
 const outPath = path.join(root, argValue('--out') ?? 'public/config.json');

--- a/apps/outlook-addin/scripts/generate-config.mjs
+++ b/apps/outlook-addin/scripts/generate-config.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Writes public/config.json (served at /config.json) from env / .env / CLI flags.
+//   node scripts/generate-config.mjs [--api-base-url https://us.2breeze.app] [--client-id <guid>] [--out public/config.json]
+// Precedence: CLI flag > process.env > .env file > localhost default.
+// This is a DEPLOY-TIME utility. The committed public/config.json holds localhost
+// defaults so the shipped bundle stays deployment-neutral; each deployment runs
+// this (or serves its own config.json) with its real API origin + Entra client ID.
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function loadDotEnv(file) {
+  if (!existsSync(file)) return {};
+  const out = {};
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    if (line.trim().startsWith('#')) continue;
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const env = { ...loadDotEnv(path.join(root, '.env')), ...process.env };
+const args = process.argv.slice(2);
+const argValue = (flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const apiBaseUrl = (
+  argValue('--api-base-url') ??
+  env.VITE_API_BASE_URL ??
+  'http://localhost:3001'
+).replace(/\/$/, '');
+const clientId =
+  argValue('--client-id') ??
+  env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
+  env.CLIENT_AI_ENTRA_CLIENT_ID ??
+  '';
+
+if (!clientId) {
+  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+}
+
+const outPath = path.join(root, argValue('--out') ?? 'public/config.json');
+writeFileSync(outPath, `${JSON.stringify({ apiBaseUrl, entraClientId: clientId }, null, 2)}\n`);
+console.log(`[generate-config] wrote ${outPath} (api: ${apiBaseUrl}, clientId: ${clientId.slice(0, 8) || '∅'}…)`);

--- a/apps/outlook-addin/src/main.tsx
+++ b/apps/outlook-addin/src/main.tsx
@@ -19,7 +19,14 @@ function render(): void {
 // bootAddin loads runtime config (/config.json) BEFORE the first render — App's
 // mount effect kicks off a silent sign-in that needs the API origin + Entra
 // client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
-const boot = (): void => void bootAddin(render);
+const boot = (): void => {
+  // boot() is the one path with no ErrorBoundary above it — surface a
+  // render-time throw instead of leaving a silent blank pane on a dropped
+  // promise rejection. (loadRuntimeConfig itself never throws.)
+  void bootAddin(render).catch((err: unknown) => {
+    console.error('[breeze] add-in failed to start', err);
+  });
+};
 
 // Inside Outlook, wait for the host handshake; in a plain browser tab (dev
 // convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.

--- a/apps/outlook-addin/src/main.tsx
+++ b/apps/outlook-addin/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { App } from '@breeze/office-addin-core';
+import { App, bootAddin } from '@breeze/office-addin-core';
 import { outlookHostAdapter } from './host/outlook';
 import './index.css';
 
@@ -16,10 +16,15 @@ function render(): void {
   );
 }
 
+// bootAddin loads runtime config (/config.json) BEFORE the first render — App's
+// mount effect kicks off a silent sign-in that needs the API origin + Entra
+// client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
+const boot = (): void => void bootAddin(render);
+
 // Inside Outlook, wait for the host handshake; in a plain browser tab (dev
-// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — render anyway.
+// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.
 if (typeof Office !== 'undefined' && typeof Office.onReady === 'function') {
-  void Office.onReady(() => render());
+  void Office.onReady(() => boot());
 } else {
-  render();
+  boot();
 }

--- a/apps/powerpoint-addin/.env.example
+++ b/apps/powerpoint-addin/.env.example
@@ -1,4 +1,7 @@
 # Breeze API origin the add-in calls. Local dev default shown.
+# Runtime config: in production these values are served at /config.json (see
+# scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
+# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/powerpoint-addin/.env.example
+++ b/apps/powerpoint-addin/.env.example
@@ -1,7 +1,9 @@
 # Breeze API origin the add-in calls. Local dev default shown.
 # Runtime config: in production these values are served at /config.json (see
 # scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
-# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
+# are dev fallbacks — they fill any field /config.json leaves absent or empty.
+# (The committed public/config.json ships an empty entraClientId, so
+# VITE_CLIENT_AI_ENTRA_CLIENT_ID fills it for local SSO.)
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/powerpoint-addin/README.md
+++ b/apps/powerpoint-addin/README.md
@@ -1,7 +1,7 @@
-# Breeze AI for Office — Excel add-in
+# Breeze AI for Office — PowerPoint add-in
 
 Task-pane add-in delivering the governed Breeze AI assistant to MSP client
-end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md`.
+end-users inside PowerPoint. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md`.
 
 ## Prerequisites
 
@@ -15,13 +15,13 @@ end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-o
 - `.env` (copy `.env.example`): `VITE_API_BASE_URL`, `VITE_CLIENT_AI_ENTRA_CLIENT_ID`
   (must equal the API's `CLIENT_AI_ENTRA_CLIENT_ID`), `ADDIN_BASE_URL`.
 - The API's `CORS_ALLOWED_ORIGINS` must include this app's origin
-  (`https://localhost:3000` for dev).
+  (`https://localhost:3003` for dev).
 
 ## Scripts
 
 | Script | What it does |
 | --- | --- |
-| `pnpm dev` | Generates icons + `manifest.xml`, serves the pane at `https://localhost:3000` |
+| `pnpm dev` | Generates icons + `manifest.xml`, serves the pane at `https://localhost:3003` |
 | `pnpm build` | Type-check + production build into `dist/` + manifest |
 | `pnpm test` | Vitest (jsdom + the Office.js mock in `src/__tests__/officeMock.ts`) |
 | `pnpm manifest` | Re-render `manifest.xml` from `manifest.template.xml` + env |
@@ -29,11 +29,11 @@ end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-o
 
 ## Sideloading the generated `manifest.xml`
 
-- **Excel on the web:** Insert ▸ Add-ins ▸ More Add-ins ▸ MY ADD-INS ▸ Upload My Add-in.
-- **Excel desktop (macOS):** copy `manifest.xml` to
-  `~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/` and restart Excel
-  (the add-in appears under Insert ▸ My Add-ins ▸ Developer Add-ins).
-- **Excel desktop (Windows):** add a shared-folder catalog pointing at the
+- **PowerPoint on the web:** Insert ▸ Add-ins ▸ More Add-ins ▸ MY ADD-INS ▸ Upload My Add-in.
+- **PowerPoint desktop (macOS):** copy `manifest.xml` to
+  `~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef/` and restart
+  PowerPoint (the add-in appears under Insert ▸ My Add-ins ▸ Developer Add-ins).
+- **PowerPoint desktop (Windows):** add a shared-folder catalog pointing at the
   directory containing `manifest.xml` (File ▸ Options ▸ Trust Center ▸ Trusted
   Add-in Catalogs), then Insert ▸ My Add-ins ▸ SHARED FOLDER.
 - Production distribution is M365 **centralized deployment** by the MSP (spec §2).

--- a/apps/powerpoint-addin/README.md
+++ b/apps/powerpoint-addin/README.md
@@ -52,7 +52,7 @@ add-in falls back to the MSAL popup — functional, just not silent.
 The JS bundle is deployment-neutral. At boot it fetches `/config.json`
 (`{ "apiBaseUrl": "...", "entraClientId": "..." }`) from its own origin. For
 local dev the committed `public/config.json` (localhost defaults) is served by
-Vite; the `VITE_*` env vars are only a fallback when `/config.json` is absent.
+Vite; the `VITE_*` env vars are dev fallbacks that fill any field `/config.json` leaves absent or empty (the committed `public/config.json` ships an empty `entraClientId`, so `VITE_CLIENT_AI_ENTRA_CLIENT_ID` fills it for local SSO).
 
 To produce a deployment's config:
 

--- a/apps/powerpoint-addin/package.json
+++ b/apps/powerpoint-addin/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "certs": "office-addin-dev-certs install",
     "manifest": "node scripts/generate-manifest.mjs",
+    "config": "node scripts/generate-config.mjs",
     "validate-manifest": "office-addin-manifest validate manifest.xml"
   },
   "dependencies": {

--- a/apps/powerpoint-addin/public/config.json
+++ b/apps/powerpoint-addin/public/config.json
@@ -1,0 +1,4 @@
+{
+  "apiBaseUrl": "http://localhost:3001",
+  "entraClientId": ""
+}

--- a/apps/powerpoint-addin/scripts/generate-config.mjs
+++ b/apps/powerpoint-addin/scripts/generate-config.mjs
@@ -34,15 +34,23 @@ const apiBaseUrl = (
   argValue('--api-base-url') ??
   env.VITE_API_BASE_URL ??
   'http://localhost:3001'
-).replace(/\/$/, '');
+).replace(/\/+$/, '');
 const clientId =
   argValue('--client-id') ??
   env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
   env.CLIENT_AI_ENTRA_CLIENT_ID ??
   '';
 
+const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/.test(apiBaseUrl);
+if (!clientId && !isLocalhost) {
+  console.error(
+    `[generate-config] ERROR: entraClientId is empty for a non-localhost apiBaseUrl (${apiBaseUrl}). ` +
+      'SSO cannot work — pass --client-id <guid> (or set VITE_CLIENT_AI_ENTRA_CLIENT_ID).',
+  );
+  process.exit(1);
+}
 if (!clientId) {
-  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+  console.warn('[generate-config] WARNING: entraClientId is empty (localhost dev) — SSO will not work until set.');
 }
 
 const outPath = path.join(root, argValue('--out') ?? 'public/config.json');

--- a/apps/powerpoint-addin/scripts/generate-config.mjs
+++ b/apps/powerpoint-addin/scripts/generate-config.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Writes public/config.json (served at /config.json) from env / .env / CLI flags.
+//   node scripts/generate-config.mjs [--api-base-url https://us.2breeze.app] [--client-id <guid>] [--out public/config.json]
+// Precedence: CLI flag > process.env > .env file > localhost default.
+// This is a DEPLOY-TIME utility. The committed public/config.json holds localhost
+// defaults so the shipped bundle stays deployment-neutral; each deployment runs
+// this (or serves its own config.json) with its real API origin + Entra client ID.
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function loadDotEnv(file) {
+  if (!existsSync(file)) return {};
+  const out = {};
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    if (line.trim().startsWith('#')) continue;
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const env = { ...loadDotEnv(path.join(root, '.env')), ...process.env };
+const args = process.argv.slice(2);
+const argValue = (flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const apiBaseUrl = (
+  argValue('--api-base-url') ??
+  env.VITE_API_BASE_URL ??
+  'http://localhost:3001'
+).replace(/\/$/, '');
+const clientId =
+  argValue('--client-id') ??
+  env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
+  env.CLIENT_AI_ENTRA_CLIENT_ID ??
+  '';
+
+if (!clientId) {
+  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+}
+
+const outPath = path.join(root, argValue('--out') ?? 'public/config.json');
+writeFileSync(outPath, `${JSON.stringify({ apiBaseUrl, entraClientId: clientId }, null, 2)}\n`);
+console.log(`[generate-config] wrote ${outPath} (api: ${apiBaseUrl}, clientId: ${clientId.slice(0, 8) || '∅'}…)`);

--- a/apps/powerpoint-addin/src/main.tsx
+++ b/apps/powerpoint-addin/src/main.tsx
@@ -19,7 +19,14 @@ function render(): void {
 // bootAddin loads runtime config (/config.json) BEFORE the first render — App's
 // mount effect kicks off a silent sign-in that needs the API origin + Entra
 // client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
-const boot = (): void => void bootAddin(render);
+const boot = (): void => {
+  // boot() is the one path with no ErrorBoundary above it — surface a
+  // render-time throw instead of leaving a silent blank pane on a dropped
+  // promise rejection. (loadRuntimeConfig itself never throws.)
+  void bootAddin(render).catch((err: unknown) => {
+    console.error('[breeze] add-in failed to start', err);
+  });
+};
 
 // Inside PowerPoint, wait for the host handshake; in a plain browser tab (dev
 // convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.

--- a/apps/powerpoint-addin/src/main.tsx
+++ b/apps/powerpoint-addin/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { App } from '@breeze/office-addin-core';
+import { App, bootAddin } from '@breeze/office-addin-core';
 import { powerpointHostAdapter } from './host/powerpoint';
 import './index.css';
 
@@ -16,10 +16,15 @@ function render(): void {
   );
 }
 
+// bootAddin loads runtime config (/config.json) BEFORE the first render — App's
+// mount effect kicks off a silent sign-in that needs the API origin + Entra
+// client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
+const boot = (): void => void bootAddin(render);
+
 // Inside PowerPoint, wait for the host handshake; in a plain browser tab (dev
-// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — render anyway.
+// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.
 if (typeof Office !== 'undefined' && typeof Office.onReady === 'function') {
-  void Office.onReady(() => render());
+  void Office.onReady(() => boot());
 } else {
-  render();
+  boot();
 }

--- a/apps/word-addin/.env.example
+++ b/apps/word-addin/.env.example
@@ -1,4 +1,7 @@
 # Breeze API origin the add-in calls. Local dev default shown.
+# Runtime config: in production these values are served at /config.json (see
+# scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
+# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/word-addin/.env.example
+++ b/apps/word-addin/.env.example
@@ -1,7 +1,9 @@
 # Breeze API origin the add-in calls. Local dev default shown.
 # Runtime config: in production these values are served at /config.json (see
 # scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
-# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
+# are dev fallbacks — they fill any field /config.json leaves absent or empty.
+# (The committed public/config.json ships an empty entraClientId, so
+# VITE_CLIENT_AI_ENTRA_CLIENT_ID fills it for local SSO.)
 VITE_API_BASE_URL=http://localhost:3001
 # Entra app registration (multi-tenant) client ID. MUST match the API's
 # CLIENT_AI_ENTRA_CLIENT_ID (apps/api .env, Plan 1 Task 6).

--- a/apps/word-addin/README.md
+++ b/apps/word-addin/README.md
@@ -1,7 +1,7 @@
-# Breeze AI for Office — Excel add-in
+# Breeze AI for Office — Word add-in
 
 Task-pane add-in delivering the governed Breeze AI assistant to MSP client
-end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md`.
+end-users inside Word. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md`.
 
 ## Prerequisites
 
@@ -15,13 +15,13 @@ end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-o
 - `.env` (copy `.env.example`): `VITE_API_BASE_URL`, `VITE_CLIENT_AI_ENTRA_CLIENT_ID`
   (must equal the API's `CLIENT_AI_ENTRA_CLIENT_ID`), `ADDIN_BASE_URL`.
 - The API's `CORS_ALLOWED_ORIGINS` must include this app's origin
-  (`https://localhost:3000` for dev).
+  (`https://localhost:3002` for dev).
 
 ## Scripts
 
 | Script | What it does |
 | --- | --- |
-| `pnpm dev` | Generates icons + `manifest.xml`, serves the pane at `https://localhost:3000` |
+| `pnpm dev` | Generates icons + `manifest.xml`, serves the pane at `https://localhost:3002` |
 | `pnpm build` | Type-check + production build into `dist/` + manifest |
 | `pnpm test` | Vitest (jsdom + the Office.js mock in `src/__tests__/officeMock.ts`) |
 | `pnpm manifest` | Re-render `manifest.xml` from `manifest.template.xml` + env |
@@ -29,11 +29,11 @@ end-users inside Excel. Spec: `docs/superpowers/specs/2026-06-12-breeze-ai-for-o
 
 ## Sideloading the generated `manifest.xml`
 
-- **Excel on the web:** Insert ▸ Add-ins ▸ More Add-ins ▸ MY ADD-INS ▸ Upload My Add-in.
-- **Excel desktop (macOS):** copy `manifest.xml` to
-  `~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/` and restart Excel
+- **Word on the web:** Insert ▸ Add-ins ▸ More Add-ins ▸ MY ADD-INS ▸ Upload My Add-in.
+- **Word desktop (macOS):** copy `manifest.xml` to
+  `~/Library/Containers/com.microsoft.Word/Data/Documents/wef/` and restart Word
   (the add-in appears under Insert ▸ My Add-ins ▸ Developer Add-ins).
-- **Excel desktop (Windows):** add a shared-folder catalog pointing at the
+- **Word desktop (Windows):** add a shared-folder catalog pointing at the
   directory containing `manifest.xml` (File ▸ Options ▸ Trust Center ▸ Trusted
   Add-in Catalogs), then Insert ▸ My Add-ins ▸ SHARED FOLDER.
 - Production distribution is M365 **centralized deployment** by the MSP (spec §2).

--- a/apps/word-addin/README.md
+++ b/apps/word-addin/README.md
@@ -52,7 +52,7 @@ add-in falls back to the MSAL popup — functional, just not silent.
 The JS bundle is deployment-neutral. At boot it fetches `/config.json`
 (`{ "apiBaseUrl": "...", "entraClientId": "..." }`) from its own origin. For
 local dev the committed `public/config.json` (localhost defaults) is served by
-Vite; the `VITE_*` env vars are only a fallback when `/config.json` is absent.
+Vite; the `VITE_*` env vars are dev fallbacks that fill any field `/config.json` leaves absent or empty (the committed `public/config.json` ships an empty `entraClientId`, so `VITE_CLIENT_AI_ENTRA_CLIENT_ID` fills it for local SSO).
 
 To produce a deployment's config:
 

--- a/apps/word-addin/package.json
+++ b/apps/word-addin/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "certs": "office-addin-dev-certs install",
     "manifest": "node scripts/generate-manifest.mjs",
+    "config": "node scripts/generate-config.mjs",
     "validate-manifest": "office-addin-manifest validate manifest.xml"
   },
   "dependencies": {

--- a/apps/word-addin/public/config.json
+++ b/apps/word-addin/public/config.json
@@ -1,0 +1,4 @@
+{
+  "apiBaseUrl": "http://localhost:3001",
+  "entraClientId": ""
+}

--- a/apps/word-addin/scripts/generate-config.mjs
+++ b/apps/word-addin/scripts/generate-config.mjs
@@ -34,15 +34,23 @@ const apiBaseUrl = (
   argValue('--api-base-url') ??
   env.VITE_API_BASE_URL ??
   'http://localhost:3001'
-).replace(/\/$/, '');
+).replace(/\/+$/, '');
 const clientId =
   argValue('--client-id') ??
   env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
   env.CLIENT_AI_ENTRA_CLIENT_ID ??
   '';
 
+const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/.test(apiBaseUrl);
+if (!clientId && !isLocalhost) {
+  console.error(
+    `[generate-config] ERROR: entraClientId is empty for a non-localhost apiBaseUrl (${apiBaseUrl}). ` +
+      'SSO cannot work — pass --client-id <guid> (or set VITE_CLIENT_AI_ENTRA_CLIENT_ID).',
+  );
+  process.exit(1);
+}
 if (!clientId) {
-  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+  console.warn('[generate-config] WARNING: entraClientId is empty (localhost dev) — SSO will not work until set.');
 }
 
 const outPath = path.join(root, argValue('--out') ?? 'public/config.json');

--- a/apps/word-addin/scripts/generate-config.mjs
+++ b/apps/word-addin/scripts/generate-config.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Writes public/config.json (served at /config.json) from env / .env / CLI flags.
+//   node scripts/generate-config.mjs [--api-base-url https://us.2breeze.app] [--client-id <guid>] [--out public/config.json]
+// Precedence: CLI flag > process.env > .env file > localhost default.
+// This is a DEPLOY-TIME utility. The committed public/config.json holds localhost
+// defaults so the shipped bundle stays deployment-neutral; each deployment runs
+// this (or serves its own config.json) with its real API origin + Entra client ID.
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function loadDotEnv(file) {
+  if (!existsSync(file)) return {};
+  const out = {};
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    if (line.trim().startsWith('#')) continue;
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const env = { ...loadDotEnv(path.join(root, '.env')), ...process.env };
+const args = process.argv.slice(2);
+const argValue = (flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const apiBaseUrl = (
+  argValue('--api-base-url') ??
+  env.VITE_API_BASE_URL ??
+  'http://localhost:3001'
+).replace(/\/$/, '');
+const clientId =
+  argValue('--client-id') ??
+  env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
+  env.CLIENT_AI_ENTRA_CLIENT_ID ??
+  '';
+
+if (!clientId) {
+  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+}
+
+const outPath = path.join(root, argValue('--out') ?? 'public/config.json');
+writeFileSync(outPath, `${JSON.stringify({ apiBaseUrl, entraClientId: clientId }, null, 2)}\n`);
+console.log(`[generate-config] wrote ${outPath} (api: ${apiBaseUrl}, clientId: ${clientId.slice(0, 8) || '∅'}…)`);

--- a/apps/word-addin/src/main.tsx
+++ b/apps/word-addin/src/main.tsx
@@ -19,7 +19,14 @@ function render(): void {
 // bootAddin loads runtime config (/config.json) BEFORE the first render — App's
 // mount effect kicks off a silent sign-in that needs the API origin + Entra
 // client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
-const boot = (): void => void bootAddin(render);
+const boot = (): void => {
+  // boot() is the one path with no ErrorBoundary above it — surface a
+  // render-time throw instead of leaving a silent blank pane on a dropped
+  // promise rejection. (loadRuntimeConfig itself never throws.)
+  void bootAddin(render).catch((err: unknown) => {
+    console.error('[breeze] add-in failed to start', err);
+  });
+};
 
 // Inside Word, wait for the host handshake; in a plain browser tab (dev
 // convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.

--- a/apps/word-addin/src/main.tsx
+++ b/apps/word-addin/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { App } from '@breeze/office-addin-core';
+import { App, bootAddin } from '@breeze/office-addin-core';
 import { wordHostAdapter } from './host/word';
 import './index.css';
 
@@ -16,10 +16,15 @@ function render(): void {
   );
 }
 
+// bootAddin loads runtime config (/config.json) BEFORE the first render — App's
+// mount effect kicks off a silent sign-in that needs the API origin + Entra
+// client ID. (Ordering is enforced + tested in office-addin-core/src/boot.ts.)
+const boot = (): void => void bootAddin(render);
+
 // Inside Word, wait for the host handshake; in a plain browser tab (dev
-// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — render anyway.
+// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.
 if (typeof Office !== 'undefined' && typeof Office.onReady === 'function') {
-  void Office.onReady(() => render());
+  void Office.onReady(() => boot());
 } else {
-  render();
+  boot();
 }

--- a/apps/word-addin/vite.config.ts
+++ b/apps/word-addin/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // Office hosts refuse to load task panes over plain http (except localhost in
-// some hosts, but Excel on the web always requires https). office-addin-dev-certs
+// some hosts, but Office on the web always requires https). office-addin-dev-certs
 // installs a locally-trusted CA + localhost cert (~/.office-addin-dev-certs) and
 // getHttpsServerOptions() returns { ca, key, cert } for Vite. Set
 // ADDIN_NO_HTTPS=1 to opt out (plain-browser debugging only).

--- a/docs/superpowers/plans/2026-06-15-office-addin-runtime-config.md
+++ b/docs/superpowers/plans/2026-06-15-office-addin-runtime-config.md
@@ -1,0 +1,533 @@
+# Office Add-in Runtime Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Office add-in JS bundle deployment-neutral by loading `apiBaseUrl` + `entraClientId` from a runtime `/config.json` instead of compile-time `import.meta.env.VITE_*`, so one prebuilt bundle works for hosted SaaS and every self-hoster without per-deployment rebuilds.
+
+**Architecture:** `packages/office-addin-core/src/config.ts` currently exports two module-level constants (`API_BASE_URL`, `ENTRA_CLIENT_ID`) read from Vite env at build time — these get frozen into `dist/`. We replace them with a small runtime loader: `loadRuntimeConfig()` fetches `/config.json` (served from the add-in's own origin) at boot, and `getApiBaseUrl()` / `getEntraClientId()` getters return the loaded values. If `/config.json` is missing or malformed, it falls back to the existing `VITE_*` / `localhost` defaults, so local dev is unchanged. The four host apps await `loadRuntimeConfig()` before rendering. A committed `public/config.json` (localhost defaults) keeps dev working; a `generate-config.mjs` operator utility (symmetric with the existing `generate-manifest.mjs`) lets each deployment emit its own `config.json`. The manifest stays per-deployment (Office reads static XML — it cannot fetch runtime config), but that is the existing tiny template step, not a Vite build.
+
+**Tech Stack:** TypeScript, Vite, Vitest + jsdom, React, pnpm workspaces. Node pinned to v22.20.0.
+
+**Out of scope (separate follow-up plan):** the deployment mechanism that *serves* the bundle + `config.json` (Caddy `file_server` / `breeze-addins` image / CI build+publish, CORS + CSP). That work is gated on the unresolved decision: does the add-in talk to a single global API hostname or per-region (`eu.`/`us.`)? This plan only makes the bundle neutral so that follow-up has a clean artifact to ship.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/office-addin-core/src/config.ts` | Runtime config state + loader + getters | Rewrite |
+| `packages/office-addin-core/src/config.test.ts` | Loader behavior (fetch ok / 404 / reject / malformed / trailing-slash / reset) | Create |
+| `packages/office-addin-core/src/auth/entraToken.ts` | Use `getEntraClientId()` instead of `ENTRA_CLIENT_ID` | Modify |
+| `packages/office-addin-core/src/auth/session.ts` | Use `getApiBaseUrl()` instead of `API_BASE_URL` | Modify |
+| `packages/office-addin-core/src/api/client.ts` | Use `getApiBaseUrl()` instead of `API_BASE_URL` | Modify |
+| `apps/{excel,word,powerpoint,outlook}-addin/src/main.tsx` | `await loadRuntimeConfig()` before render | Modify (×4) |
+| `apps/{excel,word,powerpoint,outlook}-addin/public/config.json` | Committed localhost default so dev + bundle have a neutral config | Create (×4) |
+| `apps/{excel,word,powerpoint,outlook}-addin/scripts/generate-config.mjs` | Operator utility: write `public/config.json` from env | Create (×4) |
+| `apps/{excel,word,powerpoint,outlook}-addin/.env.example` | Document that prod values come from `config.json`, not the bundle | Modify (×4) |
+| `apps/{excel,word,powerpoint,outlook}-addin/README.md` | Note the runtime-config model | Modify (×4) |
+
+**Backward-compat note:** a repo-wide grep confirms `API_BASE_URL` / `ENTRA_CLIENT_ID` are imported ONLY by the three core files above (no app code, no tests). Replacing the constants with getters is safe. `index.ts` re-exports via `export * from './config'`, so the new getters export automatically — no `index.ts` edit needed.
+
+**Node prefix for every command below:**
+```bash
+export PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH
+```
+
+---
+
+### Task 1: Runtime config loader (`config.ts`) — TDD
+
+**Files:**
+- Modify: `packages/office-addin-core/src/config.ts`
+- Create: `packages/office-addin-core/src/config.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/office-addin-core/src/config.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  __resetRuntimeConfigForTests,
+  getApiBaseUrl,
+  getEntraClientId,
+  loadRuntimeConfig,
+} from './config';
+
+/** Build a minimal fetch stub returning the given /config.json response. */
+function fetchReturning(body: unknown, ok = true): typeof fetch {
+  return (async () =>
+    ({
+      ok,
+      json: async () => body,
+    }) as unknown as Response) as unknown as typeof fetch;
+}
+
+const fetchRejecting: typeof fetch = (async () => {
+  throw new Error('network down');
+}) as unknown as typeof fetch;
+
+afterEach(() => {
+  __resetRuntimeConfigForTests();
+});
+
+describe('runtime config', () => {
+  it('defaults to localhost before any load', () => {
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+
+  it('loads apiBaseUrl + entraClientId from /config.json', async () => {
+    await loadRuntimeConfig(
+      fetchReturning({ apiBaseUrl: 'https://us.2breeze.app', entraClientId: 'abc-123' }),
+    );
+    expect(getApiBaseUrl()).toBe('https://us.2breeze.app');
+    expect(getEntraClientId()).toBe('abc-123');
+  });
+
+  it('strips a trailing slash from apiBaseUrl', async () => {
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 'https://eu.2breeze.app/', entraClientId: 'x' }));
+    expect(getApiBaseUrl()).toBe('https://eu.2breeze.app');
+  });
+
+  it('falls back to defaults on a non-ok response (404)', async () => {
+    await loadRuntimeConfig(fetchReturning({}, false));
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+
+  it('falls back to defaults when fetch rejects', async () => {
+    await loadRuntimeConfig(fetchRejecting);
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+  });
+
+  it('falls back per-field when config.json is missing/garbled fields', async () => {
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 42, entraClientId: null }));
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @breeze/office-addin-core exec vitest run src/config.test.ts
+```
+Expected: FAIL — `loadRuntimeConfig` / `getApiBaseUrl` / `getEntraClientId` / `__resetRuntimeConfigForTests` are not exported (only `API_BASE_URL` / `ENTRA_CLIENT_ID` exist today).
+
+- [ ] **Step 3: Rewrite `config.ts` with the runtime loader**
+
+Replace the entire contents of `packages/office-addin-core/src/config.ts` with:
+
+```ts
+/**
+ * Runtime configuration. The bundle is deployment-neutral: it fetches
+ * `/config.json` (served from the add-in's own origin) at boot via
+ * loadRuntimeConfig(), so one prebuilt bundle works for every deployment
+ * (hosted SaaS and self-hosters) with no per-deployment rebuild.
+ *
+ * If /config.json is absent or malformed, we fall back to the build-time
+ * VITE_* env (apps/<host>-addin/.env, gitignored — see .env.example) and then
+ * to localhost defaults, so local dev needs no config file.
+ *
+ * NOTE: the manifest is NOT runtime-configurable — Office reads static XML and
+ * cannot fetch this file. Each deployment still generates its own manifest
+ * (scripts/generate-manifest.mjs). config.json covers only the JS bundle.
+ */
+export type RuntimeConfig = {
+  /** Origin of the Breeze API, no trailing slash, e.g. https://us.2breeze.app */
+  apiBaseUrl: string;
+  /** Entra app-registration client ID; must equal the API's CLIENT_AI_ENTRA_CLIENT_ID. */
+  entraClientId: string;
+};
+
+const FALLBACK: RuntimeConfig = {
+  apiBaseUrl: ((import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001').replace(
+    /\/$/,
+    '',
+  ),
+  entraClientId: (import.meta.env.VITE_CLIENT_AI_ENTRA_CLIENT_ID as string | undefined) ?? '',
+};
+
+let runtime: RuntimeConfig = { ...FALLBACK };
+
+/** API origin (no trailing slash). Valid before load (returns the fallback). */
+export function getApiBaseUrl(): string {
+  return runtime.apiBaseUrl;
+}
+
+/** Entra client ID. Valid before load (returns the fallback). */
+export function getEntraClientId(): string {
+  return runtime.entraClientId;
+}
+
+/**
+ * Fetch /config.json once at boot and populate the runtime config. Always
+ * resolves — on any failure it keeps the fallback. Safe to call more than once
+ * (the last successful load wins). cache:'no-store' so a deploy that swaps
+ * config.json is picked up without an Office webview cache hit.
+ */
+export async function loadRuntimeConfig(fetchImpl: typeof fetch = fetch): Promise<RuntimeConfig> {
+  try {
+    const res = await fetchImpl('/config.json', { cache: 'no-store' });
+    if (res.ok) {
+      const body = (await res.json()) as Partial<RuntimeConfig>;
+      runtime = {
+        apiBaseUrl: (typeof body.apiBaseUrl === 'string' && body.apiBaseUrl
+          ? body.apiBaseUrl
+          : FALLBACK.apiBaseUrl
+        ).replace(/\/$/, ''),
+        entraClientId:
+          typeof body.entraClientId === 'string' ? body.entraClientId : FALLBACK.entraClientId,
+      };
+    }
+  } catch {
+    /* keep the fallback — dev / no config.json served */
+  }
+  return runtime;
+}
+
+/** Test-only: reset to the build-time fallback. */
+export function __resetRuntimeConfigForTests(): void {
+  runtime = { ...FALLBACK };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @breeze/office-addin-core exec vitest run src/config.test.ts
+```
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/office-addin-core/src/config.ts packages/office-addin-core/src/config.test.ts
+git commit -m "feat(office-addin): runtime config loader (config.json) replacing build-time VITE env"
+```
+
+---
+
+### Task 2: Point the three consumers at the getters
+
+**Files:**
+- Modify: `packages/office-addin-core/src/auth/entraToken.ts:13,22,45`
+- Modify: `packages/office-addin-core/src/auth/session.ts:7,123`
+- Modify: `packages/office-addin-core/src/api/client.ts:6,46`
+
+All three already read the values *inside functions* (never at module top level), so swapping a constant for a getter call is mechanical.
+
+- [ ] **Step 1: Update `entraToken.ts`**
+
+Change the import (line 13):
+```ts
+import { getEntraClientId } from '../config';
+```
+Change `msalScopes()` (line 22):
+```ts
+  return [`api://${window.location.host}/${getEntraClientId()}/access_as_user`];
+```
+Change the MSAL instance config (line 45):
+```ts
+          clientId: getEntraClientId(),
+```
+
+- [ ] **Step 2: Update `session.ts`**
+
+Change the import (line 7):
+```ts
+import { getApiBaseUrl } from '../config';
+```
+Change `exchangeOnce` (line 123):
+```ts
+  const res = await fetchImpl(`${getApiBaseUrl()}/client-ai/auth/exchange`, {
+```
+
+- [ ] **Step 3: Update `api/client.ts`**
+
+Change the import (line 6):
+```ts
+import { getApiBaseUrl } from '../config';
+```
+Change `doFetch` (line 46):
+```ts
+    return fetchImpl(`${getApiBaseUrl()}${path}`, { ...init, headers });
+```
+
+- [ ] **Step 4: Run the core package test suite + typecheck**
+
+```bash
+pnpm --filter @breeze/office-addin-core exec vitest run
+pnpm --filter @breeze/office-addin-core exec tsc --noEmit
+```
+Expected: all tests PASS, no type errors. (Existing auth/client tests inject `fetchImpl` and assert URLs against `http://localhost:3001`, which `getApiBaseUrl()` still returns by default — they pass unchanged.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/office-addin-core/src/auth/entraToken.ts packages/office-addin-core/src/auth/session.ts packages/office-addin-core/src/api/client.ts
+git commit -m "refactor(office-addin): read API/Entra config via runtime getters"
+```
+
+---
+
+### Task 3: Load config before render in all four host apps
+
+**Files:**
+- Modify: `apps/excel-addin/src/main.tsx`
+- Modify: `apps/word-addin/src/main.tsx`
+- Modify: `apps/powerpoint-addin/src/main.tsx`
+- Modify: `apps/outlook-addin/src/main.tsx`
+
+`App` triggers a silent `signIn` in its mount effect, so config must be loaded before render. Each `main.tsx` is identical except the host adapter import and the `<App>` props.
+
+- [ ] **Step 1: Update `apps/excel-addin/src/main.tsx`**
+
+Replace its contents with:
+
+```tsx
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App, loadRuntimeConfig } from '@breeze/office-addin-core';
+import { excelHostAdapter } from './host/excel';
+import './index.css';
+
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('taskpane.html is missing #root');
+const root = createRoot(rootEl);
+
+function render(): void {
+  root.render(
+    <React.StrictMode>
+      <App host={excelHostAdapter} clientHost="excel" />
+    </React.StrictMode>,
+  );
+}
+
+// Load runtime config (/config.json) BEFORE first render — App's mount effect
+// kicks off a silent sign-in that needs the API origin + Entra client ID.
+async function boot(): Promise<void> {
+  await loadRuntimeConfig();
+  render();
+}
+
+// Inside Excel, wait for the host handshake; in a plain browser tab (dev
+// convenience, ADDIN_NO_HTTPS debugging) Office is undefined — boot anyway.
+if (typeof Office !== 'undefined' && typeof Office.onReady === 'function') {
+  void Office.onReady(() => void boot());
+} else {
+  void boot();
+}
+```
+
+- [ ] **Step 2: Apply the same change to the other three apps**
+
+For each of `apps/word-addin/src/main.tsx`, `apps/powerpoint-addin/src/main.tsx`, `apps/outlook-addin/src/main.tsx`: make the identical edit — add `loadRuntimeConfig` to the `@breeze/office-addin-core` import, wrap the existing render trigger in an `async boot()` that `await loadRuntimeConfig()` first, and call `boot()` from both the `Office.onReady` and the `else` branch. Keep each file's existing host adapter import and `<App host=... clientHost=...>` props exactly as they are (word/powerpoint/outlook respectively).
+
+- [ ] **Step 3: Typecheck each app**
+
+```bash
+for a in excel word powerpoint outlook; do
+  pnpm --filter @breeze/$a-addin exec tsc --noEmit || echo "FAILED: $a";
+done
+```
+Expected: no type errors for any app.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/*-addin/src/main.tsx
+git commit -m "feat(office-addin): await runtime config before render in all four hosts"
+```
+
+---
+
+### Task 4: Default `config.json` + `generate-config.mjs` per app
+
+**Files (×4 apps):**
+- Create: `apps/<host>-addin/public/config.json`
+- Create: `apps/<host>-addin/scripts/generate-config.mjs`
+
+The committed `public/config.json` (localhost defaults) makes dev work with no extra step and keeps the shipped bundle neutral (identical for everyone, leaks nothing). `generate-config.mjs` is the operator/deploy-time utility — NOT wired into the standard build, so a clean CI build always ships the neutral localhost default.
+
+- [ ] **Step 1: Create the default `public/config.json` for each app**
+
+Write this identical file to each of `apps/excel-addin/public/config.json`, `apps/word-addin/public/config.json`, `apps/powerpoint-addin/public/config.json`, `apps/outlook-addin/public/config.json`:
+
+```json
+{
+  "apiBaseUrl": "http://localhost:3001",
+  "entraClientId": ""
+}
+```
+
+- [ ] **Step 2: Create `generate-config.mjs` for each app**
+
+Write this identical file to each of `apps/<host>-addin/scripts/generate-config.mjs`:
+
+```js
+#!/usr/bin/env node
+// Writes public/config.json (served at /config.json) from env / .env / CLI flags.
+//   node scripts/generate-config.mjs [--api-base-url https://us.2breeze.app] [--client-id <guid>] [--out public/config.json]
+// Precedence: CLI flag > process.env > .env file > localhost default.
+// This is a DEPLOY-TIME utility. The committed public/config.json holds localhost
+// defaults so the shipped bundle stays deployment-neutral; each deployment runs
+// this (or serves its own config.json) with its real API origin + Entra client ID.
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function loadDotEnv(file) {
+  if (!existsSync(file)) return {};
+  const out = {};
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    if (line.trim().startsWith('#')) continue;
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const env = { ...loadDotEnv(path.join(root, '.env')), ...process.env };
+const args = process.argv.slice(2);
+const argValue = (flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const apiBaseUrl = (
+  argValue('--api-base-url') ??
+  env.VITE_API_BASE_URL ??
+  'http://localhost:3001'
+).replace(/\/$/, '');
+const clientId =
+  argValue('--client-id') ??
+  env.VITE_CLIENT_AI_ENTRA_CLIENT_ID ??
+  env.CLIENT_AI_ENTRA_CLIENT_ID ??
+  '';
+
+if (!clientId) {
+  console.warn('[generate-config] WARNING: entraClientId is empty — SSO will not work until set.');
+}
+
+const outPath = path.join(root, argValue('--out') ?? 'public/config.json');
+writeFileSync(outPath, `${JSON.stringify({ apiBaseUrl, entraClientId: clientId }, null, 2)}\n`);
+console.log(`[generate-config] wrote ${outPath} (api: ${apiBaseUrl}, clientId: ${clientId.slice(0, 8) || '∅'}…)`);
+```
+
+- [ ] **Step 3: Verify the generator runs and round-trips**
+
+```bash
+cd apps/excel-addin
+node scripts/generate-config.mjs --api-base-url https://us.2breeze.app --client-id 11111111-2222-3333-4444-555555555555 --out /tmp/config.test.json
+cat /tmp/config.test.json
+cd ../..
+```
+Expected: `/tmp/config.test.json` contains `"apiBaseUrl": "https://us.2breeze.app"` and the client ID. (Then discard the temp file — do not commit it.)
+
+- [ ] **Step 4: Run each app's build to confirm `config.json` lands in `dist/`**
+
+```bash
+pnpm --filter @breeze/excel-addin build
+test -f apps/excel-addin/dist/config.json && echo "config.json shipped in dist" || echo "MISSING"
+```
+Expected: `config.json shipped in dist` (Vite copies `public/` to `dist/`). The dist `config.json` holds the committed localhost default — correct for a neutral bundle.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/*-addin/public/config.json apps/*-addin/scripts/generate-config.mjs
+git commit -m "feat(office-addin): default config.json + generate-config deploy utility"
+```
+
+---
+
+### Task 5: Document the runtime-config model
+
+**Files (×4 apps):**
+- Modify: `apps/<host>-addin/.env.example`
+- Modify: `apps/<host>-addin/README.md`
+
+- [ ] **Step 1: Update each `.env.example`**
+
+In each `apps/<host>-addin/.env.example`, add a comment block above the `VITE_*` lines clarifying they are now dev fallbacks only:
+
+```bash
+# Runtime config: in production these values are served at /config.json (see
+# scripts/generate-config.mjs), NOT baked into the bundle. The VITE_* vars below
+# are dev fallbacks used only when /config.json is absent (e.g. `pnpm dev`).
+```
+
+- [ ] **Step 2: Update each `README.md`**
+
+In each `apps/<host>-addin/README.md`, add a short "Runtime config" section:
+
+```markdown
+## Runtime config
+
+The JS bundle is deployment-neutral. At boot it fetches `/config.json`
+(`{ "apiBaseUrl": "...", "entraClientId": "..." }`) from its own origin. For
+local dev the committed `public/config.json` (localhost defaults) is served by
+Vite; the `VITE_*` env vars are only a fallback when `/config.json` is absent.
+
+To produce a deployment's config:
+
+    node scripts/generate-config.mjs --api-base-url https://us.2breeze.app --client-id <entra-client-id>
+
+The manifest is still per-deployment (Office reads static XML and cannot fetch
+runtime config) — keep generating it with `scripts/generate-manifest.mjs`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/*-addin/.env.example apps/*-addin/README.md
+git commit -m "docs(office-addin): document runtime config.json model"
+```
+
+---
+
+### Task 6: Full verification
+
+- [ ] **Step 1: Run the core + all four app test suites**
+
+```bash
+pnpm --filter @breeze/office-addin-core exec vitest run
+for a in excel word powerpoint outlook; do
+  pnpm --filter @breeze/$a-addin exec vitest run || echo "FAILED: $a";
+done
+```
+Expected: all green. (CI guards distinct ports/GUIDs across apps — unchanged by this work.)
+
+- [ ] **Step 2: Confirm no stale references to the old constants remain**
+
+```bash
+grep -rn "\bAPI_BASE_URL\b\|\bENTRA_CLIENT_ID\b" packages/office-addin-core/src apps/*-addin/src | grep -v node_modules
+```
+Expected: NO matches (all replaced by `getApiBaseUrl()` / `getEntraClientId()`). `VITE_API_BASE_URL` / `VITE_CLIENT_AI_ENTRA_CLIENT_ID` still appearing in `config.ts`, `generate-*.mjs`, and `.env.example` is expected and correct.
+
+- [ ] **Step 3: Sanity-check the dev fallback path**
+
+```bash
+pnpm --filter @breeze/excel-addin dev &
+sleep 6
+curl -ksf https://localhost:3000/config.json && echo "served"
+kill %1
+```
+Expected: `config.json` served with the localhost default (`https` dev cert; `-k` accepts the self-signed cert). This is the file the loader fetches in-host.
+
+---
+
+## Self-Review
+
+**Spec coverage:** The goal (deployment-neutral bundle via runtime config) is fully covered — loader (Task 1), consumers (Task 2), boot (Task 3), default + generator (Task 4), docs (Task 5), verification (Task 6). The manifest-stays-per-deployment caveat is documented (Task 1 `config.ts` header + Task 5 README). The deploy/serving mechanism is explicitly deferred and gated on the hostname decision.
+
+**Placeholder scan:** No TBD/TODO. Every code step shows full code; every command shows expected output.
+
+**Type consistency:** `RuntimeConfig`, `getApiBaseUrl()`, `getEntraClientId()`, `loadRuntimeConfig(fetchImpl?)`, `__resetRuntimeConfigForTests()` are defined in Task 1 and used consistently in Tasks 2, 3, and the Task 1 test. Consumer call sites match the getter names exactly.

--- a/packages/office-addin-core/src/api/client.ts
+++ b/packages/office-addin-core/src/api/client.ts
@@ -3,7 +3,7 @@
  * a 401 triggers ONE single-flight re-exchange (auth/session.ts) + retry.
  * Contracts: Contract reconciliation section of this plan (Plan 2 / Plan 4 pins).
  */
-import { API_BASE_URL } from '../config';
+import { getApiBaseUrl } from '../config';
 import { AuthBlockedError, clearSession, getSessionToken, reExchange } from '../auth/session';
 import { parseSseStream } from './sse';
 import {
@@ -43,7 +43,7 @@ export async function apiFetch(
     headers.set('Authorization', `Bearer ${token}`);
     if (init.body !== undefined && !headers.has('Content-Type'))
       headers.set('Content-Type', 'application/json');
-    return fetchImpl(`${API_BASE_URL}${path}`, { ...init, headers });
+    return fetchImpl(`${getApiBaseUrl()}${path}`, { ...init, headers });
   };
   let res = await doFetch();
   if (res.status === 401) {

--- a/packages/office-addin-core/src/auth/entraToken.ts
+++ b/packages/office-addin-core/src/auth/entraToken.ts
@@ -10,7 +10,7 @@
  * D4: swapping the fallback to NAA (createNestablePublicClientApplication)
  * later only touches this file.
  */
-import { ENTRA_CLIENT_ID } from '../config';
+import { getEntraClientId } from '../config';
 
 export type EntraTokenDeps = {
   getSsoToken: () => Promise<string>;
@@ -19,7 +19,7 @@ export type EntraTokenDeps = {
 
 /** Scope on the add-in's own app registration (matches the manifest's WebApplicationInfo Resource). */
 export function msalScopes(): string[] {
-  return [`api://${window.location.host}/${ENTRA_CLIENT_ID}/access_as_user`];
+  return [`api://${window.location.host}/${getEntraClientId()}/access_as_user`];
 }
 
 async function officeSsoToken(): Promise<string> {
@@ -42,7 +42,7 @@ function getMsalInstance() {
       const { PublicClientApplication } = await import('@azure/msal-browser');
       const pca = new PublicClientApplication({
         auth: {
-          clientId: ENTRA_CLIENT_ID,
+          clientId: getEntraClientId(),
           authority: 'https://login.microsoftonline.com/organizations',
           redirectUri: `${window.location.origin}/taskpane.html`,
         },

--- a/packages/office-addin-core/src/auth/session.ts
+++ b/packages/office-addin-core/src/auth/session.ts
@@ -4,7 +4,7 @@
  * in memory + sessionStorage; reExchange() is the single-flight 401 recovery
  * path the API client (Task 6) calls.
  */
-import { API_BASE_URL } from '../config';
+import { getApiBaseUrl } from '../config';
 import {
   defaultEntraTokenDeps,
   getEntraTokenInteractive,
@@ -120,7 +120,7 @@ const BLOCK_KINDS: Record<string, AuthBlockKind> = {
 };
 
 async function exchangeOnce(entraToken: string, fetchImpl: typeof fetch): Promise<ClientSession> {
-  const res = await fetchImpl(`${API_BASE_URL}/client-ai/auth/exchange`, {
+  const res = await fetchImpl(`${getApiBaseUrl()}/client-ai/auth/exchange`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ accessToken: entraToken }),

--- a/packages/office-addin-core/src/boot.test.ts
+++ b/packages/office-addin-core/src/boot.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { bootAddin } from './boot';
+import type { RuntimeConfig } from './config';
+
+describe('bootAddin', () => {
+  it('awaits the config loader BEFORE rendering', async () => {
+    const order: string[] = [];
+    let releaseLoad: () => void = () => {};
+    const loadGate = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+    const loader = (async () => {
+      order.push('load:start');
+      await loadGate;
+      order.push('load:done');
+      return { apiBaseUrl: 'http://localhost:3001', entraClientId: '' } satisfies RuntimeConfig;
+    }) as unknown as typeof import('./config').loadRuntimeConfig;
+
+    const booted = bootAddin(() => order.push('render'), loader);
+
+    // The loader has started but not resolved — render must NOT have happened.
+    await Promise.resolve();
+    expect(order).toEqual(['load:start']);
+
+    releaseLoad();
+    await booted;
+    expect(order).toEqual(['load:start', 'load:done', 'render']);
+  });
+
+  it('still renders when the loader resolves immediately', async () => {
+    const order: string[] = [];
+    const loader = (async () => {
+      order.push('load');
+      return { apiBaseUrl: 'http://localhost:3001', entraClientId: '' } satisfies RuntimeConfig;
+    }) as unknown as typeof import('./config').loadRuntimeConfig;
+    await bootAddin(() => order.push('render'), loader);
+    expect(order).toEqual(['load', 'render']);
+  });
+});

--- a/packages/office-addin-core/src/boot.ts
+++ b/packages/office-addin-core/src/boot.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared boot sequence for every host app's entry point (apps/<host>-addin/src/main.tsx).
+ *
+ * The load-bearing invariant: runtime config (/config.json) MUST be loaded
+ * before the first render, because App's mount effect kicks off a silent
+ * sign-in that lazily reads getApiBaseUrl()/getEntraClientId(). If render ran
+ * before the config load resolved, a deployed environment would silently use
+ * the build-time fallback (localhost API origin + empty Entra client ID) and
+ * the first sign-in would fail. Centralising this here keeps the four main.tsx
+ * files trivial and makes the ordering testable in one place (boot.test.ts).
+ */
+import { loadRuntimeConfig } from './config';
+
+export async function bootAddin(
+  render: () => void,
+  loader: typeof loadRuntimeConfig = loadRuntimeConfig,
+): Promise<void> {
+  await loader();
+  render();
+}

--- a/packages/office-addin-core/src/config.test.ts
+++ b/packages/office-addin-core/src/config.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  __resetRuntimeConfigForTests,
+  getApiBaseUrl,
+  getEntraClientId,
+  loadRuntimeConfig,
+} from './config';
+
+/** Build a minimal fetch stub returning the given /config.json response. */
+function fetchReturning(body: unknown, ok = true): typeof fetch {
+  return (async () =>
+    ({
+      ok,
+      json: async () => body,
+    }) as unknown as Response) as unknown as typeof fetch;
+}
+
+const fetchRejecting: typeof fetch = (async () => {
+  throw new Error('network down');
+}) as unknown as typeof fetch;
+
+/** ok:true but the body is not JSON (e.g. an HTML 200 error page) — json() throws. */
+const fetchOkButNotJson: typeof fetch = (async () =>
+  ({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError('Unexpected token < in JSON');
+    },
+  }) as unknown as Response) as unknown as typeof fetch;
+
+afterEach(() => {
+  __resetRuntimeConfigForTests();
+});
+
+describe('runtime config', () => {
+  it('defaults to localhost before any load', () => {
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+
+  it('loads apiBaseUrl + entraClientId from /config.json', async () => {
+    await loadRuntimeConfig(
+      fetchReturning({ apiBaseUrl: 'https://us.2breeze.app', entraClientId: 'abc-123' }),
+    );
+    expect(getApiBaseUrl()).toBe('https://us.2breeze.app');
+    expect(getEntraClientId()).toBe('abc-123');
+  });
+
+  it('strips a trailing slash from apiBaseUrl', async () => {
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 'https://eu.2breeze.app/', entraClientId: 'x' }));
+    expect(getApiBaseUrl()).toBe('https://eu.2breeze.app');
+  });
+
+  it('falls back to defaults on a non-ok response (404)', async () => {
+    await loadRuntimeConfig(fetchReturning({}, false));
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+
+  it('falls back to defaults when fetch rejects', async () => {
+    await loadRuntimeConfig(fetchRejecting);
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+  });
+
+  it('falls back per-field when config.json is missing/garbled fields', async () => {
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 42, entraClientId: null }));
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+
+  it('falls back when apiBaseUrl is an empty string (must not become "")', async () => {
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: '', entraClientId: '' }));
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+
+  it('falls back when the body is a non-JSON 200 (json() throws)', async () => {
+    await loadRuntimeConfig(fetchOkButNotJson);
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+    expect(getEntraClientId()).toBe('');
+  });
+
+  it('collapses multiple trailing slashes in apiBaseUrl', async () => {
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 'https://eu.2breeze.app//', entraClientId: 'x' }));
+    expect(getApiBaseUrl()).toBe('https://eu.2breeze.app');
+  });
+});

--- a/packages/office-addin-core/src/config.test.ts
+++ b/packages/office-addin-core/src/config.test.ts
@@ -84,4 +84,25 @@ describe('runtime config', () => {
     await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 'https://eu.2breeze.app//', entraClientId: 'x' }));
     expect(getApiBaseUrl()).toBe('https://eu.2breeze.app');
   });
+
+  // Guards the highest-impact silent regression this refactor exists to prevent:
+  // if a consumer ever captured the value at module-load instead of via the
+  // getter, production would silently use the localhost fallback. The getter
+  // must always reflect post-load state, never a frozen snapshot.
+  it('getters reflect post-load state, not a frozen snapshot', async () => {
+    const early = getApiBaseUrl();
+    expect(early).toBe('http://localhost:3001');
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 'https://us.2breeze.app', entraClientId: 'g' }));
+    expect(getApiBaseUrl()).toBe('https://us.2breeze.app');
+    expect(early).toBe('http://localhost:3001'); // the snapshot is stale; the getter is live
+  });
+
+  // "last successful load wins" — a failed reload must NOT clobber a good config
+  // back to localhost (the catch returns the current runtime, not FALLBACK).
+  it('a failed reload preserves the last successful config', async () => {
+    await loadRuntimeConfig(fetchReturning({ apiBaseUrl: 'https://us.2breeze.app', entraClientId: 'g' }));
+    await loadRuntimeConfig(fetchRejecting);
+    expect(getApiBaseUrl()).toBe('https://us.2breeze.app');
+    expect(getEntraClientId()).toBe('g');
+  });
 });

--- a/packages/office-addin-core/src/config.ts
+++ b/packages/office-addin-core/src/config.ts
@@ -66,8 +66,14 @@ export async function loadRuntimeConfig(fetchImpl: typeof fetch = fetch): Promis
           ? body.apiBaseUrl
           : FALLBACK.apiBaseUrl
         ).replace(/\/+$/, ''),
+        // Symmetric with apiBaseUrl: an empty string falls back too, so the
+        // committed dev config.json (entraClientId "") lets VITE_CLIENT_AI_ENTRA_CLIENT_ID
+        // fill it in, and a deployment that forgets the client ID degrades to
+        // the fallback rather than locking in an unusable empty SSO client.
         entraClientId:
-          typeof body.entraClientId === 'string' ? body.entraClientId : FALLBACK.entraClientId,
+          typeof body.entraClientId === 'string' && body.entraClientId
+            ? body.entraClientId
+            : FALLBACK.entraClientId,
       };
       return runtime;
     }

--- a/packages/office-addin-core/src/config.ts
+++ b/packages/office-addin-core/src/config.ts
@@ -1,13 +1,86 @@
 /**
- * Build-time configuration. Values come from the host app's Vite env
- * (apps/excel-addin/.env, gitignored — see .env.example). Defaults target local
- * dev against the API
- * dev server (apps/api listens on 3001; apps/web/astro.config.mjs uses the
- * same default).
+ * Runtime configuration. The bundle is deployment-neutral: it fetches
+ * `/config.json` (served from the add-in's own origin) at boot via
+ * loadRuntimeConfig(), so one prebuilt bundle works for every deployment
+ * (hosted SaaS and self-hosters) with no per-deployment rebuild.
+ *
+ * If /config.json is absent or malformed, we fall back to the build-time
+ * VITE_* env (apps/<host>-addin/.env, gitignored — see .env.example) and then
+ * to localhost defaults, so local dev needs no config file.
+ *
+ * NOTE: the manifest is NOT runtime-configurable — Office reads static XML and
+ * cannot fetch this file. Each deployment still generates its own manifest
+ * (scripts/generate-manifest.mjs). config.json covers only the JS bundle.
  */
-export const API_BASE_URL: string =
-  ((import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001').replace(/\/$/, '');
+export type RuntimeConfig = {
+  /** Origin of the Breeze API, no trailing slash, e.g. https://us.2breeze.app */
+  apiBaseUrl: string;
+  /** Entra app-registration client ID; must equal the API's CLIENT_AI_ENTRA_CLIENT_ID. */
+  entraClientId: string;
+};
 
-/** Entra app registration client ID — must equal the API's CLIENT_AI_ENTRA_CLIENT_ID (Plan 1 Task 6). */
-export const ENTRA_CLIENT_ID: string =
-  (import.meta.env.VITE_CLIENT_AI_ENTRA_CLIENT_ID as string | undefined) ?? '';
+const FALLBACK: RuntimeConfig = {
+  apiBaseUrl: ((import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001').replace(
+    /\/+$/,
+    '',
+  ),
+  entraClientId: (import.meta.env.VITE_CLIENT_AI_ENTRA_CLIENT_ID as string | undefined) ?? '',
+};
+
+function warnConfigFallback(reason: string): void {
+  // Visible in the Office webview console so a misdeployed config.json (absent,
+  // non-2xx, or malformed) is diagnosable — the getters then return the
+  // build-time fallback (localhost), which in a DEPLOYED environment almost
+  // certainly means the API origin + Entra client ID are wrong.
+  console.warn(
+    `[client-ai] runtime /config.json not loaded (${reason}); using fallback config — ` +
+      'API origin + Entra client ID may be misconfigured in this environment.',
+  );
+}
+
+let runtime: RuntimeConfig = { ...FALLBACK };
+
+/** API origin (no trailing slash). Valid before load (returns the fallback). */
+export function getApiBaseUrl(): string {
+  return runtime.apiBaseUrl;
+}
+
+/** Entra client ID. Valid before load (returns the fallback). */
+export function getEntraClientId(): string {
+  return runtime.entraClientId;
+}
+
+/**
+ * Fetch /config.json once at boot and populate the runtime config. Always
+ * resolves — on any failure it keeps the fallback. Safe to call more than once
+ * (the last successful load wins). cache:'no-store' so a deploy that swaps
+ * config.json is picked up without an Office webview cache hit.
+ */
+export async function loadRuntimeConfig(fetchImpl: typeof fetch = fetch): Promise<RuntimeConfig> {
+  try {
+    const res = await fetchImpl('/config.json', { cache: 'no-store' });
+    if (res.ok) {
+      const body = (await res.json()) as Partial<RuntimeConfig>;
+      runtime = {
+        apiBaseUrl: (typeof body.apiBaseUrl === 'string' && body.apiBaseUrl
+          ? body.apiBaseUrl
+          : FALLBACK.apiBaseUrl
+        ).replace(/\/+$/, ''),
+        entraClientId:
+          typeof body.entraClientId === 'string' ? body.entraClientId : FALLBACK.entraClientId,
+      };
+      return runtime;
+    }
+    warnConfigFallback(`HTTP ${res.status}`);
+  } catch {
+    // fetch rejected, or res.json() threw on a non-JSON body (e.g. an HTML 200
+    // error page) — keep the fallback.
+    warnConfigFallback('fetch/parse error');
+  }
+  return runtime;
+}
+
+/** Test-only: reset to the build-time fallback. */
+export function __resetRuntimeConfigForTests(): void {
+  runtime = { ...FALLBACK };
+}

--- a/packages/office-addin-core/src/index.ts
+++ b/packages/office-addin-core/src/index.ts
@@ -13,6 +13,7 @@ export type {
 } from './api/types';
 export * from './tools/helpers';
 export * from './config';
+export * from './boot';
 export * from './api/client';
 export * from './api/sse';
 export * from './auth/entraToken';


### PR DESCRIPTION
## Summary

Makes the Office add-in JS bundle **deployment-neutral** so one prebuilt bundle works for hosted SaaS *and* every self-hoster with **no per-deployment rebuild**. This is the one-time code change that keeps the release/deploy flow free of per-region build behavior.

**Before:** `VITE_API_BASE_URL` + `VITE_CLIENT_AI_ENTRA_CLIENT_ID` were compiled into `dist/` (Vite `import.meta.env`), so a bundle baked in whatever API origin it was built with. Shipping that in the public image would freeze e.g. `us.2breeze.app` into every self-hoster's add-in.

**After:** the bundle fetches `/config.json` from its own origin at boot. Each deployment serves its own `config.json`; the shipped bundle carries only a harmless localhost default.

## What changed

- `packages/office-addin-core/src/config.ts` — `loadRuntimeConfig()` fetches `/config.json` (`{apiBaseUrl, entraClientId}`), `getApiBaseUrl()`/`getEntraClientId()` getters; falls back to `VITE_*`/localhost (dev unchanged); `console.warn` on a failed/malformed load for field diagnosis.
- `packages/office-addin-core/src/boot.ts` — `bootAddin(render)` gates first render on config load (the load-bearing invariant: App's mount effect signs in and needs the live config). Tested in `boot.test.ts`.
- The 3 consumers (`auth/entraToken.ts`, `auth/session.ts`, `api/client.ts`) read the getters instead of the removed constants.
- All 4 host apps' `src/main.tsx` boot via `bootAddin`.
- Each app: committed default `public/config.json` (localhost) + `scripts/generate-config.mjs` deploy utility + `config` npm alias; `.env.example`/README document the model and the manifest↔config origin-sync caveat.

The **manifest** stays per-deployment (Office reads static XML, can't fetch runtime config) — that's the existing `generate-manifest.mjs` step, unchanged.

## Not in this PR (deferred follow-up)

The deploy wiring that *serves* the bundle + `config.json` (Caddy `file_server` / static image / CI build+publish, plus CORS + CSP/Cache-Control) is intentionally out of scope — it's gated on the open decision: single global API hostname vs per-region (`eu.`/`us.`).

## Test Plan

- [x] `office-addin-core`: 192 tests pass + `tsc --noEmit` clean (incl. 9 loader cases + 2 boot-ordering cases)
- [x] All 4 apps: `tsc --noEmit` + vitest pass (excel 83 / word 59 / powerpoint 53 / outlook 50)
- [x] `excel-addin` builds; `dist/config.json` ships the neutral localhost default
- [x] Whole-repo grep: no importers of the removed `API_BASE_URL`/`ENTRA_CLIENT_ID` exports
- [x] Adversarial 5-lens review (loader correctness, boot-race, security, docs, completeness) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)