### PR TITLE
feat(web): Invoices redesign — list, editor, detail, Stripe pay-link, PDF

### DIFF
--- a/apps/api/src/routes/invoices/index.ts
+++ b/apps/api/src/routes/invoices/index.ts
@@ -4,10 +4,12 @@ import { invoiceCrudRoutes } from './invoices';
 import { invoiceLifecycleRoutes } from './lifecycle';
 import { invoicePaymentRoutes } from './payments';
 import { invoicePdfRoutes } from './pdf'; // added in Phase 5
+import { invoiceStripeRoutes } from './stripe';
 
 export const invoiceRoutes = new Hono();
 invoiceRoutes.use('*', authMiddleware);
 invoiceRoutes.route('/', invoiceLifecycleRoutes);  // /:id/issue, /:id/send, /:id/void
 invoiceRoutes.route('/', invoicePaymentRoutes);    // /:id/payments...
+invoiceRoutes.route('/', invoiceStripeRoutes);     // /:id/pay-link
 invoiceRoutes.route('/', invoicePdfRoutes);        // /:id/pdf (Phase 5)
 invoiceRoutes.route('/', invoiceCrudRoutes);       // /, /:id, /:id/lines... (param matchers last)

--- a/apps/api/src/routes/invoices/stripe.test.ts
+++ b/apps/api/src/routes/invoices/stripe.test.ts
@@ -25,7 +25,7 @@ const payLink = vi.mocked(checkout.createInvoicePayLink);
 
 function app() {
   const a = new Hono();
-  a.use('*', async (c, next) => { c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', accessibleOrgIds: null }); await next(); });
+  a.use('*', async (c: any, next: any) => { c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', accessibleOrgIds: null }); await next(); });
   a.route('/', invoiceStripeRoutes);
   return a;
 }

--- a/apps/api/src/routes/invoices/stripe.test.ts
+++ b/apps/api/src/routes/invoices/stripe.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Thin route — assert wiring + error mapping (mirrors settings.test.ts).
+vi.mock('../../services/invoiceCheckout', () => ({ createInvoicePayLink: vi.fn() }));
+// './invoices' (for invoiceActorFrom/handleServiceError) imports invoiceService;
+// nothing is called at module load, so an empty mock keeps the chain light.
+vi.mock('../../services/invoiceService', () => ({}));
+vi.mock('../../services/invoiceTypes', () => ({
+  InvoiceServiceError: class InvoiceServiceError extends Error {
+    constructor(msg: string, public status = 400, public code?: string) { super(msg); }
+  },
+}));
+vi.mock('../../middleware/auth', () => ({
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+}));
+
+import { invoiceStripeRoutes } from './stripe';
+import * as checkout from '../../services/invoiceCheckout';
+import { InvoiceServiceError } from '../../services/invoiceTypes';
+
+const ID = '11111111-1111-1111-1111-111111111111';
+const payLink = vi.mocked(checkout.createInvoicePayLink);
+
+function app() {
+  const a = new Hono();
+  a.use('*', async (c, next) => { c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', accessibleOrgIds: null }); await next(); });
+  a.route('/', invoiceStripeRoutes);
+  return a;
+}
+
+describe('POST /invoices/:id/pay-link', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the Stripe checkout url on success', async () => {
+    payLink.mockResolvedValue({ url: 'https://checkout.stripe.com/c/pay/abc' });
+    const res = await app().request(`/${ID}/pay-link`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { url: 'https://checkout.stripe.com/c/pay/abc' } });
+    expect(payLink).toHaveBeenCalledWith(ID, expect.objectContaining({ partnerId: 'p1' }));
+  });
+
+  it('maps STRIPE_NOT_CONNECTED to a 409 with code', async () => {
+    payLink.mockRejectedValue(new InvoiceServiceError('Online payment is not available', 409, 'STRIPE_NOT_CONNECTED'));
+    const res = await app().request(`/${ID}/pay-link`, { method: 'POST' });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: 'STRIPE_NOT_CONNECTED' });
+  });
+
+  it('rejects a non-uuid id with 400', async () => {
+    const res = await app().request('/not-a-uuid/pay-link', { method: 'POST' });
+    expect(res.status).toBe(400);
+    expect(payLink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/invoices/stripe.ts
+++ b/apps/api/src/routes/invoices/stripe.ts
@@ -1,0 +1,21 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { createInvoicePayLink } from '../../services/invoiceCheckout';
+import { invoiceActorFrom, handleServiceError } from './invoices';
+
+export const invoiceStripeRoutes = new Hono();
+
+const scopes = requireScope('partner', 'system');
+const sendPerm = requirePermission(PERMISSIONS.INVOICES_SEND.resource, PERMISSIONS.INVOICES_SEND.action);
+const idParam = z.object({ id: z.string().uuid() });
+
+// POST /invoices/:id/pay-link — partner-initiated Stripe Checkout link for the
+// invoice balance (to share with the customer). Gated on the partner's Stripe
+// Connect being active; 409 STRIPE_NOT_CONNECTED otherwise.
+invoiceStripeRoutes.post('/:id/pay-link', scopes, sendPerm, zValidator('param', idParam), async (c) => {
+  try { return c.json({ data: await createInvoicePayLink(c.req.valid('param').id, invoiceActorFrom(c)) }); }
+  catch (err) { return handleServiceError(c, err); }
+});

--- a/apps/api/src/services/invoiceCheckout.ts
+++ b/apps/api/src/services/invoiceCheckout.ts
@@ -1,0 +1,85 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { invoices, invoiceStripePayments } from '../db/schema';
+import { getConnection } from './stripeConnectService';
+import { getStripe, getConnectedStripeOptions } from './stripeClient';
+import { toMinorUnits } from './stripeMoney';
+import { InvoiceServiceError, type InvoiceActor } from './invoiceTypes';
+import { requireOrgAccess } from './invoiceService';
+
+// Statuses whose balance can be collected online. Mirrors the customer-portal
+// PAYABLE set (routes/portal/invoices.ts) — drafts/paid/void are excluded.
+const PAYABLE = new Set(['sent', 'partially_paid', 'overdue']);
+
+/**
+ * Partner-initiated "Send payment link": open a Stripe Checkout session on the
+ * partner's connected account for the invoice's outstanding balance and return
+ * the hosted-checkout URL for the MSP to share with the customer. The webhook
+ * (routes/webhooks/stripe.ts → stripeReconcile) records the resulting payment
+ * idempotently via the `invoice_stripe_payments` mapping, so this only creates
+ * the session + a pending mapping row.
+ *
+ * Twin of the customer-driven POST /portal/invoices/:id/pay. This handler runs
+ * under a partner/system request scope, so the partner-axis connection row is
+ * RLS-visible directly (no system sub-context escape needed, unlike the portal's
+ * org scope).
+ */
+export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActor): Promise<{ url: string }> {
+  const [inv] = await db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1);
+  if (!inv) throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
+  requireOrgAccess(actor, inv.orgId);
+  if (!PAYABLE.has(inv.status)) throw new InvoiceServiceError('Invoice is not payable', 409, 'NOT_PAYABLE');
+
+  // Currency-aware minor units (zero-decimal currencies must not be ×100).
+  const balanceMinor = toMinorUnits(inv.balance, inv.currencyCode);
+  if (balanceMinor <= 0) throw new InvoiceServiceError('Nothing to pay', 409, 'NOTHING_TO_PAY');
+
+  const conn = await getConnection(inv.partnerId).catch(() => null);
+  if (!conn || conn.status !== 'connected') {
+    throw new InvoiceServiceError('Online payment is not available — connect Stripe first', 409, 'STRIPE_NOT_CONNECTED');
+  }
+
+  const portalBase = (process.env.PUBLIC_APP_URL || process.env.DASHBOARD_URL || 'http://localhost:4321').replace(/\/$/, '');
+
+  const session = await getStripe().checkout.sessions.create({
+    mode: 'payment',
+    payment_method_types: ['card'],
+    line_items: [{
+      price_data: {
+        currency: inv.currencyCode.toLowerCase(),
+        unit_amount: balanceMinor,
+        product_data: { name: `Invoice ${inv.invoiceNumber ?? inv.id}` },
+      },
+      quantity: 1,
+    }],
+    success_url: `${portalBase}/portal/invoices/${inv.id}?paid=1`,
+    cancel_url: `${portalBase}/portal/invoices/${inv.id}`,
+    metadata: {
+      invoice_id: inv.id,
+      org_id: inv.orgId,
+      partner_id: inv.partnerId,
+      invoice_balance_cents: String(balanceMinor),
+    },
+  }, {
+    ...getConnectedStripeOptions(conn.stripeAccountId),
+    // Identical (invoice, balance) reuses the session instead of creating a
+    // second pending mapping — safe for repeated "send link" clicks.
+    idempotencyKey: `inv_${inv.id}_${balanceMinor}`,
+  });
+
+  if (!session.url) throw new InvoiceServiceError('Stripe did not return a checkout URL', 500, 'STRIPE_NO_URL');
+
+  await db.insert(invoiceStripePayments).values({
+    orgId: inv.orgId,
+    invoiceId: inv.id,
+    stripeAccountId: conn.stripeAccountId,
+    stripeObjectType: 'checkout_session',
+    stripeObjectId: session.id,
+    stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+    amount: Number(inv.balance).toFixed(2),
+    currency: inv.currencyCode,
+    status: 'pending',
+  });
+
+  return { url: session.url };
+}

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -1,9 +1,10 @@
 import { and, or, eq, desc, lt, inArray, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
-  invoices, invoiceLines, invoicePayments, organizations, partners,
+  invoices, invoiceLines, invoicePayments, invoiceStripePayments, organizations, partners,
   catalogBundleComponents, catalogItems, timeEntries, ticketParts, tickets
 } from '../db/schema';
+import { getConnection } from './stripeConnectService';
 import { computeLineTotal, computeInvoiceTotals, resolveEffectiveTaxRate, deriveInvoiceStatus, toCents, fromCents } from './invoiceMath';
 import { resolvePrice, computeBundleEconomics } from './catalogService';
 // formatInvoiceNumber is shared with the standalone allocator; issueInvoice
@@ -258,7 +259,12 @@ export async function updateInvoice(
 export async function getInvoice(invoiceId: string, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId); requireOrgAccess(actor, inv.orgId);
   const lines = await db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, invoiceId)).orderBy(invoiceLines.sortOrder);
-  return { invoice: inv, lines }; // accounting view (all lines)
+  // Whether this invoice's partner can collect online (gates the "Send payment
+  // link" UI). Partner-axis read under a partner/system request scope, so the
+  // actor's own connection row is RLS-visible. Best-effort: a lookup failure
+  // (e.g. Stripe unconfigured) just means "not connected".
+  const conn = await getConnection(inv.partnerId).catch(() => null);
+  return { invoice: inv, lines, stripeConnected: conn?.status === 'connected' }; // accounting view (all lines)
 }
 
 export async function getCustomerInvoice(invoiceId: string, orgId?: string) {
@@ -536,7 +542,16 @@ export async function voidPayment(paymentId: string, actor: InvoiceActor) {
 export async function listPayments(invoiceId: string, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
   requireOrgAccess(actor, inv.orgId);
-  return db.select().from(invoicePayments).where(eq(invoicePayments.invoiceId, invoiceId)).orderBy(invoicePayments.receivedAt);
+  const rows = await db.select().from(invoicePayments).where(eq(invoicePayments.invoiceId, invoiceId)).orderBy(invoicePayments.receivedAt);
+  // Tag each payment's origin so the UI can badge online (Stripe) payments and
+  // hide manual-void on them (Stripe payments are refunded through Stripe, not
+  // voided by hand). A payment is Stripe-sourced when a succeeded mapping links it.
+  const linked = await db
+    .select({ invoicePaymentId: invoiceStripePayments.invoicePaymentId })
+    .from(invoiceStripePayments)
+    .where(and(eq(invoiceStripePayments.invoiceId, invoiceId), eq(invoiceStripePayments.status, 'succeeded')));
+  const stripeIds = new Set(linked.map((r) => r.invoicePaymentId).filter((x): x is string => !!x));
+  return rows.map((r) => ({ ...r, source: stripeIds.has(r.id) ? ('stripe' as const) : ('manual' as const) }));
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/invoiceTypes.ts
+++ b/apps/api/src/services/invoiceTypes.ts
@@ -25,7 +25,11 @@ export type InvoiceServiceErrorCode =
   | 'INVALID_AMOUNT'
   | 'LINE_NOT_FOUND'
   | 'PAYMENT_NOT_FOUND'
-  | 'NUMBER_ALLOCATION_FAILED';
+  | 'NUMBER_ALLOCATION_FAILED'
+  | 'NOT_PAYABLE'
+  | 'NOTHING_TO_PAY'
+  | 'STRIPE_NOT_CONNECTED'
+  | 'STRIPE_NO_URL';
 
 export class InvoiceServiceError extends Error {
   constructor(

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -91,4 +91,40 @@ describe('InvoiceDetail', () => {
     fireEvent.change(screen.getByTestId('invoice-void-reason'), { target: { value: 'Duplicate' } });
     expect(screen.getByTestId('invoice-void-submit')).not.toBeDisabled();
   });
+
+  it('shows "Send payment link" when Stripe is connected and POSTs pay-link', async () => {
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.endsWith('/pay-link') && opts?.method === 'POST') return json({ data: { url: 'https://checkout.stripe.com/x' } });
+      if (input.endsWith('/payments')) return json({ data: [] });
+      return json({ data: {} });
+    });
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    render(<InvoiceDetail detail={{ ...issued, stripeConnected: true }} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-stripe-nudge')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('invoice-pay-link'));
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith('/pay-link') && (c[1] as RequestInit)?.method === 'POST')).toBe(true);
+    });
+  });
+
+  it('shows a connect-Stripe nudge (no pay-link) when not connected', async () => {
+    render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-stripe-nudge')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+  });
+
+  it('badges Stripe payments as Online and hides manual void on them', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.endsWith('/payments')) return json({ data: [
+        { id: 'p1', invoiceId: 'inv-1', amount: '120.00', method: 'card', reference: 'pi_x', receivedAt: '2026-06-10', note: null, createdAt: '', source: 'stripe' },
+      ] });
+      return json({ data: {} });
+    });
+    render(<InvoiceDetail detail={{ ...issued, stripeConnected: true }} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-payment-p1')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-payment-online-p1')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-void-p1')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
 import { Dialog } from '../shared/Dialog';
 import {
   type InvoiceDetail as InvoiceDetailData,
@@ -25,6 +26,7 @@ interface Props {
 export default function InvoiceDetail({ detail, onChanged }: Props) {
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
+  const stripeConnected = detail.stripeConnected === true;
 
   const [accountingView, setAccountingView] = useState(false);
   const [payments, setPayments] = useState<InvoicePayment[]>([]);
@@ -126,6 +128,33 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
       setBusy(false);
     }
   }, [busy, payAmount, payMethod, payRef, payDate, invoice.id, refresh]);
