### PR TITLE
fix(ml): guard remediation execution status

### DIFF
--- a/apps/api/migrations/2026-06-18-zzz-remediation-suggestion-execution-guardrail.sql
+++ b/apps/api/migrations/2026-06-18-zzz-remediation-suggestion-execution-guardrail.sql
@@ -1,0 +1,22 @@
+-- Guard remediation suggestion terminal statuses so execution metrics cannot
+-- be spoofed without a linked execution rail. autoMigrate wraps this file in a
+-- transaction.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'remediation_suggestions_terminal_execution_link_check'
+      AND conrelid = 'public.remediation_suggestions'::regclass
+  ) THEN
+    ALTER TABLE public.remediation_suggestions
+      ADD CONSTRAINT remediation_suggestions_terminal_execution_link_check
+      CHECK (
+        status NOT IN ('executed', 'failed')
+        OR tool_execution_id IS NOT NULL
+        OR script_execution_id IS NOT NULL
+        OR playbook_execution_id IS NOT NULL
+      ) NOT VALID;
+  END IF;
+END $$;

--- a/apps/api/src/routes/remediationSuggestions.test.ts
+++ b/apps/api/src/routes/remediationSuggestions.test.ts
@@ -123,6 +123,16 @@ function mockSelectOnce(result: unknown) {
   dbMocks.selectMock.mockReturnValueOnce(createSelectChain(result));
 }
 
+function mockSuggestionLoad(suggestion: Record<string, unknown>) {
+  dbMocks.selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([suggestion]),
+      }),
+    }),
+  });
+}
+
 describe('remediation suggestion routes', () => {
   let app: Hono;
 
@@ -162,13 +172,7 @@ describe('remediation suggestion routes', () => {
   });
 
   it('updates suggestion status and emits feedback', async () => {
-    dbMocks.selectMock.mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([baseSuggestion]),
-        }),
-      }),
-    });
+    mockSuggestionLoad(baseSuggestion);
     dbMocks.updateMock.mockReturnValueOnce({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -193,6 +197,98 @@ describe('remediation suggestion routes', () => {
     }));
     const body = await res.json();
     expect(body.data.status).toBe('accepted');
+  });
+
+  it('rejects execution status without a linked execution rail', async () => {
+    mockSuggestionLoad({ ...baseSuggestion, status: 'accepted' });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'executed' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Executed or failed suggestions must link to a tool, script, or playbook execution');
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+    expect(dbMocks.emitFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct execution from suggested status', async () => {
+    mockSuggestionLoad(baseSuggestion);
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        status: 'executed',
+        scriptExecutionId: '66666666-6666-4666-8666-666666666666',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Suggestion must be accepted or edited before it can be marked executed or failed');
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+    expect(dbMocks.emitFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('requires failure details when marking a linked execution failed', async () => {
+    mockSuggestionLoad({
+      ...baseSuggestion,
+      status: 'accepted',
+      scriptExecutionId: '66666666-6666-4666-8666-666666666666',
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'failed' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Failed suggestions must include a failureMessage');
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+    expect(dbMocks.emitFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('marks accepted suggestions executed when a script execution is linked', async () => {
+    const scriptExecutionId = '66666666-6666-4666-8666-666666666666';
+    mockSuggestionLoad({ ...baseSuggestion, status: 'accepted' });
+    dbMocks.updateMock.mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            ...baseSuggestion,
+            status: 'executed',
+            scriptExecutionId,
+            executedBy: 'user-1',
+            executedAt: new Date('2026-06-18T12:10:00.000Z'),
+          }]),
+        }),
+      }),
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'executed', scriptExecutionId }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(dbMocks.emitFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: baseSuggestion.orgId,
+      suggestionId: baseSuggestion.id,
+      eventType: 'suggestion.executed',
+      outcome: 'executed',
+      actorUserId: 'user-1',
+      metadata: expect.objectContaining({ scriptExecutionId }),
+    }));
+    const body = await res.json();
+    expect(body.data.status).toBe('executed');
+    expect(body.data.scriptExecutionId).toBe(scriptExecutionId);
   });
 
   it('returns remediation status rates and lifecycle feedback counts', async () => {

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -56,6 +56,45 @@ const updateBodySchema = z.object({
   failureMessage: z.string().max(5000).nullable().optional(),
 });
 
+type UpdateRemediationSuggestionInput = z.infer<typeof updateBodySchema>;
+
+function hasExecutionLink(input: {
+  toolExecutionId: string | null;
+  scriptExecutionId: string | null;
+  playbookExecutionId: string | null;
+}): boolean {
+  return Boolean(input.toolExecutionId || input.scriptExecutionId || input.playbookExecutionId);
+}
+
+function validateSuggestionLifecycleUpdate(
+  existing: typeof remediationSuggestions.$inferSelect,
+  input: UpdateRemediationSuggestionInput,
+): string | null {
+  if (input.status !== 'executed' && input.status !== 'failed') {
+    return null;
+  }
+
+  if (existing.status !== 'accepted' && existing.status !== 'edited') {
+    return 'Suggestion must be accepted or edited before it can be marked executed or failed';
+  }
+
+  const executionLinks = {
+    toolExecutionId: input.toolExecutionId === undefined ? existing.toolExecutionId : input.toolExecutionId,
+    scriptExecutionId: input.scriptExecutionId === undefined ? existing.scriptExecutionId : input.scriptExecutionId,
+    playbookExecutionId: input.playbookExecutionId === undefined ? existing.playbookExecutionId : input.playbookExecutionId,
+  };
+  if (!hasExecutionLink(executionLinks)) {
+    return 'Executed or failed suggestions must link to a tool, script, or playbook execution';
+  }
+
+  const failureMessage = input.failureMessage === undefined ? existing.failureMessage : input.failureMessage;
+  if (input.status === 'failed' && !failureMessage?.trim()) {
+    return 'Failed suggestions must include a failureMessage';
+  }
+
+  return null;
+}
+
 function serializeSuggestion(row: typeof remediationSuggestions.$inferSelect) {
   return {
     id: row.id,
@@ -443,6 +482,11 @@ remediationSuggestionRoutes.patch(
     }
     if (!(await siteAllowedForSuggestion(existing, perms))) {
       return c.json({ error: 'Suggestion not found or access denied' }, 403);
+    }
+
+    const validationError = validateSuggestionLifecycleUpdate(existing, input);
+    if (validationError) {
+      return c.json({ error: validationError }, 400);
     }
 
     const now = new Date();


### PR DESCRIPTION
## Summary
- require remediation suggestions to be accepted or edited before they can be marked executed or failed
- require terminal executed/failed statuses to carry a linked tool, script, or playbook execution ID
- require failed suggestions to include failure details and add a DB CHECK backstop for execution-link integrity

## Validation
- pnpm --filter @breeze/api exec vitest run src/routes/remediationSuggestions.test.ts
- pnpm --filter @breeze/api exec vitest run src/routes/remediationSuggestions.test.ts src/services/remediationSuggestions.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit
- git diff --check

## Notes
- pnpm --filter @breeze/api run check:migrations and DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze pnpm --filter @breeze/api run db:check-drift both reach local Postgres but fail because local role `breeze` does not exist.
