### PR TITLE
fix(installer): run HardenProgramDataAcl deferred as LocalSystem (closes #1479)

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -97,12 +97,32 @@
       Return="ignore" />
 
     <SetProperty Id="BREEZE_ACL_CMD" Value="[System64Folder]cmd.exe" Before="HardenProgramDataAcl" Sequence="execute" />
+    <!-- MUST be deferred + non-impersonated so it runs as LocalSystem.
+         #609/#613 fixed the "folders don't exist yet" facet (added the mkdir
+         guards) but left this Execute="immediate". Immediate CAs impersonate
+         the installing user, and on an interactive double-click + UAC-consent
+         install that token is the *filtered* one (Administrators is DENY_ONLY).
+         icacls /inheritance:r needs WRITE_DAC, which the filtered token lacks,
+         so the action returned ACCESS_DENIED (5) -> 1722 -> rollback -> 1603.
+         Deferred + Impersonate="no" runs as LocalSystem (full rights). It is
+         sequenced After CreateFolders below, which now (unlike the immediate
+         case) actually runs first in the in-script, so the dirs already exist
+         and the mkdir guards are belt-and-suspenders. Return="ignore" mirrors
+         ConfigureBreezeFailureActions: ACL hardening that is blocked by an
+         external control (Controlled Folder Access / ASR / EDR / GPO) must
+         never roll back an otherwise-good install — the folders are still
+         created by CreateFolders with default ProgramData ACLs, and the agent
+         re-applies PROTECTED DACLs to the config dir and (fail-closed) to
+         secrets.yaml at runtime on first config write (see
+         agent/internal/config/permissions_windows.go), so a skipped/blocked
+         icacls here self-heals and never leaves tokens world-readable. -->
     <CustomAction
       Id="HardenProgramDataAcl"
       Property="BREEZE_ACL_CMD"
       ExeCommand="/c (if not exist &quot;[ProgramDataBreezeDir].&quot; mkdir &quot;[ProgramDataBreezeDir].&quot;) &amp;&amp; (if not exist &quot;[ProgramDataBreezeDataDir].&quot; mkdir &quot;[ProgramDataBreezeDataDir].&quot;) &amp;&amp; (if not exist &quot;[ProgramDataBreezeLogsDir].&quot; mkdir &quot;[ProgramDataBreezeLogsDir].&quot;) &amp;&amp; icacls &quot;[ProgramDataBreezeDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeDataDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F &amp;&amp; icacls &quot;[ProgramDataBreezeLogsDir].&quot; /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *S-1-5-32-544:(OI)(CI)F"
-      Execute="immediate"
-      Return="check" />
+      Execute="deferred"
+      Impersonate="no"
+      Return="ignore" />
 
     <!-- Set SCM failure-action recovery on both services after they're
          installed. Mirrors agent/cmd/breeze-agent/service_cmd_windows.go:72-79


### PR DESCRIPTION
## Problem

Installing the Windows agent MSI by **double-click + UAC consent** rolls back with `1722` -> `1603`. Verbose log:

```
CustomAction HardenProgramDataAcl returned actual error code 5   (ACCESS_DENIED)
Note: 1: 1722 2: HardenProgramDataAcl 3: C:\WINDOWS\system32\cmd.exe 4: /c ... icacls "C:\ProgramData\Breeze\." /inheritance:r /grant:r ...
Action ended: HardenProgramDataAcl. Return value 3.
MainEngineThread is returning 1603
```

No agent logs are produced because it dies before `InstallServices`.

## Root cause

`HardenProgramDataAcl` (`agent/installer/breeze.wxs`) was `Execute="immediate"`. Immediate custom actions impersonate the installing user; on the interactive UAC-consent path that is the **filtered** token (Administrators `DENY_ONLY`), which lacks `WRITE_DAC` for `icacls /inheritance:r` → `ACCESS_DENIED (5)`. `Return="check"` then rolls the entire install back, leaving the endpoint with no agent.

This is the **second facet of #609**. The #609 fix (`ad2da2b1`, #613) added the `mkdir` guards but left `Execute="immediate"`, so installs that get a filtered token (interactive UAC) still failed; elevated-shell / SYSTEM-pushed installs got a full token and worked, masking it.

## Fix

`HardenProgramDataAcl` → `Execute="deferred"` + `Impersonate="no"` (runs as **LocalSystem**, full rights) + `Return="ignore"`.

- **deferred + no-impersonate** → LocalSystem always has `WRITE_DAC`, so `icacls` succeeds regardless of how the install was launched. Mirrors the already-correct `ConfigureBreezeFailureActions` (type 3186).
- **Return="ignore"** → an external control blocking the `icacls` child (Controlled Folder Access / ASR / EDR / GPO) can no longer roll back an otherwise-good install. The dirs are still created by `CreateFolders` with default ProgramData ACLs.
- Still sequenced `After CreateFolders` — and because it's now deferred, `CreateFolders` actually runs first in the in-script, so the target dirs already exist when it runs (the `mkdir` guards become belt-and-suspenders rather than the primary mechanism).

## Verification

- `xmllint --noout breeze.wxs` → well-formed.
- Confirmed live on the failing machine: same MSI installs cleanly when run from an elevated shell (full token), proving the token is the variable. The deferred + no-impersonate CA gets that same full (LocalSystem) token on every path.
- No automated test pins the immediate behavior. The MSI is only built in the release workflow (`build-windows-msi`, requires Windows + WiX), so this isn't exercised on PR CI — flagging for a Windows smoke-install on the next release candidate.

## Related (not in this PR)

`KillBreezeProcesses` is also `Execute="immediate"` and needs admin/SeDebugPrivilege for cross-session `taskkill /F`; on the filtered-token path it likely no-ops silently (masked by `& exit /b 0`), which could resurface the #944 class on upgrades. It can't simply be made deferred (must run before `InstallValidate`); tracking separately in #1479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)