### PR TITLE
feat(ml): add user risk evaluation

### DIFF
--- a/apps/api/src/routes/userRisk.test.ts
+++ b/apps/api/src/routes/userRisk.test.ts
@@ -14,6 +14,7 @@ vi.mock('../services/auditEvents', () => ({
 
 vi.mock('../services/userRiskScoring', () => ({
   listUserRiskScores: vi.fn(),
+  getUserRiskEvaluation: vi.fn(),
   getUserRiskDetail: vi.fn(),
   getUserRiskOrgMembership: vi.fn(),
   listUserRiskEvents: vi.fn(),
@@ -22,16 +23,23 @@ vi.mock('../services/userRiskScoring', () => ({
   assignSecurityTraining: vi.fn()
 }));
 
+vi.mock('../services/mlFeedbackEmitters', () => ({
+  emitUserRiskFeedback: vi.fn()
+}));
+
 import { userRiskRoutes } from './userRisk';
 import {
   assignSecurityTraining,
   getOrCreateUserRiskPolicy,
+  getUserRiskEvaluation,
   getUserRiskDetail,
+  getUserRiskOrgMembership,
   listUserRiskEvents,
   listUserRiskScores,
   updateUserRiskPolicy
 } from '../services/userRiskScoring';
 import { resolveOrgAccess } from '../middleware/auth';
+import { emitUserRiskFeedback } from '../services/mlFeedbackEmitters';
 
 const ORG_ID = '00000000-0000-0000-0000-000000000001';
 const ORG_ID_2 = '00000000-0000-0000-0000-000000000002';
@@ -165,6 +173,76 @@ describe('userRiskRoutes', () => {
     expect(body.pagination.total).toBe(1);
   });
 
+  it('GET /evaluation returns label quality metrics', async () => {
+    vi.mocked(getUserRiskEvaluation).mockResolvedValue({
+      windowDays: 30,
+      totalLabels: 4,
+      truePositives: 3,
+      falsePositives: 1,
+      precision: 0.75,
+      trainingAssigned: 2,
+      trainingCompleted: 1,
+      trainingCompletionRate: 0.5,
+      riskSignals: 12,
+      usersWithRiskSignals: 5,
+      repeatSignalUsers: 2,
+      repeatSignalRate: 0.4
+    });
+
+    const app = buildApp();
+    const res = await app.request('/user-risk/evaluation?days=14');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.precision).toBe(0.75);
+    expect(getUserRiskEvaluation).toHaveBeenCalledWith({
+      orgIds: [ORG_ID],
+      days: 14
+    });
+  });
+
+  it('GET /evaluation returns 403 for inaccessible org filter', async () => {
+    const app = buildApp();
+    const res = await app.request(`/user-risk/evaluation?orgId=${ORG_ID_2}`);
+    expect(res.status).toBe(403);
+    expect(getUserRiskEvaluation).not.toHaveBeenCalled();
+  });
+
+  it('POST /users/:userId/feedback records a true-positive label', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(true);
+    vi.mocked(emitUserRiskFeedback).mockResolvedValue(undefined);
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}/feedback`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ outcome: 'true_positive', score: 88, reason: 'confirmed_incident' })
+    });
+
+    expect(res.status).toBe(200);
+    expect(emitUserRiskFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_ID,
+      userId: USER_ID,
+      eventType: 'user_risk.true_positive',
+      outcome: 'true_positive',
+      actorUserId: '00000000-0000-0000-0000-000000000099'
+    }));
+  });
+
+  it('POST /users/:userId/feedback returns 404 for a user outside the org', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(false);
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}/feedback`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ outcome: 'false_positive' })
+    });
+
+    expect(res.status).toBe(404);
+    expect(emitUserRiskFeedback).not.toHaveBeenCalled();
+  });
+
   it('PUT /policy updates policy', async () => {
     vi.mocked(updateUserRiskPolicy).mockResolvedValue({
       orgId: ORG_ID,
@@ -221,5 +299,11 @@ describe('userRiskRoutes', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.assignmentEventId).toBeDefined();
+    expect(emitUserRiskFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_ID,
+      userId: USER_ID,
+      eventType: 'training.assigned',
+      outcome: 'assigned'
+    }));
   });
 });

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -6,6 +6,7 @@ import { authMiddleware, requirePermission, requireScope, resolveOrgAccess } fro
 import { writeRouteAudit } from '../services/auditEvents';
 import {
   assignSecurityTraining,
+  getUserRiskEvaluation,
   getUserRiskDetail,
   getUserRiskOrgMembership,
   getOrCreateUserRiskPolicy,
@@ -13,6 +14,7 @@ import {
   listUserRiskScores,
   updateUserRiskPolicy
 } from '../services/userRiskScoring';
+import { emitUserRiskFeedback } from '../services/mlFeedbackEmitters';
 
 const listScoresQuerySchema = z.object({
   orgId: z.string().uuid().optional(),
@@ -44,6 +46,11 @@ const eventsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(500).default(50)
 });
 
+const evaluationQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  days: z.coerce.number().int().min(1).max(365).default(30)
+});
+
 const policyPayloadSchema = z.object({
   orgId: z.string().uuid().optional(),
   weights: z.record(z.string(), z.number().min(0)).optional(),
@@ -56,6 +63,15 @@ const assignTrainingSchema = z.object({
   userId: z.string().uuid(),
   moduleId: z.string().min(1).max(120).optional(),
   reason: z.string().min(1).max(500).optional()
+});
+
+const feedbackPayloadSchema = z.object({
+  orgId: z.string().uuid().optional(),
+  outcome: z.enum(['true_positive', 'false_positive']),
+  note: z.string().trim().max(1000).optional(),
+  sourceEventId: z.string().uuid().optional(),
+  score: z.number().int().min(0).max(100).optional(),
+  reason: z.string().trim().max(120).optional()
 });
 
 function resolveWriteOrgId(
@@ -252,6 +268,92 @@ userRiskRoutes.get(
   }
 );
 
+userRiskRoutes.get(
+  '/evaluation',
+  requirePermission('users', 'read'),
+  zValidator('query', evaluationQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Access denied to this organization' }, 403);
+    }
+
+    const orgIds = query.orgId
+      ? [query.orgId]
+      : auth.orgId
+        ? [auth.orgId]
+        : (auth.accessibleOrgIds?.length ? auth.accessibleOrgIds : undefined);
+
+    if (!orgIds && auth.scope !== 'system') {
+      return c.json({ error: 'Organization context required' }, 400);
+    }
+
+    const evaluation = await getUserRiskEvaluation({
+      orgIds,
+      days: query.days
+    });
+
+    return c.json({ data: evaluation });
+  }
+);
+
+userRiskRoutes.post(
+  '/users/:userId/feedback',
+  requirePermission('users', 'write'),
+  zValidator('param', detailParamSchema),
+  zValidator('json', feedbackPayloadSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { userId } = c.req.valid('param');
+    const payload = c.req.valid('json');
+
+    const resolved = resolveWriteOrgId(auth, payload.orgId);
+    if (!resolved.orgId) {
+      return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
+    }
+
+    const isMember = await getUserRiskOrgMembership(userId, resolved.orgId);
+    if (!isMember) {
+      return c.json({ error: 'User not found in this organization' }, 404);
+    }
+
+    const eventType = payload.outcome === 'true_positive'
+      ? 'user_risk.true_positive'
+      : 'user_risk.false_positive';
+
+    await emitUserRiskFeedback({
+      orgId: resolved.orgId,
+      userId,
+      eventType,
+      outcome: payload.outcome,
+      actorUserId: auth.user.id,
+      metadata: {
+        source: 'user_risk_review',
+        sourceEventId: payload.sourceEventId ?? null,
+        score: payload.score ?? null,
+        reason: payload.reason ?? null,
+        note: payload.note ?? null
+      }
+    });
+
+    writeRouteAudit(c, {
+      orgId: resolved.orgId,
+      action: eventType,
+      resourceType: 'user',
+      resourceId: userId,
+      details: {
+        outcome: payload.outcome,
+        sourceEventId: payload.sourceEventId ?? null,
+        reason: payload.reason ?? null
+      }
+    });
+
+    return c.json({ success: true, eventType });
+  }
+);
+
 userRiskRoutes.put(
   '/policy',
   requirePermission('users', 'write'),
@@ -320,6 +422,22 @@ userRiskRoutes.post(
       reason: payload.reason,
       assignedBy: auth.user.id
     });
+
+    if (!assignment.deduplicated) {
+      await emitUserRiskFeedback({
+        orgId: resolved.orgId,
+        userId: payload.userId,
+        eventType: 'training.assigned',
+        outcome: 'assigned',
+        actorUserId: auth.user.id,
+        metadata: {
+          source: 'user_risk_training_assignment',
+          assignmentEventId: assignment.assignmentEventId,
+          moduleId: assignment.moduleId,
+          reason: payload.reason ?? null
+        }
+      });
+    }
 
     writeRouteAudit(c, {
       orgId: resolved.orgId,

--- a/apps/api/src/services/mlFeedbackEmitters.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.ts
@@ -161,3 +161,24 @@ export async function emitTicketTriageFeedback(options: {
     occurredAt: options.occurredAt ?? new Date(),
   }, options.eventType);
 }
+
+export async function emitUserRiskFeedback(options: {
+  orgId: string;
+  userId: string;
+  eventType: 'user_risk.true_positive' | 'user_risk.false_positive' | 'training.assigned' | 'training.completed';
+  outcome: 'true_positive' | 'false_positive' | 'assigned' | 'completed';
+  actorUserId?: string | null;
+  occurredAt?: Date;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await emitMlFeedbackEvent({
+    orgId: options.orgId,
+    sourceType: 'user_risk',
+    sourceId: options.userId,
+    eventType: options.eventType,
+    outcome: options.outcome,
+    actorUserId: actorUserIdOrNull(options.actorUserId),
+    metadata: options.metadata ?? {},
+    occurredAt: options.occurredAt ?? new Date(),
+  });
+}

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -17,6 +17,7 @@ import {
   auditLogs,
   deviceSessions,
   devices,
+  mlFeedbackEvents,
   organizationUsers,
   securityPostureSnapshots,
   securityThreats,
@@ -282,6 +283,27 @@ export type UserRiskEventFilter = {
   to?: Date;
   limit?: number;
   offset?: number;
+};
+
+export type UserRiskEvaluationFilter = {
+  orgIds?: string[];
+  orgId?: string;
+  days?: number;
+};
+
+export type UserRiskEvaluation = {
+  windowDays: number;
+  totalLabels: number;
+  truePositives: number;
+  falsePositives: number;
+  precision: number | null;
+  trainingAssigned: number;
+  trainingCompleted: number;
+  trainingCompletionRate: number | null;
+  riskSignals: number;
+  usersWithRiskSignals: number;
+  repeatSignalUsers: number;
+  repeatSignalRate: number | null;
 };
 
 type ComputedUserRisk = {
@@ -1198,6 +1220,76 @@ export async function listUserRiskEvents(filter: UserRiskEventFilter): Promise<{
       details: (row.details as Record<string, unknown> | null) ?? null,
       occurredAt: row.occurredAt.toISOString()
     }))
+  };
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 1000) / 1000;
+}
+
+export async function getUserRiskEvaluation(filter: UserRiskEvaluationFilter): Promise<UserRiskEvaluation> {
+  const days = Math.min(Math.max(1, filter.days ?? 30), 365);
+  const since = new Date(Date.now() - days * DAY_MS);
+
+  const feedbackConditions: SQL[] = [
+    eq(mlFeedbackEvents.sourceType, 'user_risk'),
+    gte(mlFeedbackEvents.occurredAt, since)
+  ];
+  const riskEventConditions: SQL[] = [
+    gte(userRiskEvents.occurredAt, since)
+  ];
+
+  if (filter.orgId) {
+    feedbackConditions.push(eq(mlFeedbackEvents.orgId, filter.orgId));
+    riskEventConditions.push(eq(userRiskEvents.orgId, filter.orgId));
+  } else if (filter.orgIds && filter.orgIds.length > 0) {
+    feedbackConditions.push(inArray(mlFeedbackEvents.orgId, filter.orgIds));
+    riskEventConditions.push(inArray(userRiskEvents.orgId, filter.orgIds));
+  }
+
+  const [feedbackRows, signalRows] = await Promise.all([
+    db
+      .select({
+        eventType: mlFeedbackEvents.eventType,
+        count: sql<number>`count(*)::int`
+      })
+      .from(mlFeedbackEvents)
+      .where(and(...feedbackConditions))
+      .groupBy(mlFeedbackEvents.eventType),
+    db
+      .select({
+        userId: userRiskEvents.userId,
+        count: sql<number>`count(*)::int`
+      })
+      .from(userRiskEvents)
+      .where(and(...riskEventConditions))
+      .groupBy(userRiskEvents.userId)
+  ]);
+
+  const countByEventType = new Map(feedbackRows.map((row) => [row.eventType, Number(row.count) || 0]));
+  const truePositives = countByEventType.get('user_risk.true_positive') ?? 0;
+  const falsePositives = countByEventType.get('user_risk.false_positive') ?? 0;
+  const trainingAssigned = countByEventType.get('training.assigned') ?? 0;
+  const trainingCompleted = countByEventType.get('training.completed') ?? 0;
+  const totalLabels = truePositives + falsePositives;
+  const riskSignals = signalRows.reduce((sum, row) => sum + (Number(row.count) || 0), 0);
+  const usersWithRiskSignals = signalRows.length;
+  const repeatSignalUsers = signalRows.filter((row) => (Number(row.count) || 0) > 1).length;
+
+  return {
+    windowDays: days,
+    totalLabels,
+    truePositives,
+    falsePositives,
+    precision: totalLabels > 0 ? roundMetric(truePositives / totalLabels) : null,
+    trainingAssigned,
+    trainingCompleted,
+    trainingCompletionRate: trainingAssigned > 0 ? roundMetric(trainingCompleted / trainingAssigned) : null,
+    riskSignals,
+    usersWithRiskSignals,
+    repeatSignalUsers,
+    repeatSignalRate: usersWithRiskSignals > 0 ? roundMetric(repeatSignalUsers / usersWithRiskSignals) : null
   };
 }
 

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -39,6 +39,7 @@ import {
   X,
   Cloud,
   ShieldEllipsis,
+  UserCheck,
   UserX,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -150,6 +151,7 @@ export const navSections: NavSection[] = [
       { name: 'Security', href: '/security', icon: ShieldCheck },
       { name: 'DNS Security', href: '/dns-security', icon: Network },
       { name: 'PAM', href: '/pam', icon: KeyRound },
+      { name: 'User Risk', href: '/security/user-risk', icon: UserCheck },
       { name: 'Sensitive Data', href: '/sensitive-data', icon: ScanSearch },
       { name: 'Peripherals', href: '/peripherals', icon: Usb },
       { name: 'AI Risk Engine', href: '/ai-risk', icon: BrainCircuit },

--- a/apps/web/src/components/security/UserRiskPage.test.tsx
+++ b/apps/web/src/components/security/UserRiskPage.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UserRiskPage from './UserRiskPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+const showToast = vi.fn();
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: (input: unknown) => showToast(input),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const response = (payload: unknown, ok = true, status = ok ? 200 : 500): Response => ({
+  ok,
+  status,
+  statusText: ok ? 'OK' : 'ERROR',
+  json: vi.fn().mockResolvedValue(payload),
+}) as unknown as Response;
+
+const scorePayload = {
+  data: [
+    {
+      orgId: '00000000-0000-4000-8000-000000000001',
+      userId: '00000000-0000-4000-8000-000000000010',
+      userName: 'Alice Admin',
+      userEmail: 'alice@example.com',
+      score: 88,
+      trendDirection: 'up',
+      calculatedAt: '2026-06-18T12:00:00.000Z',
+      factors: { authFailureRisk: 90, mfaRisk: 10 },
+    },
+  ],
+};
+
+const evaluationPayload = {
+  data: {
+    windowDays: 30,
+    totalLabels: 4,
+    truePositives: 3,
+    falsePositives: 1,
+    precision: 0.75,
+    trainingAssigned: 2,
+    trainingCompleted: 1,
+    trainingCompletionRate: 0.5,
+    riskSignals: 7,
+    usersWithRiskSignals: 3,
+    repeatSignalUsers: 2,
+    repeatSignalRate: 0.667,
+  },
+};
+
+const detailPayload = {
+  data: {
+    user: {
+      id: '00000000-0000-4000-8000-000000000010',
+      name: 'Alice Admin',
+      email: 'alice@example.com',
+    },
+    latestScore: {
+      score: 88,
+      severity: 'critical',
+      factors: { authFailureRisk: 90, sessionAnomalyRisk: 55 },
+      calculatedAt: '2026-06-18T12:00:00.000Z',
+    },
+    recentEvents: [
+      {
+        id: 'evt-1',
+        eventType: 'auth_failure_burst',
+        severity: 'high',
+        scoreImpact: 12,
+        description: 'Multiple failed sign-in attempts',
+        occurredAt: '2026-06-18T11:00:00.000Z',
+      },
+    ],
+  },
+};
+
+describe('UserRiskPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    showToast.mockReset();
+  });
+
+  it('renders scores, evaluation metrics, and selected user evidence', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(scorePayload))
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(detailPayload));
+
+    render(<UserRiskPage />);
+
+    await screen.findByTestId('user-risk-page');
+    expect(screen.getAllByText('Alice Admin')).toHaveLength(2);
+    expect(screen.getByText('75%')).toBeTruthy();
+    expect(screen.getByText('Multiple failed sign-in attempts')).toBeTruthy();
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/user-risk/scores?limit=25&minScore=50');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/user-risk/evaluation?days=30');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/user-risk/users/00000000-0000-4000-8000-000000000010?orgId=00000000-0000-4000-8000-000000000001');
+  });
+
+  it('posts false-positive feedback through runAction', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(scorePayload))
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(detailPayload))
+      .mockResolvedValueOnce(response({ success: true }))
+      .mockResolvedValueOnce(response(scorePayload))
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(detailPayload));
+
+    render(<UserRiskPage />);
+
+    const button = await screen.findByRole('button', { name: /false positive/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/user-risk/users/00000000-0000-4000-8000-000000000010/feedback',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            orgId: '00000000-0000-4000-8000-000000000001',
+            outcome: 'false_positive',
+            score: 88,
+          }),
+        }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'False positive label saved',
+    }));
+  });
+});

