### PR TITLE
fix(agent): restart Breeze Assist on config change so policy edits apply (#1382)

### DIFF
--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -236,9 +236,38 @@ func (m *Manager) Apply(settings *Settings) {
 						log.Warn("failed to write legacy helper config fallback", "error", err.Error())
 					}
 				}
+				// The new config is on disk, but a helper that's already running
+				// only read its config at spawn — flag it for a restart so the
+				// updated tray settings actually take effect (#1382).
+				state.pendingConfigRestart = true
 			}
 
 			state.refreshPID()
+
+			// #1382: restart a running helper so it re-reads the changed config.
+			// Skip while a chat is active so we don't drop the user's
+			// conversation; the flag persists and the restart happens on a later
+			// heartbeat once the session is idle. ensureStoppedSession is a
+			// no-op when nothing is running (e.g. first spawn), so the
+			// ensureRunningSession call below just spawns fresh in that case.
+			// Runs after refreshPID so clearing the PID below isn't undone.
+			if state.pendingConfigRestart {
+				if IsIdle(state.configPath) {
+					m.stopSessionWatcher(state)
+					if err := m.ensureStoppedSession(state); err != nil {
+						log.Warn("failed to stop breeze assist for config reload", "session", si.Key, "error", err.Error())
+					} else {
+						// Clear the status-file PID too so ensureRunningSession's
+						// fallback checks don't treat the just-stopped helper as
+						// still running and skip the respawn.
+						state.pid = 0
+						state.pendingConfigRestart = false
+					}
+				} else {
+					log.Debug("deferring breeze assist config reload until idle; chat active", "session", si.Key)
+				}
+			}
+
 			if err := m.ensureRunningSession(state); err != nil {
 				log.Error("failed to start breeze assist", "session", si.Key, "error", err.Error())
 			} else {

--- a/agent/internal/helper/manager_test.go
+++ b/agent/internal/helper/manager_test.go
@@ -2,9 +2,11 @@ package helper
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 type mockEnumerator struct {
@@ -57,6 +59,125 @@ func TestApplyDisabledStopsRunningHelperAfterRestart(t *testing.T) {
 	}
 	if _, exists := mgr.sessions["501"]; !exists {
 		t.Fatal("disabled apply should keep active session state")
+	}
+}
+
+// #1382: a running Breeze Assist helper only reads its config at spawn
+// (--config), so a Configuration Policy change must restart it to take effect.
+func TestApplyRestartsHelperOnConfigChangeWhenIdle(t *testing.T) {
+	tmpDir := t.TempDir()
+	statusPath := filepath.Join(tmpDir, "sessions", "501", "helper_status.yaml")
+	if err := os.MkdirAll(filepath.Dir(statusPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// chat_active false => idle, so the restart is allowed to proceed.
+	if err := os.WriteFile(statusPath, []byte("version: 0.14.0\npid: 4242\nchat_active: false\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origRemove := removeAutoStartFunc
+	origStopLegacy := stopHelperLegacyFunc
+	t.Cleanup(func() {
+		removeAutoStartFunc = origRemove
+		stopHelperLegacyFunc = origStopLegacy
+	})
+	removeAutoStartFunc = func() error { return nil }
+	stopHelperLegacyFunc = func() {}
+
+	stopped := 0
+	spawned := 0
+	mgr := New(context.Background(), "", nil, "")
+	mgr.baseDir = tmpDir
+	mgr.sessionEnumerator = &mockEnumerator{
+		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
+	}
+	mgr.isOurProcessFunc = func(pid int, binaryPath string) bool { return pid == 4242 }
+	mgr.stopByPIDFunc = func(pid int) error { stopped++; return nil }
+	mgr.spawnFunc = func(sessionKey, binaryPath string, args ...string) (int, error) {
+		spawned++
+		_ = os.WriteFile(statusPath, []byte("version: 0.14.0\npid: 9001\n"), 0644)
+		return 9001, nil
+	}
+	helperBinary := filepath.Join(tmpDir, "breeze-helper")
+	if err := os.WriteFile(helperBinary, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	mgr.binaryPath = helperBinary
+
+	// Seed a running session whose last-applied config differs from the new one.
+	state := newSessionState("501", tmpDir)
+	state.lastConfig = &Config{ShowOpenPortal: true}
+	mgr.sessions["501"] = state
+
+	mgr.Apply(&Settings{Enabled: true, ShowOpenPortal: false})
+
+	if stopped != 1 {
+		t.Fatalf("stopByPID called %d times, want 1 (restart on config change)", stopped)
+	}
+	if spawned != 1 {
+		t.Fatalf("spawn called %d times, want 1 (respawn with new config)", spawned)
+	}
+}
+
+// #1382: do not restart (and drop the chat) while a conversation is active.
+// The new config is written to disk and applied on a later idle heartbeat.
+func TestApplyDefersRestartWhileChatActive(t *testing.T) {
+	tmpDir := t.TempDir()
+	statusPath := filepath.Join(tmpDir, "sessions", "501", "helper_status.yaml")
+	if err := os.MkdirAll(filepath.Dir(statusPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// chat_active + recent activity + a real running pid (this test process) =>
+	// IsIdle returns false, so the restart must be deferred.
+	body := fmt.Sprintf("version: 0.14.0\npid: %d\nchat_active: true\nlast_activity: %s\n",
+		os.Getpid(), time.Now().UTC().Format(time.RFC3339))
+	if err := os.WriteFile(statusPath, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origRemove := removeAutoStartFunc
+	origStopLegacy := stopHelperLegacyFunc
+	t.Cleanup(func() {
+		removeAutoStartFunc = origRemove
+		stopHelperLegacyFunc = origStopLegacy
+	})
+	removeAutoStartFunc = func() error { return nil }
+	stopHelperLegacyFunc = func() {}
+
+	stopped := 0
+	spawned := 0
+	mgr := New(context.Background(), "", nil, "")
+	mgr.baseDir = tmpDir
+	mgr.sessionEnumerator = &mockEnumerator{
+		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
+	}
+	mgr.isOurProcessFunc = func(pid int, binaryPath string) bool { return pid == os.Getpid() }
+	mgr.stopByPIDFunc = func(pid int) error { stopped++; return nil }
+	mgr.spawnFunc = func(sessionKey, binaryPath string, args ...string) (int, error) {
+		spawned++
+		return 9001, nil
+	}
+	helperBinary := filepath.Join(tmpDir, "breeze-helper")
+	if err := os.WriteFile(helperBinary, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	mgr.binaryPath = helperBinary
+
+	state := newSessionState("501", tmpDir)
+	state.lastConfig = &Config{ShowOpenPortal: true}
+	mgr.sessions["501"] = state
+
+	mgr.Apply(&Settings{Enabled: true, ShowOpenPortal: false})
+
+	if stopped != 0 {
+		t.Fatalf("restart should be deferred during active chat; stopByPID called %d times", stopped)
+	}
+	if spawned != 0 {
+		t.Fatalf("helper should keep running during active chat; spawn called %d times", spawned)
+	}
+	// The new config must still be persisted so a later idle restart applies it.
+	if state.lastConfig == nil || state.lastConfig.ShowOpenPortal != false {
+		t.Fatal("new config should be written to disk even when restart is deferred")
 	}
 }
 

--- a/agent/internal/helper/session_state.go
+++ b/agent/internal/helper/session_state.go
@@ -27,6 +27,13 @@ type sessionState struct {
 	watcher     *watcher
 	lastApplied time.Time
 
+	// Set when the on-disk config changed for a running helper that hasn't been
+	// restarted yet (#1382). The helper only reads --config at spawn, so a
+	// running session must be restarted to pick up new tray settings. We defer
+	// the restart while a chat is active, so this flag persists across
+	// heartbeats until the session goes idle and the restart actually happens.
+	pendingConfigRestart bool
+
 	// Set to true when the watcher gives up after repeated failures.
 	// Prevents Apply() from re-spawning and re-creating the watcher.
 	// Cleared on helper update or when the helper binary changes.


### PR DESCRIPTION
## Problem

Reported by @wintechspace-ai, root-caused by @bdunncompany: editing **Breeze Assist** settings in a Configuration Policy doesn't update endpoints where Breeze Assist is already installed. The only reliable way to apply changes was remove + redeploy.

The new settings reach the device fine and are written to disk (`helper.Apply` → `writeSessionConfig`), but the already-running Breeze Assist helper **only reads its config at spawn** (`--config <path>`). `Apply()`'s `ensureRunningSession` no-ops when the helper is already running, and there's no config-reload path — so the running tray app keeps the old menu until it's restarted (which today only happens on redeploy).

## Fix

`Apply()` now **restarts a running helper when its on-disk config changes**, so it re-reads `--config` and renders the updated tray menu. Key details:

- **Chat-aware:** the restart is gated on `IsIdle()`. While a chat is active it's **deferred** — a `pendingConfigRestart` flag persists across heartbeats and the restart happens on the next idle heartbeat, so we never drop a user's in-progress conversation.
- The status-file PID is cleared before respawn so `ensureRunningSession`'s "already running" fallback check doesn't suppress the restart.
- `ensureStoppedSession` is a no-op when nothing is running, so first-spawn and disabled paths are unchanged.

### Why not live config-reload over IPC?

That'd be smoother (no restart), but the assist helper holds only `ScopeAssist` — **not** the `tray` scope that the existing `TypeTrayUpdate` IPC path targets — and would also need a new receive handler in the Tauri helper app. Restart-on-change is fully agent-side, unit-testable, and a strict improvement over "never applies without redeploy." Live reload is a good follow-up.

## Testing

`go test -race ./internal/helper/` green, including two new tests:
- ✅ Restart fires (stop + respawn with the new `--config`) on a changed config when the session is idle.
- ✅ Restart is **deferred** (no stop/respawn) while a chat is active, with the new config still persisted to disk for the next idle restart.

Existing helper tests still pass; full agent `go build ./...` clean. Platform-agnostic (the change is in `manager.go` / `session_state.go`, not the per-OS files).

Closes #1382

🤖 Generated with [Claude Code](https://claude.com/claude-code)