### PR TITLE
docs(ml): add operations runbook

### DIFF
--- a/docs/runbooks/ml-operations.md
+++ b/docs/runbooks/ml-operations.md
@@ -1,0 +1,220 @@
+# Breeze ML Operations Runbook
+
+This runbook covers the ML/AI surfaces shipped by the 2026-06 roadmap stack:
+alert correlation, RCA, metric rollups, anomalies, remediation suggestions,
+device reliability evaluation, ticket triage, and user-risk scoring.
+
+The v0 rule for operators is simple: these systems may create predictions,
+groups, labels, and suggestions, but they must not execute remediation without
+an explicit user action through the existing approval/script rails.
+
+## Emergency Disable
+
+Use a global kill switch when any ML producer is creating bad output or excess
+load:
+
+```bash
+ML_FEATURES_DISABLED=true
+```
+
+Equivalent global switches are also supported:
+
+```bash
+ML_OUTPUTS_DISABLED=true
+ML_GLOBAL_KILL_SWITCH=true
+```
+
+To disable selected flags without suppressing every ML surface:
+
+```bash
+ML_DISABLED_FLAGS=ml.rca.enabled,ml.anomalies.*
+```
+
+Per-flag switches are also supported. Examples:
+
+```bash
+ML_ALERT_CORRELATION_DISABLED=true
+ML_RCA_DISABLED=true
+ML_ANOMALIES_DISABLED=true
+ML_REMEDIATION_SUGGESTIONS_DISABLED=true
+ML_TICKET_TRIAGE_DISABLED=true
+ML_USER_RISK_V0_DISABLED=true
+```
+
+After changing environment variables, restart the API/worker process that owns
+the producer. The flag helpers read env at call time, but existing long-running
+jobs may already be in memory.
+
+## Feature Flags
+
+Org and partner settings can override defaults. Supported shapes:
+
+```json
+{
+  "mlFeatureFlags": {
+    "ml.rca.enabled": true
+  },
+  "ml": {
+    "anomalies": {
+      "enabled": true,
+      "create_alerts": false
+    }
+  }
+}
+```
+
+Current flags:
+
+| Flag | Default | Produces |
+| --- | --- | --- |
+| `ml.alert_correlation.enabled` | internal/dev on, production off | Alert correlation work |
+| `ml.rca.enabled` | off | RCA explanations |
+| `ml.metric_rollups.enabled` | on | Metric rollup buckets |
+| `ml.anomalies.enabled` | off | Metric anomaly rows |
+| `ml.anomalies.create_alerts` | off | Alert promotion from anomalies |
+| `ml.remediation_suggestions.enabled` | off | Suggested remediation rows |
+| `ml.ticket_triage.enabled` | off | Ticket triage suggestions |
+| `ml.user_risk_v0.enabled` | on | Rules-v0 user-risk scoring and signals |
+| `ml.user_risk_v1.enabled` | off | Future learned baseline |
+
+## Evaluation Endpoints
+
+Use these before tuning or replacing a heuristic:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  "https://<host>/api/alerts/correlations"
+
+curl -H "Authorization: Bearer <token>" \
+  "https://<host>/api/reliability/evaluation?orgId=<org-id>"
+
+curl -H "Authorization: Bearer <token>" \
+  "https://<host>/api/tickets/triage-evaluation?orgId=<org-id>"
+
+curl -H "Authorization: Bearer <token>" \
+  "https://<host>/api/user-risk/evaluation?orgId=<org-id>&days=30"
+```
+
+Key metrics:
+
+| Surface | Primary metric |
+| --- | --- |
+| Alert correlation | Group compression fields plus split/merge/dismiss feedback labels |
+| RCA | Helpful/not-helpful and usage labels |
+| Anomalies | Dismiss/promote/resolve rates |
+| Remediation | Accepted, rejected, executed, failed |
+| Reliability | Precision against failure/replacement labels |
+| Ticket triage | Override rate for category/priority/assignee |
+| User risk | True-positive rate, training completion, repeat signal rate |
+
+## Feedback Labels
+
+Canonical labels live in `ml_feedback_events`. They are append-only and deduped
+by source, event type, and occurrence time. Use labels rather than ad hoc
+product tables when evaluating output quality.
+
+Useful label families:
+
+| Domain | Labels |
+| --- | --- |
+| Device reliability | `device.failure_confirmed`, `device.replaced`, `device.false_alarm` |
+| Ticket triage | `ticket.category_changed`, `ticket.priority_changed`, `ticket.assignee_changed` |
+| User risk | `user_risk.true_positive`, `user_risk.false_positive`, `training.assigned`, `training.completed` |
+| Remediation | `suggestion.accepted`, `suggestion.edited`, `suggestion.rejected`, `suggestion.executed`, `suggestion.failed` |
+| RCA | `rca.helpful`, `rca.not_helpful`, `rca.edited`, `rca.used_in_ticket` |
+
+## Worker Checks
+
+Confirm workers are active from logs:
+
+```bash
+docker compose logs api | grep -E "metric|anomaly|correlation|remediation|userRisk"
+```
+
+Expected queue names include:
+
+| Queue | Purpose |
+| --- | --- |
+| `metric-rollups` | Metric rollup computation |
+| `alert-correlation` | Alert grouping and clustering |
+| `metric-anomalies` | Anomaly detection |
+| `reliability-scoring` | Device reliability score computation |
+| `user-risk-scoring` | User-risk scoring and signal ingestion |
+
+If a queue is backing up, disable the relevant flag first, then inspect Redis
+and worker logs. Do not delete jobs until you know whether the worker writes are
+idempotent for that queue.
+
+Remediation suggestions are generated on demand through the remediation
+suggestion route/service. They do not currently have a dedicated BullMQ queue.
+
+## Debugging By Surface
+
+Alert correlation:
+- Check `/api/alerts/correlations` list/detail responses for the org.
+- Confirm new alert writes are not doing inline correlation work.
+- Use split/merge/dismiss labels to decide whether grouping rules are too broad.
+
+Metric rollups:
+- Verify `metric_rollups` has recent 5-minute buckets for the org/device.
+- Hourly and daily buckets must not compute p95 from lower-level p95 values.
+- If capacity or anomaly reads look empty, compare raw `device_metrics` windows
+  against rollup windows before changing thresholds.
+
+Anomalies:
+- Keep `ml.anomalies.create_alerts` off until dismiss/promote rates are acceptable.
+- Review anomaly status counts before increasing sensitivity.
+
+Remediation suggestions:
+- Suggestions should reference existing scripts/templates where possible.
+- Execution must go through existing script/approval paths. There is no separate
+  ML approval bypass.
+
+Device reliability:
+- Check `/api/reliability/evaluation` before changing thresholds.
+- False alarms should be labeled from the device reliability panel.
+
+Ticket triage:
+- Keep `ml.ticket_triage.enabled` off for orgs without clean categories.
+- Use override rate as the main signal. High override rate means the suggestion
+  rules or category hygiene are not ready for model work.
+
+User risk:
+- Check `/api/user-risk/evaluation?days=30`.
+- Rules-v0 signal ingestion currently reads script execution batches, remote
+  sessions, elevation requests, and Cloudflare Access login countries.
+- Generic impossible-travel scoring needs a production GeoIP source; do not
+  enable it from IP strings alone.
+
+## Tuning Rules
+
+Tune one surface at a time:
+
+1. Disable alert promotion or execution-producing flags first.
+2. Change one threshold or rule group.
+3. Run the relevant focused tests.
+4. Compare evaluation metrics over the same time window before and after.
+5. Re-enable output writes only when false positives and operator overrides are
+   acceptable.
+
+## Local Validation
+
+Focused checks used by the roadmap stack:
+
+```bash
+/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit
+/usr/local/bin/corepack pnpm --filter @breeze/web exec tsc --noEmit
+/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/services/userRiskSignals.test.ts src/jobs/userRiskJobs.test.ts
+/usr/local/bin/corepack pnpm --filter @breeze/web exec vitest run src/lib/__tests__/no-silent-mutations.test.ts
+```
+
+Schema drift check:
+
+```bash
+DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze \
+  /usr/local/bin/corepack pnpm --filter @breeze/api db:check-drift
+```
+
+If local Postgres reports `role "breeze" does not exist`, the check reached
+Postgres but the local DB role setup is incomplete. Fix the local role before
+using drift status as evidence.


### PR DESCRIPTION
## Summary
- add an operator runbook for the ML roadmap surfaces
- document global and per-flag kill switches, evaluation checks, feedback labels, worker queues, tuning, and debugging guidance
- call out that remediation suggestions are generated on demand and generic impossible-travel needs a real GeoIP source

## Validation
- `git diff --check`