### PR TITLE
feat(web): redesign Product Catalog + add Catalog/Contracts to sidebar

### DIFF
--- a/apps/web/src/components/layout/Sidebar.nav.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.nav.test.tsx
@@ -54,9 +54,11 @@ describe('navSections structure (#1321, #1324)', () => {
     expect(ops).not.toContain('/backup');
     expect(ops).not.toContain('/c2c');
     expect(ops).not.toContain('/dr');
-    // Operations retains its non-backup items (Invoices + Product Catalog added by the billing engine).
+    // Operations retains its non-backup items (Invoices, Contracts, Product Catalog
+    // added by the billing engine).
     expect(ops).toEqual([
       '/billing/invoices',
+      '/contracts',
       '/settings/catalog',
       '/software',
       '/software-inventory',

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   ShieldAlert,
   Terminal,
   FileText,
+  FileSignature,
   Receipt,
   Tags,
   FileSpreadsheet,
@@ -163,6 +164,7 @@ export const navSections: NavSection[] = [
     icon: Layers,
     items: [
       { name: 'Invoices', href: '/billing/invoices', icon: Receipt },
+      { name: 'Contracts', href: '/contracts', icon: FileSignature, partnerScopeOnly: true },
       { name: 'Product Catalog', href: '/settings/catalog', icon: Tags, partnerScopeOnly: true },
       { name: 'Software Library', href: '/software', icon: Package },
       { name: 'Software Policies', href: '/software-inventory', icon: Package },

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -1,0 +1,473 @@
+import {
+  useCallback, useEffect, useId, useMemo, useRef, useState,
+  type KeyboardEvent, type MouseEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { runAction, handleActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+import {
+  createCatalogItem, updateCatalogItem, getCatalogItem, setBundleComponents,
+  computeMargin, formatMargin, marginTone,
+  CATALOG_TYPE_LABELS, CATALOG_TYPE_ORDER,
+  type CatalogItem, type CatalogItemType, type CatalogItemDetail,
+} from '../../lib/api/catalog';
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+// A bundle component as edited in the form (quantity kept as a string for free typing).
+interface ComponentDraft {
+  componentItemId: string;
+  quantity: string;
+  showOnInvoice: boolean;
+}
+
+interface Props {
+  open: boolean;
+  /** The item being edited, or null to create a new one. */
+  item: CatalogItem | null;
+  /** Active catalog items, used to populate the bundle component picker. */
+  allItems: CatalogItem[];
+  onClose: () => void;
+  /** Called after a fully-successful save (item + components) so the host reloads. */
+  onSaved: () => void;
+}
+
+/** Map a server bundle error code to a short user-facing message. */
+function bundleFriendly(code: string): string | undefined {
+  switch (code) {
+    case 'BUNDLE_NESTED': return 'A bundle component cannot itself be a bundle.';
+    case 'BUNDLE_SELF_REFERENCE': return 'A bundle cannot contain itself.';
+    case 'BUNDLE_CROSS_PARTNER': return 'Components must belong to your catalog.';
+    case 'BUNDLE_COMPONENT_NOT_FOUND': return 'One or more components no longer exist.';
+    case 'BUNDLE_DUPLICATE_COMPONENT': return 'Each component can only be added once.';
+    case 'NOT_A_BUNDLE': return 'This item is not a bundle.';
+    default: return undefined;
+  }
+}
+
+export default function CatalogItemEditorDrawer({ open, item, allItems, onClose, onSaved }: Props) {
+  const editId = item?.id ?? null;
+
+  const [itemType, setItemType] = useState<CatalogItemType>('service');
+  const [name, setName] = useState('');
+  const [sku, setSku] = useState('');
+  const [unitPrice, setUnitPrice] = useState('');
+  const [costBasis, setCostBasis] = useState('');
+  const [isBundle, setIsBundle] = useState(false);
+  const [components, setComponents] = useState<ComponentDraft[]>([]);
+  const [componentsLoading, setComponentsLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // Once a *new* item is created we hold its id, so a retry after a partial
+  // failure (item saved, components failed) PATCHes instead of creating a dupe.
+  const [committedId, setCommittedId] = useState<string | null>(null);
+  const effectiveId = editId ?? committedId;
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+  const titleId = useId();
+
+  // ---- hydrate form when opened -------------------------------------------
+  useEffect(() => {
+    if (!open) return;
+    setCommittedId(null);
+    setSaving(false);
+    if (item) {
+      setItemType(item.itemType);
+      setName(item.name);
+      setSku(item.sku ?? '');
+      setUnitPrice(item.unitPrice);
+      setCostBasis(item.costBasis ?? '');
+      setIsBundle(item.isBundle);
+      setComponents([]);
+      if (item.isBundle) {
+        setComponentsLoading(true);
+        void getCatalogItem(item.id)
+          .then(async (res) => {
+            if (res.status === 401) return UNAUTHORIZED();
+            if (!res.ok) return;
+            const body = (await res.json().catch(() => null)) as { data?: CatalogItemDetail } | null;
+            const rows = body?.data?.components ?? [];
+            setComponents(rows.map((r) => ({
+              componentItemId: r.componentItemId,
+              quantity: r.quantity,
+              showOnInvoice: r.showOnInvoice,
+            })));
+          })
+          .finally(() => setComponentsLoading(false));
+      }
+    } else {
+      setItemType('service');
+      setName('');
+      setSku('');
+      setUnitPrice('');
+      setCostBasis('');
+      setIsBundle(false);
+      setComponents([]);
+    }
+  }, [open, item]);
+
+  // ---- a11y: focus, scroll-lock, escape, focus-trap -----------------------
+  useEffect(() => {
+    if (!open) return;
+    triggerRef.current = document.activeElement;
+    const raf = requestAnimationFrame(() => {
+      const first = panelRef.current?.querySelector<HTMLElement>(FOCUSABLE);
+      (first ?? panelRef.current)?.focus();
+    });
+    document.body.style.overflow = 'hidden';
+    return () => {
+      cancelAnimationFrame(raf);
+      document.body.style.overflow = '';
+      if (triggerRef.current instanceof HTMLElement) triggerRef.current.focus();
+    };
+  }, [open]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') { e.stopPropagation(); onClose(); return; }
+    if (e.key === 'Tab' && panelRef.current) {
+      const nodes = Array.from(panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    }
+  }, [onClose]);
+
+  const handleBackdropClick = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget && !saving) onClose();
+  }, [onClose, saving]);
+
+  // ---- bundle component editing -------------------------------------------
+  const selectedIds = useMemo(() => new Set(components.map((c) => c.componentItemId)), [components]);
+
+  // Items eligible to add as a component: active, not a bundle, not this item.
+  const eligible = useMemo(
+    () => allItems.filter((i) => i.isActive && !i.isBundle && i.id !== effectiveId),
+    [allItems, effectiveId],
+  );
+
+  const itemName = useCallback(
+    (id: string) => allItems.find((i) => i.id === id)?.name ?? 'Unknown item',
+    [allItems],
+  );
+
+  const addComponent = () => setComponents((cs) => [...cs, { componentItemId: '', quantity: '1', showOnInvoice: false }]);
+  const removeComponent = (idx: number) => setComponents((cs) => cs.filter((_, i) => i !== idx));
+  const patchComponent = (idx: number, patch: Partial<ComponentDraft>) =>
+    setComponents((cs) => cs.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+
+  // ---- save ----------------------------------------------------------------
+  const priceNum = Number(unitPrice);
+  const priceValid = unitPrice.trim() !== '' && Number.isFinite(priceNum);
+  const marginPreview = computeMargin(unitPrice, costBasis);
+  const canSave = !saving && name.trim() !== '' && priceValid;
+
+  const save = useCallback(async () => {
+    if (saving) return;
+    if (!name.trim()) { showToast({ message: 'Enter an item name.', type: 'error' }); return; }
+    if (!priceValid) { showToast({ message: 'Enter a valid unit price.', type: 'error' }); return; }
+
+    const comps = isBundle ? components : [];
+    for (const c of comps) {
+      if (!c.componentItemId) { showToast({ message: 'Pick an item for every bundle component.', type: 'error' }); return; }
+      const q = Number(c.quantity);
+      if (c.quantity.trim() === '' || !Number.isFinite(q) || q <= 0) {
+        showToast({ message: 'Component quantity must be greater than 0.', type: 'error' });
+        return;
+      }
+    }
+
+    const body = {
+      itemType,
+      name: name.trim(),
+      sku: sku.trim() || null,
+      unitPrice: priceNum,
+      costBasis: costBasis.trim() ? Number(costBasis) : null,
+      isBundle,
+    };
+
+    setSaving(true);
+    try {
+      const targetId = effectiveId;
+      const saved = await runAction<{ data: CatalogItem }>({
+        request: () => (targetId ? updateCatalogItem(targetId, body) : createCatalogItem(body)),
+        errorFallback: targetId ? 'Update failed. Retry.' : 'Item creation failed. Retry.',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      const savedId = saved.data.id;
+      // Remember the id so a component-step retry edits rather than re-creates.
+      if (!editId) setCommittedId(savedId);
+
+      if (isBundle) {
+        await runAction({
+          request: () => setBundleComponents(savedId, comps.map((c) => ({
+            componentItemId: c.componentItemId,
+            quantity: Number(c.quantity),
+            showOnInvoice: c.showOnInvoice,
+          }))),
+          errorFallback: 'Bundle components could not be saved. Retry.',
+          friendly: bundleFriendly,
+          onUnauthorized: UNAUTHORIZED,
+        });
+      }
+
+      showToast({ message: editId ? 'Item updated' : `Item "${body.name}" created`, type: 'success' });
+      onSaved();
+      onClose();
+    } catch (err) {
+      handleActionError(err, 'Save failed. Retry.');
+    } finally {
+      setSaving(false);
+    }
+  }, [saving, name, priceValid, isBundle, components, itemType, sku, priceNum, costBasis, effectiveId, editId, onSaved, onClose]);
+
+  if (!open || typeof document === 'undefined') return null;
+
+  const fieldCls = 'w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring';
+
+  return createPortal(
+    <div
+      className="dialog-backdrop fixed inset-0 z-50 flex justify-end bg-background/80"
+      style={{ animation: 'dialog-backdrop-in 150ms ease-out' }}
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      data-testid="catalog-editor-backdrop"
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className="drawer-panel flex h-full w-full max-w-md flex-col border-l bg-card shadow-xl focus:outline-none"
+        style={{ animation: 'slide-in-from-right 220ms cubic-bezier(0.22, 1, 0.36, 1)' }}
+        data-testid="catalog-item-editor"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-5 py-4">
+          <h2 id={titleId} className="text-base font-semibold">
+            {editId ? 'Edit item' : 'New item'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Close"
+            data-testid="catalog-form-close"
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6 6 18M6 6l12 12" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body (scrolls) */}
+        <div className="flex-1 space-y-4 overflow-y-auto px-5 py-5">
+          {/* Type — segmented */}
+          <div>
+            <span className="mb-1.5 block text-xs font-medium text-muted-foreground">Type</span>
+            <div className="grid grid-cols-3 gap-1 rounded-md border bg-muted/40 p-1" role="group" aria-label="Item type">
+              {CATALOG_TYPE_ORDER.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setItemType(t)}
+                  aria-pressed={itemType === t}
+                  className={`rounded px-2 py-1.5 text-sm font-medium transition ${
+                    itemType === t ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                  data-testid={`catalog-form-type-${t}`}
+                >
+                  {CATALOG_TYPE_LABELS[t]}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="catalog-form-name-input">Name</label>
+            <input
+              id="catalog-form-name-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={fieldCls}
+              placeholder="e.g. Managed Workstation"
+              data-testid="catalog-form-name"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="catalog-form-sku-input">SKU <span className="font-normal opacity-70">(optional)</span></label>
+            <input
+              id="catalog-form-sku-input"
+              value={sku}
+              onChange={(e) => setSku(e.target.value)}
+              className={`${fieldCls} font-mono`}
+              placeholder="SKU-001"
+              data-testid="catalog-form-sku"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="catalog-form-price-input">Unit price</label>
+              <input
+                id="catalog-form-price-input"
+                value={unitPrice}
+                onChange={(e) => setUnitPrice(e.target.value)}
+                inputMode="decimal"
+                className={`${fieldCls} text-right tabular-nums`}
+                placeholder="0.00"
+                data-testid="catalog-form-price"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="catalog-form-cost-input">Cost basis <span className="font-normal opacity-70">(optional)</span></label>
+              <input
+                id="catalog-form-cost-input"
+                value={costBasis}
+                onChange={(e) => setCostBasis(e.target.value)}
+                inputMode="decimal"
+                className={`${fieldCls} text-right tabular-nums`}
+                placeholder="0.00"
+                data-testid="catalog-form-cost"
+              />
+            </div>
+          </div>
+
+          {/* Live margin preview */}
+          <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2 text-sm" data-testid="catalog-form-margin">
+            <span className="text-muted-foreground">Margin</span>
+            <span className={`font-medium tabular-nums ${marginTone(marginPreview)}`}>
+              {marginPreview == null ? 'Add a cost basis to see margin' : formatMargin(marginPreview)}
+            </span>
+          </div>
+
+          {/* Bundle toggle */}
+          <label className="flex items-center gap-2.5 rounded-md border px-3 py-2.5 text-sm">
+            <input
+              type="checkbox"
+              checked={isBundle}
+              onChange={(e) => setIsBundle(e.target.checked)}
+              className="h-4 w-4"
+              data-testid="catalog-form-bundle"
+            />
+            <span>
+              <span className="font-medium">This item is a bundle</span>
+              <span className="block text-xs text-muted-foreground">Groups other catalog items sold together.</span>
+            </span>
+          </label>
+
+          {/* Bundle component builder */}
+          {isBundle && (
+            <div className="space-y-2 rounded-md border p-3" data-testid="catalog-bundle-builder">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">Items included in this bundle</span>
+                <button
+                  type="button"
+                  onClick={addComponent}
+                  className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted"
+                  data-testid="catalog-bundle-add"
+                >
+                  Add component
+                </button>
+              </div>
+
+              {componentsLoading ? (
+                <p className="py-2 text-center text-xs text-muted-foreground">Loading components.</p>
+              ) : components.length === 0 ? (
+                <p className="py-2 text-center text-xs text-muted-foreground" data-testid="catalog-bundle-empty">
+                  No components yet. Add the items this bundle includes.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {components.map((c, idx) => {
+                    // Options: eligible items not already chosen, plus this row's own choice.
+                    const opts = eligible.filter((e) => !selectedIds.has(e.id) || e.id === c.componentItemId);
+                    return (
+                      <li key={idx} className="space-y-1.5 rounded-md border bg-background p-2" data-testid={`catalog-bundle-row-${idx}`}>
+                        <div className="flex items-center gap-2">
+                          <select
+                            value={c.componentItemId}
+                            onChange={(e) => patchComponent(idx, { componentItemId: e.target.value })}
+                            className="h-9 flex-1 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                            data-testid={`catalog-bundle-item-${idx}`}
+                          >
+                            <option value="">Select item…</option>
+                            {c.componentItemId && !opts.some((o) => o.id === c.componentItemId) && (
+                              <option value={c.componentItemId}>{itemName(c.componentItemId)}</option>
+                            )}
+                            {opts.map((o) => (
+                              <option key={o.id} value={o.id}>{o.name}</option>
+                            ))}
+                          </select>
+                          <input
+                            value={c.quantity}
+                            onChange={(e) => patchComponent(idx, { quantity: e.target.value })}
+                            inputMode="decimal"
+                            aria-label="Quantity"
+                            className="h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
+                            data-testid={`catalog-bundle-qty-${idx}`}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removeComponent(idx)}
+                            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive"
+                            aria-label="Remove component"
+                            data-testid={`catalog-bundle-remove-${idx}`}
+                          >
+                            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                              <path d="M3 6h18M8 6V4h8v2m-9 0v14a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                          </button>
+                        </div>
+                        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                          <input
+                            type="checkbox"
+                            checked={c.showOnInvoice}
+                            onChange={(e) => patchComponent(idx, { showOnInvoice: e.target.checked })}
+                            data-testid={`catalog-bundle-showoninvoice-${idx}`}
+                          />
+                          Show this line on the invoice
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer (sticky) */}
+        <div className="flex items-center justify-end gap-2 border-t px-5 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+            data-testid="catalog-form-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={!canSave}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+            data-testid="catalog-form-save"
+          >
+            {saving ? 'Saving…' : editId ? 'Save changes' : 'Create item'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/settings/CatalogItemsTab.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.test.tsx
@@ -81,6 +81,21 @@ describe('CatalogItemsTab', () => {
     await waitFor(() => expect(detail).toHaveTextContent('60.0%'));
   });
 
+  it('archives an item from the row overflow (kebab) menu', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Laptop');
+    // Archive is hidden until the kebab is opened.
+    expect(screen.queryByTestId('catalog-archive-l1')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('catalog-actions-l1'));
+    fireEvent.click(await screen.findByTestId('catalog-archive-l1'));
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(
+        (c) => String(c[0]) === '/catalog/l1/archive' && (c[1] as RequestInit | undefined)?.method === 'POST',
+      );
+      expect(call).toBeTruthy();
+    });
+  });
+
   it('creates a bundle and PUTs components including showOnInvoice', async () => {
     render(<CatalogItemsTab />);
     await screen.findByText('Widget Service');

--- a/apps/web/src/components/settings/CatalogItemsTab.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CatalogItemsTab from './CatalogItemsTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../lib/authScope', () => ({
+  getJwtClaims: () => ({ scope: 'partner' }),
+  loginPathWithNext: () => '/login',
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const baseItem = {
+  partnerId: 'p1', description: null, billingType: 'one_time' as const,
+  markupPercent: null, unitOfMeasure: 'each', taxable: true, taxCategory: null,
+  isActive: true, createdAt: '2026-01-01', updatedAt: '2026-01-01',
+};
+const WIDGET = { ...baseItem, id: 'w1', itemType: 'service' as const, name: 'Widget Service', sku: 'WID-1', unitPrice: '100.00', costBasis: '60.00', isBundle: false };
+const LAPTOP = { ...baseItem, id: 'l1', itemType: 'hardware' as const, name: 'Laptop', sku: 'LAP-9', unitPrice: '1200.00', costBasis: null, isBundle: false };
+const BUNDLE = { ...baseItem, id: 'b1', itemType: 'service' as const, name: 'Starter Bundle', sku: null, unitPrice: '1500.00', costBasis: null, isBundle: true };
+
+function seed(active = [WIDGET, LAPTOP, BUNDLE]) {
+  fetchMock.mockImplementation(async (url, opts) => {
+    const u = String(url);
+    const method = (opts as RequestInit | undefined)?.method ?? 'GET';
+    if (u.startsWith('/catalog?')) return jsonResponse({ data: active });
+    if (u === '/catalog' && method === 'POST') return jsonResponse({ data: { ...baseItem, id: 'new-1', itemType: 'service', name: 'New', sku: null, unitPrice: '500.00', costBasis: null, isBundle: true } });
+    if (u.endsWith('/economics')) return jsonResponse({ data: { headlinePrice: '1500.00', totalCost: '600.00', margin: '900.00', marginPct: 60, allocationTotal: '0.00', allocationMatchesHeadline: true } });
+    if (u.endsWith('/components') && method === 'PUT') return jsonResponse({ data: {} });
+    if (/^\/catalog\/[^/?]+$/.test(u)) {
+      return jsonResponse({ data: { item: BUNDLE, overrides: [], components: [{ id: 'bc1', partnerId: 'p1', bundleItemId: 'b1', componentItemId: 'w1', quantity: '3.00', showOnInvoice: true, revenueAllocation: null }] } });
+    }
+    return jsonResponse({});
+  });
+}
+
+describe('CatalogItemsTab', () => {
+  beforeEach(() => { vi.clearAllMocks(); seed(); });
+
+  it('renders items with type chips and computed margin', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Widget Service');
+    expect(screen.getByText('Laptop')).toBeInTheDocument();
+    expect(screen.getByText('Starter Bundle')).toBeInTheDocument();
+    // Widget: (100-60)/100 = 40%
+    expect(screen.getByTestId('catalog-margin-w1')).toHaveTextContent('40.0%');
+    // Laptop: no cost basis → em-dash
+    expect(screen.getByTestId('catalog-margin-l1')).toHaveTextContent('—');
+    // Type chip in the Laptop row (the word also appears in the type filter).
+    expect(within(screen.getByTestId('catalog-item-row-l1')).getByText('Hardware')).toBeInTheDocument();
+  });
+
+  it('filters rows by search across name and SKU', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Widget Service');
+    fireEvent.change(screen.getByTestId('catalog-search'), { target: { value: 'LAP-9' } });
+    expect(screen.getByText('Laptop')).toBeInTheDocument();
+    expect(screen.queryByText('Widget Service')).not.toBeInTheDocument();
+  });
+
+  it('expands a bundle to show its components and rolled-up economics', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Starter Bundle');
+    fireEvent.click(screen.getByTestId('catalog-bundle-toggle-b1'));
+    const detail = await screen.findByTestId('catalog-bundle-detail-b1');
+    // component line: 3× Widget Service, plus the economics rollup
+    expect(detail).toHaveTextContent('Widget Service');
+    expect(detail).toHaveTextContent('on invoice');
+    await waitFor(() => expect(detail).toHaveTextContent('60.0%'));
+  });
+
+  it('creates a bundle and PUTs components including showOnInvoice', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Widget Service');
+
+    fireEvent.click(screen.getByTestId('catalog-add-item'));
+    const drawer = await screen.findByTestId('catalog-item-editor');
+    fireEvent.change(within(drawer).getByTestId('catalog-form-name'), { target: { value: 'Bundle X' } });
+    fireEvent.change(within(drawer).getByTestId('catalog-form-price'), { target: { value: '500' } });
+    fireEvent.click(within(drawer).getByTestId('catalog-form-bundle'));
+
+    // Add one component → Widget, qty 2, show on invoice
+    fireEvent.click(within(drawer).getByTestId('catalog-bundle-add'));
+    fireEvent.change(within(drawer).getByTestId('catalog-bundle-item-0'), { target: { value: 'w1' } });
+    fireEvent.change(within(drawer).getByTestId('catalog-bundle-qty-0'), { target: { value: '2' } });
+    fireEvent.click(within(drawer).getByTestId('catalog-bundle-showoninvoice-0'));
+
+    fireEvent.click(within(drawer).getByTestId('catalog-form-save'));
+
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(
+        (c) => String(c[0]).endsWith('/components') && (c[1] as RequestInit | undefined)?.method === 'PUT',
+      );
+      expect(put).toBeTruthy();
+      expect(String(put![0])).toBe('/catalog/new-1/components');
+      expect(JSON.parse((put![1] as RequestInit).body as string)).toEqual({
+        components: [{ componentItemId: 'w1', quantity: 2, showOnInvoice: true }],
+      });
+    });
+
+    // item POST happened before the components PUT
+    const post = fetchMock.mock.calls.find((c) => String(c[0]) === '/catalog' && (c[1] as RequestInit | undefined)?.method === 'POST');
+    expect(post).toBeTruthy();
+    expect(JSON.parse((post![1] as RequestInit).body as string)).toMatchObject({ name: 'Bundle X', unitPrice: 500, isBundle: true });
+  });
+});

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
@@ -354,37 +355,15 @@ export default function CatalogItemsTab() {
                           {formatMargin(margin)}
                         </td>
                         <td className="px-3 py-3 text-right">
-                          <span className="inline-flex gap-3 whitespace-nowrap">
-                            <button
-                              type="button"
-                              onClick={() => openEdit(it)}
-                              className="text-sm text-muted-foreground hover:text-foreground"
-                              data-testid={`catalog-edit-${it.id}`}
-                            >
-                              Edit
-                            </button>
-                            {view === 'active' ? (
-                              <button
-                                type="button"
-                                onClick={() => void archive(it.id)}
-                                disabled={archivingId !== null}
-                                className="text-sm text-destructive hover:underline disabled:opacity-50"
-                                data-testid={`catalog-archive-${it.id}`}
-                              >
-                                {archivingId === it.id ? 'Archiving…' : 'Archive'}
-                              </button>
-                            ) : (
-                              <button
-                                type="button"
-                                onClick={() => void restore(it.id)}
-                                disabled={archivingId !== null}
-                                className="text-sm text-primary hover:underline disabled:opacity-50"
-                                data-testid={`catalog-restore-${it.id}`}
-                              >
-                                {archivingId === it.id ? 'Restoring…' : 'Restore'}
-                              </button>
-                            )}
-                          </span>
+                          <RowActions
+                            item={it}
+                            view={view}
+                            busy={archivingId === it.id}
+                            disabled={archivingId !== null}
+                            onEdit={() => openEdit(it)}
+                            onArchive={() => void archive(it.id)}
+                            onRestore={() => void restore(it.id)}
+                          />
                         </td>
                       </tr>
                       {isOpen && (
@@ -450,4 +429,122 @@ export default function CatalogItemsTab() {
 // element (which would be invalid inside <tbody>).
 function FragmentRow({ children }: { children: ReactNode }) {
   return <>{children}</>;
+}
+
+// Per-row overflow ("⋯") menu. The table scrolls horizontally (overflow-x-auto),
+// which would clip an absolutely-positioned dropdown, so the menu is portalled to
+// <body> and positioned with fixed coordinates from the trigger's rect.
+function RowActions({
+  item, view, busy, disabled, onEdit, onArchive, onRestore,
+}: {
+  item: CatalogItem;
+  view: View;
+  busy: boolean;
+  disabled: boolean;
+  onEdit: () => void;
+  onArchive: () => void;
+  onRestore: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const place = useCallback(() => {
+    const r = btnRef.current?.getBoundingClientRect();
+    if (r) setCoords({ top: r.bottom + 4, right: window.innerWidth - r.right });
+  }, []);
+
+  const openMenu = () => { place(); setOpen(true); };
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current?.contains(e.target as Node) || btnRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    const close = () => setOpen(false);
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    // Any scroll/resize invalidates the fixed coords — just close.
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [open]);
+
+  const itemCls = 'flex w-full items-center px-3 py-1.5 text-left text-sm hover:bg-muted disabled:opacity-50';
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => (open ? setOpen(false) : openMenu())}
+        disabled={disabled && !busy}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Row actions"
+        className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+        data-testid={`catalog-actions-${item.id}`}
+      >
+        {busy ? (
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        ) : (
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <circle cx="5" cy="12" r="1.6" />
+            <circle cx="12" cy="12" r="1.6" />
+            <circle cx="19" cy="12" r="1.6" />
+          </svg>
+        )}
+      </button>
+
+      {open && typeof document !== 'undefined' && createPortal(
+        <div
+          ref={menuRef}
+          role="menu"
+          className="fixed z-50 w-36 overflow-hidden rounded-md border bg-card py-1 shadow-lg"
+          style={{ top: coords.top, right: coords.right }}
+          data-testid={`catalog-actions-menu-${item.id}`}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => { setOpen(false); onEdit(); }}
+            className={itemCls}
+            data-testid={`catalog-edit-${item.id}`}
+          >
+            Edit
+          </button>
+          {view === 'active' ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => { setOpen(false); onArchive(); }}
+              className={`${itemCls} text-destructive`}
+              data-testid={`catalog-archive-${item.id}`}
+            >
+              Archive
+            </button>
+          ) : (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => { setOpen(false); onRestore(); }}
+              className={`${itemCls} text-primary`}
+              data-testid={`catalog-restore-${item.id}`}
+            >
+              Restore
+            </button>
+          )}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
 }

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -1,359 +1,453 @@
-import { useCallback, useEffect, useState } from 'react';
-import { fetchWithAuth } from '../../stores/auth';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { runAction, handleActionError } from '../../lib/runAction';
-import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
-
-// Catalog items are partner-scoped. numeric(12,2) columns (unitPrice, costBasis)
-// serialize to JSON as strings, so the price fields are typed as string here.
-interface CatalogItem {
-  id: string;
-  itemType: 'hardware' | 'software' | 'service';
-  name: string;
-  sku: string | null;
-  unitPrice: string;
-  costBasis: string | null;
-  isBundle: boolean;
-  isActive: boolean;
-}
-
-interface EditForm {
-  itemType: 'hardware' | 'software' | 'service';
-  name: string;
-  sku: string;
-  unitPrice: string;
-  costBasis: string;
-  isBundle: boolean;
-}
-
-const EMPTY_FORM: EditForm = {
-  itemType: 'service',
-  name: '',
-  sku: '',
-  unitPrice: '',
-  costBasis: '',
-  isBundle: false
-};
+import { formatMoney } from '../../lib/timeFormat';
+import CatalogItemEditorDrawer from './CatalogItemEditorDrawer';
+import {
+  listCatalog, getCatalogItem, getBundleEconomics, archiveCatalogItem, updateCatalogItem,
+  computeMargin, formatMargin, marginTone,
+  CATALOG_TYPE_LABELS, CATALOG_TYPE_CHIP, CATALOG_TYPE_ORDER, CATALOG_PAGE_LIMIT,
+  type CatalogItem, type CatalogItemType, type CatalogItemDetail,
+  type BundleComponentRow, type BundleEconomics,
+} from '../../lib/api/catalog';
 
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+type View = 'active' | 'archived';
+type TypeFilter = 'all' | CatalogItemType;
+type SortKey = 'name' | 'unitPrice' | 'margin';
+interface Sort { key: SortKey; dir: 'asc' | 'desc' }
+
+interface ExpandState {
+  loading: boolean;
+  components: BundleComponentRow[];
+  economics: BundleEconomics | null;
+}
 
 export default function CatalogItemsTab() {
   const [items, setItems] = useState<CatalogItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
-  const [editorOpen, setEditorOpen] = useState(false);
-  const [editId, setEditId] = useState<string | null>(null);
-  const [form, setForm] = useState<EditForm>(EMPTY_FORM);
-  // In-flight guards prevent double-submit duplicate POSTs.
-  const [saving, setSaving] = useState(false);
+  const [view, setView] = useState<View>('active');
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<Sort>({ key: 'name', dir: 'asc' });
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editItem, setEditItem] = useState<CatalogItem | null>(null);
   const [archivingId, setArchivingId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Record<string, ExpandState>>({});
 
   // Catalog routes enforce requireScope('partner','system') server-side. Mirror
-  // that client-side so org-scope users see a clear message instead of a
-  // misleading "failed to load" 403. getJwtClaims returns null scope on a
-  // missing/undecodable token; treat only confirmed 'organization' scope as
-  // denied so we never hard-block on a decode failure (server still re-checks).
+  // that here so org-scope users get a clear message instead of a misleading
+  // load error; only a confirmed 'organization' scope is blocked (a missing or
+  // undecodable token falls through and the server re-checks).
   const isOrgScoped = getJwtClaims().scope === 'organization';
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (v: View) => {
     setLoading(true);
     setError(false);
     try {
-      const res = await fetchWithAuth('/catalog?isActive=true');
-      if (res.ok) {
-        const body = (await res.json()) as { data: CatalogItem[] };
-        setItems(body.data ?? []);
-      } else {
-        setError(true);
-      }
+      const res = await listCatalog({ isActive: v === 'active', limit: CATALOG_PAGE_LIMIT });
+      if (res.status === 401) return UNAUTHORIZED();
+      if (!res.ok) { setError(true); return; }
+      const body = (await res.json().catch(() => null)) as { data?: CatalogItem[] } | null;
+      setItems(body?.data ?? []);
+      setExpanded({});
     } catch {
       setError(true);
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   }, []);
 
-  useEffect(() => { void load(); }, [load]);
+  useEffect(() => { void load(view); }, [load, view]);
 
-  const openCreate = () => {
-    setEditId(null);
-    setForm(EMPTY_FORM);
-    setEditorOpen(true);
-  };
-
-  const openEdit = (it: CatalogItem) => {
-    setEditId(it.id);
-    setForm({
-      itemType: it.itemType,
-      name: it.name,
-      sku: it.sku ?? '',
-      unitPrice: it.unitPrice,
-      costBasis: it.costBasis ?? '',
-      isBundle: it.isBundle
-    });
-    setEditorOpen(true);
-  };
-
-  const save = useCallback(async () => {
-    if (saving) return; // guard re-entry while a save is in flight
-    if (!form.name.trim()) return;
-    const unitPrice = Number(form.unitPrice);
-    // Blank or non-finite unit price: surface feedback instead of a silent
-    // no-op. (Save is also disabled in this state — this is the belt-and-braces
-    // path for keyboard/Enter submits.)
-    if (!form.unitPrice.trim() || !Number.isFinite(unitPrice)) {
-      showToast({ message: 'Enter a valid unit price.', type: 'error' });
-      return;
-    }
-    const body: Record<string, unknown> = {
-      itemType: form.itemType,
-      name: form.name.trim(),
-      sku: form.sku.trim() || null,
-      unitPrice,
-      costBasis: form.costBasis.trim() ? Number(form.costBasis) : null,
-      isBundle: form.isBundle
-    };
-    setSaving(true);
-    try {
-      await runAction({
-        request: () =>
-          editId
-            ? fetchWithAuth(`/catalog/${editId}`, { method: 'PATCH', body: JSON.stringify(body) })
-            : fetchWithAuth('/catalog', { method: 'POST', body: JSON.stringify(body) }),
-        errorFallback: editId ? 'Update failed. Retry.' : 'Item creation failed. Retry.',
-        successMessage: editId ? 'Item updated' : `Item "${form.name.trim()}" created`,
-        onUnauthorized: UNAUTHORIZED
-      });
-      setEditorOpen(false);
-      void load();
-    } catch (err) {
-      handleActionError(err, editId ? 'Update failed. Retry.' : 'Item creation failed. Retry.');
-    } finally {
-      setSaving(false);
-    }
-  }, [form, editId, load, saving]);
+  const openCreate = () => { setEditItem(null); setDrawerOpen(true); };
+  const openEdit = (it: CatalogItem) => { setEditItem(it); setDrawerOpen(true); };
 
   const archive = useCallback(async (id: string) => {
-    if (archivingId) return; // guard re-entry while an archive is in flight
+    if (archivingId) return;
     setArchivingId(id);
     try {
       await runAction({
-        request: () => fetchWithAuth(`/catalog/${id}/archive`, { method: 'POST' }),
+        request: () => archiveCatalogItem(id),
         errorFallback: 'Archive failed. Retry.',
         successMessage: 'Item archived',
-        onUnauthorized: UNAUTHORIZED
+        onUnauthorized: UNAUTHORIZED,
       });
-      void load();
+      void load(view);
     } catch (err) {
       handleActionError(err, 'Archive failed. Retry.');
     } finally {
       setArchivingId(null);
     }
-  }, [load, archivingId]);
+  }, [load, view, archivingId]);
 
+  const restore = useCallback(async (id: string) => {
+    if (archivingId) return;
+    setArchivingId(id);
+    try {
+      await runAction({
+        request: () => updateCatalogItem(id, { isActive: true }),
+        errorFallback: 'Restore failed. Retry.',
+        successMessage: 'Item restored',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      void load(view);
+    } catch (err) {
+      handleActionError(err, 'Restore failed. Retry.');
+    } finally {
+      setArchivingId(null);
+    }
+  }, [load, view, archivingId]);
+
+  const toggleExpand = useCallback((it: CatalogItem) => {
+    setExpanded((prev) => {
+      if (prev[it.id]) {
+        const next = { ...prev };
+        delete next[it.id];
+        return next;
+      }
+      // Lazily fetch this bundle's components + rolled-up economics.
+      void Promise.all([getCatalogItem(it.id), getBundleEconomics(it.id)])
+        .then(async ([detailRes, econRes]) => {
+          if (detailRes.status === 401 || econRes.status === 401) return UNAUTHORIZED();
+          const detail = detailRes.ok
+            ? ((await detailRes.json().catch(() => null)) as { data?: CatalogItemDetail } | null)?.data ?? null
+            : null;
+          const econ = econRes.ok
+            ? ((await econRes.json().catch(() => null)) as { data?: BundleEconomics } | null)?.data ?? null
+            : null;
+          setExpanded((p) => (p[it.id]
+            ? { ...p, [it.id]: { loading: false, components: detail?.components ?? [], economics: econ } }
+            : p));
+        })
+        .catch(() => setExpanded((p) => (p[it.id] ? { ...p, [it.id]: { loading: false, components: [], economics: null } } : p)));
+      return { ...prev, [it.id]: { loading: true, components: [], economics: null } };
+    });
+  }, []);
+
+  const itemName = useCallback(
+    (id: string) => items.find((i) => i.id === id)?.name ?? 'Unknown item',
+    [items],
+  );
+
+  const toggleSort = (key: SortKey) =>
+    setSort((s) => (s.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }));
+
+  // ---- derived rows: filter (type + search) then sort ---------------------
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    let out = items.filter((it) => {
+      if (typeFilter !== 'all' && it.itemType !== typeFilter) return false;
+      if (q && !it.name.toLowerCase().includes(q) && !(it.sku ?? '').toLowerCase().includes(q)) return false;
+      return true;
+    });
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    out = [...out].sort((a, b) => {
+      if (sort.key === 'name') return a.name.localeCompare(b.name) * dir;
+      if (sort.key === 'unitPrice') return (Number(a.unitPrice) - Number(b.unitPrice)) * dir;
+      // margin: nulls always sort to the bottom regardless of direction
+      const ma = computeMargin(a.unitPrice, a.costBasis);
+      const mb = computeMargin(b.unitPrice, b.costBasis);
+      if (ma == null && mb == null) return 0;
+      if (ma == null) return 1;
+      if (mb == null) return -1;
+      return (ma - mb) * dir;
+    });
+    return out;
+  }, [items, typeFilter, search, sort]);
+
+  const capHit = items.length >= CATALOG_PAGE_LIMIT;
+
+  // ---- gated / empty-of-everything states ---------------------------------
   if (isOrgScoped) {
     return (
-      <p className="text-center text-sm text-muted-foreground" data-testid="catalog-items-org-scope">
+      <p className="rounded-lg border bg-card px-4 py-12 text-center text-sm text-muted-foreground" data-testid="catalog-items-org-scope">
         The product catalog is available to partner accounts only.
       </p>
     );
   }
 
-  if (loading) {
-    return (
-      <p className="text-center text-sm text-muted-foreground" data-testid="catalog-items-loading">
-        Loading.
-      </p>
-    );
-  }
-
-  if (error) {
-    return (
-      <p className="text-center text-sm text-muted-foreground" data-testid="catalog-items-error">
-        Catalog failed to load.{' '}
-        <button
-          type="button"
-          onClick={() => void load()}
-          className="underline hover:text-foreground"
-          data-testid="catalog-items-retry"
-        >
-          Retry
-        </button>
-      </p>
-    );
-  }
+  const SortHeader = ({ label, sortKey, align = 'left' }: { label: string; sortKey: SortKey; align?: 'left' | 'right' }) => (
+    <th className={`px-3 py-3 font-medium ${align === 'right' ? 'text-right' : ''}`}>
+      <button
+        type="button"
+        onClick={() => toggleSort(sortKey)}
+        className={`inline-flex items-center gap-1 hover:text-foreground ${align === 'right' ? 'flex-row-reverse' : ''}`}
+        data-testid={`catalog-sort-${sortKey}`}
+      >
+        {label}
+        <span className="text-[10px] leading-none">{sort.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+      </button>
+    </th>
+  );
 
   return (
     <div className="space-y-4" data-testid="catalog-items-tab">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">Items</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Hardware, software, and service items available for quotes, contracts, and invoices.
-          </p>
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2" data-testid="catalog-toolbar">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search name or SKU"
+          aria-label="Search catalog"
+          className="h-9 min-w-[12rem] flex-1 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          data-testid="catalog-search"
+        />
+
+        {/* Type filter — segmented */}
+        <div className="flex items-center gap-1 rounded-md border bg-muted/40 p-1" role="group" aria-label="Filter by type">
+          {(['all', ...CATALOG_TYPE_ORDER] as TypeFilter[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTypeFilter(t)}
+              aria-pressed={typeFilter === t}
+              className={`rounded px-2.5 py-1 text-xs font-medium transition ${
+                typeFilter === t ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+              }`}
+              data-testid={`catalog-filter-type-${t}`}
+            >
+              {t === 'all' ? 'All' : CATALOG_TYPE_LABELS[t]}
+            </button>
+          ))}
         </div>
+
+        {/* Active / archived */}
+        <div className="flex items-center gap-1 rounded-md border bg-muted/40 p-1" role="group" aria-label="Active or archived">
+          {(['active', 'archived'] as View[]).map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setView(v)}
+              aria-pressed={view === v}
+              className={`rounded px-2.5 py-1 text-xs font-medium capitalize transition ${
+                view === v ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+              }`}
+              data-testid={`catalog-view-${v}`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+
         <button
           type="button"
           onClick={openCreate}
-          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white"
+          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
           data-testid="catalog-add-item"
         >
           Add item
         </button>
       </div>
 
-      {items.length === 0 ? (
-        <p className="text-center text-sm text-muted-foreground" data-testid="catalog-items-empty">
-          No catalog items yet.
-        </p>
-      ) : (
-        <table className="min-w-full divide-y text-sm" data-testid="catalog-items-table">
-          <thead>
-            <tr className="text-left text-muted-foreground">
-              <th className="px-4 py-2 font-medium">Name</th>
-              <th className="px-4 py-2 font-medium">Type</th>
-              <th className="px-4 py-2 font-medium">SKU</th>
-              <th className="px-4 py-2 font-medium">Price</th>
-              <th className="px-4 py-2 font-medium">Bundle</th>
-              <th className="px-4 py-2" />
-            </tr>
-          </thead>
-          <tbody className="divide-y">
-            {items.map((it) => (
-              <tr key={it.id} data-testid={`catalog-item-row-${it.id}`}>
-                <td className="px-4 py-2">{it.name}</td>
-                <td className="px-4 py-2">{it.itemType}</td>
-                <td className="px-4 py-2">{it.sku ?? '—'}</td>
-                <td className="px-4 py-2">{it.unitPrice}</td>
-                <td className="px-4 py-2">{it.isBundle ? 'Yes' : '—'}</td>
-                <td className="px-4 py-2 text-right space-x-2">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(it)}
-                    className="text-sm text-muted-foreground hover:text-foreground"
-                    data-testid={`catalog-edit-${it.id}`}
-                  >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void archive(it.id)}
-                    disabled={archivingId !== null}
-                    className="text-sm text-destructive hover:underline disabled:opacity-50"
-                    data-testid={`catalog-archive-${it.id}`}
-                  >
-                    {archivingId === it.id ? 'Archiving…' : 'Archive'}
-                  </button>
-                </td>
-              </tr>
+      {/* Table card */}
+      <div className="rounded-lg border bg-card shadow-sm">
+        {loading ? (
+          <div className="divide-y" data-testid="catalog-items-loading">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-4 px-4 py-3.5">
+                <div className="h-4 w-1/3 animate-pulse rounded bg-muted" />
+                <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+                <div className="ml-auto h-4 w-20 animate-pulse rounded bg-muted" />
+              </div>
             ))}
-          </tbody>
-        </table>
+          </div>
+        ) : error ? (
+          <div className="px-4 py-12 text-center text-sm text-destructive" data-testid="catalog-items-error">
+            Catalog failed to load.
+            <div>
+              <button
+                type="button"
+                onClick={() => void load(view)}
+                className="mt-3 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+                data-testid="catalog-items-retry"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        ) : items.length === 0 ? (
+          <div className="px-4 py-14 text-center" data-testid="catalog-items-empty">
+            {view === 'archived' ? (
+              <p className="text-sm text-muted-foreground">No archived items.</p>
+            ) : (
+              <>
+                <h3 className="text-sm font-semibold">Build your catalog</h3>
+                <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
+                  Add the hardware, software, and service items you sell. Catalog items power quotes, contracts, and invoices.
+                </p>
+                <button
+                  type="button"
+                  onClick={openCreate}
+                  className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+                  data-testid="catalog-empty-add"
+                >
+                  Add your first item
+                </button>
+              </>
+            )}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="catalog-items-no-match">
+            No items match these filters.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" data-testid="catalog-items-table">
+              <thead>
+                <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <SortHeader label="Name" sortKey="name" />
+                  <th className="px-3 py-3 font-medium">Type</th>
+                  <th className="px-3 py-3 font-medium">SKU</th>
+                  <SortHeader label="Unit price" sortKey="unitPrice" align="right" />
+                  <th className="px-3 py-3 text-right font-medium">Cost</th>
+                  <SortHeader label="Margin" sortKey="margin" align="right" />
+                  <th className="px-3 py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((it) => {
+                  const margin = computeMargin(it.unitPrice, it.costBasis);
+                  const exp = expanded[it.id];
+                  const isOpen = !!exp;
+                  return (
+                    <FragmentRow key={it.id}>
+                      <tr className="border-t transition hover:bg-muted/40" data-testid={`catalog-item-row-${it.id}`}>
+                        <td className="px-3 py-3 font-medium">
+                          <span className="flex items-center gap-1.5">
+                            {it.isBundle ? (
+                              <button
+                                type="button"
+                                onClick={() => toggleExpand(it)}
+                                aria-expanded={isOpen}
+                                aria-label={isOpen ? 'Collapse bundle' : 'Expand bundle'}
+                                className="-ml-1 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                data-testid={`catalog-bundle-toggle-${it.id}`}
+                              >
+                                <svg className={`h-3.5 w-3.5 transition-transform ${isOpen ? 'rotate-90' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                                  <path d="m9 18 6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              </button>
+                            ) : (
+                              <span className="inline-block w-[18px]" />
+                            )}
+                            {it.name}
+                            {it.isBundle && (
+                              <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                                Bundle
+                              </span>
+                            )}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3">
+                          <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${CATALOG_TYPE_CHIP[it.itemType]}`}>
+                            {CATALOG_TYPE_LABELS[it.itemType]}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3 font-mono text-xs text-muted-foreground">{it.sku ?? '—'}</td>
+                        <td className="px-3 py-3 text-right tabular-nums">{formatMoney(it.unitPrice)}</td>
+                        <td className="px-3 py-3 text-right tabular-nums text-muted-foreground">{it.costBasis ? formatMoney(it.costBasis) : '—'}</td>
+                        <td className={`px-3 py-3 text-right tabular-nums ${marginTone(margin)}`} data-testid={`catalog-margin-${it.id}`}>
+                          {formatMargin(margin)}
+                        </td>
+                        <td className="px-3 py-3 text-right">
+                          <span className="inline-flex gap-3 whitespace-nowrap">
+                            <button
+                              type="button"
+                              onClick={() => openEdit(it)}
+                              className="text-sm text-muted-foreground hover:text-foreground"
+                              data-testid={`catalog-edit-${it.id}`}
+                            >
+                              Edit
+                            </button>
+                            {view === 'active' ? (
+                              <button
+                                type="button"
+                                onClick={() => void archive(it.id)}
+                                disabled={archivingId !== null}
+                                className="text-sm text-destructive hover:underline disabled:opacity-50"
+                                data-testid={`catalog-archive-${it.id}`}
+                              >
+                                {archivingId === it.id ? 'Archiving…' : 'Archive'}
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => void restore(it.id)}
+                                disabled={archivingId !== null}
+                                className="text-sm text-primary hover:underline disabled:opacity-50"
+                                data-testid={`catalog-restore-${it.id}`}
+                              >
+                                {archivingId === it.id ? 'Restoring…' : 'Restore'}
+                              </button>
+                            )}
+                          </span>
+                        </td>
+                      </tr>
+                      {isOpen && (
+                        <tr className="border-t bg-muted/20" data-testid={`catalog-bundle-detail-${it.id}`}>
+                          <td colSpan={7} className="px-3 py-3">
+                            {exp.loading ? (
+                              <p className="pl-6 text-xs text-muted-foreground">Loading components.</p>
+                            ) : exp.components.length === 0 ? (
+                              <p className="pl-6 text-xs text-muted-foreground">This bundle has no components yet.</p>
+                            ) : (
+                              <div className="pl-6">
+                                <ul className="space-y-1">
+                                  {exp.components.map((c) => (
+                                    <li key={c.id} className="flex items-center gap-2 text-xs">
+                                      <span className="tabular-nums text-muted-foreground">{Number(c.quantity)}×</span>
+                                      <span>{itemName(c.componentItemId)}</span>
+                                      {c.showOnInvoice && (
+                                        <span className="rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                                          on invoice
+                                        </span>
+                                      )}
+                                    </li>
+                                  ))}
+                                </ul>
+                                {exp.economics && (
+                                  <div className="mt-2 flex flex-wrap gap-x-6 gap-y-1 border-t pt-2 text-xs text-muted-foreground">
+                                    <span>Component cost <span className="tabular-nums text-foreground">{formatMoney(exp.economics.totalCost)}</span></span>
+                                    <span>Bundle margin <span className={`tabular-nums ${marginTone(exp.economics.marginPct)}`}>{formatMoney(exp.economics.margin)} ({formatMargin(exp.economics.marginPct)})</span></span>
+                                  </div>
+                                )}
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </FragmentRow>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {capHit && (
+        <p className="text-xs text-muted-foreground" data-testid="catalog-cap-note">
+          Showing the first {CATALOG_PAGE_LIMIT} items. Use search to narrow the list.
+        </p>
       )}
 
-      {editorOpen && (
-        <div className="rounded-md border bg-muted/30 p-4" data-testid="catalog-item-editor">
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-xs font-medium" htmlFor="catalog-form-type-select">Type</label>
-              <select
-                id="catalog-form-type-select"
-                value={form.itemType}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, itemType: e.target.value as EditForm['itemType'] }))
-                }
-                className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
-                data-testid="catalog-form-type"
-              >
-                <option value="hardware">Hardware</option>
-                <option value="software">Software</option>
-                <option value="service">Service</option>
-              </select>
-            </div>
-            <div>
-              <label className="text-xs font-medium" htmlFor="catalog-form-name-input">Name</label>
-              <input
-                id="catalog-form-name-input"
-                value={form.name}
-                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
-                className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
-                placeholder="Item name"
-                data-testid="catalog-form-name"
-              />
-            </div>
-            <div>
-              <label className="text-xs font-medium" htmlFor="catalog-form-sku-input">SKU</label>
-              <input
-                id="catalog-form-sku-input"
-                value={form.sku}
-                onChange={(e) => setForm((f) => ({ ...f, sku: e.target.value }))}
-                className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
-                placeholder="SKU (optional)"
-                data-testid="catalog-form-sku"
-              />
-            </div>
-            <div>
-              <label className="text-xs font-medium" htmlFor="catalog-form-price-input">Unit price</label>
-              <input
-                id="catalog-form-price-input"
-                value={form.unitPrice}
-                onChange={(e) => setForm((f) => ({ ...f, unitPrice: e.target.value }))}
-                inputMode="decimal"
-                className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
-                placeholder="0.00"
-                data-testid="catalog-form-price"
-              />
-            </div>
-            <div>
-              <label className="text-xs font-medium" htmlFor="catalog-form-cost-input">Cost basis</label>
-              <input
-                id="catalog-form-cost-input"
-                value={form.costBasis}
-                onChange={(e) => setForm((f) => ({ ...f, costBasis: e.target.value }))}
-                inputMode="decimal"
-                className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
-                placeholder="Cost basis (optional)"
-                data-testid="catalog-form-cost"
-              />
-            </div>
-            <div className="flex items-end">
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={form.isBundle}
-                  onChange={(e) => setForm((f) => ({ ...f, isBundle: e.target.checked }))}
-                  data-testid="catalog-form-bundle"
-                />
-                This item is a bundle
-              </label>
-            </div>
-          </div>
-          <div className="mt-3 flex gap-2">
-            <button
-              type="button"
-              onClick={() => void save()}
-              disabled={
-                saving ||
-                !form.name.trim() ||
-                !form.unitPrice.trim() ||
-                !Number.isFinite(Number(form.unitPrice))
-              }
-              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-              data-testid="catalog-form-save"
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </button>
-            <button
-              type="button"
-              onClick={() => setEditorOpen(false)}
-              className="rounded-md border px-3 py-1.5 text-sm font-medium"
-              data-testid="catalog-form-cancel"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
+      <CatalogItemEditorDrawer
+        open={drawerOpen}
+        item={editItem}
+        allItems={items}
+        onClose={() => setDrawerOpen(false)}
+        onSaved={() => void load(view)}
+      />
     </div>
   );
+}
+
+// Tiny helper so a row + its expanded detail row share one key without a wrapper
+// element (which would be invalid inside <tbody>).
+function FragmentRow({ children }: { children: ReactNode }) {
+  return <>{children}</>;
 }

--- a/apps/web/src/lib/api/catalog.test.ts
+++ b/apps/web/src/lib/api/catalog.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { computeMargin, formatMargin, marginTone } from './catalog';
+
+describe('computeMargin', () => {
+  it('returns gross margin percent from price and cost', () => {
+    expect(computeMargin(100, 60)).toBeCloseTo(40);
+    expect(computeMargin('200.00', '50.00')).toBeCloseTo(75);
+  });
+
+  it('is negative when cost exceeds price (loss leader)', () => {
+    expect(computeMargin(80, 100)).toBeCloseTo(-25);
+  });
+
+  it('returns null when cost basis is absent or blank', () => {
+    expect(computeMargin(100, null)).toBeNull();
+    expect(computeMargin(100, undefined)).toBeNull();
+    expect(computeMargin(100, '')).toBeNull();
+  });
+
+  it('returns null when price is zero, negative, or non-numeric (no divide-by-zero)', () => {
+    expect(computeMargin(0, 10)).toBeNull();
+    expect(computeMargin(-5, 10)).toBeNull();
+    expect(computeMargin('abc', 10)).toBeNull();
+    expect(computeMargin(100, 'abc')).toBeNull();
+  });
+});
+
+describe('formatMargin', () => {
+  it('renders one-decimal percent, em-dash for null', () => {
+    expect(formatMargin(42.5)).toBe('42.5%');
+    expect(formatMargin(-8)).toBe('-8.0%');
+    expect(formatMargin(null)).toBe('—');
+  });
+});
+
+describe('marginTone', () => {
+  it('flags negative margins as destructive, others neutral', () => {
+    expect(marginTone(-1)).toBe('text-destructive');
+    expect(marginTone(30)).toBe('text-foreground');
+    expect(marginTone(null)).toBe('text-muted-foreground');
+  });
+});

--- a/apps/web/src/lib/api/catalog.ts
+++ b/apps/web/src/lib/api/catalog.ts
@@ -1,0 +1,182 @@
+// Typed fetch wrappers for the Product Catalog API.
+//
+// Mirrors the contracts/invoice web layer: there is no generic apiClient in this
+// app — calls go through `fetchWithAuth` (apps/web/src/stores/auth.ts), which
+// injects the active orgId, refreshes tokens, and returns a raw `Response`. Each
+// wrapper returns that `Response` so callers keep control over 401 handling and
+// `runAction`. Every catalog route responds with a `{ data: ... }` envelope.
+//
+// Money / quantity fields arrive as numeric(12,2) strings (e.g. '150.00').
+// Catalog items have no per-item currency, so prices render in the app default
+// (USD) via lib/timeFormat.formatMoney.
+
+import { fetchWithAuth } from '../../stores/auth';
+
+export type CatalogItemType = 'hardware' | 'software' | 'service';
+export type CatalogBillingType = 'one_time' | 'recurring';
+
+/** A row from `GET /catalog` / `GET /catalog/:id`.`item`. */
+export interface CatalogItem {
+  id: string;
+  partnerId: string;
+  itemType: CatalogItemType;
+  name: string;
+  sku: string | null;
+  description: string | null;
+  billingType: CatalogBillingType;
+  unitPrice: string;
+  costBasis: string | null;
+  markupPercent: string | null;
+  unitOfMeasure: string;
+  taxable: boolean;
+  taxCategory: string | null;
+  isBundle: boolean;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A row from `catalog_bundle_components` (returned by `GET /catalog/:id`.`components`). */
+export interface BundleComponentRow {
+  id: string;
+  partnerId: string;
+  bundleItemId: string;
+  componentItemId: string;
+  quantity: string;
+  showOnInvoice: boolean;
+  revenueAllocation: string | null;
+}
+
+export interface OrgPriceOverride {
+  id: string;
+  catalogItemId: string;
+  orgId: string;
+  unitPrice: string;
+}
+
+/** Shape of `GET /catalog/:id` — `{ data: { item, overrides, components } }`. */
+export interface CatalogItemDetail {
+  item: CatalogItem;
+  overrides: OrgPriceOverride[];
+  components: BundleComponentRow[];
+}
+
+/** Shape of `GET /catalog/:id/economics` — `{ data: { ... } }`. */
+export interface BundleEconomics {
+  headlinePrice: string;
+  totalCost: string;
+  margin: string;
+  marginPct: number;
+  allocationTotal: string;
+  allocationMatchesHeadline: boolean;
+}
+
+/** One component as sent to `PUT /catalog/:id/components`. */
+export interface BundleComponentInput {
+  componentItemId: string;
+  quantity: number;
+  showOnInvoice: boolean;
+  revenueAllocation?: number | null;
+}
+
+export interface ListCatalogQuery {
+  itemType?: CatalogItemType;
+  isActive?: boolean;
+  isBundle?: boolean;
+  search?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+/** Server caps a single page at 200 rows (listCatalogQuerySchema). */
+export const CATALOG_PAGE_LIMIT = 200;
+
+function buildQuery(q: ListCatalogQuery): string {
+  const params = new URLSearchParams();
+  if (q.itemType) params.set('itemType', q.itemType);
+  if (q.isActive != null) params.set('isActive', String(q.isActive));
+  if (q.isBundle != null) params.set('isBundle', String(q.isBundle));
+  if (q.search) params.set('search', q.search);
+  if (q.limit != null) params.set('limit', String(q.limit));
+  if (q.cursor) params.set('cursor', q.cursor);
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export function listCatalog(query: ListCatalogQuery = {}): Promise<Response> {
+  return fetchWithAuth(`/catalog${buildQuery(query)}`);
+}
+
+export function getCatalogItem(id: string): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}`);
+}
+
+export function createCatalogItem(body: unknown): Promise<Response> {
+  return fetchWithAuth('/catalog', { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(body) });
+}
+
+export function updateCatalogItem(id: string, body: unknown): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}`, { method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify(body) });
+}
+
+export function archiveCatalogItem(id: string): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}/archive`, { method: 'POST' });
+}
+
+export function setBundleComponents(id: string, components: BundleComponentInput[]): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}/components`, {
+    method: 'PUT',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ components }),
+  });
+}
+
+export function getBundleEconomics(id: string, orgId?: string): Promise<Response> {
+  const qs = orgId ? `?orgId=${orgId}` : '';
+  return fetchWithAuth(`/catalog/${id}/economics${qs}`);
+}
+
+// ---- presentation helpers -------------------------------------------------
+
+export const CATALOG_TYPE_LABELS: Record<CatalogItemType, string> = {
+  hardware: 'Hardware',
+  software: 'Software',
+  service: 'Service',
+};
+
+export const CATALOG_TYPE_ORDER: CatalogItemType[] = ['hardware', 'software', 'service'];
+
+// Quiet tinted chips, one hue per type (mirrors the contract status badge style).
+// Restrained: the chip carries category, not decoration.
+export const CATALOG_TYPE_CHIP: Record<CatalogItemType, string> = {
+  hardware: 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-400',
+  software: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-400',
+  service: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+};
+
+/** Gross margin percent from price vs cost, or null when cost is absent / price ≤ 0. */
+export function computeMargin(
+  unitPrice: string | number | null | undefined,
+  costBasis: string | number | null | undefined,
+): number | null {
+  if (costBasis == null || costBasis === '') return null;
+  const price = Number(unitPrice);
+  const cost = Number(costBasis);
+  if (!Number.isFinite(price) || !Number.isFinite(cost) || price <= 0) return null;
+  return ((price - cost) / price) * 100;
+}
+
+/** '—' when no margin, else one-decimal percent (e.g. '42.5%', '-8.0%'). */
+export function formatMargin(pct: number | null): string {
+  if (pct == null) return '—';
+  return `${pct.toFixed(1)}%`;
+}
+
+/** Tailwind text tone for a margin value: destructive when the item loses money. */
+export function marginTone(pct: number | null): string {
+  if (pct == null) return 'text-muted-foreground';
+  if (pct < 0) return 'text-destructive';
+  return 'text-foreground';
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -217,11 +217,13 @@ select {
   .slide-in-right,
   .stagger-1, .stagger-2, .stagger-3, .stagger-4,
   .dialog-backdrop,
-  .dialog-panel {
+  .dialog-panel,
+  .drawer-panel {
     animation: none !important;
     opacity: 1;
   }
-  .dialog-panel {
+  .dialog-panel,
+  .drawer-panel {
     transform: none;
   }
   .hover-lift {


### PR DESCRIPTION
## Summary
Redesigns the Product Catalog page into a production-grade catalog surface and surfaces the billing tools in the sidebar.

**Sidebar** — adds **Contracts** (`/contracts`) and **Product Catalog** (`/settings/catalog`) to the Operations section, both `partnerScopeOnly` (mirrors each route's `requireScope('partner','system')`). Both pages already exist on `main`, so neither link 404s.

**Catalog page** (per `$impeccable shape` brief, partner-scoped):
- **Toolbar** — search (name/SKU), type segmented filter, Active/Archived toggle, Add item.
- **Table** — sortable Name/Unit price/Margin, quiet per-type chips, mono SKU, tabular-num money, **destructive-toned negative margin**.
- **Bundles** — rows expand in place to show components + rolled-up economics (`GET /catalog/:id/economics`).
- **Editor** — right-side drawer (portal, focus-trap, scroll-lock, Escape, reduced-motion-safe slide-in) with live margin preview and a **bundle component builder including per-component `showOnInvoice`**. Save sequences item `POST`/`PATCH` → `PUT /components`; on partial failure it remembers the new id so a retry edits instead of duplicating. Bundle error codes (`BUNDLE_NESTED`, etc.) surfaced via `runAction`'s `friendly` map.
- **States** — skeleton loading, teach-style empty state, error/retry, archived view with Restore, org-scope gate, 200-row cap note.

All bundle backend (table, RLS, routes, validators, economics) already shipped in #1365 — this is the web layer that wires to it.

## Verification
- `astro check`: **0 errors** (976 files); eslint clean.
- Vitest: helper units (6) + component tests (render/margin, search, bundle expand+economics, create-bundle-with-`showOnInvoice` asserting the exact `PUT` payload) + nav. Sidebar staleness/nav green.
- ⚠️ Draft pending Todd's in-browser UI test (user-facing). Live Playwright walkthrough screenshots to follow in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)