### PR TITLE
feat(devices): server-side software-name search for filter picker (#1459)

### DIFF
--- a/apps/api/migrations/2026-06-17-software-inventory-name-trgm.sql
+++ b/apps/api/migrations/2026-06-17-software-inventory-name-trgm.sql
@@ -1,0 +1,15 @@
+-- 2026-06-17-software-inventory-name-trgm.sql
+-- Trigram GIN index on software_inventory.name to back the device-filter
+-- "software installed / not installed" picker's server-side distinct-name
+-- search (issue #1459). The picker runs `name ILIKE '%q%'` against millions of
+-- inventory rows; without a trigram index that is a full sequential scan per
+-- keystroke. A pg_trgm GIN index makes the substring ILIKE indexable.
+--
+-- Idempotent: CREATE EXTENSION / CREATE INDEX both use IF NOT EXISTS, so
+-- re-applying is a no-op. No tenancy change here — software_inventory already
+-- has RLS enabled + forced (2026-04-11-bucket-c-phase-1-inventory-rls.sql).
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS software_inventory_name_trgm_idx
+  ON software_inventory USING gin (name gin_trgm_ops);

--- a/apps/api/src/db/schema/software.ts
+++ b/apps/api/src/db/schema/software.ts
@@ -122,4 +122,5 @@ export const softwareInventory = pgTable('software_inventory', {
   catalogIdx: index('software_inventory_catalog_id_idx').on(table.catalogId),
   nameIdx: index('software_inventory_name_idx').on(table.name),
   nameVendorIdx: index('software_inventory_name_vendor_idx').on(table.name, table.vendor),
+  nameTrgmIdx: index('software_inventory_name_trgm_idx').using('gin', sql`name gin_trgm_ops`),
 }));

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -15,6 +15,7 @@ import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthC
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { writeRouteAudit } from '../services/auditEvents';
 import { recordSoftwarePolicyAudit } from '../services/softwarePolicyService';
+import { escapeLike } from '../utils/sql';
 
 export const softwareInventoryRoutes = new Hono();
 const requireSoftwareInventoryRead = requirePermission(
@@ -57,6 +58,18 @@ const deviceDrilldownQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(200).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });
+
+const nameSearchQuerySchema = z.object({
+  q: z.string().trim().min(1).max(200),
+  limit: z.coerce.number().int().min(1).max(50).default(50),
+});
+
+// Bound the distinct-name search like the filter engine does: the picker fires
+// one query per keystroke against a table that grows to millions of rows, so a
+// transaction-local statement_timeout keeps a pathological match from pinning a
+// worker. db.transaction inside the request's RLS context becomes a SAVEPOINT
+// that inherits the tenant GUCs, so org-scoping (RLS) is preserved.
+const NAME_SEARCH_TIMEOUT_MS = 1000;
 
 // ============================================
 // Helpers
@@ -298,6 +311,34 @@ softwareInventoryRoutes.get('/', requireSoftwareInventoryRead, zValidator('query
   });
 
   return c.json({ data, pagination: { total, limit, offset } });
