### PR TITLE
fix(caddy): serve the Invoice Engine MSP page at /billing/invoices (#1417)

### DIFF
--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -96,6 +96,15 @@
     reverse_proxy api:3001
   }
 
+  # --- MSP Invoice Engine pages live in the web app at /billing/invoices*
+  #     and MUST be matched before the /billing/* sidecar route below,
+  #     otherwise the hosted billing sidecar shadows the MSP Invoices UI. ---
+  @webBillingInvoices path /billing/invoices /billing/invoices/*
+  handle @webBillingInvoices {
+    encode zstd gzip
+    reverse_proxy web:4321
+  }
+
   # --- Billing UI (proxied to billing sidecar) ---
   @billing path /billing /billing/*
   handle @billing {


### PR DESCRIPTION
**Closes #1417.**

The web app's MSP invoice management UI lives at `/billing/invoices` (and `/billing/invoices/[id]`), and the sidebar's **Invoices** link points there. But `docker/Caddyfile.prod`'s `@billing path /billing /billing/*` rule reverse-proxies that whole prefix to the hosted billing sidecar (`billing:3002`), which shadows the page — 502 where no sidecar runs, or the SaaS billing portal where it does. Either way the Invoice Engine UI is unreachable through its own nav link.

**Fix:** add a more-specific `@webBillingInvoices path /billing/invoices /billing/invoices/*` → `web:4321` handle **above** the `@billing` sidecar rule (Caddy evaluates `handle` blocks in order, first match wins). The sidecar keeps `/billing` and all its other `/billing/*` routes.

**Verified locally:** after caddy reload, `/billing/invoices` and `/billing/invoices/[id]` → 200 through caddy; `/contracts`, `/health`, `/`, and the sidecar's `/billing` are unaffected. Found via the internal Playwright UI QA sweep (2026-06-15).