### PR TITLE
feat: Contracts redesign — live estimates, shared picker, terms

### DIFF
--- a/apps/api/src/__tests__/integration/catalogService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/catalogService.integration.test.ts
@@ -586,4 +586,22 @@ describe('catalogService (breeze_app, real DB)', () => {
     expect(econ.margin).toBe('25.00');
     expect(econ.marginPct).toBe(25);
   });
+
+  runDb('updateCatalogItem: flipping a bundle to a plain item clears its components (no orphans)', async () => {
+    const fx = await seedFixture();
+    const { bundle, comp1 } = await seedBundleAndComponents(fx);
+    await withDbAccessContext(fx.ctxA, () =>
+      setBundleComponents(bundle.id, [{ componentItemId: comp1.id, quantity: 1, showOnInvoice: false }], fx.actorA));
+
+    const before = await withSystemDbAccessContext(() =>
+      db.select().from(catalogBundleComponents).where(eq(catalogBundleComponents.bundleItemId, bundle.id)));
+    expect(before).toHaveLength(1);
+
+    // true -> false must drop the component rows so they can't resurface later.
+    await withDbAccessContext(fx.ctxA, () => updateCatalogItem(bundle.id, { isBundle: false }, fx.actorA));
+
+    const after = await withSystemDbAccessContext(() =>
+      db.select().from(catalogBundleComponents).where(eq(catalogBundleComponents.bundleItemId, bundle.id)));
+    expect(after).toHaveLength(0);
+  });
 });

