### PR TITLE
fix(installer): pre-flight the /api version-metadata endpoint, not apex /health (#1470)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -318,10 +318,11 @@ app.use(
 
 const startedAt = Date.now();
 
-// Health check — basic liveness with version and uptime
-// NOTE: the agent install.sh connectivity pre-flight greps this body for
-// "status":"ok" (see routes/agents/download.ts) — keep that contract if
-// changing the payload, or healthy installs will report a captive portal.
+// Health check — basic liveness with version and uptime.
+// Consumed by Caddy/k8s probes and monitoring. (The agent install.sh pre-flight
+// used to grep this for "status":"ok"; it now probes /api/v1/agent-versions
+// instead — see routes/agents/download.ts #1470 — so this payload is no longer
+// coupled to the installer.)
 app.get('/health', (c) => {
   const uptimeSeconds = Math.floor((Date.now() - startedAt) / 1000);
   return c.json({

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -512,4 +512,75 @@ describe('install.sh functional pre-flight behavior', () => {
       breeze.close();
     }
   });
+
+  it('passes the pre-flight when /health 404s but /api/* is served (the #1470 reverse proxy)', async () => {
+    // The exact #1470 deployment: a reverse proxy forwards /api/* to the API but
+    // returns the web app's 404 page for apex /health. The pre-flight must not
+    // depend on /health — it must pass on the metadata endpoint alone.
+    const proxy = createServer((req, res) => {
+      if (req.url?.startsWith('/api/v1/agent-versions/latest')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ version: '1.2.3', downloadUrl: '/dl', checksum: 'a'.repeat(64) }));
+      } else if (req.url === '/health') {
+        // The bug's trigger: the web app answers apex /health with its 404 page.
+        res.writeHead(404, { 'Content-Type': 'text/html' });
+        res.end('<html><body>404</body></html>');
+      } else {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+      }
+    });
+    await new Promise<void>((resolve) => proxy.listen(0, '127.0.0.1', resolve));
+    const { port } = proxy.address() as AddressInfo;
+    try {
+      const { code, output } = await runScript(['--server', `http://127.0.0.1:${port}`, '--token', 'tok']);
+      expect(output).toContain('Breeze server is reachable');
+      expect(output).not.toContain('Cannot reach the Breeze');
+      // Proof it got past the pre-flight: it fails later at the binary download.
+      expect(code).not.toBe(0);
+      expect(output).toContain('Failed to');
+    } finally {
+      proxy.close();
+    }
+  });
+
+  it('reports an HTTP error from the metadata endpoint distinctly from no-response', async () => {
+    // A proxy that forwards /api/* to a backend that errors (or a path that 5xxs)
+    // must produce the API-specific message — not the "no response" network one.
+    const errsrv = createServer((_req, res) => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'boom' }));
+    });
+    await new Promise<void>((resolve) => errsrv.listen(0, '127.0.0.1', resolve));
+    const { port } = errsrv.address() as AddressInfo;
+    try {
+      const { code, output } = await runScript(['--server', `http://127.0.0.1:${port}`, '--token', 'tok']);
+      expect(code).not.toBe(0);
+      expect(output).toContain('Cannot reach the Breeze API');
+      expect(output).toContain('(HTTP 500)');
+      expect(output).not.toContain('no response');
+    } finally {
+      errsrv.close();
+    }
+  });
+
+  it('rejects a non-Breeze 200 responder that lacks the version field', async () => {
+    // A proxy/auth-gateway answering the probe with 200 + non-HTML JSON that
+    // isn't Breeze metadata must not be reported as "reachable" (the negative
+    // not-HTML guard alone would pass it; the positive version check catches it).
+    const wrong = createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'blocked' }));
+    });
+    await new Promise<void>((resolve) => wrong.listen(0, '127.0.0.1', resolve));
+    const { port } = wrong.address() as AddressInfo;
+    try {
+      const { code, output } = await runScript(['--server', `http://127.0.0.1:${port}`, '--token', 'tok']);
+      expect(code).not.toBe(0);
+      expect(output).not.toContain('Breeze server is reachable');
+      expect(output).toContain('unexpected response');
+    } finally {
+      wrong.close();
+    }
+  });
 });

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -233,10 +233,16 @@ describe('GET /install.sh — generated installer script', () => {
     expect(script).not.toContain('BREEZE_ENROLLMENT_SECRET is required');
   });
 
