### PR TITLE
fix(patches): clear pendingReboot after reboot — derive from live OS signal (#1472)

### DIFF
--- a/apps/api/src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
@@ -17,10 +17,11 @@
  * Drizzle mock would return whatever rows we fabricate and never run the
  * aggregate).
  *
- * Prerequisites:
- *   docker compose -f docker-compose.test.yml up -d
- * Run:
- *   pnpm test:integration -- src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
+ * Prerequisites (test:integration lives in apps/api; the compose file is at the
+ * repo root — `test:docker` wraps up + run + down from apps/api):
+ *   cd apps/api && pnpm test:docker:up
+ * Run (from apps/api):
+ *   cd apps/api && pnpm test:integration -- src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
  */
 import './setup';
 
@@ -143,5 +144,26 @@ describe('GET /patches/compliance — pendingReboot reflects the live OS signal 
     const listed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === deviceId);
     expect(listed).toBeDefined();
     expect(listed.pendingReboot).toBe(true);
+  });
+
+  it('keeps each device\'s flag independent — bool_or must not bleed across devices', async () => {
+    // Guards the GROUP BY: the query groups on devicePatches.deviceId, so each
+    // device's bool_or(devices.pendingReboot) must reflect only that device. A
+    // refactor that dropped the device from the grouping (or joined wrong)
+    // would aggregate one device's `true` onto the other.
+    const rebootDeviceId = await seedDevice(orgId, siteId, 'mixed-reboot-true', /* pendingReboot */ true);
+    await seedDevicePatch({ orgId, deviceId: rebootDeviceId, status: 'pending', requiresReboot: false });
+
+    const cleanDeviceId = await seedDevice(orgId, siteId, 'mixed-reboot-false', /* pendingReboot */ false);
+    await seedDevicePatch({ orgId, deviceId: cleanDeviceId, status: 'pending', requiresReboot: false });
+
+    const res = await client.get(`/patches/compliance?orgId=${orgId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const rebootListed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === rebootDeviceId);
+    const cleanListed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === cleanDeviceId);
+    expect(rebootListed?.pendingReboot).toBe(true);
+    expect(cleanListed?.pendingReboot).toBe(false);
   });
 });

--- a/apps/api/src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Patch-compliance `pendingReboot` must reflect the device's LIVE OS reboot
+ * signal (devices.pending_reboot), not a never-clearing patch-history
+ * derivation.
+ *
+ * Reproduces #1472: a Windows device installs a reboot-requiring update, the
+ * dashboard shows "reboot required", the device is rebooted — and the flag
+ * stays set forever. Root cause: the compliance endpoint derived the flag as
+ *   bool_or(patches.requiresReboot AND status='installed' AND installedAt IS NOT NULL)
+ * which stays true for the life of the installed device_patches row, regardless
+ * of whether the machine actually rebooted. Meanwhile the agent already reports
+ * an accurate, self-clearing OS signal on every heartbeat, persisted to
+ * devices.pending_reboot (heartbeat.ts) — and the devices list already reads it.
+ * The fix points the compliance query at that same live column.
+ *
+ * Asserted against a real DB so the SQL aggregation itself is exercised (a
+ * Drizzle mock would return whatever rows we fabricate and never run the
+ * aggregate).
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { getTestDb } from './setup';
+import { authMiddleware } from '../../middleware/auth';
+import { patchRoutes } from '../../routes/patches';
+import { devices, patches, devicePatches } from '../../db/schema';
+import { createIntegrationTestClient, type IntegrationTestClient } from './db-utils';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('*', authMiddleware);
+  app.route('/patches', patchRoutes);
+  return app;
+}
+
+let agentSeq = 0;
+async function seedDevice(orgId: string, siteId: string, hostname: string, pendingReboot: boolean): Promise<string> {
+  const tdb = getTestDb();
+  agentSeq++;
+  const [row] = await tdb
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-rebootflag-${agentSeq}-${Date.now()}`,
+      hostname,
+      displayName: hostname,
+      osType: 'windows',
+      osVersion: '10.0.19045',
+      osBuild: '19045',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      pendingReboot,
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('seedDevice: no row returned');
+  return row.id;
+}
+
+let patchSeq = 0;
+async function seedDevicePatch(opts: {
+  orgId: string;
+  deviceId: string;
+  status: 'pending' | 'installed';
+  requiresReboot: boolean;
+}): Promise<void> {
+  const tdb = getTestDb();
+  patchSeq++;
+  // `patches` is a GLOBAL catalog table — cleanupDatabase() only truncates
+  // tenant tables, so externalId must be globally unique.
+  const [patch] = await tdb
+    .insert(patches)
+    .values({
+      source: 'microsoft',
+      externalId: `microsoft:${randomUUID()}`,
+      title: `Test patch ${patchSeq}`,
+      severity: 'important',
+      requiresReboot: opts.requiresReboot,
+    })
+    .returning({ id: patches.id });
+  if (!patch) throw new Error('seedDevicePatch: no patch row');
+  await tdb.insert(devicePatches).values({
+    deviceId: opts.deviceId,
+    orgId: opts.orgId,
+    patchId: patch.id,
+    status: opts.status,
+    installedAt: opts.status === 'installed' ? new Date() : null,
+    lastCheckedAt: new Date(),
+  });
+}
+
+describe('GET /patches/compliance — pendingReboot reflects the live OS signal (#1472)', () => {
+  let client: IntegrationTestClient;
+  let orgId: string;
+  let siteId: string;
+
+  beforeEach(async () => {
+    const app = buildApp();
+    client = await createIntegrationTestClient(app, { scope: 'organization' });
+    orgId = client.env.organization.id;
+    siteId = client.env.site.id;
+  });
+
+  it('reports pendingReboot=false for a rebooted device even though it installed a reboot-requiring patch', async () => {
+    // The #1472 shape: a reboot-requiring patch was installed, the machine has
+    // since rebooted (devices.pending_reboot cleared), but the device still has
+    // an outstanding patch so it appears in the compliance list. The old
+    // patch-history derivation would report `true` forever.
+    const deviceId = await seedDevice(orgId, siteId, 'rebooted-host', /* pendingReboot */ false);
+    await seedDevicePatch({ orgId, deviceId, status: 'installed', requiresReboot: true });
+    await seedDevicePatch({ orgId, deviceId, status: 'pending', requiresReboot: false });
+
+    const res = await client.get(`/patches/compliance?orgId=${orgId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const listed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === deviceId);
+    expect(listed).toBeDefined();
+    // Live column says no reboot pending → flag must be false.
+    expect(listed.pendingReboot).toBe(false);
+  });
+
+  it('reports pendingReboot=true from the live column even with no installed reboot-requiring patch', async () => {
+    // The OS reports a pending reboot for a non-patch reason (CBS, pending file
+    // renames). Only `pending` patches exist, so the old patch-history
+    // derivation would report `false` and miss it.
+    const deviceId = await seedDevice(orgId, siteId, 'os-reboot-host', /* pendingReboot */ true);
+    await seedDevicePatch({ orgId, deviceId, status: 'pending', requiresReboot: false });
+
+    const res = await client.get(`/patches/compliance?orgId=${orgId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const listed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === deviceId);
+    expect(listed).toBeDefined();
+    expect(listed.pendingReboot).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchComplianceRebootFlag.integration.test.ts
@@ -163,7 +163,9 @@ describe('GET /patches/compliance — pendingReboot reflects the live OS signal 
 
     const rebootListed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === rebootDeviceId);
     const cleanListed = body.data.devicesNeedingPatches.find((d: { id: string }) => d.id === cleanDeviceId);
-    expect(rebootListed?.pendingReboot).toBe(true);
-    expect(cleanListed?.pendingReboot).toBe(false);
+    expect(rebootListed).toBeDefined();
+    expect(cleanListed).toBeDefined();
+    expect(rebootListed.pendingReboot).toBe(true);
+    expect(cleanListed.pendingReboot).toBe(false);
   });
 });

--- a/apps/api/src/routes/patches/compliance.ts
+++ b/apps/api/src/routes/patches/compliance.ts
@@ -214,7 +214,15 @@ complianceRoutes.get(
         osMissing: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.source} in ('microsoft', 'apple', 'linux'))`,
         thirdPartyMissing: sql<number>`count(*) filter (where ${isOutstanding} and ${patches.source} in ('third_party', 'custom'))`,
         lastInstalledAt: sql<string | null>`max(case when ${devicePatches.status} = 'installed' and ${devicePatches.installedAt} is not null then ${devicePatches.installedAt}::timestamptz::text end)`,
-        pendingReboot: sql<boolean>`bool_or(${patches.requiresReboot} and ${devicePatches.status} = 'installed' and ${devicePatches.installedAt} is not null)`,
+        // Live OS reboot signal persisted from the agent heartbeat
+        // (devices.pending_reboot), NOT a patch-history derivation. The old
+        // bool_or(requiresReboot AND installed) stayed true for the life of the
+        // installed device_patches row, so the flag never cleared after the
+        // machine actually rebooted (#1472). The agent self-clears this on the
+        // first post-reboot heartbeat and it also covers non-patch reboot
+        // sources (CBS, pending file renames). bool_or because the query
+        // aggregates device_patches rows per device.
+        pendingReboot: sql<boolean>`bool_or(${devices.pendingReboot})`,
         lastScannedAt: sql<string | null>`max(${devicePatches.lastCheckedAt})::timestamptz::text`
       })
       .from(devicePatches)

--- a/apps/api/src/routes/patches/compliance.ts
+++ b/apps/api/src/routes/patches/compliance.ts
@@ -218,10 +218,12 @@ complianceRoutes.get(
         // (devices.pending_reboot), NOT a patch-history derivation. The old
         // bool_or(requiresReboot AND installed) stayed true for the life of the
         // installed device_patches row, so the flag never cleared after the
-        // machine actually rebooted (#1472). The agent self-clears this on the
-        // first post-reboot heartbeat and it also covers non-patch reboot
-        // sources (CBS, pending file renames). bool_or because the query
-        // aggregates device_patches rows per device.
+        // machine actually rebooted (#1472). The heartbeat writes this column
+        // unconditionally (heartbeat.ts), so it clears on the first post-reboot
+        // heartbeat that reports false, and it also covers non-patch reboot
+        // sources (CBS, pending file renames). bool_or (not a bare column ref)
+        // because the GROUP BY keys on devicePatches.deviceId, not the devices
+        // PK, so Postgres requires the per-device value to be aggregated.
         pendingReboot: sql<boolean>`bool_or(${devices.pendingReboot})`,
         lastScannedAt: sql<string | null>`max(${devicePatches.lastCheckedAt})::timestamptz::text`
       })


### PR DESCRIPTION
## Problem

On Windows devices, the Patch-Management **Compliance** view showed *"reboot required"* indefinitely after a device installed a reboot-requiring update — the flag never cleared even after the machine was actually rebooted. Reported across v0.69.0–v0.81.0 (#1472).

## Root cause

`routes/patches/compliance.ts` derived the per-device `pendingReboot` from **patch history**:

```sql
bool_or(patches.requiresReboot AND devicePatches.status = 'installed' AND installedAt IS NOT NULL)
```

That stays `true` for the life of the installed `device_patches` row — once a reboot-requiring patch is installed, the flag is permanently latched regardless of whether the host has since rebooted.

Meanwhile the agent **already** reports an accurate, self-clearing OS reboot signal on every heartbeat (`DetectPendingReboot()` — Windows registry `RebootRequired`, CBS `RebootPending`, `PendingFileRenameOperations`), persisted to `devices.pending_reboot` (`heartbeat.ts:325`). The devices list/detail views already read that live column; only the compliance query lagged.

## Fix

Point the compliance query at the same live column:

```ts
pendingReboot: sql<boolean>`bool_or(${devices.pendingReboot})`
```

`devices` is already inner-joined and grouped per device, so `bool_or` simply surfaces that device's live flag. It now clears on the first post-reboot heartbeat and also reflects non-patch reboot sources (CBS, pending file renames).

> Note: the contributor's "Option 1" (add the column + heartbeat ingest) already shipped in `2026-06-11-j-device-pending-reboot.sql`, so the remaining gap was just this read-side reconciliation — no migration needed.

## Testing

New real-DB integration test `patchComplianceRebootFlag.integration.test.ts` (a Drizzle mock can't exercise the aggregate):
- Rebooted device that installed a reboot-requiring patch → `pendingReboot=false` ✅ (was `true`)
- OS reboot pending for a non-patch reason, no installed reboot patch → `pendingReboot=true` ✅ (was `false`)

Both **fail before** the fix and **pass after**. Full integration suite **315/315 green**; unit `compliance.test.ts` green.

Root-cause analysis credit: @bdunncompany in #1472.

Addresses #1472 — leaving the issue open for reporter verification after the next release ships (per the reporter-verifies-then-closes convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)