### PR TITLE
feat(viewer): #1449 show update download/install indicator instead of appearing to crash

### DIFF
--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -430,6 +430,35 @@ fn create_session_window(app: &tauri::AppHandle, url: String) {
     }
 }
 
+/// Update lifecycle status broadcast to all windows on the `update-status`
+/// event so the frontend can show an indicator (see
+/// `src/components/UpdateIndicator.tsx`). Without it, the window vanishing
+/// (Windows installer) or restarting (macOS/Linux) reads as a crash.
+///
+/// `#[serde(tag = "phase")]` produces `{ "phase": "downloading", ... }`, which
+/// the TS `UpdateStatus` union in `src/lib/updateStatus.ts` mirrors.
+#[derive(Clone, serde::Serialize)]
+#[serde(tag = "phase", rename_all = "lowercase")]
+enum UpdateStatus {
+    Available { version: String },
+    Downloading {
+        version: String,
+        downloaded: u64,
+        total: Option<u64>,
+    },
+    Installing { version: String },
+    Restarting { version: String },
+    Deferred { version: String },
+}
+
+/// Best-effort broadcast of update status. Emit failures are non-fatal — the
+/// update proceeds regardless of whether the UI is listening.
+fn emit_update_status(app: &tauri::AppHandle, status: UpdateStatus) {
+    if let Err(e) = app.emit("update-status", status) {
+        eprintln!("Failed to emit update-status: {}", e);
+    }
+}
+
 /// Check for updates and silently download + install if available.
 ///
 /// Platform behavior after install:
