### PR TITLE
feat(catalog): complete the billing-catalog UI — per-org pricing, ticket-part link, archive confirm (#1368)

### DIFF
--- a/apps/api/src/routes/tickets/parts.test.ts
+++ b/apps/api/src/routes/tickets/parts.test.ts
@@ -152,6 +152,34 @@ describe('parts routes', () => {
     expect(body.data).toHaveProperty('id', PART_ID);
   });
 
+  it('passes a catalogItemId through to the service (#1368 catalog link)', async () => {
+    getScopedTicketOr404Mock.mockResolvedValue({ id: TICKET_ID, orgId: 'o-1', deviceId: null });
+    timeServiceMocks.addTicketPart.mockResolvedValue({ id: PART_ID });
+    const catalogItemId = '9f3a1b2c-1111-4222-8333-444455556666';
+    const res = await ticketsRoutes.request(`/${TICKET_ID}/parts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'SSD', quantity: 1, unitPrice: 120, catalogItemId })
+    });
+    expect(res.status).toBe(201);
+    expect(timeServiceMocks.addTicketPart).toHaveBeenCalledWith(
+      TICKET_ID,
+      expect.objectContaining({ catalogItemId }),
+      expect.anything(),
+    );
+  });
+
+  it('rejects a non-UUID catalogItemId (400, no service call)', async () => {
+    getScopedTicketOr404Mock.mockResolvedValue({ id: TICKET_ID, orgId: 'o-1', deviceId: null });
+    const res = await ticketsRoutes.request(`/${TICKET_ID}/parts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'SSD', quantity: 1, unitPrice: 120, catalogItemId: 'not-a-uuid' })
+    });
+    expect(res.status).toBe(400);
+    expect(timeServiceMocks.addTicketPart).not.toHaveBeenCalled();
+  });
+
   it('GET /:id/parts returns part list for in-scope ticket', async () => {
     getScopedTicketOr404Mock.mockResolvedValue({ id: TICKET_ID, orgId: 'o-1', deviceId: null });
     dbSelectMock.mockResolvedValue([{ id: PART_ID, ticketId: TICKET_ID, description: 'SSD' }]);

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -538,6 +538,7 @@ export async function addTicketPart(ticketId: string, input: TicketPartInput, ac
       description: input.description,
       partNumber: input.partNumber ?? null,
       vendor: input.vendor ?? null,
+      catalogItemId: input.catalogItemId ?? null,
       quantity: input.quantity.toFixed(2),
       unitPrice: (input.unitPrice ?? 0).toFixed(2),
       costBasis: input.costBasis != null ? input.costBasis.toFixed(2) : null,
@@ -567,6 +568,7 @@ export async function updateTicketPart(id: string, input: Partial<TicketPartInpu
   if (input.description !== undefined) set.description = input.description;
   if (input.partNumber !== undefined) set.partNumber = input.partNumber;
   if (input.vendor !== undefined) set.vendor = input.vendor;
+  if (input.catalogItemId !== undefined) set.catalogItemId = input.catalogItemId;
   if (input.quantity !== undefined) set.quantity = input.quantity.toFixed(2);
   if (input.unitPrice !== undefined) set.unitPrice = input.unitPrice.toFixed(2);
   if (input.costBasis !== undefined) set.costBasis = input.costBasis != null ? input.costBasis.toFixed(2) : null;

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
@@ -102,4 +102,11 @@ describe('CatalogItemEditorDrawer — per-org pricing (#1368)', () => {
     await waitFor(() => expect(screen.getByTestId('catalog-item-editor')).toBeInTheDocument());
     expect(screen.queryByTestId('catalog-org-pricing')).not.toBeInTheDocument();
   });
+
+  it('hides the section for a partner-scope user with a null partnerId', async () => {
+    claimsMock.mockReturnValue({ scope: 'partner', partnerId: null, orgId: null });
+    renderDrawer();
+    await waitFor(() => expect(screen.getByTestId('catalog-item-editor')).toBeInTheDocument());
+    expect(screen.queryByTestId('catalog-org-pricing')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CatalogItemEditorDrawer from './CatalogItemEditorDrawer';
 import type { CatalogItem } from '../../lib/api/catalog';
 import * as catalogApi from '../../lib/api/catalog';
+import * as authScope from '../../lib/authScope';
 
 // Keep the real presentation helpers + constants; stub only the network calls.
 vi.mock('../../lib/api/catalog', async (importActual) => {
@@ -20,14 +21,21 @@ vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 vi.mock('../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
 vi.mock('@/stores/orgStore', () => ({
   useOrgStore: () => ({
-    partners: [{ id: 'p-1', name: 'MSP' }],
     organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
   }),
 }));
+// Per-org pricing is gated on partner scope, read from the JWT claims (not from
+// useOrgStore().partners, which is system-scope-only — #1368). Default to a
+// partner-scope user; individual tests override the scope as needed.
+vi.mock('../../lib/authScope', async (importActual) => {
+  const actual = await importActual<typeof import('../../lib/authScope')>();
+  return { ...actual, getJwtClaims: vi.fn() };
+});
 
 const getMock = vi.mocked(catalogApi.getCatalogItem);
 const setMock = vi.mocked(catalogApi.setOrgPriceOverride);
 const delMock = vi.mocked(catalogApi.removeOrgPriceOverride);
+const claimsMock = vi.mocked(authScope.getJwtClaims);
 const json = (payload: unknown, ok = true): Response =>
   ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
 
@@ -43,6 +51,8 @@ const detail = (overrides: Array<{ orgId: string; unitPrice: string }>) =>
 describe('CatalogItemEditorDrawer — per-org pricing (#1368)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: a partner-scope user (the audience for per-org pricing).
+    claimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
     getMock.mockResolvedValue(detail([{ orgId: 'org-1', unitPrice: '80.00' }]));
     setMock.mockResolvedValue(json({ data: { id: 'ov-new', catalogItemId: 'item-1', orgId: 'org-2', unitPrice: '70.00' } }));
     delMock.mockResolvedValue(json({ data: { id: 'ov-0', catalogItemId: 'item-1', orgId: 'org-1', unitPrice: '80.00' } }));
@@ -83,6 +93,13 @@ describe('CatalogItemEditorDrawer — per-org pricing (#1368)', () => {
     getMock.mockResolvedValue(json({ data: { item: item({ isBundle: true }), components: [], overrides: [] } }));
     renderDrawer({ item: item({ isBundle: true }) });
     await waitFor(() => expect(screen.getByTestId('catalog-bundle-builder')).toBeInTheDocument());
+    expect(screen.queryByTestId('catalog-org-pricing')).not.toBeInTheDocument();
+  });
+
+  it('hides the section for an org-scope (non-partner) user', async () => {
+    claimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-1' });
+    renderDrawer();
+    await waitFor(() => expect(screen.getByTestId('catalog-item-editor')).toBeInTheDocument());
     expect(screen.queryByTestId('catalog-org-pricing')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CatalogItemEditorDrawer from './CatalogItemEditorDrawer';
+import type { CatalogItem } from '../../lib/api/catalog';
+import * as catalogApi from '../../lib/api/catalog';
+
+// Keep the real presentation helpers + constants; stub only the network calls.
+vi.mock('../../lib/api/catalog', async (importActual) => {
+  const actual = await importActual<typeof import('../../lib/api/catalog')>();
+  return {
+    ...actual,
+    getCatalogItem: vi.fn(),
+    setOrgPriceOverride: vi.fn(),
+    removeOrgPriceOverride: vi.fn(),
+  };
+});
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+vi.mock('@/stores/orgStore', () => ({
+  useOrgStore: () => ({
+    partners: [{ id: 'p-1', name: 'MSP' }],
+    organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+  }),
+}));
+
+const getMock = vi.mocked(catalogApi.getCatalogItem);
+const setMock = vi.mocked(catalogApi.setOrgPriceOverride);
+const delMock = vi.mocked(catalogApi.removeOrgPriceOverride);
+const json = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const item = (over: Partial<CatalogItem> = {}): CatalogItem => ({
+  id: 'item-1', partnerId: 'p-1', itemType: 'service', name: 'Managed WS', sku: null, description: null,
+  billingType: 'one_time', unitPrice: '100.00', costBasis: null, markupPercent: null, unitOfMeasure: 'each',
+  taxable: false, taxCategory: null, isBundle: false, isActive: true, createdAt: '', updatedAt: '', ...over,
+});
+
+const detail = (overrides: Array<{ orgId: string; unitPrice: string }>) =>
+  json({ data: { item: item(), components: [], overrides: overrides.map((o, i) => ({ id: `ov-${i}`, catalogItemId: 'item-1', ...o })) } });
+
+describe('CatalogItemEditorDrawer — per-org pricing (#1368)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMock.mockResolvedValue(detail([{ orgId: 'org-1', unitPrice: '80.00' }]));
+    setMock.mockResolvedValue(json({ data: { id: 'ov-new', catalogItemId: 'item-1', orgId: 'org-2', unitPrice: '70.00' } }));
+    delMock.mockResolvedValue(json({ data: { id: 'ov-0', catalogItemId: 'item-1', orgId: 'org-1', unitPrice: '80.00' } }));
+  });
+
+  const renderDrawer = (props: Partial<React.ComponentProps<typeof CatalogItemEditorDrawer>> = {}) =>
+    render(<CatalogItemEditorDrawer open item={item()} allItems={[]} onClose={vi.fn()} onSaved={vi.fn()} {...props} />);
+
+  it('loads and lists existing overrides for an existing item', async () => {
+    renderDrawer();
+    await waitFor(() => expect(screen.getByTestId('catalog-org-pricing')).toBeInTheDocument());
+    const row = await screen.findByTestId('catalog-override-row-org-1');
+    expect(row).toHaveTextContent('Acme');
+    expect(screen.getByTestId('catalog-override-price-org-1')).toHaveTextContent('80.00');
+  });
+
+  it('sets a new override (PUT with a numeric price) and a removable existing one (DELETE)', async () => {
+    renderDrawer();
+    await screen.findByTestId('catalog-override-row-org-1');
+
+    // Only orgs without an override are offered (org-1 already has one).
+    fireEvent.change(screen.getByTestId('catalog-override-org'), { target: { value: 'org-2' } });
+    fireEvent.change(screen.getByTestId('catalog-override-price-input'), { target: { value: '70' } });
+    fireEvent.click(screen.getByTestId('catalog-override-add'));
+    await waitFor(() => expect(setMock).toHaveBeenCalledWith('item-1', 'org-2', 70));
+
+    fireEvent.click(screen.getByTestId('catalog-override-remove-org-1'));
+    await waitFor(() => expect(delMock).toHaveBeenCalledWith('item-1', 'org-1'));
+  });
+
+  it('hides the section for a new (unsaved) item', async () => {
+    renderDrawer({ item: null });
+    await waitFor(() => expect(screen.getByTestId('catalog-item-editor')).toBeInTheDocument());
+    expect(screen.queryByTestId('catalog-org-pricing')).not.toBeInTheDocument();
+  });
+
+  it('hides the section for a bundle (price derives from components)', async () => {
+    getMock.mockResolvedValue(json({ data: { item: item({ isBundle: true }), components: [], overrides: [] } }));
+    renderDrawer({ item: item({ isBundle: true }) });
+    await waitFor(() => expect(screen.getByTestId('catalog-bundle-builder')).toBeInTheDocument());
+    expect(screen.queryByTestId('catalog-org-pricing')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -6,7 +6,7 @@ import { createPortal } from 'react-dom';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
-import { loginPathWithNext } from '../../lib/authScope';
+import { loginPathWithNext, getJwtClaims } from '../../lib/authScope';
 import { usePermissions } from '../../lib/permissions';
 import { useOrgStore } from '@/stores/orgStore';
 import {
@@ -58,10 +58,13 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
 
   const { can } = usePermissions();
   const canWrite = can('catalog', 'write');
-  // Per-org overrides are a partner/system surface (an MSP pricing a customer);
-  // mirror the route's scope by gating on partner presence.
-  const { partners, organizations } = useOrgStore();
-  const isPartnerScope = partners.length > 0;
+  // Per-org overrides are a partner surface (an MSP pricing a customer). Detect
+  // partner scope from the JWT claims — useOrgStore().partners is only populated
+  // from a system-scope-only endpoint, so a real partner-scope user gets an empty
+  // array and the section would never render (#1368).
+  const { organizations } = useOrgStore();
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
 
   const [itemType, setItemType] = useState<CatalogItemType>('service');
   const [name, setName] = useState('');

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -8,11 +8,13 @@ import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 import { usePermissions } from '../../lib/permissions';
+import { useOrgStore } from '@/stores/orgStore';
 import {
   createCatalogItem, updateCatalogItem, getCatalogItem, setBundleComponents,
+  setOrgPriceOverride, removeOrgPriceOverride,
   computeMargin, formatMargin, marginTone,
   CATALOG_TYPE_LABELS, CATALOG_TYPE_ORDER,
-  type CatalogItem, type CatalogItemType, type CatalogItemDetail,
+  type CatalogItem, type CatalogItemType, type CatalogItemDetail, type OrgPriceOverride,
 } from '../../lib/api/catalog';
 
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
@@ -56,6 +58,10 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
 
   const { can } = usePermissions();
   const canWrite = can('catalog', 'write');
+  // Per-org overrides are a partner/system surface (an MSP pricing a customer);
+  // mirror the route's scope by gating on partner presence.
+  const { partners, organizations } = useOrgStore();
+  const isPartnerScope = partners.length > 0;
 
   const [itemType, setItemType] = useState<CatalogItemType>('service');
   const [name, setName] = useState('');
@@ -66,6 +72,13 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
   const [components, setComponents] = useState<ComponentDraft[]>([]);
   const [componentsLoading, setComponentsLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  // Per-org price overrides (#1368). Loaded for an existing item and edited as a
+  // sub-resource — each set/remove applies immediately (the item already exists),
+  // independent of the main Save.
+  const [overrides, setOverrides] = useState<OrgPriceOverride[]>([]);
+  const [newOverrideOrgId, setNewOverrideOrgId] = useState('');
+  const [newOverridePrice, setNewOverridePrice] = useState('');
+  const [overrideBusy, setOverrideBusy] = useState(false);
   // Once a *new* item is created we hold its id, so a retry after a partial
   // failure (item saved, components failed) PATCHes instead of creating a dupe.
   const [committedId, setCommittedId] = useState<string | null>(null);
@@ -80,6 +93,9 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
     if (!open) return;
     setCommittedId(null);
     setSaving(false);
+    setOverrides([]);
+    setNewOverrideOrgId('');
+    setNewOverridePrice('');
     if (item) {
       setItemType(item.itemType);
       setName(item.name);
@@ -88,22 +104,23 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
       setCostBasis(item.costBasis ?? '');
       setIsBundle(item.isBundle);
       setComponents([]);
-      if (item.isBundle) {
-        setComponentsLoading(true);
-        void getCatalogItem(item.id)
-          .then(async (res) => {
-            if (res.status === 401) return UNAUTHORIZED();
-            if (!res.ok) return;
-            const body = (await res.json().catch(() => null)) as { data?: CatalogItemDetail } | null;
-            const rows = body?.data?.components ?? [];
-            setComponents(rows.map((r) => ({
-              componentItemId: r.componentItemId,
-              quantity: r.quantity,
-              showOnInvoice: r.showOnInvoice,
-            })));
-          })
-          .finally(() => setComponentsLoading(false));
-      }
+      // Existing items carry sub-resources (bundle components + per-org price
+      // overrides) — load the detail once and hydrate both.
+      setComponentsLoading(item.isBundle);
+      void getCatalogItem(item.id)
+        .then(async (res) => {
+          if (res.status === 401) return UNAUTHORIZED();
+          if (!res.ok) return;
+          const body = (await res.json().catch(() => null)) as { data?: CatalogItemDetail } | null;
+          const rows = body?.data?.components ?? [];
+          setComponents(rows.map((r) => ({
+            componentItemId: r.componentItemId,
+            quantity: r.quantity,
+            showOnInvoice: r.showOnInvoice,
+          })));
+          setOverrides(body?.data?.overrides ?? []);
+        })
+        .finally(() => setComponentsLoading(false));
     } else {
       setItemType('service');
       setName('');
@@ -165,6 +182,64 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
   const removeComponent = (idx: number) => setComponents((cs) => cs.filter((_, i) => i !== idx));
   const patchComponent = (idx: number, patch: Partial<ComponentDraft>) =>
     setComponents((cs) => cs.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+
+  // ---- per-org price overrides (#1368) ------------------------------------
+  const orgNameFor = useCallback(
+    (orgId: string) => organizations.find((o) => o.id === orgId)?.name ?? orgId,
+    [organizations],
+  );
+  const overriddenOrgIds = useMemo(() => new Set(overrides.map((o) => o.orgId)), [overrides]);
+  const orgsWithoutOverride = useMemo(
+    () => organizations.filter((o) => !overriddenOrgIds.has(o.id)),
+    [organizations, overriddenOrgIds],
+  );
+  // Org pricing only applies to a persisted, non-bundle item (a bundle's price
+  // derives from its components), for a partner-scope user who can write.
+  const showOrgPricing = !!effectiveId && !isBundle && isPartnerScope && canWrite;
+
+  const addOverride = useCallback(async () => {
+    if (overrideBusy || !effectiveId) return;
+    if (!newOverrideOrgId) { showToast({ message: 'Pick an organization.', type: 'error' }); return; }
+    const price = Number(newOverridePrice);
+    if (newOverridePrice.trim() === '' || !Number.isFinite(price) || price < 0) {
+      showToast({ message: 'Enter a valid override price.', type: 'error' });
+      return;
+    }
+    setOverrideBusy(true);
+    try {
+      const saved = await runAction<{ data: OrgPriceOverride }>({
+        request: () => setOrgPriceOverride(effectiveId, newOverrideOrgId, price),
+        errorFallback: 'Could not set the override. Retry.',
+        successMessage: 'Override saved',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setOverrides((cur) => [...cur.filter((o) => o.orgId !== newOverrideOrgId), saved.data]);
+      setNewOverrideOrgId('');
+      setNewOverridePrice('');
+    } catch (err) {
+      handleActionError(err, 'Could not set the override. Retry.');
+    } finally {
+      setOverrideBusy(false);
+    }
+  }, [overrideBusy, effectiveId, newOverrideOrgId, newOverridePrice]);
+
+  const deleteOverride = useCallback(async (orgId: string) => {
+    if (overrideBusy || !effectiveId) return;
+    setOverrideBusy(true);
+    try {
+      await runAction({
+        request: () => removeOrgPriceOverride(effectiveId, orgId),
+        errorFallback: 'Could not remove the override. Retry.',
+        successMessage: 'Override removed',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setOverrides((cur) => cur.filter((o) => o.orgId !== orgId));
+    } catch (err) {
+      handleActionError(err, 'Could not remove the override. Retry.');
+    } finally {
+      setOverrideBusy(false);
+    }
+  }, [overrideBusy, effectiveId]);
 
   // ---- save ----------------------------------------------------------------
   const priceNum = Number(unitPrice);
@@ -448,6 +523,82 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                     );
                   })}
                 </ul>
+              )}
+            </div>
+          )}
+
+          {/* Per-organization price overrides (#1368) */}
+          {showOrgPricing && (
+            <div className="space-y-2 rounded-md border p-3" data-testid="catalog-org-pricing">
+              <span className="text-xs font-medium text-muted-foreground">Per-organization pricing</span>
+              <p className="text-xs text-muted-foreground">
+                Override the base unit price for a specific customer. Everyone else is billed the catalog price.
+              </p>
+
+              {overrides.length === 0 ? (
+                <p className="py-2 text-center text-xs text-muted-foreground" data-testid="catalog-org-pricing-empty">
+                  No overrides — every organization is billed the base price.
+                </p>
+              ) : (
+                <ul className="space-y-1.5">
+                  {overrides.map((o) => (
+                    <li
+                      key={o.orgId}
+                      className="flex items-center gap-2 rounded-md border bg-background p-2 text-sm"
+                      data-testid={`catalog-override-row-${o.orgId}`}
+                    >
+                      <span className="flex-1 truncate">{orgNameFor(o.orgId)}</span>
+                      <span className="tabular-nums" data-testid={`catalog-override-price-${o.orgId}`}>{o.unitPrice}</span>
+                      <button
+                        type="button"
+                        onClick={() => void deleteOverride(o.orgId)}
+                        disabled={overrideBusy}
+                        aria-label={`Remove override for ${orgNameFor(o.orgId)}`}
+                        data-testid={`catalog-override-remove-${o.orgId}`}
+                        className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive disabled:opacity-50"
+                      >
+                        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M3 6h18M8 6V4h8v2m-9 0v14a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <div className="flex items-center gap-2">
+                <select
+                  value={newOverrideOrgId}
+                  onChange={(e) => setNewOverrideOrgId(e.target.value)}
+                  className="h-9 flex-1 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  data-testid="catalog-override-org"
+                >
+                  <option value="">Select organization…</option>
+                  {orgsWithoutOverride.map((o) => (
+                    <option key={o.id} value={o.id}>{o.name}</option>
+                  ))}
+                </select>
+                <input
+                  value={newOverridePrice}
+                  onChange={(e) => setNewOverridePrice(e.target.value)}
+                  inputMode="decimal"
+                  aria-label="Override price"
+                  placeholder="0.00"
+                  className="h-9 w-20 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
+                  data-testid="catalog-override-price-input"
+                />
+                <button
+                  type="button"
+                  onClick={() => void addOverride()}
+                  disabled={overrideBusy || !newOverrideOrgId}
+                  className="rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                  data-testid="catalog-override-add"
+                >
+                  Set
+                </button>
+              </div>
+              {organizations.length > 0 && orgsWithoutOverride.length === 0 && (
+                <p className="text-center text-[11px] text-muted-foreground">All organizations have an override.</p>
               )}
             </div>
           )}

--- a/apps/web/src/components/settings/CatalogItemsTab.permissions.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.permissions.test.tsx
@@ -16,6 +16,9 @@ const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  // orgStore (pulled in transitively via the editor drawer's useOrgStore)
+  // registers an org-id provider at module load.
+  registerOrgIdProvider: vi.fn(),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
       selector({ user: { permissions: state.permissions } }),

--- a/apps/web/src/components/settings/CatalogItemsTab.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.test.tsx
@@ -6,6 +6,9 @@ import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  // orgStore (pulled in transitively via the editor drawer's useOrgStore)
+  // registers an org-id provider at module load.
+  registerOrgIdProvider: vi.fn(),
   // usePermissions() (billing-RBAC UI gating) reads grants off the store; grant
   // the admin wildcard so every gated control renders and these tests exercise
   // full functionality.

--- a/apps/web/src/components/settings/CatalogItemsTab.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.test.tsx
@@ -94,13 +94,19 @@ describe('CatalogItemsTab', () => {
     await waitFor(() => expect(detail).toHaveTextContent('60.0%'));
   });
 
-  it('archives an item from the row overflow (kebab) menu', async () => {
+  it('archives an item from the row overflow (kebab) menu — after a confirm step (#1368)', async () => {
     render(<CatalogItemsTab />);
     await screen.findByText('Laptop');
     // Archive is hidden until the kebab is opened.
     expect(screen.queryByTestId('catalog-archive-l1')).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId('catalog-actions-l1'));
     fireEvent.click(await screen.findByTestId('catalog-archive-l1'));
+
+    // Archive no longer fires on the menu click — a confirm dialog gates it.
+    const confirm = await screen.findByTestId('catalog-archive-confirm');
+    expect(fetchMock.mock.calls.some((c) => String(c[0]) === '/catalog/l1/archive')).toBe(false);
+
+    fireEvent.click(confirm);
     await waitFor(() => {
       const call = fetchMock.mock.calls.find(
         (c) => String(c[0]) === '/catalog/l1/archive' && (c[1] as RequestInit | undefined)?.method === 'POST',

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -6,6 +6,7 @@ import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import { usePermissions } from '../../lib/permissions';
 import { formatMoney } from '../../lib/timeFormat';
 import CatalogItemEditorDrawer from './CatalogItemEditorDrawer';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import {
   listCatalog, getCatalogItem, getBundleEconomics, archiveCatalogItem, updateCatalogItem,
   computeMargin, formatMargin, marginTone,
@@ -39,6 +40,9 @@ export default function CatalogItemsTab() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editItem, setEditItem] = useState<CatalogItem | null>(null);
   const [archivingId, setArchivingId] = useState<string | null>(null);
+  // Archive is a soft-delete that pulls the item from active pickers — guard it
+  // behind a confirm step (#1368) instead of acting on a single menu click.
+  const [pendingArchive, setPendingArchive] = useState<CatalogItem | null>(null);
   const [expanded, setExpanded] = useState<Record<string, ExpandState>>({});
 
   // Catalog routes enforce requireScope('partner','system') server-side. Mirror
@@ -374,7 +378,7 @@ export default function CatalogItemsTab() {
                             busy={archivingId === it.id}
                             disabled={archivingId !== null}
                             onEdit={() => openEdit(it)}
-                            onArchive={() => void archive(it.id)}
+                            onArchive={() => setPendingArchive(it)}
                             onRestore={() => void restore(it.id)}
                           />
                         </td>
@@ -438,6 +442,24 @@ export default function CatalogItemsTab() {
         allItems={items}
         onClose={() => setDrawerOpen(false)}
         onSaved={() => void load(view)}
+      />
+
+      <ConfirmDialog
+        open={pendingArchive !== null}
+        onClose={() => setPendingArchive(null)}
+        onConfirm={() => {
+          const target = pendingArchive;
+          setPendingArchive(null);
+          if (target) void archive(target.id);
+        }}
+        title="Archive item"
+        message={pendingArchive
+          ? `Archive "${pendingArchive.name}"? It will be hidden from active pickers (quotes, invoices, bundles). You can restore it from the Archived view.`
+          : ''}
+        confirmLabel="Archive"
+        variant="destructive"
+        isLoading={archivingId !== null && archivingId === pendingArchive?.id}
+        confirmTestId="catalog-archive-confirm"
       />
     </div>
   );

--- a/apps/web/src/components/tickets/TicketPartsCard.test.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.test.tsx
@@ -90,4 +90,70 @@ describe('TicketPartsCard', () => {
       expect(Object.keys(body)).not.toContain('notes');
     });
   });
+
+  it('adds a part from the catalog — prefills fields and links catalogItemId (#1368)', async () => {
+    const catItem = {
+      id: 'cat-1', partnerId: 'p1', itemType: 'hardware', name: 'NVMe 1TB', sku: 'NV-1', description: null,
+      billingType: 'one_time', unitPrice: '150.00', costBasis: '90.00', markupPercent: null, unitOfMeasure: 'each',
+      taxable: false, taxCategory: null, isBundle: false, isActive: true, createdAt: '', updatedAt: '',
+    };
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/tickets/tk-1/parts') return jsonRes(parts);
+      if (url.startsWith('/catalog')) return jsonRes([catItem]);
+      return jsonRes({});
+    });
+
+    render(<TicketPartsCard ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-parts-add-toggle'));
+
+    fireEvent.change(await screen.findByTestId('ticket-parts-catalog-picker-input'), { target: { value: 'NVMe' } });
+    fireEvent.click(await screen.findByTestId('ticket-parts-catalog-picker-option-cat-1'));
+
+    expect(screen.getByTestId('ticket-parts-form-description')).toHaveValue('NVMe 1TB');
+    expect(screen.getByTestId('ticket-parts-form-unit-price')).toHaveValue(150);
+    expect(screen.getByTestId('ticket-parts-form-linked')).toHaveTextContent('NVMe 1TB');
+
+    fireEvent.change(screen.getByTestId('ticket-parts-form-quantity'), { target: { value: '1' } });
+    fireEvent.click(screen.getByTestId('ticket-parts-form-submit'));
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find(
+        (args) => args[0] === '/tickets/tk-1/parts' && (args[1] as RequestInit)?.method === 'POST',
+      );
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toMatchObject({
+        description: 'NVMe 1TB', unitPrice: 150, catalogItemId: 'cat-1',
+      });
+    });
+  });
+
+  it('unlinks a catalog selection, keeping the prefilled fields free-text', async () => {
+    const catItem = {
+      id: 'cat-1', partnerId: 'p1', itemType: 'hardware', name: 'NVMe 1TB', sku: 'NV-1', description: null,
+      billingType: 'one_time', unitPrice: '150.00', costBasis: '90.00', markupPercent: null, unitOfMeasure: 'each',
+      taxable: false, taxCategory: null, isBundle: false, isActive: true, createdAt: '', updatedAt: '',
+    };
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/tickets/tk-1/parts') return jsonRes(parts);
+      if (url.startsWith('/catalog')) return jsonRes([catItem]);
+      return jsonRes({});
+    });
+
+    render(<TicketPartsCard ticketId="tk-1" />);
+    fireEvent.click(await screen.findByTestId('ticket-parts-add-toggle'));
+    fireEvent.change(await screen.findByTestId('ticket-parts-catalog-picker-input'), { target: { value: 'NVMe' } });
+    fireEvent.click(await screen.findByTestId('ticket-parts-catalog-picker-option-cat-1'));
+
+    fireEvent.click(screen.getByTestId('ticket-parts-form-unlink'));
+    expect(screen.queryByTestId('ticket-parts-form-linked')).toBeNull();
+    expect(screen.getByTestId('ticket-parts-form-description')).toHaveValue('NVMe 1TB');
+
+    fireEvent.change(screen.getByTestId('ticket-parts-form-quantity'), { target: { value: '1' } });
+    fireEvent.click(screen.getByTestId('ticket-parts-form-submit'));
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find(
+        (args) => args[0] === '/tickets/tk-1/parts' && (args[1] as RequestInit)?.method === 'POST',
+      );
+      expect(JSON.parse((call![1] as RequestInit).body as string).catalogItemId).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/components/tickets/TicketPartsCard.tsx
+++ b/apps/web/src/components/tickets/TicketPartsCard.tsx
@@ -3,6 +3,8 @@ import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { formatMoney } from '../../lib/timeFormat';
 import { broadcastBillingChanged } from '../../lib/timerActions';
+import CatalogItemPicker from '../catalog/CatalogItemPicker';
+import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
 
 interface PartRow {
   id: string;
@@ -11,6 +13,7 @@ interface PartRow {
   unitPrice: string;
   costBasis: string | null;
   isBillable: boolean;
+  catalogItemId: string | null;
 }
 
 export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
@@ -24,6 +27,11 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
   const [billable, setBillable] = useState(true);
   const [busy, setBusy] = useState(false);
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  // Optional catalog link (#1368): pick an item to prefill description/price/cost
+  // and record ticket_parts.catalog_item_id. Catalog + ticket parts share the
+  // partner/system scope gate, so anyone who can edit parts can read the catalog.
+  const [catalog, setCatalog] = useState<CatalogItem[]>([]);
+  const [catalogItemId, setCatalogItemId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     const res = await fetchWithAuth(`/tickets/${ticketId}/parts`)
@@ -36,6 +44,24 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
     void refresh();
   }, [refresh]);
 
+  // Load active catalog items for the picker once. A failure (e.g. nothing in
+  // the catalog) just leaves the picker empty — parts stay free-text.
+  useEffect(() => {
+    void listCatalog({ isActive: true, limit: 200 })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body) => { if (body?.data) setCatalog(body.data as CatalogItem[]); })
+      .catch(() => { /* picker simply has no options */ });
+  }, []);
+
+  const linkedItem = catalogItemId ? catalog.find((c) => c.id === catalogItemId) ?? null : null;
+
+  const pickCatalogItem = (it: CatalogItem) => {
+    setCatalogItemId(it.id);
+    setDescription(it.name);
+    setUnitPrice(String(Number(it.unitPrice)));
+    setCostBasis(it.costBasis != null ? String(Number(it.costBasis)) : '');
+  };
+
   // Reset form and list state when ticketId changes (mirror TicketTimeBilling)
   useEffect(() => {
     setFormOpen(false);
@@ -46,6 +72,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
     setCostBasis('');
     setBillable(true);
     setConfirmingDeleteId(null);
+    setCatalogItemId(null);
   }, [ticketId]);
 
   const resetForm = () => {
@@ -56,6 +83,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
     setUnitPrice('');
     setCostBasis('');
     setBillable(true);
+    setCatalogItemId(null);
   };
 
   const openAdd = () => { resetForm(); setFormOpen(true); };
@@ -67,6 +95,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
     setUnitPrice(String(Number(part.unitPrice)));
     setCostBasis(part.costBasis != null ? String(Number(part.costBasis)) : '');
     setBillable(part.isBillable);
+    setCatalogItemId(part.catalogItemId ?? null);
     setFormOpen(true);
   };
 
@@ -82,6 +111,7 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
       quantity: qty,
       unitPrice: price,
       isBillable: billable,
+      catalogItemId,
     };
     const cb = costBasis.trim();
     if (cb !== '') {
@@ -246,6 +276,33 @@ export default function TicketPartsCard({ ticketId }: { ticketId: string }) {
 
       {formOpen && (
         <div className="mt-2 space-y-1.5 rounded-md border bg-muted/30 p-2" data-testid="ticket-parts-form">
+          {/* Optional: pull a part from the catalog to prefill + link it (#1368). */}
+          {catalog.length > 0 && (
+            linkedItem ? (
+              <div className="flex items-center justify-between gap-2 rounded-md border bg-background px-2 py-1 text-xs" data-testid="ticket-parts-form-linked">
+                <span className="min-w-0 truncate">
+                  <span className="text-muted-foreground">From catalog: </span>
+                  <span className="font-medium">{linkedItem.name}</span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setCatalogItemId(null)}
+                  className="shrink-0 rounded px-1 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  data-testid="ticket-parts-form-unlink"
+                >
+                  Unlink
+                </button>
+              </div>
+            ) : (
+              <CatalogItemPicker
+                items={catalog}
+                onSelect={pickCatalogItem}
+                includeBundles={false}
+                placeholder="Add from catalog (optional)"
+                testId="ticket-parts-catalog-picker"
+              />
+            )
+          )}
           <input
             type="text"
             value={description}

--- a/apps/web/src/lib/api/catalog.ts
+++ b/apps/web/src/lib/api/catalog.ts
@@ -138,6 +138,21 @@ export function getBundleEconomics(id: string, orgId?: string): Promise<Response
   return fetchWithAuth(`/catalog/${id}/economics${qs}`);
 }
 
+// Per-org price overrides (#1368). The route is partner/system-scoped: an MSP
+// sets a customer-specific price distinct from the catalog base. unitPrice is a
+// number (money) to match orgPriceOverrideSchema.
+export function setOrgPriceOverride(id: string, orgId: string, unitPrice: number): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}/pricing/${orgId}`, {
+    method: 'PUT',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ unitPrice }),
+  });
+}
+
+export function removeOrgPriceOverride(id: string, orgId: string): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}/pricing/${orgId}`, { method: 'DELETE' });
+}
+
 // ---- presentation helpers -------------------------------------------------
 
 export const CATALOG_TYPE_LABELS: Record<CatalogItemType, string> = {

--- a/packages/shared/src/validators/timeEntries.ts
+++ b/packages/shared/src/validators/timeEntries.ts
@@ -69,6 +69,9 @@ export const ticketPartSchema = z.object({
   description: z.string().min(1).max(2_000),
   partNumber: z.string().max(100).optional(),
   vendor: z.string().max(100).optional(),
+  // Optional link to a catalog item the part was added from (#1368). Null
+  // detaches it; description/price stay free-text and editable after picking.
+  catalogItemId: z.string().uuid().nullable().optional(),
   quantity: z.number().positive().multipleOf(0.01),
   unitPrice: z.number().nonnegative().multipleOf(0.01).default(0),
   costBasis: z.number().nonnegative().multipleOf(0.01).nullable().optional(),


### PR DESCRIPTION
## Summary

Completes #1368. Wires the remaining backend-ready surfaces into the UI. (Two of the five gaps — bundle component picker #2 and live margin/derived pricing #4 — already shipped after the issue was filed; this closes the rest.)

### Gap #1 — per-org price override
- catalog API lib: `setOrgPriceOverride` / `removeOrgPriceOverride` (`unitPrice` as a number to match `orgPriceOverrideSchema`).
- `CatalogItemEditorDrawer`: a **Per-organization pricing** section for an existing non-bundle item (partner-scope writers) — lists overrides, set a customer-specific price via an org picker + price, remove one; each applied immediately via `runAction`. Hidden for bundles (price derives from components).

### Gap #3 — ticket-part → catalog link
- `ticketPartSchema` gains optional `catalogItemId` (uuid|null); `addTicketPart`/`updateTicketPart` persist it to the existing `ticket_parts.catalog_item_id` column.
- `TicketPartsCard`: a catalog typeahead in the Add-part form (reusing `CatalogItemPicker`, bundles excluded). Picking prefills description / unit price / cost and links `catalogItemId`; **Unlink** detaches it while keeping the fields free-text.

### Gap #5 — archive confirm
- `CatalogItemsTab` routes Archive through a `ConfirmDialog` instead of a single click. (The archived view + restore already existed.)

## Tests
- API: `parts.test.ts` (catalogItemId passthrough + non-UUID → 400); `CatalogItemEditorDrawer.test.tsx` (load/set/remove overrides, hidden for new/bundle).
- Web: `TicketPartsCard.test.tsx` (catalog prefill + link, unlink); `CatalogItemsTab.test.tsx` (archive now gated by confirm); completed `CatalogItemsTab` auth mocks for `orgStore.registerOrgIdProvider`.

**Verification:** web settings+tickets 410 passed (39 files) + no-silent-mutations 55; API parts 16 + timeEntryService 53; shared validators 20; `tsc --noEmit` (shared/api/web) clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)