### PR TITLE
fix(software): return 409 instead of 500 when deleting a deployed catalog item (#1407)

### DIFF
--- a/apps/api/src/__tests__/integration/softwareCatalogDelete.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwareCatalogDelete.integration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Software-catalog delete vs. deployment FK (#1407).
+ *
+ * software_deployments.software_version_id references software_versions with
+ * the default ON DELETE RESTRICT, so deleting a catalog item whose version is
+ * still referenced by a deployment used to throw an unhandled 500 (FK
+ * violation). Drives the real DELETE /software/catalog/:id route against the
+ * real docker postgres as breeze_app and proves it now returns a clean 409
+ * (and preserves the row) when a deployment still references the version, and
+ * still deletes (200) when nothing references it.
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+
+let activeOrgId: string | null = null;
+
+vi.mock('../../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../middleware/auth')>();
+  const { withDbAccessContext } = await import('../../db');
+  return {
+    ...actual,
+    authMiddleware: (c: any, next: any) => {
+      if (!activeOrgId) return c.json({ error: 'Unauthorized' }, 401);
+      c.set('auth', {
+        scope: 'organization',
+        partnerId: null,
+        orgId: activeOrgId,
+        accessibleOrgIds: [activeOrgId],
+        user: { id: null, email: 'integration@test' },
+      });
+      return withDbAccessContext(
+        {
+          scope: 'organization',
+          orgId: activeOrgId,
+          accessibleOrgIds: [activeOrgId],
+          accessiblePartnerIds: null,
+          userId: null,
+        },
+        () => next(),
+      );
+    },
+    requireScope: () => (_c: any, next: any) => next(),
+    requirePermission: () => (_c: any, next: any) => next(),
+    requireMfa: () => (_c: any, next: any) => next(),
+  };
+});
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+  writeAuditEvent: vi.fn(),
+}));
+
+import { getTestDb } from './setup';
+import { softwareCatalog, softwareVersions, softwareDeployments } from '../../db/schema';
+import { createPartner, createOrganization } from './db-utils';
+
+async function buildApp() {
+  const { softwareRoutes } = await import('../../routes/software');
+  const { authMiddleware } = await import('../../middleware/auth');
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/software', softwareRoutes);
+  return app;
+}
+
+async function seedCatalogWithVersion(orgId: string) {
+  const [catalog] = await getTestDb()
+    .insert(softwareCatalog)
+    .values({ orgId, name: 'Acme Tool' })
+    .returning();
+  if (!catalog) throw new Error('failed to seed catalog');
+  const [version] = await getTestDb()
+    .insert(softwareVersions)
+    .values({ catalogId: catalog.id, version: '1.0.0', isLatest: true })
+    .returning();
+  if (!version) throw new Error('failed to seed version');
+  return { catalog, version };
+}
+
+beforeEach(() => {
+  activeOrgId = null;
+});
+
+afterEach(() => {
+  activeOrgId = null;
+  vi.clearAllMocks();
+});
+
+describe('DELETE /software/catalog/:id vs deployment FK (#1407)', () => {
+  it('returns 409 (not 500) and preserves the item when a version is still deployed', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    activeOrgId = org.id;
+
+    const { catalog, version } = await seedCatalogWithVersion(org.id);
+    await getTestDb()
+      .insert(softwareDeployments)
+      .values({
+        orgId: org.id,
+        name: 'Deploy Acme',
+        softwareVersionId: version.id,
+        deploymentType: 'install',
+        targetType: 'device',
+        scheduleType: 'immediate',
+      });
+
+    const app = await buildApp();
+    const res = await app.request(`/software/catalog/${catalog.id}?orgId=${org.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/deployment/i);
+
+    // The catalog item (and its version) must survive — history preserved.
+    const [stillThere] = await getTestDb()
+      .select({ id: softwareCatalog.id })
+      .from(softwareCatalog)
+      .where(eq(softwareCatalog.id, catalog.id))
+      .limit(1);
+    expect(stillThere).toBeDefined();
+  });
+
+  it('deletes (200) when no deployment references the versions', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    activeOrgId = org.id;
+
+    const { catalog } = await seedCatalogWithVersion(org.id);
+
+    const app = await buildApp();
+    const res = await app.request(`/software/catalog/${catalog.id}?orgId=${org.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+
+    const [gone] = await getTestDb()
+      .select({ id: softwareCatalog.id })
+      .from(softwareCatalog)
+      .where(eq(softwareCatalog.id, catalog.id))
+      .limit(1);
+    expect(gone).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -560,6 +560,26 @@ softwareRoutes.delete(
       .where(and(eq(softwareCatalog.id, id), eq(softwareCatalog.orgId, orgId)));
     if (!existing) return c.json({ error: 'Catalog item not found' }, 404);
 
+    // A version that is still referenced by a deployment cannot be deleted —
+    // software_deployments.software_version_id is an ON DELETE RESTRICT FK, so
+    // deleting the versions below would throw an unhandled 500 (#1407).
+    // Pre-check and return a clean 409 so deployment history is preserved and
+    // the caller gets an actionable message instead of a server error.
+    const [deploymentRef] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(softwareDeployments)
+      .innerJoin(softwareVersions, eq(softwareDeployments.softwareVersionId, softwareVersions.id))
+      .where(eq(softwareVersions.catalogId, id));
+    const blockingCount = deploymentRef?.count ?? 0;
+    if (blockingCount > 0) {
+      return c.json(
+        {
+          error: `Cannot delete: ${blockingCount} deployment${blockingCount === 1 ? '' : 's'} still reference a version of this software. Remove those deployments first.`,
+        },
+        409
+      );
+    }
+
     // Delete versions first (FK constraint)
     await db.delete(softwareVersions).where(eq(softwareVersions.catalogId, id));
     await db.delete(softwareCatalog).where(eq(softwareCatalog.id, id));


### PR DESCRIPTION
## Problem

`software_deployments.software_version_id` references `software_versions` with the default `ON DELETE RESTRICT`, and `DELETE /software/catalog/:id` deletes the version rows directly (`apps/api/src/routes/software.ts`). When any deployment still referenced one of those versions, the delete failed the FK constraint and surfaced as an **unhandled 500**.

Pre-existing, but only became reachable once the Software Library delete button (#1381) gave it a UI path.

## Fix

Pre-check for deployments referencing the catalog's versions and return a clean **409** with a count instead of letting the FK throw a 500. Deployment history is preserved (the issue's preferred option) and the caller gets an actionable message: *"Cannot delete: N deployments still reference a version of this software. Remove those deployments first."*

## Testing

Real-DB integration test (`breeze_app`, forced RLS):
- ✅ Deleting a catalog item whose version is referenced by a deployment returns **409** and leaves the item + version intact (previously **500** — verified red before the fix).
- ✅ Deleting a catalog item with no referencing deployment still returns **200** and removes it.

Existing `software.test.ts` (12 tests) still green; `software.ts` typechecks clean.

Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)