### PR TITLE
fix(ai): wire script-builder library tools through the session guardrail

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -79,6 +79,14 @@ export const TOOL_TIERS = {
   sync_huntress_data: 2,
   execute_command: 3,
   run_script: 3,
+  // Script library (read-only) — used by the script-builder assistant to
+  // reference existing scripts. Absent here, createSessionPreToolUse rejects
+  // them as "Unknown tool" before execution (the script-builder could not
+  // search/read the library). Keep in sync with TOOL_PERMISSIONS in aiGuardrails.
+  list_scripts: 1,
+  get_script_details: 1,
+  list_script_templates: 1,
+  get_script_execution_history: 1,
   manage_services: 3,
   security_scan: 3,
   get_security_posture: 1,

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -84,7 +84,7 @@ const TIER3_ACTIONS: Record<string, string[]> = {
 };
 
 // RBAC permission map: tool → { resource, action } (or action-based overrides)
-const TOOL_PERMISSIONS: Record<string, { resource: string; action: string } | Record<string, { resource: string; action: string }>> = {
+export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string } | Record<string, { resource: string; action: string }>> = {
   query_devices: { resource: 'devices', action: 'read' },
   get_device_details: { resource: 'devices', action: 'read' },
   analyze_metrics: { resource: 'devices', action: 'read' },
@@ -298,7 +298,10 @@ const TOOL_PERMISSIONS: Record<string, { resource: string; action: string } | Re
   search_documentation: { resource: 'general', action: 'read' },
   // Script library tools
   search_script_library: { resource: 'scripts', action: 'read' },
+  list_scripts: { resource: 'scripts', action: 'read' },
   get_script_details: { resource: 'scripts', action: 'read' },
+  list_script_templates: { resource: 'scripts', action: 'read' },
+  get_script_execution_history: { resource: 'scripts', action: 'read' },
   // Backup & DR tools
   query_backups: { resource: 'devices', action: 'read' },
   get_backup_status: { resource: 'devices', action: 'read' },

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -974,6 +974,27 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     includeVersionHistory: z.boolean().optional(),
     includeExecutionStats: z.boolean().optional(),
   }),
