### PR TITLE
fix(api): CHECK constraints on authenticator assurance columns (#1372)

### DIFF
--- a/apps/api/migrations/2026-06-17-authenticator-assurance-check-constraints.sql
+++ b/apps/api/migrations/2026-06-17-authenticator-assurance-check-constraints.sql
@@ -13,13 +13,23 @@
 --
 -- Invariants (match assertDecisionConsistent):
 --   * decided_assurance_level, when set, is 1..4.
+--   * decided_via and decided_assurance_level are co-present (both set, or both
+--       NULL) — a recorded factor with no level, or a level with no factor, is
+--       a contradictory forensic row even though the app never writes one. This
+--       also closes the three-valued-logic gap the biconditionals below leave
+--       open: `(a) = (b)` evaluates to NULL (→ satisfied) whenever a component
+--       is NULL, so without co-presence a half-recorded decision would slip in.
 --   * session_tap  <=>  no authenticator device  (an L2+ factor records one).
 --   * session_tap  <=>  level 1                   (a proof factor is never L1).
 --   * pin_verified implies level >= 3             (legacy approver-PIN gate).
 --
 -- Every undecided / pending row (decided_via, decided_assurance_level,
--- authenticator_device_id all NULL) passes: each predicate short-circuits to
--- NULL — and a NULL CHECK result is treated as satisfied.
+-- authenticator_device_id all NULL) passes: the four factor/level predicates
+-- each evaluate to NULL or TRUE — both treated as satisfied — and the pin
+-- predicate is TRUE because pin_verified is NOT NULL DEFAULT false, so
+-- `NOT pin_verified` is TRUE. (A residual, benign looseness remains: an orphan
+-- authenticator_device_id with decided_via/level both NULL is accepted — that
+-- is incomplete, not self-contradictory, and unreachable from the app.)
 --
 -- Idempotent: each ADD CONSTRAINT is pg_constraint-guarded. No inner
 -- BEGIN/COMMIT (autoMigrate wraps each file in its own transaction). The tables
@@ -34,6 +44,11 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_decided_level_range_chk') THEN
     ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_decided_level_range_chk
       CHECK (decided_assurance_level IS NULL OR decided_assurance_level BETWEEN 1 AND 4);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_decision_copresence_chk') THEN
+    ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_decision_copresence_chk
+      CHECK ((decided_via IS NULL) = (decided_assurance_level IS NULL));
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_factor_device_chk') THEN
@@ -53,6 +68,11 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'elevation_requests_decided_level_range_chk') THEN
     ALTER TABLE elevation_requests ADD CONSTRAINT elevation_requests_decided_level_range_chk
       CHECK (decided_assurance_level IS NULL OR decided_assurance_level BETWEEN 1 AND 4);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'elevation_requests_decision_copresence_chk') THEN
+    ALTER TABLE elevation_requests ADD CONSTRAINT elevation_requests_decision_copresence_chk
+      CHECK ((decided_via IS NULL) = (decided_assurance_level IS NULL));
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'elevation_requests_factor_device_chk') THEN

