### PR TITLE
feat(ml): add anomaly evaluation metrics

### DIFF
--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -171,6 +171,20 @@ vi.mock('../db/schema', () => ({
     avgValue: 'metricRollups.avgValue',
     sampleCount: 'metricRollups.sampleCount'
   },
+  metricAnomalies: {
+    id: 'metricAnomalies.id',
+    orgId: 'metricAnomalies.orgId',
+    deviceId: 'metricAnomalies.deviceId',
+    status: 'metricAnomalies.status',
+    detectedAt: 'metricAnomalies.detectedAt'
+  },
+  mlFeedbackEvents: {
+    orgId: 'mlFeedbackEvents.orgId',
+    sourceType: 'mlFeedbackEvents.sourceType',
+    sourceId: 'mlFeedbackEvents.sourceId',
+    eventType: 'mlFeedbackEvents.eventType',
+    occurredAt: 'mlFeedbackEvents.occurredAt'
+  },
   devices: {
     id: 'devices.id',
     orgId: 'devices.orgId',
@@ -386,6 +400,52 @@ describe('analytics routes', () => {
         value: 10,
       });
       expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('GET /analytics/anomalies/evaluation', () => {
+    it('returns anomaly status rates and lifecycle feedback counts', async () => {
+      mockSelectOnce([
+        { status: 'open', count: 4 },
+        { status: 'dismissed', count: 3 },
+        { status: 'promoted', count: 2 },
+        { status: 'resolved', count: 1 },
+      ]);
+      mockSelectOnce([
+        { eventType: 'anomaly.dismissed', count: 2 },
+        { eventType: 'anomaly.promoted', count: 1 },
+        { eventType: 'anomaly.resolved', count: 1 },
+      ]);
+
+      const res = await app.request('/analytics/anomalies/evaluation?range=30d', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(10);
+      expect(body.status).toEqual({ open: 4, dismissed: 3, promoted: 2, resolved: 1 });
+      expect(body.rates).toEqual({ dismissRate: 0.3, promoteRate: 0.2, resolveRate: 0.1 });
+      expect(body.feedback).toEqual({ total: 4, dismissed: 2, promoted: 1, resolved: 1 });
+      expect(body.window.range).toBe('30d');
+      expect(body.orgId).toBe(ORG_ID);
+    });
+
+    it('returns zero rates when no anomalies match', async () => {
+      mockSelectOnce([]);
+      mockSelectOnce([]);
+
+      const res = await app.request('/analytics/anomalies/evaluation?range=7d', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(0);
+      expect(body.rates).toEqual({ dismissRate: 0, promoteRate: 0, resolveRate: 0 });
+      expect(body.feedback.total).toBe(0);
     });
   });
 
@@ -794,6 +854,63 @@ describe('analytics routes', () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.currentValue).toBe(72);
+      });
+    });
+
+    describe('GET /analytics/anomalies/evaluation', () => {
+      it('returns 403 when a site-restricted caller drills into an out-of-scope deviceId', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
+
+        const res = await app.request(
+          `/analytics/anomalies/evaluation?deviceId=${DEVICE_OUT_OF_SCOPE}`,
+          { method: 'GET', headers: { Authorization: 'Bearer token' } }
+        );
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe('Device not found or access denied');
+      });
+
+      it('narrows org-wide anomaly evaluation to in-scope devices for a site-restricted caller', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
+        mockSelectOnce([
+          { status: 'open', count: 1 },
+          { status: 'dismissed', count: 1 },
+        ]); // anomaly status counts
+        mockSelectOnce([
+          { eventType: 'anomaly.dismissed', count: 1 },
+        ]); // feedback counts
+
+        const res = await app.request('/analytics/anomalies/evaluation?range=90d', {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' }
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.total).toBe(2);
+        expect(body.status.dismissed).toBe(1);
+        expect(body.rates.dismissRate).toBe(0.5);
+        expect(body.feedback.dismissed).toBe(1);
+        expect(vi.mocked(db.select)).toHaveBeenCalledTimes(3);
+      });
+
+      it('short-circuits anomaly evaluation when a site-restricted caller has no in-scope devices', async () => {
+        currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
+        mockSelectOnce([{ id: DEVICE_OUT_OF_SCOPE, siteId: SITE_DENIED }]); // device resolution
+
+        const res = await app.request('/analytics/anomalies/evaluation', {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' }
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.total).toBe(0);
+        expect(body.status).toEqual({ open: 0, dismissed: 0, promoted: 0, resolved: 0 });
+        expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, eq, sql, gte, lte, ne, inArray, isNull, or, desc } from 'drizzle-orm';
+import { and, eq, sql, gte, lte, ne, inArray, isNull, or, desc, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   analyticsDashboards,
@@ -9,6 +9,8 @@ import {
   capacityPredictions,
   capacityThresholds,
   deviceMetrics,
+  mlFeedbackEvents,
+  metricAnomalies,
   metricRollups,
   devices,
   slaDefinitions as slaDefinitionsTable,
@@ -199,10 +201,58 @@ const capacityQuerySchema = z.object({
   range: z.string().optional().default('30d')
 });
 
+const anomalyEvaluationQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  deviceId: z.string().uuid().optional(),
+  range: z.enum(['7d', '30d', '90d']).optional().default('30d')
+});
+
 function capacityRollupMetricName(metricType: string): string {
   if (metricType === 'cpu') return 'cpu_percent';
   if (metricType === 'memory') return 'ram_percent';
   return 'disk_percent';
+}
+
+function rangeDays(range: string): number {
+  if (range === '7d') return 7;
+  if (range === '90d') return 90;
+  return 30;
+}
+
+function zeroAnomalyEvaluationResponse(options: {
+  since: Date;
+  until: Date;
+  range: string;
+  orgId?: string;
+  deviceId?: string;
+}) {
+  return {
+    window: {
+      range: options.range,
+      since: options.since.toISOString(),
+      until: options.until.toISOString(),
+    },
+    orgId: options.orgId,
+    deviceId: options.deviceId,
+    total: 0,
+    status: {
+      open: 0,
+      dismissed: 0,
+      promoted: 0,
+      resolved: 0,
+    },
+    rates: {
+      dismissRate: 0,
+      promoteRate: 0,
+      resolveRate: 0,
+    },
+    feedback: {
+      total: 0,
+      dismissed: 0,
+      promoted: 0,
+      resolved: 0,
+    },
+  };
 }
 
 const listSlaSchema = z.object({
@@ -883,6 +933,144 @@ analyticsRoutes.delete(
 // ============================================
 // CAPACITY & SLA
 // ============================================
+
+analyticsRoutes.get(
+  '/anomalies/evaluation',
+  requireScope('organization', 'partner', 'system'),
+  requireAnalyticsRead,
+  zValidator('query', anomalyEvaluationQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const query = c.req.valid('query');
+
+    if (query.orgId && !(await ensureOrgAccess(query.orgId, auth))) {
+      return c.json({ error: 'Access to this organization denied' }, 403);
+    }
+
+    const effectiveOrgId = query.orgId ?? auth.orgId;
+    const until = new Date();
+    const since = new Date(until.getTime() - rangeDays(query.range) * 24 * 60 * 60 * 1000);
+
+    let allowedDeviceIds: string[] | null = null;
+    if (perms?.allowedSiteIds && effectiveOrgId) {
+      allowedDeviceIds = await resolveSiteAllowedDeviceIds(effectiveOrgId, perms);
+      if (query.deviceId && !(allowedDeviceIds ?? []).includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      if (!query.deviceId && (allowedDeviceIds ?? []).length === 0) {
+        return c.json(zeroAnomalyEvaluationResponse({
+          since,
+          until,
+          range: query.range,
+          orgId: effectiveOrgId,
+        }));
+      }
+    }
+
+    const anomalyOrgCondition =
+      query.orgId
+        ? eq(metricAnomalies.orgId, query.orgId)
+        : typeof auth?.orgCondition === 'function'
+          ? auth.orgCondition(metricAnomalies.orgId)
+          : auth?.orgId
+            ? eq(metricAnomalies.orgId, auth.orgId)
+            : undefined;
+
+    const feedbackOrgCondition =
+      query.orgId
+        ? eq(mlFeedbackEvents.orgId, query.orgId)
+        : typeof auth?.orgCondition === 'function'
+          ? auth.orgCondition(mlFeedbackEvents.orgId)
+          : auth?.orgId
+            ? eq(mlFeedbackEvents.orgId, auth.orgId)
+            : undefined;
+
+    const anomalyConditions: SQL[] = [
+      gte(metricAnomalies.detectedAt, since),
+      ...(anomalyOrgCondition ? [anomalyOrgCondition] : []),
+      ...(query.deviceId ? [eq(metricAnomalies.deviceId, query.deviceId)] : []),
+      ...(allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length > 0
+        ? [inArray(metricAnomalies.deviceId, allowedDeviceIds)]
+        : []),
+    ];
+
+    const feedbackAnomalyConditions: SQL[] = [
+      gte(metricAnomalies.detectedAt, since),
+      ...(query.deviceId ? [eq(metricAnomalies.deviceId, query.deviceId)] : []),
+      ...(allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length > 0
+        ? [inArray(metricAnomalies.deviceId, allowedDeviceIds)]
+        : []),
+    ];
+
+    const statusRows = await db
+      .select({
+        status: metricAnomalies.status,
+        count: sql<number>`count(*)`,
+      })
+      .from(metricAnomalies)
+      .where(and(...anomalyConditions))
+      .groupBy(metricAnomalies.status);
+
+    const feedbackRows = await db
+      .select({
+        eventType: mlFeedbackEvents.eventType,
+        count: sql<number>`count(*)`,
+      })
+      .from(mlFeedbackEvents)
+      .innerJoin(
+        metricAnomalies,
+        and(
+          sql`${mlFeedbackEvents.sourceId} = ${metricAnomalies.id}::text`,
+          eq(metricAnomalies.orgId, mlFeedbackEvents.orgId),
+        ),
+      )
+      .where(and(
+        eq(mlFeedbackEvents.sourceType, 'anomaly'),
+        inArray(mlFeedbackEvents.eventType, ['anomaly.dismissed', 'anomaly.promoted', 'anomaly.resolved']),
+        gte(mlFeedbackEvents.occurredAt, since),
+        ...(feedbackOrgCondition ? [feedbackOrgCondition] : []),
+        ...feedbackAnomalyConditions,
+      ))
+      .groupBy(mlFeedbackEvents.eventType);
+
+    const status = { open: 0, dismissed: 0, promoted: 0, resolved: 0 };
+    for (const row of statusRows) {
+      const key = String(row.status);
+      if (key === 'open' || key === 'dismissed' || key === 'promoted' || key === 'resolved') {
+        status[key] = Number(row.count) || 0;
+      }
+    }
+
+    const total = status.open + status.dismissed + status.promoted + status.resolved;
+    const feedback = { total: 0, dismissed: 0, promoted: 0, resolved: 0 };
+    for (const row of feedbackRows) {
+      const count = Number(row.count) || 0;
+      if (row.eventType === 'anomaly.dismissed') feedback.dismissed += count;
+      if (row.eventType === 'anomaly.promoted') feedback.promoted += count;
+      if (row.eventType === 'anomaly.resolved') feedback.resolved += count;
+    }
+    feedback.total = feedback.dismissed + feedback.promoted + feedback.resolved;
+
+    return c.json({
+      window: {
+        range: query.range,
+        since: since.toISOString(),
+        until: until.toISOString(),
+      },
+      orgId: effectiveOrgId,
+      deviceId: query.deviceId,
+      total,
+      status,
+      rates: {
+        dismissRate: total > 0 ? status.dismissed / total : 0,
+        promoteRate: total > 0 ? status.promoted / total : 0,
+        resolveRate: total > 0 ? status.resolved / total : 0,
+      },
+      feedback,
+    });
+  }
+);
 
 analyticsRoutes.get(
   '/capacity',


### PR DESCRIPTION
## Summary
- add `/analytics/anomalies/evaluation` for org/device/window anomaly status rates
- include lifecycle feedback counts from `ml_feedback_events` joined back to `metric_anomalies` for scoped evaluation
- cover empty windows plus site-restricted access/narrowing in analytics route tests

## Validation
- pnpm --filter @breeze/api exec vitest run src/routes/analytics.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit
- pnpm --filter @breeze/api exec vitest run src/routes/analytics.test.ts src/services/metricAnomalies.test.ts src/services/metricRollups.test.ts src/jobs/metricRollupMaintenance.test.ts src/services/metricRollupMaintenance.test.ts
- git diff --check
- DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm --filter @breeze/api db:check-drift *(fails in this local environment: role "breeze" does not exist)*