### PR TITLE
fix(software): return 409 (not 500) when deleting a catalog item with live deployments

### DIFF
--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { softwareRoutes, computeSoftwareDeploymentAggregateStatus } from './software';
+import { db } from '../db';
 
 vi.mock('../services', () => ({}));
 
@@ -48,7 +49,7 @@ vi.mock('../db', () => ({
 vi.mock('../db/schema', () => ({
   softwareCatalog: { id: 'id', orgId: 'org_id', name: 'name', vendor: 'vendor', description: 'description', category: 'category' },
   softwareVersions: { id: 'id', catalogId: 'catalog_id', isLatest: 'is_latest' },
-  softwareDeployments: { id: 'id', orgId: 'org_id' },
+  softwareDeployments: { id: 'id', orgId: 'org_id', softwareVersionId: 'software_version_id' },
   deploymentResults: { deploymentId: 'deployment_id', status: 'status' },
   softwareInventory: { deviceId: 'device_id', name: 'name' },
   devices: { id: 'id', orgId: 'org_id', agentId: 'agent_id' },
@@ -121,6 +122,54 @@ describe('software routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toHaveProperty('data');
+    });
+  });
+
+  describe('DELETE /software/catalog/:id', () => {
+    const catalogId = '11111111-1111-1111-1111-111111111111';
+    const existing = [{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }];
+
+    // Thenable that resolves to `rows` regardless of chain shape
+    // (select().from().where() and select().from().innerJoin().where()).
+    const selectResult = (rows: any): any => {
+      const p: any = new Proxy(() => p, {
+        get: (_t, prop) => (prop === 'then' ? (resolve: any) => resolve(rows) : () => p),
+      });
+      return p;
+    };
+
+    it('returns 409 when a deployment still references the version (issue #1407)', async () => {
+      // 1st select: existing catalog item lookup. 2nd select: deployment ref count.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectResult(existing))
+        .mockReturnValueOnce(selectResult([{ count: 2 }]));
+
+      const res = await app.request(`/software/catalog/${catalogId}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toMatch(/2 deployments still reference/);
+      // Must not have attempted any destructive delete.
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('deletes when no deployment references the version', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectResult(existing))
+        .mockReturnValueOnce(selectResult([{ count: 0 }]));
+
+      const res = await app.request(`/software/catalog/${catalogId}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(db.delete).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -560,6 +560,22 @@ softwareRoutes.delete(
       .where(and(eq(softwareCatalog.id, id), eq(softwareCatalog.orgId, orgId)));
     if (!existing) return c.json({ error: 'Catalog item not found' }, 404);
 
+    // Refuse the delete if any deployment still references one of this item's
+    // versions. The softwareDeployments -> softwareVersions FK is RESTRICT, so
+    // deleting underneath a live deployment would otherwise surface as a 500.
+    // Returning 409 preserves deployment history (issue #1407).
+    const [refRow] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(softwareDeployments)
+      .innerJoin(softwareVersions, eq(softwareDeployments.softwareVersionId, softwareVersions.id))
+      .where(eq(softwareVersions.catalogId, id));
+    const deploymentCount = refRow?.count ?? 0;
+    if (deploymentCount > 0) {
+      return c.json({
+        error: `Cannot delete: ${deploymentCount} deployment${deploymentCount === 1 ? '' : 's'} still reference this software's versions`,
+      }, 409);
+    }
+
     // Delete versions first (FK constraint)
     await db.delete(softwareVersions).where(eq(softwareVersions.catalogId, id));
     await db.delete(softwareCatalog).where(eq(softwareCatalog.id, id));


### PR DESCRIPTION
## Problem

`DELETE /catalog/:id` (`apps/api/src/routes/software.ts`) deletes a catalog item's version rows directly. `softwareDeployments.softwareVersionId` references `softwareVersions.id` with **no `onDelete` rule**, so Postgres defaults to `RESTRICT`. When any deployment still references one of those versions, the delete fails the FK constraint and surfaces as an **unhandled 500**.

Pre-existing, but unreachable until the Software Library delete button shipped in #1381 — that's what makes it hittable now. Fixes #1407.

## Fix

Pre-check deployment references before the destructive delete and return a clean **409** with a count when any deployment still uses one of the item's versions:

```
Cannot delete: N deployment(s) still reference this software's versions
```

Chose the 409 pre-check (the issue's preferred option) over adding an `onDelete` FK policy — it preserves deployment history and needs no migration. Behavior is unchanged when nothing references the versions (still deletes, returns 200).

Scope is gated as before (`requireSoftwareWrite` + `requireMfa`, org-scoped); this is a UX/robustness fix, not an isolation change.

## Tests

`apps/api/src/routes/software.test.ts`:
- 409 when a deployment references the version — asserts no destructive `db.delete` was attempted.
- 200 + delete when nothing references it.

## Verification (local, OrbStack)

- `apps/api` full `software.test.ts`: **14/14 pass** (ran the whole file, not just the new cases — the route's catalog lookup needed a chain-shape-agnostic select stub, and the new `mockReturnValueOnce` queue consumes exactly its two selects per test, so nothing leaks into sibling tests).
- `apps/api` `tsc --noEmit`: **0 errors**.
- No dependency or migration changes (overrides/lockfile untouched).
