### PR TITLE
feat: partner-wide alert templates — API + management UI (#1425)

### DIFF
--- a/apps/api/src/__tests__/integration/alert-templates-partner-wide.integration.test.ts
+++ b/apps/api/src/__tests__/integration/alert-templates-partner-wide.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration test for #1425 — partner-wide alert templates.
+ *
+ * #1357 gave alert_templates a partner_id axis + dual-axis RLS:
+ *   SELECT  USING (breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id) OR is_built_in)
+ *   INSERT  WITH CHECK (breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id))
+ * A partner-wide template is org_id NULL + partner_id set. This proves the
+ * route's new partner-wide create path produces rows the RLS actually accepts,
+ * that they stay isolated to the owning partner, and that an org-scope caller
+ * cannot forge one — the dual-axis breeze_app checks a mocked-db unit test
+ * can't cover (the custom_field_definitions / #633 class of bug).
+ *
+ * Runs as the unprivileged breeze_app role so RLS is enforced.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext } from '../../db';
+import { alertTemplates } from '../../db/schema';
+import { createPartner, createOrganization } from './db-utils';
+import { getTestDb } from './setup';
+
+const baseValues = (name: string) => ({
+  name,
+  conditions: { metric: 'cpu', operator: '>', threshold: 90 },
+  severity: 'high' as const,
+  titleTemplate: '{{deviceName}}: ' + name,
+  messageTemplate: 'Alert: ' + name,
+  isBuiltIn: false,
+});
+
+describe('alert_templates partner-wide RLS — #1425', () => {
+  it('partner scope can INSERT and read back a partner-wide template (org_id NULL)', async () => {
+    const partner = await createPartner();
+    const name = `pw-template-${Date.now()}`;
+
+    const rows = await withDbAccessContext(
+      { scope: 'partner', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: [partner.id] },
+      async () => {
+        await db.insert(alertTemplates).values({ orgId: null, partnerId: partner.id, ...baseValues(name) });
+        return db.select().from(alertTemplates).where(eq(alertTemplates.name, name));
+      },
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.orgId).toBeNull();
+    expect(rows[0]!.partnerId).toBe(partner.id);
+  });
+
+  it('a different partner cannot see another partner’s partner-wide template', async () => {
+    const owner = await createPartner();
+    const other = await createPartner();
+    const name = `pw-isolated-${Date.now()}`;
+
+    await withDbAccessContext(
+      { scope: 'partner', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: [owner.id] },
+      async () => { await db.insert(alertTemplates).values({ orgId: null, partnerId: owner.id, ...baseValues(name) }); },
+    );
+
+    const seen = await withDbAccessContext(
+      { scope: 'partner', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: [other.id] },
+      async () => db.select().from(alertTemplates).where(eq(alertTemplates.name, name)),
+    );
+    expect(seen).toHaveLength(0);
+
+    // Superuser confirms the row really exists — the empty read above is RLS,
+    // not a failed insert.
+    const truth = await getTestDb().select().from(alertTemplates).where(eq(alertTemplates.name, name));
+    expect(truth).toHaveLength(1);
+  });
+
+  it('org scope cannot forge a partner-wide template (RLS rejects the INSERT)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const name = `pw-forge-${Date.now()}`;
+
+    let caught: unknown;
+    try {
+      await withDbAccessContext(
+        { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id] },
+        async () => {
+          await db.insert(alertTemplates).values({ orgId: null, partnerId: partner.id, ...baseValues(name) });
+        },
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    const cause = (caught as { cause?: { message?: string } } | undefined)?.cause;
+    expect(cause?.message).toMatch(/new row violates row-level security policy for table "alert_templates"/);
+
+    const truth = await getTestDb().select().from(alertTemplates).where(eq(alertTemplates.name, name));
+    expect(truth).toHaveLength(0);
+  });
+});

