### PR TITLE
feat(ml): add alert correlation evaluation

### DIFF
--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -34,6 +34,11 @@ const {
       alertId: 'alert_correlation_members.alertId', role: 'alert_correlation_members.role',
       confidence: 'alert_correlation_members.confidence', createdAt: 'alert_correlation_members.createdAt',
     },
+    mlFeedbackEvents: {
+      id: 'ml_feedback_events.id', orgId: 'ml_feedback_events.orgId', sourceType: 'ml_feedback_events.sourceType',
+      sourceId: 'ml_feedback_events.sourceId', eventType: 'ml_feedback_events.eventType',
+      outcome: 'ml_feedback_events.outcome', occurredAt: 'ml_feedback_events.occurredAt',
+    },
     devices: { id: 'devices.id', hostname: 'devices.hostname' },
   };
 
@@ -42,6 +47,7 @@ const {
   const evalPredicate = (row: Record<string, unknown>, predicate: Predicate): boolean => {
     if (!predicate) return true;
     if (predicate.op === 'eq') return row[columnKey(predicate.col)] === predicate.val;
+    if (predicate.op === 'gte') return Number(row[columnKey(predicate.col)]) >= Number(predicate.val);
     if (predicate.op === 'inArray') return (predicate.vals ?? []).includes(row[columnKey(predicate.col)]);
     if (predicate.op === 'and') return (predicate.args ?? []).every((arg) => evalPredicate(row, arg));
     if (predicate.op === 'or') return (predicate.args ?? []).some((arg) => evalPredicate(row, arg));
@@ -53,6 +59,7 @@ const {
     correlations: [] as Array<Record<string, any>>,
     groups: [] as Array<Record<string, any>>,
     members: [] as Array<Record<string, any>>,
+    feedback: [] as Array<Record<string, any>>,
     devices: [] as Array<Record<string, any>>,
   };
 
@@ -74,7 +81,9 @@ const {
             ? state.groups
             : this.table === tables.alertCorrelationMembers
               ? state.members
-              : state.devices;
+              : this.table === tables.mlFeedbackEvents
+                ? state.feedback
+                : state.devices;
       const filtered = source.filter((row) => evalPredicate(row, this.predicate));
       if (!this.projection) return filtered;
       return filtered.map((row) => {
@@ -128,6 +137,7 @@ const {
 
 vi.mock('drizzle-orm', () => ({
   eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  gte: (col: unknown, val: unknown) => ({ op: 'gte', col, val }),
   and: (...args: unknown[]) => ({ op: 'and', args }),
   or: (...args: unknown[]) => ({ op: 'or', args }),
   inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
@@ -153,6 +163,7 @@ vi.mock('../../db/schema', () => ({
   alertCorrelationMembers: tables.alertCorrelationMembers,
   alertCorrelations: tables.alertCorrelations,
   devices: tables.devices,
+  mlFeedbackEvents: tables.mlFeedbackEvents,
 }));
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../../services/alertCorrelationRca', () => ({
@@ -203,6 +214,7 @@ function seed() {
   ];
   state.groups = [];
   state.members = [];
+  state.feedback = [];
   state.devices = [{ id: DEVICE_1, hostname: 'server-1' }];
 }
 
@@ -303,6 +315,95 @@ describe('/alerts correlation routes', () => {
       status: 'open',
     }));
     expect(body.groups[0].rootCause.id).toBe(ALERT_1);
+  });
+
+  it('returns scoped alert correlation evaluation metrics and recent feedback labels', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T13:00:00Z'));
+    seedPersistedGroup();
+    state.feedback = [
+      {
+        id: '11111111-ffff-4fff-8fff-111111111111',
+        orgId: ORG_1,
+        sourceType: 'correlation',
+        sourceId: GROUP_1,
+        eventType: 'correlation.accepted',
+        outcome: 'accepted',
+        occurredAt: new Date('2026-06-18T12:10:00Z'),
+      },
+      {
+        id: '22222222-ffff-4fff-8fff-222222222222',
+        orgId: ORG_1,
+        sourceType: 'correlation',
+        sourceId: GROUP_1,
+        eventType: 'correlation.split',
+        outcome: 'split',
+        occurredAt: new Date('2026-06-18T12:11:00Z'),
+      },
+      {
+        id: '33333333-ffff-4fff-8fff-333333333333',
+        orgId: ORG_1,
+        sourceType: 'correlation',
+        sourceId: GROUP_1,
+        eventType: 'correlation.merged',
+        outcome: 'merged',
+        occurredAt: new Date('2026-06-18T12:12:00Z'),
+      },
+      {
+        id: '44444444-ffff-4fff-8fff-444444444444',
+        orgId: ORG_1,
+        sourceType: 'correlation',
+        sourceId: GROUP_1,
+        eventType: 'correlation.dismissed',
+        outcome: 'dismissed',
+        occurredAt: new Date('2026-04-01T12:00:00Z'),
+      },
+      {
+        id: '55555555-ffff-4fff-8fff-555555555555',
+        orgId: ORG_2,
+        sourceType: 'correlation',
+        sourceId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+        eventType: 'correlation.dismissed',
+        outcome: 'dismissed',
+        occurredAt: new Date('2026-06-18T12:13:00Z'),
+      },
+      {
+        id: '66666666-ffff-4fff-8fff-666666666666',
+        orgId: ORG_1,
+        sourceType: 'ticket',
+        sourceId: 'ticket-1',
+        eventType: 'correlation.dismissed',
+        outcome: 'dismissed',
+        occurredAt: new Date('2026-06-18T12:14:00Z'),
+      },
+    ];
+
+    try {
+      const res = await makeApp().request('/alerts/correlations/evaluation?labelWindowDays=30');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.evaluation).toEqual({
+        labelWindowDays: 30,
+        labelWindowStart: '2026-05-19T13:00:00.000Z',
+        groupsCreated: 1,
+        totalGroupedAlerts: 2,
+        estimatedSuppressedAlerts: 1,
+        compressionRatio: 0.5,
+        averageCorrelationScore: 0.91,
+        averageNoiseReductionPercent: 50,
+        feedback: {
+          accepted: 1,
+          split: 1,
+          merged: 1,
+          dismissed: 0,
+          totalCorrections: 2,
+        },
+      });
+      expect(body.data).toEqual(body.evaluation);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns persisted correlation group detail without leaking cross-org groups', async () => {

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -1,10 +1,10 @@
 import { Hono, type Context } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, inArray, or, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, or, type SQL } from 'drizzle-orm';
 
 import { db } from '../../db';
-import { alertCorrelationGroups, alertCorrelationMembers, alertCorrelations, alerts, devices } from '../../db/schema';
+import { alertCorrelationGroups, alertCorrelationMembers, alertCorrelations, alerts, devices, mlFeedbackEvents } from '../../db/schema';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { buildAlertCorrelationRca } from '../../services/alertCorrelationRca';
@@ -17,6 +17,9 @@ export const alertCorrelationRoutes = new Hono();
 
 const alertIdParamSchema = z.object({ alertId: z.string().uuid() });
 const groupIdParamSchema = z.object({ groupId: z.string().uuid() });
+const evaluationQuerySchema = z.object({
+  labelWindowDays: z.coerce.number().int().min(1).max(365).default(90),
+});
 const explainGroupSchema = z.object({
   windowHours: z.number().int().min(1).max(24).optional(),
   maxEvidenceItems: z.number().int().min(5).max(100).optional(),
@@ -87,6 +90,19 @@ function groupOrgConditionsForAuth(auth: AuthContext): SQL[] | null {
   if (auth.scope === 'partner') {
     const orgIds = auth.accessibleOrgIds ?? [];
     return orgIds.length > 0 ? [inArray(alertCorrelationGroups.orgId, orgIds)] : null;
+  }
+
+  return [];
+}
+
+function feedbackOrgConditionsForAuth(auth: AuthContext): SQL[] | null {
+  if (auth.scope === 'organization') {
+    return auth.orgId ? [eq(mlFeedbackEvents.orgId, auth.orgId)] : null;
+  }
+
+  if (auth.scope === 'partner') {
+    const orgIds = auth.accessibleOrgIds ?? [];
+    return orgIds.length > 0 ? [inArray(mlFeedbackEvents.orgId, orgIds)] : null;
   }
 
   return [];
@@ -326,6 +342,96 @@ async function buildPersistedCorrelationGroups(auth: AuthContext, groupId?: stri
   }).filter((group) => group.rootCause !== null);
 }
 
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 1000) / 1000;
+}
+
+async function getCorrelationFeedbackCounts(auth: AuthContext, since: Date) {
+  const feedbackOrgConditions = feedbackOrgConditionsForAuth(auth);
+  if (feedbackOrgConditions === null) {
+    return {
+      accepted: 0,
+      split: 0,
+      merged: 0,
+      dismissed: 0,
+      totalCorrections: 0,
+    };
+  }
+
+  const rows = await db
+    .select({ eventType: mlFeedbackEvents.eventType })
+    .from(mlFeedbackEvents)
+    .where(and(
+      eq(mlFeedbackEvents.sourceType, 'correlation'),
+      gte(mlFeedbackEvents.occurredAt, since),
+      ...(feedbackOrgConditions.length > 0 ? feedbackOrgConditions : [])
+    ));
+
+  const counts = {
+    accepted: 0,
+    split: 0,
+    merged: 0,
+    dismissed: 0,
+  };
+  for (const row of rows) {
+    if (row.eventType === 'correlation.accepted') counts.accepted += 1;
+    else if (row.eventType === 'correlation.split') counts.split += 1;
+    else if (row.eventType === 'correlation.merged') counts.merged += 1;
+    else if (row.eventType === 'correlation.dismissed') counts.dismissed += 1;
+  }
+
+  return {
+    ...counts,
+    totalCorrections: counts.split + counts.merged + counts.dismissed,
+  };
+}
+
+async function buildCorrelationEvaluation(auth: AuthContext, labelWindowDays: number) {
+  const persistedGroups = await buildPersistedCorrelationGroups(auth);
+  const groups = persistedGroups.length > 0 ? persistedGroups : await buildCorrelationGroups(auth);
+  const groupedAlertIds = new Set<string>();
+  let estimatedSuppressedAlerts = 0;
+  let scoreTotal = 0;
+  let scoredGroups = 0;
+  let noiseReductionTotal = 0;
+  let noiseReductionGroups = 0;
+
+  for (const group of groups) {
+    for (const alert of group.alerts) {
+      groupedAlertIds.add(alert.id);
+    }
+    estimatedSuppressedAlerts += Math.max(group.alerts.length - 1, 0);
+    if (Number.isFinite(group.correlationScore)) {
+      scoreTotal += group.correlationScore;
+      scoredGroups += 1;
+    }
+    const noiseReduction = typeof group.noiseReductionPercent === 'number'
+      ? group.noiseReductionPercent
+      : group.alerts.length > 0
+        ? (Math.max(group.alerts.length - 1, 0) / group.alerts.length) * 100
+        : 0;
+    noiseReductionTotal += noiseReduction;
+    noiseReductionGroups += 1;
+  }
+
+  const totalGroupedAlerts = groupedAlertIds.size;
+  const labelWindowStart = new Date(Date.now() - labelWindowDays * 24 * 60 * 60 * 1000);
+  const feedback = await getCorrelationFeedbackCounts(auth, labelWindowStart);
+
+  return {
+    labelWindowDays,
+    labelWindowStart: labelWindowStart.toISOString(),
+    groupsCreated: groups.length,
+    totalGroupedAlerts,
+    estimatedSuppressedAlerts,
+    compressionRatio: totalGroupedAlerts > 0 ? roundMetric(estimatedSuppressedAlerts / totalGroupedAlerts) : 0,
+    averageCorrelationScore: scoredGroups > 0 ? roundMetric(scoreTotal / scoredGroups) : 0,
+    averageNoiseReductionPercent: noiseReductionGroups > 0 ? roundMetric(noiseReductionTotal / noiseReductionGroups) : 0,
+    feedback,
+  };
+}
+
 async function getPersistedGroupAlerts(groupId: string, auth: AuthContext): Promise<AlertRow[] | null> {
   const group = await getAccessiblePersistedGroup(groupId, auth);
   if (!group) return null;
@@ -407,6 +513,19 @@ alertCorrelationRoutes.get(
     const persistedGroups = await buildPersistedCorrelationGroups(auth);
     const groups = persistedGroups.length > 0 ? persistedGroups : await buildCorrelationGroups(auth);
     return c.json({ groups, data: groups });
+  }
+);
+
+alertCorrelationRoutes.get(
+  '/correlations/evaluation',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
+  zValidator('query', evaluationQuerySchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { labelWindowDays } = c.req.valid('query');
+    const evaluation = await buildCorrelationEvaluation(auth, labelWindowDays);
+    return c.json({ evaluation, data: evaluation });
   }
 );
 


### PR DESCRIPTION
## Summary
- add `/alerts/correlations/evaluation` for alert-correlation quality metrics
- compute grouping, suppression, compression, score, and noise-reduction metrics from persisted or derived groups
- include scoped recent correction labels from `ml_feedback_events` for correlation feedback

## Validation
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/routes/alerts/correlations.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit`
- `git diff --check`
- `DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" /usr/local/bin/corepack pnpm --filter @breeze/api run db:check-drift` *(fails locally: Postgres role `breeze` does not exist)*