### PR TITLE
fix(ui): make collapsed AI + Documentation side panels inert (#1419)

### DIFF
--- a/apps/web/src/components/ai/AiChatSidebar.test.tsx
+++ b/apps/web/src/components/ai/AiChatSidebar.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AiChatSidebar from './AiChatSidebar';
+import { useAiStore } from '@/stores/aiStore';
+
+vi.mock('@/stores/aiStore', () => ({ useAiStore: vi.fn() }));
+// Children pull in streaming/fetch concerns irrelevant to the shell test.
+vi.mock('./AiChatMessages', () => ({ default: () => null }));
+vi.mock('./AiChatInput', () => ({ default: () => null }));
+vi.mock('./AiContextBadge', () => ({ default: () => null }));
+vi.mock('./AiCostIndicator', () => ({ default: () => null }));
+
+const noop = vi.fn();
+const baseState = {
+  toggle: noop, close: noop, messages: [], isStreaming: false, isLoading: false,
+  error: null, pageContext: null, pendingApproval: null, pendingPlan: null,
+  activePlan: null, approvalMode: 'manual', isPaused: false, sessionId: null,
+  showHistory: false, sessions: [], searchResults: [], isSearching: false,
+  sendMessage: noop, approveExecution: noop, approvePlan: noop, abortPlan: noop,
+  pauseAi: noop, createSession: noop, closeSession: noop, clearError: noop,
+  toggleHistory: noop, loadSessions: noop, loadSession: noop,
+  searchConversations: noop, switchSession: noop, interruptResponse: noop,
+  isInterrupting: false, isFlagged: false, flagSession: noop, unflagSession: noop,
+  m365Connections: [], selectedM365ConnectionId: null, boundM365ConnectionId: null,
+  loadM365Connections: noop, setSelectedM365Connection: noop,
+};
+
+// #1419: the off-canvas shell stays mounted (transition:persist); collapsed it
+// must be inert + pointer-events-none so it can't intercept clicks on wide
+// layouts or expose an off-viewport Close control.
+describe('AiChatSidebar collapsed-shell interactivity', () => {
+  it('is inert and pointer-events-none when collapsed', () => {
+    vi.mocked(useAiStore).mockReturnValue({ ...baseState, isOpen: false });
+    render(<AiChatSidebar />);
+    const shell = screen.getByTestId('ai-chat-sidebar');
+    expect(shell).toHaveAttribute('inert');
+    expect(shell.className).toContain('pointer-events-none');
+  });
+
+  it('is interactive (no inert, no pointer-events-none) when open', () => {
+    vi.mocked(useAiStore).mockReturnValue({ ...baseState, isOpen: true });
+    render(<AiChatSidebar />);
+    const shell = screen.getByTestId('ai-chat-sidebar');
+    expect(shell).not.toHaveAttribute('inert');
+    expect(shell.className).not.toContain('pointer-events-none');
+  });
+});

--- a/apps/web/src/components/ai/AiChatSidebar.tsx
+++ b/apps/web/src/components/ai/AiChatSidebar.tsx
@@ -111,8 +111,15 @@ export default function AiChatSidebar() {
     <>
       {/* Sidebar panel */}
       <div
+        data-testid="ai-chat-sidebar"
+        // Collapsed, the panel slides off-screen via transform but stays
+        // mounted (transition:persist). `inert` + pointer-events-none make the
+        // off-canvas shell truly non-interactive so it can't intercept clicks
+        // meant for page content on wide layouts, and its (off-viewport) Close
+        // control drops out of the focus/hit-test order (#1419).
+        inert={!isOpen}
         className={`fixed right-0 top-0 z-40 flex h-full w-[400px] flex-col border-l bg-card shadow-2xl transition-transform duration-300 ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
+          isOpen ? 'translate-x-0' : 'translate-x-full pointer-events-none'
         }`}
       >
         {/* Header */}

--- a/apps/web/src/components/help/HelpPanel.test.tsx
+++ b/apps/web/src/components/help/HelpPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHelpStore } from '@/stores/helpStore';
 import HelpPanel from './HelpPanel';
@@ -52,5 +52,26 @@ describe('HelpPanel keyboard shortcut', () => {
       new KeyboardEvent('keydown', { key: 'h', metaKey: true, bubbles: true })
     );
     expect(useHelpStore.getState().isOpen).toBe(false);
+  });
+});
+
+// #1419: the off-canvas shell stays mounted (transition:persist), so when
+// collapsed it must be inert + pointer-events-none — otherwise it intercepts
+// clicks on wide layouts and exposes an off-viewport Close control.
+describe('HelpPanel collapsed-shell interactivity', () => {
+  it('is inert and pointer-events-none when collapsed', () => {
+    useHelpStore.setState({ isOpen: false });
+    render(<HelpPanel />);
+    const shell = screen.getByTestId('help-panel');
+    expect(shell).toHaveAttribute('inert');
+    expect(shell.className).toContain('pointer-events-none');
+  });
+
+  it('is interactive (no inert, no pointer-events-none) when open', () => {
+    useHelpStore.setState({ isOpen: true });
+    render(<HelpPanel />);
+    const shell = screen.getByTestId('help-panel');
+    expect(shell).not.toHaveAttribute('inert');
+    expect(shell.className).not.toContain('pointer-events-none');
   });
 });

