### PR TITLE
fix(patches): require ring/org context for approval; move approval rules to rings

### DIFF
--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
@@ -32,7 +32,7 @@ const baseProps = {
   parentLink: null,
 } as any;
 
-describe('PatchTab patch sources', () => {
+describe('PatchTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fetchMock.mockResolvedValue({
@@ -43,30 +43,54 @@ describe('PatchTab patch sources', () => {
     saveMock.mockResolvedValue({ id: 'link-1', featureType: 'patch', inlineSettings: {} });
   });
 
-  it('renders OS checked and third-party unchecked by default', async () => {
+  // Approval rules and patch sources now live exclusively on Update Rings.
+  it('does not render the Patch Sources section', async () => {
     render(<PatchTab {...baseProps} />);
-    expect(await screen.findByLabelText(/os updates/i)).toBeChecked();
-    expect(screen.getByLabelText(/third-party applications/i)).not.toBeChecked();
+    await screen.findByText('Approval Ring');
+    expect(screen.queryByText('Patch Sources')).toBeNull();
+    expect(screen.queryByLabelText(/os updates/i)).toBeNull();
+    expect(screen.queryByLabelText(/third-party applications/i)).toBeNull();
   });
 
-  it('saves selected sources in inlineSettings', async () => {
+  it('does not render the Automatic Approval section', async () => {
     render(<PatchTab {...baseProps} />);
-    fireEvent.click(await screen.findByLabelText(/third-party applications/i));
+    await screen.findByText('Approval Ring');
+    expect(screen.queryByText('Automatic Approval')).toBeNull();
+    expect(screen.queryByTestId('auto-approve-toggle')).toBeNull();
+    expect(screen.queryByTestId('auto-approve-severity-critical')).toBeNull();
+    expect(screen.queryByTestId('auto-approve-deferral')).toBeNull();
+  });
+
+  it('keeps the Approval Ring link, Installation Schedule, and Application Rules', async () => {
+    render(<PatchTab {...baseProps} />);
+    expect(await screen.findByText('Approval Ring')).toBeInTheDocument();
+    expect(screen.getByText('No ring (manual approvals only)')).toBeInTheDocument();
+    expect(screen.getByText('Installation Schedule')).toBeInTheDocument();
+    expect(screen.getByText('Reboot Policy')).toBeInTheDocument();
+    expect(screen.getByText('Application Rules')).toBeInTheDocument();
+  });
+
+  it('links the policy to the selected ring on save', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        data: [{ id: 'ring-1', name: 'Pilot', ringOrder: 1, deferralDays: 0, gracePeriodHours: 4 }],
+      }),
+    } as unknown as Response);
+
+    render(<PatchTab {...baseProps} />);
+    fireEvent.change(await screen.findByTestId('approval-ring-select'), { target: { value: 'ring-1' } });
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => expect(saveMock).toHaveBeenCalled());
     const [, payload] = saveMock.mock.calls[0];
-    expect(payload.inlineSettings.sources).toEqual(['os', 'third_party']);
+    expect(payload.featurePolicyId).toBe('ring-1');
   });
 
-  it('keeps at least one source selected', async () => {
-    render(<PatchTab {...baseProps} />);
-    const osBox = await screen.findByLabelText(/os updates/i);
-    fireEvent.click(osBox); // attempt to uncheck the only source
-    expect(screen.getByLabelText(/os updates/i)).toBeChecked();
-  });
-
-  it('hydrates sources from an existing link', async () => {
+  // The auto-approve/sources fields are no longer editable, but existing stored
+  // values must survive a save untouched (back-compat with the deprecated fallback).
+  it('preserves stored auto-approve and sources fields in the save payload', async () => {
     render(
       <PatchTab
         {...baseProps}
@@ -74,55 +98,7 @@ describe('PatchTab patch sources', () => {
           id: 'link-1',
           featureType: 'patch',
           featurePolicyId: null,
-          inlineSettings: { sources: ['third_party'], autoApprove: false, autoApproveSeverities: [] },
-        }}
-      />
-    );
-    expect(await screen.findByLabelText(/third-party applications/i)).toBeChecked();
-    expect(screen.getByLabelText(/os updates/i)).not.toBeChecked();
-  });
-
-  it('hydrates legacy alias source values', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        existingLink={{
-          id: 'link-1',
-          featureType: 'patch',
-          featurePolicyId: null,
-          inlineSettings: { sources: ['microsoft', 'custom'] },
-        }}
-      />
-    );
-    expect(await screen.findByLabelText(/os updates/i)).toBeChecked();
-    expect(screen.getByLabelText(/third-party applications/i)).toBeChecked();
-  });
-
-  it('hydrates sources from an inherited parent link', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        parentLink={{
-          id: 'parent-link-1',
-          featureType: 'patch',
-          featurePolicyId: null,
-          inlineSettings: { sources: ['third_party'] },
-        }}
-      />
-    );
-    expect(await screen.findByLabelText(/third-party applications/i)).toBeChecked();
-    expect(screen.getByLabelText(/os updates/i)).not.toBeChecked();
-  });
-
-  it('preserves unrelated stored settings across a save', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        existingLink={{
-          id: 'link-1',
-          featureType: 'patch',
-          featurePolicyId: null,
-          inlineSettings: { sources: ['os'], autoApprove: true, autoApproveSeverities: ['critical'] },
+          inlineSettings: { sources: ['third_party'], autoApprove: true, autoApproveSeverities: ['critical'] },
         }}
       />
     );