--- a/apps/web/src/components/security/UserRiskPage.tsx
+++ b/apps/web/src/components/security/UserRiskPage.tsx
@@ -1,0 +1,363 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, ShieldAlert, UserCheck, XCircle } from 'lucide-react';
+
+import { runAction, handleActionError } from '../../lib/runAction';
+import { fetchWithAuth } from '../../stores/auth';
+
+type UserRiskScore = {
+  orgId: string;
+  userId: string;
+  userName: string;
+  userEmail: string;
+  score: number;
+  trendDirection: 'up' | 'down' | 'stable' | null;
+  calculatedAt: string;
+  factors: Record<string, number>;
+};
+
+type UserRiskEvent = {
+  id: string;
+  eventType: string;
+  severity: string | null;
+  scoreImpact: number;
+  description: string;
+  occurredAt: string;
+};
+
+type UserRiskDetail = {
+  user: {
+    id: string;
+    name: string;
+    email: string;
+  };
+  latestScore: {
+    score: number;
+    severity: 'low' | 'medium' | 'high' | 'critical';
+    factors: Record<string, number>;
+    calculatedAt: string;
+  };
+  recentEvents: UserRiskEvent[];
+};
+
+type Evaluation = {
+  windowDays: number;
+  totalLabels: number;
+  truePositives: number;
+  falsePositives: number;
+  precision: number | null;
+  trainingAssigned: number;
+  trainingCompleted: number;
+  trainingCompletionRate: number | null;
+  riskSignals: number;
+  usersWithRiskSignals: number;
+  repeatSignalUsers: number;
+  repeatSignalRate: number | null;
+};
+
+const scoreTextClass = (score: number): string => {
+  if (score >= 85) return 'text-red-700';
+  if (score >= 70) return 'text-orange-700';
+  if (score >= 50) return 'text-amber-700';
+  return 'text-emerald-700';
+};
+
+const scoreBarClass = (score: number): string => {
+  if (score >= 85) return 'bg-red-500';
+  if (score >= 70) return 'bg-orange-500';
+  if (score >= 50) return 'bg-amber-500';
+  return 'bg-emerald-500';
+};
+
+const severityClass = (severity: string | null): string => {
+  if (severity === 'critical') return 'border-red-500/40 bg-red-500/10 text-red-700';
+  if (severity === 'high') return 'border-orange-500/40 bg-orange-500/10 text-orange-700';
+  if (severity === 'medium') return 'border-amber-500/40 bg-amber-500/10 text-amber-700';
+  return 'border-blue-500/40 bg-blue-500/10 text-blue-700';
+};
+
+const formatPercent = (value: number | null): string => (
+  value === null ? 'n/a' : `${Math.round(value * 100)}%`
+);
+
+const formatDate = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+};
+
+const formatFactor = (value: string): string => (
+  value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .toLowerCase()
+);
+
+export default function UserRiskPage() {
+  const [scores, setScores] = useState<UserRiskScore[]>([]);
+  const [detail, setDetail] = useState<UserRiskDetail | null>(null);
+  const [evaluation, setEvaluation] = useState<Evaluation | null>(null);
+  const [selected, setSelected] = useState<UserRiskScore | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [labeling, setLabeling] = useState<'true_positive' | 'false_positive' | null>(null);
+
+  const loadScores = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [scoresResponse, evaluationResponse] = await Promise.all([
+        fetchWithAuth('/user-risk/scores?limit=25&minScore=50'),
+        fetchWithAuth('/user-risk/evaluation?days=30'),
+      ]);
+      if (!scoresResponse.ok) throw new Error('Failed to load user risk scores');
+      if (!evaluationResponse.ok) throw new Error('Failed to load user risk evaluation');
+      const scoresJson = await scoresResponse.json();
+      const evaluationJson = await evaluationResponse.json();
+      const rows = Array.isArray(scoresJson?.data) ? scoresJson.data as UserRiskScore[] : [];
+      setScores(rows);
+      setEvaluation(evaluationJson?.data ?? null);
+      setSelected((current) => current ?? rows[0] ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load user risk');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadScores();
+  }, [loadScores]);
+
+  useEffect(() => {
+    if (!selected) {
+      setDetail(null);
+      return;
+    }
+
+    let active = true;
+    setDetailLoading(true);
+    fetchWithAuth(`/user-risk/users/${selected.userId}?orgId=${selected.orgId}`)
+      .then(async (response) => {
+        if (!response.ok) throw new Error('Failed to load user risk detail');
+        const json = await response.json();
+        if (active) setDetail(json?.data ?? null);
+      })
+      .catch((err) => {
+        if (active) setError(err instanceof Error ? err.message : 'Failed to load user risk detail');
+      })
+      .finally(() => {
+        if (active) setDetailLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [selected]);
+
+  const factors = useMemo(() => (
+    Object.entries(detail?.latestScore.factors ?? selected?.factors ?? {})
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+  ), [detail?.latestScore.factors, selected?.factors]);
+
+  async function submitLabel(outcome: 'true_positive' | 'false_positive') {
+    if (!selected) return;
+    setLabeling(outcome);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/user-risk/users/${selected.userId}/feedback`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            orgId: selected.orgId,
+            outcome,
+            score: selected.score,
+          }),
+        }),
+        errorFallback: 'Could not save user risk feedback',
+        successMessage: outcome === 'true_positive' ? 'True positive label saved' : 'False positive label saved',
+      });
+      await loadScores();
+    } catch (err) {
+      handleActionError(err, 'Could not save user risk feedback');
+    } finally {
+      setLabeling(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[420px] items-center justify-center" data-testid="user-risk-loading">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-5 text-sm text-destructive">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4" />
+          <span>{error}</span>
+        </div>
+        <button type="button" onClick={() => void loadScores()} className="mt-4 inline-flex items-center gap-2 rounded-md border px-3 py-2 text-xs font-medium">
+          <RefreshCw className="h-4 w-4" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5" data-testid="user-risk-page">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-normal">User Risk</h1>
+          <p className="text-sm text-muted-foreground">Review rules-v0 risk scores, evidence, and evaluation labels.</p>
+        </div>
+        <button type="button" onClick={() => void loadScores()} className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted">
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
+      </header>
+
+      <section className="grid gap-3 md:grid-cols-4">
+        <MetricCard label="Precision" value={formatPercent(evaluation?.precision ?? null)} />
+        <MetricCard label="Labels" value={`${evaluation?.totalLabels ?? 0}`} />
+        <MetricCard label="Training completion" value={formatPercent(evaluation?.trainingCompletionRate ?? null)} />
+        <MetricCard label="Repeat signal users" value={`${evaluation?.repeatSignalUsers ?? 0}`} />
+      </section>
+
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.35fr)]">
+        <section className="rounded-lg border bg-card">
+          <div className="border-b p-4">
+            <h2 className="text-sm font-semibold">At-risk users</h2>
+          </div>
+          <div className="max-h-[620px] divide-y overflow-y-auto">
+            {scores.length === 0 ? (
+              <div className="p-5 text-sm text-muted-foreground">No users are above the current risk threshold.</div>
+            ) : scores.map((score) => (
+              <button
+                key={`${score.orgId}:${score.userId}`}
+                type="button"
+                onClick={() => setSelected(score)}
+                className={`block w-full p-4 text-left hover:bg-muted/60 ${selected?.userId === score.userId && selected.orgId === score.orgId ? 'bg-muted' : ''}`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{score.userName}</div>
+                    <div className="truncate text-xs text-muted-foreground">{score.userEmail}</div>
+                  </div>
+                  <div className={`text-xl font-semibold ${scoreTextClass(score.score)}`}>{score.score}</div>
+                </div>
+                <div className="mt-3 h-2 rounded-full bg-muted">
+                  <div className={`h-2 rounded-full ${scoreBarClass(score.score)}`} style={{ width: `${score.score}%` }} />
+                </div>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-lg border bg-card">
+          {!selected ? (
+            <div className="p-6 text-sm text-muted-foreground">Select a user to inspect risk evidence.</div>
+          ) : (
+            <div className="space-y-5 p-5">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <ShieldAlert className="h-5 w-5 text-orange-600" />
+                    <h2 className="text-lg font-semibold">{detail?.user.name ?? selected.userName}</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{detail?.user.email ?? selected.userEmail}</p>
+                </div>
+                <span className={`rounded-full border px-2.5 py-1 text-xs font-medium ${severityClass(detail?.latestScore.severity ?? null)}`}>
+                  {detail?.latestScore.severity ?? 'score'} {detail?.latestScore.score ?? selected.score}
+                </span>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => void submitLabel('true_positive')}
+                  disabled={labeling !== null}
+                  className="inline-flex items-center gap-2 rounded-md border border-emerald-500/40 px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-500/10 disabled:opacity-60"
+                >
+                  {labeling === 'true_positive' ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                  True positive
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void submitLabel('false_positive')}
+                  disabled={labeling !== null}
+                  className="inline-flex items-center gap-2 rounded-md border border-slate-400/50 px-3 py-2 text-sm font-medium hover:bg-muted disabled:opacity-60"
+                >
+                  {labeling === 'false_positive' ? <Loader2 className="h-4 w-4 animate-spin" /> : <XCircle className="h-4 w-4" />}
+                  False positive
+                </button>
+              </div>
+
+              <div>
+                <h3 className="mb-3 text-sm font-semibold">Top drivers</h3>
+                <div className="space-y-3">
+                  {factors.map(([factor, value]) => (
+                    <div key={factor}>
+                      <div className="mb-1 flex items-center justify-between gap-3 text-xs">
+                        <span className="capitalize text-muted-foreground">{formatFactor(factor)}</span>
+                        <span className="font-medium">{value}</span>
+                      </div>
+                      <div className="h-2 rounded-full bg-muted">
+                        <div className={`h-2 rounded-full ${scoreBarClass(value)}`} style={{ width: `${value}%` }} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="mb-3 text-sm font-semibold">Recent evidence</h3>
+                {detailLoading ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading evidence
+                  </div>
+                ) : detail?.recentEvents?.length ? (
+                  <div className="space-y-2">
+                    {detail.recentEvents.slice(0, 6).map((event) => (
+                      <div key={event.id} className="rounded-md border p-3">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <span className="text-sm font-medium">{event.description}</span>
+                          <span className={`rounded-full border px-2 py-0.5 text-xs ${severityClass(event.severity)}`}>{event.severity ?? 'info'}</span>
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                          <span>{event.eventType}</span>
+                          <span>{formatDate(event.occurredAt)}</span>
+                          <span>{event.scoreImpact >= 0 ? '+' : ''}{event.scoreImpact} impact</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="rounded-md border p-3 text-sm text-muted-foreground">No recent evidence found for this score.</div>
+                )}
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <UserCheck className="h-4 w-4" />
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold">{value}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/security/index.ts
+++ b/apps/web/src/components/security/index.ts
@@ -14,4 +14,5 @@ export { default as SecurityStatCard } from './SecurityStatCard';
 export { default as ThreatDetail } from './ThreatDetail';
 export { default as ThreatList } from './ThreatList';
 export { default as TrendsPage } from './TrendsPage';
+export { default as UserRiskPage } from './UserRiskPage';
 export { default as VulnerabilitiesPage } from './VulnerabilitiesPage';

--- a/apps/web/src/pages/security/user-risk.astro
+++ b/apps/web/src/pages/security/user-risk.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import UserRiskPage from '../../components/security/UserRiskPage';
+---
+
+<DashboardLayout title="User Risk">
+  <UserRiskPage client:load />
+</DashboardLayout>


### PR DESCRIPTION
## Summary
- add user-risk evaluation metrics from `ml_feedback_events` and recent risk signals
- add true-positive/false-positive user-risk labels and emit `training.assigned` feedback for manual training assignment
- add a Security > User Risk page for inspecting scores, drivers, evidence, and submitting labels

## Validation
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/routes/userRisk.test.ts src/services/userRiskScoring.test.ts src/services/mlFeedback.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/web exec vitest run src/components/security/UserRiskPage.test.tsx src/lib/__tests__/no-silent-mutations.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit`
- `/usr/local/bin/corepack pnpm --filter @breeze/web exec tsc --noEmit`
- `git diff --check`

## Notes
- `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze /usr/local/bin/corepack pnpm --filter @breeze/api db:check-drift` reaches local Postgres but fails with `role "breeze" does not exist` in this environment.