### PR TITLE
feat(ai-agent): make ANTHROPIC_BASE_URL configurable for self-hosted backends (#1412)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,11 +174,15 @@ ANTHROPIC_API_KEY=
 # Self-hosted only: point the AI Agent at any Anthropic-compatible
 # /v1/messages backend (local vLLM 0.23+, a LiteLLM gateway, etc.) while
 # keeping full tool-use and the guardrails stack. Must be an http(s) URL.
-# Refused at boot when IS_HOSTED=true (the hosted platform must never route AI
-# traffic to a third-party endpoint). Set ANTHROPIC_AUTH_TOKEN to the backend's
-# bearer token instead of ANTHROPIC_API_KEY. With a LiteLLM gateway, alias
+# Fail-closed: honored ONLY when IS_HOSTED is explicitly false/0/no/off. If
+# IS_HOSTED is true, unset, or invalid, the API boot-refuses this var and
+# strips it from the AI subprocess (the platform must never route AI traffic to
+# a third-party endpoint). Set ANTHROPIC_AUTH_TOKEN to the backend's bearer
+# token instead of ANTHROPIC_API_KEY. With a LiteLLM gateway, alias
 # claude-sonnet-4-6 → your backend model and leave ANTHROPIC_MODEL unset; for a
-# raw vLLM endpoint, set ANTHROPIC_MODEL to the served model id.
+# raw vLLM endpoint, set ANTHROPIC_MODEL to the served model id. Note: an
+# unrecognized model id is cost-tracked at Opus-tier DEFAULT_PRICING, not $0.
+# IS_HOSTED=false
 # ANTHROPIC_BASE_URL=http://localhost:8000
 # ANTHROPIC_AUTH_TOKEN=
 # ANTHROPIC_MODEL=

--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,18 @@ TWILIO_PHONE_NUMBER=
 # Optional: Provide your Anthropic API key to enable the AI assistant
 ANTHROPIC_API_KEY=
 
+# Self-hosted only: point the AI Agent at any Anthropic-compatible
+# /v1/messages backend (local vLLM 0.23+, a LiteLLM gateway, etc.) while
+# keeping full tool-use and the guardrails stack. Must be an http(s) URL.
+# Refused at boot when IS_HOSTED=true (the hosted platform must never route AI
+# traffic to a third-party endpoint). Set ANTHROPIC_AUTH_TOKEN to the backend's
+# bearer token instead of ANTHROPIC_API_KEY. With a LiteLLM gateway, alias
+# claude-sonnet-4-6 → your backend model and leave ANTHROPIC_MODEL unset; for a
+# raw vLLM endpoint, set ANTHROPIC_MODEL to the served model id.
+# ANTHROPIC_BASE_URL=http://localhost:8000
+# ANTHROPIC_AUTH_TOKEN=
+# ANTHROPIC_MODEL=
+
 # --------------------------------------------
 # Breeze AI for Office (Excel add-in)
 # --------------------------------------------

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -28,6 +28,18 @@ export function isHosted(): boolean {
   return envFlag('IS_HOSTED');
 }
 
+// Recognizes an AFFIRMATIVE self-host declaration: IS_HOSTED explicitly set to
+// a recognized falsey signal ('false'/'0'/'no'/'off'). Unset / empty / garbage /
+// truthy all return false, so security-weakening, self-host-only features stay
+// CLOSED unless self-host is positively declared. This is the #570 hardening
+// lesson — an unmapped IS_HOSTED (value in .env but not threaded through compose)
+// must never silently weaken security. Pure (takes the raw value) so callers
+// reading a `source`/`data` object rather than process.env can reuse it.
+// Mirrors the fail-closed gate in services/dnsProviders/index.ts.
+export function isRecognizedSelfHostSignal(raw: string | undefined): boolean {
+  return new Set(['0', 'false', 'no', 'off']).has((raw ?? '').trim().toLowerCase());
+}
+
 // Public URL of the breeze-billing payment-setup landing page. Empty on
 // self-host. Consumed by the OAuth consent redirect (see Phase 2 Task 2.1
 // of docs/superpowers/plans/2026-04-29-mcp-bootstrap-cleanup.md) — the

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -1285,4 +1285,41 @@ describe('validateConfig', () => {
       warnSpy.mockRestore();
     });
   });
