### PR TITLE
fix(users): neutralize orphaned user on delete + resurrect on re-invite (#1367)

### DIFF
--- a/apps/api/migrations/2026-06-18-neutralize-orphaned-users.sql
+++ b/apps/api/migrations/2026-06-18-neutralize-orphaned-users.sql
@@ -1,0 +1,53 @@
+-- Neutralize orphaned `users` rows left behind by membership-only deletes (#1367).
+--
+-- Before this release, DELETE /users/:id removed only the membership row
+-- (partner_users / organization_users) and left the `users` row behind with
+-- its old name, status='active', and password_hash intact. Two consequences:
+--
+--   1. SECURITY: the "deleted" user could still authenticate. login.ts only
+--      bounces on `!user.password_hash` or `status != 'active'`, and
+--      resolveCurrentUserTokenContext returns a null-context system-scope token
+--      (instead of throwing) for a membership-less user — so a removed employee
+--      who still knew their password could log back in.
+--   2. RESURRECTION: re-inviting the same email reused the orphaned row with its
+--      stale active status + password, blocking the new invitee from setting a
+--      password via the magic link ("invite already accepted").
+--
+-- The `users` row cannot simply be deleted — dozens of created_by/approved_by/
+-- triggered_by FKs reference it with ON DELETE RESTRICT. Instead we neutralize
+-- every existing orphan: disable it and strip the password + MFA secrets so it
+-- can neither authenticate nor be resurrected with old credentials. The next
+-- invite of that email resets the row to a clean invited state (handled in the
+-- invite route). Going forward the delete route neutralizes on the last
+-- membership removal, so this backfill only ever has to run once.
+--
+-- An orphan is a user with NO row in partner_users AND NO row in
+-- organization_users. Idempotent: re-running only touches rows that are still
+-- active orphans, and a clean DB neutralizes zero rows.
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  UPDATE users u
+  SET status = 'disabled',
+      disabled_reason = 'removed',
+      password_hash = NULL,
+      mfa_enabled = false,
+      mfa_secret = NULL,
+      mfa_method = NULL,
+      mfa_recovery_codes = NULL,
+      updated_at = now()
+  WHERE NOT EXISTS (SELECT 1 FROM partner_users pu WHERE pu.user_id = u.id)
+    AND NOT EXISTS (SELECT 1 FROM organization_users ou WHERE ou.user_id = u.id)
+    -- Only touch rows that still carry login-capable state, so a re-run (or a
+    -- row already neutralized by the delete route) is a true no-op.
+    AND (u.status <> 'disabled' OR u.password_hash IS NOT NULL);
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    -- Forensic trail: these rows were login-capable accounts with no
+    -- membership. A non-zero count post-deploy is worth correlating against
+    -- any "deleted user could still sign in" reports.
+    RAISE WARNING 'neutralized % orphaned user row(s) (no membership, had login-capable state) [#1367]', n;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/userDeleteResurrect.integration.test.ts
+++ b/apps/api/src/__tests__/integration/userDeleteResurrect.integration.test.ts
@@ -1,0 +1,246 @@
+/**
+ * User delete / re-invite resurrection + login-hole proof (#1367).
+ *
+ * Drives the real DELETE /users/:id and POST /users/invite routes against the
+ * real docker postgres as breeze_app, proving three things the unit tests
+ * (Drizzle mocks) cannot:
+ *
+ *   1. Deleting a user's last membership NEUTRALIZES the orphaned `users` row
+ *      (status='disabled', password_hash=NULL). This closes the security hole
+ *      where a "deleted" user could still authenticate — login.ts bounces on
+ *      a null password_hash / non-active status, so a tombstone can't log in.
+ *
+ *   2. Deleting ONE membership of a multi-membership user does NOT neutralize
+ *      them. This is the correctness proof for running the orphan check under
+ *      SYSTEM scope: an org-B admin's RLS view hides the user's org-A
+ *      membership, so a request-scoped check would falsely report them
+ *      orphaned and wrongly disable a still-active user.
+ *
+ *   3. Re-inviting the same email RESETS the tombstone to a clean invited
+ *      state (status='invited', password_hash=NULL, new name) + a fresh
+ *      membership — so the new invitee can set a password via the magic link
+ *      instead of hitting "invite already accepted".
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+
+type AuthCtx = {
+  scope: 'partner' | 'organization';
+  partnerId: string | null;
+  orgId: string | null;
+  accessibleOrgIds: string[] | null;
+  accessiblePartnerIds: string[] | null;
+};
+
+let activeAuthContext: AuthCtx | null = null;
+
+vi.mock('../../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../middleware/auth')>();
+  const { withDbAccessContext } = await import('../../db');
+  return {
+    ...actual,
+    authMiddleware: (c: any, next: any) => {
+      if (!activeAuthContext) return c.json({ error: 'Unauthorized' }, 401);
+      const ctx = activeAuthContext;
+      c.set('auth', {
+        scope: ctx.scope,
+        partnerId: ctx.partnerId,
+        orgId: ctx.orgId,
+        accessibleOrgIds: ctx.accessibleOrgIds ?? [],
+        user: { id: null, email: 'integration@test' },
+      });
+      return withDbAccessContext(
+        {
+          scope: ctx.scope,
+          orgId: ctx.orgId,
+          accessibleOrgIds: ctx.accessibleOrgIds,
+          accessiblePartnerIds: ctx.accessiblePartnerIds,
+          userId: null,
+        },
+        () => next(),
+      );
+    },
+    hasSatisfiedMfa: () => true,
+    requireMfa: () => (_c: any, next: any) => next(),
+    requirePermission: () => (_c: any, next: any) => next(),
+  };
+});
+
+import { db, withSystemDbAccessContext } from '../../db';
+import { users, partnerUsers, organizationUsers } from '../../db/schema';
+import {
+  createPartner,
+  createOrganization,
+  createRole,
+  createUser,
+  assignUserToPartner,
+  assignUserToOrganization,
+} from './db-utils';
+import { getTestDb } from './setup';
+
+async function buildApp() {
+  const { userRoutes } = await import('../../routes/users');
+  const { authMiddleware } = await import('../../middleware/auth');
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/users', userRoutes);
+  return app;
+}
+
+async function readUser(id: string) {
+  const [row] = await getTestDb()
+    .select()
+    .from(users)
+    .where(eq(users.id, id))
+    .limit(1);
+  if (!row) throw new Error(`user ${id} not found`);
+  return row;
+}
+
+beforeEach(() => {
+  activeAuthContext = null;
+});
+
+afterEach(() => {
+  activeAuthContext = null;
+  vi.clearAllMocks();
+});
+
+describe('user delete → neutralize orphan (#1367)', () => {
+  it('neutralizes the orphaned users row when the last membership is deleted', async () => {
+    const partner = await createPartner();
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const target = await createUser({
+      partnerId: partner.id,
+      email: `orphan-${Date.now()}@example.com`,
+      status: 'active',
+    });
+    await assignUserToPartner(target.id, partner.id, role.id);
+
+    activeAuthContext = {
+      scope: 'partner',
+      partnerId: partner.id,
+      orgId: null,
+      accessibleOrgIds: [],
+      accessiblePartnerIds: [partner.id],
+    };
+
+    const app = await buildApp();
+    const res = await app.request(`/users/${target.id}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+
+    // The users row survives (FKs reference it) but is neutralized: disabled +
+    // no password = cannot authenticate (the login hole is closed).
+    const row = await readUser(target.id);
+    expect(row.status).toBe('disabled');
+    expect(row.passwordHash).toBeNull();
+    expect(row.disabledReason).toBe('removed');
+
+    // Membership is gone.
+    const [link] = await getTestDb()
+      .select({ id: partnerUsers.id })
+      .from(partnerUsers)
+      .where(eq(partnerUsers.userId, target.id))
+      .limit(1);
+    expect(link).toBeUndefined();
+  });
+
+  it('does NOT neutralize a multi-org user when only one membership is removed', async () => {
+    // The correctness proof for the system-scoped orphan check: the deleting
+    // admin (org B) cannot see the user's org-A membership under RLS, but the
+    // user is still active there and must stay loginable.
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: orgB.id, partnerId: partner.id });
+    const target = await createUser({
+      partnerId: partner.id,
+      orgId: orgA.id,
+      email: `multiorg-${Date.now()}@example.com`,
+      status: 'active',
+    });
+    await assignUserToOrganization(target.id, orgA.id, role.id);
+    await assignUserToOrganization(target.id, orgB.id, role.id);
+
+    activeAuthContext = {
+      scope: 'organization',
+      partnerId: null,
+      orgId: orgB.id,
+      accessibleOrgIds: [orgB.id],
+      accessiblePartnerIds: null,
+    };
+
+    const app = await buildApp();
+    const res = await app.request(`/users/${target.id}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+
+    // Still active — org-A membership remains, so the row is NOT an orphan.
+    const row = await readUser(target.id);
+    expect(row.status).toBe('active');
+    expect(row.passwordHash).not.toBeNull();
+
+    // Only the org-B membership was removed; org-A survives.
+    const remaining = await getTestDb()
+      .select({ orgId: organizationUsers.orgId })
+      .from(organizationUsers)
+      .where(eq(organizationUsers.userId, target.id));
+    expect(remaining.map((r) => r.orgId)).toEqual([orgA.id]);
+  });
+});
+
+describe('user re-invite → resurrect tombstone (#1367)', () => {
+  it('resets a neutralized tombstone to a clean invited state on re-invite', async () => {
+    const partner = await createPartner();
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const email = `revive-${Date.now()}@example.com`;
+
+    // Seed a tombstone directly: the state a prior delete (or the backfill
+    // migration) leaves behind — disabled, no password, no membership.
+    const target = await createUser({
+      partnerId: partner.id,
+      email,
+      name: 'Old Name',
+      status: 'active',
+    });
+    await withSystemDbAccessContext(async () =>
+      db
+        .update(users)
+        .set({ status: 'disabled', disabledReason: 'removed', passwordHash: null })
+        .where(eq(users.id, target.id)),
+    );
+
+    activeAuthContext = {
+      scope: 'partner',
+      partnerId: partner.id,
+      orgId: null,
+      accessibleOrgIds: [],
+      accessiblePartnerIds: [partner.id],
+    };
+
+    const app = await buildApp();
+    const res = await app.request('/users/invite', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, name: 'New Name', roleId: role.id, orgAccess: 'none' }),
+    });
+    expect(res.status).toBe(201);
+
+    // Same row, resurrected cleanly so the magic-link set-password flow works
+    // (accept-invite requires status='invited').
+    const row = await readUser(target.id);
+    expect(row.id).toBe(target.id);
+    expect(row.status).toBe('invited');
+    expect(row.passwordHash).toBeNull();
+    expect(row.name).toBe('New Name');
+
+    // A fresh membership was created.
+    const [link] = await getTestDb()
+      .select({ id: partnerUsers.id })
+      .from(partnerUsers)
+      .where(eq(partnerUsers.userId, target.id))
+      .limit(1);
+    expect(link).toBeDefined();
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { and, eq, or } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { nanoid } from 'nanoid';
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { users, partnerUsers, organizationUsers, roles, organizations, permissions, rolePermissions } from '../db/schema';
 import { authMiddleware, hasSatisfiedMfa, requireMfa, requirePermission } from '../middleware/auth';
 import {
@@ -1069,35 +1069,32 @@ userRoutes.post(
 
       let user = existingUser;
 
-      if (!user) {
-        // Resolve the new user's primary tenancy from the caller's scope.
-        // Partner admins inviting → new user is partner-level staff
-        // (partner_id set, org_id NULL). Org admins inviting → new user is
-        // a member of that org (partner_id inherited from the org's owning
-        // partner, org_id set to the caller's org).
-        let newUserPartnerId: string;
-        let newUserOrgId: string | null;
+      // Resolve the invited user's primary tenancy from the caller's scope.
+      // Partner admins inviting → partner-level staff (partner_id set, org_id
+      // NULL). Org admins inviting → member of that org (partner_id inherited
+      // from the org's owning partner, org_id set to the caller's org).
+      const resolveInviteTenancy = async (): Promise<{ partnerId: string; orgId: string | null }> => {
         if (scopeContext.scope === 'partner') {
-          newUserPartnerId = scopeContext.partnerId;
-          newUserOrgId = null;
-        } else {
-          const [scopeOrg] = await tx
-            .select({ partnerId: organizations.partnerId })
-            .from(organizations)
-            .where(eq(organizations.id, scopeContext.orgId))
-            .limit(1);
-          if (!scopeOrg) {
-            throw new HTTPException(500, { message: 'Scope org not found' });
-          }
-          newUserPartnerId = scopeOrg.partnerId;
-          newUserOrgId = scopeContext.orgId;
+          return { partnerId: scopeContext.partnerId, orgId: null };
         }
+        const [scopeOrg] = await tx
+          .select({ partnerId: organizations.partnerId })
+          .from(organizations)
+          .where(eq(organizations.id, scopeContext.orgId))
+          .limit(1);
+        if (!scopeOrg) {
+          throw new HTTPException(500, { message: 'Scope org not found' });
+        }
+        return { partnerId: scopeOrg.partnerId, orgId: scopeContext.orgId };
+      };
 
+      if (!user) {
+        const tenancy = await resolveInviteTenancy();
         const [created] = await tx
           .insert(users)
           .values({
-            partnerId: newUserPartnerId,
-            orgId: newUserOrgId,
+            partnerId: tenancy.partnerId,
+            orgId: tenancy.orgId,
             email: normalizedEmail,
             name: data.name,
             status: 'invited'
@@ -1105,6 +1102,34 @@ userRoutes.post(
           .returning();
 
         user = created;
+      } else if (user.status === 'disabled' && user.passwordHash === null) {
+        // Resurrect a neutralized tombstone (#1367): a prior delete (or the
+        // backfill migration) left this email as a disabled, password-less,
+        // membership-less row. Reset it to a clean invited state so the new
+        // invitee can set a password via the magic link (accept-invite requires
+        // status='invited'), and re-home it under the inviting scope. We touch
+        // ONLY tombstones (disabled + no password) — an active multi-membership
+        // user being added to another scope keeps their credentials untouched.
+        const tenancy = await resolveInviteTenancy();
+        const [reset] = await tx
+          .update(users)
+          .set({
+            name: data.name,
+            status: 'invited',
+            passwordHash: null,
+            partnerId: tenancy.partnerId,
+            orgId: tenancy.orgId,
+            disabledReason: null,
+            mfaEnabled: false,
+            mfaSecret: null,
+            mfaMethod: null,
+            mfaRecoveryCodes: null,
+            updatedAt: new Date()
+          })
+          .where(eq(users.id, user.id))
+          .returning();
+
+        user = reset;
       }
 
       if (!user) {
@@ -1377,6 +1402,97 @@ userRoutes.patch(
   }
 );
 
+// A membership-only delete leaves the `users` row behind. If the user has no
+// membership left in EITHER axis, that row is an orphan, and left active it is
+// a problem two ways (#1367):
+//   1. SECURITY: the "deleted" user can still authenticate. login.ts only
+//      bounces on a null password_hash / non-active status, and
+//      resolveCurrentUserTokenContext returns a null-context system-scope token
+//      (instead of throwing) for a membership-less user — so a removed user who
+//      still knows their password logs straight back in.
+//   2. RESURRECTION: re-inviting the same email reuses the row with its stale
+//      active status + password, blocking the new invitee's magic link.
+// The row cannot be hard-deleted (dozens of created_by/approved_by FKs RESTRICT
+// it), so we neutralize it: disable + strip password and MFA secrets. A later
+// invite of this email resets it to a clean invited state (see /invite).
+//
+// MUST run under SYSTEM scope, not the caller's request scope: the orphan check
+// has to see the user's memberships across EVERY tenant. An org admin's RLS
+// view hides partner memberships and other orgs' rows, so a request-scoped
+// check would falsely report a still-active multi-org user as orphaned and
+// wrongly disable them. The caller is assumed to already be inside this file's
+// system-scoped removal transaction so the just-deleted membership is visible.
+async function neutralizeUserIfOrphaned(userId: string): Promise<void> {
+  const [partnerLink] = await db
+    .select({ id: partnerUsers.id })
+    .from(partnerUsers)
+    .where(eq(partnerUsers.userId, userId))
+    .limit(1);
+  if (partnerLink) return;
+
+  const [orgLink] = await db
+    .select({ id: organizationUsers.id })
+    .from(organizationUsers)
+    .where(eq(organizationUsers.userId, userId))
+    .limit(1);
+  if (orgLink) return;
+
+  await db
+    .update(users)
+    .set({
+      status: 'disabled',
+      disabledReason: 'removed',
+      passwordHash: null,
+      mfaEnabled: false,
+      mfaSecret: null,
+      mfaMethod: null,
+      mfaRecoveryCodes: null,
+      updatedAt: new Date()
+    })
+    .where(eq(users.id, userId));
+}
+
+/**
+ * Remove a user's membership in the caller's tenant and, if it was their last
+ * membership anywhere, neutralize the orphaned `users` row — in one
+ * SYSTEM-scoped transaction.
+ *
+ * System scope (not the request scope) is required for the orphan check to see
+ * cross-tenant memberships, and so the neutralize UPDATE can target a `users`
+ * row whose org_id lies outside the caller's scope without RLS silently
+ * dropping it (the #1375 0-row trap). Tenant safety is preserved by the
+ * explicit membership-delete WHERE clause, scoped to the caller's own
+ * partner/org from their authenticated context — exactly as the request-scoped
+ * delete was before. Running delete + check + neutralize in one transaction is
+ * what makes the just-deleted membership visible to the orphan check.
+ */
+async function removeMembershipForScope(
+  scopeContext: ScopeContext,
+  userId: string
+): Promise<{ deleted: boolean }> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const deleted =
+        scopeContext.scope === 'partner'
+          ? await db
+              .delete(partnerUsers)
+              .where(and(eq(partnerUsers.partnerId, scopeContext.partnerId), eq(partnerUsers.userId, userId)))
+              .returning({ id: partnerUsers.id })
+          : await db
+              .delete(organizationUsers)
+              .where(and(eq(organizationUsers.orgId, scopeContext.orgId), eq(organizationUsers.userId, userId)))
+              .returning({ id: organizationUsers.id });
+
+      if (deleted.length === 0) {
+        return { deleted: false };
+      }
+
+      await neutralizeUserIfOrphaned(userId);
+      return { deleted: true };
+    })
+  );
+}
+
 userRoutes.delete(
   '/:id',
   requirePermission(PERMISSIONS.USERS_DELETE.resource, PERMISSIONS.USERS_DELETE.action),
@@ -1387,12 +1503,9 @@ userRoutes.delete(
     const userId = c.req.param('id')!;
 
     if (scopeContext.scope === 'partner') {
-      const deleted = await db
-        .delete(partnerUsers)
-        .where(and(eq(partnerUsers.partnerId, scopeContext.partnerId), eq(partnerUsers.userId, userId)))
-        .returning({ id: partnerUsers.id });
+      const { deleted } = await removeMembershipForScope(scopeContext, userId);
 
-      if (deleted.length === 0) {
+      if (!deleted) {
         return c.json({ error: 'User not found' }, 404);
       }
 
@@ -1419,12 +1532,9 @@ userRoutes.delete(
       return c.json({ success: true });
     }
 
-    const deleted = await db
-      .delete(organizationUsers)
-      .where(and(eq(organizationUsers.orgId, scopeContext.orgId), eq(organizationUsers.userId, userId)))
-      .returning({ id: organizationUsers.id });
+    const { deleted } = await removeMembershipForScope(scopeContext, userId);
 
-    if (deleted.length === 0) {
+    if (!deleted) {
       return c.json({ error: 'User not found' }, 404);
     }
 


### PR DESCRIPTION
## Problem

`DELETE /users/:id` was a **membership-only** delete — it removed the `partner_users` / `organization_users` row but left the `users` row behind with its old name, `status='active'`, and `password_hash`. Three defects stacked on that orphan (reported by @TheMoroney, traced by @bdunncompany):

1. **Security** — a "deleted" user could still **log in**. `login.ts` only bounces on a null `password_hash` / non-active status, and `resolveCurrentUserTokenContext` returns a null-context **system-scope** token (rather than throwing) for a membership-less user. A removed user who knew their password logged straight back in. *(Not called out in the original report — found while tracing.)*
2. **Resurrection** — re-inviting the same email reused the orphaned row with its stale active status + password.
3. **Blocked invite** — accept-invite requires `status='invited'`, so the resurrected active row blocked the new invitee's magic link ("invite already accepted").

The `users` row **cannot be hard-deleted** — dozens of `created_by`/`approved_by`/`triggered_by` FKs reference it with `ON DELETE RESTRICT` (the #1407 class), so a delete would 500 for any user who ever created anything.

## Fix

- **Delete** removes the membership and, if it was the user's last membership anywhere, **neutralizes** the row (`status='disabled'`, `password_hash=NULL`, MFA cleared) — in one **system-scoped** transaction. System scope is required so the orphan check sees memberships across *every* tenant (an org admin's RLS view hides a multi-org user's other memberships — a request-scoped check would falsely disable a still-active user) and so the neutralize `UPDATE` isn't silently dropped by RLS (the #1375 0-row trap). Tenant safety is preserved by the explicit membership-delete `WHERE` clause, scoped to the caller's own partner/org.
- **Invite** resets a neutralized tombstone (disabled + no password) back to a clean invited state and re-homes it under the inviting scope. Active multi-membership users keep their credentials untouched.
- **Backfill migration** neutralizes pre-existing orphans so already-"deleted" users in production can no longer authenticate. Idempotent; reports the row count for the forensic trail.

## Testing

Real-DB integration test (`breeze_app`, forced RLS — verified `bypassrls=false`):

- ✅ Delete neutralizes the orphaned row (status disabled, password null) — login hole closed.
- ✅ A **multi-org user keeps access** when only one of their memberships is removed (the correctness proof for running the orphan check under system scope — the deleting org-B admin can't see the user's org-A membership under RLS).
- ✅ Re-invite resurrects the tombstone cleanly (`status='invited'`, password null, new name, fresh membership) so the magic link works.

Also: existing `users.test.ts` (59 tests) green; migration applies idempotently (twice, no-op second time); `users.ts` typechecks clean.

Closes #1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)