### PR TITLE
feat(ml): add user risk login geography signals

### DIFF
--- a/apps/api/src/middleware/cfAccessLogin.test.ts
+++ b/apps/api/src/middleware/cfAccessLogin.test.ts
@@ -322,7 +322,7 @@ describe('cfAccessLoginMiddleware', () => {
     envState.enabled = true;
     verifyState.next = {
       kind: 'claims',
-      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1, country: 'CA' },
     };
     dbState.userRow = { ...activeUser, status: 'suspended' };
     const { next, called } = createNext();
@@ -342,7 +342,7 @@ describe('cfAccessLoginMiddleware', () => {
     envState.enabled = true;
     verifyState.next = {
       kind: 'claims',
-      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1 },
+      claims: { email: activeUser.email, sub: 'cf-1', aud: envState.audience, iss: `https://${envState.teamDomain}`, exp: 999, iat: 1, country: 'CA' },
     };
     dbState.userRow = { ...activeUser };
     const { next, called } = createNext();
@@ -364,7 +364,7 @@ describe('cfAccessLoginMiddleware', () => {
     expect(dbState.lastUpdateId).toBe(activeUser.id);
     expect(auditState.audits[0]).toMatchObject({
       action: 'user.login',
-      details: expect.objectContaining({ method: 'cf_access_jwt' }),
+      details: expect.objectContaining({ method: 'cf_access_jwt', cfAccessCountry: 'CA' }),
     });
   });
 

--- a/apps/api/src/middleware/cfAccessLogin.ts
+++ b/apps/api/src/middleware/cfAccessLogin.ts
@@ -207,6 +207,7 @@ export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<R
       mfa: mfaSatisfied,
       scope: context.scope,
       cfAccessSub: claims.sub,
+      cfAccessCountry: claims.country ?? null,
     },
     ipAddress: getClientIP(c),
     userAgent: c.req.header('user-agent'),

--- a/apps/api/src/services/userRiskSignals.test.ts
+++ b/apps/api/src/services/userRiskSignals.test.ts
@@ -89,6 +89,7 @@ describe('userRiskSignals', () => {
       ])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
 
     const result = await evaluateUserRiskSignalsForOrg(ORG_ID, { lookbackHours: 24 });
@@ -102,6 +103,7 @@ describe('userRiskSignals', () => {
         offHoursMassScripts: 1,
         remoteSessionBursts: 1,
         privilegeElevationBursts: 1,
+        newGeographyLogins: 0,
       },
     });
     expect(mocks.appendUserRiskSignalEventMock).toHaveBeenCalledTimes(3);
@@ -139,6 +141,7 @@ describe('userRiskSignals', () => {
       ])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: 'existing-event' }]);
 
     const result = await evaluateUserRiskSignalsForOrg(ORG_ID);
@@ -146,5 +149,42 @@ describe('userRiskSignals', () => {
     expect(result.appended).toBe(0);
     expect(result.deduped).toBe(1);
     expect(mocks.appendUserRiskSignalEventMock).not.toHaveBeenCalled();
+  });
+
+  it('appends a new-geography login signal when Cloudflare Access country changes', async () => {
+    mocks.executeMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          user_id: USER_ID,
+          country: 'CA',
+          login_count: 1,
+          latest_at: new Date('2026-06-18T09:00:00.000Z'),
+          previous_countries: ['US'],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await evaluateUserRiskSignalsForOrg(ORG_ID);
+
+    expect(result).toMatchObject({
+      appended: 1,
+      candidates: expect.objectContaining({
+        newGeographyLogins: 1,
+      }),
+    });
+    expect(mocks.appendUserRiskSignalEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'auth.login.new_geography',
+      severity: 'medium',
+      userId: USER_ID,
+      description: 'Cloudflare Access login from new country CA',
+      details: expect.objectContaining({
+        country: 'CA',
+        previousCountries: ['US'],
+        method: 'cf_access_jwt',
+      }),
+    }));
   });
 });

--- a/apps/api/src/services/userRiskSignals.ts
+++ b/apps/api/src/services/userRiskSignals.ts
@@ -30,6 +30,14 @@ type ElevationBurstRow = {
   latest_at: Date | string;
 };
 
+type NewGeographyLoginRow = {
+  user_id: string;
+  country: string;
+  login_count: number | string;
+  latest_at: Date | string;
+  previous_countries: string[] | string | null;
+};
+
 export type UserRiskSignalEvaluationResult = {
   orgId: string;
   skipped: boolean;
@@ -39,6 +47,7 @@ export type UserRiskSignalEvaluationResult = {
     offHoursMassScripts: number;
     remoteSessionBursts: number;
     privilegeElevationBursts: number;
+    newGeographyLogins: number;
   };
 };
 