--- a/apps/api/src/__tests__/integration/contractEstimate.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contractEstimate.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Real-DB tests for the contract recurring-value estimate (computeContractEstimate)
+ * and the listContracts estimatedPeriodValue enrichment.
+ *
+ * Exercises per-line-type quantity resolution against a real Postgres:
+ *   flat → 1, manual → manualQuantity, per_device → live device count
+ *   (optionally site-scoped), per_seat → live active-seat count.
+ * The per_device-org-wide vs per_device-site-scoped pair specifically guards the
+ * memoization cache key `${orgId}|${siteId ?? 'all'}` — a key that ignored siteId
+ * would return the same (wrong) count for both lines and silently mis-bill.
+ *
+ * Per-test inline seeding (setup.ts TRUNCATEs CASCADE in beforeEach).
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, organizations, sites, devices, users, organizationUsers, roles } from '../../db/schema';
+import {
+  createContract, addContractLineToContract, computeContractEstimate, listContracts,
+  type ContractActorT,
+} from '../../services/contractService';
+
+interface Fixture { partnerId: string; orgId: string; siteAId: string }
+
+async function seedFixture(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `EP ${sfx}`, slug: `ep-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: 'EOrg', slug: `eo-${sfx}` })
+      .returning({ id: organizations.id });
+    const orgId = o!.id;
+    const [sA, sB] = await db.insert(sites)
+      .values([{ orgId, name: `A-${sfx}` }, { orgId, name: `B-${sfx}` }])
+      .returning({ id: sites.id });
+
+    // 3 billable devices (2 on siteA, 1 on siteB) + 1 decommissioned (excluded).
+    await db.insert(devices).values([
+      { orgId, siteId: sA!.id, agentId: `e1-${sfx}`, hostname: 'e1', status: 'online', osType: 'linux', osVersion: '22.04', architecture: 'x86_64', agentVersion: '1.0.0' },
+      { orgId, siteId: sA!.id, agentId: `e2-${sfx}`, hostname: 'e2', status: 'offline', osType: 'linux', osVersion: '22.04', architecture: 'x86_64', agentVersion: '1.0.0' },
+      { orgId, siteId: sB!.id, agentId: `e3-${sfx}`, hostname: 'e3', status: 'online', osType: 'linux', osVersion: '22.04', architecture: 'x86_64', agentVersion: '1.0.0' },
+      { orgId, siteId: sB!.id, agentId: `e4-${sfx}`, hostname: 'e4', status: 'decommissioned', osType: 'linux', osVersion: '22.04', architecture: 'x86_64', agentVersion: '1.0.0' },
+    ]);
+
+    // 2 active seats.
+    const [r] = await db.insert(roles)
+      .values({ name: `ERole ${sfx}`, scope: 'organization', partnerId: p!.id, orgId })
+      .returning({ id: roles.id });
+    const [u1, u2] = await db.insert(users).values([
+      { partnerId: p!.id, orgId, email: `e1-${sfx}@x.io`, name: 'E1', status: 'active' },
+      { partnerId: p!.id, orgId, email: `e2-${sfx}@x.io`, name: 'E2', status: 'active' },
+    ]).returning({ id: users.id });
+    await db.insert(organizationUsers).values([
+      { orgId, userId: u1!.id, roleId: r!.id }, { orgId, userId: u2!.id, roleId: r!.id },
+    ]);
+
+    return { partnerId: p!.id, orgId, siteAId: sA!.id };
+  });
+}
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('computeContractEstimate (breeze_app, real DB)', () => {
+  runDb('resolves every line type from live counts and sums the period total', async () => {
+    const f = await seedFixture();
+    const actor: ContractActorT = { userId: null as unknown as string, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+
+    const c = await withSystemDbAccessContext(() => createContract({
+      orgId: f.orgId, name: 'Estimate Co', billingTiming: 'advance', intervalMonths: 1, startDate: '2026-07-01',
+    }, actor));
+
+    const flat = await withSystemDbAccessContext(() => addContractLineToContract(c.id, { lineType: 'flat', description: 'Flat', unitPrice: '500.00', taxable: false }, actor));
+    const perDevAll = await withSystemDbAccessContext(() => addContractLineToContract(c.id, { lineType: 'per_device', description: 'Per device (all)', unitPrice: '15.00', taxable: true }, actor));
+    const perDevSiteA = await withSystemDbAccessContext(() => addContractLineToContract(c.id, { lineType: 'per_device', description: 'Per device (siteA)', unitPrice: '10.00', taxable: true, siteId: f.siteAId }, actor));
+    const perSeat = await withSystemDbAccessContext(() => addContractLineToContract(c.id, { lineType: 'per_seat', description: 'Per seat', unitPrice: '20.00', taxable: false }, actor));
+    const manual = await withSystemDbAccessContext(() => addContractLineToContract(c.id, { lineType: 'manual', description: 'Manual', unitPrice: '50.00', taxable: false, manualQuantity: '3' }, actor));
+
+    const est = await withSystemDbAccessContext(() => computeContractEstimate(c.id, actor));
+    const byId = new Map(est.lines.map((l) => [l.lineId, l]));
+
+    expect(byId.get(flat.id)).toMatchObject({ quantity: 1, value: '500.00', live: false });
+    // org-wide per_device = 3 billable (decommissioned excluded)
+    expect(byId.get(perDevAll.id)).toMatchObject({ quantity: 3, value: '45.00', live: true });
+    // site-scoped per_device = 2 on siteA — proves the memo key includes siteId
+    expect(byId.get(perDevSiteA.id)).toMatchObject({ quantity: 2, value: '20.00', live: true });
+    expect(byId.get(perSeat.id)).toMatchObject({ quantity: 2, value: '40.00', live: true });
+    expect(byId.get(manual.id)).toMatchObject({ quantity: 3, value: '150.00', live: false });
+
+    // 500 + 45 + 20 + 40 + 150
+    expect(est.periodTotal).toBe('755.00');
+    expect(est.currencyCode).toBe('USD');
+  });
+
+  runDb('listContracts enriches each row with estimatedPeriodValue', async () => {
+    const f = await seedFixture();
+    const actor: ContractActorT = { userId: null as unknown as string, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+
+    const c = await withSystemDbAccessContext(() => createContract({
+      orgId: f.orgId, name: 'List Co', billingTiming: 'advance', intervalMonths: 1, startDate: '2026-07-01',
+    }, actor));
+    await withSystemDbAccessContext(() => addContractLineToContract(c.id, { lineType: 'flat', description: 'Flat', unitPrice: '100.00', taxable: false }, actor));
+    await withSystemDbAccessContext(() => addContractLineToContract(c.id, { lineType: 'per_device', description: 'Per device', unitPrice: '15.00', taxable: true }, actor));
+
+    const rows = await withSystemDbAccessContext(() => listContracts({}, actor));
+    const row = rows.find((r) => r.id === c.id) as (typeof rows[number] & { estimatedPeriodValue?: string });
+    // 100 (flat) + 3×15 (per_device org-wide) = 145.00
+    expect(row?.estimatedPeriodValue).toBe('145.00');
+  });
+});

--- a/apps/api/src/__tests__/integration/invoiceCheckout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/invoiceCheckout.integration.test.ts
@@ -81,9 +81,9 @@ describe('createInvoicePayLink (breeze_app, real DB)', () => {
     expect(res.url).toBe('https://checkout.stripe.com/c/pay/abc');
     expect(sessionsCreateMock).toHaveBeenCalledTimes(1);
     // currency-aware minor units: $100.00 → 10000
-    const [args, opts] = sessionsCreateMock.mock.calls[0];
-    expect(args.line_items[0].price_data.unit_amount).toBe(10000);
-    expect(opts.idempotencyKey).toBe(`inv_${inv.id}_10000`);
+    const call = sessionsCreateMock.mock.calls[0]!;
+    expect(call[0].line_items[0].price_data.unit_amount).toBe(10000);
+    expect(call[1].idempotencyKey).toBe(`inv_${inv.id}_10000`);
 
     const mappings = await withSystemDbAccessContext(() =>
       db.select().from(invoiceStripePayments).where(eq(invoiceStripePayments.invoiceId, inv.id)));

--- a/apps/api/src/__tests__/integration/invoiceCheckout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/invoiceCheckout.integration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Real-DB tests for createInvoicePayLink (the partner "Send payment link" path).
+ * Stripe SDK + connection lookup are mocked; the invoice read, status/balance
+ * guards, and the invoice_stripe_payments mapping insert run against Postgres.
+ *
+ * Guards verified: NOT_PAYABLE (draft), NOTHING_TO_PAY (zero balance),
+ * STRIPE_NOT_CONNECTED (no active account), and the happy path (returns the
+ * checkout url + inserts exactly one pending mapping row).
+ */
+import './setup';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, organizations, users, invoices, invoiceStripePayments } from '../../db/schema';
+
+// issueInvoice enqueues a PDF render + emits events — stub the BullMQ side effects.
+vi.mock('../../services/invoiceEvents', () => ({ emitInvoiceEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../jobs/invoiceWorker', () => ({ enqueueInvoicePdfRender: vi.fn().mockResolvedValue(undefined) }));
+
+const { sessionsCreateMock, getConnectionMock } = vi.hoisted(() => ({
+  sessionsCreateMock: vi.fn(),
+  getConnectionMock: vi.fn(),
+}));
+vi.mock('../../services/stripeClient', () => ({
+  getStripe: () => ({ checkout: { sessions: { create: sessionsCreateMock } } }),
+  getConnectedStripeOptions: (acct: string) => ({ stripeAccount: acct }),
+}));
+vi.mock('../../services/stripeConnectService', () => ({ getConnection: getConnectionMock }));
+
+import * as svc from '../../services/invoiceService';
+import { createInvoicePayLink } from '../../services/invoiceCheckout';
+import type { InvoiceActor } from '../../services/invoiceTypes';
+
+interface Fixture { partnerId: string; orgId: string; userId: string }
+
+async function seedFixture(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `CP ${sfx}`, slug: `cp-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: 'COrg', slug: `co-${sfx}` })
+      .returning({ id: organizations.id });
+    const [u] = await db.insert(users)
+      .values({ partnerId: p!.id, orgId: o!.id, email: `c-${sfx}@x.io`, name: 'C', status: 'active' })
+      .returning({ id: users.id });
+    return { partnerId: p!.id, orgId: o!.id, userId: u!.id };
+  });
+}
+
+/** Seed a payable (issued) invoice with a $100 visible line. Each step runs in
+ *  its own access context so it commits before the next reads it (issueInvoice
+ *  opens its own transaction and won't see an uncommitted line otherwise). */
+async function seedIssuedInvoice(f: Fixture, actor: InvoiceActor) {
+  const draft = await withSystemDbAccessContext(() => svc.createManualInvoice({ orgId: f.orgId }, actor));
+  await withSystemDbAccessContext(() => svc.addManualLine(draft.id, { description: 'Labor', quantity: 1, unitPrice: 100, taxable: false }, actor));
+  return withSystemDbAccessContext(() => svc.issueInvoice(draft.id, actor));
+}
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('createInvoicePayLink (breeze_app, real DB)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConnectionMock.mockResolvedValue({ partnerId: 'p', stripeAccountId: 'acct_test', status: 'connected' });
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_test_123', url: 'https://checkout.stripe.com/c/pay/abc', payment_intent: null });
+  });
+
+  runDb('connected + payable → returns the checkout url and inserts one pending mapping', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    const inv = await seedIssuedInvoice(f, actor);
+    expect(inv.status).toBe('sent');
+    // Regression guard for the Issued-vs-Sent fix: issue must NOT stamp sentAt
+    // (that means "emailed"). Lives here because the co-located issue test isn't
+    // in the CI integration glob.
+    expect(inv.sentAt).toBeNull();
+
+    const res = await withSystemDbAccessContext(() => createInvoicePayLink(inv.id, actor));
+    expect(res.url).toBe('https://checkout.stripe.com/c/pay/abc');
+    expect(sessionsCreateMock).toHaveBeenCalledTimes(1);
+    // currency-aware minor units: $100.00 → 10000
+    const [args, opts] = sessionsCreateMock.mock.calls[0];
+    expect(args.line_items[0].price_data.unit_amount).toBe(10000);
+    expect(opts.idempotencyKey).toBe(`inv_${inv.id}_10000`);
+
+    const mappings = await withSystemDbAccessContext(() =>
+      db.select().from(invoiceStripePayments).where(eq(invoiceStripePayments.invoiceId, inv.id)));
+    expect(mappings).toHaveLength(1);
+    expect(mappings[0]).toMatchObject({ status: 'pending', stripeObjectType: 'checkout_session', stripeObjectId: 'cs_test_123' });
+  });
+
+  runDb('not connected → STRIPE_NOT_CONNECTED, no Stripe call, no mapping', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    const inv = await seedIssuedInvoice(f, actor);
+    getConnectionMock.mockResolvedValue(null);
+
+    await expect(withSystemDbAccessContext(() => createInvoicePayLink(inv.id, actor)))
+      .rejects.toMatchObject({ status: 409, code: 'STRIPE_NOT_CONNECTED' });
+    expect(sessionsCreateMock).not.toHaveBeenCalled();
+    const mappings = await withSystemDbAccessContext(() =>
+      db.select().from(invoiceStripePayments).where(eq(invoiceStripePayments.invoiceId, inv.id)));
+    expect(mappings).toHaveLength(0);
+  });
+
+  runDb('draft (not payable) → NOT_PAYABLE before any Stripe work', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    const draft = await withSystemDbAccessContext(() => svc.createManualInvoice({ orgId: f.orgId }, actor));
+
+    await expect(withSystemDbAccessContext(() => createInvoicePayLink(draft.id, actor)))
+      .rejects.toMatchObject({ status: 409, code: 'NOT_PAYABLE' });
+    expect(sessionsCreateMock).not.toHaveBeenCalled();
+  });
+
+  runDb('zero balance → NOTHING_TO_PAY', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    const inv = await seedIssuedInvoice(f, actor);
+    // Force a paid-in-full balance while keeping the payable 'sent' status.
+    await withSystemDbAccessContext(() => db.update(invoices).set({ balance: '0.00' }).where(eq(invoices.id, inv.id)));
+
+    await expect(withSystemDbAccessContext(() => createInvoicePayLink(inv.id, actor)))
+      .rejects.toMatchObject({ status: 409, code: 'NOTHING_TO_PAY' });
+    expect(sessionsCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/__tests__/integration/invoiceEnrichment.integration.test.ts
+++ b/apps/api/src/__tests__/integration/invoiceEnrichment.integration.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Real-DB tests for two invoice read enrichments added with the Stripe UI:
+ *  - getInvoice().stripeConnected — reflects the partner's Stripe Connect row.
+ *  - listPayments()[].source — tags each payment 'stripe' (linked to a succeeded
+ *    invoice_stripe_payments mapping) vs 'manual'. This badge gates whether the
+ *    UI offers a hand-void, so a mislabel = accounting drift.
+ *
+ * Real getConnection (not mocked) so the stripeConnected logic is exercised.
+ */
+import './setup';
+import { describe, it, expect, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  partners, organizations, users, invoices, invoicePayments, invoiceStripePayments, stripeConnectAccounts,
+} from '../../db/schema';
+
+vi.mock('../../services/invoiceEvents', () => ({ emitInvoiceEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../jobs/invoiceWorker', () => ({ enqueueInvoicePdfRender: vi.fn().mockResolvedValue(undefined) }));
+
+import * as svc from '../../services/invoiceService';
+import type { InvoiceActor } from '../../services/invoiceTypes';
+
+interface Fixture { partnerId: string; orgId: string; userId: string }
+
+async function seedFixture(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `NP ${sfx}`, slug: `np-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: 'NOrg', slug: `no-${sfx}` })
+      .returning({ id: organizations.id });
+    const [u] = await db.insert(users)
+      .values({ partnerId: p!.id, orgId: o!.id, email: `n-${sfx}@x.io`, name: 'N', status: 'active' })
+      .returning({ id: users.id });
+    return { partnerId: p!.id, orgId: o!.id, userId: u!.id };
+  });
+}
+
+async function seedIssuedInvoice(f: Fixture, actor: InvoiceActor) {
+  const draft = await withSystemDbAccessContext(() => svc.createManualInvoice({ orgId: f.orgId }, actor));
+  await withSystemDbAccessContext(() => svc.addManualLine(draft.id, { description: 'Labor', quantity: 1, unitPrice: 100, taxable: false }, actor));
+  return withSystemDbAccessContext(() => svc.issueInvoice(draft.id, actor));
+}
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('invoice read enrichments (breeze_app, real DB)', () => {
+  runDb('getInvoice.stripeConnected reflects the partner connection row', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    const inv = await seedIssuedInvoice(f, actor);
+
+    // No connection yet → false.
+    const before = await withSystemDbAccessContext(() => svc.getInvoice(inv.id, actor));
+    expect(before.stripeConnected).toBe(false);
+
+    // Connect → true.
+    await withSystemDbAccessContext(() => db.insert(stripeConnectAccounts).values({
+      partnerId: f.partnerId, stripeAccountId: `acct_${f.partnerId.slice(0, 8)}`, livemode: false,
+    }));
+    const after = await withSystemDbAccessContext(() => svc.getInvoice(inv.id, actor));
+    expect(after.stripeConnected).toBe(true);
+  });
+
+  runDb('listPayments tags stripe-linked vs manual payments', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    const inv = await seedIssuedInvoice(f, actor);
+
+    // Manual payment via the service.
+    await withSystemDbAccessContext(() => svc.recordPayment(inv.id, { amount: 40, method: 'bank_transfer', receivedAt: '2026-07-01' }, actor));
+
+    // Stripe payment: a card invoice_payments row linked by a succeeded mapping.
+    await withSystemDbAccessContext(async () => {
+      const [pay] = await db.insert(invoicePayments).values({
+        invoiceId: inv.id, orgId: f.orgId, amount: '60.00', method: 'card', reference: 'pi_enrich', receivedAt: '2026-07-01',
+      }).returning({ id: invoicePayments.id });
+      await db.insert(invoiceStripePayments).values({
+        orgId: f.orgId, invoiceId: inv.id, stripeAccountId: 'acct_x', stripeObjectType: 'checkout_session',
+        stripeObjectId: 'cs_enrich_1', amount: '60.00', currency: 'USD', status: 'succeeded', invoicePaymentId: pay!.id,
+      });
+    });
+
+    const payments = await withSystemDbAccessContext(() => svc.listPayments(inv.id, actor));
+    expect(payments).toHaveLength(2);
+    const manual = payments.find((p) => p.method === 'bank_transfer');
+    const stripe = payments.find((p) => p.method === 'card');
+    expect(manual?.source).toBe('manual');
+    expect(stripe?.source).toBe('stripe');
+  });
+});

--- a/apps/api/src/routes/contracts/contracts.test.ts
+++ b/apps/api/src/routes/contracts/contracts.test.ts
@@ -13,7 +13,8 @@ vi.mock('../../services/contractService', () => ({
   pauseContract: vi.fn(),
   resumeContract: vi.fn(),
   cancelContract: vi.fn(),
-  generateDueInvoice: vi.fn()
+  generateDueInvoice: vi.fn(),
+  computeContractEstimate: vi.fn()
 }));
 
 // Mock db context helpers used by /generate route.
@@ -270,5 +271,19 @@ describe('contract generate route', () => {
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.code).toBe('NOTHING_DUE');
+  });
+
+  it('GET /:id/estimate returns the resolved period estimate', async () => {
+    (svc.computeContractEstimate as any).mockResolvedValue({
+      currencyCode: 'USD', periodTotal: '450.00',
+      lines: [{ lineId: LINE_ID, lineType: 'per_device', quantity: 9, value: '450.00', live: true }],
+    });
+    const res = await app().request(`/${CONTRACT_ID}/estimate`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: {
+      currencyCode: 'USD', periodTotal: '450.00',
+      lines: [{ lineId: LINE_ID, lineType: 'per_device', quantity: 9, value: '450.00', live: true }],
+    } });
+    expect(svc.computeContractEstimate).toHaveBeenCalledWith(CONTRACT_ID, expect.objectContaining({ partnerId: 'p1' }));
   });
 });

--- a/apps/api/src/routes/contracts/contracts.ts
+++ b/apps/api/src/routes/contracts/contracts.ts
@@ -7,7 +7,8 @@ import {
   createContractSchema, updateContractSchema, listContractsQuerySchema
 } from '@breeze/shared';
 import {
-  createContract, getContract, listContracts, updateContract, deleteDraftContract
+  createContract, getContract, listContracts, updateContract, deleteDraftContract,
+  computeContractEstimate
 } from '../../services/contractService';
 import { ContractServiceError, type ContractActor } from '../../services/contractTypes';
 
@@ -32,6 +33,10 @@ contractCrudRoutes.get('/', scopes, readPerm, zValidator('query', listContractsQ
 });
 contractCrudRoutes.post('/', scopes, writePerm, zValidator('json', createContractSchema), async (c) => {
   try { return c.json({ data: await createContract(c.req.valid('json'), contractActorFrom(c)) }); }
+  catch (err) { return handleContractError(c, err); }
+});
+contractCrudRoutes.get('/:id/estimate', scopes, readPerm, zValidator('param', idParam), async (c) => {
+  try { return c.json({ data: await computeContractEstimate(c.req.valid('param').id, contractActorFrom(c)) }); }
   catch (err) { return handleContractError(c, err); }
 });
 contractCrudRoutes.get('/:id', scopes, readPerm, zValidator('param', idParam), async (c) => {

--- a/apps/api/src/services/catalogService.ts
+++ b/apps/api/src/services/catalogService.ts
@@ -184,6 +184,12 @@ export async function updateCatalogItem(id: string, input: UpdateCatalogItemInpu
   try {
     const rows = await db.update(catalogItems).set(patch)
       .where(and(eq(catalogItems.id, id), eq(catalogItems.partnerId, partnerId))).returning();
+    // Flipping a bundle back to a plain item (true -> false) must drop its
+    // component rows — otherwise they linger orphaned and would resurface if the
+    // item is later re-flagged as a bundle.
+    if (input.isBundle === false && existing.isBundle) {
+      await db.delete(catalogBundleComponents).where(eq(catalogBundleComponents.bundleItemId, id));
+    }
     await emitCatalogEvent({ type: 'catalog.item.updated', catalogItemId: id, partnerId, actorUserId: actor.userId });
     return rows[0]!;
   } catch (err) {

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -79,7 +79,73 @@ export async function listContracts(query: {
     .where(conds.length ? and(...conds) : undefined)
     .orderBy(desc(contracts.createdAt))
     .limit(Math.min(query.limit ?? 50, 100));
-  return rows;
+  if (rows.length === 0) return rows;
+
+  // Enrich each row with estimatedPeriodValue (live counts for per_device/per_seat
+  // lines). All lines for the page load in one query; device/seat counts are
+  // memoized per (org, site) / org so distinct counts run once, not per contract.
+  const ids = rows.map((r) => r.id);
+  const allLines = await db.select().from(contractLines).where(inArray(contractLines.contractId, ids));
+  const byContract = new Map<string, typeof allLines>();
+  for (const l of allLines) {
+    const list = byContract.get(l.contractId);
+    if (list) list.push(l); else byContract.set(l.contractId, [l]);
+  }
+  const dc: DeviceCache = new Map();
+  const sc: SeatCache = new Map();
+  const out = [];
+  for (const c of rows) {
+    let total = 0;
+    for (const l of byContract.get(c.id) ?? []) {
+      const { quantity } = await resolveLineQty(c.orgId, l, dc, sc);
+      total += Number(l.unitPrice) * quantity;
+    }
+    out.push({ ...c, estimatedPeriodValue: total.toFixed(2) });
+  }
+  return out;
+}
+
+// ---- recurring-value estimate (live per_device/per_seat resolution) --------
+type DeviceCache = Map<string, number>; // key `${orgId}|${siteId ?? 'all'}`
+type SeatCache = Map<string, number>;   // key orgId
+type ContractLineRow = typeof contractLines.$inferSelect;
+
+async function resolveLineQty(
+  orgId: string, line: ContractLineRow, dc: DeviceCache, sc: SeatCache,
+): Promise<{ quantity: number; live: boolean }> {
+  switch (line.lineType) {
+    case 'flat': return { quantity: 1, live: false };
+    case 'manual': return { quantity: Number(line.manualQuantity ?? '0'), live: false };
+    case 'per_device': {
+      const key = `${orgId}|${line.siteId ?? 'all'}`;
+      if (!dc.has(key)) dc.set(key, await countContractDevices(orgId, line.siteId));
+      return { quantity: dc.get(key)!, live: true };
+    }
+    case 'per_seat': {
+      if (!sc.has(orgId)) sc.set(orgId, await countContractSeats(orgId));
+      return { quantity: sc.get(orgId)!, live: true };
+    }
+    default: return { quantity: 0, live: false };
+  }
+}
+
+/** Per-line resolved quantities + values + period total for one contract, using
+ *  live device/seat counts as of now. Powers the editor sidebar and detail. */
+export async function computeContractEstimate(contractId: string, actor: ContractActor) {
+  const contract = await getOwnedContractOr404(contractId, actor);
+  const lines = await db.select().from(contractLines)
+    .where(eq(contractLines.contractId, contractId)).orderBy(contractLines.sortOrder);
+  const dc: DeviceCache = new Map();
+  const sc: SeatCache = new Map();
+  let total = 0;
+  const out = [];
+  for (const l of lines) {
+    const { quantity, live } = await resolveLineQty(contract.orgId, l, dc, sc);
+    const value = Number(l.unitPrice) * quantity;
+    total += value;
+    out.push({ lineId: l.id, lineType: l.lineType, quantity, value: value.toFixed(2), live });
+  }
+  return { currencyCode: contract.currencyCode, periodTotal: total.toFixed(2), lines: out };
 }
 
 export async function updateContract(contractId: string, patch: UpdateContractInput, actor: ContractActor) {

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -375,7 +375,8 @@ export interface SendInvoiceResult {
 export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): Promise<SendInvoiceResult> {
   const { issueInvoice } = await import('./invoiceService');
 
-  // 1. Issue if still draft (issueInvoice asserts draft + sets sent_at on its own).
+  // 1. Issue if still draft. issueInvoice asserts draft but intentionally does
+  //    NOT stamp sent_at (sent_at = "send attempted"); this send stamps it below.
   let [invoice] = await db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1);
   if (!invoice) throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
 
@@ -433,8 +434,11 @@ export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): 
     console.warn(`[invoicePdf] No billing email for org ${invoice.orgId} — invoice ${invoiceId} issued but not emailed`);
   }
 
-  // 5. Stamp sent_at (issueInvoice already sets it; this keeps it current for a
-  //    re-send of an already-issued invoice).
+  // 5. Stamp sent_at. This is the SOLE place sent_at is set — issueInvoice
+  //    leaves it null on purpose so a plain Issue reads "Issued", and only an
+  //    explicit send (this path) marks it. sent_at means "send attempted",
+  //    so it's stamped even when no email service / billing contact exists
+  //    (see the emailed:false case + invoicePdf.integration.test).
   await db.update(invoices).set({ sentAt: new Date(), updatedAt: new Date() }).where(eq(invoices.id, invoiceId));
 
   // 6. Emit the invoice.sent lifecycle event (spec §16). The send action has

--- a/apps/api/src/services/invoiceService.issue.integration.test.ts
+++ b/apps/api/src/services/invoiceService.issue.integration.test.ts
@@ -88,6 +88,9 @@ describe.runIf(RUN)('issueInvoice', () => {
 
     expect(issued.invoiceNumber).toMatch(/^INV-\d{4}-0001$/);
     expect(issued.status).toBe('sent');
+    // sentAt is NULL on issue — it means "emailed", stamped only by sendInvoiceEmail.
+    // This guards the Issued-vs-Sent label fix from silently regressing.
+    expect(issued.sentAt).toBeNull();
     expect(issued.subtotal).toBe('150.00');
     expect(issued.total).toBe('150.00'); // labor is non-taxable
     expect(issued.balance).toBe('150.00');

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -463,9 +463,13 @@ export async function issueInvoice(invoiceId: string, actor: InvoiceActor) {
     };
 
     await db.update(invoices).set({
+      // status 'sent' is the lifecycle "issued/finalized" state. sentAt is left
+      // NULL here on purpose — it means "emailed to the customer" and is stamped
+      // only by sendInvoiceEmail. That lets the UI distinguish "Issued" (no email
+      // yet) from "Sent" (emailed) instead of mislabeling a plain Issue as Sent.
       status: 'sent', invoiceNumber: number, currencyCode: partner?.currencyCode ?? 'USD',
       issueDate: issueDate.toISOString().slice(0, 10), dueDate: dueDate.toISOString().slice(0, 10),
-      taxRate, subtotal, taxTotal, total, balance: total, sentAt: issueDate,
+      taxRate, subtotal, taxTotal, total, balance: total,
       billToName: org?.name ?? null, billToAddress, billToTaxId: org?.taxId ?? null,
       billToTaxExempt: org?.taxExempt ?? false, terms: partner?.invoiceFooter ?? null, updatedAt: issueDate
     }).where(eq(invoices.id, invoiceId));

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -30,7 +30,7 @@ const lines: InvoiceDetailData['lines'] = [
 const issued: InvoiceDetailData = {
   invoice: {
     id: 'inv-1', invoiceNumber: 'INV-0007', orgId: 'org-1', siteId: null, status: 'sent',
-    currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30', subtotal: '120.00',
+    currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30', sentAt: null, subtotal: '120.00',
     taxRate: '0.000', taxTotal: '0.00', total: '120.00', amountPaid: '0.00', balance: '120.00',
     billToName: 'Acme', notes: null, createdAt: '2026-06-01T00:00:00Z',
   },

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -11,7 +11,7 @@ import {
   type PaymentMethod,
   PAYMENT_METHOD_LABELS,
   STATUS_COLORS,
-  STATUS_LABELS,
+  statusLabel,
   formatDate,
   formatMoney,
 } from './invoiceTypes';
@@ -256,7 +256,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
           <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="invoice-detail-summary">
             <div className="mb-3 flex items-center justify-between">
               <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`} data-testid="invoice-detail-status">
-                {STATUS_LABELS[invoice.status]}
+                {statusLabel(invoice)}
               </span>
               <span className="text-xs text-muted-foreground">Due {formatDate(invoice.dueDate)}</span>
             </div>

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -148,6 +148,10 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
           // Clipboard blocked (insecure context / permissions) — surface the URL.
           window.prompt('Share this payment link with your customer:', url);
         }
+      } else {
+        // 200 without a URL shouldn't happen (the API throws STRIPE_NO_URL), but
+        // never leave a money action with no feedback.
+        showToast({ type: 'error', message: 'No payment link was returned. Try again.' });
       }
     } catch (err) {
       handleActionError(err, 'Could not create a payment link.');

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -18,7 +18,7 @@ function draft(lines: InvoiceDetail['lines']): InvoiceDetail {
   return {
     invoice: {
       id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
-      currencyCode: 'USD', issueDate: null, dueDate: null, subtotal: '0.00', taxRate: null,
+      currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '0.00', taxRate: null,
       taxTotal: '0.00', total: '0.00', amountPaid: '0.00', balance: '0.00', billToName: 'Acme',
       notes: '', createdAt: '2026-06-01T00:00:00Z',
     },

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -19,13 +19,13 @@ const ORGS = [{ id: 'org-1', name: 'Acme Corp' }, { id: 'org-2', name: 'Globex' 
 const INVOICES = [
   {
     id: 'inv-1', invoiceNumber: 'INV-0001', orgId: 'org-1', siteId: null, status: 'overdue',
-    currencyCode: 'USD', issueDate: '2026-05-01', dueDate: '2026-05-31', subtotal: '100.00',
+    currencyCode: 'USD', issueDate: '2026-05-01', dueDate: '2026-05-31', sentAt: null, subtotal: '100.00',
     taxRate: '0.000', taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00',
     billToName: 'Acme', notes: null, createdAt: '2026-05-01T00:00:00Z',
   },
   {
     id: 'inv-2', invoiceNumber: null, orgId: 'org-2', siteId: null, status: 'draft',
-    currencyCode: 'USD', issueDate: null, dueDate: null, subtotal: '0.00',
+    currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '0.00',
     taxRate: null, taxTotal: '0.00', total: '0.00', amountPaid: '0.00', balance: '0.00',
     billToName: null, notes: null, createdAt: '2026-06-01T00:00:00Z',
   },

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -7,7 +7,7 @@ import {
   type InvoiceStatus,
   type InvoiceSummary,
   STATUS_COLORS,
-  STATUS_LABELS,
+  statusLabel,
   formatDate,
   formatMoney,
 } from './invoiceTypes';
@@ -438,7 +438,7 @@ export default function InvoicesPage() {
                           className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
                           data-testid={`invoices-status-${inv.id}`}
                         >
-                          {STATUS_LABELS[inv.status]}
+                          {statusLabel(inv)}
                         </span>
                       </td>
                     </tr>

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -232,7 +232,8 @@ export default function InvoicesPage() {
     const open = invoices.filter((i) => i.status !== 'void' && num(i.balance) > 0);
     const outstanding = open.reduce((sum, i) => sum + num(i.balance), 0);
     const overdue = invoices.filter((i) => i.status === 'overdue').length;
-    // Single-currency partners are the norm; format with the most common code.
+    // Single-currency partners are the norm; label the strip with the first
+    // invoice's currency. Multi-currency outstanding totals are not split in v1.
     const ccy = (invoices[0]?.currencyCode) || 'USD';
     return { outstanding, overdue, openCount: open.length, ccy };
   }, [invoices]);

--- a/apps/web/src/components/billing/invoiceTypes.test.ts
+++ b/apps/web/src/components/billing/invoiceTypes.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { statusLabel } from './invoiceTypes';
+
+describe('statusLabel', () => {
+  it('labels an issued-but-not-emailed invoice "Issued", not "Sent"', () => {
+    expect(statusLabel({ status: 'sent', sentAt: null })).toBe('Issued');
+  });
+
+  it('labels "Sent" only once an email actually went out', () => {
+    expect(statusLabel({ status: 'sent', sentAt: '2026-06-16T00:00:00Z' })).toBe('Sent');
+  });
+
+  it('passes other statuses through unchanged', () => {
+    expect(statusLabel({ status: 'draft', sentAt: null })).toBe('Draft');
+    expect(statusLabel({ status: 'overdue', sentAt: null })).toBe('Overdue');
+    expect(statusLabel({ status: 'paid', sentAt: '2026-06-16' })).toBe('Paid');
+  });
+});

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -15,6 +15,7 @@ export interface InvoiceSummary {
   currencyCode: string;
   issueDate: string | null;
   dueDate: string | null;
+  sentAt: string | null;
   subtotal: string;
   taxRate: string | null;
   taxTotal: string;
@@ -84,6 +85,14 @@ export const STATUS_COLORS: Record<InvoiceStatus, string> = {
   paid: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
   void: 'border-border bg-muted text-muted-foreground line-through',
 };
+
+/** Display label for an invoice's status. The 'sent' lifecycle status means
+ *  "issued"; it only reads as "Sent" once an email actually went out (sentAt).
+ *  This keeps a plain Issue from mislabeling itself as Sent. */
+export function statusLabel(invoice: { status: InvoiceStatus; sentAt: string | null }): string {
+  if (invoice.status === 'sent' && !invoice.sentAt) return 'Issued';
+  return STATUS_LABELS[invoice.status];
+}
 
 export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
   cash: 'Cash',

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -1,13 +1,15 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import {
   contractTransition,
   generateContractInvoice,
+  getContractEstimate,
   formatCadence,
   CONTRACT_STATUS_COLORS,
   CONTRACT_STATUS_LABELS,
   type ContractDetail as ContractDetailData,
+  type ContractEstimate,
   type ContractLineType,
   type ContractStatus,
   type ContractTransition,
@@ -66,6 +68,17 @@ export default function ContractDetail({ detail, onChanged }: Props) {
   const currency = contract.currencyCode;
 
   const [busy, setBusy] = useState(false);
+  const [estimate, setEstimate] = useState<ContractEstimate | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getContractEstimate(contract.id).then(async (res) => {
+      if (cancelled || !res.ok) return;
+      const body = (await res.json().catch(() => null)) as { data?: ContractEstimate } | null;
+      if (!cancelled) setEstimate(body?.data ?? null);
+    });
+    return () => { cancelled = true; };
+  }, [contract.id]);
 
   const refresh = useCallback(() => onChanged(), [onChanged]);
 
@@ -144,16 +157,11 @@ export default function ContractDetail({ detail, onChanged }: Props) {
                 <dt className="text-xs uppercase text-muted-foreground">Auto-issue</dt>
                 <dd className="mt-1 font-medium">{contract.autoIssue ? 'Yes' : 'No (drafts)'}</dd>
               </div>
-              {/* Informational stat — sourced from contract-status time reporting
-                  once that ships. No endpoint exists yet, so render a placeholder. */}
+              {/* Estimated value per billing period, from live device/seat counts. */}
               <div>
-                <dt className="text-xs uppercase text-muted-foreground">Hours under contract</dt>
-                <dd
-                  className="mt-1 font-medium text-muted-foreground"
-                  data-testid="contract-hours-stat"
-                  title="Available when contract-time reporting ships"
-                >
-                  —
+                <dt className="text-xs uppercase text-muted-foreground">Est. / period</dt>
+                <dd className="mt-1 font-medium tabular-nums" data-testid="contract-estimate-stat">
+                  {estimate ? formatMoney(estimate.periodTotal, currency) : '—'}
                 </dd>
               </div>
             </dl>

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -14,6 +14,7 @@ import {
   type ContractStatus,
   type ContractTransition,
 } from '../../lib/api/contracts';
+import { formatMoney } from '../billing/invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -45,16 +46,6 @@ const TRANSITION_LABELS: Record<ContractTransition, string> = {
   resume: 'Resume',
   cancel: 'Cancel',
 };
-
-function formatMoney(value: string | number | null | undefined, currencyCode = 'USD'): string {
-  const n = typeof value === 'number' ? value : Number(value);
-  const safe = Number.isFinite(n) ? n : 0;
-  try {
-    return safe.toLocaleString('en-US', { style: 'currency', currency: currencyCode || 'USD' });
-  } catch {
-    return `${safe.toFixed(2)} ${currencyCode || ''}`.trim();
-  }
-}
 
 function formatDate(value: string | null | undefined): string {
   if (!value) return '—';

--- a/apps/web/src/components/contracts/ContractEditor.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ContractEditor from './ContractEditor';
+import { fetchWithAuth } from '../../stores/auth';
+import * as api from '../../lib/api/contracts';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+// The catalog typeahead is exercised in the invoice-editor test; stub it here.
+vi.mock('../catalog/CatalogItemPicker', () => ({ default: () => null }));
+vi.mock('../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
+}));
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return {
+    ...actual,
+    createContract: vi.fn(),
+    updateContract: vi.fn(),
+    addContractLine: vi.fn(),
+    removeContractLine: vi.fn(),
+    contractTransition: vi.fn(),
+    getContractEstimate: vi.fn(),
+  };
+});
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+describe('ContractEditor (create)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/orgs/organizations')) return resp({ data: [{ id: 'org-1', name: 'Acme' }] });
+      if (url.startsWith('/orgs/sites')) return resp({ data: [] });
+      return resp({ data: {} });
+    });
+    (api.createContract as any).mockResolvedValue(resp({ data: { id: 'new-1' } }));
+  });
+
+  it('includes the Terms field in the create payload', async () => {
+    render(<ContractEditor />);
+    await screen.findByTestId('contract-form-org');
+
+    fireEvent.change(screen.getByTestId('contract-form-org'), { target: { value: 'org-1' } });
+    fireEvent.change(screen.getByTestId('contract-form-name'), { target: { value: 'Acme MSA' } });
+    fireEvent.change(screen.getByTestId('contract-form-terms'), { target: { value: 'Net 30. Auto-renews.' } });
+    fireEvent.click(screen.getByTestId('save-contract-btn'));
+
+    await waitFor(() => expect(api.createContract).toHaveBeenCalled());
+    expect((api.createContract as any).mock.calls[0][0]).toMatchObject({
+      orgId: 'org-1', name: 'Acme MSA', terms: 'Net 30. Auto-renews.',
+    });
+  });
+});

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../lib/api/contracts';
 import CatalogItemPicker from '../catalog/CatalogItemPicker';
 import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