+
+  // #1412: ANTHROPIC_BASE_URL lets a self-hosted operator point the AI Agent
+  // at an Anthropic-compatible /v1/messages backend (vLLM / LiteLLM). It must
+  // be a well-formed http(s) URL, and must be fail-closed on the hosted
+  // platform so a stray value can never redirect platform AI traffic.
+  describe('ANTHROPIC_BASE_URL (#1412)', () => {
+    it('accepts a well-formed http(s) base URL on a self-hosted deployment', () => {
+      withEnv({ ...validEnv, IS_HOSTED: 'false', ANTHROPIC_BASE_URL: 'http://localhost:8000' }, () => {
+        const config = validateConfig();
+        expect(config.ANTHROPIC_BASE_URL).toBe('http://localhost:8000');
+      });
+      withEnv({ ...validEnv, IS_HOSTED: 'false', ANTHROPIC_BASE_URL: 'https://litellm.internal/v1' }, () => {
+        expect(validateConfig().ANTHROPIC_BASE_URL).toBe('https://litellm.internal/v1');
+      });
+    });
+
+    it('allows ANTHROPIC_BASE_URL unset on the hosted platform', () => {
+      withEnv({ ...validEnv, IS_HOSTED: 'true' }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+
+    it.each(['ftp://example.com', 'not-a-url', 'ws://localhost:8000'])(
+      'rejects a non-http(s) ANTHROPIC_BASE_URL (%j)',
+      (value) => {
+        withEnv({ ...validEnv, IS_HOSTED: 'false', ANTHROPIC_BASE_URL: value }, () => {
+          expect(() => validateConfig()).toThrow('ANTHROPIC_BASE_URL');
+        });
+      },
+    );
+
+    it('boot-refuses ANTHROPIC_BASE_URL when IS_HOSTED is true (fail-closed)', () => {
+      withEnv({ ...validEnv, IS_HOSTED: 'true', ANTHROPIC_BASE_URL: 'https://litellm.internal/v1' }, () => {
+        expect(() => validateConfig()).toThrow('ANTHROPIC_BASE_URL');
+      });
+    });
+  });
 });

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -1288,16 +1288,23 @@ describe('validateConfig', () => {
 
   // #1412: ANTHROPIC_BASE_URL lets a self-hosted operator point the AI Agent
   // at an Anthropic-compatible /v1/messages backend (vLLM / LiteLLM). It must
-  // be a well-formed http(s) URL, and must be fail-closed on the hosted
-  // platform so a stray value can never redirect platform AI traffic.
+  // be a well-formed http(s) URL, and is FAIL-CLOSED: honored only when
+  // self-host is affirmatively declared (IS_HOSTED explicitly false/0/no/off).
+  // Unset / empty / garbage / truthy IS_HOSTED all refuse it, so a stray value
+  // or an unmapped IS_HOSTED (the #570 footgun) can never redirect AI traffic.
   describe('ANTHROPIC_BASE_URL (#1412)', () => {
-    it('accepts a well-formed http(s) base URL on a self-hosted deployment', () => {
-      withEnv({ ...validEnv, IS_HOSTED: 'false', ANTHROPIC_BASE_URL: 'http://localhost:8000' }, () => {
-        const config = validateConfig();
-        expect(config.ANTHROPIC_BASE_URL).toBe('http://localhost:8000');
-      });
-      withEnv({ ...validEnv, IS_HOSTED: 'false', ANTHROPIC_BASE_URL: 'https://litellm.internal/v1' }, () => {
-        expect(validateConfig().ANTHROPIC_BASE_URL).toBe('https://litellm.internal/v1');
+    it.each(['false', '0', 'no', 'off'])(
+      'accepts a well-formed http(s) base URL when self-host is declared (IS_HOSTED=%j)',
+      (isHosted) => {
+        withEnv({ ...validEnv, IS_HOSTED: isHosted, ANTHROPIC_BASE_URL: 'http://localhost:8000' }, () => {
+          expect(validateConfig().ANTHROPIC_BASE_URL).toBe('http://localhost:8000');
+        });
+      },
+    );
+
+    it('accepts an https URL with a port and path on a self-hosted deployment', () => {
+      withEnv({ ...validEnv, IS_HOSTED: 'false', ANTHROPIC_BASE_URL: 'https://litellm.internal:8443/v1' }, () => {
+        expect(validateConfig().ANTHROPIC_BASE_URL).toBe('https://litellm.internal:8443/v1');
       });
     });
 
@@ -1306,6 +1313,17 @@ describe('validateConfig', () => {
         expect(() => validateConfig()).not.toThrow();
       });
     });
+
+    it.each(['', '   '])(
+      'treats an empty/whitespace ANTHROPIC_BASE_URL as unset (no error, no value) (%j)',
+      (value) => {
+        withEnv({ ...validEnv, IS_HOSTED: 'true', ANTHROPIC_BASE_URL: value }, () => {
+          // Empty/whitespace short-circuits before the fail-closed gate even on
+          // a hosted deploy — it is "unset", not a misconfig.
+          expect(() => validateConfig()).not.toThrow();
+        });
+      },
+    );
 
     it.each(['ftp://example.com', 'not-a-url', 'ws://localhost:8000'])(
       'rejects a non-http(s) ANTHROPIC_BASE_URL (%j)',
@@ -1316,10 +1334,15 @@ describe('validateConfig', () => {
       },
     );
 
-    it('boot-refuses ANTHROPIC_BASE_URL when IS_HOSTED is true (fail-closed)', () => {
-      withEnv({ ...validEnv, IS_HOSTED: 'true', ANTHROPIC_BASE_URL: 'https://litellm.internal/v1' }, () => {
-        expect(() => validateConfig()).toThrow('ANTHROPIC_BASE_URL');
-      });
-    });
+    // Fail-closed: every non-affirmative-self-host IS_HOSTED value must refuse a
+    // set base URL. 'true'/'1' = hosted; '' = unmapped (#570); 'maybe' = garbage.
+    it.each(['true', '1', '', 'maybe'])(
+      'boot-refuses ANTHROPIC_BASE_URL when IS_HOSTED is not an affirmative self-host signal (%j)',
+      (isHosted) => {
+        withEnv({ ...validEnv, IS_HOSTED: isHosted, ANTHROPIC_BASE_URL: 'https://litellm.internal/v1' }, () => {
+          expect(() => validateConfig()).toThrow('ANTHROPIC_BASE_URL');
+        });
+      },
+    );
   });
 });

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -1,5 +1,6 @@
 import { isIP } from 'net';
 import { z } from 'zod';
+import { isRecognizedSelfHostSignal } from './env';
 
 // ---------------------------------------------------------------------------
 // Insecure default detection
@@ -592,21 +593,23 @@ const envSchema = z
     }
 
     // ANTHROPIC_BASE_URL (#1412): when set it must be a well-formed http(s)
-    // URL, and it is fail-closed on the hosted platform. Enforced in every
-    // environment so a misconfig is caught at boot, not at first AI request.
+    // URL, and it is fail-closed — permitted ONLY when self-host is
+    // affirmatively declared (IS_HOSTED explicitly false/0/no/off). Unset /
+    // empty / garbage / truthy IS_HOSTED all refuse it, so a stray value (or an
+    // unmapped IS_HOSTED — the #570 footgun) can never redirect platform AI
+    // traffic to a third-party endpoint. Enforced in every environment so a
+    // misconfig is caught at boot, not at first AI request.
     const anthropicBaseUrl = data.ANTHROPIC_BASE_URL?.trim();
     if (anthropicBaseUrl) {
-      const isHostedDeploy = ['true', '1', 'yes', 'on'].includes(
-        (data.IS_HOSTED ?? '').trim().toLowerCase(),
-      );
-      if (isHostedDeploy) {
+      if (!isRecognizedSelfHostSignal(data.IS_HOSTED)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['ANTHROPIC_BASE_URL'],
           message:
-            'ANTHROPIC_BASE_URL must not be set when IS_HOSTED=true. Redirecting AI traffic to a '
-            + 'custom backend is a self-hosted-only feature; on the hosted platform it is refused '
-            + 'so a stray value cannot route platform AI traffic to a third-party endpoint.',
+            'ANTHROPIC_BASE_URL is a self-hosted-only feature and is refused unless self-host is '
+            + 'affirmatively declared. Set IS_HOSTED explicitly to false (or 0/no/off) to use it. '
+            + 'On the hosted platform — or with IS_HOSTED unset/invalid — it is refused so a stray '
+            + 'value cannot route platform AI traffic to a third-party endpoint.',
         });
       }
       let parsedUrl: URL | null = null;
@@ -1321,5 +1324,25 @@ export function validateConfig(): AppConfig {
   }
 
   _config = result.data;
+
+  // #1412: surface an off-default AI route at boot so there is an audit trail
+  // (and a self-hoster sees confirmation their backend is active). Reaching
+  // here means the fail-closed gate already accepted it, i.e. self-host is
+  // affirmatively declared. Log host only — never the auth token.
+  const anthropicBaseUrl = _config.ANTHROPIC_BASE_URL?.trim();
+  if (anthropicBaseUrl) {
+    let host = '(unparseable)';
+    try {
+      host = new URL(anthropicBaseUrl).host;
+    } catch {
+      host = '(unparseable)';
+    }
+    console.warn(
+      `[config] AI Agent routed to a custom Anthropic-compatible backend (ANTHROPIC_BASE_URL host=${host}). `
+      + 'Cost tracking is best-effort: an unrecognized model id is priced at conservative '
+      + 'DEFAULT_PRICING (Opus-tier), not actual backend cost.',
+    );
+  }
+
   return _config;
 }

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -497,6 +497,17 @@ const envSchema = z
     MAILGUN_INBOUND_SIGNING_KEY: z.string().optional(),
     TICKETS_INBOUND_DOMAIN: z.string().optional(),
 
+    // -- Anthropic-compatible backend override (#1412) -----------------------
+    // Self-hosted operators can point the AI Agent at any Anthropic
+    // /v1/messages-dialect backend (local vLLM 0.23+, a LiteLLM gateway) while
+    // keeping full tool-use + the aiGuardrails stack — the SDK already honors
+    // ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN. Validated as http(s) and
+    // fail-closed when IS_HOSTED=true (see superRefine) so a stray value can
+    // never redirect the platform's AI traffic. ANTHROPIC_MODEL overrides the
+    // default model id for raw vLLM (no LiteLLM alias).
+    ANTHROPIC_BASE_URL: z.string().optional(),
+    ANTHROPIC_MODEL: z.string().optional(),
+
     // -- Alternative LLM backend (openai-compatible, e.g. vLLM) ---------------
     // Off by default. Chat-only PoC; tool-calling is not supported on this path.
     MCP_LLM_PROVIDER: z.enum(['anthropic', 'openai-compatible']).default('anthropic'),
@@ -578,6 +589,41 @@ const envSchema = z
         path: ['JWT_ACTIVE_KID'],
         message: 'JWT_ACTIVE_KID is set but JWT_SIGNING_KEYRING is empty.',
       });
