### PR TITLE
docs: billing suite + AI for Office, email-to-ticket, portal payments

### DIFF
--- a/apps/api/src/data/docsIndex.json
+++ b/apps/api/src/data/docsIndex.json
@@ -765,6 +765,21 @@
     "section": "features"
   },
   {
+    "path": "/features/ai-for-office/",
+    "title": "AI for Office",
+    "description": "A governed AI assistant delivered to your customers' end-users inside Excel, Word, PowerPoint, and Outlook -- with org policies, data-loss protection, budgets, and per-partner entitlement.",
+    "headings": [
+      "Enabling a Partner (Platform Operator)",
+      "Configuring an Organization (MSP Admin)",
+      "Mapping the Customer's Microsoft Tenant",
+      "How End-Users Sign In",
+      "Admin Visibility",
+      "Permissions",
+      "Related"
+    ],
+    "section": "features"
+  },
+  {
     "path": "/features/ai/",
     "title": "AI Features",
     "description": "AI Risk Engine, Fleet Orchestration Brain, AI Device Context Memory, Helper AI Chat, and cost tracking.",
@@ -1158,6 +1173,21 @@
     "section": "features"
   },
   {
+    "path": "/features/contracts/",
+    "title": "Recurring Contracts",
+    "description": "Managed-services agreements that generate invoices automatically on a schedule, with live per-device and per-seat counts so recurring revenue is always accurate.",
+    "headings": [
+      "How a Contract Bills",
+      "Contract Statuses",
+      "Contract Lines",
+      "Creating a Contract",
+      "Managing the Lifecycle",
+      "Permissions",
+      "Related"
+    ],
+    "section": "features"
+  },
+  {
     "path": "/features/custom-fields/",
     "title": "Custom Fields",
     "description": "Define custom metadata fields for devices to track organisation-specific information beyond built-in attributes.",
@@ -1524,6 +1554,24 @@
       "`psa_connections`",
       "`psa_ticket_mappings`",
       "Troubleshooting"
+    ],
+    "section": "features"
+  },
+  {
+    "path": "/features/invoices/",
+    "title": "Invoices",
+    "description": "Create invoices from your catalog, tracked time, and parts; issue and send them; record payments; void and reissue; and download a clean PDF -- all inside Breeze.",
+    "headings": [
+      "The Invoice List",
+      "Invoice Statuses",
+      "Creating an Invoice",
+      "Adding Line Items",
+      "Issuing and Sending",
+      "Recording Payments",
+      "Voiding and Reissuing",
+      "PDF and Accounting View",
+      "Permissions",
+      "Related"
     ],
     "section": "features"
   },
@@ -1903,6 +1951,21 @@
     "section": "features"
   },
   {
+    "path": "/features/online-payments/",
+    "title": "Online Payments",
+    "description": "Let your customers pay invoices by card online, settled directly into your own Stripe account -- Breeze takes no fee and never touches the funds.",
+    "headings": [
+      "How It Works",
+      "Connecting Stripe",
+      "Sending a Payment Link",
+      "Paying from the Customer Portal",
+      "Refunds",
+      "Permissions",
+      "Related"
+    ],
+    "section": "features"
+  },
+  {
     "path": "/features/pam/",
     "title": "Privileged Access Management",
     "description": "Eliminate standing admin rights with just-in-time elevation -- intercept Windows UAC prompts, route them to an approver, and grant temporary admin access that revokes itself.",
@@ -2130,6 +2193,8 @@
       "Creating a Ticket",
       "Ticket Comments",
       "External Ticket Integration",
+      "Invoices & Payments",
+      "Paying an Invoice",
       "Asset Checkout",
       "Checking Out an Asset",
       "Returning an Asset",
@@ -2143,6 +2208,7 @@
       "Branding",
       "Devices",
       "Tickets",
+      "Invoices",
       "Assets",
       "Profile",
       "Caching",
@@ -2153,6 +2219,21 @@
       "CSRF token errors on form submissions",
       "\"Service temporarily unavailable\" (503) on login",
       "Rate limited (429) responses"
+    ],
+    "section": "features"
+  },
+  {
+    "path": "/features/product-catalog/",
+    "title": "Product Catalog",
+    "description": "A reusable catalog of the products and services you sell, with per-customer pricing, bundles, and live margins -- the price list that invoices and contracts pull from.",
+    "headings": [
+      "Catalog Items",
+      "Fields",
+      "Per-Customer Pricing",
+      "Bundles",
+      "Archiving Items",
+      "Permissions",
+      "Related"
     ],
     "section": "features"
   },
@@ -2691,6 +2772,11 @@
       "Keyboard Shortcuts",
       "Bulk Actions",
       "Creating Tickets",
