### PR TITLE
feat(ml): promote anomalies to alerts

### DIFF
--- a/apps/api/src/routes/devices/anomalies.test.ts
+++ b/apps/api/src/routes/devices/anomalies.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  updateMock,
+  emitAnomalyFeedbackMock,
+  promoteMetricAnomalyToAlertMock,
+  getDeviceWithOrgAndSiteCheckMock,
+} = vi.hoisted(() => ({
+  updateMock: vi.fn(),
+  emitAnomalyFeedbackMock: vi.fn(),
+  promoteMetricAnomalyToAlertMock: vi.fn(),
+  getDeviceWithOrgAndSiteCheckMock: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
+  desc: (column: unknown) => ({ type: 'desc', column }),
+  eq: (left: unknown, right: unknown) => ({ type: 'eq', left, right }),
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    update: updateMock,
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  metricAnomalies: {
+    id: 'metricAnomalies.id',
+    orgId: 'metricAnomalies.orgId',
+    deviceId: 'metricAnomalies.deviceId',
+    status: 'metricAnomalies.status',
+    detectedAt: 'metricAnomalies.detectedAt',
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-1', email: 'test@example.com' },
+      orgId: '11111111-1111-4111-8111-111111111111',
+      scope: 'organization',
+    });
+    return next();
+  }),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/metricAnomalyPromotion', () => ({
+  promoteMetricAnomalyToAlert: promoteMetricAnomalyToAlertMock,
+}));
+
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitAnomalyFeedback: emitAnomalyFeedbackMock,
+}));
+
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: {
+    ALERTS_WRITE: { resource: 'alerts', action: 'write' },
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+  },
+}));
+
+vi.mock('./helpers', () => ({
+  SITE_ACCESS_DENIED: Symbol.for('site-access-denied'),
+  getDeviceWithOrgAndSiteCheck: getDeviceWithOrgAndSiteCheckMock,
+}));
+
+import { anomaliesRoutes } from './anomalies';
+
+const device = {
+  id: '22222222-2222-4222-8222-222222222222',
+  orgId: '11111111-1111-4111-8111-111111111111',
+};
+
+const anomaly = {
+  id: '33333333-3333-4333-8333-333333333333',
+  orgId: device.orgId,
+  deviceId: device.id,
+  sourceTable: 'device_metrics',
+  metricType: 'system',
+  metricName: 'cpu_percent',
+  anomalyType: 'spike',
+  status: 'open',
+  windowStart: new Date('2026-06-18T12:00:00.000Z'),
+  windowEnd: new Date('2026-06-18T12:05:00.000Z'),
+  bucketSeconds: 300,
+  observedValue: 95,
+  baselineValue: 40,
+  baselineMin: 10,
+  baselineMax: 60,
+  score: 7,
+  confidence: 0.88,
+  sampleCount: 5,
+  baselineSummary: {},
+  evidence: {},
+  linkedAlertId: null,
+  linkedCorrelationGroupId: null,
+  detectedAt: new Date('2026-06-18T12:06:00.000Z'),
+  resolvedAt: null,
+  updatedAt: new Date('2026-06-18T12:06:00.000Z'),
+};
+
+function updateChain(result: unknown) {
+  return {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  };
+}
+
+describe('device anomaly routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getDeviceWithOrgAndSiteCheckMock.mockResolvedValue(device);
+    emitAnomalyFeedbackMock.mockResolvedValue(undefined);
+    app = new Hono();
+    app.route('/devices', anomaliesRoutes);
+  });
+
+  it('promotes an anomaly through the anomaly-to-alert service', async () => {
+    promoteMetricAnomalyToAlertMock.mockResolvedValueOnce({
+      status: 'promoted',
+      anomaly: { ...anomaly, status: 'promoted', linkedAlertId: '44444444-4444-4444-8444-444444444444' },
+      alertId: '44444444-4444-4444-8444-444444444444',
+      created: true,
+    });
+
+    const res = await app.request(`/devices/${device.id}/anomalies/${anomaly.id}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'promoted', note: 'Escalate this' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(promoteMetricAnomalyToAlertMock).toHaveBeenCalledWith({
+      orgId: device.orgId,
+      deviceId: device.id,
+      anomalyId: anomaly.id,
+      actorUserId: 'user-1',
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(emitAnomalyFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'anomaly.promoted',
+      outcome: 'promoted',
+      metadata: expect.objectContaining({
+        linkedAlertId: '44444444-4444-4444-8444-444444444444',
+        createdAlert: true,
+      }),
+    }));
+    const body = await res.json();
+    expect(body.data.status).toBe('promoted');
+    expect(body.data.linkedAlertId).toBe('44444444-4444-4444-8444-444444444444');
+  });
+
+  it('returns 409 when anomaly alert promotion is disabled', async () => {
+    promoteMetricAnomalyToAlertMock.mockResolvedValueOnce({
+      status: 'disabled',
+      anomaly,
+    });
+
+    const res = await app.request(`/devices/${device.id}/anomalies/${anomaly.id}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'promoted' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(emitAnomalyFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps dismissed status updates on the existing direct update path', async () => {
+    updateMock.mockReturnValueOnce(updateChain([{ ...anomaly, status: 'dismissed', updatedAt: new Date('2026-06-18T12:10:00.000Z') }]));
+
+    const res = await app.request(`/devices/${device.id}/anomalies/${anomaly.id}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'dismissed' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(promoteMetricAnomalyToAlertMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalled();
+    expect(emitAnomalyFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'anomaly.dismissed',
+      outcome: 'dismissed',
+    }));
+  });
+});

--- a/apps/api/src/routes/devices/anomalies.ts
+++ b/apps/api/src/routes/devices/anomalies.ts
@@ -6,6 +6,7 @@ import { and, desc, eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { metricAnomalies } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
+import { promoteMetricAnomalyToAlert } from '../../services/metricAnomalyPromotion';
 import { emitAnomalyFeedback } from '../../services/mlFeedbackEmitters';
 import { PERMISSIONS } from '../../services/permissions';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
@@ -108,6 +109,40 @@ anomaliesRoutes.patch(
     }
     if (!device) {
       return c.json({ error: 'Device not found' }, 404);
+    }
+
+    if (input.status === 'promoted') {
+      const result = await promoteMetricAnomalyToAlert({
+        orgId: device.orgId,
+        deviceId,
+        anomalyId,
+        actorUserId: auth.user.id,
+      });
+
+      if (result.status === 'not_found') {
+        return c.json({ error: 'Anomaly not found' }, 404);
+      }
+      if (result.status === 'disabled') {
+        return c.json({ error: 'Anomaly alert promotion is disabled' }, 409);
+      }
+
+      await emitAnomalyFeedback({
+        orgId: result.anomaly.orgId,
+        anomalyId: result.anomaly.id,
+        eventType: 'anomaly.promoted',
+        outcome: 'promoted',
+        actorUserId: auth.user.id,
+        metadata: {
+          route: 'devices.anomalies.status',
+          metricName: result.anomaly.metricName,
+          anomalyType: result.anomaly.anomalyType,
+          linkedAlertId: result.alertId,
+          createdAlert: result.created,
+          note: input.note,
+        },
+      });
+
+      return c.json({ data: serializeAnomaly(result.anomaly) });
     }
 
     const now = new Date();

--- a/apps/api/src/services/metricAnomalyPromotion.test.ts
+++ b/apps/api/src/services/metricAnomalyPromotion.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  selectMock,
+  insertMock,
+  updateMock,
+  shouldProduceMlOutputMock,
+  publishEventMock,
+  resolveDeviceSiteIdMock,
+} = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  shouldProduceMlOutputMock: vi.fn(),
+  publishEventMock: vi.fn(),
+  resolveDeviceSiteIdMock: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
+  eq: (left: unknown, right: unknown) => ({ type: 'eq', left, right }),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  alerts: {
+    id: 'alerts.id',
+  },
+  metricAnomalies: {
+    id: 'metricAnomalies.id',
+    orgId: 'metricAnomalies.orgId',
+    deviceId: 'metricAnomalies.deviceId',
+  },
+}));
+
+vi.mock('./eventBus', () => ({
+  publishEvent: publishEventMock,
+}));
+
+vi.mock('./mlFeatureFlags', () => ({
+  shouldProduceMlOutput: shouldProduceMlOutputMock,
+}));
+
+vi.mock('./deviceSiteResolver', () => ({
+  resolveDeviceSiteId: resolveDeviceSiteIdMock,
+}));
+
+import { promoteMetricAnomalyToAlert } from './metricAnomalyPromotion';
+
+const anomaly = {
+  id: '33333333-3333-4333-8333-333333333333',
+  orgId: '11111111-1111-4111-8111-111111111111',
+  deviceId: '22222222-2222-4222-8222-222222222222',
+  sourceTable: 'device_metrics',
+  metricType: 'system',
+  metricName: 'cpu_percent',
+  anomalyType: 'spike',
+  status: 'open',
+  windowStart: new Date('2026-06-18T12:00:00.000Z'),
+  windowEnd: new Date('2026-06-18T12:05:00.000Z'),
+  bucketSeconds: 300,
+  observedValue: 97.3,
+  baselineValue: 45.1,
+  baselineMin: 20,
+  baselineMax: 60,
+  score: 8,
+  confidence: 0.87,
+  sampleCount: 5,
+  baselineSummary: { modelVersion: 'metric-anomalies-v1' },
+  evidence: {},
+  linkedAlertId: null,
+  linkedCorrelationGroupId: null,
+  detectedAt: new Date('2026-06-18T12:06:00.000Z'),
+  resolvedAt: null,
+  updatedAt: new Date('2026-06-18T12:06:00.000Z'),
+};
+
+function chain(result: unknown) {
+  const c: Record<string, any> = {};
+  for (const method of ['from', 'where', 'limit', 'values', 'set']) {
+    c[method] = vi.fn(() => c);
+  }
+  c.returning = vi.fn(() => Promise.resolve(result));
+  c.then = (onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected);
+  return c;
+}
+
+describe('metric anomaly promotion service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shouldProduceMlOutputMock.mockResolvedValue(true);
+    publishEventMock.mockResolvedValue('event-1');
+    resolveDeviceSiteIdMock.mockResolvedValue('site-1');
+  });
+
+  it('creates an alert, links the anomaly, and publishes alert.triggered', async () => {
+    selectMock.mockReturnValueOnce(chain([anomaly]));
+    insertMock.mockReturnValueOnce(chain([{ id: '44444444-4444-4444-8444-444444444444' }]));
+    updateMock.mockReturnValueOnce(chain([{ ...anomaly, status: 'promoted', linkedAlertId: '44444444-4444-4444-8444-444444444444' }]));
+
+    const result = await promoteMetricAnomalyToAlert({
+      orgId: anomaly.orgId,
+      deviceId: anomaly.deviceId,
+      anomalyId: anomaly.id,
+      actorUserId: 'user-1',
+    });
+
+    expect(result).toMatchObject({
+      status: 'promoted',
+      alertId: '44444444-4444-4444-8444-444444444444',
+      created: true,
+    });
+    expect(shouldProduceMlOutputMock).toHaveBeenCalledWith(anomaly.orgId, 'ml.anomalies.create_alerts');
+    expect(insertMock).toHaveBeenCalledWith(expect.anything());
+    expect(updateMock).toHaveBeenCalledWith(expect.anything());
+    expect(publishEventMock).toHaveBeenCalledWith(
+      'alert.triggered',
+      anomaly.orgId,
+      expect.objectContaining({
+        alertId: '44444444-4444-4444-8444-444444444444',
+        ruleId: null,
+        deviceId: anomaly.deviceId,
+        source: 'metric-anomaly',
+        anomalyId: anomaly.id,
+      }),
+      'metric-anomaly-promotion',
+      expect.objectContaining({ userId: 'user-1', siteId: 'site-1' }),
+    );
+  });
+
+  it('is idempotent when the anomaly is already linked to an alert', async () => {
+    selectMock.mockReturnValueOnce(chain([{ ...anomaly, status: 'promoted', linkedAlertId: 'alert-existing' }]));
+
+    const result = await promoteMetricAnomalyToAlert({
+      orgId: anomaly.orgId,
+      deviceId: anomaly.deviceId,
+      anomalyId: anomaly.id,
+    });
+
+    expect(result).toMatchObject({
+      status: 'promoted',
+      alertId: 'alert-existing',
+      created: false,
+    });
+    expect(shouldProduceMlOutputMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(publishEventMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses alert creation when anomaly alert promotion is disabled', async () => {
+    selectMock.mockReturnValueOnce(chain([anomaly]));
+    shouldProduceMlOutputMock.mockResolvedValue(false);
+
+    const result = await promoteMetricAnomalyToAlert({
+      orgId: anomaly.orgId,
+      deviceId: anomaly.deviceId,
+      anomalyId: anomaly.id,
+    });
+
+    expect(result).toMatchObject({ status: 'disabled' });
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(publishEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/metricAnomalyPromotion.ts
+++ b/apps/api/src/services/metricAnomalyPromotion.ts
@@ -1,0 +1,198 @@
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '../db';
+import { alerts, metricAnomalies } from '../db/schema';
+import { publishEvent } from './eventBus';
+import { shouldProduceMlOutput } from './mlFeatureFlags';
+import { resolveDeviceSiteId } from './deviceSiteResolver';
+
+type MetricAnomalyRow = typeof metricAnomalies.$inferSelect;
+
+export type MetricAnomalyPromotionResult =
+  | {
+      status: 'not_found';
+    }
+  | {
+      status: 'disabled';
+      anomaly: MetricAnomalyRow;
+    }
+  | {
+      status: 'promoted';
+      anomaly: MetricAnomalyRow;
+      alertId: string;
+      created: boolean;
+    };
+
+export type PromoteMetricAnomalyToAlertOptions = {
+  orgId: string;
+  deviceId: string;
+  anomalyId: string;
+  actorUserId?: string | null;
+};
+
+function titleForAnomaly(anomaly: MetricAnomalyRow): string {
+  const label = anomaly.anomalyType.replace(/_/g, ' ');
+  return `Metric anomaly promoted: ${label} on ${anomaly.metricName}`;
+}
+
+function severityForAnomaly(anomaly: MetricAnomalyRow): 'critical' | 'high' | 'medium' | 'low' | 'info' {
+  if (anomaly.confidence >= 0.95 || anomaly.score >= 10) return 'critical';
+  if (anomaly.anomalyType === 'network_egress' || anomaly.anomalyType === 'process_runaway') return 'high';
+  if (anomaly.confidence >= 0.75 || anomaly.score >= 5) return 'medium';
+  return 'low';
+}
+
+function messageForAnomaly(anomaly: MetricAnomalyRow): string {
+  const observed = Number.isFinite(anomaly.observedValue) ? anomaly.observedValue.toFixed(2) : String(anomaly.observedValue);
+  const baseline = anomaly.baselineValue == null
+    ? 'no baseline'
+    : Number.isFinite(anomaly.baselineValue)
+      ? anomaly.baselineValue.toFixed(2)
+      : String(anomaly.baselineValue);
+  return [
+    `${anomaly.metricName} ${anomaly.anomalyType.replace(/_/g, ' ')} was promoted from ML anomaly detection.`,
+    `Observed ${observed}; baseline ${baseline}.`,
+    `Confidence ${Math.round(anomaly.confidence * 100)}%, score ${Math.round(anomaly.score * 100) / 100}.`,
+  ].join(' ');
+}
+
+function anomalyIdentityWhere(options: PromoteMetricAnomalyToAlertOptions) {
+  return and(
+    eq(metricAnomalies.id, options.anomalyId),
+    eq(metricAnomalies.orgId, options.orgId),
+    eq(metricAnomalies.deviceId, options.deviceId),
+  );
+}
+
+export async function promoteMetricAnomalyToAlert(
+  options: PromoteMetricAnomalyToAlertOptions,
+): Promise<MetricAnomalyPromotionResult> {
+  const [anomaly] = await db
+    .select()
+    .from(metricAnomalies)
+    .where(anomalyIdentityWhere(options))
+    .limit(1);
+
+  if (!anomaly) {
+    return { status: 'not_found' };
+  }
+
+  if (anomaly.linkedAlertId) {
+    if (anomaly.status === 'promoted') {
+      return {
+        status: 'promoted',
+        anomaly,
+        alertId: anomaly.linkedAlertId,
+        created: false,
+      };
+    }
+
+    const now = new Date();
+    const [updated] = await db
+      .update(metricAnomalies)
+      .set({
+        status: 'promoted',
+        resolvedAt: null,
+        updatedAt: now,
+      })
+      .where(anomalyIdentityWhere(options))
+      .returning();
+
+    return {
+      status: 'promoted',
+      anomaly: updated ?? { ...anomaly, status: 'promoted', resolvedAt: null, updatedAt: now },
+      alertId: anomaly.linkedAlertId,
+      created: false,
+    };
+  }
+
+  if (!(await shouldProduceMlOutput(anomaly.orgId, 'ml.anomalies.create_alerts'))) {
+    return { status: 'disabled', anomaly };
+  }
+
+  const severity = severityForAnomaly(anomaly);
+  const title = titleForAnomaly(anomaly);
+  const message = messageForAnomaly(anomaly);
+  const now = new Date();
+
+  const [alert] = await db
+    .insert(alerts)
+    .values({
+      ruleId: null,
+      deviceId: anomaly.deviceId,
+      orgId: anomaly.orgId,
+      status: 'active',
+      severity,
+      title,
+      message,
+      context: {
+        source: 'metric_anomaly',
+        anomalyId: anomaly.id,
+        metricName: anomaly.metricName,
+        metricType: anomaly.metricType,
+        anomalyType: anomaly.anomalyType,
+        observedValue: anomaly.observedValue,
+        baselineValue: anomaly.baselineValue,
+        confidence: anomaly.confidence,
+        score: anomaly.score,
+        modelVersion: (anomaly.baselineSummary as { modelVersion?: unknown } | null)?.modelVersion ?? null,
+      },
+      triggeredAt: now,
+    })
+    .returning({ id: alerts.id });
+
+  if (!alert?.id) {
+    throw new Error('Failed to create alert for metric anomaly');
+  }
+
+  const [updated] = await db
+    .update(metricAnomalies)
+    .set({
+      status: 'promoted',
+      linkedAlertId: alert.id,
+      resolvedAt: null,
+      updatedAt: now,
+    })
+    .where(anomalyIdentityWhere(options))
+    .returning();
+
+  const siteId = await resolveDeviceSiteId(anomaly.deviceId);
+  await publishEvent(
+    'alert.triggered',
+    anomaly.orgId,
+    {
+      alertId: alert.id,
+      ruleId: null,
+      deviceId: anomaly.deviceId,
+      severity,
+      title,
+      message,
+      source: 'metric-anomaly',
+      anomalyId: anomaly.id,
+    },
+    'metric-anomaly-promotion',
+    {
+      userId: options.actorUserId ?? undefined,
+      siteId,
+    },
+  );
+
+  return {
+    status: 'promoted',
+    anomaly: updated ?? {
+      ...anomaly,
+      status: 'promoted',
+      linkedAlertId: alert.id,
+      resolvedAt: null,
+      updatedAt: now,
+    },
+    alertId: alert.id,
+    created: true,
+  };
+}
+
+export const __testOnly = {
+  severityForAnomaly,
+  titleForAnomaly,
+  messageForAnomaly,
+};


### PR DESCRIPTION
## Summary
- add an idempotent metric anomaly promotion service that creates rule-less alerts and links `metric_anomalies.linked_alert_id`
- gate manual alert promotion behind `ml.anomalies.create_alerts`
- route `PATCH /devices/:id/anomalies/:anomalyId/status` promotion through the alert rail while keeping dismiss/resolve on the existing status path
- publish standard `alert.triggered` events with device site attribution

## Validation
- pnpm --filter @breeze/api exec vitest run src/services/metricAnomalyPromotion.test.ts src/routes/devices/anomalies.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit
- pnpm --filter @breeze/api exec vitest run src/services/metricAnomalyPromotion.test.ts src/routes/devices/anomalies.test.ts src/services/metricAnomalies.test.ts src/routes/analytics.test.ts src/routes/remediationSuggestions.test.ts
- git diff --check
- DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm --filter @breeze/api db:check-drift *(fails in this local environment: role "breeze" does not exist)*