### PR TITLE
fix(billing): unambiguous in-flight state when issuing an invoice (#1418)

### DIFF
--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -142,6 +142,28 @@ describe('InvoiceEditor', () => {
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Invoice issued and sent' }));
   });
 
+  it('shows an "Issuing…" label on the Issue button while the mutation is in flight (#1418)', async () => {
+    let resolveIssue: (r: Response) => void = () => {};
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') {
+        return new Promise<Response>((res) => { resolveIssue = res; });
+      }
+      return json({ data: {} });
+    });
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+
+    // In flight: button is disabled AND relabelled so it never reads as a stuck "Issue".
+    await waitFor(() => expect(screen.getByTestId('invoice-issue')).toHaveTextContent('Issuing…'));
+    expect(screen.getByTestId('invoice-issue')).toBeDisabled();
+
+    resolveIssue(json({ data: { id: 'inv-1', status: 'sent' } }));
+    await waitFor(() => expect(screen.getByTestId('invoice-issue')).toHaveTextContent('Issue'));
+  });
+
   it('Issue & Send shows a WARNING toast (not error) when nothing was emailed (emailed:false)', async () => {
     const onChanged = vi.fn();
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -28,6 +28,10 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const currency = invoice.currencyCode;
 
   const [busy, setBusy] = useState(false);
+  // Distinct from `busy` (which any line edit sets) so the Issue buttons can show
+  // an unambiguous in-flight label. Without it the disabled-but-still-"Issue"
+  // button + still-"Draft" header during the POST reads as "done but stuck" (#1418).
+  const [issuing, setIssuing] = useState(false);
   const [notes, setNotes] = useState(invoice.notes ?? '');
   const [notesDirty, setNotesDirty] = useState(false);
 
@@ -174,6 +178,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const issue = useCallback(async (alsoSend: boolean) => {
     if (busy) return;
     setBusy(true);
+    setIssuing(true);
     try {
       // Issue first; on success optionally send.
       await runAction({
@@ -204,6 +209,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
       // Always refresh: if issue succeeded but send threw, we still need to leave
       // the draft editor so a second click doesn't re-issue and hit 409 NOT_A_DRAFT.
       refresh();
+      setIssuing(false);
       setBusy(false);
     }
   }, [busy, invoice.id, refresh]);
@@ -393,7 +399,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                 data-testid="invoice-issue"
                 className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
               >
-                Issue
+                {issuing ? 'Issuing…' : 'Issue'}
               </button>
             )}
             {can('invoices', 'send') && (
@@ -404,7 +410,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                 data-testid="invoice-issue-send"
                 className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
               >
-                Issue &amp; Send
+                {issuing ? 'Issuing…' : 'Issue & Send'}
               </button>
             )}
             {!hasVisibleLines && (

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceWorkspace from './InvoiceWorkspace';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  // usePermissions() reads grants off the store; grant the admin wildcard so the
+  // Issue controls render and the full flow is exercised.
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const line = {
+  id: 'line-1', invoiceId: 'inv-1', sourceType: 'manual', parentLineId: null, catalogItemId: null,
+  description: 'Consulting', quantity: '2.00', unitPrice: '50.00', costBasis: null, revenueAllocation: null,
+  taxable: false, customerVisible: true, lineTotal: '100.00', isUnapprovedTime: false, sortOrder: 1,
+};
+
+function invoice(over: Record<string, unknown>) {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
+      taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
+      notes: '', createdAt: '2026-06-01T00:00:00Z', ...over,
+    },
+    lines: [line],
+    stripeConnected: false,
+  };
+}
+
+describe('InvoiceWorkspace', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders a draft as the editor with a "Draft invoice" header', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1') return json({ data: invoice({}) });
+      return json({ data: {} });
+    });
+    render(<InvoiceWorkspace invoiceId="inv-1" />);
+    await waitFor(() => expect(screen.getByTestId('invoice-workspace-title')).toHaveTextContent('Draft invoice'));
+    expect(screen.getByTestId('invoice-editor')).toBeInTheDocument();
+  });
+
+  it('surfaces an error card when the invoice fails to load', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/invoices/inv-1') return json(null, false, 500);
+      return json({ data: {} });
+    });
+    render(<InvoiceWorkspace invoiceId="inv-1" />);
+    await waitFor(() => expect(screen.getByTestId('invoice-workspace-error')).toBeInTheDocument());
+  });
+
+  // #1418: issuing a draft must flip the header from "Draft invoice" to the
+  // assigned invoice number in place — no manual reload. The editor refetches
+  // via onChanged() after the mutation; this guards that wiring end-to-end.
+  it('updates the header from "Draft invoice" to the invoice number after Issue, without a reload', async () => {
+    let issued = false;
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') {
+        issued = true;
+        return json({ data: { id: 'inv-1', status: 'sent', invoiceNumber: 'INV-2026-0002' } });
+      }
+      if (input === '/invoices/inv-1/payments') return json({ data: [] });
+      if (input === '/invoices/inv-1') {
+        return json({ data: issued
+          ? invoice({ status: 'sent', invoiceNumber: 'INV-2026-0002', sentAt: '2026-06-17T00:00:00Z', issueDate: '2026-06-17', dueDate: '2026-07-17' })
+          : invoice({}) });
+      }
+      return json({ data: {} });
+    });
+
+    render(<InvoiceWorkspace invoiceId="inv-1" />);
+    await waitFor(() => expect(screen.getByTestId('invoice-workspace-title')).toHaveTextContent('Draft invoice'));
+
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+
+    await waitFor(() => expect(screen.getByTestId('invoice-workspace-title')).toHaveTextContent('INV-2026-0002'));
+    // The draft editor is gone once issued — the read-only detail takes over.
+    expect(screen.queryByTestId('invoice-editor')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Addresses #1418 — the invoice detail header appearing stale (still "Draft invoice", no number) after clicking **Issue**.

**Investigation:** The workspace already refetches the invoice on a successful issue mutation (`InvoiceEditor.issue()` → `onChanged()` → `InvoiceWorkspace.load()`), so the header *does* update once the round-trip settles. I added a workspace-level reproduction test and **could not reproduce a persistent stale header** on current `main` — the header flips `Draft invoice` → `INV-####` without a reload. The redesign (#1440) didn't touch this path; the `refresh()`-in-`finally` wiring has been present since #1383.

The reported symptom — *"clicking Issue correctly disables the fields but the header continues to read Draft invoice"* — exactly matches the **in-flight window** during the POST: the button is disabled but still labelled "Issue" and the header still reads "Draft", so it reads as "done but stuck" until the async refetch lands (a reload masks it by waiting for the GET).

## Changes

- **UX:** `Issue` / `Issue & Send` buttons now render **"Issuing…"** while the mutation is in flight, via a dedicated `issuing` state (distinct from the shared `busy` flag that line edits also set). The in-flight moment is no longer ambiguous.
- **Test (coverage gap):** new `InvoiceWorkspace.test.tsx` (the workspace had **no** test) covering draft → editor render, load-error card, and the header flipping `Draft invoice` → `INV-2026-0002` after Issue with no reload.
- **Test:** editor test asserting the `Issuing…` label appears/clears around the in-flight POST.

## Verification

- `vitest run src/components/billing/` → **41 passed**
- `tsc --noEmit` → no type errors in changed files

Leaving #1418 open for QA to re-verify the header behavior on current `main`.

Reported By: internal Playwright UI QA sweep 2026-06-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)