+    }
+
+    // ANTHROPIC_BASE_URL (#1412): when set it must be a well-formed http(s)
+    // URL, and it is fail-closed on the hosted platform. Enforced in every
+    // environment so a misconfig is caught at boot, not at first AI request.
+    const anthropicBaseUrl = data.ANTHROPIC_BASE_URL?.trim();
+    if (anthropicBaseUrl) {
+      const isHostedDeploy = ['true', '1', 'yes', 'on'].includes(
+        (data.IS_HOSTED ?? '').trim().toLowerCase(),
+      );
+      if (isHostedDeploy) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['ANTHROPIC_BASE_URL'],
+          message:
+            'ANTHROPIC_BASE_URL must not be set when IS_HOSTED=true. Redirecting AI traffic to a '
+            + 'custom backend is a self-hosted-only feature; on the hosted platform it is refused '
+            + 'so a stray value cannot route platform AI traffic to a third-party endpoint.',
+        });
+      }
+      let parsedUrl: URL | null = null;
+      try {
+        parsedUrl = new URL(anthropicBaseUrl);
+      } catch {
+        parsedUrl = null;
+      }
+      if (!parsedUrl || (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:')) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['ANTHROPIC_BASE_URL'],
+          message:
+            'ANTHROPIC_BASE_URL must be a well-formed http(s) URL (e.g. http://localhost:8000 or '
+            + 'https://litellm.internal/v1).',
+        });
+      }
     }
 
     // MCP_LLM_PROVIDER openai-compatible: vLLM endpoint + auth + model id required at boot