--- a/apps/api/migrations/2026-06-17-authenticator-assurance-check-constraints.sql
+++ b/apps/api/migrations/2026-06-17-authenticator-assurance-check-constraints.sql
@@ -1,0 +1,91 @@
+-- 2026-06-17-authenticator-assurance-check-constraints.sql
+-- Issue #1372 — deferred follow-up from the PR #1369 (Breeze Authenticator)
+-- review. Storage-side mirror of assertDecisionConsistent()
+-- (apps/api/src/services/authenticatorAssurance.ts).
+--
+-- The factor-recording columns on approval_requests + elevation_requests are a
+-- forensic/audit record, but the fields are independent at the DB level, so the
+-- store accepts self-contradictory tuples the application would never write
+-- (e.g. decided_via='session_tap' with a device id, decided_assurance_level=7,
+-- or an L2+ factor at level 1). The application guards this at write time, but
+-- the storage boundary — the thing actually being protected — was the loosest
+-- link. These CHECK constraints make the illegal states unrepresentable.
+--
+-- Invariants (match assertDecisionConsistent):
+--   * decided_assurance_level, when set, is 1..4.
+--   * session_tap  <=>  no authenticator device  (an L2+ factor records one).
+--   * session_tap  <=>  level 1                   (a proof factor is never L1).
+--   * pin_verified implies level >= 3             (legacy approver-PIN gate).
+--
+-- Every undecided / pending row (decided_via, decided_assurance_level,
+-- authenticator_device_id all NULL) passes: each predicate short-circuits to
+-- NULL — and a NULL CHECK result is treated as satisfied.
+--
+-- Idempotent: each ADD CONSTRAINT is pg_constraint-guarded. No inner
+-- BEGIN/COMMIT (autoMigrate wraps each file in its own transaction). The tables
+-- are effectively empty (feature ships dark at the L1 default), so validation
+-- is cheap; if any pre-existing row violates a predicate the ADD will RAISE —
+-- that is the intended loud signal that the write-time guard was bypassed, not
+-- something to silence.
+
+-- approval_requests --------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_decided_level_range_chk') THEN
+    ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_decided_level_range_chk
+      CHECK (decided_assurance_level IS NULL OR decided_assurance_level BETWEEN 1 AND 4);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_factor_device_chk') THEN
+    ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_factor_device_chk
+      CHECK ((decided_via = 'session_tap') = (authenticator_device_id IS NULL));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_factor_level_chk') THEN
+    ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_factor_level_chk
+      CHECK ((decided_via = 'session_tap') = (decided_assurance_level = 1));
+  END IF;
+END $$;
+
+-- elevation_requests -------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'elevation_requests_decided_level_range_chk') THEN
+    ALTER TABLE elevation_requests ADD CONSTRAINT elevation_requests_decided_level_range_chk
+      CHECK (decided_assurance_level IS NULL OR decided_assurance_level BETWEEN 1 AND 4);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'elevation_requests_factor_device_chk') THEN
+    ALTER TABLE elevation_requests ADD CONSTRAINT elevation_requests_factor_device_chk
+      CHECK ((decided_via = 'session_tap') = (authenticator_device_id IS NULL));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'elevation_requests_factor_level_chk') THEN
+    ALTER TABLE elevation_requests ADD CONSTRAINT elevation_requests_factor_level_chk
+      CHECK ((decided_via = 'session_tap') = (decided_assurance_level = 1));
+  END IF;
+END $$;
+
+-- pin_verified gate --------------------------------------------------------
+-- The approver PIN is being removed in favour of an L4 account re-auth
+-- (PR #1433 drops these columns). This constraint is therefore applied only
+-- while the column still exists; once the column is dropped Postgres removes
+-- the dependent CHECK automatically, and this guarded block becomes a no-op.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'approval_requests' AND column_name = 'pin_verified'
+  ) AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_pin_level_chk') THEN
+    ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_pin_level_chk
+      CHECK (NOT pin_verified OR decided_assurance_level >= 3);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'elevation_requests' AND column_name = 'pin_verified'
+  ) AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'elevation_requests_pin_level_chk') THEN
+    ALTER TABLE elevation_requests ADD CONSTRAINT elevation_requests_pin_level_chk
+      CHECK (NOT pin_verified OR decided_assurance_level >= 3);
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/authenticator-assurance-checks.integration.test.ts
+++ b/apps/api/src/__tests__/integration/authenticator-assurance-checks.integration.test.ts
@@ -69,6 +69,36 @@ function insertApproval(fields: {
   `);
 }
 
+/** Forge an approval_requests row that also sets the transitional pin_verified flag. */
+function insertApprovalWithPin(fields: {
+  decidedVia: string;
+  level: number;
+  deviceId: string | null;
+  pinVerified: boolean;
+}) {
+  const tdb = getTestDb();
+  return tdb.execute(sql`
+    INSERT INTO approval_requests
+      (user_id, requesting_client_label, action_label, action_tool_name,
+       risk_tier, risk_summary, expires_at,
+       decided_via, decided_assurance_level, authenticator_device_id, pin_verified)
+    VALUES
+      (${userId}, 'chk-test', 'chk.action', 'chk.tool',
+       'low', 'check-constraint test', now() + interval '5 minutes',
+       ${fields.decidedVia}::approval_factor, ${fields.level}::smallint,
+       ${fields.deviceId}::uuid, ${fields.pinVerified})
+  `);
+}
+
+/** pin_verified is removed by PR #1433; its constraint + tests gate on this. */
+async function pinColumnPresent(): Promise<boolean> {
+  const rows = (await getTestDb().execute(sql`
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'approval_requests' AND column_name = 'pin_verified'
+  `)) as unknown as unknown[];
+  return rows.length > 0;
+}
+
 describe('#1372 — assurance CHECK constraints accept every legitimate row', () => {
   it('accepts a pending (undecided) row where all factor fields are NULL', async () => {
     await expect(insertApproval({})).resolves.toBeDefined();
@@ -85,19 +115,28 @@ describe('#1372 — assurance CHECK constraints accept every legitimate row', ()
       insertApproval({ decidedVia: 'webauthn_platform', level: 2, deviceId }),
     ).resolves.toBeDefined();
   });
+
+  it('accepts a proof factor at L4 (the valid upper bound)', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'webauthn_platform', level: 4, deviceId }),
+    ).resolves.toBeDefined();
+  });
 });
 
 describe('#1372 — assurance CHECK constraints reject self-contradictory rows', () => {
-  it('rejects an out-of-range assurance level (> 4)', async () => {
-    await expect(insertApproval({ level: 7 })).rejects.toMatchObject({
-      cause: { code: CHECK_VIOLATION },
-    });
+  // Range cases use a coherent proof tuple (factor + device) so the ONLY
+  // violation is the range check — otherwise co-presence (a level with a NULL
+  // factor) would fire first and the test would pass for the wrong reason.
+  it('rejects level 5 (one past the valid upper bound)', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'webauthn_platform', level: 5, deviceId }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
   });
 
   it('rejects an out-of-range assurance level (0)', async () => {
-    await expect(insertApproval({ level: 0 })).rejects.toMatchObject({
-      cause: { code: CHECK_VIOLATION },
-    });
+    await expect(
+      insertApproval({ decidedVia: 'webauthn_platform', level: 0, deviceId }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
   });
 
   it('rejects session_tap carrying an authenticator device', async () => {
@@ -125,32 +164,46 @@ describe('#1372 — assurance CHECK constraints reject self-contradictory rows',
   });
 });
 
-describe('#1372 — pin_verified gate (only while the transitional column exists)', () => {
-  it('rejects pin_verified=true below L3 (or self-skips once the column is dropped)', async () => {
-    const tdb = getTestDb();
-    const present = (await tdb.execute(sql`
-      SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'approval_requests' AND column_name = 'pin_verified'
-    `)) as unknown as unknown[];
-
-    if (present.length === 0) {
-      // pin_verified removed by #1433 — the dependent CHECK is gone too; nothing
-      // to assert. Kept as a passing no-op so the suite survives that merge.
-      return;
-    }
-
+describe('#1372 — co-presence: a half-recorded decision is rejected', () => {
+  // These are the three-valued-logic holes the biconditionals alone leave open
+  // (`(a) = (b)` is NULL → satisfied when a component is NULL). The app never
+  // writes them, but the storage boundary must still reject them.
+  it('rejects a recorded factor with a NULL level', async () => {
     await expect(
-      tdb.execute(sql`
-        INSERT INTO approval_requests
-          (user_id, requesting_client_label, action_label, action_tool_name,
-           risk_tier, risk_summary, expires_at,
-           decided_via, decided_assurance_level, pin_verified)
-        VALUES
-          (${userId}, 'chk-test', 'chk.action', 'chk.tool',
-           'low', 'check-constraint test', now() + interval '5 minutes',
-           'session_tap'::approval_factor, 1::smallint, true)
-      `),
+      insertApproval({ decidedVia: 'webauthn_platform', level: null, deviceId }),
     ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+
+  it('rejects a recorded level with a NULL factor', async () => {
+    await expect(
+      insertApproval({ decidedVia: null, level: 2, deviceId: null }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+});
+
+describe('#1372 — pin_verified gate (only while the transitional column exists)', () => {
+  // authenticator_device_id carries no FK (see approvals.ts) — the device seeded
+  // in beforeEach is only a realistic UUID, so each rejection below provably
+  // trips the CHECK (23514), never an FK trigger.
+  it('rejects pin_verified=true at L1', async (ctx) => {
+    if (!(await pinColumnPresent())) return ctx.skip();
+    await expect(
+      insertApprovalWithPin({ decidedVia: 'session_tap', level: 1, deviceId: null, pinVerified: true }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+
+  it('rejects pin_verified=true at L2 (boundary — gate is level >= 3)', async (ctx) => {
+    if (!(await pinColumnPresent())) return ctx.skip();
+    await expect(
+      insertApprovalWithPin({ decidedVia: 'webauthn_platform', level: 2, deviceId, pinVerified: true }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+
+  it('accepts pin_verified=true at L3 (boundary — first valid level)', async (ctx) => {
+    if (!(await pinColumnPresent())) return ctx.skip();
+    await expect(
+      insertApprovalWithPin({ decidedVia: 'webauthn_platform', level: 3, deviceId, pinVerified: true }),
+    ).resolves.toBeDefined();
   });
 });
 
@@ -158,23 +211,50 @@ describe('#1372 — elevation_requests carries the identical constraints', () =>
   it('mirrors every stable assurance CHECK predicate onto elevation_requests', async () => {
     const tdb = getTestDb();
     const rows = (await tdb.execute(sql`
-      SELECT conrelid::regclass::text AS tbl, conname, pg_get_constraintdef(oid) AS def
+      SELECT conname, pg_get_constraintdef(oid) AS def, convalidated
       FROM pg_constraint
       WHERE contype = 'c'
         AND conrelid IN ('approval_requests'::regclass, 'elevation_requests'::regclass)
-        AND conname LIKE '%_chk'
-    `)) as unknown as Array<{ tbl: string; conname: string; def: string }>;
+        AND conname LIKE '%\_chk'
+    `)) as unknown as Array<{ conname: string; def: string; convalidated: boolean }>;
 
