### PR TITLE
feat(ml): add reliability evaluation labels

### DIFF
--- a/apps/api/src/routes/reliability.test.ts
+++ b/apps/api/src/routes/reliability.test.ts
@@ -13,10 +13,16 @@ vi.mock('../services/reliabilityScoring', () => ({
   getOrgReliabilitySummary: vi.fn(),
   getDeviceReliabilityHistory: vi.fn(),
   getDeviceReliability: vi.fn(),
+  evaluateReliabilityScores: vi.fn(),
+}));
+
+vi.mock('../services/mlFeedbackEmitters', () => ({
+  emitDeviceReliabilityFeedback: vi.fn(),
 }));
 
 vi.mock('./devices/helpers', () => ({
-  getDeviceWithOrgCheck: vi.fn(),
+  getDeviceWithOrgAndSiteCheck: vi.fn(),
+  SITE_ACCESS_DENIED: Symbol('SITE_ACCESS_DENIED'),
 }));
 
 import { reliabilityRoutes } from './reliability';
@@ -25,8 +31,10 @@ import {
   getOrgReliabilitySummary,
   getDeviceReliabilityHistory,
   getDeviceReliability,
+  evaluateReliabilityScores,
 } from '../services/reliabilityScoring';
-import { getDeviceWithOrgCheck } from './devices/helpers';
+import { emitDeviceReliabilityFeedback } from '../services/mlFeedbackEmitters';
+import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './devices/helpers';
 
 const ORG_ID = '00000000-0000-0000-0000-000000000001';
 const ORG_ID_2 = '00000000-0000-0000-0000-000000000002';
@@ -50,6 +58,7 @@ function buildApp(overrides: AuthOverrides = {}): Hono {
       accessibleOrgIds: 'accessibleOrgIds' in overrides ? overrides.accessibleOrgIds : [ORG_ID],
       canAccessOrg: overrides.canAccessOrg ?? ((id: string) => id === ORG_ID),
     });
+    c.set('permissions', { allowedSiteIds: undefined });
     await next();
   };
   const app = new Hono();
@@ -175,12 +184,52 @@ describe('public reliability routes', () => {
     });
   });
 