+import { formatMoney } from '../billing/invoiceTypes';
 
 interface Organization { id: string; name: string }
 interface Site { id: string; name: string }
@@ -47,16 +48,6 @@ interface Props {
   presetOrgId?: string;
   /** Called after a successful mutation so the parent can reload. */
   onChanged?: () => void;
-}
-
-function formatMoney(value: string | number | null | undefined, currencyCode = 'USD'): string {
-  const n = typeof value === 'number' ? value : Number(value);
-  const safe = Number.isFinite(n) ? n : 0;
-  try {
-    return safe.toLocaleString('en-US', { style: 'currency', currency: currencyCode || 'USD' });
-  } catch {
-    return `${safe.toFixed(2)} ${currencyCode || ''}`.trim();
-  }
 }
 
 export default function ContractEditor({ detail, presetOrgId, onChanged }: Props) {

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -8,15 +8,18 @@ import {
   addContractLine,
   removeContractLine,
   contractTransition,
+  getContractEstimate,
   type ContractBillingTiming,
   type ContractDetail,
   type ContractLine,
   type ContractLineType,
+  type ContractEstimate,
 } from '../../lib/api/contracts';
+import CatalogItemPicker from '../catalog/CatalogItemPicker';
+import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
 
 interface Organization { id: string; name: string }
 interface Site { id: string; name: string }
-interface CatalogItem { id: string; name: string; isBundle: boolean }
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -76,6 +79,8 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [endDate, setEndDate] = useState(contract?.endDate ?? '');
   const [autoIssue, setAutoIssue] = useState(contract?.autoIssue ?? false);
   const [notes, setNotes] = useState(contract?.notes ?? '');
+  const [terms, setTerms] = useState(contract?.terms ?? '');
+  const [liveEstimate, setLiveEstimate] = useState<ContractEstimate | null>(null);
 
   // ---- reference data ------------------------------------------------------
   const [orgs, setOrgs] = useState<Organization[]>([]);
@@ -103,7 +108,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   }, []);
 
   const loadCatalog = useCallback(async () => {
-    const res = await fetchWithAuth('/catalog?isActive=true');
+    const res = await listCatalog({ isActive: true, limit: 200 });
     if (res.status === 401) return UNAUTHORIZED();
     if (!res.ok) return; // catalog is optional context; don't block the editor
     const body = (await res.json().catch(() => null)) as { data?: CatalogItem[] } | null;
@@ -120,9 +125,19 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     setSites(Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : []);
   }, []);
 
