### PR TITLE
fix(installer): restore SELinux context on installed Linux agent binary

### DIFF
--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -196,6 +196,15 @@ describe('GET /install.sh — generated installer script', () => {
     }
   });
 
+  it('restores the SELinux context on the installed Linux binary (issue #1389)', async () => {
+    const script = await fetchScript();
+    // Without this, the binary keeps the mktemp user_tmp_t label after the mv
+    // and systemd fails to exec it (203/EXEC) on SELinux-enforcing hosts. The
+    // restorecon must be guarded so it is a no-op on non-SELinux systems.
+    expect(script).toContain('command -v restorecon');
+    expect(script).toMatch(/restorecon -v "\$INSTALL_DIR\/\$BINARY_NAME"/);
+  });
+
   it('accepts a --token argument for enrollment-key based enrollment', async () => {
     const script = await fetchScript();
     // Argument parser handles --token and forwards it to `enroll` as the

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -755,6 +755,13 @@ fi
 info "Installing to \$INSTALL_DIR/\$BINARY_NAME..."
 mv "\$TMPFILE" "\$INSTALL_DIR/\$BINARY_NAME"
 chmod 755 "\$INSTALL_DIR/\$BINARY_NAME"
+# On SELinux-enforcing hosts (Fedora family) the binary inherits the mktemp
+# file's user_tmp_t label through the mv, so systemd/init is denied execute
+# (203/EXEC) after a reboot. Restore the default context for the install path.
+# Guarded by command existence so it is a no-op on non-SELinux systems.
+if command -v restorecon &>/dev/null; then
+  restorecon -v "\$INSTALL_DIR/\$BINARY_NAME" 2>/dev/null || true
+fi
 trap - EXIT
 success "Installed \$INSTALL_DIR/\$BINARY_NAME"
 


### PR DESCRIPTION
## Problem

On SELinux-enforcing hosts (Fedora family), the Linux agent installs but `breeze-agent.service` crash-loops with `203/EXEC` after a reboot — SELinux denies `init_t` execute access to `/usr/local/bin/breeze-agent` because the file carries a `user_tmp_t` context.

Root cause (from the reporter, #1389): the generated installer (`GET /install.sh`, `apps/api/src/routes/agents/download.ts`) downloads the binary to `mktemp` and `mv`s it into `/usr/local/bin`. The temp file's `user_tmp_t` label is preserved through the move, leaving the service binary labeled as temporary user content instead of an executable system binary.

## Fix

Run `restorecon` on the installed binary immediately after `chmod`, guarded by `command -v restorecon` so it's a no-op on non-SELinux systems:

```sh
if command -v restorecon &>/dev/null; then
  restorecon -v "$INSTALL_DIR/$BINARY_NAME" 2>/dev/null || true
fi
```

This is exactly the repair the reporter verified fixes the service and survives a reboot. It's additive and idempotent — no effect on hosts that aren't SELinux-enforcing or where the context is already correct. Only the Linux install branch is touched; the macOS branch installs via a signed `.pkg` (no `mktemp`→`mv`), and the curl bootstrap one-liner's `mktemp` holds the fetched script, not the binary.

## Tests

`apps/api/src/routes/agents/download.test.ts`: asserts the generated `install.sh` contains the guarded `restorecon` on the install path. The existing `bash -n` syntax-check test covers the shell edit.

## Verification (local, OrbStack)

- `apps/api` `download.test.ts`: **26/26 pass** (includes the `bash -n` validity check and the functional `runScript` pre-flight tests).
- `apps/api` `tsc --noEmit`: **0 errors**.
- No dependency / lockfile / migration changes.
