### PR TITLE
feat: Quotes/Proposals — Phase 2 (send, portal/public view, e-sign accept → convert)

### DIFF
--- a/apps/api/migrations/2026-06-17-quote-decline-reason.sql
+++ b/apps/api/migrations/2026-06-17-quote-decline-reason.sql
@@ -1,0 +1,4 @@
+-- Phase 2: record a free-text reason when a sent quote is declined.
+-- Idempotent: ADD COLUMN IF NOT EXISTS. No new table, no RLS change
+-- (quotes already has org-axis RLS from 2026-06-16-quotes.sql).
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS decline_reason text;

--- a/apps/api/src/__tests__/integration/portalQuotes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalQuotes.integration.test.ts
@@ -1,0 +1,48 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes, quoteAcceptances } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { acceptQuote } from '../../services/quoteAcceptService';
+
+// These exercise the SERVICE layer the portal routes call, under the SAME org
+// scope the portal middleware establishes. (Full HTTP route tests would need
+// the portal session harness; the service-under-portal-scope path is the
+// security-critical surface.)
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('portal quotes (org-scoped)', () => {
+  runDb('portal accept records the portal user identity as signer + converts', async () => {
+    const fx = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id });
+      return { partnerId: partner.id, orgId: org.id };
+    });
+    const ctx: DbAccessContext = { scope: 'organization', orgId: fx.orgId, accessibleOrgIds: [fx.orgId], accessiblePartnerIds: [fx.partnerId], userId: null };
+    const actor = { userId: null, partnerId: fx.partnerId, accessibleOrgIds: [fx.orgId] };
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: fx.orgId, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+
+    // Portal handler would call acceptQuote with the portal_user's name/email.
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Portal Pat', signerEmail: 'pat@org.example' }));
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+    expect(acc!.signerName).toBe('Portal Pat');
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
+    expect(q!.status).toBe('converted');
+  });
+
+  runDb('another org cannot read this org quote (RLS hides it under portal scope)', async () => {
+    const fx = await withSystemDbAccessContext(async () => {
+      const pA = await createPartner(); const oA = await createOrganization({ partnerId: pA.id });
+      const pB = await createPartner(); const oB = await createOrganization({ partnerId: pB.id });
+      const [qA] = await db.insert(quotes).values({ partnerId: pA.id, orgId: oA.id, currencyCode: 'USD', status: 'sent' }).returning({ id: quotes.id });
+      return { orgB: oB.id, partnerB: pB.id, quoteA: qA!.id };
+    });
+    const ctxB: DbAccessContext = { scope: 'organization', orgId: fx.orgB, accessibleOrgIds: [fx.orgB], accessiblePartnerIds: [fx.partnerB], userId: null };
+    const visible = await withDbAccessContext(ctxB, () => db.select({ id: quotes.id }).from(quotes).where(eq(quotes.id, fx.quoteA)));
+    expect(visible).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
@@ -62,4 +62,27 @@ describe('quote accept → convert', () => {
     // still draft
     await expect(withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane' }))).rejects.toMatchObject({ status: 409 });
   });
+
+  // TA-1 / atom-1: accepting a quote is at-most-once. A second accept (the
+  // double-submit / replay case) must 409 and create NO second invoice — the
+  // single most important invariant of the convert pipeline.
+  runDb('a second accept of the same quote is rejected and creates no duplicate invoice', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+
+    const first = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane' }));
+    await expect(
+      withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane (again)' }))
+    ).rejects.toMatchObject({ status: 409, code: 'INVALID_STATE' });
+
+    // Exactly one invoice + one acceptance exist for the quote.
+    const invs = await withSystemDbAccessContext(() => db.select({ id: invoices.id }).from(invoices).where(eq(invoices.orgId, org.id)));
+    expect(invs).toHaveLength(1);
+    expect(invs[0]!.id).toBe(first.invoiceId);
+    const accs = await withSystemDbAccessContext(() => db.select({ id: quoteAcceptances.id }).from(quoteAcceptances).where(eq(quoteAcceptances.quoteId, created.id)));
+    expect(accs).toHaveLength(1);
+  });
 });

--- a/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
@@ -1,0 +1,65 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes, quoteAcceptances } from '../../db/schema/quotes';
+import { invoices, invoiceLines } from '../../db/schema/invoices';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { acceptQuote } from '../../services/quoteAcceptService';
+import type { QuoteActor } from '../../services/quoteTypes';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+function ctxFor(orgId: string, partnerId: string): DbAccessContext { return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [partnerId], userId: null }; }
+function actorFor(orgId: string, partnerId: string): QuoteActor { return { userId: null, partnerId, accessibleOrgIds: [orgId] }; }
+async function seed() { return withSystemDbAccessContext(async () => { const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id }); return { partner, org }; }); }
+
+describe('quote accept → convert', () => {
+  runDb('records acceptance with content hash and converts one-time lines to an invoice', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Onboarding', quantity: 1, unitPrice: 250, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Managed services', quantity: 1, unitPrice: 99, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane Buyer', signerEmail: 'jane@org.example', ipAddress: '9.9.9.9', userAgent: 'UA' }));
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
+    expect(q!.status).toBe('converted');
+    expect(q!.convertedInvoiceId).toBe(res.invoiceId);
+    expect(q!.acceptedAt).toBeTruthy();
+
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+    expect(acc!.signerName).toBe('Jane Buyer');
+    expect(acc!.quoteSha256).toMatch(/^[0-9a-f]{64}$/);
+
+    // Only the one-time line ($250) is invoiced; the monthly line is excluded.
+    const invLines = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, res.invoiceId)));
+    expect(invLines).toHaveLength(1);
+    expect(invLines[0]!.description).toBe('Onboarding');
+    const [inv] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, res.invoiceId)));
+    expect(inv!.total).toBe('250.00');
+  });
+
+  runDb('a recurring-only quote still converts but yields a $0 invoice (Phase 2 degenerate edge)', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Managed services', quantity: 1, unitPrice: 99, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Bob' }));
+    const [inv] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, res.invoiceId)));
+    expect(inv!.total).toBe('0.00');
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
+    expect(q!.status).toBe('converted');
+  });
+
+  runDb('rejects accepting a quote that is not sent/viewed', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    // still draft
+    await expect(withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane' }))).rejects.toMatchObject({ status: 409 });
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteImages.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteImages.integration.test.ts
@@ -36,4 +36,25 @@ describe('quote image storage', () => {
     expect(read?.mime).toBe('image/png');
     expect(read?.data.equals(PNG)).toBe(true);
   });
+
+  // TA-6: readQuoteImage is scoped to BOTH imageId AND quoteId. Within ONE org,
+  // RLS does NOT separate two quotes — the quote_id predicate is the ONLY barrier
+  // stopping a valid token holder for quote B from serving quote A's image bytes
+  // on the system-scope public image route. This is the test RLS can't be.
+  runDb('does not serve an image under a different quote in the same org (cross-quote IDOR guard)', async () => {
+    const { ctx, quoteA, quoteB } = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id });
+      const [qA] = await db.insert(quotes).values({ partnerId: partner.id, orgId: org.id, currencyCode: 'USD' }).returning({ id: quotes.id });
+      const [qB] = await db.insert(quotes).values({ partnerId: partner.id, orgId: org.id, currencyCode: 'USD' }).returning({ id: quotes.id });
+      const ctx: DbAccessContext = { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id], accessiblePartnerIds: [partner.id], userId: null };
+      return { ctx, quoteA: qA!.id, quoteB: qB!.id };
+    });
+    const imgA = await withDbAccessContext(ctx, () => writeQuoteImage(quoteA, ctx.orgId!, 'image/png', PNG));
+    // Same org, image belongs to quote A — requesting it under quote B must miss.
+    const crossed = await withDbAccessContext(ctx, () => readQuoteImage(imgA.id, quoteB));
+    expect(crossed).toBeNull();
+    // Sanity: the correct quote still returns the bytes (the predicate isn't deny-all).
+    const ok = await withDbAccessContext(ctx, () => readQuoteImage(imgA.id, quoteA));
+    expect(ok?.data.equals(PNG)).toBe(true);
+  });
 });

--- a/apps/api/src/__tests__/integration/quoteImages.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteImages.integration.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Quote image bytea storage — real-driver round-trip under RLS.
+ *
+ * Service under test: services/quoteImageStorage.ts. The image bytes live in
+ * `quote_images.image_data` (bytea), org-axis RLS shipped in Phase 1. These
+ * cases run through the REAL `breeze_app` driver inside withDbAccessContext, so
+ * they prove postgres.js round-trips the bytea byte-exactly AND that the
+ * insert/select pass the table's org-axis policies (the contract test alone
+ * misses write-path gaps — the custom_field_definitions #1257 class).
+ *
+ * No memoization: integration/setup.ts TRUNCATE ... CASCADEs the tenant tables
+ * on beforeEach, so each test re-seeds.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { db } from '../../db';
+import { quotes } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { writeQuoteImage, readQuoteImage } from '../../services/quoteImageStorage';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const PNG = Buffer.from([0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a,0,0,0,0]);
+
+describe('quote image storage', () => {
+  runDb('writes and reads back a PNG scoped to its quote', async () => {
+    const { ctx, quoteId } = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id });
+      const [q] = await db.insert(quotes).values({ partnerId: partner.id, orgId: org.id, currencyCode: 'USD' }).returning({ id: quotes.id, orgId: quotes.orgId });
+      const ctx: DbAccessContext = { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id], accessiblePartnerIds: [partner.id], userId: null };
+      return { ctx, quoteId: q!.id, orgId: org.id };
+    });
+    const written = await withDbAccessContext(ctx, () => writeQuoteImage(quoteId, ctx.orgId!, 'image/png', PNG));
+    expect(written.sha256).toMatch(/^[0-9a-f]{64}$/);
+    const read = await withDbAccessContext(ctx, () => readQuoteImage(written.id, quoteId));
+    expect(read?.mime).toBe('image/png');
+    expect(read?.data.equals(PNG)).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteLifecycle.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteLifecycle.integration.test.ts
@@ -1,0 +1,77 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote, markQuoteViewed, declineQuoteByActor } from '../../services/quoteLifecycle';
+import type { QuoteActor } from '../../services/quoteTypes';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seed() {
+  return withSystemDbAccessContext(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    return { partner, org };
+  });
+}
+function ctxFor(orgId: string, partnerId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [partnerId], userId: null };
+}
+function actorFor(orgId: string, partnerId: string): QuoteActor {
+  return { userId: null, partnerId, accessibleOrgIds: [orgId] };
+}
+
+describe('quote lifecycle', () => {
+  runDb('sendQuote assigns a number, sets sent + sentAt, returns an accept URL', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+
+    const result = await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    expect(result.quote.status).toBe('sent');
+    expect(result.quote.quoteNumber).toMatch(/^Q-\d{4}-\d{4}$/);
+    expect(result.quote.sentAt).toBeTruthy();
+    expect(result.acceptUrl).toContain('/quote/');
+  });
+
+  runDb('markQuoteViewed flips sent→viewed and stamps first_viewed_at once', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    await markQuoteViewed(created.id, org.id);
+    const [v1] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
+    expect(v1!.status).toBe('viewed');
+    const firstViewed = v1!.firstViewedAt;
+    await markQuoteViewed(created.id, org.id); // idempotent
+    const [v2] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
+    expect(v2!.firstViewedAt).toEqual(firstViewed);
+  });
+
+  runDb('declineQuoteByActor sets declined + reason', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    const declined = await withDbAccessContext(ctx, () => declineQuoteByActor(created.id, 'Budget cut', actor));
+    expect(declined.status).toBe('declined');
+    expect(declined.declineReason).toBe('Budget cut');
+    expect(declined.declinedAt).toBeTruthy();
+  });
+
+  runDb('sendQuote rejects a non-draft', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    await expect(withDbAccessContext(ctx, () => sendQuote(created.id, actor))).rejects.toMatchObject({ status: 409 });
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts
@@ -1,0 +1,18 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { PERMISSIONS } from '../../services/permissions';
+
+describe('quotes:send RBAC', () => {
+  // A role granted only read+write must NOT satisfy the send permission the
+  // POST /:id/send route requires. This guards against the send route being
+  // accidentally gated on write (or ungated).
+  it('quotes:read+write does not imply quotes:send', () => {
+    const granted = [
+      `${PERMISSIONS.QUOTES_READ.resource}:${PERMISSIONS.QUOTES_READ.action}`,
+      `${PERMISSIONS.QUOTES_WRITE.resource}:${PERMISSIONS.QUOTES_WRITE.action}`,
+    ];
+    const needSend = `${PERMISSIONS.QUOTES_SEND.resource}:${PERMISSIONS.QUOTES_SEND.action}`;
+    expect(granted).not.toContain(needSend);
+    expect(PERMISSIONS.QUOTES_SEND.action).toBe('send');
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts
@@ -1,18 +1,30 @@
 import './setup';
 import { describe, expect, it } from 'vitest';
-import { PERMISSIONS } from '../../services/permissions';
+import { PERMISSIONS, hasPermission, type UserPermissions } from '../../services/permissions';
 
-describe('quotes:send RBAC', () => {
-  // A role granted only read+write must NOT satisfy the send permission the
-  // POST /:id/send route requires. This guards against the send route being
-  // accidentally gated on write (or ungated).
-  it('quotes:read+write does not imply quotes:send', () => {
-    const granted = [
-      `${PERMISSIONS.QUOTES_READ.resource}:${PERMISSIONS.QUOTES_READ.action}`,
-      `${PERMISSIONS.QUOTES_WRITE.resource}:${PERMISSIONS.QUOTES_WRITE.action}`,
-    ];
-    const needSend = `${PERMISSIONS.QUOTES_SEND.resource}:${PERMISSIONS.QUOTES_SEND.action}`;
-    expect(granted).not.toContain(needSend);
+// The previously-dead quotes:send permission now gates POST /:id/send. The
+// behavioral, route-level guarantee (a read+write user gets 403; the route is
+// gated on quotes:send, not quotes:write) is enforced by the REAL middleware
+// chain in routes/quotes/lifecycle.test.ts. This file pins the authorization
+// DECISION function that requirePermission delegates to — hasPermission — so a
+// regression in the grant logic (or the QUOTES_SEND constant) is caught too.
+function userWith(grants: { resource: string; action: string }[]): UserPermissions {
+  return { permissions: grants, partnerId: 'p1', orgId: null, roleId: 'r1', scope: 'partner' };
+}
+
+describe('quotes:send authorization (hasPermission)', () => {
+  it('a quotes:read + quotes:write user is NOT authorized to send', () => {
+    const user = userWith([PERMISSIONS.QUOTES_READ, PERMISSIONS.QUOTES_WRITE]);
+    expect(hasPermission(user, PERMISSIONS.QUOTES_SEND.resource, PERMISSIONS.QUOTES_SEND.action)).toBe(false);
+  });
+
+  it('a quotes:send holder IS authorized to send', () => {
+    const user = userWith([PERMISSIONS.QUOTES_READ, PERMISSIONS.QUOTES_WRITE, PERMISSIONS.QUOTES_SEND]);
+    expect(hasPermission(user, PERMISSIONS.QUOTES_SEND.resource, PERMISSIONS.QUOTES_SEND.action)).toBe(true);
+  });
+
+  it('quotes:send is a distinct action from write (the route must not gate on write)', () => {
     expect(PERMISSIONS.QUOTES_SEND.action).toBe('send');
+    expect(PERMISSIONS.QUOTES_SEND.action).not.toBe(PERMISSIONS.QUOTES_WRITE.action);
   });
 });

--- a/apps/api/src/__tests__/integration/quotes-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quotes-rls.integration.test.ts
@@ -343,4 +343,19 @@ describe('quotes RLS isolation (breeze_app)', () => {
     );
     expect(visibleToA).toHaveLength(0);
   });
+
+  // (10) Service-layer accept forge. acceptQuote loads the quote by id; under an
+  // orgA breeze_app context, orgB's quote is invisible (RLS), so acceptQuote
+  // must 404 rather than convert a foreign tenant's quote. This guards the
+  // accept *write path* (the contract test alone misses write-path/axis gaps):
+  // a leak here would let one tenant accept-and-convert another tenant's quote
+  // into an invoice. quoteB is seeded `draft`, but the orgA caller can't see it
+  // at all, so the org-scoped SELECT yields no row → QUOTE_NOT_FOUND (404).
+  runDb('acceptQuote cannot accept another org quote (RLS hides it → 404)', async () => {
+    const fx = await seedFixture();
+    const { acceptQuote } = await import('../../services/quoteAcceptService');
+    await expect(
+      withDbAccessContext(fx.orgAContext, () => acceptQuote({ quoteId: fx.quoteB.id, signerName: 'Mallory' }))
+    ).rejects.toMatchObject({ status: 404 });
+  });
 });

--- a/apps/api/src/__tests__/integration/quotesPublic.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quotesPublic.integration.test.ts
@@ -44,20 +44,19 @@ describe('public quote token path', () => {
     const res = await withSystemDbAccessContext(() => acceptQuote({ quoteId: created.id, signerName: 'Pat' }));
     const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
 
-    // Re-render the SAME content → hash equals the recorded one. The hash was
-    // captured inside acceptQuote while the quote was 'sent'; accept then
-    // transitions it to 'converted'. Since computeQuoteSha256 is status-sensitive
-    // (it's part of the canonical content), re-render with the at-accept status
-    // ('sent') to reproduce the recorded hash — the quote body itself is immutable
-    // once sent, so this isolates the tamper-evidence check to the line content.
+    // Re-render from the LIVE quote — which is now 'converted' — and the hash
+    // STILL matches the one recorded at accept time (when it was 'sent'). This
+    // proves the content hash excludes volatile workflow fields like status (C4):
+    // a future verifier can re-hash the converted quote without a false tamper
+    // signal. A real edit to a line amount, however, still mismatches.
     const { computeQuoteSha256 } = await import('../../services/quoteContentHash');
     const { quoteBlocks, quoteLines } = await import('../../db/schema/quotes');
     const [qRow] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
-    const q = { ...qRow, status: 'sent' };
+    expect(qRow!.status).toBe('converted'); // the live status differs from the at-accept status
     const blocks = await withSystemDbAccessContext(() => db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, created.id)));
     const lines = await withSystemDbAccessContext(() => db.select().from(quoteLines).where(eq(quoteLines.quoteId, created.id)));
-    expect(computeQuoteSha256(q as any, blocks as any, lines as any)).toBe(acc!.quoteSha256);
+    expect(computeQuoteSha256(qRow as any, blocks as any, lines as any)).toBe(acc!.quoteSha256);
     const tampered = lines.map((l) => ({ ...l, unitPrice: '1.00', lineTotal: '1.00' }));
-    expect(computeQuoteSha256(q as any, blocks as any, tampered as any)).not.toBe(acc!.quoteSha256);
+    expect(computeQuoteSha256(qRow as any, blocks as any, tampered as any)).not.toBe(acc!.quoteSha256);
   });
 });

--- a/apps/api/src/__tests__/integration/quotesPublic.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quotesPublic.integration.test.ts
@@ -1,0 +1,63 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes, quoteAcceptances } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { createQuoteAcceptToken, verifyQuoteAcceptToken } from '../../services/quoteAcceptToken';
+import { acceptQuote } from '../../services/quoteAcceptService';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('public quote token path', () => {
+  runDb('an unauthenticated accept (system scope, token-resolved) records + converts', async () => {
+    const fx = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id });
+      return { partnerId: partner.id, orgId: org.id };
+    });
+    const ctx: DbAccessContext = { scope: 'organization', orgId: fx.orgId, accessibleOrgIds: [fx.orgId], accessiblePartnerIds: [fx.partnerId], userId: null };
+    const actor = { userId: null, partnerId: fx.partnerId, accessibleOrgIds: [fx.orgId] };
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: fx.orgId, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+
+    // Public path: mint+verify token, then accept under SYSTEM scope resolved from token claims.
+    const { token } = await createQuoteAcceptToken({ quoteId: created.id, orgId: fx.orgId, partnerId: fx.partnerId });
+    const claims = await verifyQuoteAcceptToken(token);
+    expect(claims?.quoteId).toBe(created.id);
+    const res = await withSystemDbAccessContext(() => acceptQuote({ quoteId: claims!.quoteId, signerName: 'Prospect Pat', acceptanceTokenJti: claims!.jti }));
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
+    expect(q!.status).toBe('converted');
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+    expect(acc!.acceptanceTokenJti).toBe(claims!.jti);
+  });
+
+  runDb('the recorded hash matches a re-render and mismatches a tampered quote', async () => {
+    const fx = await withSystemDbAccessContext(async () => { const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id }); return { partnerId: partner.id, orgId: org.id }; });
+    const ctx: DbAccessContext = { scope: 'organization', orgId: fx.orgId, accessibleOrgIds: [fx.orgId], accessiblePartnerIds: [fx.partnerId], userId: null };
+    const actor = { userId: null, partnerId: fx.partnerId, accessibleOrgIds: [fx.orgId] };
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: fx.orgId, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    const res = await withSystemDbAccessContext(() => acceptQuote({ quoteId: created.id, signerName: 'Pat' }));
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+
+    // Re-render the SAME content → hash equals the recorded one. The hash was
+    // captured inside acceptQuote while the quote was 'sent'; accept then
+    // transitions it to 'converted'. Since computeQuoteSha256 is status-sensitive
+    // (it's part of the canonical content), re-render with the at-accept status
+    // ('sent') to reproduce the recorded hash — the quote body itself is immutable
+    // once sent, so this isolates the tamper-evidence check to the line content.
+    const { computeQuoteSha256 } = await import('../../services/quoteContentHash');
+    const { quoteBlocks, quoteLines } = await import('../../db/schema/quotes');
+    const [qRow] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
+    const q = { ...qRow, status: 'sent' };
+    const blocks = await withSystemDbAccessContext(() => db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, created.id)));
+    const lines = await withSystemDbAccessContext(() => db.select().from(quoteLines).where(eq(quoteLines.quoteId, created.id)));
+    expect(computeQuoteSha256(q as any, blocks as any, lines as any)).toBe(acc!.quoteSha256);
+    const tampered = lines.map((l) => ({ ...l, unitPrice: '1.00', lineTotal: '1.00' }));
+    expect(computeQuoteSha256(q as any, blocks as any, tampered as any)).not.toBe(acc!.quoteSha256);
+  });
+});

--- a/apps/api/src/__tests__/integration/quotesPublicRoutes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quotesPublicRoutes.integration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * HTTP-level tests for the UNAUTHENTICATED public quote router
+ * (routes/quotesPublic.ts). The sibling quotesPublic.integration.test.ts drives
+ * the service layer; this file drives the real Hono routes via app.request so it
+ * covers the glue the service tests can't: the token resolve() gate, the
+ * draft-hide + customer-visible line FILTER on the public GET, the inline public
+ * decline guard, and single-use token revocation (a link can't be replayed after
+ * accept/decline). Every handler runs its DB work under
+ * runOutsideDbContext(withSystemDbAccessContext(...)) — exercised for real here,
+ * not stubbed.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { quotes, quoteLines } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuoteAcceptToken } from '../../services/quoteAcceptToken';
+import { quotesPublicRoutes } from '../../routes/quotesPublic';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function app() {
+  const a = new Hono();
+  a.route('/quotes/public', quotesPublicRoutes); // mirrors index.ts mount
+  return a;
+}
+
+/** Seed a quote (+optional lines) under system scope and mint its accept token. */
+async function seedQuote(opts: { status?: 'draft' | 'sent'; lines?: { description: string; unitPrice: string; recurrence?: string; customerVisible?: boolean }[] } = {}) {
+  return withSystemDbAccessContext(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const [q] = await db.insert(quotes).values({
+      partnerId: partner.id, orgId: org.id, currencyCode: 'USD',
+      status: opts.status ?? 'sent', quoteNumber: opts.status === 'draft' ? null : 'Q-2026-0001',
+    }).returning({ id: quotes.id });
+    for (let i = 0; i < (opts.lines?.length ?? 0); i++) {
+      const l = opts.lines![i]!;
+      await db.insert(quoteLines).values({
+        quoteId: q!.id, orgId: org.id, sourceType: 'manual', description: l.description,
+        quantity: '1', unitPrice: l.unitPrice, lineTotal: l.unitPrice,
+        recurrence: (l.recurrence ?? 'one_time') as any, taxable: false,
+        customerVisible: l.customerVisible ?? true, sortOrder: i,
+      });
+    }
+    const { token } = await createQuoteAcceptToken({ quoteId: q!.id, orgId: org.id, partnerId: partner.id });
+    return { quoteId: q!.id, orgId: org.id, token };
+  });
+}
+
+const postJson = (path: string, body: unknown) =>
+  app().request(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+
+describe('public quote routes (HTTP, unauthenticated token)', () => {
+  runDb('GET hides non-customer-visible lines and stamps sent→viewed', async () => {
+    const { quoteId, token } = await seedQuote({ lines: [
+      { description: 'Public line', unitPrice: '100.00', customerVisible: true },
+      { description: 'Internal cost note', unitPrice: '40.00', customerVisible: false },
+    ] });
+    const res = await app().request(`/quotes/public/${token}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { quote: { status: string }; lines: { description: string }[] } };
+    expect(body.data.quote.status).toBe('viewed');
+    const descriptions = body.data.lines.map((l) => l.description);
+    expect(descriptions).toContain('Public line');
+    expect(descriptions).not.toContain('Internal cost note'); // the customerVisible filter
+    // DB: first_viewed_at stamped + status flipped.
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
+    expect(q!.status).toBe('viewed');
+    expect(q!.firstViewedAt).toBeTruthy();
+  });
+
+  runDb('GET on a draft quote returns 404 (a draft is never visible via token)', async () => {
+    const { token } = await seedQuote({ status: 'draft' });
+    const res = await app().request(`/quotes/public/${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  runDb('GET with a garbage token returns 401', async () => {
+    const res = await app().request('/quotes/public/not-a-real-token-string');
+    expect(res.status).toBe(401);
+  });
+
+  runDb('POST decline flips to declined + persists the reason, then 409 on re-decline', async () => {
+    const { quoteId, token } = await seedQuote();
+    const res = await postJson(`/quotes/public/${token}/decline`, { reason: 'Chose another vendor' });
+    expect(res.status).toBe(200);
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
+    expect(q!.status).toBe('declined');
+    expect(q!.declineReason).toBe('Chose another vendor');
+    // The token is consumed on decline → re-decline resolves to 401 (revoked link).
+    const again = await postJson(`/quotes/public/${token}/decline`, { reason: 'oops' });
+    expect(again.status).toBe(401);
+  });
+
+  runDb('POST accept converts, then the single-use token can no longer view or accept', async () => {
+    const { quoteId, token } = await seedQuote({ lines: [{ description: 'Setup', unitPrice: '250.00' }] });
+    const res = await postJson(`/quotes/public/${token}/accept`, { signerName: 'Prospect Pat' });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { status: string } };
+    expect(body.data.status).toBe('converted');
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
+    expect(q!.status).toBe('converted');
+    expect(q!.convertedInvoiceId).toBeTruthy();
+    // Token revoked post-accept → replay is blocked at the resolve() gate (401, not 409).
+    expect((await app().request(`/quotes/public/${token}`)).status).toBe(401);
+    expect((await postJson(`/quotes/public/${token}/accept`, { signerName: 'Replay' })).status).toBe(401);
+  });
+
+  runDb('POST accept requires a signer name (zValidator 400)', async () => {
+    const { token } = await seedQuote({ lines: [{ description: 'Setup', unitPrice: '250.00' }] });
+    const res = await postJson(`/quotes/public/${token}/accept`, { signerName: '' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/db/schema/quotes.ts
+++ b/apps/api/src/db/schema/quotes.ts
@@ -43,6 +43,7 @@ export const quotes = pgTable('quotes', {
   billToTaxId: varchar('bill_to_tax_id', { length: 100 }),
   introNotes: text('intro_notes'),
   terms: text('terms'),
+  declineReason: text('decline_reason'),
   convertedInvoiceId: uuid('converted_invoice_id'),
   pdfDocumentRef: text('pdf_document_ref'),
   pdfSha256: char('pdf_sha256', { length: 64 }),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -34,6 +34,7 @@ import { catalogRoutes } from './routes/catalog';
 import { emailWebhookRoutes } from './routes/tickets/emailWebhook';
 import { invoiceRoutes } from './routes/invoices';
 import { quoteRoutes } from './routes/quotes';
+import { quotesPublicRoutes } from './routes/quotesPublic';
 import { stripeConnectRoutes } from './routes/stripeConnect';
 import { stripeWebhookRoutes } from './routes/webhooks/stripe';
 import { invoiceAssemblyRoutes } from './routes/invoices/assembly';
@@ -739,6 +740,12 @@ api.route('/alert-templates', alertTemplateRoutes);
 api.route('/tickets', ticketsRoutes);
 api.route('/catalog', catalogRoutes);
 api.route('/invoices', invoiceRoutes);
+// Public, token-gated quote acceptance (no auth) — MUST precede the auth-gated
+// /quotes router so the unauthenticated /quotes/public/* sub-path isn't swallowed
+// by quoteRoutes' authMiddleware (which it applies internally). partnerGuard
+// (the only global api.use) returns next() when there's no Authorization header,
+// so this surface stays unauthenticated.
+api.route('/quotes/public', quotesPublicRoutes);
 api.route('/quotes', quoteRoutes);
 api.route('/partner/stripe-connect', stripeConnectRoutes);
 api.route('/contracts', contractRoutes);

--- a/apps/api/src/routes/portal/index.ts
+++ b/apps/api/src/routes/portal/index.ts
@@ -6,6 +6,7 @@ import { ticketRoutes } from './tickets';
 import { assetRoutes } from './assets';
 import { profileRoutes } from './profile';
 import { invoiceRoutes as portalInvoiceRoutes } from './invoices';
+import { quoteRoutes as portalQuoteRoutes } from './quotes';
 
 export const portalRoutes = new Hono();
 
@@ -19,9 +20,11 @@ portalRoutes.use('/tickets/*', portalAuthMiddleware);
 portalRoutes.use('/assets/*', portalAuthMiddleware);
 portalRoutes.use('/profile/*', portalAuthMiddleware);
 portalRoutes.use('/invoices/*', portalAuthMiddleware);
+portalRoutes.use('/quotes/*', portalAuthMiddleware);
 
 portalRoutes.route('/', deviceRoutes);
 portalRoutes.route('/', ticketRoutes);
 portalRoutes.route('/', assetRoutes);
 portalRoutes.route('/', profileRoutes);
 portalRoutes.route('/', portalInvoiceRoutes);
+portalRoutes.route('/', portalQuoteRoutes);

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -1,0 +1,94 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { and, desc, eq, ne } from 'drizzle-orm';
+import { db } from '../../db';
+import { quotes, quoteBlocks, quoteLines } from '../../db/schema/quotes';
+import { partners } from '../../db/schema/orgs';
+import { portalBranding } from '../../db/schema/portal';
+import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
+import { markQuoteViewed } from '../../services/quoteLifecycle';
+import { acceptQuote } from '../../services/quoteAcceptService';
+import { readQuoteImage } from '../../services/quoteImageStorage';
+import { QuoteServiceError } from '../../services/quoteTypes';
+import { safeContentDispositionFilename } from '../../utils/httpHeaders';
+
+export const quoteRoutes = new Hono();
+const idParam = z.object({ id: z.string().guid() });
+const imageParam = z.object({ id: z.string().guid(), imageId: z.string().guid() });
+
+// GET /quotes — list (drafts filtered; org defense-in-depth atop RLS).
+quoteRoutes.get('/quotes', async (c) => {
+  const auth = c.get('portalAuth');
+  const conditions = and(eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'));
+  const data = await db.select({
+    id: quotes.id, quoteNumber: quotes.quoteNumber, status: quotes.status, currencyCode: quotes.currencyCode,
+    issueDate: quotes.issueDate, expiryDate: quotes.expiryDate, total: quotes.total,
+  }).from(quotes).where(conditions).orderBy(desc(quotes.issueDate), desc(quotes.createdAt)).limit(200);
+  return c.json({ data, pagination: { page: 1, limit: 200, total: data.length } });
+});
+
+// GET /quotes/:id — detail (+ blocks + customer-visible lines). Stamps viewed.
+quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param');
+  const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId))).limit(1);
+  if (!quote || quote.status === 'draft') return c.json({ error: 'Quote not found' }, 404);
+  const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
+  const lines = (await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible);
+  try { await markQuoteViewed(id, auth.user.orgId); } catch (err) { console.error('[portal] quote markViewed failed', { id, err }); }
+  return c.json({ data: { quote, blocks, lines } });
+});
+
+// GET /quotes/:id/pdf
+quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param');
+  const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId))).limit(1);
+  if (!quote || quote.status === 'draft') return c.json({ error: 'Quote not found' }, 404);
+  const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
+  const lines = await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder);
+  const [partner] = await db.select({ name: partners.name, footer: partners.invoiceFooter, currency: partners.currencyCode }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+  const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
+  const loadImage = async (imageId: string) => { const img = await readQuoteImage(imageId, id); return img ? { data: img.data } : null; };
+  const { renderQuotePdf } = await import('../../services/quotePdf');
+  const pdf = await renderQuotePdf(quote, blocks, lines, loadImage, {
+    partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
+    footer: quote.terms ?? partner?.footer ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? partner?.currency ?? 'USD',
+  });
+  const filename = safeContentDispositionFilename(`quote-${quote.quoteNumber || quote.id}.pdf`);
+  return new Response(new Uint8Array(pdf), { status: 200, headers: { 'Content-Type': 'application/pdf', 'Content-Disposition': `inline; filename="${filename}"`, 'Content-Length': String(pdf.length) } });
+});
+
+// GET /quotes/:id/images/:imageId
+quoteRoutes.get('/quotes/:id/images/:imageId', zValidator('param', imageParam), async (c) => {
+  const auth = c.get('portalAuth'); const { id, imageId } = c.req.valid('param');
+  const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
+  if (!quote) return c.json({ error: 'Quote not found' }, 404);
+  const img = await readQuoteImage(imageId, id);
+  if (!img) return c.json({ error: 'Image not found' }, 404);
+  return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+});
+
+// POST /quotes/:id/accept — signer identity = the authenticated portal user.
+quoteRoutes.post('/quotes/:id/accept', zValidator('param', idParam), zValidator('json', acceptQuoteSchema.partial()), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param');
+  const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
+  if (!quote) return c.json({ error: 'Quote not found' }, 404);
+  try {
+    const res = await acceptQuote({
+      quoteId: id, signerName: auth.user.name || auth.user.email, signerEmail: auth.user.email,
+      ipAddress: c.req.header('x-forwarded-for') ?? null, userAgent: c.req.header('user-agent') ?? null, actorUserId: null,
+    });
+    return c.json({ data: { invoiceId: res.invoiceId, status: res.quote.status } });
+  } catch (err) { if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status); throw err; }
+});
+
+// POST /quotes/:id/decline
+quoteRoutes.post('/quotes/:id/decline', zValidator('param', idParam), zValidator('json', declineQuoteSchema), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param'); const { reason } = c.req.valid('json');
+  const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
+  if (!quote) return c.json({ error: 'Quote not found' }, 404);
+  if (quote.status !== 'sent' && quote.status !== 'viewed') return c.json({ error: `Cannot decline a quote in status ${quote.status}`, code: 'INVALID_STATE' }, 409);
+  const now = new Date();
+  await db.update(quotes).set({ status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now }).where(eq(quotes.id, id));
+  return c.json({ data: { status: 'declined' } });
+});

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -12,6 +12,7 @@ import { acceptQuote } from '../../services/quoteAcceptService';
 import { readQuoteImage } from '../../services/quoteImageStorage';
 import { QuoteServiceError } from '../../services/quoteTypes';
 import { safeContentDispositionFilename } from '../../utils/httpHeaders';
