### PR TITLE
feat(ml): add alert correlation RCA v0

### DIFF
--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -3,9 +3,12 @@ import { Hono } from 'hono';
 
 const {
   authRef,
+  buildAlertCorrelationRcaMock,
   grantedRef,
   emitAlertStateFeedbackMock,
   emitCorrelationFeedbackMock,
+  emitRcaFeedbackMock,
+  shouldProduceMlOutputMock,
   state,
   tables,
   dbMock,
@@ -111,9 +114,12 @@ const {
 
   return {
     authRef: { current: null as any },
+    buildAlertCorrelationRcaMock: vi.fn(),
     grantedRef: { current: new Set<string>() },
     emitAlertStateFeedbackMock: vi.fn(),
     emitCorrelationFeedbackMock: vi.fn(),
+    emitRcaFeedbackMock: vi.fn(),
+    shouldProduceMlOutputMock: vi.fn(),
     state,
     tables,
     dbMock,
@@ -149,10 +155,17 @@ vi.mock('../../db/schema', () => ({
   devices: tables.devices,
 }));
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/alertCorrelationRca', () => ({
+  buildAlertCorrelationRca: buildAlertCorrelationRcaMock,
+}));
 vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn(() => Promise.resolve()) }));
 vi.mock('../../services/mlFeedbackEmitters', () => ({
   emitAlertStateFeedback: emitAlertStateFeedbackMock,
   emitCorrelationFeedback: emitCorrelationFeedbackMock,
+  emitRcaFeedback: emitRcaFeedbackMock,
+}));
+vi.mock('../../services/mlFeatureFlags', () => ({
+  shouldProduceMlOutput: shouldProduceMlOutputMock,
 }));
 vi.mock('../../services/permissions', () => ({
   PERMISSIONS: {
@@ -218,6 +231,24 @@ describe('/alerts correlation routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     seed();
+    shouldProduceMlOutputMock.mockResolvedValue(true);
+    buildAlertCorrelationRcaMock.mockResolvedValue({
+      groupId: GROUP_1,
+      scope: {
+        orgId: ORG_1,
+        deviceIds: [DEVICE_1],
+        alertIds: [ALERT_1, ALERT_2],
+        windowStart: '2026-06-18T06:00:00.000Z',
+        windowEnd: '2026-06-18T13:02:00.000Z',
+      },
+      timeline: [
+        { id: `alert:${ALERT_1}`, source: 'alert', type: 'critical', timestamp: '2026-06-18T12:00:00.000Z', title: 'CPU high', summary: 'CPU high' },
+      ],
+      rootCauseCandidates: [
+        { summary: 'CPU high was earliest', confidence: 0.91, supportingEvidenceIds: [`alert:${ALERT_1}`] },
+      ],
+      gaps: [],
+    });
     grantedRef.current = new Set(['alerts:read', 'alerts:acknowledge', 'alerts:write']);
     authRef.current = {
       scope: 'organization',
@@ -298,6 +329,115 @@ describe('/alerts correlation routes', () => {
 
     const denied = await makeApp().request('/alerts/correlations/ffffffff-ffff-4fff-8fff-ffffffffffff');
     expect(denied.status).toBe(404);
+  });
+
+  it('returns a deterministic RCA bundle for a persisted correlation group', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/explain`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ windowHours: 4, maxEvidenceItems: 12 }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(shouldProduceMlOutputMock).toHaveBeenCalledWith(ORG_1, 'ml.rca.enabled');
+    expect(buildAlertCorrelationRcaMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_1,
+      groupId: GROUP_1,
+      alerts: expect.arrayContaining([
+        expect.objectContaining({ id: ALERT_1 }),
+        expect.objectContaining({ id: ALERT_2 }),
+      ]),
+      windowHours: 4,
+      maxEvidenceItems: 12,
+    }));
+    const body = await res.json();
+    expect(body.rca.rootCauseCandidates[0]).toEqual(expect.objectContaining({ confidence: 0.91 }));
+  });
+
+  it('uses default RCA options when explain is called without a JSON body', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/explain`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    expect(buildAlertCorrelationRcaMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_1,
+      groupId: GROUP_1,
+      windowHours: undefined,
+      maxEvidenceItems: undefined,
+    }));
+  });
+
+  it('rejects invalid RCA explain options', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/explain`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ windowHours: 99 }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(buildAlertCorrelationRcaMock).not.toHaveBeenCalled();
+  });
+
+  it('does not build RCA output when the RCA flag is disabled', async () => {
+    seedPersistedGroup();
+    shouldProduceMlOutputMock.mockResolvedValue(false);
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/explain`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(403);
+    expect(buildAlertCorrelationRcaMock).not.toHaveBeenCalled();
+  });
+
+  it('records RCA feedback for a visible persisted correlation group', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/rca-feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'rca.helpful',
+        outcome: 'helpful',
+        metadata: { surface: 'test' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(emitRcaFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_1,
+      rcaId: GROUP_1,
+      eventType: 'rca.helpful',
+      outcome: 'helpful',
+      actorUserId: '99999999-9999-4999-8999-999999999999',
+      metadata: expect.objectContaining({ groupId: GROUP_1, rootAlertId: ALERT_1, surface: 'test' }),
+    }));
+  });
+
+  it('rejects inconsistent RCA feedback event/outcome pairs', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/rca-feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'rca.helpful',
+        outcome: 'not_helpful',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(emitRcaFeedbackMock).not.toHaveBeenCalled();
   });
 
   it('acknowledges all accessible alerts in a correlation group', async () => {

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, desc, eq, inArray, or, type SQL } from 'drizzle-orm';
@@ -7,14 +7,47 @@ import { db } from '../../db';
 import { alertCorrelationGroups, alertCorrelationMembers, alertCorrelations, alerts, devices } from '../../db/schema';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { buildAlertCorrelationRca } from '../../services/alertCorrelationRca';
 import { publishEvent } from '../../services/eventBus';
-import { emitAlertStateFeedback, emitCorrelationFeedback } from '../../services/mlFeedbackEmitters';
+import { emitAlertStateFeedback, emitCorrelationFeedback, emitRcaFeedback } from '../../services/mlFeedbackEmitters';
+import { shouldProduceMlOutput } from '../../services/mlFeatureFlags';
 import { PERMISSIONS } from '../../services/permissions';
 
 export const alertCorrelationRoutes = new Hono();
 
 const alertIdParamSchema = z.object({ alertId: z.string().uuid() });
 const groupIdParamSchema = z.object({ groupId: z.string().uuid() });
+const explainGroupSchema = z.object({
+  windowHours: z.number().int().min(1).max(24).optional(),
+  maxEvidenceItems: z.number().int().min(5).max(100).optional(),
+}).optional().default({});
+const rcaFeedbackSchema = z.object({
+  eventType: z.enum(['rca.helpful', 'rca.not_helpful', 'rca.edited', 'rca.used_in_ticket']),
+  outcome: z.enum(['helpful', 'not_helpful', 'edited', 'used_in_ticket']),
+  metadata: z.record(z.unknown()).optional().default({}),
+}).superRefine((value, ctx) => {
+  const expectedOutcome = value.eventType.replace('rca.', '') as typeof value.outcome;
+  if (value.outcome !== expectedOutcome) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'outcome must match eventType',
+      path: ['outcome'],
+    });
+  }
+});
+
+async function parseOptionalExplainBody(c: Context) {
+  const contentType = c.req.header('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    return {};
+  }
+
+  try {
+    return await c.req.json();
+  } catch {
+    return {};
+  }
+}
 
 const requireAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
 const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