+      "Email-to-Ticket",
+      "Your inbound address",
+      "How emails become tickets",
+      "Autoresponder",
+      "Review queue",
       "Categories and SLAs",
       "Custom Statuses & SLA Configuration",
       "Custom ticket statuses",

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -78,6 +78,15 @@ export default defineConfig({
               ],
             },
             {
+              label: 'Billing & Invoicing',
+              items: [
+                { slug: 'features/product-catalog' },
+                { slug: 'features/invoices' },
+                { slug: 'features/contracts' },
+                { slug: 'features/online-payments' },
+              ],
+            },
+            {
               label: 'Backup & Recovery',
               items: [{ autogenerate: { directory: 'backup' } }],
             },
@@ -107,6 +116,7 @@ export default defineConfig({
               items: [
                 { slug: 'features/ai' },
                 { slug: 'features/ai-computer-control' },
+                { slug: 'features/ai-for-office' },
                 { slug: 'features/mcp-server' },
               ],
             },

--- a/apps/docs/src/content/docs/features/ai-for-office.mdx
+++ b/apps/docs/src/content/docs/features/ai-for-office.mdx
@@ -1,0 +1,76 @@
+---
+title: AI for Office
+description: A governed AI assistant delivered to your customers' end-users inside Excel, Word, PowerPoint, and Outlook -- with org policies, data-loss protection, budgets, and per-partner entitlement.
+sidebar:
+  label: "AI for Office"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+AI for Office puts a branded, policy-controlled AI assistant directly inside Microsoft Office for your customers' **end-users** -- in Excel, Word, PowerPoint, and Outlook. It's not a tool for your technicians; it's a co-pilot your clients use in their own documents, governed by the same policy and data-protection controls as the rest of Breeze.
+
+End-users open the add-in task pane, sign in with their existing Microsoft identity, and chat with the assistant without leaving their document. You decide which customers can use it, what it's allowed to do, and how much it can spend.
+
+## Enabling a Partner (Platform Operator)
+
+AI for Office is a **per-partner entitlement** controlled by the platform operator. It is **off by default** for every partner, so you're never billed for AI usage by partners you haven't explicitly enabled.
+
+The entitlement is granted by the operator, not self-served -- a partner cannot turn it on for themselves. When a partner is disabled, the feature is unavailable across all of their customer organizations, and disabling a partner cuts off **live** sessions immediately, not just new ones.
+
+## Configuring an Organization (MSP Admin)
+
+Once your partner is entitled, you configure AI for Office per customer organization through its **org policy**. The policy controls who can use the assistant and what it's allowed to do.
+
+| Setting | What it controls |
+|---------|------------------|
+| Enabled | Master on/off for this organization |
+| User access | Everyone in the customer's Microsoft tenant, or a selected list of users |
+| Write mode | Whether the assistant can edit documents (read/write) or only read and inspect (read-only) |
+| Write approval | Whether each edit must be approved by the user, or applies automatically |
+| Data-loss protection | Redaction rules that strip sensitive data (such as PII) before it leaves the document |
+| Budgets | Optional daily and monthly spend caps |
+| Rate limits | Per-user and per-organization message limits |
+| Retention | How long chat history is kept |
+| Branding | A display name and logo shown to end-users |
+
+### Mapping the Customer's Microsoft Tenant
+
+Each customer organization must be mapped to its **Microsoft Entra tenant** so sign-ins resolve to the right org. This mapping is the foundation of tenant isolation and is set once per organization. Creating or changing a tenant mapping requires multi-factor authentication.
+
+<Steps>
+1. Open the AI for Office admin area and select the customer organization.
+2. Enter the customer's Entra tenant ID (Breeze suggests it automatically if you already have a Microsoft 365 connection for that customer).
+3. Grant the required admin consent for the add-in on the customer's tenant.
+4. Enable the org policy and set access, write mode, DLP, and budgets.
+</Steps>
+
+## How End-Users Sign In
+
+<Steps>
+1. The end-user opens the Breeze add-in's task pane in Excel, Word, PowerPoint, or Outlook.
+2. The add-in uses their existing **Microsoft identity** -- no separate Breeze login.
+3. Breeze verifies the identity, maps the Microsoft tenant to the correct organization, and checks that the partner is entitled, the org policy is enabled, and the user is allowed.
+4. The user starts chatting. Edits and document actions follow the org's write-mode and approval settings, and responses pass through the org's data-loss protection rules.
+</Steps>
+
+## Admin Visibility
+
+The admin area gives you operational visibility for each customer organization:
+
+- **Onboarding status** -- a per-org checklist showing whether the tenant is mapped, consent is granted, and the policy is enabled.
+- **Sessions** -- which end-users are using the assistant, in which Office host, with message and token counts.
+- **Usage and cost** -- monthly usage per user with token counts and cost, exportable as CSV for resale and accounting.
+
+<Aside>
+  Every policy change, tenant-mapping change, and session is recorded in the [audit log](/reference/audit-logs/), and all queries run under strict per-organization isolation so customer data never crosses tenants.
+</Aside>
+
+## Permissions
+
+Viewing AI for Office configuration requires organization read access; changing org policies and templates requires organization write access. Tenant-mapping changes additionally require multi-factor authentication. The per-partner entitlement is operator-only.
+
+## Related
+
+- [AI Assistant](/features/ai/) -- the in-dashboard AI for your technicians
+- [Identity Console](/features/identity-console/) -- manage Microsoft 365 and Google Workspace identities
+- [Customer Portal](/features/portal/) -- other end-user-facing capabilities

--- a/apps/docs/src/content/docs/features/contracts.mdx
+++ b/apps/docs/src/content/docs/features/contracts.mdx
@@ -1,0 +1,82 @@
+---
+title: Recurring Contracts
+description: Managed-services agreements that generate invoices automatically on a schedule, with live per-device and per-seat counts so recurring revenue is always accurate.
+sidebar:
+  label: "Recurring Contracts"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+Recurring Contracts automate your managed-services billing. Define what a customer is charged and how often, and Breeze generates the invoices on schedule -- resolving per-device and per-seat counts at billing time so the amount always reflects the customer's actual environment. Open **Contracts** from the sidebar.
+
+Contracts are **partner-scoped** and bound to a customer organization.
+
+## How a Contract Bills
+
+Two settings determine the rhythm:
+
+- **Billing timing** -- *in advance* (bill at the start of each period) or *in arrears* (bill at the end).
+- **Interval** -- monthly, quarterly, annually, or a custom number of months.
+
+From these, Breeze computes the **next billing date**. When that date arrives, a billing period is created, line quantities are resolved, and -- if **auto-issue** is on -- an invoice is generated automatically.
+
+### Contract Statuses
+
+| Status | Meaning |
+|--------|---------|
+| Draft | Being set up; not yet billing |
+| Active | Billing on schedule |
+| Paused | Billing temporarily stopped |
+| Cancelled | Ended |
+| Expired | Past its end date |
+
+## Contract Lines
+
+Each line is one charge on the contract. Lines can resolve their quantity in different ways:
+
+| Line type | How quantity is determined |
+|-----------|----------------------------|
+| Flat | A fixed amount each period, regardless of count |
+| Per device | Counts the customer's devices at billing time × unit price |
+| Per seat | Counts the customer's seats/users at billing time × unit price |
+| Manual | A fixed quantity you set × unit price |
+
+Per-device and per-seat lines can be scoped to a specific **site** so you bill only the devices or seats at that location. A line can link to a [catalog item](/features/product-catalog/), which prefills its description and price.
+
+## Creating a Contract
+
+<Steps>
+1. Go to **Contracts** and click **New contract**.
+2. Select the customer organization, name the contract, and set the billing timing, interval, and start date.
+3. Add lines -- choose flat, per device, per seat, or manual, and set the price (and quantity where applicable). Link a catalog item to prefill description and price.
+4. Add any **terms** and notes.
+5. Review the **estimated value this period** -- per-device and per-seat lines resolve to live counts so the estimate is real, not a placeholder.
+6. **Activate** the contract to start billing.
+</Steps>
+
+The contract list shows an **estimated monthly recurring** strip across active contracts (normalized for cadence) and a per-contract **estimate** column, so you can see recurring value at a glance.
+
+## Managing the Lifecycle
+
+| Action | Effect |
+|--------|--------|
+| Activate | Move a draft to active and set the next billing date |
+| Pause | Temporarily stop generating invoices |
+| Resume | Continue billing from a paused state |
+| Cancel | End the contract |
+
+You can also **generate now** to create the current period's invoice immediately rather than waiting for the schedule.
+
+<Aside>
+  When auto-issue is enabled, generated invoices can be emailed to the customer automatically if a billing email is configured. Otherwise they land as drafts for you to review and send.
+</Aside>
+
+## Permissions
+
+Contract access is governed by role permissions: viewing requires contract read access, creating and editing requires contract write access, and lifecycle actions (activate, pause, resume, cancel) require contract management access. Assign these through **Settings → Users & Roles**.
+
+## Related
+
+- [Invoices](/features/invoices/) -- where generated invoices land
+- [Product Catalog](/features/product-catalog/) -- link contract lines to catalog items
+- [Online Payments](/features/online-payments/) -- let customers pay generated invoices online

--- a/apps/docs/src/content/docs/features/invoices.mdx
+++ b/apps/docs/src/content/docs/features/invoices.mdx
@@ -1,0 +1,89 @@
+---
+title: Invoices
+description: Create invoices from your catalog, tracked time, and parts; issue and send them; record payments; void and reissue; and download a clean PDF -- all inside Breeze.
+sidebar:
+  label: "Invoices"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+Breeze's invoice engine turns the work you already track -- catalog items, time entries, and parts -- into invoices you can issue, send, and collect on without leaving the platform. Open **Billing → Invoices** to get started.
+
+Invoices are **partner-scoped**: you can invoice any of your customer organizations from one place.
+
+## The Invoice List
+
+The list shows every invoice with its number, organization, status, issue and due dates, total, and outstanding balance. An **Outstanding** summary strip at the top totals what's still owed across all invoices. Search by number or organization, filter by status, organization, or date, and sort by issued date, due date, total, or balance.
+
+### Invoice Statuses
+
+| Status | Meaning |
+|--------|---------|
+| Draft | Being assembled; not yet issued and not visible to the customer |
+| Sent | Issued and delivered to the customer |
+| Partially paid | One or more payments recorded, but a balance remains |
+| Paid | Fully paid |
+| Overdue | Past its due date with a balance remaining |
+| Void | Cancelled; no longer collectible |
+
+## Creating an Invoice
+
+<Steps>
+1. Go to **Billing → Invoices** and click **New invoice**.
+2. Choose **Assemble from work** to pull in tracked time and parts, or **Blank invoice** to start empty.
+3. Select the customer organization the invoice is for.
+4. The invoice opens as a **draft** for editing.
+</Steps>
+
+### Adding Line Items
+
+The draft editor's primary way to add lines is the shared **catalog picker** -- start typing to search your [Product Catalog](/features/product-catalog/) by name or SKU, pick an item or bundle, and set the quantity. Catalog items use the customer's per-customer price when one is set. You can also add a **manual line** with a custom description, quantity, and price for anything not in the catalog.
+
+Line items can come from several sources: catalog items, bundles, tracked time entries, parts, recurring contracts, or manual entries. The running subtotal, tax, total, and balance update live as you edit.
+
+<Aside>
+  If your catalog is empty, the editor links straight to **Product Catalog** so you can add the items you sell.
+</Aside>
+
+## Issuing and Sending
+
+**Issuing** an invoice finalizes it: it assigns the next sequential invoice number (using your partner prefix and the current year), sets the issue and due dates, and generates the PDF. **Sending** emails the invoice to the customer.
+
+<Steps>
+1. Review the draft and confirm the line items and totals.
+2. Click **Issue** to assign a number and lock the invoice.
+3. Click **Send** to email it to the customer.
+</Steps>
+
+The issued-invoice view puts the **balance due** front and center, shows recorded payments, and offers a one-click **PDF download**.
+
+## Recording Payments
+
+When a customer pays offline, record it against the invoice so the balance and status stay accurate. Payments collected online through [Stripe](/features/online-payments/) are recorded automatically and badged **Online**.
+
+<Steps>
+1. Open the issued invoice.
+2. Click **Record payment**.
+3. Choose the method -- cash, check, bank transfer, card, or other -- and enter the amount, date, and an optional reference.
+4. Save. The invoice moves to **partially paid** or **paid** automatically based on the remaining balance.
+</Steps>
+
+You can void a manually recorded payment if it was entered in error. Payments collected online through Stripe are reconciled from Stripe and can't be voided by hand.
+
+## Voiding and Reissuing
+
+If an issued invoice needs to be cancelled, **void** it with a reason. You can optionally **reissue** at the same time, which creates a fresh draft you can correct and issue anew -- keeping the original on record for audit purposes.
+
+## PDF and Accounting View
+
+Every issued invoice can be downloaded as a clean, single-page **PDF** to send or archive. The detail view also offers an accounting-oriented breakdown of subtotal, tax, total, payments, and balance.
+
+## Permissions
+
+Invoice access is governed by role permissions: viewing requires invoice read access, creating and editing drafts requires invoice write access, and issuing, sending, voiding, and recording payments require invoice send access. Assign these through **Settings → Users & Roles**.
+
+## Related
+
+- [Product Catalog](/features/product-catalog/) -- the price list invoices pull from
+- [Recurring Contracts](/features/contracts/) -- generate invoices automatically on a schedule
+- [Online Payments](/features/online-payments/) -- collect card payments online

--- a/apps/docs/src/content/docs/features/online-payments.mdx
+++ b/apps/docs/src/content/docs/features/online-payments.mdx
@@ -1,0 +1,60 @@
+---
+title: Online Payments
+description: Let your customers pay invoices by card online, settled directly into your own Stripe account -- Breeze takes no fee and never touches the funds.
+sidebar:
+  label: "Online Payments"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+Online Payments lets your customers pay their invoices by card through a secure checkout, with the money settling directly into **your own Stripe account**. Breeze stays out of the middle: there's no platform fee, no funds pass through us, and your business remains the merchant of record on your customer's statement.
+
+## How It Works
+
+You connect your Stripe account to Breeze once. After that, any issued invoice can carry a shareable **payment link**, and customers can also pay from the [Customer Portal](/features/portal/). Payments collected online are recorded against the invoice automatically.
+
+- **You are the merchant of record.** Your customer's card statement shows your business, and you handle any chargebacks -- not Breeze.
+- **No platform fee.** You receive the full payment, less Stripe's own processing fees. Breeze adds nothing.
+- **Card payments, hosted by Stripe.** Customers complete checkout on Stripe's secure hosted page; card details never touch Breeze.
+
+## Connecting Stripe
+
+Connecting Stripe is a one-time authorization, done per partner.
+
+<Steps>
+1. Go to **Settings → Billing**.
+2. In the **Online payments** section, click **Connect Stripe**.
+3. Authorize Breeze on Stripe's screen and you're returned to billing settings, now showing as connected.
+</Steps>
+
+The billing settings show your current connection status and whether you're in live or test mode. Connecting and disconnecting Stripe require multi-factor authentication.
+
+<Aside>
+  One Stripe account connects per MSP partner. Until Stripe is connected, invoices show a quiet prompt to connect rather than a payment link.
+</Aside>
+
+## Sending a Payment Link
+
+<Steps>
+1. Open an issued [invoice](/features/invoices/).
+2. Click **Send payment link** to generate a secure Stripe Checkout URL for the invoice's outstanding balance.
+3. Share the link with your customer. When they pay, the payment is recorded against the invoice automatically and badged **Online**.
+</Steps>
+
+## Paying from the Customer Portal
+
+Customers who use the [Customer Portal](/features/portal/) can view their issued invoices and pay any with an outstanding balance using a **Pay now** button, which opens the same secure Stripe Checkout. Once payment succeeds, the invoice's balance and status update on their own.
+
+## Refunds
+
+Refunds are **reflect-only**: you issue a refund from your own Stripe dashboard, and Breeze stays in sync automatically -- the refunded amount is reflected back on the invoice. There's no separate refund step inside Breeze.
+
+## Permissions
+
+Connecting and disconnecting Stripe requires billing management permission plus multi-factor authentication. Creating payment links on an invoice uses the same permission as issuing and sending invoices.
+
+## Related
+
+- [Invoices](/features/invoices/) -- send payment links from issued invoices
+- [Customer Portal](/features/portal/) -- where customers view and pay online
+- [Recurring Contracts](/features/contracts/) -- auto-generated invoices can be paid online too

--- a/apps/docs/src/content/docs/features/portal.mdx
+++ b/apps/docs/src/content/docs/features/portal.mdx
@@ -137,6 +137,27 @@ Tickets support linking to external ticketing systems through the `externalTicke
 
 ---
 
+## Invoices & Payments
+
+Portal users can view their organization's issued invoices, download the PDF, and -- when you've connected Stripe -- pay any invoice with an outstanding balance by card online.
+
+### Paying an Invoice
+
+<Steps>
+1. Log in to the customer portal and open **Invoices**.
+2. Select an invoice to see its line items, total, and balance due.
+3. Click **Pay now** to open a secure Stripe Checkout page and pay by card.
+4. Once payment succeeds, the invoice's balance and status update automatically.
+</Steps>
+
+Only issued invoices appear in the portal -- drafts are never shown. The **Pay now** button appears only on invoices with a balance due, and only when the partner has connected Stripe. Payments collected here settle directly into the MSP's own Stripe account; see [Online Payments](/features/online-payments/) for how to connect Stripe and send payment links.
+
+<Aside>
+  Invoice line items shown in the portal are limited to customer-visible lines -- internal cost and margin information is never exposed to portal users.
+</Aside>
+
+---
+
 ## Asset Checkout
 
 The asset checkout system lets portal users borrow shared devices from their organization's inventory and return them when finished.
@@ -235,6 +256,15 @@ All portal endpoints are mounted under `/api/v1/portal`. Public routes (branding
 | `POST` | `/tickets` | Yes | Create a new support ticket |
 | `GET` | `/tickets/:id` | Yes | Get ticket details with public comments |
 | `POST` | `/tickets/:id/comments` | Yes | Add a comment to a ticket |
+
+### Invoices
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/invoices` | Yes | List the organization's issued invoices |
+| `GET` | `/invoices/:id` | Yes | Get invoice detail with customer-visible lines |
+| `GET` | `/invoices/:id/pdf` | Yes | Download the invoice PDF |
+| `POST` | `/invoices/:id/pay` | Yes | Start a Stripe Checkout session to pay the balance |
 
 ### Assets
 

--- a/apps/docs/src/content/docs/features/product-catalog.mdx
+++ b/apps/docs/src/content/docs/features/product-catalog.mdx
@@ -1,0 +1,84 @@
+---
+title: Product Catalog
+description: A reusable catalog of the products and services you sell, with per-customer pricing, bundles, and live margins -- the price list that invoices and contracts pull from.
+sidebar:
+  label: "Product Catalog"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+The Product Catalog is your single, reusable price list for everything you sell -- hardware, software licenses, and services. Building it once means invoices and recurring contracts pull from consistent pricing instead of being retyped each time, and it gives you live margin visibility on every line.
+
+The catalog is **partner-scoped**: it belongs to your MSP and is shared across all of your customers. Open it from **Settings → Product Catalog**.
+
+## Catalog Items
+
+Each item represents one thing you sell. Items can be billed **one-time** (a piece of hardware, a project) or **recurring** (a monthly service), and are typed as **hardware**, **software**, or **service**.
+
+<Steps>
+1. Go to **Settings → Product Catalog**.
+2. Click **Add item**.
+3. Enter a name, choose the item type, and set whether it's one-time or recurring.
+4. Set the price -- enter a **unit price** directly, or enter your **cost** and a **markup %** and let Breeze calculate the sell price.
+5. Optionally add a **SKU**, a **unit of measure** (each, seat, device, month…), and mark the item **taxable**.
+6. Save.
+</Steps>
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| Name | What the item is called on invoices and contracts |
+| Type | Hardware, software, or service |
+| Billing | One-time or recurring |
+| SKU | Optional unique identifier for your own reference |
+| Unit price | The price you sell the item for |
+| Cost | Your internal cost, used to calculate margin |
+| Markup % | An alternative to unit price -- sell price is derived from cost |
+| Unit of measure | How the item is counted (each, seat, device, month) |
+| Taxable | Whether tax applies to the item |
+
+The list view shows each item's **margin** at a glance, with a negative margin called out in a warning color so under-priced items are easy to spot. You can search by name or SKU, filter by type, and sort by name, price, or margin.
+
+## Per-Customer Pricing
+
+You can override an item's price for a specific customer without changing the base price everyone else gets. The override applies automatically wherever that item is added to an invoice or contract for that organization.
+
+<Steps>
+1. Open an item from the catalog.
+2. In the pricing section, choose an organization and enter its custom unit price.
+3. Save. That customer now bills at the override price; all other customers keep the base price.
+</Steps>
+
+Remove an override at any time to return the customer to base pricing.
+
+## Bundles
+
+A bundle groups several catalog items together so you can sell and price them as a package. When you add a bundle to an invoice, its components are expanded automatically -- and you choose, per component, whether it appears as its own line on the customer's invoice or is rolled into the bundle.
+
+<Steps>
+1. Click **Add item** and choose to build a **bundle**.
+2. Add component items and set the quantity of each.
+3. For each component, set whether it **shows on the invoice** as a separate line.
+4. Save.
+</Steps>
+
+In the catalog list, a bundle row expands in place to show its components and the rolled-up economics -- the combined cost, price, and margin across everything in the package.
+
+## Archiving Items
+
+Items you no longer sell can be **archived** rather than deleted, so historical invoices and contracts that reference them stay intact. Switch the catalog to the **Archived** view to see them, and **Restore** an item to bring it back into active use.
+
+<Aside>
+  An item that is still attached to an active contract or a deployed deployment can't be removed outright -- Breeze returns a clear conflict message instead of an error. Archive it to retire it while preserving history.
+</Aside>
+
+## Permissions
+
+Catalog access is governed by role permissions: viewing requires catalog read access, creating and editing items and bundles requires catalog write access, and archiving requires catalog delete access. Assign these through **Settings → Users & Roles**.
+
+## Related
+
+- [Invoices](/features/invoices/) -- build invoices from catalog items and bundles
+- [Recurring Contracts](/features/contracts/) -- bill catalog items on a schedule
+- [Online Payments](/features/online-payments/) -- let customers pay invoices by card

--- a/apps/docs/src/content/docs/features/ticketing.mdx
+++ b/apps/docs/src/content/docs/features/ticketing.mdx
@@ -83,7 +83,34 @@ Tickets enter the queue from four directions:
 - **By a technician.** Click **Create ticket** on the Tickets page, pick the organization, enter a subject and description, and optionally attach a device, category, and priority.
 - **From an alert.** Open any alert and click its **Create ticket** button. The ticket is pre-filled from the alert and linked to it, so the alert shows up in the ticket's properties rail.
 - **From the customer portal.** End-users submit tickets through their [Customer Portal](/features/portal/), and those tickets land directly in the queue for triage.
+- **By email.** Customers email your inbound address and their message becomes a ticket -- see [Email-to-Ticket](#email-to-ticket) below.
 - **Through the API**, for integrations and automation.
+
+## Email-to-Ticket
+
+Breeze can turn customer emails into tickets automatically, so your help desk works entirely over email like a full PSA. Configure it under **Settings → Ticketing → Inbound email**.
+
+### Your inbound address
+
+Each partner gets an **inbound address** -- the email address customers send to. Copy it from the Inbound email card and share it with your customers (or forward your existing support mailbox to it). Mail sent to that address is converted into tickets.
+
+### How emails become tickets
+
+- **New tickets.** An email from a recognized customer creates a new ticket, with the subject as the ticket subject and the body as the first message.
+- **Threading.** Replies are matched back to their original ticket using the email's reply headers or the ticket number in the subject (for example `T-2026-0042`), so an ongoing conversation stays on one ticket. A reply to a resolved ticket reopens it.
+- **Public replies thread back.** When a technician sends a public reply, it reaches the customer over email, and their response threads back into the same ticket.
+
+### Autoresponder
+
+An optional **autoresponder** sends customers a one-time acknowledgement when their email is received, so they know the ticket was created. It's rate-limited to avoid mail loops and is toggled per partner on the Inbound email card.
+
+### Review queue
+
+Emails from **unknown senders** and any that failed to process land in a **review queue** instead of creating tickets automatically -- so unsolicited mail doesn't flood the queue. From there you can convert a message into a ticket (assigning it to the right organization) or dismiss it.
+
+<Aside>
+  An email with no usable sender address can't become a ticket. Those appear in the review queue to be dismissed or followed up out-of-band.
+</Aside>
 
 ## Categories and SLAs
 

--- a/packages/shared/src/utils/docsMapping.test.ts
+++ b/packages/shared/src/utils/docsMapping.test.ts
@@ -31,6 +31,30 @@ describe('getDocsForPath', () => {
       expect(result.label).toBe('Timesheet');
       expect(result.url).toContain('/features/ticketing/');
     });
+
+    it('/contracts maps to recurring contracts docs', () => {
+      const result = getDocsForPath('/contracts');
+      expect(result.label).toBe('Recurring Contracts');
+      expect(result.url).toContain('/features/contracts/');
+    });
+
+    it('/settings/catalog maps to product catalog docs', () => {
+      const result = getDocsForPath('/settings/catalog');
+      expect(result.label).toBe('Product Catalog');
+      expect(result.url).toContain('/features/product-catalog/');
+    });
+
+    it('/settings/billing maps to online payments docs', () => {
+      const result = getDocsForPath('/settings/billing');
+      expect(result.label).toBe('Online Payments');
+      expect(result.url).toContain('/features/online-payments/');
+    });
+
+    it('/billing/invoices maps to invoices docs, not generic billing', () => {
+      const result = getDocsForPath('/billing/invoices');
+      expect(result.label).toBe('Invoices');
+      expect(result.url).toContain('/features/invoices/');
+    });
   });
 
   describe('prefix matches', () => {

--- a/packages/shared/src/utils/docsMapping.ts
+++ b/packages/shared/src/utils/docsMapping.ts
@@ -39,6 +39,8 @@ const docsMapping: DocsEntry[] = [
   { pattern: '/settings/roles', docsPath: '/reference/users-and-roles/', label: 'Roles' },
   { pattern: '/settings/profile', docsPath: '/reference/users-and-roles/', label: 'Profile' },
   { pattern: '/settings/ticketing', docsPath: '/features/ticketing/', label: 'Ticketing' },
+  { pattern: '/settings/catalog', docsPath: '/features/product-catalog/', label: 'Product Catalog' },
+  { pattern: '/settings/billing', docsPath: '/features/online-payments/', label: 'Online Payments' },
   { pattern: '/settings', docsPath: '/reference/users-and-roles/', label: 'Settings' },
 
   // Admin / Partner
@@ -55,6 +57,9 @@ const docsMapping: DocsEntry[] = [
   { pattern: '/alerts', docsPath: '/features/alerts/', label: 'Alerts' },
   { pattern: '/tickets', docsPath: '/features/ticketing/', label: 'Ticketing' },
   { pattern: '/timesheet', docsPath: '/features/ticketing/', label: 'Timesheet' },
+  { pattern: '/billing/invoices', docsPath: '/features/invoices/', label: 'Invoices' },
+  { pattern: '/billing', docsPath: '/features/invoices/', label: 'Billing' },
+  { pattern: '/contracts', docsPath: '/features/contracts/', label: 'Recurring Contracts' },
   { pattern: '/scripts', docsPath: '/features/scripts/', label: 'Scripts' },
   { pattern: '/patches', docsPath: '/features/patch-management/', label: 'Patch Management' },
   { pattern: '/remote/tools', docsPath: '/features/system-tools/', label: 'System Tools' },

--- a/scripts/docs-review/last-reviewed.json
+++ b/scripts/docs-review/last-reviewed.json
@@ -1,5 +1,5 @@
 {
-  "lastReviewedRef": "v0.70.0",
-  "reviewedAt": "2026-06-13",
-  "notes": "Bumped after v0.69.0..v0.70.0 release docs sweep (PAM, identity console, event-log forwarding new docs; security/sso/audit/patch/passkey/edr/config-policy updates)."
+  "lastReviewedRef": "v0.81.0",
+  "reviewedAt": "2026-06-16",
+  "notes": "Bumped after v0.70.0..v0.81.0 sweep (Tier 1): new billing docs (product-catalog, invoices, contracts, online-payments) + new ai-for-office; ticketing email-to-ticket section; portal invoices/payments. Deferred Tier 2 (Breeze Authenticator/risk-tiered approvals, unified network devices in Devices list, process drill-down, warranty collection)."
 }

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -948,6 +948,124 @@
         "reference/users-and-roles.mdx",
         "security/overview.mdx"
       ]
+    },
+    {
+      "pattern": "apps/api/src/routes/catalog/**",
+      "docs": [
+        "features/product-catalog.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/catalog.ts",
+      "docs": [
+        "features/product-catalog.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/invoices/**",
+      "docs": [
+        "features/invoices.mdx",
+        "features/online-payments.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/invoices.ts",
+      "docs": [
+        "features/invoices.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/invoiceDocuments.ts",
+      "docs": [
+        "features/invoices.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/contracts/**",
+      "docs": [
+        "features/contracts.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/contracts.ts",
+      "docs": [
+        "features/contracts.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/stripePayments.ts",
+      "docs": [
+        "features/online-payments.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/portal/**",
+      "docs": [
+        "features/portal.mdx",
+        "features/online-payments.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/portal.ts",
+      "docs": [
+        "features/portal.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/clientAi/**",
+      "docs": [
+        "features/ai-for-office.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/middleware/clientAiAuth.ts",
+      "docs": [
+        "features/ai-for-office.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/clientAi.ts",
+      "docs": [
+        "features/ai-for-office.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/tickets/emailWebhook.ts",
+      "docs": [
+        "features/ticketing.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/jobs/inboundEmailWorker.ts",
+      "docs": [
+        "features/ticketing.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/inboundEmail/**",
+      "docs": [
+        "features/ticketing.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/emailInbound.ts",
+      "docs": [
+        "features/ticketing.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/components/settings/InboundEmailCard.tsx",
+      "docs": [
+        "features/ticketing.mdx"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Documentation sweep for **v0.70.0..v0.81.0** (Tier 1). The billing program (Product Catalog, Invoices, Recurring Contracts, Stripe online payments) and **AI for Office** shipped with no documentation; this fills the gap and wires up the docs plumbing.

## New feature docs
- `features/product-catalog.mdx` — catalog of products/services, per-customer pricing, bundles, margins
- `features/invoices.mdx` — create/issue/send, catalog-driven line items, record payments, void/reissue, PDF
- `features/contracts.mdx` — recurring contracts with per-device/per-seat live estimates, cadence, auto-issue
- `features/online-payments.mdx` — connect your own Stripe (no platform fee, MSP is merchant of record), pay links, reflect-only refunds
- `features/ai-for-office.mdx` — governed Office assistant for client end-users; per-partner entitlement; org policy, DLP, budgets, Entra SSO mapping

## Updates
- `features/ticketing.mdx` — new **Email-to-Ticket** section (inbound address, threading, autoresponder, review queue), verified against the `InboundEmailCard` UI
- `features/portal.mdx` — **Invoices & Payments** section + portal invoice API table

## Plumbing
- `apps/docs/astro.config.mjs` — new **Billing & Invoicing** sidebar group; `ai-for-office` added to AI & Intelligence
- `packages/shared/src/utils/docsMapping.ts` (+ tests) — help-panel routes for `/settings/catalog`, `/settings/billing`, `/billing/invoices`, `/contracts`
- `scripts/docs-review/mapping.json` — code→doc mappings for catalog, invoices, contracts, stripe, portal, clientAi, inbound email
- `scripts/docs-review/last-reviewed.json` — bump v0.70.0 → v0.81.0
- `apps/api/src/data/docsIndex.json` — rebuilt (adds the 5 new pages; purely additive)

## Verification
- `astro build` — 128 pages, clean
- shared `docsMapping` tests — 44 passed (incl. 5 new route cases)

Deferred (Tier 2, follow-up): Breeze Authenticator / risk-tiered approvals, unified network devices in the Devices list, process-level drill-down, warranty collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)