+import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 
 export const quoteRoutes = new Hono();
 const idParam = z.object({ id: z.string().guid() });
@@ -76,7 +77,7 @@ quoteRoutes.post('/quotes/:id/accept', zValidator('param', idParam), zValidator(
   try {
     const res = await acceptQuote({
       quoteId: id, signerName: auth.user.name || auth.user.email, signerEmail: auth.user.email,
-      ipAddress: c.req.header('x-forwarded-for') ?? null, userAgent: c.req.header('user-agent') ?? null, actorUserId: null,
+      ipAddress: getTrustedClientIpOrUndefined(c) ?? null, userAgent: c.req.header('user-agent') ?? null, actorUserId: null,
     });
     return c.json({ data: { invoiceId: res.invoiceId, status: res.quote.status } });
   } catch (err) { if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status); throw err; }

--- a/apps/api/src/routes/quotes/index.ts
+++ b/apps/api/src/routes/quotes/index.ts
@@ -1,7 +1,9 @@
 import { Hono } from 'hono';
 import { authMiddleware } from '../../middleware/auth';
 import { quoteCrudRoutes } from './quotes';
+import { quoteLifecycleRoutes } from './lifecycle';
 
 export const quoteRoutes = new Hono();
 quoteRoutes.use('*', authMiddleware);
 quoteRoutes.route('/', quoteCrudRoutes); // /, /:id, /:id/lines, /:id/blocks...
+quoteRoutes.route('/', quoteLifecycleRoutes); // /:id/send, /:id/images, /:id/images/:imageId

--- a/apps/api/src/routes/quotes/lifecycle.test.ts
+++ b/apps/api/src/routes/quotes/lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// Route-level RBAC test for POST /:id/send. The previously-vacuous
+// quoteSendRbac.integration.test.ts only compared permission CONSTANTS; this
+// drives the REAL requireScope + requirePermission middleware on the actual
+// mounted send route, with a controllable permission set, so it would catch the
+// exact regression the old test could not: the route being gated on the wrong
+// permission (e.g. quotes:write) or ungated.
+
+// Controllable grant set, read by the mocked getUserPermissions below.
+const permState = vi.hoisted(() => ({ perms: ['quotes:read', 'quotes:write'] }));
+
+// Keep the REAL requirePermission/requireScope/hasPermission; only stub the
+// DB-backed getUserPermissions so requirePermission resolves a known grant set.
+vi.mock('../../services/permissions', async (importActual) => {
+  const actual = await importActual<typeof import('../../services/permissions')>();
+  return {
+    ...actual,
+    getUserPermissions: vi.fn(async () => ({
+      permissions: permState.perms.map((p) => { const [resource, action] = p.split(':'); return { resource, action }; }),
+      partnerId: 'p1', orgId: null, roleId: 'r1', scope: 'partner' as const,
+    })),
+  };
+});
+
+// Stub the services the route file imports so mounting it never touches the DB.
+vi.mock('../../services/quoteLifecycle', () => ({
+  sendQuote: vi.fn(async () => ({ quote: { id: 'q1', status: 'sent' }, emailed: false, acceptUrl: 'http://x/quote/t' })),
+}));
+vi.mock('../../services/quoteService', () => ({ getQuote: vi.fn() }));
+vi.mock('../../services/quoteImageStorage', () => ({
+  writeQuoteImage: vi.fn(), readQuoteImage: vi.fn(), sniffImageMime: vi.fn(), MAX_QUOTE_IMAGE_SIZE_BYTES: 5 * 1024 * 1024,
+}));
+vi.mock('./quotes', () => ({
+  quoteActorFrom: () => ({ userId: 'u1', partnerId: 'p1', accessibleOrgIds: null }),
+  handleServiceError: (_c: unknown, err: unknown) => { throw err; },
+}));
+
+import { quoteLifecycleRoutes } from './lifecycle';
+
+const QUOTE_ID = '11111111-1111-4111-8111-111111111111';
+
+function appWith(scope: 'partner' | 'system' | 'organization', perms: string[]) {
+  permState.perms = perms;
+  const a = new Hono();
+  a.use('*', async (c, next) => { c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope } as never); await next(); });
+  a.route('/', quoteLifecycleRoutes);
+  return a;
+}
+
+describe('POST /:id/send RBAC (quotes:send)', () => {
+  it('403s a quotes:read + quotes:write user without quotes:send', async () => {
+    const res = await appWith('partner', ['quotes:read', 'quotes:write']).request(`/${QUOTE_ID}/send`, { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes the permission gate for a quotes:send holder', async () => {
+    const res = await appWith('partner', ['quotes:read', 'quotes:write', 'quotes:send']).request(`/${QUOTE_ID}/send`, { method: 'POST' });
+    expect(res.status).toBe(200);
+  });
+
+  it('403s a wrong scope (organization) even with quotes:send', async () => {
+    const res = await appWith('organization', ['quotes:send']).request(`/${QUOTE_ID}/send`, { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/quotes/lifecycle.ts
+++ b/apps/api/src/routes/quotes/lifecycle.ts
@@ -1,0 +1,57 @@
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { getQuote } from '../../services/quoteService';
+import { writeQuoteImage, readQuoteImage, sniffImageMime, MAX_QUOTE_IMAGE_SIZE_BYTES } from '../../services/quoteImageStorage';
+import { quoteActorFrom, handleServiceError } from './quotes';
+
+export const quoteLifecycleRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const readPerm = requirePermission(PERMISSIONS.QUOTES_READ.resource, PERMISSIONS.QUOTES_READ.action);
+const writePerm = requirePermission(PERMISSIONS.QUOTES_WRITE.resource, PERMISSIONS.QUOTES_WRITE.action);
+const sendPerm = requirePermission(PERMISSIONS.QUOTES_SEND.resource, PERMISSIONS.QUOTES_SEND.action);
+const idParam = z.object({ id: z.string().guid() });
+const imageParam = z.object({ id: z.string().guid(), imageId: z.string().guid() });
+
+// POST /:id/send — issue + email. Gated on the (previously dead) quotes:send permission.
+quoteLifecycleRoutes.post('/:id/send', scopes, sendPerm, zValidator('param', idParam), async (c) => {
+  try { return c.json({ data: await sendQuote(c.req.valid('param').id, quoteActorFrom(c)) }); }
+  catch (err) { return handleServiceError(c, err); }
+});
+
+// POST /:id/images — multipart upload (magic-byte sniff + 5 MB cap). quotes:write.
+quoteLifecycleRoutes.post('/:id/images',
+  scopes, writePerm, zValidator('param', idParam),
+  bodyLimit({ maxSize: MAX_QUOTE_IMAGE_SIZE_BYTES + 64 * 1024, onError: (c) => c.json({ error: 'Image too large (max 5 MB)' }, 413) }),
+  async (c) => {
+    const id = c.req.valid('param').id;
+    try {
+      const { quote } = await getQuote(id, quoteActorFrom(c)); // org-access 404
+      let body: Record<string, unknown>;
+      try { body = await c.req.parseBody({ all: true }); } catch { return c.json({ error: 'Invalid multipart body' }, 400); }
+      const file = body.file;
+      if (!(file instanceof File)) return c.json({ error: 'file field is required' }, 400);
+      if (file.size === 0) return c.json({ error: 'file is empty' }, 400);
+      if (file.size > MAX_QUOTE_IMAGE_SIZE_BYTES) return c.json({ error: 'Image too large (max 5 MB)' }, 413);
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const mime = sniffImageMime(buffer);
+      if (!mime) return c.json({ error: 'Unsupported image format. Allowed: PNG, JPEG, WebP.' }, 415);
+      const written = await writeQuoteImage(id, quote.orgId, mime, buffer);
+      return c.json({ data: { imageId: written.id, mime, byteSize: written.byteSize } });
+    } catch (err) { return handleServiceError(c, err); }
+  });
+
+// GET /:id/images/:imageId — serve for the editor preview. quotes:read.
+quoteLifecycleRoutes.get('/:id/images/:imageId', scopes, readPerm, zValidator('param', imageParam), async (c) => {
+  const { id, imageId } = c.req.valid('param');
+  try {
+    await getQuote(id, quoteActorFrom(c)); // org-access 404 before serving bytes
+    const img = await readQuoteImage(imageId, id);
+    if (!img) return c.json({ error: 'Image not found' }, 404);
+    return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+  } catch (err) { return handleServiceError(c, err); }
+});

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -1,0 +1,97 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { eq, and } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { quotes, quoteBlocks, quoteLines } from '../db/schema/quotes';
+import { partners } from '../db/schema/orgs';
+import { portalBranding } from '../db/schema/portal';
+import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
+import { verifyQuoteAcceptToken, isQuoteAcceptJtiRevoked } from '../services/quoteAcceptToken';
+import { markQuoteViewed } from '../services/quoteLifecycle';
+import { acceptQuote } from '../services/quoteAcceptService';
+import { readQuoteImage } from '../services/quoteImageStorage';
+import { QuoteServiceError } from '../services/quoteTypes';
+
+/**
+ * Unauthenticated, token-gated quote acceptance surface for prospects without a
+ * portal account. SECURITY: this router has NO auth middleware, so every DB op
+ * runs through runOutsideDbContext(() => withSystemDbAccessContext(...)) scoped
+ * to the org_id/quote_id resolved from a *signature-verified* token (a bare `db`
+ * write here would silently match 0 rows under breeze_app RLS — the
+ * rls_silent_zero_row_write class). The token is the only authorization: it is
+ * minted on send, revocable by jti, and carries the orgId/quoteId/partnerId.
+ * Mounted at /quotes/public BEFORE the auth-gated /quotes router in index.ts.
+ */
+export const quotesPublicRoutes = new Hono();
+const tokenParam = z.object({ token: z.string().min(10) });
+const tokenImageParam = z.object({ token: z.string().min(10), imageId: z.string().guid() });
+
+// Resolve + verify the token, returning the scoped claims or null.
+async function resolve(c: { req: { valid: (k: 'param') => { token: string } } }) {
+  const { token } = c.req.valid('param');
+  const claims = await verifyQuoteAcceptToken(token);
+  if (!claims) return null;
+  if (await isQuoteAcceptJtiRevoked(claims.jti)) return null;
+  return claims;
+}
+
+// GET /:token — view. Stamps first_viewed_at + sent→viewed. Customer-visible content only.
+quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => {
+  const claims = await resolve(c);
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  const data = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    if (!quote || quote.status === 'draft') return null;
+    const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, quote.id)).orderBy(quoteBlocks.sortOrder);
+    const lines = (await db.select().from(quoteLines).where(eq(quoteLines.quoteId, quote.id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible);
+    const [partner] = await db.select({ name: partners.name }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+    const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
+    await markQuoteViewed(quote.id, quote.orgId);
+    return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
+  }));
+  if (!data) return c.json({ error: 'Quote not found' }, 404);
+  return c.json({ data });
+});
+
+// GET /:token/images/:imageId
+quotesPublicRoutes.get('/:token/images/:imageId', zValidator('param', tokenImageParam), async (c) => {
+  const claims = await resolve(c); const { imageId } = c.req.valid('param');
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  const img = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    if (!quote) return null;
+    return readQuoteImage(imageId, quote.id);
+  }));
+  if (!img) return c.json({ error: 'Image not found' }, 404);
+  return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+});
+
+// POST /:token/accept — typed signature. System-scope write, token-resolved.
+quotesPublicRoutes.post('/:token/accept', zValidator('param', tokenParam), zValidator('json', acceptQuoteSchema), async (c) => {
+  const claims = await resolve(c); const body = c.req.valid('json');
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  try {
+    const res = await runOutsideDbContext(() => withSystemDbAccessContext(() => acceptQuote({
+      quoteId: claims.quoteId, signerName: body.signerName, signerEmail: body.signerEmail ?? null,
+      ipAddress: c.req.header('x-forwarded-for') ?? null, userAgent: c.req.header('user-agent') ?? null,
+      acceptanceTokenJti: claims.jti, actorUserId: null,
+    })));
+    return c.json({ data: { status: res.quote.status, invoiceNumber: null } });
+  } catch (err) { if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status); throw err; }
+});
+
+// POST /:token/decline
+quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zValidator('json', declineQuoteSchema), async (c) => {
+  const claims = await resolve(c); const { reason } = c.req.valid('json');
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  const ok = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    if (!quote || (quote.status !== 'sent' && quote.status !== 'viewed')) return false;
+    const now = new Date();
+    await db.update(quotes).set({ status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now }).where(eq(quotes.id, quote.id));
+    return true;
+  }));
+  if (!ok) return c.json({ error: 'This quote can no longer be declined' }, 409);
+  return c.json({ data: { status: 'declined' } });
+});

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -7,11 +7,12 @@ import { quotes, quoteBlocks, quoteLines } from '../db/schema/quotes';
 import { partners } from '../db/schema/orgs';
 import { portalBranding } from '../db/schema/portal';
 import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
-import { verifyQuoteAcceptToken, isQuoteAcceptJtiRevoked } from '../services/quoteAcceptToken';
+import { verifyQuoteAcceptToken, isQuoteAcceptJtiRevoked, revokeQuoteAcceptJti } from '../services/quoteAcceptToken';
 import { markQuoteViewed } from '../services/quoteLifecycle';
 import { acceptQuote } from '../services/quoteAcceptService';
 import { readQuoteImage } from '../services/quoteImageStorage';
 import { QuoteServiceError } from '../services/quoteTypes';
+import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 
 /**
  * Unauthenticated, token-gated quote acceptance surface for prospects without a
@@ -74,9 +75,11 @@ quotesPublicRoutes.post('/:token/accept', zValidator('param', tokenParam), zVali
   try {
     const res = await runOutsideDbContext(() => withSystemDbAccessContext(() => acceptQuote({
       quoteId: claims.quoteId, signerName: body.signerName, signerEmail: body.signerEmail ?? null,
-      ipAddress: c.req.header('x-forwarded-for') ?? null, userAgent: c.req.header('user-agent') ?? null,
+      ipAddress: getTrustedClientIpOrUndefined(c) ?? null, userAgent: c.req.header('user-agent') ?? null,
       acceptanceTokenJti: claims.jti, actorUserId: null,
     })));
+    // Post-commit (atom-2): consume the single-use token so the link can't be replayed.
+    try { await revokeQuoteAcceptJti(claims.jti); } catch (err) { console.error('[quotesPublic] jti revoke failed', err); }
     return c.json({ data: { status: res.quote.status, invoiceNumber: null } });
   } catch (err) { if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status); throw err; }
 });
@@ -93,5 +96,7 @@ quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zVal
     return true;
   }));
   if (!ok) return c.json({ error: 'This quote can no longer be declined' }, 409);
+  // Consume the single-use token post-commit so a declined link can't be replayed.
+  try { await revokeQuoteAcceptJti(claims.jti); } catch (err) { console.error('[quotesPublic] jti revoke failed', err); }
   return c.json({ data: { status: 'declined' } });
 });

--- a/apps/api/src/services/acceptanceProvider.test.ts
+++ b/apps/api/src/services/acceptanceProvider.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getAcceptanceProvider } from './acceptanceProvider';
+
+describe('TypedSignatureProvider', () => {
+  it('captures a typed signature with method=typed-signature', async () => {
+    const p = getAcceptanceProvider();
+    expect(p.kind).toBe('builtin');
+    const r = await p.capture({ quoteId: 'q1', signerName: '  Jane Buyer ', signerEmail: 'jane@x.com', ipAddress: '1.2.3.4', userAgent: 'UA', acceptanceTokenJti: 'jti1' });
+    expect(r).toEqual({ signerName: 'Jane Buyer', signerEmail: 'jane@x.com', method: 'typed-signature' });
+  });
+  it('rejects an empty typed name', async () => {
+    const p = getAcceptanceProvider();
+    await expect(p.capture({ quoteId: 'q1', signerName: '   ' })).rejects.toThrow();
+  });
+  it('normalizes a missing email to null', async () => {
+    const r = await getAcceptanceProvider().capture({ quoteId: 'q1', signerName: 'Bob' });
+    expect(r.signerEmail).toBeNull();
+  });
+});

--- a/apps/api/src/services/acceptanceProvider.ts
+++ b/apps/api/src/services/acceptanceProvider.ts
@@ -1,0 +1,41 @@
+export interface AcceptanceCaptureInput {
+  quoteId: string;
+  signerName: string;
+  signerEmail?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  acceptanceTokenJti?: string | null;
+}
+
+export interface AcceptanceCaptureResult {
+  signerName: string;
+  signerEmail: string | null;
+  method: string;
+}
+
+export interface AcceptanceProvider {
+  readonly kind: string;
+  capture(input: AcceptanceCaptureInput): Promise<AcceptanceCaptureResult>;
+}
+
+/**
+ * Built-in typed-signature provider. The signer types their full name; we record
+ * it plus the method. A future DocuSign/PandaDoc adapter implements the same
+ * interface and maps its envelope reference onto
+ * quote_acceptances.acceptance_token_jti — same columns, no schema change.
+ */
+export class TypedSignatureProvider implements AcceptanceProvider {
+  readonly kind = 'builtin';
+  async capture(input: AcceptanceCaptureInput): Promise<AcceptanceCaptureResult> {
+    const signerName = input.signerName.trim();
+    if (!signerName) throw new Error('signerName is required for a typed signature');
+    const email = input.signerEmail?.trim();
+    return { signerName, signerEmail: email && email.length > 0 ? email : null, method: 'typed-signature' };
+  }
+}
+
+let provider: AcceptanceProvider | null = null;
+export function getAcceptanceProvider(): AcceptanceProvider {
+  if (!provider) provider = new TypedSignatureProvider();
+  return provider;
+}

--- a/apps/api/src/services/email.ts
+++ b/apps/api/src/services/email.ts
@@ -94,7 +94,7 @@ export interface AlertNotificationEmailParams {
   orgName?: string;
 }
 
-interface EmailTemplate {
+export interface EmailTemplate {
   subject: string;
   html: string;
   text: string;
@@ -614,10 +614,10 @@ async function sendViaMailgun(
   }
 }
 
-const BODY_PARA = 'margin: 0 0 12px; font-size: 15px; line-height: 1.55; color: #1f2937;';
-const MUTED_PARA = 'margin: 12px 0 0; font-size: 13px; line-height: 1.55; color: #6b7280;';
+export const BODY_PARA = 'margin: 0 0 12px; font-size: 15px; line-height: 1.55; color: #1f2937;';
+export const MUTED_PARA = 'margin: 12px 0 0; font-size: 13px; line-height: 1.55; color: #6b7280;';
 
-function supportFooter(explicit: string | undefined, prefix: string): string | undefined {
+export function supportFooter(explicit: string | undefined, prefix: string): string | undefined {
   const support = getSupportEmail(explicit);
   return support ? `${prefix} ${support}.` : undefined;
 }

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -452,7 +452,7 @@ export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): 
 }
 
 /** Pull an email address out of the organizations.billing_contact JSONB blob. */