@@ -390,6 +423,102 @@ alertCorrelationRoutes.get(
     }
 
     return c.json({ group, data: group });
+  }
+);
+
+alertCorrelationRoutes.post(
+  '/correlations/:groupId/explain',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
+  zValidator('param', groupIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { groupId } = c.req.valid('param');
+    const parsedBody = explainGroupSchema.safeParse(await parseOptionalExplainBody(c));
+    if (!parsedBody.success) {
+      return c.json({ error: 'Invalid RCA options', details: parsedBody.error.flatten() }, 400);
+    }
+    const body = parsedBody.data;
+    const group = await getAccessiblePersistedGroup(groupId, auth);
+    if (!group) {
+      return c.json({ error: 'Correlation group not found' }, 404);
+    }
+
+    if (!(await shouldProduceMlOutput(group.orgId, 'ml.rca.enabled'))) {
+      return c.json({ error: 'RCA is disabled for this organization' }, 403);
+    }
+
+    const groupAlerts = await getPersistedGroupAlerts(groupId, auth);
+    if (groupAlerts === null) {
+      return c.json({ error: 'Correlation group not found' }, 404);
+    }
+
+    const rca = await buildAlertCorrelationRca({
+      orgId: group.orgId,
+      groupId: group.id,
+      groupScore: group.score === null ? null : Number(group.score),
+      alerts: groupAlerts,
+      windowHours: body.windowHours,
+      maxEvidenceItems: body.maxEvidenceItems,
+    });
+
+    writeRouteAudit(c, {
+      orgId: group.orgId,
+      action: 'alert_correlation.explain_group',
+      resourceType: 'alert_correlation',
+      resourceId: group.id,
+      details: {
+        alertIds: rca.scope.alertIds,
+        deviceIds: rca.scope.deviceIds,
+        evidenceCount: rca.timeline.length,
+        candidateCount: rca.rootCauseCandidates.length,
+      },
+    });
+
+    return c.json({ rca, data: rca });
+  }
+);
+
+alertCorrelationRoutes.post(
+  '/correlations/:groupId/rca-feedback',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
+  zValidator('param', groupIdParamSchema),
+  zValidator('json', rcaFeedbackSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { groupId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const group = await getAccessiblePersistedGroup(groupId, auth);
+    if (!group) {
+      return c.json({ error: 'Correlation group not found' }, 404);
+    }
+
+    await emitRcaFeedback({
+      orgId: group.orgId,
+      rcaId: group.id,
+      eventType: body.eventType,
+      outcome: body.outcome,
+      actorUserId: auth.user.id,
+      metadata: {
+        ...body.metadata,
+        groupId: group.id,
+        rootAlertId: group.rootAlertId,
+      },
+    });
+
+    writeRouteAudit(c, {
+      orgId: group.orgId,
+      action: 'alert_correlation.rca_feedback',
+      resourceType: 'alert_correlation',
+      resourceId: group.id,
+      details: {
+        eventType: body.eventType,
+        outcome: body.outcome,
+      },
+    });
+
+    return c.json({ success: true });
   }
 );
 

--- a/apps/api/src/services/alertCorrelationRca.test.ts
+++ b/apps/api/src/services/alertCorrelationRca.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock, state, tables } = vi.hoisted(() => {
+  const tables = {
+    devices: { id: 'devices.id', orgId: 'devices.orgId', hostname: 'devices.hostname', osType: 'devices.osType' },
+    alertCorrelations: {
+      parentAlertId: 'alert_correlations.parentAlertId',
+      childAlertId: 'alert_correlations.childAlertId',
+      correlationType: 'alert_correlations.correlationType',
+      confidence: 'alert_correlations.confidence',
+      createdAt: 'alert_correlations.createdAt',
+    },
+    brainDeviceContext: {
+      id: 'brainDeviceContext.id',
+      orgId: 'brainDeviceContext.orgId',
+      deviceId: 'brainDeviceContext.deviceId',
+      contextType: 'brainDeviceContext.contextType',
+      summary: 'brainDeviceContext.summary',
+      details: 'brainDeviceContext.details',
+      createdAt: 'brainDeviceContext.createdAt',
+      resolvedAt: 'brainDeviceContext.resolvedAt',
+    },
+    deviceChangeLog: {
+      id: 'deviceChangeLog.id',
+      orgId: 'deviceChangeLog.orgId',
+      deviceId: 'deviceChangeLog.deviceId',
+      timestamp: 'deviceChangeLog.timestamp',
+      changeType: 'deviceChangeLog.changeType',
+      changeAction: 'deviceChangeLog.changeAction',
+      subject: 'deviceChangeLog.subject',
+    },
+    deviceEventLogs: {
+      id: 'deviceEventLogs.id',
+      orgId: 'deviceEventLogs.orgId',
+      deviceId: 'deviceEventLogs.deviceId',
+      timestamp: 'deviceEventLogs.timestamp',
+      level: 'deviceEventLogs.level',
+      category: 'deviceEventLogs.category',
+      source: 'deviceEventLogs.source',
+      eventId: 'deviceEventLogs.eventId',
+      message: 'deviceEventLogs.message',
+    },
+    agentLogs: {
+      id: 'agentLogs.id',
+      orgId: 'agentLogs.orgId',
+      deviceId: 'agentLogs.deviceId',
+      timestamp: 'agentLogs.timestamp',
+      level: 'agentLogs.level',
+      component: 'agentLogs.component',
+      message: 'agentLogs.message',
+    },
+    metricRollups: {
+      orgId: 'metricRollups.orgId',
+      sourceTable: 'metricRollups.sourceTable',
+      deviceId: 'metricRollups.deviceId',
+      bucketSeconds: 'metricRollups.bucketSeconds',
+      metricName: 'metricRollups.metricName',
+      bucketStart: 'metricRollups.bucketStart',
+      avgValue: 'metricRollups.avgValue',
+      maxValue: 'metricRollups.maxValue',
+    },
+  };
+
+  type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
+  const columnKey = (col: unknown) => String(col).split('.').pop()!;
+  const evalPredicate = (row: Record<string, unknown>, predicate: Predicate): boolean => {
+    if (!predicate) return true;
+    const left = row[columnKey(predicate.col)];
+    if (predicate.op === 'eq') return left === predicate.val;
+    if (predicate.op === 'inArray') return (predicate.vals ?? []).includes(left);
+    if (predicate.op === 'isNull') return left === null || left === undefined;
+    if (predicate.op === 'gte') return new Date(left as any).getTime() >= new Date(predicate.val as any).getTime();
+    if (predicate.op === 'lte') return new Date(left as any).getTime() <= new Date(predicate.val as any).getTime();
+    if (predicate.op === 'and') return (predicate.args ?? []).every((arg) => evalPredicate(row, arg));
+    if (predicate.op === 'or') return (predicate.args ?? []).some((arg) => evalPredicate(row, arg));
+    return true;
+  };
+
+  const state = {
+    devices: [] as Array<Record<string, any>>,
+    correlations: [] as Array<Record<string, any>>,
+    context: [] as Array<Record<string, any>>,
+    changes: [] as Array<Record<string, any>>,
+    eventLogs: [] as Array<Record<string, any>>,
+    agentLogs: [] as Array<Record<string, any>>,
+    metricRollups: [] as Array<Record<string, any>>,
+  };
+
+  class SelectQuery {
+    private predicate: Predicate;
+    constructor(private table: unknown, private projection?: Record<string, unknown>) {}
+    where(predicate: Predicate) { this.predicate = predicate; return this; }
+    orderBy() { return this; }
+    limit(limit: number) { return Promise.resolve(this.rows().slice(0, limit)); }
+    then(resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) {
+      return Promise.resolve(this.rows()).then(resolve, reject);
+    }
+    private rows() {
+      const source = this.table === tables.devices
+        ? state.devices
+        : this.table === tables.alertCorrelations
+          ? state.correlations
+          : this.table === tables.brainDeviceContext
+            ? state.context
+            : this.table === tables.deviceChangeLog
+              ? state.changes
+              : this.table === tables.deviceEventLogs
+                ? state.eventLogs
+                : this.table === tables.agentLogs
+                  ? state.agentLogs
+                  : state.metricRollups;
+      const filtered = source.filter((row) => evalPredicate(row, this.predicate));
+      if (!this.projection) return filtered;
+      return filtered.map((row) => {
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(this.projection!)) {
+          out[key] = row[columnKey(this.projection![key])];
+        }
+        return out;
+      });
+    }
+  }
+
+  const dbMock = {
+    select: vi.fn((projection?: Record<string, unknown>) => ({
+      from: (table: unknown) => new SelectQuery(table, projection),
+    })),
+  };
+
+  return { dbMock, state, tables };
+});
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  gte: (col: unknown, val: unknown) => ({ op: 'gte', col, val }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+  lte: (col: unknown, val: unknown) => ({ op: 'lte', col, val }),
+  or: (...args: unknown[]) => ({ op: 'or', args }),
+}));
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('../db/schema', () => ({
+  agentLogs: tables.agentLogs,
+  alertCorrelations: tables.alertCorrelations,
+  brainDeviceContext: tables.brainDeviceContext,
+  deviceChangeLog: tables.deviceChangeLog,
+  deviceEventLogs: tables.deviceEventLogs,
+  devices: tables.devices,
+  metricRollups: tables.metricRollups,
+}));
+
+import { buildAlertCorrelationRca } from './alertCorrelationRca';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const DEVICE_ID = '22222222-2222-4222-8222-222222222222';
+const ALERT_1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ALERT_2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+describe('alert correlation RCA evidence builder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.devices = [{ id: DEVICE_ID, orgId: ORG_ID, hostname: 'server-1', osType: 'windows' }];
+    state.correlations = [{
+      parentAlertId: ALERT_1,
+      childAlertId: ALERT_2,
+      correlationType: 'same_device_temporal',
+      confidence: '0.91',
+      createdAt: new Date('2026-06-18T12:03:00Z'),
+    }];
+    state.context = [{
+      id: 'ctx-1',
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      contextType: 'issue',
+      summary: 'Known CPU contention',
+      details: { service: 'backup' },
+      createdAt: new Date('2026-06-18T11:00:00Z'),
+      resolvedAt: null,
+    }];
+    state.changes = [{
+      id: 'change-1',
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      timestamp: new Date('2026-06-18T11:30:00Z'),
+      changeType: 'service',
+      changeAction: 'modified',
+      subject: 'Backup service schedule changed',
+    }];
+    state.eventLogs = [{
+      id: 'event-1',
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      timestamp: new Date('2026-06-18T12:01:00Z'),
+      level: 'error',
+      category: 'system',
+      source: 'Service Control Manager',
+      eventId: '7031',
+      message: 'Service terminated unexpectedly',
+    }];
+    state.agentLogs = [{
+      id: 'agent-1',
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      timestamp: new Date('2026-06-18T12:02:00Z'),
+      level: 'error',
+      component: 'watchdog.service',
+      message: 'Watchdog restart threshold exceeded',
+    }];
+    state.metricRollups = [{
+      orgId: ORG_ID,
+      sourceTable: 'device_metrics',
+      deviceId: DEVICE_ID,
+      bucketSeconds: 300,
+      metricName: 'cpu_percent',
+      bucketStart: new Date('2026-06-18T12:00:00Z'),
+      avgValue: 92,
+      maxValue: 99,
+    }];
+  });
+
+  it('builds bounded evidence and likely-cause candidates for grouped alerts', async () => {
+    const result = await buildAlertCorrelationRca({
+      orgId: ORG_ID,
+      groupId: 'group-1',
+      groupScore: 0.91,
+      windowHours: 4,
+      maxEvidenceItems: 20,
+      alerts: [
+        { id: ALERT_1, orgId: ORG_ID, deviceId: DEVICE_ID, ruleId: 'rule-1', configPolicyId: null, configItemName: null, status: 'active', severity: 'critical', title: 'CPU high', message: 'CPU over 90%', context: {}, triggeredAt: new Date('2026-06-18T12:00:00Z'), acknowledgedAt: null, acknowledgedBy: null, resolvedAt: null, resolvedBy: null, resolutionNote: null, suppressedUntil: null, createdAt: new Date('2026-06-18T12:00:00Z') },
+        { id: ALERT_2, orgId: ORG_ID, deviceId: DEVICE_ID, ruleId: 'rule-2', configPolicyId: null, configItemName: null, status: 'active', severity: 'high', title: 'Memory high', message: 'RAM over 90%', context: {}, triggeredAt: new Date('2026-06-18T12:02:00Z'), acknowledgedAt: null, acknowledgedBy: null, resolvedAt: null, resolvedBy: null, resolutionNote: null, suppressedUntil: null, createdAt: new Date('2026-06-18T12:02:00Z') },
+      ],
+    });
+
+    expect(result.scope).toMatchObject({
+      orgId: ORG_ID,
+      deviceIds: [DEVICE_ID],
+      alertIds: [ALERT_1, ALERT_2],
+    });
+    expect(result.timeline.map((item) => item.source)).toEqual(expect.arrayContaining([
+      'alert',
+      'correlation',
+      'device_change',
+      'event_log',
+      'agent_log',
+      'metric_rollup',
+    ]));
+    expect(result.rootCauseCandidates).toEqual(expect.arrayContaining([
+      expect.objectContaining({ confidence: 0.91 }),
+      expect.objectContaining({ confidence: 0.58 }),
+      expect.objectContaining({ confidence: 0.52 }),
+    ]));
+    expect(result.gaps).toEqual([]);
+  });
+});

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -1,0 +1,341 @@
+import { and, desc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
+
+import { db } from '../db';
+import {
+  agentLogs,
+  alertCorrelations,
+  alerts,
+  brainDeviceContext,
+  deviceChangeLog,
+  deviceEventLogs,
+  devices,
+  metricRollups,
+} from '../db/schema';
+
+type AlertRow = typeof alerts.$inferSelect;
+type CorrelationRow = typeof alertCorrelations.$inferSelect;
+type DeviceRow = Pick<typeof devices.$inferSelect, 'id' | 'hostname' | 'osType'>;
+
+export interface RcaEvidenceItem {
+  id: string;
+  source: 'alert' | 'correlation' | 'device_context' | 'device_change' | 'event_log' | 'agent_log' | 'metric_rollup';
+  type: string;
+  timestamp: string;
+  deviceId?: string;
+  alertId?: string;
+  severity?: string;
+  title: string;
+  summary: string;
+}
+
+export interface RcaRootCauseCandidate {
+  summary: string;
+  confidence: number;
+  supportingEvidenceIds: string[];
+}
+
+export interface AlertCorrelationRcaResult {
+  groupId: string;
+  scope: {
+    orgId: string;
+    deviceIds: string[];
+    alertIds: string[];
+    windowStart: string;
+    windowEnd: string;
+  };
+  timeline: RcaEvidenceItem[];
+  rootCauseCandidates: RcaRootCauseCandidate[];
+  gaps: string[];
+}
+
+interface BuildRcaOptions {
+  orgId: string;
+  groupId: string;
+  groupScore?: number | null;
+  alerts: AlertRow[];
+  windowHours?: number;
+  maxEvidenceItems?: number;
+}
+
+function toIso(value: Date): string {
+  return value.toISOString();
+}
+
+function asDate(value: Date | string | null | undefined): Date {
+  if (value instanceof Date) return value;
+  const parsed = value ? new Date(value) : new Date();
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+function clampConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Math.round(value * 100) / 100));
+}
+
+function summarizeJson(value: unknown, maxLength = 180): string {
+  if (value == null) return '';
+  const raw = typeof value === 'string' ? value : JSON.stringify(value);
+  return raw.length > maxLength ? `${raw.slice(0, maxLength)}...` : raw;
+}
+
+function rankEvidence(items: RcaEvidenceItem[]): RcaEvidenceItem[] {
+  const sourceWeight: Record<RcaEvidenceItem['source'], number> = {
+    alert: 100,
+    correlation: 80,
+    device_change: 75,
+    event_log: 70,
+    agent_log: 65,
+    metric_rollup: 55,
+    device_context: 45,
+  };
+
+  return [...items].sort((a, b) => {
+    const timeDiff = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+    if (timeDiff !== 0) return timeDiff;
+    return sourceWeight[b.source] - sourceWeight[a.source];
+  });
+}
+
+function buildAlertEvidence(alertRows: AlertRow[], deviceNames: Map<string, DeviceRow>): RcaEvidenceItem[] {
+  return alertRows.map((alert) => {
+    const device = deviceNames.get(alert.deviceId);
+    return {
+      id: `alert:${alert.id}`,
+      source: 'alert',
+      type: alert.severity,
+      timestamp: toIso(asDate(alert.triggeredAt)),
+      deviceId: alert.deviceId,
+      alertId: alert.id,
+      severity: alert.severity,
+      title: alert.title,
+      summary: `${alert.severity.toUpperCase()} alert on ${device?.hostname ?? alert.deviceId}: ${alert.message ?? alert.title}`,
+    };
+  });
+}
+
+function buildPrimaryAlertCandidate(alertRows: AlertRow[], groupScore: number | null | undefined): RcaRootCauseCandidate | null {
+  const sorted = [...alertRows].sort((a, b) => a.triggeredAt.getTime() - b.triggeredAt.getTime());
+  const root = sorted[0];
+  if (!root) return null;
+  const related = Math.max(sorted.length - 1, 0);
+  return {
+    summary: `${root.title} was the earliest alert in the correlated incident and may be the initiating symptom for ${related} related alert${related === 1 ? '' : 's'}.`,
+    confidence: clampConfidence(Math.max(Number(groupScore ?? 0), 0.45)),
+    supportingEvidenceIds: [`alert:${root.id}`],
+  };
+}
+
+function buildChangeCandidate(evidence: RcaEvidenceItem[]): RcaRootCauseCandidate | null {
+  const change = evidence.find((item) => item.source === 'device_change');
+  if (!change) return null;
+  return {
+    summary: `A recent device change occurred before or during the incident window: ${change.summary}`,
+    confidence: 0.58,
+    supportingEvidenceIds: [change.id],
+  };
+}
+
+function buildLogCandidate(evidence: RcaEvidenceItem[]): RcaRootCauseCandidate | null {
+  const log = evidence.find((item) => item.source === 'event_log' || item.source === 'agent_log');
+  if (!log) return null;
+  return {
+    summary: `A high-severity log entry aligns with the incident window: ${log.summary}`,
+    confidence: 0.52,
+    supportingEvidenceIds: [log.id],
+  };
+}
+
+export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promise<AlertCorrelationRcaResult> {
+  const alertRows = [...options.alerts].sort((a, b) => a.triggeredAt.getTime() - b.triggeredAt.getTime());
+  const alertIds = alertRows.map((alert) => alert.id);
+  const deviceIds = [...new Set(alertRows.map((alert) => alert.deviceId))];
+  const firstAlertAt = alertRows[0]?.triggeredAt ?? new Date();
+  const lastAlertAt = alertRows[alertRows.length - 1]?.triggeredAt ?? firstAlertAt;
+  const windowHours = Math.min(Math.max(options.windowHours ?? 6, 1), 24);
+  const maxEvidenceItems = Math.min(Math.max(options.maxEvidenceItems ?? 30, 5), 100);
+  const windowStart = new Date(firstAlertAt.getTime() - windowHours * 60 * 60 * 1000);
+  const windowEnd = new Date(Math.max(Date.now(), lastAlertAt.getTime() + 60 * 60 * 1000));
+  const gaps: string[] = [];
+
+  if (alertRows.length === 0) {
+    return {
+      groupId: options.groupId,
+      scope: {
+        orgId: options.orgId,
+        deviceIds: [],
+        alertIds: [],
+        windowStart: toIso(windowStart),
+        windowEnd: toIso(windowEnd),
+      },
+      timeline: [],
+      rootCauseCandidates: [],
+      gaps: ['No alerts were attached to this correlation group.'],
+    };
+  }
+
+  const deviceRows = deviceIds.length > 0
+    ? await db
+        .select({ id: devices.id, hostname: devices.hostname, osType: devices.osType })
+        .from(devices)
+        .where(and(eq(devices.orgId, options.orgId), inArray(devices.id, deviceIds)))
+    : [];
+  const deviceNames = new Map(deviceRows.map((device) => [device.id, device]));
+
+  const correlationRows = alertIds.length > 1
+    ? await db
+        .select()
+        .from(alertCorrelations)
+        .where(and(inArray(alertCorrelations.parentAlertId, alertIds), inArray(alertCorrelations.childAlertId, alertIds)))
+    : [];
+
+  const contextRows = deviceIds.length > 0
+    ? await db
+        .select()
+        .from(brainDeviceContext)
+        .where(and(eq(brainDeviceContext.orgId, options.orgId), inArray(brainDeviceContext.deviceId, deviceIds), isNull(brainDeviceContext.resolvedAt)))
+        .limit(10)
+    : [];
+
+  const changeRows = deviceIds.length > 0
+    ? await db
+        .select()
+        .from(deviceChangeLog)
+        .where(and(eq(deviceChangeLog.orgId, options.orgId), inArray(deviceChangeLog.deviceId, deviceIds), gte(deviceChangeLog.timestamp, windowStart), lte(deviceChangeLog.timestamp, windowEnd)))
+        .orderBy(desc(deviceChangeLog.timestamp))
+        .limit(10)
+    : [];
+
+  const eventRows = deviceIds.length > 0
+    ? await db
+        .select()
+        .from(deviceEventLogs)
+        .where(and(
+          eq(deviceEventLogs.orgId, options.orgId),
+          inArray(deviceEventLogs.deviceId, deviceIds),
+          inArray(deviceEventLogs.level, ['warning', 'error', 'critical']),
+          gte(deviceEventLogs.timestamp, windowStart),
+          lte(deviceEventLogs.timestamp, windowEnd)
+        ))
+        .orderBy(desc(deviceEventLogs.timestamp))
+        .limit(10)
+    : [];
+
+  const agentLogRows = deviceIds.length > 0
+    ? await db
+        .select()
+        .from(agentLogs)
+        .where(and(
+          eq(agentLogs.orgId, options.orgId),
+          inArray(agentLogs.deviceId, deviceIds),
+          or(eq(agentLogs.level, 'warn'), eq(agentLogs.level, 'error')),
+          gte(agentLogs.timestamp, windowStart),
+          lte(agentLogs.timestamp, windowEnd)
+        ))
+        .orderBy(desc(agentLogs.timestamp))
+        .limit(10)
+    : [];
+
+  const metricRows = deviceIds.length > 0
+    ? await db
+        .select()
+        .from(metricRollups)
+        .where(and(
+          eq(metricRollups.orgId, options.orgId),
+          eq(metricRollups.sourceTable, 'device_metrics'),
+          eq(metricRollups.bucketSeconds, 300),
+          inArray(metricRollups.deviceId, deviceIds),
+          inArray(metricRollups.metricName, ['cpu_percent', 'ram_percent', 'disk_percent']),
+          gte(metricRollups.bucketStart, windowStart),
+          lte(metricRollups.bucketStart, windowEnd)
+        ))
+        .orderBy(desc(metricRollups.bucketStart))
+        .limit(15)
+    : [];
+
+  if (correlationRows.length === 0) gaps.push('No correlation edge evidence was found for the grouped alerts.');
+  if (changeRows.length === 0) gaps.push('No device changes were found in the incident window.');
+  if (eventRows.length === 0 && agentLogRows.length === 0) gaps.push('No warning/error logs were found in the incident window.');
+  if (metricRows.length === 0) gaps.push('No 5-minute metric rollups were available in the incident window.');
+
+  const evidence: RcaEvidenceItem[] = [
+    ...buildAlertEvidence(alertRows, deviceNames),
+    ...correlationRows.map((link) => ({
+      id: `correlation:${link.parentAlertId}:${link.childAlertId}`,
+      source: 'correlation' as const,
+      type: link.correlationType,
+      timestamp: toIso(asDate(link.createdAt)),
+      alertId: link.parentAlertId,
+      title: `Correlation: ${link.correlationType}`,
+      summary: `Alert ${link.parentAlertId} is correlated with ${link.childAlertId} at confidence ${Number(link.confidence ?? 0).toFixed(2)}.`,
+    })),
+    ...contextRows.map((row) => ({
+      id: `device_context:${row.id}`,
+      source: 'device_context' as const,
+      type: row.contextType,
+      timestamp: toIso(asDate(row.createdAt)),
+      deviceId: row.deviceId,
+      title: row.summary,
+      summary: row.details ? `${row.summary}: ${summarizeJson(row.details)}` : row.summary,
+    })),
+    ...changeRows.map((row) => ({
+      id: `device_change:${row.id}`,
+      source: 'device_change' as const,
+      type: `${row.changeType}.${row.changeAction}`,
+      timestamp: toIso(asDate(row.timestamp)),
+      deviceId: row.deviceId,
+      title: row.subject,
+      summary: `${row.changeAction} ${row.changeType}: ${row.subject}`,
+    })),
+    ...eventRows.map((row) => ({
+      id: `event_log:${row.id}`,
+      source: 'event_log' as const,
+      type: row.category,
+      timestamp: toIso(asDate(row.timestamp)),
+      deviceId: row.deviceId,
+      severity: row.level,
+      title: `${row.source}${row.eventId ? ` ${row.eventId}` : ''}`,
+      summary: row.message,
+    })),
+    ...agentLogRows.map((row) => ({
+      id: `agent_log:${row.id}`,
+      source: 'agent_log' as const,
+      type: row.component,
+      timestamp: toIso(asDate(row.timestamp)),
+      deviceId: row.deviceId,
+      severity: row.level,
+      title: row.component,
+      summary: row.message,
+    })),
+    ...metricRows
+      .filter((row) => Number(row.avgValue ?? 0) >= 85 || Number(row.maxValue ?? 0) >= 90)
+      .map((row) => ({
+        id: `metric_rollup:${row.deviceId}:${row.metricName}:${row.bucketStart.toISOString()}`,
+        source: 'metric_rollup' as const,
+        type: row.metricName,
+        timestamp: toIso(asDate(row.bucketStart)),
+        deviceId: row.deviceId,
+        title: `${row.metricName} elevated`,
+        summary: `${row.metricName} averaged ${Number(row.avgValue ?? 0).toFixed(1)} with max ${Number(row.maxValue ?? 0).toFixed(1)} over a 5-minute bucket.`,
+      })),
+  ];
+
+  const timeline = rankEvidence(evidence).slice(0, maxEvidenceItems);
+  const candidates = [
+    buildPrimaryAlertCandidate(alertRows, options.groupScore),
+    buildChangeCandidate(timeline),
+    buildLogCandidate(timeline),
+  ].filter((candidate): candidate is RcaRootCauseCandidate => Boolean(candidate));
+
+  return {
+    groupId: options.groupId,
+    scope: {
+      orgId: options.orgId,
+      deviceIds,
+      alertIds,
+      windowStart: toIso(windowStart),
+      windowEnd: toIso(windowEnd),
+    },
+    timeline,
+    rootCauseCandidates: candidates,
+    gaps,
+  };
+}