+
+  const sendPayLink = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const result = await runAction<{ data: { url: string } }>({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/pay-link`, { method: 'POST' }),
+        errorFallback: 'Could not create a payment link.',
+        friendly: (code) => (code === 'STRIPE_NOT_CONNECTED' ? 'Connect Stripe to accept online payments.' : undefined),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      const url = result?.data?.url;
+      if (url) {
+        try {
+          await navigator.clipboard.writeText(url);
+          showToast({ type: 'success', message: 'Payment link copied to clipboard' });
+        } catch {
+          // Clipboard blocked (insecure context / permissions) — surface the URL.
+          window.prompt('Share this payment link with your customer:', url);
+        }
+      }
+    } catch (err) {
+      handleActionError(err, 'Could not create a payment link.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, invoice.id]);
 
   const voidPayment = useCallback(async (paymentId: string) => {
     if (busy) return;
@@ -231,13 +260,22 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
               </span>
               <span className="text-xs text-muted-foreground">Due {formatDate(invoice.dueDate)}</span>
             </div>
-            <dl className="space-y-1 text-sm">
+            <dl className="space-y-1 text-sm tabular-nums">
               <div className="flex justify-between"><dt className="text-muted-foreground">Subtotal</dt><dd>{formatMoney(invoice.subtotal, currency)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(invoice.taxTotal, currency)}</dd></div>
               <div className="flex justify-between font-semibold"><dt>Total</dt><dd>{formatMoney(invoice.total, currency)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Paid</dt><dd>{formatMoney(invoice.amountPaid, currency)}</dd></div>
-              <div className="flex justify-between border-t pt-1 font-semibold"><dt>Balance</dt><dd data-testid="invoice-detail-balance">{formatMoney(invoice.balance, currency)}</dd></div>
             </dl>
+            {/* Balance-due focal number */}
+            <div className="mt-3 flex items-end justify-between border-t pt-3">
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Balance due</span>
+              <span
+                className={`text-2xl font-semibold tabular-nums ${Number(invoice.balance) > 0 && invoice.status !== 'void' ? '' : 'text-muted-foreground'}`}
+                data-testid="invoice-detail-balance"
+              >
+                {formatMoney(invoice.balance, currency)}
+              </span>
+            </div>
           </div>
 
           {/* PDF + void */}
@@ -273,20 +311,50 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
             ) : (
               <ul className="divide-y text-sm">
                 {payments.map((p) => (
-                  <li key={p.id} className="flex items-center justify-between py-2" data-testid={`invoice-payment-${p.id}`}>
-                    <span>
-                      {formatMoney(p.amount, currency)} · {PAYMENT_METHOD_LABELS[p.method]} · {formatDate(p.receivedAt)}
+                  <li key={p.id} className="flex items-center justify-between gap-2 py-2" data-testid={`invoice-payment-${p.id}`}>
+                    <span className="flex flex-wrap items-center gap-1.5">
+                      <span className="tabular-nums">{formatMoney(p.amount, currency)}</span>
+                      <span className="text-muted-foreground">· {PAYMENT_METHOD_LABELS[p.method]} · {formatDate(p.receivedAt)}</span>
+                      {p.source === 'stripe' && (
+                        <span
+                          className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+                          data-testid={`invoice-payment-online-${p.id}`}
+                        >
+                          Online
+                        </span>
+                      )}
                     </span>
-                    <button
-                      type="button" onClick={() => void voidPayment(p.id)} disabled={busy || invoice.status === 'void'}
-                      data-testid={`invoice-payment-void-${p.id}`}
-                      className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                    >
-                      Void
-                    </button>
+                    {/* Stripe payments are refunded through Stripe, never hand-voided. */}
+                    {p.source === 'stripe' ? (
+                      <span className="whitespace-nowrap text-[11px] text-muted-foreground">via Stripe</span>
+                    ) : (
+                      <button
+                        type="button" onClick={() => void voidPayment(p.id)} disabled={busy || invoice.status === 'void'}
+                        data-testid={`invoice-payment-void-${p.id}`}
+                        className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                      >
+                        Void
+                      </button>
+                    )}
                   </li>
                 ))}
               </ul>
+            )}
+
+            {canRecordPayment && stripeConnected && (
+              <button
+                type="button" onClick={() => void sendPayLink()} disabled={busy}
+                data-testid="invoice-pay-link"
+                className="mt-3 inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              >
+                Send payment link
+              </button>
+            )}
+            {canRecordPayment && !stripeConnected && (
+              <p className="mt-3 text-xs text-muted-foreground" data-testid="invoice-stripe-nudge">
+                Connect Stripe to accept online card payments.{' '}
+                <a href="/settings/billing" className="underline hover:text-foreground">Set up</a>
+              </p>
             )}
 
             {canRecordPayment && (

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -66,6 +66,8 @@ describe('InvoiceEditor', () => {
     render(<InvoiceEditor detail={draft([])} onChanged={onChanged} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
+    // Catalog is the default add mode now; switch to the manual line form.
+    fireEvent.click(screen.getByTestId('invoice-add-mode-manual'));
     fireEvent.change(screen.getByTestId('invoice-manual-desc'), { target: { value: 'New work' } });
     fireEvent.change(screen.getByTestId('invoice-manual-qty'), { target: { value: '3' } });
     fireEvent.change(screen.getByTestId('invoice-manual-price'), { target: { value: '20' } });
@@ -76,6 +78,35 @@ describe('InvoiceEditor', () => {
     expect(postCall).toBeTruthy();
     expect(JSON.parse((postCall![1] as RequestInit).body as string)).toMatchObject({
       description: 'New work', quantity: 3, unitPrice: 20, taxable: false,
+    });
+  });
+
+  it('adds a catalog item via the typeahead picker', async () => {
+    const catItem = (over: Record<string, unknown>) => ({
+      id: 'cat-1', partnerId: 'p1', itemType: 'service', name: 'Onboarding', sku: 'ONB-1',
+      description: null, billingType: 'one_time', unitPrice: '500.00', costBasis: null,
+      markupPercent: null, unitOfMeasure: 'each', taxable: true, taxCategory: null,
+      isBundle: false, isActive: true, createdAt: '', updatedAt: '', ...over,
+    });
+    const onChanged = vi.fn();
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [catItem({}), catItem({ id: 'bun-1', name: 'Starter Bundle', isBundle: true })] });
+      if (input === '/invoices/inv-1/lines/catalog' && opts?.method === 'POST') return json({ data: { id: 'line-9' } });
+      return json({ data: {} });
+    });
+    render(<InvoiceEditor detail={draft([])} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    // Catalog is the default mode — search and pick via the typeahead.
+    fireEvent.change(screen.getByTestId('invoice-catalog-picker-input'), { target: { value: 'Onb' } });
+    fireEvent.click(await screen.findByTestId('invoice-catalog-picker-option-cat-1'));
+    fireEvent.change(screen.getByTestId('invoice-pick-qty'), { target: { value: '2' } });
+    fireEvent.click(screen.getByTestId('invoice-catalog-add'));
+
+    await waitFor(() => {
+      const c = fetchMock.mock.calls.find((call) => call[0] === '/invoices/inv-1/lines/catalog');
+      expect(c).toBeTruthy();
+      expect(JSON.parse((c![1] as RequestInit).body as string)).toMatchObject({ catalogItemId: 'cat-1', quantity: 2 });
     });
   });
 

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -8,8 +8,8 @@ import {
   type InvoiceLine,
   formatMoney,
 } from './invoiceTypes';
-
-interface CatalogItem { id: string; name: string; isBundle: boolean }
+import CatalogItemPicker from '../catalog/CatalogItemPicker';
+import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -18,7 +18,7 @@ interface Props {
   onChanged: () => void;
 }
 
-type AddMode = 'manual' | 'catalog' | 'bundle';
+type AddMode = 'catalog' | 'manual';
 
 export default function InvoiceEditor({ detail, onChanged }: Props) {
   const { invoice, lines } = detail;
@@ -29,26 +29,23 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const [notesDirty, setNotesDirty] = useState(false);
 
   // Add-line form
-  const [addMode, setAddMode] = useState<AddMode>('manual');
+  const [addMode, setAddMode] = useState<AddMode>('catalog');
   const [manualDesc, setManualDesc] = useState('');
   const [manualQty, setManualQty] = useState('1');
   const [manualPrice, setManualPrice] = useState('0.00');
   const [manualTaxable, setManualTaxable] = useState(false);
-  const [catalogItems, setCatalogItems] = useState<CatalogItem[]>([]);
-  const [bundles, setBundles] = useState<CatalogItem[]>([]);
-  const [pickItemId, setPickItemId] = useState('');
+  const [catalog, setCatalog] = useState<CatalogItem[]>([]);
+  const [picked, setPicked] = useState<CatalogItem | null>(null);
   const [pickQty, setPickQty] = useState('1');
 
   useEffect(() => { setNotes(invoice.notes ?? ''); setNotesDirty(false); }, [invoice.notes]);
 
   const loadCatalog = useCallback(async () => {
-    const res = await fetchWithAuth('/catalog?isActive=true');
+    const res = await listCatalog({ isActive: true, limit: 200 });
     if (res.status === 401) return UNAUTHORIZED();
     if (!res.ok) { handleActionError(new Error(res.statusText), 'Failed to load catalog.'); return; }
     const body = (await res.json()) as { data: CatalogItem[] };
-    const all = body.data ?? [];
-    setCatalogItems(all.filter((i) => !i.isBundle));
-    setBundles(all.filter((i) => i.isBundle));
+    setCatalog(body.data ?? []);
   }, []);
 
   useEffect(() => { void loadCatalog(); }, [loadCatalog]);
@@ -90,20 +87,20 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
         });
         setManualDesc(''); setManualQty('1'); setManualPrice('0.00'); setManualTaxable(false);
       } else {
-        if (!pickItemId) return;
-        const path = addMode === 'catalog'
-          ? `/invoices/${invoice.id}/lines/catalog`
-          : `/invoices/${invoice.id}/lines/bundle`;
-        const body = addMode === 'catalog'
-          ? { catalogItemId: pickItemId, quantity: Number(pickQty) }
-          : { bundleId: pickItemId, quantity: Number(pickQty) };
+        if (!picked) return;
+        const path = picked.isBundle
+          ? `/invoices/${invoice.id}/lines/bundle`
+          : `/invoices/${invoice.id}/lines/catalog`;
+        const body = picked.isBundle
+          ? { bundleId: picked.id, quantity: Number(pickQty) }
+          : { catalogItemId: picked.id, quantity: Number(pickQty) };
         await runAction({
           request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify(body) }),
           errorFallback: 'Could not add line.',
           successMessage: 'Line added',
           onUnauthorized: UNAUTHORIZED,
         });
-        setPickItemId(''); setPickQty('1');
+        setPicked(null); setPickQty('1');
       }
       refresh();
     } catch (err) {
@@ -111,7 +108,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
     } finally {
       setBusy(false);
     }
-  }, [busy, addMode, manualDesc, manualQty, manualPrice, manualTaxable, pickItemId, pickQty, invoice.id, refresh]);
+  }, [busy, addMode, manualDesc, manualQty, manualPrice, manualTaxable, picked, pickQty, invoice.id, refresh]);
 
   const patchLine = useCallback(async (lineId: string, patch: Record<string, unknown>) => {
     if (busy) return;
@@ -264,17 +261,17 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           {/* Add line */}
           <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="invoice-add-line">
             <div className="mb-3 flex gap-2">
-              {(['manual', 'catalog', 'bundle'] as AddMode[]).map((m) => (
+              {(['catalog', 'manual'] as AddMode[]).map((m) => (
                 <button
                   key={m}
                   type="button"
                   onClick={() => setAddMode(m)}
                   data-testid={`invoice-add-mode-${m}`}
-                  className={`rounded-md border px-3 py-1.5 text-xs font-medium capitalize ${
+                  className={`rounded-md border px-3 py-1.5 text-xs font-medium ${
                     addMode === m ? 'border-primary bg-primary/10 text-primary' : 'hover:bg-muted'
                   }`}
                 >
-                  {m}
+                  {m === 'catalog' ? 'Catalog item' : 'Manual line'}
                 </button>
               ))}
             </div>
