### PR TITLE
test(ml): cover metric rollup phase one behavior

### DIFF
--- a/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
@@ -1,0 +1,196 @@
+import './setup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { devices, deviceMetrics, metricRollups } from '../../db/schema';
+import { rollupDeviceMetricsRange } from '../../services/metricRollups';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const ORG_B_USER = '99999999-9999-4999-8999-999999999999';
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: ORG_B_USER,
+    currentPartnerId: null,
+  };
+}
+
+let agentIdCounter = 0;
+async function insertDevice(options: { orgId: string; siteId: string; hostname: string }): Promise<string> {
+  agentIdCounter++;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId: options.orgId,
+      siteId: options.siteId,
+      agentId: `metric-rollup-test-${Date.now()}-${agentIdCounter}`,
+      hostname: options.hostname,
+      displayName: options.hostname,
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date('2026-06-18T00:00:00.000Z'),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice returned no row');
+  return row.id;
+}
+
+async function insertMetric(options: {
+  orgId: string;
+  deviceId: string;
+  timestamp: Date;
+  cpuPercent: number;
+}): Promise<void> {
+  await (getTestDb() as any).insert(deviceMetrics).values({
+    orgId: options.orgId,
+    deviceId: options.deviceId,
+    timestamp: options.timestamp,
+    cpuPercent: options.cpuPercent,
+    ramPercent: 50,
+    ramUsedMb: 2048,
+    diskPercent: 40,
+    diskUsedGb: 120,
+    diskReadBps: 100,
+    diskWriteBps: 200,
+    bandwidthInBps: 300,
+    bandwidthOutBps: 400,
+    processCount: 50,
+  });
+}
+
+async function runRollup(orgId: string, from: Date, to: Date): Promise<void> {
+  await withSystemDbAccessContext(() =>
+    rollupDeviceMetricsRange({
+      orgId,
+      from,
+      to,
+      expectedSampleSeconds: 60,
+    })
+  );
+}
+
+async function selectCpuRollups(orgId: string, deviceId: string) {
+  return getTestDb()
+    .select()
+    .from(metricRollups)
+    .where(and(
+      eq(metricRollups.orgId, orgId),
+      eq(metricRollups.deviceId, deviceId),
+      eq(metricRollups.sourceTable, 'device_metrics'),
+      eq(metricRollups.metricName, 'cpu_percent'),
+      eq(metricRollups.bucketSeconds, 300)
+    ))
+    .orderBy(metricRollups.bucketStart);
+}
+
+describe('metric rollups integration', () => {
+  let orgA: string;
+  let orgB: string;
+  let siteA: string;
+  let siteB: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const organizationA = await createOrganization({ partnerId: partner.id, name: 'Rollup Org A' });
+    const organizationB = await createOrganization({ partnerId: partner.id, name: 'Rollup Org B' });
+    orgA = organizationA.id;
+    orgB = organizationB.id;
+    siteA = (await createSite({ orgId: orgA, name: 'Rollup Site A' })).id;
+    siteB = (await createSite({ orgId: orgB, name: 'Rollup Site B' })).id;
+  });
+
+  it('handles empty windows without writing rollups', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'empty-window-device' });
+
+    await runRollup(orgA, new Date('2026-06-18T12:00:00.000Z'), new Date('2026-06-18T12:15:00.000Z'));
+
+    await expect(selectCpuRollups(orgA, device)).resolves.toHaveLength(0);
+  });
+
+  it('materializes sparse buckets and replay-updates late-arriving samples', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'sparse-device' });
+    await insertMetric({ orgId: orgA, deviceId: device, timestamp: new Date('2026-06-18T12:00:00.000Z'), cpuPercent: 10 });
+    await insertMetric({ orgId: orgA, deviceId: device, timestamp: new Date('2026-06-18T12:10:00.000Z'), cpuPercent: 50 });
+
+    const from = new Date('2026-06-18T12:00:00.000Z');
+    const to = new Date('2026-06-18T12:15:00.000Z');
+    await runRollup(orgA, from, to);
+
+    const firstPass = await selectCpuRollups(orgA, device);
+    expect(firstPass.map((row) => ({
+      bucketStart: row.bucketStart.toISOString(),
+      avgValue: row.avgValue,
+      sampleCount: row.sampleCount,
+      gapSeconds: row.gapSeconds,
+      isGap: (row.metadata as Record<string, unknown>).isGap,
+    }))).toEqual([
+      { bucketStart: '2026-06-18T12:00:00.000Z', avgValue: 10, sampleCount: 1, gapSeconds: 240, isGap: false },
+      { bucketStart: '2026-06-18T12:05:00.000Z', avgValue: null, sampleCount: 0, gapSeconds: 300, isGap: true },
+      { bucketStart: '2026-06-18T12:10:00.000Z', avgValue: 50, sampleCount: 1, gapSeconds: 240, isGap: false },
+    ]);
+
+    await insertMetric({ orgId: orgA, deviceId: device, timestamp: new Date('2026-06-18T12:06:00.000Z'), cpuPercent: 30 });
+    await runRollup(orgA, from, to);
+
+    const secondPass = await selectCpuRollups(orgA, device);
+    expect(secondPass).toHaveLength(3);
+    const updatedGapBucket = secondPass[1];
+    if (!updatedGapBucket) throw new Error('expected replay to preserve the middle bucket');
+    expect(updatedGapBucket).toEqual(expect.objectContaining({
+      avgValue: 30,
+      sampleCount: 1,
+      gapSeconds: 240,
+    }));
+    expect((updatedGapBucket.metadata as Record<string, unknown>).isGap).toBe(false);
+  });
+
+  it('enforces org RLS for metric rollup reads and forged writes', async () => {
+    const deviceA = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'org-a-device' });
+    const deviceB = await insertDevice({ orgId: orgB, siteId: siteB, hostname: 'org-b-device' });
+    await insertMetric({ orgId: orgA, deviceId: deviceA, timestamp: new Date('2026-06-18T12:00:00.000Z'), cpuPercent: 42 });
+    await runRollup(orgA, new Date('2026-06-18T12:00:00.000Z'), new Date('2026-06-18T12:05:00.000Z'));
+
+    const visibleToOrgB = await withDbAccessContext(orgContext(orgB), () =>
+      db
+        .select()
+        .from(metricRollups)
+        .where(eq(metricRollups.metricName, 'cpu_percent'))
+    );
+    expect(visibleToOrgB).toHaveLength(0);
+
+    await expect(async () => {
+      try {
+        await withDbAccessContext(orgContext(orgB), () =>
+          db.insert(metricRollups).values({
+            orgId: orgA,
+            sourceTable: 'device_metrics',
+            deviceId: deviceB,
+            metricType: 'cpu',
+            metricName: 'cpu_percent',
+            bucketStart: new Date('2026-06-18T12:00:00.000Z'),
+            bucketSeconds: 300,
+            avgValue: 99,
+            minValue: 99,
+            maxValue: 99,
+            sampleCount: 1,
+            gapSeconds: 0,
+            metadata: { forged: true },
+          })
+        );
+      } catch (error) {
+        expect((error as { cause?: { code?: string } }).cause?.code).toBe('42501');
+        throw error;
+      }
+    }).rejects.toThrow(/metric_rollups/);
+  });
+});

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -42,7 +42,8 @@ export interface MetricRollupResult {
 }
 
 function bucketStartSql(timestampSql: SQL, bucketSeconds: number): SQL<Date> {
-  return sql<Date>`to_timestamp(floor(extract(epoch from ${timestampSql}) / ${bucketSeconds}) * ${bucketSeconds})::timestamp`;
+  const bucketSecondsSql = sql.raw(String(bucketSeconds));
+  return sql<Date>`to_timestamp(floor(extract(epoch from ${timestampSql}) / ${bucketSecondsSql}) * ${bucketSecondsSql})::timestamp`;
 }
 
 function upsertAssignments(): SQL {
@@ -71,6 +72,8 @@ function normalizeRange(from: Date, to: Date): { from: Date; to: Date } {
 
 async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof DEVICE_METRIC_ROLLUP_SOURCES)[number]): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
   const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
   const valueSql = sql.raw(`dm.${metric.column}`);
 
