### PR TITLE
feat(ml): add metric rollup pipeline

### DIFF
--- a/apps/api/migrations/2026-06-18-metric-rollups.sql
+++ b/apps/api/migrations/2026-06-18-metric-rollups.sql
@@ -1,0 +1,94 @@
+-- Canonical metric rollups foundation (Phase 1 / C4).
+-- Direct org_id RLS shape 1. Partitioned by bucket_start from day one.
+-- Idempotent throughout. autoMigrate wraps this file in a transaction.
+
+CREATE TABLE IF NOT EXISTS metric_rollups (
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  source_table VARCHAR(80) NOT NULL,
+  device_id UUID NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  metric_type VARCHAR(80) NOT NULL,
+  metric_name VARCHAR(120) NOT NULL,
+  bucket_start TIMESTAMP NOT NULL,
+  bucket_seconds INTEGER NOT NULL,
+  avg_value DOUBLE PRECISION,
+  min_value DOUBLE PRECISION,
+  max_value DOUBLE PRECISION,
+  p95_value DOUBLE PRECISION,
+  sum_value DOUBLE PRECISION,
+  sample_count INTEGER NOT NULL DEFAULT 0,
+  gap_seconds INTEGER NOT NULL DEFAULT 0,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT metric_rollups_source_table_check CHECK (
+    source_table IN ('device_metrics', 'snmp_metrics', 'device_process_samples')
+  ),
+  CONSTRAINT metric_rollups_bucket_seconds_check CHECK (bucket_seconds IN (300, 3600, 86400)),
+  CONSTRAINT metric_rollups_sample_count_check CHECK (sample_count >= 0),
+  CONSTRAINT metric_rollups_gap_seconds_check CHECK (gap_seconds >= 0),
+  CONSTRAINT metric_rollups_metadata_object_check CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT metric_rollups_metadata_size_check CHECK (octet_length(metadata::text) <= 8192),
+  -- Avoid deriving p95-of-p95s. Phase 1 computes p95 only for raw 5-minute buckets.
+  CONSTRAINT metric_rollups_p95_raw_bucket_check CHECK (
+    p95_value IS NULL OR bucket_seconds = 300
+  )
+) PARTITION BY RANGE (bucket_start);
+
+CREATE TABLE IF NOT EXISTS metric_rollups_default
+  PARTITION OF metric_rollups DEFAULT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS metric_rollups_key_uq
+  ON metric_rollups (
+    org_id,
+    source_table,
+    device_id,
+    metric_type,
+    metric_name,
+    bucket_seconds,
+    bucket_start
+  );
+
+CREATE INDEX IF NOT EXISTS metric_rollups_org_bucket_idx
+  ON metric_rollups (org_id, bucket_seconds, bucket_start DESC);
+
+CREATE INDEX IF NOT EXISTS metric_rollups_device_metric_idx
+  ON metric_rollups (device_id, metric_name, bucket_seconds, bucket_start DESC);
+
+ALTER TABLE metric_rollups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE metric_rollups FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON metric_rollups;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON metric_rollups;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON metric_rollups;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON metric_rollups;
+
+CREATE POLICY breeze_org_isolation_select ON metric_rollups
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON metric_rollups
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON metric_rollups
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON metric_rollups
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+ALTER TABLE metric_rollups_default ENABLE ROW LEVEL SECURITY;
+ALTER TABLE metric_rollups_default FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON metric_rollups_default;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON metric_rollups_default;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON metric_rollups_default;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON metric_rollups_default;
+
+CREATE POLICY breeze_org_isolation_select ON metric_rollups_default
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON metric_rollups_default
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON metric_rollups_default
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON metric_rollups_default
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE metric_rollups TO breeze_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE metric_rollups_default TO breeze_app;

--- a/apps/api/src/db/schema/analytics.ts
+++ b/apps/api/src/db/schema/analytics.ts
@@ -8,7 +8,8 @@ import {
   jsonb,
   integer,
   doublePrecision,
-  index
+  index,
+  uniqueIndex
 } from 'drizzle-orm/pg-core';
 import { organizations } from './orgs';
 import { devices } from './devices';
