### PR TITLE
feat(ml): add user risk signal ingestion

### DIFF
--- a/apps/api/src/jobs/userRiskJobs.test.ts
+++ b/apps/api/src/jobs/userRiskJobs.test.ts
@@ -44,6 +44,10 @@ vi.mock('../services/userRiskScoring', () => ({
   publishUserRiskScoreEvents: vi.fn(),
 }));
 
+vi.mock('../services/userRiskSignals', () => ({
+  evaluateUserRiskSignalsForOrg: vi.fn(),
+}));
+
 import {
   enqueueUserRiskSignalEvent,
   shutdownUserRiskJobs,

--- a/apps/api/src/jobs/userRiskJobs.ts
+++ b/apps/api/src/jobs/userRiskJobs.ts
@@ -10,6 +10,7 @@ import {
   computeAndPersistOrgUserRisk,
   publishUserRiskScoreEvents
 } from '../services/userRiskScoring';
+import { evaluateUserRiskSignalsForOrg } from '../services/userRiskSignals';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
 
@@ -144,10 +145,13 @@ async function processComputeOrg(data: ComputeOrgJobData): Promise<{
   usersProcessed: number;
   changedUsers: number;
   autoTrainingAssigned: number;
+  signalsAppended: number;
+  signalsDeduped: number;
   publishedHigh: number;
   publishedSpikes: number;
   publishFailures: number;
 }> {
+  const signalEvaluation = await evaluateUserRiskSignalsForOrg(data.orgId);
   const result = await computeAndPersistOrgUserRisk(data.orgId);
   const published = await publishUserRiskScoreEvents({
     orgId: data.orgId,
@@ -161,6 +165,8 @@ async function processComputeOrg(data: ComputeOrgJobData): Promise<{
     usersProcessed: result.usersProcessed,
     changedUsers: result.changedUsers.length,
     autoTrainingAssigned: result.autoTrainingAssigned,
+    signalsAppended: signalEvaluation.appended,
+    signalsDeduped: signalEvaluation.deduped,
     publishedHigh: published.publishedHigh,
     publishedSpikes: published.publishedSpikes,
     publishFailures: published.failed

--- a/apps/api/src/services/userRiskSignals.test.ts
+++ b/apps/api/src/services/userRiskSignals.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  appendUserRiskSignalEventMock: vi.fn(),
+  resolveMlFeatureFlagForOrgMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    execute: mocks.executeMock,
+  },
+}));
+
+vi.mock('./userRiskScoring', () => ({
+  appendUserRiskSignalEvent: mocks.appendUserRiskSignalEventMock,
+}));
+
+vi.mock('./mlFeatureFlags', () => ({
+  resolveMlFeatureFlagForOrg: mocks.resolveMlFeatureFlagForOrgMock,
+}));
+
+import { evaluateUserRiskSignalsForOrg } from './userRiskSignals';
+
+const ORG_ID = '00000000-0000-4000-8000-000000000001';
+const USER_ID = '00000000-0000-4000-8000-000000000010';
+
+describe('userRiskSignals', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00.000Z'));
+    mocks.executeMock.mockReset();
+    mocks.appendUserRiskSignalEventMock.mockReset();
+    mocks.resolveMlFeatureFlagForOrgMock.mockReset();
+    mocks.resolveMlFeatureFlagForOrgMock.mockResolvedValue({
+      flag: 'ml.user_risk_v0.enabled',
+      enabled: true,
+      defaultEnabled: true,
+      source: 'default',
+    });
+    mocks.appendUserRiskSignalEventMock.mockResolvedValue('event-1');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('skips scanning when user-risk v0 is disabled', async () => {
+    mocks.resolveMlFeatureFlagForOrgMock.mockResolvedValue({
+      flag: 'ml.user_risk_v0.enabled',
+      enabled: false,
+      defaultEnabled: true,
+      source: 'org_settings',
+    });
+
+    const result = await evaluateUserRiskSignalsForOrg(ORG_ID);
+
+    expect(result.skipped).toBe(true);
+    expect(result.appended).toBe(0);
+    expect(mocks.executeMock).not.toHaveBeenCalled();
+    expect(mocks.appendUserRiskSignalEventMock).not.toHaveBeenCalled();
+  });
+
+  it('appends off-hours script, remote-session, and elevation burst signals', async () => {
+    mocks.executeMock
+      .mockResolvedValueOnce([
+        {
+          batch_id: '00000000-0000-4000-8000-000000000111',
+          user_id: USER_ID,
+          script_id: '00000000-0000-4000-8000-000000000222',
+          devices_targeted: 14,
+          created_at: new Date('2026-06-18T03:00:00.000Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          user_id: USER_ID,
+          session_count: 6,
+          latest_at: new Date('2026-06-18T11:00:00.000Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          user_id: USER_ID,
+          request_count: 3,
+          approved_count: 2,
+          latest_at: new Date('2026-06-18T10:00:00.000Z'),
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const result = await evaluateUserRiskSignalsForOrg(ORG_ID, { lookbackHours: 24 });
+
+    expect(result).toMatchObject({
+      orgId: ORG_ID,
+      skipped: false,
+      appended: 3,
+      deduped: 0,
+      candidates: {
+        offHoursMassScripts: 1,
+        remoteSessionBursts: 1,
+        privilegeElevationBursts: 1,
+      },
+    });
+    expect(mocks.appendUserRiskSignalEventMock).toHaveBeenCalledTimes(3);
+    expect(mocks.appendUserRiskSignalEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'script.off_hours_mass_execution',
+      severity: 'high',
+      userId: USER_ID,
+      details: expect.objectContaining({
+        batchId: '00000000-0000-4000-8000-000000000111',
+        devicesTargeted: 14,
+      }),
+    }));
+    expect(mocks.appendUserRiskSignalEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'remote_session_burst',
+      severity: 'medium',
+      userId: USER_ID,
+    }));
+    expect(mocks.appendUserRiskSignalEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'privilege_elevation_burst',
+      severity: 'medium',
+      userId: USER_ID,
+    }));
+  });
+
+  it('does not append an event when the same fingerprint already exists', async () => {
+    mocks.executeMock
+      .mockResolvedValueOnce([
+        {
+          batch_id: '00000000-0000-4000-8000-000000000111',
+          user_id: USER_ID,
+          script_id: '00000000-0000-4000-8000-000000000222',
+          devices_targeted: 20,
+          created_at: new Date('2026-06-18T02:00:00.000Z'),
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'existing-event' }]);
+
+    const result = await evaluateUserRiskSignalsForOrg(ORG_ID);
+
+    expect(result.appended).toBe(0);
+    expect(result.deduped).toBe(1);
+    expect(mocks.appendUserRiskSignalEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/userRiskSignals.ts
+++ b/apps/api/src/services/userRiskSignals.ts
@@ -1,0 +1,262 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '../db';
+import { appendUserRiskSignalEvent } from './userRiskScoring';
+import { resolveMlFeatureFlagForOrg } from './mlFeatureFlags';
+
+const DEFAULT_LOOKBACK_HOURS = 24;
+const OFF_HOURS_MASS_SCRIPT_TARGETS = 10;
+const REMOTE_SESSION_BURST_COUNT = 5;
+const ELEVATION_BURST_COUNT = 3;
+
+type OffHoursScriptRow = {
+  batch_id: string;
+  user_id: string;
+  script_id: string;
+  devices_targeted: number | string;
+  created_at: Date | string;
+};
+
+type RemoteSessionBurstRow = {
+  user_id: string;
+  session_count: number | string;
+  latest_at: Date | string;
+};
+
+type ElevationBurstRow = {
+  user_id: string;
+  request_count: number | string;
+  approved_count: number | string;
+  latest_at: Date | string;
+};
+
+export type UserRiskSignalEvaluationResult = {
+  orgId: string;
+  skipped: boolean;
+  appended: number;
+  deduped: number;
+  candidates: {
+    offHoursMassScripts: number;
+    remoteSessionBursts: number;
+    privilegeElevationBursts: number;
+  };
+};
+
+function toInt(value: number | string | null | undefined): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function windowKey(date: Date, hours: number): string {
+  const widthMs = Math.max(1, hours) * 60 * 60 * 1000;
+  return new Date(Math.floor(date.getTime() / widthMs) * widthMs).toISOString();
+}
+
+async function hasExistingSignal(input: {
+  orgId: string;
+  userId: string;
+  eventType: string;
+  fingerprint: string;
+  sinceIso: string;
+}): Promise<boolean> {
+  const rows = await db.execute(sql`
+    SELECT id
+    FROM user_risk_events
+    WHERE org_id = ${input.orgId}
+      AND user_id = ${input.userId}
+      AND event_type = ${input.eventType}
+      AND occurred_at >= ${input.sinceIso}::timestamptz
+      AND details->>'fingerprint' = ${input.fingerprint}
+    LIMIT 1
+  `) as Array<{ id: string }>;
+  return rows.length > 0;
+}
+
+async function appendDedupedSignal(input: {
+  orgId: string;
+  userId: string;
+  eventType: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  scoreImpact: number;
+  description: string;
+  details: Record<string, unknown>;
+  occurredAt: Date;
+  sinceIso: string;
+}): Promise<'appended' | 'deduped'> {
+  const fingerprint = String(input.details.fingerprint ?? '');
+  if (fingerprint && await hasExistingSignal({
+    orgId: input.orgId,
+    userId: input.userId,
+    eventType: input.eventType,
+    fingerprint,
+    sinceIso: input.sinceIso,
+  })) {
+    return 'deduped';
+  }
+
+  await appendUserRiskSignalEvent({
+    orgId: input.orgId,
+    userId: input.userId,
+    eventType: input.eventType,
+    severity: input.severity,
+    scoreImpact: input.scoreImpact,
+    description: input.description,
+    details: input.details,
+    occurredAt: input.occurredAt,
+  });
+  return 'appended';
+}
+
+export async function evaluateUserRiskSignalsForOrg(
+  orgId: string,
+  options: { now?: Date; lookbackHours?: number } = {},
+): Promise<UserRiskSignalEvaluationResult> {
+  const flag = await resolveMlFeatureFlagForOrg(orgId, 'ml.user_risk_v0.enabled');
+  if (!flag.enabled) {
+    return {
+      orgId,
+      skipped: true,
+      appended: 0,
+      deduped: 0,
+      candidates: {
+        offHoursMassScripts: 0,
+        remoteSessionBursts: 0,
+        privilegeElevationBursts: 0,
+      },
+    };
+  }
+
+  const now = options.now ?? new Date();
+  const lookbackHours = Math.min(Math.max(1, options.lookbackHours ?? DEFAULT_LOOKBACK_HOURS), 168);
+  const since = new Date(now.getTime() - lookbackHours * 60 * 60 * 1000);
+  const sinceIso = since.toISOString();
+
+  const [scriptRows, remoteRows, elevationRows] = await Promise.all([
+    db.execute(sql`
+      SELECT id AS batch_id, triggered_by AS user_id, script_id, devices_targeted, created_at
+      FROM script_execution_batches
+      WHERE org_id = ${orgId}
+        AND triggered_by IS NOT NULL
+        AND trigger_type = 'manual'
+        AND devices_targeted >= ${OFF_HOURS_MASS_SCRIPT_TARGETS}
+        AND created_at >= ${sinceIso}::timestamptz
+        AND (EXTRACT(HOUR FROM created_at AT TIME ZONE 'UTC') < 6 OR EXTRACT(HOUR FROM created_at AT TIME ZONE 'UTC') >= 20)
+    `) as Promise<OffHoursScriptRow[]>,
+    db.execute(sql`
+      SELECT user_id, count(*)::int AS session_count, max(created_at) AS latest_at
+      FROM remote_sessions
+      WHERE org_id = ${orgId}
+        AND created_at >= ${sinceIso}::timestamptz
+      GROUP BY user_id
+      HAVING count(*) >= ${REMOTE_SESSION_BURST_COUNT}
+    `) as Promise<RemoteSessionBurstRow[]>,
+    db.execute(sql`
+      SELECT subject_user_id AS user_id,
+        count(*)::int AS request_count,
+        count(*) FILTER (WHERE status IN ('approved', 'auto_approved', 'actuating'))::int AS approved_count,
+        max(requested_at) AS latest_at
+      FROM elevation_requests
+      WHERE org_id = ${orgId}
+        AND subject_user_id IS NOT NULL
+        AND requested_at >= ${sinceIso}::timestamptz
+      GROUP BY subject_user_id
+      HAVING count(*) >= ${ELEVATION_BURST_COUNT}
+    `) as Promise<ElevationBurstRow[]>,
+  ]);
+
+  let appended = 0;
+  let deduped = 0;
+  const record = async (result: 'appended' | 'deduped') => {
+    if (result === 'appended') appended += 1;
+    else deduped += 1;
+  };
+
+  for (const row of scriptRows) {
+    const devicesTargeted = toInt(row.devices_targeted);
+    const occurredAt = toDate(row.created_at);
+    await record(await appendDedupedSignal({
+      orgId,
+      userId: row.user_id,
+      eventType: 'script.off_hours_mass_execution',
+      severity: devicesTargeted >= 25 ? 'critical' : 'high',
+      scoreImpact: Math.min(30, 10 + Math.ceil(devicesTargeted / 5)),
+      description: `Off-hours manual script execution targeted ${devicesTargeted} devices`,
+      details: {
+        fingerprint: `script-off-hours:${row.batch_id}`,
+        source: 'script_execution_batches',
+        batchId: row.batch_id,
+        scriptId: row.script_id,
+        devicesTargeted,
+        offHoursBasis: 'utc',
+      },
+      occurredAt,
+      sinceIso,
+    }));
+  }
+
+  for (const row of remoteRows) {
+    const count = toInt(row.session_count);
+    const latestAt = toDate(row.latest_at);
+    const key = windowKey(latestAt, lookbackHours);
+    await record(await appendDedupedSignal({
+      orgId,
+      userId: row.user_id,
+      eventType: 'remote_session_burst',
+      severity: count >= 10 ? 'high' : 'medium',
+      scoreImpact: Math.min(24, 6 + count * 2),
+      description: `${count} remote sessions started in the last ${lookbackHours} hours`,
+      details: {
+        fingerprint: `remote-session-burst:${orgId}:${row.user_id}:${key}`,
+        source: 'remote_sessions',
+        sessionCount: count,
+        lookbackHours,
+      },
+      occurredAt: latestAt,
+      sinceIso,
+    }));
+  }
+
+  for (const row of elevationRows) {
+    const requestCount = toInt(row.request_count);
+    const approvedCount = toInt(row.approved_count);
+    const latestAt = toDate(row.latest_at);
+    const key = windowKey(latestAt, lookbackHours);
+    await record(await appendDedupedSignal({
+      orgId,
+      userId: row.user_id,
+      eventType: 'privilege_elevation_burst',
+      severity: approvedCount >= ELEVATION_BURST_COUNT ? 'high' : 'medium',
+      scoreImpact: Math.min(28, 8 + requestCount * 4 + approvedCount * 2),
+      description: `${requestCount} privilege elevation requests in the last ${lookbackHours} hours`,
+      details: {
+        fingerprint: `privilege-elevation-burst:${orgId}:${row.user_id}:${key}`,
+        source: 'elevation_requests',
+        requestCount,
+        approvedCount,
+        lookbackHours,
+      },
+      occurredAt: latestAt,
+      sinceIso,
+    }));
+  }
+
+  return {
+    orgId,
+    skipped: false,
+    appended,
+    deduped,
+    candidates: {
+      offHoursMassScripts: scriptRows.length,
+      remoteSessionBursts: remoteRows.length,
+      privilegeElevationBursts: elevationRows.length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a feature-flagged user-risk signal evaluator for off-hours mass script execution, remote session bursts, and privilege elevation bursts
- append replay-safe `user_risk_events` with source fingerprints before org recompute jobs run
- cover disabled-flag behavior, signal emission, and dedupe behavior with focused service tests

## Validation
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/services/userRiskSignals.test.ts src/jobs/userRiskJobs.test.ts src/routes/userRisk.test.ts src/services/userRiskScoring.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit`
- `git diff --check`

## Notes
- `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze /usr/local/bin/corepack pnpm --filter @breeze/api db:check-drift` reaches local Postgres but fails with `role "breeze" does not exist` in this environment.