### PR TITLE
feat(ml): add phase 0 foundations

### DIFF
--- a/apps/api/migrations/2026-06-18-ml-feedback-events.sql
+++ b/apps/api/migrations/2026-06-18-ml-feedback-events.sql
@@ -1,0 +1,90 @@
+-- Canonical ML feedback events foundation (Phase 0 / C1).
+-- Append-only label capture table with direct org_id RLS shape 1.
+-- Idempotent throughout. autoMigrate wraps this file in a transaction.
+
+CREATE TABLE IF NOT EXISTS ml_feedback_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  source_type VARCHAR(40) NOT NULL,
+  source_id VARCHAR(255) NOT NULL,
+  event_type VARCHAR(80) NOT NULL,
+  actor_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  outcome VARCHAR(60) NOT NULL,
+  confidence REAL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT ml_feedback_events_source_type_check CHECK (
+    source_type IN ('alert', 'ticket', 'device', 'anomaly', 'correlation', 'rca', 'remediation', 'user_risk')
+  ),
+  CONSTRAINT ml_feedback_events_confidence_check CHECK (
+    confidence IS NULL OR (confidence >= 0 AND confidence <= 1)
+  ),
+  CONSTRAINT ml_feedback_events_metadata_object_check CHECK (
+    jsonb_typeof(metadata) = 'object'
+  ),
+  CONSTRAINT ml_feedback_events_metadata_size_check CHECK (
+    octet_length(metadata::text) <= 8192
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ml_feedback_events_dedupe_uq
+  ON ml_feedback_events (source_type, source_id, event_type, occurred_at);
+
+CREATE INDEX IF NOT EXISTS ml_feedback_events_org_occurred_idx
+  ON ml_feedback_events (org_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS ml_feedback_events_org_event_idx
+  ON ml_feedback_events (org_id, event_type, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS ml_feedback_events_source_idx
+  ON ml_feedback_events (source_type, source_id, occurred_at DESC);
+
+ALTER TABLE ml_feedback_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ml_feedback_events FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON ml_feedback_events;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON ml_feedback_events;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON ml_feedback_events;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON ml_feedback_events;
+
+CREATE POLICY breeze_org_isolation_select ON ml_feedback_events
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON ml_feedback_events
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON ml_feedback_events
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON ml_feedback_events
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- App role may read and append only. Tenant erasure deletes through the
+-- audit-admin path used by audit_logs/audit_log_chain.
+GRANT SELECT, INSERT ON TABLE ml_feedback_events TO breeze_app;
+REVOKE UPDATE, DELETE ON TABLE ml_feedback_events FROM breeze_app;
+GRANT SELECT, DELETE ON TABLE ml_feedback_events TO breeze_audit_admin;
+REVOKE UPDATE ON TABLE ml_feedback_events FROM breeze_audit_admin;
+
+CREATE OR REPLACE FUNCTION ml_feedback_events_append_only() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  allow_retention text := current_setting('breeze.allow_audit_retention', true);
+BEGIN
+  IF TG_OP = 'DELETE' AND allow_retention = '1' THEN
+    RETURN OLD;
+  END IF;
+
+  RAISE EXCEPTION USING
+    ERRCODE = 'P0001',
+    MESSAGE = 'ml_feedback_events is append-only',
+    HINT = 'ML feedback labels cannot be modified or deleted. Tenant erasure uses breeze_audit_admin plus the breeze.allow_audit_retention GUC (DELETE only).';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ml_feedback_events_block_update ON ml_feedback_events;
+CREATE TRIGGER ml_feedback_events_block_update BEFORE UPDATE ON ml_feedback_events
+  FOR EACH ROW EXECUTE FUNCTION ml_feedback_events_append_only();
+
+DROP TRIGGER IF EXISTS ml_feedback_events_block_delete ON ml_feedback_events;
+CREATE TRIGGER ml_feedback_events_block_delete BEFORE DELETE ON ml_feedback_events
+  FOR EACH ROW EXECUTE FUNCTION ml_feedback_events_append_only();

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, it, expect } from 'vitest';
 import { eq, sql } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
-import { partners, users, organizations, invoices, invoiceLines, invoiceDocuments, contracts, contractLines, contractBillingPeriods } from '../../db/schema';
+import { partners, users, organizations, invoices, invoiceLines, invoiceDocuments, contracts, contractLines, contractBillingPeriods, mlFeedbackEvents } from '../../db/schema';
 import { approvalRequests } from '../../db/schema/approvals';
 import { manifestSigningKeys } from '../../db/schema/manifestSigningKeys';
 import { automations, automationRuns } from '../../db/schema/automations';
@@ -2036,6 +2036,84 @@ describe('invoice_documents RLS forge (shape 1, org-axis)', () => {
     });
     const visible = await withDbAccessContext(orgContext(orgBId), async () =>
       db.select({ id: invoiceDocuments.id }).from(invoiceDocuments).where(eq(invoiceDocuments.id, createdId))
+    );
+    expect(visible).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ml_feedback_events — shape 1 (direct org_id) forge test
+// ---------------------------------------------------------------------------
+// ml_feedback_events is the canonical append-only ML label table. It carries a
+// direct org_id and is auto-discovered by the coverage scan above; this block
+// proves hostile cross-org INSERT/SELECT attempts are blocked under breeze_app.
+describe('ml_feedback_events RLS forge (shape 1, org-axis)', () => {
+  const runSuffix = Math.random().toString(36).slice(2, 8);
+  let partnerId = '';
+  let orgAId = '';
+  let orgBId = '';
+
+  function orgContext(orgId: string) {
+    return { scope: 'organization' as const, orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null };
+  }
+
+  async function ensureFixtures(): Promise<void> {
+    if (partnerId) return;
+    await withSystemDbAccessContext(async () => {
+      const [partner] = await db.insert(partners).values({
+        name: `RLS ML Feedback Partner ${runSuffix}`, slug: `rls-ml-feedback-${runSuffix}`,
+        type: 'msp', plan: 'pro', status: 'active'
+      }).returning({ id: partners.id });
+      if (!partner) throw new Error('failed to seed partner for ml_feedback_events forge');
+      partnerId = partner.id;
+      const [orgA, orgB] = await db.insert(organizations).values([
+        { partnerId: partner.id, name: 'RLS ML Feedback Org A', slug: `rls-ml-feedback-a-${runSuffix}` },
+        { partnerId: partner.id, name: 'RLS ML Feedback Org B', slug: `rls-ml-feedback-b-${runSuffix}` }
+      ]).returning({ id: organizations.id });
+      if (!orgA || !orgB) throw new Error('failed to seed orgs for ml_feedback_events forge');
+      orgAId = orgA.id; orgBId = orgB.id;
+    });
+  }
+
+  it.runIf(!!process.env.DATABASE_URL)('org B INSERT with org A org_id is rejected by WITH CHECK', async () => {
+    await ensureFixtures();
+    let caught: unknown;
+    try {
+      await withDbAccessContext(orgContext(orgBId), async () =>
+        db.insert(mlFeedbackEvents).values({
+          orgId: orgAId,
+          sourceType: 'alert',
+          sourceId: `alert-${runSuffix}`,
+          eventType: 'alert.acknowledged',
+          outcome: 'acknowledged',
+          metadata: {},
+          occurredAt: new Date('2026-06-18T12:00:00.000Z'),
+        })
+      );
+    } catch (err) { caught = err; }
+    expect(caught).toBeDefined();
+    const cause = caught as { cause?: { message?: string }; message?: string } | undefined;
+    const message = cause?.cause?.message ?? cause?.message ?? '';
+    expect(message).toMatch(/new row violates row-level security policy for table "ml_feedback_events"/);
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)("org B cannot SELECT org A's feedback event", async () => {
+    await ensureFixtures();
+    let createdId = '';
+    await withSystemDbAccessContext(async () => {
+      const [event] = await db.insert(mlFeedbackEvents).values({
+        orgId: orgAId,
+        sourceType: 'alert',
+        sourceId: `alert-visible-${runSuffix}`,
+        eventType: 'alert.resolved',
+        outcome: 'resolved',
+        metadata: {},
+        occurredAt: new Date('2026-06-18T12:01:00.000Z'),
+      }).returning({ id: mlFeedbackEvents.id });
+      createdId = event!.id;
+    });
+    const visible = await withDbAccessContext(orgContext(orgBId), async () =>
+      db.select({ id: mlFeedbackEvents.id }).from(mlFeedbackEvents).where(eq(mlFeedbackEvents.id, createdId))
     );
     expect(visible).toHaveLength(0);
   });

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,4 +1,4 @@
-function envFlag(name: string, fallback = false): boolean {
+export function envFlag(name: string, fallback = false): boolean {
   const raw = process.env[name];
   if (!raw) return fallback;
   const v = raw.trim().toLowerCase();
@@ -85,4 +85,48 @@ export function cfAccessAud(): string {
 }
 export function cfAccessTrustsMfa(): boolean {
   return envFlag('CF_ACCESS_TRUSTS_MFA');
+}
+
+// Emergency kill switches for ML/AI producers. These are intentionally read at
+// call time so ops can flip process/runtime env and workers can stop writing
+// outputs without a redeploy.
+export function mlFeaturesGloballyDisabled(): boolean {
+  return (
+    envFlag('ML_FEATURES_DISABLED') ||
+    envFlag('ML_OUTPUTS_DISABLED') ||
+    envFlag('ML_GLOBAL_KILL_SWITCH')
+  );
+}
+
+function mlFlagEnvNames(flag: string): string[] {
+  const normalized = flag
+    .replace(/^ml\./, '')
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase();
+  const disabledName = `ML_${normalized}_DISABLED`;
+  const names = [disabledName];
+  if (disabledName.endsWith('_ENABLED_DISABLED')) {
+    names.push(disabledName.replace(/_ENABLED_DISABLED$/, '_DISABLED'));
+  }
+  return names;
+}
+
+function isFlagListed(raw: string | undefined, flag: string): boolean {
+  if (!raw) return false;
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .some((entry) => {
+      if (entry === flag || entry === '*' || entry === 'ml.*') return true;
+      if (entry.endsWith('.*')) return flag.startsWith(entry.slice(0, -1));
+      return false;
+    });
+}
+
+export function mlFeatureGloballyDisabled(flag: string): boolean {
+  if (mlFeaturesGloballyDisabled()) return true;
+  if (isFlagListed(process.env.ML_DISABLED_FLAGS, flag)) return true;
+  return mlFlagEnvNames(flag).some((name) => envFlag(name));
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -89,3 +89,4 @@ export * from './stripePayments';
 export * from './invoiceDocuments';
 export * from './contracts';
 export * from './clientAi';
+export * from './mlFeedback';

--- a/apps/api/src/db/schema/mlFeedback.ts
+++ b/apps/api/src/db/schema/mlFeedback.ts
@@ -1,0 +1,41 @@
+import {
+  index,
+  jsonb,
+  pgTable,
+  real,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { users } from './users';
+import type {
+  MlFeedbackEventOutcome,
+  MlFeedbackEventSourceType,
+  MlFeedbackEventType,
+} from '@breeze/shared';
+
+export const mlFeedbackEvents = pgTable('ml_feedback_events', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  sourceType: varchar('source_type', { length: 40 }).$type<MlFeedbackEventSourceType>().notNull(),
+  sourceId: varchar('source_id', { length: 255 }).notNull(),
+  eventType: varchar('event_type', { length: 80 }).$type<MlFeedbackEventType>().notNull(),
+  actorUserId: uuid('actor_user_id').references(() => users.id, { onDelete: 'set null' }),
+  outcome: varchar('outcome', { length: 60 }).$type<MlFeedbackEventOutcome>().notNull(),
+  confidence: real('confidence'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default({}),
+  occurredAt: timestamp('occurred_at').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  dedupeIdx: uniqueIndex('ml_feedback_events_dedupe_uq').on(
+    table.sourceType,
+    table.sourceId,
+    table.eventType,
+    table.occurredAt,
+  ),
+  orgOccurredIdx: index('ml_feedback_events_org_occurred_idx').on(table.orgId, table.occurredAt),
+  orgEventIdx: index('ml_feedback_events_org_event_idx').on(table.orgId, table.eventType, table.occurredAt),
+  sourceIdx: index('ml_feedback_events_source_idx').on(table.sourceType, table.sourceId, table.occurredAt),
+}));

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -149,6 +149,7 @@ import { initializeNotificationDispatcher, shutdownNotificationDispatcher } from
 import { initializeEventLogRetention, shutdownEventLogRetention } from './jobs/eventLogRetention';
 import { initializeAgentLogRetention, shutdownAgentLogRetention } from './jobs/agentLogRetention';
 import { initializeLogCorrelationWorker, shutdownLogCorrelationWorker } from './jobs/logCorrelation';
+import { initializeAlertCorrelationWorker, shutdownAlertCorrelationWorker } from './jobs/alertCorrelation';
 import { initializeIPHistoryRetention, shutdownIPHistoryRetention } from './jobs/ipHistoryRetention';
 import { initializeChangeLogRetention, shutdownChangeLogRetention } from './jobs/changeLogRetention';
 import { initializeOauthCleanupWorker, shutdownOauthCleanupWorker } from './jobs/oauthCleanup';
@@ -1041,6 +1042,7 @@ async function initializeWorkers(): Promise<void> {
 
   const workers: Array<[string, () => Promise<void>]> = [
     ['alertWorkers', initializeAlertWorkers],
+    ['alertCorrelationWorker', initializeAlertCorrelationWorker],
     ['offlineDetector', initializeOfflineDetector],
     ['notificationDispatcher', initializeNotificationDispatcher],
     ['webhookDelivery', initializeWebhookDeliveryWorker],
@@ -1255,6 +1257,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownPolicyEvaluationWorker,
     shutdownNotificationDispatcher,
     shutdownOfflineDetector,
+    shutdownAlertCorrelationWorker,
     shutdownAlertWorkers,
     shutdownStaleCommandReaper,
     shutdownPamJobs,

--- a/apps/api/src/jobs/alertCorrelation.test.ts
+++ b/apps/api/src/jobs/alertCorrelation.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getJobMock, addMock, closeMock, shouldProduceMlOutputMock } = vi.hoisted(() => ({
+  getJobMock: vi.fn(),
+  addMock: vi.fn(),
+  closeMock: vi.fn(),
+  shouldProduceMlOutputMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    getJob = getJobMock;
+    add = addMock;
+    close = closeMock;
+  },
+  Worker: class {
+    close = closeMock;
+    on = vi.fn();
+  },
+  Job: class {},
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('../services/bullmqUtils', () => ({
+  isReusableState: vi.fn((state: string) => ['waiting', 'delayed', 'active'].includes(state)),
+}));
+
+vi.mock('../services/mlFeatureFlags', () => ({
+  shouldProduceMlOutput: shouldProduceMlOutputMock,
+}));
+
+vi.mock('../db', () => ({
+  db: {},
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  alerts: {},
+  alertCorrelations: {},
+}));
+
+import {
+  buildAlertCorrelationJobId,
+  enqueueAlertCorrelation,
+  runAlertCorrelationForDevice,
+  shutdownAlertCorrelationWorker,
+} from './alertCorrelation';
+
+describe('alert correlation queue helpers', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00.000Z'));
+    getJobMock.mockReset();
+    addMock.mockReset();
+    closeMock.mockReset();
+    shouldProduceMlOutputMock.mockReset();
+    shouldProduceMlOutputMock.mockResolvedValue(true);
+    getJobMock.mockResolvedValue(null);
+    addMock.mockResolvedValue({ id: 'queued-correlation-job' });
+    await shutdownAlertCorrelationWorker();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses a stable BullMQ job id per org/device debounce slot', async () => {
+    const jobId = buildAlertCorrelationJobId('org-1', 'device-1');
+
+    await enqueueAlertCorrelation({ orgId: 'org-1', deviceId: 'device-1' });
+
+    expect(jobId).toMatch(/^alert-correlation-org-1-device-1-[a-z0-9]+$/);
+    expect(addMock).toHaveBeenCalledWith(
+      'correlate-device-alerts',
+      expect.objectContaining({ orgId: 'org-1', deviceId: 'device-1' }),
+      expect.objectContaining({ jobId, delay: 5000 }),
+    );
+  });
+
+  it('reuses an already queued device correlation job in the same slot', async () => {
+    getJobMock.mockResolvedValue({
+      id: 'existing-correlation-job',
+      getState: vi.fn().mockResolvedValue('delayed'),
+    });
+
+    const jobId = await enqueueAlertCorrelation({ orgId: 'org-1', deviceId: 'device-1' });
+
+    expect(jobId).toBe('existing-correlation-job');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses worker scans when alert correlation is disabled for the org', async () => {
+    shouldProduceMlOutputMock.mockResolvedValue(false);
+
+    const result = await runAlertCorrelationForDevice({ orgId: 'org-1', deviceId: 'device-1' });
+
+    expect(result).toEqual({ scanned: 0, created: 0 });
+    expect(shouldProduceMlOutputMock).toHaveBeenCalledWith('org-1', 'ml.alert_correlation.enabled');
+  });
+});

--- a/apps/api/src/jobs/alertCorrelation.ts
+++ b/apps/api/src/jobs/alertCorrelation.ts
@@ -1,0 +1,191 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { and, desc, eq, gte, inArray } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../db';
+import { alertCorrelations, alerts } from '../db/schema';
+import { isReusableState } from '../services/bullmqUtils';
+import { shouldProduceMlOutput } from '../services/mlFeatureFlags';
+import { getBullMQConnection } from '../services/redis';
+
+const ALERT_CORRELATION_QUEUE = 'alert-correlation';
+const DEDUPE_WINDOW_MS = 30 * 1000;
+const DEFAULT_DELAY_MS = 5 * 1000;
+const DEFAULT_WINDOW_MINUTES = 30;
+const MAX_ALERTS_PER_DEVICE_PASS = 50;
+
+export type AlertCorrelationJobData = {
+  orgId: string;
+  deviceId: string;
+  queuedAt: string;
+  windowMinutes?: number;
+};
+
+let alertCorrelationQueue: Queue<AlertCorrelationJobData> | null = null;
+let alertCorrelationWorker: Worker<AlertCorrelationJobData> | null = null;
+
+export function getAlertCorrelationQueue(): Queue<AlertCorrelationJobData> {
+  if (!alertCorrelationQueue) {
+    alertCorrelationQueue = new Queue<AlertCorrelationJobData>(ALERT_CORRELATION_QUEUE, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return alertCorrelationQueue;
+}
+
+export function buildAlertCorrelationJobId(orgId: string, deviceId: string, now = Date.now()): string {
+  const slot = Math.floor(now / DEDUPE_WINDOW_MS).toString(36);
+  return ['alert-correlation', orgId, deviceId, slot].join('-');
+}
+
+export async function enqueueAlertCorrelation(options: {
+  orgId: string;
+  deviceId: string;
+  windowMinutes?: number;
+}): Promise<string> {
+  const queue = getAlertCorrelationQueue();
+  const jobId = buildAlertCorrelationJobId(options.orgId, options.deviceId);
+
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (isReusableState(state)) {
+      return String(existing.id);
+    }
+    await existing.remove().catch((error) => {
+      console.error(`[AlertCorrelationWorker] Failed to remove stale job ${jobId}:`, error);
+    });
+  }
+
+  const job = await queue.add(
+    'correlate-device-alerts',
+    {
+      orgId: options.orgId,
+      deviceId: options.deviceId,
+      windowMinutes: options.windowMinutes,
+      queuedAt: new Date().toISOString(),
+    },
+    {
+      jobId,
+      delay: DEFAULT_DELAY_MS,
+      removeOnComplete: true,
+      removeOnFail: { count: 50 },
+    }
+  );
+
+  return String(job.id);
+}
+
+export async function runAlertCorrelationForDevice(options: {
+  orgId: string;
+  deviceId: string;
+  windowMinutes?: number;
+}): Promise<{ scanned: number; created: number }> {
+  if (!(await shouldProduceMlOutput(options.orgId, 'ml.alert_correlation.enabled'))) {
+    return { scanned: 0, created: 0 };
+  }
+
+  const windowMinutes = options.windowMinutes ?? DEFAULT_WINDOW_MINUTES;
+  const windowStart = new Date(Date.now() - windowMinutes * 60 * 1000);
+
+  const recentAlerts = await db
+    .select({ id: alerts.id, triggeredAt: alerts.triggeredAt })
+    .from(alerts)
+    .where(
+      and(
+        eq(alerts.deviceId, options.deviceId),
+        eq(alerts.orgId, options.orgId),
+        gte(alerts.triggeredAt, windowStart),
+        inArray(alerts.status, ['active', 'acknowledged'])
+      )
+    )
+    .orderBy(desc(alerts.triggeredAt))
+    .limit(MAX_ALERTS_PER_DEVICE_PASS);
+
+  if (recentAlerts.length < 2) {
+    return { scanned: recentAlerts.length, created: 0 };
+  }
+
+  const alertIds = recentAlerts.map((alert) => alert.id);
+  const existingLinks = await db
+    .select({
+      parentAlertId: alertCorrelations.parentAlertId,
+      childAlertId: alertCorrelations.childAlertId,
+    })
+    .from(alertCorrelations)
+    .where(
+      and(
+        inArray(alertCorrelations.parentAlertId, alertIds),
+        inArray(alertCorrelations.childAlertId, alertIds)
+      )
+    );
+
+  const linkedPairs = new Set(
+    existingLinks.map((link) => [link.parentAlertId, link.childAlertId].sort().join('|'))
+  );
+
+  let created = 0;
+  const maxWindowMs = windowMinutes * 60 * 1000;
+  for (let i = 0; i < recentAlerts.length; i += 1) {
+    for (let j = i + 1; j < recentAlerts.length; j += 1) {
+      const newer = recentAlerts[i]!;
+      const older = recentAlerts[j]!;
+      const pairKey = [newer.id, older.id].sort().join('|');
+      if (linkedPairs.has(pairKey)) continue;
+
+      const timeDiffMs = Math.abs(newer.triggeredAt.getTime() - older.triggeredAt.getTime());
+      const confidence = Math.round((1 - timeDiffMs / maxWindowMs) * 100) / 100;
+      if (confidence < 0.3) continue;
+
+      await db
+        .insert(alertCorrelations)
+        .values({
+          parentAlertId: older.id,
+          childAlertId: newer.id,
+          correlationType: 'same_device_temporal',
+          confidence: String(confidence),
+          metadata: {
+            timeDiffMinutes: Math.round(timeDiffMs / 60000),
+            deviceId: options.deviceId,
+          },
+        });
+
+      linkedPairs.add(pairKey);
+      created += 1;
+    }
+  }
+
+  return { scanned: recentAlerts.length, created };
+}
+
+export function createAlertCorrelationWorker(): Worker<AlertCorrelationJobData> {
+  return new Worker<AlertCorrelationJobData>(
+    ALERT_CORRELATION_QUEUE,
+    async (job: Job<AlertCorrelationJobData>) =>
+      withSystemDbAccessContext(() => runAlertCorrelationForDevice(job.data)),
+    {
+      connection: getBullMQConnection(),
+      concurrency: 2,
+    }
+  );
+}
+
+export async function initializeAlertCorrelationWorker(): Promise<void> {
+  alertCorrelationWorker = createAlertCorrelationWorker();
+  alertCorrelationWorker.on('error', (error) => {
+    console.error('[AlertCorrelationWorker] Worker error:', error);
+  });
+  alertCorrelationWorker.on('failed', (job, error) => {
+    console.error(`[AlertCorrelationWorker] Job ${job?.id} failed:`, error);
+  });
+}
+
+export async function shutdownAlertCorrelationWorker(): Promise<void> {
+  if (alertCorrelationWorker) {
+    await alertCorrelationWorker.close();
+    alertCorrelationWorker = null;
+  }
+  if (alertCorrelationQueue) {
+    await alertCorrelationQueue.close();
+    alertCorrelationQueue = null;
+  }
+}

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -54,6 +54,11 @@ vi.mock('../services/eventBus', () => ({
   publishEvent: publishEventMock
 }));
 
+vi.mock('../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: vi.fn(),
+  emitCorrelationFeedback: vi.fn(),
+}));
+
 vi.mock('../services/alertCooldown', () => ({
   setCooldown: vi.fn().mockResolvedValue(undefined),
   markConfigPolicyRuleCooldown: vi.fn().mockResolvedValue(undefined)

--- a/apps/api/src/routes/alerts/alerts.authz.test.ts
+++ b/apps/api/src/routes/alerts/alerts.authz.test.ts
@@ -47,6 +47,10 @@ vi.mock('../../services/alertCooldown', () => ({
 }));
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: vi.fn(),
+  emitCorrelationFeedback: vi.fn(),
+}));
 vi.mock('../../services/ticketService', () => ({
   createTicketFromAlert: vi.fn(),
   TicketServiceError: class TicketServiceError extends Error { status = 400; },

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -17,6 +17,7 @@ import { requireScope, requirePermission } from '../../middleware/auth';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../../services/alertCooldown';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { publishEvent } from '../../services/eventBus';
+import { emitAlertStateFeedback } from '../../services/mlFeedbackEmitters';
 import { listAlertsSchema, resolveAlertSchema, suppressAlertSchema, bulkAlertActionSchema } from './schemas';
 import { getPagination, ensureOrgAccess, getAlertWithOrgCheck } from './helpers';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
@@ -362,6 +363,19 @@ alertsRoutes.post(
             eventErr instanceof Error ? eventErr.message : eventErr
           );
         }
+
+        await emitAlertStateFeedback({
+          orgId: alert.orgId,
+          alertId: alert.id,
+          eventType: action === 'acknowledge' ? 'alert.acknowledged' : 'alert.resolved',
+          outcome: action === 'acknowledge' ? 'acknowledged' : 'resolved',
+          actorUserId: auth.user.id,
+          occurredAt: now,
+          metadata: {
+            source: 'alerts.bulk',
+            previousStatus: alert.status,
+          },
+        });
       } catch (dbErr) {
         console.error(`[alerts/bulk] Failed to ${action} alert ${alert.id}:`, dbErr instanceof Error ? dbErr.message : dbErr);
         results.failed++;
@@ -405,11 +419,12 @@ alertsRoutes.post(
       return c.json({ error: `Cannot acknowledge alert with status: ${alert.status}` }, 400);
     }
 
+    const acknowledgedAt = new Date();
     const [updated] = await db
       .update(alerts)
       .set({
         status: 'acknowledged',
-        acknowledgedAt: new Date(),
+        acknowledgedAt,
         acknowledgedBy: auth.user.id
       })
       .where(eq(alerts.id, alertId))
@@ -434,6 +449,19 @@ alertsRoutes.post(
     } catch (error) {
       console.error('[AlertsRoute] Failed to publish alert.acknowledged event:', error);
     }
+
+    await emitAlertStateFeedback({
+      orgId: alert.orgId,
+      alertId: updated.id,
+      eventType: 'alert.acknowledged',
+      outcome: 'acknowledged',
+      actorUserId: auth.user.id,
+      occurredAt: acknowledgedAt,
+      metadata: {
+        source: 'alerts.route',
+        previousStatus: alert.status,
+      },
+    });
 
     writeRouteAudit(c, {
       orgId: alert.orgId,
@@ -472,11 +500,12 @@ alertsRoutes.post(
       return c.json({ error: 'Alert is already resolved' }, 400);
     }
 
+    const resolvedAt = new Date();
     const [updated] = await db
       .update(alerts)
       .set({
         status: 'resolved',
-        resolvedAt: new Date(),
+        resolvedAt,
         resolvedBy: auth.user.id,
         resolutionNote: data.note
       })
@@ -530,6 +559,20 @@ alertsRoutes.post(
     } catch (error) {
       console.error('[AlertsRoute] Failed to publish alert.resolved event:', error);
     }
+
+    await emitAlertStateFeedback({
+      orgId: alert.orgId,
+      alertId: updated.id,
+      eventType: 'alert.resolved',
+      outcome: 'resolved',
+      actorUserId: auth.user.id,
+      occurredAt: resolvedAt,
+      metadata: {
+        source: 'alerts.route',
+        previousStatus: alert.status,
+        hasResolutionNote: Boolean(data.note),
+      },
+    });
 
     writeRouteAudit(c, {
       orgId: alert.orgId,
@@ -585,6 +628,20 @@ alertsRoutes.post(
     if (!updated) {
       return c.json({ error: 'Failed to suppress alert' }, 500);
     }
+
+    await emitAlertStateFeedback({
+      orgId: alert.orgId,
+      alertId: updated.id,
+      eventType: 'alert.suppressed',
+      outcome: 'suppressed',
+      actorUserId: auth.user.id,
+      occurredAt: new Date(),
+      metadata: {
+        source: 'alerts.route',
+        previousStatus: alert.status,
+        suppressedUntil: suppressedUntil.toISOString(),
+      },
+    });
 
     writeRouteAudit(c, {
       orgId: alert.orgId,

--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  authRef,
+  grantedRef,
+  emitAlertStateFeedbackMock,
+  emitCorrelationFeedbackMock,
+  state,
+  tables,
+  dbMock,
+} = vi.hoisted(() => {
+  const tables = {
+    alerts: {
+      id: 'alerts.id', orgId: 'alerts.orgId', deviceId: 'alerts.deviceId', status: 'alerts.status',
+      severity: 'alerts.severity', title: 'alerts.title', triggeredAt: 'alerts.triggeredAt', createdAt: 'alerts.createdAt',
+    },
+    alertCorrelations: {
+      id: 'alert_correlations.id', parentAlertId: 'alert_correlations.parentAlertId', childAlertId: 'alert_correlations.childAlertId',
+      correlationType: 'alert_correlations.correlationType', confidence: 'alert_correlations.confidence', createdAt: 'alert_correlations.createdAt',
+    },
+    devices: { id: 'devices.id', hostname: 'devices.hostname' },
+  };
+
+  type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
+  const columnKey = (col: unknown) => String(col).split('.').pop()!;
+  const evalPredicate = (row: Record<string, unknown>, predicate: Predicate): boolean => {
+    if (!predicate) return true;
+    if (predicate.op === 'eq') return row[columnKey(predicate.col)] === predicate.val;
+    if (predicate.op === 'inArray') return (predicate.vals ?? []).includes(row[columnKey(predicate.col)]);
+    if (predicate.op === 'and') return (predicate.args ?? []).every((arg) => evalPredicate(row, arg));
+    if (predicate.op === 'or') return (predicate.args ?? []).some((arg) => evalPredicate(row, arg));
+    return true;
+  };
+
+  const state = {
+    alerts: [] as Array<Record<string, any>>,
+    correlations: [] as Array<Record<string, any>>,
+    devices: [] as Array<Record<string, any>>,
+  };
+
+  class SelectQuery {
+    private predicate: Predicate;
+    constructor(private table: unknown, private projection?: Record<string, unknown>) {}
+    where(predicate: Predicate) { this.predicate = predicate; return this; }
+    orderBy() { return this; }
+    limit(limit: number) { return Promise.resolve(this.rows().slice(0, limit)); }
+    then(resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) {
+      return Promise.resolve(this.rows()).then(resolve, reject);
+    }
+    private rows() {
+      const source = this.table === tables.alerts
+        ? state.alerts
+        : this.table === tables.alertCorrelations
+          ? state.correlations
+          : state.devices;
+      const filtered = source.filter((row) => evalPredicate(row, this.predicate));
+      if (!this.projection) return filtered;
+      return filtered.map((row) => {
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(this.projection!)) {
+          out[key] = row[columnKey(this.projection![key])];
+        }
+        return out;
+      });
+    }
+  }
+
+  const dbMock = {
+    select: vi.fn((projection?: Record<string, unknown>) => ({
+      from: (table: unknown) => new SelectQuery(table, projection),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: async (predicate: Predicate) => {
+          const source = table === tables.alerts ? state.alerts : [];
+          let updated = 0;
+          for (const row of source) {
+            if (evalPredicate(row, predicate)) {
+              Object.assign(row, values);
+              updated += 1;
+            }
+          }
+          return Array.from({ length: updated }, () => ({}));
+        },
+      }),
+    })),
+  };
+
+  return {
+    authRef: { current: null as any },
+    grantedRef: { current: new Set<string>() },
+    emitAlertStateFeedbackMock: vi.fn(),
+    emitCorrelationFeedbackMock: vi.fn(),
+    state,
+    tables,
+    dbMock,
+  };
+});
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  or: (...args: unknown[]) => ({ op: 'or', args }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: (resource: string, action: string) => async (_c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) return _c.json({ error: 'Forbidden' }, 403);
+    await next();
+  },
+}));
+
+vi.mock('../../db', () => ({ db: dbMock }));
+vi.mock('../../db/schema', () => ({
+  alerts: tables.alerts,
+  alertCorrelations: tables.alertCorrelations,
+  devices: tables.devices,
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn(() => Promise.resolve()) }));
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: emitAlertStateFeedbackMock,
+  emitCorrelationFeedback: emitCorrelationFeedbackMock,
+}));
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: {
+    ALERTS_READ: { resource: 'alerts', action: 'read' },
+    ALERTS_WRITE: { resource: 'alerts', action: 'write' },
+    ALERTS_ACKNOWLEDGE: { resource: 'alerts', action: 'acknowledge' },
+  },
+}));
+
+import { alertCorrelationRoutes } from './correlations';
+
+const ORG_1 = '11111111-1111-4111-8111-111111111111';
+const ORG_2 = '22222222-2222-4222-8222-222222222222';
+const ALERT_1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ALERT_2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const ALERT_3 = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const DEVICE_1 = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', alertCorrelationRoutes);
+  return app;
+}
+
+function seed() {
+  state.alerts = [
+    { id: ALERT_1, orgId: ORG_1, deviceId: DEVICE_1, status: 'active', severity: 'critical', title: 'CPU high', ruleId: 'rule-1', triggeredAt: new Date('2026-06-18T12:00:00Z'), createdAt: new Date('2026-06-18T12:00:00Z') },
+    { id: ALERT_2, orgId: ORG_1, deviceId: DEVICE_1, status: 'active', severity: 'high', title: 'Memory high', ruleId: 'rule-2', triggeredAt: new Date('2026-06-18T12:02:00Z'), createdAt: new Date('2026-06-18T12:02:00Z') },
+    { id: ALERT_3, orgId: ORG_2, deviceId: DEVICE_1, status: 'active', severity: 'low', title: 'Other org', ruleId: 'rule-3', triggeredAt: new Date('2026-06-18T12:03:00Z'), createdAt: new Date('2026-06-18T12:03:00Z') },
+  ];
+  state.correlations = [
+    { id: '11111111-aaaa-4aaa-8aaa-111111111111', parentAlertId: ALERT_1, childAlertId: ALERT_2, correlationType: 'same_device_temporal', confidence: '0.91', createdAt: new Date('2026-06-18T12:03:00Z') },
+    { id: '22222222-aaaa-4aaa-8aaa-222222222222', parentAlertId: ALERT_1, childAlertId: ALERT_3, correlationType: 'same_device_temporal', confidence: '0.88', createdAt: new Date('2026-06-18T12:04:00Z') },
+  ];
+  state.devices = [{ id: DEVICE_1, hostname: 'server-1' }];
+}
+
+describe('/alerts correlation routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seed();
+    grantedRef.current = new Set(['alerts:read', 'alerts:acknowledge', 'alerts:write']);
+    authRef.current = {
+      scope: 'organization',
+      orgId: ORG_1,
+      accessibleOrgIds: null,
+      user: { id: '99999999-9999-4999-8999-999999999999' },
+      canAccessOrg: (orgId: string) => orgId === ORG_1,
+    };
+  });
+
+  it('returns detail correlations at GET /alerts/:alertId/correlations without leaking cross-org links', async () => {
+    const res = await makeApp().request(`/alerts/${ALERT_1}/correlations`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.correlations).toEqual([
+      expect.objectContaining({ id: '11111111-aaaa-4aaa-8aaa-111111111111', title: 'Memory high', confidence: 0.91 }),
+    ]);
+    expect(body.correlationLinks).toHaveLength(1);
+    expect(body.summary.relatedCount).toBe(1);
+  });
+
+  it('returns 404 when the alert exists but belongs to another org', async () => {
+    const res = await makeApp().request(`/alerts/${ALERT_3}/correlations`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns grouped correlations at GET /alerts/correlations', async () => {
+    const res = await makeApp().request('/alerts/correlations');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.groups).toHaveLength(1);
+    expect(body.groups[0]).toEqual(expect.objectContaining({ relatedCount: 1, correlationScore: 0.91 }));
+    expect(body.groups[0].rootCause.device).toBe('server-1');
+  });
+
+  it('acknowledges all accessible alerts in a correlation group', async () => {
+    const groupsRes = await makeApp().request('/alerts/correlations');
+    const groupsBody = await groupsRes.json();
+    const res = await makeApp().request(`/alerts/correlations/${groupsBody.groups[0].id}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ updated: 2, skipped: 0 });
+    expect(state.alerts.find((alert) => alert.id === ALERT_1)?.status).toBe('acknowledged');
+    expect(state.alerts.find((alert) => alert.id === ALERT_2)?.status).toBe('acknowledged');
+    expect(state.alerts.find((alert) => alert.id === ALERT_3)?.status).toBe('active');
+    expect(emitAlertStateFeedbackMock).toHaveBeenCalledTimes(2);
+    expect(emitCorrelationFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_1,
+      correlationId: groupsBody.groups[0].id,
+      eventType: 'correlation.accepted',
+      outcome: 'accepted',
+      actorUserId: '99999999-9999-4999-8999-999999999999',
+    }));
+  });
+});

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -1,0 +1,444 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { and, desc, eq, inArray, or, type SQL } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { alertCorrelations, alerts, devices } from '../../db/schema';
+import { requirePermission, requireScope } from '../../middleware/auth';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { publishEvent } from '../../services/eventBus';
+import { emitAlertStateFeedback, emitCorrelationFeedback } from '../../services/mlFeedbackEmitters';
+import { PERMISSIONS } from '../../services/permissions';
+
+export const alertCorrelationRoutes = new Hono();
+
+const alertIdParamSchema = z.object({ alertId: z.string().uuid() });
+const groupIdParamSchema = z.object({ groupId: z.string().uuid() });
+
+const requireAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
+const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
+const requireAlertAcknowledge = requirePermission(PERMISSIONS.ALERTS_ACKNOWLEDGE.resource, PERMISSIONS.ALERTS_ACKNOWLEDGE.action);
+
+type AuthContext = {
+  scope: 'organization' | 'partner' | 'system';
+  orgId?: string | null;
+  accessibleOrgIds?: string[] | null;
+  user: { id: string };
+  canAccessOrg: (orgId: string) => boolean;
+};
+
+type AlertRow = typeof alerts.$inferSelect;
+type CorrelationRow = typeof alertCorrelations.$inferSelect;
+
+function orgConditionsForAuth(auth: AuthContext): SQL[] | null {
+  if (auth.scope === 'organization') {
+    return auth.orgId ? [eq(alerts.orgId, auth.orgId)] : null;
+  }
+
+  if (auth.scope === 'partner') {
+    const orgIds = auth.accessibleOrgIds ?? [];
+    return orgIds.length > 0 ? [inArray(alerts.orgId, orgIds)] : null;
+  }
+
+  return [];
+}
+
+async function getAccessibleAlert(alertId: string, auth: AuthContext): Promise<AlertRow | null> {
+  const [alert] = await db
+    .select()
+    .from(alerts)
+    .where(eq(alerts.id, alertId))
+    .limit(1);
+
+  if (!alert || !auth.canAccessOrg(alert.orgId)) {
+    return null;
+  }
+
+  return alert;
+}
+
+async function listAccessibleAlerts(auth: AuthContext): Promise<AlertRow[]> {
+  const orgConditions = orgConditionsForAuth(auth);
+  if (orgConditions === null) {
+    return [];
+  }
+  if (orgConditions.length === 0) {
+    return db.select().from(alerts);
+  }
+  return db.select().from(alerts).where(and(...orgConditions));
+}
+
+function alertDisplayDevice(alert: AlertRow & { deviceHostname?: string | null }) {
+  return alert.deviceHostname ?? alert.deviceId;
+}
+
+function toGroupAlert(alert: AlertRow & { deviceHostname?: string | null }) {
+  return {
+    id: alert.id,
+    title: alert.title,
+    severity: alert.severity,
+    status: alert.status,
+    device: alertDisplayDevice(alert),
+    triggeredAt: alert.triggeredAt,
+  };
+}
+
+function correlationTypeForUi(link: CorrelationRow): 'causal' | 'symptom' | 'duplicate' {
+  if (link.correlationType.includes('duplicate')) return 'duplicate';
+  if (link.correlationType.includes('causal')) return 'causal';
+  return 'symptom';
+}
+
+async function buildCorrelationGroups(auth: AuthContext) {
+  const orgAlerts = await listAccessibleAlerts(auth);
+  const orgAlertIds = orgAlerts.map((alert) => alert.id);
+  if (orgAlertIds.length === 0) {
+    return [];
+  }
+
+  const deviceRows = await db
+    .select({ id: devices.id, hostname: devices.hostname })
+    .from(devices)
+    .where(inArray(devices.id, orgAlerts.map((alert) => alert.deviceId)));
+  const deviceNames = new Map(deviceRows.map((device) => [device.id, device.hostname]));
+  const alertMap = new Map(
+    orgAlerts.map((alert) => [alert.id, { ...alert, deviceHostname: deviceNames.get(alert.deviceId) ?? null }])
+  );
+
+  const scopedCorrelations = await db
+    .select()
+    .from(alertCorrelations)
+    .where(
+      and(
+        inArray(alertCorrelations.parentAlertId, orgAlertIds),
+        inArray(alertCorrelations.childAlertId, orgAlertIds)
+      )
+    )
+    .orderBy(desc(alertCorrelations.createdAt));
+
+  const parent = new Map<string, string>();
+  const find = (id: string): string => {
+    if (!parent.has(id)) parent.set(id, id);
+    if (parent.get(id) !== id) parent.set(id, find(parent.get(id)!));
+    return parent.get(id)!;
+  };
+  const union = (a: string, b: string) => {
+    parent.set(find(a), find(b));
+  };
+
+  for (const correlation of scopedCorrelations) {
+    union(correlation.parentAlertId, correlation.childAlertId);
+  }
+
+  const groupMap = new Map<string, string[]>();
+  for (const correlation of scopedCorrelations) {
+    const root = find(correlation.parentAlertId);
+    const alertIds = groupMap.get(root) ?? [];
+    if (!alertIds.includes(correlation.parentAlertId)) alertIds.push(correlation.parentAlertId);
+    if (!alertIds.includes(correlation.childAlertId)) alertIds.push(correlation.childAlertId);
+    groupMap.set(root, alertIds);
+  }
+
+  return [...groupMap.entries()].map(([rootId, alertIds]) => {
+    const groupAlerts = alertIds
+      .map((id) => alertMap.get(id))
+      .filter((alert): alert is AlertRow & { deviceHostname?: string | null } => Boolean(alert))
+      .sort((a, b) => b.triggeredAt.getTime() - a.triggeredAt.getTime());
+    const groupCorrelations = scopedCorrelations.filter(
+      (correlation) => alertIds.includes(correlation.parentAlertId) || alertIds.includes(correlation.childAlertId)
+    );
+    const rootCause = groupAlerts[0] ?? alertMap.get(rootId);
+    const avgConfidence = groupCorrelations.length > 0
+      ? groupCorrelations.reduce((sum, correlation) => sum + Number(correlation.confidence ?? 0), 0) / groupCorrelations.length
+      : 0;
+
+    return {
+      id: rootId,
+      rootCause: rootCause ? toGroupAlert(rootCause) : null,
+      relatedCount: Math.max(groupAlerts.length - 1, 0),
+      alerts: groupAlerts.map(toGroupAlert),
+      correlationScore: Math.round(avgConfidence * 100) / 100,
+      correlationLinks: groupCorrelations,
+      createdAt: groupCorrelations[0]?.createdAt ?? new Date(),
+    };
+  }).filter((group) => group.rootCause !== null);
+}
+
+async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'resolve', userId: string) {
+  const now = new Date();
+  const eligible = action === 'acknowledge'
+    ? alertRows.filter((alert) => alert.status === 'active')
+    : alertRows.filter((alert) => alert.status !== 'resolved');
+
+  if (eligible.length === 0) {
+    return { updated: 0, skipped: alertRows.length };
+  }
+
+  const alertIds = eligible.map((alert) => alert.id);
+  await db
+    .update(alerts)
+    .set(action === 'acknowledge'
+      ? { status: 'acknowledged', acknowledgedAt: now, acknowledgedBy: userId }
+      : { status: 'resolved', resolvedAt: now, resolvedBy: userId })
+    .where(inArray(alerts.id, alertIds));
+
+  for (const alert of eligible) {
+    void publishEvent(
+      action === 'acknowledge' ? 'alert.acknowledged' : 'alert.resolved',
+      alert.orgId,
+      {
+        alertId: alert.id,
+        ruleId: alert.ruleId,
+        deviceId: alert.deviceId,
+        ...(action === 'acknowledge' ? { acknowledgedBy: userId } : { resolvedBy: userId }),
+      },
+      'alerts-correlation-route',
+      { userId }
+    ).catch((error) => {
+      console.error(`[AlertCorrelationRoute] Failed to publish alert.${action}d event:`, error);
+    });
+
+    void emitAlertStateFeedback({
+      orgId: alert.orgId,
+      alertId: alert.id,
+      eventType: action === 'acknowledge' ? 'alert.acknowledged' : 'alert.resolved',
+      outcome: action === 'acknowledge' ? 'acknowledged' : 'resolved',
+      actorUserId: userId,
+      occurredAt: now,
+      metadata: {
+        source: 'alert_correlation',
+        previousStatus: alert.status,
+      },
+    });
+  }
+
+  return { updated: eligible.length, skipped: alertRows.length - eligible.length };
+}
+
+alertCorrelationRoutes.get(
+  '/correlations',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const groups = await buildCorrelationGroups(auth);
+    return c.json({ groups, data: groups });
+  }
+);
+
+alertCorrelationRoutes.post(
+  '/correlations/:groupId/acknowledge',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertAcknowledge,
+  zValidator('param', groupIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { groupId } = c.req.valid('param');
+    const groups = await buildCorrelationGroups(auth);
+    const group = groups.find((candidate) => candidate.id === groupId);
+    if (!group) {
+      return c.json({ error: 'Correlation group not found' }, 404);
+    }
+
+    const groupAlertIds = group.alerts.map((alert) => alert.id);
+    const groupAlerts = await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
+    const result = await mutateAlerts(groupAlerts, 'acknowledge', auth.user.id);
+
+    writeRouteAudit(c, {
+      orgId: groupAlerts[0]?.orgId,
+      action: 'alert_correlation.acknowledge_group',
+      resourceType: 'alert_correlation',
+      resourceId: groupId,
+      details: { alertIds: groupAlertIds, ...result },
+    });
+
+    if (groupAlerts[0]) {
+      void emitCorrelationFeedback({
+        orgId: groupAlerts[0].orgId,
+        correlationId: groupId,
+        eventType: 'correlation.accepted',
+        outcome: 'accepted',
+        actorUserId: auth.user.id,
+        metadata: {
+          action: 'acknowledge_group',
+          alertIds: groupAlertIds,
+          updated: result.updated,
+          skipped: result.skipped,
+        },
+      });
+    }
+
+    return c.json(result);
+  }
+);
+
+alertCorrelationRoutes.post(
+  '/correlations/:groupId/resolve',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertWrite,
+  zValidator('param', groupIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { groupId } = c.req.valid('param');
+    const groups = await buildCorrelationGroups(auth);
+    const group = groups.find((candidate) => candidate.id === groupId);
+    if (!group) {
+      return c.json({ error: 'Correlation group not found' }, 404);
+    }
+
+    const groupAlertIds = group.alerts.map((alert) => alert.id);
+    const groupAlerts = await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
+    const result = await mutateAlerts(groupAlerts, 'resolve', auth.user.id);
+
+    writeRouteAudit(c, {
+      orgId: groupAlerts[0]?.orgId,
+      action: 'alert_correlation.resolve_group',
+      resourceType: 'alert_correlation',
+      resourceId: groupId,
+      details: { alertIds: groupAlertIds, ...result },
+    });
+
+    if (groupAlerts[0]) {
+      void emitCorrelationFeedback({
+        orgId: groupAlerts[0].orgId,
+        correlationId: groupId,
+        eventType: 'correlation.accepted',
+        outcome: 'accepted',
+        actorUserId: auth.user.id,
+        metadata: {
+          action: 'resolve_group',
+          alertIds: groupAlertIds,
+          updated: result.updated,
+          skipped: result.skipped,
+        },
+      });
+    }
+
+    return c.json(result);
+  }
+);
+
+alertCorrelationRoutes.get(
+  '/:alertId/correlations',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
+  zValidator('param', alertIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { alertId } = c.req.valid('param');
+
+    const alert = await getAccessibleAlert(alertId, auth);
+    if (!alert) {
+      return c.json({ error: 'Alert not found' }, 404);
+    }
+
+    const links = await db
+      .select()
+      .from(alertCorrelations)
+      .where(
+        or(
+          eq(alertCorrelations.parentAlertId, alertId),
+          eq(alertCorrelations.childAlertId, alertId)
+        )
+      )
+      .orderBy(desc(alertCorrelations.createdAt));
+
+    const relatedIds = [...new Set(links.map((link) =>
+      link.parentAlertId === alertId ? link.childAlertId : link.parentAlertId
+    ))];
+    const relatedAlerts = relatedIds.length > 0
+      ? await db.select().from(alerts).where(and(eq(alerts.orgId, alert.orgId), inArray(alerts.id, relatedIds)))
+      : [];
+    const relatedById = new Map(relatedAlerts.map((relatedAlert) => [relatedAlert.id, relatedAlert]));
+
+    const visibleLinks: CorrelationRow[] = [];
+    const correlations = links
+      .map((link) => {
+        const relatedId = link.parentAlertId === alertId ? link.childAlertId : link.parentAlertId;
+        const relatedAlert = relatedById.get(relatedId);
+        if (!relatedAlert) return null;
+        visibleLinks.push(link);
+        return {
+          id: link.id,
+          title: relatedAlert.title,
+          type: correlationTypeForUi(link),
+          confidence: Number(link.confidence ?? 0),
+        };
+      })
+      .filter((item): item is { id: string; title: string; type: 'causal' | 'symptom' | 'duplicate'; confidence: number } => Boolean(item));
+
+    const timelineAlerts = [alert, ...relatedAlerts].sort((a, b) => a.triggeredAt.getTime() - b.triggeredAt.getTime());
+    const timeline = timelineAlerts.map((timelineAlert) => ({
+      id: timelineAlert.id,
+      label: timelineAlert.title,
+      time: timelineAlert.triggeredAt.toISOString(),
+      severity: timelineAlert.severity,
+    }));
+    const maxConfidence = correlations.reduce((max, correlation) => Math.max(max, correlation.confidence), 0);
+
+    return c.json({
+      alert,
+      correlations,
+      correlationLinks: visibleLinks,
+      relatedAlerts,
+      timeline,
+      summary: {
+        relatedCount: relatedAlerts.length,
+        rootCauseConfidence: maxConfidence,
+        lastUpdate: (visibleLinks[0]?.createdAt ?? alert.createdAt).toISOString(),
+      },
+      data: { alert, correlations: visibleLinks, relatedAlerts },
+    });
+  }
+);
+
+alertCorrelationRoutes.post(
+  '/:alertId/correlations/acknowledge',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertAcknowledge,
+  zValidator('param', alertIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { alertId } = c.req.valid('param');
+    const alert = await getAccessibleAlert(alertId, auth);
+    if (!alert) {
+      return c.json({ error: 'Alert not found' }, 404);
+    }
+
+    const links = await db
+      .select()
+      .from(alertCorrelations)
+      .where(or(eq(alertCorrelations.parentAlertId, alertId), eq(alertCorrelations.childAlertId, alertId)));
+    const relatedIdsForMutation = links.map((link) => link.parentAlertId === alertId ? link.childAlertId : link.parentAlertId);
+    const relatedAlerts = relatedIdsForMutation.length > 0
+      ? await db.select().from(alerts).where(and(eq(alerts.orgId, alert.orgId), inArray(alerts.id, relatedIdsForMutation)))
+      : [];
+    const result = await mutateAlerts([alert, ...relatedAlerts], 'acknowledge', auth.user.id);
+
+    writeRouteAudit(c, {
+      orgId: alert.orgId,
+      action: 'alert_correlation.acknowledge_related',
+      resourceType: 'alert',
+      resourceId: alert.id,
+      resourceName: alert.title,
+      details: { relatedAlertIds: relatedAlerts.map((relatedAlert) => relatedAlert.id), ...result },
+    });
+
+    void emitCorrelationFeedback({
+      orgId: alert.orgId,
+      correlationId: alert.id,
+      eventType: 'correlation.accepted',
+      outcome: 'accepted',
+      actorUserId: auth.user.id,
+      metadata: {
+        action: 'acknowledge_related',
+        relatedAlertIds: relatedAlerts.map((relatedAlert) => relatedAlert.id),
+        updated: result.updated,
+        skipped: result.skipped,
+      },
+    });
+
+    return c.json(result);
+  }
+);

--- a/apps/api/src/routes/alerts/index.ts
+++ b/apps/api/src/routes/alerts/index.ts
@@ -5,6 +5,7 @@ import { alertsRoutes } from './alerts';
 import { channelsRoutes } from './channels';
 import { policiesRoutes } from './policies';
 import { routingRoutes } from './routing';
+import { alertCorrelationRoutes } from './correlations';
 
 export const alertRoutes = new Hono();
 
@@ -16,5 +17,6 @@ alertRoutes.route('/', rulesRoutes);
 alertRoutes.route('/', channelsRoutes);
 alertRoutes.route('/', policiesRoutes);
 alertRoutes.route('/', routingRoutes);
+alertRoutes.route('/', alertCorrelationRoutes);
 alertRoutes.route('/', alertsRoutes);
 

--- a/apps/api/src/services/alertService.test.ts
+++ b/apps/api/src/services/alertService.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock, insertCalls, enqueueAlertCorrelationMock, alertsTable, alertCorrelationsTable } = vi.hoisted(() => {
+  const alertsTable = { id: 'alerts.id', ruleId: 'alerts.ruleId', deviceId: 'alerts.deviceId', status: 'alerts.status' };
+  const alertCorrelationsTable = { id: 'alert_correlations.id' };
+  const selectResults: unknown[][] = [];
+  const insertReturnResults: unknown[][] = [];
+  const dbMock = {
+    _selectResults: selectResults,
+    _insertReturnResults: insertReturnResults,
+    select: vi.fn(() => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(selectResults.shift() ?? []),
+        }),
+      }),
+    })),
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve(insertReturnResults.shift() ?? [])),
+      })),
+      _table: table,
+    })),
+  };
+  return {
+    dbMock,
+    alertsTable,
+    alertCorrelationsTable,
+    insertCalls: dbMock.insert,
+    enqueueAlertCorrelationMock: vi.fn(() => Promise.resolve('correlation-job-1')),
+  };
+});
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+  isNotNull: (col: unknown) => ({ op: 'isNotNull', col }),
+  or: (...args: unknown[]) => ({ op: 'or', args }),
+}));
+
+vi.mock('../db', () => ({ db: dbMock }));
+
+vi.mock('../db/schema', () => ({
+  alerts: alertsTable,
+  alertRules: { id: 'alert_rules.id', templateId: 'alert_rules.templateId' },
+  alertTemplates: { id: 'alert_templates.id' },
+  alertCorrelations: alertCorrelationsTable,
+  devices: {},
+  deviceGroups: {},
+  deviceGroupMemberships: {},
+  sites: {},
+  configPolicyAlertRules: {},
+}));
+
+vi.mock('./alertConditions', () => ({
+  evaluateConditions: vi.fn(),
+  evaluateAutoResolveConditions: vi.fn(),
+  interpolateTemplate: vi.fn((template: string) => template),
+}));
+
+vi.mock('./alertCooldown', () => ({
+  isCooldownActive: vi.fn(() => Promise.resolve(false)),
+  setCooldown: vi.fn(() => Promise.resolve()),
+  isConfigPolicyRuleCooling: vi.fn(),
+  markConfigPolicyRuleCooldown: vi.fn(),
+  recordStateTransition: vi.fn(() => Promise.resolve()),
+  isFlapping: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock('./featureConfigResolver', () => ({
+  resolveAlertRulesForDevice: vi.fn(),
+  resolveMaintenanceConfigForDevice: vi.fn(),
+  isInMaintenanceWindow: vi.fn(),
+}));
+
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn(() => Promise.resolve()) }));
+vi.mock('./deviceSiteResolver', () => ({ resolveDeviceSiteId: vi.fn(() => Promise.resolve('site-1')) }));
+vi.mock('../jobs/alertCorrelation', () => ({ enqueueAlertCorrelation: enqueueAlertCorrelationMock }));
+
+import { createAlert } from './alertService';
+
+describe('createAlert correlation enqueue boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock._selectResults.length = 0;
+    dbMock._insertReturnResults.length = 0;
+    dbMock._selectResults.push(
+      [{ id: 'rule-1', templateId: 'template-1', overrideSettings: null }],
+      [{ id: 'template-1', cooldownMinutes: 5 }],
+      [],
+    );
+    dbMock._insertReturnResults.push([{ id: 'alert-1' }]);
+  });
+
+  it('enqueues device correlation instead of inserting correlation links inline', async () => {
+    const alertId = await createAlert({
+      ruleId: 'rule-1',
+      deviceId: 'device-1',
+      orgId: 'org-1',
+      severity: 'critical',
+      title: 'CPU high',
+      message: 'CPU high on device',
+    });
+
+    expect(alertId).toBe('alert-1');
+    expect(enqueueAlertCorrelationMock).toHaveBeenCalledWith({ orgId: 'org-1', deviceId: 'device-1' });
+    expect(insertCalls).toHaveBeenCalledTimes(1);
+    expect(insertCalls).not.toHaveBeenCalledWith(alertCorrelationsTable);
+  });
+});

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -13,19 +13,19 @@ import {
   alerts,
   alertRules,
   alertTemplates,
-  alertCorrelations,
   devices,
   deviceGroups,
   deviceGroupMemberships,
   sites,
   configPolicyAlertRules
 } from '../db/schema';
-import { eq, and, inArray, isNull, isNotNull, or, gte } from 'drizzle-orm';
+import { eq, and, inArray, isNull, isNotNull, or } from 'drizzle-orm';
 import { evaluateConditions, evaluateAutoResolveConditions, interpolateTemplate } from './alertConditions';
 import { isCooldownActive, setCooldown, isConfigPolicyRuleCooling, markConfigPolicyRuleCooldown, recordStateTransition, isFlapping } from './alertCooldown';
 import { resolveAlertRulesForDevice, resolveMaintenanceConfigForDevice, isInMaintenanceWindow } from './featureConfigResolver';
 import { publishEvent } from './eventBus';
 import { resolveDeviceSiteId } from './deviceSiteResolver';
+import { enqueueAlertCorrelation } from '../jobs/alertCorrelation';
 
 // Types for alert creation
 export interface CreateAlertParams {
@@ -147,8 +147,7 @@ export async function createAlert(params: CreateAlertParams): Promise<string | n
   // Set cooldown
   await setCooldown(ruleId, deviceId, cooldownMinutes);
 
-  // Phase 6b: Auto-correlate with other recent alerts on the same device
-  await autoCorrelateAlert(newAlert.id, deviceId, orgId);
+  enqueueAlertCorrelationForDevice(orgId, deviceId);
 
   // Publish event — attach the device's site so site-restricted users see it
   const siteId = await resolveDeviceSiteId(deviceId);
@@ -675,8 +674,7 @@ export async function evaluateDeviceAlertsFromPolicy(deviceId: string): Promise<
           // 10. Set cooldown
           await markConfigPolicyRuleCooldown(rule.id, deviceId, rule.cooldownMinutes);
 
-          // Phase 6b: Auto-correlate with other recent alerts on the same device
-          await autoCorrelateAlert(newAlert.id, deviceId, device.orgId);
+          enqueueAlertCorrelationForDevice(device.orgId, deviceId);
 
           // 11. Publish event — carry siteId so site-restricted users get it
           await publishEvent(
@@ -829,54 +827,13 @@ export async function checkAllAutoResolve(orgId?: string): Promise<number> {
   return resolvedCount;
 }
 
-/**
- * Phase 6b: Auto-correlate a new alert with other recent alerts on the same device.
- * Creates correlation links between alerts that occur close together in time.
- */
-async function autoCorrelateAlert(alertId: string, deviceId: string, orgId: string): Promise<void> {
-  try {
-    const windowStart = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes
-
-    const recentAlerts = await db
-      .select({ id: alerts.id, triggeredAt: alerts.triggeredAt })
-      .from(alerts)
-      .where(
-        and(
-          eq(alerts.deviceId, deviceId),
-          eq(alerts.orgId, orgId),
-          gte(alerts.triggeredAt, windowStart),
-          inArray(alerts.status, ['active', 'acknowledged'])
-        )
-      );
-
-    // Correlate with each recent alert on the same device (excluding self)
-    for (const recentAlert of recentAlerts) {
-      if (recentAlert.id === alertId) continue;
-
-      // Confidence based on time proximity (closer = higher)
-      const timeDiffMs = Math.abs(Date.now() - recentAlert.triggeredAt.getTime());
-      const maxWindowMs = 30 * 60 * 1000;
-      const confidence = Math.round((1 - timeDiffMs / maxWindowMs) * 100) / 100;
-
-      if (confidence < 0.3) continue; // Skip very weak correlations
-
-      await db
-        .insert(alertCorrelations)
-        .values({
-          parentAlertId: recentAlert.id,
-          childAlertId: alertId,
-          correlationType: 'same_device_temporal',
-          confidence: String(confidence),
-          metadata: {
-            timeDiffMinutes: Math.round(timeDiffMs / 60000),
-            deviceId,
-          },
-        });
-    }
-  } catch (error) {
-    // Non-critical — don't block alert creation
-    console.error(`[AlertService] Auto-correlation failed for alert ${alertId}:`, error);
-  }
+function enqueueAlertCorrelationForDevice(orgId: string, deviceId: string): void {
+  void enqueueAlertCorrelation({ orgId, deviceId }).catch((error) => {
+    console.error(
+      `[AlertService] Failed to enqueue alert correlation for org=${orgId} device=${deviceId}:`,
+      error
+    );
+  });
 }
 
 /**

--- a/apps/api/src/services/mlFeatureFlags.integration-notes.md
+++ b/apps/api/src/services/mlFeatureFlags.integration-notes.md
@@ -1,0 +1,44 @@
+# ML Feature Flag Integration Notes
+
+Use `shouldProduceMlOutput(orgId, flag)` before a worker enqueues or writes any ML/AI output. It resolves the typed flag, org/partner settings overrides, and global emergency kill switches in one place.
+
+Worker A correlation enqueue gate:
+
+```ts
+import { shouldProduceMlOutput } from './mlFeatureFlags';
+
+if (!(await shouldProduceMlOutput(orgId, 'ml.alert_correlation.enabled'))) {
+  return;
+}
+
+await alertCorrelationQueue.add(jobName, payload, { jobId });
+```
+
+Future producers should gate the write-producing step, not just UI reads:
+
+- Metric rollup worker: `ml.metric_rollups.enabled`
+- Anomaly output worker: `ml.anomalies.enabled`
+- Anomaly-to-alert promotion: `ml.anomalies.create_alerts`
+- RCA generation: `ml.rca.enabled`
+- Remediation suggestions: `ml.remediation_suggestions.enabled`
+- Ticket triage suggestions: `ml.ticket_triage.enabled`
+- Existing user-risk rules: `ml.user_risk_v0.enabled`
+- Learned user-risk baseline: `ml.user_risk_v1.enabled`
+
+Supported org/partner settings shapes:
+
+```json
+{
+  "mlFeatureFlags": {
+    "ml.rca.enabled": true
+  },
+  "ml": {
+    "anomalies": {
+      "enabled": true,
+      "create_alerts": false
+    }
+  }
+}
+```
+
+Org settings override partner settings. Global env switches always win and suppress output writes: `ML_FEATURES_DISABLED=true`, `ML_DISABLED_FLAGS=ml.rca.enabled,ml.anomalies.*`, or a per-flag switch such as `ML_ALERT_CORRELATION_DISABLED=true`.

--- a/apps/api/src/services/mlFeatureFlags.test.ts
+++ b/apps/api/src/services/mlFeatureFlags.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const { dbSelect, withSystemDbAccessContext } = vi.hoisted(() => ({
+  dbSelect: vi.fn(),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db', () => ({
+  db: { select: dbSelect },
+  withSystemDbAccessContext,
+}));
+
+vi.mock('../db/schema', () => ({
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+    settings: 'organizations.settings',
+    type: 'organizations.type',
+  },
+  partners: {
+    id: 'partners.id',
+    settings: 'partners.settings',
+    type: 'partners.type',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((left, right) => ({ eq: [left, right] })),
+}));
+
+import {
+  assertMlFeatureFlagName,
+  defaultMlFeatureFlagValue,
+  isMlFeatureEnabledForOrg,
+  resolveMlFeatureFlag,
+  resolveMlFeatureFlagForOrg,
+} from './mlFeatureFlags';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function mockOrgSettingsRow(row: unknown | null) {
+  dbSelect.mockReturnValueOnce({
+    from: vi.fn(() => ({
+      innerJoin: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue(row ? [row] : []),
+        })),
+      })),
+    })),
+  } as any);
+}
+
+describe('mlFeatureFlags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.ML_FEATURES_DISABLED;
+    delete process.env.ML_OUTPUTS_DISABLED;
+    delete process.env.ML_GLOBAL_KILL_SWITCH;
+    delete process.env.ML_DISABLED_FLAGS;
+    delete process.env.ML_RCA_DISABLED;
+    delete process.env.ML_ALERT_CORRELATION_DISABLED;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('uses conservative production defaults and enables dev/internal wedge flags', () => {
+    expect(defaultMlFeatureFlagValue('ml.alert_correlation.enabled', {
+      nodeEnv: 'production',
+      orgType: 'customer',
+      partnerType: 'msp',
+    })).toBe(false);
+    expect(defaultMlFeatureFlagValue('ml.alert_correlation.enabled', {
+      nodeEnv: 'development',
+      orgType: 'customer',
+      partnerType: 'msp',
+    })).toBe(true);
+    expect(defaultMlFeatureFlagValue('ml.alert_correlation.enabled', {
+      nodeEnv: 'production',
+      orgType: 'customer',
+      partnerType: 'internal',
+    })).toBe(true);
+    expect(defaultMlFeatureFlagValue('ml.metric_rollups.enabled', { nodeEnv: 'production' })).toBe(true);
+    expect(defaultMlFeatureFlagValue('ml.user_risk_v0.enabled', { nodeEnv: 'production' })).toBe(true);
+    expect(defaultMlFeatureFlagValue('ml.rca.enabled', { nodeEnv: 'production' })).toBe(false);
+  });
+
+  it('lets org settings override partner/default settings', () => {
+    const enabled = resolveMlFeatureFlag('ml.rca.enabled', {
+      nodeEnv: 'production',
+      partnerSettings: { mlFeatureFlags: { 'ml.rca.enabled': false } },
+      orgSettings: { mlFeatureFlags: { 'ml.rca.enabled': true } },
+    });
+
+    expect(enabled).toMatchObject({
+      flag: 'ml.rca.enabled',
+      enabled: true,
+      source: 'org_settings',
+    });
+
+    const disabled = resolveMlFeatureFlag('ml.metric_rollups.enabled', {
+      orgSettings: { ml: { metric_rollups: { enabled: false } } },
+    });
+
+    expect(disabled).toMatchObject({
+      enabled: false,
+      defaultEnabled: true,
+      source: 'org_settings',
+    });
+  });
+
+  it('resolves org overrides through existing org and partner settings columns', async () => {
+    mockOrgSettingsRow({
+      orgSettings: { mlFeatureFlags: { 'ml.ticket_triage.enabled': true } },
+      orgType: 'customer',
+      partnerSettings: {},
+      partnerType: 'msp',
+    });
+
+    const resolution = await resolveMlFeatureFlagForOrg('org-1', 'ml.ticket_triage.enabled');
+
+    expect(resolution).toMatchObject({
+      enabled: true,
+      source: 'org_settings',
+    });
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('global kill switches suppress enabled flags before producers write outputs', async () => {
+    process.env.ML_RCA_DISABLED = 'true';
+    mockOrgSettingsRow({
+      orgSettings: { mlFeatureFlags: { 'ml.rca.enabled': true } },
+      orgType: 'customer',
+      partnerSettings: {},
+      partnerType: 'msp',
+    });
+
+    await expect(isMlFeatureEnabledForOrg('org-1', 'ml.rca.enabled')).resolves.toBe(false);
+
+    const direct = resolveMlFeatureFlag('ml.alert_correlation.enabled', {
+      nodeEnv: 'development',
+      orgSettings: { mlFeatureFlags: { 'ml.alert_correlation.enabled': true } },
+    });
+    expect(direct.enabled).toBe(true);
+
+    process.env.ML_FEATURES_DISABLED = 'true';
+    expect(resolveMlFeatureFlag('ml.alert_correlation.enabled', {
+      nodeEnv: 'development',
+      orgSettings: { mlFeatureFlags: { 'ml.alert_correlation.enabled': true } },
+    })).toMatchObject({
+      enabled: false,
+      source: 'global_kill_switch',
+    });
+
+    process.env.ML_FEATURES_DISABLED = 'false';
+    process.env.ML_DISABLED_FLAGS = 'ml.anomalies.*';
+    expect(resolveMlFeatureFlag('ml.anomalies.enabled', {
+      orgSettings: { mlFeatureFlags: { 'ml.anomalies.enabled': true } },
+    })).toMatchObject({
+      enabled: false,
+      source: 'global_kill_switch',
+    });
+  });
+
+  it('rejects unknown flag names at runtime', () => {
+    expect(() => assertMlFeatureFlagName('ml.unknown.enabled')).toThrow('Unknown ML feature flag');
+    expect(() => resolveMlFeatureFlag('ml.unknown.enabled' as never)).toThrow('Unknown ML feature flag');
+  });
+
+  it('fails closed when the org is missing', async () => {
+    mockOrgSettingsRow(null);
+
+    await expect(resolveMlFeatureFlagForOrg('missing-org', 'ml.metric_rollups.enabled')).resolves.toMatchObject({
+      enabled: false,
+      source: 'org_not_found',
+      defaultEnabled: true,
+    });
+  });
+});

--- a/apps/api/src/services/mlFeatureFlags.ts
+++ b/apps/api/src/services/mlFeatureFlags.ts
@@ -1,0 +1,200 @@
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import { organizations, partners } from '../db/schema';
+import { mlFeatureGloballyDisabled } from '../config/env';
+
+export const ML_FEATURE_FLAGS = [
+  'ml.alert_correlation.enabled',
+  'ml.rca.enabled',
+  'ml.metric_rollups.enabled',
+  'ml.anomalies.enabled',
+  'ml.anomalies.create_alerts',
+  'ml.remediation_suggestions.enabled',
+  'ml.ticket_triage.enabled',
+  'ml.user_risk_v0.enabled',
+  'ml.user_risk_v1.enabled',
+] as const;
+
+export type MlFeatureFlagName = (typeof ML_FEATURE_FLAGS)[number];
+
+export type MlFeatureFlagSource =
+  | 'global_kill_switch'
+  | 'org_settings'
+  | 'partner_settings'
+  | 'default'
+  | 'org_not_found';
+
+export interface MlFeatureFlagDefaultContext {
+  nodeEnv?: string | null;
+  orgType?: string | null;
+  partnerType?: string | null;
+}
+
+export interface MlFeatureFlagResolution {
+  flag: MlFeatureFlagName;
+  enabled: boolean;
+  defaultEnabled: boolean;
+  source: MlFeatureFlagSource;
+}
+
+interface MlFeatureFlagSettingsContext extends MlFeatureFlagDefaultContext {
+  orgSettings?: unknown;
+  partnerSettings?: unknown;
+}
+
+const ML_FEATURE_FLAG_SET = new Set<string>(ML_FEATURE_FLAGS);
+
+export function isMlFeatureFlagName(flag: string): flag is MlFeatureFlagName {
+  return ML_FEATURE_FLAG_SET.has(flag);
+}
+
+export function assertMlFeatureFlagName(flag: string): asserts flag is MlFeatureFlagName {
+  if (!isMlFeatureFlagName(flag)) {
+    throw new Error(`Unknown ML feature flag: ${flag}`);
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function lookupPath(root: Record<string, unknown>, path: string[]): unknown {
+  let current: unknown = root;
+  for (const segment of path) {
+    const record = asRecord(current);
+    if (!(segment in record)) return undefined;
+    current = record[segment];
+  }
+  return current;
+}
+
+function flagOverrideFromSettings(settings: unknown, flag: MlFeatureFlagName): boolean | undefined {
+  const root = asRecord(settings);
+  const ml = asRecord(root.ml);
+  const flatContainers = [
+    root,
+    asRecord(root.mlFeatureFlags),
+    asRecord(root.featureFlags),
+    asRecord(ml.featureFlags),
+    asRecord(ml.flags),
+  ];
+
+  for (const container of flatContainers) {
+    const value = booleanValue(container[flag]);
+    if (value !== undefined) return value;
+  }
+
+  const nestedPath = flag.replace(/^ml\./, '').split('.');
+  return booleanValue(lookupPath(ml, nestedPath));
+}
+
+export function defaultMlFeatureFlagValue(
+  flag: MlFeatureFlagName,
+  context: MlFeatureFlagDefaultContext = {},
+): boolean {
+  assertMlFeatureFlagName(flag);
+
+  if (flag === 'ml.metric_rollups.enabled' || flag === 'ml.user_risk_v0.enabled') {
+    return true;
+  }
+
+  if (flag === 'ml.alert_correlation.enabled') {
+    if (context.orgType === 'internal' || context.partnerType === 'internal') return true;
+    return (context.nodeEnv ?? process.env.NODE_ENV ?? 'development') !== 'production';
+  }
+
+  return false;
+}
+
+export function resolveMlFeatureFlag(
+  flag: MlFeatureFlagName,
+  context: MlFeatureFlagSettingsContext = {},
+): MlFeatureFlagResolution {
+  assertMlFeatureFlagName(flag);
+
+  const defaultEnabled = defaultMlFeatureFlagValue(flag, context);
+  const partnerOverride = flagOverrideFromSettings(context.partnerSettings, flag);
+  const orgOverride = flagOverrideFromSettings(context.orgSettings, flag);
+
+  let enabled = defaultEnabled;
+  let source: MlFeatureFlagSource = 'default';
+
+  if (partnerOverride !== undefined) {
+    enabled = partnerOverride;
+    source = 'partner_settings';
+  }
+
+  if (orgOverride !== undefined) {
+    enabled = orgOverride;
+    source = 'org_settings';
+  }
+
+  if (mlFeatureGloballyDisabled(flag)) {
+    return { flag, enabled: false, defaultEnabled, source: 'global_kill_switch' };
+  }
+
+  return { flag, enabled, defaultEnabled, source };
+}
+
+export async function resolveMlFeatureFlagForOrg(
+  orgId: string,
+  flag: MlFeatureFlagName,
+): Promise<MlFeatureFlagResolution> {
+  assertMlFeatureFlagName(flag);
+
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({
+        orgSettings: organizations.settings,
+        orgType: organizations.type,
+        partnerSettings: partners.settings,
+        partnerType: partners.type,
+      })
+      .from(organizations)
+      .innerJoin(partners, eq(organizations.partnerId, partners.id))
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    if (!row) {
+      const defaultEnabled = defaultMlFeatureFlagValue(flag);
+      return { flag, enabled: false, defaultEnabled, source: 'org_not_found' };
+    }
+
+    return resolveMlFeatureFlag(flag, {
+      orgSettings: row.orgSettings,
+      orgType: row.orgType,
+      partnerSettings: row.partnerSettings,
+      partnerType: row.partnerType,
+    });
+  });
+}
+
+export async function isMlFeatureEnabledForOrg(
+  orgId: string,
+  flag: MlFeatureFlagName,
+): Promise<boolean> {
+  return (await resolveMlFeatureFlagForOrg(orgId, flag)).enabled;
+}
+
+export async function shouldProduceMlOutput(
+  orgId: string,
+  flag: MlFeatureFlagName,
+): Promise<boolean> {
+  return isMlFeatureEnabledForOrg(orgId, flag);
+}
+
+export async function resolveAllMlFeatureFlagsForOrg(
+  orgId: string,
+): Promise<Record<MlFeatureFlagName, MlFeatureFlagResolution>> {
+  const entries = await Promise.all(
+    ML_FEATURE_FLAGS.map(async (flag) => [flag, await resolveMlFeatureFlagForOrg(orgId, flag)] as const),
+  );
+  return Object.fromEntries(entries) as Record<MlFeatureFlagName, MlFeatureFlagResolution>;
+}

--- a/apps/api/src/services/mlFeedback.test.ts
+++ b/apps/api/src/services/mlFeedback.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  insertMock: vi.fn(),
+  valuesMock: vi.fn(),
+  onConflictDoNothingMock: vi.fn(),
+  returningMock: vi.fn(),
+  runOutsideDbContextMock: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    insert: dbMocks.insertMock,
+  },
+  runOutsideDbContext: dbMocks.runOutsideDbContextMock,
+  withSystemDbAccessContext: dbMocks.withSystemDbAccessContextMock,
+}));
+
+import {
+  emitMlFeedbackEvent,
+  emitSystemMlFeedbackEvent,
+} from './mlFeedback';
+
+const validEvent = {
+  orgId: '00000000-0000-4000-8000-000000000001',
+  sourceType: 'alert',
+  sourceId: '00000000-0000-4000-8000-000000000002',
+  eventType: 'alert.acknowledged',
+  actorUserId: '00000000-0000-4000-8000-000000000003',
+  outcome: 'acknowledged',
+  confidence: 0.9,
+  metadata: { route: 'alerts.acknowledge' },
+  occurredAt: new Date('2026-06-18T12:00:00.000Z'),
+} as const;
+
+describe('mlFeedback service', () => {
+  beforeEach(() => {
+    dbMocks.insertMock.mockReset();
+    dbMocks.valuesMock.mockReset();
+    dbMocks.onConflictDoNothingMock.mockReset();
+    dbMocks.returningMock.mockReset();
+    dbMocks.runOutsideDbContextMock.mockClear();
+    dbMocks.withSystemDbAccessContextMock.mockClear();
+
+    dbMocks.insertMock.mockReturnValue({ values: dbMocks.valuesMock });
+    dbMocks.valuesMock.mockReturnValue({ onConflictDoNothing: dbMocks.onConflictDoNothingMock });
+    dbMocks.onConflictDoNothingMock.mockReturnValue({ returning: dbMocks.returningMock });
+  });
+
+  it('inserts a valid feedback event with replay-safe dedupe semantics', async () => {
+    dbMocks.returningMock.mockResolvedValue([{ id: '00000000-0000-4000-8000-000000000010' }]);
+
+    const result = await emitMlFeedbackEvent(validEvent);
+
+    expect(result).toEqual({ id: '00000000-0000-4000-8000-000000000010', inserted: true });
+    expect(dbMocks.valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: validEvent.orgId,
+      sourceType: 'alert',
+      eventType: 'alert.acknowledged',
+      actorUserId: validEvent.actorUserId,
+      confidence: 0.9,
+      metadata: { route: 'alerts.acknowledge' },
+    }));
+    const conflictTarget = dbMocks.onConflictDoNothingMock.mock.calls[0]?.[0]?.target;
+    expect(conflictTarget).toHaveLength(4);
+  });
+
+  it('returns inserted=false when the dedupe constraint absorbs a replay', async () => {
+    dbMocks.returningMock.mockResolvedValue([]);
+
+    const result = await emitMlFeedbackEvent(validEvent);
+
+    expect(result).toEqual({ id: null, inserted: false });
+    expect(dbMocks.onConflictDoNothingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects oversized metadata before issuing a database write', async () => {
+    await expect(emitMlFeedbackEvent({
+      ...validEvent,
+      metadata: { notes: 'x'.repeat(9000) },
+    })).rejects.toThrow(/metadata/i);
+
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+  });
+
+  it('wraps system emission in runOutsideDbContext and withSystemDbAccessContext', async () => {
+    dbMocks.returningMock.mockResolvedValue([{ id: '00000000-0000-4000-8000-000000000011' }]);
+
+    await emitSystemMlFeedbackEvent({ ...validEvent, actorUserId: null });
+
+    expect(dbMocks.runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+    expect(dbMocks.withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/mlFeedback.ts
+++ b/apps/api/src/services/mlFeedback.ts
@@ -1,0 +1,67 @@
+import {
+  ML_FEEDBACK_METADATA_MAX_BYTES,
+  getJsonByteLength,
+  mlFeedbackEventSchema,
+  type MlFeedbackEventInput,
+} from '@breeze/shared';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { mlFeedbackEvents } from '../db/schema';
+
+type MlFeedbackWritableDb = Pick<typeof db, 'insert'>;
+
+export interface EmitMlFeedbackResult {
+  id: string | null;
+  inserted: boolean;
+}
+
+export function assertMlFeedbackMetadataWithinLimit(metadata: Record<string, unknown>): void {
+  const metadataBytes = getJsonByteLength(metadata);
+  if (metadataBytes > ML_FEEDBACK_METADATA_MAX_BYTES) {
+    throw new Error(`ml_feedback_events metadata exceeds ${ML_FEEDBACK_METADATA_MAX_BYTES} bytes`);
+  }
+}
+
+export async function emitMlFeedbackEvent(
+  input: MlFeedbackEventInput,
+  database: MlFeedbackWritableDb = db,
+): Promise<EmitMlFeedbackResult> {
+  const event = mlFeedbackEventSchema.parse(input);
+  assertMlFeedbackMetadataWithinLimit(event.metadata);
+
+  const rows = await database
+    .insert(mlFeedbackEvents)
+    .values({
+      orgId: event.orgId,
+      sourceType: event.sourceType,
+      sourceId: event.sourceId,
+      eventType: event.eventType,
+      actorUserId: event.actorUserId ?? null,
+      outcome: event.outcome,
+      confidence: event.confidence ?? null,
+      metadata: event.metadata,
+      occurredAt: event.occurredAt,
+    })
+    .onConflictDoNothing({
+      target: [
+        mlFeedbackEvents.sourceType,
+        mlFeedbackEvents.sourceId,
+        mlFeedbackEvents.eventType,
+        mlFeedbackEvents.occurredAt,
+      ],
+    })
+    .returning({ id: mlFeedbackEvents.id });
+
+  const row = rows[0];
+  return {
+    id: row?.id ?? null,
+    inserted: row !== undefined,
+  };
+}
+
+export async function emitSystemMlFeedbackEvent(
+  input: MlFeedbackEventInput,
+): Promise<EmitMlFeedbackResult> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(() => emitMlFeedbackEvent(input)),
+  );
+}

--- a/apps/api/src/services/mlFeedbackEmitters.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.ts
@@ -1,0 +1,58 @@
+import type { MlFeedbackEventInput } from '@breeze/shared';
+import { emitMlFeedbackEvent } from './mlFeedback';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function actorUserIdOrNull(actorUserId: string | null | undefined): string | null {
+  return actorUserId && UUID_RE.test(actorUserId) ? actorUserId : null;
+}
+
+async function emitFeedbackBestEffort(input: MlFeedbackEventInput, logContext: string): Promise<void> {
+  try {
+    await emitMlFeedbackEvent(input);
+  } catch (error) {
+    console.error(`[MlFeedback] Failed to emit ${logContext}:`, error);
+  }
+}
+
+export async function emitAlertStateFeedback(options: {
+  orgId: string;
+  alertId: string;
+  eventType: 'alert.acknowledged' | 'alert.resolved' | 'alert.suppressed' | 'alert.dismissed' | 'alert.reopened';
+  outcome: 'acknowledged' | 'resolved' | 'suppressed' | 'dismissed' | 'reopened';
+  actorUserId?: string | null;
+  occurredAt?: Date;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await emitFeedbackBestEffort({
+    orgId: options.orgId,
+    sourceType: 'alert',
+    sourceId: options.alertId,
+    eventType: options.eventType,
+    outcome: options.outcome,
+    actorUserId: actorUserIdOrNull(options.actorUserId),
+    metadata: options.metadata ?? {},
+    occurredAt: options.occurredAt ?? new Date(),
+  }, options.eventType);
+}
+
+export async function emitCorrelationFeedback(options: {
+  orgId: string;
+  correlationId: string;
+  eventType: 'correlation.accepted' | 'correlation.split' | 'correlation.merged' | 'correlation.dismissed';
+  outcome: 'accepted' | 'split' | 'merged' | 'dismissed';
+  actorUserId?: string | null;
+  occurredAt?: Date;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await emitFeedbackBestEffort({
+    orgId: options.orgId,
+    sourceType: 'correlation',
+    sourceId: options.correlationId,
+    eventType: options.eventType,
+    outcome: options.outcome,
+    actorUserId: actorUserIdOrNull(options.actorUserId),
+    metadata: options.metadata ?? {},
+    occurredAt: options.occurredAt ?? new Date(),
+  }, options.eventType);
+}

--- a/apps/api/src/services/tenantCascade.test.ts
+++ b/apps/api/src/services/tenantCascade.test.ts
@@ -86,6 +86,11 @@ describe('ORG_CASCADE_DELETE_ORDER', () => {
     expect(ORG_CASCADE_DELETE_ORDER.at(-1)).toBe('organizations');
   });
 
+  it('routes append-only ML feedback labels through the audit-admin delete path', () => {
+    expect(ORG_CASCADE_DELETE_ORDER).toContain('ml_feedback_events');
+    expect(__testOnly.AUDIT_ADMIN_REQUIRED_TABLES.has('ml_feedback_events')).toBe(true);
+  });
+
   it('includes the canonical tenant tables', () => {
     const set = new Set(ORG_CASCADE_DELETE_ORDER);
     for (const required of [
@@ -95,6 +100,7 @@ describe('ORG_CASCADE_DELETE_ORDER', () => {
       'alerts',
       'audit_logs',
       'agent_logs',
+      'ml_feedback_events',
       'organizations',
     ]) {
       expect(set.has(required), `missing required table ${required}`).toBe(true);

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -177,6 +177,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'log_search_queries',
   'm365_connections',
   'maintenance_windows',
+  'ml_feedback_events',
   'network_baselines',
   'network_change_events',
   'network_monitors',
@@ -291,10 +292,15 @@ const ASSOCIATED_SYSTEM_SCOPED_TABLES: ReadonlyArray<{
 
 /**
  * Tables in the cascade set that require the `breeze_audit_admin` role
- * to DELETE. These are gated by the audit_log_immutable trigger and
- * the per-role DELETE grant established in migration 2026-05-25-i.
+ * to DELETE. These are gated by append-only triggers plus per-role DELETE
+ * grants so ordinary app paths can append/read but cannot mutate them.
  */
-const AUDIT_ADMIN_REQUIRED_TABLES: ReadonlySet<string> = new Set<string>(['audit_logs', 'audit_log_chain', 'audit_chain_anchors']);
+const AUDIT_ADMIN_REQUIRED_TABLES: ReadonlySet<string> = new Set<string>([
+  'audit_logs',
+  'audit_log_chain',
+  'audit_chain_anchors',
+  'ml_feedback_events',
+]);
 
 interface FkEdge {
   // SQL aliases are snake_case (postgres-js does not auto-camelCase).

--- a/apps/web/src/components/alerts/AlertCorrelationView.tsx
+++ b/apps/web/src/components/alerts/AlertCorrelationView.tsx
@@ -61,7 +61,8 @@ export default function AlertCorrelationView() {
       }
 
       const data = await response.json();
-      const alertList = (data.alerts || []).map((a: AlertSummary) => ({
+      const rawAlerts = data.alerts || data.data || [];
+      const alertList = rawAlerts.map((a: AlertSummary) => ({
         id: a.id,
         title: a.title,
         severity: a.severity,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -20,6 +20,7 @@ export * from './authenticator';
 export * from './catalog';
 export * from './invoices';
 export * from './contracts';
+export * from './mlFeedback';
 
 // ============================================
 // Device Roles

--- a/packages/shared/src/validators/mlFeedback.test.ts
+++ b/packages/shared/src/validators/mlFeedback.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ML_FEEDBACK_METADATA_MAX_BYTES,
+  getJsonByteLength,
+  mlFeedbackEventSchema,
+} from './mlFeedback';
+
+const validEvent = {
+  orgId: '00000000-0000-4000-8000-000000000001',
+  sourceType: 'alert',
+  sourceId: '00000000-0000-4000-8000-000000000002',
+  eventType: 'alert.acknowledged',
+  actorUserId: '00000000-0000-4000-8000-000000000003',
+  outcome: 'acknowledged',
+  confidence: 0.95,
+  metadata: { alertSeverity: 'high' },
+  occurredAt: '2026-06-18T10:00:00.000Z',
+} as const;
+
+describe('mlFeedbackEventSchema', () => {
+  it('accepts a canonical feedback event and coerces occurredAt', () => {
+    const parsed = mlFeedbackEventSchema.parse(validEvent);
+    expect(parsed.eventType).toBe('alert.acknowledged');
+    expect(parsed.occurredAt).toBeInstanceOf(Date);
+  });
+
+  it('allows system labels without an actor user', () => {
+    const parsed = mlFeedbackEventSchema.parse({
+      ...validEvent,
+      actorUserId: null,
+      sourceType: 'anomaly',
+      eventType: 'device.false_alarm',
+      outcome: 'false_alarm',
+    });
+    expect(parsed.actorUserId).toBeNull();
+  });
+
+  it('rejects metadata over the byte cap', () => {
+    const oversized = { notes: 'x'.repeat(ML_FEEDBACK_METADATA_MAX_BYTES + 1) };
+    expect(getJsonByteLength(oversized)).toBeGreaterThan(ML_FEEDBACK_METADATA_MAX_BYTES);
+    expect(() => mlFeedbackEventSchema.parse({ ...validEvent, metadata: oversized })).toThrow();
+  });
+
+  it('rejects invalid confidence values', () => {
+    expect(() => mlFeedbackEventSchema.parse({ ...validEvent, confidence: 1.1 })).toThrow();
+    expect(() => mlFeedbackEventSchema.parse({ ...validEvent, confidence: -0.1 })).toThrow();
+  });
+});

--- a/packages/shared/src/validators/mlFeedback.ts
+++ b/packages/shared/src/validators/mlFeedback.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+
+export const ML_FEEDBACK_METADATA_MAX_BYTES = 8192;
+
+export const ML_FEEDBACK_SOURCE_TYPES = [
+  'alert',
+  'ticket',
+  'device',
+  'anomaly',
+  'correlation',
+  'rca',
+  'remediation',
+  'user_risk',
+] as const;
+
+export const ML_FEEDBACK_EVENT_TYPES = [
+  'alert.acknowledged',
+  'alert.resolved',
+  'alert.suppressed',
+  'alert.dismissed',
+  'alert.reopened',
+  'correlation.accepted',
+  'correlation.split',
+  'correlation.merged',
+  'correlation.dismissed',
+  'rca.helpful',
+  'rca.not_helpful',
+  'rca.edited',
+  'rca.used_in_ticket',
+  'suggestion.accepted',
+  'suggestion.edited',
+  'suggestion.rejected',
+  'suggestion.executed',
+  'suggestion.failed',
+  'ticket.category_changed',
+  'ticket.priority_changed',
+  'ticket.assignee_changed',
+  'ticket.resolved',
+  'ticket.reopened',
+  'device.failure_confirmed',
+  'device.replaced',
+  'device.false_alarm',
+  'user_risk.true_positive',
+  'user_risk.false_positive',
+  'training.assigned',
+  'training.completed',
+] as const;
+
+export const ML_FEEDBACK_OUTCOMES = [
+  'acknowledged',
+  'resolved',
+  'suppressed',
+  'dismissed',
+  'reopened',
+  'accepted',
+  'split',
+  'merged',
+  'helpful',
+  'not_helpful',
+  'edited',
+  'used_in_ticket',
+  'rejected',
+  'executed',
+  'failed',
+  'category_changed',
+  'priority_changed',
+  'assignee_changed',
+  'failure_confirmed',
+  'replaced',
+  'false_alarm',
+  'true_positive',
+  'false_positive',
+  'assigned',
+  'completed',
+] as const;
+
+export type MlFeedbackEventSourceType = typeof ML_FEEDBACK_SOURCE_TYPES[number];
+export type MlFeedbackEventType = typeof ML_FEEDBACK_EVENT_TYPES[number];
+export type MlFeedbackEventOutcome = typeof ML_FEEDBACK_OUTCOMES[number];
+
+export function getJsonByteLength(value: unknown): number {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) return 0;
+  return new TextEncoder().encode(encoded).length;
+}
+
+export const mlFeedbackMetadataSchema = z.record(z.string(), z.unknown()).refine(
+  (value) => getJsonByteLength(value) <= ML_FEEDBACK_METADATA_MAX_BYTES,
+  `metadata must be ${ML_FEEDBACK_METADATA_MAX_BYTES} bytes or less`,
+);
+
+export const mlFeedbackEventSchema = z.object({
+  orgId: z.string().uuid(),
+  sourceType: z.enum(ML_FEEDBACK_SOURCE_TYPES),
+  sourceId: z.string().min(1).max(255),
+  eventType: z.enum(ML_FEEDBACK_EVENT_TYPES),
+  actorUserId: z.string().uuid().nullable().optional(),
+  outcome: z.enum(ML_FEEDBACK_OUTCOMES),
+  confidence: z.number().min(0).max(1).nullable().optional(),
+  metadata: mlFeedbackMetadataSchema.default({}),
+  occurredAt: z.coerce.date().default(() => new Date()),
+});
+
+export type MlFeedbackEventInput = z.input<typeof mlFeedbackEventSchema>;
+export type MlFeedbackEvent = z.output<typeof mlFeedbackEventSchema>;


### PR DESCRIPTION
## Summary

Begins the ML roadmap Phase 0 foundation work by integrating the first three implementation tracks into one branch:

- Adds typed ML feature flags and global kill switches for ML/AI producers.
- Adds the append-only `ml_feedback_events` foundation with shared validators, API emit service, RLS coverage, and tenant-cascade audit-admin handling.
- Moves alert correlation off the synchronous alert creation path into a BullMQ worker and exposes the correlation product API under `/alerts`.
- Emits best-effort feedback labels for alert state changes and correlation group actions.

## Why

The ML roadmap needs label capture, feature flags, and a non-blocking alert-correlation path before later RCA/anomaly/remediation workers can safely produce outputs. This also fixes the current `/alerts` UI contract mismatch by mounting correlation endpoints under the existing alerts API prefix.

## Validation

- `git diff --check`
- API focused Vitest: `src/jobs/alertCorrelation.test.ts`, `src/routes/alerts/correlations.test.ts`, `src/services/mlFeatureFlags.test.ts`, `src/services/mlFeedback.test.ts`, `src/services/tenantCascade.test.ts` - 5 files, 32 tests passed.
- Shared validator Vitest: `src/validators/mlFeedback.test.ts` - 4 tests passed.

## Notes

This PR targets `feat/authenticator-registration-redesign` because the integration worktree was intentionally based on that branch. Retargeting to `main` would include unrelated authenticator branch history unless the branch is rebased first.