-  it('pre-flights server connectivity via /health before downloading anything', async () => {
+  it('pre-flights connectivity via the /api version-metadata endpoint, not apex /health', async () => {
     const script = await fetchScript();
-    expect(script).toContain('/health"');
-    expect(script).toContain('Cannot reach the Breeze server');
+    // Probes an /api/* path the install actually depends on. A reverse proxy
+    // that forwards /api/* but not bare /health must not false-abort the
+    // install (#1470), so the pre-flight must NOT hit /health.
+    expect(script).toContain('"$VERSION_METADATA_URL"');
+    expect(script).toContain('agent-versions/latest');
+    // The probe must not target apex /health (the #1470 regression).
+    expect(script).not.toContain('"$BREEZE_SERVER/health"');
+    expect(script).toContain('Cannot reach the Breeze');
   });
 
   it('diagnoses TLS failures distinctly from generic unreachability', async () => {
@@ -249,10 +255,10 @@ describe('GET /install.sh — generated installer script', () => {
 
   it('flags intercepted responses (captive portal / wrong responder) distinctly', async () => {
     const script = await fetchScript();
-    // A 200 whose body is not Breeze's health JSON almost always means an
-    // intercepting device answered (captive portal, router, web filter) —
-    // the guest-VLAN field report behind this feature. The message must say
-    // so instead of letting `installer` fail cryptically.
+    // A 200 whose body is HTML almost always means an intercepting device
+    // answered (captive portal, router, web filter) — the guest-VLAN field
+    // report behind this feature. The message must say so instead of letting
+    // `installer` fail cryptically.
     expect(script).toContain('captive portal');
   });
 
@@ -400,15 +406,15 @@ describe('install.sh functional pre-flight behavior', () => {
     }
   });
 
-  it('attributes an intercepted download to the network when /health is clean', async () => {
-    // A path-selective middlebox (web filter allowlisting /health, or a
-    // portal that whitelists short URLs) passes the pre-flight and then
-    // serves HTML where the pkg/metadata should be. The failure must still
-    // point at interception — not at Gatekeeper or "missing checksum".
+  it('attributes an intercepted binary download to the network after a clean pre-flight', async () => {
+    // A path-selective middlebox that allowlists the metadata endpoint (so the
+    // pre-flight passes) but serves HTML where the binary/pkg should be. The
+    // tampered download must still be rejected after the pre-flight — not
+    // installed, and not blamed on Gatekeeper.
     const filter = createServer((req, res) => {
-      if (req.url === '/health') {
+      if (req.url?.startsWith('/api/v1/agent-versions/latest')) {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ status: 'ok', version: 'test', uptime: 1 }));
+        res.end(JSON.stringify({ version: '1.2.3', downloadUrl: '/dl', checksum: 'a'.repeat(64) }));
       } else {
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end('<html><body>Filtered</body></html>');
@@ -426,10 +432,9 @@ describe('install.sh functional pre-flight behavior', () => {
       expect(killed).toBe(false);
       expect(code).not.toBe(0);
       expect(output).toContain('Breeze server is reachable');
-      // Both platform branches must blame the network: darwin downloads the
-      // HTML as a .pkg (caught by the xar magic check), linux gets HTML as
-      // release metadata (caught before the checksum-extraction error).
-      expect(output).toContain('intercepting');
+      // Past the clean pre-flight the tampered download is rejected: linux by the
+      // checksum mismatch, macOS by the .pkg xar-magic interception guard.
+      expect(output).toMatch(/Checksum verification failed|intercepting/);
       expect(output).not.toContain('Gatekeeper');
     } finally {
       filter.close();
@@ -479,16 +484,14 @@ describe('install.sh functional pre-flight behavior', () => {
     expect(output).toContain('Cannot reach the Breeze server');
   });
 
-  it('proceeds past the pre-flight when /health returns the real Breeze body', async () => {
-    // Guards the cross-file contract between the script's grep and the
-    // GET /health payload in apps/api/src/index.ts: if either side drifts,
-    // a pre-flight that ALWAYS fails would still pass the failure-oriented
-    // tests above while bricking every real install.
+  it('proceeds past the pre-flight when the agent-versions endpoint returns real metadata', async () => {
+    // Guards against a pre-flight that ALWAYS fails — which would still pass the
+    // failure-oriented tests above while bricking every real install. The probe
+    // must accept a genuine /api/v1/agent-versions/latest response and continue.
     const breeze = createServer((req, res) => {
-      if (req.url === '/health') {
+      if (req.url?.startsWith('/api/v1/agent-versions/latest')) {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        // Mirrors the exact body shape of GET /health in index.ts.
-        res.end(JSON.stringify({ status: 'ok', version: 'test', uptime: 1 }));
+        res.end(JSON.stringify({ version: '1.2.3', downloadUrl: '/dl', checksum: 'a'.repeat(64) }));
       } else {
         res.writeHead(404, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'not found' }));
@@ -499,10 +502,10 @@ describe('install.sh functional pre-flight behavior', () => {
     try {
       const { code, output } = await runScript(['--server', `http://127.0.0.1:${port}`, '--token', 'tok']);
       expect(output).toContain('Breeze server is reachable');
-      expect(output).not.toContain('Cannot reach the Breeze server');
+      expect(output).not.toContain('Cannot reach the Breeze');
       expect(output).not.toContain('captive portal');
-      // It then fails at the download step (the fake server 404s everything
-      // else) — beyond the pre-flight under test, but proof it got there.
+      // It then fails at the download step (the fake server 404s the binary) —
+      // beyond the pre-flight under test, but proof it got there.
       expect(code).not.toBe(0);
       expect(output).toContain('Failed to');
     } finally {

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -580,15 +580,31 @@ if [[ "\$PREFLIGHT_CODE" != "200" ]]; then
       fatal "Connection to \$BREEZE_SERVER timed out. Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions." ;;
   esac
   if [[ "\$PREFLIGHT_CODE" == "000" ]]; then
-    fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (no response). Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions."
+    # No HTTP status line came back. Distinguish "connected, but the server gave
+    # an empty/garbled reply" (API down/crashing behind a working proxy) from a
+    # true network-layer failure — the remediation points at different layers.
+    case "\$CURL_RC" in
+      52|56|18|55)
+        fatal "\$BREEZE_SERVER accepted the connection but returned no valid HTTP response (curl error \$CURL_RC). The API may be down or crashing behind your reverse proxy — check the API service logs." ;;
+      *)
+        fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (no response, curl error \$CURL_RC). Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions." ;;
+    esac
   fi
   fatal "Cannot reach the Breeze API at \$BREEZE_SERVER (HTTP \$PREFLIGHT_CODE). Verify the server URL is correct, the API is running, and your reverse proxy forwards /api/* to it (not just the web app)."
 fi
 
 # A 200 whose body is HTML means a middlebox answered for the API endpoint
-# instead of the Breeze server. Same guard as the metadata/pkg downloads below.
+# instead of the Breeze server. Same interception guard as the metadata download
+# below (the .pkg path checks xar magic bytes instead).
 if grep -qiE '<html|<!doctype' "\$PREFLIGHT_FILE"; then
   fatal "Got a web page instead of an API response from \$BREEZE_SERVER — a captive portal, router, or web filter may be intercepting traffic on this network."
+fi
+
+# Positively confirm the Breeze API answered — not merely "not HTML". The
+# agent-versions metadata always carries a "version" field; a 200 without it is
+# a wrong responder (proxy stub, auth gateway), so don't claim "reachable".
+if ! grep -q '"version"[[:space:]]*:' "\$PREFLIGHT_FILE"; then
+  fatal "Reached \$BREEZE_SERVER but the agent-versions API returned an unexpected response — something other than the Breeze server may be answering on this network."
 fi
 
 rm -f "\$PREFLIGHT_FILE"

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -553,18 +553,24 @@ if ! command -v curl &>/dev/null; then
   fatal "curl is required but not installed. Install it and try again."
 fi
 
-# ----- Pre-flight: verify this machine can actually reach the Breeze server -----
+# ----- Pre-flight: verify this machine can actually reach the Breeze API -----
 # Catches split-connectivity setups (guest VLANs, no NAT hairpinning, web
 # filters) up front, instead of letting a later step fail with a cryptic
 # OS-level error after downloading garbage.
+#
+# Probe the version-metadata endpoint — an /api/* path the install genuinely
+# depends on (it is re-fetched below for the checksum) — NOT the apex /health.
+# A reverse proxy that forwards /api/* to the API but not bare /health is a
+# common self-hosted setup; probing /health there returns the web app's 404 and
+# aborts an install that would otherwise succeed (issue #1470).
 info "Checking connectivity to \$BREEZE_SERVER..."
-HEALTH_FILE="$(mktemp)"
-trap 'rm -f "\$HEALTH_FILE"' EXIT
+PREFLIGHT_FILE="$(mktemp)"
+trap 'rm -f "\$PREFLIGHT_FILE"' EXIT
 CURL_RC=0
-HEALTH_CODE="$(curl -fsSL -m 20 -w '%{http_code}' -o "\$HEALTH_FILE" "\$BREEZE_SERVER/health" 2>/dev/null)" || CURL_RC=\$?
-HEALTH_CODE="\${HEALTH_CODE:-000}"
+PREFLIGHT_CODE="$(curl -fsSL -m 20 -w '%{http_code}' -o "\$PREFLIGHT_FILE" "\$VERSION_METADATA_URL" 2>/dev/null)" || CURL_RC=\$?
+PREFLIGHT_CODE="\${PREFLIGHT_CODE:-000}"
 
-if [[ "\$HEALTH_CODE" != "200" ]]; then
+if [[ "\$PREFLIGHT_CODE" != "200" ]]; then
   # curl's exit code names the transport failure precisely — branch on the
   # ones whose remediation differs from generic "check your network".
   case "\$CURL_RC" in
@@ -573,20 +579,19 @@ if [[ "\$HEALTH_CODE" != "200" ]]; then
     28)
       fatal "Connection to \$BREEZE_SERVER timed out. Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions." ;;
   esac
-  if [[ "\$HEALTH_CODE" == "000" ]]; then
+  if [[ "\$PREFLIGHT_CODE" == "000" ]]; then
     fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (no response). Verify this machine has network access to the server — check DNS, firewall rules, and VLAN restrictions."
   fi
-  fatal "Cannot reach the Breeze server at \$BREEZE_SERVER (HTTP \$HEALTH_CODE). Verify the server URL is correct and this machine has network access to it."
+  fatal "Cannot reach the Breeze API at \$BREEZE_SERVER (HTTP \$PREFLIGHT_CODE). Verify the server URL is correct, the API is running, and your reverse proxy forwards /api/* to it (not just the web app)."
 fi
 
-# NOTE: stays in lockstep with GET /health in apps/api/src/index.ts — the
-# body must contain "status":"ok". If that payload changes, healthy installs
-# would start failing with the (misleading) interception message below.
-if ! grep -q '"status"[[:space:]]*:[[:space:]]*"ok"' "\$HEALTH_FILE"; then
-  fatal "Got an unexpected response from \$BREEZE_SERVER/health — something other than the Breeze server answered. A captive portal, router, or web filter may be intercepting traffic on this network."
+# A 200 whose body is HTML means a middlebox answered for the API endpoint
+# instead of the Breeze server. Same guard as the metadata/pkg downloads below.
+if grep -qiE '<html|<!doctype' "\$PREFLIGHT_FILE"; then
+  fatal "Got a web page instead of an API response from \$BREEZE_SERVER — a captive portal, router, or web filter may be intercepting traffic on this network."
 fi
 
-rm -f "\$HEALTH_FILE"
+rm -f "\$PREFLIGHT_FILE"
 trap - EXIT
 success "Breeze server is reachable"
 
@@ -640,7 +645,7 @@ if [[ "\$OS" == "darwin" ]]; then
 
   success "Downloaded installer package ($(wc -c < "\$TMPPKG" | tr -d ' ') bytes)"
 
-  # A path-selective middlebox can pass the /health pre-flight and still
+  # A path-selective middlebox can pass the connectivity pre-flight and still
   # intercept the download path. macOS .pkg files are xar archives — anything
   # else (typically a portal's HTML) must be blamed on the network, not on
   # Gatekeeper below.


### PR DESCRIPTION
## Problem

A self-hosted user couldn't run the agent installer — it aborted with:

```
[ERROR] Cannot reach the Breeze server at https://… (HTTP 404). Verify the server URL is correct…
```

…even though `wget …/api/v1/agents/download/linux/amd64` worked. Their reverse proxy forwards `/api/*` to the API but not the apex `/health`, so the pre-flight's probe of `$BREEZE_SERVER/health` hit the web frontend and got Astro's `404.astro`. The install only needs `/api/v1/*`, which was healthy — so the check was a **false negative**.

It also cascaded: blocked from the installer, the user hand-swapped the agent binary, which skipped systemd-unit/watchdog regeneration and left a dead `breeze-watchdog` (#1297 residual). See #1470 for the full thread.

## Fix

Probe `$VERSION_METADATA_URL` (`/api/v1/agent-versions/latest`) instead of apex `/health`:

- It's an `/api/*` path the install **already depends on** (re-fetched for the checksum at `download.ts:709`), so the pre-flight now tests exactly the routing the install needs.
- Any proxy that forwards `/api/*` — the minimum for an install to work at all — passes the pre-flight.
- Non-200 now says *"Cannot reach the Breeze API … your reverse proxy forwards /api/\* to it (not just the web app)."*
- A 200 with an HTML body still trips the captive-portal/interception guard.
- Dropped the now-stale `/health` ⇄ install.sh contract note in `index.ts` (`/health` is still served for Caddy/k8s probes — just no longer coupled to the installer).

## Tests

`apps/api/src/routes/agents/download.test.ts` — 26/26 green (functional bash-execution harness against mock servers):
- pre-flight test asserts the metadata probe and that it does **not** target `/health`
- path-selective-interception case now models a clean metadata endpoint + an intercepted binary download (rejected by checksum on Linux / xar-magic on macOS)
- "proceeds past pre-flight" case returns real `agent-versions` metadata

Closes #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)