### PR TITLE
fix(agent): restore SELinux context on installed Linux binary (#1389)

### DIFF
--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -251,6 +251,20 @@ describe('GET /install.sh — generated installer script', () => {
     const script = await fetchScript();
     expect(script).toContain('--token YOUR_ENROLLMENT_TOKEN');
   });
+
+  it('restores the SELinux context on the installed Linux binary (#1389)', async () => {
+    const script = await fetchScript();
+    // The binary is downloaded to mktemp (/tmp, labeled user_tmp_t) and moved
+    // to /usr/local/bin. mv preserves the source SELinux label, leaving the
+    // service binary mislabeled so init_t/systemd is denied execute access
+    // (203/EXEC) after reboot on SELinux-enforcing hosts. restorecon resets it
+    // to the destination directory's default type (bin_t).
+    expect(script).toContain('restorecon');
+    // Must be guarded so it is a no-op on systems without SELinux tooling.
+    expect(script).toMatch(/command -v restorecon/);
+    // And it must target the installed binary, not the temp file.
+    expect(script).toContain('restorecon -F "$INSTALL_DIR/$BINARY_NAME"');
+  });
 });
 
 describe('GET /uninstall.sh — generated uninstaller script', () => {

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -755,6 +755,15 @@ fi
 info "Installing to \$INSTALL_DIR/\$BINARY_NAME..."
 mv "\$TMPFILE" "\$INSTALL_DIR/\$BINARY_NAME"
 chmod 755 "\$INSTALL_DIR/\$BINARY_NAME"
+# Restore the SELinux file context on the installed binary. The download lands
+# in mktemp (/tmp, labeled user_tmp_t) and \`mv\` preserves that label onto
+# /usr/local/bin, so init_t/systemd is denied execute access and the service
+# enters a 203/EXEC restart loop after reboot on SELinux-enforcing hosts
+# (#1389). restorecon resets it to the destination directory's default type
+# (bin_t). Guarded so it is a no-op where SELinux tooling is absent.
+if command -v restorecon &>/dev/null; then
+  restorecon -F "\$INSTALL_DIR/\$BINARY_NAME" 2>/dev/null || true
+fi
 trap - EXIT
 success "Installed \$INSTALL_DIR/\$BINARY_NAME"
 


### PR DESCRIPTION
## Problem

On SELinux-enforcing hosts (Fedora/RHEL family), the Linux agent installs but `breeze-agent.service` enters a `203/EXEC` auto-restart loop after reboot:

```
breeze-agent.service: Failed at step EXEC spawning /usr/local/bin/breeze-agent: Permission denied
breeze-agent.service: Main process exited, code=exited, status=203/EXEC
```

AVC logs show `init_t` denied execute access to `/usr/local/bin/breeze-agent` because the file is labeled `user_tmp_t`.

**Root cause:** the generated `install.sh` (`apps/api/src/routes/agents/download.ts`) downloads the binary to `mktemp` (in `/tmp`, labeled `user_tmp_t`) and then `mv`s it to `/usr/local/bin`. `mv` preserves the source SELinux label, leaving the service binary mislabeled as temporary user content instead of an executable system binary (`bin_t`).

## Fix

Run `restorecon -F` on the installed binary immediately after `chmod`, resetting it to the destination directory's default type (`bin_t`). Guarded on `command -v restorecon` so it is a no-op on systems without SELinux tooling. This is exactly the manual repair the reporter verified survives reboot.

## Testing

- Added a regression test asserting the generated `install.sh` contains a guarded `restorecon -F "$INSTALL_DIR/$BINARY_NAME"`.
- Wrote it failing first (red), then implemented the fix (green).
- Full `download.test.ts` suite passes (26/26), including the existing `bash -n` syntax check that confirms the script is still valid bash.

**Scope note:** the bundled `agent/scripts/install/install-linux.sh` uses `cp` (new inode inherits the dir's default `bin_t` via type transition), so it does not reproduce the bug and is left unchanged. Only the `mv`-from-tmp path in the server-generated one-liner was affected.

Closes #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)