@@ -131,81 +107,7 @@ describe('PatchTab patch sources', () => {
     const [, payload] = saveMock.mock.calls[0];
     expect(payload.inlineSettings.autoApprove).toBe(true);
     expect(payload.inlineSettings.autoApproveSeverities).toEqual(['critical']);
-  });
-
-  it('includes wired auto-approve fields and apps in the save payload', async () => {
-    render(<PatchTab {...baseProps} />);
-
-    fireEvent.click(await screen.findByTestId('auto-approve-toggle'));
-    fireEvent.click(screen.getByTestId('auto-approve-severity-critical'));
-    fireEvent.change(screen.getByTestId('auto-approve-deferral'), { target: { value: '3' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-
-    await waitFor(() => expect(saveMock).toHaveBeenCalled());
-    const [, payload] = saveMock.mock.calls[0];
-    expect(payload.inlineSettings).toMatchObject({
-      autoApprove: true,
-      autoApproveSeverities: ['critical'],
-      autoApproveDeferralDays: 3,
-      apps: [],
-    });
-  });
-
-  it('disables the auto-approve section and shows the ring-precedence notice when a ring is linked', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        existingLink={{
-          id: 'link-1',
-          featureType: 'patch',
-          featurePolicyId: 'ring-1',
-          inlineSettings: { sources: ['os'], autoApprove: true, autoApproveSeverities: ['critical'] },
-        }}
-      />
-    );
-
-    expect(await screen.findByTestId('auto-approve-ring-notice')).toHaveTextContent(/governed by the linked update ring/i);
-    expect(screen.getByTestId('auto-approve-toggle')).toBeDisabled();
-  });
-
-  it('hydrates auto-approve fields and apps from existing inline settings', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        existingLink={{
-          id: 'link-1',
-          featureType: 'patch',
-          featurePolicyId: null,
-          inlineSettings: {
-            sources: ['third_party'],
-            autoApprove: true,
-            autoApproveSeverities: ['important'],
-            autoApproveDeferralDays: 7,
-            apps: [{ source: 'third_party', packageId: 'A.B', action: 'block' }],
-          },
-        }}
-      />
-    );
-
-    expect(await screen.findByTestId('auto-approve-toggle')).toBeChecked();
-    expect(screen.getByTestId('auto-approve-severity-important')).toBeChecked();
-    expect(screen.getByTestId('auto-approve-deferral')).toHaveValue(7);
-    expect(screen.getAllByText('A.B').length).toBeGreaterThan(0);
-  });
-
-  it('blocks save when auto-approve is on with no severities and no ring, then proceeds once fixed', async () => {
-    render(<PatchTab {...baseProps} />);
-
-    fireEvent.click(await screen.findByTestId('auto-approve-toggle'));
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-
-    expect(saveMock).not.toHaveBeenCalled();
-    // Inline hint plus the error banner surfaced through the shell's error path.
-    expect(screen.getAllByText('Select at least one severity for auto-approval.').length).toBe(2);
-
-    fireEvent.click(screen.getByTestId('auto-approve-severity-critical'));
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(payload.inlineSettings.sources).toEqual(['third_party']);
   });
 
   it('blocks save when a pinned app rule has no version, then proceeds once fixed', async () => {
@@ -235,59 +137,5 @@ describe('PatchTab patch sources', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
     await waitFor(() => expect(saveMock).toHaveBeenCalled());
-  });
-
-  it('blocks override when inherited settings fail validation', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        parentLink={{
-          id: 'parent-link-1',
-          featureType: 'patch',
-          featurePolicyId: null,
-          inlineSettings: { sources: ['os'], autoApprove: true, autoApproveSeverities: [] },
-        }}
-      />
-    );
-
-    fireEvent.click(await screen.findByRole('button', { name: /override/i }));
-
-    expect(saveMock).not.toHaveBeenCalled();
-    expect(screen.getAllByText('Select at least one severity for auto-approval.').length).toBeGreaterThan(0);
-  });
-
-  it('shows the dormant auto-approve note when a ring is linked and stored autoApprove is true', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        existingLink={{
-          id: 'link-1',
-          featureType: 'patch',
-          featurePolicyId: 'ring-1',
-          inlineSettings: { sources: ['os'], autoApprove: true, autoApproveSeverities: ['critical'] },
-        }}
-      />
-    );
-
-    expect(await screen.findByTestId('auto-approve-dormant-note')).toHaveTextContent(
-      /inactive while a ring is linked/i
-    );
-  });
-
-  it('does not show the dormant note when a ring is linked but autoApprove is off', async () => {
-    render(
-      <PatchTab
-        {...baseProps}
-        existingLink={{
-          id: 'link-1',
-          featureType: 'patch',
-          featurePolicyId: 'ring-1',
-          inlineSettings: { sources: ['os'], autoApprove: false, autoApproveSeverities: [] },
-        }}
-      />
-    );
-
-    expect(await screen.findByTestId('auto-approve-ring-notice')).toBeInTheDocument();
-    expect(screen.queryByTestId('auto-approve-dormant-note')).toBeNull();
   });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
