### PR TITLE
fix(scripts): gate availability picker on JWT scope, not partners list

### DIFF
--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -33,8 +33,12 @@ vi.mock('@/stores/scriptAiStore', () => ({
 // Partner-scope gate (#1386 sibling): the availability picker keys off the JWT
 // scope claim, not `useOrgStore().partners`. Mock both so the gate is testable.
 const { getJwtClaimsMock, orgStoreMock } = vi.hoisted(() => ({
-  getJwtClaimsMock: vi.fn(() => ({ scope: 'partner', partnerId: 'p-1', orgId: null })),
-  orgStoreMock: vi.fn(() => ({ organizations: [], partners: [], sites: [] }))
+  getJwtClaimsMock: vi.fn<() => { scope: 'system' | 'partner' | 'organization' | null; partnerId: string | null; orgId: string | null }>(
+    () => ({ scope: 'partner', partnerId: 'p-1', orgId: null })
+  ),
+  orgStoreMock: vi.fn<() => { organizations: Array<{ id: string; name: string }>; partners: unknown[]; sites: unknown[] }>(
+    () => ({ organizations: [], partners: [], sites: [] })
+  )
 }));
 
 vi.mock('@/lib/authScope', async () => {

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -144,6 +144,13 @@ describe('ScriptForm availability picker — partner-scope gate', () => {
     expect(queryByText('Available to')).toBeNull();
   });
 
+  it('hides the picker for a partner-scope user with a null partnerId — guards the `&& !!partnerId` half of the gate', async () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: null, orgId: null });
+    const { queryByText } = render(<ScriptForm isNew />);
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(queryByText('Available to')).toBeNull();
+  });
+
   it('hides the picker for a single-org partner user', async () => {
     orgStoreMock.mockReturnValue({
       organizations: [{ id: 'o-1', name: 'Org One' }],

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -30,6 +30,23 @@ vi.mock('@/stores/scriptAiStore', () => ({
   useScriptAiStore: () => ({ panelOpen: false, togglePanel: vi.fn() })
 }));
 
+// Partner-scope gate (#1386 sibling): the availability picker keys off the JWT
+// scope claim, not `useOrgStore().partners`. Mock both so the gate is testable.
+const { getJwtClaimsMock, orgStoreMock } = vi.hoisted(() => ({
+  getJwtClaimsMock: vi.fn(() => ({ scope: 'partner', partnerId: 'p-1', orgId: null })),
+  orgStoreMock: vi.fn(() => ({ organizations: [], partners: [], sites: [] }))
+}));
+
+vi.mock('@/lib/authScope', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/authScope')>('@/lib/authScope');
+  return { ...actual, getJwtClaims: getJwtClaimsMock };
+});
+
+vi.mock('@/stores/orgStore', async () => {
+  const actual = await vi.importActual<typeof import('@/stores/orgStore')>('@/stores/orgStore');
+  return { ...actual, useOrgStore: orgStoreMock };
+});
+
 import ScriptForm from './ScriptForm';
 
 describe('ScriptForm Monaco lifecycle (issue #1186)', () => {
@@ -96,5 +113,51 @@ describe('ScriptForm Monaco lifecycle (issue #1186)', () => {
   // catch someone "cleaning up an unused import" and silently regressing the fix.
   it('keeps the static Monaco editor.main.css import (headline #1186 cure)', () => {
     expect(scriptFormSource).toMatch(/import\s+['"]monaco-editor\/min\/vs\/editor\/editor\.main\.css['"]/);
+  });
+});
+
+describe('ScriptForm availability picker — partner-scope gate', () => {
+  beforeEach(() => {
+    editorInstances.length = 0;
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+    orgStoreMock.mockReturnValue({
+      organizations: [{ id: 'o-1', name: 'Org One' }, { id: 'o-2', name: 'Org Two' }],
+      partners: [],
+      sites: []
+    });
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the "Available to" picker for a partner-scope user creating a new script with >1 org', async () => {
+    const { findByText } = render(<ScriptForm isNew />);
+    expect(await findByText('Available to')).toBeTruthy();
+  });
+
+  it('hides the picker for an org-scope user even with >1 org — must not gate on the (empty) partners list', async () => {
+    // A real partner user has partners=[] (the system-scope-only /orgs/partners 403s);
+    // the OLD `partners.length > 0` gate hid the picker from partner users and is the bug.
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'o-1' });
+    const { queryByText } = render(<ScriptForm isNew />);
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(queryByText('Available to')).toBeNull();
+  });
+
+  it('hides the picker for a single-org partner user', async () => {
+    orgStoreMock.mockReturnValue({
+      organizations: [{ id: 'o-1', name: 'Org One' }],
+      partners: [],
+      sites: []
+    });
+    const { queryByText } = render(<ScriptForm isNew />);
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(queryByText('Available to')).toBeNull();
+  });
+
+  it('hides the picker when editing an existing script (not isNew)', async () => {
+    const { queryByText } = render(<ScriptForm />);
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(queryByText('Available to')).toBeNull();
   });
 });

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -25,6 +25,7 @@ import { useScriptAiStore } from '@/stores/scriptAiStore';
 import type { ScriptFormBridge } from '@/stores/scriptAiStore';
 import type { OSType } from './ScriptList';
 import { useOrgStore } from '@/stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import {
   scriptSchema, languageOptions, categoryOptions,
   runAsOptions, parameterTypeOptions, severityOptions,
@@ -237,12 +238,17 @@ export default function ScriptForm({
   const watchParameters = watch('parameters');
   const watchAvailability = watch('availability');
 
-  // Partner-scope detection: a partner-scope user has partners loaded in the store.
-  // The "Available to" picker shows only for partner-scope users creating a NEW script
-  // with >1 accessible org (single-org partner users don't need to pick; org-scope users
-  // always write to their own org — the backend forces it).
-  const { partners, organizations } = useOrgStore();
-  const isPartnerScope = partners.length > 0;
+  // Partner-scope detection comes from the JWT scope claim — NOT
+  // `useOrgStore().partners`, which is populated only from the system-scope-only
+  // `GET /orgs/partners` endpoint and so is always empty for a real partner-scope
+  // user (the picker would never render for its own audience). `organizations` IS
+  // populated for partner users, so it still drives the >1-org check.
+  // The "Available to" picker shows only for partner-scope users creating a NEW
+  // script with >1 accessible org (single-org partner users don't need to pick;
+  // org-scope users always write to their own org — the backend forces it).
+  const { organizations } = useOrgStore();
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
   const showAvailabilityPicker = isNew && isPartnerScope && organizations.length > 1;
 
   const monacoLanguage = useMemo(() => {


### PR DESCRIPTION
## Problem
The Scripts "Available to" picker (partner-wide vs a specific org) on the new-script form is gated on `useOrgStore().partners.length > 0`. That list is populated only from `GET /orgs/partners`, which is **system-scope-only** (`requireScope('system')`). A real partner-scope user gets a 403, so `partners` is always `[]` → `isPartnerScope` is always false → **the picker never renders for the exact audience it's built for**, and partner users can't set a script's availability.

Found while verifying PRs #1466 / #1467 in the local browser — both shipped the same broken pattern, copied from here (`// mirrors Scripts #1357/#1425`). Those two are fixed on their branches; this PR fixes the original on `main`.

## Fix
`apps/web/src/components/scripts/ScriptForm.tsx` — gate on the JWT scope claim instead:

```ts
const { organizations } = useOrgStore();
const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
const showAvailabilityPicker = isNew && isPartnerScope && organizations.length > 1;
```

`useOrgStore().organizations` **is** populated for partner users, so it still drives the >1-org check. `getJwtClaims()` is the established canonical scope signal (already used by `CatalogItemsTab`, `PartnerSettingsPage`, etc.).

## Tests
`ScriptForm.test.tsx` previously had **no** coverage of the picker (which is why this slipped through). Added four cases:
- shows for a multi-org partner-scope user creating a new script
- hidden for an org-scope user even with >1 org (guards the bug — must not gate on the empty partners list)
- hidden for a single-org partner
- hidden when editing an existing script (not `isNew`)

`pnpm vitest run src/components/scripts/ScriptForm.test.tsx` → **8/8 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)