@@ -79,14 +82,14 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
       SELECT DISTINCT dm.org_id, dm.device_id
       FROM device_metrics dm
       WHERE dm.org_id = ${options.orgId}
-        AND dm.timestamp >= ${from}
-        AND dm.timestamp < ${to}
+        AND dm.timestamp >= ${fromIso}::timestamp
+        AND dm.timestamp < ${toIso}::timestamp
         AND ${valueSql} IS NOT NULL
     ),
     buckets AS (
       SELECT generate_series(
-        ${from}::timestamp,
-        ${to}::timestamp - interval '1 second' * ${RAW_BUCKET_SECONDS},
+        ${fromIso}::timestamp,
+        ${toIso}::timestamp - interval '1 second' * ${RAW_BUCKET_SECONDS},
         interval '1 second' * ${RAW_BUCKET_SECONDS}
       )::timestamp AS bucket_start
     ),
@@ -128,9 +131,9 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
       count(${valueSql})::integer,
       greatest(${RAW_BUCKET_SECONDS} - (count(${valueSql})::integer * ${expectedSampleSeconds}), 0)::integer,
       jsonb_build_object(
-        'rollupVersion', ${METRIC_ROLLUP_VERSION},
+        'rollupVersion', ${METRIC_ROLLUP_VERSION}::text,
         'source', 'raw',
-        'expectedSampleSeconds', ${expectedSampleSeconds},
+        'expectedSampleSeconds', ${expectedSampleSeconds}::integer,
         'isGap', count(${valueSql}) = 0
       )
     FROM bucket_grid bg