@@ -465,13 +494,36 @@ async fn auto_update(app: tauri::AppHandle) {
 
     eprintln!("Update {} available, downloading...", update.version);
 
-    let mut downloaded: usize = 0;
+    let version = update.version.clone();
+    emit_update_status(&app, UpdateStatus::Available { version: version.clone() });
+
+    let progress_app = app.clone();
+    let progress_version = version.clone();
+    let mut downloaded: u64 = 0;
+    // Throttle UI events to whole-percent changes so a fast download doesn't
+    // emit thousands of events; stderr logging stays per-chunk for forensics.
+    let mut last_emitted_pct: i64 = -1;
     let bytes = match update
         .download(
-            |chunk_len, content_len| {
-                downloaded += chunk_len;
+            move |chunk_len, content_len| {
+                downloaded += chunk_len as u64;
                 if let Some(total) = content_len {
                     eprintln!("Update download: {downloaded}/{total} bytes");
+                }
+                let pct = match content_len {
+                    Some(total) if total > 0 => ((downloaded * 100) / total) as i64,
+                    _ => -1,
+                };
+                if pct != last_emitted_pct {
+                    last_emitted_pct = pct;
+                    emit_update_status(
+                        &progress_app,
+                        UpdateStatus::Downloading {
+                            version: progress_version.clone(),
+                            downloaded,
+                            total: content_len,
+                        },
+                    );
                 }
             },
             || {
@@ -488,6 +540,10 @@ async fn auto_update(app: tauri::AppHandle) {
     };
 
     eprintln!("Update {} downloaded, installing...", update.version);
+    // On Windows install() does not return (process exits after launching the
+    // installer), so this "Installing…" notice is the last thing the user sees
+    // — which is exactly the point: a labelled exit, not a silent crash.
+    emit_update_status(&app, UpdateStatus::Installing { version: version.clone() });
 
     // install() behaviour varies by platform — see doc comment above.
     // On Windows this call does not return (process exits after launching installer).
@@ -515,8 +571,10 @@ async fn auto_update(app: tauri::AppHandle) {
 
         if has_active_sessions {
             eprintln!("Active remote session detected — deferring restart to next launch");
+            emit_update_status(&app, UpdateStatus::Deferred { version: version.clone() });
         } else {
             eprintln!("No active sessions — restarting to apply update");
+            emit_update_status(&app, UpdateStatus::Restarting { version: version.clone() });
             app.restart();
         }
     }

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -449,6 +449,7 @@ enum UpdateStatus {
     Installing { version: String },
     Restarting { version: String },
     Deferred { version: String },
+    Failed { version: String },
 }
 
 /// Best-effort broadcast of update status. Emit failures are non-fatal — the
@@ -456,6 +457,18 @@ enum UpdateStatus {
 fn emit_update_status(app: &tauri::AppHandle, status: UpdateStatus) {
     if let Err(e) = app.emit("update-status", status) {
         eprintln!("Failed to emit update-status: {}", e);
+    }
+}
+
+/// Whole-percent download progress, used to throttle UI events to one event
+/// per percent. Returns `-1` as a sentinel when the total is unknown or zero
+/// (no Content-Length) so the first such call matches the caller's initial
+/// `-1` and no spurious `downloading` event is emitted — the banner stays on
+/// its indeterminate state instead.
+fn download_percent(downloaded: u64, total: Option<u64>) -> i64 {
+    match total {
+        Some(total) if total > 0 => ((downloaded * 100) / total) as i64,
+        _ => -1,
     }
 }
 
@@ -510,10 +523,7 @@ async fn auto_update(app: tauri::AppHandle) {
                 if let Some(total) = content_len {
                     eprintln!("Update download: {downloaded}/{total} bytes");
                 }
-                let pct = match content_len {
-                    Some(total) if total > 0 => ((downloaded * 100) / total) as i64,
-                    _ => -1,
-                };
+                let pct = download_percent(downloaded, content_len);
                 if pct != last_emitted_pct {
                     last_emitted_pct = pct;
                     emit_update_status(
@@ -535,6 +545,9 @@ async fn auto_update(app: tauri::AppHandle) {
         Ok(bytes) => bytes,
         Err(e) => {
             eprintln!("Update download failed: {}", e);
+            // Surface the failure so a banner already showing "Downloading…"
+            // doesn't stay pinned forever, reintroducing the silent-crash look.
+            emit_update_status(&app, UpdateStatus::Failed { version: version.clone() });
             return;
         }
     };
@@ -549,6 +562,9 @@ async fn auto_update(app: tauri::AppHandle) {
     // On Windows this call does not return (process exits after launching installer).
     if let Err(e) = update.install(bytes) {
         eprintln!("Update install failed: {}", e);
+        // On Windows install() doesn't return on success; reaching here means it
+        // failed, so clear the pinned "Installing…" banner with a failure notice.
+        emit_update_status(&app, UpdateStatus::Failed { version: version.clone() });
         return;
     }
 
@@ -737,6 +753,78 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn download_percent_cases() {
+        let cases = [
+            // (downloaded, total, expected)
+            (0, Some(200), 0),
+            (50, Some(200), 25),
+            (1, Some(3), 33),   // integer floor, matches the throttle's intent
+            (2, Some(3), 66),   // floor, not rounded — display rounds separately
+            (200, Some(200), 100),
+            (210, Some(200), 105), // overshoot is not clamped here; the TS display clamps
+            (0, Some(0), -1),      // zero total → sentinel, no divide-by-zero
+            (50, None, -1),        // unknown total → sentinel
+        ];
+        for (downloaded, total, expected) in cases {
+            assert_eq!(
+                download_percent(downloaded, total),
+                expected,
+                "download_percent({downloaded}, {total:?})"
+            );
+        }
+    }
+
+    /// Locks the wire shape the TS `UpdateStatus` union in
+    /// `src/lib/updateStatus.ts` depends on. If a variant is renamed or a field
+    /// changes, this fails — forcing the TS mirror to be updated in lockstep.
+    #[test]
+    fn update_status_serializes_to_expected_shape() {
+        use serde_json::json;
+        let v = "1.2.3".to_string();
+        let cases = [
+            (
+                UpdateStatus::Available { version: v.clone() },
+                json!({ "phase": "available", "version": "1.2.3" }),
+            ),
+            (
+                UpdateStatus::Downloading {
+                    version: v.clone(),
+                    downloaded: 50,
+                    total: Some(200),
+                },
+                json!({ "phase": "downloading", "version": "1.2.3", "downloaded": 50, "total": 200 }),
+            ),
+            (
+                UpdateStatus::Downloading {
+                    version: v.clone(),
+                    downloaded: 50,
+                    total: None,
+                },
+                json!({ "phase": "downloading", "version": "1.2.3", "downloaded": 50, "total": null }),
+            ),
+            (
+                UpdateStatus::Installing { version: v.clone() },
+                json!({ "phase": "installing", "version": "1.2.3" }),
+            ),
+            (
+                UpdateStatus::Restarting { version: v.clone() },
+                json!({ "phase": "restarting", "version": "1.2.3" }),
+            ),
+            (
+                UpdateStatus::Deferred { version: v.clone() },
+                json!({ "phase": "deferred", "version": "1.2.3" }),
+            ),
+            (
+                UpdateStatus::Failed { version: v.clone() },
+                json!({ "phase": "failed", "version": "1.2.3" }),
+            ),
+        ];
+        for (status, expected) in cases {
+            assert_eq!(serde_json::to_value(&status).unwrap(), expected);
+        }
+    }
 
     #[test]
     fn extract_device_id_cases() {

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import DesktopViewer from './components/DesktopViewer';
+import UpdateIndicator from './components/UpdateIndicator';
 import { parseDeepLink, type ConnectionParams } from './lib/protocol';
 
 /**
@@ -94,26 +95,35 @@ export default function App() {
   }
 
   // ── Session window: viewer ─────────────────────────────────────────
+  // UpdateIndicator overlays every session-window state so an in-progress
+  // auto-update is visible whether connected or still connecting (the
+  // updater fires ~3s after launch, often during connection setup).
   if (params) {
     return (
-      <DesktopViewer
-        params={params}
-        onDisconnect={handleDisconnect}
-        onError={handleError}
-      />
+      <>
+        <UpdateIndicator />
+        <DesktopViewer
+          params={params}
+          onDisconnect={handleDisconnect}
+          onError={handleError}
+        />
+      </>
     );
   }
 
   // Waiting for deep link
   return (
-    <div className="flex items-center justify-center h-screen bg-gray-900">
-      <div className="text-center">
-        <div className="w-6 h-6 border-2 border-blue-400 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
-        <p className="text-gray-400 text-sm">Connecting...</p>
-        {error && (
-          <p className="text-red-400 text-sm mt-2">{error}</p>
-        )}
+    <>
+      <UpdateIndicator />
+      <div className="flex items-center justify-center h-screen bg-gray-900">
+        <div className="text-center">
+          <div className="w-6 h-6 border-2 border-blue-400 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+          <p className="text-gray-400 text-sm">Connecting...</p>
+          {error && (
+            <p className="text-red-400 text-sm mt-2">{error}</p>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/viewer/src/components/UpdateIndicator.tsx
+++ b/apps/viewer/src/components/UpdateIndicator.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import { Download, RefreshCw, CheckCircle2 } from 'lucide-react';
+import {
+  updateStatusMessage,
+  updateProgressPercent,
+  isUpdateActive,
+  shouldAutoDismiss,
+  type UpdateStatus,
+} from '../lib/updateStatus';
+
+/** How long a deferred-update notice lingers before auto-dismissing (ms). */
+const DEFERRED_DISMISS_MS = 10_000;
+
+/**
+ * Small fixed banner that surfaces the otherwise-silent auto-updater.
+ *
+ * The Rust updater (`src-tauri/src/lib.rs` `auto_update`) downloads and
+ * installs in the background, then the window vanishes (Windows installer)
+ * or the app restarts (macOS/Linux). Without this banner that looks like a
+ * crash. We listen for the broadcast `update-status` event and show what's
+ * actually happening.
+ */
+export default function UpdateIndicator() {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+
+  useEffect(() => {
+    const unlisten = listen<UpdateStatus>('update-status', (event) => {
+      setStatus(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn()).catch(() => {});
+    };
+  }, []);
+
+  // Auto-dismiss informational (deferred) notices; in-flight phases stay
+  // pinned until the process exits or restarts.
+  useEffect(() => {
+    if (!status || !shouldAutoDismiss(status)) return;
+    const timer = setTimeout(() => setStatus(null), DEFERRED_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [status]);
+
+  if (!status) return null;
+
+  const message = updateStatusMessage(status);
+  const percent = updateProgressPercent(status);
+  const active = isUpdateActive(status);
+
+  const Icon =
+    status.phase === 'deferred'
+      ? CheckCircle2
+      : status.phase === 'restarting'
+        ? RefreshCw
+        : Download;
+
+  return (
+    <div
+      data-testid="update-indicator"
+      role="status"
+      aria-live="polite"
+      className="fixed top-3 left-1/2 -translate-x-1/2 z-50 max-w-[90vw]
+                 flex flex-col gap-1 px-3 py-2 rounded-lg shadow-lg
+                 bg-gray-800/95 border border-gray-700 text-gray-100
+                 backdrop-blur-sm pointer-events-none"
+    >
+      <div className="flex items-center gap-2 text-xs">
+        <Icon
+          className={`w-3.5 h-3.5 text-blue-400 ${status.phase === 'restarting' ? 'animate-spin' : ''}`}
+        />
+        <span className="whitespace-nowrap">{message}</span>
+      </div>
+      {active && (
+        <div className="h-1 w-full rounded bg-gray-700 overflow-hidden">
+          {percent == null ? (
+            // Indeterminate: animated pulse when total size is unknown.
+            <div className="h-full w-full bg-blue-500 animate-pulse" />
+          ) : (
+            <div
+              data-testid="update-progress-bar"
+              className="h-full bg-blue-500 transition-[width] duration-200"
+              style={{ width: `${percent}%` }}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/UpdateIndicator.tsx
+++ b/apps/viewer/src/components/UpdateIndicator.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { listen } from '@tauri-apps/api/event';
-import { Download, RefreshCw, CheckCircle2 } from 'lucide-react';
+import { Download, RefreshCw, CheckCircle2, AlertTriangle } from 'lucide-react';
 import {
   updateStatusMessage,
   updateProgressPercent,
   isUpdateActive,
+  isUpdateStatus,
   shouldAutoDismiss,
   type UpdateStatus,
 } from '../lib/updateStatus';
@@ -25,11 +26,19 @@ export default function UpdateIndicator() {
   const [status, setStatus] = useState<UpdateStatus | null>(null);
 
   useEffect(() => {
-    const unlisten = listen<UpdateStatus>('update-status', (event) => {
-      setStatus(event.payload);
+    const unlisten = listen<unknown>('update-status', (event) => {
+      // Validate at the IPC boundary: a drifted/renamed Rust variant is dropped
+      // (banner just doesn't show) rather than crashing the render.
+      if (isUpdateStatus(event.payload)) {
+        setStatus(event.payload);
+      } else {
+        console.warn('Ignoring malformed update-status payload', event.payload);
+      }
     });
     return () => {
-      unlisten.then((fn) => fn()).catch(() => {});
+      unlisten
+        .then((fn) => fn())
+        .catch((e) => console.error('Failed to detach update-status listener', e));
     };
   }, []);
 
@@ -50,9 +59,12 @@ export default function UpdateIndicator() {
   const Icon =
     status.phase === 'deferred'
       ? CheckCircle2
-      : status.phase === 'restarting'
-        ? RefreshCw
-        : Download;
+      : status.phase === 'failed'
+        ? AlertTriangle
+        : status.phase === 'restarting'
+          ? RefreshCw
+          : Download;
+  const iconColor = status.phase === 'failed' ? 'text-amber-400' : 'text-blue-400';
 
   return (
     <div
@@ -66,7 +78,7 @@ export default function UpdateIndicator() {
     >
       <div className="flex items-center gap-2 text-xs">
         <Icon
-          className={`w-3.5 h-3.5 text-blue-400 ${status.phase === 'restarting' ? 'animate-spin' : ''}`}
+          className={`w-3.5 h-3.5 ${iconColor} ${status.phase === 'restarting' ? 'animate-spin' : ''}`}
         />
         <span className="whitespace-nowrap">{message}</span>
       </div>

--- a/apps/viewer/src/lib/updateStatus.test.ts
+++ b/apps/viewer/src/lib/updateStatus.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  updateProgressPercent,
+  updateStatusMessage,
+  isUpdateActive,
+  shouldAutoDismiss,
+  type UpdateStatus,
+} from './updateStatus';
+
+describe('updateProgressPercent', () => {
+  it('computes a whole-number percent for downloads with a known total', () => {
+    expect(
+      updateProgressPercent({ phase: 'downloading', version: '1.0.0', downloaded: 50, total: 200 }),
+    ).toBe(25);
+  });
+
+  it('rounds to the nearest whole percent', () => {
+    expect(
+      updateProgressPercent({ phase: 'downloading', version: '1.0.0', downloaded: 1, total: 3 }),
+    ).toBe(33);
+  });
+
+  it('clamps overshoot to 100', () => {
+    expect(
+      updateProgressPercent({ phase: 'downloading', version: '1.0.0', downloaded: 210, total: 200 }),
+    ).toBe(100);
+  });
+
+  it('returns null when the total is unknown', () => {
+    expect(
+      updateProgressPercent({ phase: 'downloading', version: '1.0.0', downloaded: 50, total: null }),
+    ).toBeNull();
+  });
+
+  it('returns null for a zero or negative total (no divide-by-zero)', () => {
+    expect(
+      updateProgressPercent({ phase: 'downloading', version: '1.0.0', downloaded: 0, total: 0 }),
+    ).toBeNull();
+  });
+
+  it('returns null for non-download phases', () => {
+    expect(updateProgressPercent({ phase: 'installing', version: '1.0.0' })).toBeNull();
+    expect(updateProgressPercent({ phase: 'available', version: '1.0.0' })).toBeNull();
+  });
+});
+
+describe('updateStatusMessage', () => {
+  it('names the version while downloading without a total', () => {
+    expect(
+      updateStatusMessage({ phase: 'downloading', version: '1.2.3', downloaded: 10, total: null }),
+    ).toBe('Downloading update 1.2.3…');
+  });
+
+  it('includes the percent while downloading with a total', () => {
+    expect(
+      updateStatusMessage({ phase: 'downloading', version: '1.2.3', downloaded: 50, total: 100 }),
+    ).toBe('Downloading update 1.2.3… 50%');
+  });
+
+  it('explains the restart so it does not read as a crash', () => {
+    expect(updateStatusMessage({ phase: 'restarting', version: '1.2.3' })).toMatch(/restarting/i);
+  });
+
+  it('explains a deferred update applies after the session', () => {
+    expect(updateStatusMessage({ phase: 'deferred', version: '1.2.3' })).toMatch(/session ends/i);
+  });
+
+  it('covers every phase with a non-empty message', () => {
+    const phases: UpdateStatus[] = [
+      { phase: 'available', version: '1.0.0' },
+      { phase: 'downloading', version: '1.0.0', downloaded: 1, total: 2 },
+      { phase: 'installing', version: '1.0.0' },
+      { phase: 'restarting', version: '1.0.0' },
+      { phase: 'deferred', version: '1.0.0' },
+    ];
+    for (const p of phases) {
+      expect(updateStatusMessage(p).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isUpdateActive', () => {
+  it('treats in-flight phases as active', () => {
+    expect(isUpdateActive({ phase: 'available', version: '1.0.0' })).toBe(true);
+    expect(isUpdateActive({ phase: 'downloading', version: '1.0.0', downloaded: 1, total: 2 })).toBe(true);
+    expect(isUpdateActive({ phase: 'installing', version: '1.0.0' })).toBe(true);
+    expect(isUpdateActive({ phase: 'restarting', version: '1.0.0' })).toBe(true);
+  });
+
+  it('treats deferred as inactive', () => {
+    expect(isUpdateActive({ phase: 'deferred', version: '1.0.0' })).toBe(false);
+  });
+});
+
+describe('shouldAutoDismiss', () => {
+  it('auto-dismisses only the deferred phase', () => {
+    expect(shouldAutoDismiss({ phase: 'deferred', version: '1.0.0' })).toBe(true);
+    expect(shouldAutoDismiss({ phase: 'installing', version: '1.0.0' })).toBe(false);
+    expect(shouldAutoDismiss({ phase: 'restarting', version: '1.0.0' })).toBe(false);
+  });
+});

--- a/apps/viewer/src/lib/updateStatus.test.ts
+++ b/apps/viewer/src/lib/updateStatus.test.ts
@@ -3,6 +3,7 @@ import {
   updateProgressPercent,
   updateStatusMessage,
   isUpdateActive,
+  isUpdateStatus,
   shouldAutoDismiss,
   type UpdateStatus,
 } from './updateStatus';
@@ -65,6 +66,11 @@ describe('updateStatusMessage', () => {
     expect(updateStatusMessage({ phase: 'deferred', version: '1.2.3' })).toMatch(/session ends/i);
   });
 
+  it('explains a failed update will retry instead of leaving the banner stuck', () => {
+    expect(updateStatusMessage({ phase: 'failed', version: '1.2.3' })).toMatch(/failed/i);
+    expect(updateStatusMessage({ phase: 'failed', version: '1.2.3' })).toMatch(/retry/i);
+  });
+
   it('covers every phase with a non-empty message', () => {
     const phases: UpdateStatus[] = [
       { phase: 'available', version: '1.0.0' },
@@ -72,6 +78,7 @@ describe('updateStatusMessage', () => {
       { phase: 'installing', version: '1.0.0' },
       { phase: 'restarting', version: '1.0.0' },
       { phase: 'deferred', version: '1.0.0' },
+      { phase: 'failed', version: '1.0.0' },
     ];
     for (const p of phases) {
       expect(updateStatusMessage(p).length).toBeGreaterThan(0);
@@ -87,15 +94,47 @@ describe('isUpdateActive', () => {
     expect(isUpdateActive({ phase: 'restarting', version: '1.0.0' })).toBe(true);
   });
 
-  it('treats deferred as inactive', () => {
+  it('treats terminal notices (deferred / failed) as inactive', () => {
     expect(isUpdateActive({ phase: 'deferred', version: '1.0.0' })).toBe(false);
+    expect(isUpdateActive({ phase: 'failed', version: '1.0.0' })).toBe(false);
   });
 });
 
 describe('shouldAutoDismiss', () => {
-  it('auto-dismisses only the deferred phase', () => {
+  it('auto-dismisses terminal notices (deferred / failed)', () => {
     expect(shouldAutoDismiss({ phase: 'deferred', version: '1.0.0' })).toBe(true);
+    expect(shouldAutoDismiss({ phase: 'failed', version: '1.0.0' })).toBe(true);
+  });
+
+  it('keeps in-flight phases pinned', () => {
     expect(shouldAutoDismiss({ phase: 'installing', version: '1.0.0' })).toBe(false);
     expect(shouldAutoDismiss({ phase: 'restarting', version: '1.0.0' })).toBe(false);
+    expect(shouldAutoDismiss({ phase: 'downloading', version: '1.0.0', downloaded: 1, total: 2 })).toBe(false);
+  });
+});
+
+describe('isUpdateStatus', () => {
+  it('accepts every well-formed phase payload', () => {
+    const valid: UpdateStatus[] = [
+      { phase: 'available', version: '1.0.0' },
+      { phase: 'downloading', version: '1.0.0', downloaded: 1, total: 2 },
+      { phase: 'installing', version: '1.0.0' },
+      { phase: 'restarting', version: '1.0.0' },
+      { phase: 'deferred', version: '1.0.0' },
+      { phase: 'failed', version: '1.0.0' },
+    ];
+    for (const v of valid) {
+      expect(isUpdateStatus(v)).toBe(true);
+    }
+  });
+
+  it('rejects unknown, malformed, or non-object payloads (boundary guard)', () => {
+    expect(isUpdateStatus({ phase: 'paused', version: '1.0.0' })).toBe(false); // drifted Rust variant
+    expect(isUpdateStatus({ phase: 'available' })).toBe(false); // missing version
+    expect(isUpdateStatus({ version: '1.0.0' })).toBe(false); // missing phase
+    expect(isUpdateStatus({ phase: 7, version: '1.0.0' })).toBe(false); // non-string phase
+    expect(isUpdateStatus(null)).toBe(false);
+    expect(isUpdateStatus('downloading')).toBe(false);
+    expect(isUpdateStatus(undefined)).toBe(false);
   });
 });

--- a/apps/viewer/src/lib/updateStatus.ts
+++ b/apps/viewer/src/lib/updateStatus.ts
@@ -1,0 +1,72 @@
+/**
+ * Update lifecycle status broadcast from the Rust auto-updater.
+ *
+ * The viewer's updater is otherwise silent (see `src-tauri/src/lib.rs`
+ * `auto_update`). Without a visible indicator, the window disappearing
+ * (Windows installer) or restarting (macOS/Linux) reads as a crash. These
+ * events drive a small banner so the user knows an update — not a crash —
+ * is happening.
+ *
+ * The shape mirrors the serde-tagged `UpdateStatus` enum emitted on the
+ * `update-status` event. `phase` is the serde tag.
+ */
+export type UpdateStatus =
+  | { phase: 'available'; version: string }
+  | { phase: 'downloading'; version: string; downloaded: number; total: number | null }
+  | { phase: 'installing'; version: string }
+  | { phase: 'restarting'; version: string }
+  | { phase: 'deferred'; version: string };
+
+/** Phases that represent in-flight work (animated spinner appropriate). */
+const ACTIVE_PHASES: ReadonlySet<UpdateStatus['phase']> = new Set([
+  'available',
+  'downloading',
+  'installing',
+  'restarting',
+]);
+
+/**
+ * Download progress as a whole-number percent (0-100), or null when the
+ * total size is unknown or the phase isn't a download.
+ */
+export function updateProgressPercent(status: UpdateStatus): number | null {
+  if (status.phase !== 'downloading') return null;
+  const { downloaded, total } = status;
+  if (total == null || total <= 0) return null;
+  const pct = Math.round((downloaded / total) * 100);
+  // Clamp to guard against a final chunk overshooting the reported total.
+  return Math.max(0, Math.min(100, pct));
+}
+
+/** Human-readable, single-line message for the indicator. */
+export function updateStatusMessage(status: UpdateStatus): string {
+  switch (status.phase) {
+    case 'available':
+      return `Update ${status.version} available — downloading…`;
+    case 'downloading': {
+      const pct = updateProgressPercent(status);
+      return pct == null
+        ? `Downloading update ${status.version}…`
+        : `Downloading update ${status.version}… ${pct}%`;
+    }
+    case 'installing':
+      return `Installing update ${status.version}…`;
+    case 'restarting':
+      return `Update ${status.version} installed — restarting…`;
+    case 'deferred':
+      return `Update ${status.version} ready — applies when this session ends.`;
+  }
+}
+
+/** Whether the indicator should show an animated/in-progress affordance. */
+export function isUpdateActive(status: UpdateStatus): boolean {
+  return ACTIVE_PHASES.has(status.phase);
+}
+
+/**
+ * Deferred updates are informational and shouldn't linger forever. All other
+ * phases stay pinned until the process exits or restarts.
+ */
+export function shouldAutoDismiss(status: UpdateStatus): boolean {
+  return status.phase === 'deferred';
+}

--- a/apps/viewer/src/lib/updateStatus.ts
+++ b/apps/viewer/src/lib/updateStatus.ts
@@ -8,22 +8,54 @@
  * is happening.
  *
  * The shape mirrors the serde-tagged `UpdateStatus` enum emitted on the
- * `update-status` event. `phase` is the serde tag.
+ * `update-status` event. `phase` is the serde tag. The Rust side has a
+ * `serialize_*` contract test (`src-tauri/src/lib.rs`) that locks these tag
+ * names and field shapes so the two definitions can't silently drift.
  */
 export type UpdateStatus =
   | { phase: 'available'; version: string }
   | { phase: 'downloading'; version: string; downloaded: number; total: number | null }
   | { phase: 'installing'; version: string }
   | { phase: 'restarting'; version: string }
-  | { phase: 'deferred'; version: string };
+  | { phase: 'deferred'; version: string }
+  | { phase: 'failed'; version: string };
 
-/** Phases that represent in-flight work (animated spinner appropriate). */
-const ACTIVE_PHASES: ReadonlySet<UpdateStatus['phase']> = new Set([
-  'available',
-  'downloading',
-  'installing',
-  'restarting',
-]);
+/** Compile-time exhaustiveness guard: a new phase that isn't handled becomes a type error. */
+function assertNever(value: never): never {
+  throw new Error(`Unhandled update phase: ${JSON.stringify(value)}`);
+}
+
+/**
+ * Every known phase, keyed by the union's `phase` discriminant. Typed as
+ * `Record<UpdateStatus['phase'], true>` so adding a phase to the union without
+ * listing it here is a compile error — this stays in sync automatically.
+ */
+const KNOWN_PHASES: Record<UpdateStatus['phase'], true> = {
+  available: true,
+  downloading: true,
+  installing: true,
+  restarting: true,
+  deferred: true,
+  failed: true,
+};
+
+/**
+ * Validate an inbound `update-status` payload at the IPC trust boundary.
+ *
+ * Tauri's `listen` payload is `any`, so a drifted/renamed Rust variant would
+ * otherwise flow straight into the UI. Rejecting an unrecognized payload here
+ * degrades gracefully (the banner just doesn't show) rather than crashing the
+ * render on an unhandled phase.
+ */
+export function isUpdateStatus(value: unknown): value is UpdateStatus {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.phase === 'string' &&
+    record.phase in KNOWN_PHASES &&
+    typeof record.version === 'string'
+  );
+}
 
 /**
  * Download progress as a whole-number percent (0-100), or null when the
@@ -55,18 +87,37 @@ export function updateStatusMessage(status: UpdateStatus): string {
       return `Update ${status.version} installed — restarting…`;
     case 'deferred':
       return `Update ${status.version} ready — applies when this session ends.`;
+    case 'failed':
+      return `Update ${status.version} failed — will retry on next launch.`;
+    default:
+      return assertNever(status);
   }
 }
 
-/** Whether the indicator should show an animated/in-progress affordance. */
+/**
+ * Whether the indicator should show an animated/in-progress affordance
+ * (the determinate progress bar or indeterminate pulse). Only the in-flight
+ * phases qualify — `deferred` and `failed` are terminal notices.
+ */
 export function isUpdateActive(status: UpdateStatus): boolean {
-  return ACTIVE_PHASES.has(status.phase);
+  switch (status.phase) {
+    case 'available':
+    case 'downloading':
+    case 'installing':
+    case 'restarting':
+      return true;
+    case 'deferred':
+    case 'failed':
+      return false;
+    default:
+      return assertNever(status);
+  }
 }
 
 /**
- * Deferred updates are informational and shouldn't linger forever. All other
- * phases stay pinned until the process exits or restarts.
+ * Terminal notices (deferred / failed) are informational and shouldn't linger
+ * forever. In-flight phases stay pinned until the process exits or restarts.
  */
 export function shouldAutoDismiss(status: UpdateStatus): boolean {
-  return status.phase === 'deferred';
+  return status.phase === 'deferred' || status.phase === 'failed';
 }


### PR DESCRIPTION
Closes #1449

## Problem

The Breeze Viewer's auto-updater was fully silent. It checked, downloaded, and installed an update with no UI, then the window disappeared (Windows MSI installer) or the app restarted (macOS/Linux). To users this looked like a **crash**.

## Fix

Broadcast the update lifecycle on a new `update-status` Tauri event and render a small, non-blocking banner in session windows.

**Rust (`src-tauri/src/lib.rs`)**
- New `UpdateStatus` enum (`#[serde(tag = "phase")]`) emitted at each phase: `available → downloading → installing → restarting | deferred`.
- Download progress is throttled to whole-percent changes (stderr logging stays per-chunk for forensics).
- The `Installing…` notice is emitted right before `install()` — which on Windows never returns — so the process exit is **labelled**, not silent.
- Emit failures are non-fatal; the update proceeds regardless of whether the UI is listening.

**Frontend**
- `src/lib/updateStatus.ts` — pure helpers (`updateStatusMessage`, `updateProgressPercent`, `isUpdateActive`, `shouldAutoDismiss`) mirroring the Rust enum, with full unit coverage.
- `src/components/UpdateIndicator.tsx` — listens for the broadcast and shows a fixed banner with a progress bar (determinate when total size is known, indeterminate pulse otherwise).
- Wired into both session-window states in `App.tsx` (connected viewer + "Connecting…"), since the updater fires ~3s after launch, often during connection setup.

Deferred (active-session) notices auto-dismiss after 10s; in-flight notices stay pinned until the process exits/restarts. The hidden main/anchor window renders nothing, so the banner only appears in visible session windows.

## Testing

- `apps/viewer`: full suite green — **134 tests passed** (14 new for `updateStatus`).
- `tsc --noEmit`: clean.
- `cargo check`: clean (the pre-existing `auto_update` "never used" warning in debug is the `#[cfg(not(debug_assertions))]` gate, unchanged by this PR).

Note: the in-host visual (the banner rendering during a real update) is best verified by Todd's UI test, as the updater path is release-only.