### PR TITLE
feat(ml): add metric rollup backfill command

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "dev": "tsx watch src/index.ts",
     "lint": "eslint src",
     "oauth:gen-keys": "tsx scripts/oauth-gen-keys.ts",
+    "metric-rollups:backfill": "tsx scripts/metric-rollup-backfill.ts",
     "recover:stuck-agents": "tsx scripts/recover-stuck-agents.ts",
     "recover:stuck-agents:prod": "node dist/scripts/recover-stuck-agents.cjs",
     "secrets:reencrypt": "tsx ../../scripts/re-encrypt-secrets.ts",

--- a/apps/api/scripts/metric-rollup-backfill.lib.ts
+++ b/apps/api/scripts/metric-rollup-backfill.lib.ts
@@ -1,0 +1,84 @@
+export const MAX_BACKFILL_DAYS = 31;
+
+export interface MetricRollupBackfillOptions {
+  orgId: string;
+  from: Date;
+  to: Date;
+  expectedSampleSeconds?: number;
+  dryRun: boolean;
+}
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  pnpm metric-rollups:backfill -- --org-id <uuid> --from <iso> --to <iso> [--expected-sample-seconds 60] [--dry-run]',
+    '',
+    `The time range must be positive and no longer than ${MAX_BACKFILL_DAYS} days.`,
+  ].join('\n');
+}
+
+function readOption(args: string[], name: string): string | undefined {
+  const equalsPrefix = `${name}=`;
+  const equalsValue = args.find((arg) => arg.startsWith(equalsPrefix));
+  if (equalsValue) return equalsValue.slice(equalsPrefix.length);
+
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  return args[index + 1];
+}
+
+function parseDateOption(value: string | undefined, name: string): Date {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} is required\n\n${usage()}`);
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${name} must be a valid ISO timestamp`);
+  }
+  return parsed;
+}
+
+function parsePositiveInteger(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (value.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || String(parsed) !== value) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function parseMetricRollupBackfillArgs(args: string[]): MetricRollupBackfillOptions {
+  if (args.includes('--help') || args.includes('-h')) {
+    throw new Error(usage());
+  }
+
+  const orgId = readOption(args, '--org-id');
+  if (!orgId || orgId.startsWith('--')) {
+    throw new Error(`--org-id is required\n\n${usage()}`);
+  }
+
+  const from = parseDateOption(readOption(args, '--from'), '--from');
+  const to = parseDateOption(readOption(args, '--to'), '--to');
+  if (from >= to) {
+    throw new Error('--from must be before --to');
+  }
+
+  const rangeMs = to.getTime() - from.getTime();
+  const maxRangeMs = MAX_BACKFILL_DAYS * 24 * 60 * 60 * 1000;
+  if (rangeMs > maxRangeMs) {
+    throw new Error(`Backfill range must be ${MAX_BACKFILL_DAYS} days or less`);
+  }
+
+  return {
+    orgId,
+    from,
+    to,
+    expectedSampleSeconds: parsePositiveInteger(readOption(args, '--expected-sample-seconds'), '--expected-sample-seconds'),
+    dryRun: args.includes('--dry-run'),
+  };
+}

--- a/apps/api/scripts/metric-rollup-backfill.test.ts
+++ b/apps/api/scripts/metric-rollup-backfill.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_BACKFILL_DAYS, parseMetricRollupBackfillArgs } from './metric-rollup-backfill.lib';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('parseMetricRollupBackfillArgs', () => {
+  it('parses a bounded org/time-range backfill request', () => {
+    const options = parseMetricRollupBackfillArgs([
+      '--org-id',
+      ORG_ID,
+      '--from',
+      '2026-06-18T00:00:00.000Z',
+      '--to',
+      '2026-06-19T00:00:00.000Z',
+      '--expected-sample-seconds',
+      '30',
+      '--dry-run',
+    ]);
+
+    expect(options).toEqual({
+      orgId: ORG_ID,
+      from: new Date('2026-06-18T00:00:00.000Z'),
+      to: new Date('2026-06-19T00:00:00.000Z'),
+      expectedSampleSeconds: 30,
+      dryRun: true,
+    });
+  });
+
+  it('accepts equals-style arguments for shell-friendly use', () => {
+    const options = parseMetricRollupBackfillArgs([
+      `--org-id=${ORG_ID}`,
+      '--from=2026-06-18T00:00:00.000Z',
+      '--to=2026-06-18T01:00:00.000Z',
+    ]);
+
+    expect(options.orgId).toBe(ORG_ID);
+    expect(options.from.toISOString()).toBe('2026-06-18T00:00:00.000Z');
+    expect(options.to.toISOString()).toBe('2026-06-18T01:00:00.000Z');
+    expect(options.expectedSampleSeconds).toBeUndefined();
+    expect(options.dryRun).toBe(false);
+  });
+
+  it('rejects ranges longer than the bounded backfill limit', () => {
+    expect(() =>
+      parseMetricRollupBackfillArgs([
+        '--org-id',
+        ORG_ID,
+        '--from',
+        '2026-06-01T00:00:00.000Z',
+        '--to',
+        new Date(Date.UTC(2026, 5, 1 + MAX_BACKFILL_DAYS, 0, 0, 1)).toISOString(),
+      ])
+    ).toThrow(`${MAX_BACKFILL_DAYS} days or less`);
+  });
+
+  it('rejects invalid and inverted ranges before any database work', () => {
+    expect(() =>
+      parseMetricRollupBackfillArgs([
+        '--org-id',
+        ORG_ID,
+        '--from',
+        'not-a-date',
+        '--to',
+        '2026-06-18T01:00:00.000Z',
+      ])
+    ).toThrow('--from must be a valid ISO timestamp');
+
+    expect(() =>
+      parseMetricRollupBackfillArgs([
+        '--org-id',
+        ORG_ID,
+        '--from',
+        '2026-06-18T02:00:00.000Z',
+        '--to',
+        '2026-06-18T01:00:00.000Z',
+      ])
+    ).toThrow('--from must be before --to');
+  });
+
+  it('requires org and timestamps', () => {
+    expect(() => parseMetricRollupBackfillArgs([])).toThrow('--org-id is required');
+    expect(() => parseMetricRollupBackfillArgs(['--org-id', ORG_ID])).toThrow('--from is required');
+  });
+});