-function resolveBillingEmail(billingContact: unknown): string | null {
+export function resolveBillingEmail(billingContact: unknown): string | null {
   if (billingContact && typeof billingContact === 'object') {
     const email = (billingContact as { email?: unknown }).email;
     if (typeof email === 'string' && email.includes('@')) return email;

--- a/apps/api/src/services/jwt.ts
+++ b/apps/api/src/services/jwt.ts
@@ -123,8 +123,11 @@ function getLegacySecretKey(): Uint8Array | null {
 /**
  * Returns the key used to sign *new* tokens, and the `kid` that should be
  * emitted in the protected header (omitted in legacy single-secret mode).
+ *
+ * Exported so sibling token modules (e.g. quoteAcceptToken.ts) sign with the
+ * same keyring instead of duplicating key material.
  */
-function getSignKey(): { key: Uint8Array; kid?: string } {
+export function getSignKey(): { key: Uint8Array; kid?: string } {
   const activeKid = getActiveSigningKid();
   if (activeKid) {
     const keyring = getSigningKeyring();
@@ -152,7 +155,7 @@ function getSignKey(): { key: Uint8Array; kid?: string } {
  * who minted a token with a forged kid mustn't get a free pass through the
  * legacy path).
  */
-function getVerifyKey(header: JWTHeaderParameters): Uint8Array {
+export function getVerifyKey(header: JWTHeaderParameters): Uint8Array {
   const kid = header.kid;
   if (typeof kid === 'string' && kid.length > 0) {
     const keyring = getSigningKeyring();
@@ -208,7 +211,7 @@ export interface ViewerTokenPayload {
   iat?: number;
 }
 
-function buildHeader(kid?: string): { alg: 'HS256'; kid?: string } {
+export function buildHeader(kid?: string): { alg: 'HS256'; kid?: string } {
   return kid ? { alg: 'HS256', kid } : { alg: 'HS256' };
 }
 

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -1,0 +1,155 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { quotes, quoteBlocks, quoteLines, quoteAcceptances } from '../db/schema/quotes';
+import { invoices, invoiceLines } from '../db/schema/invoices';
+import { QuoteServiceError } from './quoteTypes';
+import { computeQuoteSha256 } from './quoteContentHash';
+import { getAcceptanceProvider } from './acceptanceProvider';
+import { revokeQuoteAcceptJti } from './quoteAcceptToken';
+import { computeLineTotal, computeInvoiceTotals } from './invoiceMath';
+
+export interface AcceptQuoteParams {
+  quoteId: string;
+  signerName: string;
+  signerEmail?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  acceptanceTokenJti?: string | null;
+  actorUserId?: string | null;
+}
+
+type QuoteRow = typeof quotes.$inferSelect;
+
+/**
+ * Shared accept pipeline for both the portal and public paths. The CALLER is
+ * responsible for establishing the DB access context: portal handlers run under
+ * org scope; the public route wraps this in
+ * runOutsideDbContext(withSystemDbAccessContext(...)) because it's unauthenticated.
+ *
+ * Pipeline: guard status → compute content hash → provider.capture →
+ * insert quote_acceptances → convert ONE-TIME lines to a draft invoice via
+ * invoiceMath → status→converted → revoke the public token jti.
+ */
+export async function acceptQuote(
+  params: AcceptQuoteParams
+): Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string }> {
+  const [quote] = await db.select().from(quotes).where(eq(quotes.id, params.quoteId)).limit(1);
+  if (!quote) throw new QuoteServiceError('Quote not found', 404, 'QUOTE_NOT_FOUND');
+  if (quote.status !== 'sent' && quote.status !== 'viewed') {
+    throw new QuoteServiceError(`Cannot accept a quote in status ${quote.status}`, 409, 'INVALID_STATE');
+  }
+
+  const blocks = await db
+    .select()
+    .from(quoteBlocks)
+    .where(eq(quoteBlocks.quoteId, quote.id))
+    .orderBy(quoteBlocks.sortOrder);
+  const lines = await db
+    .select()
+    .from(quoteLines)
+    .where(eq(quoteLines.quoteId, quote.id))
+    .orderBy(quoteLines.sortOrder);
+
+  const quoteSha256 = computeQuoteSha256(quote as any, blocks as any, lines as any);
+  const captured = await getAcceptanceProvider().capture({
+    quoteId: quote.id,
+    signerName: params.signerName,
+    signerEmail: params.signerEmail,
+    ipAddress: params.ipAddress,
+    userAgent: params.userAgent,
+    acceptanceTokenJti: params.acceptanceTokenJti,
+  });
+
+  const now = new Date();
+
+  // 1. Record the acceptance.
+  const [acceptance] = await db
+    .insert(quoteAcceptances)
+    .values({
+      quoteId: quote.id,
+      orgId: quote.orgId,
+      signerName: captured.signerName,
+      signerEmail: captured.signerEmail,
+      ipAddress: params.ipAddress ?? null,
+      userAgent: params.userAgent ?? null,
+      quoteSha256,
+      acceptanceTokenJti: params.acceptanceTokenJti ?? null,
+    })
+    .returning({ id: quoteAcceptances.id });
+
+  // 2. Convert ONE-TIME lines to a draft invoice (Phase 2: recurring lines deferred to the Phase 4 Contract).
+  const oneTime = lines.filter((l) => l.recurrence === 'one_time' && l.customerVisible);
+  const [invoice] = await db
+    .insert(invoices)
+    .values({
+      partnerId: quote.partnerId,
+      orgId: quote.orgId,
+      siteId: quote.siteId ?? null,
+      status: 'draft',
+      currencyCode: quote.currencyCode,
+      taxRate: quote.taxRate ?? null,
+      createdBy: params.actorUserId ?? null,
+      notes: quote.quoteNumber ? `Converted from quote ${quote.quoteNumber}` : 'Converted from quote',
+    })
+    .returning();
+
+  const totalsLines: { lineTotal: string; taxable: boolean; customerVisible: boolean }[] = [];
+  for (let i = 0; i < oneTime.length; i++) {
+    const l = oneTime[i]!;
+    const lineTotal = computeLineTotal(l.quantity, l.unitPrice);
+    await db.insert(invoiceLines).values({
+      invoiceId: invoice!.id,
+      orgId: quote.orgId,
+      sourceType: 'manual',
+      sourceId: null,
+      catalogItemId: l.catalogItemId ?? null,
+      parentLineId: null,
+      ticketId: null,
+      description: l.description,
+      quantity: l.quantity,
+      unitPrice: l.unitPrice,
+      costBasis: null,
+      taxable: l.taxable,
+      customerVisible: true,
+      lineTotal,
+      isUnapprovedTime: false,
+      sortOrder: i,
+    });
+    totalsLines.push({ lineTotal, taxable: l.taxable, customerVisible: true });
+  }
+  const totals = computeInvoiceTotals(totalsLines, quote.taxRate ?? null);
+  await db
+    .update(invoices)
+    .set({
+      subtotal: totals.subtotal,
+      taxTotal: totals.taxTotal,
+      total: totals.total,
+      balance: totals.total,
+      updatedAt: now,
+    })
+    .where(eq(invoices.id, invoice!.id));
+
+  // 3. Transition the quote to converted.
+  await db
+    .update(quotes)
+    .set({
+      status: 'converted',
+      acceptedAt: now,
+      convertedAt: now,
+      convertedInvoiceId: invoice!.id,
+      updatedAt: now,
+    })
+    .where(eq(quotes.id, quote.id));
+
+  // 4. Best-effort revoke the public token so the link can't be reused.
+  if (params.acceptanceTokenJti) {
+    try {
+      await revokeQuoteAcceptJti(params.acceptanceTokenJti);
+    } catch (err) {
+      console.error('[quoteAcceptService] jti revoke failed', err);
+    }
+  }
+
+  const [updated] = await db.select().from(quotes).where(eq(quotes.id, quote.id)).limit(1);
+  return { quote: updated!, acceptanceId: acceptance!.id, invoiceId: invoice!.id };
+}

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -5,7 +5,6 @@ import { invoices, invoiceLines } from '../db/schema/invoices';
 import { QuoteServiceError } from './quoteTypes';
 import { computeQuoteSha256 } from './quoteContentHash';
 import { getAcceptanceProvider } from './acceptanceProvider';
-import { revokeQuoteAcceptJti } from './quoteAcceptToken';
 import { computeLineTotal, computeInvoiceTotals } from './invoiceMath';
 
 export interface AcceptQuoteParams {
@@ -26,14 +25,24 @@ type QuoteRow = typeof quotes.$inferSelect;
  * org scope; the public route wraps this in
  * runOutsideDbContext(withSystemDbAccessContext(...)) because it's unauthenticated.
  *
- * Pipeline: guard status → compute content hash → provider.capture →
- * insert quote_acceptances → convert ONE-TIME lines to a draft invoice via
- * invoiceMath → status→converted → revoke the public token jti.
+ * Pipeline: lock quote row → guard status → compute content hash →
+ * provider.capture → insert quote_acceptances → convert ONE-TIME lines to a
+ * draft invoice via invoiceMath → status→converted.
+ *
+ * The caller's context wraps this in ONE Postgres transaction, so the whole
+ * accept is atomic. The opening SELECT ... FOR UPDATE serializes concurrent
+ * accepts of the same quote (double-submit / two tabs): the second transaction
+ * blocks on the row lock, then re-reads status='converted' and 409s — preventing
+ * duplicate acceptances + duplicate draft invoices. Revoking the public token's
+ * jti is left to the caller, post-commit (so a rolled-back accept never revokes).
  */
 export async function acceptQuote(
   params: AcceptQuoteParams
 ): Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string }> {
-  const [quote] = await db.select().from(quotes).where(eq(quotes.id, params.quoteId)).limit(1);
+  // FOR UPDATE: serialize concurrent accepts on the same quote (we're already in
+  // the caller's transaction). Without the row lock two READ COMMITTED accepts
+  // both pass the status guard and each create an invoice (atom-1/C2).
+  const [quote] = await db.select().from(quotes).where(eq(quotes.id, params.quoteId)).for('update').limit(1);
   if (!quote) throw new QuoteServiceError('Quote not found', 404, 'QUOTE_NOT_FOUND');
   if (quote.status !== 'sent' && quote.status !== 'viewed') {
     throw new QuoteServiceError(`Cannot accept a quote in status ${quote.status}`, 409, 'INVALID_STATE');
@@ -70,7 +79,10 @@ export async function acceptQuote(
       orgId: quote.orgId,
       signerName: captured.signerName,
       signerEmail: captured.signerEmail,
-      ipAddress: params.ipAddress ?? null,
+      // Defense-in-depth: routes already resolve a single validated client IP,
+      // but ip_address is varchar(64) — clamp so a stray long value can never
+      // overflow and roll back the whole accept (C1).
+      ipAddress: params.ipAddress ? params.ipAddress.slice(0, 64) : null,
       userAgent: params.userAgent ?? null,
       quoteSha256,
       acceptanceTokenJti: params.acceptanceTokenJti ?? null,
@@ -141,14 +153,8 @@ export async function acceptQuote(
     })
     .where(eq(quotes.id, quote.id));
 
-  // 4. Best-effort revoke the public token so the link can't be reused.
-  if (params.acceptanceTokenJti) {
-    try {
-      await revokeQuoteAcceptJti(params.acceptanceTokenJti);
-    } catch (err) {
-      console.error('[quoteAcceptService] jti revoke failed', err);
-    }
-  }
+  // Note: the public token's jti is revoked by the CALLER after the transaction
+  // commits (atom-2) — revoking here would fire even if the txn later rolled back.
 
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, quote.id)).limit(1);
   return { quote: updated!, acceptanceId: acceptance!.id, invoiceId: invoice!.id };

--- a/apps/api/src/services/quoteAcceptToken.test.ts
+++ b/apps/api/src/services/quoteAcceptToken.test.ts
@@ -17,4 +17,14 @@ describe('quote-accept token', () => {
     const viewer = await createViewerAccessToken({ sub: 'u1', email: 'a@b.com', sessionId: 's1' });
     expect(await verifyQuoteAcceptToken(viewer)).toBeNull();
   });
+  it('honors a future expiresAt (quote expiry_date in the future)', async () => {
+    const { token } = await createQuoteAcceptToken({ quoteId: 'q1', orgId: 'o1', partnerId: 'p1', expiresAt: new Date(Date.now() + 3_600_000) });
+    expect(await verifyQuoteAcceptToken(token)).not.toBeNull();
+  });
+  it('a past expiresAt falls back to the default TTL (never mints an already-expired token)', async () => {
+    // The expiry derivation deliberately defaults to +30d when expiresAt is in
+    // the past, so a stale quote.expiry_date can't produce a born-dead link.
+    const { token } = await createQuoteAcceptToken({ quoteId: 'q1', orgId: 'o1', partnerId: 'p1', expiresAt: new Date(Date.now() - 60_000) });
+    expect(await verifyQuoteAcceptToken(token)).not.toBeNull();
+  });
 });

--- a/apps/api/src/services/quoteAcceptToken.test.ts
+++ b/apps/api/src/services/quoteAcceptToken.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createQuoteAcceptToken, verifyQuoteAcceptToken } from './quoteAcceptToken';
+
+beforeAll(() => { process.env.JWT_SECRET ||= 'test-secret-test-secret-test-secret-123'; });
+
+describe('quote-accept token', () => {
+  it('round-trips quoteId/orgId/partnerId/jti', async () => {
+    const { token, jti } = await createQuoteAcceptToken({ quoteId: 'q1', orgId: 'o1', partnerId: 'p1' });
+    const claims = await verifyQuoteAcceptToken(token);
+    expect(claims).toEqual({ quoteId: 'q1', orgId: 'o1', partnerId: 'p1', jti });
+  });
+  it('rejects a garbage token', async () => {
+    expect(await verifyQuoteAcceptToken('not.a.jwt')).toBeNull();
+  });
+  it('rejects a viewer-purpose token (wrong audience/purpose)', async () => {
+    const { createViewerAccessToken } = await import('./jwt');
+    const viewer = await createViewerAccessToken({ sub: 'u1', email: 'a@b.com', sessionId: 's1' });
+    expect(await verifyQuoteAcceptToken(viewer)).toBeNull();
+  });
+});

--- a/apps/api/src/services/quoteAcceptToken.ts
+++ b/apps/api/src/services/quoteAcceptToken.ts
@@ -1,0 +1,65 @@
+import { SignJWT, jwtVerify } from 'jose';
+import { randomUUID } from 'node:crypto';
+import { getRedis } from './redis';
+import { getSignKey, getVerifyKey, buildHeader } from './jwt';
+
+const ISSUER = 'breeze';
+const AUDIENCE = 'breeze-quote-accept';
+const PURPOSE = 'quote-accept';
+const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const REVOKE_TTL_SECONDS = DEFAULT_TTL_SECONDS;
+
+export interface QuoteAcceptClaims { quoteId: string; orgId: string; partnerId: string; jti: string; }
+
+/**
+ * Mint a signed, revocable token that lets a prospect without a portal account
+ * open + accept exactly one quote. Mirrors the viewer-token pattern (jwt.ts +
+ * viewerTokenRevocation.ts) but with its own audience/purpose so a viewer token
+ * can never be replayed against the accept path.
+ */
+export async function createQuoteAcceptToken(input: {
+  quoteId: string; orgId: string; partnerId: string; expiresAt?: Date | null;
+}): Promise<{ token: string; jti: string }> {
+  const { key, kid } = getSignKey();
+  const jti = randomUUID();
+  // Expiry = the quote's expiry_date if it's in the future, else +30d. jose's
+  // setExpirationTime accepts a number of seconds since the epoch.
+  const expSeconds = input.expiresAt && input.expiresAt.getTime() > Date.now()
+    ? Math.floor(input.expiresAt.getTime() / 1000)
+    : Math.floor(Date.now() / 1000) + DEFAULT_TTL_SECONDS;
+  const token = await new SignJWT({ quoteId: input.quoteId, orgId: input.orgId, partnerId: input.partnerId, purpose: PURPOSE })
+    .setProtectedHeader(buildHeader(kid))
+    .setJti(jti)
+    .setIssuedAt()
+    .setExpirationTime(expSeconds)
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .sign(key);
+  return { token, jti };
+}
+
+export async function verifyQuoteAcceptToken(token: string): Promise<QuoteAcceptClaims | null> {
+  try {
+    const { payload } = await jwtVerify(token, getVerifyKey, { issuer: ISSUER, audience: AUDIENCE, algorithms: ['HS256'] });
+    if (payload.purpose !== PURPOSE) return null;
+    if (typeof payload.jti !== 'string' || payload.jti.length === 0) return null;
+    const { quoteId, orgId, partnerId } = payload as Record<string, unknown>;
+    if (typeof quoteId !== 'string' || typeof orgId !== 'string' || typeof partnerId !== 'string') return null;
+    return { quoteId, orgId, partnerId, jti: payload.jti };
+  } catch (err) {
+    console.debug('[quoteAcceptToken] verification failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+export async function revokeQuoteAcceptJti(jti: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) { console.error('[quoteAcceptToken] Redis unavailable — jti revocation skipped'); return; }
+  await redis.set(`quote-accept-jti-revoked:${jti}`, '1', 'EX', REVOKE_TTL_SECONDS);
+}
+
+export async function isQuoteAcceptJtiRevoked(jti: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) { console.error('[quoteAcceptToken] Redis unavailable — failing closed on jti check'); return true; }
+  return (await redis.get(`quote-accept-jti-revoked:${jti}`)) === '1';
+}

--- a/apps/api/src/services/quoteContentHash.test.ts
+++ b/apps/api/src/services/quoteContentHash.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { computeQuoteSha256 } from './quoteContentHash';
+
+const quote = { id: 'q1', quoteNumber: 'Q-2026-0001', status: 'sent', currencyCode: 'USD', total: '100.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', taxTotal: '0.00', subtotal: '100.00' } as any;
+const blocks = [{ id: 'b1', blockType: 'heading', content: { text: 'Proposal' }, sortOrder: 0 }] as any;
+const lines = [{ id: 'l1', description: 'Setup', quantity: '1', unitPrice: '100.00', lineTotal: '100.00', recurrence: 'one_time', taxable: false, customerVisible: true, sortOrder: 0 }] as any;
+
+describe('computeQuoteSha256', () => {
+  it('returns a stable 64-char hex hash for the same content', () => {
+    const a = computeQuoteSha256(quote, blocks, lines);
+    const b = computeQuoteSha256(quote, blocks, lines);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).toBe(b);
+  });
+  it('is order-independent on input arrays but content-sensitive', () => {
+    const reordered = computeQuoteSha256(quote, blocks, [...lines].reverse());
+    expect(reordered).toBe(computeQuoteSha256(quote, blocks, lines));
+  });
+  it('changes when a line amount is tampered', () => {
+    const tampered = [{ ...lines[0], unitPrice: '1.00', lineTotal: '1.00' }];
+    expect(computeQuoteSha256(quote, blocks, tampered)).not.toBe(computeQuoteSha256(quote, blocks, lines));
+  });
+});

--- a/apps/api/src/services/quoteContentHash.test.ts
+++ b/apps/api/src/services/quoteContentHash.test.ts
@@ -20,4 +20,10 @@ describe('computeQuoteSha256', () => {
     const tampered = [{ ...lines[0], unitPrice: '1.00', lineTotal: '1.00' }];
     expect(computeQuoteSha256(quote, blocks, tampered)).not.toBe(computeQuoteSha256(quote, blocks, lines));
   });
+  it('ignores volatile workflow fields — status + quote number (C4)', () => {
+    // The quote legitimately transitions sent→converted (and gets a number) during
+    // accept; the content hash must NOT change, or a later re-verify false-positives.
+    const evolved = { ...quote, status: 'converted', quoteNumber: 'Q-9999-9999' };
+    expect(computeQuoteSha256(evolved, blocks, lines)).toBe(computeQuoteSha256(quote, blocks, lines));
+  });
 });

--- a/apps/api/src/services/quoteContentHash.ts
+++ b/apps/api/src/services/quoteContentHash.ts
@@ -1,0 +1,44 @@
+import { createHash } from 'node:crypto';
+
+type HashableQuote = {
+  id: string; quoteNumber: string | null; status: string; currencyCode: string;
+  subtotal: string; taxTotal: string; total: string;
+  oneTimeTotal: string; monthlyRecurringTotal: string; annualRecurringTotal: string;
+};
+type HashableBlock = { id: string; blockType: string; content: unknown; sortOrder: number };
+type HashableLine = {
+  id: string; description: string; quantity: string; unitPrice: string; lineTotal: string;
+  recurrence: string; taxable: boolean; customerVisible: boolean; sortOrder: number;
+};
+
+/**
+ * Canonical, order-independent serialization of a quote's billable content,
+ * hashed with SHA-256. Captured at accept time and stored on
+ * quote_acceptances.quote_sha256 so a later edit (or a forged re-render) can be
+ * detected. Sorting by (sortOrder, id) makes the hash independent of the array
+ * order the caller happens to pass while staying sensitive to any value change.
+ */
+export function computeQuoteSha256(
+  quote: HashableQuote,
+  blocks: HashableBlock[],
+  lines: HashableLine[]
+): string {
+  const canonical = {
+    quote: {
+      id: quote.id, number: quote.quoteNumber, status: quote.status, currency: quote.currencyCode,
+      subtotal: quote.subtotal, taxTotal: quote.taxTotal, total: quote.total,
+      oneTime: quote.oneTimeTotal, monthly: quote.monthlyRecurringTotal, annual: quote.annualRecurringTotal,
+    },
+    blocks: [...blocks]
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id))
+      .map((b) => ({ id: b.id, type: b.blockType, sortOrder: b.sortOrder, content: b.content })),
+    lines: [...lines]
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id))
+      .map((l) => ({
+        id: l.id, description: l.description, quantity: l.quantity, unitPrice: l.unitPrice,
+        lineTotal: l.lineTotal, recurrence: l.recurrence, taxable: l.taxable,
+        customerVisible: l.customerVisible, sortOrder: l.sortOrder,
+      })),
+  };
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
+}

--- a/apps/api/src/services/quoteContentHash.ts
+++ b/apps/api/src/services/quoteContentHash.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 type HashableQuote = {
-  id: string; quoteNumber: string | null; status: string; currencyCode: string;
+  id: string; currencyCode: string;
   subtotal: string; taxTotal: string; total: string;
   oneTimeTotal: string; monthlyRecurringTotal: string; annualRecurringTotal: string;
 };
@@ -12,11 +12,17 @@ type HashableLine = {
 };
 
 /**
- * Canonical, order-independent serialization of a quote's billable content,
+ * Canonical, order-independent serialization of a quote's billable CONTENT,
  * hashed with SHA-256. Captured at accept time and stored on
  * quote_acceptances.quote_sha256 so a later edit (or a forged re-render) can be
  * detected. Sorting by (sortOrder, id) makes the hash independent of the array
  * order the caller happens to pass while staying sensitive to any value change.
+ *
+ * Deliberately EXCLUDES volatile workflow fields (status, quote number): the
+ * quote legitimately transitions sent→converted during accept, so folding
+ * `status` in would make a future re-verification of the now-'converted' quote
+ * false-positive on tampering (C4). Only content that must stay immutable for
+ * the signature to mean anything (money, lines, blocks, currency) is hashed.
  */
 export function computeQuoteSha256(
   quote: HashableQuote,
@@ -25,7 +31,7 @@ export function computeQuoteSha256(
 ): string {
   const canonical = {
     quote: {
-      id: quote.id, number: quote.quoteNumber, status: quote.status, currency: quote.currencyCode,
+      id: quote.id, currency: quote.currencyCode,
       subtotal: quote.subtotal, taxTotal: quote.taxTotal, total: quote.total,
       oneTime: quote.oneTimeTotal, monthly: quote.monthlyRecurringTotal, annual: quote.annualRecurringTotal,
     },

--- a/apps/api/src/services/quoteEmail.test.ts
+++ b/apps/api/src/services/quoteEmail.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { buildQuoteTemplate } from './quoteEmail';
+
+describe('buildQuoteTemplate', () => {
+  it('builds a subject + accept link + html/text', () => {
+    const t = buildQuoteTemplate({ quoteNumber: 'Q-2026-0001', partnerName: 'Acme MSP', total: '$1,200.00', acceptUrl: 'https://portal.example.com/quote/TOKEN', expiryDate: '2026-07-01' });
+    expect(t.subject).toContain('Q-2026-0001');
+    expect(t.subject).toContain('Acme MSP');
+    expect(t.html).toContain('https://portal.example.com/quote/TOKEN');
+    expect(t.text).toContain('https://portal.example.com/quote/TOKEN');
+    expect(t.html).toContain('1,200.00');
+  });
+});

--- a/apps/api/src/services/quoteEmail.ts
+++ b/apps/api/src/services/quoteEmail.ts
@@ -1,0 +1,41 @@
+import { renderLayout, renderButton, escapeHtml, getSupportEmail } from './emailLayout';
+import { supportFooter, BODY_PARA, MUTED_PARA, type EmailTemplate } from './email';
+
+export interface QuoteEmailParams {
+  quoteNumber: string;
+  partnerName: string;
+  total: string;        // pre-formatted money
+  expiryDate?: string;  // pre-formatted date or empty
+  acceptUrl: string;
+  supportEmail?: string;
+}
+
+/**
+ * Mirror of `buildInvoiceTemplate`, but the CTA points at the public accept
+ * link (apps/portal `/quote/<token>`), not the portal invoice. The quote PDF is
+ * attached by the caller (quoteLifecycle.sendQuote).
+ */
+export function buildQuoteTemplate(params: QuoteEmailParams): EmailTemplate {
+  const number = params.quoteNumber.trim();
+  const subject = `Proposal ${number} from ${params.partnerName}`;
+  const preheader = `Proposal ${number} — ${params.total}${params.expiryDate ? `, valid until ${params.expiryDate}` : ''}.`;
+  const expiryLine = params.expiryDate
+    ? `<p style="${MUTED_PARA}">This proposal is valid until <strong>${escapeHtml(params.expiryDate)}</strong>.</p>`
+    : '';
+  const body = `
+      <p style="${BODY_PARA}">Hi there,</p>
+      <p style="${BODY_PARA}">${escapeHtml(params.partnerName)} has sent you proposal <strong>${escapeHtml(number)}</strong> for <strong>${escapeHtml(params.total)}</strong>. A PDF copy is attached.</p>
+      ${renderButton('Review & accept', params.acceptUrl)}
+      ${expiryLine}
+  `;
+  const html = renderLayout({ title: subject, preheader, heading: `Proposal ${number}`, body, footer: supportFooter(params.supportEmail, 'Questions about this proposal? Contact') });
+  const support = getSupportEmail(params.supportEmail);
+  const text = [
+    'Hi there,',
+    `${params.partnerName} has sent you proposal ${number} for ${params.total}. A PDF copy is attached.`,
+    `Review & accept: ${params.acceptUrl}`,
+    params.expiryDate ? `Valid until ${params.expiryDate}.` : null,
+    support ? `Questions? Contact ${support}.` : null,
+  ].filter(Boolean).join('\n');
+  return { subject, html, text };
+}

--- a/apps/api/src/services/quoteImageStorage.ts
+++ b/apps/api/src/services/quoteImageStorage.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { quoteImages } from '../db/schema/quotes';
+import { sniffImageMime } from './avatarStorage';
+
+export { sniffImageMime };
+export const MAX_QUOTE_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // reuse the avatar cap
+
+/**
+ * Persist a proposal image as a bytea blob on `quote_images`, scoped to its
+ * quote + org. The org-axis RLS on `quote_images` is the access boundary; the
+ * caller must be inside a request/system DB access context. Magic-byte sniffing
+ * and the size cap are enforced by the route before this is reached.
+ */
+export async function writeQuoteImage(quoteId: string, orgId: string, mime: string, buffer: Buffer): Promise<{ id: string; byteSize: number; sha256: string }> {
+  const sha256 = createHash('sha256').update(buffer).digest('hex');
+  const [row] = await db.insert(quoteImages).values({
+    quoteId, orgId, imageData: buffer, mime, byteSize: buffer.length, sha256,
+  }).returning({ id: quoteImages.id });
+  return { id: row!.id, byteSize: buffer.length, sha256 };
+}
+
+/** Read constrained to BOTH the image id AND its quote (closes same-org cross-quote embed). */
+export async function readQuoteImage(imageId: string, quoteId: string): Promise<{ data: Buffer; mime: string; byteSize: number } | null> {
+  const [img] = await db.select({ data: quoteImages.imageData, mime: quoteImages.mime, byteSize: quoteImages.byteSize })
+    .from(quoteImages).where(and(eq(quoteImages.id, imageId), eq(quoteImages.quoteId, quoteId))).limit(1);
+  return img?.data ? { data: img.data, mime: img.mime, byteSize: img.byteSize } : null;
+}

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -24,7 +24,7 @@ function formatMoneyish(n: string | null | undefined, currency: string): string 
   return currency === 'USD' ? `$${v}` : `${v} ${currency}`;
 }
 
-/** Issue (if draft) + send: assign number, status→sent, sentAt, mint token, email post-commit. */
+/** Issue (if draft) + send: assign number, status→sent, sentAt, mint token, best-effort email. */
 export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote: QuoteRow; emailed: boolean; acceptUrl: string }> {
   const { quote, blocks, lines } = await getQuote(id, actor); // getQuote enforces org-access (404)
   if (quote.status !== 'draft') {
@@ -39,7 +39,17 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
 
   const now = new Date();
   const issueDate = quote.issueDate ?? now.toISOString().slice(0, 10);
-  await db.update(quotes).set({ status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now }).where(eq(quotes.id, id));
+  // Conditional on status='draft' so two concurrent sends can't both flip the
+  // quote (the second matches 0 rows and 409s). Counter gaps from the losing
+  // send are acceptable, per allocateQuoteCounter's contract (C3).
+  const claimed = await db
+    .update(quotes)
+    .set({ status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now })
+    .where(and(eq(quotes.id, id), eq(quotes.status, 'draft')))
+    .returning({ id: quotes.id });
+  if (claimed.length === 0) {
+    throw new QuoteServiceError('Quote was already sent', 409, 'INVALID_STATE');
+  }
 
   // Mint the public accept token (expiry = quote.expiryDate if future, else +30d).
   const { token } = await createQuoteAcceptToken({
@@ -48,7 +58,12 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
   });
   const acceptUrl = `${portalBase()}/quote/${token}`;
 
-  // Post-commit email — never block or fail the send on email/PDF I/O (mirrors invoice send).
+  // Best-effort email, rendered + sent here within the request transaction
+  // (it commits when the handler returns). A failure is swallowed so the send
+  // still commits. NOTE: unlike the invoice path (contractService returns a
+  // deferred so the caller emails AFTER commit), this is not yet truly
+  // post-commit — moving PDF+email outside the request txn is a tracked
+  // follow-up (atom-3); the email-failure swallow keeps the send safe meanwhile.
   let emailed = false;
   try {
     const [org] = await db.select({ billingContact: organizations.billingContact }).from(organizations).where(eq(organizations.id, quote.orgId)).limit(1);

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -1,0 +1,126 @@
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { quotes, quoteImages } from '../db/schema/quotes';
+import { organizations, partners } from '../db/schema/orgs';
+import { portalBranding } from '../db/schema/portal';
+import { getQuote } from './quoteService';
+import { QuoteServiceError, type QuoteActor } from './quoteTypes';
+import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
+import { createQuoteAcceptToken } from './quoteAcceptToken';
+import { buildQuoteTemplate } from './quoteEmail';
+import { getEmailService } from './email';
+import { resolveBillingEmail } from './invoicePdf';
+
+type QuoteRow = typeof quotes.$inferSelect;
+
+function portalBase(): string {
+  // The customer portal app (apps/portal) is where /quote/<token> is served.
+  return (process.env.PUBLIC_PORTAL_URL || process.env.PUBLIC_APP_URL || process.env.DASHBOARD_URL || 'http://localhost:4321').replace(/\/$/, '');
+}
+
+/** Light money formatter for the email body (invoicePdf's formatMoney is module-private). */
+function formatMoneyish(n: string | null | undefined, currency: string): string {
+  const v = Number(n ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return currency === 'USD' ? `$${v}` : `${v} ${currency}`;
+}
+
+/** Issue (if draft) + send: assign number, status→sent, sentAt, mint token, email post-commit. */
+export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote: QuoteRow; emailed: boolean; acceptUrl: string }> {
+  const { quote, blocks, lines } = await getQuote(id, actor); // getQuote enforces org-access (404)
+  if (quote.status !== 'draft') {
+    // Phase 2 send is issue-once: a non-draft quote (already sent/viewed/etc.) cannot be re-sent.
+    throw new QuoteServiceError(`Cannot send a quote in status ${quote.status}`, 409, 'INVALID_STATE');
+  }
+
+  // Assign a number on first issue. (A draft never has a number yet.)
+  const year = new Date(quote.issueDate ?? Date.now()).getUTCFullYear();
+  const counter = await allocateQuoteCounter(quote.partnerId, year);
+  const quoteNumber = formatQuoteNumber('Q', year, counter);
+
+  const now = new Date();
+  const issueDate = quote.issueDate ?? now.toISOString().slice(0, 10);
+  await db.update(quotes).set({ status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now }).where(eq(quotes.id, id));
+
+  // Mint the public accept token (expiry = quote.expiryDate if future, else +30d).
+  const { token } = await createQuoteAcceptToken({
+    quoteId: id, orgId: quote.orgId, partnerId: quote.partnerId,
+    expiresAt: quote.expiryDate ? new Date(`${quote.expiryDate}T23:59:59Z`) : null,
+  });
+  const acceptUrl = `${portalBase()}/quote/${token}`;
+
+  // Post-commit email — never block or fail the send on email/PDF I/O (mirrors invoice send).
+  let emailed = false;
+  try {
+    const [org] = await db.select({ billingContact: organizations.billingContact }).from(organizations).where(eq(organizations.id, quote.orgId)).limit(1);
+    const [partner] = await db.select({ name: partners.name }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+    const recipient = resolveBillingEmail(org?.billingContact);
+    const emailService = getEmailService();
+    if (emailService && recipient) {
+      const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
+      // Real image loader: pull bytes from quote_images, scoped to BOTH the image id
+      // AND this quote (RLS blocks cross-tenant; the quote_id match closes the
+      // same-org cross-quote case). Same loader the PDF route uses.
+      const loadImage = async (imageId: string): Promise<{ data: Buffer } | null> => {
+        const [img] = await db
+          .select({ data: quoteImages.imageData })
+          .from(quoteImages)
+          .where(and(eq(quoteImages.id, imageId), eq(quoteImages.quoteId, id)))
+          .limit(1);
+        return img?.data ? { data: img.data } : null;
+      };
+      const { renderQuotePdf } = await import('./quotePdf');
+      const pdf = await renderQuotePdf({ ...quote, status: 'sent', quoteNumber }, blocks, lines, loadImage, {
+        partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
+        footer: quote.terms ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? 'USD',
+      });
+      const template = buildQuoteTemplate({
+        quoteNumber, partnerName: partner?.name ?? 'your provider',
+        total: formatMoneyish(quote.total, quote.currencyCode), acceptUrl,
+        expiryDate: quote.expiryDate ?? undefined,
+      });
+      await emailService.sendEmail({ to: recipient, subject: template.subject, html: template.html, text: template.text, attachments: [{ filename: `${quoteNumber}.pdf`, content: pdf, contentType: 'application/pdf' }] });
+      emailed = true;
+    } else if (!emailService) {
+      console.warn(`[quoteLifecycle] Email not configured — quote ${id} sent but not emailed`);
+    } else {
+      console.warn(`[quoteLifecycle] No billing email for org ${quote.orgId} — quote ${id} sent but not emailed`);
+    }
+  } catch (err) {
+    console.error(`[quoteLifecycle] send email failed for quote ${id}:`, err);
+  }
+
+  const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
+  return { quote: updated!, emailed, acceptUrl };
+}
+
+/**
+ * sent→viewed + first_viewed_at (once). orgId is the resolved tenant (from the
+ * portal session or the verified public token). Runs under a system DB context
+ * (escaping any caller context first) so the read+stamp is never a silent 0-row
+ * no-op under forced `breeze_app` RLS on the unauthenticated public path
+ * (the rls_silent_zero_row_write class). Tenant scoping is preserved by the
+ * `q.orgId !== orgId` guard. Never throws on a view stamp.
+ */
+export async function markQuoteViewed(quoteId: string, orgId: string): Promise<void> {
+  await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [q] = await db.select().from(quotes).where(eq(quotes.id, quoteId)).limit(1);
+    if (!q || q.orgId !== orgId) return; // scoped no-op
+    const now = new Date();
+    const set: Record<string, unknown> = { viewedAt: now, updatedAt: now };
+    if (!q.firstViewedAt) set.firstViewedAt = now;
+    if (q.status === 'sent') set.status = 'viewed';
+    await db.update(quotes).set(set).where(eq(quotes.id, quoteId));
+  }));
+}
+
+/** Internal/portal decline. */
+export async function declineQuoteByActor(id: string, reason: string | undefined, actor: QuoteActor): Promise<QuoteRow> {
+  const { quote } = await getQuote(id, actor);
+  if (quote.status !== 'sent' && quote.status !== 'viewed') {
+    throw new QuoteServiceError(`Cannot decline a quote in status ${quote.status}`, 409, 'INVALID_STATE');
+  }
+  const now = new Date();
+  await db.update(quotes).set({ status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now }).where(eq(quotes.id, id));
+  const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
+  return updated!;
+}

--- a/apps/api/src/services/quoteNumbers.test.ts
+++ b/apps/api/src/services/quoteNumbers.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { formatQuoteNumber } from './quoteNumbers';
+
+describe('formatQuoteNumber', () => {
+  it('zero-pads the counter to 4 digits', () => {
+    expect(formatQuoteNumber('Q', 2026, 7)).toBe('Q-2026-0007');
+    expect(formatQuoteNumber('QUO', 2026, 1234)).toBe('QUO-2026-1234');
+  });
+});

--- a/apps/api/src/services/quoteNumbers.ts
+++ b/apps/api/src/services/quoteNumbers.ts
@@ -1,0 +1,34 @@
+import { sql } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { QuoteServiceError } from './quoteTypes';
+
+export function formatQuoteNumber(prefix: string, year: number, counter: number): string {
+  return `${prefix}-${year}-${String(counter).padStart(4, '0')}`;
+}
+
+/**
+ * Allocate the next partner-scoped quote counter for `year`, gaplessly. Race-safe
+ * via INSERT ... ON CONFLICT DO UPDATE ... RETURNING — two concurrent sends can
+ * never read the same counter. Mirrors `allocateInvoiceCounter`: runs in a
+ * system-scope context outside the caller's request transaction because
+ * `partner_quote_sequences` is partner-axis (an org-scoped request context can't
+ * satisfy its RLS policy), and a gap from a failed standalone allocation is
+ * harmless. Self-wraps in `runOutsideDbContext → withSystemDbAccessContext`, so
+ * it is safe to call standalone.
+ */
+export async function allocateQuoteCounter(partnerId: string, year: number): Promise<number> {
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db.execute(sql`
+        INSERT INTO partner_quote_sequences (partner_id, year, counter)
+        VALUES (${partnerId}, ${year}, 1)
+        ON CONFLICT (partner_id, year)
+        DO UPDATE SET counter = partner_quote_sequences.counter + 1
+        RETURNING counter
+      `)
+    )
+  );
+  const counter = Number((rows as unknown as Array<{ counter: number }>)[0]?.counter);
+  if (!Number.isFinite(counter) || counter < 1) throw new QuoteServiceError('Failed to allocate quote number', 500, 'INVALID_STATE');
+  return counter;
+}

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -137,7 +137,7 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
 
       {status === 'converted' && (
         <div data-testid="public-quote-accepted" className="rounded-md bg-success/10 p-4 text-sm text-success">
-          {msg}
+          {msg ?? 'This proposal has already been accepted.'}
         </div>
       )}
       {status === 'declined' && msg && (

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import { portalApi, buildPortalApiUrl, type PublicQuoteDetail } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { QuoteBlocks, money } from './quoteBlocks';
+
+interface PublicQuoteViewProps {
+  token: string;
+  initial: PublicQuoteDetail | null;
+  error?: string | null;
+}
+
+function shortDate(value: string | null | undefined): string {
+  if (!value) return '';
+  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString();
+}
+
+export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps) {
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState(initial?.quote.status ?? '');
+  const [msg, setMsg] = useState<string | null>(null);
+  const [msgError, setMsgError] = useState(false);
+
+  if (error || !initial) {
+    return (
+      <div data-testid="public-quote-error" className="mx-auto max-w-lg p-8 text-center text-destructive">
+        <p className="text-sm">{error ?? 'This proposal link is invalid or has expired.'}</p>
+      </div>
+    );
+  }
+
+  const { quote, blocks, lines, branding } = initial;
+  const currency = quote.currencyCode;
+  const open = status === 'sent' || status === 'viewed';
+  const hasRecurring =
+    Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+
+  const accept = async () => {
+    if (busy) return;
+    if (!name.trim()) {
+      setMsg('Please type your full name to sign.');
+      setMsgError(true);
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    setMsgError(false);
+    const res = await portalApi.acceptPublicQuote(token, name.trim());
+    setBusy(false);
+    if (res.error) {
+      setMsg(res.error);
+      setMsgError(true);
+      return;
+    }
+    setStatus('converted');
+    setMsg('Thank you — your acceptance has been recorded.');
+  };
+
+  const decline = async () => {
+    if (busy) return;
+    const reason = window.prompt('Optionally, tell us why:') ?? undefined;
+    setBusy(true);
+    setMsg(null);
+    setMsgError(false);
+    const res = await portalApi.declinePublicQuote(token, reason);
+    setBusy(false);
+    if (res.error) {
+      setMsg(res.error);
+      setMsgError(true);
+      return;
+    }
+    setStatus('declined');
+    setMsg('You have declined this proposal.');
+  };
+
+  return (
+    <div data-testid="public-quote" className="mx-auto w-full max-w-2xl space-y-6 p-2 sm:p-6">
+      <header className="flex items-center gap-3 border-b pb-4">
+        {branding.logoUrl && (
+          <img src={branding.logoUrl} alt={branding.partnerName} className="h-10 w-auto" />
+        )}
+        <div>
+          <h1 className="text-xl font-semibold">
+            Proposal {quote.quoteNumber ?? ''}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            from {branding.partnerName}
+            {quote.expiryDate ? ` · valid until ${shortDate(quote.expiryDate)}` : ''}
+          </p>
+        </div>
+      </header>
+
+      {quote.introNotes && (
+        <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">{quote.introNotes}</p>
+      )}
+
+      <QuoteBlocks
+        blocks={blocks}
+        lines={lines}
+        currency={currency}
+        imageUrl={(imageId) =>
+          buildPortalApiUrl(`/quotes/public/${encodeURIComponent(token)}/images/${imageId}`)
+        }
+      />
+
+      <div className="ml-auto max-w-xs space-y-1 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">One-time</span>
+          <span>{money(quote.oneTimeTotal ?? 0, currency)}</span>
+        </div>
+        {Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Monthly</span>
+            <span>{money(quote.monthlyRecurringTotal ?? 0, currency)}/mo</span>
+          </div>
+        )}
+        {Number(quote.annualRecurringTotal ?? 0) > 0 && (
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Annual</span>
+            <span>{money(quote.annualRecurringTotal ?? 0, currency)}/yr</span>
+          </div>
+        )}
+        <div className="flex justify-between border-t pt-1 font-semibold">
+          <span>{hasRecurring ? 'First invoice total' : 'Total'}</span>
+          <span>{money(quote.total, currency)}</span>
+        </div>
+      </div>
+
+      {quote.terms && (
+        <div className="rounded-lg border p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.terms}</p>
+        </div>
+      )}
+
+      {status === 'converted' && (
+        <div data-testid="public-quote-accepted" className="rounded-md bg-success/10 p-4 text-sm text-success">
+          {msg}
+        </div>
+      )}
+      {status === 'declined' && msg && (
+        <div className="rounded-md bg-muted p-3 text-sm">{msg}</div>
+      )}
+      {open && msg && (
+        <div
+          className={cn(
+            'rounded-md p-3 text-sm',
+            msgError ? 'bg-destructive/10 text-destructive' : 'bg-muted'
+          )}
+        >
+          {msg}
+        </div>
+      )}
+
+      {open && (
+        <div className="space-y-3 rounded-md border p-4">
+          <label htmlFor="public-quote-signer" className="block text-sm font-medium">
+            Type your full name to accept &amp; sign
+          </label>
+          <input
+            id="public-quote-signer"
+            data-testid="public-quote-signer"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={busy}
+            className="w-full rounded-md border px-3 py-2 text-sm disabled:opacity-50"
+            placeholder="Your full name"
+          />
+          <div className="flex gap-3">
+            <button
+              type="button"
+              data-testid="public-quote-accept"
+              disabled={busy}
+              onClick={() => void accept()}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {busy ? 'Working…' : 'Accept & sign'}
+            </button>
+            <button
+              type="button"
+              data-testid="public-quote-decline"
+              disabled={busy}
+              onClick={() => void decline()}
+              className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+            >
+              Decline
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PublicQuoteView;

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react';
+import { ArrowLeft, AlertCircle, Download } from 'lucide-react';
+import { type QuoteDetail, buildPortalApiUrl, portalApi } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { QuoteBlocks, money } from './quoteBlocks';
+
+interface QuoteDetailViewProps {
+  detail: QuoteDetail | null;
+  error?: string | null;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  sent: 'Sent',
+  viewed: 'Viewed',
+  accepted: 'Accepted',
+  declined: 'Declined',
+  expired: 'Expired',
+  converted: 'Accepted',
+};
+
+function statusColor(status: string): string {
+  switch (status) {
+    case 'accepted':
+    case 'converted':
+      return 'bg-success/10 text-success';
+    case 'declined':
+    case 'expired':
+      return 'bg-destructive/10 text-destructive';
+    case 'viewed':
+    case 'sent':
+      return 'bg-warning/10 text-warning';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function shortDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString();
+}
+
+export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [msgError, setMsgError] = useState(false);
+  const [status, setStatus] = useState(detail?.quote.status ?? '');
+
+  if (error || !detail) {
+    return (
+      <div className="text-center">
+        <AlertCircle className="mx-auto h-12 w-12 text-destructive" />
+        <h3 className="mt-4 text-lg font-medium">Proposal not found</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {error || 'The proposal you are looking for does not exist.'}
+        </p>
+        <a href="/quotes" className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
+          <ArrowLeft className="h-4 w-4" />
+          Back to proposals
+        </a>
+      </div>
+    );
+  }
+
+  const { quote, blocks, lines } = detail;
+  const currency = quote.currencyCode;
+  const open = status === 'sent' || status === 'viewed';
+
+  const accept = async () => {
+    if (busy) return;
+    setBusy(true);
+    setMsg(null);
+    setMsgError(false);
+    const res = await portalApi.acceptQuote(quote.id);
+    setBusy(false);
+    if (res.error) {
+      setMsg(res.error);
+      setMsgError(true);
+      return;
+    }
+    setStatus('converted');
+    setMsg('Accepted — an invoice has been created.');
+  };
+
+  const decline = async () => {
+    if (busy) return;
+    const reason = window.prompt('Optionally, tell us why you are declining:') ?? undefined;
+    setBusy(true);
+    setMsg(null);
+    setMsgError(false);
+    const res = await portalApi.declineQuote(quote.id, reason);
+    setBusy(false);
+    if (res.error) {
+      setMsg(res.error);
+      setMsgError(true);
+      return;
+    }
+    setStatus('declined');
+    setMsg('Proposal declined.');
+  };
+
+  const hasRecurring =
+    Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+
+  return (
+    <div className="space-y-6" data-testid="quote-detail">
+      <a href="/quotes" className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
+        <ArrowLeft className="h-4 w-4" />
+        Back to proposals
+      </a>
+
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Proposal {quote.quoteNumber ?? ''}</h1>
+          <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
+            <span className={cn('inline-flex rounded-full px-2 py-1 text-xs font-medium', statusColor(status))}>
+              {STATUS_LABELS[status] ?? status}
+            </span>
+            <span>Issued {shortDate(quote.issueDate)}</span>
+            {quote.expiryDate && (
+              <>
+                <span>·</span>
+                <span>Valid until {shortDate(quote.expiryDate)}</span>
+              </>
+            )}
+          </div>
+        </div>
+        <a
+          href={buildPortalApiUrl(`/portal/quotes/${quote.id}/pdf`)}
+          target="_blank"
+          rel="noreferrer"
+          data-testid="quote-download-pdf"
+          className="inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+        >
+          <Download className="h-4 w-4" />
+          Download PDF
+        </a>
+      </div>
+
+      {quote.introNotes && (
+        <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">{quote.introNotes}</p>
+      )}
+
+      <QuoteBlocks
+        blocks={blocks}
+        lines={lines}
+        currency={currency}
+        imageUrl={(imageId) => buildPortalApiUrl(`/portal/quotes/${quote.id}/images/${imageId}`)}
+      />
+
+      <div className="ml-auto max-w-xs space-y-1 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">One-time</span>
+          <span>{money(quote.oneTimeTotal ?? 0, currency)}</span>
+        </div>
+        {hasRecurring && (
+          <>
+            {Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Monthly</span>
+                <span>{money(quote.monthlyRecurringTotal ?? 0, currency)}/mo</span>
+              </div>
+            )}
+            {Number(quote.annualRecurringTotal ?? 0) > 0 && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Annual</span>
+                <span>{money(quote.annualRecurringTotal ?? 0, currency)}/yr</span>
+              </div>
+            )}
+          </>
+        )}
+        <div className="flex justify-between border-t pt-1 font-semibold">
+          <span>{hasRecurring ? 'First invoice total' : 'Total'}</span>
+          <span>{money(quote.total, currency)}</span>
+        </div>
+      </div>
+
+      {quote.terms && (
+        <div className="rounded-lg border p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.terms}</p>
+        </div>
+      )}
+
+      {msg && (
+        <div
+          data-testid={status === 'converted' ? 'quote-accept-success' : 'quote-msg'}
+          className={cn(
+            'rounded-md p-3 text-sm',
+            msgError ? 'bg-destructive/10 text-destructive' : 'bg-muted'
+          )}
+        >
+          {msg}
+        </div>
+      )}
+
+      {open && (
+        <div className="flex gap-3">
+          <button
+            type="button"
+            data-testid="quote-accept"
+            disabled={busy}
+            onClick={() => void accept()}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {busy ? 'Working…' : 'Accept & sign'}
+          </button>
+          <button
+            type="button"
+            data-testid="quote-decline"
+            disabled={busy}
+            onClick={() => void decline()}
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+          >
+            Decline
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default QuoteDetailView;

--- a/apps/portal/src/components/portal/QuoteList.tsx
+++ b/apps/portal/src/components/portal/QuoteList.tsx
@@ -1,0 +1,119 @@
+import { FileText, AlertCircle } from 'lucide-react';
+import { type QuoteSummary } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+interface QuoteListProps {
+  quotes: QuoteSummary[];
+  error?: string | null;
+}
+
+// 'converted' is shown to the customer as 'Accepted' — the conversion to an
+// invoice is an internal detail; from the prospect's point of view they accepted.
+const STATUS_LABELS: Record<string, string> = {
+  sent: 'Sent',
+  viewed: 'Viewed',
+  accepted: 'Accepted',
+  declined: 'Declined',
+  expired: 'Expired',
+  converted: 'Accepted',
+};
+
+function statusColor(status: string): string {
+  switch (status) {
+    case 'accepted':
+    case 'converted':
+      return 'bg-success/10 text-success';
+    case 'declined':
+    case 'expired':
+      return 'bg-destructive/10 text-destructive';
+    case 'viewed':
+    case 'sent':
+      return 'bg-warning/10 text-warning';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function money(value: string | number, currencyCode: string): string {
+  const n = Number(value);
+  const safe = Number.isFinite(n) ? n : 0;
+  try {
+    return safe.toLocaleString('en-US', { style: 'currency', currency: currencyCode || 'USD' });
+  } catch {
+    return `${safe.toFixed(2)} ${currencyCode || ''}`.trim();
+  }
+}
+
+function shortDate(value: string | null): string {
+  if (!value) return '—';
+  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString();
+}
+
+export function QuoteList({ quotes, error }: QuoteListProps) {
+  if (error) {
+    return (
+      <div className="rounded-md bg-destructive/10 p-4 text-center text-destructive">
+        <AlertCircle className="mx-auto h-8 w-8" />
+        <p className="mt-2">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Proposals</h2>
+      </div>
+
+      {quotes.length === 0 ? (
+        <div
+          data-testid="portal-quotes-empty"
+          className="rounded-md border border-dashed p-8 text-center"
+        >
+          <FileText className="mx-auto h-12 w-12 text-muted-foreground" />
+          <h3 className="mt-4 text-lg font-medium">No proposals</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            You don't have any proposals yet.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          <table className="w-full">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Number</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Issued</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Valid until</th>
+                <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">Total</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {quotes.map((q) => (
+                <tr key={q.id} data-testid={`quote-row-${q.id}`} className="hover:bg-muted/50">
+                  <td className="px-4 py-3">
+                    <a className="font-medium hover:underline" href={`/quotes/${q.id}`}>
+                      {q.quoteNumber ?? q.id.slice(0, 8)}
+                    </a>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{shortDate(q.issueDate)}</td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{shortDate(q.expiryDate)}</td>
+                  <td className="px-4 py-3 text-right text-sm">{money(q.total, q.currencyCode)}</td>
+                  <td className="px-4 py-3">
+                    <span className={cn('inline-flex rounded-full px-2 py-1 text-xs font-medium', statusColor(q.status))}>
+                      {STATUS_LABELS[q.status] ?? q.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default QuoteList;

--- a/apps/portal/src/components/portal/quoteBlocks.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.tsx
@@ -1,0 +1,208 @@
+// Shared block/line rendering for the portal proposal views (authed
+// QuoteDetailView + public PublicQuoteView). Mirrors the block walk in the web
+// dashboard's QuoteDetail.tsx and the quote PDF renderer (quotePdf.ts): blocks
+// are drawn in sortOrder, and a `line_items` block renders its own lines as a
+// pricing table grouped by recurrence (one-time / monthly / annual). Orphan
+// lines (no blockId) fall into a trailing default pricing table — same as the
+// PDF, which appends un-blocked lines after the block walk.
+import { Fragment } from 'react';
+import type { QuoteBlock, QuoteLine } from '@/lib/api';
+
+export function money(value: string | number, currencyCode: string): string {
+  const n = Number(value);
+  const safe = Number.isFinite(n) ? n : 0;
+  try {
+    return safe.toLocaleString('en-US', { style: 'currency', currency: currencyCode || 'USD' });
+  } catch {
+    return `${safe.toFixed(2)} ${currencyCode || ''}`.trim();
+  }
+}
+
+// rich_text blocks store author HTML. The portal has no HTML sanitizer
+// dependency, and rendering untrusted HTML on the *unauthenticated* public page
+// would be an XSS sink, so we strip all tags to plain text (matching the PDF's
+// stripHtml + the web detail view, which also renders rich_text as text) and
+// preserve line breaks with whitespace-pre-wrap. This is the safe sanitization.
+function stripHtml(html: string): string {
+  return html
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\/(p|div|h[1-6]|li)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+const RECURRENCE_GROUPS: ReadonlyArray<{ key: string; label: string; suffix: string }> = [
+  { key: 'one_time', label: 'One-time', suffix: '' },
+  { key: 'monthly', label: 'Monthly', suffix: '/mo' },
+  { key: 'annual', label: 'Annual', suffix: '/yr' },
+];
+
+function PricingTable({
+  lines,
+  currency,
+  label,
+  testId,
+}: {
+  lines: QuoteLine[];
+  currency: string;
+  label?: string;
+  testId: string;
+}) {
+  if (lines.length === 0) return null;
+  // Preserve sortOrder within each recurrence group, in the canonical group order.
+  const grouped = RECURRENCE_GROUPS.map((g) => ({
+    ...g,
+    rows: lines.filter((l) => (l.recurrence || 'one_time') === g.key),
+  })).filter((g) => g.rows.length > 0);
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card" data-testid={testId}>
+      {label && (
+        <h3 className="border-b px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {label}
+        </h3>
+      )}
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Description</th>
+            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">Qty</th>
+            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">Unit</th>
+            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">Total</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {grouped.map((g) => (
+            <Fragment key={g.key}>
+              {grouped.length > 1 && (
+                <tr className="bg-muted/30">
+                  <td colSpan={4} className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {g.label}
+                  </td>
+                </tr>
+              )}
+              {g.rows.map((l) => (
+                <tr key={l.id} data-testid={`quote-line-${l.id}`}>
+                  <td className="px-4 py-3">{l.description}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{Number(l.quantity)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{money(l.unitPrice, currency)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {money(l.lineTotal, currency)}
+                    {g.suffix}
+                  </td>
+                </tr>
+              ))}
+            </Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function QuoteBlocks({
+  blocks,
+  lines,
+  currency,
+  imageUrl,
+}: {
+  blocks: QuoteBlock[];
+  lines: QuoteLine[];
+  currency: string;
+  // Builds the (authed or token-scoped) URL to fetch a quote image by id.
+  imageUrl: (imageId: string) => string;
+}) {
+  const ordered = [...blocks].sort((a, b) => a.sortOrder - b.sortOrder);
+  // Track lines already consumed by a line_items block so orphan lines render once.
+  const consumed = new Set<string>();
+
+  const rendered = ordered.map((block) => {
+    const content = (block.content ?? {}) as Record<string, unknown>;
+
+    if (block.blockType === 'heading') {
+      const level = Number(content.level ?? 1);
+      const text = String(content.text ?? '');
+      const cls = level <= 1 ? 'text-2xl font-bold' : level === 2 ? 'text-xl font-semibold' : 'text-lg font-semibold';
+      return (
+        <h2 key={block.id} className={cls} data-testid={`quote-block-${block.id}`}>
+          {text}
+        </h2>
+      );
+    }
+
+    if (block.blockType === 'rich_text') {
+      const text = stripHtml(String(content.html ?? ''));
+      if (!text) return null;
+      return (
+        <p
+          key={block.id}
+          className="whitespace-pre-wrap text-sm leading-relaxed text-foreground"
+          data-testid={`quote-block-${block.id}`}
+        >
+          {text}
+        </p>
+      );
+    }
+
+    if (block.blockType === 'image') {
+      const imageId = typeof content.imageId === 'string' ? content.imageId : null;
+      const caption = typeof content.caption === 'string' ? content.caption : '';
+      const width = Number(content.width);
+      return (
+        <figure key={block.id} data-testid={`quote-block-${block.id}`}>
+          {imageId ? (
+            <img
+              src={imageUrl(imageId)}
+              alt={caption || 'Proposal image'}
+              className="rounded-lg border"
+              style={Number.isFinite(width) && width > 0 ? { maxWidth: `${width}px`, width: '100%' } : { maxWidth: '100%' }}
+            />
+          ) : (
+            <div className="rounded-lg border bg-muted/50 p-4 text-sm text-muted-foreground">Image unavailable</div>
+          )}
+          {caption && <figcaption className="mt-2 text-xs text-muted-foreground">{caption}</figcaption>}
+        </figure>
+      );
+    }
+
+    if (block.blockType === 'line_items') {
+      const blockLines = lines.filter((l) => l.blockId === block.id);
+      blockLines.forEach((l) => consumed.add(l.id));
+      const label = typeof content.label === 'string' && content.label ? content.label : 'Pricing';
+      return (
+        <PricingTable
+          key={block.id}
+          lines={blockLines}
+          currency={currency}
+          label={label}
+          testId={`quote-lines-${block.id}`}
+        />
+      );
+    }
+
+    return null;
+  });
+
+  // Any customer-visible lines not attached to a line_items block (orphans) get a
+  // trailing default pricing table — mirrors quotePdf appending un-blocked lines.
+  const orphanLines = lines.filter((l) => !consumed.has(l.id) && !l.blockId);
+
+  return (
+    <div className="space-y-6">
+      {rendered}
+      {orphanLines.length > 0 && (
+        <PricingTable lines={orphanLines} currency={currency} label="Pricing" testId="quote-lines-default" />
+      )}
+    </div>
+  );
+}
+
+export default QuoteBlocks;

--- a/apps/portal/src/layouts/PortalLayout.astro
+++ b/apps/portal/src/layouts/PortalLayout.astro
@@ -13,6 +13,7 @@ const branding = await loadPortalBranding(Astro.request);
 const navItems = [
   { label: 'Devices', href: '/devices' },
   { label: 'Tickets', href: '/tickets' },
+  { label: 'Quotes', href: '/quotes' },
   { label: 'Invoices', href: '/invoices' },
   { label: 'Assets', href: '/assets' },
   { label: 'Profile', href: '/profile' }

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -313,6 +313,74 @@ export interface InvoiceDetail {
   lines: InvoiceLine[];
 }
 
+export type QuoteStatus =
+  | 'draft'
+  | 'sent'
+  | 'viewed'
+  | 'accepted'
+  | 'declined'
+  | 'expired'
+  | 'converted';
+
+export interface QuoteSummary {
+  id: string;
+  quoteNumber: string | null;
+  status: string;
+  currencyCode: string;
+  issueDate: string | null;
+  expiryDate: string | null;
+  total: string;
+}
+
+export interface QuoteBlock {
+  id: string;
+  blockType: string;
+  content: Record<string, unknown> | null;
+  sortOrder: number;
+}
+
+export interface QuoteLine {
+  id: string;
+  blockId?: string | null;
+  description: string;
+  quantity: string;
+  unitPrice: string;
+  lineTotal: string;
+  recurrence: string;
+  customerVisible: boolean;
+  sortOrder: number;
+}
+
+export interface QuoteHeader extends QuoteSummary {
+  introNotes?: string | null;
+  terms?: string | null;
+  subtotal?: string;
+  taxTotal?: string;
+  oneTimeTotal?: string;
+  monthlyRecurringTotal?: string;
+  annualRecurringTotal?: string;
+  billToName?: string | null;
+}
+
+export interface QuoteDetail {
+  quote: QuoteHeader;
+  blocks: QuoteBlock[];
+  lines: QuoteLine[];
+}
+
+export interface QuoteBranding {
+  partnerName: string;
+  logoUrl: string | null;
+  primaryColor: string | null;
+}
+
+export interface PublicQuoteDetail {
+  quote: QuoteHeader;
+  blocks: QuoteBlock[];
+  lines: QuoteLine[];
+  branding: QuoteBranding;
+}
+
 export interface Profile {
   id: string;
   orgId: string;
@@ -534,5 +602,47 @@ export const portalApi = {
       statusCode: response.statusCode,
       headers: response.headers
     };
+  },
+
+  getQuotes: async (
+    params: ListParams = {},
+    config: ApiRequestConfig = {}
+  ): Promise<PaginatedResult<QuoteSummary>> => {
+    const query = buildQueryString({ page: params.page ?? 1, limit: params.limit ?? 200 });
+    const response = await apiGet<{ data: QuoteSummary[]; pagination: Pagination }>(
+      `/portal/quotes${query}`,
+      config
+    );
+    return mapPaginatedData(response);
+  },
+
+  getQuote: async (
+    id: string,
+    config: ApiRequestConfig = {}
+  ): Promise<ApiResponse<{ data: QuoteDetail }>> => {
+    return apiGet<{ data: QuoteDetail }>(`/portal/quotes/${id}`, config);
+  },
+
+  acceptQuote: async (
+    id: string,
+    config: ApiRequestConfig = {}
+  ): Promise<ApiResponse<{ data: { invoiceId: string; status: string } }>> => {
+    return apiPost<{ data: { invoiceId: string; status: string } }>(
+      `/portal/quotes/${id}/accept`,
+      {},
+      config
+    );
+  },
+
+  declineQuote: async (
+    id: string,
+    reason: string | undefined,
+    config: ApiRequestConfig = {}
+  ): Promise<ApiResponse<{ data: { status: string } }>> => {
+    return apiPost<{ data: { status: string } }>(
+      `/portal/quotes/${id}/decline`,
+      { reason },
+      config
+    );
   }
 };

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -644,5 +644,40 @@ export const portalApi = {
       { reason },
       config
     );
+  },
+
+  // Public, token-gated proposal access for prospects without a portal account.
+  // These hit /quotes/public/* (NOT /portal/*) — no auth cookie required.
+  getPublicQuote: async (
+    token: string,
+    config: ApiRequestConfig = {}
+  ): Promise<ApiResponse<{ data: PublicQuoteDetail }>> => {
+    return apiGet<{ data: PublicQuoteDetail }>(
+      `/quotes/public/${encodeURIComponent(token)}`,
+      config
+    );
+  },
+
+  acceptPublicQuote: async (
+    token: string,
+    signerName: string,
+    signerEmail?: string
+  ): Promise<ApiResponse<{ data: { status: string; invoiceNumber: string | null } }>> => {
+    return apiPost<{ data: { status: string; invoiceNumber: string | null } }>(
+      `/quotes/public/${encodeURIComponent(token)}/accept`,
+      { signerName, signerEmail },
+      { redirectOnUnauthorized: false }
+    );
+  },
+
+  declinePublicQuote: async (
+    token: string,
+    reason?: string
+  ): Promise<ApiResponse<{ data: { status: string } }>> => {
+    return apiPost<{ data: { status: string } }>(
+      `/quotes/public/${encodeURIComponent(token)}/decline`,
+      { reason },
+      { redirectOnUnauthorized: false }
+    );
   }
 };

--- a/apps/portal/src/pages/quote/[token].astro
+++ b/apps/portal/src/pages/quote/[token].astro
@@ -1,0 +1,20 @@
+---
+import AuthLayout from '../../layouts/AuthLayout.astro';
+import PublicQuoteView from '../../components/portal/PublicQuoteView';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+
+const { token } = Astro.params;
+const response = await portalApi.getPublicQuote(token!, buildServerApiConfig(Astro.request));
+
+// An invalid/expired/revoked token returns 401 from the API. This page is
+// public, so we must NOT redirect a prospect to the portal login — just render
+// PublicQuoteView's own "invalid or expired" fallback (no specific error text
+// for the generic 401, which would otherwise read "Session expired").
+const initial = response.data?.data ?? null;
+const error = response.statusCode === 401 ? undefined : response.error;
+---
+
+<AuthLayout title="Proposal">
+  <PublicQuoteView token={token!} initial={initial} error={error} client:load />
+</AuthLayout>

--- a/apps/portal/src/pages/quotes/[id].astro
+++ b/apps/portal/src/pages/quotes/[id].astro
@@ -1,0 +1,17 @@
+---
+import PortalLayout from '../../layouts/PortalLayout.astro';
+import QuoteDetailView from '../../components/portal/QuoteDetailView';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+
+const { id } = Astro.params;
+const response = await portalApi.getQuote(id!, buildServerApiConfig(Astro.request));
+
+if (response.statusCode === 401) {
+  return Astro.redirect('/login');
+}
+---
+
+<PortalLayout title="Proposal">
+  <QuoteDetailView detail={response.data?.data ?? null} error={response.error} client:load />
+</PortalLayout>

--- a/apps/portal/src/pages/quotes/index.astro
+++ b/apps/portal/src/pages/quotes/index.astro
@@ -1,0 +1,19 @@
+---
+import PortalLayout from '../../layouts/PortalLayout.astro';
+import QuoteList from '../../components/portal/QuoteList';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+
+const response = await portalApi.getQuotes(
+  { page: 1, limit: 200 },
+  buildServerApiConfig(Astro.request)
+);
+
+if (response.statusCode === 401) {
+  return Astro.redirect('/login');
+}
+---
+
+<PortalLayout title="Proposals">
+  <QuoteList quotes={response.data ?? []} error={response.error} />
+</PortalLayout>

--- a/apps/web/src/components/billing/quotes/QuoteDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.permissions.test.tsx
@@ -9,9 +9,9 @@ type Perm = { resource: string; action: string };
 // Mutable grant set the mocked auth store reads from. This file pins the read vs
 // send distinction on the detail view's two action affordances: the PDF download
 // is a read affordance (quotes has no `export` action, so it gates on
-// quotes:read), and the Send placeholder gates on quotes:send. A read-only
-// operator must see the PDF but NOT the send affordance; a writer (without send)
-// still must not see send; granting send reveals it.
+// quotes:read), and the Send button gates on quotes:send AND a draft status. A
+// read-only operator must see the PDF but NOT the send affordance; a writer
+// (without send) still must not see send; granting send on a draft reveals it.
 const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
 
 vi.mock('../../../stores/auth', () => ({
@@ -25,13 +25,15 @@ vi.mock('../../../stores/auth', () => ({
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
 
+// A draft quote — the Send button only renders for a draft (a sent quote has no
+// Send affordance; the status pill reflects the new state instead).
 const detail: QuoteDetailData = {
   quote: {
-    id: 'q-1', quoteNumber: 'Q-0001', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'sent',
-    currencyCode: 'USD', issueDate: '2026-06-01', expiryDate: null, subtotal: '50.00', taxRate: null,
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '50.00', taxRate: null,
     taxTotal: '0.00', total: '50.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '50.00',
     annualRecurringTotal: '0.00', billToName: 'Acme', introNotes: null, terms: null, acceptedAt: null,
-    declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: '2026-06-02T00:00:00Z',
+    declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null,
     viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
   },
   blocks: [],
@@ -44,7 +46,7 @@ beforeEach(() => {
 });
 
 describe('QuoteDetail — permission gating', () => {
-  it('read-only (quotes:read) shows Download PDF but hides the Send affordance', async () => {
+  it('read-only (quotes:read) shows Download PDF but hides the Send button', async () => {
     state.permissions = [{ resource: 'quotes', action: 'read' }];
     render(<QuoteDetail detail={detail} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
@@ -52,10 +54,10 @@ describe('QuoteDetail — permission gating', () => {
     // PDF is a read affordance → visible to a viewer.
     expect(screen.getByTestId('quote-download-pdf')).toBeInTheDocument();
     // Send is gated on quotes:send → hidden.
-    expect(screen.queryByTestId('quote-send-disabled')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-send')).not.toBeInTheDocument();
   });
 
-  it('quotes:write WITHOUT quotes:send still hides the Send affordance (and shows no PDF without read)', async () => {
+  it('quotes:write WITHOUT quotes:send still hides the Send button (and shows no PDF without read)', async () => {
     // write alone does not grant read or send: the PDF (read) and Send (send)
     // affordances both stay hidden. Proves the gates are independent.
     state.permissions = [{ resource: 'quotes', action: 'write' }];
@@ -63,12 +65,12 @@ describe('QuoteDetail — permission gating', () => {
     await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
 
     expect(screen.queryByTestId('quote-download-pdf')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('quote-send-disabled')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-send')).not.toBeInTheDocument();
   });
 
-  it('quotes:send reveals the Send affordance (positive control)', async () => {
-    // A user with both read and send sees both affordances — discriminates the
-    // negative cases above.
+  it('quotes:send on a draft reveals the Send button (positive control)', async () => {
+    // A user with both read and send sees both affordances on a draft —
+    // discriminates the negative cases above.
     state.permissions = [
       { resource: 'quotes', action: 'read' },
       { resource: 'quotes', action: 'send' },
@@ -77,6 +79,22 @@ describe('QuoteDetail — permission gating', () => {
     await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
 
     expect(screen.getByTestId('quote-download-pdf')).toBeInTheDocument();
-    expect(screen.getByTestId('quote-send-disabled')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-send')).toBeInTheDocument();
+  });
+
+  it('hides the Send button on a non-draft quote even with quotes:send', async () => {
+    // Once a quote is sent, there is no Send affordance — only a draft is sendable.
+    state.permissions = [
+      { resource: 'quotes', action: 'read' },
+      { resource: 'quotes', action: 'send' },
+    ];
+    const sent: QuoteDetailData = {
+      ...detail,
+      quote: { ...detail.quote, status: 'sent', sentAt: '2026-06-02T00:00:00Z' },
+    };
+    render(<QuoteDetail detail={sent} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-send')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
-import { handleActionError } from '../../../lib/runAction';
+import { runAction, handleActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
-import { quotePdfUrl } from '../../../lib/api/quotes';
+import { quotePdfUrl, sendQuote } from '../../../lib/api/quotes';
 import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
@@ -19,17 +19,38 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 interface Props {
   detail: QuoteDetailData;
-  // Kept for symmetry with the editor/workspace contract (the parent reloads on
-  // change); the detail view has no mutations in Phase 1.
+  // The parent reloads the quote when an action mutates it (e.g. send flips the
+  // status draft→sent and stamps sentAt). Phase 1 had no detail-view mutations;
+  // Phase 2's Send button uses it.
   onChanged?: () => void;
 }
 
-export default function QuoteDetail({ detail }: Props) {
+export default function QuoteDetail({ detail, onChanged }: Props) {
   const { can } = usePermissions();
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
 
   const [busy, setBusy] = useState(false);
+  const [sending, setSending] = useState(false);
+  const refresh = useCallback(() => onChanged?.(), [onChanged]);
+
+  const send = useCallback(async () => {
+    if (sending) return;
+    setSending(true);
+    try {
+      await runAction({
+        request: () => sendQuote(quote.id),
+        errorFallback: 'Could not send the proposal.',
+        successMessage: 'Proposal sent',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not send the proposal.');
+    } finally {
+      setSending(false);
+    }
+  }, [sending, quote.id, refresh]);
 
   const sortedBlocks = useMemo(
     () => [...blocks].sort((a, b) => a.sortOrder - b.sortOrder),
@@ -160,18 +181,19 @@ export default function QuoteDetail({ detail }: Props) {
                 Download PDF
               </button>
             )}
-            {/* Sending is Phase 2 — show the affordance disabled so the surface is
-                discoverable without implying it works yet. Gated on quotes:send so
-                only operators who will be able to send ever see it. */}
-            {can('quotes', 'send') && (
+            {/* Send a draft proposal: issues a number, emails the customer's billing
+                contact with the PDF + a public accept link, and flips draft→sent.
+                Gated on quotes:send. Only a draft can be sent — once sent, the
+                button drops out (the status pill above reflects the new state). */}
+            {can('quotes', 'send') && quote.status === 'draft' && (
               <button
                 type="button"
-                disabled
-                title="Sending quotes is coming soon"
-                data-testid="quote-send-disabled"
-                className="inline-flex w-full cursor-not-allowed items-center justify-center rounded-md border px-4 py-2 text-sm font-medium opacity-50"
+                onClick={() => void send()}
+                disabled={sending}
+                data-testid="quote-send"
+                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
               >
-                Send (coming soon)
+                {sending ? 'Sending…' : 'Send proposal'}
               </button>
             )}
           </div>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { navigateTo } from '@/lib/navigation';
+import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
 import {
@@ -107,7 +108,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         const uploaded = await runAction<{ imageId: string }>({
           request: () => uploadQuoteImage(quote.id, file),
           errorFallback: 'Could not upload the image.',
-          successMessage: 'Image uploaded',
+          // No success toast: the upload is an internal step of "add image block";
+          // only the final "Image block added" toast below is meaningful (web-2).
           onUnauthorized: UNAUTHORIZED,
           parseSuccess: (d) => (d as { data: { imageId: string } }).data,
         });
@@ -504,14 +506,7 @@ function BlockCard({
         {block.blockType === 'image' && (
           imageId ? (
             <figure className="space-y-1" data-testid={`quote-block-image-content-${block.id}`}>
-              {/* Served by GET /quotes/:id/images/:imageId (quotes:read). fetchWithAuth
-                  is not used for <img src>; the route allows a cookie-backed session
-                  and the editor is already an authed surface. */}
-              <img
-                src={quoteImageUrl(quoteId, imageId)}
-                alt={imageCaption || 'Quote image'}
-                className="max-h-64 rounded border"
-              />
+              <QuoteImagePreview quoteId={quoteId} imageId={imageId} caption={imageCaption} />
               {imageCaption && <figcaption className="text-xs text-muted-foreground">{imageCaption}</figcaption>}
             </figure>
           ) : (
@@ -667,4 +662,34 @@ function BlockCard({
       </div>
     </div>
   );
+}
+
+// Editor image preview. GET /quotes/:id/images/:imageId requires the Bearer auth
+// header, so a bare <img src> would 401 (web-1). Mirror QuoteWorkspace's PDF
+// preview: fetchWithAuth → blob → object URL, revoked on unmount/change.
+function QuoteImagePreview({ quoteId, imageId, caption }: { quoteId: string; imageId: string; caption?: string }) {
+  const [url, setUrl] = useState<string>();
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let objectUrl: string | undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth(quoteImageUrl(quoteId, imageId));
+        if (!res.ok) { if (!cancelled) setFailed(true); return; }
+        const blob = await res.blob();
+        if (cancelled) return;
+        objectUrl = window.URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    })();
+    return () => { cancelled = true; if (objectUrl) window.URL.revokeObjectURL(objectUrl); };
+  }, [quoteId, imageId]);
+
+  if (failed) return <p className="text-sm text-muted-foreground">Image preview unavailable.</p>;
+  if (!url) return <div className="h-24 w-full animate-pulse rounded border bg-muted" data-testid="quote-image-loading" />;
+  return <img src={url} alt={caption || 'Quote image'} className="max-h-64 rounded border" />;
 }

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -8,6 +8,8 @@ import {
   addManualLine,
   addCatalogLine,
   removeLine,
+  uploadQuoteImage,
+  quoteImageUrl,
 } from '../../../lib/api/quotes';
 import { listCatalog, createCatalogItem, type CatalogItem } from '../../../lib/api/catalog';
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
@@ -22,13 +24,15 @@ import {
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
-// Phase 1: only these three block kinds are offered. The schema + PDF renderer
-// support `image`, but there is no image-upload endpoint yet (Phase 2), so the
-// add-block menu intentionally does NOT expose it.
-type AddableBlockType = 'heading' | 'rich_text' | 'line_items';
+// Phase 2: the add-block menu now offers `image` as well. Because there is no
+// block-update endpoint (blocks are add/remove only), an image block is created
+// with its uploaded `imageId` already in `content` — the editor uploads the file
+// first (POST /:id/images), then adds the block with `{ imageId }`.
+type AddableBlockType = 'heading' | 'rich_text' | 'image' | 'line_items';
 const ADD_BLOCK_OPTIONS: { value: AddableBlockType; label: string }[] = [
   { value: 'heading', label: 'Heading' },
   { value: 'rich_text', label: 'Rich text' },
+  { value: 'image', label: 'Image' },
   { value: 'line_items', label: 'Pricing table' },
 ];
 
@@ -58,6 +62,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const [headingText, setHeadingText] = useState('');
   const [richText, setRichText] = useState('');
   const [tableLabel, setTableLabel] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imageCaption, setImageCaption] = useState('');
 
   const refresh = useCallback(() => onChanged(), [onChanged]);
 
@@ -88,6 +94,44 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   // ---- add block -----------------------------------------------------------
   const submitBlock = useCallback(async () => {
     if (busy) return;
+
+    // Image blocks have no block-update endpoint, so the file must exist before
+    // the block: upload it (POST /:id/images → { data: { imageId } }), then add
+    // an image block with that imageId already in its content. Both steps go
+    // through runAction so success/failure is always surfaced.
+    if (addType === 'image') {
+      const file = imageFile;
+      if (!file) return;
+      setBusy(true);
+      try {
+        const uploaded = await runAction<{ imageId: string }>({
+          request: () => uploadQuoteImage(quote.id, file),
+          errorFallback: 'Could not upload the image.',
+          successMessage: 'Image uploaded',
+          onUnauthorized: UNAUTHORIZED,
+          parseSuccess: (d) => (d as { data: { imageId: string } }).data,
+        });
+        await runAction({
+          request: () => addBlock(quote.id, {
+            blockType: 'image' as const,
+            content: imageCaption.trim()
+              ? { imageId: uploaded.imageId, caption: imageCaption.trim() }
+              : { imageId: uploaded.imageId },
+          }),
+          errorFallback: 'Image uploaded, but adding the block failed.',
+          successMessage: 'Image block added',
+          onUnauthorized: UNAUTHORIZED,
+        });
+        setImageFile(null); setImageCaption('');
+        refresh();
+      } catch (err) {
+        handleActionError(err, 'Could not add the image block.');
+      } finally {
+        setBusy(false);
+      }
+      return;
+    }
+
     let body;
     if (addType === 'heading') {
       if (!headingText.trim()) return;
@@ -116,7 +160,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     } finally {
       setBusy(false);
     }
-  }, [busy, addType, headingText, richText, tableLabel, quote.id, refresh]);
+  }, [busy, addType, headingText, richText, tableLabel, imageFile, imageCaption, quote.id, refresh]);
 
   // Real block delete: removes the block and (server-side) any lines attached to
   // it. Works for every block type — heading, rich_text, and line_items — so the
@@ -244,6 +288,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
               <BlockCard
                 key={block.id}
                 block={block}
+                quoteId={quote.id}
                 lines={linesForBlock(block.id)}
                 currency={currency}
                 catalog={catalog}
@@ -297,6 +342,26 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 className="mb-3 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
               />
             )}
+            {addType === 'image' && (
+              <div className="mb-3 space-y-2">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
+                  data-testid="quote-block-image-file"
+                  className="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-md file:border file:bg-muted file:px-3 file:py-1.5 file:text-xs file:font-medium"
+                />
+                <input
+                  type="text"
+                  value={imageCaption}
+                  onChange={(e) => setImageCaption(e.target.value)}
+                  placeholder="Caption (optional)"
+                  data-testid="quote-block-image-caption"
+                  className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+                <p className="text-xs text-muted-foreground">PNG, JPEG, or WebP, up to 5 MB.</p>
+              </div>
+            )}
             {addType === 'line_items' && (
               <input
                 type="text"
@@ -315,12 +380,13 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 disabled={
                   busy ||
                   (addType === 'heading' && !headingText.trim()) ||
-                  (addType === 'rich_text' && !richText.trim())
+                  (addType === 'rich_text' && !richText.trim()) ||
+                  (addType === 'image' && !imageFile)
                 }
                 data-testid="quote-add-block-submit"
                 className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
               >
-                Add block
+                {addType === 'image' ? 'Upload & add image' : 'Add block'}
               </button>
             </div>
           </div>
@@ -371,9 +437,10 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, lines, currency, catalog, busy, canWrite, onAddCatalog, onAddManual, onRemoveLine, onRemoveBlock,
+  block, quoteId, lines, currency, catalog, busy, canWrite, onAddCatalog, onAddManual, onRemoveLine, onRemoveBlock,
 }: {
   block: QuoteBlock;
+  quoteId: string;
   lines: QuoteLine[];
   currency: string;
   catalog: CatalogItem[];
@@ -399,6 +466,8 @@ function BlockCard({
   const heading = (block.content?.text as string | undefined) ?? '';
   const html = (block.content?.html as string | undefined) ?? '';
   const tableLabel = (block.content?.label as string | undefined) ?? '';
+  const imageId = (block.content?.imageId as string | undefined) ?? '';
+  const imageCaption = (block.content?.caption as string | undefined) ?? '';
 
   const submitManual = () => {
     onAddManual(block.id, { description: desc, quantity: qty, unitPrice: price, taxable, recurrence, saveToCatalog });
@@ -433,7 +502,21 @@ function BlockCard({
           <p className="whitespace-pre-wrap text-sm text-foreground" data-testid={`quote-block-rich-content-${block.id}`}>{html}</p>
         )}
         {block.blockType === 'image' && (
-          <p className="text-sm text-muted-foreground">Image block (rendered in the PDF).</p>
+          imageId ? (
+            <figure className="space-y-1" data-testid={`quote-block-image-content-${block.id}`}>
+              {/* Served by GET /quotes/:id/images/:imageId (quotes:read). fetchWithAuth
+                  is not used for <img src>; the route allows a cookie-backed session
+                  and the editor is already an authed surface. */}
+              <img
+                src={quoteImageUrl(quoteId, imageId)}
+                alt={imageCaption || 'Quote image'}
+                className="max-h-64 rounded border"
+              />
+              {imageCaption && <figcaption className="text-xs text-muted-foreground">{imageCaption}</figcaption>}
+            </figure>
+          ) : (
+            <p className="text-sm text-muted-foreground">Image block (rendered in the PDF).</p>
+          )
         )}
 
         {isTable && (

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -132,3 +132,27 @@ export function removeLine(id: string, lineId: string): Promise<Response> {
 export function quotePdfUrl(id: string): string {
   return `/api/v1/quotes/${id}/pdf`;
 }
+
+// ---- Phase 2 lifecycle / image upload -------------------------------------
+
+/** Issue + send a draft quote (POST /quotes/:id/send). Gated server-side on
+ *  quotes:send. Responds with the updated quote in a `{ data }` envelope. */
+export function sendQuote(id: string): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/send`, { method: 'POST' });
+}
+
+/** Upload an image for a quote (POST /quotes/:id/images). The body is multipart
+ *  FormData — `fetchWithAuth` deliberately does NOT set a JSON Content-Type for
+ *  FormData so the browser appends the multipart boundary itself. Responds with
+ *  `{ data: { imageId, mime, byteSize } }`. Gated server-side on quotes:write. */
+export function uploadQuoteImage(id: string, file: File): Promise<Response> {
+  const form = new FormData();
+  form.append('file', file);
+  return fetchWithAuth(`/quotes/${id}/images`, { method: 'POST', body: form });
+}
+
+/** Absolute API path for a quote image (`GET /api/v1/quotes/:id/images/:imageId`).
+ *  The route serves the raw bytes; used as an `<img src>` for the editor preview. */
+export function quoteImageUrl(id: string, imageId: string): string {
+  return `/api/v1/quotes/${id}/images/${imageId}`;
+}

--- a/docs/superpowers/plans/2026-06-17-quotes-proposals-phase2.md
+++ b/docs/superpowers/plans/2026-06-17-quotes-proposals-phase2.md
@@ -1,0 +1,2269 @@
+# Quotes / Proposals — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make sent quotes acceptable end-to-end — issue + email a quote, let the customer view it (portal account or public tokenized link), e-sign acceptance with a tamper-evident content hash, auto-convert the accepted quote to an invoice, and support decline + image upload.
+
+**Architecture:** Build on the Phase 1 quote engine (schema, service, PDF, block editor — merged #1455) and the billing RBAC (#1454). Lifecycle + accept logic live in new API services (`quoteLifecycle`, `quoteAcceptService`, `quoteContentHash`, `acceptanceProvider`, `quoteAcceptToken`, `quoteImageStorage`). Three route surfaces consume them: internal authed routes (`routes/quotes/*`), portal authed routes (`routes/portal/quotes.ts`), and **unauthenticated** token-gated public routes (`routes/quotesPublic.ts`). The customer-facing UI lives in `apps/portal/` (authed pages + a public `/quote/[token]` page); the main dashboard (`apps/web/`) gets the Send button + image-upload wiring.
+
+**Tech Stack:** Hono + Drizzle + PostgreSQL (RLS-forced, `breeze_app`), `jose` JWT, BullMQ/Redis (jti revocation), Astro + React islands (portal + web), Vitest (unit + integration), `pnpm` workspaces.
+
+**Authoritative docs:** `docs/superpowers/specs/2026-06-16-quotes-proposals-design.md` (all-phase spec) and `docs/superpowers/specs/2026-06-17-quotes-proposals-phase2-decisions.md` (the locked cut — read it; it overrides the spec's self-disagreements).
+
+## Global Constraints
+
+- **Node is pinned.** Prefix every `pnpm`/`vitest`/`tsx` command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`. Default Node 23 breaks pnpm engine-strict.
+- **Real-DB tests** go in `apps/api/src/__tests__/integration/*.integration.test.ts` (run by `vitest.integration.config.ts`, BLOCKING `integration-test` CI job, connects code-under-test as `breeze_app`). The unit `test-api` job has **no** `DATABASE_URL`, so real-DB cases under `it.runIf(!!process.env.DATABASE_URL)` skip vacuously there. Never put a real-DB assertion in a `*.test.ts` unit file.
+- **The public path is unauthenticated.** Every read/write on `routes/quotesPublic.ts` runs via `runOutsideDbContext(() => withSystemDbAccessContext(() => ...))`, scoped to the `org_id`/`quote_id` resolved from verified token claims. A bare `db` write there silently matches 0 rows under `breeze_app` RLS (the `rls_silent_zero_row_write` class). Token lookups are scoped, never global.
+- **Penny math** routes through `invoiceMath` (`computeLineTotal`, `computeInvoiceTotals`, `toCents`/`fromCents`) and `quoteMath` (`computeQuoteTotals`). Never hand-roll money arithmetic.
+- **Web mutations** in `apps/web/` route through `runAction` (`apps/web/src/lib/runAction.ts`). The customer portal (`apps/portal/`) uses its own `portalApi` + `ApiResponse` error handling (no `runAction` there).
+- **Migrations** are idempotent (`ADD COLUMN IF NOT EXISTS`), named `YYYY-MM-DD-<slug>.sql`, no inner `BEGIN;`/`COMMIT;`. Never edit a shipped migration.
+- **No new tables.** `quote_images` and `quote_acceptances` shipped in Phase 1 with RLS enabled+forced+org-axis policies and are already in the cascade + rls-coverage allowlists. The only schema delta is `quotes.decline_reason`.
+- **Out of scope (Phase 3+):** expiry sweep / read-time expiry guard; payment after convert (pay-link redirect); recurring-lines→Contract. Convert invoices **one-time lines only**.
+
+---
+
+## File Structure
+
+**Create (API):**
+- `apps/api/migrations/2026-06-17-quote-decline-reason.sql` — add `quotes.decline_reason`.
+- `apps/api/src/services/quoteContentHash.ts` — deterministic `quote_sha256` over header+blocks+lines+totals.
+- `apps/api/src/services/acceptanceProvider.ts` — `AcceptanceProvider` interface + `TypedSignatureProvider` (built-in).
+- `apps/api/src/services/quoteAcceptToken.ts` — `quote-accept` JWT mint/verify (jti) + revocation wrappers.
+- `apps/api/src/services/quoteNumbers.ts` — `formatQuoteNumber` + `allocateQuoteCounter` (mirror `invoiceNumbers.ts`).
+- `apps/api/src/services/quoteLifecycle.ts` — `sendQuote`, `markQuoteViewed`, `declineQuoteByActor` (issue + status transitions + post-commit email).
+- `apps/api/src/services/quoteAcceptService.ts` — shared accept→convert pipeline (`acceptQuote`, `convertQuoteToInvoice`).
+- `apps/api/src/services/quoteImageStorage.ts` — `writeQuoteImage`, `readQuoteImage`.
+- `apps/api/src/services/quoteEmail.ts` — `buildQuoteTemplate` (mirror `buildInvoiceTemplate`).
+- `apps/api/src/routes/quotes/lifecycle.ts` — `POST /:id/send` (`quotes:send`) + image upload/serve routes.
+- `apps/api/src/routes/portal/quotes.ts` — portal list/detail/pdf/image/accept/decline.
+- `apps/api/src/routes/quotesPublic.ts` — unauthenticated token routes.
+
+**Create (tests):**
+- `apps/api/src/services/quoteContentHash.test.ts`, `acceptanceProvider.test.ts`, `quoteAcceptToken.test.ts`, `quoteNumbers.test.ts`, `quoteEmail.test.ts` (unit).
+- `apps/api/src/__tests__/integration/quoteLifecycle.integration.test.ts`, `quoteAccept.integration.test.ts`, `quoteImages.integration.test.ts`, `quotesPublic.integration.test.ts`, `portalQuotes.integration.test.ts`, `quoteSendRbac.integration.test.ts`.
+
+**Create (web):**
+- `apps/portal/src/pages/quotes/index.astro`, `apps/portal/src/pages/quotes/[id].astro`, `apps/portal/src/pages/quote/[token].astro`.
+- `apps/portal/src/components/portal/QuoteList.tsx`, `QuoteDetailView.tsx`, `PublicQuoteView.tsx`.
+
+**Modify:**
+- `apps/api/src/db/schema/quotes.ts:54` — add `declineReason: text('decline_reason')`.
+- `packages/shared/src/validators/quotes.ts` — `acceptQuoteSchema`, `declineQuoteSchema`.
+- `apps/api/src/services/jwt.ts` — (only if shared key helpers must be exported; otherwise self-contained in `quoteAcceptToken.ts`).
+- `apps/api/src/routes/quotes/index.ts` — mount `lifecycle.ts` routes.
+- `apps/api/src/routes/portal/index.ts` — mount `quoteRoutes`.
+- `apps/api/src/index.ts:~775` — mount `quotesPublicRoutes` BEFORE auth-gated routes.
+- `apps/portal/src/lib/api.ts` — `getQuotes`, `getQuote`, `acceptQuote`, `declineQuote`, `getPublicQuote`, `acceptPublicQuote`, `declinePublicQuote`.
+- `apps/portal/src/layouts/PortalLayout.astro:13-19` — add `{ label: 'Quotes', href: '/quotes' }`.
+- `apps/web/src/components/billing/quotes/QuoteDetail.tsx:166-176` — wire the real Send button.
+- `apps/web/src/components/billing/quotes/QuoteEditor.tsx:28-40,435` — add `image` block option + upload.
+- `apps/web/src/lib/quotesApi.ts` (or wherever quote fetch helpers live) — `sendQuote`, `uploadQuoteImage`.
+- `docker/Caddyfile.prod` — carve-outs so `/quotes/public/*` (API) and portal `/quote/*` aren't shadowed.
+
+---
+
+## Task 1: Migration + schema — `quotes.decline_reason`
+
+Adds the single Phase 2 schema delta. Decline records a reason; there is no column for it yet.
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-17-quote-decline-reason.sql`
+- Modify: `apps/api/src/db/schema/quotes.ts:54`
+- Test: `apps/api/src/db/autoMigrate.test.ts` (existing ordering regression test must still pass) + `pnpm db:check-drift`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 2026-06-17-quote-decline-reason.sql
+-- Phase 2: record a free-text reason when a sent quote is declined.
+-- Idempotent: ADD COLUMN IF NOT EXISTS. No new table, no RLS change
+-- (quotes already has org-axis RLS from 2026-06-16-quotes.sql).
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS decline_reason text;
+```
+
+- [ ] **Step 2: Add the Drizzle field**
+
+In `apps/api/src/db/schema/quotes.ts`, add after `terms: text('terms'),` (line 45) — keep it grouped with the other nullable text fields:
+
+```ts
+  declineReason: text('decline_reason'),
+```
+
+- [ ] **Step 3: Apply the migration + verify no drift**
+
+Run:
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH \
+  DATABASE_URL="postgresql://breeze_test:breeze_test@localhost:5433/breeze_test" \
+  npx tsx -e "import('./src/db/autoMigrate').then(m => m.runMigrations()).then(()=>process.exit(0))"
+cd ../.. && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH \
+  DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm db:check-drift
+```
+Expected: migration applies clean; `db:check-drift` reports **no drift** (the new column matches the new Drizzle field).
+
+> Note for the implementer: the exact `runMigrations` export name is in `apps/api/src/db/autoMigrate.ts` — if it differs, apply via the integration setup path (`autoMigrate` runs inside `setupIntegrationTests`). The drift check is the real gate.
+
+- [ ] **Step 4: Run the migration-ordering regression test**
+
+Run:
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/db/autoMigrate.test.ts
+```
+Expected: PASS (the new date-prefixed file sorts correctly after `2026-06-16-quotes.sql`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-17-quote-decline-reason.sql apps/api/src/db/schema/quotes.ts
+git commit -m "feat(quotes): add decline_reason column (Phase 2)"
+```
+
+---
+
+## Task 2: Shared validators — accept / decline payloads
+
+Adds the request schemas Phase 2 routes validate against. Phase 1 added create/update/line/block schemas but no accept/decline.
+
+**Files:**
+- Modify: `packages/shared/src/validators/quotes.ts`
+- Test: `packages/shared/src/validators/quotes.test.ts`
+
+**Interfaces:**
+- Produces: `acceptQuoteSchema` → `{ signerName: string; signerEmail?: string }`; `declineQuoteSchema` → `{ reason?: string }`; types `AcceptQuoteInput`, `DeclineQuoteInput`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/shared/src/validators/quotes.test.ts` (create if absent; mirror `catalog.test.ts` style):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { acceptQuoteSchema, declineQuoteSchema } from './quotes';
+
+describe('acceptQuoteSchema', () => {
+  it('requires a non-empty signer name', () => {
+    expect(acceptQuoteSchema.safeParse({ signerName: '' }).success).toBe(false);
+    expect(acceptQuoteSchema.safeParse({ signerName: 'Jane Buyer' }).success).toBe(true);
+  });
+  it('accepts an optional email and rejects a malformed one', () => {
+    expect(acceptQuoteSchema.safeParse({ signerName: 'Jane', signerEmail: 'jane@x.com' }).success).toBe(true);
+    expect(acceptQuoteSchema.safeParse({ signerName: 'Jane', signerEmail: 'not-an-email' }).success).toBe(false);
+  });
+});
+
+describe('declineQuoteSchema', () => {
+  it('allows an optional bounded reason', () => {
+    expect(declineQuoteSchema.safeParse({}).success).toBe(true);
+    expect(declineQuoteSchema.safeParse({ reason: 'Too expensive' }).success).toBe(true);
+    expect(declineQuoteSchema.safeParse({ reason: 'x'.repeat(5001) }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/validators/quotes.test.ts
+```
+Expected: FAIL — `acceptQuoteSchema`/`declineQuoteSchema` are not exported.
+
+- [ ] **Step 3: Add the schemas**
+
+Append to `packages/shared/src/validators/quotes.ts` (note: this repo is on Zod 4 — use `.email()` which still validates; do NOT use `.uuid()` for the nil sentinel elsewhere, but these fields don't use uuids):
+
+```ts
+export const acceptQuoteSchema = z.object({
+  signerName: z.string().min(1).max(255),
+  signerEmail: z.string().email().max(255).optional(),
+});
+
+export const declineQuoteSchema = z.object({
+  reason: z.string().max(5000).optional(),
+});
+
+export type AcceptQuoteInput = z.infer<typeof acceptQuoteSchema>;
+export type DeclineQuoteInput = z.infer<typeof declineQuoteSchema>;
+```
+
+Ensure both are re-exported from `packages/shared/src/index.ts` if it uses an explicit export list (grep for `quoteStatusSchema` to find the export site and add alongside).
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+cd packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/validators/quotes.test.ts
+```
+Expected: PASS. Then typecheck shared: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared typecheck`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/quotes.ts packages/shared/src/validators/quotes.test.ts packages/shared/src/index.ts
+git commit -m "feat(quotes): add accept/decline payload validators (Phase 2)"
+```
+
+---
+
+## Task 3: Quote content hash (`quoteContentHash.ts`)
+
+Deterministic SHA-256 of the rendered quote, captured at accept time for tamper-evidence. Pure function — no DB.
+
+**Files:**
+- Create: `apps/api/src/services/quoteContentHash.ts`
+- Test: `apps/api/src/services/quoteContentHash.test.ts`
+
+**Interfaces:**
+- Consumes: the `quotes`, `quoteBlocks`, `quoteLines` row types (from `getQuote`).
+- Produces: `computeQuoteSha256(quote, blocks, lines): string` (64-char lowercase hex).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computeQuoteSha256 } from './quoteContentHash';
+
+const quote = { id: 'q1', quoteNumber: 'Q-2026-0001', status: 'sent', currencyCode: 'USD', total: '100.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', taxTotal: '0.00', subtotal: '100.00' } as any;
+const blocks = [{ id: 'b1', blockType: 'heading', content: { text: 'Proposal' }, sortOrder: 0 }] as any;
+const lines = [{ id: 'l1', description: 'Setup', quantity: '1', unitPrice: '100.00', lineTotal: '100.00', recurrence: 'one_time', taxable: false, customerVisible: true, sortOrder: 0 }] as any;
+
+describe('computeQuoteSha256', () => {
+  it('returns a stable 64-char hex hash for the same content', () => {
+    const a = computeQuoteSha256(quote, blocks, lines);
+    const b = computeQuoteSha256(quote, blocks, lines);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).toBe(b);
+  });
+  it('is order-independent on input arrays but content-sensitive', () => {
+    const reordered = computeQuoteSha256(quote, blocks, [...lines].reverse());
+    expect(reordered).toBe(computeQuoteSha256(quote, blocks, lines));
+  });
+  it('changes when a line amount is tampered', () => {
+    const tampered = [{ ...lines[0], unitPrice: '1.00', lineTotal: '1.00' }];
+    expect(computeQuoteSha256(quote, blocks, tampered)).not.toBe(computeQuoteSha256(quote, blocks, lines));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/quoteContentHash.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { createHash } from 'node:crypto';
+
+type HashableQuote = {
+  id: string; quoteNumber: string | null; status: string; currencyCode: string;
+  subtotal: string; taxTotal: string; total: string;
+  oneTimeTotal: string; monthlyRecurringTotal: string; annualRecurringTotal: string;
+};
+type HashableBlock = { id: string; blockType: string; content: unknown; sortOrder: number };
+type HashableLine = {
+  id: string; description: string; quantity: string; unitPrice: string; lineTotal: string;
+  recurrence: string; taxable: boolean; customerVisible: boolean; sortOrder: number;
+};
+
+/**
+ * Canonical, order-independent serialization of a quote's billable content,
+ * hashed with SHA-256. Captured at accept time and stored on
+ * quote_acceptances.quote_sha256 so a later edit (or a forged re-render) can be
+ * detected. Sorting by (sortOrder, id) makes the hash independent of the array
+ * order the caller happens to pass while staying sensitive to any value change.
+ */
+export function computeQuoteSha256(
+  quote: HashableQuote,
+  blocks: HashableBlock[],
+  lines: HashableLine[]
+): string {
+  const canonical = {
+    quote: {
+      id: quote.id, number: quote.quoteNumber, status: quote.status, currency: quote.currencyCode,
+      subtotal: quote.subtotal, taxTotal: quote.taxTotal, total: quote.total,
+      oneTime: quote.oneTimeTotal, monthly: quote.monthlyRecurringTotal, annual: quote.annualRecurringTotal,
+    },
+    blocks: [...blocks]
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id))
+      .map((b) => ({ id: b.id, type: b.blockType, sortOrder: b.sortOrder, content: b.content })),
+    lines: [...lines]
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id))
+      .map((l) => ({
+        id: l.id, description: l.description, quantity: l.quantity, unitPrice: l.unitPrice,
+        lineTotal: l.lineTotal, recurrence: l.recurrence, taxable: l.taxable,
+        customerVisible: l.customerVisible, sortOrder: l.sortOrder,
+      })),
+  };
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/quoteContentHash.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteContentHash.ts apps/api/src/services/quoteContentHash.test.ts
+git commit -m "feat(quotes): deterministic quote content hash for acceptance tamper-evidence"
+```
+
+---
+
+## Task 4: AcceptanceProvider interface + TypedSignatureProvider
+
+The provider seam so a vendor e-sign adapter can be added later without a data-model change. Built-in typed-signature provider now.
+
+**Files:**
+- Create: `apps/api/src/services/acceptanceProvider.ts`
+- Test: `apps/api/src/services/acceptanceProvider.test.ts`
+
+**Interfaces:**
+- Produces: `AcceptanceProvider`, `AcceptanceCaptureInput`, `AcceptanceCaptureResult`, `TypedSignatureProvider`, `getAcceptanceProvider(): AcceptanceProvider`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getAcceptanceProvider } from './acceptanceProvider';
+
+describe('TypedSignatureProvider', () => {
+  it('captures a typed signature with method=typed-signature', async () => {
+    const p = getAcceptanceProvider();
+    expect(p.kind).toBe('builtin');
+    const r = await p.capture({ quoteId: 'q1', signerName: '  Jane Buyer ', signerEmail: 'jane@x.com', ipAddress: '1.2.3.4', userAgent: 'UA', acceptanceTokenJti: 'jti1' });
+    expect(r).toEqual({ signerName: 'Jane Buyer', signerEmail: 'jane@x.com', method: 'typed-signature' });
+  });
+  it('rejects an empty typed name', async () => {
+    const p = getAcceptanceProvider();
+    await expect(p.capture({ quoteId: 'q1', signerName: '   ' })).rejects.toThrow();
+  });
+  it('normalizes a missing email to null', async () => {
+    const r = await getAcceptanceProvider().capture({ quoteId: 'q1', signerName: 'Bob' });
+    expect(r.signerEmail).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/acceptanceProvider.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface AcceptanceCaptureInput {
+  quoteId: string;
+  signerName: string;
+  signerEmail?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  acceptanceTokenJti?: string | null;
+}
+
+export interface AcceptanceCaptureResult {
+  signerName: string;
+  signerEmail: string | null;
+  method: string;
+}
+
+export interface AcceptanceProvider {
+  readonly kind: string;
+  capture(input: AcceptanceCaptureInput): Promise<AcceptanceCaptureResult>;
+}
+
+/**
+ * Built-in typed-signature provider. The signer types their full name; we record
+ * it plus the method. A future DocuSign/PandaDoc adapter implements the same
+ * interface and maps its envelope reference onto
+ * quote_acceptances.acceptance_token_jti — same columns, no schema change.
+ */
+export class TypedSignatureProvider implements AcceptanceProvider {
+  readonly kind = 'builtin';
+  async capture(input: AcceptanceCaptureInput): Promise<AcceptanceCaptureResult> {
+    const signerName = input.signerName.trim();
+    if (!signerName) throw new Error('signerName is required for a typed signature');
+    const email = input.signerEmail?.trim();
+    return { signerName, signerEmail: email && email.length > 0 ? email : null, method: 'typed-signature' };
+  }
+}
+
+let provider: AcceptanceProvider | null = null;
+export function getAcceptanceProvider(): AcceptanceProvider {
+  if (!provider) provider = new TypedSignatureProvider();
+  return provider;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — same command as Step 2; Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/acceptanceProvider.ts apps/api/src/services/acceptanceProvider.test.ts
+git commit -m "feat(quotes): AcceptanceProvider seam + built-in typed-signature provider"
+```
+
+---
+
+## Task 5: Quote-accept token (`quoteAcceptToken.ts`)
+
+A signed, revocable token that lets a prospect without a portal account open + accept exactly one quote. Mirrors the viewer-token pattern (`jwt.ts` + `viewerTokenRevocation.ts`).
+
+**Files:**
+- Create: `apps/api/src/services/quoteAcceptToken.ts`
+- Test: `apps/api/src/services/quoteAcceptToken.test.ts`
+
+**Interfaces:**
+- Produces: `createQuoteAcceptToken({ quoteId, orgId, partnerId, expiresAt? }): Promise<{ token: string; jti: string }>`; `verifyQuoteAcceptToken(token): Promise<QuoteAcceptClaims | null>` where `QuoteAcceptClaims = { quoteId; orgId; partnerId; jti }`; `revokeQuoteAcceptJti(jti)`, `isQuoteAcceptJtiRevoked(jti)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createQuoteAcceptToken, verifyQuoteAcceptToken } from './quoteAcceptToken';
+
+beforeAll(() => { process.env.JWT_SECRET ||= 'test-secret-test-secret-test-secret-123'; });
+
+describe('quote-accept token', () => {
+  it('round-trips quoteId/orgId/partnerId/jti', async () => {
+    const { token, jti } = await createQuoteAcceptToken({ quoteId: 'q1', orgId: 'o1', partnerId: 'p1' });
+    const claims = await verifyQuoteAcceptToken(token);
+    expect(claims).toEqual({ quoteId: 'q1', orgId: 'o1', partnerId: 'p1', jti });
+  });
+  it('rejects a garbage token', async () => {
+    expect(await verifyQuoteAcceptToken('not.a.jwt')).toBeNull();
+  });
+  it('rejects a viewer-purpose token (wrong audience/purpose)', async () => {
+    const { createViewerAccessToken } = await import('./jwt');
+    const viewer = await createViewerAccessToken({ sub: 'u1', email: 'a@b.com', sessionId: 's1' });
+    expect(await verifyQuoteAcceptToken(viewer)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/quoteAcceptToken.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Reuse the signing key helpers. `getSignKey`/`getVerifyKey`/`buildHeader` are module-private in `jwt.ts`; export them there (add `export` to `getSignKey`, `getVerifyKey`, `buildHeader` in `apps/api/src/services/jwt.ts`) so this module signs with the same keyring. Then:
+
+```ts
+import { SignJWT, jwtVerify } from 'jose';
+import { randomUUID } from 'node:crypto';
+import { getRedis } from './redis';
+import { getSignKey, getVerifyKey, buildHeader } from './jwt';
+
+const ISSUER = 'breeze';
+const AUDIENCE = 'breeze-quote-accept';
+const PURPOSE = 'quote-accept';
+const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const REVOKE_TTL_SECONDS = DEFAULT_TTL_SECONDS;
+
+export interface QuoteAcceptClaims { quoteId: string; orgId: string; partnerId: string; jti: string; }
+
+export async function createQuoteAcceptToken(input: {
+  quoteId: string; orgId: string; partnerId: string; expiresAt?: Date | null;
+}): Promise<{ token: string; jti: string }> {
+  const { key, kid } = getSignKey();
+  const jti = randomUUID();
+  // Expiry = the quote's expiry_date if it's in the future, else +30d. jose
+  // accepts a number (seconds since epoch) or a duration string.
+  const expSeconds = input.expiresAt && input.expiresAt.getTime() > Date.now()
+    ? Math.floor(input.expiresAt.getTime() / 1000)
+    : Math.floor(Date.now() / 1000) + DEFAULT_TTL_SECONDS;
+  const token = await new SignJWT({ quoteId: input.quoteId, orgId: input.orgId, partnerId: input.partnerId, purpose: PURPOSE })
+    .setProtectedHeader(buildHeader(kid))
+    .setJti(jti)
+    .setIssuedAt()
+    .setExpirationTime(expSeconds)
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .sign(key);
+  return { token, jti };
+}
+
+export async function verifyQuoteAcceptToken(token: string): Promise<QuoteAcceptClaims | null> {
+  try {
+    const { payload } = await jwtVerify(token, getVerifyKey, { issuer: ISSUER, audience: AUDIENCE, algorithms: ['HS256'] });
+    if (payload.purpose !== PURPOSE) return null;
+    if (typeof payload.jti !== 'string' || payload.jti.length === 0) return null;
+    const { quoteId, orgId, partnerId } = payload as Record<string, unknown>;
+    if (typeof quoteId !== 'string' || typeof orgId !== 'string' || typeof partnerId !== 'string') return null;
+    return { quoteId, orgId, partnerId, jti: payload.jti };
+  } catch (err) {
+    console.debug('[quoteAcceptToken] verification failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+export async function revokeQuoteAcceptJti(jti: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) { console.error('[quoteAcceptToken] Redis unavailable — jti revocation skipped'); return; }
+  await redis.set(`quote-accept-jti-revoked:${jti}`, '1', 'EX', REVOKE_TTL_SECONDS);
+}
+
+export async function isQuoteAcceptJtiRevoked(jti: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) { console.error('[quoteAcceptToken] Redis unavailable — failing closed on jti check'); return true; }
+  return (await redis.get(`quote-accept-jti-revoked:${jti}`)) === '1';
+}
+```
+
+> Note for the implementer: confirm `getVerifyKey` exists in `jwt.ts` (it's the JWKS/`getKey` callback `jwtVerify` already uses for viewer tokens — see `verifyViewerAccessToken`). If it's named differently, export that symbol. Do NOT duplicate key material.
+
+- [ ] **Step 4: Run to verify it passes** — same command as Step 2; Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteAcceptToken.ts apps/api/src/services/quoteAcceptToken.test.ts apps/api/src/services/jwt.ts
+git commit -m "feat(quotes): revocable quote-accept JWT (public tokenized access)"
+```
+
+---
+
+## Task 6: Quote numbering (`quoteNumbers.ts`)
+
+Gapless per-partner-per-year quote numbers, allocated when a draft is sent. Mirror of `invoiceNumbers.ts` against `partner_quote_sequences` (shipped Phase 1).
+
+**Files:**
+- Create: `apps/api/src/services/quoteNumbers.ts`
+- Test: `apps/api/src/services/quoteNumbers.test.ts` (unit, pure formatter) + covered functionally in Task 7's integration test.
+
+**Interfaces:**
+- Produces: `formatQuoteNumber(prefix, year, counter): string`; `allocateQuoteCounter(partnerId, year): Promise<number>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { formatQuoteNumber } from './quoteNumbers';
+
+describe('formatQuoteNumber', () => {
+  it('zero-pads the counter to 4 digits', () => {
+    expect(formatQuoteNumber('Q', 2026, 7)).toBe('Q-2026-0007');
+    expect(formatQuoteNumber('QUO', 2026, 1234)).toBe('QUO-2026-1234');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run src/services/quoteNumbers.test.ts`; Expected: FAIL.
+
+- [ ] **Step 3: Implement** (mirror `invoiceNumbers.ts`)
+
+```ts
+import { sql } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { QuoteServiceError } from './quoteTypes';
+
+export function formatQuoteNumber(prefix: string, year: number, counter: number): string {
+  return `${prefix}-${year}-${String(counter).padStart(4, '0')}`;
+}
+
+/**
+ * Gapless counter via INSERT ... ON CONFLICT ... RETURNING on
+ * partner_quote_sequences (year-keyed). partner_quote_sequences is partner-axis;
+ * sendQuote calls this inside its own withSystemDbAccessContext transaction, so
+ * this helper is also safe to call standalone (it self-wraps).
+ */
+export async function allocateQuoteCounter(partnerId: string, year: number): Promise<number> {
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db.execute(sql`
+        INSERT INTO partner_quote_sequences (partner_id, year, counter)
+        VALUES (${partnerId}, ${year}, 1)
+        ON CONFLICT (partner_id, year)
+        DO UPDATE SET counter = partner_quote_sequences.counter + 1
+        RETURNING counter
+      `)
+    )
+  );
+  const counter = Number((rows as unknown as Array<{ counter: number }>)[0]?.counter);
+  if (!Number.isFinite(counter) || counter < 1) throw new QuoteServiceError('Failed to allocate quote number', 500, 'INVALID_STATE');
+  return counter;
+}
+```
+
+> Note: the prefix — invoices read `partner.invoiceNumberPrefix ?? 'INV'`. Quotes have no `quoteNumberPrefix` column; use the literal `'Q'`. If a per-partner prefix is wanted later it's an additive column, not Phase 2.
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteNumbers.ts apps/api/src/services/quoteNumbers.test.ts
+git commit -m "feat(quotes): gapless per-partner quote numbering"
+```
+
+---
+
+## Task 7: Quote email template (`quoteEmail.ts`)
+
+`buildQuoteTemplate` — mirror of `buildInvoiceTemplate`, but the CTA points at the public accept link, not the portal invoice.
+
+**Files:**
+- Create: `apps/api/src/services/quoteEmail.ts`
+- Test: `apps/api/src/services/quoteEmail.test.ts`
+
+**Interfaces:**
+- Produces: `buildQuoteTemplate(params: QuoteEmailParams): { subject; html; text }` where `QuoteEmailParams = { quoteNumber; partnerName; total; expiryDate?; acceptUrl; supportEmail? }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildQuoteTemplate } from './quoteEmail';
+
+describe('buildQuoteTemplate', () => {
+  it('builds a subject + accept link + html/text', () => {
+    const t = buildQuoteTemplate({ quoteNumber: 'Q-2026-0001', partnerName: 'Acme MSP', total: '$1,200.00', acceptUrl: 'https://portal.example.com/quote/TOKEN', expiryDate: '2026-07-01' });
+    expect(t.subject).toContain('Q-2026-0001');
+    expect(t.subject).toContain('Acme MSP');
+    expect(t.html).toContain('https://portal.example.com/quote/TOKEN');
+    expect(t.text).toContain('https://portal.example.com/quote/TOKEN');
+    expect(t.html).toContain('1,200.00');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run src/services/quoteEmail.test.ts`; Expected: FAIL.
+
+- [ ] **Step 3: Implement** — reuse the shared email layout helpers (`renderLayout`, `renderButton`, `escapeHtml`, `supportFooter`, `getSupportEmail`, `BODY_PARA`, `MUTED_PARA`, `EmailTemplate`) from `email.ts`. Export them from `email.ts` if not already exported (grep `export function renderLayout`; add `export` as needed).
+
+```ts
+import { renderLayout, renderButton, escapeHtml, supportFooter, getSupportEmail, BODY_PARA, MUTED_PARA, type EmailTemplate } from './email';
+
+export interface QuoteEmailParams {
+  quoteNumber: string;
+  partnerName: string;
+  total: string;        // pre-formatted money
+  expiryDate?: string;  // pre-formatted date or empty
+  acceptUrl: string;
+  supportEmail?: string;
+}
+
+export function buildQuoteTemplate(params: QuoteEmailParams): EmailTemplate {
+  const number = params.quoteNumber.trim();
+  const subject = `Proposal ${number} from ${params.partnerName}`;
+  const preheader = `Proposal ${number} — ${params.total}${params.expiryDate ? `, valid until ${params.expiryDate}` : ''}.`;
+  const expiryLine = params.expiryDate
+    ? `<p style="${MUTED_PARA}">This proposal is valid until <strong>${escapeHtml(params.expiryDate)}</strong>.</p>`
+    : '';
+  const body = `
+      <p style="${BODY_PARA}">Hi there,</p>
+      <p style="${BODY_PARA}">${escapeHtml(params.partnerName)} has sent you proposal <strong>${escapeHtml(number)}</strong> for <strong>${escapeHtml(params.total)}</strong>. A PDF copy is attached.</p>
+      ${renderButton('Review & accept', params.acceptUrl)}
+      ${expiryLine}
+  `;
+  const html = renderLayout({ title: subject, preheader, heading: `Proposal ${number}`, body, footer: supportFooter(params.supportEmail, 'Questions about this proposal? Contact') });
+  const support = getSupportEmail(params.supportEmail);
+  const text = [
+    'Hi there,',
+    `${params.partnerName} has sent you proposal ${number} for ${params.total}. A PDF copy is attached.`,
+    `Review & accept: ${params.acceptUrl}`,
+    params.expiryDate ? `Valid until ${params.expiryDate}.` : null,
+    support ? `Questions? Contact ${support}.` : null,
+  ].filter(Boolean).join('\n');
+  return { subject, html, text };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteEmail.ts apps/api/src/services/quoteEmail.test.ts apps/api/src/services/email.ts
+git commit -m "feat(quotes): quote email template with public accept CTA"
+```
+
+---
+
+## Task 8: Quote lifecycle service (`quoteLifecycle.ts`) — send + view + decline
+
+`sendQuote` issues a draft (assign number + issueDate), transitions to `sent`, stamps `sentAt`, mints the public accept token, and emails the customer post-commit. `markQuoteViewed` does the `sent→viewed` + `first_viewed_at` stamp. `declineQuoteByActor` handles internal/portal decline.
+
+**Files:**
+- Create: `apps/api/src/services/quoteLifecycle.ts`
+- Test: `apps/api/src/__tests__/integration/quoteLifecycle.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `getQuote` (quoteService), `allocateQuoteCounter`/`formatQuoteNumber`, `createQuoteAcceptToken`, `buildQuoteTemplate`, `getEmailService`, `resolveBillingEmail` (export it from `invoicePdf.ts` or inline a copy — see note), `renderQuotePdf` (quotePdf), `computeQuoteTotals` is not needed here.
+- Produces:
+  - `sendQuote(id: string, actor: QuoteActor): Promise<{ quote: QuoteRow; emailed: boolean; acceptUrl: string }>`
+  - `markQuoteViewed(quoteId: string, orgId: string): Promise<void>` (idempotent; only stamps `first_viewed_at` once; flips `sent→viewed`)
+  - `declineQuoteByActor(id: string, reason: string | undefined, actor: QuoteActor): Promise<QuoteRow>`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote, markQuoteViewed, declineQuoteByActor } from '../../services/quoteLifecycle';
+import type { QuoteActor } from '../../services/quoteTypes';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seed() {
+  return withSystemDbAccessContext(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    return { partner, org };
+  });
+}
+function ctxFor(orgId: string, partnerId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [partnerId], userId: null };
+}
+function actorFor(orgId: string, partnerId: string): QuoteActor {
+  return { userId: null, partnerId, accessibleOrgIds: [orgId] };
+}
+
+describe('quote lifecycle', () => {
+  runDb('sendQuote assigns a number, sets sent + sentAt, returns an accept URL', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.quote.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+
+    const result = await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+    expect(result.quote.status).toBe('sent');
+    expect(result.quote.quoteNumber).toMatch(/^Q-\d{4}-\d{4}$/);
+    expect(result.quote.sentAt).toBeTruthy();
+    expect(result.acceptUrl).toContain('/quote/');
+  });
+
+  runDb('markQuoteViewed flips sent→viewed and stamps first_viewed_at once', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+    await markQuoteViewed(created.quote.id, org.id);
+    const [v1] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.quote.id)));
+    expect(v1!.status).toBe('viewed');
+    const firstViewed = v1!.firstViewedAt;
+    await markQuoteViewed(created.quote.id, org.id); // idempotent
+    const [v2] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.quote.id)));
+    expect(v2!.firstViewedAt).toEqual(firstViewed);
+  });
+
+  runDb('declineQuoteByActor sets declined + reason', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+    const declined = await withDbAccessContext(ctx, () => declineQuoteByActor(created.quote.id, 'Budget cut', actor));
+    expect(declined.status).toBe('declined');
+    expect(declined.declineReason).toBe('Budget cut');
+    expect(declined.declinedAt).toBeTruthy();
+  });
+
+  runDb('sendQuote rejects a non-draft', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+    await expect(withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor))).rejects.toMatchObject({ status: 409 });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/quoteLifecycle.integration.test.ts
+```
+Expected: FAIL — `quoteLifecycle` module not found.
+
+- [ ] **Step 3: Implement**
+
+First, export `resolveBillingEmail` from `invoicePdf.ts` (change `function resolveBillingEmail` → `export function resolveBillingEmail`) so the quote path reuses the exact same JSONB extraction. Then:
+
+```ts
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { quotes } from '../db/schema/quotes';
+import { organizations, partners } from '../db/schema/orgs';
+import { portalBranding } from '../db/schema/portal';
+import { getQuote } from './quoteService';
+import { QuoteServiceError, type QuoteActor } from './quoteTypes';
+import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
+import { createQuoteAcceptToken } from './quoteAcceptToken';
+import { buildQuoteTemplate } from './quoteEmail';
+import { getEmailService } from './email';
+import { resolveBillingEmail } from './invoicePdf';
+
+type QuoteRow = typeof quotes.$inferSelect;
+
+function portalBase(): string {
+  // The customer portal app (apps/portal) is where /quote/<token> is served.
+  return (process.env.PUBLIC_PORTAL_URL || process.env.PUBLIC_APP_URL || process.env.DASHBOARD_URL || 'http://localhost:4321').replace(/\/$/, '');
+}
+function formatMoneyish(n: string, currency: string): string {
+  // Light formatter for the email body; invoicePdf uses formatMoney — reuse if exported.
+  const v = Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return currency === 'USD' ? `$${v}` : `${v} ${currency}`;
+}
+
+/** Issue (if draft) + send: assign number, status→sent, sentAt, mint token, email post-commit. */
+export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote: QuoteRow; emailed: boolean; acceptUrl: string }> {
+  const { quote, blocks, lines } = await getQuote(id, actor); // getQuote enforces org-access 404
+  if (quote.status !== 'draft' && quote.status !== 'sent') {
+    throw new QuoteServiceError(`Cannot send a quote in status ${quote.status}`, 409, 'INVALID_STATE');
+  }
+
+  // Assign a number on first issue only (idempotent re-send of an already-numbered sent quote keeps its number).
+  let quoteNumber = quote.quoteNumber;
+  if (quote.status === 'draft') {
+    if (!quoteNumber) {
+      const year = new Date(quote.issueDate ?? Date.now()).getUTCFullYear();
+      const counter = await allocateQuoteCounter(quote.partnerId, year);
+      quoteNumber = formatQuoteNumber('Q', year, counter);
+    }
+  } else {
+    throw new QuoteServiceError('Quote already sent', 409, 'INVALID_STATE');
+  }
+
+  const now = new Date();
+  const issueDate = quote.issueDate ?? now.toISOString().slice(0, 10);
+  await db.update(quotes).set({ status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now }).where(eq(quotes.id, id));
+
+  // Mint the public accept token (expiry = quote.expiryDate if future, else +30d).
+  const { token } = await createQuoteAcceptToken({
+    quoteId: id, orgId: quote.orgId, partnerId: quote.partnerId,
+    expiresAt: quote.expiryDate ? new Date(`${quote.expiryDate}T23:59:59Z`) : null,
+  });
+  const acceptUrl = `${portalBase()}/quote/${token}`;
+
+  // Post-commit email — never block or fail the send on email/PDF I/O.
+  let emailed = false;
+  try {
+    const [org] = await db.select({ billingContact: organizations.billingContact }).from(organizations).where(eq(organizations.id, quote.orgId)).limit(1);
+    const [partner] = await db.select({ name: partners.name }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+    const recipient = resolveBillingEmail(org?.billingContact);
+    const emailService = getEmailService();
+    if (emailService && recipient) {
+      const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
+      const loadImage = async () => null; // PDF email attach renders without embedded images is acceptable; full image load happens in the route path
+      const { renderQuotePdf } = await import('./quotePdf');
+      const pdf = await renderQuotePdf({ ...quote, status: 'sent', quoteNumber }, blocks, lines, loadImage, {
+        partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
+        footer: quote.terms ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? 'USD',
+      });
+      const template = buildQuoteTemplate({
+        quoteNumber: quoteNumber ?? '', partnerName: partner?.name ?? 'your provider',
+        total: formatMoneyish(quote.total, quote.currencyCode), acceptUrl,
+        expiryDate: quote.expiryDate ?? undefined,
+      });
+      await emailService.sendEmail({ to: recipient, subject: template.subject, html: template.html, text: template.text, attachments: [{ filename: `${quoteNumber ?? 'quote'}.pdf`, content: pdf, contentType: 'application/pdf' }] });
+      emailed = true;
+    } else if (!emailService) {
+      console.warn(`[quoteLifecycle] Email not configured — quote ${id} sent but not emailed`);
+    } else {
+      console.warn(`[quoteLifecycle] No billing email for org ${quote.orgId} — quote ${id} sent but not emailed`);
+    }
+  } catch (err) {
+    console.error(`[quoteLifecycle] send email failed for quote ${id}:`, err);
+  }
+
+  const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
+  return { quote: updated!, emailed, acceptUrl };
+}
+
+/** sent→viewed + first_viewed_at (once). orgId is the resolved tenant (from session or token). */
+export async function markQuoteViewed(quoteId: string, orgId: string): Promise<void> {
+  const [q] = await db.select().from(quotes).where(eq(quotes.id, quoteId)).limit(1);
+  if (!q || q.orgId !== orgId) return; // scoped no-op; never throw on a view stamp
+  const now = new Date();
+  const set: Record<string, unknown> = { viewedAt: now, updatedAt: now };
+  if (!q.firstViewedAt) set.firstViewedAt = now;
+  if (q.status === 'sent') set.status = 'viewed';
+  await db.update(quotes).set(set).where(eq(quotes.id, quoteId));
+}
+
+/** Internal/portal decline. */
+export async function declineQuoteByActor(id: string, reason: string | undefined, actor: QuoteActor): Promise<QuoteRow> {
+  const { quote } = await getQuote(id, actor);
+  if (quote.status !== 'sent' && quote.status !== 'viewed') {
+    throw new QuoteServiceError(`Cannot decline a quote in status ${quote.status}`, 409, 'INVALID_STATE');
+  }
+  const now = new Date();
+  await db.update(quotes).set({ status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now }).where(eq(quotes.id, id));
+  const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
+  return updated!;
+}
+```
+
+> Note for the implementer: confirm `renderQuotePdf`'s signature from the Phase 1 route (`apps/api/src/routes/quotes/quotes.ts:124-125`): `renderQuotePdf(quote, blocks, lines, loadImage, branding)`. If `formatMoney`/`formatDate` are exported from `invoicePdf.ts`, prefer them over the local `formatMoneyish`. Email failures are swallowed by design (send already committed) — mirrors invoice send.
+
+- [ ] **Step 4: Run to verify it passes** — same command as Step 2; Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteLifecycle.ts apps/api/src/services/invoicePdf.ts apps/api/src/__tests__/integration/quoteLifecycle.integration.test.ts
+git commit -m "feat(quotes): send (issue+email), view-stamp, and decline lifecycle"
+```
+
+---
+
+## Task 9: Accept → convert service (`quoteAcceptService.ts`)
+
+The shared accept pipeline used by BOTH the portal and public routes: guard status → compute content hash → provider.capture → insert `quote_acceptances` → convert one-time lines to an invoice → status→converted → revoke token jti.
+
+**Files:**
+- Create: `apps/api/src/services/quoteAcceptService.ts`
+- Test: `apps/api/src/__tests__/integration/quoteAccept.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `getQuote`, `computeQuoteSha256`, `getAcceptanceProvider`, `createManualInvoice`+`addManualLine`+`issueInvoice` (invoiceService) OR a direct invoice insert (see note), `revokeQuoteAcceptJti`.
+- Produces: `acceptQuote(input: AcceptQuoteParams): Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string }>` where `AcceptQuoteParams = { quoteId; signerName; signerEmail?; ipAddress?; userAgent?; acceptanceTokenJti?; actorUserId?: string | null }`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes, quoteAcceptances } from '../../db/schema/quotes';
+import { invoices, invoiceLines } from '../../db/schema/invoices';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { acceptQuote } from '../../services/quoteAcceptService';
+import type { QuoteActor } from '../../services/quoteTypes';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+function ctxFor(orgId: string, partnerId: string): DbAccessContext { return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [partnerId], userId: null }; }
+function actorFor(orgId: string, partnerId: string): QuoteActor { return { userId: null, partnerId, accessibleOrgIds: [orgId] }; }
+async function seed() { return withSystemDbAccessContext(async () => { const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id }); return { partner, org }; }); }
+
+describe('quote accept → convert', () => {
+  runDb('records acceptance with content hash and converts one-time lines to an invoice', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.quote.id, { sourceType: 'manual', description: 'Onboarding', quantity: 1, unitPrice: 250, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.quote.id, { sourceType: 'manual', description: 'Managed services', quantity: 1, unitPrice: 99, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.quote.id, signerName: 'Jane Buyer', signerEmail: 'jane@org.example', ipAddress: '9.9.9.9', userAgent: 'UA' }));
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.quote.id)));
+    expect(q!.status).toBe('converted');
+    expect(q!.convertedInvoiceId).toBe(res.invoiceId);
+    expect(q!.acceptedAt).toBeTruthy();
+
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+    expect(acc!.signerName).toBe('Jane Buyer');
+    expect(acc!.quoteSha256).toMatch(/^[0-9a-f]{64}$/);
+
+    // Only the one-time line ($250) is invoiced; the monthly line is excluded.
+    const invLines = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, res.invoiceId)));
+    expect(invLines).toHaveLength(1);
+    expect(invLines[0]!.description).toBe('Onboarding');
+    const [inv] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, res.invoiceId)));
+    expect(inv!.total).toBe('250.00');
+  });
+
+  runDb('a recurring-only quote still converts but yields a $0 invoice (Phase 2 degenerate edge)', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.quote.id, { sourceType: 'manual', description: 'Managed services', quantity: 1, unitPrice: 99, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.quote.id, signerName: 'Bob' }));
+    const [inv] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, res.invoiceId)));
+    expect(inv!.total).toBe('0.00');
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.quote.id)));
+    expect(q!.status).toBe('converted');
+  });
+
+  runDb('rejects accepting a quote that is not sent/viewed', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    // still draft
+    await expect(withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.quote.id, signerName: 'Jane' }))).rejects.toMatchObject({ status: 409 });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/quoteAccept.integration.test.ts`; Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { eq, and } from 'drizzle-orm';
+import { db } from '../db';
+import { quotes, quoteBlocks, quoteLines, quoteAcceptances } from '../db/schema/quotes';
+import { invoices, invoiceLines } from '../db/schema/invoices';
+import { QuoteServiceError } from './quoteTypes';
+import { computeQuoteSha256 } from './quoteContentHash';
+import { getAcceptanceProvider } from './acceptanceProvider';
+import { revokeQuoteAcceptJti } from './quoteAcceptToken';
+import { computeLineTotal, computeInvoiceTotals } from './invoiceMath';
+
+export interface AcceptQuoteParams {
+  quoteId: string;
+  signerName: string;
+  signerEmail?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  acceptanceTokenJti?: string | null;
+  actorUserId?: string | null;
+}
+
+type QuoteRow = typeof quotes.$inferSelect;
+
+/**
+ * Shared accept pipeline for both the portal and public paths. The CALLER is
+ * responsible for establishing the DB access context: portal handlers run under
+ * org scope; the public route wraps this in
+ * runOutsideDbContext(withSystemDbAccessContext(...)) because it's unauthenticated.
+ */
+export async function acceptQuote(params: AcceptQuoteParams): Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string }> {
+  const [quote] = await db.select().from(quotes).where(eq(quotes.id, params.quoteId)).limit(1);
+  if (!quote) throw new QuoteServiceError('Quote not found', 404, 'QUOTE_NOT_FOUND');
+  if (quote.status !== 'sent' && quote.status !== 'viewed') {
+    throw new QuoteServiceError(`Cannot accept a quote in status ${quote.status}`, 409, 'INVALID_STATE');
+  }
+
+  const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, quote.id)).orderBy(quoteBlocks.sortOrder);
+  const lines = await db.select().from(quoteLines).where(eq(quoteLines.quoteId, quote.id)).orderBy(quoteLines.sortOrder);
+
+  const quoteSha256 = computeQuoteSha256(quote as any, blocks as any, lines as any);
+  const captured = await getAcceptanceProvider().capture({
+    quoteId: quote.id, signerName: params.signerName, signerEmail: params.signerEmail,
+    ipAddress: params.ipAddress, userAgent: params.userAgent, acceptanceTokenJti: params.acceptanceTokenJti,
+  });
+
+  const now = new Date();
+
+  // 1. Record the acceptance.
+  const [acceptance] = await db.insert(quoteAcceptances).values({
+    quoteId: quote.id, orgId: quote.orgId, signerName: captured.signerName, signerEmail: captured.signerEmail,
+    ipAddress: params.ipAddress ?? null, userAgent: params.userAgent ?? null, quoteSha256,
+    acceptanceTokenJti: params.acceptanceTokenJti ?? null,
+  }).returning({ id: quoteAcceptances.id });
+
+  // 2. Convert ONE-TIME lines to a draft invoice (Phase 2: recurring lines deferred to the Phase 4 Contract).
+  const oneTime = lines.filter((l) => l.recurrence === 'one_time' && l.customerVisible);
+  const [invoice] = await db.insert(invoices).values({
+    partnerId: quote.partnerId, orgId: quote.orgId, siteId: quote.siteId ?? null, status: 'draft',
+    currencyCode: quote.currencyCode, taxRate: quote.taxRate ?? null, createdBy: params.actorUserId ?? null,
+    notes: quote.quoteNumber ? `Converted from quote ${quote.quoteNumber}` : 'Converted from quote',
+  }).returning();
+
+  const totalsLines: { lineTotal: string; taxable: boolean; customerVisible: boolean }[] = [];
+  for (let i = 0; i < oneTime.length; i++) {
+    const l = oneTime[i]!;
+    const lineTotal = computeLineTotal(l.quantity, l.unitPrice);
+    await db.insert(invoiceLines).values({
+      invoiceId: invoice!.id, orgId: quote.orgId, sourceType: 'manual', sourceId: null, catalogItemId: l.catalogItemId ?? null,
+      parentLineId: null, ticketId: null, description: l.description, quantity: l.quantity,
+      unitPrice: Number(l.unitPrice).toFixed(2), costBasis: null, taxable: l.taxable, customerVisible: true,
+      lineTotal, isUnapprovedTime: false, sortOrder: i,
+    });
+    totalsLines.push({ lineTotal, taxable: l.taxable, customerVisible: true });
+  }
+  const totals = computeInvoiceTotals(totalsLines, quote.taxRate ?? null);
+  await db.update(invoices).set({ subtotal: totals.subtotal, taxTotal: totals.taxTotal, total: totals.total, balance: totals.total, updatedAt: now }).where(eq(invoices.id, invoice!.id));
+
+  // 3. Transition the quote to converted.
+  await db.update(quotes).set({ status: 'converted', acceptedAt: now, convertedAt: now, convertedInvoiceId: invoice!.id, updatedAt: now }).where(eq(quotes.id, quote.id));
+
+  // 4. Best-effort revoke the public token so the link can't be reused.
+  if (params.acceptanceTokenJti) {
+    try { await revokeQuoteAcceptJti(params.acceptanceTokenJti); } catch (err) { console.error('[quoteAcceptService] jti revoke failed', err); }
+  }
+
+  const [updated] = await db.select().from(quotes).where(eq(quotes.id, quote.id)).limit(1);
+  return { quote: updated!, acceptanceId: acceptance!.id, invoiceId: invoice!.id };
+}
+```
+
+> Note for the implementer: the convert path inserts the invoice + lines directly rather than going through `invoiceService.createManualInvoice` so the whole accept is one logical unit and the line `recurrence` filter is explicit. If `invoiceService` later grows a `createInvoiceFromLines` helper, refactor to it. The invoice is left in `draft` (un-numbered) — issuing/sending the invoice is the existing invoice flow, not part of accept. `computeInvoiceTotals` on an empty `totalsLines` returns `'0.00'` totals (verify against `invoiceMath.test.ts`), which is the recurring-only $0 edge.
+
+- [ ] **Step 4: Run to verify it passes** — same command as Step 2; Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteAcceptService.ts apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+git commit -m "feat(quotes): accept records signature+hash and converts one-time lines to an invoice"
+```
+
+---
+
+## Task 10: Quote image storage (`quoteImageStorage.ts`)
+
+Bytea-in-DB image store for proposal image blocks. Reuses `sniffImageMime` + the 5 MB cap from `avatarStorage.ts`.
+
+**Files:**
+- Create: `apps/api/src/services/quoteImageStorage.ts`
+- Test: `apps/api/src/__tests__/integration/quoteImages.integration.test.ts`
+
+**Interfaces:**
+- Produces: `writeQuoteImage(quoteId, orgId, mime, buffer): Promise<{ id: string; byteSize: number; sha256: string }>`; `readQuoteImage(imageId, quoteId): Promise<{ data: Buffer; mime: string; byteSize: number } | null>`; re-exports `sniffImageMime` and `MAX_QUOTE_IMAGE_SIZE_BYTES`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { db } from '../../db';
+import { quotes } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { writeQuoteImage, readQuoteImage } from '../../services/quoteImageStorage';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const PNG = Buffer.from([0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a,0,0,0,0]);
+
+describe('quote image storage', () => {
+  runDb('writes and reads back a PNG scoped to its quote', async () => {
+    const { ctx, quoteId } = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id });
+      const [q] = await db.insert(quotes).values({ partnerId: partner.id, orgId: org.id, currencyCode: 'USD' }).returning({ id: quotes.id, orgId: quotes.orgId });
+      const ctx: DbAccessContext = { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id], accessiblePartnerIds: [partner.id], userId: null };
+      return { ctx, quoteId: q!.id, orgId: org.id };
+    });
+    const written = await withDbAccessContext(ctx, () => writeQuoteImage(quoteId, ctx.orgId!, 'image/png', PNG));
+    expect(written.sha256).toMatch(/^[0-9a-f]{64}$/);
+    const read = await withDbAccessContext(ctx, () => readQuoteImage(written.id, quoteId));
+    expect(read?.mime).toBe('image/png');
+    expect(read?.data.equals(PNG)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/quoteImages.integration.test.ts`; Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { createHash } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { quoteImages } from '../db/schema/quotes';
+import { sniffImageMime } from './avatarStorage';
+
+export { sniffImageMime };
+export const MAX_QUOTE_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // reuse the avatar cap
+
+export async function writeQuoteImage(quoteId: string, orgId: string, mime: string, buffer: Buffer): Promise<{ id: string; byteSize: number; sha256: string }> {
+  const sha256 = createHash('sha256').update(buffer).digest('hex');
+  const [row] = await db.insert(quoteImages).values({
+    quoteId, orgId, imageData: buffer, mime, byteSize: buffer.length, sha256,
+  }).returning({ id: quoteImages.id });
+  return { id: row!.id, byteSize: buffer.length, sha256 };
+}
+
+/** Read constrained to BOTH the image id AND its quote (closes same-org cross-quote embed). */
+export async function readQuoteImage(imageId: string, quoteId: string): Promise<{ data: Buffer; mime: string; byteSize: number } | null> {
+  const [img] = await db.select({ data: quoteImages.imageData, mime: quoteImages.mime, byteSize: quoteImages.byteSize })
+    .from(quoteImages).where(and(eq(quoteImages.id, imageId), eq(quoteImages.quoteId, quoteId))).limit(1);
+  return img?.data ? { data: img.data, mime: img.mime, byteSize: img.byteSize } : null;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteImageStorage.ts apps/api/src/__tests__/integration/quoteImages.integration.test.ts
+git commit -m "feat(quotes): quote image bytea storage (magic-byte sniff + sha256)"
+```
+
+---
+
+## Task 11: Internal routes — send + image upload/serve
+
+Wire the three authed routes onto the Phase 1 quote router. **This is where the dead `quotes:send` permission gets wired.**
+
+**Files:**
+- Create: `apps/api/src/routes/quotes/lifecycle.ts`
+- Modify: `apps/api/src/routes/quotes/index.ts` (mount), `apps/api/src/routes/quotes/quotes.ts` (export `quoteActorFrom`, `handleServiceError` — already exported)
+- Test: `apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts` (Task 13 adds the negative RBAC case; here add a smoke route test if the repo has a route-test harness, else cover via the lifecycle integration test already written).
+
+**Interfaces:**
+- Consumes: `sendQuote`, `writeQuoteImage`/`readQuoteImage`/`sniffImageMime`/`MAX_QUOTE_IMAGE_SIZE_BYTES`, `getQuote` (org guard for image ops), `quoteActorFrom`, `handleServiceError`.
+- Produces: `quoteLifecycleRoutes` (Hono) with `POST /:id/send`, `POST /:id/images`, `GET /:id/images/:imageId`.
+
+- [ ] **Step 1: Write the route module**
+
+```ts
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { getQuote } from '../../services/quoteService';
+import { writeQuoteImage, readQuoteImage, sniffImageMime, MAX_QUOTE_IMAGE_SIZE_BYTES } from '../../services/quoteImageStorage';
+import { quoteActorFrom, handleServiceError } from './quotes';
+
+export const quoteLifecycleRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const readPerm = requirePermission(PERMISSIONS.QUOTES_READ.resource, PERMISSIONS.QUOTES_READ.action);
+const writePerm = requirePermission(PERMISSIONS.QUOTES_WRITE.resource, PERMISSIONS.QUOTES_WRITE.action);
+const sendPerm = requirePermission(PERMISSIONS.QUOTES_SEND.resource, PERMISSIONS.QUOTES_SEND.action);
+const idParam = z.object({ id: z.string().uuid() });
+const imageParam = z.object({ id: z.string().uuid(), imageId: z.string().uuid() });
+
+// POST /:id/send — issue + email. Gated on the (previously dead) quotes:send permission.
+quoteLifecycleRoutes.post('/:id/send', scopes, sendPerm, zValidator('param', idParam), async (c) => {
+  try { return c.json({ data: await sendQuote(c.req.valid('param').id, quoteActorFrom(c)) }); }
+  catch (err) { return handleServiceError(c, err); }
+});
+
+// POST /:id/images — multipart upload (magic-byte sniff + 5 MB cap). quotes:write.
+quoteLifecycleRoutes.post('/:id/images',
+  scopes, writePerm, zValidator('param', idParam),
+  bodyLimit({ maxSize: MAX_QUOTE_IMAGE_SIZE_BYTES + 64 * 1024, onError: (c) => c.json({ error: 'Image too large (max 5 MB)' }, 413) }),
+  async (c) => {
+    const id = c.req.valid('param').id;
+    try {
+      const { quote } = await getQuote(id, quoteActorFrom(c)); // org-access 404
+      let body: Record<string, unknown>;
+      try { body = await c.req.parseBody({ all: true }); } catch { return c.json({ error: 'Invalid multipart body' }, 400); }
+      const file = body.file;
+      if (!(file instanceof File)) return c.json({ error: 'file field is required' }, 400);
+      if (file.size === 0) return c.json({ error: 'file is empty' }, 400);
+      if (file.size > MAX_QUOTE_IMAGE_SIZE_BYTES) return c.json({ error: 'Image too large (max 5 MB)' }, 413);
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const mime = sniffImageMime(buffer);
+      if (!mime) return c.json({ error: 'Unsupported image format. Allowed: PNG, JPEG, WebP.' }, 415);
+      const written = await writeQuoteImage(id, quote.orgId, mime, buffer);
+      return c.json({ data: { imageId: written.id, mime, byteSize: written.byteSize } });
+    } catch (err) { return handleServiceError(c, err); }
+  });
+
+// GET /:id/images/:imageId — serve for the editor preview. quotes:read.
+quoteLifecycleRoutes.get('/:id/images/:imageId', scopes, readPerm, zValidator('param', imageParam), async (c) => {
+  const { id, imageId } = c.req.valid('param');
+  try {
+    await getQuote(id, quoteActorFrom(c)); // org-access 404 before serving bytes
+    const img = await readQuoteImage(imageId, id);
+    if (!img) return c.json({ error: 'Image not found' }, 404);
+    return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+  } catch (err) { return handleServiceError(c, err); }
+});
+```
+
+- [ ] **Step 2: Mount it** — in `apps/api/src/routes/quotes/index.ts`, mount alongside `quoteCrudRoutes`:
+
+```ts
+import { quoteLifecycleRoutes } from './lifecycle';
+// ... after the existing quoteCrudRoutes mount:
+quoteRoutes.route('/', quoteLifecycleRoutes);
+```
+
+(Match the existing mount style — if `index.ts` does `quoteRoutes.route('/', quoteCrudRoutes)` after `authMiddleware`, append the same for lifecycle so both sit behind auth.)
+
+- [ ] **Step 3: Typecheck the API**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: no NEW errors (pre-existing `agents.test.ts`/`apiKeyAuth.test.ts` errors per memory are acceptable).
+
+- [ ] **Step 4: Smoke the send path** — the Task 8 lifecycle integration test already exercises `sendQuote`; re-run it to confirm nothing regressed:
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/quoteLifecycle.integration.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/quotes/lifecycle.ts apps/api/src/routes/quotes/index.ts
+git commit -m "feat(quotes): internal send (quotes:send) + image upload/serve routes"
+```
+
+---
+
+## Task 12: Portal routes (`routes/portal/quotes.ts`)
+
+Customer-portal view for org users with portal accounts. Org-scoped under `portalAuthMiddleware`; drafts filtered; accept records the `portal_user` as signer.
+
+**Files:**
+- Create: `apps/api/src/routes/portal/quotes.ts`
+- Modify: `apps/api/src/routes/portal/index.ts` (mount `quoteRoutes`)
+- Test: `apps/api/src/__tests__/integration/portalQuotes.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `c.get('portalAuth')` (`auth.user.orgId`, `auth.user.id`, `auth.user.name`, `auth.user.email`), `getQuote` is NOT used (portal reads directly, org-scoped); `markQuoteViewed`, `acceptQuote`, `declineQuoteByActor`-equivalent inline decline, `renderQuotePdf`, `readQuoteImage`.
+- Produces: `quoteRoutes` (Hono) — `GET /quotes`, `GET /quotes/:id`, `GET /quotes/:id/pdf`, `GET /quotes/:id/images/:imageId`, `POST /quotes/:id/accept`, `POST /quotes/:id/decline`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes, quoteAcceptances } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { acceptQuote } from '../../services/quoteAcceptService';
+
+// These exercise the SERVICE layer the portal routes call, under the SAME org
+// scope the portal middleware establishes. (Full HTTP route tests would need
+// the portal session harness; the service-under-portal-scope path is the
+// security-critical surface.)
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('portal quotes (org-scoped)', () => {
+  runDb('portal accept records the portal user identity as signer + converts', async () => {
+    const fx = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id });
+      return { partnerId: partner.id, orgId: org.id };
+    });
+    const ctx: DbAccessContext = { scope: 'organization', orgId: fx.orgId, accessibleOrgIds: [fx.orgId], accessiblePartnerIds: [fx.partnerId], userId: null };
+    const actor = { userId: null, partnerId: fx.partnerId, accessibleOrgIds: [fx.orgId] };
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: fx.orgId, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.quote.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+
+    // Portal handler would call acceptQuote with the portal_user's name/email.
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.quote.id, signerName: 'Portal Pat', signerEmail: 'pat@org.example' }));
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+    expect(acc!.signerName).toBe('Portal Pat');
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.quote.id)));
+    expect(q!.status).toBe('converted');
+  });
+
+  runDb('another org cannot read this org quote (RLS hides it under portal scope)', async () => {
+    const fx = await withSystemDbAccessContext(async () => {
+      const pA = await createPartner(); const oA = await createOrganization({ partnerId: pA.id });
+      const pB = await createPartner(); const oB = await createOrganization({ partnerId: pB.id });
+      const [qA] = await db.insert(quotes).values({ partnerId: pA.id, orgId: oA.id, currencyCode: 'USD', status: 'sent' }).returning({ id: quotes.id });
+      return { orgB: oB.id, partnerB: pB.id, quoteA: qA!.id };
+    });
+    const ctxB: DbAccessContext = { scope: 'organization', orgId: fx.orgB, accessibleOrgIds: [fx.orgB], accessiblePartnerIds: [fx.partnerB], userId: null };
+    const visible = await withDbAccessContext(ctxB, () => db.select({ id: quotes.id }).from(quotes).where(eq(quotes.id, fx.quoteA)));
+    expect(visible).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/portalQuotes.integration.test.ts`; Expected: FAIL only if `acceptQuote`/imports are wrong; if Task 9 is done it may PASS the first case but the route file still doesn't exist — the route file is exercised in feature-testing. (This test guards the service-under-portal-scope contract; keep it.)
+
+- [ ] **Step 3: Implement the portal route module** (mirror `portal/invoices.ts`)
+
+```ts
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { and, desc, eq, ne, sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { quotes, quoteBlocks, quoteLines } from '../../db/schema/quotes';
+import { partners } from '../../db/schema/orgs';
+import { portalBranding } from '../../db/schema/portal';
+import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
+import { markQuoteViewed } from '../../services/quoteLifecycle';
+import { acceptQuote } from '../../services/quoteAcceptService';
+import { readQuoteImage } from '../../services/quoteImageStorage';
+import { QuoteServiceError } from '../../services/quoteTypes';
+import { safeContentDispositionFilename } from '../../utils/httpHeaders';
+
+export const quoteRoutes = new Hono();
+const idParam = z.object({ id: z.string().uuid() });
+const imageParam = z.object({ id: z.string().uuid(), imageId: z.string().uuid() });
+
+// GET /quotes — list (drafts filtered; org defense-in-depth atop RLS).
+quoteRoutes.get('/quotes', async (c) => {
+  const auth = c.get('portalAuth');
+  const conditions = and(eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'));
+  const data = await db.select({
+    id: quotes.id, quoteNumber: quotes.quoteNumber, status: quotes.status, currencyCode: quotes.currencyCode,
+    issueDate: quotes.issueDate, expiryDate: quotes.expiryDate, total: quotes.total,
+  }).from(quotes).where(conditions).orderBy(desc(quotes.issueDate), desc(quotes.createdAt)).limit(200);
+  return c.json({ data, pagination: { page: 1, limit: 200, total: data.length } });
+});
+
+// GET /quotes/:id — detail (+ blocks + customer-visible lines). Stamps viewed.
+quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param');
+  const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId))).limit(1);
+  if (!quote || quote.status === 'draft') return c.json({ error: 'Quote not found' }, 404);
+  const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
+  const lines = (await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible);
+  try { await markQuoteViewed(id, auth.user.orgId); } catch (err) { console.error('[portal] quote markViewed failed', { id, err }); }
+  return c.json({ data: { quote, blocks, lines } });
+});
+
+// GET /quotes/:id/pdf
+quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param');
+  const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId))).limit(1);
+  if (!quote || quote.status === 'draft') return c.json({ error: 'Quote not found' }, 404);
+  const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
+  const lines = await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder);
+  const [partner] = await db.select({ name: partners.name, footer: partners.invoiceFooter, currency: partners.currencyCode }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+  const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
+  const loadImage = async (imageId: string) => { const img = await readQuoteImage(imageId, id); return img ? { data: img.data } : null; };
+  const { renderQuotePdf } = await import('../../services/quotePdf');
+  const pdf = await renderQuotePdf(quote, blocks, lines, loadImage, {
+    partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
+    footer: quote.terms ?? partner?.footer ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? partner?.currency ?? 'USD',
+  });
+  const filename = safeContentDispositionFilename(`quote-${quote.quoteNumber || quote.id}.pdf`);
+  return new Response(new Uint8Array(pdf), { status: 200, headers: { 'Content-Type': 'application/pdf', 'Content-Disposition': `inline; filename="${filename}"`, 'Content-Length': String(pdf.length) } });
+});
+
+// GET /quotes/:id/images/:imageId
+quoteRoutes.get('/quotes/:id/images/:imageId', zValidator('param', imageParam), async (c) => {
+  const auth = c.get('portalAuth'); const { id, imageId } = c.req.valid('param');
+  const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
+  if (!quote) return c.json({ error: 'Quote not found' }, 404);
+  const img = await readQuoteImage(imageId, id);
+  if (!img) return c.json({ error: 'Image not found' }, 404);
+  return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+});
+
+// POST /quotes/:id/accept — signer identity = the authenticated portal user.
+quoteRoutes.post('/quotes/:id/accept', zValidator('param', idParam), zValidator('json', acceptQuoteSchema.partial()), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param');
+  const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
+  if (!quote) return c.json({ error: 'Quote not found' }, 404);
+  try {
+    const res = await acceptQuote({
+      quoteId: id, signerName: auth.user.name || auth.user.email, signerEmail: auth.user.email,
+      ipAddress: c.req.header('x-forwarded-for') ?? null, userAgent: c.req.header('user-agent') ?? null, actorUserId: null,
+    });
+    return c.json({ data: { invoiceId: res.invoiceId, status: res.quote.status } });
+  } catch (err) { if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status); throw err; }
+});
+
+// POST /quotes/:id/decline
+quoteRoutes.post('/quotes/:id/decline', zValidator('param', idParam), zValidator('json', declineQuoteSchema), async (c) => {
+  const auth = c.get('portalAuth'); const { id } = c.req.valid('param'); const { reason } = c.req.valid('json');
+  const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
+  if (!quote) return c.json({ error: 'Quote not found' }, 404);
+  if (quote.status !== 'sent' && quote.status !== 'viewed') return c.json({ error: `Cannot decline a quote in status ${quote.status}`, code: 'INVALID_STATE' }, 409);
+  const now = new Date();
+  await db.update(quotes).set({ status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now }).where(eq(quotes.id, id));
+  return c.json({ data: { status: 'declined' } });
+});
+```
+
+- [ ] **Step 4: Mount in `routes/portal/index.ts`** — alongside the invoice mount, behind `portalAuthMiddleware`:
+
+```ts
+import { quoteRoutes as portalQuoteRoutes } from './quotes';
+// after the invoiceRoutes mount (same middleware chain):
+portal.route('/', portalQuoteRoutes);
+```
+
+(Match the existing portal mount style — if invoices mount as `portal.route('/', invoiceRoutes)` after `portal.use('*', portalAuthMiddleware)`, do the same.)
+
+- [ ] **Step 5: Run the portal integration test + typecheck**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/portalQuotes.integration.test.ts && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: PASS + no new type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/portal/quotes.ts apps/api/src/routes/portal/index.ts apps/api/src/__tests__/integration/portalQuotes.integration.test.ts
+git commit -m "feat(quotes): customer-portal quote view + accept/decline routes"
+```
+
+---
+
+## Task 13: Public tokenized routes (`routes/quotesPublic.ts`) + RBAC negative test
+
+The unauthenticated surface. **Every DB op goes through `runOutsideDbContext(() => withSystemDbAccessContext(...))`, scoped to the token's quoteId/orgId.** Also adds the negative-RBAC test proving a `quotes:read`/`write` user without `send` cannot send.
+
+**Files:**
+- Create: `apps/api/src/routes/quotesPublic.ts`
+- Modify: `apps/api/src/index.ts` (mount BEFORE auth-gated routes)
+- Test: `apps/api/src/__tests__/integration/quotesPublic.integration.test.ts`, `apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `verifyQuoteAcceptToken`, `isQuoteAcceptJtiRevoked`, `markQuoteViewed`, `acceptQuote`, `readQuoteImage`, `computeQuoteSha256` (indirect via acceptQuote), `runOutsideDbContext`, `withSystemDbAccessContext`.
+- Produces: `quotesPublicRoutes` (Hono) — `GET /:token`, `GET /:token/images/:imageId`, `POST /:token/accept`, `POST /:token/decline`. Mounted at `/quotes/public`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes, quoteAcceptances } from '../../db/schema/quotes';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { createQuoteAcceptToken, verifyQuoteAcceptToken } from '../../services/quoteAcceptToken';
+import { acceptQuote } from '../../services/quoteAcceptService';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('public quote token path', () => {
+  runDb('an unauthenticated accept (system scope, token-resolved) records + converts', async () => {
+    const fx = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id });
+      return { partnerId: partner.id, orgId: org.id };
+    });
+    const ctx: DbAccessContext = { scope: 'organization', orgId: fx.orgId, accessibleOrgIds: [fx.orgId], accessiblePartnerIds: [fx.partnerId], userId: null };
+    const actor = { userId: null, partnerId: fx.partnerId, accessibleOrgIds: [fx.orgId] };
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: fx.orgId, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.quote.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+
+    // Public path: mint+verify token, then accept under SYSTEM scope resolved from token claims.
+    const { token } = await createQuoteAcceptToken({ quoteId: created.quote.id, orgId: fx.orgId, partnerId: fx.partnerId });
+    const claims = await verifyQuoteAcceptToken(token);
+    expect(claims?.quoteId).toBe(created.quote.id);
+    const res = await withSystemDbAccessContext(() => acceptQuote({ quoteId: claims!.quoteId, signerName: 'Prospect Pat', acceptanceTokenJti: claims!.jti }));
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.quote.id)));
+    expect(q!.status).toBe('converted');
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+    expect(acc!.acceptanceTokenJti).toBe(claims!.jti);
+  });
+
+  runDb('the recorded hash matches a re-render and mismatches a tampered quote', async () => {
+    const fx = await withSystemDbAccessContext(async () => { const partner = await createPartner(); const org = await createOrganization({ partnerId: partner.id }); return { partnerId: partner.id, orgId: org.id }; });
+    const ctx: DbAccessContext = { scope: 'organization', orgId: fx.orgId, accessibleOrgIds: [fx.orgId], accessiblePartnerIds: [fx.partnerId], userId: null };
+    const actor = { userId: null, partnerId: fx.partnerId, accessibleOrgIds: [fx.orgId] };
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: fx.orgId, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.quote.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.quote.id, actor));
+    const res = await withSystemDbAccessContext(() => acceptQuote({ quoteId: created.quote.id, signerName: 'Pat' }));
+    const [acc] = await withSystemDbAccessContext(() => db.select().from(quoteAcceptances).where(eq(quoteAcceptances.id, res.acceptanceId)));
+
+    // Re-render the SAME content → hash equals the recorded one.
+    const { computeQuoteSha256 } = await import('../../services/quoteContentHash');
+    const { quoteBlocks, quoteLines } = await import('../../db/schema/quotes');
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.quote.id)));
+    const blocks = await withSystemDbAccessContext(() => db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, created.quote.id)));
+    const lines = await withSystemDbAccessContext(() => db.select().from(quoteLines).where(eq(quoteLines.quoteId, created.quote.id)));
+    expect(computeQuoteSha256(q as any, blocks as any, lines as any)).toBe(acc!.quoteSha256);
+    const tampered = lines.map((l) => ({ ...l, unitPrice: '1.00', lineTotal: '1.00' }));
+    expect(computeQuoteSha256(q as any, blocks as any, tampered as any)).not.toBe(acc!.quoteSha256);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/quotesPublic.integration.test.ts`; Expected: FAIL until Tasks 5/9 are present (token + acceptQuote). If those tasks are done, the test may PASS at the service level — that's fine; it locks the public-path contract. The HTTP route is exercised in feature-testing.
+
+- [ ] **Step 3: Implement the public route module**
+
+```ts
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { eq, and } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { quotes, quoteBlocks, quoteLines } from '../db/schema/quotes';
+import { partners } from '../db/schema/orgs';
+import { portalBranding } from '../db/schema/portal';
+import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
+import { verifyQuoteAcceptToken, isQuoteAcceptJtiRevoked } from '../services/quoteAcceptToken';
+import { markQuoteViewed } from '../services/quoteLifecycle';
+import { acceptQuote } from '../services/quoteAcceptService';
+import { readQuoteImage } from '../services/quoteImageStorage';
+import { QuoteServiceError } from '../services/quoteTypes';
+
+export const quotesPublicRoutes = new Hono();
+const tokenParam = z.object({ token: z.string().min(10) });
+const tokenImageParam = z.object({ token: z.string().min(10), imageId: z.string().uuid() });
+
+// Resolve + verify the token, returning the scoped claims or null.
+async function resolve(c: { req: { valid: (k: 'param') => { token: string } } }) {
+  const { token } = c.req.valid('param');
+  const claims = await verifyQuoteAcceptToken(token);
+  if (!claims) return null;
+  if (await isQuoteAcceptJtiRevoked(claims.jti)) return null;
+  return claims;
+}
+
+// GET /:token — view. Stamps first_viewed_at + sent→viewed. Customer-visible content only.
+quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => {
+  const claims = await resolve(c);
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  const data = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    if (!quote || quote.status === 'draft') return null;
+    const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, quote.id)).orderBy(quoteBlocks.sortOrder);
+    const lines = (await db.select().from(quoteLines).where(eq(quoteLines.quoteId, quote.id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible);
+    const [partner] = await db.select({ name: partners.name }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+    const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
+    await markQuoteViewed(quote.id, quote.orgId);
+    return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
+  }));
+  if (!data) return c.json({ error: 'Quote not found' }, 404);
+  return c.json({ data });
+});
+
+// GET /:token/images/:imageId
+quotesPublicRoutes.get('/:token/images/:imageId', zValidator('param', tokenImageParam), async (c) => {
+  const claims = await resolve(c); const { imageId } = c.req.valid('param');
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  const img = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    if (!quote) return null;
+    return readQuoteImage(imageId, quote.id);
+  }));
+  if (!img) return c.json({ error: 'Image not found' }, 404);
+  return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+});
+
+// POST /:token/accept — typed signature. System-scope write, token-resolved.
+quotesPublicRoutes.post('/:token/accept', zValidator('param', tokenParam), zValidator('json', acceptQuoteSchema), async (c) => {
+  const claims = await resolve(c); const body = c.req.valid('json');
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  try {
+    const res = await runOutsideDbContext(() => withSystemDbAccessContext(() => acceptQuote({
+      quoteId: claims.quoteId, signerName: body.signerName, signerEmail: body.signerEmail ?? null,
+      ipAddress: c.req.header('x-forwarded-for') ?? null, userAgent: c.req.header('user-agent') ?? null,
+      acceptanceTokenJti: claims.jti, actorUserId: null,
+    })));
+    return c.json({ data: { status: res.quote.status, invoiceNumber: null } });
+  } catch (err) { if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status); throw err; }
+});
+
+// POST /:token/decline
+quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zValidator('json', declineQuoteSchema), async (c) => {
+  const claims = await resolve(c); const { reason } = c.req.valid('json');
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  const ok = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    if (!quote || (quote.status !== 'sent' && quote.status !== 'viewed')) return false;
+    const now = new Date();
+    await db.update(quotes).set({ status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now }).where(eq(quotes.id, quote.id));
+    return true;
+  }));
+  if (!ok) return c.json({ error: 'This quote can no longer be declined' }, 409);
+  return c.json({ data: { status: 'declined' } });
+});
+```
+
+- [ ] **Step 4: Mount BEFORE auth in `apps/api/src/index.ts`** — next to the other public mounts (around line 775, alongside `publicEnrollmentRoutes`), and BEFORE `api.route('/quotes', quoteRoutes)` so the unauthenticated sub-path isn't swallowed by the authed `/quotes` router:
+
+```ts
+import { quotesPublicRoutes } from './routes/quotesPublic';
+// Public, token-gated quote acceptance (no auth) — MUST precede the auth-gated /quotes router.
+api.route('/quotes/public', quotesPublicRoutes);
+```
+
+> Note for the implementer: confirm the authed `/quotes` router does not register a `/:id` that would match `/quotes/public` first. Hono matches static segments before params, and a separately-mounted `/quotes/public` router takes precedence for that prefix — but verify by hitting `GET /api/v1/quotes/public/<token>` without an Authorization header and confirming you do NOT get a 401 from `authMiddleware`.
+
+- [ ] **Step 5: Write the RBAC negative test**
+
+`apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts` — prove a `quotes:read`+`quotes:write` actor without `quotes:send` is refused at the permission layer. The cleanest assertion exercises the `requirePermission` middleware via the route; if the repo lacks an authed-route HTTP harness, assert the permission set directly against the guard the route uses:
+
+```ts
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { hasPermission } from '../../services/permissions';
+import { PERMISSIONS } from '../../services/permissions';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('quotes:send RBAC', () => {
+  // A role granted only read+write must NOT satisfy the send permission the
+  // POST /:id/send route requires. This guards against the send route being
+  // accidentally gated on write (or ungated).
+  it('quotes:read+write does not imply quotes:send', () => {
+    const granted = [
+      `${PERMISSIONS.QUOTES_READ.resource}:${PERMISSIONS.QUOTES_READ.action}`,
+      `${PERMISSIONS.QUOTES_WRITE.resource}:${PERMISSIONS.QUOTES_WRITE.action}`,
+    ];
+    const needSend = `${PERMISSIONS.QUOTES_SEND.resource}:${PERMISSIONS.QUOTES_SEND.action}`;
+    expect(granted).not.toContain(needSend);
+    expect(PERMISSIONS.QUOTES_SEND.action).toBe('send');
+  });
+});
+```
+
+> Note: this asserts the permission *wiring* (the route uses `QUOTES_SEND`, which is distinct from read/write). The end-to-end 403 (a real user with read+write hitting `POST /:id/send`) is verified through the browser/API in the feature-testing pass (Task 18) where a live session + role exist. If `hasPermission(grantedSet, required)` exists as a helper, prefer asserting `expect(hasPermission(granted, needSend)).toBe(false)`.
+
+- [ ] **Step 6: Run both tests + typecheck**
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/quotesPublic.integration.test.ts src/__tests__/integration/quoteSendRbac.integration.test.ts && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+```
+Expected: PASS + no new type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/quotesPublic.ts apps/api/src/index.ts apps/api/src/__tests__/integration/quotesPublic.integration.test.ts apps/api/src/__tests__/integration/quoteSendRbac.integration.test.ts
+git commit -m "feat(quotes): public tokenized view/accept/decline (system-scope writes) + send RBAC guard"
+```
+
+---
+
+## Task 14: Forge tests for the new write paths
+
+Extend the Phase 1 forge file with cross-tenant denial for the accept/image *write* paths now that services write them (the contract test alone misses write-path/axis gaps). Most cases already exist in `quotes-rls.integration.test.ts` (cases 6–9 cover `quote_images`/`quote_acceptances` raw inserts). Add a service-level forge: `acceptQuote` under an orgA context cannot accept an orgB quote.
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/quotes-rls.integration.test.ts`
+
+- [ ] **Step 1: Add the failing case** (append inside the existing `describe`)
+
+```ts
+  // (10) Service-layer accept forge. acceptQuote loads the quote by id; under an
+  // orgA breeze_app context, orgB's quote is invisible (RLS), so acceptQuote
+  // must 404 rather than convert a foreign tenant's quote.
+  runDb('acceptQuote cannot accept another org quote (RLS hides it → 404)', async () => {
+    const fx = await seedFixture();
+    const { acceptQuote } = await import('../../services/quoteAcceptService');
+    await expect(
+      withDbAccessContext(fx.orgAContext, () => acceptQuote({ quoteId: fx.quoteB.id, signerName: 'Mallory' }))
+    ).rejects.toMatchObject({ status: 404 });
+  });
+```
+
+> Note: `quoteB` is seeded with status defaulting to `draft`; to make the 404-vs-409 distinction meaningful, the seed should leave it `draft` (acceptQuote of an invisible row returns 404 because the org-scoped SELECT yields no row). If the existing fixture sets a different status, the assertion still holds: an orgA caller cannot see orgB's quote at all, so `acceptQuote` throws `QUOTE_NOT_FOUND` (404).
+
+- [ ] **Step 2: Run to verify it passes** (the policy already exists, so this should pass once the import resolves)
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/quotes-rls.integration.test.ts
+```
+Expected: PASS (all original cases + the new one).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/quotes-rls.integration.test.ts
+git commit -m "test(quotes): service-layer cross-tenant accept forge"
+```
+
+---
+
+## Task 15: Portal web — api client + list/detail pages + nav
+
+Customer-facing authed UI in `apps/portal/`. Mirrors the invoice pages/components.
+
+**Files:**
+- Modify: `apps/portal/src/lib/api.ts` (add quote methods + types)
+- Create: `apps/portal/src/pages/quotes/index.astro`, `apps/portal/src/pages/quotes/[id].astro`
+- Create: `apps/portal/src/components/portal/QuoteList.tsx`, `apps/portal/src/components/portal/QuoteDetailView.tsx`
+- Modify: `apps/portal/src/layouts/PortalLayout.astro:13-19` (nav)
+- Test: `apps/portal/src/components/portal/QuoteDetailView.test.tsx` (if portal has a vitest/jsdom config; else verified in feature-testing)
+
+**Interfaces:**
+- Produces (api.ts): `getQuotes(params, config)`, `getQuote(id, config)`, `acceptQuote(id, config)`, `declineQuote(id, body, config)` on `portalApi`, plus `QuoteSummary`/`QuoteDetail` types.
+
+- [ ] **Step 1: Add the api client methods** — in `apps/portal/src/lib/api.ts`, mirror `getInvoices`/`getInvoice`/`payInvoice`:
+
+```ts
+// Types (near InvoiceSummary/InvoiceDetail)
+export interface QuoteSummary { id: string; quoteNumber: string | null; status: string; currencyCode: string; issueDate: string | null; expiryDate: string | null; total: string; }
+export interface QuoteBlock { id: string; blockType: string; content: unknown; sortOrder: number; }
+export interface QuoteLine { id: string; description: string; quantity: string; unitPrice: string; lineTotal: string; recurrence: string; customerVisible: boolean; sortOrder: number; }
+export interface QuoteDetail { quote: QuoteSummary & { introNotes?: string | null; terms?: string | null }; blocks: QuoteBlock[]; lines: QuoteLine[]; }
+
+// On the portalApi object:
+getQuotes: async (params: ListParams = {}, config: ApiRequestConfig = {}): Promise<PaginatedResult<QuoteSummary>> => {
+  const query = buildQueryString({ page: params.page ?? 1, limit: params.limit ?? 200 });
+  const response = await apiGet<{ data: QuoteSummary[]; pagination: Pagination }>(`/portal/quotes${query}`, config);
+  return mapPaginatedData(response);
+},
+getQuote: async (id: string, config: ApiRequestConfig = {}): Promise<ApiResponse<{ data: QuoteDetail }>> => {
+  return apiGet<{ data: QuoteDetail }>(`/portal/quotes/${id}`, config);
+},
+acceptQuote: async (id: string, config: ApiRequestConfig = {}): Promise<ApiResponse<{ data: { invoiceId: string; status: string } }>> => {
+  return apiPost<{ data: { invoiceId: string; status: string } }>(`/portal/quotes/${id}/accept`, {}, config);
+},
+declineQuote: async (id: string, reason: string | undefined, config: ApiRequestConfig = {}): Promise<ApiResponse<{ data: { status: string } }>> => {
+  return apiPost<{ data: { status: string } }>(`/portal/quotes/${id}/decline`, { reason }, config);
+},
+```
+
+- [ ] **Step 2: Create the list page** (`apps/portal/src/pages/quotes/index.astro`) — mirror `invoices/index.astro`:
+
+```astro
+---
+import PortalLayout from '../../layouts/PortalLayout.astro';
+import QuoteList from '../../components/portal/QuoteList';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+
+const response = await portalApi.getQuotes({ page: 1, limit: 200 }, buildServerApiConfig(Astro.request));
+if (response.statusCode === 401) { return Astro.redirect('/login'); }
+---
+<PortalLayout title="Proposals">
+  <QuoteList quotes={response.data ?? []} error={response.error} />
+</PortalLayout>
+```
+
+- [ ] **Step 3: Create the detail page** (`apps/portal/src/pages/quotes/[id].astro`):
+
+```astro
+---
+import PortalLayout from '../../layouts/PortalLayout.astro';
+import QuoteDetailView from '../../components/portal/QuoteDetailView';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+
+const { id } = Astro.params;
+const response = await portalApi.getQuote(id!, buildServerApiConfig(Astro.request));
+if (response.statusCode === 401) { return Astro.redirect('/login'); }
+---
+<PortalLayout title="Proposal">
+  <QuoteDetailView detail={response.data?.data ?? null} error={response.error} client:load />
+</PortalLayout>
+```
+
+- [ ] **Step 4: Create `QuoteList.tsx`** — mirror `InvoiceList.tsx` (table of number/status/total/expiry, link to `/quotes/:id`). Use `data-testid="quote-row-<id>"` on each row and `data-testid="portal-quotes-empty"` on the empty state (e2e convention).
+
+```tsx
+import { AlertCircle, FileText } from 'lucide-react';
+import type { QuoteSummary } from '../../lib/api';
+
+const STATUS_LABELS: Record<string, string> = { sent: 'Sent', viewed: 'Viewed', accepted: 'Accepted', declined: 'Declined', expired: 'Expired', converted: 'Accepted' };
+function money(v: string, c: string) { const n = Number(v).toLocaleString('en-US', { minimumFractionDigits: 2 }); return c === 'USD' ? `$${n}` : `${n} ${c}`; }
+function shortDate(d: string | null) { return d ? new Date(d).toLocaleDateString() : '—'; }
+
+export default function QuoteList({ quotes, error }: { quotes: QuoteSummary[]; error?: string }) {
+  if (error) return (<div className="rounded-md bg-destructive/10 p-4 text-center text-destructive"><AlertCircle className="mx-auto h-8 w-8" /><p className="mt-2">{error}</p></div>);
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Proposals</h2>
+      {quotes.length === 0 ? (
+        <div data-testid="portal-quotes-empty" className="rounded-md border border-dashed p-8 text-center">
+          <FileText className="mx-auto h-12 w-12 text-muted-foreground" />
+          <p className="mt-1 text-sm text-muted-foreground">You don't have any proposals yet.</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          <table className="w-full">
+            <thead className="bg-muted/50"><tr>
+              <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Number</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Issued</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Valid until</th>
+              <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">Total</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Status</th>
+            </tr></thead>
+            <tbody className="divide-y">{quotes.map((q) => (
+              <tr key={q.id} data-testid={`quote-row-${q.id}`} className="hover:bg-muted/50">
+                <td className="px-4 py-3"><a className="font-medium hover:underline" href={`/quotes/${q.id}`}>{q.quoteNumber ?? q.id.slice(0, 8)}</a></td>
+                <td className="px-4 py-3 text-sm text-muted-foreground">{shortDate(q.issueDate)}</td>
+                <td className="px-4 py-3 text-sm text-muted-foreground">{shortDate(q.expiryDate)}</td>
+                <td className="px-4 py-3 text-right text-sm">{money(q.total, q.currencyCode)}</td>
+                <td className="px-4 py-3 text-sm">{STATUS_LABELS[q.status] ?? q.status}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Create `QuoteDetailView.tsx`** — renders blocks + customer-visible lines + Accept / Decline buttons calling `portalApi.acceptQuote`/`declineQuote`, with loading/disabled state and an error banner. On accept success show "Accepted — invoice created"; buttons only when `status` is `sent`/`viewed`. Use `data-testid="quote-accept"`, `data-testid="quote-decline"`, `data-testid="quote-accept-success"`.
+
+```tsx
+import { useState } from 'react';
+import { portalApi, buildPortalApiUrl, type QuoteDetail } from '../../lib/api';
+
+export default function QuoteDetailView({ detail, error }: { detail: { quote: QuoteDetail['quote']; blocks: QuoteDetail['blocks']; lines: QuoteDetail['lines'] } | null; error?: string }) {
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [status, setStatus] = useState(detail?.quote.status ?? '');
+  if (error || !detail) return <div className="rounded-md bg-destructive/10 p-4 text-destructive">{error ?? 'Proposal not found'}</div>;
+  const open = status === 'sent' || status === 'viewed';
+
+  async function accept() {
+    setBusy(true); setMsg(null);
+    const res = await portalApi.acceptQuote(detail!.quote.id);
+    setBusy(false);
+    if (res.error) { setMsg(res.error); return; }
+    setStatus('converted'); setMsg('Accepted — an invoice has been created.');
+  }
+  async function decline() {
+    const reason = window.prompt('Optionally, tell us why you are declining:') ?? undefined;
+    setBusy(true); setMsg(null);
+    const res = await portalApi.declineQuote(detail!.quote.id, reason);
+    setBusy(false);
+    if (res.error) { setMsg(res.error); return; }
+    setStatus('declined'); setMsg('Proposal declined.');
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Proposal {detail.quote.quoteNumber ?? ''}</h1>
+        <a className="text-sm underline" href={buildPortalApiUrl(`/portal/quotes/${detail.quote.id}/pdf`)} target="_blank" rel="noreferrer">Download PDF</a>
+      </div>
+      {/* Block + line rendering omitted for brevity — render blocks in sortOrder; for line_items blocks, render detail.lines as a pricing table grouped by recurrence (one-time / monthly / annual), mirroring the PDF. */}
+      {msg && <div data-testid={status === 'converted' ? 'quote-accept-success' : 'quote-msg'} className="rounded-md bg-muted p-3 text-sm">{msg}</div>}
+      {open && (
+        <div className="flex gap-3">
+          <button data-testid="quote-accept" disabled={busy} onClick={accept} className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50">Accept &amp; sign</button>
+          <button data-testid="quote-decline" disabled={busy} onClick={decline} className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50">Decline</button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+> Note for the implementer: flesh out the block/line rendering to match `QuoteDetailView`'s PDF layout — headings, rich text (sanitize `content.html` with the same sanitizer the editor uses), image blocks via `<img src={buildPortalApiUrl('/portal/quotes/:id/images/:imageId')}>`, and a pricing table from `detail.lines`. Keep money formatting consistent with `QuoteList`.
+
+- [ ] **Step 6: Add the nav entry** — `apps/portal/src/layouts/PortalLayout.astro:13-19`:
+
+```astro
+const navItems = [
+  { label: 'Devices', href: '/devices' },
+  { label: 'Tickets', href: '/tickets' },
+  { label: 'Quotes', href: '/quotes' },
+  { label: 'Invoices', href: '/invoices' },
+  { label: 'Assets', href: '/assets' },
+  { label: 'Profile', href: '/profile' }
+];
+```
+
+- [ ] **Step 7: Typecheck / build the portal**
+
+```bash
+cd apps/portal && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx astro check
+```
+Expected: no errors (plain `tsc` skips `.astro` — `astro check` is required, per memory `ci_astro_check_and_integration_tests_gotchas`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/portal/src/lib/api.ts apps/portal/src/pages/quotes apps/portal/src/components/portal/QuoteList.tsx apps/portal/src/components/portal/QuoteDetailView.tsx apps/portal/src/layouts/PortalLayout.astro
+git commit -m "feat(quotes): portal proposal list + detail (accept/decline) + nav"
+```
+
+---
+
+## Task 16: Portal web — public acceptance page (`/quote/[token]`)
+
+The unauthenticated prospect page. Lives at `apps/portal/src/pages/quote/[token].astro` — NOT under a `protectedPrefixes` entry, so the portal middleware leaves it public.
+
+**Files:**
+- Modify: `apps/portal/src/lib/api.ts` (public methods: `getPublicQuote`, `acceptPublicQuote`, `declinePublicQuote`)
+- Create: `apps/portal/src/pages/quote/[token].astro`, `apps/portal/src/components/portal/PublicQuoteView.tsx`
+- Test: feature-testing (Task 18)
+
+**Interfaces:**
+- Produces (api.ts): `getPublicQuote(token, config)`, `acceptPublicQuote(token, body)`, `declinePublicQuote(token, body)` → hit `/quotes/public/:token...`.
+
+- [ ] **Step 1: Add public api methods** — these call the API `/quotes/public/*` routes (note: NOT `/portal/*`; build the URL with `buildPortalApiUrl('/quotes/public/...')`):
+
+```ts
+getPublicQuote: async (token: string, config: ApiRequestConfig = {}): Promise<ApiResponse<{ data: { quote: QuoteSummary & { introNotes?: string|null; terms?: string|null }; blocks: QuoteBlock[]; lines: QuoteLine[]; branding: { partnerName: string; logoUrl: string|null; primaryColor: string|null } } }>> => {
+  return apiGet(`/quotes/public/${encodeURIComponent(token)}`, config);
+},
+acceptPublicQuote: async (token: string, signerName: string, signerEmail?: string): Promise<ApiResponse<{ data: { status: string } }>> => {
+  return apiPost(`/quotes/public/${encodeURIComponent(token)}/accept`, { signerName, signerEmail }, {});
+},
+declinePublicQuote: async (token: string, reason?: string): Promise<ApiResponse<{ data: { status: string } }>> => {
+  return apiPost(`/quotes/public/${encodeURIComponent(token)}/decline`, { reason }, {});
+},
+```
+
+- [ ] **Step 2: Create the public page** (`apps/portal/src/pages/quote/[token].astro`) — uses a minimal `AuthLayout`-style wrapper (the pre-auth layout the login page uses) so there's no portal chrome:
+
+```astro
+---
+import AuthLayout from '../../layouts/AuthLayout.astro';
+import PublicQuoteView from '../../components/portal/PublicQuoteView';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+
+const { token } = Astro.params;
+const response = await portalApi.getPublicQuote(token!, buildServerApiConfig(Astro.request));
+---
+<AuthLayout title="Proposal">
+  <PublicQuoteView token={token!} initial={response.data?.data ?? null} error={response.error} client:load />
+</AuthLayout>
+```
+
+- [ ] **Step 3: Create `PublicQuoteView.tsx`** — renders the branded proposal + a typed-signature accept form (full-name input) + decline, calling the public api methods. `data-testid`: `public-quote`, `public-quote-signer`, `public-quote-accept`, `public-quote-decline`, `public-quote-accepted`, `public-quote-error`.
+
+```tsx
+import { useState } from 'react';
+import { portalApi } from '../../lib/api';
+
+type Initial = { quote: { quoteNumber: string | null; status: string; total: string; currencyCode: string }; blocks: any[]; lines: any[]; branding: { partnerName: string; logoUrl: string|null; primaryColor: string|null } } | null;
+
+export default function PublicQuoteView({ token, initial, error }: { token: string; initial: Initial; error?: string }) {
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState(initial?.quote.status ?? '');
+  const [msg, setMsg] = useState<string | null>(null);
+  if (error || !initial) return <div data-testid="public-quote-error" className="mx-auto max-w-lg p-8 text-center text-destructive">{error ?? 'This proposal link is invalid or has expired.'}</div>;
+  const open = status === 'sent' || status === 'viewed';
+
+  async function accept() {
+    if (!name.trim()) { setMsg('Please type your full name to sign.'); return; }
+    setBusy(true); setMsg(null);
+    const res = await portalApi.acceptPublicQuote(token, name.trim());
+    setBusy(false);
+    if (res.error) { setMsg(res.error); return; }
+    setStatus('converted'); setMsg('Thank you — your acceptance has been recorded.');
+  }
+  async function decline() {
+    const reason = window.prompt('Optionally, tell us why:') ?? undefined;
+    setBusy(true); setMsg(null);
+    const res = await portalApi.declinePublicQuote(token, reason);
+    setBusy(false);
+    if (res.error) { setMsg(res.error); return; }
+    setStatus('declined'); setMsg('You have declined this proposal.');
+  }
+
+  return (
+    <div data-testid="public-quote" className="mx-auto max-w-2xl space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        {initial.branding.logoUrl && <img src={initial.branding.logoUrl} alt="" className="h-8" />}
+        <h1 className="text-xl font-semibold">Proposal {initial.quote.quoteNumber ?? ''} from {initial.branding.partnerName}</h1>
+      </header>
+      {/* Render blocks (sortOrder) + a pricing table from initial.lines — same layout as the portal detail view. */}
+      {status === 'converted' && <div data-testid="public-quote-accepted" className="rounded-md bg-green-50 p-4 text-green-900">{msg}</div>}
+      {msg && status !== 'converted' && <div className="rounded-md bg-muted p-3 text-sm">{msg}</div>}
+      {open && (
+        <div className="space-y-3 rounded-md border p-4">
+          <label className="block text-sm font-medium">Type your full name to accept &amp; sign</label>
+          <input data-testid="public-quote-signer" value={name} onChange={(e) => setName(e.target.value)} className="w-full rounded-md border px-3 py-2" placeholder="Your full name" />
+          <div className="flex gap-3">
+            <button data-testid="public-quote-accept" disabled={busy} onClick={accept} className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50">Accept &amp; sign</button>
+            <button data-testid="public-quote-decline" disabled={busy} onClick={decline} className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50">Decline</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+> Note for the implementer: confirm `AuthLayout.astro` exists (the login page imports it). If the pre-auth wrapper has a different name, use whatever `login.astro` imports. Render blocks/lines to match the portal detail + PDF.
+
+- [ ] **Step 4: Typecheck** — `cd apps/portal && PATH=... npx astro check`; Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/portal/src/lib/api.ts apps/portal/src/pages/quote apps/portal/src/components/portal/PublicQuoteView.tsx
+git commit -m "feat(quotes): public tokenized acceptance page (typed-signature)"
+```
+
+---
+
+## Task 17: Main web app — wire Send button + image upload
+
+Turn the dashboard's disabled "Send (coming soon)" button into a real action, and add image-block upload to the editor. Both via `runAction`.
+
+**Files:**
+- Modify: `apps/web/src/components/billing/quotes/QuoteDetail.tsx:166-176`, `apps/web/src/components/billing/quotes/QuoteEditor.tsx:28-40,415-437`
+- Modify: the web quote API helper module (the file exporting `addBlock`/`deleteBlock` used by `QuoteEditor` — grep `export.*addBlock` under `apps/web/src`) to add `sendQuote(id)` and `uploadQuoteImage(id, file)`.
+- Test: `apps/web/src/components/billing/quotes/QuoteDetail.test.tsx` (if present; else feature-testing)
+
+- [ ] **Step 1: Add the web API helpers** — in the web quotes API module (mirror the `addBlock` fetch helper):
+
+```ts
+export function sendQuote(id: string): Promise<Response> {
+  return fetch(`${API_BASE}/api/v1/quotes/${id}/send`, { method: 'POST', credentials: 'include', headers: csrfHeaders() });
+}
+export function uploadQuoteImage(id: string, file: File): Promise<Response> {
+  const form = new FormData(); form.append('file', file);
+  return fetch(`${API_BASE}/api/v1/quotes/${id}/images`, { method: 'POST', credentials: 'include', body: form, headers: csrfHeaders() });
+}
+```
+
+(Match the existing helper's base-URL + CSRF-header pattern exactly — reuse whatever `addBlock` uses; do not hand-roll a new auth scheme.)
+
+- [ ] **Step 2: Wire the Send button** — replace the disabled button at `QuoteDetail.tsx:166-176`:
+
+```tsx
+{can('quotes', 'send') && quote.status === 'draft' && (
+  <button
+    type="button"
+    disabled={sending}
+    data-testid="quote-send"
+    onClick={async () => {
+      setSending(true);
+      try {
+        await runAction({
+          request: () => sendQuote(quote.id),
+          errorFallback: 'Could not send the proposal.',
+          successMessage: 'Proposal sent',
+          onUnauthorized: UNAUTHORIZED,
+        });
+        refresh();
+      } catch { /* runAction already toasted */ }
+      finally { setSending(false); }
+    }}
+    className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+  >
+    {sending ? 'Sending…' : 'Send proposal'}
+  </button>
+)}
+```
+
+Add `const [sending, setSending] = useState(false);` and import `runAction`, `sendQuote`, `UNAUTHORIZED`/`refresh` consistent with `QuoteEditor`'s usage.
+
+- [ ] **Step 3: Add the image block option + upload** — in `QuoteEditor.tsx`, add `image` to `ADD_BLOCK_OPTIONS` (so the menu offers it), and in the image-block render branch (line ~435) add a file input that uploads then creates the image block with the returned `imageId`:
+
+```tsx
+// ADD_BLOCK_OPTIONS:
+const ADD_BLOCK_OPTIONS: { value: AddableBlockType; label: string }[] = [
+  { value: 'heading', label: 'Heading' },
+  { value: 'rich_text', label: 'Rich text' },
+  { value: 'image', label: 'Image' },
+  { value: 'line_items', label: 'Pricing table' },
+];
+// AddableBlockType union must include 'image'.
+```
+
+For an image block, render an upload control (when `canWrite` and the block has no `content.imageId` yet):
+
+```tsx
+{block.blockType === 'image' && (
+  block.content?.imageId
+    ? <img src={`${API_BASE}/api/v1/quotes/${quote.id}/images/${block.content.imageId}`} alt="" className="max-h-64 rounded" />
+    : (
+      <input type="file" accept="image/png,image/jpeg,image/webp" data-testid={`quote-image-upload-${block.id}`}
+        disabled={busy}
+        onChange={async (e) => {
+          const file = e.target.files?.[0]; if (!file) return;
+          await runAction({
+            request: () => uploadQuoteImage(quote.id, file),
+            errorFallback: 'Could not upload the image.',
+            successMessage: 'Image uploaded',
+            onUnauthorized: UNAUTHORIZED,
+            parseSuccess: (d: any) => d?.data,
+          }).then((data) => onSetImage(block, data.imageId)).catch(() => {});
+        }} />
+    )
+)}
+```
+
+> Note for the implementer: `onSetImage` updates the block's `content.imageId` — wire it to the existing block-update path the editor uses (if blocks are immutable add/remove only in Phase 1, add an `updateBlock`/`PATCH /:id/blocks/:blockId` is NOT in scope; instead create the image block with the imageId in its content after upload). Simplest Phase-2-correct flow: upload first → then `addBlock({ blockType: 'image', content: { imageId } })`. Reorder the UI so the "Add image" action prompts a file, uploads, then adds the block in one go. Keep it `runAction`-wrapped.
+
+- [ ] **Step 4: Web tests + typecheck**
+
+```bash
+cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/components/billing/quotes && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx astro check
+```
+Expected: PASS + no astro/type errors. (If a chart/ResizeObserver appears, it won't here — these are billing components.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/billing/quotes apps/web/src/lib
+git commit -m "feat(quotes): wire Send button + image upload in the dashboard editor"
+```
+
+---
+
+## Task 18: Caddy carve-outs + end-to-end verification
+
+Ensure the new public API path and the portal public page aren't shadowed, then verify the whole flow.
+
+**Files:**
+- Modify: `docker/Caddyfile.prod`
+
+- [ ] **Step 1: Audit caddy routing** — read `docker/Caddyfile.prod` and determine how the API (`/api/*`), the web app, and the customer portal (`apps/portal`) are routed (hostname/path → container). The `@webBillingInvoices`/`@webBillingQuotes` carve-outs route `/billing/quotes*` to `web:4321` ahead of the `@billing → billing:3002` sidecar. Confirm:
+  1. `GET /api/v1/quotes/public/<token>` reaches the API container (it should already, via the API host/`/api/*` block) — the new unauthenticated route is under the existing API mount, so no new caddy rule is typically needed. Verify it is NOT caught by any `/quotes*` web carve-out.
+  2. The portal `/quote/<token>` page is served by the portal app. If the portal is on its own hostname, no carve-out is needed. If it shares a host with path-routing, add a carve-out for `/quote /quote/*` → the portal container ahead of any catch-all, mirroring `@webBillingQuotes`.
+
+- [ ] **Step 2: Add carve-outs only where the audit shows a shadow.** If the portal shares the web host, add (ahead of the catch-all):
+
+```caddyfile
+@portalPublicQuote path /quote /quote/*
+handle @portalPublicQuote {
+  encode zstd gzip
+  reverse_proxy portal:3000
+}
+```
+
+(Use the actual portal container name/port from the compose file. If the portal is on a separate hostname, SKIP this — document in the commit message that no carve-out was needed and why.)
+
+- [ ] **Step 3: Feature-test the full flow** — see the Final Verification section. Commit any caddy change:
+
+```bash
+git add docker/Caddyfile.prod
+git commit -m "chore(quotes): caddy carve-out for the public proposal page"
+```
+
+> Note: per memory `ops_droplet_caddyfile_deploy`, a Caddyfile change does NOT deploy via a `BREEZE_VERSION` bump — production needs a manual `/opt/breeze/Caddyfile.prod` edit + `docker compose restart caddy`. Call this out in the PR description as a deploy step. Local feature-testing uses `http://localhost` (memory `local_playwright_env_setup`), not caddy.
+
+---
+
+## Final verification
+
+- [ ] **API unit tests (affected, single fork)** — the full suite is known-flaky in parallel (memory `api_test_suite_parallel_flakiness`); run affected files single-fork:
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --pool=forks --poolOptions.forks.singleFork=true \
+  src/services/quoteContentHash.test.ts src/services/acceptanceProvider.test.ts src/services/quoteAcceptToken.test.ts src/services/quoteNumbers.test.ts src/services/quoteEmail.test.ts
+```
+
+- [ ] **Shared tests** — `cd packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/validators/quotes.test.ts`
+
+- [ ] **Integration (real DB, breeze_app)** — the BLOCKING job; run the Phase 2 files + the extended forge:
+
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/quoteLifecycle.integration.test.ts \
+  src/__tests__/integration/quoteAccept.integration.test.ts \
+  src/__tests__/integration/quoteImages.integration.test.ts \
+  src/__tests__/integration/quotesPublic.integration.test.ts \
+  src/__tests__/integration/portalQuotes.integration.test.ts \
+  src/__tests__/integration/quoteSendRbac.integration.test.ts \
+  src/__tests__/integration/quotes-rls.integration.test.ts
+```
+
+- [ ] **RLS coverage contract test** — `cd apps/api && PATH=... npx vitest run --config vitest.config.rls-coverage.ts` (no new tables, so this should still pass unchanged).
+
+- [ ] **Drift + types + astro** —
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm db:check-drift
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit
+cd ../portal && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx astro check
+cd ../web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx astro check
+```
+
+- [ ] **Feature-testing skill** — verify end-to-end (dashboard send → email link → public accept → invoice created; portal accept; tamper-evidence; **negative RBAC**: a `quotes:read`+`write` user must NOT see/use Send and `POST /:id/send` returns 403). Test the public path unauthenticated.
+
+- [ ] **Open the PR** on branch `feat/quotes-proposals-phase2` once green. Sequence after main; do not fuse with other work.
+
+---
+
+## Deferred to later plans (NOT in this plan)
+
+- **Phase 3:** accept → pay (portal pay redirect + public pay-link), expiry sweep + read-time expiry guard, `expired` status transition.
+- **Phase 4 (optional):** recurring lines → auto-create Contract (the monthly/annual lines Phase 2's convert intentionally skips).
+- **Quote-block `image` update-in-place** (`PATCH /:id/blocks/:blockId`) if the editor flow needs editing an existing image block rather than remove+re-add.

--- a/docs/superpowers/specs/2026-06-17-quotes-proposals-phase2-decisions.md
+++ b/docs/superpowers/specs/2026-06-17-quotes-proposals-phase2-decisions.md
@@ -1,0 +1,149 @@
+# Quotes / Proposals — Phase 2 Scope & Decisions
+
+**Date:** 2026-06-17
+**Parent spec:** `docs/superpowers/specs/2026-06-16-quotes-proposals-design.md` (all-phase design)
+**Phase 1 plan:** `docs/superpowers/plans/2026-06-16-quotes-proposals-phase1.md` (merged #1455)
+**Billing RBAC:** merged #1454
+**Status:** scope locked via brainstorming; implementation plan follows in `docs/superpowers/plans/`.
+
+This document records the **locked cut** for Phase 2 and resolves the disagreements the
+parent spec has with itself. The parent spec's narrative (§ Summary / §2 / §4) describes
+acceptance as one atomic action that auto-creates an invoice, while both phasing sections
+(spec §9 + Phase 1 plan "Deferred to later plans") split acceptance-record from
+invoice-conversion. Where they conflict, **this document wins for Phase 2**.
+
+## Locked scope — IN
+
+1. **Lifecycle transitions** (Phase 1 stopped at `draft`/`sent` existence):
+   - `draft → sent` (issue + send)
+   - `sent → viewed` (first customer view, portal or public token)
+   - `sent|viewed → accepted` (e-sign)
+   - `sent|viewed → declined` (with reason)
+   - `accepted → converted` (auto-create invoice)
+2. **Send-email** — render PDF (reuse `quotePdf`), email the customer's billing contact with
+   the PDF attached and a public accept link; stamp `sent_at`. The email is sent post-commit,
+   outside the DB context (the contracts `generate` / invoice-send pattern).
+   **Gated on `requirePermission('quotes','send')`** — wiring the currently-dead `quotes:send`
+   permission registered in Phase 1.
+3. **Customer-portal view** — `apps/portal/` quote list + detail + PDF + accept + decline,
+   under `portalAuthMiddleware`, org-scoped (drafts filtered; `eq(org_id)` defense-in-depth
+   atop RLS). Signer identity on accept = the authenticated `portal_user`.
+4. **Public tokenized acceptance page** — unauthenticated, signed-token access for prospects
+   without a portal account. Stamps `first_viewed_at`, transitions `sent → viewed`, renders
+   customer-visible content, offers **Accept & Sign** / **Decline**. Signer identity = typed
+   signature + token claims.
+5. **Built-in e-sign accept** behind an `AcceptanceProvider` interface — typed-signature
+   provider now; a DocuSign/PandaDoc adapter can be added later **without a data-model
+   change**. Writes `quote_acceptances` with a `quote_sha256` content hash of the rendered
+   quote at accept time (tamper-evidence).
+6. **Accept → convert-to-invoice** *(decision: pulled forward into Phase 2)* — on accept,
+   after recording the acceptance, create an invoice and set `quotes.status = 'converted'`
+   with `converted_invoice_id`. **Only `one_time` lines are invoiced.** `monthly`/`annual`
+   recurring lines are intentionally left out — Phase 4 turns them into a Contract.
+   See "Recurring-line handling" below.
+7. **`quote_images` upload + serve** — authed multipart upload (magic-byte sniff PNG/JPEG/WebP,
+   reuse the avatar 5 MB cap), authed serve for the editor preview, and token-scoped serve for
+   the public acceptance page. `bytea`-in-DB, RLS-protected (table shipped in Phase 1).
+8. **Decline flow** *(decision: in scope)* — `sent|viewed → declined` with a reason, on both
+   the portal and public paths. Requires one new column (below).
+
+## Locked scope — OUT (Phase 3+)
+
+- **Expiry** — neither the background sweep nor a read-time guard. *(decision: no guard now.)*
+  A past-`expiry_date` quote can still be viewed and accepted in Phase 2; Phase 3 adds the
+  sweep that flips status to `expired` and the accept-time guard.
+- **Payment after convert** — the portal pay + public pay-link redirect. Convert *creates*
+  the invoice; it does not start payment. Portal users reach the new invoice through the
+  existing invoice pay flow (#1422); public-token users see an acceptance confirmation with
+  the invoice number. Wiring accept → pay-link redirect is Phase 3.
+- **Recurring-lines → Contract** — Phase 4.
+
+## Key decisions (resolving spec/plan disagreements)
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| D1 | Does accept stop at `accepted` or go to `converted`? | **Go to `converted`** — accept auto-creates the invoice. | User decision. Matches the spec narrative; pulls the spec §9 / plan "Phase 3" convert step forward. |
+| D2 | How are recurring lines handled on convert? | **One-time lines only.** Recurring lines are skipped and left for the Phase 4 Contract. | User decision. No double-billing risk. Trade-off accepted: a purely-recurring quote converts to a $0 invoice (see degenerate edge). |
+| D3 | Is decline in Phase 2? | **Yes**, with reason, both paths. | User decision. Natural counterpart to accept; it's a "sent transition" the Phase 1 plan already filed under Phase 2. |
+| D4 | Expiry guard at view/accept time? | **No.** Fully Phase 3. | User decision. Keeps Phase 2 focused; the sweep + guard ship together in Phase 3. |
+
+### Recurring-line handling on convert (D2 detail)
+
+- Convert builds the invoice from `quote_lines WHERE recurrence = 'one_time'` only, using
+  `invoiceMath` for penny-exact totals (the quote's own `one_time_total` is the cross-check).
+- **Degenerate edge:** a quote with **no** one-time lines (pure MRR) still transitions to
+  `converted` and still creates an invoice, which will be `$0`. This is an accepted Phase 2
+  trade-off; Phase 4 will route recurring-only quotes to a Contract instead. The plan must
+  cover this case explicitly in a test (convert of a recurring-only quote ⇒ `$0` invoice,
+  status `converted`, `converted_invoice_id` set) so the behavior is intentional, not a bug.
+
+## Schema delta (Phase 2)
+
+Exactly **one** migration, idempotent, no new tables (all Phase 2 tables shipped in Phase 1):
+
+```sql
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS decline_reason text;
+```
+
+Plus the matching Drizzle field on `quotes`. All other lifecycle columns already exist
+(`sent_at`, `first_viewed_at`, `viewed_at`, `accepted_at`, `declined_at`, `converted_at`,
+`converted_invoice_id`). `quote_images` and `quote_acceptances` already have RLS enabled +
+forced + org-axis policies and are already in the cascade + rls-coverage allowlists — **no
+new RLS/cascade registration is required.** Functional `breeze_app` forge tests for the new
+accept/image *write paths* are still added (the contract test alone misses write-path gaps).
+
+## AcceptanceProvider interface (D1/§5 detail)
+
+```ts
+export interface AcceptanceCaptureInput {
+  quoteId: string;
+  signerName: string;          // typed signature (public) or portal_user name
+  signerEmail?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  acceptanceTokenJti?: string | null;
+}
+export interface AcceptanceCaptureResult {
+  signerName: string;
+  signerEmail: string | null;
+  method: string;              // e.g. 'typed-signature'
+}
+export interface AcceptanceProvider {
+  readonly kind: string;       // 'builtin'
+  capture(input: AcceptanceCaptureInput): Promise<AcceptanceCaptureResult>;
+}
+```
+
+- The **content hash** (`quote_sha256`) is computed by the accept *service*, not the provider:
+  a deterministic canonical serialization of the quote header + ordered blocks + ordered lines
+  + computed totals, SHA-256 hex. Quotes are immutable once `sent` (edits only in `draft`), so
+  the hash is stable from send through accept.
+- `TypedSignatureProvider` (`kind = 'builtin'`) validates a non-empty typed name and passes the
+  fields through. A future vendor adapter performs the external signing handshake and maps the
+  envelope reference into `quote_acceptances.acceptance_token_jti` — **same columns, no schema
+  change**, satisfying the spec's provider-agnostic requirement.
+
+## Security & trap checklist (carried into the plan)
+
+1. **Public path is unauthenticated** — every read/write on the public token routes runs via
+   `runOutsideDbContext → withSystemDbAccessContext`, scoped to the token's `org_id`/`quote_id`
+   resolved from verified token claims. No bare `db` writes (the `rls_silent_zero_row_write`
+   class). Token lookups are scoped, never global.
+2. **Caddy** — the customer portal (`apps/portal/`) is a separate app from the web app. Verify
+   the public page route (`/quote/*`) and the public API route (`/quotes/public/*`) are not
+   shadowed by the hosted billing sidecar; add explicit carve-outs ahead of the catch-all and
+   test the real URL through caddy, not just the dev port.
+3. **Dual-map drift** — `quotes:send` is already in the registry/seed/Partner Billing roles, but
+   confirm the `'send'` action has a label in `permissionsCatalog` `ACTION_LABELS` (the catalog
+   test asserts every used resource/action has a label).
+4. **Web mutations** route through `runAction`; penny math routes through `invoiceMath`/`quoteMath`.
+5. **Real-DB tests** live in `apps/api/src/__tests__/integration/*.integration.test.ts`
+   (the unit job has no `DATABASE_URL`). Required: public-token view/accept path, tamper-hash
+   mismatch, accept→convert (one-time-only + recurring-only $0 edge), RBAC 403 on send for a
+   `quotes:read`/`write`-only user, portal cross-org 404.
+
+## Out-of-scope confirmation
+
+Per the parent spec phasing, **Phase 3** = accept→pay-link (portal pay + public pay-link) +
+expiry sweep; **Phase 4** = recurring lines → Contract. Phase 2 delivers everything above and
+nothing beyond it.

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -2142,7 +2142,7 @@ Loaded the branch into the local dev Docker stack (rebuilt `api` from the worktr
 - [x] API (real running branch on :3009): login → create quote → add lines → **send (quotes:send)** → status=sent, number assigned, emailed=true; **public GET (unauth)** → sent→viewed; **public accept (unauth typed signature)** → converted; **single-use token** → reuse 401. DB verified: converted invoice total $500.00 = one-time line ONLY ($80 monthly excluded), acceptance row has signer + 64-char content hash + jti.
 - [x] UI dashboard (Playwright, interactive): quotes list shows Phase 2 statuses + a Converted quote; opened a draft; Detail tab shows the real **"Send proposal"** button (not "coming soon"); clicked it → number Q-2026-0002 assigned, status→Sent, button correctly hidden (gated on status==='draft'). Editor offers the **Image** block.
 - [x] UI public page (Playwright, SSR): /quote/<token> renders branded proposal + intro + heading block + pricing table with **only the customer-visible line** (a customerVisible:false line was correctly filtered out) + typed-signature accept form.
-- [~] UI public **Accept button click**: not exercised in dev — see Notes. Logic covered by API + quotesPublicRoutes.integration.test.ts.
+- [x] UI public **Accept button click** (verified on a PRODUCTION build, :4334 via `astro build` + node adapter): the React island hydrated, the typed-signature Accept fired, and the page transitioned to "Thank you — your acceptance has been recorded." DB confirmed quote→converted, invoice total $640.00 (one-time), acceptance "Casey Customer" + 64-char hash + jti.
 
 ### Evidence
 - Converted invoice: status=draft, total=500.00 (one-time only); invoice_lines = ["Onboarding setup" $500.00].
@@ -2150,7 +2150,7 @@ Loaded the branch into the local dev Docker stack (rebuilt `api` from the worktr
 - Dashboard: heading "Draft quote" → "Q-2026-0002", status badge Draft → Sent after clicking Send.
 
 ### Issues found
-- None in the feature. The public Accept button could not be clicked through `astro dev` because (1) the portal's hardened CSP `script-src 'self'` blocks astro dev-mode inline hydration scripts (production uses external hashed module scripts → works), and (2) the dev CSP `connect-src` allows only :3001 while this test ran the API on :3009. Both are environmental; the accept path is fully covered by the API run + the HTTP-level integration test.
+- None in the feature. The public Accept button does not work under `astro dev` (dev-only): the portal's hardened CSP `script-src 'self'` blocks astro's dev-mode *un-hashed* inline hydration scripts, so the React island never hydrates. RESOLVED by testing a PRODUCTION build (`astro build`), where Astro emits **hashed** inline scripts (`script-src 'self' 'sha256-…'`) → the island hydrates and the Accept button works end-to-end (confirmed above). The accept fetch additionally needs the API origin in `connect-src` — production's `connect-src … https:` (apps/portal/astro.config.mjs:21) covers any HTTPS API; the only reason it failed locally is the test API was HTTP (`http://localhost:3009`). Verified by temporarily adding the local origin to connect-src (reverted after).
 
 ### Notes
 - `apps/portal` is not deployed in prod (no compose service / caddy upstream) — pre-existing gap; the portal/public pages are dormant until a serving layer is added.

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -2130,3 +2130,27 @@ Loaded the branch into the local dev Docker stack (rebuilt `api` from the worktr
 ### Notes
 - **Dev DB test data seeded:** 2 billable time entries (1 unapproved) + 1 ticket part on "Default Organization"; re-activated 2 archived catalog items; set org + partner billing settings; created `INV-2026-0001` (number burned). All on the dev DB (5432).
 - **Stack state:** the dev stack is currently running the **`feat/invoice-engine`** code (swapped from `main`). To restore: `docker compose down` from the worktree, `docker compose up -d` from `/Users/toddhebebrand/breeze`, and remove the worktree `.env` symlink.
+
+## Quotes/Proposals Phase 2 — 2026-06-17
+
+**Branch:** `feat/quotes-proposals-phase2` (PR #1468)
+**Commit:** a4c2b719
+**Tested by:** Claude (ultracode)
+**Result:** PASS (logic + UI render), with the public Accept *button click* verified via API rather than the dev browser (env-blocked — see Notes)
+
+### What was tested
+- [x] API (real running branch on :3009): login → create quote → add lines → **send (quotes:send)** → status=sent, number assigned, emailed=true; **public GET (unauth)** → sent→viewed; **public accept (unauth typed signature)** → converted; **single-use token** → reuse 401. DB verified: converted invoice total $500.00 = one-time line ONLY ($80 monthly excluded), acceptance row has signer + 64-char content hash + jti.
+- [x] UI dashboard (Playwright, interactive): quotes list shows Phase 2 statuses + a Converted quote; opened a draft; Detail tab shows the real **"Send proposal"** button (not "coming soon"); clicked it → number Q-2026-0002 assigned, status→Sent, button correctly hidden (gated on status==='draft'). Editor offers the **Image** block.
+- [x] UI public page (Playwright, SSR): /quote/<token> renders branded proposal + intro + heading block + pricing table with **only the customer-visible line** (a customerVisible:false line was correctly filtered out) + typed-signature accept form.
+- [~] UI public **Accept button click**: not exercised in dev — see Notes. Logic covered by API + quotesPublicRoutes.integration.test.ts.
+
+### Evidence
+- Converted invoice: status=draft, total=500.00 (one-time only); invoice_lines = ["Onboarding setup" $500.00].
+- quote_acceptances: signer "Pat Prospect", quote_sha256 len 64, jti present, ip_address empty (no proxy header on localhost — the C1-safe path).
+- Dashboard: heading "Draft quote" → "Q-2026-0002", status badge Draft → Sent after clicking Send.
+
+### Issues found
+- None in the feature. The public Accept button could not be clicked through `astro dev` because (1) the portal's hardened CSP `script-src 'self'` blocks astro dev-mode inline hydration scripts (production uses external hashed module scripts → works), and (2) the dev CSP `connect-src` allows only :3001 while this test ran the API on :3009. Both are environmental; the accept path is fully covered by the API run + the HTTP-level integration test.
+
+### Notes
+- `apps/portal` is not deployed in prod (no compose service / caddy upstream) — pre-existing gap; the portal/public pages are dormant until a serving layer is added.

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   createQuoteSchema, quoteLineInputSchema, quoteBlockInputSchema, listQuotesQuerySchema,
+  acceptQuoteSchema, declineQuoteSchema,
 } from './quotes';
 
 describe('quote validators', () => {
@@ -24,5 +25,24 @@ describe('quote validators', () => {
 
   it('defaults list limit to 50', () => {
     expect(listQuotesQuerySchema.parse({}).limit).toBe(50);
+  });
+});
+
+describe('acceptQuoteSchema', () => {
+  it('requires a non-empty signer name', () => {
+    expect(acceptQuoteSchema.safeParse({ signerName: '' }).success).toBe(false);
+    expect(acceptQuoteSchema.safeParse({ signerName: 'Jane Buyer' }).success).toBe(true);
+  });
+  it('accepts an optional email and rejects a malformed one', () => {
+    expect(acceptQuoteSchema.safeParse({ signerName: 'Jane', signerEmail: 'jane@x.com' }).success).toBe(true);
+    expect(acceptQuoteSchema.safeParse({ signerName: 'Jane', signerEmail: 'not-an-email' }).success).toBe(false);
+  });
+});
+
+describe('declineQuoteSchema', () => {
+  it('allows an optional bounded reason', () => {
+    expect(declineQuoteSchema.safeParse({}).success).toBe(true);
+    expect(declineQuoteSchema.safeParse({ reason: 'Too expensive' }).success).toBe(true);
+    expect(declineQuoteSchema.safeParse({ reason: 'x'.repeat(5001) }).success).toBe(false);
   });
 });

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -74,6 +74,15 @@ export const updateQuoteSchema = z.object({
 
 export const reorderBlocksSchema = z.object({ blockIds: z.array(z.string().guid()).min(1) });
 
+export const acceptQuoteSchema = z.object({
+  signerName: z.string().min(1).max(255),
+  signerEmail: z.string().email().max(255).optional(),
+});
+
+export const declineQuoteSchema = z.object({
+  reason: z.string().max(5000).optional(),
+});
+
 export const listQuotesQuerySchema = z.object({
   orgId: z.string().guid().optional(),
   status: quoteStatusSchema.optional(),
@@ -88,3 +97,5 @@ export type QuoteBlockInput = z.infer<typeof quoteBlockInputSchema>;
 export type CreateQuoteInput = z.infer<typeof createQuoteSchema>;
 export type UpdateQuoteInput = z.infer<typeof updateQuoteSchema>;
 export type ListQuotesQuery = z.infer<typeof listQuotesQuerySchema>;
+export type AcceptQuoteInput = z.infer<typeof acceptQuoteSchema>;
+export type DeclineQuoteInput = z.infer<typeof declineQuoteSchema>;


### PR DESCRIPTION
Closes #1465. Phase 2 of the Quotes/Proposals program (Phase 1 #1455, billing RBAC #1454). Makes a sent quote acceptable end-to-end.

**Plan:** `docs/superpowers/plans/2026-06-17-quotes-proposals-phase2.md` · **Decisions:** `docs/superpowers/specs/2026-06-17-quotes-proposals-phase2-decisions.md`

## What's in scope
- **Lifecycle:** `draft→sent` (issue + email), `sent→viewed`, `→accepted`, `→declined` (with reason), `accepted→converted`.
- **Send-email** (PDF + public accept link), gated on the now-wired `quotes:send` permission (previously registered but dead).
- **Customer-portal view** (`apps/portal/` + `routes/portal/quotes.ts`) — list / detail / pdf / accept / decline, org-scoped.
- **Public tokenized acceptance page** — unauthenticated, signed `quote-accept` JWT for prospects without a portal account.
- **Built-in e-sign accept** behind an `AcceptanceProvider` interface (typed-signature now; a vendor adapter later maps onto the same columns — no data-model change), writing `quote_acceptances` with a `quote_sha256` content hash (tamper-evidence).
- **Accept → convert-to-invoice** — **one-time lines only** (recurring lines deferred to the Phase 4 Contract; a purely-recurring quote converts to a $0 invoice, tested as intentional).
- **`quote_images`** upload + serve (authed editor + token-scoped public).

**Out of scope (Phase 3+):** payment after convert (pay-link redirect), expiry sweep / read-time guard, recurring→Contract.

## Schema
One idempotent migration — `quotes.decline_reason`. **No new tables** (`quote_images`/`quote_acceptances` shipped in Phase 1 with RLS + cascade + coverage allowlists).

## Security model (honored traps)
- **Public path is unauthenticated:** every DB op runs via `runOutsideDbContext(() => withSystemDbAccessContext(...))` scoped to *signature-verified* token claims (`org_id`/`quote_id`) — avoids the `rls_silent_zero_row_write` 0-row class. Mounted at `/quotes/public` **before** the auth-gated `/quotes` router.
- **Single-use tokens:** the `quote-accept` jti is revoked (Redis) post-commit on accept/decline so a link can't be replayed.
- **Tenant isolation:** portal queries carry `eq(org_id)` defense-in-depth atop RLS; `readQuoteImage` is scoped to `(imageId AND quoteId)` to close a same-org cross-quote IDOR that RLS can't.

## Adversarial self-review (multi-agent) → fixes
Ran a 7-dimension review fleet with skeptic verification; **19 findings confirmed**, all addressed:
- **C1 (high):** raw `X-Forwarded-For` → `ip_address varchar(64)` overflow → 500 on accept behind real proxies → use `getTrustedClientIpOrUndefined()` + service-side clamp.
- **C2/atom-1 (high):** concurrent double-accept → duplicate invoices → `SELECT … FOR UPDATE` serializes; loser 409s.
- **C3 (low):** concurrent double-send → conditional `WHERE status='draft'`.
- **C4:** content hash folded in volatile `status`/number → would false-positive a Phase-3 re-verify → hash immutable content only.
- **atom-2/atom-3 (low):** jti revoke moved post-commit; corrected a misleading comment.
- **web-1 (medium):** editor image preview `<img src>` 401'd the Bearer-only API → blob-fetch via `fetchWithAuth`. Plus two UX nits.

## Tests
- Unit (`apps/api`): content hash, provider, token (expiry derivation), numbers, email, **route-level `quotes:send` RBAC** (real `requirePermission`: 403 read+write / 200 send-holder / 403 wrong scope).
- Integration (real-DB `breeze_app`): lifecycle, accept→convert (+ recurring-only $0 + **double-accept idempotency**), image storage (+ **cross-quote IDOR**), **HTTP-level public routes** (view filter, draft-hide, decline, accept, single-use revocation), portal, RLS forge (11 cases incl. service-layer cross-org accept 404). 34 integration tests pass together; RLS-coverage contract 43/43.
- `tsc`, web + portal `astro check`, `no-silent-mutations` all clean.

## Deploy note
**No Caddyfile change needed:** the public API route is served via the existing `@api path /api/*` matcher (not shadowed by `/billing/quotes*`). The portal/public **pages** live in `apps/portal`, which is **not yet deployed** in prod (no compose service / caddy upstream) — a pre-existing gap shared with the Phase 1 portal *invoice* pages, tracked separately, not introduced here.

Refs #1455 #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)