### PR TITLE
feat(rbac): dedicated billing roles, tighten technician grants, permission-aware UI

### DIFF
--- a/apps/api/migrations/2026-06-19-billing-roles.sql
+++ b/apps/api/migrations/2026-06-19-billing-roles.sql
@@ -1,0 +1,97 @@
+-- 2026-06-19-billing-roles.sql
+-- Dedicated partner-scope billing roles + tighten over-broad grants.
+--
+-- Context: catalog/invoices/contracts permissions previously rode on the
+-- Partner Technician role (the feature backfill migrations granted them because
+-- Technician holds tickets:write), and catalog:read sat on Partner Viewer. This
+-- introduces two dedicated billing roles and revokes billing from Technician and
+-- Viewer, so billing access lives ONLY in Partner Admin + the new roles.
+--
+-- Operates ONLY on the global system role rows (partner_id IS NULL,
+-- is_system = TRUE). Per-partner cloned Partner Admin rows (which carry the *:*
+-- wildcard, so they keep everything) and partner-authored custom roles are
+-- untouched.
+--
+-- Idempotent: NOT EXISTS guards on every insert; the DELETEs are naturally
+-- repeatable (re-running removes nothing once the grants are gone). On a fresh
+-- DB this runs before seed.ts, so the role inserts here and the authoritative
+-- definitions in seed.ts converge on the same end state.
+
+-- 1. Ensure the two new global partner-scope system roles exist.
+INSERT INTO roles (partner_id, scope, name, description, is_system)
+SELECT NULL, 'partner', 'Partner Billing',
+       'Full access to product catalog, invoices, and contracts', TRUE
+WHERE NOT EXISTS (
+  SELECT 1 FROM roles
+  WHERE partner_id IS NULL AND scope = 'partner'
+    AND name = 'Partner Billing' AND is_system = TRUE
+);
+
+INSERT INTO roles (partner_id, scope, name, description, is_system)
+SELECT NULL, 'partner', 'Partner Billing Viewer',
+       'Read-only access to product catalog, invoices, and contracts', TRUE
+WHERE NOT EXISTS (
+  SELECT 1 FROM roles
+  WHERE partner_id IS NULL AND scope = 'partner'
+    AND name = 'Partner Billing Viewer' AND is_system = TRUE
+);
+
+-- 2a. Grant Partner Billing every catalog/invoices/contracts permission.
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.resource IN ('catalog', 'invoices', 'contracts')
+WHERE r.partner_id IS NULL AND r.scope = 'partner'
+  AND r.name = 'Partner Billing' AND r.is_system = TRUE
+  AND NOT EXISTS (
+    SELECT 1 FROM role_permissions x WHERE x.role_id = r.id AND x.permission_id = p.id
+  );
+
+-- 2b. Grant Partner Billing Viewer the read-only billing set
+--     (catalog:read, invoices:read, invoices:export, contracts:read).
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON (
+       (p.resource = 'catalog'   AND p.action = 'read')
+    OR (p.resource = 'invoices'  AND p.action IN ('read', 'export'))
+    OR (p.resource = 'contracts' AND p.action = 'read')
+)
+WHERE r.partner_id IS NULL AND r.scope = 'partner'
+  AND r.name = 'Partner Billing Viewer' AND r.is_system = TRUE
+  AND NOT EXISTS (
+    SELECT 1 FROM role_permissions x WHERE x.role_id = r.id AND x.permission_id = p.id
+  );
+
+-- 3a. Revoke ALL billing permissions from the global Partner Technician role.
+--     Row count is logged so the change leaves a forensic trail in PG logs.
+DO $$
+DECLARE n integer;
+BEGIN
+  DELETE FROM role_permissions rp
+  USING roles r, permissions p
+  WHERE rp.role_id = r.id AND rp.permission_id = p.id
+    AND r.partner_id IS NULL AND r.scope = 'partner'
+    AND r.name = 'Partner Technician' AND r.is_system = TRUE
+    AND p.resource IN ('catalog', 'invoices', 'contracts');
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'billing-roles: revoked % billing permission(s) from Partner Technician', n;
+  END IF;
+END $$;
+
+-- 3b. Revoke catalog access from the global Partner Viewer role.
+DO $$
+DECLARE n integer;
+BEGIN
+  DELETE FROM role_permissions rp
+  USING roles r, permissions p
+  WHERE rp.role_id = r.id AND rp.permission_id = p.id
+    AND r.partner_id IS NULL AND r.scope = 'partner'
+    AND r.name = 'Partner Viewer' AND r.is_system = TRUE
+    AND p.resource = 'catalog';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'billing-roles: revoked % catalog permission(s) from Partner Viewer', n;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-06-20-role-permissions-unique.sql
+++ b/apps/api/migrations/2026-06-20-role-permissions-unique.sql
@@ -1,0 +1,46 @@
+-- 2026-06-20-role-permissions-unique.sql
+-- Give role_permissions a composite primary key on (role_id, permission_id).
+--
+-- The table shipped with no PK or unique constraint, so re-running the seed
+-- (whose grant loop swallows 23505 expecting a conflict) silently inserted
+-- DUPLICATE (role_id, permission_id) rows. This de-dups any existing duplicates
+-- and adds the PK so the conflict path is real and grants are unique going
+-- forward.
+--
+-- Idempotent: the de-dup is naturally repeatable; the PK is added only if absent.
+-- Runs after 2026-06-19-billing-roles so the new billing-role grants are deduped
+-- and constrained too.
+
+-- 1. Collapse duplicate grant rows, keeping one row per (role_id, permission_id).
+--    Prefer a row carrying constraints (non-null) when duplicates disagree, then
+--    fall back to ctid for a deterministic survivor.
+DO $$
+DECLARE n integer;
+BEGIN
+  DELETE FROM role_permissions rp
+  USING (
+    SELECT ctid,
+           row_number() OVER (
+             PARTITION BY role_id, permission_id
+             ORDER BY (constraints IS NULL), ctid
+           ) AS rn
+    FROM role_permissions
+  ) d
+  WHERE rp.ctid = d.ctid AND d.rn > 1;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'role-permissions-unique: removed % duplicate grant row(s)', n;
+  END IF;
+END $$;
+
+-- 2. Add the composite primary key if it isn't already present.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.role_permissions'::regclass AND contype = 'p'
+  ) THEN
+    ALTER TABLE role_permissions
+      ADD CONSTRAINT role_permissions_pkey PRIMARY KEY (role_id, permission_id);
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/seed-idempotency.integration.test.ts
+++ b/apps/api/src/__tests__/integration/seed-idempotency.integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Real-DB idempotency guard for the role/permission seed.
+ *
+ * This PR added the `role_permissions` composite PK `(role_id, permission_id)`
+ * and switched seedRoles() to `.onConflictDoNothing()` so a re-seed is a no-op
+ * instead of throwing a 23505 unique_violation. That headline change had no
+ * coverage: a mocked unit test can't exercise the real PK conflict, and the
+ * pre-PR hand-rolled catch would have re-thrown it anyway (err.code is
+ * undefined under Drizzle's DrizzleQueryError wrapper — the pg code lives on
+ * err.cause). This test seeds twice against the real DB and asserts:
+ *   (a) the second seedRoles() run does not throw, and
+ *   (b) there is exactly ONE role_permissions row per (role_id, permission_id)
+ *       grant — no duplicates.
+ *
+ * Runs under vitest.integration.config.ts — seedPermissions()/seedRoles() wrap
+ * themselves in withSystemDbAccessContext, so they write through the system
+ * (RLS-bypassing) path on the breeze_app pool. setup.ts's beforeEach TRUNCATEs
+ * roles + role_permissions (and we re-seed permissions per test), so each it()
+ * starts from a clean slate — no memoization.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { roles, rolePermissions } from '../../db/schema';
+import { seedPermissions, seedRoles, SYSTEM_ROLES } from '../../db/seed';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function roleAndGrantCounts() {
+  return withSystemDbAccessContext(async () => {
+    const roleRows = await db
+      .select({ roleCount: sql<number>`count(*)::int` })
+      .from(roles);
+    const grantRows = await db
+      .select({ grantCount: sql<number>`count(*)::int` })
+      .from(rolePermissions);
+    return { roleCount: roleRows[0]!.roleCount, grantCount: grantRows[0]!.grantCount };
+  });
+}
+
+// Duplicate rows on the composite PK itself. With the PK in place this must
+// always be empty; it's the direct invariant the PR's onConflictDoNothing protects.
+async function duplicatePkGrants() {
+  return (await withSystemDbAccessContext(() =>
+    db.execute(sql`
+      SELECT role_id, permission_id, count(*) AS n
+      FROM role_permissions
+      GROUP BY role_id, permission_id
+      HAVING count(*) > 1
+    `),
+  )) as unknown as Array<{ role_id: string; permission_id: string; n: number }>;
+}
+
+// Duplicate LOGICAL grants — a role holding the same resource:action more than
+// once, even via different permission_id rows. This is stricter than the PK
+// check and catches the case where a polluted `permissions` table (duplicate
+// resource:action rows) lets seedRoles map a permKey to a different permission
+// id on re-seed, slipping a second grant past the (role_id, permission_id) PK.
+async function duplicateLogicalGrants() {
+  return (await withSystemDbAccessContext(() =>
+    db.execute(sql`
+      SELECT rp.role_id, p.resource, p.action, count(*) AS n
+      FROM role_permissions rp
+      JOIN permissions p ON p.id = rp.permission_id
+      GROUP BY rp.role_id, p.resource, p.action
+      HAVING count(*) > 1
+    `),
+  )) as unknown as Array<{ role_id: string; resource: string; action: string; n: number }>;
+}
+
+describe('role/permission seed idempotency', () => {
+  // The PR under test added the role_permissions composite PK
+  // (role_id, permission_id) and switched seedRoles() to onConflictDoNothing.
+  // We pin both the PK-level invariant (no duplicate (role_id, permission_id)
+  // rows) and the stronger logical invariant (no role holds the same
+  // resource:action twice, even via different permission ids). The latter is
+  // what surfaced — and now guards — the seedPermissions() dedup fix in the
+  // same change: re-seeding permissions used to re-insert duplicate
+  // resource:action rows, which then leaked extra grants past the PK.
+  runDb('seeding twice does not throw and produces no duplicate grants', async () => {
+    // Start from a clean catalog so counts are deterministic. setup.ts wipes
+    // roles + role_permissions per test but NOT `permissions` (it accumulates
+    // across runs), so clear all three here for a true single-seed -> re-seed
+    // cycle. Done under system scope on the breeze_app pool, which has DELETE
+    // (but not TRUNCATE) on these tables; FK order is grants -> roles -> permissions.
+    await withSystemDbAccessContext(async () => {
+      await db.execute(sql`DELETE FROM role_permissions`);
+      await db.execute(sql`DELETE FROM roles`);
+      await db.execute(sql`DELETE FROM permissions`);
+    });
+
+    // First seed.
+    await seedPermissions();
+    await seedRoles();
+
+    const afterFirst = await roleAndGrantCounts();
+    expect(afterFirst.roleCount).toBe(SYSTEM_ROLES.length);
+    expect(afterFirst.grantCount).toBeGreaterThan(0);
+    expect((await duplicatePkGrants()).length).toBe(0);
+    expect((await duplicateLogicalGrants()).length).toBe(0);
+
+    // Second seed — the headline change: must not throw on the (role_id,
+    // permission_id) PK conflict (the .onConflictDoNothing() guard).
+    await expect(seedPermissions()).resolves.not.toThrow();
+    await expect(seedRoles()).resolves.not.toThrow();
+
+    const afterSecond = await roleAndGrantCounts();
+
+    // No new roles and no new grants created on re-seed — idempotent.
+    expect(afterSecond.roleCount).toBe(afterFirst.roleCount);
+    expect(afterSecond.grantCount).toBe(afterFirst.grantCount);
+
+    // Exactly one row per (role_id, permission_id) — the composite PK invariant —
+    // and no role holds the same resource:action twice.
+    expect((await duplicatePkGrants()).length).toBe(0);
+    expect((await duplicateLogicalGrants()).length).toBe(0);
+  });
+});

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, integer, pgEnum, customType } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, integer, pgEnum, customType, primaryKey } from 'drizzle-orm/pg-core';
 import { partners, organizations } from './orgs';
 
 // Postgres `bytea` mapped to a Node Buffer. postgres.js returns bytea columns