+  describe('GET /evaluation', () => {
+    it('returns reliability evaluation summary for accessible org context', async () => {
+      const summary = {
+        atRiskMaxScore: 70,
+        labelWindowDays: 90,
+        evaluatedDevices: 3,
+        atRiskDevices: 2,
+        labeledAtRiskDevices: 2,
+        truePositiveDevices: 1,
+        falsePositiveDevices: 1,
+        missedFailureDevices: 0,
+        unlabeledAtRiskDevices: 0,
+        confirmedFailureLabels: 1,
+        replacementLabels: 0,
+        falseAlarmLabels: 1,
+        precision: 0.5,
+      };
+      vi.mocked(evaluateReliabilityScores).mockResolvedValue(summary);
+
+      const app = buildApp();
+      const res = await app.request('/reliability/evaluation?atRiskMaxScore=70&labelWindowDays=90');
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.summary).toEqual(summary);
+      expect(vi.mocked(evaluateReliabilityScores)).toHaveBeenCalledWith(expect.objectContaining({
+        orgIds: [ORG_ID],
+        atRiskMaxScore: 70,
+        labelWindowDays: 90,
+      }));
+    });
+
+    it('returns 403 when evaluation orgId is not accessible', async () => {
+      const app = buildApp();
+      const res = await app.request(`/reliability/evaluation?orgId=${ORG_ID_2}`);
+      expect(res.status).toBe(403);
+      expect(vi.mocked(evaluateReliabilityScores)).not.toHaveBeenCalled();
+    });
+  });
+
   // ──────────────────────────────────────────────────────────
   // GET /:deviceId  (detail)
   // ──────────────────────────────────────────────────────────
   describe('GET /:deviceId (detail)', () => {
     it('returns 404 when device is not found', async () => {
-      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(null);
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(null);
 
       const app = buildApp();
       const res = await app.request(`/reliability/${DEVICE_ID}`);
@@ -191,7 +240,7 @@ describe('public reliability routes', () => {
     });
 
     it('returns 404 when no reliability snapshot exists yet', async () => {
-      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
       vi.mocked(getDeviceReliability).mockResolvedValue(null);
       vi.mocked(getDeviceReliabilityHistory).mockResolvedValue([]);
 
@@ -215,7 +264,7 @@ describe('public reliability routes', () => {
         { collectedAt: '2026-02-20T00:00:00Z', uptimeSeconds: 86400, reliabilityScore: 85 },
       ];
 
-      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
       vi.mocked(getDeviceReliability).mockResolvedValue(snapshot as any);
       vi.mocked(getDeviceReliabilityHistory).mockResolvedValue(history as any);
 
@@ -227,6 +276,72 @@ describe('public reliability routes', () => {
       expect(body.snapshot).toEqual(snapshot);
       expect(body.history).toEqual(history);
     });
+
+    it('returns 403 when device site is denied', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SITE_ACCESS_DENIED as never);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}`);
+      expect(res.status).toBe(403);
+      expect(vi.mocked(getDeviceReliability)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /:deviceId/feedback', () => {
+    it('emits reliability feedback with snapshot metadata', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+      vi.mocked(getDeviceReliability).mockResolvedValue({
+        deviceId: DEVICE_ID,
+        orgId: ORG_ID,
+        siteId: 'site-1',
+        hostname: 'host-1',
+        osType: 'windows',
+        status: 'online',
+        reliabilityScore: 42,
+        trendDirection: 'degrading',
+        trendConfidence: 0.8,
+        uptime30d: 96,
+        crashCount30d: 3,
+        hangCount30d: 0,
+        serviceFailureCount30d: 0,
+        hardwareErrorCount30d: 1,
+        mtbfHours: 120,
+        topIssues: [{ type: 'crashes', count: 3, severity: 'critical' }],
+        computedAt: '2026-06-18T12:00:00.000Z',
+      } as any);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ outcome: 'false_alarm', metadata: { note: 'Known maintenance window' } }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(vi.mocked(emitDeviceReliabilityFeedback)).toHaveBeenCalledWith(expect.objectContaining({
+        orgId: ORG_ID,
+        deviceId: DEVICE_ID,
+        eventType: 'device.false_alarm',
+        outcome: 'false_alarm',
+        actorUserId: 'user-1',
+        metadata: expect.objectContaining({
+          note: 'Known maintenance window',
+          reliabilityScore: 42,
+        }),
+      }));
+    });
+
+    it('rejects inconsistent feedback payloads through validation', async () => {
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ outcome: 'resolved' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(vi.mocked(emitDeviceReliabilityFeedback)).not.toHaveBeenCalled();
+    });
   });
 
   // ──────────────────────────────────────────────────────────
@@ -234,7 +349,7 @@ describe('public reliability routes', () => {
   // ──────────────────────────────────────────────────────────
   describe('GET /:deviceId/history', () => {
     it('returns 404 when device not found', async () => {
-      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(null);
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(null);
 
       const app = buildApp();
       const res = await app.request(`/reliability/${DEVICE_ID}/history`);
@@ -251,7 +366,7 @@ describe('public reliability routes', () => {
         { collectedAt: '2026-02-20T00:00:00Z', uptimeSeconds: 86400, reliabilityScore: 85 },
       ];
 
-      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
       vi.mocked(getDeviceReliabilityHistory).mockResolvedValue(points as any);
 
       const app = buildApp();
@@ -265,7 +380,7 @@ describe('public reliability routes', () => {
     });
 
     it('respects custom days query parameter', async () => {
-      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
       vi.mocked(getDeviceReliabilityHistory).mockResolvedValue([]);
 
       const app = buildApp();

--- a/apps/api/src/routes/reliability.ts
+++ b/apps/api/src/routes/reliability.ts
@@ -8,10 +8,12 @@ import {
   getDeviceReliability,
   getDeviceReliabilityHistory,
   getOrgReliabilitySummary,
+  evaluateReliabilityScores,
   listReliabilityDevices,
   type ReliabilityScoreRange,
 } from '../services/reliabilityScoring';
-import { getDeviceWithOrgCheck } from './devices/helpers';
+import { emitDeviceReliabilityFeedback } from '../services/mlFeedbackEmitters';
+import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './devices/helpers';
 
 const listQuerySchema = z.object({
   orgId: z.string().uuid().optional(),
@@ -35,6 +37,19 @@ const orgIdParamSchema = z.object({
 
 const historyQuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(365).default(90),
+});
+
+const evaluationQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  siteId: z.string().uuid().optional(),
+  atRiskMaxScore: z.coerce.number().int().min(0).max(100).default(70),
+  labelWindowDays: z.coerce.number().int().min(1).max(365).default(90),
+});
+
+const feedbackBodySchema = z.object({
+  outcome: z.enum(['failure_confirmed', 'replaced', 'false_alarm']),
+  occurredAt: z.coerce.date().optional(),
+  metadata: z.record(z.string(), z.unknown()).default({}),
 });
 
 function parseScoreRange(value: string | undefined): ReliabilityScoreRange | undefined {
@@ -127,6 +142,45 @@ reliabilityRoutes.get(
 );
 
 reliabilityRoutes.get(
+  '/evaluation',
+  requireScope('organization', 'partner', 'system'),
+  requireReliabilityRead,
+  zValidator('query', evaluationQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Access denied to this organization' }, 403);
+    }
+    if (permissions?.allowedSiteIds && query.siteId && !canAccessSite(permissions, query.siteId)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+
+    const orgIds = query.orgId
+      ? [query.orgId]
+      : auth.orgId
+        ? [auth.orgId]
+        : (auth.accessibleOrgIds?.length ? auth.accessibleOrgIds : undefined);
+
+    if (!orgIds && auth.scope !== 'system') {
+      return c.json({ error: 'Organization context required' }, 400);
+    }
+
+    const summary = await evaluateReliabilityScores({
+      orgIds,
+      siteId: query.siteId,
+      siteIds: query.siteId ? undefined : permissions?.allowedSiteIds,
+      atRiskMaxScore: query.atRiskMaxScore,
+      labelWindowDays: query.labelWindowDays,
+    });
+
+    return c.json({ summary });
+  }
+);
+
+reliabilityRoutes.get(
   '/org/:orgId/summary',
   requireScope('organization', 'partner', 'system'),
   requireReliabilityRead,
@@ -162,12 +216,12 @@ reliabilityRoutes.get(
     const { deviceId } = c.req.valid('param');
     const { days } = c.req.valid('query');
 
-    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
     if (!device) {
       return c.json({ error: 'Device not found' }, 404);
-    }
-    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
-      return c.json({ error: 'Access to this site denied' }, 403);
     }
 
     const points = await getDeviceReliabilityHistory(deviceId, days);
@@ -175,6 +229,62 @@ reliabilityRoutes.get(
       deviceId,
       days,
       points,
+    });
+  }
+);
+
+reliabilityRoutes.post(
+  '/:deviceId/feedback',
+  requireScope('organization', 'partner', 'system'),
+  requireReliabilityRead,
+  zValidator('param', deviceIdParamSchema),
+  zValidator('json', feedbackBodySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceId } = c.req.valid('param');
+    const body = c.req.valid('json');
+
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    const snapshot = await getDeviceReliability(deviceId);
+    if (!snapshot) {
+      return c.json({ error: 'No reliability snapshot available for this device yet' }, 404);
+    }
+
+    const eventType = body.outcome === 'failure_confirmed'
+      ? 'device.failure_confirmed'
+      : body.outcome === 'replaced'
+        ? 'device.replaced'
+        : 'device.false_alarm';
+
+    await emitDeviceReliabilityFeedback({
+      orgId: device.orgId,
+      deviceId,
+      eventType,
+      outcome: body.outcome,
+      actorUserId: auth.user?.id,
+      occurredAt: body.occurredAt,
+      metadata: {
+        ...body.metadata,
+        reliabilityScore: snapshot.reliabilityScore,
+        topIssues: snapshot.topIssues,
+        computedAt: snapshot.computedAt,
+      },
+    });
+
+    return c.json({
+      success: true,
+      feedback: {
+        deviceId,
+        eventType,
+        outcome: body.outcome,
+      },
     });
   }
 );
@@ -188,12 +298,12 @@ reliabilityRoutes.get(
     const auth = c.get('auth');
     const { deviceId } = c.req.valid('param');
 
-    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
     if (!device) {
       return c.json({ error: 'Device not found' }, 404);
-    }
-    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
-      return c.json({ error: 'Access to this site denied' }, 403);
     }
 
     const [snapshot, history] = await Promise.all([

--- a/apps/api/src/services/mlFeedbackEmitters.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.ts
@@ -119,3 +119,24 @@ export async function emitRemediationSuggestionFeedback(options: {
     occurredAt: options.occurredAt ?? new Date(),
   }, options.eventType);
 }
+
+export async function emitDeviceReliabilityFeedback(options: {
+  orgId: string;
+  deviceId: string;
+  eventType: 'device.failure_confirmed' | 'device.replaced' | 'device.false_alarm';
+  outcome: 'failure_confirmed' | 'replaced' | 'false_alarm';
+  actorUserId?: string | null;
+  occurredAt?: Date;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await emitMlFeedbackEvent({
+    orgId: options.orgId,
+    sourceType: 'device',
+    sourceId: options.deviceId,
+    eventType: options.eventType,
+    outcome: options.outcome,
+    actorUserId: actorUserIdOrNull(options.actorUserId),
+    metadata: options.metadata ?? {},
+    occurredAt: options.occurredAt ?? new Date(),
+  });
+}

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -233,3 +233,87 @@ describe('computeTopIssues', () => {
     expect(issues.length).toBeLessThanOrEqual(5);
   });
 });
+
+describe('reliability explanation drivers', () => {
+  it('orders drivers by weighted lost points and keeps numeric evidence only', () => {
+    const drivers = reliabilityScoringInternals.buildReliabilityDrivers({
+      factors: {
+        uptime: { score: 90, weight: 30, uptime30d: 99.2, ignored: 'not-number' },
+        crashes: { score: 20, weight: 25, crashCount30d: 4 },
+        hangs: { score: 100, weight: 15, hangCount30d: 0 },
+      },
+    });
+
+    expect(drivers.map((driver) => driver.factor)).toEqual(['crashes', 'uptime', 'hangs']);
+    expect(drivers[0]).toEqual(expect.objectContaining({
+      factor: 'crashes',
+      label: 'Crashes',
+      lostPoints: 20,
+      evidence: { crashCount30d: 4 },
+    }));
+    expect(drivers[1]?.evidence).toEqual({ uptime30d: 99.2 });
+  });
+});
+
+describe('computeReliabilityEvaluationSummary', () => {
+  const devices = [
+    {
+      deviceId: 'device-a',
+      orgId: 'org-1',
+      siteId: 'site-1',
+      hostname: 'alpha',
+      reliabilityScore: 45,
+      computedAt: new Date('2026-06-18T12:00:00.000Z'),
+    },
+    {
+      deviceId: 'device-b',
+      orgId: 'org-1',
+      siteId: 'site-1',
+      hostname: 'beta',
+      reliabilityScore: 62,
+      computedAt: new Date('2026-06-18T12:00:00.000Z'),
+    },
+    {
+      deviceId: 'device-c',
+      orgId: 'org-1',
+      siteId: 'site-2',
+      hostname: 'gamma',
+      reliabilityScore: 91,
+      computedAt: new Date('2026-06-18T12:00:00.000Z'),
+    },
+  ];
+
+  it('computes precision from labeled at-risk devices and reports missed failures', () => {
+    const summary = reliabilityScoringInternals.computeReliabilityEvaluationSummary(devices, [
+      { deviceId: 'device-a', outcome: 'failure_confirmed', occurredAt: new Date('2026-06-18T13:00:00.000Z') },
+      { deviceId: 'device-b', outcome: 'false_alarm', occurredAt: new Date('2026-06-18T13:00:00.000Z') },
+      { deviceId: 'device-c', outcome: 'replaced', occurredAt: new Date('2026-06-18T13:00:00.000Z') },
+    ], { atRiskMaxScore: 70, labelWindowDays: 90 });
+
+    expect(summary).toEqual(expect.objectContaining({
+      evaluatedDevices: 3,
+      atRiskDevices: 2,
+      labeledAtRiskDevices: 2,
+      truePositiveDevices: 1,
+      falsePositiveDevices: 1,
+      missedFailureDevices: 1,
+      unlabeledAtRiskDevices: 0,
+      confirmedFailureLabels: 1,
+      replacementLabels: 1,
+      falseAlarmLabels: 1,
+      precision: 0.5,
+    }));
+  });
+
+  it('uses the latest label per device for prediction outcome scoring', () => {
+    const summary = reliabilityScoringInternals.computeReliabilityEvaluationSummary(devices, [
+      { deviceId: 'device-a', outcome: 'false_alarm', occurredAt: new Date('2026-06-18T12:00:00.000Z') },
+      { deviceId: 'device-a', outcome: 'failure_confirmed', occurredAt: new Date('2026-06-18T13:00:00.000Z') },
+    ], { atRiskMaxScore: 70, labelWindowDays: 90 });
+
+    expect(summary.truePositiveDevices).toBe(1);
+    expect(summary.falsePositiveDevices).toBe(0);
+    expect(summary.unlabeledAtRiskDevices).toBe(1);
+    expect(summary.precision).toBe(1);
+  });
+});

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -5,6 +5,7 @@ import {
   deviceReliability,
   deviceReliabilityHistory,
   devices,
+  mlFeedbackEvents,
   type ReliabilityTopIssue,
 } from '../db/schema';
 
@@ -84,6 +85,7 @@ export interface ReliabilityListItem {
   mtbfHours: number | null;
   topIssues: ReliabilityTopIssue[];
   computedAt: string;
+  drivers?: ReliabilityFactorDriver[];
 }
 
 export interface DeviceReliabilityHistoryPoint {
@@ -95,6 +97,57 @@ export interface DeviceReliabilityHistoryPoint {
   serviceFailureCount: number;
   hardwareErrorCount: number;
   reliabilityEstimate: number;
+}
+
+export type ReliabilityFactorName = 'uptime' | 'crashes' | 'hangs' | 'serviceFailures' | 'hardwareErrors';
+
+export interface ReliabilityFactorDriver {
+  factor: ReliabilityFactorName;
+  label: string;
+  score: number;
+  weight: number;
+  lostPoints: number;
+  evidence: Record<string, number>;
+}
+
+export interface ReliabilityEvaluationInput {
+  orgId?: string;
+  orgIds?: string[];
+  siteId?: string;
+  siteIds?: string[];
+  atRiskMaxScore?: number;
+  labelWindowDays?: number;
+}
+
+export interface ReliabilityEvaluationDevice {
+  deviceId: string;
+  orgId: string;
+  siteId: string | null;
+  hostname: string;
+  reliabilityScore: number;
+  computedAt: Date;
+}
+
+export interface ReliabilityEvaluationLabel {
+  deviceId: string;
+  outcome: 'failure_confirmed' | 'replaced' | 'false_alarm';
+  occurredAt: Date;
+}
+
+export interface ReliabilityEvaluationSummary {
+  atRiskMaxScore: number;
+  labelWindowDays: number;
+  evaluatedDevices: number;
+  atRiskDevices: number;
+  labeledAtRiskDevices: number;
+  truePositiveDevices: number;
+  falsePositiveDevices: number;
+  missedFailureDevices: number;
+  unlabeledAtRiskDevices: number;
+  confirmedFailureLabels: number;
+  replacementLabels: number;
+  falseAlarmLabels: number;
+  precision: number | null;
 }
 
 function clampScore(value: number): number {
@@ -224,6 +277,24 @@ function asObject(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
+}
+
+function coerceFiniteNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function coerceDriverEvidence(value: unknown): Record<string, number> {
+  const obj = asObject(value);
+  if (!obj) return {};
+  const evidence: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(obj)) {
+    if (key === 'score' || key === 'weight') continue;
+    const numeric = coerceFiniteNumber(raw);
+    if (numeric === null) continue;
+    evidence[key] = round2(numeric);
+  }
+  return evidence;
 }
 
 function sanitizeTimestamp(value: unknown): string | undefined {
@@ -554,6 +625,100 @@ function computeTopIssues(input: {
       return b.count - a.count;
     })
     .slice(0, 5);
+}
+
+function buildReliabilityDrivers(details: unknown): ReliabilityFactorDriver[] {
+  const root = asObject(details);
+  const factors = asObject(root?.factors);
+  if (!factors) return [];
+
+  const configs: Array<{ factor: ReliabilityFactorName; label: string }> = [
+    { factor: 'uptime', label: 'Uptime' },
+    { factor: 'crashes', label: 'Crashes' },
+    { factor: 'hangs', label: 'Application hangs' },
+    { factor: 'serviceFailures', label: 'Service failures' },
+    { factor: 'hardwareErrors', label: 'Hardware errors' },
+  ];
+
+  return configs
+    .map(({ factor, label }) => {
+      const raw = asObject(factors[factor]);
+      if (!raw) return null;
+      const score = coerceFiniteNumber(raw.score);
+      const weight = coerceFiniteNumber(raw.weight);
+      if (score === null || weight === null) return null;
+      return {
+        factor,
+        label,
+        score: clampScore(score),
+        weight: round2(weight),
+        lostPoints: round2(((100 - clampScore(score)) * weight) / 100),
+        evidence: coerceDriverEvidence(raw),
+      };
+    })
+    .filter((driver): driver is ReliabilityFactorDriver => driver !== null)
+    .sort((left, right) => right.lostPoints - left.lostPoints);
+}
+
+function latestLabelsByDevice(labels: ReliabilityEvaluationLabel[]): Map<string, ReliabilityEvaluationLabel> {
+  const latest = new Map<string, ReliabilityEvaluationLabel>();
+  for (const label of labels) {
+    const existing = latest.get(label.deviceId);
+    if (!existing || label.occurredAt.getTime() > existing.occurredAt.getTime()) {
+      latest.set(label.deviceId, label);
+    }
+  }
+  return latest;
+}
+
+export function computeReliabilityEvaluationSummary(
+  devicesForEvaluation: ReliabilityEvaluationDevice[],
+  labels: ReliabilityEvaluationLabel[],
+  options: { atRiskMaxScore: number; labelWindowDays: number }
+): ReliabilityEvaluationSummary {
+  const latestLabels = latestLabelsByDevice(labels);
+  const atRisk = devicesForEvaluation.filter((device) => device.reliabilityScore <= options.atRiskMaxScore);
+  const atRiskIds = new Set(atRisk.map((device) => device.deviceId));
+
+  let truePositiveDevices = 0;
+  let falsePositiveDevices = 0;
+  let missedFailureDevices = 0;
+  let labeledAtRiskDevices = 0;
+
+  for (const device of devicesForEvaluation) {
+    const label = latestLabels.get(device.deviceId);
+    if (!label) continue;
+    const positive = label.outcome === 'failure_confirmed' || label.outcome === 'replaced';
+    const isAtRisk = atRiskIds.has(device.deviceId);
+
+    if (isAtRisk) {
+      labeledAtRiskDevices += 1;
+      if (positive) {
+        truePositiveDevices += 1;
+      } else {
+        falsePositiveDevices += 1;
+      }
+    } else if (positive) {
+      missedFailureDevices += 1;
+    }
+  }
+
+  const denominator = truePositiveDevices + falsePositiveDevices;
+  return {
+    atRiskMaxScore: options.atRiskMaxScore,
+    labelWindowDays: options.labelWindowDays,
+    evaluatedDevices: devicesForEvaluation.length,
+    atRiskDevices: atRisk.length,
+    labeledAtRiskDevices,
+    truePositiveDevices,
+    falsePositiveDevices,
+    missedFailureDevices,
+    unlabeledAtRiskDevices: Math.max(0, atRisk.length - labeledAtRiskDevices),
+    confirmedFailureLabels: labels.filter((label) => label.outcome === 'failure_confirmed').length,
+    replacementLabels: labels.filter((label) => label.outcome === 'replaced').length,
+    falseAlarmLabels: labels.filter((label) => label.outcome === 'false_alarm').length,
+    precision: denominator > 0 ? round2(truePositiveDevices / denominator) : null,
+  };
 }
 
 async function getHistoryForDevice(deviceId: string, days: number): Promise<HistoryRow[]> {
@@ -974,6 +1139,7 @@ export async function getDeviceReliability(deviceId: string): Promise<Reliabilit
       hardwareErrorCount30d: deviceReliability.hardwareErrorCount30d,
       mtbfHours: deviceReliability.mtbfHours,
       topIssues: deviceReliability.topIssues,
+      details: deviceReliability.details,
       computedAt: deviceReliability.computedAt,
     })
     .from(deviceReliability)
@@ -1000,7 +1166,73 @@ export async function getDeviceReliability(deviceId: string): Promise<Reliabilit
     mtbfHours: row.mtbfHours,
     topIssues: Array.isArray(row.topIssues) ? row.topIssues : [],
     computedAt: row.computedAt.toISOString(),
+    drivers: buildReliabilityDrivers(row.details),
   };
+}
+
+export async function evaluateReliabilityScores(input: ReliabilityEvaluationInput = {}): Promise<ReliabilityEvaluationSummary> {
+  const atRiskMaxScore = Math.min(Math.max(Number(input.atRiskMaxScore ?? 70), 0), 100);
+  const labelWindowDays = Math.min(Math.max(Number(input.labelWindowDays ?? 90), 1), 365);
+  const since = getSince(labelWindowDays);
+
+  const conditions: SQL[] = [];
+  if (input.orgId) {
+    conditions.push(eq(deviceReliability.orgId, input.orgId));
+  } else if (input.orgIds && input.orgIds.length > 0) {
+    conditions.push(inArray(deviceReliability.orgId, input.orgIds));
+  }
+  if (input.siteId) {
+    conditions.push(eq(devices.siteId, input.siteId));
+  } else if (input.siteIds && input.siteIds.length > 0) {
+    conditions.push(inArray(devices.siteId, input.siteIds));
+  }
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const deviceRows = await db
+    .select({
+      deviceId: deviceReliability.deviceId,
+      orgId: deviceReliability.orgId,
+      siteId: devices.siteId,
+      hostname: devices.hostname,
+      reliabilityScore: deviceReliability.reliabilityScore,
+      computedAt: deviceReliability.computedAt,
+    })
+    .from(deviceReliability)
+    .innerJoin(devices, eq(deviceReliability.deviceId, devices.id))
+    .where(where);
+
+  const orgIds = Array.from(new Set(deviceRows.map((row) => row.orgId)));
+  if (orgIds.length === 0) {
+    return computeReliabilityEvaluationSummary([], [], { atRiskMaxScore, labelWindowDays });
+  }
+
+  const labelRows = await db
+    .select({
+      deviceId: mlFeedbackEvents.sourceId,
+      outcome: mlFeedbackEvents.outcome,
+      occurredAt: mlFeedbackEvents.occurredAt,
+    })
+    .from(mlFeedbackEvents)
+    .where(and(
+      inArray(mlFeedbackEvents.orgId, orgIds),
+      eq(mlFeedbackEvents.sourceType, 'device'),
+      inArray(mlFeedbackEvents.eventType, ['device.failure_confirmed', 'device.replaced', 'device.false_alarm']),
+      gte(mlFeedbackEvents.occurredAt, since),
+    ));
+
+  const deviceIds = new Set(deviceRows.map((row) => row.deviceId));
+  const labels = labelRows
+    .filter((row): row is typeof row & { outcome: 'failure_confirmed' | 'replaced' | 'false_alarm' } => (
+      deviceIds.has(row.deviceId)
+      && (row.outcome === 'failure_confirmed' || row.outcome === 'replaced' || row.outcome === 'false_alarm')
+    ))
+    .map((row) => ({
+      deviceId: row.deviceId,
+      outcome: row.outcome,
+      occurredAt: row.occurredAt,
+    }));
+
+  return computeReliabilityEvaluationSummary(deviceRows, labels, { atRiskMaxScore, labelWindowDays });
 }
 
 export async function getDeviceReliabilityHistory(deviceId: string, days: number): Promise<DeviceReliabilityHistoryPoint[]> {
@@ -1162,4 +1394,6 @@ export const reliabilityScoringInternals = {
   scoreHardwareErrors,
   scoreBand,
   computeTopIssues,
+  buildReliabilityDrivers,
+  computeReliabilityEvaluationSummary,
 };

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -55,6 +55,7 @@ import { OverflowTabs } from '../shared/OverflowTabs';
 import DeviceBackupTab from '../backup/DeviceBackupTab';
 import DeviceTicketsTab from '../tickets/DeviceTicketsTab';
 import DeviceAnomaliesPanel from './DeviceAnomaliesPanel';
+import DeviceReliabilityPanel from './DeviceReliabilityPanel';
 
 type Tab =
   | 'overview'
@@ -279,6 +280,8 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
                 </div>
               </div>
             </div>
+
+            <DeviceReliabilityPanel deviceId={device.id} />
 
             <DevicePerformanceGraphs deviceId={device.id} compact />
 

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceReliabilityPanel from './DeviceReliabilityPanel';
+import { fetchWithAuth } from '../../stores/auth';
+
+const showToast = vi.fn();
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: (input: unknown) => showToast(input),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+describe('DeviceReliabilityPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    showToast.mockReset();
+  });
+
+  it('renders reliability score drivers for a device', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          reliabilityScore: 44,
+          trendDirection: 'degrading',
+          trendConfidence: 0.8,
+          uptime30d: 94.2,
+          crashCount30d: 4,
+          hangCount30d: 1,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 1,
+          mtbfHours: 72,
+          topIssues: [{ type: 'crashes', count: 4, severity: 'critical' }],
+          drivers: [
+            {
+              factor: 'crashes',
+              label: 'Crashes',
+              score: 20,
+              weight: 25,
+              lostPoints: 20,
+              evidence: { crashCount30d: 4 },
+            },
+          ],
+          computedAt: '2026-06-18T12:00:00.000Z',
+        },
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    await screen.findByText('Reliability');
+    expect(screen.getByText('44')).toBeTruthy();
+    expect(screen.getByText('At risk')).toBeTruthy();
+    expect(screen.getByText('Crashes')).toBeTruthy();
+    expect(screen.getByText('crash count30d')).toBeTruthy();
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/reliability/dev-1');
+  });
+
+  it('posts false alarm feedback through runAction', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          snapshot: {
+            deviceId: 'dev-1',
+            reliabilityScore: 65,
+            trendDirection: 'stable',
+            trendConfidence: 0.4,
+            uptime30d: 99.1,
+            crashCount30d: 0,
+            hangCount30d: 1,
+            serviceFailureCount30d: 0,
+            hardwareErrorCount30d: 0,
+            mtbfHours: null,
+            topIssues: [],
+            drivers: [],
+            computedAt: '2026-06-18T12:00:00.000Z',
+          },
+          history: [],
+        }),
+      )
+      .mockResolvedValueOnce(makeJsonResponse({ success: true }));
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    const falseAlarm = await screen.findByRole('button', { name: /false alarm/i });
+    fireEvent.click(falseAlarm);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/reliability/dev-1/feedback',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ outcome: 'false_alarm' }),
+        }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'False alarm label saved',
+    }));
+  });
+
+  it('renders an empty state when no snapshot exists yet', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ error: 'No snapshot' }, false, 404));
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    await screen.findByText('No reliability snapshot available yet.');
+  });
+});

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -1,0 +1,285 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle, RefreshCw, ShieldCheck, Wrench, XCircle } from 'lucide-react';
+
+import { runAction, handleActionError } from '../../lib/runAction';
+import { fetchWithAuth } from '../../stores/auth';
+
+type ReliabilityTopIssue = {
+  type: 'crashes' | 'hangs' | 'services' | 'hardware' | 'uptime';
+  count: number;
+  severity: 'critical' | 'error' | 'warning' | 'info';
+  lastOccurrence?: string;
+};
+
+type ReliabilityDriver = {
+  factor: string;
+  label: string;
+  score: number;
+  weight: number;
+  lostPoints: number;
+  evidence: Record<string, number>;
+};
+
+type ReliabilitySnapshot = {
+  deviceId: string;
+  reliabilityScore: number;
+  trendDirection: 'improving' | 'stable' | 'degrading';
+  trendConfidence: number;
+  uptime30d: number;
+  crashCount30d: number;
+  hangCount30d: number;
+  serviceFailureCount30d: number;
+  hardwareErrorCount30d: number;
+  mtbfHours: number | null;
+  topIssues: ReliabilityTopIssue[];
+  drivers?: ReliabilityDriver[];
+  computedAt: string;
+};
+
+type DeviceReliabilityPanelProps = {
+  deviceId: string;
+};
+
+const issueLabels: Record<ReliabilityTopIssue['type'], string> = {
+  crashes: 'Crashes',
+  hangs: 'Application hangs',
+  services: 'Service failures',
+  hardware: 'Hardware errors',
+  uptime: 'Uptime',
+};
+
+function scoreClass(score: number): string {
+  if (score <= 50) return 'text-destructive';
+  if (score <= 70) return 'text-warning';
+  if (score <= 85) return 'text-info';
+  return 'text-success';
+}
+
+function scoreBarClass(score: number): string {
+  if (score <= 50) return 'bg-destructive';
+  if (score <= 70) return 'bg-warning';
+  if (score <= 85) return 'bg-info';
+  return 'bg-success';
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function formatEvidenceKey(value: string): string {
+  return value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .toLowerCase();
+}
+
+function formatEvidenceValue(key: string, value: number): string {
+  if (key.toLowerCase().includes('uptime')) return `${value.toFixed(1)}%`;
+  return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(1);
+}
+
+export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPanelProps) {
+  const [snapshot, setSnapshot] = useState<ReliabilitySnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [labeling, setLabeling] = useState<string | null>(null);
+
+  const fetchReliability = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const response = await fetchWithAuth(`/reliability/${deviceId}`);
+      if (response.status === 404) {
+        setSnapshot(null);
+        return;
+      }
+      if (!response.ok) throw new Error('Failed to load reliability score');
+      const json = await response.json();
+      setSnapshot(json?.snapshot ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load reliability score');
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId]);
+
+  useEffect(() => {
+    void fetchReliability();
+  }, [fetchReliability]);
+
+  const drivers = useMemo(() => (snapshot?.drivers ?? []).slice(0, 3), [snapshot?.drivers]);
+
+  async function submitFeedback(outcome: 'failure_confirmed' | 'replaced' | 'false_alarm') {
+    setLabeling(outcome);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/reliability/${deviceId}/feedback`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ outcome }),
+        }),
+        errorFallback: 'Could not save reliability feedback',
+        successMessage: outcome === 'false_alarm'
+          ? 'False alarm label saved'
+          : outcome === 'replaced'
+            ? 'Replacement label saved'
+            : 'Failure label saved',
+      });
+    } catch (err) {
+      handleActionError(err, 'Could not save reliability feedback');
+    } finally {
+      setLabeling(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border bg-card p-5 shadow-sm">
+        <div className="flex items-center justify-center py-6">
+          <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-destructive">{error}</p>
+          <button
+            type="button"
+            onClick={() => void fetchReliability()}
+            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!snapshot) {
+    return (
+      <div className="rounded-lg border bg-card p-5 shadow-sm">
+        <div className="flex items-center gap-3">
+          <ShieldCheck className="h-5 w-5 text-muted-foreground" />
+          <div>
+            <h3 className="text-base font-semibold">Reliability</h3>
+            <p className="text-sm text-muted-foreground">No reliability snapshot available yet.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-muted-foreground" />
+            <h3 className="text-base font-semibold">Reliability</h3>
+            {snapshot.reliabilityScore <= 70 && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                At risk
+              </span>
+            )}
+          </div>
+          <div className="mt-3 flex flex-wrap items-end gap-x-5 gap-y-2">
+            <div>
+              <div className="text-xs text-muted-foreground">Score</div>
+              <div className={`text-3xl font-semibold tabular-nums ${scoreClass(snapshot.reliabilityScore)}`}>
+                {snapshot.reliabilityScore}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Trend</div>
+              <div className="text-sm font-medium capitalize">{snapshot.trendDirection}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">30d uptime</div>
+              <div className="text-sm font-medium tabular-nums">{snapshot.uptime30d.toFixed(1)}%</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">MTBF</div>
+              <div className="text-sm font-medium tabular-nums">
+                {snapshot.mtbfHours === null ? '—' : `${Math.round(snapshot.mtbfHours)}h`}
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 h-2 rounded-full bg-muted">
+            <div
+              className={`h-2 rounded-full ${scoreBarClass(snapshot.reliabilityScore)}`}
+              style={{ width: `${snapshot.reliabilityScore}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">Updated {formatDate(snapshot.computedAt)}</p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => void submitFeedback('failure_confirmed')}
+            disabled={labeling !== null}
+            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <CheckCircle className="h-4 w-4" />
+            Failure
+          </button>
+          <button
+            type="button"
+            onClick={() => void submitFeedback('replaced')}
+            disabled={labeling !== null}
+            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Wrench className="h-4 w-4" />
+            Replaced
+          </button>
+          <button
+            type="button"
+            onClick={() => void submitFeedback('false_alarm')}
+            disabled={labeling !== null}
+            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <XCircle className="h-4 w-4" />
+            False alarm
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3 lg:grid-cols-3">
+        {drivers.length > 0 ? drivers.map((driver) => (
+          <div key={driver.factor} className="rounded-md border p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{driver.label}</p>
+                <p className="text-xs text-muted-foreground">{driver.weight}% weight</p>
+              </div>
+              <span className={`text-sm font-semibold tabular-nums ${scoreClass(driver.score)}`}>{driver.score}</span>
+            </div>
+            <div className="mt-3 space-y-1 text-xs text-muted-foreground">
+              {Object.entries(driver.evidence).slice(0, 3).map(([key, value]) => (
+                <div key={key} className="flex justify-between gap-3">
+                  <span className="truncate">{formatEvidenceKey(key)}</span>
+                  <span className="shrink-0 tabular-nums">{formatEvidenceValue(key, value)}</span>
+                </div>
+              ))}
+              {Object.keys(driver.evidence).length === 0 && <span>No factor detail</span>}
+            </div>
+          </div>
+        )) : snapshot.topIssues.slice(0, 3).map((issue) => (
+          <div key={issue.type} className="rounded-md border p-3">
+            <p className="text-sm font-medium">{issueLabels[issue.type]}</p>
+            <p className="mt-1 text-xs capitalize text-muted-foreground">{issue.severity}</p>
+            <p className="mt-3 text-lg font-semibold tabular-nums">{issue.count}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reliability feedback labels for device failure, replacement, and false alarms through ml_feedback_events
- expose reliability evaluation metrics with at-risk precision and missed/unlabeled counts
- return factor drivers on reliability details and show them in a device overview panel

## Validation
- /usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/routes/reliability.test.ts src/services/reliabilityScoring.test.ts src/services/mlFeedback.test.ts
- /usr/local/bin/corepack pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceReliabilityPanel.test.tsx src/lib/__tests__/no-silent-mutations.test.ts
- /usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit
- /usr/local/bin/corepack pnpm --filter @breeze/web exec tsc --noEmit
- git diff --check

## Drift check
- DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze /usr/local/bin/corepack pnpm --filter @breeze/api db:check-drift currently fails locally with Postgres role "breeze" does not exist.