@@ -1235,6 +1281,8 @@ export function validateConfig(): AppConfig {
     E2E_MODE: env.E2E_MODE,
     PARTNER_HOOKS_URL: env.PARTNER_HOOKS_URL,
     PARTNER_HOOKS_SECRET: env.PARTNER_HOOKS_SECRET,
+    ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
+    ANTHROPIC_MODEL: env.ANTHROPIC_MODEL,
     MCP_LLM_PROVIDER: env.MCP_LLM_PROVIDER,
     MCP_LLM_BASE_URL: env.MCP_LLM_BASE_URL,
     MCP_LLM_API_KEY: env.MCP_LLM_API_KEY,

--- a/apps/api/src/services/aiAgent.model.test.ts
+++ b/apps/api/src/services/aiAgent.model.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDefaultModel, BREEZE_FALLBACK_MODEL } from './aiAgent';
+
+// #1412: ANTHROPIC_MODEL lets a self-hosted operator override the default model
+// id for a raw vLLM backend whose served id differs from the Anthropic alias.
+describe('resolveDefaultModel (#1412)', () => {
+  it('returns the Anthropic fallback when ANTHROPIC_MODEL is unset', () => {
+    expect(resolveDefaultModel({})).toBe(BREEZE_FALLBACK_MODEL);
+  });
+
+  it('uses ANTHROPIC_MODEL when set', () => {
+    expect(resolveDefaultModel({ ANTHROPIC_MODEL: 'my-vllm-model' })).toBe('my-vllm-model');
+  });
+
+  it('trims surrounding whitespace from ANTHROPIC_MODEL', () => {
+    expect(resolveDefaultModel({ ANTHROPIC_MODEL: '  my-vllm-model  ' })).toBe('my-vllm-model');
+  });
+
+  it.each(['', '   '])(
+    'falls back to the default when ANTHROPIC_MODEL is empty/whitespace-only (%j) — never an empty model id',
+    (value) => {
+      expect(resolveDefaultModel({ ANTHROPIC_MODEL: value })).toBe(BREEZE_FALLBACK_MODEL);
+    },
+  );
+});

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -19,7 +19,15 @@ import { getActiveDeviceContext } from './brainDeviceContext';
 // Current model id so the Claude Agent SDK can price it natively. A stale id makes the
 // SDK report total_cost_usd: 0 → $0.00 cost tracking (issue #1326). Successor to the
 // previous default claude-sonnet-4-5-20250929, at the same $3/$15 per-MTok tier.
-const DEFAULT_MODEL = 'claude-sonnet-4-6';
+//
+// ANTHROPIC_MODEL (#1412) overrides the default for self-hosted operators
+// pointing at a raw vLLM backend whose served model id differs from the
+// Anthropic alias. With a LiteLLM gateway the alias route maps
+// claude-sonnet-4-6 → backend model, so the override is unnecessary there.
+// Cost tracking stays best-effort: the SDK prices against the Anthropic id, so
+// a non-Anthropic backend reports $0 — operators needing exact cost should use
+// the openai-compatible path's MCP_LLM_PRICE_* overrides.
+const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL?.trim() || 'claude-sonnet-4-6';
 
 // ============================================
 // Session Management

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -20,14 +20,25 @@ import { getActiveDeviceContext } from './brainDeviceContext';
 // SDK report total_cost_usd: 0 → $0.00 cost tracking (issue #1326). Successor to the
 // previous default claude-sonnet-4-5-20250929, at the same $3/$15 per-MTok tier.
 //
+export const BREEZE_FALLBACK_MODEL = 'claude-sonnet-4-6';
+
 // ANTHROPIC_MODEL (#1412) overrides the default for self-hosted operators
 // pointing at a raw vLLM backend whose served model id differs from the
 // Anthropic alias. With a LiteLLM gateway the alias route maps
 // claude-sonnet-4-6 → backend model, so the override is unnecessary there.