@@ -49,18 +49,6 @@ const defaults: PatchDeploymentSettings = {
   rebootPolicy: 'if_required',
 };
 
-const sourceOptions: { value: PatchSourceOption; label: string; description: string }[] = [
-  { value: 'os', label: 'OS updates', description: 'Windows Update, macOS software updates, and Linux package updates.' },
-  { value: 'third_party', label: 'Third-party applications', description: 'Application updates via winget, Chocolatey, and Homebrew.' },
-];
-
-const severityOptions: { value: PatchSeverity; label: string }[] = [
-  { value: 'critical', label: 'Critical' },
-  { value: 'important', label: 'Important' },
-  { value: 'moderate', label: 'Moderate' },
-  { value: 'low', label: 'Low' },
-];
-
 const OS_VALUE_ALIASES = new Set(['os', 'microsoft', 'apple', 'linux']);
 const THIRD_PARTY_VALUE_ALIASES = new Set(['third_party', 'custom']);
 
@@ -145,23 +133,9 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
   const update = <K extends keyof PatchDeploymentSettings>(key: K, value: PatchDeploymentSettings[K]) =>
     setSettings((prev) => ({ ...prev, [key]: value }));
 
-  const toggleSource = (value: PatchSourceOption) => {
-    setSettings((prev) => {
-      const has = prev.sources.includes(value);
-      if (has && prev.sources.length === 1) return prev; // validator requires min 1
-      return {
-        ...prev,
-        sources: has ? prev.sources.filter((s) => s !== value) : [...prev.sources, value],
-      };
-    });
-  };
-
   // Client-side mirror of the server-side Zod checks so users get inline
   // feedback instead of a round-trip rejection.
   const validateSettings = (): string | null => {
-    if (!selectedRingId && settings.autoApprove && settings.autoApproveSeverities.length === 0) {
-      return 'Select at least one severity for auto-approval.';
-    }
     if (settings.apps.some((app) => app.action === 'pin' && !app.pinnedVersion?.trim())) {
       return 'Pinned applications need a version.';
     }
@@ -223,44 +197,8 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
       onOverride={isInherited ? handleOverride : undefined}
       onRevert={!isInherited && !!linkedPolicyId && !!existingLink ? handleRevert : undefined}
     >
-      {/* Patch Sources */}
-      <div>
-        <h3 className="text-sm font-semibold">Patch Sources</h3>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Which update sources this policy manages on assigned devices.
-        </p>
-        <div className="mt-2 grid gap-3 sm:grid-cols-2">
-          {sourceOptions.map((option) => (
-            <label
-              key={option.value}
-              className={cn(
-                'flex cursor-pointer flex-col gap-1 rounded-md border p-3 text-sm transition',
-                settings.sources.includes(option.value)
-                  ? 'border-primary/40 bg-primary/10 text-primary'
-                  : 'border-muted text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <input
-                type="checkbox"
-                aria-label={option.label}
-                checked={settings.sources.includes(option.value)}
-                onChange={() => toggleSource(option.value)}
-                className="hidden"
-              />
-              <span className="font-medium text-foreground">{option.label}</span>
-              <span className="text-xs text-muted-foreground">{option.description}</span>
-            </label>
-          ))}
-        </div>
-        {settings.sources.length === 1 && (
-          <p className="mt-2 text-xs text-muted-foreground">
-            At least one patch source must be selected.
-          </p>
-        )}
-      </div>
-
       {/* Approval Ring */}
-      <div className="mt-6">
+      <div>
         <h3 className="text-sm font-semibold">Approval Ring</h3>
         <p className="mt-1 text-xs text-muted-foreground">
           Select which update ring governs patch approvals for this policy. Leave empty for manual-only approvals.
@@ -272,6 +210,7 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
           </div>
         ) : (
           <select
+            data-testid="approval-ring-select"
             value={selectedRingId}
             onChange={(e) => setSelectedRingId(e.target.value)}
             className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
@@ -290,78 +229,6 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
             <span>Deferral: {selectedRing.deferralDays === 0 ? 'None' : `${selectedRing.deferralDays}d`}</span>
             <span>Deadline: {selectedRing.deadlineDays == null ? 'None' : `${selectedRing.deadlineDays}d`}</span>
             <span>Grace: {selectedRing.gracePeriodHours}h</span>
-          </div>
-        )}
-      </div>
-
-      {/* Automatic Approval */}
-      <div className="mt-6">
-        <h3 className="text-sm font-semibold">Automatic Approval</h3>
-        {selectedRingId ? (
-          <p className="mt-1 text-xs text-muted-foreground" data-testid="auto-approve-ring-notice">
-            Automatic approval is governed by the linked update ring
-            {selectedRing ? ` "${selectedRing.name}"` : ''}. These settings apply only when no ring is linked.
-          </p>
-        ) : (
-          <p className="mt-1 text-xs text-muted-foreground">
-            Automatically approve patches by severity when no update ring is linked.
-          </p>
-        )}
-        <label className="mt-2 flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            data-testid="auto-approve-toggle"
-            checked={settings.autoApprove}
-            disabled={!!selectedRingId}
-            onChange={(event) => update('autoApprove', event.target.checked)}
-          />
-          Enable automatic approval
-        </label>
-        {/* Spec: policy auto-approval fields are ignored (not cleared) while a ring is linked. */}
-        {!!selectedRingId && settings.autoApprove && (
-          <p className="mt-1 text-xs text-muted-foreground" data-testid="auto-approve-dormant-note">
-            Saved automatic-approval settings are inactive while a ring is linked.
-          </p>
-        )}
-        {settings.autoApprove && !selectedRingId && (
-          <div className="mt-2 space-y-2">
-            <div className="flex flex-wrap gap-3">
-              {severityOptions.map((option) => (
-                <label key={option.value} className="flex items-center gap-1.5 text-sm">
-                  <input
-                    type="checkbox"
-                    data-testid={`auto-approve-severity-${option.value}`}
-                    checked={settings.autoApproveSeverities.includes(option.value)}
-                    onChange={() =>
-                      update(
-                        'autoApproveSeverities',
-                        settings.autoApproveSeverities.includes(option.value)
-                          ? settings.autoApproveSeverities.filter((severity) => severity !== option.value)
-                          : [...settings.autoApproveSeverities, option.value]
-                      )
-                    }
-                  />
-                  {option.label}
-                </label>
-              ))}
-            </div>
-            {settings.autoApproveSeverities.length === 0 && (
-              <p className="text-xs text-destructive">Select at least one severity for auto-approval.</p>
-            )}
-            <div>
-              <label className="text-xs text-muted-foreground">Deferral (days after release)</label>
-              <input
-                type="number"
-                min={0}
-                max={60}
-                data-testid="auto-approve-deferral"
-                value={settings.autoApproveDeferralDays}
-                onChange={(event) =>
-                  update('autoApproveDeferralDays', Math.max(0, Math.min(60, Number(event.target.value) || 0)))
-                }
-                className="mt-1 h-9 w-28 rounded-md border bg-background px-2 text-sm"
-              />
-            </div>
           </div>
         )}
       </div>

--- a/apps/web/src/components/patches/PatchApprovalModal.test.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.test.tsx
@@ -65,6 +65,32 @@ describe('PatchApprovalModal', () => {
     );
   });
 