--- a/apps/api/src/routes/alertTemplates.test.ts
+++ b/apps/api/src/routes/alertTemplates.test.ts
@@ -125,6 +125,8 @@ vi.mock('../middleware/auth', () => ({
       scope: 'organization',
       orgId: '11111111-1111-1111-1111-111111111111',
       partnerId: null,
+      accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+      canAccessOrg: (id: string) => id === '11111111-1111-1111-1111-111111111111',
       user: { id: 'user-123', email: 'test@example.com' },
     });
     return next();
@@ -175,6 +177,8 @@ describe('alert template routes', () => {
         scope: 'organization',
         orgId: ORG_ID,
         partnerId: null,
+        accessibleOrgIds: [ORG_ID],
+        canAccessOrg: (id: string) => id === ORG_ID,
         user: { id: 'user-123', email: 'test@example.com' },
       });
       return next();

--- a/apps/api/src/routes/alertTemplates/schemas.ts
+++ b/apps/api/src/routes/alertTemplates/schemas.ts
@@ -85,6 +85,11 @@ export const createTemplateSchema = z.object({
   description: z.string().optional(),
   category: z.string().min(1).max(100).optional(),
   severity: severitySchema,
+  // Scope selector for partner-scope creators (#1425). 'partner' → a partner-
+  // wide template (org_id NULL); 'org' (default) → a specific org. The backend
+  // ignores it for org-scope users. orgId targets a specific org under 'org'.
+  availability: z.enum(['org', 'partner']).optional(),
+  orgId: z.string().uuid().optional(),
   conditions: z.record(z.any()).refine(
     (val) => JSON.stringify(val).length <= 65536,
     { message: 'Object too large (max 64KB)' }

--- a/apps/api/src/routes/alertTemplates/templates.guard.test.ts
+++ b/apps/api/src/routes/alertTemplates/templates.guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { canWriteTemplate } from './templates';
+
+// #1425: partner-wide alert templates. canWriteTemplate is the write boundary
+// for PATCH/DELETE — the DB's dual-axis RLS is the real enforcement, but this
+// returns the correct 403/404 UX and stops org-scope users editing shared rows.
+
+type Row = { orgId: string | null; partnerId: string | null; isBuiltIn: boolean };
+const orgRow: Row = { orgId: 'org-1', partnerId: 'p-1', isBuiltIn: false };
+const partnerWide: Row = { orgId: null, partnerId: 'p-1', isBuiltIn: false };
+const builtIn: Row = { orgId: null, partnerId: null, isBuiltIn: true };
+
+const orgUser = { scope: 'organization' as const, partnerId: 'p-1', canAccessOrg: (id: string) => id === 'org-1' };
+const partnerUser = { scope: 'partner' as const, partnerId: 'p-1', canAccessOrg: (id: string) => id === 'org-1' };
+const otherPartnerUser = { scope: 'partner' as const, partnerId: 'p-2', canAccessOrg: () => false };
+const systemUser = { scope: 'system' as const, partnerId: null, canAccessOrg: () => true };
+
+describe('canWriteTemplate', () => {
+  it('blocks editing built-in templates for every scope', () => {
+    for (const u of [orgUser, partnerUser, systemUser]) {
+      const r = canWriteTemplate(u, builtIn);
+      expect(r).toMatchObject({ ok: false, status: 403 });
+    }
+  });
+
+  it('lets an org user edit their own org template', () => {
+    expect(canWriteTemplate(orgUser, orgRow)).toEqual({ ok: true });
+  });
+
+  it('makes partner-wide templates read-only (403) for org-scope users', () => {
+    const r = canWriteTemplate(orgUser, partnerWide);
+    expect(r).toMatchObject({ ok: false, status: 403 });
+    if (!r.ok) expect(r.error).toMatch(/read-only/i);
+  });
+
+  it('lets the owning partner edit a partner-wide template', () => {
+    expect(canWriteTemplate(partnerUser, partnerWide)).toEqual({ ok: true });
+  });
+
+  it('hides another partner’s partner-wide template (404)', () => {
+    expect(canWriteTemplate(otherPartnerUser, partnerWide)).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it('404s an org-specific template the caller cannot access', () => {
+    const r = canWriteTemplate(partnerUser, { orgId: 'org-99', partnerId: 'p-1', isBuiltIn: false });
+    expect(r).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it('lets system scope edit any non-built-in template', () => {
+    expect(canWriteTemplate(systemUser, partnerWide)).toEqual({ ok: true });
+    expect(canWriteTemplate(systemUser, orgRow)).toEqual({ ok: true });
+  });
+});

--- a/apps/api/src/routes/alertTemplates/templates.ts
+++ b/apps/api/src/routes/alertTemplates/templates.ts
@@ -2,17 +2,65 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { db } from '../../db';
 import { alertTemplates } from '../../db/schema';
-import { eq, and, or, ilike, desc } from 'drizzle-orm';
-import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
+import { eq, and, or, ilike, desc, inArray } from 'drizzle-orm';
+import { requireMfa, requirePermission, requireScope, type AuthContext } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { listTemplatesSchema, createTemplateSchema, updateTemplateSchema } from './schemas';
-import { resolveScopedOrgId, parseBoolean } from './helpers';
+import { parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
 import { PERMISSIONS } from '../../services/permissions';
 
 export const templateRoutes = new Hono();
 
 const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
+
+// Visibility predicate mirroring the Scripts dual-axis union (#1357/#1425): a
+// caller sees built-in templates (global) ∪ their org's custom templates ∪
+// partner-wide templates owned by their partner. Partner scope spans every org
+// it can access; system scope sees everything (returns undefined → no filter).
+// RLS on alert_templates is the real boundary; this just shapes which of the
+// visible rows to return. Returns a 403 sentinel string when org scope lacks an
+// org context.
+export function templateScopeCondition(auth: AuthContext): ReturnType<typeof or> | 'no-org-context' | undefined {
+  if (auth.scope === 'system') return undefined;
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) return 'no-org-context';
+    const ors: ReturnType<typeof eq>[] = [
+      eq(alertTemplates.isBuiltIn, true),
+      eq(alertTemplates.orgId, auth.orgId),
+    ];
+    if (auth.partnerId) ors.push(eq(alertTemplates.partnerId, auth.partnerId));
+    return or(...ors);
+  }
+  // partner scope
+  const orgIds = auth.accessibleOrgIds ?? [];
+  const ors: ReturnType<typeof eq>[] = [eq(alertTemplates.isBuiltIn, true)];
+  if (orgIds.length > 0) ors.push(inArray(alertTemplates.orgId, orgIds) as ReturnType<typeof eq>);
+  if (auth.partnerId) ors.push(eq(alertTemplates.partnerId, auth.partnerId));
+  return or(...ors);
+}
+
+// Whether this caller may edit/delete an existing template row. Partner-wide
+// rows belong to the MSP and are read-only for org scope; built-in rows are
+// read-only for everyone (only seeding creates them). Caller is the AuthContext.
+export function canWriteTemplate(
+  auth: Pick<AuthContext, 'scope' | 'partnerId' | 'canAccessOrg'>,
+  row: { orgId: string | null; partnerId: string | null; isBuiltIn: boolean },
+): { ok: true } | { ok: false; status: 403 | 404; error: string } {
+  if (row.isBuiltIn) return { ok: false, status: 403, error: 'Built-in templates cannot be modified' };
+  if (auth.scope === 'system') return { ok: true };
+  // Partner-wide record (org_id NULL, partner_id set).
+  if (row.orgId === null && row.partnerId !== null) {
+    if (auth.scope === 'organization') {
+      return { ok: false, status: 403, error: 'This template is shared across your organization and is read-only here' };
+    }
+    if (row.partnerId === auth.partnerId) return { ok: true };
+    return { ok: false, status: 404, error: 'Template not found' };
+  }
+  // Org-specific record: caller must be able to access that org.
+  if (row.orgId !== null && auth.canAccessOrg(row.orgId)) return { ok: true };
+  return { ok: false, status: 404, error: 'Template not found' };
+}
 
 templateRoutes.get(
   '/templates',
@@ -21,19 +69,14 @@ templateRoutes.get(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = resolveScopedOrgId(auth);
-      if (!orgId) {
-        return c.json({ error: 'orgId is required for this scope' }, 400);
+      const query = c.req.valid('query');
+
+      const scopeCondition = templateScopeCondition(auth);
+      if (scopeCondition === 'no-org-context') {
+        return c.json({ error: 'Organization context required' }, 403);
       }
 
-      const query = c.req.valid('query');
       const conditions: ReturnType<typeof eq>[] = [];
-
-      // Built-in templates (orgId IS NULL) + org's custom templates
-      const scopeCondition = or(
-        eq(alertTemplates.isBuiltIn, true),
-        eq(alertTemplates.orgId, orgId)
-      );
 
       const builtInFlag = parseBoolean(query.builtIn);
       if (builtInFlag !== undefined) {
@@ -55,13 +98,13 @@ templateRoutes.get(
       }
 
       const allConditions = scopeCondition
-        ? [scopeCondition, ...conditions]
+        ? [scopeCondition as ReturnType<typeof eq>, ...conditions]
         : conditions;
 
       const rows = await db
         .select()
         .from(alertTemplates)
-        .where(and(...allConditions))
+        .where(allConditions.length > 0 ? and(...allConditions) : undefined)
         .orderBy(desc(alertTemplates.isBuiltIn), alertTemplates.name);
 
       const { page, limit, offset } = getPagination(query);
@@ -130,12 +173,40 @@ templateRoutes.post(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = resolveScopedOrgId(auth);
-      if (!orgId) {
-        return c.json({ error: 'orgId is required for this scope' }, 400);
-      }
-
       const data = c.req.valid('json');
+
+      // Resolve org/partner axes from scope + the requested availability,
+      // mirroring Scripts (#1357). partner_id is denormalized onto org rows for
+      // RLS consistency; a partner-wide template has org_id NULL.
+      let orgId: string | null = data.orgId ?? null;
+      let partnerId: string | null = null;
+
+      if (auth.scope === 'organization') {
+        if (!auth.orgId) return c.json({ error: 'Organization context required' }, 403);
+        orgId = auth.orgId;
+        partnerId = auth.partnerId ?? null;
+      } else if (auth.scope === 'partner') {
+        if (data.availability === 'partner') {
+          orgId = null;
+          partnerId = auth.partnerId ?? null;
+          if (!partnerId) return c.json({ error: 'Partner context required' }, 403);
+        } else {
+          if (!orgId) {
+            const single = auth.accessibleOrgIds?.[0];
+            if (auth.accessibleOrgIds?.length === 1 && single) {
+              orgId = single;
+            } else {
+              return c.json({ error: 'orgId is required when the partner has multiple organizations' }, 400);
+            }
+          }
+          if (!auth.canAccessOrg(orgId)) {
+            return c.json({ error: 'Access to this organization denied' }, 403);
+          }
+          partnerId = auth.partnerId ?? null;
+        }
+      }
+      // System scope: orgId from the request body (may be null), no partner axis.
+
       const targets = data.targets && Object.keys(data.targets).length > 0
         ? data.targets
         : { scope: 'organization' };
@@ -144,6 +215,7 @@ templateRoutes.post(
         .insert(alertTemplates)
         .values({
           orgId,
+          partnerId,
           name: data.name.trim(),
           description: data.description,
           category: data.category ?? 'Custom',
@@ -162,7 +234,7 @@ templateRoutes.post(
       }
 
       writeRouteAudit(c, {
-        orgId,
+        orgId: template.orgId ?? auth.orgId ?? null,
         action: 'alert_template.create',
         resourceType: 'alert_template',
         resourceId: template.id,
@@ -170,6 +242,7 @@ templateRoutes.post(
         details: {
           category: template.category,
           severity: template.severity,
+          availability: template.orgId === null && template.partnerId !== null ? 'partner' : 'org',
         },
       });
       return c.json({ data: template }, 201);
@@ -185,24 +258,17 @@ templateRoutes.get(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = resolveScopedOrgId(auth);
-      if (!orgId) {
-        return c.json({ error: 'orgId is required for this scope' }, 400);
+      const scopeCondition = templateScopeCondition(auth);
+      if (scopeCondition === 'no-org-context') {
+        return c.json({ error: 'Organization context required' }, 403);
       }
 
       const templateId = c.req.param('id')!;
+      const idCondition = eq(alertTemplates.id, templateId);
       const [template] = await db
         .select()
         .from(alertTemplates)
-        .where(
-          and(
-            eq(alertTemplates.id, templateId),
-            or(
-              eq(alertTemplates.isBuiltIn, true),
-              eq(alertTemplates.orgId, orgId)
-            )
-          )
-        )
+        .where(scopeCondition ? and(idCondition, scopeCondition as ReturnType<typeof eq>) : idCondition)
         .limit(1);
 
       if (!template) {
@@ -225,15 +291,9 @@ templateRoutes.patch(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = resolveScopedOrgId(auth);
-      if (!orgId) {
-        return c.json({ error: 'orgId is required for this scope' }, 400);
-      }
-
       const templateId = c.req.param('id')!;
       const updates = c.req.valid('json');
 
-      // Check if template exists and is accessible
       const [existing] = await db
         .select()
         .from(alertTemplates)
@@ -244,12 +304,9 @@ templateRoutes.patch(
         return c.json({ error: 'Template not found' }, 404);
       }
 
-      if (existing.isBuiltIn) {
-        return c.json({ error: 'Built-in templates cannot be modified' }, 403);
-      }
-
-      if (existing.orgId !== orgId) {
-        return c.json({ error: 'Template not found' }, 404);
+      const writable = canWriteTemplate(auth, existing);
+      if (!writable.ok) {
+        return c.json({ error: writable.error }, writable.status);
       }
 
       if (Object.keys(updates).length === 0) {
@@ -272,7 +329,7 @@ templateRoutes.patch(
         .returning();
 
       writeRouteAudit(c, {
-        orgId,
+        orgId: existing.orgId ?? auth.orgId ?? null,
         action: 'alert_template.update',
         resourceType: 'alert_template',
         resourceId: templateId,
@@ -294,11 +351,6 @@ templateRoutes.delete(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = resolveScopedOrgId(auth);
-      if (!orgId) {
-        return c.json({ error: 'orgId is required for this scope' }, 400);
-      }
-
       const templateId = c.req.param('id')!;
 
       const [existing] = await db
@@ -311,12 +363,9 @@ templateRoutes.delete(
         return c.json({ error: 'Template not found' }, 404);
       }
 
-      if (existing.isBuiltIn) {
-        return c.json({ error: 'Built-in templates cannot be deleted' }, 403);
-      }
-
-      if (existing.orgId !== orgId) {
-        return c.json({ error: 'Template not found' }, 404);
+      const writable = canWriteTemplate(auth, existing);
+      if (!writable.ok) {
+        return c.json({ error: writable.error }, writable.status);
       }
 
       await db
@@ -324,7 +373,7 @@ templateRoutes.delete(
         .where(eq(alertTemplates.id, templateId));
 
       writeRouteAudit(c, {
-        orgId,
+        orgId: existing.orgId ?? auth.orgId ?? null,
         action: 'alert_template.delete',
         resourceType: 'alert_template',
         resourceId: existing.id,

--- a/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AlertTemplateEditor from './AlertTemplateEditor';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('@/stores/orgStore', () => ({
+  useOrgStore: () => ({
+    partners: [{ id: 'p-1', name: 'MSP' }],
+    organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+  }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const navMock = vi.mocked(navigateTo);
+const json = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+describe('AlertTemplateEditor — create mode (#1425)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input === '/alert-templates/templates' && opts?.method === 'POST') {
+        return json({ data: { id: 'new-1', orgId: null, partnerId: 'p-1' } });
+      }
+      return json({ data: [] });
+    });
+  });
+
+  it('shows the partner-wide availability picker for a partner-scope creator', async () => {
+    render(<AlertTemplateEditor templateId="new" />);
+    await waitFor(() => expect(screen.getByTestId('template-availability')).toBeInTheDocument());
+    expect(screen.getByTestId('availability-partner')).toBeChecked();
+    // No GET for a template id — new templates don't load.
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).match(/\/alert-templates\/templates\/[^?]/))).toBe(false);
+  });
+
+  it('POSTs a partner-wide template (availability:partner) and returns to the list', async () => {
+    render(<AlertTemplateEditor templateId="new" />);
+    await waitFor(() => expect(screen.getByTestId('template-availability')).toBeInTheDocument());
+
+    // The Name field is the first text input in the metadata card.
+    const nameInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'My New Template' } });
+
+    fireEvent.click(screen.getByText('Create template'));
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => c[0] === '/alert-templates/templates' && (c[1] as RequestInit)?.method === 'POST');
+      expect(post).toBeTruthy();
+      const body = JSON.parse((post![1] as RequestInit).body as string);
+      expect(body.availability).toBe('partner');
+      expect(body.name).toBe('My New Template');
+    });
+    expect(navMock).toHaveBeenCalledWith('/settings/alert-templates');
+  });
+
+  it('switches to a specific org and sends orgId', async () => {
+    render(<AlertTemplateEditor templateId="new" />);
+    await waitFor(() => expect(screen.getByTestId('template-availability')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('availability-org'));
+    fireEvent.change(screen.getByTestId('availability-org-select'), { target: { value: 'org-2' } });
+    const nameInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'Org Scoped' } });
+    fireEvent.click(screen.getByText('Create template'));
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => c[0] === '/alert-templates/templates' && (c[1] as RequestInit)?.method === 'POST');
+      expect(post).toBeTruthy();
+      const body = JSON.parse((post![1] as RequestInit).body as string);
+      expect(body.availability).toBe('org');
+      expect(body.orgId).toBe('org-2');
+    });
+  });
+});

--- a/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
@@ -9,9 +9,14 @@ vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 // Partner scope is detected from the JWT claims, NOT from useOrgStore().partners
 // (that array is system-scope-only and is always [] for a real partner user — #1425).
-vi.mock('@/lib/authScope', () => ({
-  getJwtClaims: () => ({ scope: 'partner', partnerId: 'p-1', orgId: null }),
+// Hoisted vi.fn so each test can override scope; default is partner-scope.
+const { getJwtClaimsMock } = vi.hoisted(() => ({
+  getJwtClaimsMock: vi.fn(() => ({ scope: 'partner', partnerId: 'p-1', orgId: null })),
 }));
+vi.mock('@/lib/authScope', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/authScope')>('@/lib/authScope');
+  return { ...actual, getJwtClaims: getJwtClaimsMock };
+});
 vi.mock('@/stores/orgStore', () => ({
   useOrgStore: () => ({
     // partners is empty for a real partner-scope user (403 on /orgs/partners).
@@ -28,6 +33,8 @@ const json = (payload: unknown, ok = true): Response =>
 describe('AlertTemplateEditor — create mode (#1425)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset to partner-scope default so the existing tests pass unchanged.
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
       if (input === '/alert-templates/templates' && opts?.method === 'POST') {
         return json({ data: { id: 'new-1', orgId: null, partnerId: 'p-1' } });
@@ -80,6 +87,40 @@ describe('AlertTemplateEditor — create mode (#1425)', () => {
       const body = JSON.parse((post![1] as RequestInit).body as string);
       expect(body.availability).toBe('org');
       expect(body.orgId).toBe('org-2');
+    });
+  });
+
+  it('hides the availability picker for an org-scope creator', async () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-1' });
+    render(<AlertTemplateEditor templateId="new" />);
+    // Wait for first paint via an always-present anchor before asserting absence.
+    await screen.findByText('Create template');
+    expect(screen.queryByTestId('template-availability')).not.toBeInTheDocument();
+  });
+
+  it('hides the availability picker for a partner-scope creator with no partnerId', async () => {
+    // Guards the `&& !!partnerId` half of the gate (organizations length still > 1).
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: null, orgId: null });
+    render(<AlertTemplateEditor templateId="new" />);
+    await screen.findByText('Create template');
+    expect(screen.queryByTestId('template-availability')).not.toBeInTheDocument();
+  });
+
+  it('omits availability from the POST body for an org-scope creator', async () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-1' });
+    render(<AlertTemplateEditor templateId="new" />);
+    await screen.findByText('Create template');
+
+    const nameInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'Org User Template' } });
+    fireEvent.click(screen.getByText('Create template'));
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => c[0] === '/alert-templates/templates' && (c[1] as RequestInit)?.method === 'POST');
+      expect(post).toBeTruthy();
+      const body = JSON.parse((post![1] as RequestInit).body as string);
+      expect('availability' in body).toBe(false);
+      expect(body.name).toBe('Org User Template');
     });
   });
 });

--- a/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
@@ -11,7 +11,9 @@ vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 // (that array is system-scope-only and is always [] for a real partner user — #1425).
 // Hoisted vi.fn so each test can override scope; default is partner-scope.
 const { getJwtClaimsMock } = vi.hoisted(() => ({
-  getJwtClaimsMock: vi.fn(() => ({ scope: 'partner', partnerId: 'p-1', orgId: null })),
+  getJwtClaimsMock: vi.fn<() => { scope: 'system' | 'partner' | 'organization' | null; partnerId: string | null; orgId: string | null }>(
+    () => ({ scope: 'partner', partnerId: 'p-1', orgId: null })
+  ),
 }));
 vi.mock('@/lib/authScope', async () => {
   const actual = await vi.importActual<typeof import('@/lib/authScope')>('@/lib/authScope');

--- a/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateEditor.create.test.tsx
@@ -7,9 +7,15 @@ import { navigateTo } from '@/lib/navigation';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+// Partner scope is detected from the JWT claims, NOT from useOrgStore().partners
+// (that array is system-scope-only and is always [] for a real partner user — #1425).
+vi.mock('@/lib/authScope', () => ({
+  getJwtClaims: () => ({ scope: 'partner', partnerId: 'p-1', orgId: null }),
+}));
 vi.mock('@/stores/orgStore', () => ({
   useOrgStore: () => ({
-    partners: [{ id: 'p-1', name: 'MSP' }],
+    // partners is empty for a real partner-scope user (403 on /orgs/partners).
+    partners: [],
     organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
   }),
 }));

--- a/apps/web/src/components/alerts/AlertTemplateEditor.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateEditor.tsx
@@ -5,6 +5,7 @@ import { extractApiError } from '@/lib/apiError';
 import type { AlertSeverity } from './AlertList';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '@/stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import { navigateTo } from '@/lib/navigation';
 import { ScopeBadge } from '../shared/ScopeBadge';
 import Breadcrumbs from '../layout/Breadcrumbs';
@@ -383,8 +384,9 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
   // Partner-wide create controls (#1425). Only surfaced for partner-scope users
   // with more than one org; org-scope users always create for their own org and
   // the backend ignores these.
-  const { partners, organizations: scopeOrganizations } = useOrgStore();
-  const isPartnerScope = partners.length > 0;
+  const { organizations: scopeOrganizations } = useOrgStore();
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
   const showAvailabilityPicker = isNew && isPartnerScope && scopeOrganizations.length > 1;
   const [availability, setAvailability] = useState<Availability>('partner');
   const [availabilityOrgId, setAvailabilityOrgId] = useState('');

--- a/apps/web/src/components/alerts/AlertTemplateEditor.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateEditor.tsx
@@ -4,11 +4,17 @@ import { cn } from '@/lib/utils';
 import { extractApiError } from '@/lib/apiError';
 import type { AlertSeverity } from './AlertList';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '@/stores/orgStore';
+import { navigateTo } from '@/lib/navigation';
+import { ScopeBadge } from '../shared/ScopeBadge';
 import Breadcrumbs from '../layout/Breadcrumbs';
 
 type AlertTemplateEditorProps = {
   templateId?: string;
 };
+
+// Availability axis for partner-scope creators (mirrors Scripts #1357/#1425).
+type Availability = 'org' | 'partner';
 
 type MetricOption = 'cpu.usage' | 'memory.usage' | 'disk.free' | 'network.throughput' | 'latency.ms';
 
@@ -108,6 +114,9 @@ type AlertTemplateResponse = {
   category?: string;
   severity: AlertSeverity;
   builtIn?: boolean;
+  orgId?: string | null;
+  partnerId?: string | null;
+  isBuiltIn?: boolean;
   conditions?: Partial<TemplateConditionsPayload>;
   targets?: Record<string, unknown>;
   defaultCooldownMinutes?: number;
@@ -361,10 +370,26 @@ const stripEscalationIds = (rules: EscalationRule[]) =>
   }));
 
 export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorProps) {
-  const [loading, setLoading] = useState(true);
-  const [hasLoaded, setHasLoaded] = useState(false);
+  const isNew = templateId === 'new';
+  const [loading, setLoading] = useState(!isNew);
+  const [hasLoaded, setHasLoaded] = useState(isNew);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
+
+  // Scope of the template being edited (for the header badge); null until an
+  // existing template loads. New templates have no scope yet.
+  const [scopeInfo, setScopeInfo] = useState<{ orgId: string | null; partnerId: string | null; isBuiltIn: boolean } | null>(null);
+
+  // Partner-wide create controls (#1425). Only surfaced for partner-scope users
+  // with more than one org; org-scope users always create for their own org and
+  // the backend ignores these.
+  const { partners, organizations: scopeOrganizations } = useOrgStore();
+  const isPartnerScope = partners.length > 0;
+  const showAvailabilityPicker = isNew && isPartnerScope && scopeOrganizations.length > 1;
+  const [availability, setAvailability] = useState<Availability>('partner');
+  const [availabilityOrgId, setAvailabilityOrgId] = useState('');
+
+  const readOnly = scopeInfo?.isBuiltIn === true;
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -415,6 +440,12 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
   const selectedTargetIds = targetScope[targetKeyByType[targetScope.type]];
 
   const loadTemplate = useCallback(async () => {
+    // New templates have nothing to fetch — render the empty form immediately.
+    if (isNew) {
+      setLoading(false);
+      setHasLoaded(true);
+      return;
+    }
     if (!templateId) {
       setError('Missing alert template id.');
       setLoading(false);
@@ -466,6 +497,11 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
         normalizeSuppressionRules(conditionsPayload.suppression, template.defaultCooldownMinutes)
       );
       setTargetScope(normalizeTargets(template.targets));
+      setScopeInfo({
+        orgId: template.orgId ?? null,
+        partnerId: template.partnerId ?? null,
+        isBuiltIn: template.isBuiltIn ?? template.builtIn ?? false,
+      });
 
       setHasLoaded(true);
     } catch (err) {
@@ -473,7 +509,7 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
     } finally {
       setLoading(false);
     }
-  }, [templateId]);
+  }, [templateId, isNew]);
 
   const fetchOrganizations = useCallback(async () => {
     try {
@@ -667,7 +703,7 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
   };
 
   const handleSave = async () => {
-    if (!templateId) {
+    if (!isNew && !templateId) {
       setError('Missing alert template id.');
       return;
     }
@@ -681,7 +717,7 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
     setError(undefined);
 
     try {
-      const payload = {
+      const payload: Record<string, unknown> = {
         name: name.trim(),
         description: description.trim(),
         category,
@@ -705,15 +741,31 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
           : 0
       };
 
-      const response = await fetchWithAuth(`/alert-templates/templates/${templateId}`, {
-        method: 'PATCH',
-        body: JSON.stringify(payload)
-      });
+      if (isNew && showAvailabilityPicker) {
+        // Partner-scope creator chose the audience. Org-scope users omit this
+        // entirely (the backend ignores it and uses their own org).
+        payload.availability = availability;
+        if (availability === 'org' && availabilityOrgId) payload.orgId = availabilityOrgId;
+      }
+
+      const response = isNew
+        ? await fetchWithAuth('/alert-templates/templates', {
+            method: 'POST',
+            body: JSON.stringify(payload)
+          })
+        : await fetchWithAuth(`/alert-templates/templates/${templateId}`, {
+            method: 'PATCH',
+            body: JSON.stringify(payload)
+          });
 
       if (!response.ok) {
         const data = await response.json().catch(() => null);
         throw new Error(extractApiError(data, 'Failed to save alert template.'));
       }
+
+      // After creating, return to the list so the new row (with its scope badge)
+      // is visible; editing stays in place.
+      if (isNew) void navigateTo('/settings/alert-templates');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred.');
     } finally {
@@ -751,21 +803,33 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
     <div className="space-y-6">
       <Breadcrumbs items={[
         { label: 'Settings', href: '/settings' },
-        { label: name || 'Alert Template' }
+        { label: 'Alert Templates', href: '/settings/alert-templates' },
+        { label: isNew ? 'New template' : (name || 'Alert Template') }
       ]} />
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-xl font-semibold tracking-tight">Alert Template Editor</h1>
-          <p className="text-muted-foreground">Configure trigger logic, routing, and automation responses.</p>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-semibold tracking-tight">
+              {isNew ? 'New Alert Template' : 'Alert Template Editor'}
+            </h1>
+            {scopeInfo && (
+              <ScopeBadge orgId={scopeInfo.orgId} partnerId={scopeInfo.partnerId} isSystem={scopeInfo.isBuiltIn} />
+            )}
+          </div>
+          <p className="text-muted-foreground">
+            {readOnly
+              ? 'Built-in template — read-only. Duplicate it to customize.'
+              : 'Configure trigger logic, routing, and automation responses.'}
+          </p>
         </div>
         <button
           type="button"
           onClick={handleSave}
-          disabled={saving}
+          disabled={saving || readOnly}
           className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-60"
         >
           <Save className="h-4 w-4" />
-          {saving ? 'Saving...' : 'Save template'}
+          {saving ? 'Saving...' : isNew ? 'Create template' : 'Save template'}
         </button>
       </div>
 
@@ -788,6 +852,53 @@ export default function AlertTemplateEditor({ templateId }: AlertTemplateEditorP
                   className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </div>
+
+              {showAvailabilityPicker && (
+                <fieldset className="sm:col-span-2 space-y-2 rounded-md border p-4" data-testid="template-availability">
+                  <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Available to</legend>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="availability"
+                      value="partner"
+                      checked={availability === 'partner'}
+                      onChange={() => setAvailability('partner')}
+                      data-testid="availability-partner"
+                    />
+                    All my organizations <span className="text-muted-foreground">(partner-wide)</span>
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="availability"
+                      value="org"
+                      checked={availability === 'org'}
+                      onChange={() => setAvailability('org')}
+                      data-testid="availability-org"
+                    />
+                    A specific organization
+                  </label>
+                  {availability === 'org' && (
+                    <div className="mt-2 space-y-1 pl-6">
+                      <label className="text-xs font-medium text-muted-foreground" htmlFor="template-availability-org">
+                        Organization
+                      </label>
+                      <select
+                        id="template-availability-org"
+                        value={availabilityOrgId}
+                        onChange={event => setAvailabilityOrgId(event.target.value)}
+                        data-testid="availability-org-select"
+                        className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value="">Select an organization</option>
+                        {scopeOrganizations.map(org => (
+                          <option key={org.id} value={org.id}>{org.name}</option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+                </fieldset>
+              )}
               <div>
                 <label className="text-xs font-medium uppercase text-muted-foreground">Severity</label>
                 <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">

--- a/apps/web/src/components/alerts/AlertTemplateList.test.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateList.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AlertTemplateList from './AlertTemplateList';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('@/stores/orgStore', () => ({
+  useOrgStore: () => ({ organizations: [{ id: 'org-1', name: 'Acme Co' }] }),
+}));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const navMock = vi.mocked(navigateTo);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const rows = [
+  { id: 't-pw', name: 'Partner CPU', description: null, category: 'Performance', severity: 'high', orgId: null, partnerId: 'p-1', isBuiltIn: false, autoResolve: false },
+  { id: 't-org', name: 'Org Disk', description: null, category: 'Capacity', severity: 'medium', orgId: 'org-1', partnerId: 'p-1', isBuiltIn: false, autoResolve: false },
+  { id: 't-bi', name: 'Built-in Down', description: null, category: 'Availability', severity: 'critical', orgId: null, partnerId: null, isBuiltIn: true, autoResolve: true },
+];
+
+describe('AlertTemplateList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/alert-templates/templates')) return json({ data: rows });
+      return json({ data: [] });
+    });
+  });
+
+  it('fetches the scoped CRUD endpoint and renders a scope badge per row', async () => {
+    render(<AlertTemplateList />);
+    await waitFor(() => expect(screen.getByTestId('alert-template-list')).toBeInTheDocument());
+
+    expect(fetchMock.mock.calls[0]![0]).toMatch(/^\/alert-templates\/templates/);
+
+    expect(within(screen.getByTestId('alert-template-row-t-pw')).getByText('Partner-wide')).toBeInTheDocument();
+    expect(within(screen.getByTestId('alert-template-row-t-org')).getByText('Acme Co')).toBeInTheDocument();
+    expect(within(screen.getByTestId('alert-template-row-t-bi')).getByText('System')).toBeInTheDocument();
+  });
+
+  it('filters by scope', async () => {
+    render(<AlertTemplateList />);
+    await waitFor(() => expect(screen.getByTestId('alert-template-list')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('alert-template-scope-filter'), { target: { value: 'partner' } });
+    expect(screen.getByTestId('alert-template-row-t-pw')).toBeInTheDocument();
+    expect(screen.queryByTestId('alert-template-row-t-org')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('alert-template-row-t-bi')).not.toBeInTheDocument();
+  });
+
+  it('navigates to the create and edit routes', async () => {
+    render(<AlertTemplateList />);
+    await waitFor(() => expect(screen.getByTestId('alert-template-list')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('alert-template-create'));
+    expect(navMock).toHaveBeenCalledWith('/settings/alert-templates/new');
+
+    fireEvent.click(screen.getByTestId('alert-template-edit-t-org'));
+    expect(navMock).toHaveBeenCalledWith('/settings/alert-templates/t-org');
+  });
+
+  it('disables delete on built-in templates and deletes a custom one via runAction', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    render(<AlertTemplateList />);
+    await waitFor(() => expect(screen.getByTestId('alert-template-list')).toBeInTheDocument());
+
+    expect(screen.getByTestId('alert-template-delete-t-bi')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('alert-template-delete-t-org'));
+    await waitFor(() => {
+      const del = fetchMock.mock.calls.find((c) => c[0] === '/alert-templates/templates/t-org' && (c[1] as RequestInit)?.method === 'DELETE');
+      expect(del).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/components/alerts/AlertTemplateList.tsx
+++ b/apps/web/src/components/alerts/AlertTemplateList.tsx
@@ -1,27 +1,30 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Copy, Pencil, Plus, Trash2 } from 'lucide-react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
-import type { AlertSeverity } from './AlertList';
 import { navigateTo } from '@/lib/navigation';
+import { useOrgStore } from '@/stores/orgStore';
+import { runAction, handleActionError, ActionError } from '../../lib/runAction';
+import { ScopeBadge } from '../shared/ScopeBadge';
+import { PageScopeIndicator } from '../layout/PageScopeIndicator';
+import type { AlertSeverity } from './AlertList';
 
+// Raw row shape returned by GET /alert-templates/templates (the scope-aware CRUD
+// route). Partner-wide rows have orgId === null && partnerId !== null; built-in
+// rows have isBuiltIn === true.
 type AlertTemplate = {
   id: string;
   name: string;
-  description: string;
+  description: string | null;
+  category: string | null;
   severity: AlertSeverity;
-  conditions: string[];
+  orgId: string | null;
+  partnerId: string | null;
+  isBuiltIn: boolean;
   autoResolve: boolean;
-  usageCount: number;
-  builtIn: boolean;
 };
 
-type AlertTemplateListProps = {
-  onEdit?: (template: AlertTemplate) => void;
-  onDuplicate?: (template: AlertTemplate) => void;
-  onDelete?: (template: AlertTemplate) => void;
-  onCreate?: () => void;
-};
+const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 const severityStyles: Record<AlertSeverity, { label: string; className: string }> = {
   critical: { label: 'Critical', className: 'bg-red-500/20 text-red-700 border-red-500/40' },
@@ -31,36 +34,23 @@ const severityStyles: Record<AlertSeverity, { label: string; className: string }
   info: { label: 'Info', className: 'bg-gray-500/20 text-gray-700 border-gray-500/40' }
 };
 
-export default function AlertTemplateList({
-  onEdit,
-  onDuplicate,
-  onDelete,
-  onCreate
-}: AlertTemplateListProps) {
+export default function AlertTemplateList() {
+  const { organizations } = useOrgStore();
   const [templates, setTemplates] = useState<AlertTemplate[]>([]);
   const [severityFilter, setSeverityFilter] = useState('all');
-  const [sourceFilter, setSourceFilter] = useState('all');
+  const [scopeFilter, setScopeFilter] = useState('all');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchTemplates = useCallback(async () => {
     setIsLoading(true);
     setError(null);
-
     try {
-      const response = await fetchWithAuth('/alerts/templates');
-
-      if (response.status === 401) {
-        void navigateTo('/login', { replace: true });
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch templates');
-      }
-
-      const data = await response.json();
-      setTemplates(data.templates || []);
+      const response = await fetchWithAuth('/alert-templates/templates?limit=200');
+      if (response.status === 401) return UNAUTHORIZED();
+      if (!response.ok) throw new Error('Failed to fetch templates');
+      const body = (await response.json()) as { data: AlertTemplate[] };
+      setTemplates(body.data ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load templates');
     } finally {
@@ -68,66 +58,42 @@ export default function AlertTemplateList({
     }
   }, []);
 
-  useEffect(() => {
-    fetchTemplates();
-  }, [fetchTemplates]);
+  useEffect(() => { void fetchTemplates(); }, [fetchTemplates]);
 
   const handleDelete = async (template: AlertTemplate) => {
-    if (template.builtIn) return;
-
+    if (template.isBuiltIn) return;
+    if (!window.confirm(`Delete template "${template.name}"? This cannot be undone.`)) return;
     try {
-      const response = await fetchWithAuth(`/alerts/templates/${template.id}`, {
-        method: 'DELETE'
+      await runAction({
+        request: () => fetchWithAuth(`/alert-templates/templates/${template.id}`, { method: 'DELETE' }),
+        errorFallback: 'Could not delete template.',
+        successMessage: 'Template deleted',
+        onUnauthorized: UNAUTHORIZED,
       });
-
-      if (response.status === 401) {
-        void navigateTo('/login', { replace: true });
-        return;
-      }
-
-      if (response.ok) {
-        fetchTemplates();
-        onDelete?.(template);
-      }
-    } catch {
-      // Handle error silently or show notification
+      void fetchTemplates();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      handleActionError(err, 'Could not delete template.');
     }
   };
 
-  const handleDuplicate = async (template: AlertTemplate) => {
-    try {
-      const response = await fetchWithAuth(`/alerts/templates/${template.id}/duplicate`, {
-        method: 'POST'
-      });
-
-      if (response.status === 401) {
-        void navigateTo('/login', { replace: true });
-        return;
-      }
-
-      if (response.ok) {
-        fetchTemplates();
-        onDuplicate?.(template);
-      }
-    } catch {
-      // Handle error silently or show notification
-    }
-  };
+  const orgNameFor = useCallback(
+    (orgId: string | null) => organizations.find(o => o.id === orgId)?.name,
+    [organizations],
+  );
 
   const filteredTemplates = useMemo(() => {
     return templates.filter(template => {
-      const matchesSeverity =
-        severityFilter === 'all' ? true : template.severity === severityFilter;
-      const matchesSource =
-        sourceFilter === 'all'
-          ? true
-          : sourceFilter === 'built-in'
-            ? template.builtIn
-            : !template.builtIn;
-
-      return matchesSeverity && matchesSource;
+      const matchesSeverity = severityFilter === 'all' ? true : template.severity === severityFilter;
+      const scope = template.isBuiltIn
+        ? 'built-in'
+        : template.orgId === null && template.partnerId !== null
+          ? 'partner'
+          : 'org';
+      const matchesScope = scopeFilter === 'all' ? true : scope === scopeFilter;
+      return matchesSeverity && matchesScope;
     });
-  }, [templates, severityFilter, sourceFilter]);
+  }, [templates, severityFilter, scopeFilter]);
 
   if (isLoading) {
     return (
@@ -142,13 +108,9 @@ export default function AlertTemplateList({
   if (error) {
     return (
       <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <div className="flex h-48 flex-col items-center justify-center gap-2 text-muted-foreground">
+        <div className="flex h-48 flex-col items-center justify-center gap-2 text-muted-foreground" data-testid="alert-template-list-error">
           <p>{error}</p>
-          <button
-            type="button"
-            onClick={fetchTemplates}
-            className="text-sm text-primary hover:underline"
-          >
+          <button type="button" onClick={() => void fetchTemplates()} className="text-sm text-primary hover:underline">
             Try again
           </button>
         </div>
@@ -157,17 +119,21 @@ export default function AlertTemplateList({
   }
 
   return (
-    <div className="rounded-lg border bg-card p-6 shadow-sm">
+    <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="alert-template-list">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-lg font-semibold">Alert Templates</h2>
+          <div className="flex flex-wrap items-center gap-3">
+            <h2 className="text-lg font-semibold">Alert Templates</h2>
+            <PageScopeIndicator pathname={typeof window !== 'undefined' ? window.location.pathname : '/settings/alert-templates'} />
+          </div>
           <p className="text-sm text-muted-foreground">
             {filteredTemplates.length} of {templates.length} templates
           </p>
         </div>
         <button
           type="button"
-          onClick={onCreate}
+          onClick={() => void navigateTo('/settings/alert-templates/new')}
+          data-testid="alert-template-create"
           className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
         >
           <Plus className="h-4 w-4" />
@@ -189,13 +155,15 @@ export default function AlertTemplateList({
           <option value="info">Info</option>
         </select>
         <select
-          value={sourceFilter}
-          onChange={event => setSourceFilter(event.target.value)}
-          className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-40"
+          value={scopeFilter}
+          onChange={event => setScopeFilter(event.target.value)}
+          data-testid="alert-template-scope-filter"
+          className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-44"
         >
-          <option value="all">All sources</option>
+          <option value="all">All scopes</option>
+          <option value="partner">Partner-wide</option>
+          <option value="org">Organization</option>
           <option value="built-in">Built-in</option>
-          <option value="custom">Custom</option>
         </select>
       </div>
 
@@ -204,100 +172,63 @@ export default function AlertTemplateList({
           <thead className="bg-muted/40">
             <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               <th className="px-4 py-3">Name</th>
+              <th className="px-4 py-3">Scope</th>
               <th className="px-4 py-3">Severity</th>
-              <th className="px-4 py-3">Conditions</th>
-              <th className="px-4 py-3">Auto-resolve</th>
-              <th className="px-4 py-3">Usage</th>
+              <th className="px-4 py-3">Category</th>
               <th className="px-4 py-3 text-right">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y">
             {filteredTemplates.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-4 py-6 text-center text-sm text-muted-foreground">
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-muted-foreground">
                   No templates match your filters.
                 </td>
               </tr>
             ) : (
               filteredTemplates.map(template => (
-                <tr key={template.id} className="transition hover:bg-muted/40">
+                <tr key={template.id} className="transition hover:bg-muted/40" data-testid={`alert-template-row-${template.id}`}>
                   <td className="px-4 py-3">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <p className="text-sm font-medium">{template.name}</p>
-                        <span
-                          className={cn(
-                            'rounded-full border px-2 py-0.5 text-[11px] font-medium',
-                            template.builtIn
-                              ? 'border-emerald-500/40 bg-emerald-500/20 text-emerald-700'
-                              : 'border-slate-500/40 bg-slate-500/20 text-slate-700'
-                          )}
-                        >
-                          {template.builtIn ? 'Built-in' : 'Custom'}
-                        </span>
-                      </div>
-                      <p className="text-xs text-muted-foreground truncate max-w-xs">
-                        {template.description}
-                      </p>
-                    </div>
+                    <p className="text-sm font-medium">{template.name}</p>
+                    {template.description && (
+                      <p className="text-xs text-muted-foreground truncate max-w-xs">{template.description}</p>
+                    )}
                   </td>
                   <td className="px-4 py-3">
-                    <span
-                      className={cn(
-                        'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium',
-                        severityStyles[template.severity].className
-                      )}
-                    >
+                    <ScopeBadge
+                      orgId={template.orgId}
+                      partnerId={template.partnerId}
+                      isSystem={template.isBuiltIn}
+                      orgName={orgNameFor(template.orgId)}
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={cn('inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium', severityStyles[template.severity].className)}>
                       {severityStyles[template.severity].label}
                     </span>
                   </td>
-                  <td className="px-4 py-3">
-                    <p className="text-sm text-muted-foreground truncate max-w-xs">
-                      {template.conditions.join(' • ')}
-                    </p>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={cn(
-                        'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium',
-                        template.autoResolve
-                          ? 'bg-emerald-500/20 text-emerald-700 border-emerald-500/40'
-                          : 'bg-gray-500/20 text-gray-700 border-gray-500/40'
-                      )}
-                    >
-                      {template.autoResolve ? 'Enabled' : 'Off'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm font-medium">{template.usageCount}</td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{template.category ?? '—'}</td>
                   <td className="px-4 py-3">
                     <div className="flex items-center justify-end gap-1">
                       <button
                         type="button"
-                        onClick={() => onEdit?.(template)}
+                        onClick={() => void navigateTo(`/settings/alert-templates/${template.id}`)}
+                        data-testid={`alert-template-edit-${template.id}`}
                         className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
-                        title="Edit template"
+                        title={template.isBuiltIn ? 'View template' : 'Edit template'}
                       >
                         <Pencil className="h-4 w-4" />
                       </button>
                       <button
                         type="button"
-                        onClick={() => handleDuplicate(template)}
-                        className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
-                        title="Duplicate template"
-                      >
-                        <Copy className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(template)}
-                        disabled={template.builtIn}
+                        onClick={() => void handleDelete(template)}
+                        disabled={template.isBuiltIn}
+                        data-testid={`alert-template-delete-${template.id}`}
                         className={cn(
                           'flex h-8 w-8 items-center justify-center rounded-md text-destructive transition',
-                          template.builtIn
-                            ? 'cursor-not-allowed opacity-40'
-                            : 'hover:bg-destructive/10'
+                          template.isBuiltIn ? 'cursor-not-allowed opacity-40' : 'hover:bg-destructive/10'
                         )}
-                        title={template.builtIn ? 'Built-in templates cannot be deleted' : 'Delete template'}
+                        title={template.isBuiltIn ? 'Built-in templates cannot be deleted' : 'Delete template'}
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>

--- a/apps/web/src/lib/routeScope.test.ts
+++ b/apps/web/src/lib/routeScope.test.ts
@@ -15,6 +15,11 @@ describe('isGlobalScopeRoute', () => {
   it('treats alert templates as global', () => {
     expect(isGlobalScopeRoute('/alert-templates')).toBe(true);
   });
+  it('treats the settings alert-template catalog (list/new/edit) as global (#1425)', () => {
+    expect(isGlobalScopeRoute('/settings/alert-templates')).toBe(true);
+    expect(isGlobalScopeRoute('/settings/alert-templates/new')).toBe(true);
+    expect(isGlobalScopeRoute('/settings/alert-templates/abc-123')).toBe(true);
+  });
   it('treats script execution history as org-scoped (exception)', () => {
     // Execution history lives at /scripts/:id/executions (not /scripts/executions)
     expect(isGlobalScopeRoute('/scripts/abc-123/executions')).toBe(false);

--- a/apps/web/src/lib/routeScope.ts
+++ b/apps/web/src/lib/routeScope.ts
@@ -9,6 +9,7 @@ const GLOBAL_ROUTE_PATTERNS: RegExp[] = [
   /^\/scripts(\/.*)?$/, // script library / new / detail+edit
   /^\/patches(\/.*)?$/, // approvals + compliance derive org from the selected ring
   /^\/alert-templates(\/.*)?$/,
+  /^\/settings\/alert-templates(\/.*)?$/, // partner-wide alert-template catalog (#1425)
 ];
 
 // Routes that share a global prefix but are genuinely per-org state.

--- a/apps/web/src/pages/settings/alert-templates/index.astro
+++ b/apps/web/src/pages/settings/alert-templates/index.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../../../layouts/DashboardLayout.astro';
+import AlertTemplateList from '../../../components/alerts/AlertTemplateList';
+---
+
+<DashboardLayout title="Alert Templates">
+  <AlertTemplateList client:load />
+</DashboardLayout>


### PR DESCRIPTION
## Summary

Implements #1425 end-to-end — partner-wide alert templates, mirroring the shipped Scripts pattern. #1357 gave `alert_templates` a `partner_id` axis + dual-axis RLS; this wires the route **and** builds the management UI (which was previously near-absent).

## API (`apps/api/src/routes/alertTemplates/`)

- **LIST / GET** union built-in ∪ the caller's org templates ∪ partner-wide templates for their partner (partner scope spans `accessibleOrgIds`; system sees all). Drops the `resolveScopedOrgId` 400 that blocked multi-org partner-scope callers.
- **CREATE** accepts `availability: 'org' | 'partner'` (+ optional `orgId`): partner scope + `'partner'` → partner-wide row (`org_id NULL`, `partner_id` set); else org-specific with `partner_id` denormalized. Org scope always creates for its own org.
- **PATCH / DELETE** gate through `canWriteTemplate`: built-in read-only for all; partner-wide read-only for org scope (403), editable only by the owning partner/system; org rows require `canAccessOrg`. RLS remains the real boundary.

## UI (`apps/web/`)

- **New list page** `settings/alert-templates/index.astro` mounting a **rewritten `AlertTemplateList`** — fetches the scope-aware CRUD route, renders a **`ScopeBadge`** (Partner-wide / Org / System) per row, scope + severity filters, **`PageScopeIndicator`** in the header, `runAction`-wrapped delete, create/edit navigation. (The old component called non-existent endpoints and was mounted nowhere.)
- **`AlertTemplateEditor` create mode**: `templateId="new"` skips the load and renders the **availability picker** (All my organizations vs a specific org) for partner-scope users with >1 org — mirroring `ScriptForm` — then POSTs with `availability`/`orgId`; existing templates still PATCH. Shows a `ScopeBadge` for the loaded template; built-in templates are read-only.
- `routeScope`: `/settings/alert-templates` is a global catalog surface.

## Tests

- **API**: `templates.guard.test.ts` (canWriteTemplate matrix) + `alert-templates-partner-wide.integration.test.ts` (**real `breeze_app` + RLS**: partner-wide insert+read, cross-partner isolation, org-scope forge rejected) + completed the `alertTemplates.test.ts` mock AuthContext.
- **Web**: `AlertTemplateList.test.tsx` (endpoint, scope badges, scope filter, create/edit nav, runAction delete), `AlertTemplateEditor.create.test.tsx` (picker visibility, partner-wide POST, org-specific POST with orgId), `routeScope.test.ts` cases.

**Verification:** API 17 + integration 3 + web alerts 36 + routeScope/list 10 + no-silent-mutations 55 — all green. `tsc --noEmit` (api + web) → 0 errors.

Leaving #1425 open for UI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)