### PR TITLE
fix(devices): stop Role and Type columns duplicating on agent rows (#1386)

### DIFF
--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -227,19 +227,21 @@ const sortValue: Record<ColumnId, (d: Device) => string | number | null> = {
   // Unified-list columns (#1322): sort by the same value the cell renders so
   // header sort stays consistent with every other column (#1284 invariant).
   class: d => ((d.deviceClass ?? 'agent') === 'network' ? 'Network' : 'Agent'),
+  // Type renders only for network rows now (#1386); agent rows show a dash, so
+  // they sort as blanks-last (null) to match the cell — the #1284 invariant.
   type: d =>
-    getDeviceRoleLabel(
-      (d.deviceClass ?? 'agent') === 'network'
-        ? (d.assetType ?? 'unknown')
-        : (d.deviceRole ?? 'unknown'),
-    ),
+    (d.deviceClass ?? 'agent') === 'network'
+      ? getDeviceRoleLabel(d.assetType ?? 'unknown')
+      : null,
   organization: d => d.orgName || null,
   site: d => d.siteName || null,
   os: d => osLabels[d.os],
   osVersion: d => formatDeviceOsVersion(d.os, d.osVersion) || null,
   osBuild: d => d.osBuild || null,
   architecture: d => d.architecture || null,
-  role: d => getDeviceRoleLabel(d.deviceRole ?? 'unknown'),
+  // Role renders only for agent rows now (#1386); network rows show a dash and
+  // sort blanks-last (null) to match the cell — the #1284 invariant.
+  role: d => ((d.deviceClass ?? 'agent') === 'network' ? null : getDeviceRoleLabel(d.deviceRole ?? 'unknown')),
   isHeadless: d => (typeof d.isHeadless === 'boolean' ? (d.isHeadless ? 1 : 0) : null),
   status: d => statusSortRank[d.status],
   // false/absent renders as a dash (see the cell), so it maps to null like
@@ -639,14 +641,19 @@ export default function DeviceList({
     type: {
       header: () => sortHeader('type', 'Type', 'Sort by type'),
       cell: (device) => {
-        // Network rows carry assetType; agent rows fall back to deviceRole.
-        const typeValue = (device.deviceClass ?? 'agent') === 'network'
-          ? (device.assetType ?? 'unknown')
-          : (device.deviceRole ?? 'unknown');
+        // Type is the asset_type of a *network-discovered* device (printer,
+        // switch, NAS…). For agent rows the equivalent question — what kind of
+        // endpoint is this — is answered by the Role column, so Type renders a
+        // dash rather than echoing deviceRole and duplicating Role side by
+        // side (#1386). Role and Type are complementary axes, one per class.
+        if ((device.deviceClass ?? 'agent') !== 'network') {
+          return <td key="type" className="px-3 py-3 text-sm whitespace-nowrap">{dash}</td>;
+        }
+        const typeValue = device.assetType ?? 'unknown';
         const TypeIcon = getDeviceRoleIcon(typeValue);
         const typeLabel = getDeviceRoleLabel(typeValue);
         return (
-          <td key="type" className="px-3 py-3 text-sm whitespace-nowrap">
+          <td key="type" className="px-3 py-3 text-sm whitespace-nowrap" data-testid={`device-${device.id}-type`}>
             <span className="inline-flex items-center gap-1.5 text-muted-foreground" title={typeLabel}>
               <TypeIcon className="h-3.5 w-3.5" />
               <span className="truncate">{typeLabel}</span>
@@ -706,18 +713,24 @@ export default function DeviceList({
     role: {
       header: () => sortHeader('role', 'Role', 'Sort by role'),
       cell: (device) => {
+        // Role is the function of an *agent-managed* endpoint and drives
+        // config-policy targeting; it's meaningless for a network-discovered
+        // asset (a printer has no agent role), so network rows render a dash —
+        // the inverse of the Type column above (#1386, #1322 dash convention).
         const role = device.deviceRole ?? 'unknown';
         const RoleIcon = getDeviceRoleIcon(role);
         const roleLabel = getDeviceRoleLabel(role);
         return (
-          <td key="role" className="px-3 py-3 text-sm">
-            <span
-              className="inline-flex items-center justify-center rounded-full border bg-muted/50 p-1.5"
-              title={roleLabel}
-              aria-label={roleLabel}
-            >
-              <RoleIcon className="h-3.5 w-3.5" />
-            </span>
+          <td key="role" className="px-3 py-3 text-sm" data-testid={`device-${device.id}-role`}>
+            {agentCell(device, (
+              <span
+                className="inline-flex items-center justify-center rounded-full border bg-muted/50 p-1.5"
+                title={roleLabel}
+                aria-label={roleLabel}
+              >
+                <RoleIcon className="h-3.5 w-3.5" />
+              </span>
+            ))}
           </td>
         );
       },

--- a/apps/web/src/components/devices/DeviceList.unified.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.unified.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import DeviceList, { type Device } from './DeviceList';
+import { DEFAULT_VISIBLE_COLUMNS, writeColumnVisibility } from './columnVisibility';
 
 // Unified Devices list (#1322): network-discovered devices render alongside
 // agent endpoints with a class badge, a type badge, an All/Agent/Network
@@ -109,5 +110,45 @@ describe('DeviceList — unified agent + network (#1322)', () => {
     // CPU/RAM are rendered as an em-dash placeholder (—) not a 0% bar; the
     // agent-only cells must not render a progressbar-style metric element.
     expect(within(row).queryByText('0%')).toBeNull();
+  });
+
+  // #1386: Role (agent function) and Type (network asset_type) used to collapse
+  // to the same deviceRole value+icon on agent rows, reading as a duplicate
+  // column. They're now complementary — each populated for exactly one class,
+  // a dash for the other — so they never show the same value side by side.
+  describe('Role and Type are complementary, never duplicated (#1386)', () => {
+    const agentWorkstation: Device = { ...agent, deviceRole: 'workstation' };
+
+    beforeEach(() => {
+      // Type is opt-in now (default-off); enable it so this view exercises both
+      // columns. writeColumnVisibility persists to localStorage, which the list
+      // reads at mount.
+      writeColumnVisibility([...DEFAULT_VISIBLE_COLUMNS, 'type']);
+    });
+    afterEach(() => window.localStorage.clear());
+
+    it('agent row: Role shows the function, Type is a dash (not an echo of Role)', () => {
+      render(<DeviceList devices={[agentWorkstation]} pageSize={50} networkDevicesEnabled />);
+
+      // Role is populated for the agent.
+      const roleCell = screen.getByTestId(`device-${agentWorkstation.id}-role`);
+      expect(within(roleCell).getByLabelText('Workstation')).toBeTruthy();
+
+      // Type renders nothing meaningful for an agent — it has no populated
+      // (testid-bearing) cell, just a dash — so it can't duplicate Role.
+      expect(screen.queryByTestId(`device-${agentWorkstation.id}-type`)).toBeNull();
+    });
+
+    it('network row: Type shows the asset type, Role is a dash', () => {
+      render(<DeviceList devices={[networkPrinter]} pageSize={50} networkDevicesEnabled />);
+
+      const typeCell = screen.getByTestId(`device-${networkPrinter.id}-type`);
+      expect(typeCell.textContent).toMatch(/printer/i);
+
+      // Role is meaningless for a printer — rendered as a dash, no role badge.
+      const roleCell = screen.getByTestId(`device-${networkPrinter.id}-role`);
+      expect(roleCell.textContent).toMatch(/—/);
+      expect(within(roleCell).queryByLabelText(/workstation|server|printer/i)).toBeNull();
+    });
   });
 });

--- a/apps/web/src/components/devices/columnVisibility.ts
+++ b/apps/web/src/components/devices/columnVisibility.ts
@@ -69,7 +69,11 @@ export const COLUMN_LABELS: Record<ColumnId, string> = {
 export const DEFAULT_VISIBLE_COLUMNS: ReadonlyArray<ColumnId> = [
   'hostname',
   'class',
-  'type',
+  // 'type' is opt-in (#1386): it carries the asset_type of network-discovered
+  // devices and renders a dash for agent rows, so default-on it would show a
+  // column of dashes for the common agent-only fleet. The Class column already
+  // distinguishes Agent/Network; enable Type from the column picker when you
+  // have network inventory to inspect.
   'organization',
   'site',
   'os',


### PR DESCRIPTION
## Summary

Fixes #1386. On the unified Devices list, the **Type** column fell back to `deviceRole` for agent rows — the same value and icon the **Role** column already shows — so agent-only fleets saw two identical columns side by side (a community member, Ramphex on Discord, asked whether Role was being retired for Type; it isn't).

This makes Role and Type **complementary axes, one per device class**, so they can never show the same value:

| | Role | Type |
|---|---|---|
| **Agent** row | function (workstation/server…) | — |
| **Network** row | — | asset type (printer/switch/NAS…) |

## Changes (`apps/web/src/components/devices/`)

- **`DeviceList.tsx`** — Type cell renders the network `assetType` for network rows and a dash for agents (no longer echoes `deviceRole`); Role cell renders the agent function for agent rows and a dash for network rows via the existing #1322 `agentCell` dash convention. `sortValue` for both follows the cell (the #1284 invariant) — the dashed class sorts blanks-last (`null`). Added `data-testid`s to both populated cells.
- **`columnVisibility.ts`** — removed `type` from `DEFAULT_VISIBLE_COLUMNS`. It's a `NETWORK_ONLY_COLUMN` carrying network asset types; default-on it would render a column of dashes for the common agent-only fleet. The `Class` column already distinguishes Agent/Network; enable Type from the column picker when you have network inventory. **Role stays default-on** and keeps driving config-policy targeting.
- **`DeviceList.unified.test.tsx`** — new tests asserting the two columns are populated for exactly one class each and never duplicate.

This implements the issue's recommended (b)+(c) combination. I went with a render-time dash + opt-in default rather than data-driven auto-enable, because column visibility is persisted per-user (merge-on-read) and a data-driven toggle would fight stored user choice.

## Verification

- `vitest run src/components/devices/` → **172 passed**
- `tsc --noEmit` → no type errors in changed files

Leaving #1386 open for verification.

Reported by Ramphex (Discord).

🤖 Generated with [Claude Code](https://claude.com/claude-code)