### PR TITLE
feat(billing): Stripe payments integrity guards + type/UX polish (follow-up to #1422)

### DIFF
--- a/apps/api/migrations/2026-06-17-stripe-payments-guards.sql
+++ b/apps/api/migrations/2026-06-17-stripe-payments-guards.sql
@@ -1,0 +1,23 @@
+-- Stripe Payments integrity guards (follow-up to #1422).
+-- Promotes two state-machine invariants the reconcile code already upholds from
+-- "every writer must remember" to DB-enforced CHECK constraints, so a future
+-- writer that violates them fails loudly instead of leaving inconsistent rows.
+-- Both tables are empty in production (the feature is dormant until STRIPE_* is
+-- set), so ADD CONSTRAINT validates against zero rows. Idempotent.
+
+-- A mapping marked 'succeeded' must link a recorded invoice_payments row.
+-- (pending/failed/refunded/partially_refunded legitimately may not — a terminal
+--  failure or a fully-refunded row carries invoice_payment_id IS NULL.)
+DO $$ BEGIN
+  ALTER TABLE invoice_stripe_payments
+    ADD CONSTRAINT invoice_stripe_payments_succeeded_has_payment
+    CHECK (status <> 'succeeded' OR invoice_payment_id IS NOT NULL);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- A connected account's disconnected_at is set if and only if status='disconnected'
+-- (keeps the two columns, which together encode one fact, from drifting).
+DO $$ BEGIN
+  ALTER TABLE stripe_connect_accounts
+    ADD CONSTRAINT stripe_connect_accounts_disconnect_coupling
+    CHECK ((status = 'disconnected') = (disconnected_at IS NOT NULL));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/api/src/__tests__/integration/stripe-payments-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/stripe-payments-rls.integration.test.ts
@@ -224,3 +224,40 @@ describe('invoice_stripe_payments RLS (breeze_app)', () => {
     await expect(insertOnce()).rejects.toMatchObject({ cause: { code: '23505' } });
   });
 });