+  // Script-library read tools used by the script-builder assistant. These were
+  // wired through TOOL_TIERS + TOOL_PERMISSIONS (#1457) but lacked an input
+  // schema here, so validateToolInput rejected every call ("No input schema
+  // defined") — the tool surfaced past the guardrail yet still never executed.
+  // Shapes mirror the script-builder tool registrations in scriptBuilderTools.ts.
+  list_scripts: z.object({
+    search: z.string().max(200).optional(),
+    category: z.string().optional(),
+    language: z.enum(['powershell', 'bash', 'python', 'cmd']).optional(),
+    osType: z.enum(['windows', 'macos', 'linux']).optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
+  list_script_templates: z.object({
+    search: z.string().max(200).optional(),
+    category: z.string().optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
+  get_script_execution_history: z.object({
+    scriptId: uuid,
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
 
   // Monitoring tools
   query_monitors: z.object({

--- a/apps/api/src/services/scriptBuilderTools.guard.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.guard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { TOOL_TIERS } from './aiAgentSdkTools';
 import { TOOL_PERMISSIONS, checkGuardrails } from './aiGuardrails';
 import { SCRIPT_BUILDER_TOOL_TIERS } from './scriptBuilderTools';
+import { toolInputSchemas, validateToolInput } from './aiToolSchemas';
 
 /**
  * Guard against the "Unknown tool" regression (script-builder could not search
@@ -76,5 +77,35 @@ describe('script-builder context tools are fully wired for the session guardrail
     expect(result.allowed).toBe(true);
     expect(result.tier).toBe(1);
     expect(result.requiresApproval).toBe(false);
+  });
+
+  // The THIRD map: validateToolInput rejects any tool missing from
+  // toolInputSchemas ("No input schema defined for tool"), so a tool can clear
+  // TOOL_TIERS and TOOL_PERMISSIONS above and STILL never execute. That was the
+  // #1457 follow-on bug — list_scripts surfaced past the guard but every call
+  // was rejected for lack of a schema, and the AI looped until it gave up.
+  it.each(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS)(
+    '%s has a registered input schema (validateToolInput would otherwise reject every call)',
+    (toolName) => {
+      expect(
+        toolInputSchemas[toolName],
+        `${toolName} is missing from toolInputSchemas — validateToolInput rejects input as "No input schema defined for tool"`,
+      ).toBeDefined();
+    },
+  );
+
+  it('validateToolInput accepts a no-arg list_scripts call (the script-builder default)', () => {
+    expect(validateToolInput('list_scripts', {})).toEqual({ success: true });
+  });
+
+  it('validateToolInput accepts representative library-tool inputs', () => {
+    expect(validateToolInput('list_scripts', { search: 'backup', language: 'powershell', limit: 5 }).success).toBe(true);
+    expect(validateToolInput('list_script_templates', { category: 'Maintenance' }).success).toBe(true);
+    expect(
+      validateToolInput('get_script_execution_history', {
+        scriptId: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+        limit: 10,
+      }).success,
+    ).toBe(true);
   });
 });

--- a/apps/api/src/services/scriptBuilderTools.guard.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.guard.test.ts
@@ -1,37 +1,48 @@
 import { describe, it, expect } from 'vitest';
 import { TOOL_TIERS } from './aiAgentSdkTools';
-import { TOOL_PERMISSIONS } from './aiGuardrails';
+import { TOOL_PERMISSIONS, checkGuardrails } from './aiGuardrails';
+import { SCRIPT_BUILDER_TOOL_TIERS } from './scriptBuilderTools';
 
 /**
  * Guard against the "Unknown tool" regression (script-builder could not search
  * or read the existing script library).
  *
- * The script-builder assistant exposes a curated set of context tools that flow
- * through makeExistingHandler -> createSessionPreToolUse -> executeTool. Each
- * such tool MUST be present in BOTH:
+ * Every script-builder *context* tool flows through makeExistingHandler ->
+ * createSessionPreToolUse -> executeTool, and MUST be present in BOTH:
  *   - TOOL_TIERS (aiAgentSdkTools)    — else createSessionPreToolUse rejects it
  *                                        as "Unknown tool" before execution.
  *   - TOOL_PERMISSIONS (aiGuardrails) — else checkToolPermission denies it with
  *                                        "No RBAC permission mapping for tool".
  *
- * These are the executeTool handler names passed to makeExistingHandler in
- * createScriptBuilderMcpServer (scriptBuilderTools.ts). The apply tools
- * (apply_script_code / apply_script_metadata) intentionally bypass preToolUse
- * via makeApplyHandler, so they are excluded here. Keep this list in sync with
- * createScriptBuilderMcpServer.
+ * The list is DERIVED from the script-builder's own source-of-truth tool list
+ * (SCRIPT_BUILDER_TOOL_TIERS) rather than hardcoded, so adding a new context
+ * tool there without wiring it into the global maps fails this test — the exact
+ * drift that caused the original bug.
  */
-const SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS = [
-  'query_devices',
-  'get_device_details',
-  'manage_alerts',
-  'list_scripts',
-  'get_script_details',
-  'list_script_templates',
-  'get_script_execution_history',
-  'run_script', // exposed to the model as execute_script_on_device
-] as const;
+
+// The apply tools bypass preToolUse via makeApplyHandler, so they don't need
+// (and must not require) TOOL_TIERS / TOOL_PERMISSIONS entries.
+const APPLY_TOOLS = new Set(['apply_script_code', 'apply_script_metadata']);
+
+// A few MCP tool names dispatch to a differently-named executeTool handler;
+// preToolUse / checkToolPermission see the HANDLER name. Keep in sync with the
+// makeExistingHandler(...) call sites in createScriptBuilderMcpServer.
+const MCP_NAME_TO_HANDLER: Record<string, string> = {
+  execute_script_on_device: 'run_script',
+};
+
+const SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS = Object.keys(SCRIPT_BUILDER_TOOL_TIERS)
+  .filter((name) => !APPLY_TOOLS.has(name))
+  .map((name) => MCP_NAME_TO_HANDLER[name] ?? name);
 
 describe('script-builder context tools are fully wired for the session guardrail', () => {
+  it('derives the handler-tool list from SCRIPT_BUILDER_TOOL_TIERS (so new tools cannot silently skip the guard)', () => {
+    expect(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS.length).toBeGreaterThan(0);
+    expect(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS).toContain('list_scripts');
+    expect(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS).toContain('run_script'); // execute_script_on_device
+    expect(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS).not.toContain('apply_script_code');
+  });
+
   it.each(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS)(
     '%s has a TOOL_TIERS entry (preToolUse would otherwise reject it as "Unknown tool")',
     (toolName) => {
@@ -51,4 +62,19 @@ describe('script-builder context tools are fully wired for the session guardrail
       ).toBeDefined();
     },
   );
+
+  // Membership is necessary but not sufficient: a mis-set tier or an unintended
+  // action-escalation could still block a read-only library call. Verify the
+  // four library tools actually resolve as allowed, tier-1 (auto-execute) reads.
+  it.each([
+    'list_scripts',
+    'get_script_details',
+    'list_script_templates',
+    'get_script_execution_history',
+  ])('checkGuardrails permits %s as a tier-1 read tool (no approval)', (toolName) => {
+    const result = checkGuardrails(toolName, {});
+    expect(result.allowed).toBe(true);
+    expect(result.tier).toBe(1);
+    expect(result.requiresApproval).toBe(false);
+  });
 });

--- a/apps/api/src/services/scriptBuilderTools.guard.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.guard.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { TOOL_TIERS } from './aiAgentSdkTools';
+import { TOOL_PERMISSIONS } from './aiGuardrails';
+
+/**
+ * Guard against the "Unknown tool" regression (script-builder could not search
+ * or read the existing script library).
+ *
+ * The script-builder assistant exposes a curated set of context tools that flow
+ * through makeExistingHandler -> createSessionPreToolUse -> executeTool. Each
+ * such tool MUST be present in BOTH:
+ *   - TOOL_TIERS (aiAgentSdkTools)    — else createSessionPreToolUse rejects it
+ *                                        as "Unknown tool" before execution.
+ *   - TOOL_PERMISSIONS (aiGuardrails) — else checkToolPermission denies it with
+ *                                        "No RBAC permission mapping for tool".
+ *
+ * These are the executeTool handler names passed to makeExistingHandler in
+ * createScriptBuilderMcpServer (scriptBuilderTools.ts). The apply tools
+ * (apply_script_code / apply_script_metadata) intentionally bypass preToolUse
+ * via makeApplyHandler, so they are excluded here. Keep this list in sync with
+ * createScriptBuilderMcpServer.
+ */
+const SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS = [
+  'query_devices',
+  'get_device_details',
+  'manage_alerts',
+  'list_scripts',
+  'get_script_details',
+  'list_script_templates',
+  'get_script_execution_history',
+  'run_script', // exposed to the model as execute_script_on_device
+] as const;
+
+describe('script-builder context tools are fully wired for the session guardrail', () => {
+  it.each(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS)(
+    '%s has a TOOL_TIERS entry (preToolUse would otherwise reject it as "Unknown tool")',
+    (toolName) => {
+      expect(
+        TOOL_TIERS[toolName],
+        `${toolName} is missing from TOOL_TIERS — createSessionPreToolUse rejects it as "Unknown tool"`,
+      ).toBeDefined();
+    },
+  );
+
+  it.each(SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS)(
+    '%s has a TOOL_PERMISSIONS mapping (checkToolPermission would otherwise deny it)',
+    (toolName) => {
+      expect(
+        TOOL_PERMISSIONS[toolName],
+        `${toolName} is missing from TOOL_PERMISSIONS — checkToolPermission denies "No RBAC permission mapping"`,
+      ).toBeDefined();
+    },
+  );
+});


### PR DESCRIPTION
## Problem

The script-builder AI assistant's system prompt advertises *"Search the existing script library for reference,"* but that capability never worked. Asking it to look up or adapt an existing script causes it to call `list_scripts` and receive `{"error":"Unknown tool: list_scripts"}` on every turn, looping until it hits the 50-turn cap and gives up.

Found while investigating the blast radius of the #568 compaction change — **this is a separate, pre-existing bug, not caused by #568.** The guardrail involved dates to #74 (Feb 2026) and these tools were never wired into it.

## Root cause

Two registration gaps, both upstream of execution:

1. **`createSessionPreToolUse`** (`aiAgentSdk.ts`) rejects any tool absent from **`TOOL_TIERS`** as `Unknown tool`. The four script-library tools — `list_scripts`, `get_script_details`, `list_script_templates`, `get_script_execution_history` — were missing from `TOOL_TIERS`.
2. **`checkToolPermission`** (`aiGuardrails.ts`) denies any tool with no RBAC mapping (`No RBAC permission mapping for tool`). Three of the four were missing from **`TOOL_PERMISSIONS`** (only `get_script_details` was mapped).

Why the bug is narrow: the `apply_*` tools work because `makeApplyHandler` bypasses `preToolUse`; `query_devices`/`get_device_details`/`manage_alerts`/`run_script` work because they were already in both maps. The tools **are** correctly registered in the executor (`aiTools.has('list_scripts') === true`) — they're just blocked by the guardrail before they run.

## Fix

- Add the four read-only tools to `TOOL_TIERS` (tier 1).
- Add the three missing `scripts:read` mappings to `TOOL_PERMISSIONS`.
- `checkGuardrails` already resolves their tier from the registry, so no change there.
- Export `TOOL_PERMISSIONS` and add a **guard test** asserting every script-builder context-handler tool is present in *both* maps — so this drift class fails CI instead of silently breaking the assistant.

## Verification

- Reproduced the live failure (`list_scripts` → "Unknown tool", 50× loop) against a running instance; confirmed `query_devices` works and the registry contains all the script tools.
- Traced both gates; confirmed `checkGuardrails` passes (registry tier 1).
- Guard test (16 assertions) passes; failed pre-fix since the tools were absent on `main`.
- Affected suites green: `aiGuardrails`, `aiAgentSdk`, `streamingSessionManager.clientLoop`, `clientAiTools.registry`, m365 suites — 193 tests. Typecheck clean.
- The remaining RBAC link (admin role holds `scripts:read`) is already proven: the script-builder route is gated by `requireScriptAiRead` (`SCRIPTS_READ`), which passed throughout testing.

> Note: a live browser re-run wasn't done because the local dev checkout is currently occupied by an unrelated branch; the fix is validated via the guard test + the traced gates above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)