-    const byName = new Map(rows.map((r) => [r.conname, r.def]));
+    const byName = new Map(rows.map((r) => [r.conname, r]));
 
-    for (const suffix of ['decided_level_range_chk', 'factor_device_chk', 'factor_level_chk']) {
-      const approvalDef = byName.get(`approval_requests_${suffix}`);
-      const elevationDef = byName.get(`elevation_requests_${suffix}`);
-      expect(approvalDef, `approval_requests_${suffix} missing`).toBeDefined();
-      expect(elevationDef, `elevation_requests_${suffix} missing`).toBeDefined();
+    const stable = [
+      'decided_level_range_chk',
+      'decision_copresence_chk',
+      'factor_device_chk',
+      'factor_level_chk',
+    ];
+    for (const suffix of stable) {
+      const approval = byName.get(`approval_requests_${suffix}`);
+      const elevation = byName.get(`elevation_requests_${suffix}`);
+      expect(approval, `approval_requests_${suffix} missing`).toBeDefined();
+      expect(elevation, `elevation_requests_${suffix} missing`).toBeDefined();
       // pg_get_constraintdef omits the table name, so identical invariants yield
       // byte-identical defs.
-      expect(elevationDef).toBe(approvalDef);
+      expect(elevation!.def).toBe(approval!.def);
+      // Guard against a future copy-paste shipping the constraint NOT VALID,
+      // which would advertise an invariant the DB does not actually enforce.
+      expect(approval!.convalidated, `${suffix} on approval not validated`).toBe(true);
+      expect(elevation!.convalidated, `${suffix} on elevation not validated`).toBe(true);
     }
+  });
+
+  it('mirrors the transitional pin_verified gate while the column exists', async () => {
+    if (!(await pinColumnPresent())) return; // dropped by #1433 — nothing to mirror
+    const tdb = getTestDb();
+    const rows = (await tdb.execute(sql`
+      SELECT conname, pg_get_constraintdef(oid) AS def
+      FROM pg_constraint
+      WHERE contype = 'c'
+        AND conrelid IN ('approval_requests'::regclass, 'elevation_requests'::regclass)
+        AND conname LIKE '%pin_level_chk'
+    `)) as unknown as Array<{ conname: string; def: string }>;
+    const byName = new Map(rows.map((r) => [r.conname, r.def]));
+    expect(byName.get('approval_requests_pin_level_chk')).toBeDefined();
+    expect(byName.get('elevation_requests_pin_level_chk')).toBe(
+      byName.get('approval_requests_pin_level_chk'),
+    );
   });
 });