--- a/apps/api/src/services/mlFeedbackEmitters.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.ts
@@ -56,3 +56,24 @@ export async function emitCorrelationFeedback(options: {
     occurredAt: options.occurredAt ?? new Date(),
   }, options.eventType);
 }
+
+export async function emitRcaFeedback(options: {
+  orgId: string;
+  rcaId: string;
+  eventType: 'rca.helpful' | 'rca.not_helpful' | 'rca.edited' | 'rca.used_in_ticket';
+  outcome: 'helpful' | 'not_helpful' | 'edited' | 'used_in_ticket';
+  actorUserId?: string | null;
+  occurredAt?: Date;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await emitFeedbackBestEffort({
+    orgId: options.orgId,
+    sourceType: 'rca',
+    sourceId: options.rcaId,
+    eventType: options.eventType,
+    outcome: options.outcome,
+    actorUserId: actorUserIdOrNull(options.actorUserId),
+    metadata: options.metadata ?? {},
+    occurredAt: options.occurredAt ?? new Date(),
+  }, options.eventType);
+}


### PR DESCRIPTION
## Summary
- add a deterministic, read-only RCA evidence builder for persisted alert correlation groups
- add POST /alerts/correlations/:groupId/explain gated by ml.rca.enabled
- add RCA feedback labels for helpful/not helpful/edited/used in ticket
- keep RCA pull-only; no automatic LLM calls from correlation workers

## Validation
- /usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/services/alertCorrelationRca.test.ts src/routes/alerts/correlations.test.ts --config vitest.config.ts
- /usr/local/bin/corepack pnpm --filter @breeze/api exec tsup --no-dts
- git diff --check

## Notes
- Stacked on #1487 / feat/ml-correlation-groups.
- Full pnpm --filter @breeze/api build CJS output succeeds, but DTS generation hangs in this worktree; stopped after a 60s wait, same as #1487.
- codebase-memory MCP transport/index was unavailable or sparse, so discovery fell back to local reads.