+  it('blocks approve and prompts for a ring when there is no ring or org context', async () => {
+    render(
+      <PatchApprovalModal
+        open
+        patch={{
+          id: 'patch-1',
+          title: 'Security Update',
+          severity: 'critical',
+          source: 'Microsoft',
+          os: 'Windows',
+          releaseDate: '2026-04-01T00:00:00.000Z',
+          approvalStatus: 'pending',
+        }}
+        ringId={null}
+        currentOrgId={null}
+        onClose={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Approve/i }).at(-1)!);
+
+    await screen.findByText(/select an update ring/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('confirm-fleet-action')).toBeNull();
+  });
+
   it('surfaces backend approval errors instead of a generic message', async () => {
     fetchMock.mockResolvedValueOnce(makeJsonResponse({ error: 'Ring access denied' }, false, 403));
 

--- a/apps/web/src/components/patches/PatchApprovalModal.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.tsx
@@ -14,6 +14,9 @@ type PatchApprovalModalProps = {
   open: boolean;
   patch?: Patch | null;
   ringId?: string | null;
+  /** Current org context (from the org switcher). When absent and no ring is
+   * selected, approval has no org to resolve, so the action is blocked. */
+  currentOrgId?: string | null;
   /** Name of the organization this patch approval applies to, for the confirm message. */
   orgName?: string | null;
   /** Number of devices in the target ring/scope, for the confirm message. */
@@ -55,6 +58,7 @@ export default function PatchApprovalModal({
   open,
   patch,
   ringId,
+  currentOrgId,
   orgName,
   ringDeviceCount,
   onClose,
@@ -89,6 +93,14 @@ export default function PatchApprovalModal({
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
+    // Approval is ring-scoped. With no ring and no current org (a partner on the
+    // global /patches view), the API has no org to attach the approval to and
+    // returns 400. Block early with a clear prompt — before opening the approve
+    // confirm dialog — instead of firing a doomed request.
+    if (!ringId && !currentOrgId) {
+      setSubmitError(`Select an update ring to ${action} patches`);
+      return;
+    }
     // Gate approve behind a scope-naming confirm dialog.
     if (action === 'approve') {
       setApproveConfirmOpen(true);

--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -12,26 +12,18 @@ vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
-vi.mock('../../stores/orgStore', () => ({
-  useOrgStore: Object.assign(
-    () => ({
-      currentOrgId: null,
-      organizations: [
-        { id: 'org-1', name: 'Acme Corp' },
-        { id: 'org-2', name: 'Globex' },
-      ],
-    }),
-    {
-      getState: () => ({
-        currentOrgId: null,
-        organizations: [
-          { id: 'org-1', name: 'Acme Corp' },
-          { id: 'org-2', name: 'Globex' },
-        ],
-      }),
-    }
-  ),
-}));
+// Mutable org-shell state so individual tests can model an org-scoped user
+// (currentOrgId set) vs. a partner on the global /patches view (currentOrgId null).
+const orgState = vi.hoisted(() => ({ currentOrgId: null as string | null }));
+
+vi.mock('../../stores/orgStore', () => {
+  const organizations = [
+    { id: 'org-1', name: 'Acme Corp' },
+    { id: 'org-2', name: 'Globex' },
+  ];
+  const read = () => ({ currentOrgId: orgState.currentOrgId, organizations });
+  return { useOrgStore: Object.assign(read, { getState: read }) };
+});
 
 const fetchMock = vi.mocked(fetchWithAuth);
 
@@ -46,10 +38,14 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
 describe('PatchesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    orgState.currentOrgId = null;
     window.history.replaceState({}, '', '/?tab=patches');
   });
 
   it('keeps failed bulk approvals pending when the API only approves some patches', async () => {
+    // Org-scoped session: the API derives the target org from auth.orgId, so the
+    // bulk-approve request fires without an explicit org/ring selection.
+    orgState.currentOrgId = 'org-1';
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
 
@@ -116,6 +112,42 @@ describe('PatchesPage', () => {
     await screen.findByText('Failed to approve 1 patch');
     expect(screen.getAllByRole('button', { name: 'Deploy' })).toHaveLength(1);
     expect(screen.getAllByRole('button', { name: 'Review' })).toHaveLength(1);
+  });
+
+  it('blocks bulk approve and prompts for an update ring when there is no org context', async () => {
+    // Partner on the global /patches view: no current org and no ring selected.
+    // Approval is ring-scoped, so the request would 400 ('orgId is required for
+    // partner/system scope') — guard it client-side with a clear prompt instead.
+    orgState.currentOrgId = null;
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/update-rings') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') {
+        return makeJsonResponse({
+          data: [
+            {
+              id: 'patch-1',
+              title: 'Critical Security Update',
+              severity: 'critical',
+              source: 'microsoft',
+              os: 'windows',
+              releaseDate: '2026-04-01T00:00:00.000Z',
+              approvalStatus: 'pending',
+            },
+          ],
+        });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchesPage />);
+
+    await screen.findByText('Critical Security Update');
+    fireEvent.click(screen.getByRole('button', { name: 'Select Critical Security Update' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Approve 1' }));
+
+    await screen.findByText(/select an update ring/i);
+    expect(fetchMock).not.toHaveBeenCalledWith('/patches/bulk-approve', expect.anything());
   });
 
   it('does NOT fire the scan POST until the confirm button is clicked', async () => {

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -184,6 +184,13 @@ export default function PatchesPage() {
   // runAction's per-call toast. This is a deliberate, valid feedback pattern — not a silent failure.
   // See spec 2026-05-15-ws-a-action-feedback-design.md (targeted scope; sweeping migration is a non-goal).
   const handleBulkApprove = async (patchIds: string[]) => {
+    // Approval is ring-scoped. With no current org (a partner on the global
+    // /patches catalog view) and no ring selected, the API has no org to attach
+    // the approval to and returns 400 ('orgId is required for partner/system
+    // scope'). Guard with a clear prompt instead of firing a doomed request.
+    if (!selectedRingId && !currentOrgId) {
+      throw new Error('Select an update ring to approve patches');
+    }
     // runaction-exempt: aggregate/partial-success — inline bulkError UI (see NOTE above)
     const response = await fetchWithAuth('/patches/bulk-approve', {
       method: 'POST',
@@ -213,6 +220,10 @@ export default function PatchesPage() {
   };
 
   const handleBulkDecline = async (patchIds: string[]) => {
+    // Same ring/org context requirement as approve (see handleBulkApprove).
+    if (!selectedRingId && !currentOrgId) {
+      throw new Error('Select an update ring to decline patches');
+    }
     const failed: string[] = [];
     for (const id of patchIds) {
       // runaction-exempt: aggregate/partial-success — inline bulkError UI (see NOTE above)
@@ -569,6 +580,7 @@ export default function PatchesPage() {
         open={modalOpen}
         patch={selectedPatch}
         ringId={selectedRingId}
+        currentOrgId={currentOrgId}
         orgName={currentOrg?.name ?? null}
         ringDeviceCount={selectedRingId ? (rings.find(r => r.id === selectedRingId)?.deviceCount ?? null) : null}
         onClose={() => {


### PR DESCRIPTION
## Problem

On the global `/patches` view, a **partner-scope** user (`org_access: all`, no single implicit org) clicking Approve got a generic **"Failed to approve patches."** Confirmed against US prod logs: `POST /api/v1/patches/bulk-approve → 400`.

**Root cause:** approval is per-org, but bulk/single approve-decline-defer posted no `orgId`. `fetchWithAuth` only auto-injects `?orgId=` when an org is selected; with none, the API's `resolvePatchApprovalOrgId` returns `400 "orgId is required for partner/system scope"`. Org-scoped sessions were unaffected (org derived from `auth.orgId`).

## Fix

Approval is **ring-scoped** — a selected update ring resolves the org server-side. All three entry points now guard on `!ring && !currentOrgId` and show **"Select an update ring to {approve/decline/defer} patches"** instead of firing a doomed request:

- `PatchesPage.handleBulkApprove` / `handleBulkDecline`
- `PatchApprovalModal` (single Review→Approve/Decline/Defer) — new `currentOrgId` prop; blocks **before** the approve confirm dialog opens

Genuine server errors still surface verbatim (existing "Ring access denied" test unchanged).

## Also: Config Policy "Patches" tab trim

Per design, approval rules and patch sources live on **Update Rings** only. Removed the duplicate **Automatic Approval** block and **Patch Sources** from `PatchTab.tsx`; kept the Approval Ring link, Installation Schedule, Reboot Policy, and Application Rules. Stored inline settings are preserved in the save payload — **no server-contract change**.

## Tests

- TDD throughout (RED→GREEN). 49/49 patches tests + 6/6 PatchTab tests pass; `tsc` and `eslint` clean.

## Note

Immediate workaround on US until this ships: select an update ring (or a specific org) before approving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)