### PR TITLE
feat(db): #1105 Phase 1 — tripwires for txn-around-slow-work pool poisoning

### DIFF
--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -8,8 +8,8 @@
  *      inside a held context; warn-only by default, throws under strict mode.
  *   2. the held-context duration warning baked into withDbAccessContext.
  *
- * Real-DB integration test because both mechanisms depend on a genuinely held
- * transaction (withSystemDbAccessContext opens one on the breeze_app pool).
+ * Real-DB integration test because the duration warning depends on a genuinely
+ * held transaction (withSystemDbAccessContext opens one on the breeze_app pool).
  */
 import './setup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -19,8 +19,14 @@ import {
   assertOutsideHeldDbContext,
 } from '../../db';
 
+const HELD = 'held a pooled connection';
+
 describe('#1105 DB-context tripwires', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  function heldWarns(): unknown[][] {
+    return warnSpy.mock.calls.filter((c: unknown[]) => String(c[0]).includes(HELD));
+  }
 
   beforeEach(() => {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -29,6 +35,7 @@ describe('#1105 DB-context tripwires', () => {
   afterEach(() => {
     warnSpy.mockRestore();
     delete process.env.DB_CONTEXT_TRIPWIRE_STRICT;
+    delete process.env.DB_CONTEXT_HELD_WARN_MS;
   });
 
   describe('assertOutsideHeldDbContext', () => {
@@ -56,8 +63,17 @@ describe('#1105 DB-context tripwires', () => {
       expect(hit).toBeUndefined();
     });
 
-    it('throws inside a held context under strict mode (CI)', async () => {
+    it('throws inside a held context under strict mode (=1)', async () => {
       process.env.DB_CONTEXT_TRIPWIRE_STRICT = '1';
+      await expect(
+        withSystemDbAccessContext(async () => {
+          assertOutsideHeldDbContext('redis.enqueue');
+        }),
+      ).rejects.toThrow(/#1105/);
+    });
+
+    it('accepts truthy spellings for strict mode (e.g. "true")', async () => {
+      process.env.DB_CONTEXT_TRIPWIRE_STRICT = 'true';
       await expect(
         withSystemDbAccessContext(async () => {
           assertOutsideHeldDbContext('redis.enqueue');
@@ -67,36 +83,57 @@ describe('#1105 DB-context tripwires', () => {
   });
 
   describe('held-context duration warning', () => {
-    it('warns when a context is held longer than DB_CONTEXT_HELD_WARN_MS', async () => {
-      const prev = process.env.DB_CONTEXT_HELD_WARN_MS;
+    it('warns (with scope) when a context is held longer than DB_CONTEXT_HELD_WARN_MS', async () => {
       process.env.DB_CONTEXT_HELD_WARN_MS = '50';
-      try {
+      await withSystemDbAccessContext(async () => {
+        // Stand in for slow non-DB work (Redis/HTTP) inside the context.
+        await new Promise((resolve) => setTimeout(resolve, 90));
+      });
+      const hits = heldWarns();
+      expect(hits).toHaveLength(1);
+      expect(String(hits[0]![0])).toContain('#1105');
+      expect(String(hits[0]![0])).toContain('scope=system');
+    });
+
+    it('still warns when fn THROWS after holding the context too long (the finally path)', async () => {
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+      await expect(
+        withSystemDbAccessContext(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 90));
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+      // The original error must still propagate AND the warn must have fired.
+      expect(heldWarns()).toHaveLength(1);
+    });
+
+    it('does not double-warn for a nested context (only the outermost holds the txn)', async () => {
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+      await withSystemDbAccessContext(async () => {
+        // Nested call short-circuits (reuses the parent context, no new txn).
         await withSystemDbAccessContext(async () => {
-          // Stand in for slow non-DB work (Redis/HTTP) inside the context.
           await new Promise((resolve) => setTimeout(resolve, 90));
         });
-      } finally {
-        if (prev === undefined) delete process.env.DB_CONTEXT_HELD_WARN_MS;
-        else process.env.DB_CONTEXT_HELD_WARN_MS = prev;
-      }
-      const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes('held a pooled connection'));
-      expect(hit).toBeTruthy();
-      expect(String(hit![0])).toContain('#1105');
+      });
+      expect(heldWarns()).toHaveLength(1);
+    });
+
+    it('disables the duration warn when DB_CONTEXT_HELD_WARN_MS=0', async () => {
+      process.env.DB_CONTEXT_HELD_WARN_MS = '0';
+      await withSystemDbAccessContext(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 60));
+      });
+      expect(heldWarns()).toHaveLength(0);
     });
 
     it('does not warn for a fast DB-only context (no slow work)', async () => {
-      const prev = process.env.DB_CONTEXT_HELD_WARN_MS;
-      process.env.DB_CONTEXT_HELD_WARN_MS = '500';
-      try {
-        await withSystemDbAccessContext(async () => {
-          // trivial; well under threshold
-        });
-      } finally {
-        if (prev === undefined) delete process.env.DB_CONTEXT_HELD_WARN_MS;
-        else process.env.DB_CONTEXT_HELD_WARN_MS = prev;
-      }
-      const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes('held a pooled connection'));
-      expect(hit).toBeUndefined();
+      // Generous threshold so the real set_config round-trips on a slow CI DB
+      // can't spuriously trip it.
+      process.env.DB_CONTEXT_HELD_WARN_MS = '5000';
+      await withSystemDbAccessContext(async () => {
+        // trivial; well under threshold
+      });
+      expect(heldWarns()).toHaveLength(0);
     });
   });
 });

--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #1105 Phase 1 — DB-context tripwires.
+ *
+ * Exercises the two detection mechanisms added to surface the
+ * txn-around-slow-work foot-gun (a withDbAccessContext transaction held across
+ * slow non-DB work, which poisons the pool under a mass agent reconnect):
+ *   1. `assertOutsideHeldDbContext(op)` — fires when a slow primitive runs
+ *      inside a held context; warn-only by default, throws under strict mode.
+ *   2. the held-context duration warning baked into withDbAccessContext.
+ *
+ * Real-DB integration test because both mechanisms depend on a genuinely held
+ * transaction (withSystemDbAccessContext opens one on the breeze_app pool).
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  withSystemDbAccessContext,
+  runOutsideDbContext,
+  assertOutsideHeldDbContext,
+} from '../../db';
+
+describe('#1105 DB-context tripwires', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    delete process.env.DB_CONTEXT_TRIPWIRE_STRICT;
+  });
+
+  describe('assertOutsideHeldDbContext', () => {
+    it('is a no-op outside any DB context', () => {
+      expect(() => assertOutsideHeldDbContext('redis.enqueue')).not.toThrow();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns (warn-only default) when called inside a held context', async () => {
+      await withSystemDbAccessContext(async () => {
+        assertOutsideHeldDbContext('redis.enqueue');
+      });
+      const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes('redis.enqueue'));
+      expect(hit).toBeTruthy();
+      expect(String(hit![0])).toContain('#1105');
+    });
+
+    it('does NOT fire when the slow work is wrapped in runOutsideDbContext (escape hatch)', async () => {
+      await withSystemDbAccessContext(async () => {
+        await runOutsideDbContext(async () => {
+          assertOutsideHeldDbContext('redis.enqueue');
+        });
+      });
+      const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes('redis.enqueue'));
+      expect(hit).toBeUndefined();
+    });
+
+    it('throws inside a held context under strict mode (CI)', async () => {
+      process.env.DB_CONTEXT_TRIPWIRE_STRICT = '1';
+      await expect(
+        withSystemDbAccessContext(async () => {
+          assertOutsideHeldDbContext('redis.enqueue');
+        }),
+      ).rejects.toThrow(/#1105/);
+    });
+  });
+
+  describe('held-context duration warning', () => {
+    it('warns when a context is held longer than DB_CONTEXT_HELD_WARN_MS', async () => {
+      const prev = process.env.DB_CONTEXT_HELD_WARN_MS;
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+      try {
+        await withSystemDbAccessContext(async () => {
+          // Stand in for slow non-DB work (Redis/HTTP) inside the context.
+          await new Promise((resolve) => setTimeout(resolve, 90));
+        });
+      } finally {
+        if (prev === undefined) delete process.env.DB_CONTEXT_HELD_WARN_MS;
+        else process.env.DB_CONTEXT_HELD_WARN_MS = prev;
+      }
+      const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes('held a pooled connection'));
+      expect(hit).toBeTruthy();
+      expect(String(hit![0])).toContain('#1105');
+    });
+
+    it('does not warn for a fast DB-only context (no slow work)', async () => {
+      const prev = process.env.DB_CONTEXT_HELD_WARN_MS;
+      process.env.DB_CONTEXT_HELD_WARN_MS = '500';
+      try {
+        await withSystemDbAccessContext(async () => {
+          // trivial; well under threshold
+        });
+      } finally {
+        if (prev === undefined) delete process.env.DB_CONTEXT_HELD_WARN_MS;
+        else process.env.DB_CONTEXT_HELD_WARN_MS = prev;
+      }
+      const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes('held a pooled connection'));
+      expect(hit).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -117,15 +117,20 @@ function serializeAccessibleIds(scope: DbAccessScope, accessibleIds: string[] | 
 // does slow NON-DB work (Redis/BullMQ enqueue, outbound HTTP, per-device
 // loops) the connection sits idle-in-transaction; under a mass agent reconnect
 // those connections are killed by idle_in_transaction_session_timeout and
-// cascade into a pool-poisoning login outage. A context held far longer than
-// pure DB work should take is the signal. Warn-only (prod-safe, like the
-// contextless-write guard below); tune or disable via DB_CONTEXT_HELD_WARN_MS
-// (0 disables). The fix at a flagged site is to move the slow work after the
-// context closes, or wrap it in runOutsideDbContext().
+// cascade into a pool-poisoning connection-exhaustion outage.
+//
+// This is a COARSE heuristic: it measures total time `fn` held the context,
+// which it cannot distinguish from a legitimately slow DB query that keeps the
+// connection busy (not idle). Both are worth knowing about, but the precise
+// "slow non-DB work inside a context" signal comes from assertOutsideHeldDbContext
+// once it is wired into the slow primitives (Phase 2). The default threshold is
+// therefore set well above normal request latency to stay an outlier signal.
+// Warn-only (prod-safe, mirroring the contextless-write guard, #1375); tune or
+// disable via DB_CONTEXT_HELD_WARN_MS (0 disables).
 function getHeldContextWarnMs(): number {
   const raw = Number.parseInt(process.env.DB_CONTEXT_HELD_WARN_MS ?? '', 10);
   if (!Number.isFinite(raw) || raw < 0) {
-    return 500;
+    return 2000;
   }
   return raw;
 }
@@ -155,17 +160,25 @@ export async function withDbAccessContext<T>(
     try {
       return await dbContextStorage.run(tx as unknown as typeof baseDb, fn);
     } finally {
-      if (warnMs > 0) {
-        const heldMs = Date.now() - startedAt;
-        if (heldMs >= warnMs) {
-          const message =
-            `withDbAccessContext (scope=${context.scope}) held a pooled connection in an open `
-            + `transaction for ${heldMs}ms (>= ${warnMs}ms) — likely slow non-DB work inside the `
-            + `context. Move Redis/HTTP/loops after the context closes or wrap them in `
-            + `runOutsideDbContext (#1105).`;
-          console.warn(message);
-          captureMessage(message, 'warning', { heldMs, scope: context.scope, stack: new Error().stack });
+      // The whole point of this block is to SURFACE problems, so it must never
+      // BECOME one: any throw here (e.g. a Sentry transport hiccup) would, from
+      // a finally, mask fn's real return value or error. Swallow instrumentation
+      // failures so the transaction's true outcome always propagates unchanged.
+      try {
+        if (warnMs > 0) {
+          const heldMs = Date.now() - startedAt;
+          if (heldMs >= warnMs) {
+            const message =
+              `withDbAccessContext (scope=${context.scope}) held a pooled connection in an open `
+              + `transaction for ${heldMs}ms (>= ${warnMs}ms) — long enough that it likely did slow `
+              + `non-DB work (Redis/HTTP/loops) or a slow query inside the context. If the former, `
+              + `move it after the context closes or wrap it in runOutsideDbContext (#1105).`;
+            console.warn(message);
+            captureMessage(message, 'warning', { heldMs, scope: context.scope, stack: new Error().stack });
+          }
         }
+      } catch {
+        // Detection instrumentation must never alter fn's real result/error.
       }
     }
   });
@@ -202,20 +215,22 @@ export const runOutsideDbContext: RunOutsideDbContextFn = <T>(fn: () => T): T =>
 
 /**
  * #1105 tripwire guard. Call at the top of a known-slow primitive — a
- * Redis/BullMQ enqueue, an outbound HTTP request, or anything that acquires a
- * second pooled connection — to flag when it runs while a withDbAccessContext
- * transaction is still held. That is the txn-around-slow-work pattern: the
- * primitive pins the open transaction's pooled connection idle-in-transaction
- * across its own latency, and under a mass agent reconnect those connections
- * are killed and cascade into a pool-poisoning login outage.
+ * Redis/BullMQ enqueue or an outbound HTTP request — to flag when it runs while
+ * a withDbAccessContext transaction is still held. That is the txn-around-slow-
+ * work pattern: the held transaction's pooled connection sits idle across the
+ * primitive's latency, and under a mass agent reconnect those connections are
+ * killed and cascade into a pool-poisoning connection-exhaustion outage.
  *
  * The fix at a call site is to do the slow work AFTER the context closes, or
  * inside `runOutsideDbContext(...)` (which exits the context so this guard is a
  * no-op). Warn-only by default — prod-safe, mirroring the contextless-write
- * guard — so it never breaks a running deploy. Set DB_CONTEXT_TRIPWIRE_STRICT=1
- * (intended for CI) to throw instead, so a newly-introduced violation fails the
- * build rather than only surfacing in Sentry after an incident.
+ * guard (#1375) — so it never breaks a running deploy. Set
+ * DB_CONTEXT_TRIPWIRE_STRICT (1/true/yes/on) to throw instead, so a
+ * newly-introduced violation fails the build rather than only surfacing in
+ * Sentry after an incident.
  */
+const STRICT_TRIPWIRE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
 export function assertOutsideHeldDbContext(operation: string): void {
   if (!hasDbAccessContext()) {
     return;
@@ -224,7 +239,7 @@ export function assertOutsideHeldDbContext(operation: string): void {
     `${operation} ran inside a held withDbAccessContext transaction — it pins a pooled `
     + `connection idle-in-transaction across slow work (#1105). Move it after the context `
     + `closes or wrap it in runOutsideDbContext().`;
-  if (process.env.DB_CONTEXT_TRIPWIRE_STRICT === '1') {
+  if (STRICT_TRIPWIRE_VALUES.has((process.env.DB_CONTEXT_TRIPWIRE_STRICT ?? '').trim().toLowerCase())) {
     throw new Error(message);
   }
   console.warn(message);

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -111,6 +111,25 @@ function serializeAccessibleIds(scope: DbAccessScope, accessibleIds: string[] | 
   return accessibleIds.join(',');
 }
 
+// #1105 — held-context duration tripwire. withDbAccessContext sets the RLS
+// GUCs with SET LOCAL, so it MUST hold an open transaction for the full
+// duration of `fn` — pinning one pooled connection the whole time. If `fn`
+// does slow NON-DB work (Redis/BullMQ enqueue, outbound HTTP, per-device
+// loops) the connection sits idle-in-transaction; under a mass agent reconnect
+// those connections are killed by idle_in_transaction_session_timeout and
+// cascade into a pool-poisoning login outage. A context held far longer than
+// pure DB work should take is the signal. Warn-only (prod-safe, like the
+// contextless-write guard below); tune or disable via DB_CONTEXT_HELD_WARN_MS
+// (0 disables). The fix at a flagged site is to move the slow work after the
+// context closes, or wrap it in runOutsideDbContext().
+function getHeldContextWarnMs(): number {
+  const raw = Number.parseInt(process.env.DB_CONTEXT_HELD_WARN_MS ?? '', 10);
+  if (!Number.isFinite(raw) || raw < 0) {
+    return 500;
+  }
+  return raw;
+}
+
 export async function withDbAccessContext<T>(
   context: DbAccessContext,
   fn: () => Promise<T>
@@ -131,7 +150,24 @@ export async function withDbAccessContext<T>(
     await tx.execute(sql`select set_config('breeze.user_id', ${serializedUserId}, true)`);
     await tx.execute(sql`select set_config('breeze.current_partner_id', ${context.currentPartnerId ?? ''}, true)`);
 
-    return dbContextStorage.run(tx as unknown as typeof baseDb, fn);
+    const warnMs = getHeldContextWarnMs();
+    const startedAt = warnMs > 0 ? Date.now() : 0;
+    try {
+      return await dbContextStorage.run(tx as unknown as typeof baseDb, fn);
+    } finally {
+      if (warnMs > 0) {
+        const heldMs = Date.now() - startedAt;
+        if (heldMs >= warnMs) {
+          const message =
+            `withDbAccessContext (scope=${context.scope}) held a pooled connection in an open `
+            + `transaction for ${heldMs}ms (>= ${warnMs}ms) — likely slow non-DB work inside the `
+            + `context. Move Redis/HTTP/loops after the context closes or wrap them in `
+            + `runOutsideDbContext (#1105).`;
+          console.warn(message);
+          captureMessage(message, 'warning', { heldMs, scope: context.scope, stack: new Error().stack });
+        }
+      }
+    }
   });
 }
 
@@ -163,6 +199,37 @@ export type RunOutsideDbContextFn = <T>(fn: () => T) => T;
 export const runOutsideDbContext: RunOutsideDbContextFn = <T>(fn: () => T): T => {
   return dbContextStorage.exit(fn);
 };
+
+/**
+ * #1105 tripwire guard. Call at the top of a known-slow primitive — a
+ * Redis/BullMQ enqueue, an outbound HTTP request, or anything that acquires a
+ * second pooled connection — to flag when it runs while a withDbAccessContext
+ * transaction is still held. That is the txn-around-slow-work pattern: the
+ * primitive pins the open transaction's pooled connection idle-in-transaction
+ * across its own latency, and under a mass agent reconnect those connections
+ * are killed and cascade into a pool-poisoning login outage.
+ *
+ * The fix at a call site is to do the slow work AFTER the context closes, or
+ * inside `runOutsideDbContext(...)` (which exits the context so this guard is a
+ * no-op). Warn-only by default — prod-safe, mirroring the contextless-write
+ * guard — so it never breaks a running deploy. Set DB_CONTEXT_TRIPWIRE_STRICT=1
+ * (intended for CI) to throw instead, so a newly-introduced violation fails the
+ * build rather than only surfacing in Sentry after an incident.
+ */
+export function assertOutsideHeldDbContext(operation: string): void {
+  if (!hasDbAccessContext()) {
+    return;
+  }
+  const message =
+    `${operation} ran inside a held withDbAccessContext transaction — it pins a pooled `
+    + `connection idle-in-transaction across slow work (#1105). Move it after the context `
+    + `closes or wrap it in runOutsideDbContext().`;
+  if (process.env.DB_CONTEXT_TRIPWIRE_STRICT === '1') {
+    throw new Error(message);
+  }
+  console.warn(message);
+  captureMessage(message, 'warning', { operation, stack: new Error().stack });
+}
 
 // Write methods that, when invoked on the bare pool (no active RLS access
 // context), silently match 0 rows under the forced-RLS `breeze_app` role


### PR DESCRIPTION
**Phase 1 of the #1105 design proposal** (#1439). Detection only — no migration, no behavior change by default.

## Why
The architectural root of #1105: `withDbAccessContext` sets the RLS GUCs with `SET LOCAL`, so it **must** hold an open transaction for the full duration of its callback — pinning one pooled connection. When the callback does slow non-DB work (Redis/BullMQ enqueue, HTTP, per-device loops), the connection sits idle-in-transaction; under a mass agent reconnect those connections are killed by `idle_in_transaction_session_timeout` and cascade into a pool-poisoning login outage.

The two prior fixes (#1116, #1313) each needed a **production incident** to find, because nothing *detects* the pattern. Phase 1 fixes that.

## What this adds
- **Held-context duration warning** in `withDbAccessContext`: if a context is held ≥ `DB_CONTEXT_HELD_WARN_MS` (default 500ms) → `console.warn` + Sentry. A context held far longer than pure DB work almost always means slow non-DB work ran inside it. Universal net, warn-only, prod-safe; set the env to `0` to disable.
- **`assertOutsideHeldDbContext(op)`**: a reusable guard to tag known-slow primitives. Warn-only by default; `DB_CONTEXT_TRIPWIRE_STRICT=1` (for a CI job) makes it **throw**, so a newly-introduced violation fails the build. Escape hatch is `runOutsideDbContext()`, which exits the context and makes the guard a no-op.

Both default to **warn-only**, mirroring the existing contextless-write guard (`#1375`), so nothing breaks on deploy.

## Scope / what's deliberately deferred
- Wiring `assertOutsideHeldDbContext` into the ~56 enqueue sites (no central wrapper exists) **and migrating the offenders** is **Phase 2** — it comes with the agent-middleware default flip and per-route call-order tests.
- A small deviation from the proposal's wording: the duration warn is **warn-only**, not "throw in CI." Throwing before Phase 2 migrates the known offenders would break the suite, so strict-throw is opt-in via env and intended to be switched on in CI once the offender list is clean. (Updated my read of the right sequencing while implementing.)

## Tests
Real-DB integration test (`breeze_app`): no-op outside a context; warns inside; silent under `runOutsideDbContext`; throws under strict mode; duration warn fires for a slow-held context but not a fast DB-only one. `db/index.ts` typechecks clean.

Refs #1105 · builds on #1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)