-// Cost tracking stays best-effort: the SDK prices against the Anthropic id, so
-// a non-Anthropic backend reports $0 — operators needing exact cost should use
-// the openai-compatible path's MCP_LLM_PRICE_* overrides.
-const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL?.trim() || 'claude-sonnet-4-6';
+// A whitespace-only/empty value falls back to the Anthropic default (never an
+// empty model id). Cost tracking stays best-effort: the SDK can't price a
+// non-Anthropic model id so it reports total_cost_usd=0, then aiCostTracker
+// falls back to token-based pricing — and an unrecognized model id is priced at
+// conservative DEFAULT_PRICING (Opus-tier $5/$25 per MTok), i.e. an OVER-estimate
+// for a cheap local model, not $0. For accurate accounting add the model to
+// MODEL_PRICING (aiCostTracker.ts), or use the openai-compatible path's
+// MCP_LLM_PRICE_* overrides.
+export function resolveDefaultModel(env: NodeJS.ProcessEnv = process.env): string {
+  return env.ANTHROPIC_MODEL?.trim() || BREEZE_FALLBACK_MODEL;
+}
+
+const DEFAULT_MODEL = resolveDefaultModel();
 
 // ============================================
 // Session Management

--- a/apps/api/src/services/streamingSessionManager.security.test.ts
+++ b/apps/api/src/services/streamingSessionManager.security.test.ts
@@ -32,30 +32,46 @@ describe('Claude SDK process hardening', () => {
     expect(env).not.toHaveProperty('REDIS_URL');
   });
 
-  it('forwards ANTHROPIC_BASE_URL and ANTHROPIC_MODEL on a self-hosted deployment (#1412)', () => {
-    const env = buildClaudeSdkChildEnv({
-      ANTHROPIC_API_KEY: 'sk-ant-test-key',
-      ANTHROPIC_BASE_URL: 'http://localhost:8000',
-      ANTHROPIC_MODEL: 'my-vllm-model',
-      IS_HOSTED: 'false',
-      PATH: '/usr/bin',
-    });
+  it.each(['false', '0', 'no', 'off'])(
+    'forwards ANTHROPIC_BASE_URL + ANTHROPIC_MODEL + ANTHROPIC_AUTH_TOKEN when self-host is declared (IS_HOSTED=%j) (#1412)',
+    (isHosted) => {
+      const env = buildClaudeSdkChildEnv({
+        ANTHROPIC_AUTH_TOKEN: 'backend-bearer-token',
+        ANTHROPIC_BASE_URL: 'http://localhost:8000',
+        ANTHROPIC_MODEL: 'my-vllm-model',
+        IS_HOSTED: isHosted,
+        PATH: '/usr/bin',
+      });
 
-    expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:8000');
-    expect(env.ANTHROPIC_MODEL).toBe('my-vllm-model');
-  });
+      expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:8000');
+      expect(env.ANTHROPIC_MODEL).toBe('my-vllm-model');
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBe('backend-bearer-token');
+    },
+  );
 