+  const loadEstimate = useCallback(async () => {
+    if (!contract) return;
+    const res = await getContractEstimate(contract.id);
+    if (res.status === 401) return UNAUTHORIZED();
+    if (!res.ok) return; // estimate is best-effort; the static fallback still shows
+    const body = (await res.json().catch(() => null)) as { data?: ContractEstimate } | null;
+    setLiveEstimate(body?.data ?? null);
+  }, [contract]);
+
   useEffect(() => { if (isCreate) void loadOrgs(); }, [isCreate, loadOrgs]);
   useEffect(() => { void loadCatalog(); }, [loadCatalog]);
   useEffect(() => { void loadSites(orgId); }, [orgId, loadSites]);
+  useEffect(() => { if (!isCreate) void loadEstimate(); }, [isCreate, loadEstimate]);
 
   const intervalIsValid = intervalMonths >= 1 && intervalMonths <= 60;
   const canSaveHeader = !!orgId && name.trim().length > 0 && !!startDate && intervalIsValid;
@@ -141,13 +156,20 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     return { known, hasAuto };
   }, [lines]);
 
+  // Resolved live quantity per line (per_device/per_seat) from the estimate.
+  const estByLine = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const e of liveEstimate?.lines ?? []) m.set(e.lineId, e.quantity);
+    return m;
+  }, [liveEstimate]);
+
   const newLineEstimate = useMemo(() => {
     if (AUTO_QTY_TYPES.has(lineType)) return null;
     const qty = lineType === 'manual' ? Number(lineQty || '0') : 1;
     return qty * Number(linePrice || '0');
   }, [lineType, lineQty, linePrice]);
 
