### PR TITLE
feat(ml): maintain metric rollup partitions

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -152,6 +152,10 @@ import { initializeAgentLogRetention, shutdownAgentLogRetention } from './jobs/a
 import { initializeLogCorrelationWorker, shutdownLogCorrelationWorker } from './jobs/logCorrelation';
 import { initializeAlertCorrelationWorker, shutdownAlertCorrelationWorker } from './jobs/alertCorrelation';
 import { initializeMetricRollupsWorker, shutdownMetricRollupsWorker } from './jobs/metricRollups';
+import {
+  initializeMetricRollupMaintenanceWorker,
+  shutdownMetricRollupMaintenanceWorker,
+} from './jobs/metricRollupMaintenance';
 import { initializeMetricAnomaliesWorker, shutdownMetricAnomaliesWorker } from './jobs/metricAnomalies';
 import { initializeIPHistoryRetention, shutdownIPHistoryRetention } from './jobs/ipHistoryRetention';
 import { initializeChangeLogRetention, shutdownChangeLogRetention } from './jobs/changeLogRetention';
@@ -1048,6 +1052,7 @@ async function initializeWorkers(): Promise<void> {
     ['alertWorkers', initializeAlertWorkers],
     ['alertCorrelationWorker', initializeAlertCorrelationWorker],
     ['metricRollupsWorker', initializeMetricRollupsWorker],
+    ['metricRollupMaintenance', initializeMetricRollupMaintenanceWorker],
     ['metricAnomaliesWorker', initializeMetricAnomaliesWorker],
     ['offlineDetector', initializeOfflineDetector],
     ['notificationDispatcher', initializeNotificationDispatcher],
@@ -1264,6 +1269,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownNotificationDispatcher,
     shutdownOfflineDetector,
     shutdownMetricAnomaliesWorker,
+    shutdownMetricRollupMaintenanceWorker,
     shutdownMetricRollupsWorker,
     shutdownAlertCorrelationWorker,
     shutdownAlertWorkers,

--- a/apps/api/src/jobs/metricRollupMaintenance.test.ts
+++ b/apps/api/src/jobs/metricRollupMaintenance.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  withSystemDbAccessContextMock,
+  runMaintenanceMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runMaintenanceMock: vi.fn(),
+  capturedWorkerProcessor: { current: null as null | ((job: unknown) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: unknown) => Promise<unknown>) {
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: vi.fn(),
+}));
+
+vi.mock('../services/metricRollupMaintenance', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/metricRollupMaintenance')>();
+  return {
+    ...actual,
+    runMetricRollupMaintenance: (...args: unknown[]) => runMaintenanceMock(...(args as [])),
+  };
+});
+
+import {
+  __testOnly,
+  createMetricRollupMaintenanceWorker,
+  initializeMetricRollupMaintenanceWorker,
+  scheduleMetricRollupMaintenance,
+  shutdownMetricRollupMaintenanceWorker,
+} from './metricRollupMaintenance';
+
+const ORIGINAL_FLAG = process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED;
+
+describe('metric rollup maintenance worker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getRepeatableJobsMock.mockResolvedValue([]);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    addMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    runMaintenanceMock.mockResolvedValue({
+      ensuredPartitions: ['metric_rollups_y2026m06'],
+      droppedPartitions: [],
+      retention: [{ bucketSeconds: 300, deleted: 4 }],
+      durationMs: 12,
+    });
+    capturedWorkerProcessor.current = null;
+    delete process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED;
+  });
+
+  afterEach(async () => {
+    await shutdownMetricRollupMaintenanceWorker();
+    if (ORIGINAL_FLAG === undefined) {
+      delete process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED;
+    } else {
+      process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED = ORIGINAL_FLAG;
+    }
+  });
+
+  it('exposes stable queue metadata for scheduling', () => {
+    expect(__testOnly.QUEUE_NAME).toBe('metric-rollup-maintenance');
+    expect(__testOnly.JOB_NAME).toBe('metric-rollup-maintenance');
+    expect(__testOnly.REPEAT_JOB_ID).toBe('metric-rollup-maintenance');
+    expect(__testOnly.DAILY_CRON).toBe('15 3 * * *');
+  });
+
+  it('isMaintenanceEnabled defaults ON and accepts standard falsy values', () => {
+    delete process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED;
+    expect(__testOnly.isMaintenanceEnabled()).toBe(true);
+    process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED = 'false';
+    expect(__testOnly.isMaintenanceEnabled()).toBe(false);
+    process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED = '0';
+    expect(__testOnly.isMaintenanceEnabled()).toBe(false);
+    process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED = 'true';
+    expect(__testOnly.isMaintenanceEnabled()).toBe(true);
+  });
+
+  it('registers a daily repeatable job with a stable jobId', async () => {
+    await scheduleMetricRollupMaintenance();
+
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock).toHaveBeenCalledWith(
+      'metric-rollup-maintenance',
+      expect.objectContaining({
+        partitionMonthsAhead: expect.any(Number),
+        deleteBatchSize: expect.any(Number),
+      }),
+      expect.objectContaining({
+        jobId: 'metric-rollup-maintenance',
+        repeat: { pattern: '15 3 * * *' },
+      }),
+    );
+  });
+
+  it('removes stale repeatables for the same job before scheduling', async () => {
+    getRepeatableJobsMock.mockResolvedValue([
+      { name: 'metric-rollup-maintenance', key: 'old-key' },
+      { name: 'other-job', key: 'keep-key' },
+    ]);
+
+    await scheduleMetricRollupMaintenance();
+
+    expect(removeRepeatableByKeyMock).toHaveBeenCalledTimes(1);
+    expect(removeRepeatableByKeyMock).toHaveBeenCalledWith('old-key');
+    expect(addMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips schedule registration when disabled by env', async () => {
+    process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED = 'off';
+
+    await scheduleMetricRollupMaintenance();
+
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('runs maintenance inside system DB context', async () => {
+    createMetricRollupMaintenanceWorker();
+    expect(capturedWorkerProcessor.current).toBeTypeOf('function');
+
+    const result = await capturedWorkerProcessor.current!({
+      id: 'job-1',
+      name: 'metric-rollup-maintenance',
+      data: {
+        requestedAt: '2026-06-18T12:00:00.000Z',
+        deleteBatchSize: 250,
+        maxDeleteBatches: 2,
+      },
+    });
+
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    expect(runMaintenanceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        now: new Date('2026-06-18T12:00:00.000Z'),
+        deleteBatchSize: 250,
+        maxDeleteBatches: 2,
+      }),
+    );
+    expect(result).toMatchObject({ ensuredPartitions: ['metric_rollups_y2026m06'] });
+  });
+
+  it('ignores unknown job names without running maintenance', async () => {
+    createMetricRollupMaintenanceWorker();
+
+    const result = await capturedWorkerProcessor.current!({
+      id: 'job-2',
+      name: 'something-else',
+      data: {},
+    });
+
+    expect(runMaintenanceMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ skipped: true });
+  });
+
+  it('initializes, schedules, and shuts down idempotently', async () => {
+    await initializeMetricRollupMaintenanceWorker();
+    expect(addMock).toHaveBeenCalledTimes(1);
+
+    await shutdownMetricRollupMaintenanceWorker();
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+
+    await shutdownMetricRollupMaintenanceWorker();
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/jobs/metricRollupMaintenance.ts
+++ b/apps/api/src/jobs/metricRollupMaintenance.ts
@@ -1,0 +1,147 @@
+import { Job, Queue, Worker } from 'bullmq';
+
+import * as dbModule from '../db';
+import {
+  DEFAULT_METRIC_ROLLUP_DELETE_BATCH_SIZE,
+  DEFAULT_METRIC_ROLLUP_MAX_DELETE_BATCHES,
+  DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_AHEAD,
+  DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_BACK,
+  runMetricRollupMaintenance,
+  type MetricRollupMaintenanceResult,
+} from '../services/metricRollupMaintenance';
+import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
+
+const QUEUE_NAME = 'metric-rollup-maintenance';
+const JOB_NAME = 'metric-rollup-maintenance';
+const REPEAT_JOB_ID = 'metric-rollup-maintenance';
+const DAILY_CRON = process.env.METRIC_ROLLUP_MAINTENANCE_CRON || '15 3 * * *';
+
+export type MetricRollupMaintenanceJobData = {
+  requestedAt?: string;
+  partitionMonthsBack?: number;
+  partitionMonthsAhead?: number;
+  deleteBatchSize?: number;
+  maxDeleteBatches?: number;
+};
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error(
+      '[MetricRollupMaintenance] withSystemDbAccessContext is not available — DB module may not have loaded correctly',
+    );
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+function isMaintenanceEnabled(): boolean {
+  const raw = process.env.METRIC_ROLLUP_MAINTENANCE_ENABLED;
+  if (raw === undefined || raw === '') return true;
+  const value = raw.trim().toLowerCase();
+  return !(value === '0' || value === 'false' || value === 'no' || value === 'off');
+}
+
+let maintenanceQueue: Queue<MetricRollupMaintenanceJobData> | null = null;
+let maintenanceWorker: Worker<MetricRollupMaintenanceJobData> | null = null;
+
+export function getMetricRollupMaintenanceQueue(): Queue<MetricRollupMaintenanceJobData> {
+  if (!maintenanceQueue) {
+    maintenanceQueue = new Queue<MetricRollupMaintenanceJobData>(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return maintenanceQueue;
+}
+
+export function createMetricRollupMaintenanceWorker(): Worker<MetricRollupMaintenanceJobData> {
+  return new Worker<MetricRollupMaintenanceJobData>(
+    QUEUE_NAME,
+    async (job: Job<MetricRollupMaintenanceJobData>): Promise<MetricRollupMaintenanceResult | { skipped: true }> => {
+      if (job.name !== JOB_NAME) {
+        console.warn(`[MetricRollupMaintenance] Ignoring unknown job name: ${job.name}`);
+        return { skipped: true };
+      }
+
+      return runWithSystemDbAccess(async () => {
+        const result = await runMetricRollupMaintenance({
+          now: job.data.requestedAt ? new Date(job.data.requestedAt) : undefined,
+          partitionMonthsBack: job.data.partitionMonthsBack,
+          partitionMonthsAhead: job.data.partitionMonthsAhead,
+          deleteBatchSize: job.data.deleteBatchSize,
+          maxDeleteBatches: job.data.maxDeleteBatches,
+        });
+        const deleted = result.retention.reduce((sum, tier) => sum + tier.deleted, 0);
+        console.log(
+          `[MetricRollupMaintenance] ensured=${result.ensuredPartitions.length} dropped=${result.droppedPartitions.length} deleted=${deleted} durationMs=${result.durationMs}`,
+        );
+        return result;
+      });
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+      lockDuration: 300_000,
+      stalledInterval: 60_000,
+      maxStalledCount: 2,
+    },
+  );
+}
+
+export async function scheduleMetricRollupMaintenance(
+  queue: Queue<MetricRollupMaintenanceJobData> = getMetricRollupMaintenanceQueue(),
+): Promise<void> {
+  const existingJobs = await queue.getRepeatableJobs();
+  for (const job of existingJobs) {
+    if (job.name === JOB_NAME) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  if (!isMaintenanceEnabled()) {
+    console.log('[MetricRollupMaintenance] METRIC_ROLLUP_MAINTENANCE_ENABLED=false — skipping schedule registration');
+    return;
+  }
+
+  await queue.add(
+    JOB_NAME,
+    {
+      partitionMonthsBack: DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_BACK,
+      partitionMonthsAhead: DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_AHEAD,
+      deleteBatchSize: DEFAULT_METRIC_ROLLUP_DELETE_BATCH_SIZE,
+      maxDeleteBatches: DEFAULT_METRIC_ROLLUP_MAX_DELETE_BATCHES,
+    },
+    {
+      jobId: REPEAT_JOB_ID,
+      repeat: { pattern: DAILY_CRON },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 25 },
+    },
+  );
+  console.log(`[MetricRollupMaintenance] Scheduled daily maintenance (cron "${DAILY_CRON}", jobId=${REPEAT_JOB_ID})`);
+}
+
+export async function initializeMetricRollupMaintenanceWorker(): Promise<void> {
+  maintenanceWorker = createMetricRollupMaintenanceWorker();
+  attachWorkerObservability(maintenanceWorker, 'metricRollupMaintenance');
+  await scheduleMetricRollupMaintenance();
+  console.log('[MetricRollupMaintenance] Worker initialized');
+}
+
+export async function shutdownMetricRollupMaintenanceWorker(): Promise<void> {
+  if (maintenanceWorker) {
+    await maintenanceWorker.close();
+    maintenanceWorker = null;
+  }
+  if (maintenanceQueue) {
+    await maintenanceQueue.close();
+    maintenanceQueue = null;
+  }
+}
+
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  DAILY_CRON,
+  isMaintenanceEnabled,
+};

--- a/apps/api/src/services/metricRollupMaintenance.test.ts
+++ b/apps/api/src/services/metricRollupMaintenance.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    execute: executeMock,
+  },
+}));
+
+import {
+  deleteExpiredMetricRollupsForBucket,
+  dropExpiredMetricRollupPartitions,
+  ensureMetricRollupPartitions,
+  metricRollupPartitionName,
+  parseMetricRollupPartitionMonth,
+  runMetricRollupMaintenance,
+} from './metricRollupMaintenance';
+
+describe('metric rollup maintenance service', () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    executeMock.mockResolvedValue([]);
+  });
+
+  it('uses deterministic month partition names', () => {
+    expect(metricRollupPartitionName(new Date('2026-06-18T12:00:00.000Z'))).toBe('metric_rollups_y2026m06');
+    expect(parseMetricRollupPartitionMonth('metric_rollups_y2026m06')?.toISOString()).toBe(
+      '2026-06-01T00:00:00.000Z',
+    );
+    expect(parseMetricRollupPartitionMonth('metric_rollups_default')).toBeNull();
+  });
+
+  it('creates monthly partitions with RLS policies and breeze_app grants', async () => {
+    await ensureMetricRollupPartitions({
+      referenceDate: new Date('2026-06-18T12:00:00.000Z'),
+      monthsBack: 0,
+      monthsAhead: 1,
+    });
+
+    const executedSql = JSON.stringify(executeMock.mock.calls);
+    expect(executeMock).toHaveBeenCalledTimes(24);
+    expect(executedSql).toContain('metric_rollups_y2026m06');
+    expect(executedSql).toContain('metric_rollups_y2026m07');
+    expect(executedSql).toContain('PARTITION OF metric_rollups');
+    expect(executedSql).toContain('FOR VALUES FROM');
+    expect(executedSql).toContain('ENABLE ROW LEVEL SECURITY');
+    expect(executedSql).toContain('FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))');
+    expect(executedSql).toContain('GRANT SELECT, INSERT, UPDATE, DELETE');
+  });
+
+  it('uses tableoid and ctid for bounded deletes through the partitioned parent', async () => {
+    executeMock.mockResolvedValueOnce({ rowCount: 5000 }).mockResolvedValueOnce({ rowCount: 25 });
+
+    const result = await deleteExpiredMetricRollupsForBucket({
+      bucketSeconds: 300,
+      cutoff: new Date('2026-03-20T00:00:00.000Z'),
+      batchSize: 5000,
+      maxBatches: 3,
+    });
+
+    expect(result).toEqual({ deleted: 5025, batches: 2, hasMore: false });
+    const executedSql = JSON.stringify(executeMock.mock.calls);
+    expect(executedSql).toContain('SELECT tableoid, ctid');
+    expect(executedSql).toContain('mr.tableoid = doomed.tableoid');
+    expect(executedSql).toContain('mr.ctid = doomed.ctid');
+    expect(executedSql).toContain('ORDER BY bucket_start');
+    expect(executedSql).toContain('LIMIT');
+  });
+
+  it('reports hasMore when bounded deletes stop at the configured batch cap', async () => {
+    executeMock.mockResolvedValue({ rowCount: 100 });
+
+    const result = await deleteExpiredMetricRollupsForBucket({
+      bucketSeconds: 3600,
+      cutoff: new Date('2025-01-01T00:00:00.000Z'),
+      batchSize: 100,
+      maxBatches: 2,
+    });
+
+    expect(result).toEqual({ deleted: 200, batches: 2, hasMore: true });
+  });
+
+  it('drops only managed partitions whose whole month is past the daily retention window', async () => {
+    executeMock
+      .mockResolvedValueOnce([
+        { partitionName: 'metric_rollups_y2022m12' },
+        { partitionName: 'metric_rollups_y2026m06' },
+        { partitionName: 'metric_rollups_default' },
+      ])
+      .mockResolvedValueOnce({ rowCount: 0 });
+
+    const dropped = await dropExpiredMetricRollupPartitions(new Date('2026-06-18T12:00:00.000Z'));
+
+    expect(dropped).toEqual(['metric_rollups_y2022m12']);
+    expect(executeMock).toHaveBeenCalledTimes(2);
+    const dropSql = JSON.stringify(executeMock.mock.calls[1]);
+    expect(dropSql).toContain('DROP TABLE IF EXISTS');
+    expect(dropSql).toContain('metric_rollups_y2022m12');
+  });
+
+  it('skips maintenance when another worker holds the advisory lock', async () => {
+    executeMock.mockResolvedValueOnce([{ acquired: false }]);
+
+    const result = await runMetricRollupMaintenance({ now: new Date('2026-06-18T12:00:00.000Z') });
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: 'maintenance lock already held',
+      ensuredPartitions: [],
+      droppedPartitions: [],
+      retention: [],
+    });
+    expect(executeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/metricRollupMaintenance.ts
+++ b/apps/api/src/services/metricRollupMaintenance.ts
@@ -1,0 +1,363 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '../db';
+
+export const METRIC_ROLLUP_BUCKET_RETENTION_DAYS = {
+  fiveMinute: Math.max(30, parsePositiveIntEnv('METRIC_ROLLUP_5M_RETENTION_DAYS', 90)),
+  hourly: Math.max(365, parsePositiveIntEnv('METRIC_ROLLUP_HOURLY_RETENTION_DAYS', 548)),
+  daily: Math.max(730, parsePositiveIntEnv('METRIC_ROLLUP_DAILY_RETENTION_DAYS', 1095)),
+} as const;
+
+export const DEFAULT_METRIC_ROLLUP_DELETE_BATCH_SIZE = Math.max(
+  100,
+  parsePositiveIntEnv('METRIC_ROLLUP_DELETE_BATCH_SIZE', 5000),
+);
+export const DEFAULT_METRIC_ROLLUP_MAX_DELETE_BATCHES = Math.max(
+  1,
+  parsePositiveIntEnv('METRIC_ROLLUP_MAX_DELETE_BATCHES', 20),
+);
+export const DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_BACK = Math.max(
+  0,
+  parsePositiveIntEnv('METRIC_ROLLUP_PARTITION_MONTHS_BACK', 0),
+);
+export const DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_AHEAD = Math.max(
+  1,
+  parsePositiveIntEnv('METRIC_ROLLUP_PARTITION_MONTHS_AHEAD', 3),
+);
+
+type EnsurePartitionOptions = {
+  referenceDate?: Date;
+  monthsBack?: number;
+  monthsAhead?: number;
+};
+
+type DeleteOptions = {
+  bucketSeconds: 300 | 3600 | 86400;
+  cutoff: Date;
+  batchSize?: number;
+  maxBatches?: number;
+};
+
+export type MetricRollupBucketRetentionResult = {
+  bucketSeconds: 300 | 3600 | 86400;
+  retentionDays: number;
+  cutoff: string;
+  deleted: number;
+  batches: number;
+  hasMore: boolean;
+};
+
+export type MetricRollupMaintenanceResult = {
+  ensuredPartitions: string[];
+  droppedPartitions: string[];
+  retention: MetricRollupBucketRetentionResult[];
+  durationMs: number;
+  skipped?: boolean;
+  reason?: string;
+};
+
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`[MetricRollupMaintenance] Invalid ${name}="${raw}", using default ${defaultValue}`);
+    return defaultValue;
+  }
+  return parsed;
+}
+
+function assertValidDate(value: Date, name: string): void {
+  if (Number.isNaN(value.getTime())) {
+    throw new Error(`${name} must be a valid Date`);
+  }
+}
+
+function monthStartUtc(value: Date): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), 1));
+}
+
+function addMonths(value: Date, months: number): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth() + months, 1));
+}
+
+function formatTimestampLiteral(value: Date): string {
+  return value.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function quoteIdentifier(identifier: string): string {
+  if (!/^[a-z0-9_]+$/.test(identifier)) {
+    throw new Error(`Unsafe SQL identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
+}
+
+function isDefaultPartitionOverlapError(error: unknown): boolean {
+  const message = String((error as { message?: unknown })?.message ?? error);
+  return (
+    message.includes('updated partition constraint for default partition') &&
+    message.includes('would be violated by some row')
+  );
+}
+
+export function metricRollupPartitionName(monthStart: Date): string {
+  assertValidDate(monthStart, 'monthStart');
+  return `metric_rollups_y${monthStart.getUTCFullYear()}m${String(monthStart.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+export function parseMetricRollupPartitionMonth(partitionName: string): Date | null {
+  const match = /^metric_rollups_y(\d{4})m(\d{2})$/.exec(partitionName);
+  if (!match) return null;
+  const [, yearRaw, monthRaw] = match;
+  if (!yearRaw || !monthRaw) return null;
+  const year = Number.parseInt(yearRaw, 10);
+  const month = Number.parseInt(monthRaw, 10);
+  if (month < 1 || month > 12) return null;
+  return new Date(Date.UTC(year, month - 1, 1));
+}
+
+export function extractRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? result.length : 0;
+}
+
+async function tryAcquireMaintenanceLock(): Promise<boolean> {
+  const result = await db.execute(sql`
+    SELECT pg_try_advisory_lock(hashtext('metric_rollup_maintenance')) AS "acquired"
+  `);
+  const row = Array.isArray(result) ? (result[0] as { acquired?: unknown } | undefined) : undefined;
+  return row?.acquired === true;
+}
+
+async function releaseMaintenanceLock(): Promise<void> {
+  await db.execute(sql`SELECT pg_advisory_unlock(hashtext('metric_rollup_maintenance'))`);
+}
+
+export async function ensureMetricRollupPartitions(options: EnsurePartitionOptions = {}): Promise<string[]> {
+  const referenceDate = options.referenceDate ?? new Date();
+  assertValidDate(referenceDate, 'referenceDate');
+
+  const monthsBack = Math.max(0, options.monthsBack ?? DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_BACK);
+  const monthsAhead = Math.max(1, options.monthsAhead ?? DEFAULT_METRIC_ROLLUP_PARTITION_MONTHS_AHEAD);
+  const anchor = monthStartUtc(referenceDate);
+  const ensured: string[] = [];
+
+  for (let offset = -monthsBack; offset <= monthsAhead; offset += 1) {
+    const from = addMonths(anchor, offset);
+    const to = addMonths(from, 1);
+    const partitionName = metricRollupPartitionName(from);
+    const partitionIdentifier = sql.raw(quoteIdentifier(partitionName));
+    const fromLiteral = sql.raw(`'${formatTimestampLiteral(from)}'::timestamp`);
+    const toLiteral = sql.raw(`'${formatTimestampLiteral(to)}'::timestamp`);
+
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS ${partitionIdentifier}
+          PARTITION OF metric_rollups
+          FOR VALUES FROM (${fromLiteral}) TO (${toLiteral});
+      `);
+    } catch (error) {
+      if (isDefaultPartitionOverlapError(error)) {
+        console.warn(
+          `[MetricRollupMaintenance] Skipping ${partitionName}; metric_rollups_default already contains rows for that month`,
+        );
+        continue;
+      }
+      throw error;
+    }
+    await db.execute(sql`ALTER TABLE ${partitionIdentifier} ENABLE ROW LEVEL SECURITY`);
+    await db.execute(sql`ALTER TABLE ${partitionIdentifier} FORCE ROW LEVEL SECURITY`);
+    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_select ON ${partitionIdentifier}`);
+    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_insert ON ${partitionIdentifier}`);
+    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_update ON ${partitionIdentifier}`);
+    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_delete ON ${partitionIdentifier}`);
+    await db.execute(sql`
+      CREATE POLICY breeze_org_isolation_select ON ${partitionIdentifier}
+        FOR SELECT USING (public.breeze_has_org_access(org_id))
+    `);
+    await db.execute(sql`
+      CREATE POLICY breeze_org_isolation_insert ON ${partitionIdentifier}
+        FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))
+    `);
+    await db.execute(sql`
+      CREATE POLICY breeze_org_isolation_update ON ${partitionIdentifier}
+        FOR UPDATE USING (public.breeze_has_org_access(org_id))
+        WITH CHECK (public.breeze_has_org_access(org_id))
+    `);
+    await db.execute(sql`
+      CREATE POLICY breeze_org_isolation_delete ON ${partitionIdentifier}
+        FOR DELETE USING (public.breeze_has_org_access(org_id))
+    `);
+    await db.execute(sql`GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE ${partitionIdentifier} TO breeze_app`);
+    ensured.push(partitionName);
+  }
+
+  return ensured;
+}
+
+export async function listMetricRollupPartitions(): Promise<string[]> {
+  const result = await db.execute(sql`
+    SELECT child.relname AS "partitionName"
+    FROM pg_inherits
+    JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+    JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+    JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+    JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+    WHERE parent.relname = 'metric_rollups'
+      AND parent_ns.nspname = 'public'
+      AND child_ns.nspname = 'public'
+      AND child.relname LIKE 'metric_rollups_y____m__'
+    ORDER BY child.relname
+  `);
+
+  return (Array.isArray(result) ? result : [])
+    .map((row) => (row as { partitionName?: unknown }).partitionName)
+    .filter((value): value is string => typeof value === 'string');
+}
+
+export async function dropExpiredMetricRollupPartitions(now = new Date()): Promise<string[]> {
+  assertValidDate(now, 'now');
+  const dailyCutoff = new Date(now.getTime() - METRIC_ROLLUP_BUCKET_RETENTION_DAYS.daily * 24 * 60 * 60 * 1000);
+  const partitionNames = await listMetricRollupPartitions();
+  const dropped: string[] = [];
+
+  for (const partitionName of partitionNames) {
+    const partitionStart = parseMetricRollupPartitionMonth(partitionName);
+    if (!partitionStart) continue;
+
+    const partitionEnd = addMonths(partitionStart, 1);
+    if (partitionEnd.getTime() > dailyCutoff.getTime()) continue;
+
+    await db.execute(sql`DROP TABLE IF EXISTS ${sql.raw(quoteIdentifier(partitionName))}`);
+    dropped.push(partitionName);
+  }
+
+  return dropped;
+}
+
+export async function deleteExpiredMetricRollupsForBucket(options: DeleteOptions): Promise<{
+  deleted: number;
+  batches: number;
+  hasMore: boolean;
+}> {
+  const batchSize = Math.max(1, options.batchSize ?? DEFAULT_METRIC_ROLLUP_DELETE_BATCH_SIZE);
+  const maxBatches = Math.max(1, options.maxBatches ?? DEFAULT_METRIC_ROLLUP_MAX_DELETE_BATCHES);
+  assertValidDate(options.cutoff, 'cutoff');
+
+  let deleted = 0;
+  let batches = 0;
+  let lastBatchCount = 0;
+
+  for (let attempted = 0; attempted < maxBatches; attempted += 1) {
+    const result = await db.execute(sql`
+      WITH doomed AS (
+        SELECT tableoid, ctid
+        FROM metric_rollups
+        WHERE bucket_seconds = ${options.bucketSeconds}
+          AND bucket_start < ${options.cutoff.toISOString()}::timestamp
+        ORDER BY bucket_start
+        LIMIT ${batchSize}
+      )
+      DELETE FROM metric_rollups AS mr
+      USING doomed
+      WHERE mr.tableoid = doomed.tableoid
+        AND mr.ctid = doomed.ctid
+      RETURNING 1
+    `);
+    lastBatchCount = extractRowCount(result);
+    batches += 1;
+    deleted += lastBatchCount;
+    if (lastBatchCount < batchSize) break;
+  }
+
+  return {
+    deleted,
+    batches,
+    hasMore: lastBatchCount === batchSize && batches === maxBatches,
+  };
+}
+
+export async function pruneMetricRollups(options: {
+  now?: Date;
+  batchSize?: number;
+  maxBatches?: number;
+} = {}): Promise<MetricRollupBucketRetentionResult[]> {
+  const now = options.now ?? new Date();
+  assertValidDate(now, 'now');
+
+  const tiers: Array<{ bucketSeconds: 300 | 3600 | 86400; retentionDays: number }> = [
+    { bucketSeconds: 300, retentionDays: METRIC_ROLLUP_BUCKET_RETENTION_DAYS.fiveMinute },
+    { bucketSeconds: 3600, retentionDays: METRIC_ROLLUP_BUCKET_RETENTION_DAYS.hourly },
+    { bucketSeconds: 86400, retentionDays: METRIC_ROLLUP_BUCKET_RETENTION_DAYS.daily },
+  ];
+
+  const results: MetricRollupBucketRetentionResult[] = [];
+  for (const tier of tiers) {
+    const cutoff = new Date(now.getTime() - tier.retentionDays * 24 * 60 * 60 * 1000);
+    const result = await deleteExpiredMetricRollupsForBucket({
+      bucketSeconds: tier.bucketSeconds,
+      cutoff,
+      batchSize: options.batchSize,
+      maxBatches: options.maxBatches,
+    });
+    results.push({
+      bucketSeconds: tier.bucketSeconds,
+      retentionDays: tier.retentionDays,
+      cutoff: cutoff.toISOString(),
+      deleted: result.deleted,
+      batches: result.batches,
+      hasMore: result.hasMore,
+    });
+  }
+
+  return results;
+}
+
+export async function runMetricRollupMaintenance(options: {
+  now?: Date;
+  partitionMonthsBack?: number;
+  partitionMonthsAhead?: number;
+  deleteBatchSize?: number;
+  maxDeleteBatches?: number;
+} = {}): Promise<MetricRollupMaintenanceResult> {
+  const startedAt = Date.now();
+  const now = options.now ?? new Date();
+  assertValidDate(now, 'now');
+
+  const acquired = await tryAcquireMaintenanceLock();
+  if (!acquired) {
+    return {
+      ensuredPartitions: [],
+      droppedPartitions: [],
+      retention: [],
+      durationMs: Date.now() - startedAt,
+      skipped: true,
+      reason: 'maintenance lock already held',
+    };
+  }
+
+  try {
+    const ensuredPartitions = await ensureMetricRollupPartitions({
+      referenceDate: now,
+      monthsBack: options.partitionMonthsBack,
+      monthsAhead: options.partitionMonthsAhead,
+    });
+    const droppedPartitions = await dropExpiredMetricRollupPartitions(now);
+    const retention = await pruneMetricRollups({
+      now,
+      batchSize: options.deleteBatchSize,
+      maxBatches: options.maxDeleteBatches,
+    });
+
+    return {
+      ensuredPartitions,
+      droppedPartitions,
+      retention,
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    await releaseMaintenanceLock();
+  }
+}


### PR DESCRIPTION
## Summary
- add metric rollup maintenance service for monthly partitions, conservative expired partition drops, and bounded per-bucket retention deletes
- add BullMQ maintenance worker with stable repeat job id, system DB context, advisory-lock protected execution, and env kill switch
- wire the worker into API startup/shutdown and cover service/job behavior with unit tests

## Validation
- pnpm --filter @breeze/api exec vitest run src/services/metricRollupMaintenance.test.ts src/jobs/metricRollupMaintenance.test.ts src/services/metricRollups.test.ts src/jobs/metricRollups.test.ts scripts/metric-rollup-backfill.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit
- git diff --check
- DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm --filter @breeze/api db:check-drift *(fails in this local environment: role "breeze" does not exist)*