--- a/apps/web/src/components/help/HelpPanel.tsx
+++ b/apps/web/src/components/help/HelpPanel.tsx
@@ -58,8 +58,15 @@ export default function HelpPanel() {
   return (
     <>
       <div
+        data-testid="help-panel"
+        // When collapsed the panel slides off-screen via transform but stays
+        // mounted (transition:persist). `inert` + pointer-events-none make the
+        // off-canvas shell truly non-interactive so it can't intercept clicks
+        // meant for page content on wide layouts, and its (off-viewport) Close
+        // control drops out of the focus/hit-test order (#1419).
+        inert={!isOpen}
         className={`fixed right-0 top-0 z-40 flex h-full w-[400px] flex-col border-l bg-card shadow-2xl transition-transform duration-300 ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
+          isOpen ? 'translate-x-0' : 'translate-x-full pointer-events-none'
         }`}
       >
         <div className="flex items-center justify-between border-b bg-card px-4 py-3">


### PR DESCRIPTION
## Summary

Fixes #1419. The two right-rail panels (**Breeze AI**, **Documentation**) are always mounted and slide off-screen via a CSS transform when collapsed (`transition:persist` keeps them across navigations). While off-canvas they stayed fully interactive, which caused the reported problems:

- they could **intercept clicks** meant for page content on wide layouts (hit on the Contracts editor, Organizations panel, and device-detail "More" menu during QA sweeps), and
- their now-**off-viewport Close control** stayed in the focus/hit-test order (Playwright reported it "outside of the viewport" and couldn't click it).

## Fix

Mark the off-canvas shell **`inert`** + **`pointer-events-none`** whenever the panel is collapsed. `inert` (React 19 renders it as a real boolean attribute, omitting it when open) drops the subtree out of hit-testing, the tab order, and the accessibility tree in one move — so a collapsed panel can't swallow clicks or expose an off-screen control. `pointer-events-none` is CSS defense-in-depth. Open state is unchanged.

On the issue's other suggestions:
- *"Default the panels to collapsed"* — already the case: neither store persists `isOpen` (`aiStore` only persists `sessionId`), so panels always start collapsed. No docked-open default to fix.
- The docs-iframe-on-every-page CSP spam noted in the issue was already resolved (lazy-mount on first open); left untouched.

## Changes (`apps/web/src/components/`)

- `ai/AiChatSidebar.tsx`, `help/HelpPanel.tsx` — `inert={!isOpen}` + `pointer-events-none` on the collapsed shell; added `data-testid`s.
- `ai/AiChatSidebar.test.tsx` (new), `help/HelpPanel.test.tsx` — assert collapsed → inert + pointer-events-none, open → interactive.

## Verification

- `vitest run` on both panel tests → **8 passed**
- `tsc --noEmit` → no type errors in changed files

Leaving #1419 open for QA to re-verify on a wide (1680px) layout.

Reported By: internal Playwright UI QA sweep 2026-06-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)