--- a/apps/api/src/__tests__/integration/authenticator-assurance-checks.integration.test.ts
+++ b/apps/api/src/__tests__/integration/authenticator-assurance-checks.integration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration test for issue #1372 — storage-side mirror of the assurance
+ * decision invariants on `approval_requests` + `elevation_requests`.
+ *
+ * The four factor-recording columns (`decided_assurance_level`, `decided_via`,
+ * `authenticator_device_id`, and the transitional `pin_verified`) are a
+ * forensic record. The application guards their consistency at write time via
+ * `assertDecisionConsistent` (authenticatorAssurance.ts), but the DB itself
+ * accepted self-contradictory tuples until the CHECK constraints added by
+ * `2026-06-17-authenticator-assurance-check-constraints.sql`.
+ *
+ * These assertions run against a real DB. CHECK constraints fire regardless of
+ * the connection role, so the superuser test connection (`getTestDb`) is used
+ * directly — the RLS role is irrelevant to what this test proves. They fail
+ * (RED) until the constraint migration ships.
+ *
+ * Invariants enforced (matching assertDecisionConsistent):
+ *   - decided_assurance_level, when set, is 1..4.
+ *   - session_tap  <=>  no authenticator device  (an L2+ factor records one).
+ *   - session_tap  <=>  level 1                   (a proof factor is never L1).
+ *   - pin_verified implies level >= 3             (legacy approver-PIN gate).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import './setup';
+import { getTestDb } from './setup';
+import { createPartner, createUser } from './db-utils';
+
+/** Postgres SQLSTATE for a CHECK constraint violation. */
+const CHECK_VIOLATION = '23514';
+
+let userId: string;
+let deviceId: string;
+
+beforeEach(async () => {
+  // setup.ts's beforeEach TRUNCATEs users CASCADE, so the authenticator device
+  // and any forged approval rows are cleared transitively each test.
+  const partner = await createPartner();
+  const user = await createUser({ partnerId: partner.id });
+  userId = user.id;
+
+  const tdb = getTestDb();
+  const rows = (await tdb.execute(sql`
+    INSERT INTO authenticator_devices (user_id, kind, public_key, is_platform_bound)
+    VALUES (${userId}, 'webauthn_platform', 'test-public-key', true)
+    RETURNING id
+  `)) as unknown as Array<{ id: string }>;
+  deviceId = rows[0]!.id;
+});
+
+/** Forge an approval_requests row with explicit factor-recording fields. */
+function insertApproval(fields: {
+  decidedVia?: string | null;
+  level?: number | null;
+  deviceId?: string | null;
+}) {
+  const tdb = getTestDb();
+  return tdb.execute(sql`
+    INSERT INTO approval_requests
+      (user_id, requesting_client_label, action_label, action_tool_name,
+       risk_tier, risk_summary, expires_at,
+       decided_via, decided_assurance_level, authenticator_device_id)
+    VALUES
+      (${userId}, 'chk-test', 'chk.action', 'chk.tool',
+       'low', 'check-constraint test', now() + interval '5 minutes',
+       ${fields.decidedVia ?? null}::approval_factor,
+       ${fields.level ?? null}::smallint,
+       ${fields.deviceId ?? null}::uuid)
+  `);
+}
+
+describe('#1372 — assurance CHECK constraints accept every legitimate row', () => {
+  it('accepts a pending (undecided) row where all factor fields are NULL', async () => {
+    await expect(insertApproval({})).resolves.toBeDefined();
+  });
+
+  it('accepts a session_tap decision at L1 with no device', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'session_tap', level: 1, deviceId: null }),
+    ).resolves.toBeDefined();
+  });
+
+  it('accepts an L2 proof factor that records a device', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'webauthn_platform', level: 2, deviceId }),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('#1372 — assurance CHECK constraints reject self-contradictory rows', () => {
+  it('rejects an out-of-range assurance level (> 4)', async () => {
+    await expect(insertApproval({ level: 7 })).rejects.toMatchObject({
+      cause: { code: CHECK_VIOLATION },
+    });
+  });
+
+  it('rejects an out-of-range assurance level (0)', async () => {
+    await expect(insertApproval({ level: 0 })).rejects.toMatchObject({
+      cause: { code: CHECK_VIOLATION },
+    });
+  });
+
+  it('rejects session_tap carrying an authenticator device', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'session_tap', level: 1, deviceId }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+
+  it('rejects session_tap recorded above L1', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'session_tap', level: 2, deviceId: null }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+
+  it('rejects an L2+ proof factor with no device id', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'webauthn_platform', level: 2, deviceId: null }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+
+  it('rejects a proof factor recorded at L1', async () => {
+    await expect(
+      insertApproval({ decidedVia: 'webauthn_platform', level: 1, deviceId }),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+});
+
+describe('#1372 — pin_verified gate (only while the transitional column exists)', () => {
+  it('rejects pin_verified=true below L3 (or self-skips once the column is dropped)', async () => {
+    const tdb = getTestDb();
+    const present = (await tdb.execute(sql`
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'approval_requests' AND column_name = 'pin_verified'
+    `)) as unknown as unknown[];
+
+    if (present.length === 0) {
+      // pin_verified removed by #1433 — the dependent CHECK is gone too; nothing
+      // to assert. Kept as a passing no-op so the suite survives that merge.
+      return;
+    }
+
+    await expect(
+      tdb.execute(sql`
+        INSERT INTO approval_requests
+          (user_id, requesting_client_label, action_label, action_tool_name,
+           risk_tier, risk_summary, expires_at,
+           decided_via, decided_assurance_level, pin_verified)
+        VALUES
+          (${userId}, 'chk-test', 'chk.action', 'chk.tool',
+           'low', 'check-constraint test', now() + interval '5 minutes',
+           'session_tap'::approval_factor, 1::smallint, true)
+      `),
+    ).rejects.toMatchObject({ cause: { code: CHECK_VIOLATION } });
+  });
+});
+
+describe('#1372 — elevation_requests carries the identical constraints', () => {
+  it('mirrors every stable assurance CHECK predicate onto elevation_requests', async () => {
+    const tdb = getTestDb();
+    const rows = (await tdb.execute(sql`
+      SELECT conrelid::regclass::text AS tbl, conname, pg_get_constraintdef(oid) AS def
+      FROM pg_constraint
+      WHERE contype = 'c'
+        AND conrelid IN ('approval_requests'::regclass, 'elevation_requests'::regclass)
+        AND conname LIKE '%_chk'
+    `)) as unknown as Array<{ tbl: string; conname: string; def: string }>;
+
+    const byName = new Map(rows.map((r) => [r.conname, r.def]));
+
+    for (const suffix of ['decided_level_range_chk', 'factor_device_chk', 'factor_level_chk']) {
+      const approvalDef = byName.get(`approval_requests_${suffix}`);
+      const elevationDef = byName.get(`elevation_requests_${suffix}`);
+      expect(approvalDef, `approval_requests_${suffix} missing`).toBeDefined();
+      expect(elevationDef, `elevation_requests_${suffix} missing`).toBeDefined();
+      // pg_get_constraintdef omits the table name, so identical invariants yield
+      // byte-identical defs.
+      expect(elevationDef).toBe(approvalDef);
+    }
+  });
+});

--- a/apps/api/src/db/schema/approvals.ts
+++ b/apps/api/src/db/schema/approvals.ts
@@ -1,4 +1,5 @@
 import { pgTable, uuid, text, varchar, timestamp, jsonb, pgEnum, index, foreignKey, boolean, smallint } from 'drizzle-orm/pg-core';
+import type { AssuranceLevel } from '@breeze/shared';
 import { users } from './users';
 import { oauthClients, oauthSessions } from './oauth';
 import { aiToolExecutions } from './ai';
@@ -61,8 +62,12 @@ export const approvalRequests = pgTable(
      */
     isRecursive: boolean('is_recursive').notNull().default(false),
 
-    /** Assurance level actually satisfied by the decision (1..4). */
-    decidedAssuranceLevel: smallint('decided_assurance_level'),
+    /**
+     * Assurance level actually satisfied by the decision (1..4). The DB caps
+     * the range via `approval_requests_decided_level_range_chk`; `.$type` keeps
+     * the inferred read type aligned with that invariant (issue #1372).
+     */
+    decidedAssuranceLevel: smallint('decided_assurance_level').$type<AssuranceLevel>(),
     /** Factor actually used to decide: session_tap (L1), webauthn_platform or mobile_hw_key (L2+). */
     decidedVia: approvalFactorEnum('decided_via'),
     /** The authenticator device that signed the decision (null for session_tap). */

--- a/apps/api/src/db/schema/elevations.ts
+++ b/apps/api/src/db/schema/elevations.ts
@@ -19,6 +19,7 @@ import { devices } from './devices';
 import { approvalRequests, approvalFactorEnum } from './approvals';
 import { softwarePolicies } from './softwarePolicies';
 import { aiToolExecutions } from './ai';
+import type { AssuranceLevel } from '@breeze/shared';
 
 // PAM Track 1: privileged access management.
 //
@@ -140,7 +141,10 @@ export const elevationRequests = pgTable(
     actionDigest: varchar('action_digest', { length: 64 }),
     riskTier: smallint('risk_tier'),
 
-    decidedAssuranceLevel: smallint('decided_assurance_level'),
+    // Level satisfied by the decision (1..4); DB-capped by
+    // elevation_requests_decided_level_range_chk. `.$type` aligns the inferred
+    // read type with that invariant (issue #1372).
+    decidedAssuranceLevel: smallint('decided_assurance_level').$type<AssuranceLevel>(),
     decidedVia: approvalFactorEnum('decided_via'),
     authenticatorDeviceId: uuid('authenticator_device_id'),
     pinVerified: boolean('pin_verified').notNull().default(false),


### PR DESCRIPTION
## What

Deferred follow-up from the PR #1369 (Breeze Authenticator) review. Closes #1372.

The four factor-recording columns on `approval_requests` + `elevation_requests` (`decided_assurance_level`, `decided_via`, `authenticator_device_id`, and the transitional `pin_verified`) form a forensic/audit record, but were independent at the DB level — the store accepted self-contradictory tuples the application would never write (e.g. `decided_via='session_tap'` with a non-null device id, `decided_assurance_level=7`, or an L2+ factor at level 1). `assertDecisionConsistent` (`authenticatorAssurance.ts`) guards this at *write* time; this PR mirrors those invariants at the *storage* boundary — the loosest link — so the illegal states are unrepresentable.

## Changes

**New idempotent migration** `2026-06-17-authenticator-assurance-check-constraints.sql` adds, to **both** tables:
- `decided_assurance_level`, when set, `BETWEEN 1 AND 4`
- `session_tap` ⟺ no authenticator device (an L2+ factor must record one)
- `session_tap` ⟺ level 1 (a proof factor is never L1)
- `pin_verified` ⟹ level ≥ 3 — **guarded by column existence**. The approver PIN is being removed in #1433; once that column is dropped Postgres removes the dependent CHECK automatically and the guarded block becomes a no-op, so this PR is safe to merge in either order relative to #1433.

Every undecided/pending row (all factor fields NULL) passes — each predicate short-circuits to NULL, which a CHECK treats as satisfied.

**Schema:** `.$type<AssuranceLevel>()` on `decidedAssuranceLevel` in both schema files, so `$inferSelect` stops advertising the looser `number | null` than the `1|2|3|4` the read path already assumes.

> Note on scope vs. the issue: the issue listed three constraints. `pin_verified` is now transitional (#1433), so it's column-guarded; and the `session_tap ⟺ L1` binding was added to fully mirror `assertDecisionConsistent` (its invariant #1), which the issue's listed set didn't cover.

## Testing

New `authenticator-assurance-checks.integration.test.ts` (real DB, 11 cases):
- forges every illegal tuple → rejected with SQLSTATE `23514`
- legitimate (session_tap/L1, L2+/device) and pending (all-NULL) rows still insert
- asserts `elevation_requests` carries byte-identical CHECK predicates (`pg_get_constraintdef`)

Verified RED (8 fail) → GREEN (11 pass) across adding the migration. Also green: `autoMigrate.test.ts` (43), `approval-system-scope` + `authenticatorRls` integration (7), `authenticatorAssurance` unit (25), `tsc --noEmit` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)