### PR TITLE
feat(ml): add remediation evaluation metrics

### DIFF
--- a/apps/api/src/routes/remediationSuggestions.test.ts
+++ b/apps/api/src/routes/remediationSuggestions.test.ts
@@ -9,6 +9,8 @@ const dbMocks = vi.hoisted(() => ({
   emitFeedbackMock: vi.fn(),
 }));
 
+let currentPermissions: { allowedSiteIds?: string[] } | undefined;
+
 vi.mock('../db', () => ({
   db: {
     select: dbMocks.selectMock,
@@ -19,7 +21,15 @@ vi.mock('../db', () => ({
 vi.mock('../db/schema', () => ({
   devices: {
     id: 'devices.id',
+    orgId: 'devices.orgId',
     siteId: 'devices.siteId',
+  },
+  mlFeedbackEvents: {
+    orgId: 'mlFeedbackEvents.orgId',
+    sourceType: 'mlFeedbackEvents.sourceType',
+    sourceId: 'mlFeedbackEvents.sourceId',
+    eventType: 'mlFeedbackEvents.eventType',
+    occurredAt: 'mlFeedbackEvents.occurredAt',
   },
   remediationSuggestions: {
     id: 'remediationSuggestions.id',
@@ -43,7 +53,7 @@ vi.mock('../middleware/auth', () => ({
       orgCondition: () => undefined,
       canAccessOrg: (orgId: string) => orgId === '11111111-1111-4111-8111-111111111111',
     });
-    c.set('permissions', {});
+    c.set('permissions', currentPermissions ?? {});
     return next();
   }),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
@@ -99,11 +109,26 @@ const baseSuggestion = {
   executedAt: null,
 };
 
+function createSelectChain(result: unknown = []) {
+  const chain: Record<string, any> = {};
+  for (const method of ['from', 'where', 'innerJoin', 'groupBy', 'orderBy', 'limit']) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.then = (onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected);
+  return chain;
+}
+
+function mockSelectOnce(result: unknown) {
+  dbMocks.selectMock.mockReturnValueOnce(createSelectChain(result));
+}
+
 describe('remediation suggestion routes', () => {
   let app: Hono;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    currentPermissions = undefined;
     app = new Hono();
     app.route('/remediation-suggestions', remediationSuggestionRoutes);
   });
@@ -168,5 +193,111 @@ describe('remediation suggestion routes', () => {
     }));
     const body = await res.json();
     expect(body.data.status).toBe('accepted');
+  });
+
+  it('returns remediation status rates and lifecycle feedback counts', async () => {
+    mockSelectOnce([
+      { status: 'suggested', count: 4 },
+      { status: 'accepted', count: 3 },
+      { status: 'rejected', count: 2 },
+      { status: 'executed', count: 1 },
+      { status: 'failed', count: 1 },
+    ]);
+    mockSelectOnce([
+      { eventType: 'suggestion.accepted', count: 3 },
+      { eventType: 'suggestion.rejected', count: 2 },
+      { eventType: 'suggestion.executed', count: 1 },
+      { eventType: 'suggestion.failed', count: 1 },
+    ]);
+
+    const res = await app.request('/remediation-suggestions/evaluation?days=30', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(11);
+    expect(body.status).toMatchObject({
+      suggested: 4,
+      accepted: 3,
+      rejected: 2,
+      executed: 1,
+      failed: 1,
+    });
+    expect(body.rates).toEqual({
+      acceptRate: 3 / 11,
+      rejectRate: 2 / 11,
+      executeRate: 1 / 11,
+      failureRate: 1 / 11,
+    });
+    expect(body.feedback).toEqual({
+      total: 7,
+      accepted: 3,
+      edited: 0,
+      rejected: 2,
+      executed: 1,
+      failed: 1,
+    });
+    expect(body.window.days).toBe(30);
+  });
+
+  it('returns 403 for an inaccessible org filter', async () => {
+    const res = await app.request('/remediation-suggestions/evaluation?orgId=99999999-9999-4999-8999-999999999999', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(dbMocks.selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns zero rates when no suggestions match', async () => {
+    mockSelectOnce([]);
+    mockSelectOnce([]);
+
+    const res = await app.request('/remediation-suggestions/evaluation?days=7', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(0);
+    expect(body.rates).toEqual({ acceptRate: 0, rejectRate: 0, executeRate: 0, failureRate: 0 });
+    expect(body.feedback.total).toBe(0);
+  });
+
+  it('returns 403 when a site-restricted caller drills into an out-of-scope deviceId', async () => {
+    currentPermissions = { allowedSiteIds: ['22222222-2222-4222-8222-222222222222'] };
+    mockSelectOnce([{ id: baseSuggestion.deviceId, siteId: '33333333-3333-4333-8333-333333333333' }]);
+
+    const res = await app.request(`/remediation-suggestions/evaluation?deviceId=${baseSuggestion.deviceId}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Device not found or access denied');
+  });
+
+  it('narrows remediation evaluation to in-scope devices for a site-restricted caller', async () => {
+    currentPermissions = { allowedSiteIds: ['22222222-2222-4222-8222-222222222222'] };
+    mockSelectOnce([{ id: baseSuggestion.deviceId, siteId: '22222222-2222-4222-8222-222222222222' }]);
+    mockSelectOnce([{ status: 'accepted', count: 1 }]);
+    mockSelectOnce([{ eventType: 'suggestion.accepted', count: 1 }]);
+
+    const res = await app.request('/remediation-suggestions/evaluation?days=90', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(1);
+    expect(body.status.accepted).toBe(1);
+    expect(body.rates.acceptRate).toBe(1);
+    expect(body.feedback.accepted).toBe(1);
   });
 });

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, inArray, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';
-import { devices, remediationSuggestions } from '../db/schema';
+import { devices, mlFeedbackEvents, remediationSuggestions } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { emitRemediationSuggestionFeedback } from '../services/mlFeedbackEmitters';
@@ -24,6 +24,14 @@ const listQuerySchema = z.object({
   deviceId: z.string().uuid().optional(),
   status: statusSchema.or(z.literal('all')).optional().default('all'),
   limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+});
+
+const evaluationQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+  sourceType: sourceTypeSchema.optional(),
+  sourceId: z.string().min(1).max(255).optional(),
+  deviceId: z.string().uuid().optional(),
+  days: z.coerce.number().int().min(1).max(365).optional().default(30),
 });
 
 const generateBodySchema = z.object({
@@ -85,6 +93,51 @@ function serializeSuggestion(row: typeof remediationSuggestions.$inferSelect) {
   };
 }
 
+function zeroEvaluationResponse(options: {
+  since: Date;
+  until: Date;
+  days: number;
+  orgId?: string;
+  deviceId?: string;
+  sourceType?: string;
+  sourceId?: string;
+}) {
+  return {
+    window: {
+      days: options.days,
+      since: options.since.toISOString(),
+      until: options.until.toISOString(),
+    },
+    orgId: options.orgId,
+    deviceId: options.deviceId,
+    sourceType: options.sourceType,
+    sourceId: options.sourceId,
+    total: 0,
+    status: {
+      suggested: 0,
+      accepted: 0,
+      edited: 0,
+      rejected: 0,
+      executed: 0,
+      failed: 0,
+    },
+    rates: {
+      acceptRate: 0,
+      rejectRate: 0,
+      executeRate: 0,
+      failureRate: 0,
+    },
+    feedback: {
+      total: 0,
+      accepted: 0,
+      edited: 0,
+      rejected: 0,
+      executed: 0,
+      failed: 0,
+    },
+  };
+}
+
 async function siteAllowedForSuggestion(
   row: Pick<typeof remediationSuggestions.$inferSelect, 'deviceId'>,
   perms: UserPermissions | undefined,
@@ -96,6 +149,20 @@ async function siteAllowedForSuggestion(
     .where(eq(devices.id, row.deviceId))
     .limit(1);
   return Boolean(device && typeof device.siteId === 'string' && canAccessSite(perms, device.siteId));
+}
+
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  perms: UserPermissions | undefined,
+): Promise<string[] | null> {
+  if (!perms?.allowedSiteIds) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((device) => typeof device.siteId === 'string' && canAccessSite(perms, device.siteId))
+    .map((device) => device.id);
 }
 
 async function filterSiteAllowedSuggestions<T extends typeof remediationSuggestions.$inferSelect>(
@@ -144,6 +211,166 @@ remediationSuggestionRoutes.get(
 
     const visible = await filterSiteAllowedSuggestions(rows, perms);
     return c.json({ data: visible.map(serializeSuggestion) });
+  }
+);
+
+remediationSuggestionRoutes.get(
+  '/evaluation',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  zValidator('query', evaluationQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const query = c.req.valid('query');
+
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Organization not found or access denied' }, 403);
+    }
+
+    const effectiveOrgId = query.orgId ?? auth.orgId;
+    const until = new Date();
+    const since = new Date(until.getTime() - query.days * 24 * 60 * 60 * 1000);
+
+    let allowedDeviceIds: string[] | null = null;
+    if (perms?.allowedSiteIds && effectiveOrgId) {
+      allowedDeviceIds = await resolveSiteAllowedDeviceIds(effectiveOrgId, perms);
+      if (query.deviceId && !(allowedDeviceIds ?? []).includes(query.deviceId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      if (!query.deviceId && (allowedDeviceIds ?? []).length === 0) {
+        return c.json(zeroEvaluationResponse({
+          since,
+          until,
+          days: query.days,
+          orgId: effectiveOrgId,
+          sourceType: query.sourceType,
+          sourceId: query.sourceId,
+        }));
+      }
+    }
+
+    const suggestionOrgCondition =
+      query.orgId
+        ? eq(remediationSuggestions.orgId, query.orgId)
+        : auth.orgCondition(remediationSuggestions.orgId);
+    const feedbackOrgCondition =
+      query.orgId
+        ? eq(mlFeedbackEvents.orgId, query.orgId)
+        : auth.orgCondition(mlFeedbackEvents.orgId);
+
+    const suggestionFilters: SQL[] = [
+      gte(remediationSuggestions.createdAt, since),
+      ...(suggestionOrgCondition ? [suggestionOrgCondition] : []),
+      ...(query.sourceType ? [eq(remediationSuggestions.sourceType, query.sourceType)] : []),
+      ...(query.sourceId ? [eq(remediationSuggestions.sourceId, query.sourceId)] : []),
+      ...(query.deviceId ? [eq(remediationSuggestions.deviceId, query.deviceId)] : []),
+      ...(allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length > 0
+        ? [inArray(remediationSuggestions.deviceId, allowedDeviceIds)]
+        : []),
+    ];
+
+    const feedbackSuggestionFilters: SQL[] = [
+      gte(remediationSuggestions.createdAt, since),
+      ...(query.sourceType ? [eq(remediationSuggestions.sourceType, query.sourceType)] : []),
+      ...(query.sourceId ? [eq(remediationSuggestions.sourceId, query.sourceId)] : []),
+      ...(query.deviceId ? [eq(remediationSuggestions.deviceId, query.deviceId)] : []),
+      ...(allowedDeviceIds !== null && !query.deviceId && allowedDeviceIds.length > 0
+        ? [inArray(remediationSuggestions.deviceId, allowedDeviceIds)]
+        : []),
+    ];
+
+    const statusRows = await db
+      .select({
+        status: remediationSuggestions.status,
+        count: sql<number>`count(*)`,
+      })
+      .from(remediationSuggestions)
+      .where(and(...suggestionFilters))
+      .groupBy(remediationSuggestions.status);
+
+    const feedbackRows = await db
+      .select({
+        eventType: mlFeedbackEvents.eventType,
+        count: sql<number>`count(*)`,
+      })
+      .from(mlFeedbackEvents)
+      .innerJoin(
+        remediationSuggestions,
+        and(
+          sql`${mlFeedbackEvents.sourceId} = ${remediationSuggestions.id}::text`,
+          eq(remediationSuggestions.orgId, mlFeedbackEvents.orgId),
+        ),
+      )
+      .where(and(
+        eq(mlFeedbackEvents.sourceType, 'remediation'),
+        inArray(mlFeedbackEvents.eventType, [
+          'suggestion.accepted',
+          'suggestion.edited',
+          'suggestion.rejected',
+          'suggestion.executed',
+          'suggestion.failed',
+        ]),
+        gte(mlFeedbackEvents.occurredAt, since),
+        ...(feedbackOrgCondition ? [feedbackOrgCondition] : []),
+        ...feedbackSuggestionFilters,
+      ))
+      .groupBy(mlFeedbackEvents.eventType);
+
+    const status = {
+      suggested: 0,
+      accepted: 0,
+      edited: 0,
+      rejected: 0,
+      executed: 0,
+      failed: 0,
+    };
+    for (const row of statusRows) {
+      const key = String(row.status);
+      if (key === 'suggested' || key === 'accepted' || key === 'edited' || key === 'rejected' || key === 'executed' || key === 'failed') {
+        status[key] = Number(row.count) || 0;
+      }
+    }
+
+    const total = status.suggested + status.accepted + status.edited + status.rejected + status.executed + status.failed;
+    const feedback = {
+      total: 0,
+      accepted: 0,
+      edited: 0,
+      rejected: 0,
+      executed: 0,
+      failed: 0,
+    };
+    for (const row of feedbackRows) {
+      const count = Number(row.count) || 0;
+      if (row.eventType === 'suggestion.accepted') feedback.accepted += count;
+      if (row.eventType === 'suggestion.edited') feedback.edited += count;
+      if (row.eventType === 'suggestion.rejected') feedback.rejected += count;
+      if (row.eventType === 'suggestion.executed') feedback.executed += count;
+      if (row.eventType === 'suggestion.failed') feedback.failed += count;
+    }
+    feedback.total = feedback.accepted + feedback.edited + feedback.rejected + feedback.executed + feedback.failed;
+
+    return c.json({
+      window: {
+        days: query.days,
+        since: since.toISOString(),
+        until: until.toISOString(),
+      },
+      orgId: effectiveOrgId,
+      deviceId: query.deviceId,
+      sourceType: query.sourceType,
+      sourceId: query.sourceId,
+      total,
+      status,
+      rates: {
+        acceptRate: total > 0 ? status.accepted / total : 0,
+        rejectRate: total > 0 ? status.rejected / total : 0,
+        executeRate: total > 0 ? status.executed / total : 0,
+        failureRate: total > 0 ? status.failed / total : 0,
+      },
+      feedback,
+    });
   }
 );
 


### PR DESCRIPTION
## Summary
- add `GET /remediation-suggestions/evaluation` for remediation suggestion status/rate metrics
- include lifecycle feedback counts from `ml_feedback_events` joined back to remediation suggestions
- cover inaccessible org filters, empty windows, and site-restricted evaluation narrowing

## Validation
- pnpm --filter @breeze/api exec vitest run src/routes/remediationSuggestions.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit
- pnpm --filter @breeze/api exec vitest run src/routes/remediationSuggestions.test.ts src/routes/analytics.test.ts src/services/metricAnomalies.test.ts src/services/remediationSuggestions.test.ts
- git diff --check
- DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm --filter @breeze/api db:check-drift *(fails in this local environment: role "breeze" does not exist)*