-  const refresh = useCallback(() => { onChanged?.(); }, [onChanged]);
+  const refresh = useCallback(() => { onChanged?.(); void loadEstimate(); }, [onChanged, loadEstimate]);
 
   // ---- create flow ---------------------------------------------------------
   const saveCreate = useCallback(async () => {
@@ -164,6 +186,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           endDate: endDate || null,
           autoIssue,
           notes: notes.trim() || null,
+          terms: terms.trim() || null,
         }),
         errorFallback: 'Could not create the contract.',
         successMessage: 'Contract created',
@@ -176,7 +199,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } finally {
       setBusy(false);
     }
-  }, [busy, canSaveHeader, orgId, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, notes]);
+  }, [busy, canSaveHeader, orgId, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, notes, terms]);
 
   // ---- edit flow -----------------------------------------------------------
   const saveHeader = useCallback(async () => {
@@ -192,6 +215,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           endDate: endDate || null,
           autoIssue,
           notes: notes.trim() || null,
+          terms: terms.trim() || null,
         }),
         errorFallback: 'Could not save the contract.',
         successMessage: 'Contract saved',
@@ -203,7 +227,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } finally {
       setBusy(false);
     }
-  }, [busy, contract, canSaveHeader, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, notes, refresh]);
+  }, [busy, contract, canSaveHeader, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, notes, terms, refresh]);
 
   const addLine = useCallback(async () => {
     if (busy || !contract || !lineDesc.trim()) return;
@@ -377,6 +401,15 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                   className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </label>
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
+                Terms (optional, shown on the invoice)
+                <textarea
+                  value={terms} onChange={(e) => setTerms(e.target.value)} rows={2}
+                  data-testid="contract-form-terms"
+                  placeholder="e.g. Net 30. Auto-renews unless cancelled 30 days prior."
+                  className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </label>
             </div>
           </div>
 
@@ -413,9 +446,11 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                           </td>
                           <td className="px-3 py-2">{l.description}</td>
                           <td className="px-3 py-2 text-right">{formatMoney(l.unitPrice, contract?.currencyCode)}</td>
-                          <td className="px-3 py-2 text-right">
+                          <td className="px-3 py-2 text-right tabular-nums">
                             {AUTO_QTY_TYPES.has(l.lineType)
-                              ? <span className="text-muted-foreground">auto</span>
+                              ? (estByLine.has(l.id)
+                                  ? estByLine.get(l.id)
+                                  : <span className="text-muted-foreground">auto</span>)
                               : (l.lineType === 'manual' ? (l.manualQuantity ?? '0') : '1')}
                           </td>
                           <td className="px-3 py-2 text-center">{l.taxable ? '✓' : '—'}</td>
@@ -494,17 +529,27 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                     </label>
                   )}
                   {catalogItems.length > 0 && (
-                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                    <div className="flex flex-col gap-1 text-xs text-muted-foreground">
                       Link catalog item (optional)
-                      <select
-                        value={lineCatalogId} onChange={(e) => setLineCatalogId(e.target.value)}
-                        data-testid="contract-line-catalog"
-                        className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                      >
-                        <option value="">No catalog link</option>
-                        {catalogItems.map((i) => <option key={i.id} value={i.id}>{i.name}</option>)}
-                      </select>
-                    </label>
+                      {lineCatalogId ? (
+                        <span className="inline-flex h-9 items-center gap-1.5 self-start rounded-md border bg-muted/40 px-2.5 text-sm text-foreground" data-testid="contract-line-catalog-picked">
+                          <span className="font-medium">{catalogItems.find((i) => i.id === lineCatalogId)?.name ?? 'Item'}</span>
+                          <button type="button" onClick={() => setLineCatalogId('')} aria-label="Clear catalog link" className="ml-1 text-muted-foreground hover:text-foreground">×</button>
+                        </span>
+                      ) : (
+                        <CatalogItemPicker
+                          items={catalogItems}
+                          includeBundles={false}
+                          onSelect={(it) => {
+                            setLineCatalogId(it.id);
+                            if (!lineDesc.trim()) setLineDesc(it.name);
+                            setLinePrice(it.unitPrice);
+                          }}
+                          testId="contract-line-catalog-picker"
+                          placeholder="Search catalog…"
+                        />
+                      )}
+                    </div>
                   )}
                   <label className="flex items-center gap-2 text-sm">
                     <input
