### PR TITLE
feat(ml): productize alert correlation UI

### DIFF
--- a/apps/web/src/components/alerts/AlertsTabStrip.tsx
+++ b/apps/web/src/components/alerts/AlertsTabStrip.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 const TABS = [
   { href: '/alerts', label: 'Alerts' },
+  { href: '/alerts/correlations', label: 'Correlations' },
   { href: '/alerts/rules', label: 'Rules' },
   { href: '/alerts/channels', label: 'Channels' },
 ] as const;
@@ -10,6 +11,7 @@ export default function AlertsTabStrip() {
   const activeHref = useMemo(() => {
     if (typeof window === 'undefined') return '/alerts';
     const path = window.location.pathname;
+    if (path.startsWith('/alerts/correlations')) return '/alerts/correlations';
     if (path.startsWith('/alerts/channels')) return '/alerts/channels';
     if (path.startsWith('/alerts/rules')) return '/alerts/rules';
     return '/alerts';

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CorrelatedAlertGroups from './CorrelatedAlertGroups';
+import AlertsTabStrip from './AlertsTabStrip';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (toast: unknown) => showToast(toast) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const GROUP_ID = '11111111-1111-4111-8111-111111111111';
+
+const groupPayload = {
+  id: GROUP_ID,
+  rootCause: {
+    id: '22222222-2222-4222-8222-222222222222',
+    title: 'High CPU on SRV-01',
+    severity: 'critical',
+    status: 'active',
+    device: 'SRV-01',
+    triggeredAt: '2026-06-18T12:00:00.000Z'
+  },
+  relatedCount: 2,
+  memberCount: 3,
+  correlationScore: 0.88,
+  noiseReductionPercent: 67,
+  status: 'active',
+  firstSeenAt: '2026-06-18T12:00:00.000Z',
+  lastSeenAt: '2026-06-18T12:10:00.000Z',
+  alerts: [
+    {
+      id: '22222222-2222-4222-8222-222222222222',
+      title: 'High CPU on SRV-01',
+      severity: 'critical',
+      status: 'active',
+      device: 'SRV-01',
+      triggeredAt: '2026-06-18T12:00:00.000Z'
+    },
+    {
+      id: '33333333-3333-4333-8333-333333333333',
+      title: 'Service timeout on SRV-01',
+      severity: 'high',
+      status: 'acknowledged',
+      device: 'SRV-01',
+      triggeredAt: '2026-06-18T12:05:00.000Z'
+    },
+    {
+      id: '44444444-4444-4444-8444-444444444444',
+      title: 'Queue backlog on SRV-01',
+      severity: 'medium',
+      status: 'active',
+      device: 'SRV-01',
+      triggeredAt: '2026-06-18T12:10:00.000Z'
+    }
+  ]
+};
+
+const rcaPayload = {
+  groupId: GROUP_ID,
+  scope: {
+    deviceIds: ['device-1'],
+    alertIds: groupPayload.alerts.map((alert) => alert.id),
+    windowStart: '2026-06-18T06:00:00.000Z',
+    windowEnd: '2026-06-18T13:00:00.000Z'
+  },
+  rootCauseCandidates: [
+    {
+      summary: 'A recent service restart lines up with the alert burst.',
+      confidence: 0.58,
+      supportingEvidenceIds: ['device_change:1']
+    }
+  ],
+  timeline: [
+    {
+      id: 'device_change:1',
+      source: 'device_change',
+      type: 'service.restart',
+      timestamp: '2026-06-18T11:55:00.000Z',
+      title: 'Service restart',
+      summary: 'Restarted API service before the incident.'
+    }
+  ],
+  gaps: ['No warning/error logs were found in the incident window.']
+};
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+function mockGroupsResponse() {
+  fetchMock.mockImplementation((input, init) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url === '/alerts/correlations' && method === 'GET') {
+      return Promise.resolve(makeJsonResponse({ groups: [groupPayload] }));
+    }
+    if (url === `/alerts/correlations/${GROUP_ID}/acknowledge` && method === 'POST') {
+      return Promise.resolve(makeJsonResponse({ updated: 2, skipped: 1 }));
+    }
+    if (url === `/alerts/correlations/${GROUP_ID}/resolve` && method === 'POST') {
+      return Promise.resolve(makeJsonResponse({ updated: 3, skipped: 0 }));
+    }
+    if (url === `/alerts/correlations/${GROUP_ID}/explain` && method === 'POST') {
+      return Promise.resolve(makeJsonResponse({ rca: rcaPayload }));
+    }
+    if (url === `/alerts/correlations/${GROUP_ID}/rca-feedback` && method === 'POST') {
+      return Promise.resolve(makeJsonResponse({ success: true }));
+    }
+    return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+  });
+}
+
+describe('CorrelatedAlertGroups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders grouped alert summary and expanded members', async () => {
+    mockGroupsResponse();
+
+    render(<CorrelatedAlertGroups />);
+
+    expect((await screen.findAllByText('High CPU on SRV-01')).length).toBeGreaterThan(0);
+    expect(screen.getByText('67%')).toBeInTheDocument();
+    expect(within(screen.getByText('Grouped alerts').parentElement!).getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Service timeout on SRV-01')).toBeInTheDocument();
+    expect(screen.getByText('Queue backlog on SRV-01')).toBeInTheDocument();
+  });
+
+  it('acknowledges the group through runAction feedback', async () => {
+    mockGroupsResponse();
+
+    render(<CorrelatedAlertGroups />);
+
+    const groupTitle = (await screen.findAllByText('High CPU on SRV-01'))[0];
+    const section = groupTitle.closest('section')!;
+    fireEvent.click(within(section).getByRole('button', { name: /Acknowledge group/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(`/alerts/correlations/${GROUP_ID}/acknowledge`, { method: 'POST' });
+    });
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Alert group acknowledged' }));
+    });
+  });
+
+  it('runs explicit RCA and records feedback', async () => {
+    mockGroupsResponse();
+
+    render(<CorrelatedAlertGroups />);
+
+    await screen.findAllByText('High CPU on SRV-01');
+    fireEvent.click(screen.getAllByRole('button', { name: /Explain incident/i })[0]);
+
+    expect(await screen.findByText('A recent service restart lines up with the alert burst.')).toBeInTheDocument();
+    expect(screen.getByText('Restarted API service before the incident.')).toBeInTheDocument();
+    expect(screen.getByText('No warning/error logs were found in the incident window.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Mark RCA helpful/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/alerts/correlations/${GROUP_ID}/rca-feedback`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('rca.helpful')
+        })
+      );
+    });
+  });
+
+  it('marks the correlations tab active on the correlations route', () => {
+    window.history.pushState({}, '', '/alerts/correlations');
+
+    render(<AlertsTabStrip />);
+
+    expect(screen.getByRole('link', { name: 'Correlations' })).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -1,16 +1,32 @@
-import { useState, useEffect, useCallback } from 'react';
-import { CheckCircle, ChevronDown, ChevronRight, XCircle } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Brain,
+  CheckCircle,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ExternalLink,
+  FileText,
+  Loader2,
+  RefreshCw,
+  ThumbsDown,
+  ThumbsUp,
+  XCircle
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { runAction, handleActionError } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
-import type { AlertSeverity } from './AlertList';
+import type { AlertSeverity, AlertStatus } from './AlertList';
 import { navigateTo } from '@/lib/navigation';
+import { showToast } from '../shared/Toast';
 
 type AlertItem = {
   id: string;
   title: string;
   severity: AlertSeverity;
-  status: 'active' | 'acknowledged' | 'resolved';
+  status: AlertStatus;
   device: string;
+  triggeredAt?: string;
 };
 
 type AlertGroup = {
@@ -18,27 +34,102 @@ type AlertGroup = {
   rootCause: AlertItem;
   relatedCount: number;
   alerts: AlertItem[];
+  correlationScore: number;
+  noiseReductionPercent?: number;
+  status?: AlertStatus | string;
+  memberCount?: number;
+  firstSeenAt?: string;
+  lastSeenAt?: string;
+};
+
+type RcaEvidenceItem = {
+  id: string;
+  source: string;
+  type: string;
+  timestamp: string;
+  title: string;
+  summary: string;
+  severity?: string;
+};
+
+type RcaCandidate = {
+  summary: string;
+  confidence: number;
+  supportingEvidenceIds: string[];
+};
+
+type RcaResult = {
+  groupId: string;
+  timeline: RcaEvidenceItem[];
+  rootCauseCandidates: RcaCandidate[];
+  gaps: string[];
+  scope: {
+    deviceIds: string[];
+    alertIds: string[];
+    windowStart: string;
+    windowEnd: string;
+  };
 };
 
 const severityStyles: Record<AlertSeverity, string> = {
-  critical: 'bg-red-500/20 text-red-700 border-red-500/40',
-  high: 'bg-orange-500/20 text-orange-700 border-orange-500/40',
-  medium: 'bg-yellow-500/20 text-yellow-700 border-yellow-500/40',
-  low: 'bg-blue-500/20 text-blue-700 border-blue-500/40',
-  info: 'bg-gray-500/20 text-gray-700 border-gray-500/40'
+  critical: 'bg-red-500/15 text-red-700 border-red-500/35',
+  high: 'bg-orange-500/15 text-orange-700 border-orange-500/35',
+  medium: 'bg-yellow-500/15 text-yellow-700 border-yellow-500/35',
+  low: 'bg-blue-500/15 text-blue-700 border-blue-500/35',
+  info: 'bg-gray-500/15 text-gray-700 border-gray-500/35'
 };
 
-const statusStyles: Record<AlertItem['status'], string> = {
-  active: 'bg-red-500/20 text-red-700 border-red-500/40',
-  acknowledged: 'bg-yellow-500/20 text-yellow-700 border-yellow-500/40',
-  resolved: 'bg-emerald-500/20 text-emerald-700 border-emerald-500/40'
+const statusStyles: Partial<Record<AlertStatus | string, string>> = {
+  active: 'bg-red-500/15 text-red-700 border-red-500/35',
+  acknowledged: 'bg-yellow-500/15 text-yellow-700 border-yellow-500/35',
+  resolved: 'bg-emerald-500/15 text-emerald-700 border-emerald-500/35',
+  suppressed: 'bg-slate-500/15 text-slate-700 border-slate-500/35'
 };
+
+function formatPercent(value: number | undefined) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '0%';
+  return `${Math.round(value)}%`;
+}
+
+function formatScore(value: number | undefined) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '0.00';
+  return value.toFixed(2);
+}
+
+function formatDateTime(value: string | undefined) {
+  if (!value) return 'Unknown';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(parsed);
+}
+
+function evidenceLabel(source: string) {
+  return source.replace(/_/g, ' ');
+}
 
 export default function CorrelatedAlertGroups() {
   const [groups, setGroups] = useState<AlertGroup[]>([]);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [rcaByGroup, setRcaByGroup] = useState<Record<string, RcaResult | undefined>>({});
+  const [loadingRcaGroupId, setLoadingRcaGroupId] = useState<string | null>(null);
+  const [busyGroupId, setBusyGroupId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const summary = useMemo(() => {
+    const incidentCount = groups.length;
+    const memberCount = groups.reduce((sum, group) => sum + (group.memberCount ?? group.alerts.length), 0);
+    const suppressedAlerts = Math.max(memberCount - incidentCount, 0);
+    const avgReduction = groups.length === 0
+      ? 0
+      : groups.reduce((sum, group) => sum + (group.noiseReductionPercent ?? 0), 0) / groups.length;
+    return { incidentCount, memberCount, suppressedAlerts, avgReduction };
+  }, [groups]);
 
   const fetchGroups = useCallback(async () => {
     setIsLoading(true);
@@ -57,11 +148,13 @@ export default function CorrelatedAlertGroups() {
       }
 
       const data = await response.json();
-      setGroups(data.groups || []);
-      // Auto-expand first group if available
-      if (data.groups?.length > 0) {
-        setExpandedGroups(new Set([data.groups[0].id]));
-      }
+      const nextGroups = (data.groups ?? data.data ?? []) as AlertGroup[];
+      setGroups(nextGroups);
+      setExpandedGroups((previous) => {
+        const stillValid = new Set([...previous].filter((id) => nextGroups.some((group) => group.id === id)));
+        if (stillValid.size === 0 && nextGroups[0]) stillValid.add(nextGroups[0].id);
+        return stillValid;
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load alert groups');
     } finally {
@@ -70,7 +163,7 @@ export default function CorrelatedAlertGroups() {
   }, []);
 
   useEffect(() => {
-    fetchGroups();
+    void fetchGroups();
   }, [fetchGroups]);
 
   const toggleGroup = (groupId: string) => {
@@ -85,51 +178,91 @@ export default function CorrelatedAlertGroups() {
     });
   };
 
-  const handleAcknowledgeGroup = async (groupId: string) => {
+  const handleAcknowledgeGroup = async (group: AlertGroup) => {
+    setBusyGroupId(group.id);
     try {
-      const response = await fetchWithAuth(`/alerts/correlations/${groupId}/acknowledge`, {
-        method: 'POST'
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/correlations/${group.id}/acknowledge`, { method: 'POST' }),
+        errorFallback: 'Failed to acknowledge alert group',
+        successMessage: 'Alert group acknowledged',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (response.status === 401) {
-        void navigateTo('/login', { replace: true });
-        return;
-      }
-
-      if (response.ok) {
-        fetchGroups();
-      }
-    } catch {
-      // Handle error silently or show notification
+      await fetchGroups();
+    } catch (err) {
+      handleActionError(err, 'Failed to acknowledge alert group');
+    } finally {
+      setBusyGroupId(null);
     }
   };
 
-  const handleResolveGroup = async (groupId: string) => {
+  const handleResolveGroup = async (group: AlertGroup) => {
+    setBusyGroupId(group.id);
     try {
-      const response = await fetchWithAuth(`/alerts/correlations/${groupId}/resolve`, {
-        method: 'POST'
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/correlations/${group.id}/resolve`, { method: 'POST' }),
+        errorFallback: 'Failed to resolve alert group',
+        successMessage: 'Alert group resolved',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
+      await fetchGroups();
+    } catch (err) {
+      handleActionError(err, 'Failed to resolve alert group');
+    } finally {
+      setBusyGroupId(null);
+    }
+  };
 
-      if (response.status === 401) {
-        void navigateTo('/login', { replace: true });
+  const handleExplainGroup = async (group: AlertGroup) => {
+    setLoadingRcaGroupId(group.id);
+    try {
+      const result = await runAction<{ data?: RcaResult; rca?: RcaResult }>({
+        request: () => fetchWithAuth(`/alerts/correlations/${group.id}/explain`, {
+          method: 'POST',
+          body: JSON.stringify({ windowHours: 6, maxEvidenceItems: 30 })
+        }),
+        errorFallback: 'Failed to explain incident',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      const rca = result.data ?? result.rca;
+      if (!rca) {
+        showToast({ message: 'RCA response was empty', type: 'error' });
         return;
       }
+      setRcaByGroup((prev) => ({ ...prev, [group.id]: rca }));
+      setExpandedGroups((prev) => new Set(prev).add(group.id));
+    } catch (err) {
+      handleActionError(err, 'Failed to explain incident');
+    } finally {
+      setLoadingRcaGroupId(null);
+    }
+  };
 
-      if (response.ok) {
-        fetchGroups();
-      }
-    } catch {
-      // Handle error silently or show notification
+  const sendRcaFeedback = async (group: AlertGroup, eventType: 'rca.helpful' | 'rca.not_helpful' | 'rca.used_in_ticket') => {
+    const outcome = eventType.replace('rca.', '') as 'helpful' | 'not_helpful' | 'used_in_ticket';
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/correlations/${group.id}/rca-feedback`, {
+          method: 'POST',
+          body: JSON.stringify({
+            eventType,
+            outcome,
+            metadata: { source: 'correlated_alert_groups_ui' }
+          })
+        }),
+        errorFallback: 'Failed to record RCA feedback',
+        successMessage: 'RCA feedback recorded',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+    } catch (err) {
+      handleActionError(err, 'Failed to record RCA feedback');
     }
   };
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <div className="flex h-48 items-center justify-center">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          </div>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <div className="flex h-48 items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
       </div>
     );
@@ -137,54 +270,85 @@ export default function CorrelatedAlertGroups() {
 
   if (error) {
     return (
-      <div className="space-y-6">
-        <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <div className="flex h-48 flex-col items-center justify-center gap-2 text-muted-foreground">
-            <p>{error}</p>
-            <button
-              type="button"
-              onClick={fetchGroups}
-              className="text-sm text-primary hover:underline"
-            >
-              Try again
-            </button>
-          </div>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <div className="flex h-48 flex-col items-center justify-center gap-2 text-muted-foreground">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={() => void fetchGroups()}
+            className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </button>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
-      <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <div className="flex flex-col gap-2">
-          <h2 className="text-lg font-semibold">Correlated Alert Groups</h2>
-          <p className="text-sm text-muted-foreground">Cluster alerts by probable root cause.</p>
+    <div className="space-y-5">
+      <div className="grid gap-3 sm:grid-cols-4">
+        <div className="rounded-md border bg-card px-4 py-3">
+          <p className="text-xs text-muted-foreground">Incidents</p>
+          <p className="mt-1 text-xl font-semibold">{summary.incidentCount}</p>
+        </div>
+        <div className="rounded-md border bg-card px-4 py-3">
+          <p className="text-xs text-muted-foreground">Grouped alerts</p>
+          <p className="mt-1 text-xl font-semibold">{summary.memberCount}</p>
+        </div>
+        <div className="rounded-md border bg-card px-4 py-3">
+          <p className="text-xs text-muted-foreground">Inbox reduction</p>
+          <p className="mt-1 text-xl font-semibold">{summary.suppressedAlerts}</p>
+        </div>
+        <div className="rounded-md border bg-card px-4 py-3">
+          <p className="text-xs text-muted-foreground">Avg noise cut</p>
+          <p className="mt-1 text-xl font-semibold">{formatPercent(summary.avgReduction)}</p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-card shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold">Correlated Alert Groups</h2>
+            <p className="text-sm text-muted-foreground">Cluster alerts by likely incident and shared evidence.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void fetchGroups()}
+            className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </button>
         </div>
 
-        <div className="mt-6 space-y-4">
+        <div className="divide-y">
           {groups.length === 0 ? (
-            <div className="py-8 text-center text-muted-foreground">
+            <div className="py-12 text-center text-muted-foreground">
               No correlated alert groups found.
             </div>
           ) : (
             groups.map(group => {
               const isExpanded = expandedGroups.has(group.id);
+              const groupRca = rcaByGroup[group.id];
+              const isBusy = busyGroupId === group.id;
+              const isExplaining = loadingRcaGroupId === group.id;
               return (
-                <div key={group.id} className="rounded-md border">
-                  <button
-                    type="button"
-                    onClick={() => toggleGroup(group.id)}
-                    className="flex w-full items-center justify-between gap-4 px-4 py-3 text-left"
-                  >
-                    <div className="flex items-start gap-3">
+                <section key={group.id}>
+                  <div className="flex flex-col gap-3 px-4 py-3 lg:flex-row lg:items-start lg:justify-between">
+                    <button
+                      type="button"
+                      onClick={() => toggleGroup(group.id)}
+                      className="flex min-w-0 flex-1 items-start gap-3 text-left"
+                    >
                       {isExpanded ? (
-                        <ChevronDown className="mt-1 h-4 w-4 text-muted-foreground" />
+                        <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-muted-foreground" />
                       ) : (
-                        <ChevronRight className="mt-1 h-4 w-4 text-muted-foreground" />
+                        <ChevronRight className="mt-1 h-4 w-4 shrink-0 text-muted-foreground" />
                       )}
-                      <div>
-                        <p className="text-sm font-medium">{group.rootCause.title}</p>
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">{group.rootCause.title}</p>
                         <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                           <span
                             className={cn(
@@ -194,74 +358,215 @@ export default function CorrelatedAlertGroups() {
                           >
                             {group.rootCause.severity}
                           </span>
-                          <span>Root cause: {group.rootCause.device}</span>
-                          <span>·</span>
-                          <span>{group.relatedCount} related alerts</span>
+                          {group.status && (
+                            <span
+                              className={cn(
+                                'rounded-full border px-2 py-0.5 font-medium',
+                                statusStyles[group.status] ?? 'bg-muted text-muted-foreground border-border'
+                              )}
+                            >
+                              {group.status}
+                            </span>
+                          )}
+                          <span>{group.rootCause.device}</span>
+                          <span>{group.relatedCount} related</span>
+                          <span>score {formatScore(group.correlationScore)}</span>
+                          <span>{formatPercent(group.noiseReductionPercent)} noise cut</span>
                         </div>
                       </div>
-                    </div>
-                    <div className="flex items-center gap-2">
+                    </button>
+
+                    <div className="flex flex-wrap items-center gap-2 lg:justify-end">
                       <button
                         type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleAcknowledgeGroup(group.id);
-                        }}
-                        className="inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs font-medium hover:bg-muted"
+                        onClick={() => void handleExplainGroup(group)}
+                        disabled={isBusy || isExplaining}
+                        className="inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
                       >
-                        <CheckCircle className="h-3.5 w-3.5" />
+                        {isExplaining ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Brain className="h-3.5 w-3.5" />}
+                        Explain incident
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleAcknowledgeGroup(group)}
+                        disabled={isBusy || isExplaining}
+                        className="inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                      >
+                        {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle className="h-3.5 w-3.5" />}
                         Acknowledge group
                       </button>
                       <button
                         type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleResolveGroup(group.id);
-                        }}
-                        className="inline-flex h-8 items-center gap-2 rounded-md border border-destructive/40 px-3 text-xs font-medium text-destructive hover:bg-destructive/10"
+                        onClick={() => void handleResolveGroup(group)}
+                        disabled={isBusy || isExplaining}
+                        className="inline-flex h-8 items-center gap-2 rounded-md border border-destructive/40 px-3 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
                       >
-                        <XCircle className="h-3.5 w-3.5" />
+                        {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
                         Resolve group
                       </button>
                     </div>
-                  </button>
+                  </div>
 
                   {isExpanded && (
-                    <div className="border-t bg-muted/30 px-4 py-3">
-                      <div className="space-y-2">
-                        {group.alerts.map(alert => (
-                          <div
-                            key={alert.id}
-                            className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background px-3 py-2"
-                          >
-                            <div>
-                              <p className="text-sm font-medium">{alert.title}</p>
-                              <p className="text-xs text-muted-foreground">{alert.device}</p>
+                    <div className="border-t bg-muted/20 px-4 py-4">
+                      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]">
+                        <div className="space-y-3">
+                          <div className="grid gap-2 sm:grid-cols-3">
+                            <div className="rounded-md border bg-background px-3 py-2">
+                              <p className="text-xs text-muted-foreground">First seen</p>
+                              <p className="text-sm font-medium">{formatDateTime(group.firstSeenAt ?? group.rootCause.triggeredAt)}</p>
                             </div>
-                            <div className="flex items-center gap-2">
-                              <span
-                                className={cn(
-                                  'rounded-full border px-2 py-0.5 text-[11px] font-medium',
-                                  severityStyles[alert.severity]
-                                )}
-                              >
-                                {alert.severity}
-                              </span>
-                              <span
-                                className={cn(
-                                  'rounded-full border px-2 py-0.5 text-[11px] font-medium',
-                                  statusStyles[alert.status]
-                                )}
-                              >
-                                {alert.status}
-                              </span>
+                            <div className="rounded-md border bg-background px-3 py-2">
+                              <p className="text-xs text-muted-foreground">Last seen</p>
+                              <p className="text-sm font-medium">{formatDateTime(group.lastSeenAt)}</p>
+                            </div>
+                            <div className="rounded-md border bg-background px-3 py-2">
+                              <p className="text-xs text-muted-foreground">Members</p>
+                              <p className="text-sm font-medium">{group.memberCount ?? group.alerts.length}</p>
                             </div>
                           </div>
-                        ))}
+
+                          <div className="space-y-2">
+                            {group.alerts.map(alert => (
+                              <div
+                                key={alert.id}
+                                className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background px-3 py-2"
+                              >
+                                <div className="min-w-0">
+                                  <a href={`/alerts/${alert.id}`} className="inline-flex max-w-full items-center gap-1 text-sm font-medium hover:underline">
+                                    <span className="truncate">{alert.title}</span>
+                                    <ExternalLink className="h-3 w-3 shrink-0" />
+                                  </a>
+                                  <p className="text-xs text-muted-foreground">{alert.device}</p>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span
+                                    className={cn(
+                                      'rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                                      severityStyles[alert.severity]
+                                    )}
+                                  >
+                                    {alert.severity}
+                                  </span>
+                                  <span
+                                    className={cn(
+                                      'rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                                      statusStyles[alert.status] ?? 'bg-muted text-muted-foreground border-border'
+                                    )}
+                                  >
+                                    {alert.status}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div className="rounded-md border bg-background">
+                          <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+                            <div>
+                              <h3 className="text-sm font-semibold">Incident RCA</h3>
+                              <p className="text-xs text-muted-foreground">Evidence is gathered on demand.</p>
+                            </div>
+                            {groupRca && (
+                              <div className="flex items-center gap-1">
+                                <button
+                                  type="button"
+                                  onClick={() => void sendRcaFeedback(group, 'rca.helpful')}
+                                  className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+                                  aria-label="Mark RCA helpful"
+                                >
+                                  <ThumbsUp className="h-4 w-4" />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => void sendRcaFeedback(group, 'rca.not_helpful')}
+                                  className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+                                  aria-label="Mark RCA not helpful"
+                                >
+                                  <ThumbsDown className="h-4 w-4" />
+                                </button>
+                              </div>
+                            )}
+                          </div>
+
+                          {!groupRca ? (
+                            <div className="flex min-h-48 flex-col items-center justify-center gap-3 px-4 py-8 text-center text-sm text-muted-foreground">
+                              <Brain className="h-8 w-8" />
+                              <button
+                                type="button"
+                                onClick={() => void handleExplainGroup(group)}
+                                disabled={isExplaining}
+                                className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                              >
+                                {isExplaining ? <Loader2 className="h-4 w-4 animate-spin" /> : <Brain className="h-4 w-4" />}
+                                Explain incident
+                              </button>
+                            </div>
+                          ) : (
+                            <div className="space-y-4 p-4">
+                              <div className="space-y-2">
+                                {groupRca.rootCauseCandidates.length === 0 ? (
+                                  <p className="text-sm text-muted-foreground">No likely cause candidates were found.</p>
+                                ) : (
+                                  groupRca.rootCauseCandidates.map((candidate, index) => (
+                                    <div key={`${candidate.summary}-${index}`} className="rounded-md border bg-muted/20 px-3 py-2">
+                                      <div className="flex items-center justify-between gap-3">
+                                        <p className="text-sm font-medium">Candidate {index + 1}</p>
+                                        <span className="rounded-full border bg-background px-2 py-0.5 text-xs">
+                                          {formatPercent(candidate.confidence * 100)} confidence
+                                        </span>
+                                      </div>
+                                      <p className="mt-1 text-sm text-muted-foreground">{candidate.summary}</p>
+                                    </div>
+                                  ))
+                                )}
+                              </div>
+
+                              <div>
+                                <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                                  <Clock className="h-4 w-4" />
+                                  Evidence timeline
+                                </div>
+                                <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+                                  {groupRca.timeline.map((item) => (
+                                    <div key={item.id} className="rounded-md border px-3 py-2">
+                                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                        <span>{formatDateTime(item.timestamp)}</span>
+                                        <span className="rounded-full border bg-muted px-2 py-0.5">{evidenceLabel(item.source)}</span>
+                                        <span>{item.type}</span>
+                                      </div>
+                                      <p className="mt-1 text-sm font-medium">{item.title}</p>
+                                      <p className="mt-0.5 text-xs text-muted-foreground">{item.summary}</p>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+
+                              {groupRca.gaps.length > 0 && (
+                                <div className="rounded-md border border-warning/40 bg-warning/10 px-3 py-2">
+                                  <p className="text-sm font-medium">Evidence gaps</p>
+                                  <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
+                                    {groupRca.gaps.map((gap) => <li key={gap}>{gap}</li>)}
+                                  </ul>
+                                </div>
+                              )}
+
+                              <button
+                                type="button"
+                                onClick={() => void sendRcaFeedback(group, 'rca.used_in_ticket')}
+                                className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+                              >
+                                <FileText className="h-4 w-4" />
+                                Used in ticket
+                              </button>
+                            </div>
+                          )}
+                        </div>
                       </div>
                     </div>
                   )}
-                </div>
+                </section>
               );
             })
           )}

--- a/apps/web/src/pages/alerts/correlations.astro
+++ b/apps/web/src/pages/alerts/correlations.astro
@@ -1,0 +1,18 @@
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import AlertsTabStrip from '../../components/alerts/AlertsTabStrip';
+import CorrelatedAlertGroups from '../../components/alerts/CorrelatedAlertGroups';
+---
+
+<DashboardLayout title="Alert Correlations">
+  <div class="space-y-5">
+    <AlertsTabStrip client:load />
+    <div>
+      <h1 class="text-xl font-bold tracking-tight">Alert Correlations</h1>
+      <p class="mt-1 text-sm text-muted-foreground">
+        Review grouped alert incidents, shared evidence, and on-demand RCA.
+      </p>
+    </div>
+    <CorrelatedAlertGroups client:load />
+  </div>
+</DashboardLayout>


### PR DESCRIPTION
## Summary
- add a reachable /alerts/correlations page and Alerts tab entry
- expand correlated alert groups with noise reduction metrics, member details, group actions, and on-demand RCA display
- capture RCA feedback from the correlation UI and surface group mutations through runAction

## Validation
- ./node_modules/.bin/vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx src/components/alerts/AlertsPage.test.tsx (from apps/web) — 2 files, 7 tests passed
- ./node_modules/.bin/tsc -p apps/web/tsconfig.json --noEmit — passed
- ./node_modules/.bin/astro check — 0 errors; existing warnings/hints elsewhere
- git diff --check — passed

Stacked on #1488 / feat/ml-rca-v0.