### PR TITLE
feat(ml): persist alert correlation groups

### DIFF
--- a/apps/api/migrations/2026-06-18-alert-correlation-groups.sql
+++ b/apps/api/migrations/2026-06-18-alert-correlation-groups.sql
@@ -1,0 +1,105 @@
+-- Persisted alert correlation groups (Phase 2).
+-- Direct org_id RLS shape 1 for both tables.
+-- Idempotent throughout. autoMigrate wraps this file in a transaction.
+
+CREATE TABLE IF NOT EXISTS alert_correlation_groups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  group_key VARCHAR(255) NOT NULL,
+  root_alert_id UUID REFERENCES alerts(id) ON DELETE SET NULL,
+  status VARCHAR(40) NOT NULL DEFAULT 'open',
+  score NUMERIC(3, 2),
+  noise_reduction_percent INTEGER NOT NULL DEFAULT 0,
+  member_count INTEGER NOT NULL DEFAULT 0,
+  first_seen_at TIMESTAMP NOT NULL,
+  last_seen_at TIMESTAMP NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT alert_correlation_groups_status_check CHECK (
+    status IN ('open', 'acknowledged', 'resolved', 'dismissed', 'split', 'merged')
+  ),
+  CONSTRAINT alert_correlation_groups_score_check CHECK (
+    score IS NULL OR (score >= 0 AND score <= 1)
+  ),
+  CONSTRAINT alert_correlation_groups_noise_reduction_check CHECK (
+    noise_reduction_percent >= 0 AND noise_reduction_percent <= 100
+  ),
+  CONSTRAINT alert_correlation_groups_member_count_check CHECK (member_count >= 0),
+  CONSTRAINT alert_correlation_groups_metadata_object_check CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT alert_correlation_groups_metadata_size_check CHECK (octet_length(metadata::text) <= 8192)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS alert_correlation_groups_org_key_uq
+  ON alert_correlation_groups (org_id, group_key);
+
+CREATE INDEX IF NOT EXISTS alert_correlation_groups_org_status_seen_idx
+  ON alert_correlation_groups (org_id, status, last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS alert_correlation_groups_root_alert_idx
+  ON alert_correlation_groups (root_alert_id);
+
+CREATE TABLE IF NOT EXISTS alert_correlation_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  group_id UUID NOT NULL REFERENCES alert_correlation_groups(id) ON DELETE CASCADE,
+  alert_id UUID NOT NULL REFERENCES alerts(id) ON DELETE CASCADE,
+  role VARCHAR(40) NOT NULL DEFAULT 'related',
+  confidence NUMERIC(3, 2),
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT alert_correlation_members_role_check CHECK (role IN ('root', 'related')),
+  CONSTRAINT alert_correlation_members_confidence_check CHECK (
+    confidence IS NULL OR (confidence >= 0 AND confidence <= 1)
+  ),
+  CONSTRAINT alert_correlation_members_evidence_object_check CHECK (jsonb_typeof(evidence) = 'object'),
+  CONSTRAINT alert_correlation_members_evidence_size_check CHECK (octet_length(evidence::text) <= 8192)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS alert_correlation_members_group_alert_uq
+  ON alert_correlation_members (group_id, alert_id);
+
+CREATE INDEX IF NOT EXISTS alert_correlation_members_org_alert_idx
+  ON alert_correlation_members (org_id, alert_id);
+
+CREATE INDEX IF NOT EXISTS alert_correlation_members_org_group_idx
+  ON alert_correlation_members (org_id, group_id);
+
+ALTER TABLE alert_correlation_groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE alert_correlation_groups FORCE ROW LEVEL SECURITY;
+ALTER TABLE alert_correlation_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE alert_correlation_members FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON alert_correlation_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON alert_correlation_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON alert_correlation_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON alert_correlation_groups;
+
+CREATE POLICY breeze_org_isolation_select ON alert_correlation_groups
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON alert_correlation_groups
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON alert_correlation_groups
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON alert_correlation_groups
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON alert_correlation_members;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON alert_correlation_members;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON alert_correlation_members;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON alert_correlation_members;
+
+CREATE POLICY breeze_org_isolation_select ON alert_correlation_members
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON alert_correlation_members
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON alert_correlation_members
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON alert_correlation_members
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE alert_correlation_groups TO breeze_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE alert_correlation_members TO breeze_app;

--- a/apps/api/src/db/schema/alerts.ts
+++ b/apps/api/src/db/schema/alerts.ts
@@ -9,7 +9,8 @@ import {
   pgEnum,
   integer,
   index,
-  numeric
+  numeric,
+  uniqueIndex
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { NOTIFICATION_CHANNEL_TYPES } from '@breeze/shared';
@@ -94,6 +95,42 @@ export const alertCorrelations = pgTable('alert_correlations', {
 }, (table) => ({
   parentAlertIdIdx: index('alert_correlations_parent_alert_id_idx').on(table.parentAlertId),
   childAlertIdIdx: index('alert_correlations_child_alert_id_idx').on(table.childAlertId)
+}));
+
+export const alertCorrelationGroups = pgTable('alert_correlation_groups', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  groupKey: varchar('group_key', { length: 255 }).notNull(),
+  rootAlertId: uuid('root_alert_id').references(() => alerts.id, { onDelete: 'set null' }),
+  status: varchar('status', { length: 40 }).notNull().default('open'),
+  score: numeric('score', { precision: 3, scale: 2 }),
+  noiseReductionPercent: integer('noise_reduction_percent').notNull().default(0),
+  memberCount: integer('member_count').notNull().default(0),
+  firstSeenAt: timestamp('first_seen_at').notNull(),
+  lastSeenAt: timestamp('last_seen_at').notNull(),
+  metadata: jsonb('metadata').notNull().default({}),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  orgKeyUniq: uniqueIndex('alert_correlation_groups_org_key_uq').on(table.orgId, table.groupKey),
+  orgStatusSeenIdx: index('alert_correlation_groups_org_status_seen_idx').on(table.orgId, table.status, table.lastSeenAt),
+  rootAlertIdx: index('alert_correlation_groups_root_alert_idx').on(table.rootAlertId)
+}));
+
+export const alertCorrelationMembers = pgTable('alert_correlation_members', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  groupId: uuid('group_id').notNull().references(() => alertCorrelationGroups.id, { onDelete: 'cascade' }),
+  alertId: uuid('alert_id').notNull().references(() => alerts.id, { onDelete: 'cascade' }),
+  role: varchar('role', { length: 40 }).notNull().default('related'),
+  confidence: numeric('confidence', { precision: 3, scale: 2 }),
+  evidence: jsonb('evidence').notNull().default({}),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  groupAlertUniq: uniqueIndex('alert_correlation_members_group_alert_uq').on(table.groupId, table.alertId),
+  orgAlertIdx: index('alert_correlation_members_org_alert_idx').on(table.orgId, table.alertId),
+  orgGroupIdx: index('alert_correlation_members_org_group_idx').on(table.orgId, table.groupId)
 }));
 
 export const notificationChannels = pgTable('notification_channels', {

--- a/apps/api/src/jobs/alertCorrelation.test.ts
+++ b/apps/api/src/jobs/alertCorrelation.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getJobMock, addMock, closeMock, shouldProduceMlOutputMock } = vi.hoisted(() => ({
+const { getJobMock, addMock, closeMock, shouldProduceMlOutputMock, persistGroupsMock } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
   closeMock: vi.fn(),
   shouldProduceMlOutputMock: vi.fn(),
+  persistGroupsMock: vi.fn(),
 }));
 
 vi.mock('bullmq', () => ({
@@ -32,6 +33,10 @@ vi.mock('../services/mlFeatureFlags', () => ({
   shouldProduceMlOutput: shouldProduceMlOutputMock,
 }));
 
+vi.mock('../services/alertCorrelationGroups', () => ({
+  persistAlertCorrelationGroupsForAlerts: persistGroupsMock,
+}));
+
 vi.mock('../db', () => ({
   db: {},
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
@@ -57,7 +62,9 @@ describe('alert correlation queue helpers', () => {
     addMock.mockReset();
     closeMock.mockReset();
     shouldProduceMlOutputMock.mockReset();
+    persistGroupsMock.mockReset();
     shouldProduceMlOutputMock.mockResolvedValue(true);
+    persistGroupsMock.mockResolvedValue({ scanned: 0, groupsWritten: 0, membersWritten: 0 });
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queued-correlation-job' });
     await shutdownAlertCorrelationWorker();

--- a/apps/api/src/jobs/alertCorrelation.ts
+++ b/apps/api/src/jobs/alertCorrelation.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, gte, inArray } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
 import { alertCorrelations, alerts } from '../db/schema';
+import { persistAlertCorrelationGroupsForAlerts } from '../services/alertCorrelationGroups';
 import { isReusableState } from '../services/bullmqUtils';
 import { shouldProduceMlOutput } from '../services/mlFeatureFlags';
 import { getBullMQConnection } from '../services/redis';
@@ -153,6 +154,11 @@ export async function runAlertCorrelationForDevice(options: {
       created += 1;
     }
   }
+
+  await persistAlertCorrelationGroupsForAlerts({
+    orgId: options.orgId,
+    alertIds,
+  });
 
   return { scanned: recentAlerts.length, created };
 }

--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -19,6 +19,18 @@ const {
       id: 'alert_correlations.id', parentAlertId: 'alert_correlations.parentAlertId', childAlertId: 'alert_correlations.childAlertId',
       correlationType: 'alert_correlations.correlationType', confidence: 'alert_correlations.confidence', createdAt: 'alert_correlations.createdAt',
     },
+    alertCorrelationGroups: {
+      id: 'alert_correlation_groups.id', orgId: 'alert_correlation_groups.orgId', groupKey: 'alert_correlation_groups.groupKey',
+      rootAlertId: 'alert_correlation_groups.rootAlertId', status: 'alert_correlation_groups.status', score: 'alert_correlation_groups.score',
+      noiseReductionPercent: 'alert_correlation_groups.noiseReductionPercent', memberCount: 'alert_correlation_groups.memberCount',
+      firstSeenAt: 'alert_correlation_groups.firstSeenAt', lastSeenAt: 'alert_correlation_groups.lastSeenAt',
+      metadata: 'alert_correlation_groups.metadata', createdAt: 'alert_correlation_groups.createdAt',
+    },
+    alertCorrelationMembers: {
+      id: 'alert_correlation_members.id', orgId: 'alert_correlation_members.orgId', groupId: 'alert_correlation_members.groupId',
+      alertId: 'alert_correlation_members.alertId', role: 'alert_correlation_members.role',
+      confidence: 'alert_correlation_members.confidence', createdAt: 'alert_correlation_members.createdAt',
+    },
     devices: { id: 'devices.id', hostname: 'devices.hostname' },
   };
 
@@ -36,6 +48,8 @@ const {
   const state = {
     alerts: [] as Array<Record<string, any>>,
     correlations: [] as Array<Record<string, any>>,
+    groups: [] as Array<Record<string, any>>,
+    members: [] as Array<Record<string, any>>,
     devices: [] as Array<Record<string, any>>,
   };
 
@@ -53,7 +67,11 @@ const {
         ? state.alerts
         : this.table === tables.alertCorrelations
           ? state.correlations
-          : state.devices;
+          : this.table === tables.alertCorrelationGroups
+            ? state.groups
+            : this.table === tables.alertCorrelationMembers
+              ? state.members
+              : state.devices;
       const filtered = source.filter((row) => evalPredicate(row, this.predicate));
       if (!this.projection) return filtered;
       return filtered.map((row) => {
@@ -73,7 +91,11 @@ const {
     update: vi.fn((table: unknown) => ({
       set: (values: Record<string, unknown>) => ({
         where: async (predicate: Predicate) => {
-          const source = table === tables.alerts ? state.alerts : [];
+          const source = table === tables.alerts
+            ? state.alerts
+            : table === tables.alertCorrelationGroups
+              ? state.groups
+              : [];
           let updated = 0;
           for (const row of source) {
             if (evalPredicate(row, predicate)) {
@@ -121,6 +143,8 @@ vi.mock('../../middleware/auth', () => ({
 vi.mock('../../db', () => ({ db: dbMock }));
 vi.mock('../../db/schema', () => ({
   alerts: tables.alerts,
+  alertCorrelationGroups: tables.alertCorrelationGroups,
+  alertCorrelationMembers: tables.alertCorrelationMembers,
   alertCorrelations: tables.alertCorrelations,
   devices: tables.devices,
 }));
@@ -146,6 +170,7 @@ const ALERT_1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const ALERT_2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 const ALERT_3 = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const DEVICE_1 = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const GROUP_1 = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
 
 function makeApp() {
   const app = new Hono();
@@ -163,7 +188,30 @@ function seed() {
     { id: '11111111-aaaa-4aaa-8aaa-111111111111', parentAlertId: ALERT_1, childAlertId: ALERT_2, correlationType: 'same_device_temporal', confidence: '0.91', createdAt: new Date('2026-06-18T12:03:00Z') },
     { id: '22222222-aaaa-4aaa-8aaa-222222222222', parentAlertId: ALERT_1, childAlertId: ALERT_3, correlationType: 'same_device_temporal', confidence: '0.88', createdAt: new Date('2026-06-18T12:04:00Z') },
   ];
+  state.groups = [];
+  state.members = [];
   state.devices = [{ id: DEVICE_1, hostname: 'server-1' }];
+}
+
+function seedPersistedGroup() {
+  state.groups = [{
+    id: GROUP_1,
+    orgId: ORG_1,
+    groupKey: `root:${ALERT_1}`,
+    rootAlertId: ALERT_1,
+    status: 'open',
+    score: '0.91',
+    noiseReductionPercent: 50,
+    memberCount: 2,
+    firstSeenAt: new Date('2026-06-18T12:00:00Z'),
+    lastSeenAt: new Date('2026-06-18T12:02:00Z'),
+    metadata: { version: 'test' },
+    createdAt: new Date('2026-06-18T12:03:00Z'),
+  }];
+  state.members = [
+    { id: 'eeeeeeee-0001-4eee-8eee-eeeeeeeeeeee', orgId: ORG_1, groupId: GROUP_1, alertId: ALERT_1, role: 'root', confidence: '1.00', createdAt: new Date('2026-06-18T12:03:00Z') },
+    { id: 'eeeeeeee-0002-4eee-8eee-eeeeeeeeeeee', orgId: ORG_1, groupId: GROUP_1, alertId: ALERT_2, role: 'related', confidence: '0.91', createdAt: new Date('2026-06-18T12:03:00Z') },
+  ];
 }
 
 describe('/alerts correlation routes', () => {
@@ -208,20 +256,64 @@ describe('/alerts correlation routes', () => {
     expect(body.groups[0].rootCause.device).toBe('server-1');
   });
 
+  it('returns persisted correlation groups before falling back to derived groups', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request('/alerts/correlations');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.groups).toHaveLength(1);
+    expect(body.groups[0]).toEqual(expect.objectContaining({
+      id: GROUP_1,
+      relatedCount: 1,
+      correlationScore: 0.91,
+      noiseReductionPercent: 50,
+      status: 'open',
+    }));
+    expect(body.groups[0].rootCause.id).toBe(ALERT_1);
+  });
+
+  it('returns persisted correlation group detail without leaking cross-org groups', async () => {
+    seedPersistedGroup();
+    state.groups.push({
+      id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      orgId: ORG_2,
+      groupKey: `root:${ALERT_3}`,
+      rootAlertId: ALERT_3,
+      status: 'open',
+      score: '0.88',
+      noiseReductionPercent: 0,
+      memberCount: 1,
+      firstSeenAt: new Date('2026-06-18T12:03:00Z'),
+      lastSeenAt: new Date('2026-06-18T12:03:00Z'),
+      metadata: {},
+      createdAt: new Date('2026-06-18T12:04:00Z'),
+    });
+
+    const allowed = await makeApp().request(`/alerts/correlations/${GROUP_1}`);
+    expect(allowed.status).toBe(200);
+    const allowedBody = await allowed.json();
+    expect(allowedBody.group.id).toBe(GROUP_1);
+
+    const denied = await makeApp().request('/alerts/correlations/ffffffff-ffff-4fff-8fff-ffffffffffff');
+    expect(denied.status).toBe(404);
+  });
+
   it('acknowledges all accessible alerts in a correlation group', async () => {
-    const groupsRes = await makeApp().request('/alerts/correlations');
-    const groupsBody = await groupsRes.json();
-    const res = await makeApp().request(`/alerts/correlations/${groupsBody.groups[0].id}/acknowledge`, { method: 'POST' });
+    seedPersistedGroup();
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/acknowledge`, { method: 'POST' });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ updated: 2, skipped: 0 });
     expect(state.alerts.find((alert) => alert.id === ALERT_1)?.status).toBe('acknowledged');
     expect(state.alerts.find((alert) => alert.id === ALERT_2)?.status).toBe('acknowledged');
     expect(state.alerts.find((alert) => alert.id === ALERT_3)?.status).toBe('active');
+    expect(state.groups.find((group) => group.id === GROUP_1)?.status).toBe('acknowledged');
     expect(emitAlertStateFeedbackMock).toHaveBeenCalledTimes(2);
     expect(emitCorrelationFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
       orgId: ORG_1,
-      correlationId: groupsBody.groups[0].id,
+      correlationId: GROUP_1,
       eventType: 'correlation.accepted',
       outcome: 'accepted',
       actorUserId: '99999999-9999-4999-8999-999999999999',

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { and, desc, eq, inArray, or, type SQL } from 'drizzle-orm';
 
 import { db } from '../../db';
-import { alertCorrelations, alerts, devices } from '../../db/schema';
+import { alertCorrelationGroups, alertCorrelationMembers, alertCorrelations, alerts, devices } from '../../db/schema';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { publishEvent } from '../../services/eventBus';
@@ -30,6 +30,7 @@ type AuthContext = {
 
 type AlertRow = typeof alerts.$inferSelect;
 type CorrelationRow = typeof alertCorrelations.$inferSelect;
+type CorrelationGroupRow = typeof alertCorrelationGroups.$inferSelect;
 
 function orgConditionsForAuth(auth: AuthContext): SQL[] | null {
   if (auth.scope === 'organization') {
@@ -39,6 +40,19 @@ function orgConditionsForAuth(auth: AuthContext): SQL[] | null {
   if (auth.scope === 'partner') {
     const orgIds = auth.accessibleOrgIds ?? [];
     return orgIds.length > 0 ? [inArray(alerts.orgId, orgIds)] : null;
+  }
+
+  return [];
+}
+
+function groupOrgConditionsForAuth(auth: AuthContext): SQL[] | null {
+  if (auth.scope === 'organization') {
+    return auth.orgId ? [eq(alertCorrelationGroups.orgId, auth.orgId)] : null;
+  }
+
+  if (auth.scope === 'partner') {
+    const orgIds = auth.accessibleOrgIds ?? [];
+    return orgIds.length > 0 ? [inArray(alertCorrelationGroups.orgId, orgIds)] : null;
   }
 
   return [];
@@ -84,13 +98,31 @@ function toGroupAlert(alert: AlertRow & { deviceHostname?: string | null }) {
   };
 }
 
+type GroupAlert = ReturnType<typeof toGroupAlert>;
+
+interface CorrelationGroupForUi {
+  id: string;
+  rootCause: GroupAlert | null;
+  relatedCount: number;
+  alerts: GroupAlert[];
+  correlationScore: number;
+  correlationLinks: CorrelationRow[];
+  createdAt: Date;
+  noiseReductionPercent?: number;
+  status?: string;
+  memberCount?: number;
+  firstSeenAt?: Date;
+  lastSeenAt?: Date;
+  metadata?: unknown;
+}
+
 function correlationTypeForUi(link: CorrelationRow): 'causal' | 'symptom' | 'duplicate' {
   if (link.correlationType.includes('duplicate')) return 'duplicate';
   if (link.correlationType.includes('causal')) return 'causal';
   return 'symptom';
 }
 
-async function buildCorrelationGroups(auth: AuthContext) {
+async function buildCorrelationGroups(auth: AuthContext): Promise<CorrelationGroupForUi[]> {
   const orgAlerts = await listAccessibleAlerts(auth);
   const orgAlertIds = orgAlerts.map((alert) => alert.id);
   if (orgAlertIds.length === 0) {
@@ -165,6 +197,122 @@ async function buildCorrelationGroups(auth: AuthContext) {
   }).filter((group) => group.rootCause !== null);
 }
 
+async function getAccessiblePersistedGroup(groupId: string, auth: AuthContext): Promise<CorrelationGroupRow | null> {
+  const groupOrgConditions = groupOrgConditionsForAuth(auth);
+  if (groupOrgConditions === null) {
+    return null;
+  }
+
+  const where = and(
+    eq(alertCorrelationGroups.id, groupId),
+    ...(groupOrgConditions.length > 0 ? groupOrgConditions : [])
+  );
+
+  const [group] = await db
+    .select()
+    .from(alertCorrelationGroups)
+    .where(where)
+    .limit(1);
+
+  return group ?? null;
+}
+
+async function buildPersistedCorrelationGroups(auth: AuthContext, groupId?: string): Promise<CorrelationGroupForUi[]> {
+  const groupOrgConditions = groupOrgConditionsForAuth(auth);
+  if (groupOrgConditions === null) {
+    return [];
+  }
+
+  const groupsWhere = and(
+    ...(groupId ? [eq(alertCorrelationGroups.id, groupId)] : []),
+    ...(groupOrgConditions.length > 0 ? groupOrgConditions : [])
+  );
+
+  const persistedGroups = await db
+    .select()
+    .from(alertCorrelationGroups)
+    .where(groupsWhere)
+    .orderBy(desc(alertCorrelationGroups.lastSeenAt))
+    .limit(groupId ? 1 : 50);
+
+  if (persistedGroups.length === 0) {
+    return [];
+  }
+
+  const groupIds = persistedGroups.map((group) => group.id);
+  const members = await db
+    .select()
+    .from(alertCorrelationMembers)
+    .where(inArray(alertCorrelationMembers.groupId, groupIds));
+
+  const alertIds = [...new Set(members.map((member) => member.alertId))];
+  const memberAlerts = alertIds.length > 0
+    ? await db.select().from(alerts).where(inArray(alerts.id, alertIds))
+    : [];
+  const alertById = new Map(memberAlerts.map((alert) => [alert.id, alert]));
+
+  const deviceIds = [...new Set(memberAlerts.map((alert) => alert.deviceId))];
+  const deviceRows = deviceIds.length > 0
+    ? await db.select({ id: devices.id, hostname: devices.hostname }).from(devices).where(inArray(devices.id, deviceIds))
+    : [];
+  const deviceNames = new Map(deviceRows.map((device) => [device.id, device.hostname]));
+
+  return persistedGroups.map((group) => {
+    const groupMembers = members
+      .filter((member) => member.groupId === group.id)
+      .sort((a, b) => {
+        if (a.role === b.role) return a.createdAt.getTime() - b.createdAt.getTime();
+        return a.role === 'root' ? -1 : 1;
+      });
+    const groupAlerts = groupMembers
+      .map((member) => alertById.get(member.alertId))
+      .filter((alert): alert is AlertRow => Boolean(alert))
+      .map((alert) => ({ ...alert, deviceHostname: deviceNames.get(alert.deviceId) ?? null }))
+      .sort((a, b) => b.triggeredAt.getTime() - a.triggeredAt.getTime());
+    const rootCause =
+      (group.rootAlertId ? groupAlerts.find((alert) => alert.id === group.rootAlertId) : undefined) ??
+      groupAlerts[0] ??
+      null;
+
+    return {
+      id: group.id,
+      rootCause: rootCause ? toGroupAlert(rootCause) : null,
+      relatedCount: Math.max(groupAlerts.length - 1, 0),
+      alerts: groupAlerts.map(toGroupAlert),
+      correlationScore: Number(group.score ?? 0),
+      noiseReductionPercent: group.noiseReductionPercent,
+      status: group.status,
+      memberCount: group.memberCount,
+      firstSeenAt: group.firstSeenAt,
+      lastSeenAt: group.lastSeenAt,
+      metadata: group.metadata ?? {},
+      correlationLinks: [],
+      createdAt: group.createdAt,
+    };
+  }).filter((group) => group.rootCause !== null);
+}
+
+async function getPersistedGroupAlerts(groupId: string, auth: AuthContext): Promise<AlertRow[] | null> {
+  const group = await getAccessiblePersistedGroup(groupId, auth);
+  if (!group) return null;
+
+  const members = await db
+    .select()
+    .from(alertCorrelationMembers)
+    .where(and(eq(alertCorrelationMembers.orgId, group.orgId), eq(alertCorrelationMembers.groupId, group.id)));
+  if (members.length === 0) return [];
+
+  const alertIds = members.map((member) => member.alertId);
+  return db.select().from(alerts).where(and(eq(alerts.orgId, group.orgId), inArray(alerts.id, alertIds)));
+}
+
+async function updatePersistedGroupStatus(groupId: string, status: 'acknowledged' | 'resolved'): Promise<void> {
+  await db
+    .update(alertCorrelationGroups)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(alertCorrelationGroups.id, groupId));
+}
+
 async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'resolve', userId: string) {
   const now = new Date();
   const eligible = action === 'acknowledge'
@@ -222,8 +370,26 @@ alertCorrelationRoutes.get(
   requireAlertRead,
   async (c) => {
     const auth = c.get('auth') as AuthContext;
-    const groups = await buildCorrelationGroups(auth);
+    const persistedGroups = await buildPersistedCorrelationGroups(auth);
+    const groups = persistedGroups.length > 0 ? persistedGroups : await buildCorrelationGroups(auth);
     return c.json({ groups, data: groups });
+  }
+);
+
+alertCorrelationRoutes.get(
+  '/correlations/:groupId',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
+  zValidator('param', groupIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { groupId } = c.req.valid('param');
+    const [group] = await buildPersistedCorrelationGroups(auth, groupId);
+    if (!group) {
+      return c.json({ error: 'Correlation group not found' }, 404);
+    }
+
+    return c.json({ group, data: group });
   }
 );
 
@@ -235,15 +401,19 @@ alertCorrelationRoutes.post(
   async (c) => {
     const auth = c.get('auth') as AuthContext;
     const { groupId } = c.req.valid('param');
-    const groups = await buildCorrelationGroups(auth);
+    const persistedGroupAlerts = await getPersistedGroupAlerts(groupId, auth);
+    const groups = persistedGroupAlerts === null ? await buildCorrelationGroups(auth) : [];
     const group = groups.find((candidate) => candidate.id === groupId);
-    if (!group) {
+    if (persistedGroupAlerts === null && !group) {
       return c.json({ error: 'Correlation group not found' }, 404);
     }
 
-    const groupAlertIds = group.alerts.map((alert) => alert.id);
-    const groupAlerts = await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
+    const groupAlertIds = persistedGroupAlerts !== null ? persistedGroupAlerts.map((alert) => alert.id) : group!.alerts.map((alert) => alert.id);
+    const groupAlerts = persistedGroupAlerts ?? await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
     const result = await mutateAlerts(groupAlerts, 'acknowledge', auth.user.id);
+    if (persistedGroupAlerts !== null) {
+      await updatePersistedGroupStatus(groupId, 'acknowledged');
+    }
 
     writeRouteAudit(c, {
       orgId: groupAlerts[0]?.orgId,
@@ -281,15 +451,19 @@ alertCorrelationRoutes.post(
   async (c) => {
     const auth = c.get('auth') as AuthContext;
     const { groupId } = c.req.valid('param');
-    const groups = await buildCorrelationGroups(auth);
+    const persistedGroupAlerts = await getPersistedGroupAlerts(groupId, auth);
+    const groups = persistedGroupAlerts === null ? await buildCorrelationGroups(auth) : [];
     const group = groups.find((candidate) => candidate.id === groupId);
-    if (!group) {
+    if (persistedGroupAlerts === null && !group) {
       return c.json({ error: 'Correlation group not found' }, 404);
     }
 
-    const groupAlertIds = group.alerts.map((alert) => alert.id);
-    const groupAlerts = await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
+    const groupAlertIds = persistedGroupAlerts !== null ? persistedGroupAlerts.map((alert) => alert.id) : group!.alerts.map((alert) => alert.id);
+    const groupAlerts = persistedGroupAlerts ?? await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
     const result = await mutateAlerts(groupAlerts, 'resolve', auth.user.id);
+    if (persistedGroupAlerts !== null) {
+      await updatePersistedGroupStatus(groupId, 'resolved');
+    }
 
     writeRouteAudit(c, {
       orgId: groupAlerts[0]?.orgId,

--- a/apps/api/src/services/alertCorrelationGroups.test.ts
+++ b/apps/api/src/services/alertCorrelationGroups.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock, state, tables } = vi.hoisted(() => {
+  const tables = {
+    alerts: {
+      id: 'alerts.id',
+      orgId: 'alerts.orgId',
+      deviceId: 'alerts.deviceId',
+    },
+    alertCorrelations: {
+      parentAlertId: 'alert_correlations.parentAlertId',
+      childAlertId: 'alert_correlations.childAlertId',
+    },
+  };
+
+  type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
+  const columnKey = (col: unknown) => String(col).split('.').pop()!;
+  const evalPredicate = (row: Record<string, unknown>, predicate: Predicate): boolean => {
+    if (!predicate) return true;
+    if (predicate.op === 'eq') return row[columnKey(predicate.col)] === predicate.val;
+    if (predicate.op === 'inArray') return (predicate.vals ?? []).includes(row[columnKey(predicate.col)]);
+    if (predicate.op === 'and') return (predicate.args ?? []).every((arg) => evalPredicate(row, arg));
+    return true;
+  };
+
+  const state = {
+    alerts: [] as Array<Record<string, any>>,
+    correlations: [] as Array<Record<string, any>>,
+  };
+
+  class SelectQuery {
+    private predicate: Predicate;
+    constructor(private table: unknown) {}
+    where(predicate: Predicate) { this.predicate = predicate; return this; }
+    then(resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) {
+      const source = this.table === tables.alerts ? state.alerts : state.correlations;
+      return Promise.resolve(source.filter((row) => evalPredicate(row, this.predicate))).then(resolve, reject);
+    }
+  }
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: (table: unknown) => new SelectQuery(table),
+    })),
+    execute: vi.fn(async () => [{ id: '99999999-9999-4999-8999-999999999999' }]),
+  };
+
+  return { dbMock, state, tables };
+});
+
+vi.mock('drizzle-orm', () => {
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values });
+  return {
+    and: (...args: unknown[]) => ({ op: 'and', args }),
+    eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+    inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+    sql,
+  };
+});
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('../db/schema', () => ({
+  alerts: tables.alerts,
+  alertCorrelations: tables.alertCorrelations,
+}));
+
+import { persistAlertCorrelationGroupsForAlerts } from './alertCorrelationGroups';
+
+const ORG_1 = '11111111-1111-4111-8111-111111111111';
+const ORG_2 = '22222222-2222-4222-8222-222222222222';
+const ALERT_1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ALERT_2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const ALERT_3 = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+describe('alert correlation group materializer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.alerts = [
+      { id: ALERT_1, orgId: ORG_1, deviceId: 'device-1', ruleId: 'rule-1', status: 'active', severity: 'critical', title: 'CPU high', triggeredAt: new Date('2026-06-18T12:00:00Z'), createdAt: new Date('2026-06-18T12:00:00Z') },
+      { id: ALERT_2, orgId: ORG_1, deviceId: 'device-1', ruleId: 'rule-2', status: 'active', severity: 'high', title: 'Memory high', triggeredAt: new Date('2026-06-18T12:02:00Z'), createdAt: new Date('2026-06-18T12:02:00Z') },
+      { id: ALERT_3, orgId: ORG_2, deviceId: 'device-1', ruleId: 'rule-3', status: 'active', severity: 'low', title: 'Other org', triggeredAt: new Date('2026-06-18T12:03:00Z'), createdAt: new Date('2026-06-18T12:03:00Z') },
+    ];
+    state.correlations = [
+      { parentAlertId: ALERT_1, childAlertId: ALERT_2, correlationType: 'same_device_temporal', confidence: '0.91', createdAt: new Date('2026-06-18T12:03:00Z') },
+      { parentAlertId: ALERT_1, childAlertId: ALERT_3, correlationType: 'same_device_temporal', confidence: '0.88', createdAt: new Date('2026-06-18T12:04:00Z') },
+    ];
+  });
+
+  it('upserts one group and scoped members without crossing org boundaries', async () => {
+    const result = await persistAlertCorrelationGroupsForAlerts({
+      orgId: ORG_1,
+      alertIds: [ALERT_1, ALERT_2, ALERT_3],
+    });
+
+    expect(result).toEqual({ scanned: 2, groupsWritten: 1, membersWritten: 2 });
+    expect(dbMock.execute).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(dbMock.execute.mock.calls)).toContain('ON CONFLICT');
+  });
+
+  it('skips materialization when fewer than two alerts are in scope', async () => {
+    const result = await persistAlertCorrelationGroupsForAlerts({
+      orgId: ORG_1,
+      alertIds: [ALERT_1],
+    });
+
+    expect(result).toEqual({ scanned: 1, groupsWritten: 0, membersWritten: 0 });
+    expect(dbMock.execute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/alertCorrelationGroups.ts
+++ b/apps/api/src/services/alertCorrelationGroups.ts
@@ -1,0 +1,230 @@
+import { and, eq, inArray, sql } from 'drizzle-orm';
+
+import { db } from '../db';
+import { alertCorrelations, alerts } from '../db/schema';
+
+const GROUP_METADATA_VERSION = 'alert-correlation-groups-v1';
+
+type AlertForGrouping = Pick<
+  typeof alerts.$inferSelect,
+  'id' | 'orgId' | 'deviceId' | 'ruleId' | 'status' | 'severity' | 'title' | 'triggeredAt' | 'createdAt'
+>;
+
+type CorrelationForGrouping = Pick<
+  typeof alertCorrelations.$inferSelect,
+  'parentAlertId' | 'childAlertId' | 'correlationType' | 'confidence' | 'createdAt'
+>;
+
+export interface PersistAlertCorrelationGroupsResult {
+  scanned: number;
+  groupsWritten: number;
+  membersWritten: number;
+}
+
+interface Component {
+  root: AlertForGrouping;
+  alerts: AlertForGrouping[];
+  correlations: CorrelationForGrouping[];
+}
+
+function sortByTriggeredAt(alertRows: AlertForGrouping[]): AlertForGrouping[] {
+  return [...alertRows].sort((a, b) => {
+    const diff = a.triggeredAt.getTime() - b.triggeredAt.getTime();
+    return diff === 0 ? a.id.localeCompare(b.id) : diff;
+  });
+}
+
+function buildComponents(alertRows: AlertForGrouping[], correlations: CorrelationForGrouping[]): Component[] {
+  const alertById = new Map(alertRows.map((alert) => [alert.id, alert]));
+  const parent = new Map<string, string>();
+  const find = (id: string): string => {
+    if (!parent.has(id)) parent.set(id, id);
+    if (parent.get(id) !== id) parent.set(id, find(parent.get(id)!));
+    return parent.get(id)!;
+  };
+  const union = (a: string, b: string) => {
+    parent.set(find(a), find(b));
+  };
+
+  for (const link of correlations) {
+    if (alertById.has(link.parentAlertId) && alertById.has(link.childAlertId)) {
+      union(link.parentAlertId, link.childAlertId);
+    }
+  }
+
+  const componentAlertIds = new Map<string, string[]>();
+  for (const link of correlations) {
+    const root = find(link.parentAlertId);
+    const ids = componentAlertIds.get(root) ?? [];
+    if (!ids.includes(link.parentAlertId)) ids.push(link.parentAlertId);
+    if (!ids.includes(link.childAlertId)) ids.push(link.childAlertId);
+    componentAlertIds.set(root, ids);
+  }
+
+  const components: Component[] = [];
+  for (const ids of componentAlertIds.values()) {
+    if (ids.length < 2) continue;
+    const componentAlerts = sortByTriggeredAt(
+      ids.map((id) => alertById.get(id)).filter((alert): alert is AlertForGrouping => Boolean(alert))
+    );
+    if (componentAlerts.length < 2) continue;
+    const idSet = new Set(componentAlerts.map((alert) => alert.id));
+    components.push({
+      root: componentAlerts[0]!,
+      alerts: componentAlerts,
+      correlations: correlations.filter(
+        (link) => idSet.has(link.parentAlertId) && idSet.has(link.childAlertId)
+      ),
+    });
+  }
+
+  return components;
+}
+
+function averageConfidence(correlations: CorrelationForGrouping[]): number {
+  if (correlations.length === 0) return 0;
+  const avg = correlations.reduce((sum, link) => sum + Number(link.confidence ?? 0), 0) / correlations.length;
+  return Math.max(0, Math.min(1, Math.round(avg * 100) / 100));
+}
+
+function confidenceForAlert(alertId: string, component: Component): number {
+  if (alertId === component.root.id) return 1;
+  const confidences = component.correlations
+    .filter((link) => link.parentAlertId === alertId || link.childAlertId === alertId)
+    .map((link) => Number(link.confidence ?? 0));
+  return confidences.length > 0 ? Math.max(...confidences) : 0;
+}
+
+async function upsertGroup(orgId: string, component: Component): Promise<string> {
+  const memberCount = component.alerts.length;
+  const score = averageConfidence(component.correlations);
+  const noiseReductionPercent = Math.round(((memberCount - 1) / memberCount) * 100);
+  const firstSeenAt = component.alerts[0]!.triggeredAt;
+  const lastSeenAt = component.alerts[memberCount - 1]!.triggeredAt;
+  const correlationTypes = [...new Set(component.correlations.map((link) => link.correlationType))];
+  const groupKey = `root:${component.root.id}`;
+
+  const rows = (await db.execute(sql`
+    INSERT INTO alert_correlation_groups (
+      org_id,
+      group_key,
+      root_alert_id,
+      status,
+      score,
+      noise_reduction_percent,
+      member_count,
+      first_seen_at,
+      last_seen_at,
+      metadata
+    )
+    VALUES (
+      ${orgId},
+      ${groupKey},
+      ${component.root.id},
+      'open',
+      ${score.toFixed(2)},
+      ${noiseReductionPercent},
+      ${memberCount},
+      ${firstSeenAt},
+      ${lastSeenAt},
+      jsonb_build_object(
+        'version', ${GROUP_METADATA_VERSION},
+        'correlationTypes', ${JSON.stringify(correlationTypes)}
+      )
+    )
+    ON CONFLICT (org_id, group_key)
+    DO UPDATE SET
+      root_alert_id = EXCLUDED.root_alert_id,
+      score = EXCLUDED.score,
+      noise_reduction_percent = EXCLUDED.noise_reduction_percent,
+      member_count = EXCLUDED.member_count,
+      first_seen_at = EXCLUDED.first_seen_at,
+      last_seen_at = EXCLUDED.last_seen_at,
+      metadata = EXCLUDED.metadata,
+      updated_at = now()
+    RETURNING id
+  `)) as unknown as Array<{ id: string }>;
+
+  const groupId = rows[0]?.id;
+  if (!groupId) {
+    throw new Error('Failed to upsert alert correlation group');
+  }
+  return groupId;
+}
+
+async function upsertMembers(orgId: string, groupId: string, component: Component): Promise<number> {
+  let written = 0;
+  for (const alert of component.alerts) {
+    const role = alert.id === component.root.id ? 'root' : 'related';
+    const confidence = confidenceForAlert(alert.id, component);
+    await db.execute(sql`
+      INSERT INTO alert_correlation_members (
+        org_id,
+        group_id,
+        alert_id,
+        role,
+        confidence,
+        evidence
+      )
+      VALUES (
+        ${orgId},
+        ${groupId},
+        ${alert.id},
+        ${role},
+        ${confidence.toFixed(2)},
+        jsonb_build_object('version', ${GROUP_METADATA_VERSION})
+      )
+      ON CONFLICT (group_id, alert_id)
+      DO UPDATE SET
+        role = EXCLUDED.role,
+        confidence = EXCLUDED.confidence,
+        evidence = EXCLUDED.evidence,
+        updated_at = now()
+    `);
+    written += 1;
+  }
+  return written;
+}
+
+export async function persistAlertCorrelationGroupsForAlerts(options: {
+  orgId: string;
+  alertIds: string[];
+}): Promise<PersistAlertCorrelationGroupsResult> {
+  const alertIds = [...new Set(options.alertIds)].filter(Boolean);
+  if (alertIds.length < 2) {
+    return { scanned: alertIds.length, groupsWritten: 0, membersWritten: 0 };
+  }
+
+  const alertRows = await db
+    .select()
+    .from(alerts)
+    .where(and(eq(alerts.orgId, options.orgId), inArray(alerts.id, alertIds)));
+
+  if (alertRows.length < 2) {
+    return { scanned: alertRows.length, groupsWritten: 0, membersWritten: 0 };
+  }
+
+  const scopedAlertIds = alertRows.map((alert) => alert.id);
+  const correlations = await db
+    .select()
+    .from(alertCorrelations)
+    .where(
+      and(
+        inArray(alertCorrelations.parentAlertId, scopedAlertIds),
+        inArray(alertCorrelations.childAlertId, scopedAlertIds)
+      )
+    );
+
+  const components = buildComponents(alertRows, correlations);
+  let membersWritten = 0;
+  for (const component of components) {
+    const groupId = await upsertGroup(options.orgId, component);
+    membersWritten += await upsertMembers(options.orgId, groupId, component);
+  }
+
+  return {
+    scanned: alertRows.length,
+    groupsWritten: components.length,
+    membersWritten,
+  };
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -64,6 +64,8 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'ai_cost_usage',
   'ai_screenshots',
   'ai_sessions',
+  'alert_correlation_groups',
+  'alert_correlation_members',
   'alert_rules',
   'alert_templates',
   'alerts',


### PR DESCRIPTION
## Summary
- add direct-org RLS tables for persisted alert correlation groups and members
- materialize stable groups from alert correlation edges in the alert-correlation worker
- make /alerts/correlations prefer persisted groups while preserving derived fallback and existing response shape
- update group acknowledge/resolve actions to use persisted membership and update group status

## Validation
- /usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/services/alertCorrelationGroups.test.ts src/routes/alerts/correlations.test.ts src/jobs/alertCorrelation.test.ts --config vitest.config.ts
- /usr/local/bin/corepack pnpm --filter @breeze/api exec tsup --no-dts
- git diff --check

## Notes
- Stacked on #1486 / feat/ml-metric-rollups.
- Full pnpm --filter @breeze/api build CJS output succeeds, but the DTS build hangs in this worktree; stopped after repeated waits.
- Migration checker could not run locally because Postgres rejected the configured role: role "breeze" does not exist.
- codebase-memory MCP transport/index was unavailable or incomplete, so discovery fell back to local reads.