@@ -310,32 +307,41 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                   Add
                 </button>
               </div>
-            ) : (
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_80px_auto]">
-                <select
-                  value={pickItemId} onChange={(e) => setPickItemId(e.target.value)}
-                  data-testid="invoice-pick-item"
-                  className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                >
-                  <option value="">{addMode === 'catalog' ? 'Select an item…' : 'Select a bundle…'}</option>
-                  {(addMode === 'catalog' ? catalogItems : bundles).map((i) => (
-                    <option key={i.id} value={i.id}>{i.name}</option>
-                  ))}
-                </select>
+            ) : picked ? (
+              <div className="flex flex-wrap items-center gap-2" data-testid="invoice-catalog-picked">
+                <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1.5 text-sm">
+                  <span className="font-medium">{picked.name}</span>
+                  {picked.isBundle && (
+                    <span className="rounded border border-border bg-background px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Bundle</span>
+                  )}
+                  <button type="button" onClick={() => setPicked(null)} aria-label="Clear selection" className="ml-1 text-muted-foreground hover:text-foreground">×</button>
+                </span>
                 <input
-                  type="number" min="0" step="0.01" placeholder="Qty" value={pickQty}
-                  onChange={(e) => setPickQty(e.target.value)}
+                  type="number" min="0" step="0.01" value={pickQty}
+                  onChange={(e) => setPickQty(e.target.value)} aria-label="Quantity"
                   data-testid="invoice-pick-qty"
-                  className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="h-9 w-20 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
                 <button
-                  type="button" onClick={() => void addLine()} disabled={busy || !pickItemId}
-                  data-testid="invoice-add-line-submit"
+                  type="button" onClick={() => void addLine()} disabled={busy}
+                  data-testid="invoice-catalog-add"
                   className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                 >
                   Add
                 </button>
               </div>
+            ) : catalog.length === 0 ? (
+              <p className="text-sm text-muted-foreground" data-testid="invoice-catalog-empty">
+                No catalog items.{' '}
+                <a href="/settings/catalog" className="underline hover:text-foreground">Add some in Product Catalog</a>.
+              </p>
+            ) : (
+              <CatalogItemPicker
+                items={catalog}
+                onSelect={(it) => { setPicked(it); setPickQty('1'); }}
+                testId="invoice-catalog-picker"
+                placeholder="Search catalog by name or SKU"
+              />
             )}
           </div>
         </div>

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -56,9 +56,10 @@ describe('InvoicesPage', () => {
     expect(within(row).getByText('Acme Corp')).toBeInTheDocument();
     // Total + balance both render $100.00 in this row.
     expect(within(row).getAllByText('$100.00')).toHaveLength(2);
-    // Overdue badge label + danger row background.
+    // Overdue badge label + restrained overdue cue (red dot indicator + due tone),
+    // replacing the old full-row red tint.
     expect(screen.getByTestId('invoices-status-inv-1')).toHaveTextContent('Overdue');
-    expect(row.className).toContain('bg-red-500/5');
+    expect(row.querySelector('.bg-red-500')).not.toBeNull();
   });
 
   it('writes filter selections to the URL hash', async () => {

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -31,6 +31,9 @@ const STATUS_OPTIONS: { value: '' | InvoiceStatus; label: string }[] = [
   { value: 'void', label: 'Void' },
 ];
 
+type SortKey = 'issued' | 'due' | 'total' | 'balance';
+interface Sort { key: SortKey; dir: 'asc' | 'desc' }
+
 // ---- hash filter state (key=value&key=value) ----------------------------
 interface Filters {
   orgId: string;
@@ -64,6 +67,8 @@ function writeFilters(f: Filters): void {
 }
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
+const num = (s: string | null | undefined) => { const n = Number(s); return Number.isFinite(n) ? n : 0; };
+const ts = (d: string | null) => (d ? new Date(d.length === 10 ? `${d}T00:00:00` : d).getTime() : null);
 
 export default function InvoicesPage() {
   const [invoices, setInvoices] = useState<InvoiceSummary[]>([]);
@@ -71,9 +76,12 @@ export default function InvoicesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [filters, setFilters] = useState<Filters>(() => readFilters());
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<Sort | null>(null);
 
-  // Assemble dialog state
+  // New-invoice dialog state
   const [assembleOpen, setAssembleOpen] = useState(false);
+  const [mode, setMode] = useState<'assemble' | 'blank'>('assemble');
   const [assembleOrgId, setAssembleOrgId] = useState('');
   const [assembleSiteId, setAssembleSiteId] = useState('');
   const [assembleFrom, setAssembleFrom] = useState('');
@@ -134,7 +142,7 @@ export default function InvoicesPage() {
     });
   }, []);
 
-  // Load sites for the assemble org picker.
+  // Load sites for the org picker in the dialog.
   const loadAssembleSites = useCallback(async (orgId: string) => {
     setAssembleSiteId('');
     setAssembleSites([]);
@@ -147,6 +155,7 @@ export default function InvoicesPage() {
   }, []);
 
   const openAssemble = useCallback(() => {
+    setMode('assemble');
     setAssembleOrgId(filters.orgId || '');
     setAssembleSiteId('');
     setAssembleSites([]);
@@ -158,23 +167,26 @@ export default function InvoicesPage() {
     if (filters.orgId) void loadAssembleSites(filters.orgId);
   }, [filters.orgId, loadAssembleSites]);
 
-  const submitAssemble = useCallback(async () => {
-    if (assembling) return;
-    if (!assembleOrgId || !assembleFrom || !assembleTo) return;
+  const submitDialog = useCallback(async () => {
+    if (assembling || !assembleOrgId) return;
+    if (mode === 'assemble' && (!assembleFrom || !assembleTo)) return;
     setAssembling(true);
     try {
       const result = await runAction<{ data: { invoice: { id: string } } }>({
         request: () =>
-          fetchWithAuth(`/orgs/${assembleOrgId}/invoices/assemble`, {
-            method: 'POST',
-            body: JSON.stringify({
-              siteId: assembleSiteId || undefined,
-              from: assembleFrom,
-              to: assembleTo,
-            }),
-          }),
-        errorFallback: 'Could not assemble an invoice for that range.',
-        successMessage: 'Draft invoice assembled',
+          mode === 'assemble'
+            ? fetchWithAuth(`/orgs/${assembleOrgId}/invoices/assemble`, {
+                method: 'POST',
+                body: JSON.stringify({ siteId: assembleSiteId || undefined, from: assembleFrom, to: assembleTo }),
+              })
+            : fetchWithAuth('/invoices', {
+                method: 'POST',
+                body: JSON.stringify({ orgId: assembleOrgId, siteId: assembleSiteId || undefined }),
+              }),
+        errorFallback: mode === 'assemble'
+          ? 'Could not assemble an invoice for that range.'
+          : 'Could not create a draft invoice.',
+        successMessage: mode === 'assemble' ? 'Draft invoice assembled' : 'Draft invoice created',
         onUnauthorized: UNAUTHORIZED,
       });
       setAssembleOpen(false);
@@ -182,18 +194,64 @@ export default function InvoicesPage() {
       if (newId) void navigateTo(`/billing/invoices/${newId}`);
       else void loadInvoices(filters);
     } catch (err) {
-      handleActionError(err, 'Could not assemble an invoice for that range.');
+      handleActionError(err, 'Could not create the invoice.');
     } finally {
       setAssembling(false);
     }
-  }, [assembling, assembleOrgId, assembleSiteId, assembleFrom, assembleTo, filters, loadInvoices]);
+  }, [assembling, mode, assembleOrgId, assembleSiteId, assembleFrom, assembleTo, filters, loadInvoices]);
 
-  const isOverdue = (inv: InvoiceSummary) => inv.status === 'overdue';
+  const toggleSort = (key: SortKey) =>
+    setSort((s) => (s?.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' }));
 
-  const rows = useMemo(() => invoices, [invoices]);
+  // ---- derived rows: search filter (client) then optional sort ------------
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    let out = invoices.filter((inv) => {
+      if (!q) return true;
+      return (inv.invoiceNumber ?? '').toLowerCase().includes(q) || orgName(inv.orgId).toLowerCase().includes(q);
+    });
+    if (sort) {
+      const dir = sort.dir === 'asc' ? 1 : -1;
+      out = [...out].sort((a, b) => {
+        if (sort.key === 'total') return (num(a.total) - num(b.total)) * dir;
+        if (sort.key === 'balance') return (num(a.balance) - num(b.balance)) * dir;
+        const av = ts(sort.key === 'issued' ? a.issueDate : a.dueDate);
+        const bv = ts(sort.key === 'issued' ? b.issueDate : b.dueDate);
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1; // nulls (drafts) always last
+        if (bv == null) return -1;
+        return (av - bv) * dir;
+      });
+    }
+    return out;
+  }, [invoices, search, sort, orgName]);
+
+  // ---- outstanding summary (open balance + overdue count) -----------------
+  const summary = useMemo(() => {
+    const open = invoices.filter((i) => i.status !== 'void' && num(i.balance) > 0);
+    const outstanding = open.reduce((sum, i) => sum + num(i.balance), 0);
+    const overdue = invoices.filter((i) => i.status === 'overdue').length;
+    // Single-currency partners are the norm; format with the most common code.
+    const ccy = (invoices[0]?.currencyCode) || 'USD';
+    return { outstanding, overdue, openCount: open.length, ccy };
+  }, [invoices]);
+
+  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => (
+    <th className="px-3 py-3 text-right font-medium">
+      <button
+        type="button"
+        onClick={() => toggleSort(sortKey)}
+        className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
+        data-testid={`invoices-sort-${sortKey}`}
+      >
+        {label}
+        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+      </button>
+    </th>
+  );
 
   return (
-    <div className="space-y-6" data-testid="invoices-page">
+    <div className="space-y-5" data-testid="invoices-page">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold">Invoices</h1>
@@ -207,66 +265,96 @@ export default function InvoicesPage() {
           data-testid="invoices-assemble-open"
           className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
         >
-          Assemble invoice
+          New invoice
         </button>
       </div>
 
-      {/* Filters */}
-      <div className="flex flex-wrap items-end gap-3" data-testid="invoices-filters">
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          Organization
-          <select
-            value={filters.orgId}
-            onChange={(e) => applyFilter({ orgId: e.target.value })}
-            data-testid="invoices-filter-org"
-            className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          >
-            <option value="">All organizations</option>
-            {orgs.map((o) => (
-              <option key={o.id} value={o.id}>{o.name}</option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          Status
-          <select
-            value={filters.status}
-            onChange={(e) => applyFilter({ status: e.target.value as Filters['status'] })}
-            data-testid="invoices-filter-status"
-            className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          >
-            {STATUS_OPTIONS.map((s) => (
-              <option key={s.value} value={s.value}>{s.label}</option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          From
-          <input
-            type="date"
-            value={filters.from}
-            onChange={(e) => applyFilter({ from: e.target.value })}
-            data-testid="invoices-filter-from"
-            className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-        </label>
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          To
-          <input
-            type="date"
-            value={filters.to}
-            onChange={(e) => applyFilter({ to: e.target.value })}
-            data-testid="invoices-filter-to"
-            className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-        </label>
+      {/* Outstanding summary */}
+      {!loading && !error && invoices.length > 0 && (
+        <div className="flex flex-wrap gap-3" data-testid="invoices-outstanding-strip">
+          <div className="rounded-lg border bg-card px-4 py-3">
+            <div className="text-xs text-muted-foreground">Outstanding</div>
+            <div className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(summary.outstanding, summary.ccy)}</div>
+            <div className="text-xs text-muted-foreground">{summary.openCount} open</div>
+          </div>
+          {summary.overdue > 0 && (
+            <button
+              type="button"
+              onClick={() => applyFilter({ status: 'overdue' })}
+              className="rounded-lg border border-red-500/30 bg-red-500/5 px-4 py-3 text-left transition hover:bg-red-500/10"
+              data-testid="invoices-overdue-card"
+            >
+              <div className="text-xs text-red-700 dark:text-red-400">Overdue</div>
+              <div className="mt-0.5 text-lg font-semibold tabular-nums text-red-700 dark:text-red-400">{summary.overdue}</div>
+              <div className="text-xs text-muted-foreground">needs follow-up</div>
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Toolbar: search + filters */}
+      <div className="flex flex-wrap items-end gap-2" data-testid="invoices-filters">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search number or org"
+          aria-label="Search invoices"
+          className="h-10 min-w-[12rem] flex-1 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          data-testid="invoices-search"
+        />
+        <select
+          value={filters.orgId}
+          onChange={(e) => applyFilter({ orgId: e.target.value })}
+          data-testid="invoices-filter-org"
+          aria-label="Filter by organization"
+          className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">All organizations</option>
+          {orgs.map((o) => (
+            <option key={o.id} value={o.id}>{o.name}</option>
+          ))}
+        </select>
+        <select
+          value={filters.status}
+          onChange={(e) => applyFilter({ status: e.target.value as Filters['status'] })}
+          data-testid="invoices-filter-status"
+          aria-label="Filter by status"
+          className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+        <input
+          type="date"
+          value={filters.from}
+          onChange={(e) => applyFilter({ from: e.target.value })}
+          data-testid="invoices-filter-from"
+          aria-label="Issued from"
+          className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <input
+          type="date"
+          value={filters.to}
+          onChange={(e) => applyFilter({ to: e.target.value })}
+          data-testid="invoices-filter-to"
+          aria-label="Issued to"
+          className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
       </div>
 
       {/* Table */}
       <div className="rounded-lg border bg-card shadow-sm">
         {loading ? (
-          <div className="flex items-center justify-center py-12" data-testid="invoices-loading">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <div className="divide-y" data-testid="invoices-loading">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-4 px-4 py-3.5">
+                <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+                <div className="h-4 w-1/4 animate-pulse rounded bg-muted" />
+                <div className="ml-auto h-4 w-24 animate-pulse rounded bg-muted" />
+                <div className="h-5 w-16 animate-pulse rounded-full bg-muted" />
+              </div>
+            ))}
           </div>
         ) : error ? (
           <div className="p-6 text-center text-sm text-destructive" data-testid="invoices-error">
@@ -281,8 +369,23 @@ export default function InvoicesPage() {
               </button>
             </div>
           </div>
+        ) : invoices.length === 0 ? (
+          <div className="px-4 py-14 text-center" data-testid="invoices-empty">
+            <h3 className="text-sm font-semibold">No invoices yet</h3>
+            <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
+              Assemble unbilled time and parts into a draft, or start a blank invoice.
+            </p>
+            <button
+              type="button"
+              onClick={openAssemble}
+              className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+              data-testid="invoices-empty-new"
+            >
+              New invoice
+            </button>
+          </div>
         ) : rows.length === 0 ? (
-          <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="invoices-empty">
+          <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="invoices-no-match">
             No invoices match these filters.
           </div>
         ) : (
@@ -292,62 +395,94 @@ export default function InvoicesPage() {
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-3 py-3 font-medium">Number</th>
                   <th className="px-3 py-3 font-medium">Organization</th>
-                  <th className="px-3 py-3 font-medium">Issued</th>
-                  <th className="px-3 py-3 font-medium">Due</th>
-                  <th className="px-3 py-3 text-right font-medium">Total</th>
-                  <th className="px-3 py-3 text-right font-medium">Balance</th>
+                  <SortHeaderLeft label="Issued" sortKey="issued" sort={sort} onSort={toggleSort} />
+                  <SortHeaderLeft label="Due" sortKey="due" sort={sort} onSort={toggleSort} />
+                  <SortHeader label="Total" sortKey="total" />
+                  <SortHeader label="Balance" sortKey="balance" />
                   <th className="px-3 py-3 font-medium">Status</th>
                 </tr>
               </thead>
               <tbody>
-                {rows.map((inv) => (
-                  <tr
-                    key={inv.id}
-                    onClick={() => void navigateTo(`/billing/invoices/${inv.id}`)}
-                    data-testid={`invoices-row-${inv.id}`}
-                    className={`cursor-pointer border-t transition hover:bg-muted/40 ${
-                      isOverdue(inv) ? 'bg-red-500/5' : ''
-                    }`}
-                  >
-                    <td className="px-3 py-3 font-medium">
-                      {inv.invoiceNumber ?? <span className="text-muted-foreground">Draft</span>}
-                    </td>
-                    <td className="px-3 py-3">{orgName(inv.orgId)}</td>
-                    <td className="px-3 py-3">{formatDate(inv.issueDate)}</td>
-                    <td className="px-3 py-3">{formatDate(inv.dueDate)}</td>
-                    <td className="px-3 py-3 text-right">{formatMoney(inv.total, inv.currencyCode)}</td>
-                    <td className="px-3 py-3 text-right">{formatMoney(inv.balance, inv.currencyCode)}</td>
-                    <td className="px-3 py-3">
-                      <span
-                        className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
-                        data-testid={`invoices-status-${inv.id}`}
-                      >
-                        {STATUS_LABELS[inv.status]}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
+                {rows.map((inv) => {
+                  const overdue = inv.status === 'overdue';
+                  const hasBalance = num(inv.balance) > 0 && inv.status !== 'void';
+                  return (
+                    <tr
+                      key={inv.id}
+                      onClick={() => void navigateTo(`/billing/invoices/${inv.id}`)}
+                      data-testid={`invoices-row-${inv.id}`}
+                      className="cursor-pointer border-t transition hover:bg-muted/40"
+                    >
+                      <td className="px-3 py-3 font-medium">
+                        <span className="flex items-center gap-2">
+                          <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-red-500' : 'bg-transparent'}`} aria-hidden="true" />
+                          {inv.invoiceNumber ?? (
+                            <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              Draft
+                            </span>
+                          )}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3">{orgName(inv.orgId)}</td>
+                      <td className="px-3 py-3 text-muted-foreground">{formatDate(inv.issueDate)}</td>
+                      <td className={`px-3 py-3 ${overdue ? 'font-medium text-red-700 dark:text-red-400' : 'text-muted-foreground'}`}>
+                        {formatDate(inv.dueDate)}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums">{formatMoney(inv.total, inv.currencyCode)}</td>
+                      <td className={`px-3 py-3 text-right tabular-nums ${hasBalance ? 'font-medium' : 'text-muted-foreground'}`}>
+                        {formatMoney(inv.balance, inv.currencyCode)}
+                      </td>
+                      <td className="px-3 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
+                          data-testid={`invoices-status-${inv.id}`}
+                        >
+                          {STATUS_LABELS[inv.status]}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
         )}
       </div>
 
-      {/* Assemble dialog */}
+      {/* New-invoice dialog (assemble | blank) */}
       <Dialog
         open={assembleOpen}
         onClose={() => setAssembleOpen(false)}
-        title="Assemble invoice"
+        title="New invoice"
         maxWidth="lg"
         className="p-6"
       >
         <div className="space-y-4" data-testid="invoices-assemble-dialog">
           <div>
-            <h2 className="text-lg font-semibold">Assemble invoice</h2>
+            <h2 className="text-lg font-semibold">New invoice</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Pull unbilled time entries and parts for an organization into a new draft.
+              Assemble unbilled work into a draft, or start a blank invoice.
             </p>
           </div>
+
+          {/* Mode toggle */}
+          <div className="flex gap-1 rounded-md border bg-muted/40 p-1" role="group" aria-label="Invoice source">
+            {(['assemble', 'blank'] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                aria-pressed={mode === m}
+                className={`flex-1 rounded px-3 py-1.5 text-sm font-medium transition ${
+                  mode === m ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+                }`}
+                data-testid={`invoices-mode-${m}`}
+              >
+                {m === 'assemble' ? 'Assemble from work' : 'Blank invoice'}
+              </button>
+            ))}
+          </div>
+
           <label className="flex flex-col gap-1 text-sm">
             Organization
             <select
@@ -377,28 +512,32 @@ export default function InvoicesPage() {
               ))}
             </select>
           </label>
-          <div className="grid grid-cols-2 gap-3">
-            <label className="flex flex-col gap-1 text-sm">
-              From
-              <input
-                type="date"
-                value={assembleFrom}
-                onChange={(e) => setAssembleFrom(e.target.value)}
-                data-testid="invoices-assemble-from"
-                className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-sm">
-              To
-              <input
-                type="date"
-                value={assembleTo}
-                onChange={(e) => setAssembleTo(e.target.value)}
-                data-testid="invoices-assemble-to"
-                className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-            </label>
-          </div>
+
+          {mode === 'assemble' && (
+            <div className="grid grid-cols-2 gap-3">
+              <label className="flex flex-col gap-1 text-sm">
+                From
+                <input
+                  type="date"
+                  value={assembleFrom}
+                  onChange={(e) => setAssembleFrom(e.target.value)}
+                  data-testid="invoices-assemble-from"
+                  className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                To
+                <input
+                  type="date"
+                  value={assembleTo}
+                  onChange={(e) => setAssembleTo(e.target.value)}
+                  data-testid="invoices-assemble-to"
+                  className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </label>
+            </div>
+          )}
+
           <div className="flex justify-end gap-2 pt-2">
             <button
               type="button"
@@ -409,17 +548,37 @@ export default function InvoicesPage() {
             </button>
             <button
               type="button"
-              onClick={() => void submitAssemble()}
-              disabled={!assembleOrgId || !assembleFrom || !assembleTo || assembling}
+              onClick={() => void submitDialog()}
+              disabled={!assembleOrgId || (mode === 'assemble' && (!assembleFrom || !assembleTo)) || assembling}
               data-testid="invoices-assemble-submit"
               className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
             >
-              {assembling ? 'Assembling…' : 'Assemble'}
+              {assembling ? 'Working…' : mode === 'assemble' ? 'Assemble' : 'Create draft'}
             </button>
           </div>
         </div>
       </Dialog>
     </div>
+  );
+}
+
+// Left-aligned sortable header (Issued/Due). Right-aligned headers use the inline
+// SortHeader defined in the component.
+function SortHeaderLeft({
+  label, sortKey, sort, onSort,
+}: { label: string; sortKey: SortKey; sort: Sort | null; onSort: (k: SortKey) => void }) {
+  return (
+    <th className="px-3 py-3 font-medium">
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className="inline-flex items-center gap-1 hover:text-foreground"
+        data-testid={`invoices-sort-${sortKey}`}
+      >
+        {label}
+        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+      </button>
+    </th>
   );
 }
 

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -172,7 +172,7 @@ export default function InvoicesPage() {
     if (mode === 'assemble' && (!assembleFrom || !assembleTo)) return;
     setAssembling(true);
     try {
-      const result = await runAction<{ data: { invoice: { id: string } } }>({
+      const result = await runAction<{ data: { id?: string; invoice?: { id?: string } } }>({
         request: () =>
           mode === 'assemble'
             ? fetchWithAuth(`/orgs/${assembleOrgId}/invoices/assemble`, {
@@ -190,7 +190,8 @@ export default function InvoicesPage() {
         onUnauthorized: UNAUTHORIZED,
       });
       setAssembleOpen(false);
-      const newId = result?.data?.invoice?.id;
+      // assemble nests under data.invoice.id; blank create returns the row at data.id.
+      const newId = result?.data?.invoice?.id ?? result?.data?.id;
       if (newId) void navigateTo(`/billing/invoices/${newId}`);
       else void loadInvoices(filters);
     } catch (err) {

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -47,6 +47,9 @@ export interface InvoiceLine {
 export interface InvoiceDetail {
   invoice: InvoiceSummary;
   lines: InvoiceLine[];
+  /** Whether the partner has an active Stripe Connect account (gates "Send
+   *  payment link"). Absent on older API responses → treated as not connected. */
+  stripeConnected?: boolean;
 }
 
 export interface InvoicePayment {
@@ -58,6 +61,9 @@ export interface InvoicePayment {
   receivedAt: string;
   note: string | null;
   createdAt: string;
+  /** Origin of the payment: 'stripe' = collected via online checkout (refund
+   *  through Stripe, no manual void), 'manual' = recorded by an operator. */
+  source?: 'stripe' | 'manual';
 }
 
 export const STATUS_LABELS: Record<InvoiceStatus, string> = {

--- a/apps/web/src/components/catalog/CatalogItemPicker.tsx
+++ b/apps/web/src/components/catalog/CatalogItemPicker.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { formatMoney } from '../../lib/timeFormat';
+import {
+  CATALOG_TYPE_CHIP, CATALOG_TYPE_LABELS,
+  type CatalogItem,
+} from '../../lib/api/catalog';
+
+interface Props {
+  /** Active catalog items to search (caller loads via lib/api/catalog.listCatalog). */
+  items: CatalogItem[];
+  /** Called when the user picks an item (cleared after). */
+  onSelect: (item: CatalogItem) => void;
+  /** Include bundles in results (badged). Default true. */
+  includeBundles?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  testId?: string;
+}
+
+const MAX_RESULTS = 8;
+
+/**
+ * Shared catalog typeahead: search active catalog items by name or SKU, see the
+ * type chip + unit price (+ Bundle badge), pick to add. Reused by the invoice and
+ * contract line builders. The dropdown is absolutely positioned within a relative
+ * wrapper (callers place it in non-overflow-clipped form areas).
+ */
+export default function CatalogItemPicker({
+  items, onSelect, includeBundles = true, placeholder = 'Search catalog by name or SKU', disabled, testId = 'catalog-picker',
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return items
+      .filter((i) => i.isActive && (includeBundles || !i.isBundle))
+      .filter((i) => !q || i.name.toLowerCase().includes(q) || (i.sku ?? '').toLowerCase().includes(q))
+      .slice(0, MAX_RESULTS);
+  }, [items, query, includeBundles]);
+
+  useEffect(() => { setActive(0); }, [query, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  const choose = (item: CatalogItem) => {
+    onSelect(item);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') { setOpen(false); return; }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setOpen(true); setActive((a) => Math.min(a + 1, results.length - 1)); return; }
+    if (e.key === 'ArrowUp') { e.preventDefault(); setActive((a) => Math.max(a - 1, 0)); return; }
+    if (e.key === 'Enter' && open && results[active]) { e.preventDefault(); choose(results[active]); }
+  };
+
+  return (
+    <div ref={wrapRef} className="relative" data-testid={testId}>
+      <input
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        value={query}
+        disabled={disabled}
+        placeholder={placeholder}
+        onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+        className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+        data-testid={`${testId}-input`}
+      />
+      {open && results.length > 0 && (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute z-30 mt-1 max-h-64 w-full overflow-auto rounded-md border bg-card py-1 shadow-lg"
+          data-testid={`${testId}-list`}
+        >
+          {results.map((item, idx) => (
+            <li key={item.id} role="option" aria-selected={idx === active}>
+              <button
+                type="button"
+                onMouseEnter={() => setActive(idx)}
+                onClick={() => choose(item)}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm ${idx === active ? 'bg-muted' : ''}`}
+                data-testid={`${testId}-option-${item.id}`}
+              >
+                <span className="flex-1 truncate font-medium">{item.name}</span>
+                {item.isBundle && (
+                  <span className="rounded border border-border bg-muted px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    Bundle
+                  </span>
+                )}
+                <span className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${CATALOG_TYPE_CHIP[item.itemType]}`}>
+                  {CATALOG_TYPE_LABELS[item.itemType]}
+                </span>
+                {item.sku && <span className="font-mono text-[11px] text-muted-foreground">{item.sku}</span>}
+                <span className="tabular-nums text-muted-foreground">{formatMoney(item.unitPrice)}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {open && query.trim() !== '' && results.length === 0 && (
+        <div
+          className="absolute z-30 mt-1 w-full rounded-md border bg-card px-3 py-2 text-xs text-muted-foreground shadow-lg"
+          data-testid={`${testId}-noresults`}
+        >
+          No matching catalog items.
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
**Stacked on #1435 (Catalog).** Review/merge #1435 first; this branch contains its commits until then.

Production redesign of the Invoices feature (per `$impeccable shape` brief), reusing the Catalog/Contracts vocabulary. **Feature complete; pending Todd's UI test.**

### List
Search (number/org), org/status/date filters, sortable Issued/Due/Total/Balance, status chips, emphasized balance, restrained overdue cue, skeleton/teach states, **Outstanding summary strip**.

### Create
"New invoice" dialog: **Assemble-from-work** vs **Blank invoice**.

### Draft editor
- **Shared Catalog typeahead picker** (search by name/SKU → type chip · price · Bundle badge) is the primary add path; manual line secondary.
- Picked item → qty → `POST /lines/catalog` or `/lines/bundle`. Empty-catalog links to Product Catalog.

### Issued detail
- **Balance-due focal** number; accounting view; void/reissue dialog.
- **Stripe online payments** (gated on the partner's Stripe Connect): **Send payment link** copies a Checkout URL to share; quiet connect nudge when not connected. Stripe-collected payments badged **Online** (no manual void).
- **PDF download** verified (valid %PDF, 1 page).

### Backend
- `POST /invoices/:id/pay-link` (new `invoiceCheckout` service, twin of the portal pay route; 409 when Stripe not connected).
- `getInvoice` → `stripeConnected`; `listPayments` → per-payment `source`.

### Verification
`astro check` clean · web tests: list 4/4, editor 7/7, detail 6/6 · api pay-link route 3/3 · live in-browser: list, create→editor→add catalog line→totals, detail, PDF download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)