@@ -26,6 +27,38 @@ export const timeSeriesMetrics = pgTable('time_series_metrics', {
 }, (table) => ({
   deviceTimestampIdx: index('time_series_metrics_device_timestamp_idx').on(table.timestamp, table.deviceId),
   orgTimestampIdx: index('time_series_metrics_org_timestamp_idx').on(table.orgId, table.timestamp)
+}));
+
+export const metricRollups = pgTable('metric_rollups', {
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  sourceTable: varchar('source_table', { length: 80 }).notNull(),
+  deviceId: uuid('device_id').notNull().references(() => devices.id, { onDelete: 'cascade' }),
+  metricType: varchar('metric_type', { length: 80 }).notNull(),
+  metricName: varchar('metric_name', { length: 120 }).notNull(),
+  bucketStart: timestamp('bucket_start').notNull(),
+  bucketSeconds: integer('bucket_seconds').notNull(),
+  avgValue: doublePrecision('avg_value'),
+  minValue: doublePrecision('min_value'),
+  maxValue: doublePrecision('max_value'),
+  p95Value: doublePrecision('p95_value'),
+  sumValue: doublePrecision('sum_value'),
+  sampleCount: integer('sample_count').notNull().default(0),
+  gapSeconds: integer('gap_seconds').notNull().default(0),
+  metadata: jsonb('metadata').notNull().default({}),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  keyUniq: uniqueIndex('metric_rollups_key_uq').on(
+    table.orgId,
+    table.sourceTable,
+    table.deviceId,
+    table.metricType,
+    table.metricName,
+    table.bucketSeconds,
+    table.bucketStart
+  ),
+  orgBucketIdx: index('metric_rollups_org_bucket_idx').on(table.orgId, table.bucketSeconds, table.bucketStart),
+  deviceMetricIdx: index('metric_rollups_device_metric_idx').on(table.deviceId, table.metricName, table.bucketSeconds, table.bucketStart)
 }));
 
 export const analyticsDashboards = pgTable('analytics_dashboards', {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -150,6 +150,7 @@ import { initializeEventLogRetention, shutdownEventLogRetention } from './jobs/e
 import { initializeAgentLogRetention, shutdownAgentLogRetention } from './jobs/agentLogRetention';
 import { initializeLogCorrelationWorker, shutdownLogCorrelationWorker } from './jobs/logCorrelation';
 import { initializeAlertCorrelationWorker, shutdownAlertCorrelationWorker } from './jobs/alertCorrelation';
+import { initializeMetricRollupsWorker, shutdownMetricRollupsWorker } from './jobs/metricRollups';
 import { initializeIPHistoryRetention, shutdownIPHistoryRetention } from './jobs/ipHistoryRetention';
 import { initializeChangeLogRetention, shutdownChangeLogRetention } from './jobs/changeLogRetention';
 import { initializeOauthCleanupWorker, shutdownOauthCleanupWorker } from './jobs/oauthCleanup';
@@ -1043,6 +1044,7 @@ async function initializeWorkers(): Promise<void> {
   const workers: Array<[string, () => Promise<void>]> = [
     ['alertWorkers', initializeAlertWorkers],
     ['alertCorrelationWorker', initializeAlertCorrelationWorker],
+    ['metricRollupsWorker', initializeMetricRollupsWorker],
     ['offlineDetector', initializeOfflineDetector],
     ['notificationDispatcher', initializeNotificationDispatcher],
     ['webhookDelivery', initializeWebhookDeliveryWorker],
@@ -1257,6 +1259,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownPolicyEvaluationWorker,
     shutdownNotificationDispatcher,
     shutdownOfflineDetector,
+    shutdownMetricRollupsWorker,
     shutdownAlertCorrelationWorker,
     shutdownAlertWorkers,
     shutdownStaleCommandReaper,

--- a/apps/api/src/jobs/metricRollups.test.ts
+++ b/apps/api/src/jobs/metricRollups.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getJobMock, addMock, closeMock } = vi.hoisted(() => ({
+  getJobMock: vi.fn(),
+  addMock: vi.fn(),
+  closeMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    getJob = getJobMock;
+    add = addMock;
+    close = closeMock;
+  },
+  Worker: class {
+    close = closeMock;
+    on = vi.fn();
+  },
+  Job: class {},
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('../services/bullmqUtils', () => ({
+  isReusableState: vi.fn((state: string) => ['waiting', 'delayed', 'active'].includes(state)),
+}));
+
+vi.mock('../db', () => ({
+  db: {},
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {},
+}));
+
+vi.mock('../services/metricRollups', () => ({
+  rollupDeviceMetricsRange: vi.fn(),
+}));
+
+import {
+  buildMetricRollupJobId,
+  enqueueMetricRollupBackfill,
+  shutdownMetricRollupsWorker,
+} from './metricRollups';
+
+describe('metric rollups queue helpers', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00.000Z'));
+    getJobMock.mockReset();
+    addMock.mockReset();
+    closeMock.mockReset();
+    getJobMock.mockResolvedValue(null);
+    addMock.mockResolvedValue({ id: 'queued-rollup-job' });
+    await shutdownMetricRollupsWorker();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses a stable BullMQ job id per org and time range', async () => {
+    const from = new Date('2026-06-18T11:00:00.000Z');
+    const to = new Date('2026-06-18T12:00:00.000Z');
+    const jobId = buildMetricRollupJobId('org-1', from, to);
+
+    await enqueueMetricRollupBackfill({ orgId: 'org-1', from, to });
+
+    expect(jobId).toBe('metric-rollups-org-1-20260618T110000000Z-20260618T120000000Z');
+    expect(addMock).toHaveBeenCalledWith(
+      'rollup-org-range',
+      expect.objectContaining({
+        type: 'rollup-org-range',
+        orgId: 'org-1',
+        from: '2026-06-18T11:00:00.000Z',
+        to: '2026-06-18T12:00:00.000Z',
+      }),
+      expect.objectContaining({ jobId }),
+    );
+  });
+
+  it('reuses an existing queued backfill job for the same org and time range', async () => {
+    getJobMock.mockResolvedValue({
+      id: 'existing-rollup-job',
+      getState: vi.fn().mockResolvedValue('waiting'),
+    });
+
+    const jobId = await enqueueMetricRollupBackfill({
+      orgId: 'org-1',
+      from: new Date('2026-06-18T11:00:00.000Z'),
+      to: new Date('2026-06-18T12:00:00.000Z'),
+    });
+
+    expect(jobId).toBe('existing-rollup-job');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/metricRollups.ts
+++ b/apps/api/src/jobs/metricRollups.ts
@@ -1,0 +1,202 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../db';
+import { devices } from '../db/schema';
+import { isReusableState } from '../services/bullmqUtils';
+import { rollupDeviceMetricsRange, type MetricRollupResult } from '../services/metricRollups';
+import { getBullMQConnection } from '../services/redis';
+
+const METRIC_ROLLUPS_QUEUE = 'metric-rollups';
+const DEFAULT_LOOKBACK_MINUTES = 15;
+const JOB_REUSE_STATES = new Set(['waiting', 'delayed', 'active']);
+
+type ScanOrgsJobData = {
+  type: 'scan-orgs';
+  queuedAt: string;
+  lookbackMinutes?: number;
+};
+
+type RollupOrgRangeJobData = {
+  type: 'rollup-org-range';
+  orgId: string;
+  from: string;
+  to: string;
+  queuedAt: string;
+};
+
+export type MetricRollupJobData = ScanOrgsJobData | RollupOrgRangeJobData;
+
+let metricRollupsQueue: Queue<MetricRollupJobData> | null = null;
+let metricRollupsWorker: Worker<MetricRollupJobData> | null = null;
+
+export function getMetricRollupsQueue(): Queue<MetricRollupJobData> {
+  if (!metricRollupsQueue) {
+    metricRollupsQueue = new Queue<MetricRollupJobData>(METRIC_ROLLUPS_QUEUE, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return metricRollupsQueue;
+}
+
+function compactIso(value: Date | string): string {
+  return new Date(value).toISOString().replace(/[^0-9A-Za-z]/g, '');
+}
+
+export function buildMetricRollupJobId(orgId: string, from: Date | string, to: Date | string): string {
+  return ['metric-rollups', orgId, compactIso(from), compactIso(to)].join('-');
+}
+
+function recentWindow(now = new Date(), lookbackMinutes = DEFAULT_LOOKBACK_MINUTES): { from: Date; to: Date } {
+  const bucketMs = 5 * 60 * 1000;
+  const to = new Date(Math.floor(now.getTime() / bucketMs) * bucketMs);
+  const from = new Date(to.getTime() - lookbackMinutes * 60 * 1000);
+  return { from, to };
+}
+
+async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
+  const orgRows = await db
+    .select({ orgId: devices.orgId })
+    .from(devices)
+    .where(sql`${devices.status} <> 'decommissioned'`)
+    .groupBy(devices.orgId);
+
+  if (orgRows.length === 0) {
+    return { queued: 0 };
+  }
+
+  const { from, to } = recentWindow(new Date(data.queuedAt), data.lookbackMinutes);
+  const queue = getMetricRollupsQueue();
+  await queue.addBulk(
+    orgRows.map((row) => ({
+      name: 'rollup-org-range',
+      data: {
+        type: 'rollup-org-range' as const,
+        orgId: row.orgId,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        queuedAt: data.queuedAt,
+      },
+      opts: {
+        jobId: buildMetricRollupJobId(row.orgId, from, to),
+        removeOnComplete: { count: 100 },
+        removeOnFail: { count: 200 },
+      },
+    }))
+  );
+
+  return { queued: orgRows.length };
+}
+
+async function processRollupOrgRange(data: RollupOrgRangeJobData): Promise<MetricRollupResult> {
+  return rollupDeviceMetricsRange({
+    orgId: data.orgId,
+    from: new Date(data.from),
+    to: new Date(data.to),
+  });
+}
+
+export function createMetricRollupsWorker(): Worker<MetricRollupJobData> {
+  return new Worker<MetricRollupJobData>(
+    METRIC_ROLLUPS_QUEUE,
+    async (job: Job<MetricRollupJobData>) =>
+      withSystemDbAccessContext(async () => {
+        if (job.data.type === 'scan-orgs') {
+          return processScanOrgs(job.data);
+        }
+        return processRollupOrgRange(job.data);
+      }),
+    {
+      connection: getBullMQConnection(),
+      concurrency: 2,
+      lockDuration: 300_000,
+      stalledInterval: 60_000,
+      maxStalledCount: 2,
+    }
+  );
+}
+
+async function scheduleMetricRollupsScan(): Promise<void> {
+  const queue = getMetricRollupsQueue();
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    if (job.name === 'scan-orgs') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  await queue.add(
+    'scan-orgs',
+    {
+      type: 'scan-orgs',
+      queuedAt: new Date().toISOString(),
+      lookbackMinutes: DEFAULT_LOOKBACK_MINUTES,
+    },
+    {
+      jobId: 'metric-rollups-scan-orgs',
+      repeat: { pattern: '*/5 * * * *' },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 100 },
+    }
+  );
+}
+
+export async function initializeMetricRollupsWorker(): Promise<void> {
+  metricRollupsWorker = createMetricRollupsWorker();
+  metricRollupsWorker.on('error', (error) => {
+    console.error('[MetricRollupsWorker] Worker error:', error);
+  });
+  metricRollupsWorker.on('failed', (job, error) => {
+    console.error(`[MetricRollupsWorker] Job ${job?.id} (${job?.data?.type}) failed:`, error);
+  });
+  await scheduleMetricRollupsScan();
+  console.log('[MetricRollupsWorker] Metric rollups worker initialized');
+}
+
+export async function shutdownMetricRollupsWorker(): Promise<void> {
+  if (metricRollupsWorker) {
+    await metricRollupsWorker.close();
+    metricRollupsWorker = null;
+  }
+  if (metricRollupsQueue) {
+    await metricRollupsQueue.close();
+    metricRollupsQueue = null;
+  }
+}
+
+export async function enqueueMetricRollupBackfill(options: {
+  orgId: string;
+  from: Date;
+  to: Date;
+}): Promise<string> {
+  const queue = getMetricRollupsQueue();
+  const jobId = buildMetricRollupJobId(options.orgId, options.from, options.to);
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (JOB_REUSE_STATES.has(state) || isReusableState(state)) {
+      return String(existing.id);
+    }
+    await existing.remove().catch((error) => {
+      console.error(`[MetricRollupsWorker] Failed to remove stale job ${jobId}:`, error);
+    });
+  }
+
+  const job = await queue.add(
+    'rollup-org-range',
+    {
+      type: 'rollup-org-range',
+      orgId: options.orgId,
+      from: options.from.toISOString(),
+      to: options.to.toISOString(),
+      queuedAt: new Date().toISOString(),
+    },
+    {
+      jobId,
+      removeOnComplete: { count: 100 },
+      removeOnFail: { count: 200 },
+    }
+  );
+
+  return String(job.id);
+}

--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -161,6 +161,16 @@ vi.mock('../db/schema', () => ({
     bandwidthInBps: 'deviceMetrics.bandwidthInBps',
     processCount: 'deviceMetrics.processCount'
   },
+  metricRollups: {
+    orgId: 'metricRollups.orgId',
+    sourceTable: 'metricRollups.sourceTable',
+    deviceId: 'metricRollups.deviceId',
+    metricName: 'metricRollups.metricName',
+    bucketStart: 'metricRollups.bucketStart',
+    bucketSeconds: 'metricRollups.bucketSeconds',
+    avgValue: 'metricRollups.avgValue',
+    sampleCount: 'metricRollups.sampleCount'
+  },
   devices: {
     id: 'devices.id',
     orgId: 'devices.orgId',
@@ -354,6 +364,28 @@ describe('analytics routes', () => {
       expect(body.predictions).toHaveLength(1);
       expect(body.predictions[0].value).toBe(76);
       expect(body.thresholds).toEqual({ warning: 80, critical: 90 });
+    });
+
+    it('uses daily metric rollups before falling back to raw device metrics', async () => {
+      mockSelectOnce([]); // stored predictions empty
+      mockSelectOnce([
+        { timestamp: new Date('2026-06-17T00:00:00.000Z'), value: 10 },
+        { timestamp: new Date('2026-06-18T00:00:00.000Z'), value: 20 },
+      ]); // metric_rollups aggregate
+
+      const res = await app.request('/analytics/capacity?metricType=disk', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.currentValue).toBe(20);
+      expect(body.predictions[0]).toMatchObject({
+        timestamp: '2026-06-17T00:00:00.000Z',
+        value: 10,
+      });
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -727,6 +759,7 @@ describe('analytics routes', () => {
         currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
         mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
         mockSelectOnce([]); // predictions empty -> fall through to live metrics
+        mockSelectOnce([]); // metric_rollups aggregate empty
         mockSelectOnce([]); // live device_metrics aggregate
 
         const res = await app.request('/analytics/capacity?metricType=disk', {

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -9,6 +9,7 @@ import {
   capacityPredictions,
   capacityThresholds,
   deviceMetrics,
+  metricRollups,
   devices,
   slaDefinitions as slaDefinitionsTable,
   slaCompliance as slaComplianceTable
@@ -197,6 +198,12 @@ const capacityQuerySchema = z.object({
   metricType: z.string().min(1).optional().default('disk'),
   range: z.string().optional().default('30d')
 });
+
+function capacityRollupMetricName(metricType: string): string {
+  if (metricType === 'cpu') return 'cpu_percent';
+  if (metricType === 'memory') return 'ram_percent';
+  return 'disk_percent';
+}
 
 const listSlaSchema = z.object({
   page: z.string().optional(),
@@ -988,18 +995,18 @@ analyticsRoutes.get(
     const rangeDays = normalizedRange === '7d' ? 7 : normalizedRange === '90d' ? 90 : 30;
     const rangeStart = new Date(Date.now() - rangeDays * 24 * 60 * 60 * 1000);
 
-    const metricColumn =
-      metricType === 'cpu'
-        ? deviceMetrics.cpuPercent
-        : metricType === 'memory'
-          ? deviceMetrics.ramPercent
-          : deviceMetrics.diskPercent;
-
     const metricsOrgCondition =
       typeof auth?.orgCondition === 'function'
         ? auth.orgCondition(devices.orgId)
         : auth?.orgId
           ? eq(devices.orgId, auth.orgId)
+          : undefined;
+
+    const rollupsOrgCondition =
+      typeof auth?.orgCondition === 'function'
+        ? auth.orgCondition(metricRollups.orgId)
+        : auth?.orgId
+          ? eq(metricRollups.orgId, auth.orgId)
           : undefined;
 
     // device_metrics.deviceId is NOT NULL — constrain the broad (no-deviceId)
@@ -1008,6 +1015,37 @@ analyticsRoutes.get(
     if (allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length === 0) {
       return c.json({ currentValue: 0, predictions: [], thresholds: undefined });
     }
+
+    const rollupsWhere = and(
+      eq(metricRollups.sourceTable, 'device_metrics'),
+      eq(metricRollups.bucketSeconds, 86400),
+      eq(metricRollups.metricName, capacityRollupMetricName(metricType)),
+      gte(metricRollups.bucketStart, rangeStart),
+      sql`${metricRollups.sampleCount} > 0`,
+      sql`${metricRollups.avgValue} IS NOT NULL`,
+      ...(rollupsOrgCondition ? [rollupsOrgCondition] : []),
+      ...(query.deviceId ? [eq(metricRollups.deviceId, query.deviceId)] : []),
+      ...(allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length > 0
+        ? [inArray(metricRollups.deviceId, allowedDeviceIds)]
+        : [])
+    );
+
+    const rollupRows = await db
+      .select({
+        timestamp: metricRollups.bucketStart,
+        value: sql<number>`sum(${metricRollups.avgValue} * ${metricRollups.sampleCount}) / nullif(sum(${metricRollups.sampleCount}), 0)`
+      })
+      .from(metricRollups)
+      .where(rollupsWhere)
+      .groupBy(metricRollups.bucketStart)
+      .orderBy(metricRollups.bucketStart);
+
+    const metricColumn =
+      metricType === 'cpu'
+        ? deviceMetrics.cpuPercent
+        : metricType === 'memory'
+          ? deviceMetrics.ramPercent
+          : deviceMetrics.diskPercent;
 
     const metricsWhere = and(
       gte(deviceMetrics.timestamp, rangeStart),
@@ -1018,16 +1056,18 @@ analyticsRoutes.get(
         : [])
     );
 
-    const actualRows = await db
-      .select({
-        timestamp: sql<Date>`date_trunc('day', ${deviceMetrics.timestamp})`,
-        value: sql<number>`avg(${metricColumn})`
-      })
-      .from(deviceMetrics)
-      .innerJoin(devices, eq(deviceMetrics.deviceId, devices.id))
-      .where(metricsWhere)
-      .groupBy(sql`date_trunc('day', ${deviceMetrics.timestamp})`)
-      .orderBy(sql`date_trunc('day', ${deviceMetrics.timestamp})`);
+    const actualRows = rollupRows.length > 0
+      ? rollupRows
+      : await db
+          .select({
+            timestamp: sql<Date>`date_trunc('day', ${deviceMetrics.timestamp})`,
+            value: sql<number>`avg(${metricColumn})`
+          })
+          .from(deviceMetrics)
+          .innerJoin(devices, eq(deviceMetrics.deviceId, devices.id))
+          .where(metricsWhere)
+          .groupBy(sql`date_trunc('day', ${deviceMetrics.timestamp})`)
+          .orderBy(sql`date_trunc('day', ${deviceMetrics.timestamp})`);
 
     const actuals = actualRows.map((row) => ({
       timestamp: row.timestamp instanceof Date ? row.timestamp.toISOString() : String(row.timestamp),

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -109,6 +109,7 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
   'elevation_requests',
   'group_membership_log',
   'huntress_agents', 'huntress_incidents', 'hyperv_vms', 'local_vaults',
+  'metric_rollups',
   'peripheral_events', 'playbook_executions', 'provision_credential_handles',
   'recovery_readiness', 'recovery_tokens', 'remote_sessions', 'restore_jobs',
   's1_actions', 's1_agents', 's1_threats',
@@ -201,7 +202,7 @@ export const DEVICE_CASCADE_DELETE_TABLES = [
   // Analytics & reliability
   'device_reliability_history', 'device_reliability',
   'playbook_executions', 'time_series_metrics', 'capacity_predictions',
-  'device_process_samples',
+  'device_process_samples', 'metric_rollups',
   // Portal & integrations (tickets are detached, not deleted —
   // see DEVICE_DETACH_DEVICE_ID_TABLES)
   'psa_ticket_mappings', 'asset_checkouts',

--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeMock, shouldProduceMlOutputMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  shouldProduceMlOutputMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    execute: executeMock,
+  },
+}));
+
+vi.mock('./mlFeatureFlags', () => ({
+  shouldProduceMlOutput: shouldProduceMlOutputMock,
+}));
+
+import { rollupDeviceMetricsRange } from './metricRollups';
+
+describe('metric rollups service', () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    executeMock.mockResolvedValue([]);
+    shouldProduceMlOutputMock.mockReset();
+    shouldProduceMlOutputMock.mockResolvedValue(true);
+  });
+
+  it('gates all writes behind the metric rollups ML feature flag', async () => {
+    shouldProduceMlOutputMock.mockResolvedValue(false);
+
+    const result = await rollupDeviceMetricsRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    expect(result).toEqual({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: '2026-06-18T12:00:00.000Z',
+      to: '2026-06-18T12:15:00.000Z',
+      statements: 0,
+      skipped: true,
+    });
+    expect(shouldProduceMlOutputMock).toHaveBeenCalledWith(
+      '11111111-1111-1111-1111-111111111111',
+      'ml.metric_rollups.enabled',
+    );
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('upserts raw 5-minute buckets and derived hourly/daily buckets idempotently', async () => {
+    const result = await rollupDeviceMetricsRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T13:00:00.000Z'),
+    });
+
+    expect(result).toMatchObject({ statements: 12, skipped: false });
+    expect(executeMock).toHaveBeenCalledTimes(12);
+    const executedSql = JSON.stringify(executeMock.mock.calls);
+    expect(executedSql).toContain('ON CONFLICT');
+    expect(executedSql).toContain('percentile_cont(0.95)');
+    expect(executedSql).toContain('NULL::double precision');
+  });
+
+  it('rejects invalid ranges before executing writes', async () => {
+    await expect(
+      rollupDeviceMetricsRange({
+        orgId: '11111111-1111-1111-1111-111111111111',
+        from: new Date('2026-06-18T13:00:00.000Z'),
+        to: new Date('2026-06-18T12:00:00.000Z'),
+      }),
+    ).rejects.toThrow('from < to');
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -1,0 +1,205 @@
+import { sql, type SQL } from 'drizzle-orm';
+
+import { db } from '../db';
+import { shouldProduceMlOutput } from './mlFeatureFlags';
+
+export const METRIC_ROLLUP_VERSION = 'metric-rollups-v1';
+
+export const METRIC_ROLLUP_BUCKETS = [300, 3600, 86400] as const;
+export type MetricRollupBucketSeconds = (typeof METRIC_ROLLUP_BUCKETS)[number];
+
+const RAW_BUCKET_SECONDS = 300;
+const HOUR_BUCKET_SECONDS = 3600;
+const DAY_BUCKET_SECONDS = 86400;
+const DEFAULT_EXPECTED_SAMPLE_SECONDS = 60;
+
+const DEVICE_METRIC_ROLLUP_SOURCES = [
+  { metricType: 'cpu', metricName: 'cpu_percent', column: 'cpu_percent' },
+  { metricType: 'memory', metricName: 'ram_percent', column: 'ram_percent' },
+  { metricType: 'memory', metricName: 'ram_used_mb', column: 'ram_used_mb' },
+  { metricType: 'disk', metricName: 'disk_percent', column: 'disk_percent' },
+  { metricType: 'disk', metricName: 'disk_used_gb', column: 'disk_used_gb' },
+  { metricType: 'disk', metricName: 'disk_read_bps', column: 'disk_read_bps' },
+  { metricType: 'disk', metricName: 'disk_write_bps', column: 'disk_write_bps' },
+  { metricType: 'network', metricName: 'bandwidth_in_bps', column: 'bandwidth_in_bps' },
+  { metricType: 'network', metricName: 'bandwidth_out_bps', column: 'bandwidth_out_bps' },
+  { metricType: 'process', metricName: 'process_count', column: 'process_count' },
+] as const;
+
+export interface MetricRollupRange {
+  orgId: string;
+  from: Date;
+  to: Date;
+  expectedSampleSeconds?: number;
+}
+
+export interface MetricRollupResult {
+  orgId: string;
+  from: string;
+  to: string;
+  statements: number;
+  skipped: boolean;
+}
+
+function bucketStartSql(timestampSql: SQL, bucketSeconds: number): SQL<Date> {
+  return sql<Date>`to_timestamp(floor(extract(epoch from ${timestampSql}) / ${bucketSeconds}) * ${bucketSeconds})::timestamp`;
+}
+
+function upsertAssignments(): SQL {
+  return sql`
+    avg_value = EXCLUDED.avg_value,
+    min_value = EXCLUDED.min_value,
+    max_value = EXCLUDED.max_value,
+    p95_value = EXCLUDED.p95_value,
+    sum_value = EXCLUDED.sum_value,
+    sample_count = EXCLUDED.sample_count,
+    gap_seconds = EXCLUDED.gap_seconds,
+    metadata = EXCLUDED.metadata,
+    updated_at = now()
+  `;
+}
+
+function normalizeRange(from: Date, to: Date): { from: Date; to: Date } {
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    throw new Error('Invalid metric rollup range');
+  }
+  if (from >= to) {
+    throw new Error('Metric rollup range must have from < to');
+  }
+  return { from, to };
+}
+
+async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof DEVICE_METRIC_ROLLUP_SOURCES)[number]): Promise<void> {
+  const { from, to } = normalizeRange(options.from, options.to);
+  const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
+  const valueSql = sql.raw(`dm.${metric.column}`);
+  const bucketSql = bucketStartSql(sql`dm.timestamp`, RAW_BUCKET_SECONDS);
+
+  await db.execute(sql`
+    INSERT INTO metric_rollups (
+      org_id,
+      source_table,
+      device_id,
+      metric_type,
+      metric_name,
+      bucket_start,
+      bucket_seconds,
+      avg_value,
+      min_value,
+      max_value,
+      p95_value,
+      sum_value,
+      sample_count,
+      gap_seconds,
+      metadata
+    )
+    SELECT
+      dm.org_id,
+      'device_metrics',
+      dm.device_id,
+      ${metric.metricType},
+      ${metric.metricName},
+      ${bucketSql},
+      ${RAW_BUCKET_SECONDS},
+      avg(${valueSql})::double precision,
+      min(${valueSql})::double precision,
+      max(${valueSql})::double precision,
+      percentile_cont(0.95) within group (order by ${valueSql})::double precision,
+      sum(${valueSql})::double precision,
+      count(*)::integer,
+      greatest(${RAW_BUCKET_SECONDS} - (count(*)::integer * ${expectedSampleSeconds}), 0)::integer,
+      jsonb_build_object('rollupVersion', ${METRIC_ROLLUP_VERSION}, 'source', 'raw', 'expectedSampleSeconds', ${expectedSampleSeconds})
+    FROM device_metrics dm
+    WHERE dm.org_id = ${options.orgId}
+      AND dm.timestamp >= ${from}
+      AND dm.timestamp < ${to}
+      AND ${valueSql} IS NOT NULL
+    GROUP BY dm.org_id, dm.device_id, ${bucketSql}
+    ON CONFLICT (org_id, source_table, device_id, metric_type, metric_name, bucket_seconds, bucket_start)
+    DO UPDATE SET ${upsertAssignments()}
+  `);
+}
+
+async function rollupDerivedDeviceMetrics(options: MetricRollupRange, sourceBucketSeconds: MetricRollupBucketSeconds, targetBucketSeconds: MetricRollupBucketSeconds): Promise<void> {
+  const { from, to } = normalizeRange(options.from, options.to);
+  const targetBucketSql = bucketStartSql(sql`mr.bucket_start`, targetBucketSeconds);
+
+  await db.execute(sql`
+    INSERT INTO metric_rollups (
+      org_id,
+      source_table,
+      device_id,
+      metric_type,
+      metric_name,
+      bucket_start,
+      bucket_seconds,
+      avg_value,
+      min_value,
+      max_value,
+      p95_value,
+      sum_value,
+      sample_count,
+      gap_seconds,
+      metadata
+    )
+    SELECT
+      mr.org_id,
+      mr.source_table,
+      mr.device_id,
+      mr.metric_type,
+      mr.metric_name,
+      ${targetBucketSql},
+      ${targetBucketSeconds},
+      (sum(mr.avg_value * mr.sample_count) / nullif(sum(mr.sample_count), 0))::double precision,
+      min(mr.min_value)::double precision,
+      max(mr.max_value)::double precision,
+      NULL::double precision,
+      sum(mr.sum_value)::double precision,
+      sum(mr.sample_count)::integer,
+      sum(mr.gap_seconds)::integer,
+      jsonb_build_object('rollupVersion', ${METRIC_ROLLUP_VERSION}, 'source', 'derived', 'sourceBucketSeconds', ${sourceBucketSeconds})
+    FROM metric_rollups mr
+    WHERE mr.org_id = ${options.orgId}
+      AND mr.source_table = 'device_metrics'
+      AND mr.bucket_seconds = ${sourceBucketSeconds}
+      AND mr.bucket_start >= ${from}
+      AND mr.bucket_start < ${to}
+      AND mr.sample_count > 0
+    GROUP BY mr.org_id, mr.source_table, mr.device_id, mr.metric_type, mr.metric_name, ${targetBucketSql}
+    HAVING sum(mr.sample_count) > 0
+    ON CONFLICT (org_id, source_table, device_id, metric_type, metric_name, bucket_seconds, bucket_start)
+    DO UPDATE SET ${upsertAssignments()}
+  `);
+}
+
+export async function rollupDeviceMetricsRange(options: MetricRollupRange): Promise<MetricRollupResult> {
+  const { from, to } = normalizeRange(options.from, options.to);
+  if (!(await shouldProduceMlOutput(options.orgId, 'ml.metric_rollups.enabled'))) {
+    return {
+      orgId: options.orgId,
+      from: from.toISOString(),
+      to: to.toISOString(),
+      statements: 0,
+      skipped: true,
+    };
+  }
+
+  let statements = 0;
+  for (const metric of DEVICE_METRIC_ROLLUP_SOURCES) {
+    await rollupRawDeviceMetric(options, metric);
+    statements += 1;
+  }
+
+  await rollupDerivedDeviceMetrics(options, RAW_BUCKET_SECONDS, HOUR_BUCKET_SECONDS);
+  statements += 1;
+  await rollupDerivedDeviceMetrics(options, HOUR_BUCKET_SECONDS, DAY_BUCKET_SECONDS);
+  statements += 1;
+
+  return {
+    orgId: options.orgId,
+    from: from.toISOString(),
+    to: to.toISOString(),
+    statements,
+    skipped: false,
+  };
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -177,6 +177,8 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'log_search_queries',
   'm365_connections',
   'maintenance_windows',
+  'metric_rollups',
+  'metric_rollups_default',
   'ml_feedback_events',
   'network_baselines',
   'network_change_events',


### PR DESCRIPTION
## Summary
- add partitioned metric_rollups table with direct org_id RLS and cascade/device metadata coverage
- add metric rollup service and BullMQ worker gated by ml.metric_rollups.enabled
- prefer daily metric rollups in /analytics/capacity, falling back to raw device_metrics when no rollups exist

## Validation
- /usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/routes/devices/cascadeDelete.test.ts src/routes/devices/moveOrg.coverage.test.ts src/routes/analytics.test.ts src/services/metricRollups.test.ts src/jobs/metricRollups.test.ts --config vitest.config.ts
- /usr/local/bin/corepack pnpm --filter @breeze/api build
- git diff --check

## Notes
- Stacked on #1485 / feat/ml-phase0-foundations.
- Migration checker could not run locally because Postgres rejected the configured role: role "breeze" does not exist.