### PR TITLE
feat(portal): deploy customer portal under /c path prefix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -71,12 +71,11 @@ docs
 # Claude/AI
 .claude
 
-# Apps not needed in Docker (API + web only)
+# Apps not needed in Docker (API + web + portal only)
 apps/helper
 apps/viewer
 apps/mobile
 apps/docs
-apps/portal
 apps/agent
 
 # Go agent (not needed in Docker)

--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,15 @@ PUBLIC_API_URL=
 # Legacy API URL fallback used by installer/share-link generation when PUBLIC_API_URL is unset.
 API_URL=
 
+# Customer portal (apps/portal) — served under a base path on the main domain
+# (default /c) via the Caddy carve-out, so it needs no dedicated hostname/cert.
+# PORTAL_BASE_PATH is baked into the portal image at build time; keep it in sync
+# with the Caddyfile carve-out (docker/Caddyfile.prod) and the build-arg.
+PORTAL_BASE_PATH=/c
+# Public origin for portal links in outbound email (e.g. quote accept links).
+# Defaults to https://${BREEZE_DOMAIN}/c; falls back to PUBLIC_APP_URL if unset.
+PUBLIC_PORTAL_URL=
+
 # --------------------------------------------
 # Production Deploy
 # --------------------------------------------
@@ -495,6 +504,7 @@ BREEZE_VERSION=0.67.1
 # and is enforced by scripts/security/check-supply-chain-hardening.sh.
 BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:${BREEZE_VERSION}
 BREEZE_WEB_IMAGE_REF=ghcr.io/lanternops/breeze/web:${BREEZE_VERSION}
+BREEZE_PORTAL_IMAGE_REF=ghcr.io/lanternops/breeze/portal:${BREEZE_VERSION}
 BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:${BREEZE_VERSION}
 
 # Third-party sidecar images. Pinned to specific minor versions to match what

--- a/.env.example
+++ b/.env.example
@@ -101,12 +101,12 @@ PUBLIC_API_URL=
 API_URL=
 
 # Customer portal (apps/portal) — served under a base path on the main domain
-# (default /c) via the Caddy carve-out, so it needs no dedicated hostname/cert.
+# (default /portal) via the Caddy carve-out, so it needs no dedicated hostname/cert.
 # PORTAL_BASE_PATH is baked into the portal image at build time; keep it in sync
 # with the Caddyfile carve-out (docker/Caddyfile.prod) and the build-arg.
-PORTAL_BASE_PATH=/c
+PORTAL_BASE_PATH=/portal
 # Public origin for portal links in outbound email (e.g. quote accept links).
-# Defaults to https://${BREEZE_DOMAIN}/c; falls back to PUBLIC_APP_URL if unset.
+# Defaults to https://${BREEZE_DOMAIN}/portal; falls back to PUBLIC_APP_URL if unset.
 PUBLIC_PORTAL_URL=
 
 # --------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,30 @@ jobs:
       - name: Run Web tests
         run: pnpm test --filter=@breeze/web
 
+  test-portal:
+    name: Test Portal
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Portal tests
+        run: pnpm test --filter=@breeze/portal
+
   test-office-addin-core:
     name: Test Office Add-in Core
     runs-on: ubuntu-latest
@@ -489,11 +513,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Build with the production base path so a broken /c link or asset ref
+      # Build with the production base path so a broken /portal link or asset ref
       # fails CI here rather than in prod.
       - name: Build Portal
         env:
-          PORTAL_BASE_PATH: /c
+          PORTAL_BASE_PATH: /portal
         run: pnpm build --filter=@breeze/portal
 
       - name: Upload Portal artifact
@@ -876,14 +900,18 @@ jobs:
           timeout 120 bash -c 'until curl -sf http://localhost:4321/ 2>/dev/null; do sleep 2; done'
           echo "Web is healthy."
 
-      - name: Wait for Portal health (/c)
+      - name: Wait for Portal health (/portal)
         run: |
-          echo "Waiting for Portal on :4322/c/login..."
-          timeout 120 bash -c 'until curl -sf http://localhost:4322/c/login 2>/dev/null; do sleep 2; done'
+          echo "Waiting for Portal on :4322/portal/login..."
+          timeout 120 bash -c 'until curl -sf http://localhost:4322/portal/login 2>/dev/null; do sleep 2; done'
           echo "Portal is healthy."
           # The portal must NOT answer outside its base path (web owns the root).
           ROOT_LOGIN=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4322/login || true)
           echo "Portal GET /login (expect 404) -> ${ROOT_LOGIN}"
+          if [ "${ROOT_LOGIN}" != "404" ]; then
+            echo "ERROR: portal answered un-based path /login with ${ROOT_LOGIN} (expected 404)"
+            exit 1
+          fi
 
       - name: Login and export token
         id: login
@@ -1031,7 +1059,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-api, test-web, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-web, build-portal, build-agent, test-agent, integration-test, rust-check, smoke-test]
+    needs: [lint, typecheck, test-api, test-web, test-portal, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-web, build-portal, build-agent, test-agent, integration-test, rust-check, smoke-test]
     if: ${{ !cancelled() }}
     steps:
       - name: Check all jobs passed
@@ -1040,6 +1068,7 @@ jobs:
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           TEST_API_RESULT: ${{ needs.test-api.result }}
           TEST_WEB_RESULT: ${{ needs.test-web.result }}
+          TEST_PORTAL_RESULT: ${{ needs.test-portal.result }}
           TEST_OFFICE_ADDIN_CORE_RESULT: ${{ needs.test-office-addin-core.result }}
           TEST_EXCEL_ADDIN_RESULT: ${{ needs.test-excel-addin.result }}
           TEST_WORD_ADDIN_RESULT: ${{ needs.test-word-addin.result }}
@@ -1060,6 +1089,7 @@ jobs:
              [[ "${TYPECHECK_RESULT}" != "success" ]] || \
              [[ "${TEST_API_RESULT}" != "success" ]] || \
              [[ "${TEST_WEB_RESULT}" != "success" ]] || \
+             [[ "${TEST_PORTAL_RESULT}" != "success" ]] || \
              [[ "${TEST_OFFICE_ADDIN_CORE_RESULT}" != "success" ]] || \
              [[ "${TEST_EXCEL_ADDIN_RESULT}" != "success" ]] || \
              [[ "${TEST_WORD_ADDIN_RESULT}" != "success" ]] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,42 @@ jobs:
           path: apps/web/dist
           retention-days: 7
 
+  build-portal:
+    name: Build Portal
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build with the production base path so a broken /c link or asset ref
+      # fails CI here rather than in prod.
+      - name: Build Portal
+        env:
+          PORTAL_BASE_PATH: /c
+        run: pnpm build --filter=@breeze/portal
+
+      - name: Upload Portal artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: portal-dist
+          path: apps/portal/dist
+          retention-days: 7
+
   build-agent:
     name: Build Agent (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ${{ matrix.runner }}
@@ -808,6 +844,7 @@ jobs:
           # here since this stack is ephemeral (torn down in Teardown step).
           BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:latest
           BREEZE_WEB_IMAGE_REF=ghcr.io/lanternops/breeze/web:latest
+          BREEZE_PORTAL_IMAGE_REF=ghcr.io/lanternops/breeze/portal:latest
           BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:latest
           CADDY_IMAGE_REF=caddy:2-alpine
           POSTGRES_IMAGE_REF=postgres:16-alpine
@@ -838,6 +875,15 @@ jobs:
           echo "Waiting for Web on :4321..."
           timeout 120 bash -c 'until curl -sf http://localhost:4321/ 2>/dev/null; do sleep 2; done'
           echo "Web is healthy."
+
+      - name: Wait for Portal health (/c)
+        run: |
+          echo "Waiting for Portal on :4322/c/login..."
+          timeout 120 bash -c 'until curl -sf http://localhost:4322/c/login 2>/dev/null; do sleep 2; done'
+          echo "Portal is healthy."
+          # The portal must NOT answer outside its base path (web owns the root).
+          ROOT_LOGIN=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4322/login || true)
+          echo "Portal GET /login (expect 404) -> ${ROOT_LOGIN}"
 
       - name: Login and export token
         id: login
@@ -985,7 +1031,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-api, test-web, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-web, build-agent, test-agent, integration-test, rust-check, smoke-test]
+    needs: [lint, typecheck, test-api, test-web, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-web, build-portal, build-agent, test-agent, integration-test, rust-check, smoke-test]
     if: ${{ !cancelled() }}
     steps:
       - name: Check all jobs passed
@@ -1002,6 +1048,7 @@ jobs:
           SECURITY_AUDIT_RESULT: ${{ needs.security-audit.result }}
           BUILD_API_RESULT: ${{ needs.build-api.result }}
           BUILD_WEB_RESULT: ${{ needs.build-web.result }}
+          BUILD_PORTAL_RESULT: ${{ needs.build-portal.result }}
           BUILD_AGENT_RESULT: ${{ needs.build-agent.result }}
           TEST_AGENT_RESULT: ${{ needs.test-agent.result }}
           INTEGRATION_TEST_RESULT: ${{ needs.integration-test.result }}
@@ -1021,6 +1068,7 @@ jobs:
              [[ "${SECURITY_AUDIT_RESULT}" != "success" ]] || \
              [[ "${BUILD_API_RESULT}" != "success" ]] || \
              [[ "${BUILD_WEB_RESULT}" != "success" ]] || \
+             [[ "${BUILD_PORTAL_RESULT}" != "success" ]] || \
              [[ "${BUILD_AGENT_RESULT}" != "success" ]] || \
              [[ "${TEST_AGENT_RESULT}" != "success" ]] || \
              [[ "${INTEGRATION_TEST_RESULT}" != "success" ]] || \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2368,3 +2368,53 @@ jobs:
             PUBLIC_APP_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-docker-portal:
+    name: Build & Push Portal Docker Image
+    runs-on: ubuntu-latest
+    needs: [create-release]
+    if: >-
+      !cancelled()
+      && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/portal
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=sha
+
+      - name: Build and push Portal image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: apps/portal/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PORTAL_BASE_PATH=/c
+            PUBLIC_API_URL=
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2414,7 +2414,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            PORTAL_BASE_PATH=/c
+            PORTAL_BASE_PATH=/portal
             PUBLIC_API_URL=
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Build Web image
         run: docker build -f docker/Dockerfile.web -t breeze-web:security-scan .
 
+      - name: Build Portal image
+        run: docker build -f apps/portal/Dockerfile -t breeze-portal:security-scan .
+
       - name: Scan API image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -164,6 +167,14 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'breeze-web:security-scan'