@@ -130,6 +139,7 @@ export async function evaluateUserRiskSignalsForOrg(
         offHoursMassScripts: 0,
         remoteSessionBursts: 0,
         privilegeElevationBursts: 0,
+        newGeographyLogins: 0,
       },
     };
   }
@@ -139,7 +149,7 @@ export async function evaluateUserRiskSignalsForOrg(
   const since = new Date(now.getTime() - lookbackHours * 60 * 60 * 1000);
   const sinceIso = since.toISOString();
 
-  const [scriptRows, remoteRows, elevationRows] = await Promise.all([
+  const [scriptRows, remoteRows, elevationRows, newGeographyRows] = await Promise.all([
     db.execute(sql`
       SELECT id AS batch_id, triggered_by AS user_id, script_id, devices_targeted, created_at
       FROM script_execution_batches
@@ -170,6 +180,47 @@ export async function evaluateUserRiskSignalsForOrg(
       GROUP BY subject_user_id
       HAVING count(*) >= ${ELEVATION_BURST_COUNT}
     `) as Promise<ElevationBurstRow[]>,
+    db.execute(sql`
+      WITH recent AS (
+        SELECT actor_id AS user_id,
+          upper(details->>'cfAccessCountry') AS country,
+          timestamp
+        FROM audit_logs
+        WHERE org_id = ${orgId}
+          AND actor_type = 'user'
+          AND action = 'user.login'
+          AND result = 'success'
+          AND details->>'method' = 'cf_access_jwt'
+          AND details->>'cfAccessCountry' IS NOT NULL
+          AND timestamp >= ${sinceIso}::timestamptz
+      ),
+      history AS (
+        SELECT actor_id AS user_id,
+          upper(details->>'cfAccessCountry') AS country
+        FROM audit_logs
+        WHERE org_id = ${orgId}
+          AND actor_type = 'user'
+          AND action = 'user.login'
+          AND result = 'success'
+          AND details->>'method' = 'cf_access_jwt'
+          AND details->>'cfAccessCountry' IS NOT NULL
+          AND timestamp < ${sinceIso}::timestamptz
+      )
+      SELECT recent.user_id,
+        recent.country,
+        count(*)::int AS login_count,
+        max(recent.timestamp) AS latest_at,
+        array_agg(DISTINCT history.country) AS previous_countries
+      FROM recent
+      JOIN history ON history.user_id = recent.user_id
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM history same_country
+        WHERE same_country.user_id = recent.user_id
+          AND same_country.country = recent.country
+      )
+      GROUP BY recent.user_id, recent.country
+    `) as Promise<NewGeographyLoginRow[]>,
   ]);
 
   let appended = 0;
@@ -248,6 +299,36 @@ export async function evaluateUserRiskSignalsForOrg(
     }));
   }
 
+  for (const row of newGeographyRows) {
+    const loginCount = toInt(row.login_count);
+    const latestAt = toDate(row.latest_at);
+    const key = windowKey(latestAt, lookbackHours);
+    const previousCountries = Array.isArray(row.previous_countries)
+      ? row.previous_countries
+      : typeof row.previous_countries === 'string'
+        ? row.previous_countries.replace(/[{}"]/g, '').split(',').filter(Boolean)
+        : [];
+    await record(await appendDedupedSignal({
+      orgId,
+      userId: row.user_id,
+      eventType: 'auth.login.new_geography',
+      severity: previousCountries.length >= 2 ? 'high' : 'medium',
+      scoreImpact: Math.min(24, 10 + previousCountries.length * 3 + loginCount),
+      description: `Cloudflare Access login from new country ${row.country}`,
+      details: {
+        fingerprint: `cf-access-new-country:${orgId}:${row.user_id}:${row.country}:${key}`,
+        source: 'audit_logs',
+        method: 'cf_access_jwt',
+        country: row.country,
+        previousCountries,
+        loginCount,
+        lookbackHours,
+      },
+      occurredAt: latestAt,
+      sinceIso,
+    }));
+  }
+
   return {
     orgId,
     skipped: false,
@@ -257,6 +338,7 @@ export async function evaluateUserRiskSignalsForOrg(
       offHoursMassScripts: scriptRows.length,
       remoteSessionBursts: remoteRows.length,
       privilegeElevationBursts: elevationRows.length,
+      newGeographyLogins: newGeographyRows.length,
     },
   };
 }


### PR DESCRIPTION
## Summary
- persist the Cloudflare Access country claim on successful CF Access login audit events
- extend user-risk signal evaluation with `auth.login.new_geography` for new CF Access countries when prior country history exists
- add focused tests for CF Access audit enrichment and new-geography signal emission

## Validation
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/services/userRiskSignals.test.ts src/middleware/cfAccessLogin.test.ts src/jobs/userRiskJobs.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit`
- `git diff --check`

## Notes
- `DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze /usr/local/bin/corepack pnpm --filter @breeze/api db:check-drift` reaches local Postgres but fails with `role "breeze" does not exist` in this environment.