@@ -98,7 +98,11 @@ export const rolePermissions = pgTable('role_permissions', {
   roleId: uuid('role_id').notNull().references(() => roles.id),
   permissionId: uuid('permission_id').notNull().references(() => permissions.id),
   constraints: jsonb('constraints')
-});
+}, (t) => ({
+  // A role holds a given permission at most once. Composite PK both de-dups and
+  // makes the seed's ON-conflict (23505) path real, so re-seeding is idempotent.
+  pk: primaryKey({ columns: [t.roleId, t.permissionId] })
+}));
 
 export const partnerUsers = pgTable('partner_users', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/apps/api/src/db/seed.test.ts
+++ b/apps/api/src/db/seed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveBootstrapAdminConfig } from './seed';
+import { resolveBootstrapAdminConfig, DEFAULT_PERMISSIONS, SYSTEM_ROLES } from './seed';
 
 describe('resolveBootstrapAdminConfig', () => {
   it('keeps the development convenience admin when no explicit bootstrap env is set', () => {
@@ -77,5 +77,44 @@ describe('resolveBootstrapAdminConfig', () => {
       password: 'operator-generated-credential-32-chars',
       logPassword: false,
     });
+  });
+});
+
+describe('SYSTEM_ROLES ⊆ DEFAULT_PERMISSIONS', () => {
+  // seedRoles() looks each role permission up in a Map built from the rows
+  // seedPermissions() inserted from DEFAULT_PERMISSIONS. A permission a role
+  // references but DEFAULT_PERMISSIONS omits is silently dropped at seed time
+  // (a console.warn + continue), producing a partial grant set with no surfaced
+  // error. This pure-data invariant converts that silent runtime partial-grant
+  // into a failing test.
+  //
+  // Scope note: this asserts the SECURITY-relevant direction only — every
+  // permission a system role grants must be seeded. The reverse is NOT asserted:
+  // DEFAULT_PERMISSIONS (and the shared PERMISSION_GRANTS registry) may legitimately
+  // be a superset, defining permissions no system role grants yet (e.g.
+  // time_entries:*, automations:* live in the registry but aren't seeded because
+  // no system role references them). A registry/seed superset is fine; an
+  // unseeded role grant is the bug.
+  const seededKeys = new Set(
+    DEFAULT_PERMISSIONS.map((p) => `${p.resource}:${p.action}`),
+  );
+
+  for (const role of SYSTEM_ROLES) {
+    for (const permKey of role.permissions) {
+      // The wildcard grant is matched at authorization time (resource '*',
+      // action '*'), not looked up as a literal in DEFAULT_PERMISSIONS — but it
+      // IS seeded as the '*:*' row, so it's present anyway. Skip it explicitly
+      // to keep intent clear.
+      if (permKey === '*:*') continue;
+
+      it(`role "${role.name}" grant "${permKey}" exists in DEFAULT_PERMISSIONS`, () => {
+        expect(seededKeys.has(permKey)).toBe(true);
+      });
+    }
+  }
+
+  it('every DEFAULT_PERMISSIONS entry is a unique resource:action', () => {
+    const keys = DEFAULT_PERMISSIONS.map((p) => `${p.resource}:${p.action}`);
+    expect(new Set(keys).size).toBe(keys.length);
   });
 });

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -784,20 +784,16 @@ export async function seedRoles() {
         console.warn(`  Role "${roleDef.name}" references unknown permission "${permKey}" — skipping`);
         continue;
       }
-      try {
-        await db.insert(rolePermissions).values({
-          roleId,
-          permissionId: permId
-        });
-      } catch (err) {
-        // 23505 = unique_violation. Permission already assigned — safe to
-        // ignore. Any other error (RLS, connection loss, FK) must surface
-        // so a broken seed doesn't silently leave partial role grants.
-        if ((err as { code?: string } | null)?.code === '23505') {
-          continue;
-        }
-        throw err;
-      }
+      // Permission may already be assigned (re-seed, or a duplicate key in
+      // roleDef.permissions). Let the DB no-op on the (role_id, permission_id)
+      // PK conflict rather than catching a unique_violation — postgres.js wraps
+      // the error in a DrizzleQueryError, so the pg `23505` code lives on
+      // err.cause, not err, and a hand-rolled catch silently re-throws it.
+      // Any genuine error (RLS, FK, connection loss) still surfaces.
+      await db
+        .insert(rolePermissions)
+        .values({ roleId, permissionId: permId })
+        .onConflictDoNothing();
     }
   }
 

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -96,7 +96,15 @@ export function resolveBootstrapAdminConfig(
 }
 
 // Default permissions