+          severity: 'HIGH,CRITICAL'
+          format: 'table'
+          exit-code: '1'
+
+      - name: Scan Portal image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'breeze-portal:security-scan'
           severity: 'HIGH,CRITICAL'
           format: 'table'
           exit-code: '1'

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -410,7 +410,16 @@ export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): 
   let emailed = false;
   let reason: SendInvoiceResult['reason'];
   if (emailService && recipient) {
-    const portalLink = `${(process.env.PUBLIC_APP_URL || process.env.DASHBOARD_URL || 'http://localhost:4321').replace(/\/$/, '')}/portal/invoices/${invoiceId}`;
+    // The customer portal is served under PUBLIC_PORTAL_URL (e.g.
+    // https://<domain>/c); the invoice detail page lives at <portal>/invoices/<id>.
+    // Fall back to the app/dashboard origin when the portal URL isn't configured.
+    const portalBase = (
+      process.env.PUBLIC_PORTAL_URL ||
+      process.env.PUBLIC_APP_URL ||
+      process.env.DASHBOARD_URL ||
+      'http://localhost:4321'
+    ).replace(/\/$/, '');
+    const portalLink = `${portalBase}/invoices/${invoiceId}`;
     const template = buildInvoiceTemplate({
       invoiceNumber: invoice.invoiceNumber ?? '',
       partnerName: partner?.name ?? 'your provider',

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -67,8 +67,8 @@ All configuration is done through environment variables, defined in your `.env.p
 | `IP_ALLOWLIST_ENFORCEMENT_MODE` | `enforce` | | Partner dashboard IP allowlist mode. Use `off` only as a break-glass switch if an allowlist locks everyone out. The allowlist only enforces when a partner has entries configured and proxy trust is working through `TRUST_PROXY_HEADERS` plus `TRUSTED_PROXY_CIDRS`. |
 | `DASHBOARD_URL` | — | | URL for links in emails |
 | `PUBLIC_APP_URL` | — | | Public-facing app URL |
-| `PUBLIC_PORTAL_URL` | `https://${BREEZE_DOMAIN}/c` (bundled compose only) | | Public origin for customer-portal links in outbound email (e.g. quote acceptance). Falls back to `PUBLIC_APP_URL` if unset. The portal is served under `/c` on the main domain. |
-| `PORTAL_BASE_PATH` | `/c` | | Base path the customer portal is served under. Baked into the portal image at build time — changing it requires rebuilding the portal image and keeping the Caddy `/c` route in sync. |
+| `PUBLIC_PORTAL_URL` | `https://${BREEZE_DOMAIN}/portal` (bundled compose only) | | Public origin for customer-portal links in outbound email (e.g. invoice emails). Falls back to `PUBLIC_APP_URL` if unset. The portal is served under `/portal` on the main domain. |
+| `PORTAL_BASE_PATH` | `/portal` | | Base path the customer portal is served under. Baked into the portal image at build time — changing it requires rebuilding the portal image and keeping the Caddy `/portal` route in sync. |
 
 ## Email
 

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -67,6 +67,8 @@ All configuration is done through environment variables, defined in your `.env.p
 | `IP_ALLOWLIST_ENFORCEMENT_MODE` | `enforce` | | Partner dashboard IP allowlist mode. Use `off` only as a break-glass switch if an allowlist locks everyone out. The allowlist only enforces when a partner has entries configured and proxy trust is working through `TRUST_PROXY_HEADERS` plus `TRUSTED_PROXY_CIDRS`. |
 | `DASHBOARD_URL` | — | | URL for links in emails |
 | `PUBLIC_APP_URL` | — | | Public-facing app URL |
+| `PUBLIC_PORTAL_URL` | `https://${BREEZE_DOMAIN}/c` (bundled compose only) | | Public origin for customer-portal links in outbound email (e.g. quote acceptance). Falls back to `PUBLIC_APP_URL` if unset. The portal is served under `/c` on the main domain. |
+| `PORTAL_BASE_PATH` | `/c` | | Base path the customer portal is served under. Baked into the portal image at build time — changing it requires rebuilding the portal image and keeping the Caddy `/c` route in sync. |
 
 ## Email
 

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -20,11 +20,16 @@ The core stack (`docker-compose.yml`) includes:
 | **Caddy** | `caddy:2.8-alpine` | Reverse proxy, auto-TLS, security headers |
 | **API** | `ghcr.io/lanternops/breeze/api` | Hono API server |
 | **Web** | `ghcr.io/lanternops/breeze/web` | Astro SSR dashboard |
+| **Portal** | `ghcr.io/lanternops/breeze/portal` | Astro SSR customer portal, served under `/c` (see [Customer Portal](/features/portal/)) |
 | **PostgreSQL** | `postgres:16-alpine` | Primary database |
 | **Redis** | `redis:7-alpine` | Job queue, caching, rate limiting |
 | **Coturn** | `coturn/coturn:4-alpine` | TURN relay server for WebRTC remote desktop (opt-in via `--profile turn`) |
 
 An optional monitoring stack (Prometheus, Grafana, Alertmanager, Loki, Promtail, exporters) is available as a separate overlay — see [Monitoring](#adding-monitoring).
+
+<Aside type="note" title="Customer portal lives at /c">
+The customer portal is served under the `/c` path on your main domain (for example `https://breeze.example.com/c/login`) — no separate hostname or TLS certificate is required. It reaches the API on the same origin, so there is no extra CORS configuration. Set `PUBLIC_PORTAL_URL` (default `https://${BREEZE_DOMAIN}/c`) so customer-facing links in emails resolve correctly. If you maintain a **custom Compose file**, a `BREEZE_VERSION` bump alone won't add the portal — make sure the `portal` service and the Caddy `/c` route are present, then `docker compose up -d portal && docker compose restart caddy`.
+</Aside>
 
 ## Deploy Steps
 

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -20,15 +20,15 @@ The core stack (`docker-compose.yml`) includes:
 | **Caddy** | `caddy:2.8-alpine` | Reverse proxy, auto-TLS, security headers |
 | **API** | `ghcr.io/lanternops/breeze/api` | Hono API server |
 | **Web** | `ghcr.io/lanternops/breeze/web` | Astro SSR dashboard |
-| **Portal** | `ghcr.io/lanternops/breeze/portal` | Astro SSR customer portal, served under `/c` (see [Customer Portal](/features/portal/)) |
+| **Portal** | `ghcr.io/lanternops/breeze/portal` | Astro SSR customer portal, served under `/portal` (see [Customer Portal](/features/portal/)) |
 | **PostgreSQL** | `postgres:16-alpine` | Primary database |
 | **Redis** | `redis:7-alpine` | Job queue, caching, rate limiting |
 | **Coturn** | `coturn/coturn:4-alpine` | TURN relay server for WebRTC remote desktop (opt-in via `--profile turn`) |
 
 An optional monitoring stack (Prometheus, Grafana, Alertmanager, Loki, Promtail, exporters) is available as a separate overlay — see [Monitoring](#adding-monitoring).
 
-<Aside type="note" title="Customer portal lives at /c">
-The customer portal is served under the `/c` path on your main domain (for example `https://breeze.example.com/c/login`) — no separate hostname or TLS certificate is required. It reaches the API on the same origin, so there is no extra CORS configuration. Set `PUBLIC_PORTAL_URL` (default `https://${BREEZE_DOMAIN}/c`) so customer-facing links in emails resolve correctly. If you maintain a **custom Compose file**, a `BREEZE_VERSION` bump alone won't add the portal — make sure the `portal` service and the Caddy `/c` route are present, then `docker compose up -d portal && docker compose restart caddy`.
+<Aside type="note" title="Customer portal lives at /portal">
+The customer portal is served under the `/portal` path on your main domain (for example `https://breeze.example.com/portal/login`) — no separate hostname or TLS certificate is required. It reaches the API on the same origin, so there is no extra CORS configuration. Set `PUBLIC_PORTAL_URL` (default `https://${BREEZE_DOMAIN}/portal`) so customer-facing links in emails resolve correctly. If you maintain a **custom Compose file**, a `BREEZE_VERSION` bump alone won't add the portal — make sure the `portal` service and the Caddy `/portal` route are present, then `docker compose up -d portal && docker compose restart caddy`.
 </Aside>
 
 ## Deploy Steps

--- a/apps/docs/src/content/docs/features/portal.mdx
+++ b/apps/docs/src/content/docs/features/portal.mdx
@@ -13,10 +13,10 @@ Each organization gets its own portal instance with customizable branding, a ded
 
 ## Accessing the Portal
 
-The portal is served under the `/c` path on your Breeze domain — for example, if your dashboard is at `https://breeze.example.com`, portal users sign in at **`https://breeze.example.com/c/login`**. No separate hostname or DNS record is required. Share this link (or the per-quote/invoice links Breeze emails, which already point at `/c`) with your end-users.
+The portal is served under the `/portal` path on your Breeze domain — for example, if your dashboard is at `https://breeze.example.com`, portal users sign in at **`https://breeze.example.com/portal/login`**. No separate hostname or DNS record is required. Share this link (or the per-quote/invoice links Breeze emails, which already point at `/portal`) with your end-users.
 
 <Aside type="note" title="Custom portal domains">
-You can configure a per-organization custom domain in branding (`customDomain`, e.g. `support.acme.com`), but **serving the portal on a custom domain is not available yet** — for now all organizations reach the portal at `https://<your-breeze-domain>/c`. The branding for an organization still applies once a user signs in.
+You can configure a per-organization custom domain in branding (`customDomain`, e.g. `support.acme.com`), but **serving the portal on a custom domain is not available yet** — for now all organizations reach the portal at `https://<your-breeze-domain>/portal`. The branding for an organization still applies once a user signs in.
 </Aside>
 
 ## Key Concepts
@@ -95,7 +95,7 @@ The portal applies per-IP and per-account rate limiting to authentication endpoi
 
 ## Branding
 
-Each organization can customize the portal appearance and contact information. Branding is resolved by domain — when a portal user visits a configured custom domain, Breeze serves that organization's matching branding. Because [custom-domain serving is not enabled yet](#accessing-the-portal), the shared `/c` portal currently shows the default branding at the login screen; configured branding still applies to the organization elsewhere.
+Each organization can customize the portal appearance and contact information. Branding is resolved by domain — when a portal user visits a configured custom domain, Breeze serves that organization's matching branding. Because [custom-domain serving is not enabled yet](#accessing-the-portal), the shared `/portal` portal currently shows the default branding at the login screen; configured branding still applies to the organization elsewhere.
 
 ### Branding Fields
 

--- a/apps/docs/src/content/docs/features/portal.mdx
+++ b/apps/docs/src/content/docs/features/portal.mdx
@@ -11,6 +11,14 @@ Each organization gets its own portal instance with customizable branding, a ded
 
 ---
 
+## Accessing the Portal
+
+The portal is served under the `/c` path on your Breeze domain — for example, if your dashboard is at `https://breeze.example.com`, portal users sign in at **`https://breeze.example.com/c/login`**. No separate hostname or DNS record is required. Share this link (or the per-quote/invoice links Breeze emails, which already point at `/c`) with your end-users.
+
+<Aside type="note" title="Custom portal domains">
+You can configure a per-organization custom domain in branding (`customDomain`, e.g. `support.acme.com`), but **serving the portal on a custom domain is not available yet** — for now all organizations reach the portal at `https://<your-breeze-domain>/c`. The branding for an organization still applies once a user signs in.
+</Aside>
+
 ## Key Concepts
 
 ### Portal Feature Toggles
@@ -87,7 +95,7 @@ The portal applies per-IP and per-account rate limiting to authentication endpoi
 
 ## Branding
 
-Each organization can customize the portal appearance and contact information. Branding is resolved by custom domain -- when a portal user visits their organization's custom domain, Breeze serves the matching branding configuration.
+Each organization can customize the portal appearance and contact information. Branding is resolved by domain — when a portal user visits a configured custom domain, Breeze serves that organization's matching branding. Because [custom-domain serving is not enabled yet](#accessing-the-portal), the shared `/c` portal currently shows the default branding at the login screen; configured branding still applies to the organization elsewhere.
 
 ### Branding Fields
 

--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -1,7 +1,7 @@
 # ============================================
 # Breeze RMM Customer Portal - Multi-stage Dockerfile
 # ============================================
-# Astro SSR (node standalone) app served under a base path (default /c) behind
+# Astro SSR (node standalone) app served under a base path (default /portal) behind
 # the main domain's reverse proxy. See docker/Caddyfile.prod for the carve-out.
 
 # Stage 1: Base image with pnpm
@@ -27,9 +27,10 @@ WORKDIR /app
 
 ARG NODE_ENV=production
 # Base path the portal is served under. Baked at build time (Astro `base`).
-ARG PORTAL_BASE_PATH=/c
-# PUBLIC_API_URL is intentionally empty: the portal calls the API same-origin
-# (/api/v1/...), which the reverse proxy routes to the API service.
+ARG PORTAL_BASE_PATH=/portal
+# PUBLIC_API_URL is intentionally empty: the browser calls the API same-origin
+# (/api/v1/...), which the reverse proxy routes to the API service. Server-side
+# rendering uses INTERNAL_API_URL at runtime (see docker-compose.yml).
 ARG PUBLIC_API_URL=
 ENV NODE_ENV=${NODE_ENV}
 ENV PORTAL_BASE_PATH=${PORTAL_BASE_PATH}
@@ -58,7 +59,7 @@ RUN apk add --no-cache wget
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=4322
-ENV PORTAL_BASE_PATH=/c
+ENV PORTAL_BASE_PATH=/portal
 
 # Create non-root user for security
 RUN addgroup --system --gid 1001 nodejs && \

--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -1,0 +1,88 @@
+# ============================================
+# Breeze RMM Customer Portal - Multi-stage Dockerfile
+# ============================================
+# Astro SSR (node standalone) app served under a base path (default /c) behind
+# the main domain's reverse proxy. See docker/Caddyfile.prod for the carve-out.
+
+# Stage 1: Base image with pnpm
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS base
+RUN npm install -g pnpm@10.33.4
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Stage 2: Install dependencies
+FROM base AS deps
+WORKDIR /app
+
+# Copy workspace configuration + portal manifest (portal has no workspace deps)
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/portal/package.json ./apps/portal/
+
+# Install all dependencies
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+# Stage 3: Build the application
+FROM base AS builder
+WORKDIR /app
+
+ARG NODE_ENV=production
+# Base path the portal is served under. Baked at build time (Astro `base`).
+ARG PORTAL_BASE_PATH=/c
+# PUBLIC_API_URL is intentionally empty: the portal calls the API same-origin
+# (/api/v1/...), which the reverse proxy routes to the API service.
+ARG PUBLIC_API_URL=
+ENV NODE_ENV=${NODE_ENV}
+ENV PORTAL_BASE_PATH=${PORTAL_BASE_PATH}
+ENV PUBLIC_API_URL=${PUBLIC_API_URL}
+
+# Copy dependencies from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/portal/node_modules ./apps/portal/node_modules
+
+# Copy source code
+COPY apps/portal ./apps/portal
+COPY tsconfig.json ./
+
+# Build the Astro application
+WORKDIR /app/apps/portal
+RUN pnpm build
+
+# Stage 4: Production runner
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS runner
+WORKDIR /app
+
+# Install wget for healthcheck
+RUN apk add --no-cache wget
+
+# Default base path used by the healthcheck (overridable at runtime).
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=4322
+ENV PORTAL_BASE_PATH=/c
+
+# Create non-root user for security
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 astro
+
+# Copy built application and dependencies while preserving pnpm workspace symlink layout.
+COPY --from=builder --chown=astro:nodejs /app/apps/portal/dist ./apps/portal/dist
+COPY --from=builder --chown=astro:nodejs /app/apps/portal/package.json ./apps/portal/package.json
+COPY --from=deps --chown=astro:nodejs /app/apps/portal/node_modules ./apps/portal/node_modules
+COPY --from=deps --chown=astro:nodejs /app/node_modules ./node_modules
+
+# Run the portal app from its workspace path so module resolution uses
+# apps/portal/node_modules first.
+WORKDIR /app/apps/portal
+
+# Switch to non-root user
+USER astro
+
+# Expose portal port
+EXPOSE 4322
+
+# Health check — hits the login page under the configured base path.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider "http://localhost:4322${PORTAL_BASE_PATH}/login" || exit 1
+
+# Start the Astro SSR server
+CMD ["node", "dist/server/entry.mjs"]

--- a/apps/portal/astro.config.mjs
+++ b/apps/portal/astro.config.mjs
@@ -3,11 +3,11 @@ import react from '@astrojs/react';
 import tailwind from '@astrojs/tailwind';
 import node from '@astrojs/node';
 
-// Base path the portal is served under. Defaults to `/c` so the portal can be
-// reverse-proxied behind the main domain (e.g. https://example.com/c/...) without
+// Base path the portal is served under. Defaults to `/portal` so the portal can be
+// reverse-proxied behind the main domain (e.g. https://example.com/portal/...) without
 // a dedicated hostname. Override with PORTAL_BASE_PATH (build-time) — set to `/`
-// to serve at the root. See docker/Caddyfile.prod for the matching `/c` carve-out.
-const PORTAL_BASE = process.env.PORTAL_BASE_PATH || '/c';
+// to serve at the root. See docker/Caddyfile.prod for the matching `/portal` carve-out.
+const PORTAL_BASE = process.env.PORTAL_BASE_PATH || '/portal';
 
 export default defineConfig({
   output: 'server',

--- a/apps/portal/astro.config.mjs
+++ b/apps/portal/astro.config.mjs
@@ -3,8 +3,15 @@ import react from '@astrojs/react';
 import tailwind from '@astrojs/tailwind';
 import node from '@astrojs/node';
 
+// Base path the portal is served under. Defaults to `/c` so the portal can be
+// reverse-proxied behind the main domain (e.g. https://example.com/c/...) without
+// a dedicated hostname. Override with PORTAL_BASE_PATH (build-time) — set to `/`
+// to serve at the root. See docker/Caddyfile.prod for the matching `/c` carve-out.
+const PORTAL_BASE = process.env.PORTAL_BASE_PATH || '/c';
+
 export default defineConfig({
   output: 'server',
+  base: PORTAL_BASE,
   adapter: node({
     mode: 'standalone'
   }),

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "test": "vitest run",
     "clean": "rm -rf dist .astro"
   },
   "dependencies": {
@@ -34,6 +35,7 @@
     "autoprefixer": "^10.5.0",
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.9"
   }
 }

--- a/apps/portal/src/components/portal/AcceptInviteForm.tsx
+++ b/apps/portal/src/components/portal/AcceptInviteForm.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -103,7 +104,7 @@ export default function AcceptInviteForm({ token }: AcceptInviteFormProps) {
         </div>
 
         <a
-          href="/login"
+          href={withBase("/login")}
           className={cn(
             'flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
             'hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2'

--- a/apps/portal/src/components/portal/ForgotPasswordForm.tsx
+++ b/apps/portal/src/components/portal/ForgotPasswordForm.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -57,7 +58,7 @@ export function ForgotPasswordForm() {
         </div>
 
         <a
-          href="/login"
+          href={withBase("/login")}
           className="flex items-center justify-center gap-2 text-sm text-primary hover:text-primary/80"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -126,7 +127,7 @@ export function ForgotPasswordForm() {
       </button>
 
       <a
-        href="/login"
+        href={withBase("/login")}
         className="flex items-center justify-center gap-2 text-sm text-muted-foreground hover:text-foreground"
       >
         <ArrowLeft className="h-4 w-4" />

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import { useState } from 'react';
 import { ArrowLeft, AlertCircle, Download, CreditCard } from 'lucide-react';
 import { type InvoiceDetail, type InvoiceStatus, buildPortalApiUrl, portalApi } from '@/lib/api';
@@ -65,7 +66,7 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
         <p className="mt-1 text-sm text-muted-foreground">
           {error || 'The invoice you are looking for does not exist.'}
         </p>
-        <a href="/invoices" className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
+        <a href={withBase("/invoices")} className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
           <ArrowLeft className="h-4 w-4" />
           Back to invoices
         </a>
@@ -127,7 +128,7 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
 
   return (
     <div className="space-y-6">
-      <a href="/invoices" className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
+      <a href={withBase("/invoices")} className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
         <ArrowLeft className="h-4 w-4" />
         Back to invoices
       </a>

--- a/apps/portal/src/components/portal/InvoiceList.tsx
+++ b/apps/portal/src/components/portal/InvoiceList.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import { Receipt, AlertCircle } from 'lucide-react';
 import { type InvoiceSummary, type InvoiceStatus } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -88,7 +89,7 @@ export function InvoiceList({ invoices, error }: InvoiceListProps) {
               {invoices.map((inv) => (
                 <tr key={inv.id} className="hover:bg-muted/50">
                   <td className="px-4 py-3">
-                    <a className="font-medium hover:underline" href={`/invoices/${inv.id}`}>
+                    <a className="font-medium hover:underline" href={withBase(`/invoices/${inv.id}`)}>
                       {inv.invoiceNumber ?? inv.id.slice(0, 8)}
                     </a>
                   </td>

--- a/apps/portal/src/components/portal/LoginForm.tsx
+++ b/apps/portal/src/components/portal/LoginForm.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -118,7 +119,7 @@ export function LoginForm() {
 
         <div className="text-sm">
           <a
-            href="/forgot-password"
+            href={withBase("/forgot-password")}
             className="font-medium text-primary hover:text-primary/80"
           >
             Forgot your password?

--- a/apps/portal/src/components/portal/NewTicketForm.tsx
+++ b/apps/portal/src/components/portal/NewTicketForm.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -49,7 +50,7 @@ export function NewTicketForm() {
     <div className="mx-auto max-w-2xl">
       <div className="mb-6">
         <a
-          href="/tickets"
+          href={withBase("/tickets")}
           className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -148,7 +149,7 @@ export function NewTicketForm() {
 
           <div className="flex justify-end gap-3">
             <a
-              href="/tickets"
+              href={withBase("/tickets")}
               className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
             >
               Cancel

--- a/apps/portal/src/components/portal/PortalHeader.tsx
+++ b/apps/portal/src/components/portal/PortalHeader.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React, { useState } from 'react';
 import { Bell, ChevronDown, LogOut, Settings, User } from 'lucide-react';
 import { usePortalAuth, portalLogout } from '@/lib/auth';
@@ -58,7 +59,7 @@ export function PortalHeader() {
               />
               <div className="absolute right-0 top-full z-20 mt-1 w-48 rounded-md border bg-popover py-1 shadow-lg">
                 <a
-                  href="/profile"
+                  href={withBase("/profile")}
                   className="flex items-center gap-2 px-4 py-2 text-sm hover:bg-accent"
                 >
                   <Settings className="h-4 w-4" />

--- a/apps/portal/src/components/portal/PortalSidebar.tsx
+++ b/apps/portal/src/components/portal/PortalSidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { useBranding } from './BrandingProvider';
 import { cn } from '@/lib/utils';
+import { stripBase, withBase } from '@/lib/basePath';
 
 interface NavItem {
   name: string;
@@ -28,8 +29,9 @@ export function PortalSidebar() {
   const { branding } = useBranding();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
-  // Get current path for active state
-  const currentPath = typeof window !== 'undefined' ? window.location.pathname : '';
+  // Get current path for active state (de-based so comparisons stay base-agnostic).
+  const currentPath =
+    typeof window !== 'undefined' ? stripBase(window.location.pathname) : '';
 
   const isActive = (href: string) => {
     if (href === '/') return currentPath === '/';
@@ -45,7 +47,7 @@ export function PortalSidebar() {
         return (
           <a
             key={item.name}
-            href={item.href}
+            href={withBase(item.href)}
             className={cn(
               'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
               active

--- a/apps/portal/src/components/portal/ResetPasswordForm.tsx
+++ b/apps/portal/src/components/portal/ResetPasswordForm.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -72,7 +73,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
         </div>
 
         <a
-          href="/login"
+          href={withBase("/login")}
           className={cn(
             'flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
             'hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2'
@@ -101,7 +102,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
         </div>
 
         <a
-          href="/forgot-password"
+          href={withBase("/forgot-password")}
           className={cn(
             'flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
             'hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2'

--- a/apps/portal/src/components/portal/TicketDetails.tsx
+++ b/apps/portal/src/components/portal/TicketDetails.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React from 'react';
 import { ArrowLeft, AlertCircle, Clock, Tag } from 'lucide-react';
 import { type TicketDetails as TicketDetailsType, type TicketPriority, type TicketStatus } from '@/lib/api';
@@ -58,7 +59,7 @@ export function TicketDetails({ ticket, error }: TicketDetailsProps) {
           {error || 'The ticket you are looking for does not exist.'}
         </p>
         <a
-          href="/tickets"
+          href={withBase("/tickets")}
           className="mt-4 inline-flex items-center gap-2 text-sm text-primary hover:text-primary/80"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -72,7 +73,7 @@ export function TicketDetails({ ticket, error }: TicketDetailsProps) {
     <div className="mx-auto max-w-3xl">
       <div className="mb-6">
         <a
-          href="/tickets"
+          href={withBase("/tickets")}
           className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" />

--- a/apps/portal/src/components/portal/TicketList.tsx
+++ b/apps/portal/src/components/portal/TicketList.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '@/lib/basePath';
 import React from 'react';
 import { Ticket, Plus, AlertCircle } from 'lucide-react';
 import { type TicketSummary, type TicketPriority, type TicketStatus } from '@/lib/api';
@@ -63,7 +64,7 @@ export function TicketList({ tickets, error }: TicketListProps) {
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Support Tickets</h2>
         <a
-          href="/tickets/new"
+          href={withBase("/tickets/new")}
           className={cn(
             'flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
             'hover:bg-primary/90'
@@ -82,7 +83,7 @@ export function TicketList({ tickets, error }: TicketListProps) {
             You haven't submitted any support tickets yet.
           </p>
           <a
-            href="/tickets/new"
+            href={withBase("/tickets/new")}
             className={cn(
               'mt-4 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
               'hover:bg-primary/90'
@@ -119,7 +120,7 @@ export function TicketList({ tickets, error }: TicketListProps) {
                 >
                   <td className="px-4 py-3">
                     <div>
-                      <a className="font-medium hover:underline" href={`/tickets/${ticket.id}`}>
+                      <a className="font-medium hover:underline" href={withBase(`/tickets/${ticket.id}`)}>
                         {ticket.subject}
                       </a>
                       <p className="text-sm text-muted-foreground">

--- a/apps/portal/src/layouts/AuthLayout.astro
+++ b/apps/portal/src/layouts/AuthLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/globals.css';
 import { ClientRouter } from 'astro:transitions';
+import { withBase } from '../lib/basePath';
 
 interface Props {
   title: string;
@@ -15,7 +16,7 @@ const { title } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Customer Portal - Secure Access" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
     <title>{title} | Customer Portal</title>
     <ClientRouter />
   </head>

--- a/apps/portal/src/layouts/PortalLayout.astro
+++ b/apps/portal/src/layouts/PortalLayout.astro
@@ -2,7 +2,7 @@
 import '../styles/globals.css';
 import { ClientRouter } from 'astro:transitions';
 import { loadPortalBranding } from '../lib/server';
-import { BASE_PATH, stripBase, withBase } from '../lib/basePath';
+import { stripBase, withBase } from '../lib/basePath';
 
 interface Props {
   title: string;
@@ -115,6 +115,7 @@ const isActive = (href: string) => {
             <button
               type="button"
               data-portal-logout
+              data-login-path={withBase('/login')}
               class="rounded-md px-3 py-2 text-sm text-destructive hover:bg-accent"
             >
               Sign Out
@@ -127,14 +128,23 @@ const isActive = (href: string) => {
         </main>
       </div>
     </div>
-    <script is:inline define:vars={{ basePath: BASE_PATH }}>
-      (() => {
-        if (window.__portalLogoutInit) {
+    {/*
+      Bundled (NOT is:inline) so Astro serves it from /portal/_astro/ — allowed by
+      `script-src 'self'` with no per-page hash. An inline script would need a hash
+      that changes per page, which the View-Transitions ClientRouter can't satisfy
+      after a client-side navigation (the initial document's CSP stays in force).
+      The base-aware login path is read from the button's data attribute rather
+      than via define:vars (which would force is:inline again).
+    */}
+    <script>
+      function bindPortalLogout() {
+        const btn = document.querySelector('[data-portal-logout]');
+        if (!(btn instanceof HTMLButtonElement) || btn.dataset.logoutBound === 'true') {
           return;
         }
-        window.__portalLogoutInit = true;
+        btn.dataset.logoutBound = 'true';
 
-        const getCookie = (name) => {
+        const getCookie = (name: string): string | null => {
           const target = `${name}=`;
           for (const part of document.cookie.split(';')) {
             const trimmed = part.trim();
@@ -145,43 +155,35 @@ const isActive = (href: string) => {
           return null;
         };
 
-        const bindLogout = () => {
-          const logoutButton = document.querySelector('[data-portal-logout]');
-          if (!logoutButton || !(logoutButton instanceof HTMLButtonElement)) {
-            return;
+        btn.addEventListener('click', async () => {
+          btn.disabled = true;
+          const loginPath = btn.dataset.loginPath || '/login';
+          try {
+            const csrf = getCookie('breeze_portal_csrf_token');
+            const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+            if (csrf) {
+              headers['x-breeze-csrf'] = csrf;
+            }
+            await fetch('/api/v1/portal/auth/logout', {
+              method: 'POST',
+              credentials: 'include',
+              headers
+            });
+          } catch {
+            // Continue to login even if the logout request fails.
           }
 
-          logoutButton.onclick = async () => {
-            logoutButton.disabled = true;
-            try {
-              const csrf = getCookie('breeze_portal_csrf_token');
-              const headers = { 'Content-Type': 'application/json' };
-              if (csrf) {
-                headers['x-breeze-csrf'] = csrf;
-              }
+          try {
+            const { navigate } = await import('astro:transitions/client');
+            await navigate(loginPath, { history: 'replace' });
+          } catch {
+            window.location.replace(loginPath);
+          }
+        });
+      }
 
-              await fetch('/api/v1/portal/auth/logout', {
-                method: 'POST',
-                credentials: 'include',
-                headers
-              });
-            } catch {
-              // Continue to login even if logout request fails.
-            }
-
-            const loginPath = `${basePath}/login`;
-            try {
-              const { navigate } = await import('astro:transitions/client');
-              await navigate(loginPath, { history: 'replace' });
-            } catch {
-              window.location.replace(loginPath);
-            }
-          };
-        };
-
-        bindLogout();
-        document.addEventListener('astro:page-load', bindLogout);
-      })();
+      bindPortalLogout();
+      document.addEventListener('astro:page-load', bindPortalLogout);
     </script>
   </body>
 </html>

--- a/apps/portal/src/layouts/PortalLayout.astro
+++ b/apps/portal/src/layouts/PortalLayout.astro
@@ -2,13 +2,16 @@
 import '../styles/globals.css';
 import { ClientRouter } from 'astro:transitions';
 import { loadPortalBranding } from '../lib/server';
+import { BASE_PATH, stripBase, withBase } from '../lib/basePath';
 
 interface Props {
   title: string;
 }
 
 const { title } = Astro.props;
-const pathname = Astro.url.pathname;
+// Astro.url.pathname includes the base (e.g. /c/devices); strip it so the
+// active-nav comparison below stays base-agnostic.
+const pathname = stripBase(Astro.url.pathname);
 const branding = await loadPortalBranding(Astro.request);
 const navItems = [
   { label: 'Devices', href: '/devices' },
@@ -30,7 +33,7 @@ const isActive = (href: string) => {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Customer Portal" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
     <title>{title} | Customer Portal</title>
     <ClientRouter />
   </head>
@@ -48,7 +51,7 @@ const isActive = (href: string) => {
         <nav class="flex-1 space-y-1 p-4">
           {navItems.map((item) => (
             <a
-              href={item.href}
+              href={withBase(item.href)}
               class:list={[
                 'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
                 isActive(item.href)
@@ -89,7 +92,7 @@ const isActive = (href: string) => {
               <nav class="absolute left-0 top-12 z-30 w-56 rounded-md border bg-card p-2 shadow-lg">
                 {navItems.map((item) => (
                   <a
-                    href={item.href}
+                    href={withBase(item.href)}
                     class:list={[
                       'block rounded-md px-3 py-2 text-sm',
                       isActive(item.href)
@@ -106,7 +109,7 @@ const isActive = (href: string) => {
           </div>
 
           <div class="flex items-center gap-2">
-            <a href="/profile" class="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground">
+            <a href={withBase('/profile')} class="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground">
               Profile
             </a>
             <button
@@ -124,7 +127,7 @@ const isActive = (href: string) => {
         </main>
       </div>
     </div>
-    <script is:inline>
+    <script is:inline define:vars={{ basePath: BASE_PATH }}>
       (() => {
         if (window.__portalLogoutInit) {
           return;
@@ -166,11 +169,12 @@ const isActive = (href: string) => {
               // Continue to login even if logout request fails.
             }
 
+            const loginPath = `${basePath}/login`;
             try {
               const { navigate } = await import('astro:transitions/client');
-              await navigate('/login', { history: 'replace' });
+              await navigate(loginPath, { history: 'replace' });
             } catch {
-              window.location.replace('/login');
+              window.location.replace(loginPath);
             }
           };
         };

--- a/apps/portal/src/lib/api.test.ts
+++ b/apps/portal/src/lib/api.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildPortalApiUrl } from './api';
+
+// Regression guard for the same-origin client API base (the deploy relies on it):
+// with PUBLIC_API_URL unset, the browser must issue RELATIVE /api/v1 requests so
+// the reverse proxy routes them to the API. A previous default of
+// `http://localhost:3001` produced an absolute, CSP-blocked, wrong-port URL.
+//
+// Simulate the browser by defining a minimal `window` (the empty-base path returns
+// before reading window.location, so a stub is enough).
+describe('buildPortalApiUrl (client, PUBLIC_API_URL unset)', () => {
+  beforeAll(() => {
+    (globalThis as unknown as { window?: unknown }).window = {
+      location: { origin: 'http://localhost', hostname: 'localhost' }
+    };
+  });
+  afterAll(() => {
+    delete (globalThis as unknown as { window?: unknown }).window;
+  });
+
+  it('produces a same-origin relative /api/v1 path', () => {
+    expect(buildPortalApiUrl('/portal/auth/login')).toBe('/api/v1/portal/auth/login');
+  });
+
+  it('does not emit an absolute http://localhost:3001 origin', () => {
+    expect(buildPortalApiUrl('/portal/devices')).not.toMatch(/^https?:\/\//);
+  });
+
+  it('rewrites a leading /api/ to the versioned /api/v1 prefix', () => {
+    expect(buildPortalApiUrl('/api/portal/branding/x')).toBe('/api/v1/portal/branding/x');
+  });
+
+  it('passes absolute URLs through untouched', () => {
+    expect(buildPortalApiUrl('https://files.example/x.pdf')).toBe('https://files.example/x.pdf');
+  });
+});

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -35,12 +35,21 @@ function isLoopbackHostname(hostname: string): boolean {
 }
 
 function resolveApiBase(): string {
-  if (!API_BASE) {
-    return '';
+  // Server-side (SSR): there is no window to rewrite the loopback host against,
+  // so the same-origin trick used on the client doesn't apply. The portal
+  // container reaches the API over the internal network (e.g. http://api:3001)
+  // via INTERNAL_API_URL. Fall back to PUBLIC_API_URL, then the dev default.
+  if (typeof window === 'undefined') {
+    const internal =
+      (typeof process !== 'undefined' &&
+        process.env &&
+        (process.env.INTERNAL_API_URL || process.env.PUBLIC_API_URL)) ||
+      '';
+    return (internal || API_BASE).replace(/\/+$/, '');
   }
 
-  if (typeof window === 'undefined') {
-    return API_BASE;
+  if (!API_BASE) {
+    return '';
   }
 
   try {

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -5,7 +5,12 @@
 
 import { navigateTo } from './navigation';
 
-const API_BASE = import.meta.env.PUBLIC_API_URL || 'http://localhost:3001';
+// Client API base. Empty (the default) → same-origin **relative** requests
+// (`/api/v1/...`), which the reverse proxy routes to the API under `/api/*`. This
+// is the production + full-stack-dev path and needs no per-origin configuration.
+// Set PUBLIC_API_URL to an absolute origin only for a standalone portal dev server
+// without a proxy, or a genuinely cross-origin API.
+const PUBLIC_API_BASE = import.meta.env.PUBLIC_API_URL || '';
 const CSRF_HEADER_NAME = 'x-breeze-csrf';
 const CSRF_COOKIE_NAME = 'breeze_portal_csrf_token';
 
@@ -35,25 +40,29 @@ function isLoopbackHostname(hostname: string): boolean {
 }
 
 function resolveApiBase(): string {
-  // Server-side (SSR): there is no window to rewrite the loopback host against,
-  // so the same-origin trick used on the client doesn't apply. The portal
+  // Server-side (SSR): there is no window to derive same-origin from. The portal
   // container reaches the API over the internal network (e.g. http://api:3001)
   // via INTERNAL_API_URL. Fall back to PUBLIC_API_URL, then the dev default.
   if (typeof window === 'undefined') {
-    const internal =
+    const fromEnv =
       (typeof process !== 'undefined' &&
         process.env &&
         (process.env.INTERNAL_API_URL || process.env.PUBLIC_API_URL)) ||
       '';
-    return (internal || API_BASE).replace(/\/+$/, '');
+    return (fromEnv || PUBLIC_API_BASE || 'http://localhost:3001').replace(/\/+$/, '');
   }
 
-  if (!API_BASE) {
+  // Client: empty base → same-origin relative requests (return ''). buildPortalApiUrl
+  // then produces `/api/v1/...`, which the reverse proxy routes to the API. This
+  // avoids the localhost:PORT trap (a loopback rewrite can't fix a port mismatch).
+  if (!PUBLIC_API_BASE) {
     return '';
   }
 
+  // Explicit absolute base: normalize, rewriting a loopback host to the current
+  // origin for dev convenience.
   try {
-    const parsed = new URL(API_BASE, window.location.origin);
+    const parsed = new URL(PUBLIC_API_BASE, window.location.origin);
     const windowHostname = window.location.hostname;
 
     if (isLoopbackHostname(windowHostname) && parsed.hostname !== windowHostname) {
@@ -67,7 +76,7 @@ function resolveApiBase(): string {
 
     return parsed.origin;
   } catch {
-    return API_BASE;
+    return PUBLIC_API_BASE;
   }
 }
 

--- a/apps/portal/src/lib/basePath.test.ts
+++ b/apps/portal/src/lib/basePath.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeBase, withBaseFor, stripBaseFor, withBase, stripBase, BASE_PATH } from './basePath';
+
+describe('normalizeBase', () => {
+  it.each([
+    ['/portal/', '/portal'],
+    ['/portal', '/portal'],
+    ['/c/', '/c'],
+    ['/foo/bar/', '/foo/bar'],
+    ['/', ''],
+    ['', ''],
+    [undefined, ''],
+    [null, ''],
+  ])('normalizes %j → %j', (input, expected) => {
+    expect(normalizeBase(input as string)).toBe(expected);
+  });
+});
+
+describe('withBaseFor (base = /portal)', () => {
+  const base = '/portal';
+
+  it('prefixes an app-relative path', () => {
+    expect(withBaseFor(base, '/login')).toBe('/portal/login');
+  });
+
+  it('is idempotent on an already-based path', () => {
+    expect(withBaseFor(base, '/portal/login')).toBe('/portal/login');
+  });
+
+  it('treats the bare base as already-based', () => {
+    expect(withBaseFor(base, '/portal')).toBe('/portal');
+  });
+
+  it('does NOT treat a path that merely shares the base prefix as based', () => {
+    // boundary: "/portalish" must be prefixed, not mistaken for "/portal"
+    expect(withBaseFor(base, '/portalish')).toBe('/portal/portalish');
+    expect(withBaseFor(base, '/console')).toBe('/portal/console');
+  });
+
+  it('adds a leading slash to relative input', () => {
+    expect(withBaseFor(base, 'login')).toBe('/portal/login');
+  });
+
+  it('returns the base root for empty input', () => {
+    expect(withBaseFor(base, '')).toBe('/portal');
+  });
+
+  it('passes external URLs and anchors through untouched', () => {
+    for (const ext of ['https://x.com/a', 'http://x.com', 'mailto:a@b.com', 'tel:+15551234567', '//cdn.example/x', '#section']) {
+      expect(withBaseFor(base, ext)).toBe(ext);
+    }
+  });
+});
+
+describe('withBaseFor (base = "" / root deploy)', () => {
+  it('is a no-op for app paths', () => {
+    expect(withBaseFor('', '/login')).toBe('/login');
+  });
+  it('returns "/" for empty input', () => {
+    expect(withBaseFor('', '')).toBe('/');
+  });
+});
+
+describe('stripBaseFor (base = /portal)', () => {
+  const base = '/portal';
+
+  it.each([
+    ['/portal/login', '/login'],
+    ['/portal/tickets/123', '/tickets/123'],
+    ['/portal', '/'],
+    ['/portal/', '/'],
+    ['/login', '/login'], // already de-based / absent → no-op
+    ['/portalish', '/portalish'], // boundary: shared prefix is not the base
+  ])('strips %j → %j', (input, expected) => {
+    expect(stripBaseFor(base, input)).toBe(expected);
+  });
+});
+
+describe('stripBaseFor (base = "" / root deploy)', () => {
+  it('returns the pathname unchanged', () => {
+    expect(stripBaseFor('', '/login')).toBe('/login');
+    expect(stripBaseFor('', '/')).toBe('/');
+  });
+});
+
+describe('round-trip', () => {
+  it('stripBaseFor ∘ withBaseFor === identity for app paths', () => {
+    const base = '/portal';
+    for (const p of ['/login', '/tickets/123', '/invoices', '/profile']) {
+      expect(stripBaseFor(base, withBaseFor(base, p))).toBe(p);
+    }
+  });
+});
+
+describe('bound exports honor the build-time BASE_PATH', () => {
+  it('withBase/stripBase use BASE_PATH and are mutually consistent', () => {
+    // BASE_PATH is whatever the test build injected (root "" under vitest).
+    expect(withBase('/login')).toBe(withBaseFor(BASE_PATH, '/login'));
+    expect(stripBase('/login')).toBe(stripBaseFor(BASE_PATH, '/login'));
+    // Round-trips regardless of the configured base.
+    expect(stripBase(withBase('/devices'))).toBe('/devices');
+  });
+});

--- a/apps/portal/src/lib/basePath.test.ts
+++ b/apps/portal/src/lib/basePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeBase, withBaseFor, stripBaseFor, withBase, stripBase, BASE_PATH } from './basePath';
+import { normalizeBase, withBaseFor, stripBaseFor, isOutsideBaseFor, withBase, stripBase, isOutsideBase, BASE_PATH } from './basePath';
 
 describe('normalizeBase', () => {
   it.each([
@@ -83,6 +83,33 @@ describe('stripBaseFor (base = "" / root deploy)', () => {
   });
 });
 
+describe('isOutsideBaseFor (base = /portal)', () => {
+  const base = '/portal';
+
+  it.each([
+    ['/portal', false], // the bare base is in-base
+    ['/portal/', false],
+    ['/portal/login', false],
+    ['/portal/quotes/123', false],
+    ['/portal/_astro/app.js', false],
+    ['/login', true], // web owns the un-based root — portal must 404 it
+    ['/', true],
+    ['/quotes', true],
+    ['/api/v1/portal/auth/login', true], // API is same-origin via Caddy, never the portal
+    ['/portalish', true], // boundary: shared prefix is NOT the base
+  ])('%j → outside=%s', (pathname, expected) => {
+    expect(isOutsideBaseFor(base, pathname as string)).toBe(expected);
+  });
+});
+
+describe('isOutsideBaseFor (base = "" / root deploy)', () => {
+  it('is never outside the base when the portal owns the root', () => {
+    for (const p of ['/', '/login', '/anything']) {
+      expect(isOutsideBaseFor('', p)).toBe(false);
+    }
+  });
+});
+
 describe('round-trip', () => {
   it('stripBaseFor ∘ withBaseFor === identity for app paths', () => {
     const base = '/portal';
@@ -99,5 +126,6 @@ describe('bound exports honor the build-time BASE_PATH', () => {
     expect(stripBase('/login')).toBe(stripBaseFor(BASE_PATH, '/login'));
     // Round-trips regardless of the configured base.
     expect(stripBase(withBase('/devices'))).toBe('/devices');
+    expect(isOutsideBase('/login')).toBe(isOutsideBaseFor(BASE_PATH, '/login'));
   });
 });

--- a/apps/portal/src/lib/basePath.ts
+++ b/apps/portal/src/lib/basePath.ts
@@ -1,7 +1,7 @@
 /**
  * Base-path helpers for the customer portal.
  *
- * The portal is served under a configurable base path (default `/c`, set via
+ * The portal is served under a configurable base path (default `/portal`, set via
  * `PORTAL_BASE_PATH` at build time — see astro.config.mjs). Astro automatically
  * prefixes the base onto bundled assets and its own routing, but it does NOT
  * rewrite hand-authored `href`/redirect/`window.location` strings. Route every
@@ -11,19 +11,24 @@
  *
  * NB: API calls go through `buildPortalApiUrl()` in lib/api.ts and are served
  * same-origin under `/api/v1/...` (NOT under the base) — do not pass those here.
+ *
+ * The pure `*For(base, ...)` variants take the base explicitly and carry all the
+ * logic; the default exports bind them to the build-time `BASE_PATH`. Tests use
+ * the `*For` variants to cover every base (incl. root) without env stubbing.
  */
 
-// Astro/Vite injects import.meta.env.BASE_URL from the `base` config (e.g. "/c/").
+// Astro/Vite injects import.meta.env.BASE_URL from the `base` config (e.g. "/portal/").
 const RAW_BASE = (import.meta.env.BASE_URL as string | undefined) ?? '/';
 
-/** Normalized base path: leading slash, no trailing slash. Empty string at root. */
-export const BASE_PATH = normalizeBase(RAW_BASE);
-
-function normalizeBase(base: string): string {
+/** Normalize a base to: leading slash, no trailing slash. Empty string at root. */
+export function normalizeBase(base: string | undefined | null): string {
   if (!base || base === '/') return '';
   const withLeading = base.startsWith('/') ? base : `/${base}`;
   return withLeading.replace(/\/+$/, '');
 }
+
+/** Normalized base path the portal is served under (e.g. "/portal", or "" at root). */
+export const BASE_PATH = normalizeBase(RAW_BASE);
 
 function isExternal(path: string): boolean {
   return (
@@ -33,29 +38,45 @@ function isExternal(path: string): boolean {
   );
 }
 
+/** Prefix an app-internal absolute path with an explicit base. See `withBase`. */
+export function withBaseFor(base: string, path: string): string {
+  if (!path) return base || '/';
+  if (isExternal(path)) return path;
+  // Dev-only footgun guard: API calls must go through buildPortalApiUrl, not here.
+  if (import.meta.env.DEV && (path === '/api' || path.startsWith('/api/'))) {
+    // eslint-disable-next-line no-console
+    console.warn(`[basePath] withBase() received an API path "${path}" — use buildPortalApiUrl() instead.`);
+  }
+  if (!base) return path;
+
+  const clean = path.startsWith('/') ? path : `/${path}`;
+  if (clean === base || clean.startsWith(`${base}/`)) return clean;
+  return `${base}${clean}`;
+}
+
+/** Strip an explicit base from a raw pathname. See `stripBase`. */
+export function stripBaseFor(base: string, pathname: string): string {
+  if (!base) return pathname;
+  if (pathname === base) return '/';
+  if (pathname.startsWith(`${base}/`)) {
+    return pathname.slice(base.length) || '/';
+  }
+  return pathname;
+}
+
 /**
  * Prefix an app-internal absolute path (e.g. "/login") with the base path.
  * Pass-through for external URLs, mailto/tel, anchors, and already-prefixed paths.
+ * Idempotent — safe to apply at call sites without checking if a path is based.
  */
 export function withBase(path: string): string {
-  if (!path) return BASE_PATH || '/';
-  if (isExternal(path)) return path;
-  if (!BASE_PATH) return path;
-
-  const clean = path.startsWith('/') ? path : `/${path}`;
-  if (clean === BASE_PATH || clean.startsWith(`${BASE_PATH}/`)) return clean;
-  return `${BASE_PATH}${clean}`;
+  return withBaseFor(BASE_PATH, path);
 }
 
 /**
  * Strip the base path from a raw request pathname → app-relative path.
- * "/c/login" → "/login", "/c" → "/", "/c/" → "/". No-op when already de-based.
+ * "/portal/login" → "/login", "/portal" → "/", "/portal/" → "/". No-op when already de-based.
  */
 export function stripBase(pathname: string): string {
-  if (!BASE_PATH) return pathname;
-  if (pathname === BASE_PATH) return '/';
-  if (pathname.startsWith(`${BASE_PATH}/`)) {
-    return pathname.slice(BASE_PATH.length) || '/';
-  }
-  return pathname;
+  return stripBaseFor(BASE_PATH, pathname);
 }

--- a/apps/portal/src/lib/basePath.ts
+++ b/apps/portal/src/lib/basePath.ts
@@ -1,0 +1,61 @@
+/**
+ * Base-path helpers for the customer portal.
+ *
+ * The portal is served under a configurable base path (default `/c`, set via
+ * `PORTAL_BASE_PATH` at build time — see astro.config.mjs). Astro automatically
+ * prefixes the base onto bundled assets and its own routing, but it does NOT
+ * rewrite hand-authored `href`/redirect/`window.location` strings. Route every
+ * app-internal absolute path through `withBase()` so links keep working when the
+ * base changes, and use `stripBase()` when matching against the raw request
+ * pathname (which includes the base).
+ *
+ * NB: API calls go through `buildPortalApiUrl()` in lib/api.ts and are served
+ * same-origin under `/api/v1/...` (NOT under the base) — do not pass those here.
+ */
+
+// Astro/Vite injects import.meta.env.BASE_URL from the `base` config (e.g. "/c/").
+const RAW_BASE = (import.meta.env.BASE_URL as string | undefined) ?? '/';
+
+/** Normalized base path: leading slash, no trailing slash. Empty string at root. */
+export const BASE_PATH = normalizeBase(RAW_BASE);
+
+function normalizeBase(base: string): string {
+  if (!base || base === '/') return '';
+  const withLeading = base.startsWith('/') ? base : `/${base}`;
+  return withLeading.replace(/\/+$/, '');
+}
+
+function isExternal(path: string): boolean {
+  return (
+    /^[a-z][a-z0-9+.-]*:/i.test(path) || // scheme: http:, https:, mailto:, tel:, etc.
+    path.startsWith('//') ||
+    path.startsWith('#')
+  );
+}
+
+/**
+ * Prefix an app-internal absolute path (e.g. "/login") with the base path.
+ * Pass-through for external URLs, mailto/tel, anchors, and already-prefixed paths.
+ */
+export function withBase(path: string): string {
+  if (!path) return BASE_PATH || '/';
+  if (isExternal(path)) return path;
+  if (!BASE_PATH) return path;
+
+  const clean = path.startsWith('/') ? path : `/${path}`;
+  if (clean === BASE_PATH || clean.startsWith(`${BASE_PATH}/`)) return clean;
+  return `${BASE_PATH}${clean}`;
+}
+
+/**
+ * Strip the base path from a raw request pathname → app-relative path.
+ * "/c/login" → "/login", "/c" → "/", "/c/" → "/". No-op when already de-based.
+ */
+export function stripBase(pathname: string): string {
+  if (!BASE_PATH) return pathname;
+  if (pathname === BASE_PATH) return '/';
+  if (pathname.startsWith(`${BASE_PATH}/`)) {
+    return pathname.slice(BASE_PATH.length) || '/';
+  }
+  return pathname;
+}

--- a/apps/portal/src/lib/basePath.ts
+++ b/apps/portal/src/lib/basePath.ts
@@ -54,6 +54,15 @@ export function withBaseFor(base: string, path: string): string {
   return `${base}${clean}`;
 }
 
+/**
+ * True when a raw request pathname falls outside the given base. Always false at
+ * root deploy (empty base owns everything). See `isOutsideBase`.
+ */
+export function isOutsideBaseFor(base: string, pathname: string): boolean {
+  if (!base) return false;
+  return pathname !== base && !pathname.startsWith(`${base}/`);
+}
+
 /** Strip an explicit base from a raw pathname. See `stripBase`. */
 export function stripBaseFor(base: string, pathname: string): string {
   if (!base) return pathname;
@@ -79,4 +88,13 @@ export function withBase(path: string): string {
  */
 export function stripBase(pathname: string): string {
   return stripBaseFor(BASE_PATH, pathname);
+}
+
+/**
+ * True when a raw request pathname is outside the build-time base path. Used by the
+ * middleware to 404 requests the portal should never serve (the portal is mounted
+ * under BASE_PATH in prod; the root belongs to the web app). No-op at root deploy.
+ */
+export function isOutsideBase(pathname: string): boolean {
+  return isOutsideBaseFor(BASE_PATH, pathname);
 }

--- a/apps/portal/src/lib/navigation.ts
+++ b/apps/portal/src/lib/navigation.ts
@@ -1,3 +1,5 @@
+import { withBase } from './basePath';
+
 interface NavigateOptions {
   replace?: boolean;
 }
@@ -7,16 +9,21 @@ export async function navigateTo(path: string, options: NavigateOptions = {}): P
     return;
   }
 
+  // Callers pass app-relative paths (e.g. "/login"); prefix the portal base path
+  // so navigation works when served under /c. withBase is idempotent and leaves
+  // external URLs untouched.
+  const target = withBase(path);
+
   try {
     const { navigate } = await import('astro:transitions/client');
-    await navigate(path, {
+    await navigate(target, {
       history: options.replace ? 'replace' : 'auto'
     });
   } catch {
     if (options.replace) {
-      window.location.replace(path);
+      window.location.replace(target);
     } else {
-      window.location.assign(path);
+      window.location.assign(target);
     }
   }
 }

--- a/apps/portal/src/lib/navigation.ts
+++ b/apps/portal/src/lib/navigation.ts
@@ -10,7 +10,7 @@ export async function navigateTo(path: string, options: NavigateOptions = {}): P
   }
 
   // Callers pass app-relative paths (e.g. "/login"); prefix the portal base path
-  // so navigation works when served under /c. withBase is idempotent and leaves
+  // so navigation works when served under /portal. withBase is idempotent and leaves
   // external URLs untouched.
   const target = withBase(path);
 

--- a/apps/portal/src/middleware.ts
+++ b/apps/portal/src/middleware.ts
@@ -51,7 +51,7 @@ const fallbackCspDirectives = [
 ].join('; ');
 
 export const onRequest = defineMiddleware(async (context, next) => {
-  // context.url.pathname includes the configured base (e.g. /c/login); strip it
+  // context.url.pathname includes the configured base (e.g. /portal/login); strip it
   // so the route checks below stay base-agnostic, and re-apply withBase on redirect.
   const pathname = stripBase(context.url.pathname);
   const hasSession = hasPortalSessionCookie(context.request);

--- a/apps/portal/src/middleware.ts
+++ b/apps/portal/src/middleware.ts
@@ -1,6 +1,6 @@
 import { defineMiddleware } from 'astro:middleware';
 import { hasPortalSessionCookie } from './lib/session';
-import { stripBase, withBase } from './lib/basePath';
+import { isOutsideBase, stripBase, withBase } from './lib/basePath';
 
 const protectedPrefixes = ['/devices', '/tickets', '/assets', '/profile'];
 const authOnlyPaths = new Set(['/login', '/forgot-password']);
@@ -51,9 +51,20 @@ const fallbackCspDirectives = [
 ].join('; ');
 
 export const onRequest = defineMiddleware(async (context, next) => {
+  // Defense-in-depth: the portal is mounted under BASE_PATH in prod — Caddy only
+  // reverse-proxies `/portal` and `/portal/*` here (handle, not handle_path), so a
+  // request outside the base never legitimately reaches us (web owns the root).
+  // Astro's node server is base-optional in routing and would otherwise serve pages
+  // at un-based paths (e.g. /login → the portal login page); return 404 instead so
+  // the portal answers strictly within its base.
+  const rawPathname = context.url.pathname;
+  if (isOutsideBase(rawPathname)) {
+    return new Response('Not Found', { status: 404 });
+  }
+
   // context.url.pathname includes the configured base (e.g. /portal/login); strip it
   // so the route checks below stay base-agnostic, and re-apply withBase on redirect.
-  const pathname = stripBase(context.url.pathname);
+  const pathname = stripBase(rawPathname);
   const hasSession = hasPortalSessionCookie(context.request);
 
   if (pathname === '/') {

--- a/apps/portal/src/middleware.ts
+++ b/apps/portal/src/middleware.ts
@@ -1,5 +1,6 @@
 import { defineMiddleware } from 'astro:middleware';
 import { hasPortalSessionCookie } from './lib/session';
+import { stripBase, withBase } from './lib/basePath';
 
 const protectedPrefixes = ['/devices', '/tickets', '/assets', '/profile'];
 const authOnlyPaths = new Set(['/login', '/forgot-password']);
@@ -50,19 +51,21 @@ const fallbackCspDirectives = [
 ].join('; ');
 
 export const onRequest = defineMiddleware(async (context, next) => {
-  const pathname = context.url.pathname;
+  // context.url.pathname includes the configured base (e.g. /c/login); strip it
+  // so the route checks below stay base-agnostic, and re-apply withBase on redirect.
+  const pathname = stripBase(context.url.pathname);
   const hasSession = hasPortalSessionCookie(context.request);
 
   if (pathname === '/') {
-    return context.redirect(hasSession ? '/devices' : '/login', 302);
+    return context.redirect(withBase(hasSession ? '/devices' : '/login'), 302);
   }
 
   if (isProtectedPath(pathname) && !hasSession) {
-    return context.redirect('/login', 302);
+    return context.redirect(withBase('/login'), 302);
   }
 
   if (hasSession && authOnlyPaths.has(pathname)) {
-    return context.redirect('/devices', 302);
+    return context.redirect(withBase('/devices'), 302);
   }
 
   const response = await next();

--- a/apps/portal/src/pages/assets/index.astro
+++ b/apps/portal/src/pages/assets/index.astro
@@ -1,5 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
+import { withBase } from '../../lib/basePath';
 import AssetList from '../../components/portal/AssetList';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -10,7 +11,7 @@ const response = await portalApi.getAssets(
 );
 
 if (response.statusCode === 401) {
-  return Astro.redirect('/login');
+  return Astro.redirect(withBase('/login'));
 }
 ---
 

--- a/apps/portal/src/pages/devices/index.astro
+++ b/apps/portal/src/pages/devices/index.astro
@@ -1,5 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
+import { withBase } from '../../lib/basePath';
 import DeviceList from '../../components/portal/DeviceList';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -10,7 +11,7 @@ const response = await portalApi.getDevices(
 );
 
 if (response.statusCode === 401) {
-  return Astro.redirect('/login');
+  return Astro.redirect(withBase('/login'));
 }
 ---
 

--- a/apps/portal/src/pages/index.astro
+++ b/apps/portal/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { hasPortalSessionCookie } from '../lib/session';
+import { withBase } from '../lib/basePath';
 
 const target = hasPortalSessionCookie(Astro.request) ? '/devices' : '/login';
-return Astro.redirect(target, 302);
+return Astro.redirect(withBase(target), 302);
 ---

--- a/apps/portal/src/pages/invoices/[id].astro
+++ b/apps/portal/src/pages/invoices/[id].astro
@@ -1,5 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
+import { withBase } from '../../lib/basePath';
 import InvoiceDetailView from '../../components/portal/InvoiceDetailView';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -8,7 +9,7 @@ const { id } = Astro.params;
 const response = await portalApi.getInvoice(id!, buildServerApiConfig(Astro.request));
 
 if (response.statusCode === 401) {
-  return Astro.redirect('/login');
+  return Astro.redirect(withBase('/login'));
 }
 ---
 

--- a/apps/portal/src/pages/invoices/index.astro
+++ b/apps/portal/src/pages/invoices/index.astro
@@ -1,5 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
+import { withBase } from '../../lib/basePath';
 import InvoiceList from '../../components/portal/InvoiceList';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -10,7 +11,7 @@ const response = await portalApi.getInvoices(
 );
 
 if (response.statusCode === 401) {
-  return Astro.redirect('/login');
+  return Astro.redirect(withBase('/login'));
 }
 ---
 

--- a/apps/portal/src/pages/tickets/[id].astro
+++ b/apps/portal/src/pages/tickets/[id].astro
@@ -1,5 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
+import { withBase } from '../../lib/basePath';
 import TicketDetails from '../../components/portal/TicketDetails';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -8,7 +9,7 @@ const { id } = Astro.params;
 const response = await portalApi.getTicket(id!, buildServerApiConfig(Astro.request));
 
 if (response.statusCode === 401) {
-  return Astro.redirect('/login');
+  return Astro.redirect(withBase('/login'));
 }
 ---
 

--- a/apps/portal/src/pages/tickets/index.astro
+++ b/apps/portal/src/pages/tickets/index.astro
@@ -1,5 +1,6 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
+import { withBase } from '../../lib/basePath';
 import TicketList from '../../components/portal/TicketList';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -10,7 +11,7 @@ const response = await portalApi.getTickets(
 );
 
 if (response.statusCode === 401) {
-  return Astro.redirect('/login');
+  return Astro.redirect(withBase('/login'));
 }
 ---
 

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+    passWithNoTests: true
+  }
+});

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -26,6 +26,7 @@ BREEZE_VERSION=0.0.0
 # and copy the digest of the tag you want to deploy.
 BREEZE_API_IMAGE_DIGEST=sha256:replace-with-release-api-image-digest
 BREEZE_WEB_IMAGE_DIGEST=sha256:replace-with-release-web-image-digest
+BREEZE_PORTAL_IMAGE_DIGEST=sha256:replace-with-release-portal-image-digest
 BREEZE_BINARIES_IMAGE_DIGEST=sha256:replace-with-release-binaries-image-digest
 
 # Third-party runtime images must also be digest pinned. Obtain via:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -38,6 +38,8 @@ services:
     depends_on:
       web:
         condition: service_healthy
+      portal:
+        condition: service_healthy
       api:
         condition: service_healthy
     healthcheck:
@@ -87,6 +89,9 @@ services:
       PUBLIC_APP_URL: https://${BREEZE_DOMAIN}
       DASHBOARD_URL: https://${BREEZE_DOMAIN}
       PUBLIC_API_URL: https://${BREEZE_DOMAIN}
+      # Customer-portal origin for emailed links (quotes, invoices). Portal is
+      # served under /c on the main domain.
+      PUBLIC_PORTAL_URL: ${PUBLIC_PORTAL_URL:-https://${BREEZE_DOMAIN}/c}
       API_URL: ${API_URL:-}
       FORCE_HTTPS: ${FORCE_HTTPS:-true}
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY:?Set APP_ENCRYPTION_KEY in .env}
@@ -177,6 +182,31 @@ services:
     healthcheck:
       <<: *healthcheck
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:4321/']
+      start_period: 30s
+    networks:
+      - breeze
+
+  portal:
+    image: ghcr.io/lanternops/breeze/portal@${BREEZE_PORTAL_IMAGE_DIGEST:?Set BREEZE_PORTAL_IMAGE_DIGEST to the release image digest}
+    platform: linux/amd64
+    container_name: breeze-portal
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 4322
+      PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/c}
+      # Same-origin API access via the /api/* Caddy route — no absolute URL needed.
+      PUBLIC_API_URL: ""
+      PUBLIC_SENTRY_DSN_WEB: ${PUBLIC_SENTRY_DSN_WEB:-}
+      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-production}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      <<: *healthcheck
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/c}/login"']
       start_period: 30s
     networks:
       - breeze

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -90,8 +90,8 @@ services:
       DASHBOARD_URL: https://${BREEZE_DOMAIN}
       PUBLIC_API_URL: https://${BREEZE_DOMAIN}
       # Customer-portal origin for emailed links (quotes, invoices). Portal is
-      # served under /c on the main domain.
-      PUBLIC_PORTAL_URL: ${PUBLIC_PORTAL_URL:-https://${BREEZE_DOMAIN}/c}
+      # served under /portal on the main domain.
+      PUBLIC_PORTAL_URL: ${PUBLIC_PORTAL_URL:-https://${BREEZE_DOMAIN}/portal}
       API_URL: ${API_URL:-}
       FORCE_HTTPS: ${FORCE_HTTPS:-true}
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY:?Set APP_ENCRYPTION_KEY in .env}
@@ -195,9 +195,12 @@ services:
       NODE_ENV: production
       HOST: 0.0.0.0
       PORT: 4322
-      PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/c}
-      # Same-origin API access via the /api/* Caddy route — no absolute URL needed.
+      PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/portal}
+      # Browser calls the API same-origin via the /api/* Caddy route, so the
+      # public (client) base stays empty. SSR has no window to derive same-origin,
+      # so it reaches the API over the internal network.
       PUBLIC_API_URL: ""
+      INTERNAL_API_URL: ${INTERNAL_API_URL:-http://api:3001}
       PUBLIC_SENTRY_DSN_WEB: ${PUBLIC_SENTRY_DSN_WEB:-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-production}
       SENTRY_RELEASE: ${SENTRY_RELEASE:-}
@@ -206,7 +209,7 @@ services:
         condition: service_healthy
     healthcheck:
       <<: *healthcheck
-      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/c}/login"']
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/portal}/login"']
       start_period: 30s
     networks:
       - breeze

--- a/docker-compose.override.yml.ci
+++ b/docker-compose.override.yml.ci
@@ -30,7 +30,7 @@ services:
       context: .
       dockerfile: apps/portal/Dockerfile
       args:
-        PORTAL_BASE_PATH: /c
+        PORTAL_BASE_PATH: /portal
         PUBLIC_API_URL: ""
     ports:
       - '4322:4322'

--- a/docker-compose.override.yml.ci
+++ b/docker-compose.override.yml.ci
@@ -25,6 +25,16 @@ services:
     ports:
       - '4321:4321'
 
+  portal:
+    build:
+      context: .
+      dockerfile: apps/portal/Dockerfile
+      args:
+        PORTAL_BASE_PATH: /c
+        PUBLIC_API_URL: ""
+    ports:
+      - '4322:4322'
+
   # Expose DB and Redis to host for integration tests
   postgres:
     ports:

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -128,9 +128,9 @@ services:
       NODE_ENV: development
       HOST: 0.0.0.0
       PORT: 4322
-      PORTAL_BASE_PATH: /c
+      PORTAL_BASE_PATH: /portal
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:4322/c/login']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:4322/portal/login']
       start_period: 60s
 
   coturn:

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -105,6 +105,34 @@ services:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:4321/']
       start_period: 60s
 
+  portal:
+    image: breeze-portal:dev
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.portal.dev
+    ports:
+      - '4322:4322'
+    volumes:
+      # Mount source code for hot-reloading
+      - ./apps/portal/src:/app/apps/portal/src:cached
+      - ./apps/portal/public:/app/apps/portal/public:cached
+      # Mount config files
+      - ./apps/portal/package.json:/app/apps/portal/package.json:ro
+      - ./apps/portal/tsconfig.json:/app/apps/portal/tsconfig.json:ro
+      - ./apps/portal/astro.config.mjs:/app/apps/portal/astro.config.mjs:ro
+      - ./apps/portal/tailwind.config.mjs:/app/apps/portal/tailwind.config.mjs:ro
+      # Exclude node_modules (use container's)
+      - /app/node_modules
+      - /app/apps/portal/node_modules
+    environment:
+      NODE_ENV: development
+      HOST: 0.0.0.0
+      PORT: 4322
+      PORTAL_BASE_PATH: /c
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:4322/c/login']
+      start_period: 60s
+
   coturn:
     image: coturn/coturn:4-alpine
     container_name: breeze-coturn-dev

--- a/docker-compose.override.yml.ghcr
+++ b/docker-compose.override.yml.ghcr
@@ -6,6 +6,9 @@ services:
   web:
     platform: linux/amd64
 
+  portal:
+    platform: linux/amd64
+
   api:
     environment:
       ENROLLMENT_KEY_PEPPER: ${ENROLLMENT_KEY_PEPPER:?Set ENROLLMENT_KEY_PEPPER in .env}

--- a/docker-compose.override.yml.local-build
+++ b/docker-compose.override.yml.local-build
@@ -48,10 +48,10 @@ services:
       context: .
       dockerfile: apps/portal/Dockerfile
       args:
-        PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/c}
+        PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/portal}
         PUBLIC_API_URL: ""
     healthcheck:
-      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/c}/login"']
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/portal}/login"']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.override.yml.local-build
+++ b/docker-compose.override.yml.local-build
@@ -40,3 +40,19 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  portal:
+    image: breeze-portal:local
+    platform: linux/arm64
+    build:
+      context: .
+      dockerfile: apps/portal/Dockerfile
+      args:
+        PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/c}
+        PUBLIC_API_URL: ""
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/c}/login"']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,8 @@ services:
       DASHBOARD_URL: ${DASHBOARD_URL:-https://${BREEZE_DOMAIN}}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-https://${BREEZE_DOMAIN}}
       # Public origin for customer-portal links (e.g. quote accept emails). The
-      # portal is served under /c on the main domain; falls back to PUBLIC_APP_URL.
-      PUBLIC_PORTAL_URL: ${PUBLIC_PORTAL_URL:-https://${BREEZE_DOMAIN}/c}
+      # portal is served under /portal on the main domain; falls back to PUBLIC_APP_URL.
+      PUBLIC_PORTAL_URL: ${PUBLIC_PORTAL_URL:-https://${BREEZE_DOMAIN}/portal}
       API_URL: ${API_URL:-}
       FORCE_HTTPS: ${FORCE_HTTPS:-true}
       TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
@@ -200,7 +200,7 @@ services:
     networks:
       - breeze
 
-  # Customer portal (Astro SSR). Served under /c on the main domain via the
+  # Customer portal (Astro SSR). Served under /portal on the main domain via the
   # Caddy carve-out — calls the API same-origin (/api/v1/...), so PUBLIC_API_URL
   # stays empty. PORTAL_BASE_PATH is baked at build time; keep it in sync with
   # the Caddyfile carve-out and the image build-arg.
@@ -213,8 +213,12 @@ services:
       NODE_ENV: production
       HOST: 0.0.0.0
       PORT: 4322
-      PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/c}
+      PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/portal}
+      # Browser calls the API same-origin via the /api/* Caddy route, so the
+      # public (client) base stays empty. Server-side rendering has no window to
+      # derive same-origin from, so it reaches the API over the internal network.
       PUBLIC_API_URL: ${PUBLIC_API_URL:-}
+      INTERNAL_API_URL: ${INTERNAL_API_URL:-http://api:3001}
       PUBLIC_SENTRY_DSN_WEB: ${PUBLIC_SENTRY_DSN_WEB:-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-production}
       SENTRY_RELEASE: ${SENTRY_RELEASE:-}
@@ -223,7 +227,7 @@ services:
         condition: service_healthy
     healthcheck:
       <<: *healthcheck
-      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/c}/login"']
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/portal}/login"']
       start_period: 30s
     networks:
       - breeze

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     depends_on:
       web:
         condition: service_healthy
+      portal:
+        condition: service_healthy
       api:
         condition: service_healthy
     healthcheck:
@@ -88,6 +90,9 @@ services:
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-https://${BREEZE_DOMAIN}}
       DASHBOARD_URL: ${DASHBOARD_URL:-https://${BREEZE_DOMAIN}}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-https://${BREEZE_DOMAIN}}
+      # Public origin for customer-portal links (e.g. quote accept emails). The
+      # portal is served under /c on the main domain; falls back to PUBLIC_APP_URL.
+      PUBLIC_PORTAL_URL: ${PUBLIC_PORTAL_URL:-https://${BREEZE_DOMAIN}/c}
       API_URL: ${API_URL:-}
       FORCE_HTTPS: ${FORCE_HTTPS:-true}
       TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
@@ -191,6 +196,34 @@ services:
     healthcheck:
       <<: *healthcheck
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:4321/']
+      start_period: 30s
+    networks:
+      - breeze
+
+  # Customer portal (Astro SSR). Served under /c on the main domain via the
+  # Caddy carve-out — calls the API same-origin (/api/v1/...), so PUBLIC_API_URL
+  # stays empty. PORTAL_BASE_PATH is baked at build time; keep it in sync with
+  # the Caddyfile carve-out and the image build-arg.
+  portal:
+    image: ${BREEZE_PORTAL_IMAGE_REF:?Set BREEZE_PORTAL_IMAGE_REF to a digest-pinned image ref}
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    container_name: breeze-portal
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 4322
+      PORTAL_BASE_PATH: ${PORTAL_BASE_PATH:-/c}
+      PUBLIC_API_URL: ${PUBLIC_API_URL:-}
+      PUBLIC_SENTRY_DSN_WEB: ${PUBLIC_SENTRY_DSN_WEB:-}
+      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-production}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      <<: *healthcheck
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider "http://127.0.0.1:4322${PORTAL_BASE_PATH:-/c}/login"']
       start_period: 30s
     networks:
       - breeze

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -119,6 +119,17 @@
     reverse_proxy billing:3002
   }
 
+  # --- Customer portal (Astro SSR) under /c ---
+  # Served on the main domain under a base path so it needs no dedicated
+  # hostname/cert. The portal app emits /c-prefixed URLs (Astro `base`), so we
+  # keep the prefix (handle, not handle_path). Must come BEFORE the web catch-all.
+  # API calls stay on the /api/* block above (same-origin → no CORS).
+  @portal path /c /c/*
+  handle @portal {
+    encode zstd gzip
+    reverse_proxy portal:4322
+  }
+
   # --- Web frontend (catch-all, with compression) ---
   handle {
     encode zstd gzip

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -119,12 +119,12 @@
     reverse_proxy billing:3002
   }
 
-  # --- Customer portal (Astro SSR) under /c ---
+  # --- Customer portal (Astro SSR) under /portal ---
   # Served on the main domain under a base path so it needs no dedicated
-  # hostname/cert. The portal app emits /c-prefixed URLs (Astro `base`), so we
+  # hostname/cert. The portal app emits /portal-prefixed URLs (Astro `base`), so we
   # keep the prefix (handle, not handle_path). Must come BEFORE the web catch-all.
   # API calls stay on the /api/* block above (same-origin → no CORS).
-  @portal path /c /c/*
+  @portal path /portal /portal/*
   handle @portal {
     encode zstd gzip
     reverse_proxy portal:4322

--- a/docker/Dockerfile.portal.dev
+++ b/docker/Dockerfile.portal.dev
@@ -1,0 +1,33 @@
+# Development Dockerfile for the Customer Portal with hot-reloading
+FROM node:24-alpine
+
+# Install pnpm (pinned to match prod / packageManager field)
+RUN npm install -g pnpm@10.33.4
+
+# Set working directory
+WORKDIR /app
+
+# Copy workspace configuration
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY turbo.json tsconfig.json ./
+
+# Copy package.json for dependency installation (portal has no workspace deps)
+COPY apps/portal/package.json ./apps/portal/
+
+# Install all dependencies (including devDependencies for development)
+RUN pnpm install
+
+# Copy source code (will be overridden by volume mounts in dev)
+COPY apps/portal ./apps/portal
+
+# Set working directory to portal
+WORKDIR /app/apps/portal
+
+# Base path the dev server serves under (matches the Caddy carve-out).
+ENV PORTAL_BASE_PATH=/c
+
+# Expose port
+EXPOSE 4322
+
+# Sync dependencies on container start so package.json changes don't break hot-reload.
+CMD ["sh", "-lc", "pnpm install --prefer-offline --no-frozen-lockfile && pnpm dev --host 0.0.0.0"]

--- a/docker/Dockerfile.portal.dev
+++ b/docker/Dockerfile.portal.dev
@@ -24,7 +24,7 @@ COPY apps/portal ./apps/portal
 WORKDIR /app/apps/portal
 
 # Base path the dev server serves under (matches the Caddy carve-out).
-ENV PORTAL_BASE_PATH=/c
+ENV PORTAL_BASE_PATH=/portal
 
 # Expose port
 EXPOSE 4322

--- a/docs/DEPLOY_PRODUCTION.md
+++ b/docs/DEPLOY_PRODUCTION.md
@@ -64,7 +64,7 @@ Set at least these values in `.env.prod`:
 ```bash
 # Replace 0.67.1 with the release you intend to deploy.
 TAG=0.67.1
-for img in api web binaries; do
+for img in api web portal binaries; do
   digest=$(docker buildx imagetools inspect "ghcr.io/lanternops/breeze/$img:$TAG" \
     --format '{{json .Manifest}}' | jq -r .digest)
   echo "BREEZE_${img^^}_IMAGE_DIGEST=$digest"
@@ -103,6 +103,7 @@ What the script does:
 
 - App: `https://<BREEZE_DOMAIN>/health`
 - API through edge: `https://<BREEZE_DOMAIN>/api/v1/alerts` (auth required)
+- Customer portal: `https://<BREEZE_DOMAIN>/c/login` (renders the portal login)
 - Grafana (local bind): `http://127.0.0.1:${GRAFANA_PORT:-3000}`
 - Prometheus (local bind): `http://127.0.0.1:${PROMETHEUS_PORT:-9090}`
 
@@ -118,3 +119,17 @@ You can also run:
 - Public ingress is only through Caddy on `80/443`.
 - In Cloudflare Tunnel mode, Caddy trusts client-IP headers only from the configured `BREEZE_CLOUDFLARED_IP`, and the API trusts forwarded headers only from `BREEZE_CADDY_IP`. Keep `CADDY_TRUSTED_PROXIES` and `TRUSTED_PROXY_CIDRS` pinned to exact proxy hops, not broad private ranges.
 - Container resource limits, restart policies, and no-new-privileges are configured in prod compose.
+- **Customer portal (`apps/portal`)** runs as its own `portal` service and is served under the
+  `/c` path prefix on the main domain — no dedicated hostname, DNS record, or TLS cert is required.
+  Caddy routes `/c/*` to `portal:4322` (ahead of the web catch-all); the portal calls the API
+  same-origin via `/api/*`, so there is no CORS surface. The base path is baked into the portal
+  image at build time (`PORTAL_BASE_PATH`, default `/c`) — changing it requires an image rebuild,
+  and the Caddyfile carve-out + `PUBLIC_PORTAL_URL` must stay in sync. `PUBLIC_PORTAL_URL`
+  (default `https://<BREEZE_DOMAIN>/c`) is what the API uses to mint customer-facing links
+  (e.g. quote acceptance emails). Per-org custom portal domains are not served yet.
+- **Manual droplet rollout note:** a `BREEZE_VERSION` bump only swaps the `api`/`web` images. To
+  light up the portal on an existing droplet you must also: add `BREEZE_PORTAL_IMAGE_REF` (or
+  `BREEZE_PORTAL_IMAGE_DIGEST` for the digest-pinned prod compose) and `PUBLIC_PORTAL_URL` to
+  `/opt/breeze/.env`, ensure the `portal` service + the `/c` carve-out are present in the deployed
+  `docker-compose.yml`/`Caddyfile.prod`, then `docker compose up -d portal && docker compose
+  restart caddy`.

--- a/docs/DEPLOY_PRODUCTION.md
+++ b/docs/DEPLOY_PRODUCTION.md
@@ -103,7 +103,7 @@ What the script does:
 
 - App: `https://<BREEZE_DOMAIN>/health`
 - API through edge: `https://<BREEZE_DOMAIN>/api/v1/alerts` (auth required)
-- Customer portal: `https://<BREEZE_DOMAIN>/c/login` (renders the portal login)
+- Customer portal: `https://<BREEZE_DOMAIN>/portal/login` (renders the portal login)
 - Grafana (local bind): `http://127.0.0.1:${GRAFANA_PORT:-3000}`
 - Prometheus (local bind): `http://127.0.0.1:${PROMETHEUS_PORT:-9090}`
 
@@ -120,16 +120,16 @@ You can also run:
 - In Cloudflare Tunnel mode, Caddy trusts client-IP headers only from the configured `BREEZE_CLOUDFLARED_IP`, and the API trusts forwarded headers only from `BREEZE_CADDY_IP`. Keep `CADDY_TRUSTED_PROXIES` and `TRUSTED_PROXY_CIDRS` pinned to exact proxy hops, not broad private ranges.
 - Container resource limits, restart policies, and no-new-privileges are configured in prod compose.
 - **Customer portal (`apps/portal`)** runs as its own `portal` service and is served under the
-  `/c` path prefix on the main domain — no dedicated hostname, DNS record, or TLS cert is required.
-  Caddy routes `/c/*` to `portal:4322` (ahead of the web catch-all); the portal calls the API
+  `/portal` path prefix on the main domain — no dedicated hostname, DNS record, or TLS cert is required.
+  Caddy routes `/portal/*` to `portal:4322` (ahead of the web catch-all); the portal calls the API
   same-origin via `/api/*`, so there is no CORS surface. The base path is baked into the portal
-  image at build time (`PORTAL_BASE_PATH`, default `/c`) — changing it requires an image rebuild,
+  image at build time (`PORTAL_BASE_PATH`, default `/portal`) — changing it requires an image rebuild,
   and the Caddyfile carve-out + `PUBLIC_PORTAL_URL` must stay in sync. `PUBLIC_PORTAL_URL`
-  (default `https://<BREEZE_DOMAIN>/c`) is what the API uses to mint customer-facing links
+  (default `https://<BREEZE_DOMAIN>/portal`) is what the API uses to mint customer-facing links
   (e.g. quote acceptance emails). Per-org custom portal domains are not served yet.
 - **Manual droplet rollout note:** a `BREEZE_VERSION` bump only swaps the `api`/`web` images. To
   light up the portal on an existing droplet you must also: add `BREEZE_PORTAL_IMAGE_REF` (or
   `BREEZE_PORTAL_IMAGE_DIGEST` for the digest-pinned prod compose) and `PUBLIC_PORTAL_URL` to
-  `/opt/breeze/.env`, ensure the `portal` service + the `/c` carve-out are present in the deployed
+  `/opt/breeze/.env`, ensure the `portal` service + the `/portal` carve-out are present in the deployed
   `docker-compose.yml`/`Caddyfile.prod`, then `docker compose up -d portal && docker compose
   restart caddy`.

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -4,6 +4,30 @@ Tracking file for post-implementation feature verification results. Entries are 
 
 Use the `feature-testing` skill to run structured verification and record results here.
 
+## Customer Portal deploy under `/portal` (PR #1474) — local Docker + Playwright — 2026-06-17
+
+**Branch:** `feat/portal-deploy-c-prefix`
+**Stack:** full local Docker (`-p breeze`, dev override + prod portal image) behind Caddy on `http://localhost`; API reachable via Caddy `/api/*` → `api:3001`.
+**Tested by:** Claude
+**Result:** PASS (after fixing one blocker found during testing)
+
+### What was tested (Playwright MCP, http://localhost)
+- [x] `/portal/login` renders through Caddy (200), prod assets under `/portal/_astro/*`, favicon `/portal/favicon.svg`.
+- [x] React island hydrates — login form interactive; "Forgot your password?" → `/portal/forgot-password` (`withBase` correct in-browser).
+- [x] Clean console on fresh prod load (0 errors/0 warnings); prod CSP header carries Astro script/style hashes.
+- [x] Login submit → **same-origin** `POST http://localhost/api/v1/portal/auth/login` → `401` for bad creds (no CSP block, no `localhost:3001`); UI shows "Invalid email or password".
+- [x] Unauth deep-link `/portal/devices` → middleware redirects to `/portal/login` (base-aware redirect in-browser).
+- [x] Web dashboard `/` unaffected (200); `/login` (un-based) served by web, not portal.
+- [x] SSR reaches the API over the internal network (`INTERNAL_API_URL=http://api:3001`) — verified separately via a stub-API container (authed `/portal/devices` → 200, API hit on `api:3001`).
+
+### Issues found & fixed during testing
+- **BLOCKER (fixed):** client API base resolved to `http://localhost:3001` when `PUBLIC_API_URL` empty — the `|| 'http://localhost:3001'` default plus a loopback rewrite that can't fix a port mismatch. Login was CSP-blocked. Fixed in `apps/portal/src/lib/api.ts`: empty `PUBLIC_API_URL` → **same-origin relative** (`/api/v1/...`) on the client; SSR uses `INTERNAL_API_URL`. Added `api.test.ts` regression guard.
+- **False alarm:** initial run showed inline-CSP + `/node_modules/.vite` errors — these were dev-server contamination in the browser session from earlier timed-out astro-dev navigations, not the prod portal (confirmed clean on a fresh load).
+
+### Notes
+- astro **dev** server + Caddy hung Playwright on `domcontentloaded` (on-demand vite compile). Swapped to the **prod** portal image behind Caddy for reliable, representative E2E.
+- Full authenticated portal session → live SSR data pages not exercised in-browser (no seeded `portal_users` row; web admin UI to create one is blocked by an unrelated pre-existing web dev-container `zod` resolution error). SSR-reaches-API is covered by the stub-container test.
+
 ## Breeze AI for Office (PR #1314) — Tier B in-Excel SSO + session loop — 2026-06-13
 
 **Branch:** `feat/ai-for-office` @ `4d1a3ab6` (worktree `breeze-ai4office`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,6 +575,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/powerpoint-addin:
     dependencies:

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -1018,6 +1018,18 @@
       ]
     },
     {
+      "pattern": "apps/portal/**",
+      "docs": [
+        "features/portal.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/portal/Dockerfile",
+      "docs": [
+        "deploy/production.mdx"
+      ]
+    },
+    {
       "pattern": "apps/api/src/routes/clientAi/**",
       "docs": [
         "features/ai-for-office.mdx"


### PR DESCRIPTION
## What

Wires up production serving for the customer portal (`apps/portal`), which had **no serving layer at all** — never built into an image, no compose service, not routed by Caddy. Every portal page (Phase 1 invoice pages today, the incoming Phase 2 quote-accept pages) was dormant in prod. This is the follow-up gap tracked on #1465.

Served under a **`/portal` path prefix on the main domain** — no new hostname, DNS record, or TLS cert. (`/portal` chosen over the initial `/c` because it's self-explanatory to end-users and nothing live used it — only dead `apps/web/src/components/portal/*` and a stale invoice link referenced it.) The portal is Astro SSR, so it runs as its own container; `/portal` only changes routing + makes the app base-path aware.

## How

- **Base-path aware app** — Astro `base = PORTAL_BASE_PATH` (default `/portal`) + pure helpers `withBase`/`stripBase` (`apps/portal/src/lib/basePath.ts`) threaded through every internal link, redirect, the inline logout script (`define:vars`), and active-nav check. `navigateTo()` prefixes the base centrally.
- **SSR API reachability** — the browser calls the API same-origin (`/api/*`); SSR has no window to derive that, so it uses `INTERNAL_API_URL` (default `http://api:3001`) wired onto the portal service. (Found in review — without it, authed pages errored.)
- **Containerized** — `apps/portal/Dockerfile` (prod) + `docker/Dockerfile.portal.dev`; `.dockerignore` un-ignores `apps/portal`.
- **Compose** — `portal` service (`:4322`) in `docker-compose.yml`, `deploy/docker-compose.prod.yml` (digest-pinned), and all overrides (dev/ghcr/local-build/ci). `PUBLIC_PORTAL_URL` added to the `api` service; `invoicePdf.ts` now mints invoice links at `<portal>/invoices/<id>`.
- **Caddy** — `@portal path /portal /portal/*` → `portal:4322`, before the web catch-all. No CORS (same-origin `/api/*`).
- **CI/release** — `build-portal` + `test-portal` jobs (gated in `CI Success`), a hard `/portal/login`=200 / `/login`=404 smoke assertion, `build-docker-portal` publishing `ghcr.io/lanternops/breeze/portal`, and a Trivy scan.
- **Docs/env** — `apps/docs` (production/environment/portal), `docs/DEPLOY_PRODUCTION.md`, `.env.example`, `deploy/.env.example`.

## Verification (local)

- `pnpm --filter @breeze/portal test` → 26/26 (basePath: idempotency, prefix-boundary, external passthrough, strip edge cases, root base).
- Build with `PORTAL_BASE_PATH=/portal` ✓ (assets at `/portal/_astro/...`); `astro check` 0 errors/0 warnings.
- Docker image builds → healthcheck **healthy**; authed `GET /portal/devices` → 200, **no error state**, and the API was hit over **`api:3001`** (SSR fix proven), not localhost.
- **Caddy routing proof** (real `Caddyfile.prod` + stub upstreams): `/`→web, `/portal/login`→portal, `/health`→api, `/login`→404. No shadowing.
- `docker compose config` valid for canonical + all overrides + deploy prod; `caddy validate` ✓; supply-chain hardening ✓.

## Out of scope

Per-org custom portal domains (`orgPortalSettings.customDomain`) — needs Caddy `on_demand_tls`; deferred.

## Deploy note

A `BREEZE_VERSION` bump alone won't light this up on existing droplets — the `portal` service + `/portal` carve-out + `BREEZE_PORTAL_IMAGE_REF`/`PUBLIC_PORTAL_URL` must be added to `/opt/breeze` manually (documented in `docs/DEPLOY_PRODUCTION.md`).

Refs #1465

🤖 Generated with [Claude Code](https://claude.com/claude-code)