+});
+
+// ============================================
+// GET /names — Distinct software-name search (filter picker)
+// ============================================
+
+softwareInventoryRoutes.get('/names', requireSoftwareInventoryRead, zValidator('query', nameSearchQuerySchema), async (c) => {
+  const { q, limit } = c.req.valid('query');
+  const pattern = `%${escapeLike(q)}%`;
+
+  // No manual org filter: software_inventory has RLS enabled + forced
+  // (org_id, shape 1), and the request runs inside the auth-established
+  // withDbAccessContext, so the proxied db auto-scopes to the caller's orgs.
+  const rows = await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select set_config('statement_timeout', ${`${NAME_SEARCH_TIMEOUT_MS}ms`}, true)`
+    );
+    return tx.execute(sql`
+      SELECT DISTINCT ${softwareInventory.name} AS name
+      FROM ${softwareInventory}
+      WHERE ${softwareInventory.name} ILIKE ${pattern}
+      ORDER BY ${softwareInventory.name}
+      LIMIT ${limit}
+    `);
+  });
+
+  const names = (rows as unknown as Array<{ name: string }>).map((row) => row.name);
+  return c.json({ data: names });
 });
 
 // ============================================

--- a/apps/api/src/routes/softwareInventory_names_search.test.ts
+++ b/apps/api/src/routes/softwareInventory_names_search.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+/**
+ * Server-side distinct software-name search for the device-filter picker
+ * (issue #1459). GET /software-inventory/names?q=... runs a bounded
+ * `SELECT DISTINCT name ... WHERE name ILIKE '%q%' ORDER BY name LIMIT 50`
+ * inside the request's RLS transaction.
+ *
+ * Org isolation is enforced by row-level security on `software_inventory`
+ * (shape 1, direct org_id — see rls-coverage.integration.test.ts), not by an
+ * app-layer org filter, so the route deliberately adds no org predicate. These
+ * unit tests mock the DB away; they assert the route's own contract: distinct
+ * matching names, the 50-row cap, LIKE-wildcard escaping, and that the query
+ * runs under a transaction-local statement_timeout.
+ */
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    transaction: vi.fn(),
+    execute: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  configPolicyAssignments: {},
+  configPolicyFeatureLinks: {},
+  configurationPolicies: {},
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  softwareInventory: {
+    name: 'softwareInventory.name',
+  },
+  softwarePolicies: {},
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      partnerId: null,
+      orgId: '11111111-1111-1111-1111-111111111111',
+      accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+      canAccessOrg: (id: string) => id === '11111111-1111-1111-1111-111111111111',
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    DEVICES_WRITE: { resource: 'devices', action: 'write' },
+  },
+}));
+
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit: vi.fn() }));
+
+import { softwareInventoryRoutes } from './softwareInventory';
+import { db } from '../db';
+
+function dumpSql(value: unknown, seen = new WeakSet<object>()): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'function') return '';
+  if (typeof value !== 'object') return String(value);
+  if (seen.has(value)) return '';
+  seen.add(value);
+  const parts: string[] = [value.constructor?.name ?? 'Object'];
+  for (const key of Reflect.ownKeys(value)) {
+    const prop = (value as Record<PropertyKey, unknown>)[key];
+    parts.push(String(key), dumpSql(prop, seen));
+  }
+  return parts.join(' ');
+}
+
+describe('GET /software-inventory/names', () => {
+  let app: Hono;
+  // Captures the SQL passed to tx.execute inside the bounded transaction.
+  let executedSql: unknown[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executedSql = [];
+    app = new Hono();
+    app.route('/software-inventory', softwareInventoryRoutes);
+  });
+
+  // Wire db.transaction(cb) -> cb(tx); the first tx.execute is the
+  // set_config('statement_timeout', …) call, the second is the DISTINCT query
+  // whose resolved value `rows` becomes the response.
+  function mockTransaction(rows: Array<{ name: string }>) {
+    vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
+      const tx = {
+        execute: vi.fn((sql: unknown) => {
+          executedSql.push(sql);
+          // First execute = set_config (return value unused); second = query rows.
+          return Promise.resolve(executedSql.length === 1 ? [] : rows);
+        }),
+      };
+      return cb(tx);
+    });
+  }
+
+  it('returns matching distinct names as a string array', async () => {
+    mockTransaction([{ name: 'Google Chrome' }, { name: 'Google Drive' }]);
+
+    const res = await app.request('/software-inventory/names?q=google', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: ['Google Chrome', 'Google Drive'] });
+  });
+
+  it('runs the query under a transaction-local statement_timeout', async () => {
+    mockTransaction([{ name: 'Firefox' }]);
+
+    await app.request('/software-inventory/names?q=fire', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(executedSql).toHaveLength(2);
+    expect(dumpSql(executedSql[0])).toContain('statement_timeout');
+    const querySql = dumpSql(executedSql[1]);
+    expect(querySql).toContain('DISTINCT');
+    expect(querySql).toContain('ILIKE');
+  });
+
+  it('escapes LIKE wildcards in the search term', async () => {
+    mockTransaction([]);
+
+    await app.request(`/software-inventory/names?q=${encodeURIComponent('50%_off')}`, {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    // escapeLike turns %/_ into \% / \_ so they match literally, not as wildcards.
+    const querySql = dumpSql(executedSql[1]);
+    expect(querySql).toContain('%50\\%\\_off%');
+  });
+
+  it('caps the LIMIT at 50 even when a larger limit is requested', async () => {
+    mockTransaction([]);
+
+    const res = await app.request('/software-inventory/names?q=a&limit=500', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    // zod clamps via max(50); an over-cap value fails validation → 400, so the
+    // picker never asks the DB for more than the cap.
+    expect(res.status).toBe(400);
+  });
+
+  it('defaults the LIMIT to 50 when none is supplied', async () => {
+    mockTransaction([]);
+
+    await app.request('/software-inventory/names?q=a', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(dumpSql(executedSql[1])).toContain('50');
+  });
+
+  it('rejects an empty query', async () => {
+    mockTransaction([]);
+
+    const res = await app.request('/software-inventory/names?q=', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -94,6 +94,43 @@ export default function DevicesPage() {
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [autoSelectGroupId, setAutoSelectGroupId] = useState<string | null>(null);
 
+  // #1459 — distinct software names for the filter picker, fetched server-side
+  // (debounced) as the user types so the picker searches the real inventory
+  // instead of falling back to free-text. Passing a defined array also flips
+  // SoftwareMultiSelect out of its `noBackend` CSV fallback.
+  const [softwareOptions, setSoftwareOptions] = useState<string[]>([]);
+  const softwareSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const softwareSearchAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => {
+    if (softwareSearchTimerRef.current) clearTimeout(softwareSearchTimerRef.current);
+    softwareSearchAbortRef.current?.abort();
+  }, []);
+  const handleSoftwareSearch = useCallback((q: string) => {
+    if (softwareSearchTimerRef.current) clearTimeout(softwareSearchTimerRef.current);
+    const term = q.trim();
+    if (!term) {
+      setSoftwareOptions([]);
+      return;
+    }
+    softwareSearchTimerRef.current = setTimeout(async () => {
+      softwareSearchAbortRef.current?.abort();
+      const ctrl = new AbortController();
+      softwareSearchAbortRef.current = ctrl;
+      try {
+        const res = await fetchWithAuth(
+          `/software-inventory/names?q=${encodeURIComponent(term)}`,
+          { signal: ctrl.signal }
+        );
+        if (!res.ok) return;
+        const body = await res.json();
+        setSoftwareOptions(Array.isArray(body.data) ? body.data : []);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        console.warn('Failed to fetch software names:', err);
+      }
+    }, 250);
+  }, []);
+
   // Track every in-flight wake watcher so navigating away aborts the
   // long-running poll loop. Without this, each wake fired on this page
   // keeps polling /devices/:id for up to 4 minutes after unmount and
@@ -851,6 +888,8 @@ export default function DevicesPage() {
             onChange={setAdvancedFilter}
             orgs={orgs}
             sites={sites}
+            softwareOptions={softwareOptions}
+            onSoftwareSearch={handleSoftwareSearch}
           />
           <QuickAddChips value={advancedFilter} onChange={setAdvancedFilter} />
         </div>

--- a/apps/web/src/components/devices/FilterChipBar.test.tsx
+++ b/apps/web/src/components/devices/FilterChipBar.test.tsx
@@ -165,6 +165,27 @@ describe('FilterChipBar', () => {
     expect(lastCall.operator).toBe('hasAll');
   });
 
+  // #1459 — typing in the software picker calls onSoftwareSearch so the parent
+  // can debounce-fetch matching names from the server-side endpoint.
+  it('software picker calls onSoftwareSearch as the user types', () => {
+    const onSoftwareSearch = vi.fn();
+    render(
+      <FilterValueEditor
+        field={getFieldDef('software.installed')!}
+        condition={{ field: 'software.installed', operator: 'hasAny', value: [] }}
+        onChange={vi.fn()}
+        softwareOptions={[]}
+        onSoftwareSearch={onSoftwareSearch}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('filter-software-search'), {
+      target: { value: 'chrome' }
+    });
+
+    expect(onSoftwareSearch).toHaveBeenCalledWith('chrome');
+  });
+
   // ---- Spec 4.4 — Quick-add chip adds correct condition ----
   it('quick-add chip toggles the canonical condition (add, mark active, remove)', () => {
     const onChange = vi.fn();

--- a/apps/web/src/components/devices/FilterChipBar.tsx
+++ b/apps/web/src/components/devices/FilterChipBar.tsx
@@ -33,6 +33,9 @@ export interface FilterChipBarProps {
   // undefined the editor falls back to comma-separated text input.
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
+  // #1459 — debounced by the parent; fired as the user types in the software
+  // picker so the parent can refetch matching names from the server.
+  onSoftwareSearch?: (q: string) => void;
   // Spec 4.12 — `Ctrl+S` invokes save. Parent owns saved-filter state, so
   // this callback is fired with the current group (parent prompts for name).
   onSaveRequested?: (group: FilterConditionGroup) => void;
@@ -51,7 +54,7 @@ function defaultConditionForField(field: FilterFieldDefinition): FilterCondition
 }
 
 export function FilterChipBar({
-  value, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSaveRequested
+  value, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, onSaveRequested
 }: FilterChipBarProps) {
   const group = value ?? EMPTY_GROUP;
   const chips: FilterCondition[] = group.conditions.filter(
@@ -213,6 +216,7 @@ export function FilterChipBar({
               sites={sites}
               softwareOptions={softwareOptions}
               softwareOptionCounts={softwareOptionCounts}
+              onSoftwareSearch={onSoftwareSearch}
               btnRef={el => { chipBtnRefs.current[i] = el; }}
               onKeyDown={(e) => onChipKeyDown(e, i)}
               focused={focusedChipIdx === i}
@@ -238,6 +242,7 @@ export function FilterChipBar({
           sites={sites}
           softwareOptions={softwareOptions}
           softwareOptionCounts={softwareOptionCounts}
+          onSoftwareSearch={onSoftwareSearch}
           onSaveRequested={onSaveRequested}
         />
       )}
@@ -255,12 +260,13 @@ interface ChipProps {
   sites?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
+  onSoftwareSearch?: (q: string) => void;
   btnRef?: (el: HTMLButtonElement | null) => void;
   onKeyDown?: (e: React.KeyboardEvent) => void;
   focused?: boolean;
 }
 
-function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, btnRef, onKeyDown, focused }: ChipProps) {
+function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, btnRef, onKeyDown, focused }: ChipProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const field = getFieldDef(condition.field)
@@ -319,6 +325,7 @@ function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptions, sof
             sites={sites}
             softwareOptions={softwareOptions}
             softwareOptionCounts={softwareOptionCounts}
+            onSoftwareSearch={onSoftwareSearch}
           />
           <div className="mt-3 flex items-center justify-between gap-2">
             <FilterPreviewFooter group={previewGroup} />

--- a/apps/web/src/components/devices/FilterSentenceBuilder.tsx
+++ b/apps/web/src/components/devices/FilterSentenceBuilder.tsx
@@ -29,6 +29,8 @@ export interface FilterSentenceBuilderProps {
   sites?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
+  // #1459 — debounced server-side software-name search, threaded to the picker.
+  onSoftwareSearch?: (q: string) => void;
   // When set, Save button is rendered. Parent owns the save dialog flow.
   onSaveRequested?: (group: FilterConditionGroup) => void;
 }
@@ -58,7 +60,7 @@ export function isChipRenderable(group: FilterConditionGroup | null): boolean {
 const EMPTY_GROUP: FilterConditionGroup = { operator: 'AND', conditions: [] };
 
 export function FilterSentenceBuilder({
-  value, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSaveRequested
+  value, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, onSaveRequested
 }: FilterSentenceBuilderProps) {
   const hasConditions = value.conditions.length > 0;
   return (
@@ -73,6 +75,7 @@ export function FilterSentenceBuilder({
         sites={sites}
         softwareOptions={softwareOptions}
         softwareOptionCounts={softwareOptionCounts}
+        onSoftwareSearch={onSoftwareSearch}
         depth={0}
       />
       <div className="mt-3 flex items-center justify-between gap-2 border-t pt-2">
@@ -119,9 +122,10 @@ interface GroupEditorProps {
   sites?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
+  onSoftwareSearch?: (q: string) => void;
   depth: number;
 }
-function GroupEditor({ group, onChange, orgs, sites, softwareOptions, softwareOptionCounts, depth }: GroupEditorProps) {
+function GroupEditor({ group, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, depth }: GroupEditorProps) {
   const toggleOp = () => onChange({ ...group, operator: group.operator === 'AND' ? 'OR' : 'AND' });
   const addCondition = () => {
     const def = V2_FILTER_FIELDS[0]; // pick a stable default; user changes it via dropdown
@@ -174,6 +178,7 @@ function GroupEditor({ group, onChange, orgs, sites, softwareOptions, softwareOp
                   sites={sites}
                   softwareOptions={softwareOptions}
                   softwareOptionCounts={softwareOptionCounts}
+                  onSoftwareSearch={onSoftwareSearch}
                   depth={depth + 1}
                 />
                 <button
@@ -198,6 +203,7 @@ function GroupEditor({ group, onChange, orgs, sites, softwareOptions, softwareOp
               sites={sites}
               softwareOptions={softwareOptions}
               softwareOptionCounts={softwareOptionCounts}
+              onSoftwareSearch={onSoftwareSearch}
               rowId={`${depth}-${i}`}
             />
           );
@@ -233,9 +239,10 @@ interface ConditionRowProps {
   sites?: NamedRef[];
   softwareOptions?: string[];
   softwareOptionCounts?: Record<string, number>;
+  onSoftwareSearch?: (q: string) => void;
   rowId: string;
 }
-function ConditionRow({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, rowId }: ConditionRowProps) {
+function ConditionRow({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, rowId }: ConditionRowProps) {
   const field = getFieldDef(condition.field) ?? V2_FILTER_FIELDS[0];
   const setField = (key: string) => {
     const def = getFieldDef(key);
@@ -268,6 +275,7 @@ function ConditionRow({ condition, onChange, onRemove, orgs, sites, softwareOpti
           sites={sites}
           softwareOptions={softwareOptions}
           softwareOptionCounts={softwareOptionCounts}
+          onSoftwareSearch={onSoftwareSearch}
         />
       </div>
       <button

--- a/apps/web/src/components/devices/FilterValueEditor.tsx
+++ b/apps/web/src/components/devices/FilterValueEditor.tsx
@@ -41,6 +41,10 @@ export interface FilterValueEditorProps {
   softwareOptions?: string[];
   // Optional per-name device counts to surface in the picker list.
   softwareOptionCounts?: Record<string, number>;
+  // #1459 — called (debounced by the parent) as the user types in the
+  // software picker, so the parent can refetch matching names from the
+  // server-side distinct-name endpoint.
+  onSoftwareSearch?: (q: string) => void;
 }
 
 function defaultValueForOp(field: FilterFieldDefinition, op: FilterOperator): FilterValue {
@@ -60,7 +64,7 @@ function isOrgField(key: string): boolean { return key === 'orgId'; }
 function isSiteField(key: string): boolean { return key === 'siteId'; }
 
 export function FilterValueEditor({
-  field, condition, onChange, orgs, sites, softwareOptions, softwareOptionCounts
+  field, condition, onChange, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch
 }: FilterValueEditorProps) {
   const op = condition.operator;
 
@@ -116,6 +120,7 @@ export function FilterValueEditor({
         onChange={onChange}
         options={softwareOptions}
         optionCounts={softwareOptionCounts}
+        onSearch={onSoftwareSearch}
       />
     );
   }
@@ -236,8 +241,9 @@ interface SoftwareMultiSelectProps {
   onChange: (c: FilterCondition) => void;
   options?: string[];
   optionCounts?: Record<string, number>;
+  onSearch?: (q: string) => void;
 }
-function SoftwareMultiSelect({ field, condition, onChange, options, optionCounts }: SoftwareMultiSelectProps) {
+function SoftwareMultiSelect({ field, condition, onChange, options, optionCounts, onSearch }: SoftwareMultiSelectProps) {
   const [q, setQ] = useState('');
   const selected: string[] = Array.isArray(condition.value)
     ? (condition.value as string[])
@@ -316,7 +322,7 @@ function SoftwareMultiSelect({ field, condition, onChange, options, optionCounts
             <input
               type="text"
               value={q}
-              onChange={e => setQ(e.target.value)}
+              onChange={e => { setQ(e.target.value); onSearch?.(e.target.value); }}
               placeholder="Search software…"
               data-testid="filter-software-search"
               className="flex-1 bg-transparent text-xs outline-none"


### PR DESCRIPTION
Closes #1459.

Per your greenlight on the issue — focused, single-commit, against current `main`. #981 stays closed as the stale fork bundle.

## What

Server-side distinct software-name search to back the "software installed / not installed" filter picker, so it works at fleet scale instead of relying on the free-text fallback.

1. **Endpoint** — `GET /api/v1/software-inventory/names?q=<term>&limit=<1..50, default 50>` → `{ data: string[] }`. `SELECT DISTINCT name … WHERE name ILIKE '%q%' ORDER BY name LIMIT 50`, `q` escaped via `escapeLike`, run in a `db.transaction` that sets a 1s transaction-local `statement_timeout` (same bounded-query pattern as `filterEngine.ts`). **No app-layer org filter** — `software_inventory` is RLS enabled+forced (shape 1, direct `org_id`; `2026-04-11-bucket-c-phase-1-inventory-rls.sql`) and the handler runs inside the auth `withDbAccessContext`, so the nested transaction inherits the tenant GUCs as a SAVEPOINT and auto-scopes.
2. **Trigram index** — `2026-06-17-software-inventory-name-trgm.sql`: `CREATE EXTENSION IF NOT EXISTS pg_trgm` + `CREATE INDEX IF NOT EXISTS software_inventory_name_trgm_idx ON software_inventory USING gin (name gin_trgm_ops)`. Exact index name as you specified — so it's a clean no-op on the bdunn-vps02 leftover. Mirrored in `software.ts` for drift.
3. **Wire `DevicesPage`** — a 250ms debounced, abortable fetch to the endpoint feeds the existing `softwareOptions` prop (threaded via a new optional `onSoftwareSearch` callback through FilterChipBar → FilterValueEditor → SoftwareMultiSelect). Passing a defined (empty) `softwareOptions` flips the picker out of its `noBackend` free-text fallback into the real multi-select.

## Verification (local, OrbStack)
- `apps/api` `tsc --noEmit`: 0 errors. `apps/web` `tsc --noEmit`: 0 errors.
- New `softwareInventory_names_search.test.ts`: 6 pass (distinct names, ≤50 cap, LIKE-escaping, statement_timeout set, empty-`q` reject). Touched web tests (FilterChipBar, DevicesPage): 22 pass. `autoMigrate.test.ts` ordering: green.

## Judgment calls for your review
- **Limit > 50 → `400` (zod `.max(50)`), not silent clamp.** Frontend never exceeds the cap; test asserts the real `400`. One-line `.transform` if you'd prefer clamp.
- **RLS test:** the existing software-route unit tests mock the DB, so a true cross-org assertion isn't possible there — org isolation is covered by `rls-coverage.integration.test.ts` (software_inventory is in the allowlist). The unit test asserts what the handler controls and doesn't fabricate an RLS check the mock can't enforce.
- **Migration date `2026-06-17`** sorts before some existing `2026-06-20` files; purely additive + dependency-free so ordering is harmless (autoMigrate test green). Happy to rename to a later date if you want strict chronology.
- **Endpoint path `/names`** under the existing `/software-inventory` mount (no collision with `/` or `/:name/devices`).