@@ -148,6 +151,8 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
 
 async function rollupDerivedDeviceMetrics(options: MetricRollupRange, sourceBucketSeconds: MetricRollupBucketSeconds, targetBucketSeconds: MetricRollupBucketSeconds): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
   const targetBucketSql = bucketStartSql(sql`mr.bucket_start`, targetBucketSeconds);
 
   await db.execute(sql`
@@ -183,13 +188,17 @@ async function rollupDerivedDeviceMetrics(options: MetricRollupRange, sourceBuck
       sum(mr.sum_value)::double precision,
       sum(mr.sample_count)::integer,
       sum(mr.gap_seconds)::integer,
-      jsonb_build_object('rollupVersion', ${METRIC_ROLLUP_VERSION}, 'source', 'derived', 'sourceBucketSeconds', ${sourceBucketSeconds})
+      jsonb_build_object(
+        'rollupVersion', ${METRIC_ROLLUP_VERSION}::text,
+        'source', 'derived',
+        'sourceBucketSeconds', ${sourceBucketSeconds}::integer
+      )
     FROM metric_rollups mr
     WHERE mr.org_id = ${options.orgId}
       AND mr.source_table = 'device_metrics'
       AND mr.bucket_seconds = ${sourceBucketSeconds}
-      AND mr.bucket_start >= ${from}
-      AND mr.bucket_start < ${to}
+      AND mr.bucket_start >= ${fromIso}::timestamp
+      AND mr.bucket_start < ${toIso}::timestamp
     GROUP BY mr.org_id, mr.source_table, mr.device_id, mr.metric_type, mr.metric_name, ${targetBucketSql}
     HAVING sum(mr.sample_count) > 0
     ON CONFLICT (org_id, source_table, device_id, metric_type, metric_name, bucket_seconds, bucket_start)


### PR DESCRIPTION
## Summary
- add real Postgres integration coverage for Phase 1 metric rollup acceptance
- verify empty windows, sparse bucket materialization, late-arriving replay updates, and cross-org RLS read/forge behavior
- fix runtime SQL issues surfaced by the integration test: metadata parameter casts, ISO timestamp binding, and derived bucket GROUP BY expression stability

## Validation
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/metricRollups.integration.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec vitest run src/services/metricRollups.test.ts scripts/metric-rollup-backfill.test.ts`
- `/usr/local/bin/corepack pnpm --filter @breeze/api exec tsc --noEmit`
- `git diff --check`
- `DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" /usr/local/bin/corepack pnpm --filter @breeze/api run db:check-drift` *(fails locally: Postgres role `breeze` does not exist)*