### PR TITLE
fix(software): stream package upload to disk instead of buffering into heap

### DIFF
--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { softwareRoutes, computeSoftwareDeploymentAggregateStatus } from './software';
+import { db } from '../db';
+import { uploadBinary, isS3Configured } from '../services/s3Storage';
+import { createHash } from 'node:crypto';
 
 vi.mock('../services', () => ({}));
 
@@ -121,6 +124,51 @@ describe('software routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toHaveProperty('data');
+    });
+  });
+
+  describe('POST /software/catalog/:id/versions/upload', () => {
+    const catalogId = '11111111-1111-1111-1111-111111111111';
+
+    // Thenable that resolves to `rows` regardless of Drizzle chain shape.
+    const selectResult = (rows: any): any => {
+      const p: any = new Proxy(() => p, {
+        get: (_t, prop) => (prop === 'then' ? (resolve: any) => resolve(rows) : () => p),
+      });
+      return p;
+    };
+
+    it('streams the file to disk and hashes it incrementally (issue #1408)', async () => {
+      const content = 'hello-breeze-package-payload';
+      const expectedChecksum = createHash('sha256').update(content).digest('hex');
+
+      vi.mocked(isS3Configured).mockReturnValueOnce(true);
+      // catalog lookup
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+      );
+      // insertLatestSoftwareVersion wraps everything in a transaction
+      vi.mocked(db.transaction).mockResolvedValueOnce({
+        id: 'ver-1', catalogId, version: '1.0.0', isLatest: true,
+      } as any);
+
+      const fd = new FormData();
+      fd.append('version', '1.0.0');
+      fd.append('file', new File([content], 'pkg.msi', { type: 'application/octet-stream' }));
+
+      const res = await app.request(`/software/catalog/${catalogId}/versions/upload`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: fd,
+      });
+
+      expect(res.status).toBe(201);
+      // The streamed path must produce the correct checksum and hand the temp
+      // file (not an in-memory buffer) to S3.
+      expect(uploadBinary).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(uploadBinary).mock.calls[0]!;
+      expect(call[2]).toBe(expectedChecksum); // checksum from the streamed hash
+      expect(typeof call[0]).toBe('string');  // temp file path, not an in-memory buffer
     });
   });
 

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -17,7 +17,10 @@ import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
 import { uploadBinary, getPresignedUrl, isS3Configured } from '../services/s3Storage';
 import { sendCommandToAgent, type AgentCommand } from './agentWs';
 import { createHash } from 'node:crypto';
-import { writeFile, unlink, mkdir } from 'node:fs/promises';
+import { unlink, mkdir } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -726,13 +729,24 @@ softwareRoutes.post(
     const tempPath = join(tempDir, `${randomUUID()}${ext}`);
 
     try {
-      const arrayBuffer = await file.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-      await writeFile(tempPath, buffer);
-
+      // Stream the upload straight to the temp file, hashing incrementally,
+      // instead of buffering the whole file into an ArrayBuffer and again into
+      // a Buffer (~2x the file size, transiently, on top of the parsed body).
+      // Follows the pipeline(stream, hash) pattern in s3Storage.ts. Cuts the
+      // peak transient heap per upload (partially addresses #1408).
       const hash = createHash('sha256');
-      hash.update(buffer);
+      await pipeline(
+        Readable.fromWeb(file.stream() as Parameters<typeof Readable.fromWeb>[0]),
+        async function* (source) {
+          for await (const chunk of source) {
+            hash.update(chunk as Buffer);
+            yield chunk;
+          }
+        },
+        createWriteStream(tempPath),
+      );
       const checksum = hash.digest('hex');
+      const fileSize = file.size;
 
       // Generate version ID for S3 key path
       const versionId = randomUUID();
@@ -750,7 +764,7 @@ softwareRoutes.post(
         fileType,
         originalFileName,
         checksum,
-        fileSize: buffer.length,
+        fileSize,
         supportedOs,
         architecture,
         silentInstallArgs,
@@ -769,7 +783,7 @@ softwareRoutes.post(
         resourceType: 'software_version',
         resourceId: versionRecord.id,
         resourceName: catalogItem.name,
-        details: { version, fileType, fileSize: buffer.length, checksum },
+        details: { version, fileType, fileSize, checksum },
       });
 
       return c.json({ data: versionRecord }, 201);


### PR DESCRIPTION
## Problem

`POST /catalog/:id/versions/upload` (`apps/api/src/routes/software.ts`) read the entire upload into memory with `file.arrayBuffer()`, then copied it **again** into a `Buffer` before writing to a temp file — ~2x the file size transiently (~1GB for a 500MB package), on top of the body the multipart parse already buffered. A handful of concurrent large uploads could pressure / OOM the API process. Unmasked by #1378 raising the body cap to 500MB for this route (correctly — it fixes #1377).

## Fix

Stream the `File` straight to the temp file via `pipeline()`, hashing incrementally through a passthrough generator, and take the size from `file.size`. No `arrayBuffer()`, no second `Buffer` copy. This follows the `pipeline(stream, hash)` pattern already used in `s3Storage.ts` / `binarySync.ts`.

Peak transient heap per upload drops ~3x (the two full-size copies are gone). No new dependency, no behavior change to the response or the S3 path.

### What this does NOT do (deliberately)

`c.req.parseBody()` still buffers the parsed `File` before the handler runs, so peak memory isn't yet *constant* regardless of file size — the issue's full goal. Bounding it completely means replacing `parseBody` with a streaming multipart parser (e.g. busboy), which is a **new dependency** and an architectural change to the upload path (and the sibling `devPush.ts` upload shares the same shape). That's a maintainer call, so I scoped this PR to the dependency-free win and left the parser swap as a follow-up. Hence **Partially addresses #1408** rather than closing it.

## Tests

`apps/api/src/routes/software.test.ts`: a multipart upload through the real route asserts 201, that `uploadBinary` is handed a temp-file path (not an in-memory buffer), and that the checksum equals the SHA-256 of the streamed content — exercising the new streaming + incremental-hash path end to end.

## Verification (local, OrbStack)

- `apps/api` `software.test.ts`: **13/13 pass** (ran the whole file; the new `*Once` mocks consume exactly their queued calls — no leak into siblings).
- `apps/api` `tsc --noEmit`: **0 errors**.
- No dependency / lockfile / migration changes.