-const DEFAULT_PERMISSIONS = [
+//
+// Exported for the seed↔registry consistency test (seed.test.ts), which
+// asserts every resource:action referenced by SYSTEM_ROLES below exists here.
+// This is intentionally a subset of PERMISSION_GRANTS (the shared registry):
+// the registry may define permissions no system role grants yet (e.g.
+// time_entries:*, automations:*) without those needing a seeded row — only
+// permissions a system role actually references must be seeded, or seedRoles
+// silently drops the grant.
+export const DEFAULT_PERMISSIONS = [
   // Backup / recovery
   { resource: 'backup', action: 'read', description: 'View backup and recovery resources' },
   { resource: 'backup', action: 'write', description: 'Create and manage backup and recovery resources' },
@@ -175,7 +183,8 @@ const DEFAULT_PERMISSIONS = [
 ];
 
 // Default system roles
-const SYSTEM_ROLES = [
+// Exported for the seed↔registry consistency test (seed.test.ts).
+export const SYSTEM_ROLES = [
   {
     name: 'Partner Admin',
     scope: 'partner' as const,
@@ -719,15 +728,20 @@ export async function seedPermissions() {
   console.log('Seeding permissions...');
 
   for (const perm of DEFAULT_PERMISSIONS) {
+    // Match on the full (resource, action) pair. The previous existence check
+    // filtered on resource alone with .limit(1), so for a resource with several
+    // actions (e.g. devices read/write/delete/execute) the single returned row
+    // frequently had the wrong action — the .find(action) missed and re-inserted
+    // a duplicate on every re-seed. permissions has no unique constraint to catch
+    // that, and the duplicate ids then let seedRoles slip extra role_permissions
+    // grants past the (role_id, permission_id) PK. Make the dedup exact.
     const existing = await db
       .select()
       .from(permissions)
-      .where(eq(permissions.resource, perm.resource))
+      .where(and(eq(permissions.resource, perm.resource), eq(permissions.action, perm.action)))
       .limit(1);
 
-    const match = existing.find(e => e.action === perm.action);
-
-    if (!match) {
+    if (existing.length === 0) {
       await db.insert(permissions).values(perm);
       console.log('  Created permission:', perm.resource + ':' + perm.action);
     }
@@ -785,11 +799,14 @@ export async function seedRoles() {
         continue;
       }
       // Permission may already be assigned (re-seed, or a duplicate key in
-      // roleDef.permissions). Let the DB no-op on the (role_id, permission_id)
-      // PK conflict rather than catching a unique_violation — postgres.js wraps
-      // the error in a DrizzleQueryError, so the pg `23505` code lives on
-      // err.cause, not err, and a hand-rolled catch silently re-throws it.
-      // Any genuine error (RLS, FK, connection loss) still surfaces.
+      // roleDef.permissions). This PR added the (role_id, permission_id)
+      // composite PK and switched to onConflictDoNothing so the DB no-ops on a
+      // re-seed. A hand-rolled catch is the wrong tool here: it would have
+      // checked `err.code === '23505'`, but under Drizzle's DrizzleQueryError
+      // wrapper `err.code` is undefined (the pg `23505` lives on `err.cause`),
+      // so the catch would have re-thrown the conflict and broken re-seeding.
+      // onConflictDoNothing absorbs only the PK conflict — any genuine error
+      // (RLS, FK, connection loss) still surfaces.
       await db
         .insert(rolePermissions)
         .values({ roleId, permissionId: permId })

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -127,6 +127,17 @@ const DEFAULT_PERMISSIONS = [
   { resource: 'catalog', action: 'write', description: 'Create and update catalog items, pricing, and bundles' },
   { resource: 'catalog', action: 'delete', description: 'Archive/delete catalog items' },
 
+  // Invoices (billing/invoicing program)
+  { resource: 'invoices', action: 'read', description: 'View invoices and payment history' },
+  { resource: 'invoices', action: 'write', description: 'Create, edit, and delete draft invoices and lines' },
+  { resource: 'invoices', action: 'send', description: 'Issue, send, void invoices and record/remove payments' },
+  { resource: 'invoices', action: 'export', description: 'Export and download invoice PDFs' },
+
+  // Contracts (recurring billing program)
+  { resource: 'contracts', action: 'read', description: 'View contracts, lines, and billing-period history' },
+  { resource: 'contracts', action: 'write', description: 'Create/edit/delete draft contracts and lines' },
+  { resource: 'contracts', action: 'manage', description: 'Activate/pause/resume/cancel contracts and generate invoices' },
+
   // Users
   { resource: 'users', action: 'read', description: 'View users' },
   { resource: 'users', action: 'write', description: 'Edit users' },
@@ -181,7 +192,6 @@ const SYSTEM_ROLES = [
       'scripts:read', 'scripts:execute',
       'alerts:read', 'alerts:acknowledge',
       'tickets:read',
-      'catalog:read', 'catalog:write',
       'reports:read', 'reports:write',
       'sites:read',
       'organizations:read'
@@ -196,10 +206,29 @@ const SYSTEM_ROLES = [
       'scripts:read',
       'alerts:read',
       'tickets:read',
-      'catalog:read',
       'reports:read',
       'sites:read',
       'organizations:read'
+    ]
+  },
+  {
+    name: 'Partner Billing',
+    scope: 'partner' as const,
+    description: 'Full access to product catalog, invoices, and contracts',
+    permissions: [
+      'catalog:read', 'catalog:write', 'catalog:delete',
+      'invoices:read', 'invoices:write', 'invoices:send', 'invoices:export',
+      'contracts:read', 'contracts:write', 'contracts:manage'
+    ]
+  },
+  {
+    name: 'Partner Billing Viewer',
+    scope: 'partner' as const,
+    description: 'Read-only access to product catalog, invoices, and contracts',
+    permissions: [
+      'catalog:read',
+      'invoices:read', 'invoices:export',
+      'contracts:read'
     ]
   },
   {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -523,6 +523,40 @@ describe('user routes', () => {
       const body = await res.json() as { isPlatformAdmin?: boolean };
       expect(body.isPlatformAdmin).toBe(true);
     });
+
+    // The web app hides billing nav and action buttons off this list. If /me
+    // stops surfacing the user's grants, gated controls would render for users
+    // who lack the permission (server still 403s, but it's a UX regression).
+    it('returns the user permission grants for client-side UI gating', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'user-123',
+              email: 'admin@example.com',
+              name: 'Admin',
+              avatarUrl: null,
+              status: 'active',
+              mfaEnabled: false,
+              isPlatformAdmin: false,
+              createdAt: new Date(),
+              lastLoginAt: new Date(),
+              setupCompletedAt: new Date(),
+              passwordChangedAt: new Date(),
+              preferences: {}
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/users/me', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { permissions?: { resource: string; action: string }[] };
+      // Mocked getUserPermissions returns the admin wildcard grant.
+      expect(body.permissions).toEqual([{ resource: '*', action: '*' }]);
+    });
   });
 
   describe('PATCH /users/me validation', () => {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -442,8 +442,14 @@ userRoutes.get('/me', async (c) => {
   const requiresSetup = userRequiresSetup(user);
 
   // Surface the user's effective permission grants so the web app can hide nav
-  // items and action buttons the user can't use (e.g. billing pages/controls).
-  // This is UX only — every route still enforces requirePermission server-side.
+  // items and action buttons the user can't use. This is UX only — every route
+  // still enforces requirePermission server-side.
+  //
+  // Contract: getUserPermissions returns null ONLY for "no resolvable role"
+  // (no membership row / null roleId) — a genuine zero-grant user, for whom
+  // `?? []` is correct fail-closed behavior. It must NEVER swallow a transient
+  // cache/DB fault into null: those throw, so /me 500s and the client keeps its
+  // last-known grants rather than silently blanking every gated control.
   const userPerms = await getUserPermissions(auth.user.id, {
     partnerId: auth.partnerId || undefined,
     orgId: auth.orgId || undefined

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -441,11 +441,20 @@ userRoutes.get('/me', async (c) => {
 
   const requiresSetup = userRequiresSetup(user);
 
+  // Surface the user's effective permission grants so the web app can hide nav
+  // items and action buttons the user can't use (e.g. billing pages/controls).
+  // This is UX only — every route still enforces requirePermission server-side.
+  const userPerms = await getUserPermissions(auth.user.id, {
+    partnerId: auth.partnerId || undefined,
+    orgId: auth.orgId || undefined
+  });
+
   return c.json({
     ...user,
     partnerId: auth.partnerId,
     orgId: auth.orgId,
     scope: auth.scope,
+    permissions: userPerms?.permissions ?? [],
     requiresSetup
   });
 });

--- a/apps/api/src/services/permissions.ts
+++ b/apps/api/src/services/permissions.ts
@@ -2,6 +2,7 @@ import { db } from '../db';
 import { roles, permissions, rolePermissions, partnerUsers, organizationUsers } from '../db/schema';
 import { eq, and } from 'drizzle-orm';
 import { getRedis } from './redis';
+import { PERMISSION_GRANTS } from '@breeze/shared';
 
 export interface Permission {
   resource: string;
@@ -237,93 +238,10 @@ export async function clearPermissionCache(userId?: string): Promise<void> {
   await bumpSharedPermissionCacheVersion(userId);
 }
 
-// Built-in system permissions
-export const PERMISSIONS = {
-  // Backup / recovery
-  BACKUP_READ: { resource: 'backup', action: 'read' },
-  BACKUP_WRITE: { resource: 'backup', action: 'write' },
-
-  // Devices
-  DEVICES_READ: { resource: 'devices', action: 'read' },
-  DEVICES_WRITE: { resource: 'devices', action: 'write' },
-  DEVICES_DELETE: { resource: 'devices', action: 'delete' },
-  DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
-
-  // Scripts
-  SCRIPTS_READ: { resource: 'scripts', action: 'read' },
-  SCRIPTS_WRITE: { resource: 'scripts', action: 'write' },
-  SCRIPTS_DELETE: { resource: 'scripts', action: 'delete' },
-  SCRIPTS_EXECUTE: { resource: 'scripts', action: 'execute' },
-
-  // Alerts
-  ALERTS_READ: { resource: 'alerts', action: 'read' },
-  ALERTS_WRITE: { resource: 'alerts', action: 'write' },
-  ALERTS_ACKNOWLEDGE: { resource: 'alerts', action: 'acknowledge' },
-
-  // Tickets
-  TICKETS_READ: { resource: 'tickets', action: 'read' },
-  TICKETS_WRITE: { resource: 'tickets', action: 'write' },
-
-  // Catalog (billing/invoicing program)
-  CATALOG_READ: { resource: 'catalog', action: 'read' },
-  CATALOG_WRITE: { resource: 'catalog', action: 'write' },
-  CATALOG_DELETE: { resource: 'catalog', action: 'delete' },
-
-  // Invoices (billing/invoicing program — sub-project 2)
-  INVOICES_READ: { resource: 'invoices', action: 'read' },
-  INVOICES_WRITE: { resource: 'invoices', action: 'write' },
-  INVOICES_SEND: { resource: 'invoices', action: 'send' },
-  INVOICES_EXPORT: { resource: 'invoices', action: 'export' },
-
-  // Contracts (recurring-contracts — sub-project 3)
-  CONTRACTS_READ: { resource: 'contracts', action: 'read' },
-  CONTRACTS_WRITE: { resource: 'contracts', action: 'write' },
-  CONTRACTS_MANAGE: { resource: 'contracts', action: 'manage' },
-
-  // Time entries (ticketing Phase 3)
-  TIME_ENTRIES_READ: { resource: 'time_entries', action: 'read' },
-  TIME_ENTRIES_WRITE: { resource: 'time_entries', action: 'write' },
-
-  // Users
-  USERS_READ: { resource: 'users', action: 'read' },
-  USERS_WRITE: { resource: 'users', action: 'write' },
-  USERS_DELETE: { resource: 'users', action: 'delete' },
-  USERS_INVITE: { resource: 'users', action: 'invite' },
-
-  // Organizations
-  ORGS_READ: { resource: 'organizations', action: 'read' },
-  ORGS_WRITE: { resource: 'organizations', action: 'write' },
-  ORGS_DELETE: { resource: 'organizations', action: 'delete' },
-
-  // Sites
-  SITES_READ: { resource: 'sites', action: 'read' },
-  SITES_WRITE: { resource: 'sites', action: 'write' },
-  SITES_DELETE: { resource: 'sites', action: 'delete' },
-
-  // Automations
-  AUTOMATIONS_READ: { resource: 'automations', action: 'read' },
-  AUTOMATIONS_WRITE: { resource: 'automations', action: 'write' },
-  AUTOMATIONS_DELETE: { resource: 'automations', action: 'delete' },
-
-  // Remote access
-  REMOTE_ACCESS: { resource: 'remote', action: 'access' },
-
-  // Audit
-  AUDIT_READ: { resource: 'audit', action: 'read' },
-  AUDIT_EXPORT: { resource: 'audit', action: 'export' },
-
-  // Reports
-  REPORTS_READ: { resource: 'reports', action: 'read' },
-  REPORTS_WRITE: { resource: 'reports', action: 'write' },
-  REPORTS_DELETE: { resource: 'reports', action: 'delete' },
-  REPORTS_EXPORT: { resource: 'reports', action: 'export' },
-
-  // Billing
-  BILLING_MANAGE: { resource: 'billing', action: 'manage' },
-
-  // Admin
-  ADMIN_ALL: { resource: '*', action: '*' }
-} as const;
+// Built-in system permissions. The registry itself lives in @breeze/shared (as
+// PERMISSION_GRANTS) so the web UI can type its gate literals against the same
+// closed set; aliased here as PERMISSIONS so existing call sites are unchanged.
+export const PERMISSIONS = PERMISSION_GRANTS;
 
 export function permissionKey(permission: Permission): string {
   return `${permission.resource}:${permission.action}`;

--- a/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceDetail from './InvoiceDetail';
+import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+type Perm = { resource: string; action: string };
+
+// Mutable grant set the mocked auth store reads from, so each test can vary the
+// invoice permissions the detail view sees. This file exists to cover the
+// NEGATIVE gating branches — the sibling InvoiceDetail.test.tsx grants the `*:*`
+// wildcard and only ever exercises the visible/true branch, so a mis-wired
+// (resource,action) pair (e.g. gating Void on invoices:write instead of
+// invoices:send, or the PDF on invoices:send instead of invoices:export) would
+// pass there. These tests pin the security-relevant read vs export vs send
+// distinction: a read-only or write-only operator must NOT see send/void/
+// record-payment/pay-link controls.
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const lines: InvoiceDetailData['lines'] = [
+  {
+    id: 'l1', invoiceId: 'inv-1', sourceType: 'catalog', parentLineId: null, catalogItemId: 'c1',
+    description: 'Widget', quantity: '1.00', unitPrice: '120.00', costBasis: '80.00', revenueAllocation: '120.00',
+    taxable: true, customerVisible: true, lineTotal: '120.00', isUnapprovedTime: false, sortOrder: 0,
+  },
+];
+
+// Issued invoice with a balance due and Stripe connected, so that canVoid,
+// canRecordPayment and the pay-link branch are all *otherwise* satisfied — the
+// only thing keeping the controls hidden is the permission gate under test.
+const issued: InvoiceDetailData = {
+  invoice: {
+    id: 'inv-1', invoiceNumber: 'INV-0007', orgId: 'org-1', siteId: null, status: 'sent',
+    currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30', sentAt: null, subtotal: '120.00',
+    taxRate: '0.000', taxTotal: '0.00', total: '120.00', amountPaid: '0.00', balance: '120.00',
+    billToName: 'Acme', notes: null, createdAt: '2026-06-01T00:00:00Z',
+  },
+  lines,
+  stripeConnected: true,
+};
+
+const stripePayment = {
+  id: 'p1', invoiceId: 'inv-1', amount: '120.00', method: 'bank_transfer' as const, reference: 'ref',
+  receivedAt: '2026-06-10', note: null, createdAt: '', source: 'manual' as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [];
+  fetchMock.mockImplementation(async (input: string) => {
+    if (input.endsWith('/payments')) return json({ data: [stripePayment] });
+    return json({ data: {} });
+  });
+});
+
+describe('InvoiceDetail — permission gating', () => {
+  it('read-only (invoices:read) hides export, void, pay-link, payment-void and the record-payment form', async () => {
+    state.permissions = [{ resource: 'invoices', action: 'read' }];
+    render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+
+    // export gate → Download PDF
+    expect(screen.queryByTestId('invoice-download-pdf')).not.toBeInTheDocument();
+    // send gate → void, pay-link, manual payment void, record-payment form/submit
+    expect(screen.queryByTestId('invoice-void-open')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-void-p1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-form')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-submit')).not.toBeInTheDocument();
+  });
+
+  it('invoices:write WITHOUT invoices:send still hides every send-gated control', async () => {
+    // The security-relevant case: write is the editing grant, NOT a license to
+    // issue/void/take payments. Those all gate on invoices:send.
+    state.permissions = [{ resource: 'invoices', action: 'write' }];
+    render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('invoice-void-open')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-void-p1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-form')).not.toBeInTheDocument();
+    // write does not grant export either.
+    expect(screen.queryByTestId('invoice-download-pdf')).not.toBeInTheDocument();
+  });
+
+  it('invoices:export reveals Download PDF but NOT the send-gated controls', async () => {
+    // Proves export and send are independent gates — export must not leak void/
+    // pay-link/record-payment.
+    state.permissions = [{ resource: 'invoices', action: 'export' }];
+    render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('invoice-download-pdf')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-void-open')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-form')).not.toBeInTheDocument();
+  });
+
+  it('invoices:send reveals void, pay-link, payment-void and the record-payment form', async () => {
+    // Positive control proving the test discriminates: the send-gated controls
+    // DO appear once invoices:send is granted.
+    state.permissions = [{ resource: 'invoices', action: 'send' }];
+    render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('invoice-void-open')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-pay-link')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-payment-void-p1')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-payment-form')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-payment-submit')).toBeInTheDocument();
+    // send is not export → still no PDF button.
+    expect(screen.queryByTestId('invoice-download-pdf')).not.toBeInTheDocument();
+  });
+
+  it('hides the void-dialog submit when invoices:send is absent', async () => {
+    // The void dialog renders a confirm button only behind invoices:send; with
+    // read-only the dialog markup is not even reachable (the open button is
+    // hidden), so the submit must be absent.
+    state.permissions = [{ resource: 'invoices', action: 'read' }];
+    render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-void-submit')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -5,7 +5,17 @@ import InvoiceDetail from './InvoiceDetail';
 import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
 import { fetchWithAuth } from '../../stores/auth';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  // usePermissions() (billing-RBAC UI gating) reads grants off the store; grant
+  // the admin wildcard so every gated control renders and these tests exercise
+  // full functionality.
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 const showToast = vi.fn();
 vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { Dialog } from '../shared/Dialog';
 import {
@@ -24,6 +25,7 @@ interface Props {
 }
 
 export default function InvoiceDetail({ detail, onChanged }: Props) {
+  const { can } = usePermissions();
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
   const stripeConnected = detail.stripeConnected === true;
@@ -284,14 +286,16 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
 
           {/* PDF + void */}
           <div className="space-y-2">
-            <button
-              type="button" onClick={() => void downloadPdf()} disabled={busy}
-              data-testid="invoice-download-pdf"
-              className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-            >
-              Download PDF
-            </button>
-            {canVoid && (
+            {can('invoices', 'export') && (
+              <button
+                type="button" onClick={() => void downloadPdf()} disabled={busy}
+                data-testid="invoice-download-pdf"
+                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              >
+                Download PDF
+              </button>
+            )}
+            {canVoid && can('invoices', 'send') && (
               <button
                 type="button" onClick={() => { setVoidReason(''); setVoidReissue(false); setVoidOpen(true); }}
                 data-testid="invoice-void-open"
@@ -331,7 +335,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                     {/* Stripe payments are refunded through Stripe, never hand-voided. */}
                     {p.source === 'stripe' ? (
                       <span className="whitespace-nowrap text-[11px] text-muted-foreground">via Stripe</span>
-                    ) : (
+                    ) : can('invoices', 'send') ? (
                       <button
                         type="button" onClick={() => void voidPayment(p.id)} disabled={busy || invoice.status === 'void'}
                         data-testid={`invoice-payment-void-${p.id}`}
@@ -339,13 +343,13 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                       >
                         Void
                       </button>
-                    )}
+                    ) : null}
                   </li>
                 ))}
               </ul>
             )}
 
-            {canRecordPayment && stripeConnected && (
+            {canRecordPayment && stripeConnected && can('invoices', 'send') && (
               <button
                 type="button" onClick={() => void sendPayLink()} disabled={busy}
                 data-testid="invoice-pay-link"
@@ -361,7 +365,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
               </p>
             )}
 
-            {canRecordPayment && (
+            {canRecordPayment && can('invoices', 'send') && (
               <div className="mt-3 space-y-2 border-t pt-3" data-testid="invoice-payment-form">
                 <div className="grid grid-cols-2 gap-2">
                   <input
@@ -427,13 +431,15 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
           </label>
           <div className="flex justify-end gap-2">
             <button type="button" onClick={() => setVoidOpen(false)} className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted">Cancel</button>
-            <button
-              type="button" onClick={() => void submitVoid()} disabled={busy || !voidReason.trim()}
-              data-testid="invoice-void-submit"
-              className="inline-flex items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-            >
-              Void invoice
-            </button>
+            {can('invoices', 'send') && (
+              <button
+                type="button" onClick={() => void submitVoid()} disabled={busy || !voidReason.trim()}
+                data-testid="invoice-void-submit"
+                className="inline-flex items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+              >
+                Void invoice
+              </button>
+            )}
           </div>
         </div>
       </Dialog>

--- a/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceEditor from './InvoiceEditor';
+import type { InvoiceDetail } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+type Perm = { resource: string; action: string };
+
+// Mutable grant set the mocked auth store reads from. Covers the NEGATIVE gating
+// branches the wildcard-positive sibling (InvoiceEditor.test.tsx) never touches:
+// the editor draws a hard line between invoices:write (edit lines/notes) and
+// invoices:send (issue / issue & send). A write-only operator must be able to
+// build the draft but NOT issue or send it.
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const visibleLine: InvoiceDetail['lines'][number] = {
+  id: 'line-1', invoiceId: 'inv-1', sourceType: 'manual', parentLineId: null, catalogItemId: null,
+  description: 'Consulting', quantity: '2.00', unitPrice: '50.00', costBasis: null, revenueAllocation: null,
+  taxable: false, customerVisible: true, lineTotal: '100.00', isUnapprovedTime: false, sortOrder: 1,
+};
+
+// Draft with a customer-visible line so issue/send buttons are *otherwise*
+// enabled — only the permission gate keeps them hidden.
+const draft: InvoiceDetail = {
+  invoice: {
+    id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
+    taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
+    notes: '', createdAt: '2026-06-01T00:00:00Z',
+  },
+  lines: [visibleLine],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [];
+  fetchMock.mockImplementation(async (input: string) => {
+    if (input.startsWith('/catalog')) return json({ data: [] });
+    return json({ data: {} });
+  });
+});
+
+describe('InvoiceEditor — permission gating', () => {
+  it('read-only (invoices:read) hides the add-line form, per-line remove, and issue/send', async () => {
+    state.permissions = [{ resource: 'invoices', action: 'read' }];
+    render(<InvoiceEditor detail={draft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('invoice-add-line')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-line-remove-line-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
+    // Notes entry is disabled (gated on write) rather than removed.
+    expect(screen.getByTestId('invoice-notes')).toBeDisabled();
+  });
+
+  it('invoices:write reveals editing controls but still hides Issue / Issue & Send', async () => {
+    // The security-relevant line: write builds the draft; issuing/sending is a
+    // separate grant (invoices:send).
+    state.permissions = [{ resource: 'invoices', action: 'write' }];
+    render(<InvoiceEditor detail={draft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    expect(screen.getByTestId('invoice-add-line')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-line-remove-line-1')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-notes')).not.toBeDisabled();
+    // send-gated:
+    expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
+  });
+
+  it('invoices:send reveals Issue / Issue & Send but NOT the editing controls', async () => {
+    // Mirror image: send is not a license to edit lines. add-line and per-line
+    // remove gate on invoices:write and must stay hidden.
+    state.permissions = [{ resource: 'invoices', action: 'send' }];
+    render(<InvoiceEditor detail={draft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    expect(screen.getByTestId('invoice-issue')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-issue-send')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-add-line')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-line-remove-line-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoice-notes')).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -5,7 +5,17 @@ import InvoiceEditor from './InvoiceEditor';
 import type { InvoiceDetail } from './invoiceTypes';
 import { fetchWithAuth } from '../../stores/auth';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  // usePermissions() (billing-RBAC UI gating) reads grants off the store; grant
+  // the admin wildcard so every gated control renders and these tests exercise
+  // full functionality.
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 const showToast = vi.fn();
 vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import {
   type InvoiceDetail,
@@ -21,6 +22,8 @@ interface Props {
 type AddMode = 'catalog' | 'manual';
 
 export default function InvoiceEditor({ detail, onChanged }: Props) {
+  const { can } = usePermissions();
+  const canWrite = can('invoices', 'write');
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
 
@@ -259,6 +262,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           </div>
 
           {/* Add line */}
+          {canWrite && (
           <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="invoice-add-line">
             <div className="mb-3 flex gap-2">
               {(['catalog', 'manual'] as AddMode[]).map((m) => (
@@ -344,6 +348,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               />
             )}
           </div>
+          )}
         </div>
 
         {/* Summary + bill-to + notes + actions */}
@@ -367,33 +372,38 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             <textarea
               value={notes}
               onChange={(e) => { setNotes(e.target.value); setNotesDirty(true); }}
-              onBlur={() => void saveNotes()}
+              onBlur={() => { if (canWrite) void saveNotes(); }}
+              readOnly={!canWrite}
               data-testid="invoice-notes"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring read-only:opacity-60"
               placeholder="Internal or customer notes…"
             />
           </div>
 
           <div className="space-y-2">
-            <button
-              type="button"
-              onClick={() => void issue(false)}
-              disabled={busy || !hasVisibleLines}
-              data-testid="invoice-issue"
-              className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-            >
-              Issue
-            </button>
-            <button
-              type="button"
-              onClick={() => void issue(true)}
-              disabled={busy || !hasVisibleLines}
-              data-testid="invoice-issue-send"
-              className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-            >
-              Issue &amp; Send
-            </button>
+            {can('invoices', 'send') && (
+              <button
+                type="button"
+                onClick={() => void issue(false)}
+                disabled={busy || !hasVisibleLines}
+                data-testid="invoice-issue"
+                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              >
+                Issue
+              </button>
+            )}
+            {can('invoices', 'send') && (
+              <button
+                type="button"
+                onClick={() => void issue(true)}
+                disabled={busy || !hasVisibleLines}
+                data-testid="invoice-issue-send"
+                className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                Issue &amp; Send
+              </button>
+            )}
             {!hasVisibleLines && (
               <p className="text-center text-xs text-muted-foreground" data-testid="invoice-no-visible-hint">
                 Add at least one customer-visible line to issue.
@@ -416,6 +426,9 @@ function LineRow({
   onPatch: (lineId: string, patch: Record<string, unknown>) => void;
   onRemove: (lineId: string) => void;
 }) {
+  const { can } = usePermissions();
+  const canWrite = can('invoices', 'write');
+  const editDisabled = disabled || !canWrite;
   const [qty, setQty] = useState(line.quantity);
   const [price, setPrice] = useState(line.unitPrice);
   useEffect(() => { setQty(line.quantity); setPrice(line.unitPrice); }, [line.quantity, line.unitPrice]);
@@ -426,45 +439,47 @@ function LineRow({
         <td className="px-3 py-2">{line.description}</td>
         <td className="px-3 py-2 text-right">
           <input
-            type="number" min="0" step="0.01" value={qty} disabled={disabled}
+            type="number" min="0" step="0.01" value={qty} disabled={editDisabled}
             onChange={(e) => setQty(e.target.value)}
-            onBlur={() => { if (qty !== line.quantity) onPatch(line.id, { quantity: Number(qty) }); }}
+            onBlur={() => { if (canWrite && qty !== line.quantity) onPatch(line.id, { quantity: Number(qty) }); }}
             data-testid={`invoice-line-qty-${line.id}`}
             className="h-8 w-20 rounded-md border bg-background px-2 text-right text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </td>
         <td className="px-3 py-2 text-right">
           <input
-            type="number" min="0" step="0.01" value={price} disabled={disabled}
+            type="number" min="0" step="0.01" value={price} disabled={editDisabled}
             onChange={(e) => setPrice(e.target.value)}
-            onBlur={() => { if (price !== line.unitPrice) onPatch(line.id, { unitPrice: Number(price) }); }}
+            onBlur={() => { if (canWrite && price !== line.unitPrice) onPatch(line.id, { unitPrice: Number(price) }); }}
             data-testid={`invoice-line-price-${line.id}`}
             className="h-8 w-24 rounded-md border bg-background px-2 text-right text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </td>
         <td className="px-3 py-2 text-center">
           <input
-            type="checkbox" checked={line.taxable} disabled={disabled}
+            type="checkbox" checked={line.taxable} disabled={editDisabled}
             onChange={(e) => onPatch(line.id, { taxable: e.target.checked })}
             data-testid={`invoice-line-taxable-${line.id}`}
           />
         </td>
         <td className="px-3 py-2 text-center">
           <input
-            type="checkbox" checked={line.customerVisible} disabled={disabled}
+            type="checkbox" checked={line.customerVisible} disabled={editDisabled}
             onChange={(e) => onPatch(line.id, { customerVisible: e.target.checked })}
             data-testid={`invoice-line-visible-${line.id}`}
           />
         </td>
         <td className="px-3 py-2 text-right">{formatMoney(line.lineTotal, currency)}</td>
         <td className="px-3 py-2 text-right">
-          <button
-            type="button" onClick={() => onRemove(line.id)} disabled={disabled}
-            data-testid={`invoice-line-remove-${line.id}`}
-            className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-          >
-            Remove
-          </button>
+          {canWrite && (
+            <button
+              type="button" onClick={() => onRemove(line.id)} disabled={disabled}
+              data-testid={`invoice-line-remove-${line.id}`}
+              className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+            >
+              Remove
+            </button>
+          )}
         </td>
       </tr>
       {children.map((ch) => (

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -372,11 +372,14 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             <textarea
               value={notes}
               onChange={(e) => { setNotes(e.target.value); setNotesDirty(true); }}
+              // Gate ENTRY, not save (disabled, like the qty/price inputs) — a
+              // readOnly field is still focusable, so if canWrite flipped false
+              // mid-edit the onBlur guard would silently drop the typed note.
               onBlur={() => { if (canWrite) void saveNotes(); }}
-              readOnly={!canWrite}
+              disabled={!canWrite}
               data-testid="invoice-notes"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring read-only:opacity-60"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
               placeholder="Internal or customer notes…"
             />
           </div>

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -4,7 +4,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import InvoicesPage from './InvoicesPage';
 import { fetchWithAuth } from '../../stores/auth';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  // usePermissions() (billing-RBAC UI gating) reads grants off the store; grant
+  // the admin wildcard so every gated control renders and these tests exercise
+  // full functionality.
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
 const navigateTo = vi.fn();
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
 const showToast = vi.fn();

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
+import { usePermissions } from '../../lib/permissions';
 import { Dialog } from '../shared/Dialog';
 import {
   type InvoiceStatus,
@@ -71,6 +72,7 @@ const num = (s: string | null | undefined) => { const n = Number(s); return Numb
 const ts = (d: string | null) => (d ? new Date(d.length === 10 ? `${d}T00:00:00` : d).getTime() : null);
 
 export default function InvoicesPage() {
+  const { can } = usePermissions();
   const [invoices, setInvoices] = useState<InvoiceSummary[]>([]);
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
@@ -261,14 +263,16 @@ export default function InvoicesPage() {
             Assemble, issue, and track customer invoices.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={openAssemble}
-          data-testid="invoices-assemble-open"
-          className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-        >
-          New invoice
-        </button>
+        {can('invoices', 'write') && (
+          <button
+            type="button"
+            onClick={openAssemble}
+            data-testid="invoices-assemble-open"
+            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+          >
+            New invoice
+          </button>
+        )}
       </div>
 
       {/* Outstanding summary */}
@@ -377,14 +381,16 @@ export default function InvoicesPage() {
             <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
               Assemble unbilled time and parts into a draft, or start a blank invoice.
             </p>
-            <button
-              type="button"
-              onClick={openAssemble}
-              className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-              data-testid="invoices-empty-new"
-            >
-              New invoice
-            </button>
+            {can('invoices', 'write') && (
+              <button
+                type="button"
+                onClick={openAssemble}
+                className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+                data-testid="invoices-empty-new"
+              >
+                New invoice
+              </button>
+            )}
           </div>
         ) : rows.length === 0 ? (
           <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="invoices-no-match">
@@ -548,15 +554,17 @@ export default function InvoicesPage() {
             >
               Cancel
             </button>
-            <button
-              type="button"
-              onClick={() => void submitDialog()}
-              disabled={!assembleOrgId || (mode === 'assemble' && (!assembleFrom || !assembleTo)) || assembling}
-              data-testid="invoices-assemble-submit"
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
-            >
-              {assembling ? 'Working…' : mode === 'assemble' ? 'Assemble' : 'Create draft'}
-            </button>
+            {can('invoices', 'write') && (
+              <button
+                type="button"
+                onClick={() => void submitDialog()}
+                disabled={!assembleOrgId || (mode === 'assemble' && (!assembleFrom || !assembleTo)) || assembling}
+                data-testid="invoices-assemble-submit"
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+              >
+                {assembling ? 'Working…' : mode === 'assemble' ? 'Assemble' : 'Create draft'}
+              </button>
+            )}
           </div>
         </div>
       </Dialog>

--- a/apps/web/src/components/contracts/ContractDetail.permissions.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.permissions.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ContractDetail from './ContractDetail';
+import * as api from '../../lib/api/contracts';
+import type { ContractDetail as ContractDetailData, ContractStatus } from '../../lib/api/contracts';
+
+type Perm = { resource: string; action: string };
+
+// Mutable grant set the mocked auth store reads from. Covers the NEGATIVE gating
+// branches absent from the rest of the contracts tests. The lifecycle actions
+// (pause/resume/cancel) and "Generate invoice now" are the highest-risk controls
+// in the contracts surface — they gate on contracts:manage, NOT contracts:write.
+// A write-only operator must NOT see them.
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return {
+    ...actual,
+    contractTransition: vi.fn(),
+    generateContractInvoice: vi.fn(),
+    getContractEstimate: vi.fn(),
+  };
+});
+
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function detail(status: ContractStatus): ContractDetailData {
+  return {
+    contract: {
+      id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status,
+      billingTiming: 'advance', intervalMonths: 1, startDate: '2026-06-01', endDate: null,
+      nextBillingAt: null, autoIssue: false, currencyCode: 'USD', notes: null, terms: null,
+      createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    },
+    lines: [
+      {
+        id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed services',
+        catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, taxable: false,
+        sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+      },
+    ],
+    periods: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [];
+  (api.getContractEstimate as any).mockResolvedValue(resp({ data: { currencyCode: 'USD', periodTotal: '500.00', lines: [] } }));
+});
+
+describe('ContractDetail — permission gating', () => {
+  it('contracts:write WITHOUT contracts:manage hides the lifecycle actions on an active contract', async () => {
+    // Active contract offers pause + cancel — both manage-gated. write alone must
+    // not surface them, and must not surface "Generate invoice now".
+    state.permissions = [{ resource: 'contracts', action: 'write' }];
+    render(<ContractDetail detail={detail('active')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('contract-lifecycle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('contract-pause-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('contract-cancel-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('generate-now-btn')).not.toBeInTheDocument();
+  });
+
+  it('read-only (contracts:read) also hides lifecycle + generate', async () => {
+    state.permissions = [{ resource: 'contracts', action: 'read' }];
+    render(<ContractDetail detail={detail('active')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('contract-lifecycle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('generate-now-btn')).not.toBeInTheDocument();
+  });
+
+  it('contracts:manage reveals pause/cancel and Generate invoice now on an active contract', async () => {
+    // Positive control proving the gate discriminates.
+    state.permissions = [{ resource: 'contracts', action: 'manage' }];
+    render(<ContractDetail detail={detail('active')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('contract-lifecycle')).toBeInTheDocument();
+    expect(screen.getByTestId('contract-pause-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('contract-cancel-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('generate-now-btn')).toBeInTheDocument();
+  });
+
+  it('contracts:manage on a paused contract offers resume/cancel (no generate)', async () => {
+    // Paused contracts can resume or cancel; generate is active-only, so even
+    // with manage it stays hidden — pins the canGenerate side of the gate.
+    state.permissions = [{ resource: 'contracts', action: 'manage' }];
+    render(<ContractDetail detail={detail('paused')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('contract-resume-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('contract-cancel-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('generate-now-btn')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -15,6 +15,7 @@ import {
   type ContractTransition,
 } from '../../lib/api/contracts';
 import { formatMoney } from '../billing/invoiceTypes';
+import { usePermissions } from '../../lib/permissions';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -55,6 +56,7 @@ function formatDate(value: string | null | undefined): string {
 }
 
 export default function ContractDetail({ detail, onChanged }: Props) {
+  const { can } = usePermissions();
   const { contract, lines, periods } = detail;
   const currency = contract.currencyCode;
 
@@ -268,7 +270,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
           </div>
 
           {/* Lifecycle */}
-          {availableTransitions.length > 0 && (
+          {can('contracts', 'manage') && availableTransitions.length > 0 && (
             <div className="space-y-2" data-testid="contract-lifecycle">
               {availableTransitions.map((verb) => {
                 const destructive = verb === 'cancel';
@@ -295,7 +297,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
           )}
 
           {/* Generate now */}
-          {canGenerate && (
+          {can('contracts', 'manage') && canGenerate && (
             <button
               type="button"
               onClick={() => void generateNow()}

--- a/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ContractEditor from './ContractEditor';
+import { fetchWithAuth } from '../../stores/auth';
+import * as api from '../../lib/api/contracts';
+import type { ContractDetail } from '../../lib/api/contracts';
+
+type Perm = { resource: string; action: string };
+
+// Mutable grant set the mocked auth store reads from. Covers the NEGATIVE gating
+// branches the wildcard-positive sibling (ContractEditor.test.tsx) never touches.
+// The editor separates contracts:write (create/edit headers + lines) from
+// contracts:manage (activate, a lifecycle action). A write-only operator must be
+// able to build a draft contract but NOT activate it.
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../catalog/CatalogItemPicker', () => ({ default: () => null }));
+vi.mock('../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
+}));
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return {
+    ...actual,
+    createContract: vi.fn(),
+    updateContract: vi.fn(),
+    addContractLine: vi.fn(),
+    removeContractLine: vi.fn(),
+    contractTransition: vi.fn(),
+    getContractEstimate: vi.fn(),
+  };
+});
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const draftDetail: ContractDetail = {
+  contract: {
+    id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status: 'draft',
+    billingTiming: 'advance', intervalMonths: 1, startDate: '2026-06-01', endDate: null,
+    nextBillingAt: null, autoIssue: false, currencyCode: 'USD', notes: null, terms: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  lines: [
+    {
+      id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed services',
+      catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, taxable: false,
+      sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    },
+  ],
+  periods: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [];
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith('/orgs/organizations')) return resp({ data: [{ id: 'org-1', name: 'Acme' }] });
+    if (url.startsWith('/orgs/sites')) return resp({ data: [] });
+    return resp({ data: {} });
+  });
+  (api.getContractEstimate as any).mockResolvedValue(resp({ data: { currencyCode: 'USD', periodTotal: '500.00', lines: [] } }));
+});
+
+describe('ContractEditor — permission gating', () => {
+  it('read-only (contracts:read) hides create/save, add-line and per-line remove', async () => {
+    state.permissions = [{ resource: 'contracts', action: 'read' }];
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-editor')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('save-contract-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('add-line-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('line-remove-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('activate-contract-btn')).not.toBeInTheDocument();
+  });
+
+  it('contracts:write WITHOUT contracts:manage shows edit controls but NOT Activate', async () => {
+    // The security-relevant distinction: write builds/edits the draft; activating
+    // (a lifecycle transition) requires contracts:manage.
+    state.permissions = [{ resource: 'contracts', action: 'write' }];
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-editor')).toBeInTheDocument());
+
+    expect(screen.getByTestId('save-contract-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('add-line-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('line-remove-0')).toBeInTheDocument();
+    // manage-gated:
+    expect(screen.queryByTestId('activate-contract-btn')).not.toBeInTheDocument();
+  });
+
+  it('contracts:manage reveals Activate (positive control)', async () => {
+    // Save/add/remove stay hidden without write, proving the gates are
+    // independent; Activate appears for a draft contract once manage is granted.
+    state.permissions = [{ resource: 'contracts', action: 'manage' }];
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-editor')).toBeInTheDocument());
+
+    expect(screen.getByTestId('activate-contract-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('save-contract-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('add-line-btn')).not.toBeInTheDocument();
+  });
+
+  it('create mode: contracts:read hides the Create button', async () => {
+    state.permissions = [{ resource: 'contracts', action: 'read' }];
+    render(<ContractEditor />);
+    await waitFor(() => expect(screen.getByTestId('contract-editor')).toBeInTheDocument());
+    expect(screen.queryByTestId('save-contract-btn')).not.toBeInTheDocument();
+  });
+
+  it('create mode: contracts:write reveals the Create button', async () => {
+    state.permissions = [{ resource: 'contracts', action: 'write' }];
+    render(<ContractEditor />);
+    await waitFor(() => expect(screen.getByTestId('contract-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('save-contract-btn')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/contracts/ContractEditor.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.test.tsx
@@ -5,7 +5,17 @@ import ContractEditor from './ContractEditor';
 import { fetchWithAuth } from '../../stores/auth';
 import * as api from '../../lib/api/contracts';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  // usePermissions() (billing-RBAC UI gating) reads grants off the store; grant
+  // the admin wildcard so every gated control renders and these tests exercise
+  // full functionality.
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 // The catalog typeahead is exercised in the invoice-editor test; stub it here.

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -18,6 +18,7 @@ import {
 import CatalogItemPicker from '../catalog/CatalogItemPicker';
 import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
 import { formatMoney } from '../billing/invoiceTypes';
+import { usePermissions } from '../../lib/permissions';
 
 interface Organization { id: string; name: string }
 interface Site { id: string; name: string }
@@ -51,6 +52,7 @@ interface Props {
 }
 
 export default function ContractEditor({ detail, presetOrgId, onChanged }: Props) {
+  const { can } = usePermissions();
   const isCreate = !detail;
   const contract = detail?.contract;
 
@@ -453,13 +455,15 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                           </td>
                           <td className="px-3 py-2 text-center">{l.taxable ? '✓' : '—'}</td>
                           <td className="px-3 py-2 text-right">
-                            <button
-                              type="button" onClick={() => void removeLine(l.id)} disabled={busy}
-                              data-testid={`line-remove-${idx}`}
-                              className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                            >
-                              Remove
-                            </button>
+                            {can('contracts', 'write') && (
+                              <button
+                                type="button" onClick={() => void removeLine(l.id)} disabled={busy}
+                                data-testid={`line-remove-${idx}`}
+                                className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                              >
+                                Remove
+                              </button>
+                            )}
                           </td>
                         </tr>
                       ))
@@ -563,13 +567,15 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       ? 'Quantity resolved automatically at billing time.'
                       : `Line total: ${formatMoney(newLineEstimate, contract?.currencyCode)}`}
                   </span>
-                  <button
-                    type="button" onClick={() => void addLine()} disabled={busy || !lineDesc.trim()}
-                    data-testid="add-line-btn"
-                    className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-                  >
-                    Add line
-                  </button>
+                  {can('contracts', 'write') && (
+                    <button
+                      type="button" onClick={() => void addLine()} disabled={busy || !lineDesc.trim()}
+                      data-testid="add-line-btn"
+                      className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    >
+                      Add line
+                    </button>
+                  )}
                 </div>
               </div>
             </div>
@@ -609,23 +615,27 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
 
           <div className="space-y-2">
             {isCreate ? (
-              <button
-                type="button" onClick={() => void saveCreate()} disabled={busy || !canSaveHeader}
-                data-testid="save-contract-btn"
-                className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-              >
-                Create contract
-              </button>
+              can('contracts', 'write') && (
+                <button
+                  type="button" onClick={() => void saveCreate()} disabled={busy || !canSaveHeader}
+                  data-testid="save-contract-btn"
+                  className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  Create contract
+                </button>
+              )
             ) : (
               <>
-                <button
-                  type="button" onClick={() => void saveHeader()} disabled={busy || !canSaveHeader}
-                  data-testid="save-contract-btn"
-                  className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-                >
-                  Save changes
-                </button>
-                {contract?.status === 'draft' && (
+                {can('contracts', 'write') && (
+                  <button
+                    type="button" onClick={() => void saveHeader()} disabled={busy || !canSaveHeader}
+                    data-testid="save-contract-btn"
+                    className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                  >
+                    Save changes
+                  </button>
+                )}
+                {can('contracts', 'manage') && contract?.status === 'draft' && (
                   <button
                     type="button" onClick={() => void activate()} disabled={busy || lines.length === 0}
                     data-testid="activate-contract-btn"

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -12,6 +12,7 @@ import {
   type ContractSummary,
 } from '../../lib/api/contracts';
 import { formatMoney } from '../billing/invoiceTypes';
+import { usePermissions } from '../../lib/permissions';
 
 interface Organization {
   id: string;
@@ -71,6 +72,7 @@ interface Props {
 }
 
 export default function ContractsList({ lockedOrgId }: Props = {}) {
+  const { can } = usePermissions();
   const [contracts, setContracts] = useState<ContractSummary[]>([]);
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
@@ -154,13 +156,15 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
             Recurring agreements that auto-generate draft invoices on a cadence.
           </p>
         </div>
-        <a
-          href={newContractHref}
-          data-testid="new-contract-btn"
-          className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-        >
-          New contract
-        </a>
+        {can('contracts', 'write') && (
+          <a
+            href={newContractHref}
+            data-testid="new-contract-btn"
+            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+          >
+            New contract
+          </a>
+        )}
       </div>
 
       {/* Filters */}

--- a/apps/web/src/components/layout/Sidebar.billing.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.billing.test.tsx
@@ -1,0 +1,80 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Perm = { resource: string; action: string };
+
+// Mutable user state the mocked auth store reads from, so each test can vary the
+// permission grants the sidebar sees.
+const state = vi.hoisted(() => ({
+  user: { isPlatformAdmin: false, permissions: [] as Perm[] },
+}));
+const fetchWithAuthMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: fetchWithAuthMock,
+  useAuthStore: Object.assign(
+    (selector: (s: { user: typeof state.user }) => unknown) => selector({ user: state.user }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('../../stores/uiStore', () => ({
+  useUiStore: () => ({ isMobileMenuOpen: false, closeMobileMenu: vi.fn() }),
+}));
+// Partner scope so the billing items pass partnerScopeOnly and only the
+// permission gate decides visibility.
+vi.mock('../../lib/authScope', () => ({ getJwtClaims: () => ({ scope: 'partner' }) }));
+vi.mock('./BrandHeader', () => ({ default: () => null }));
+
+import Sidebar from './Sidebar';
+
+function setPermissions(perms: Perm[]) {
+  state.user.permissions = perms;
+}
+
+beforeEach(() => {
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) } as Response);
+  state.user.permissions = [];
+  localStorage.clear();
+  localStorage.setItem('sidebar-mode', 'open');
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false, media: query,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(),
+    dispatchEvent: vi.fn(), onchange: null,
+  })) as unknown as typeof window.matchMedia;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('Sidebar — billing nav permission gate', () => {
+  it('hides Invoices, Contracts, and Catalog when the user has no billing grants', async () => {
+    setPermissions([{ resource: 'devices', action: 'read' }]);
+    const { container } = render(<Sidebar currentPath="/fleet" />);
+    await waitFor(() => expect(container.querySelector('a[href="/fleet"]')).not.toBeNull());
+    expect(container.querySelector('a[href="/billing/invoices"]')).toBeNull();
+    expect(container.querySelector('a[href="/contracts"]')).toBeNull();
+    expect(container.querySelector('a[href="/settings/catalog"]')).toBeNull();
+  });
+
+  it('shows only the items the user has the matching :read grant for', async () => {
+    setPermissions([{ resource: 'invoices', action: 'read' }]);
+    const { container } = render(<Sidebar currentPath="/fleet" />);
+    await waitFor(() =>
+      expect(container.querySelector('a[href="/billing/invoices"]')).not.toBeNull(),
+    );
+    // No contracts:read / catalog:read → those stay hidden.
+    expect(container.querySelector('a[href="/contracts"]')).toBeNull();
+    expect(container.querySelector('a[href="/settings/catalog"]')).toBeNull();
+  });
+
+  it('shows all billing nav for an admin wildcard grant', async () => {
+    setPermissions([{ resource: '*', action: '*' }]);
+    const { container } = render(<Sidebar currentPath="/fleet" />);
+    await waitFor(() =>
+      expect(container.querySelector('a[href="/billing/invoices"]')).not.toBeNull(),
+    );
+    expect(container.querySelector('a[href="/contracts"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/settings/catalog"]')).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -45,7 +45,8 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUiStore } from '../../stores/uiStore';
-import { fetchWithAuth, useAuthStore, type Permission } from '../../stores/auth';
+import type { PermissionGrant } from '@breeze/shared';
+import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { hasPermission } from '../../lib/permissions';
 import { WEB_VERSION } from '../../lib/version';
 import { semverCompare } from '@breeze/shared';
@@ -99,8 +100,9 @@ type NavItem = {
   requiresAiForOffice?: boolean;
   // Hidden unless the user holds this permission (e.g. billing nav gated on
   // invoices:read). UX only — the route still enforces it server-side. While
-  // the permission set is still loading, the item stays hidden.
-  requiredPermission?: Permission;
+  // the permission set is still loading, the item stays hidden. Typed as the
+  // exact-pair union so a typo'd resource/action fails to compile.
+  requiredPermission?: PermissionGrant;
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -45,7 +45,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUiStore } from '../../stores/uiStore';
-import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { fetchWithAuth, useAuthStore, type Permission } from '../../stores/auth';
 import { hasPermission } from '../../lib/permissions';
 import { WEB_VERSION } from '../../lib/version';
 import { semverCompare } from '@breeze/shared';
@@ -100,7 +100,7 @@ type NavItem = {
   // Hidden unless the user holds this permission (e.g. billing nav gated on
   // invoices:read). UX only — the route still enforces it server-side. While
   // the permission set is still loading, the item stays hidden.
-  requiredPermission?: { resource: string; action: string };
+  requiredPermission?: Permission;
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -46,6 +46,7 @@ import {
 import { cn } from '@/lib/utils';
 import { useUiStore } from '../../stores/uiStore';
 import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { hasPermission } from '../../lib/permissions';
 import { WEB_VERSION } from '../../lib/version';
 import { semverCompare } from '@breeze/shared';
 import { getJwtClaims } from '../../lib/authScope';
@@ -96,6 +97,10 @@ type NavItem = {
   // Shown only when the current partner has AI for Office enabled (runtime flag
   // from /orgs/partners/me). Undefined means not gated on the partner flag.
   requiresAiForOffice?: boolean;
+  // Hidden unless the user holds this permission (e.g. billing nav gated on
+  // invoices:read). UX only — the route still enforces it server-side. While
+  // the permission set is still loading, the item stays hidden.
+  requiredPermission?: { resource: string; action: string };
 };
 
 // ---------------------------------------------------------------------------
@@ -163,9 +168,9 @@ export const navSections: NavSection[] = [
     label: 'Operations',
     icon: Layers,
     items: [
-      { name: 'Invoices', href: '/billing/invoices', icon: Receipt },
-      { name: 'Contracts', href: '/contracts', icon: FileSignature, partnerScopeOnly: true },
-      { name: 'Product Catalog', href: '/settings/catalog', icon: Tags, partnerScopeOnly: true },
+      { name: 'Invoices', href: '/billing/invoices', icon: Receipt, partnerScopeOnly: true, requiredPermission: { resource: 'invoices', action: 'read' } },
+      { name: 'Contracts', href: '/contracts', icon: FileSignature, partnerScopeOnly: true, requiredPermission: { resource: 'contracts', action: 'read' } },
+      { name: 'Product Catalog', href: '/settings/catalog', icon: Tags, partnerScopeOnly: true, requiredPermission: { resource: 'catalog', action: 'read' } },
       { name: 'Software Library', href: '/software', icon: Package },
       { name: 'Software Policies', href: '/software-inventory', icon: Package },
       { name: 'Config Policies', href: '/configuration-policies', icon: Layers },
@@ -297,6 +302,7 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
   const [hovered, setHovered] = useState(false);
   const currentPath = useCurrentPath(initialPath);
   const isPlatformAdmin = useAuthStore((s) => s.user?.isPlatformAdmin === true);
+  const permissions = useAuthStore((s) => s.user?.permissions);
 
   // --- Responsive breakpoints -----------------------------------------------
   // Track whether viewport is below lg (1024px) or md (768px) to override mode
@@ -457,6 +463,11 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
     if (item.partnerScopeOnly) {
       const { scope } = getJwtClaims();
       if (scope !== null && scope !== 'partner') return null;
+    }
+    if (item.requiredPermission) {
+      if (!hasPermission(permissions, item.requiredPermission.resource, item.requiredPermission.action)) {
+        return null;
+      }
     }
     const isActive = item.href === activeHref;
     const labels = forMobileOverlay ? true : showLabels;

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -7,6 +7,7 @@ import { runAction, handleActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
+import { usePermissions } from '../../lib/permissions';
 import {
   createCatalogItem, updateCatalogItem, getCatalogItem, setBundleComponents,
   computeMargin, formatMargin, marginTone,
@@ -52,6 +53,9 @@ function bundleFriendly(code: string): string | undefined {
 
 export default function CatalogItemEditorDrawer({ open, item, allItems, onClose, onSaved }: Props) {
   const editId = item?.id ?? null;
+
+  const { can } = usePermissions();
+  const canWrite = can('catalog', 'write');
 
   const [itemType, setItemType] = useState<CatalogItemType>('service');
   const [name, setName] = useState('');
@@ -369,14 +373,16 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
             <div className="space-y-2 rounded-md border p-3" data-testid="catalog-bundle-builder">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium text-muted-foreground">Items included in this bundle</span>
-                <button
-                  type="button"
-                  onClick={addComponent}
-                  className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted"
-                  data-testid="catalog-bundle-add"
-                >
-                  Add component
-                </button>
+                {canWrite && (
+                  <button
+                    type="button"
+                    onClick={addComponent}
+                    className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted"
+                    data-testid="catalog-bundle-add"
+                  >
+                    Add component
+                  </button>
+                )}
               </div>
 
               {componentsLoading ? (
@@ -415,17 +421,19 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                             className="h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
                             data-testid={`catalog-bundle-qty-${idx}`}
                           />
-                          <button
-                            type="button"
-                            onClick={() => removeComponent(idx)}
-                            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive"
-                            aria-label="Remove component"
-                            data-testid={`catalog-bundle-remove-${idx}`}
-                          >
-                            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                              <path d="M3 6h18M8 6V4h8v2m-9 0v14a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6" strokeLinecap="round" strokeLinejoin="round" />
-                            </svg>
-                          </button>
+                          {canWrite && (
+                            <button
+                              type="button"
+                              onClick={() => removeComponent(idx)}
+                              className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive"
+                              aria-label="Remove component"
+                              data-testid={`catalog-bundle-remove-${idx}`}
+                            >
+                              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <path d="M3 6h18M8 6V4h8v2m-9 0v14a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            </button>
+                          )}
                         </div>
                         <label className="flex items-center gap-2 text-xs text-muted-foreground">
                           <input
@@ -456,15 +464,17 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
           >
             Cancel
           </button>
-          <button
-            type="button"
-            onClick={() => void save()}
-            disabled={!canSave}
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
-            data-testid="catalog-form-save"
-          >
-            {saving ? 'Saving…' : editId ? 'Save changes' : 'Create item'}
-          </button>
+          {canWrite && (
+            <button
+              type="button"
+              onClick={() => void save()}
+              disabled={!canSave}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+              data-testid="catalog-form-save"
+            >
+              {saving ? 'Saving…' : editId ? 'Save changes' : 'Create item'}
+            </button>
+          )}
         </div>
       </div>
     </div>,

--- a/apps/web/src/components/settings/CatalogItemsTab.permissions.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.permissions.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CatalogItemsTab from './CatalogItemsTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+type Perm = { resource: string; action: string };
+
+// Mutable grant set the mocked auth store reads from, so each test can vary the
+// catalog permissions the tab sees. This file exists to cover the NEGATIVE
+// gating branches — the sibling CatalogItemsTab.test.tsx grants the wildcard and
+// only ever exercises the visible/true branch, so a mis-wired (resource,action)
+// pair (e.g. gating Archive on catalog:write instead of catalog:delete) would
+// pass there. These tests pin the read vs write vs delete distinction.
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('../../lib/authScope', () => ({
+  getJwtClaims: () => ({ scope: 'partner' }),
+  loginPathWithNext: () => '/login',
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const LAPTOP = {
+  partnerId: 'p1', description: null, billingType: 'one_time' as const,
+  markupPercent: null, unitOfMeasure: 'each', taxable: true, taxCategory: null,
+  isActive: true, createdAt: '2026-01-01', updatedAt: '2026-01-01',
+  id: 'l1', itemType: 'hardware' as const, name: 'Laptop', sku: 'LAP-9',
+  unitPrice: '1200.00', costBasis: null, isBundle: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [];
+  fetchMock.mockImplementation(async (url) => {
+    if (String(url).startsWith('/catalog?')) return jsonResponse({ data: [LAPTOP] });
+    return jsonResponse({});
+  });
+});
+
+describe('CatalogItemsTab — permission gating', () => {
+  it('read-only (catalog:read) hides Add item and the whole row action menu', async () => {
+    state.permissions = [{ resource: 'catalog', action: 'read' }];
+    render(<CatalogItemsTab />);
+    await screen.findByText('Laptop');
+
+    expect(screen.queryByTestId('catalog-add-item')).not.toBeInTheDocument();
+    // RowActions has nothing actionable → it renders no kebab trigger at all.
+    expect(screen.queryByTestId('catalog-actions-l1')).not.toBeInTheDocument();
+  });
+
+  it('write-without-delete shows Add item and Edit but NOT Archive', async () => {
+    // The subtle case: Archive needs catalog:delete, Edit needs catalog:write.
+    state.permissions = [{ resource: 'catalog', action: 'write' }];
+    render(<CatalogItemsTab />);
+    await screen.findByText('Laptop');
+
+    expect(screen.getByTestId('catalog-add-item')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('catalog-actions-l1'));
+    expect(await screen.findByTestId('catalog-edit-l1')).toBeInTheDocument();
+    expect(screen.queryByTestId('catalog-archive-l1')).not.toBeInTheDocument();
+  });
+
+  it('delete grant reveals Archive in the row menu', async () => {
+    state.permissions = [
+      { resource: 'catalog', action: 'write' },
+      { resource: 'catalog', action: 'delete' },
+    ];
+    render(<CatalogItemsTab />);
+    await screen.findByText('Laptop');
+
+    fireEvent.click(screen.getByTestId('catalog-actions-l1'));
+    await waitFor(() => expect(screen.getByTestId('catalog-archive-l1')).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/settings/CatalogItemsTab.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.test.tsx
@@ -4,7 +4,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CatalogItemsTab from './CatalogItemsTab';
 import { fetchWithAuth } from '../../stores/auth';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  // usePermissions() (billing-RBAC UI gating) reads grants off the store; grant
+  // the admin wildcard so every gated control renders and these tests exercise
+  // full functionality.
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
 vi.mock('../../lib/authScope', () => ({
   getJwtClaims: () => ({ scope: 'partner' }),
   loginPathWithNext: () => '/login',

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
+import { usePermissions } from '../../lib/permissions';
 import { formatMoney } from '../../lib/timeFormat';
 import CatalogItemEditorDrawer from './CatalogItemEditorDrawer';
 import {
@@ -45,6 +46,9 @@ export default function CatalogItemsTab() {
   // load error; only a confirmed 'organization' scope is blocked (a missing or
   // undecodable token falls through and the server re-checks).
   const isOrgScoped = getJwtClaims().scope === 'organization';
+
+  const { can } = usePermissions();
+  const canWrite = can('catalog', 'write');
 
   const load = useCallback(async (v: View) => {
     setLoading(true);
@@ -239,14 +243,16 @@ export default function CatalogItemsTab() {
           ))}
         </div>
 
-        <button
-          type="button"
-          onClick={openCreate}
-          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-          data-testid="catalog-add-item"
-        >
-          Add item
-        </button>
+        {canWrite && (
+          <button
+            type="button"
+            onClick={openCreate}
+            className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+            data-testid="catalog-add-item"
+          >
+            Add item
+          </button>
+        )}
       </div>
 
       {/* Table card */}
@@ -285,14 +291,16 @@ export default function CatalogItemsTab() {
                 <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
                   Add the hardware, software, and service items you sell. Catalog items power quotes, contracts, and invoices.
                 </p>
-                <button
-                  type="button"
-                  onClick={openCreate}
-                  className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-                  data-testid="catalog-empty-add"
-                >
-                  Add your first item
-                </button>
+                {canWrite && (
+                  <button
+                    type="button"
+                    onClick={openCreate}
+                    className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+                    data-testid="catalog-empty-add"
+                  >
+                    Add your first item
+                  </button>
+                )}
               </>
             )}
           </div>
@@ -455,6 +463,15 @@ function RowActions({
   onArchive: () => void;
   onRestore: () => void;
 }) {
+  const { can } = usePermissions();
+  const canWrite = can('catalog', 'write');
+  const canDelete = can('catalog', 'delete');
+  // Edit/Restore need write; Archive needs delete. View determines which of
+  // archive/restore is even offered.
+  const showEdit = canWrite;
+  const showArchive = view === 'active' && canDelete;
+  const showRestore = view === 'archived' && canWrite;
+
   const [open, setOpen] = useState(false);
   const [coords, setCoords] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
   const btnRef = useRef<HTMLButtonElement>(null);
@@ -490,6 +507,9 @@ function RowActions({
 
   const itemCls = 'flex w-full items-center px-3 py-1.5 text-left text-sm hover:bg-muted disabled:opacity-50';
 
+  // Nothing actionable for this user → don't render an empty popover trigger.
+  if (!showEdit && !showArchive && !showRestore) return null;
+
   return (
     <>
       <button
@@ -522,16 +542,18 @@ function RowActions({
           style={{ top: coords.top, right: coords.right }}
           data-testid={`catalog-actions-menu-${item.id}`}
         >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => { setOpen(false); onEdit(); }}
-            className={itemCls}
-            data-testid={`catalog-edit-${item.id}`}
-          >
-            Edit
-          </button>
-          {view === 'active' ? (
+          {showEdit && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => { setOpen(false); onEdit(); }}
+              className={itemCls}
+              data-testid={`catalog-edit-${item.id}`}
+            >
+              Edit
+            </button>
+          )}
+          {showArchive && (
             <button
               type="button"
               role="menuitem"
@@ -541,7 +563,8 @@ function RowActions({
             >
               Archive
             </button>
-          ) : (
+          )}
+          {showRestore && (
             <button
               type="button"
               role="menuitem"

--- a/apps/web/src/lib/permissions.test.ts
+++ b/apps/web/src/lib/permissions.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { hasPermission } from './permissions';
+import type { Permission } from '../stores/auth';
+
+describe('hasPermission', () => {
+  it('matches an exact resource:action grant', () => {
+    const perms: Permission[] = [{ resource: 'invoices', action: 'read' }];
+    expect(hasPermission(perms, 'invoices', 'read')).toBe(true);
+  });
+
+  it('denies when the grant is absent', () => {
+    const perms: Permission[] = [{ resource: 'invoices', action: 'read' }];
+    expect(hasPermission(perms, 'invoices', 'write')).toBe(false);
+    expect(hasPermission(perms, 'contracts', 'read')).toBe(false);
+  });
+
+  it('honors the admin wildcard (*:*) for any check', () => {
+    const perms: Permission[] = [{ resource: '*', action: '*' }];
+    expect(hasPermission(perms, 'invoices', 'send')).toBe(true);
+    expect(hasPermission(perms, 'catalog', 'delete')).toBe(true);
+  });
+
+  it('honors a resource wildcard with a specific action', () => {
+    const perms: Permission[] = [{ resource: '*', action: 'read' }];
+    expect(hasPermission(perms, 'contracts', 'read')).toBe(true);
+    expect(hasPermission(perms, 'contracts', 'write')).toBe(false);
+  });
+
+  it('honors an action wildcard scoped to one resource', () => {
+    const perms: Permission[] = [{ resource: 'invoices', action: '*' }];
+    expect(hasPermission(perms, 'invoices', 'send')).toBe(true);
+    expect(hasPermission(perms, 'contracts', 'send')).toBe(false);
+  });
+
+  it('returns false while permissions are still loading (undefined)', () => {
+    // Gated UI must stay hidden until grants resolve, not flash then disappear.
+    expect(hasPermission(undefined, 'invoices', 'read')).toBe(false);
+  });
+
+  it('returns false for an empty grant list', () => {
+    expect(hasPermission([], 'invoices', 'read')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/permissions.test.ts
+++ b/apps/web/src/lib/permissions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hasPermission } from './permissions';
+import { hasPermission, usePermissions } from './permissions';
 import type { Permission } from '../stores/auth';
 
 describe('hasPermission', () => {
@@ -39,5 +39,45 @@ describe('hasPermission', () => {
 
   it('returns false for an empty grant list', () => {
     expect(hasPermission([], 'invoices', 'read')).toBe(false);
+  });
+});
+
+/**
+ * Compile-time gate typing. This is the PR's central claim: a typo'd gate
+ * (wrong resource OR wrong action literal) must fail to compile, since no
+ * runtime test can catch a gate that's simply never reached. These assertions
+ * have no runtime body — they exist purely so `tsc` rejects them. If the
+ * PermissionResource / PermissionAction types were ever widened back to `string`,
+ * the calls below would type-check fine and the `@ts-expect-error` directives
+ * would themselves become errors ("unused @ts-expect-error"), failing the build
+ * — which is exactly the regression alarm we want.
+ */
+describe('permission gate typing (compile-time)', () => {
+  it('rejects invalid resource/action literals at the type level', () => {
+    const perms: Permission[] = [];
+
+    // bare hasPermission(): unknown action on a known resource
+    // @ts-expect-error 'frobnicate' is not a PermissionAction
+    hasPermission(perms, 'invoices', 'frobnicate');
+    // bare hasPermission(): unknown resource
+    // @ts-expect-error 'nonsense' is not a PermissionResource
+    hasPermission(perms, 'nonsense', 'read');
+    // bare hasPermission(): unknown action on an unknown resource
+    // @ts-expect-error both literals are invalid
+    hasPermission(perms, 'nonsense', 'frobnicate');
+
+    // The hook's can() is typed identically. We only need the type of `can`,
+    // not a live React render, so guard the call so it never actually runs.
+    if (Math.random() < 0) {
+      const { can } = usePermissions();
+      // @ts-expect-error 'frobnicate' is not a PermissionAction
+      can('invoices', 'frobnicate');
+      // @ts-expect-error 'nonsense' is not a PermissionResource
+      can('nonsense', 'read');
+    }
+
+    // A valid (resource, action) pair must still compile — proves the rejections
+    // above are about the literals, not a blanket failure.
+    expect(hasPermission(perms, 'invoices', 'send')).toBe(false);
   });
 });

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -1,0 +1,42 @@
+import { useAuthStore, type Permission } from '../stores/auth';
+
+/**
+ * Wildcard-aware permission check, mirroring the server's `hasPermission`
+ * (apps/api/src/services/permissions.ts). A grant matches when its resource and
+ * action equal the requested ones, or are the `*` wildcard (held by admins via
+ * the `*:*` grant).
+ *
+ * UX only — never an authorization decision. Every API route re-checks the same
+ * permission server-side, so a stale or spoofed client list cannot grant access.
+ */
+export function hasPermission(
+  permissions: Permission[] | undefined,
+  resource: string,
+  action: string,
+): boolean {
+  if (!permissions) return false;
+  return permissions.some(
+    (p) =>
+      (p.resource === resource || p.resource === '*') &&
+      (p.action === action || p.action === '*'),
+  );
+}
+
+/**
+ * React hook returning a `can(resource, action)` checker bound to the current
+ * user's permissions. Re-renders when the permission set changes.
+ *
+ * While permissions are still loading (undefined — e.g. a freshly restored
+ * session before /users/me resolves), `can` returns false, so gated UI stays
+ * hidden until grants are known rather than flashing then disappearing.
+ */
+export function usePermissions(): {
+  permissions: Permission[] | undefined;
+  can: (resource: string, action: string) => boolean;
+} {
+  const permissions = useAuthStore((s) => s.user?.permissions);
+  return {
+    permissions,
+    can: (resource: string, action: string) => hasPermission(permissions, resource, action),
+  };
+}

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -1,3 +1,4 @@
+import type { PermissionResource, PermissionAction } from '@breeze/shared';
 import { useAuthStore, type Permission } from '../stores/auth';
 
 /**
@@ -11,8 +12,8 @@ import { useAuthStore, type Permission } from '../stores/auth';
  */
 export function hasPermission(
   permissions: Permission[] | undefined,
-  resource: string,
-  action: string,
+  resource: PermissionResource,
+  action: PermissionAction,
 ): boolean {
   if (!permissions) return false;
   return permissions.some(
@@ -32,11 +33,12 @@ export function hasPermission(
  */
 export function usePermissions(): {
   permissions: Permission[] | undefined;
-  can: (resource: string, action: string) => boolean;
+  can: (resource: PermissionResource, action: PermissionAction) => boolean;
 } {
   const permissions = useAuthStore((s) => s.user?.permissions);
   return {
     permissions,
-    can: (resource: string, action: string) => hasPermission(permissions, resource, action),
+    can: (resource: PermissionResource, action: PermissionAction) =>
+      hasPermission(permissions, resource, action),
   };
 }

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -22,6 +22,12 @@ export interface UserPreferences {
   font?: FontPreference;
 }
 
+/** A single permission grant ({ resource, action }), mirroring the API. */
+export interface Permission {
+  resource: string;
+  action: string;
+}
+
 export interface User {
   id: string;
   email: string;
@@ -33,6 +39,10 @@ export interface User {
   // account-deletion-requests) so ordinary users don't trigger its 403 badge
   // fetch. Absent/false for partner & org users.
   isPlatformAdmin?: boolean;
+  // Effective permission grants from the user's role, surfaced by /users/me so
+  // the UI can hide nav/actions the user can't use. UX only — the server still
+  // enforces every route. Absent on sessions persisted before this field.
+  permissions?: Permission[];
   preferences?: UserPreferences;
 }
 
@@ -800,6 +810,11 @@ export async function fetchAndApplyPreferences(): Promise<void> {
     // until the next re-login.
     if (typeof data.isPlatformAdmin === 'boolean') {
       useAuthStore.getState().updateUser({ isPlatformAdmin: data.isPlatformAdmin });
+    }
+    // Permissions ride along on the same refresh so sessions persisted before
+    // the field existed still pick up their grants without a re-login.
+    if (Array.isArray(data.permissions)) {
+      useAuthStore.getState().updateUser({ permissions: data.permissions });
     }
     if (data.preferences) {
       useAuthStore.getState().updateUser({ preferences: data.preferences });

--- a/docs/superpowers/specs/2026-06-16-billing-rbac-roles-design.md
+++ b/docs/superpowers/specs/2026-06-16-billing-rbac-roles-design.md
@@ -1,0 +1,118 @@
+# Billing RBAC: dedicated roles, tightened grants, permission-aware UI
+
+**Date:** 2026-06-16
+**Status:** Approved (design)
+**Author:** Claude (with Todd)
+
+## Problem
+
+The three billing features — Product Catalog, Invoices, Recurring Contracts — are fully
+RBAC-gated on the API (`requirePermission()` + `requireScope('partner','system')`), and the
+`catalog`/`invoices`/`contracts` permissions are seeded onto partner system roles. But:
+
+1. **No dedicated billing role exists.** Outside of Partner Admin (`*:*`), billing access only
+   rides on **Partner Technician** — a broad operational role (device execute, scripts execute,
+   etc.). You cannot grant *just* billing without also handing out technician capabilities.
+2. **Partner Technician was over-granted.** The feature backfill migrations gave Technician full
+   `invoices:send` (issue/void/record-payment) and `contracts:manage` (activate/cancel) because it
+   held `tickets:write`. A technician can void invoices and cancel contracts — broader than intended.
+3. **The web UI is permission-blind.** Nav gates by scope only; action buttons always render and
+   rely on a server 403. Users see controls they can't use.
+
+## Decisions (locked)
+
+- **Two new global partner-scope system roles:**
+  - **Partner Billing** — full billing: every action on `catalog`, `invoices`, `contracts`.
+  - **Partner Billing Viewer** — read-only: `catalog:read`, `invoices:read`, `invoices:export`,
+    `contracts:read`.
+- **Strip billing from existing roles:** remove ALL `catalog`/`invoices`/`contracts` grants from
+  **Partner Technician**, and remove `catalog:read` from **Partner Viewer**. Billing access then
+  lives solely in Partner Admin + the two new roles.
+- **UI hiding:** hide Invoices/Contracts/Catalog nav items when the user lacks the matching `:read`
+  permission, AND hide write/send/manage/delete action buttons when the user lacks the matching
+  grant. Requires exposing the user's permission set to the browser.
+
+## Data model facts that shape the implementation
+
+- System roles are **global singleton rows** (`partner_id = NULL, is_system = true`), with one
+  exception: **Partner Admin** is cloned per-partner at registration (with the `*:*` wildcard, so
+  admins keep everything automatically — no change needed). So a new global role + edits to the
+  global Technician/Viewer rows cover all existing and future partners. Per-partner custom roles are
+  untouched.
+- `roles` has **no unique constraint** beyond the PK, so inserts must be `NOT EXISTS`-guarded.
+- On a **fresh DB**, migrations run before `seed.ts`, so the feature backfill migrations no-op
+  (roles don't exist yet) and **`seed.ts` is authoritative**. On an **existing DB** (prod EU/US),
+  roles exist and the backfills already granted Technician/Viewer the billing perms, so the
+  **migration must revoke them**. Both paths must converge to the same end state.
+- `seed.ts` `DEFAULT_PERMISSIONS` lists `catalog` but **not** `invoices`/`contracts` (those rows are
+  created only by the feature migrations). Add them so the seed path is self-consistent.
+- Permission cache is **5-min TTL** (Redis version + in-memory). A pure-SQL migration is picked up
+  automatically on next refresh — no code-side cache bump needed.
+
+## Part A — Roles & permissions
+
+**New migration** `apps/api/migrations/2026-06-19-billing-roles.sql` (dated to sort after all
+existing backfills; idempotent, mirrors the `NOT EXISTS`-guard pattern from the existing billing
+migrations):
+
+1. Create the two roles (`partner_id = NULL, scope = 'partner', is_system = true`), guarded by
+   `NOT EXISTS` on `(partner_id IS NULL, scope, name, is_system)`.
+2. Grant perms via `NOT EXISTS`-guarded `role_permissions` inserts:
+   - Partner Billing ← all permissions where `resource IN ('catalog','invoices','contracts')`.
+   - Partner Billing Viewer ← `catalog:read`, `invoices:read`, `invoices:export`, `contracts:read`.
+3. Revoke from the global system rows only (`partner_id IS NULL AND is_system = true`):
+   - Partner Technician ← delete all `catalog`/`invoices`/`contracts` grants.
+   - Partner Viewer ← delete `catalog:read`.
+   - Each `DELETE` wrapped in `DO $$ … GET DIAGNOSTICS n = ROW_COUNT; IF n > 0 THEN RAISE WARNING
+     'revoked % …', n; END IF; END $$;` per the repo cleanup-statement convention.
+
+**`seed.ts`** (fresh-install authority):
+- Add `invoices` (read/write/send/export) and `contracts` (read/write/manage) entries to
+  `DEFAULT_PERMISSIONS`.
+- Add `Partner Billing` and `Partner Billing Viewer` to `SYSTEM_ROLES` with their permission lists.
+- Remove `catalog:read`/`catalog:write` from `Partner Technician`; remove `catalog:read` from
+  `Partner Viewer`.
+- Verify `seedRoles` re-grant is idempotent so it co-exists with the migration on a fresh DB.
+
+## Part B — Expose permissions to the browser
+
+- Extend `GET /users/me` to include `permissions: [{ resource, action }]` via the existing
+  `getUserPermissions()` (route already authenticated; `/me` is fetched at startup).
+- Web: add `permissions` to the `User` type + auth store, populated from the `/me` fetch.
+- Add a wildcard-aware `hasPermission(perms, resource, action)` helper on the web mirroring the
+  server check (`*` resource/action match).
+
+## Part C — Permission-aware UI hiding
+
+- **Sidebar** (`apps/web/src/components/layout/Sidebar.tsx`): extend `NavItem` with
+  `requiredPermission?: { resource, action }`; set Invoices→`invoices:read`,
+  Contracts→`contracts:read`, Product Catalog→`catalog:read` (keep existing `partnerScopeOnly`).
+  Hide via the same inline pattern as the scope check.
+- **Action gating** on the pages (hide buttons; server still enforces):
+  - Invoices: create/edit/delete → `invoices:write`; issue/send/void/record-payment →
+    `invoices:send`; PDF/export → `invoices:export`.
+  - Contracts: create/edit/delete-draft/add-line → `contracts:write`;
+    activate/pause/resume/cancel/generate → `contracts:manage`.
+  - Catalog: create/edit → `catalog:write`; archive → `catalog:delete`.
+
+## Testing
+
+- **API:** unit test `/me` includes permissions (Drizzle mock per `breeze-testing`). Migration
+  ordering covered by `autoMigrate.test`. Optional integration assertion: Technician no longer holds
+  billing perms; Partner Billing holds the full set.
+- **Web:** Sidebar hides nav by permission; action buttons hidden by permission (vitest + jsdom,
+  mocked auth store).
+- **Agent:** no changes.
+
+## Operational note (deploy)
+
+On existing prod (EU/US), any user **currently on Partner Technician who does billing loses access**
+within ≤5 min (cache TTL) once this migration runs. They must be reassigned to **Partner Billing**
+(or **Partner Billing Viewer**). This is the intended effect — but it needs a heads-up / comms
+before deploy.
+
+## Out of scope
+
+- No "Org"-scope billing roles (billing is partner-scoped by `requireScope`).
+- No migration of existing user→role assignments (operators reassign as needed).
+- No Stripe/portal changes (customer-facing portal routes are intentionally un-RBAC'd).

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,3 +1,6 @@
+// Permission registry (resource:action grants) + derived literal-union types.
+export * from './permissions';
+
 // OS Types
 export const OS_TYPES = ['windows', 'macos', 'linux'] as const;
 

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -10,8 +10,7 @@
 // fails to compile instead of silently never matching.
 //
 // NB: named PERMISSION_GRANTS (not PERMISSIONS) to avoid colliding with the
-// older nested PERMISSIONS constant in this package. The API re-exports this as
-// `PERMISSIONS` from services/permissions.ts.
+// older nested PERMISSIONS constant in this package.
 export const PERMISSION_GRANTS = {
   // Backup / recovery
   BACKUP_READ: { resource: 'backup', action: 'read' },

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -1,0 +1,107 @@
+// Canonical permission registry — the single source of truth for resource:action
+// grants. Shared so the API (requirePermission, role seeding) and the web UI
+// (permission-aware nav/action gating) type their permission references against
+// the same closed set. The API re-exports this as `PERMISSIONS` from
+// `services/permissions.ts`; the web derives `PermissionGrant`/`PermissionResource`/
+// `PermissionAction` for its gate literals.
+//
+// Adding a permission: add it here (and to DEFAULT_PERMISSIONS in the API seed +
+// a migration that inserts the row). A typo'd resource/action in any gate then
+// fails to compile instead of silently never matching.
+//
+// NB: named PERMISSION_GRANTS (not PERMISSIONS) to avoid colliding with the
+// older nested PERMISSIONS constant in this package. The API re-exports this as
+// `PERMISSIONS` from services/permissions.ts.
+export const PERMISSION_GRANTS = {
+  // Backup / recovery
+  BACKUP_READ: { resource: 'backup', action: 'read' },
+  BACKUP_WRITE: { resource: 'backup', action: 'write' },
+
+  // Devices
+  DEVICES_READ: { resource: 'devices', action: 'read' },
+  DEVICES_WRITE: { resource: 'devices', action: 'write' },
+  DEVICES_DELETE: { resource: 'devices', action: 'delete' },
+  DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
+
+  // Scripts
+  SCRIPTS_READ: { resource: 'scripts', action: 'read' },
+  SCRIPTS_WRITE: { resource: 'scripts', action: 'write' },
+  SCRIPTS_DELETE: { resource: 'scripts', action: 'delete' },
+  SCRIPTS_EXECUTE: { resource: 'scripts', action: 'execute' },
+
+  // Alerts
+  ALERTS_READ: { resource: 'alerts', action: 'read' },
+  ALERTS_WRITE: { resource: 'alerts', action: 'write' },
+  ALERTS_ACKNOWLEDGE: { resource: 'alerts', action: 'acknowledge' },
+
+  // Tickets
+  TICKETS_READ: { resource: 'tickets', action: 'read' },
+  TICKETS_WRITE: { resource: 'tickets', action: 'write' },
+
+  // Catalog (billing/invoicing program)
+  CATALOG_READ: { resource: 'catalog', action: 'read' },
+  CATALOG_WRITE: { resource: 'catalog', action: 'write' },
+  CATALOG_DELETE: { resource: 'catalog', action: 'delete' },
+
+  // Invoices (billing/invoicing program — sub-project 2)
+  INVOICES_READ: { resource: 'invoices', action: 'read' },
+  INVOICES_WRITE: { resource: 'invoices', action: 'write' },
+  INVOICES_SEND: { resource: 'invoices', action: 'send' },
+  INVOICES_EXPORT: { resource: 'invoices', action: 'export' },
+
+  // Contracts (recurring-contracts — sub-project 3)
+  CONTRACTS_READ: { resource: 'contracts', action: 'read' },
+  CONTRACTS_WRITE: { resource: 'contracts', action: 'write' },
+  CONTRACTS_MANAGE: { resource: 'contracts', action: 'manage' },
+
+  // Time entries (ticketing Phase 3)
+  TIME_ENTRIES_READ: { resource: 'time_entries', action: 'read' },
+  TIME_ENTRIES_WRITE: { resource: 'time_entries', action: 'write' },
+
+  // Users
+  USERS_READ: { resource: 'users', action: 'read' },
+  USERS_WRITE: { resource: 'users', action: 'write' },
+  USERS_DELETE: { resource: 'users', action: 'delete' },
+  USERS_INVITE: { resource: 'users', action: 'invite' },
+
+  // Organizations
+  ORGS_READ: { resource: 'organizations', action: 'read' },
+  ORGS_WRITE: { resource: 'organizations', action: 'write' },
+  ORGS_DELETE: { resource: 'organizations', action: 'delete' },
+
+  // Sites
+  SITES_READ: { resource: 'sites', action: 'read' },
+  SITES_WRITE: { resource: 'sites', action: 'write' },
+  SITES_DELETE: { resource: 'sites', action: 'delete' },
+
+  // Automations
+  AUTOMATIONS_READ: { resource: 'automations', action: 'read' },
+  AUTOMATIONS_WRITE: { resource: 'automations', action: 'write' },
+  AUTOMATIONS_DELETE: { resource: 'automations', action: 'delete' },
+
+  // Remote access
+  REMOTE_ACCESS: { resource: 'remote', action: 'access' },
+
+  // Audit
+  AUDIT_READ: { resource: 'audit', action: 'read' },
+  AUDIT_EXPORT: { resource: 'audit', action: 'export' },
+
+  // Reports
+  REPORTS_READ: { resource: 'reports', action: 'read' },
+  REPORTS_WRITE: { resource: 'reports', action: 'write' },
+  REPORTS_DELETE: { resource: 'reports', action: 'delete' },
+  REPORTS_EXPORT: { resource: 'reports', action: 'export' },
+
+  // Billing
+  BILLING_MANAGE: { resource: 'billing', action: 'manage' },
+
+  // Admin
+  ADMIN_ALL: { resource: '*', action: '*' },
+} as const;
+
+/** Union of the exact `{ resource, action }` literal pairs in the registry. */
+export type PermissionGrant = (typeof PERMISSION_GRANTS)[keyof typeof PERMISSION_GRANTS];
+/** Union of every known resource (includes the `*` wildcard). */
+export type PermissionResource = PermissionGrant['resource'];
+/** Union of every known action (includes the `*` wildcard). */
+export type PermissionAction = PermissionGrant['action'];


### PR DESCRIPTION
## Summary

Billing features (Catalog, Invoices, Contracts) were RBAC-gated on the API, but there was **no dedicated billing role** — outside Partner Admin, billing only rode on **Partner Technician** (a broad operational role), the Technician was **over-granted** (`invoices:send`, `contracts:manage`), and the **web UI was permission-blind** (controls rendered then 403'd). This PR fixes all three.

### Roles (migration `2026-06-19-billing-roles.sql` + `seed.ts`)
- **Partner Billing** — full `catalog`/`invoices`/`contracts` (10 actions)
- **Partner Billing Viewer** — read-only + invoice export (`catalog:read`, `invoices:read`, `invoices:export`, `contracts:read`)
- **Partner Technician** → all billing permissions revoked
- **Partner Viewer** → `catalog:read` revoked

Billing access now lives only in Partner Admin + the two new roles. The migration touches **only global system rows** (`partner_id IS NULL, is_system`); per-partner cloned Partner Admin rows (which carry `*:*`) and partner-authored custom roles are untouched. `seed.ts` is authoritative for fresh installs and now carries the same end state (incl. `invoices`/`contracts` added to `DEFAULT_PERMISSIONS`).

### Permission-aware UI
- `GET /users/me` now returns the caller's permission grants (**UX only** — every route still enforces `requirePermission` server-side).
- Web `usePermissions()`/`hasPermission()` helper (wildcard-aware; hides while permissions load).
- Sidebar hides **Invoices / Contracts / Catalog** unless the user has the matching `:read`.
- Action controls hidden by grant: invoices write/send/export, contracts write/manage, catalog write/delete — across the editors, detail views, and row menus.

## Verification
- Migration applied + **re-applied** on a real DB: Partner Billing = 10 distinct actions, Viewer = 4, Technician = 0, Partner Viewer = 0; re-apply is a clean no-op (`INSERT 0 0`, DO-blocks no-op).
- Tests: migration-ordering (43), API `/me` permissions, web `hasPermission` + Sidebar billing gate, and all billing/contracts/catalog component suites green (236). Both apps typecheck clean. The 5 existing component test files that asserted now-gated buttons were updated to grant the wildcard.

## ⚠️ Deploy / comms note
On existing deployments, anyone **currently on Partner Technician who does billing loses access within ~5 min** (permission-cache TTL) and must be reassigned to **Partner Billing** / **Partner Billing Viewer**. No automatic reassignment is performed.

## Follow-up (out of scope)
The `permissions` table has no unique constraint on `(resource, action)` — the dev DB has duplicate `catalog:write`/`catalog:delete` rows from repeated seeding. Functionally harmless (grants still match) but worth a later cleanup migration + constraint.

Design spec: `docs/superpowers/specs/2026-06-16-billing-rbac-roles-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)