### PR TITLE
feat(ml): add ticket triage suggestions

### DIFF
--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs, lastOrderByArgs, writeRouteAuditMock } = vi.hoisted(() => {
+const { serviceMocks, ticketTriageMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs, lastOrderByArgs, writeRouteAuditMock } = vi.hoisted(() => {
   const lastWhereArgs: { conditions: unknown[] }[] = [];
   const lastOrderByArgs: unknown[][] = [];
   return {
@@ -14,6 +14,10 @@ const { serviceMocks, dbSelectMock, dbGroupByMock, authRef, lastWhereArgs, lastO
       unlinkAlertFromTicket: vi.fn(),
       updateTicketFields: vi.fn(),
       getAssigneeForValidation: vi.fn(),
+    },
+    ticketTriageMocks: {
+      getTicketTriageSuggestion: vi.fn(),
+      evaluateTicketTriage: vi.fn(),
     },
     dbSelectMock: vi.fn(),
     dbGroupByMock: vi.fn(),
@@ -43,6 +47,12 @@ vi.mock('../../services/ticketService', async () => {
   const actual = await vi.importActual<typeof import('../../services/ticketService')>('../../services/ticketService');
   return { ...actual, ...serviceMocks };
 });
+
+vi.mock('../../services/ticketTriage', () => ticketTriageMocks);
+
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitTicketTriageFeedback: vi.fn(),
+}));
 
 // Mirror the REAL middleware contract: authMiddleware is the ONLY thing that
 // populates c.get('auth'); requireScope 401s when it is missing (exactly the
@@ -179,6 +189,7 @@ import { ticketsRoutes } from './index';
 // Real class (the service mock spreads importActual), so handleServiceError's
 // instanceof check in the route works against errors thrown by the mocks.
 import { TicketServiceError } from '../../services/ticketService';
+import { evaluateTicketTriage, getTicketTriageSuggestion } from '../../services/ticketTriage';
 
 const TICKET_ID = '3f2f1d8e-1111-4222-8333-444455556666';
 const ORG_ID    = '3f2f1d8e-1111-4222-8333-444455556666';
@@ -516,6 +527,108 @@ describe('GET /tickets/:id — scoped pre-check', () => {
     expect(body.data.orgName).toBeNull();
     expect(body.data.deviceHostname).toBeNull();
     expect(body.data.assigneeName).toBeNull();
+  });
+});
+
+describe('ticket triage suggestion routes', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('GET /tickets/triage-evaluation returns scoped evaluation summary', async () => {
+    vi.mocked(evaluateTicketTriage).mockResolvedValue({
+      labelWindowDays: 90,
+      totalLabels: 3,
+      acceptedSuggestionLabels: 1,
+      manualOverrideLabels: 2,
+      categoryLabels: 1,
+      priorityLabels: 1,
+      assigneeLabels: 1,
+      overrideRate: 0.67,
+    });
+
+    const res = await makeApp().request('/tickets/triage-evaluation?labelWindowDays=90');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.summary.overrideRate).toBe(0.67);
+    expect(vi.mocked(evaluateTicketTriage)).toHaveBeenCalledWith(expect.objectContaining({
+      labelWindowDays: 90,
+    }));
+  });
+
+  it('GET /tickets/:id/triage-suggestion returns a scoped suggestion', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    vi.mocked(getTicketTriageSuggestion).mockResolvedValue({
+      enabled: true,
+      flagSource: 'org_settings',
+      suggestion: {
+        modelVersion: 'ticket-triage-rules-v0',
+        confidence: 0.72,
+        priority: 'high',
+        categoryId: null,
+        categoryName: null,
+        reasons: ['high-impact keywords'],
+      },
+    });
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/triage-suggestion`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.suggestion.priority).toBe('high');
+    expect(vi.mocked(getTicketTriageSuggestion)).toHaveBeenCalledWith(expect.objectContaining({ id: TICKET_ID }));
+  });
+
+  it('POST /tickets/:id/triage-suggestion/apply tags update as suggestion feedback', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    vi.mocked(getTicketTriageSuggestion).mockResolvedValue({
+      enabled: true,
+      flagSource: 'org_settings',
+      suggestion: {
+        modelVersion: 'ticket-triage-rules-v0',
+        confidence: 0.72,
+        priority: 'high',
+        categoryId: null,
+        categoryName: null,
+        reasons: ['high-impact keywords'],
+      },
+    });
+    serviceMocks.updateTicketFields.mockResolvedValue({ ...STUB_TICKET, priority: 'high' });
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/triage-suggestion/apply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ priority: 'high' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(serviceMocks.updateTicketFields).toHaveBeenCalledWith(
+      TICKET_ID,
+      { priority: 'high' },
+      expect.objectContaining({ userId: 'u-1', triageFeedbackSource: 'suggestion' }),
+    );
+  });
+
+  it('POST /tickets/:id/triage-suggestion/apply rejects stale suggested values', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    vi.mocked(getTicketTriageSuggestion).mockResolvedValue({
+      enabled: true,
+      flagSource: 'org_settings',
+      suggestion: {
+        modelVersion: 'ticket-triage-rules-v0',
+        confidence: 0.72,
+        priority: 'high',
+        categoryId: null,
+        categoryName: null,
+        reasons: ['high-impact keywords'],
+      },
+    });
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/triage-suggestion/apply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ priority: 'urgent' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -16,6 +16,10 @@ import {
   linkAlertToTicket, unlinkAlertFromTicket, updateTicketFields,
   TicketServiceError
 } from '../../services/ticketService';
+import {
+  evaluateTicketTriage,
+  getTicketTriageSuggestion,
+} from '../../services/ticketTriage';
 import type { AuthContext } from '../../middleware/auth';
 
 // NOTE: authMiddleware is applied by the hub router in ./index.ts (alerts pattern) —
@@ -23,6 +27,15 @@ import type { AuthContext } from '../../middleware/auth';
 export const ticketsRoutes = new Hono();
 
 const idParam = z.object({ id: z.string().uuid() });
+const triageEvaluationQuerySchema = z.object({
+  labelWindowDays: z.coerce.number().int().min(1).max(365).default(90),
+});
+const applyTriageSuggestionSchema = z.object({
+  categoryId: z.string().uuid().nullable().optional(),
+  priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
+}).refine((value) => value.categoryId !== undefined || value.priority !== undefined, {
+  message: 'At least one suggested field is required',
+});
 
 const OPEN_STATUSES = ['new', 'open', 'pending', 'on_hold'] as const;
 const CLOSED_STATUSES = ['resolved', 'closed'] as const;
@@ -186,6 +199,34 @@ ticketsRoutes.get(
       .where(whereCondition);
     const atRisk = Number(slaRows[0]?.atRisk ?? 0);
     return c.json({ data: { open, unassigned, mine, breached, atRisk } });
+  }
+);
+
+ticketsRoutes.get(
+  '/triage-evaluation',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_READ.resource, PERMISSIONS.TICKETS_READ.action),
+  zValidator('query', triageEvaluationQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    if (auth.scope === 'partner' && !auth.partnerId) {
+      return c.json({ error: 'Partner context required' }, 403);
+    }
+
+    const orgIds = auth.scope === 'organization'
+      ? [auth.orgId as string]
+      : auth.accessibleOrgIds?.length ? auth.accessibleOrgIds : undefined;
+
+    const summary = await evaluateTicketTriage({
+      orgIds,
+      labelWindowDays: query.labelWindowDays,
+    });
+
+    return c.json({ summary });
   }
 );
 
@@ -382,6 +423,69 @@ ticketsRoutes.get(
       .where(eq(ticketAlertLinks.ticketId, id));
 
     return c.json({ data: { ...ticket, orgName, deviceHostname, assigneeName, statusName, statusColor, comments, alertLinks } });
+  }
+);
+
+ticketsRoutes.get(
+  '/:id/triage-suggestion',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_READ.resource, PERMISSIONS.TICKETS_READ.action),
+  zValidator('param', idParam),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const ticket = await getScopedTicketOr404(auth, id);
+    if (!ticket) return c.json({ error: 'Ticket not found' }, 404);
+
+    const result = await getTicketTriageSuggestion(ticket);
+    return c.json(result);
+  }
+);
+
+ticketsRoutes.post(
+  '/:id/triage-suggestion/apply',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('param', idParam),
+  zValidator('json', applyTriageSuggestionSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+    const body = c.req.valid('json');
+
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const ticket = await getScopedTicketOr404(auth, id);
+    if (!ticket) return c.json({ error: 'Ticket not found' }, 404);
+
+    const suggestion = await getTicketTriageSuggestion(ticket);
+    if (!suggestion.enabled) {
+      return c.json({ error: 'Ticket triage suggestions are disabled' }, 409);
+    }
+    if (!suggestion.suggestion) {
+      return c.json({ error: 'No ticket triage suggestion is currently available' }, 409);
+    }
+    if (body.priority !== undefined && body.priority !== suggestion.suggestion.priority) {
+      return c.json({ error: 'Priority no longer matches the current suggestion' }, 409);
+    }
+    if (body.categoryId !== undefined && (suggestion.suggestion.categoryId === null || body.categoryId !== suggestion.suggestion.categoryId)) {
+      return c.json({ error: 'Category no longer matches the current suggestion' }, 409);
+    }
+
+    try {
+      const ticket = await updateTicketFields(id, body, {
+        ...actorFrom(c),
+        triageFeedbackSource: 'suggestion',
+      });
+      return c.json({ data: ticket, suggestion: suggestion.suggestion });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
   }
 );
 

--- a/apps/api/src/services/mlFeedbackEmitters.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.ts
@@ -140,3 +140,24 @@ export async function emitDeviceReliabilityFeedback(options: {
     occurredAt: options.occurredAt ?? new Date(),
   });
 }
+
+export async function emitTicketTriageFeedback(options: {
+  orgId: string;
+  ticketId: string;
+  eventType: 'ticket.category_changed' | 'ticket.priority_changed' | 'ticket.assignee_changed' | 'ticket.resolved' | 'ticket.reopened';
+  outcome: 'category_changed' | 'priority_changed' | 'assignee_changed' | 'resolved' | 'reopened';
+  actorUserId?: string | null;
+  occurredAt?: Date;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await emitFeedbackBestEffort({
+    orgId: options.orgId,
+    sourceType: 'ticket',
+    sourceId: options.ticketId,
+    eventType: options.eventType,
+    outcome: options.outcome,
+    actorUserId: actorUserIdOrNull(options.actorUserId),
+    metadata: options.metadata ?? {},
+    occurredAt: options.occurredAt ?? new Date(),
+  }, options.eventType);
+}

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -7,6 +7,7 @@ import { emitTicketEvent } from './ticketEvents';
 import { createAuditLogAsync } from './auditService';
 import { resolveSlaTargets } from './ticketSla';
 import { getOrgSlaOverride, getPartnerPrioritySla, getSystemStatusId, getTicketStatusById } from './ticketConfigService';
+import { emitTicketTriageFeedback } from './mlFeedbackEmitters';
 
 export type TicketStatus = (typeof ticketStatusEnum.enumValues)[number];
 export type TicketSource = (typeof ticketSourceEnum.enumValues)[number];
@@ -54,6 +55,7 @@ export interface TicketActor {
   userId: string;
   name?: string;
   email?: string;
+  triageFeedbackSource?: 'manual' | 'suggestion';
 }
 
 // Legacy display identifier (NOT NULL UNIQUE), retry loop dropped when creation
@@ -524,6 +526,15 @@ function ticketFieldChanged(key: keyof UpdateTicketFieldsInput, oldValue: unknow
   return (oldValue ?? null) !== (newValue ?? null);
 }
 
+function ticketTriageFeedbackMetadata(actor: TicketActor, extra: Record<string, unknown>): Record<string, unknown> {
+  const acceptedSuggestion = actor.triageFeedbackSource === 'suggestion';
+  return {
+    source: acceptedSuggestion ? 'ticket_triage_v0' : 'manual_update',
+    acceptedSuggestion,
+    ...extra,
+  };
+}
+
 export async function updateTicketFields(
   ticketId: string,
   fields: UpdateTicketFieldsInput,
@@ -604,6 +615,32 @@ export async function updateTicketFields(
     details: { changed },
     result: 'success'
   });
+  if (changed.includes('categoryId')) {
+    await emitTicketTriageFeedback({
+      orgId: ticket.orgId,
+      ticketId,
+      eventType: 'ticket.category_changed',
+      outcome: 'category_changed',
+      actorUserId: actor.userId,
+      metadata: ticketTriageFeedbackMetadata(actor, {
+        oldValue: ticket.categoryId ?? null,
+        newValue: updated[0]?.categoryId ?? null,
+      }),
+    });
+  }
+  if (changed.includes('priority')) {
+    await emitTicketTriageFeedback({
+      orgId: ticket.orgId,
+      ticketId,
+      eventType: 'ticket.priority_changed',
+      outcome: 'priority_changed',
+      actorUserId: actor.userId,
+      metadata: ticketTriageFeedbackMetadata(actor, {
+        oldValue: ticket.priority,
+        newValue: updated[0]?.priority ?? null,
+      }),
+    });
+  }
   return updated[0];
 }
 
@@ -660,6 +697,17 @@ export async function assignTicket(ticketId: string, assigneeId: string | null, 
     resourceId: ticketId,
     details: { from: prevAssignedTo ?? null, to: assigneeId },
     result: 'success'
+  });
+  await emitTicketTriageFeedback({
+    orgId: ticket.orgId,
+    ticketId,
+    eventType: 'ticket.assignee_changed',
+    outcome: 'assignee_changed',
+    actorUserId: actor.userId,
+    metadata: ticketTriageFeedbackMetadata(actor, {
+      oldValue: prevAssignedTo ?? null,
+      newValue: assigneeId,
+    }),
   });
   return updated[0];
 }

--- a/apps/api/src/services/ticketTriage.test.ts
+++ b/apps/api/src/services/ticketTriage.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {},
+}));
+
+vi.mock('../db/schema', () => ({
+  mlFeedbackEvents: {},
+  ticketCategories: {},
+  tickets: {},
+}));
+
+vi.mock('./mlFeatureFlags', () => ({
+  resolveMlFeatureFlagForOrg: vi.fn(),
+}));
+
+import { ticketTriageInternals } from './ticketTriage';
+
+describe('ticketTriageInternals', () => {
+  it('suggests urgent priority for outage/security language', () => {
+    expect(ticketTriageInternals.suggestTicketPriority('ransomware breach on server')).toMatchObject({
+      priority: 'urgent',
+      reason: 'critical-impact keywords',
+    });
+    expect(ticketTriageInternals.suggestTicketPriority('email is down for everyone')).toMatchObject({
+      priority: 'urgent',
+    });
+  });
+
+  it('chooses matching category from ticket text', () => {
+    const category = ticketTriageInternals.chooseTicketCategory('printer is offline and jammed', [
+      { id: 'cat-network', name: 'Network', defaultPriority: null },
+      { id: 'cat-hardware', name: 'Hardware', defaultPriority: 'high' },
+    ]);
+
+    expect(category).toMatchObject({ id: 'cat-hardware', defaultPriority: 'high' });
+  });
+
+  it('computes override rate from accepted suggestion and manual labels', () => {
+    const summary = ticketTriageInternals.computeTicketTriageEvaluationSummary([
+      { eventType: 'ticket.priority_changed', metadata: { acceptedSuggestion: true } },
+      { eventType: 'ticket.category_changed', metadata: { acceptedSuggestion: false } },
+      { eventType: 'ticket.assignee_changed', metadata: { source: 'manual_update' } },
+    ], 90);
+
+    expect(summary).toEqual(expect.objectContaining({
+      totalLabels: 3,
+      acceptedSuggestionLabels: 1,
+      manualOverrideLabels: 2,
+      categoryLabels: 1,
+      priorityLabels: 1,
+      assigneeLabels: 1,
+      overrideRate: 0.67,
+    }));
+  });
+});

--- a/apps/api/src/services/ticketTriage.ts
+++ b/apps/api/src/services/ticketTriage.ts
@@ -1,0 +1,212 @@
+import { and, eq, gte, inArray } from 'drizzle-orm';
+import type { TicketPriority } from '@breeze/shared';
+
+import { db } from '../db';
+import { mlFeedbackEvents, ticketCategories, tickets } from '../db/schema';
+import { resolveMlFeatureFlagForOrg } from './mlFeatureFlags';
+
+const MODEL_VERSION = 'ticket-triage-rules-v0';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type TicketRow = typeof tickets.$inferSelect;
+type CategoryRow = Pick<typeof ticketCategories.$inferSelect, 'id' | 'name' | 'defaultPriority'>;
+
+export interface TicketTriageSuggestion {
+  modelVersion: string;
+  confidence: number;
+  priority: TicketPriority | null;
+  categoryId: string | null;
+  categoryName: string | null;
+  reasons: string[];
+}
+
+export interface TicketTriageSuggestionResult {
+  enabled: boolean;
+  flagSource: string;
+  suggestion: TicketTriageSuggestion | null;
+}
+
+export interface TicketTriageEvaluationInput {
+  orgIds?: string[];
+  labelWindowDays?: number;
+}
+
+export interface TicketTriageEvaluationSummary {
+  labelWindowDays: number;
+  totalLabels: number;
+  acceptedSuggestionLabels: number;
+  manualOverrideLabels: number;
+  categoryLabels: number;
+  priorityLabels: number;
+  assigneeLabels: number;
+  overrideRate: number | null;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function ticketText(ticket: Pick<TicketRow, 'subject' | 'description' | 'source'>): string {
+  return `${ticket.subject ?? ''} ${ticket.description ?? ''} ${ticket.source ?? ''}`.toLowerCase();
+}
+
+function hasAny(text: string, keywords: string[]): boolean {
+  return keywords.some((keyword) => text.includes(keyword));
+}
+
+export function suggestTicketPriority(text: string): { priority: TicketPriority; confidence: number; reason: string } {
+  if (hasAny(text, ['ransomware', 'breach', 'security incident', 'data loss', 'outage', 'offline', 'down for everyone', 'cannot work', 'critical'])) {
+    return { priority: 'urgent', confidence: 0.82, reason: 'critical-impact keywords' };
+  }
+  if (hasAny(text, ['down', 'failing', 'failed', 'failure', 'error', 'broken', 'urgent', 'vip', 'email down', 'vpn'])) {
+    return { priority: 'high', confidence: 0.72, reason: 'high-impact keywords' };
+  }
+  if (hasAny(text, ['question', 'how do i', 'request', 'access request', 'new user', 'install'])) {
+    return { priority: 'low', confidence: 0.58, reason: 'request-style wording' };
+  }
+  return { priority: 'normal', confidence: 0.5, reason: 'default ticket baseline' };
+}
+
+const CATEGORY_KEYWORDS: Record<string, string[]> = {
+  security: ['security', 'ransomware', 'breach', 'mfa', 'phishing', 'suspicious'],
+  password: ['password', 'login', 'locked out', 'reset', 'mfa', 'sign in', 'signin'],
+  email: ['email', 'mailbox', 'outlook', 'exchange', 'smtp'],
+  network: ['network', 'wifi', 'wi-fi', 'vpn', 'internet', 'dns', 'dhcp', 'firewall'],
+  hardware: ['printer', 'laptop', 'desktop', 'monitor', 'keyboard', 'mouse', 'hardware'],
+  backup: ['backup', 'restore', 'snapshot', 'recovery'],
+  software: ['software', 'install', 'application', 'app', 'license'],
+};
+
+function categoryMatchScore(categoryName: string, text: string): number {
+  const normalized = categoryName.toLowerCase();
+  let score = 0;
+  for (const token of normalized.split(/[^a-z0-9]+/).filter(Boolean)) {
+    if (token.length >= 3 && text.includes(token)) score += 2;
+  }
+  for (const [bucket, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
+    if (normalized.includes(bucket) && hasAny(text, keywords)) score += 5;
+  }
+  return score;
+}
+
+export function chooseTicketCategory(text: string, categories: CategoryRow[]): CategoryRow | null {
+  let best: { category: CategoryRow; score: number } | null = null;
+  for (const category of categories) {
+    const score = categoryMatchScore(category.name, text);
+    if (score <= 0) continue;
+    if (!best || score > best.score) {
+      best = { category, score };
+    }
+  }
+  return best?.category ?? null;
+}
+
+export async function getTicketTriageSuggestion(ticket: TicketRow): Promise<TicketTriageSuggestionResult> {
+  const flag = await resolveMlFeatureFlagForOrg(ticket.orgId, 'ml.ticket_triage.enabled');
+  if (!flag.enabled) {
+    return { enabled: false, flagSource: flag.source, suggestion: null };
+  }
+
+  const text = ticketText(ticket);
+  const categories = ticket.partnerId
+    ? await db
+      .select({
+        id: ticketCategories.id,
+        name: ticketCategories.name,
+        defaultPriority: ticketCategories.defaultPriority,
+      })
+      .from(ticketCategories)
+      .where(and(eq(ticketCategories.partnerId, ticket.partnerId), eq(ticketCategories.isActive, true)))
+    : [];
+
+  const prioritySuggestion = suggestTicketPriority(text);
+  const category = chooseTicketCategory(text, categories);
+  const suggestedPriority = category?.defaultPriority ?? prioritySuggestion.priority;
+  const reasons = [prioritySuggestion.reason];
+  if (category) reasons.push(`matched ${category.name}`);
+
+  const changesPriority = suggestedPriority !== ticket.priority;
+  const changesCategory = Boolean(category && category.id !== ticket.categoryId);
+  if (!changesPriority && !changesCategory) {
+    return { enabled: true, flagSource: flag.source, suggestion: null };
+  }
+
+  const confidence = round2(Math.max(
+    prioritySuggestion.confidence,
+    category ? 0.68 : 0,
+  ));
+
+  return {
+    enabled: true,
+    flagSource: flag.source,
+    suggestion: {
+      modelVersion: MODEL_VERSION,
+      confidence,
+      priority: changesPriority ? suggestedPriority : null,
+      categoryId: changesCategory && category ? category.id : null,
+      categoryName: changesCategory && category ? category.name : null,
+      reasons,
+    },
+  };
+}
+
+export function computeTicketTriageEvaluationSummary(
+  labels: Array<{ eventType: string; metadata: Record<string, unknown> | null }>,
+  labelWindowDays: number,
+): TicketTriageEvaluationSummary {
+  let acceptedSuggestionLabels = 0;
+  let manualOverrideLabels = 0;
+  let categoryLabels = 0;
+  let priorityLabels = 0;
+  let assigneeLabels = 0;
+
+  for (const label of labels) {
+    const metadata = label.metadata ?? {};
+    if (label.eventType === 'ticket.category_changed') categoryLabels += 1;
+    if (label.eventType === 'ticket.priority_changed') priorityLabels += 1;
+    if (label.eventType === 'ticket.assignee_changed') assigneeLabels += 1;
+    if (metadata.acceptedSuggestion === true) acceptedSuggestionLabels += 1;
+    else manualOverrideLabels += 1;
+  }
+
+  const denominator = acceptedSuggestionLabels + manualOverrideLabels;
+  return {
+    labelWindowDays,
+    totalLabels: labels.length,
+    acceptedSuggestionLabels,
+    manualOverrideLabels,
+    categoryLabels,
+    priorityLabels,
+    assigneeLabels,
+    overrideRate: denominator > 0 ? round2(manualOverrideLabels / denominator) : null,
+  };
+}
+
+export async function evaluateTicketTriage(input: TicketTriageEvaluationInput = {}): Promise<TicketTriageEvaluationSummary> {
+  const labelWindowDays = Math.min(Math.max(Number(input.labelWindowDays ?? 90), 1), 365);
+  const since = new Date(Date.now() - labelWindowDays * DAY_MS);
+  const conditions = [
+    eq(mlFeedbackEvents.sourceType, 'ticket'),
+    inArray(mlFeedbackEvents.eventType, ['ticket.category_changed', 'ticket.priority_changed', 'ticket.assignee_changed']),
+    gte(mlFeedbackEvents.occurredAt, since),
+  ];
+  if (input.orgIds && input.orgIds.length > 0) {
+    conditions.push(inArray(mlFeedbackEvents.orgId, input.orgIds));
+  }
+
+  const rows = await db
+    .select({
+      eventType: mlFeedbackEvents.eventType,
+      metadata: mlFeedbackEvents.metadata,
+    })
+    .from(mlFeedbackEvents)
+    .where(and(...conditions));
+
+  return computeTicketTriageEvaluationSummary(rows, labelWindowDays);
+}
+
+export const ticketTriageInternals = {
+  suggestTicketPriority,
+  chooseTicketCategory,
+  computeTicketTriageEvaluationSummary,
+};

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -338,6 +338,84 @@ describe('TicketWorkbench assignee picker', () => {
   });
 });
 
+describe('TicketWorkbench ML triage suggestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders suggested priority/category and applies it through runAction', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1', priority: 'normal', categoryId: null }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({
+          enabled: true,
+          flagSource: 'org_settings',
+          suggestion: {
+            modelVersion: 'ticket-triage-rules-v0',
+            confidence: 0.72,
+            priority: 'high',
+            categoryId: 'cat-hardware',
+            categoryName: 'Hardware',
+            reasons: ['matched Hardware'],
+          },
+        });
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(
+      <TicketWorkbench
+        ticketId="tk-1"
+        assignees={[]}
+        categories={[{ id: 'cat-hardware', name: 'Hardware' }]}
+      />,
+    );
+
+    await screen.findByTestId('ticket-triage-suggestion');
+    expect(screen.getByText(/Priority: High/i)).toBeInTheDocument();
+    expect(screen.getByText(/Category: Hardware/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ticket-triage-apply'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/triage-suggestion/apply',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ categoryId: 'cat-hardware', priority: 'high' }),
+        }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'Ticket triage suggestion applied',
+    }));
+  });
+
+  it('hides the suggestion strip when triage is disabled', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1' }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ enabled: false, flagSource: 'default', suggestion: null });
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-triage-suggestion')).toBeNull();
+    });
+  });
+});
+
 describe('TicketWorkbench pending/on_hold prompt', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
@@ -30,12 +30,22 @@ interface Props {
   // workbench skips its own /users fetch; undefined keeps the standalone
   // self-fetch (full-page /tickets/[id] view).
   assignees?: Array<{ id: string; name: string | null; email: string }> | null;
+  categories?: Array<{ id: string; name: string }>;
 }
 
 const STATUS_OPTIONS: TicketStatus[] = ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'];
 const PRIORITY_OPTIONS: TicketPriority[] = ['urgent', 'high', 'normal', 'low'];
 
-export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, expanded, resolveRequestToken, refreshToken, assignees: assigneesProp }: Props) {
+type TicketTriageSuggestion = {
+  modelVersion: string;
+  confidence: number;
+  priority: TicketPriority | null;
+  categoryId: string | null;
+  categoryName: string | null;
+  reasons: string[];
+};
+
+export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, expanded, resolveRequestToken, refreshToken, assignees: assigneesProp, categories = [] }: Props) {
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -52,6 +62,9 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   // Ticket configuration (custom statuses + priority labels). null = not loaded
   // or fetch failed; every render falls back to the static core config.
   const [config, setConfig] = useState<TicketConfig | null>(null);
+  const [triageSuggestion, setTriageSuggestion] = useState<TicketTriageSuggestion | null>(null);
+  const [triageLoading, setTriageLoading] = useState(false);
+  const [applyingTriage, setApplyingTriage] = useState(false);
 
   // null = picker hidden (no USERS_READ etc.); degrade to a label + unassign-only button.
   const [fetchedAssignees, setFetchedAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
@@ -90,6 +103,28 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   }, [ticketId]);
 
   useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    if (!ticket) {
+      setTriageSuggestion(null);
+      return;
+    }
+    let cancelled = false;
+    setTriageLoading(true);
+    void fetchWithAuth(`/tickets/${ticketId}/triage-suggestion`)
+      .then(async (res) => (res.ok ? res.json() : null))
+      .then((body) => {
+        if (cancelled) return;
+        setTriageSuggestion(body?.enabled ? (body.suggestion ?? null) : null);
+      })
+      .catch(() => {
+        if (!cancelled) setTriageSuggestion(null);
+      })
+      .finally(() => {
+        if (!cancelled) setTriageLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [ticket, ticketId]);
 
   // Bulk actions in the queue mutate tickets behind the pane's back; the parent
   // bumps refreshToken after a bulk apply so the detail can't go stale. The ref
@@ -208,6 +243,33 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     }
   }, [ticketId, creatingInvoice]);
 
+  const applyTriageSuggestion = useCallback(async () => {
+    if (!triageSuggestion || applyingTriage) return;
+    const body: Partial<Pick<TicketDetail, 'categoryId' | 'priority'>> = {};
+    if (triageSuggestion.categoryId !== null) body.categoryId = triageSuggestion.categoryId;
+    if (triageSuggestion.priority !== null) body.priority = triageSuggestion.priority;
+    if (Object.keys(body).length === 0) return;
+
+    setApplyingTriage(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/tickets/${ticketId}/triage-suggestion/apply`, {
+          method: 'POST',
+          body: JSON.stringify(body),
+        }),
+        errorFallback: 'Could not apply ticket triage suggestion.',
+        successMessage: 'Ticket triage suggestion applied',
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+      setTriageSuggestion(null);
+      afterMutation(body);
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setApplyingTriage(false);
+    }
+  }, [afterMutation, applyingTriage, ticketId, triageSuggestion]);
+
   // Fallback path: option values are the six core enums; POST {status}.
   const onStatusChange = useCallback(async (status: TicketStatus) => {
     setPendingStatusId(null);
@@ -296,6 +358,9 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
         ?? config.statuses.find((s) => s.coreStatus === ticket.status && s.isSystem))?.id ?? null
     : null;
   const headerStatusColor = ticket.statusColor ?? config?.statuses.find((s) => s.id === selectedStatusId)?.color ?? null;
+  const suggestedCategoryName = triageSuggestion?.categoryId
+    ? (categories.find((category) => category.id === triageSuggestion.categoryId)?.name ?? triageSuggestion.categoryName ?? 'Suggested category')
+    : null;
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="ticket-workbench" aria-busy={loading || undefined}>
@@ -421,6 +486,38 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
             {creatingInvoice ? 'Creating…' : 'Create invoice'}
           </button>
         </div>
+        {(triageSuggestion || triageLoading) && (
+          <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-triage-suggestion">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5 text-xs font-medium">
+                  <Sparkles className="h-3.5 w-3.5 text-primary" />
+                  Suggested triage
+                </div>
+                {triageLoading ? (
+                  <p className="mt-1 text-xs text-muted-foreground">Checking ticket signals…</p>
+                ) : triageSuggestion ? (
+                  <div className="mt-1 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
+                    {triageSuggestion.priority && <span>Priority: {priorityLabel(config, triageSuggestion.priority)}</span>}
+                    {suggestedCategoryName && <span>Category: {suggestedCategoryName}</span>}
+                    <span>{Math.round(triageSuggestion.confidence * 100)}% confidence</span>
+                  </div>
+                ) : null}
+              </div>
+              {triageSuggestion && (
+                <button
+                  type="button"
+                  onClick={() => void applyTriageSuggestion()}
+                  disabled={applyingTriage}
+                  className="inline-flex shrink-0 items-center justify-center rounded-md border px-2.5 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                  data-testid="ticket-triage-apply"
+                >
+                  {applyingTriage ? 'Applying…' : 'Apply'}
+                </button>
+              )}
+            </div>
+          </div>
+        )}
         {resolveOpen && (
           <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-workbench-resolve-form">
             <label className="text-xs font-medium" htmlFor="resolve-note">Resolution note (visible to requester)</label>

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -645,7 +645,7 @@ export default function TicketsPage() {
           </div>
           <div className="hidden min-w-0 flex-1 min-[1100px]:block">
             {selected ? (
-              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} refreshToken={paneRefresh} assignees={assignees} onTicketPatched={patchTicketRow} onChanged={scheduleReconcile} />
+              <TicketWorkbench ticketId={selected.id} resolveRequestToken={resolveToken} refreshToken={paneRefresh} assignees={assignees} categories={categories} onTicketPatched={patchTicketRow} onChanged={scheduleReconcile} />
             ) : (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground" data-testid="tickets-no-selection">
                 <p>Select a ticket. Use j/k to move, Enter to expand.</p>


### PR DESCRIPTION
## Summary
- add feature-flagged ticket triage suggestions for priority/category
- capture accepted suggestion and manual override labels in `ml_feedback_events`
- add triage evaluation endpoints and a workbench apply UI

## Validation
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/services/ticketTriage.test.ts src/routes/tickets/tickets.test.ts src/services/ticketService.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx src/lib/__tests__/no-silent-mutations.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit`
- `/usr/local/bin/corepack pnpm --filter @breeze/web exec tsc --noEmit`
- `git diff --check`

## Notes
- `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze /usr/local/bin/corepack pnpm --filter @breeze/api db:check-drift` reaches local Postgres but fails with `role "breeze" does not exist` in this environment.