--- a/apps/api/scripts/metric-rollup-backfill.ts
+++ b/apps/api/scripts/metric-rollup-backfill.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env tsx
+import { closeDb, withSystemDbAccessContext } from '../src/db';
+import { rollupDeviceMetricsRange } from '../src/services/metricRollups';
+import { parseMetricRollupBackfillArgs } from './metric-rollup-backfill.lib';
+
+async function main(): Promise<void> {
+  const options = parseMetricRollupBackfillArgs(process.argv.slice(2));
+  const summary = {
+    orgId: options.orgId,
+    from: options.from.toISOString(),
+    to: options.to.toISOString(),
+    expectedSampleSeconds: options.expectedSampleSeconds ?? null,
+  };
+
+  if (options.dryRun) {
+    console.log('[metric-rollup-backfill] Dry run; no rollups written.');
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  const result = await withSystemDbAccessContext(() =>
+    rollupDeviceMetricsRange({
+      orgId: options.orgId,
+      from: options.from,
+      to: options.to,
+      expectedSampleSeconds: options.expectedSampleSeconds,
+    })
+  );
+
+  console.log('[metric-rollup-backfill] Completed.');
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error('[metric-rollup-backfill] Failed:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });


### PR DESCRIPTION
## Summary
- add `metric-rollups:backfill` for bounded one-org/time-range rollup backfills
- run backfills under `withSystemDbAccessContext` and support dry-run mode
- validate required org/time args, positive ranges, sample interval, and a 31-day max window

## Validation
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run scripts/metric-rollup-backfill.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit`
- `git diff --check`
- `/usr/local/bin/corepack pnpm --filter @breeze/api metric-rollups:backfill -- --org-id 11111111-1111-4111-8111-111111111111 --from 2026-06-18T00:00:00.000Z --to 2026-06-18T01:00:00.000Z --dry-run`
- `DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" /usr/local/bin/corepack pnpm --filter @breeze/api run db:check-drift` *(fails locally: Postgres role `breeze` does not exist)*