@@ -541,13 +586,17 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
               <p className="text-sm text-muted-foreground">Save the contract, then add lines to see an estimate.</p>
             ) : (
               <>
-                <p className="text-2xl font-semibold" data-testid="contract-estimate-total">
-                  {formatMoney(estimate.known, contract?.currencyCode)}
-                  {estimate.hasAuto && <span className="ml-1 align-middle text-sm font-normal text-muted-foreground">+ auto</span>}
+                <p className="text-2xl font-semibold tabular-nums" data-testid="contract-estimate-total">
+                  {liveEstimate
+                    ? formatMoney(liveEstimate.periodTotal, contract?.currencyCode)
+                    : formatMoney(estimate.known, contract?.currencyCode)}
+                  {!liveEstimate && estimate.hasAuto && (
+                    <span className="ml-1 align-middle text-sm font-normal text-muted-foreground">+ auto</span>
+                  )}
                 </p>
-                {estimate.hasAuto && (
+                {liveEstimate && liveEstimate.lines.some((l) => l.live) && (
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Per-device / per-seat lines are quantified from live counts when the invoice is generated.
+                    Includes live device / seat counts as of today.
                   </p>
                 )}
               </>

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -81,6 +81,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [notes, setNotes] = useState(contract?.notes ?? '');
   const [terms, setTerms] = useState(contract?.terms ?? '');
   const [liveEstimate, setLiveEstimate] = useState<ContractEstimate | null>(null);
+  const [estimateFailed, setEstimateFailed] = useState(false);
 
   // ---- reference data ------------------------------------------------------
   const [orgs, setOrgs] = useState<Organization[]>([]);
@@ -127,10 +128,16 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
 
   const loadEstimate = useCallback(async () => {
     if (!contract) return;
-    const res = await getContractEstimate(contract.id);
+    let res: Response;
+    try {
+      res = await getContractEstimate(contract.id);
+    } catch {
+      setEstimateFailed(true); return;
+    }
     if (res.status === 401) return UNAUTHORIZED();
-    if (!res.ok) return; // estimate is best-effort; the static fallback still shows
+    if (!res.ok) { setEstimateFailed(true); return; }
     const body = (await res.json().catch(() => null)) as { data?: ContractEstimate } | null;
+    setEstimateFailed(false);
     setLiveEstimate(body?.data ?? null);
   }, [contract]);
 
@@ -597,6 +604,12 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                 {liveEstimate && liveEstimate.lines.some((l) => l.live) && (
                   <p className="mt-1 text-xs text-muted-foreground">
                     Includes live device / seat counts as of today.
+                  </p>
+                )}
+                {!liveEstimate && estimateFailed && (
+                  <p className="mt-1 text-xs text-amber-600 dark:text-amber-500" data-testid="contract-estimate-stale">
+                    Couldn&rsquo;t load live counts{estimate.hasAuto ? ' — per-device/seat lines are not included in this total.' : '.'}{' '}
+                    <button type="button" onClick={() => void loadEstimate()} className="underline hover:text-foreground">Retry</button>
                   </p>
                 )}
               </>

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -5,11 +5,13 @@ import { handleActionError } from '../../lib/runAction';
 import {
   listContracts,
   formatCadence,
+  monthlyValue,
   CONTRACT_STATUS_COLORS,
   CONTRACT_STATUS_LABELS,
   type ContractStatus,
   type ContractSummary,
 } from '../../lib/api/contracts';
+import { formatMoney } from '../billing/invoiceTypes';
 
 interface Organization {
   id: string;
@@ -132,6 +134,13 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
 
   const rows = useMemo(() => contracts, [contracts]);
 
+  // Estimated monthly recurring across active contracts (normalized by cadence).
+  const mrr = useMemo(() => {
+    const active = contracts.filter((c) => c.status === 'active');
+    const total = active.reduce((sum, c) => sum + monthlyValue(c.estimatedPeriodValue, c.intervalMonths), 0);
+    return { total, count: active.length, ccy: contracts[0]?.currencyCode || 'USD' };
+  }, [contracts]);
+
   return (
     <div className="space-y-6" data-testid="contracts-page">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -187,6 +196,15 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
         </label>
       </div>
 
+      {/* Estimated monthly recurring */}
+      {!loading && !error && rows.length > 0 && (
+        <div className="inline-flex flex-col rounded-lg border bg-card px-4 py-3" data-testid="contracts-mrr-strip">
+          <span className="text-xs text-muted-foreground">Est. monthly recurring</span>
+          <span className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(mrr.total, mrr.ccy)}</span>
+          <span className="text-xs text-muted-foreground">{mrr.count} active contract{mrr.count === 1 ? '' : 's'}</span>
+        </div>
+      )}
+
       {/* Table */}
       <div className="rounded-lg border bg-card shadow-sm">
         {loading ? (
@@ -220,6 +238,7 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
                   <th className="px-3 py-3 font-medium">Status</th>
                   <th className="px-3 py-3 font-medium">Cadence</th>
                   <th className="px-3 py-3 font-medium">Next bill</th>
+                  <th className="px-3 py-3 text-right font-medium">Est. / period</th>
                 </tr>
               </thead>
               <tbody>
@@ -242,6 +261,9 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
                     </td>
                     <td className="px-3 py-3">{formatCadence(ctr.intervalMonths)}</td>
                     <td className="px-3 py-3">{formatDate(ctr.nextBillingAt)}</td>
+                    <td className="px-3 py-3 text-right tabular-nums" data-testid={`contract-estimate-${ctr.id}`}>
+                      {ctr.estimatedPeriodValue != null ? formatMoney(ctr.estimatedPeriodValue, ctr.currencyCode) : '—'}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -22,6 +22,7 @@ interface Sort { key: SortKey; dir: 'asc' | 'desc' }
 
 interface ExpandState {
   loading: boolean;
+  failed: boolean;
   components: BundleComponentRow[];
   economics: BundleEconomics | null;
 }
@@ -114,18 +115,22 @@ export default function CatalogItemsTab() {
       void Promise.all([getCatalogItem(it.id), getBundleEconomics(it.id)])
         .then(async ([detailRes, econRes]) => {
           if (detailRes.status === 401 || econRes.status === 401) return UNAUTHORIZED();
-          const detail = detailRes.ok
-            ? ((await detailRes.json().catch(() => null)) as { data?: CatalogItemDetail } | null)?.data ?? null
-            : null;
+          // The component list is the load-bearing read; a failure must NOT render
+          // as "empty bundle" (that misrepresents contents). Economics is optional.
+          if (!detailRes.ok) {
+            setExpanded((p) => (p[it.id] ? { ...p, [it.id]: { loading: false, failed: true, components: [], economics: null } } : p));
+            return;
+          }
+          const detail = ((await detailRes.json().catch(() => null)) as { data?: CatalogItemDetail } | null)?.data ?? null;
           const econ = econRes.ok
             ? ((await econRes.json().catch(() => null)) as { data?: BundleEconomics } | null)?.data ?? null
             : null;
           setExpanded((p) => (p[it.id]
-            ? { ...p, [it.id]: { loading: false, components: detail?.components ?? [], economics: econ } }
+            ? { ...p, [it.id]: { loading: false, failed: false, components: detail?.components ?? [], economics: econ } }
             : p));
         })
-        .catch(() => setExpanded((p) => (p[it.id] ? { ...p, [it.id]: { loading: false, components: [], economics: null } } : p)));
-      return { ...prev, [it.id]: { loading: true, components: [], economics: null } };
+        .catch(() => setExpanded((p) => (p[it.id] ? { ...p, [it.id]: { loading: false, failed: true, components: [], economics: null } } : p)));
+      return { ...prev, [it.id]: { loading: true, failed: false, components: [], economics: null } };
     });
   }, []);
 
@@ -371,6 +376,11 @@ export default function CatalogItemsTab() {
                           <td colSpan={7} className="px-3 py-3">
                             {exp.loading ? (
                               <p className="pl-6 text-xs text-muted-foreground">Loading components.</p>
+                            ) : exp.failed ? (
+                              <p className="pl-6 text-xs text-destructive">
+                                Couldn&rsquo;t load components.{' '}
+                                <button type="button" onClick={() => { toggleExpand(it); toggleExpand(it); }} className="underline hover:text-foreground">Retry</button>
+                              </p>
                             ) : exp.components.length === 0 ? (
                               <p className="pl-6 text-xs text-muted-foreground">This bundle has no components yet.</p>
                             ) : (

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -36,6 +36,22 @@ export interface ContractSummary {
   createdBy: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Resolved period value (live per_device/per_seat counts), added by GET /contracts. */
+  estimatedPeriodValue?: string;
+}
+
+/** One line's resolved estimate from GET /contracts/:id/estimate. */
+export interface ContractEstimateLine {
+  lineId: string;
+  lineType: ContractLineType;
+  quantity: number;
+  value: string;
+  live: boolean;
+}
+export interface ContractEstimate {
+  currencyCode: string;
+  periodTotal: string;
+  lines: ContractEstimateLine[];
 }
 
 export interface ContractLine {
@@ -93,6 +109,10 @@ export function listContracts(query: ListContractsQuery = {}): Promise<Response>
 
 export function getContract(id: string): Promise<Response> {
   return fetchWithAuth(`/contracts/${id}`);
+}
+
+export function getContractEstimate(id: string): Promise<Response> {
+  return fetchWithAuth(`/contracts/${id}/estimate`);
 }
 
 export function createContract(body: unknown): Promise<Response> {
@@ -168,4 +188,12 @@ export function formatCadence(intervalMonths: number): string {
     default:
       return `Every ${intervalMonths} months`;
   }
+}
+
+/** Normalize a per-period value to an estimated monthly figure (annual ÷ 12,
+ *  quarterly ÷ 3) for an "Est. monthly recurring" rollup. */
+export function monthlyValue(periodValue: string | number | null | undefined, intervalMonths: number): number {
+  const v = Number(periodValue);
+  if (!Number.isFinite(v) || intervalMonths <= 0) return 0;
+  return v / intervalMonths;
 }


### PR DESCRIPTION
**Stacked on #1440 (Invoices) → #1435 (Catalog).** Merge those first; this branch contains their commits until then.

Production redesign of Recurring Contracts (per `$impeccable shape` brief), reusing the Catalog/Invoices vocabulary, with **live device/seat counts** so recurring value is accurate.

### Backend
- `computeContractEstimate(id)` + `GET /contracts/:id/estimate` — per-line resolved quantity/value + period total, resolving per_device/per_seat via the existing count helpers.
- `listContracts` returns `estimatedPeriodValue` per row (one lines query + counts memoized per (org,site)/org — no per-contract N+1).

### List
"Est. monthly recurring" strip (active contracts, cadence-normalized) + an **Est./period** column.

### Editor
- Live "Estimated this period" from the estimate endpoint (replaces the "+ auto" placeholder; line table shows resolved live quantities).
- Catalog-item link is now the **shared CatalogItemPicker** typeahead (prefills description + price).
- New **Terms** field (schema-supported; now sent on create/update).

### Detail
- Live **Est./period** stat replaces the "hours under contract" placeholder.

### Verification
`astro check` clean · contract editor test green · API route tests: contracts 20/20 (incl. estimate), stripe 3/3.
⚠️ Live in-browser verification blocked: the local dev Docker API predates contracts (`GET /contracts` → 404). UI renders the graceful error state; estimate values light up against a current-main API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)