+
+// DB-enforced state-machine invariants (migration 2026-06-17-stripe-payments-guards).
+// These run under system scope (RLS bypassed) so the ONLY reason an insert fails is
+// the CHECK constraint, surfacing as a 23514 (check_violation) on the wrapper cause.
+describe('stripe payments integrity CHECKs (breeze_app)', () => {
+  runDb("a 'succeeded' mapping with no linked payment is rejected", async () => {
+    const { orgA, invoiceA } = await seed();
+    await expect(
+      withSystemDbAccessContext(() =>
+        db.insert(invoiceStripePayments).values({
+          orgId: orgA.id,
+          invoiceId: invoiceA.id,
+          stripeAccountId: 'acct_chk',
+          stripeObjectType: 'checkout_session',
+          stripeObjectId: 'cs_succeeded_no_payment',
+          amount: '1.00',
+          currency: 'USD',
+          status: 'succeeded', // succeeded but invoicePaymentId omitted (null) → CHECK fails
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  runDb("a 'disconnected' account with a null disconnected_at is rejected", async () => {
+    const { partnerB } = await seed();
+    await expect(
+      withSystemDbAccessContext(() =>
+        db.insert(stripeConnectAccounts).values({
+          partnerId: partnerB.id,
+          stripeAccountId: 'acct_chk_disc',
+          livemode: false,
+          status: 'disconnected', // disconnected but disconnectedAt omitted (null) → CHECK fails
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+});

--- a/apps/api/src/db/schema/stripePayments.ts
+++ b/apps/api/src/db/schema/stripePayments.ts
@@ -25,7 +25,7 @@ export const stripeConnectAccounts = pgTable('stripe_connect_accounts', {
   partnerId: uuid('partner_id').notNull().references(() => partners.id),
   stripeAccountId: text('stripe_account_id').notNull(),
   // encrypted via secretCrypto; used only for deauthorize. Charges use platform key + Stripe-Account header.
-  credentials: jsonb('credentials'),
+  credentials: jsonb('credentials').$type<{ accessToken: string | null }>(),
   livemode: boolean('livemode').notNull().default(false),
   status: stripeConnectStatusEnum('status').notNull().default('connected'),
   scope: varchar('scope', { length: 50 }),

--- a/apps/api/src/services/stripeConnectService.ts
+++ b/apps/api/src/services/stripeConnectService.ts
@@ -50,12 +50,11 @@ export async function consumeState(state: string, partnerId: string): Promise<bo
 export async function completeOAuth(input: { code: string; partnerId: string; userId: string }): Promise<{ stripeAccountId: string }> {
   const resp = await getStripe().oauth.token({ grant_type: 'authorization_code', code: input.code });
   const stripeAccountId = resp.stripe_user_id!;
-  const credentials = JSON.stringify({ accessToken: encryptSecret(resp.access_token ?? null) });
   await withSystemDbAccessContext(async () => {
     await db.insert(stripeConnectAccounts).values({
       partnerId: input.partnerId,
       stripeAccountId,
-      credentials: JSON.parse(credentials),
+      credentials: { accessToken: encryptSecret(resp.access_token ?? null) },
       livemode: Boolean(resp.livemode),
       status: 'connected',
       scope: resp.scope ?? 'read_write',

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -86,7 +86,13 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
       window.location.href = result.data.url;
       return; // keep the button disabled while the browser navigates to Checkout
     }
-    setPayError(result.error || 'Could not start the payment. Please try again.');
+    if (result.statusCode === 409) {
+      // Terminal condition (online payment unavailable / invoice not payable). Show the
+      // server's reason verbatim — "Please try again" would mislead since a retry won't help.
+      setPayError(result.error || 'Online payment is not available for this invoice.');
+    } else {
+      setPayError(result.error || 'Could not start the payment. Please try again.');
+    }
     setPaying(false);
   };
 


### PR DESCRIPTION
Small follow-up to the merged Stripe Payments PR (#1422) — picks up the bounded, safe items from that PR's review, deferring the invasive ones.

## What's in
- **DB integrity guards** (new idempotent migration `2026-06-17-stripe-payments-guards.sql`) — promotes two state-machine invariants the reconcile code already upholds to DB-enforced CHECKs:
  - `invoice_stripe_payments`: a `'succeeded'` mapping must link an `invoice_payment_id` (terminal-failed / fully-refunded rows legitimately may not).
  - `stripe_connect_accounts`: `disconnected_at` is set **iff** `status='disconnected'` (keeps the two columns that encode one fact from drifting).
  - +2 integration tests asserting both CHECKs reject (`23514`).
- **Typed `credentials` jsonb** — `stripe_connect_accounts.credentials` gets a `$type<{ accessToken: string | null }>()`, and `completeOAuth` drops the pointless `JSON.stringify`→`JSON.parse` round-trip.
- **Portal Pay error copy** — a terminal `409` ("Online payment is not available" / "Invoice is not payable") is now shown verbatim instead of an unhelpful "Please try again."

## Intentionally NOT in (explained, not forgotten)
- **Full `Money`/`StripeAccountId`/`CurrencyCode` branding** — genuinely valuable but invasive (threads branded types through many signatures); better as its own focused refactor than bundled here.
- **A `UNIQUE(invoice_id) WHERE status='pending'` index** to dedupe pending mappings — left out deliberately: duplicate pending mappings are *benign* (if a client somehow pays two sessions for one invoice, the second hits `recordStripePayment`'s overpayment guard → terminal-fail + `payment.failed`, no double-record), and a delete-based cleanup would race a still-payable older Checkout session. Not worth the constraint+conflict-handling for a cosmetic issue.

## Verification
- Integration (real DB, `breeze_app`, non-vacuous): **9/9** (incl. the 2 new CHECK cases)
- Stripe unit: **42/42**; API typecheck clean; `db:check-drift` clean; portal `astro check` 0 errors

Feature remains dormant unless `STRIPE_*` is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