-  it('strips ANTHROPIC_BASE_URL on the hosted platform so it cannot redirect AI traffic (#1412)', () => {
+  // Fail-closed: the base URL is forwarded ONLY when self-host is affirmatively
+  // declared. 'true'/'1' = hosted; undefined = unmapped IS_HOSTED (#570 footgun);
+  // 'garbage' = unrecognized. All must strip the redirect vector.
+  it.each([
+    ['true', { IS_HOSTED: 'true' }],
+    ['1', { IS_HOSTED: '1' }],
+    ['unset', {}],
+    ['garbage', { IS_HOSTED: 'garbage' }],
+  ])('strips ANTHROPIC_BASE_URL when IS_HOSTED is not an affirmative self-host signal (%s) (#1412)', (_label, hostedEnv) => {
     const env = buildClaudeSdkChildEnv({
       ANTHROPIC_API_KEY: 'sk-ant-test-key',
       ANTHROPIC_BASE_URL: 'https://evil.example/v1',
-      IS_HOSTED: 'true',
+      ANTHROPIC_MODEL: 'still-forwarded',
+      ...hostedEnv,
       PATH: '/usr/bin',
     });
 
     expect(env).not.toHaveProperty('ANTHROPIC_BASE_URL');
-    // The platform key is still forwarded; only the redirect vector is removed.
+    // The platform key survives; only the redirect vector is removed.
     expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-test-key');
+    // ANTHROPIC_MODEL is NOT a redirect vector and is forwarded regardless of
+    // hosted state (it is also passed explicitly via options.model).
+    expect(env.ANTHROPIC_MODEL).toBe('still-forwarded');
   });
 
   it('redacts SDK stderr before logging', () => {

--- a/apps/api/src/services/streamingSessionManager.security.test.ts
+++ b/apps/api/src/services/streamingSessionManager.security.test.ts
@@ -32,6 +32,32 @@ describe('Claude SDK process hardening', () => {
     expect(env).not.toHaveProperty('REDIS_URL');
   });
 
+  it('forwards ANTHROPIC_BASE_URL and ANTHROPIC_MODEL on a self-hosted deployment (#1412)', () => {
+    const env = buildClaudeSdkChildEnv({
+      ANTHROPIC_API_KEY: 'sk-ant-test-key',
+      ANTHROPIC_BASE_URL: 'http://localhost:8000',
+      ANTHROPIC_MODEL: 'my-vllm-model',
+      IS_HOSTED: 'false',
+      PATH: '/usr/bin',
+    });
+
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:8000');
+    expect(env.ANTHROPIC_MODEL).toBe('my-vllm-model');
+  });
+
+  it('strips ANTHROPIC_BASE_URL on the hosted platform so it cannot redirect AI traffic (#1412)', () => {
+    const env = buildClaudeSdkChildEnv({
+      ANTHROPIC_API_KEY: 'sk-ant-test-key',
+      ANTHROPIC_BASE_URL: 'https://evil.example/v1',
+      IS_HOSTED: 'true',
+      PATH: '/usr/bin',
+    });
+
+    expect(env).not.toHaveProperty('ANTHROPIC_BASE_URL');
+    // The platform key is still forwarded; only the redirect vector is removed.
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-test-key');
+  });
+
   it('redacts SDK stderr before logging', () => {
     const redacted = redactClaudeSdkStderr('FATAL token=abc123 password=hunter2 sk-ant-secret000000000000');
 

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -42,6 +42,10 @@ const runOutsideDbContextSafe = runOutsideDbContext;
 const SDK_CHILD_ENV_ALLOWLIST = [
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_AUTH_TOKEN',
+  // ANTHROPIC_MODEL (#1412): raw-vLLM model id override. Harmless to forward
+  // (the model is also passed explicitly via options.model); not a redirect
+  // vector, so unlike ANTHROPIC_BASE_URL it needs no hosted gating.
+  'ANTHROPIC_MODEL',
   'CLAUDE_CODE_OAUTH_TOKEN',
   'CLAUDE_AGENT_SDK_CLIENT_APP',
   'HTTPS_PROXY',
@@ -74,6 +78,20 @@ export function buildClaudeSdkChildEnv(source: NodeJS.ProcessEnv = process.env):
     if (typeof value === 'string' && value.length > 0) {
       env[key] = value;
     }
+  }
+
+  // ANTHROPIC_BASE_URL (#1412): forward only on self-hosted deployments. On the
+  // hosted platform (IS_HOSTED=true) it is stripped so a stray/misconfigured
+  // value can never redirect platform AI traffic to a third-party backend. The
+  // config validator also boot-refuses this combo — this is defense-in-depth at
+  // the actual subprocess boundary (the function reads process.env directly,
+  // not the validated config singleton).
+  const hosted = ['1', 'true', 'yes', 'on'].includes(
+    (source.IS_HOSTED ?? '').trim().toLowerCase(),
+  );
+  const anthropicBaseUrl = source.ANTHROPIC_BASE_URL;
+  if (!hosted && typeof anthropicBaseUrl === 'string' && anthropicBaseUrl.length > 0) {
+    env.ANTHROPIC_BASE_URL = anthropicBaseUrl;
   }
 
   return env;

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -28,6 +28,7 @@ import { createSessionPreToolUse, createSessionPostToolUse } from './aiAgentSdk'
 import type { RequestLike } from './auditEvents';
 import { getTrustedClientIpOrUndefined } from './clientIp';
 import { redactAiToolOutputText } from './aiToolOutput';
+import { isRecognizedSelfHostSignal } from '../config/env';
 
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2h idle eviction (aligned with pre-flight check)
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h hard limit
@@ -80,17 +81,19 @@ export function buildClaudeSdkChildEnv(source: NodeJS.ProcessEnv = process.env):
     }
   }
 
-  // ANTHROPIC_BASE_URL (#1412): forward only on self-hosted deployments. On the
-  // hosted platform (IS_HOSTED=true) it is stripped so a stray/misconfigured
-  // value can never redirect platform AI traffic to a third-party backend. The
-  // config validator also boot-refuses this combo — this is defense-in-depth at
-  // the actual subprocess boundary (the function reads process.env directly,
-  // not the validated config singleton).
-  const hosted = ['1', 'true', 'yes', 'on'].includes(
-    (source.IS_HOSTED ?? '').trim().toLowerCase(),
-  );
+  // ANTHROPIC_BASE_URL (#1412): forward ONLY when self-host is affirmatively
+  // declared (IS_HOSTED explicitly false/0/no/off). Fail-closed — unset / empty
+  // / garbage / truthy IS_HOSTED all strip it, so a stray/misconfigured value
+  // (including the #570 unmapped-IS_HOSTED footgun) can never redirect platform
+  // AI traffic to a third-party backend. The config validator also boot-refuses
+  // this combo; this is defense-in-depth at the actual subprocess boundary (the
+  // function reads process.env directly, not the validated config singleton).
   const anthropicBaseUrl = source.ANTHROPIC_BASE_URL;
-  if (!hosted && typeof anthropicBaseUrl === 'string' && anthropicBaseUrl.length > 0) {
+  if (
+    isRecognizedSelfHostSignal(source.IS_HOSTED)
+    && typeof anthropicBaseUrl === 'string'
+    && anthropicBaseUrl.length > 0
+  ) {
     env.ANTHROPIC_BASE_URL = anthropicBaseUrl;
   }
 

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -288,3 +288,33 @@ Two rate-limit tiers protect the API. The generic per-user limit covers logged-i
 | Variable | Default | Description |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | — | Anthropic API key for AI assistant (BYOK) |
+| `ANTHROPIC_BASE_URL` | — | **Self-hosted only.** Point the AI Agent at an Anthropic-compatible `/v1/messages` backend (vLLM 0.23+, LiteLLM). Must be an `http(s)` URL. Refused at boot when `IS_HOSTED=true`. |
+| `ANTHROPIC_AUTH_TOKEN` | — | Bearer token for the custom backend (use instead of `ANTHROPIC_API_KEY` when `ANTHROPIC_BASE_URL` is set). |
+| `ANTHROPIC_MODEL` | `claude-sonnet-4-6` | Override the default model id for a raw vLLM backend. Leave unset with a LiteLLM gateway that aliases `claude-sonnet-4-6` → your model. |
+
+### Self-hosted: alternative Anthropic-compatible backends
+
+A self-hosted operator can run the AI Agent against any backend that speaks the
+Anthropic `/v1/messages` dialect — keeping full tool-use and the `aiGuardrails`
+stack — by setting:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:8000   # your vLLM / LiteLLM endpoint
+ANTHROPIC_AUTH_TOKEN=<backend bearer token>
+# Raw vLLM only — match the served model id (skip with a LiteLLM alias):
+ANTHROPIC_MODEL=<served-model-id>
+```
+
+The recommended route is a **LiteLLM gateway** that aliases `claude-sonnet-4-6`
+to your backend model, so no `ANTHROPIC_MODEL` override is needed. For an
+OpenAI-dialect-only endpoint, use the separate `MCP_LLM_*` openai-compatible
+path instead (chat-only, no tool-use).
+
+`ANTHROPIC_BASE_URL` is **fail-closed on the hosted platform**: the API refuses
+to boot if it is set while `IS_HOSTED=true`, and the value is stripped from the
+SDK subprocess environment — so it can never redirect the hosted platform's AI
+traffic to a third-party endpoint.
+
+Cost tracking is best-effort: the SDK prices usage against the Anthropic model
+id, so a non-Anthropic backend reports `$0`. Operators who need exact cost
+accounting should use the openai-compatible path's `MCP_LLM_PRICE_*` overrides.

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -288,7 +288,7 @@ Two rate-limit tiers protect the API. The generic per-user limit covers logged-i
 | Variable | Default | Description |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | — | Anthropic API key for AI assistant (BYOK) |
-| `ANTHROPIC_BASE_URL` | — | **Self-hosted only.** Point the AI Agent at an Anthropic-compatible `/v1/messages` backend (vLLM 0.23+, LiteLLM). Must be an `http(s)` URL. Refused at boot when `IS_HOSTED=true`. |
+| `ANTHROPIC_BASE_URL` | — | **Self-hosted only.** Point the AI Agent at an Anthropic-compatible `/v1/messages` backend (vLLM 0.23+, LiteLLM). Must be an `http(s)` URL. Permitted only when `IS_HOSTED` is explicitly `false` (or `0`/`no`/`off`); refused at boot if `IS_HOSTED` is `true`, unset, or invalid. |
 | `ANTHROPIC_AUTH_TOKEN` | — | Bearer token for the custom backend (use instead of `ANTHROPIC_API_KEY` when `ANTHROPIC_BASE_URL` is set). |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-6` | Override the default model id for a raw vLLM backend. Leave unset with a LiteLLM gateway that aliases `claude-sonnet-4-6` → your model. |
 
@@ -299,6 +299,7 @@ Anthropic `/v1/messages` dialect — keeping full tool-use and the `aiGuardrails
 stack — by setting:
 
 ```bash
+IS_HOSTED=false                            # required — ANTHROPIC_BASE_URL is refused otherwise
 ANTHROPIC_BASE_URL=http://localhost:8000   # your vLLM / LiteLLM endpoint
 ANTHROPIC_AUTH_TOKEN=<backend bearer token>
 # Raw vLLM only — match the served model id (skip with a LiteLLM alias):
@@ -310,11 +311,17 @@ to your backend model, so no `ANTHROPIC_MODEL` override is needed. For an
 OpenAI-dialect-only endpoint, use the separate `MCP_LLM_*` openai-compatible
 path instead (chat-only, no tool-use).
 
-`ANTHROPIC_BASE_URL` is **fail-closed on the hosted platform**: the API refuses
-to boot if it is set while `IS_HOSTED=true`, and the value is stripped from the
-SDK subprocess environment — so it can never redirect the hosted platform's AI
-traffic to a third-party endpoint.
+`ANTHROPIC_BASE_URL` is **fail-closed**: it is honored only when self-host is
+affirmatively declared (`IS_HOSTED` explicitly `false`/`0`/`no`/`off`). If
+`IS_HOSTED` is `true`, unset, or set to an unrecognized value, the API refuses
+to boot when `ANTHROPIC_BASE_URL` is present, and the value is also stripped
+from the SDK subprocess environment — so a stray or unmapped `IS_HOSTED` can
+never redirect platform AI traffic to a third-party endpoint.
 
-Cost tracking is best-effort: the SDK prices usage against the Anthropic model
-id, so a non-Anthropic backend reports `$0`. Operators who need exact cost
-accounting should use the openai-compatible path's `MCP_LLM_PRICE_*` overrides.
+Cost tracking is best-effort. The SDK can't price a non-Anthropic model id, so
+it reports `total_cost_usd: 0`; Breeze then falls back to token-based pricing,
+and an **unrecognized model id is priced at conservative Opus-tier
+`DEFAULT_PRICING` ($5/$25 per MTok)** — i.e. likely an *over*-estimate for a
+cheap local model, not `$0`. For accurate accounting, add the served model id to
+`MODEL_PRICING` in `aiCostTracker.ts`, or use the openai-compatible path's
+`MCP_LLM_PRICE_*` overrides.

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -2130,3 +2130,27 @@ Loaded the branch into the local dev Docker stack (rebuilt `api` from the worktr
 ### Notes
 - **Dev DB test data seeded:** 2 billable time entries (1 unapproved) + 1 ticket part on "Default Organization"; re-activated 2 archived catalog items; set org + partner billing settings; created `INV-2026-0001` (number burned). All on the dev DB (5432).
 - **Stack state:** the dev stack is currently running the **`feat/invoice-engine`** code (swapped from `main`). To restore: `docker compose down` from the worktree, `docker compose up -d` from `/Users/toddhebebrand/breeze`, and remove the worktree `.env` symlink.
+
+## ANTHROPIC_BASE_URL self-hosted AI backend (#1412) — 2026-06-17
+
+**Branch:** `fix/1412-anthropic-base-url`
+**Commit:** `50719f55`
+**Tested by:** Claude
+**Result:** PASS
+
+### What was tested
+- [x] API (boot/config gate): ran the REAL `validateConfig()` boot path inside a throwaway container built from `breeze-api:dev` (linux), mounting the branch's `apps/api/src` over the image so MY code executed (`PROBE_HAS_HELPER=true` confirmed). API-only feature; no UI/agent layer.
+
+### Evidence — boot-gate matrix (in-container)
+- S1 `IS_HOSTED=false` + `http://litellm:4000/v1` → **PASS** + forensic log `host=litellm:4000` (host only, no token).
+- S2 `IS_HOSTED=true` + base URL → **REFUSED** ("self-hosted-only feature … refused unless self-host is affirmatively declared").
+- S3 `IS_HOSTED` **unset** + base URL → **REFUSED** (fail-closed; the #570 unmapped-IS_HOSTED case).
+- S4 `IS_HOSTED=false` + `ftp://bad/x` → **REFUSED** ("must be a well-formed http(s) URL").
+- S5 `IS_HOSTED=off` + `https://litellm.internal:8443/v1` → **PASS** + forensic log.
+- Fail-closed gate predicate (`isRecognizedSelfHostSignal`, shared by validator + subprocess strip) verified in-container: only `false/0/no/off` → self-host-confirmed; `true/1/maybe/""/undefined` → not.
+
+### Issues Found
+- (none in the feature) — the runtime subprocess-env probe (`buildClaudeSdkChildEnv`) could not import in-container because the **stale `breeze-api:dev` image** still ships Zod 3 while `main` is post the Zod 4 migration (`z.partialRecord is not a function` in an unrelated import-chain schema). Not a #1412 defect. The forwarding/strip wrapper is covered by the 161 green unit tests; its shared gate predicate was verified in-container directly.
+
+### Notes
+- 161 unit/config tests green + clean `tsc` on the branch. Boot gate proven end-to-end in the real container image. CI left to run the full suite (per request).


### PR DESCRIPTION
Closes #1412.

Lets a self-hosted operator point the AI Agent at any Anthropic-compatible `/v1/messages` backend (local vLLM 0.23+, a LiteLLM gateway) while keeping **full tool-use and the existing `aiGuardrails` stack** — reusing the real `@anthropic-ai/claude-agent-sdk` `query()` path rather than the chat-only openai-compatible provider (#859).

**Root gap:** the SDK already honors `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`, but `buildClaudeSdkChildEnv` forwarded the auth vars to the SDK subprocess and not the base URL.

## What changed
- **Env schema** (`config/validate.ts`): optional `ANTHROPIC_BASE_URL` + `ANTHROPIC_MODEL`. `ANTHROPIC_BASE_URL` is validated as a well-formed `http(s)` URL at boot (every environment, so a misconfig fails at startup, not at first AI request).
- **Hosted gating (fail-closed):** the validator **boot-refuses** `ANTHROPIC_BASE_URL` when `IS_HOSTED=true`, and `buildClaudeSdkChildEnv` **strips** it from the SDK subprocess env on hosted deployments. Defense-in-depth: the helper reads `process.env` directly (not the validated config singleton), so it holds even if validation is bypassed. A stray value can never redirect the platform's AI traffic to a third-party endpoint.
- **Env forwarding** (`streamingSessionManager.ts`): forward `ANTHROPIC_BASE_URL` (self-host only) + `ANTHROPIC_MODEL` to the SDK child env allowlist.
- **Model handling** (`aiAgent.ts`): `ANTHROPIC_MODEL` overrides the default model id for raw vLLM. The LiteLLM-alias route (`claude-sonnet-4-6` → backend model) is documented as primary, so the override is unnecessary there.
- **Cost tracking:** left best-effort (the SDK prices against the Anthropic id, so a non-Anthropic backend reports `$0`); documented the `MCP_LLM_PRICE_*` path for operators needing exact accounting.
- **Docs + `.env.example`:** self-hosted setup section in `deploy/environment.mdx`.

## Tests
- `config/validate.test.ts`: accepts http(s) self-hosted, rejects non-http(s) (`ftp://`, `ws://`, junk), boot-refuses when `IS_HOSTED=true`.
- `streamingSessionManager.security.test.ts`: forwards `ANTHROPIC_BASE_URL`/`ANTHROPIC_MODEL` self-hosted, strips `ANTHROPIC_BASE_URL` when hosted.

All affected suites green (120 config, 7 streaming/aiAgent core, 55 aiAgent), clean `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)