### PR TITLE
feat(ml): execute script remediation suggestions

### DIFF
--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RemediationSuggestionsPanel from './RemediationSuggestionsPanel';
+import { executeScript } from '../../services/deviceActions';
 import { fetchWithAuth } from '../../stores/auth';
 
 const showToast = vi.fn();
@@ -10,11 +11,16 @@ vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
+vi.mock('../../services/deviceActions', () => ({
+  executeScript: vi.fn(),
+}));
+
 vi.mock('../shared/Toast', () => ({
   showToast: (input: unknown) => showToast(input),
 }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const executeScriptMock = vi.mocked(executeScript);
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({
@@ -28,6 +34,7 @@ const suggestion = {
   id: 'suggestion-1',
   sourceType: 'anomaly',
   sourceId: 'anomaly-1',
+  deviceId: '22222222-2222-4222-8222-222222222222',
   targetType: 'script',
   scriptId: '11111111-1111-4111-8111-111111111111',
   scriptTemplateId: null,
@@ -38,6 +45,9 @@ const suggestion = {
   riskTier: 'medium',
   status: 'suggested',
   confidence: 0.82,
+  parameters: { dryRun: false },
+  targetDeviceIds: ['22222222-2222-4222-8222-222222222222'],
+  scriptExecutionId: null,
 };
 
 describe('RemediationSuggestionsPanel', () => {
@@ -89,5 +99,72 @@ describe('RemediationSuggestionsPanel', () => {
       );
     });
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Suggested fix accepted' }));
+  });
+
+  it('executes an accepted single-device script suggestion and links the execution', async () => {
+    const accepted = { ...suggestion, status: 'accepted' };
+    const executed = {
+      ...accepted,
+      status: 'executed',
+      scriptExecutionId: '33333333-3333-4333-8333-333333333333',
+    };
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({ data: [accepted] }))
+      .mockResolvedValueOnce(makeJsonResponse({ data: executed }));
+    executeScriptMock.mockResolvedValueOnce({
+      batchId: null,
+      scriptId: suggestion.scriptId,
+      devicesTargeted: 1,
+      executions: [{
+        executionId: '33333333-3333-4333-8333-333333333333',
+        deviceId: suggestion.deviceId,
+        commandId: '44444444-4444-4444-8444-444444444444',
+      }],
+      status: 'queued',
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /execute/i }));
+
+    await waitFor(() => {
+      expect(executeScriptMock).toHaveBeenCalledWith(
+        suggestion.scriptId,
+        [suggestion.deviceId],
+        suggestion.parameters,
+      );
+    });
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/remediation-suggestions/suggestion-1',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({
+          status: 'executed',
+          scriptExecutionId: '33333333-3333-4333-8333-333333333333',
+        }),
+      }),
+    );
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'Script queued and suggested fix updated',
+    }));
+  });
+
+  it('does not show execute for multi-device script suggestions', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({
+      data: [{
+        ...suggestion,
+        status: 'accepted',
+        targetDeviceIds: [
+          '22222222-2222-4222-8222-222222222222',
+          '33333333-3333-4333-8333-333333333333',
+        ],
+      }],
+    }));
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    await screen.findByText('Disk Cleanup');
+    expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
   });
 });

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import { CheckCircle, RefreshCw, Sparkles, XCircle } from 'lucide-react';
+import { CheckCircle, PlayCircle, RefreshCw, Sparkles, XCircle } from 'lucide-react';
 
 import { handleActionError, runAction } from '../../lib/runAction';
+import { executeScript } from '../../services/deviceActions';
 import { fetchWithAuth } from '../../stores/auth';
 
 type SuggestionStatus = 'suggested' | 'accepted' | 'edited' | 'rejected' | 'executed' | 'failed';
@@ -10,6 +11,7 @@ type RemediationSuggestion = {
   id: string;
   sourceType: string;
   sourceId: string;
+  deviceId: string | null;
   targetType: 'script' | 'script_template' | 'playbook' | 'diagnostic';
   scriptId: string | null;
   scriptTemplateId: string | null;
@@ -20,6 +22,9 @@ type RemediationSuggestion = {
   riskTier: 'low' | 'medium' | 'high' | 'critical';
   status: SuggestionStatus;
   confidence: number | null;
+  parameters: Record<string, unknown>;
+  targetDeviceIds: string[];
+  scriptExecutionId: string | null;
 };
 
 type RemediationSuggestionsPanelProps = {
@@ -41,11 +46,28 @@ function targetLabel(suggestion: RemediationSuggestion): string {
   return 'Diagnostic';
 }
 
+function singleTargetDeviceId(suggestion: RemediationSuggestion): string | null {
+  if (suggestion.targetDeviceIds.length === 1) return suggestion.targetDeviceIds[0] ?? null;
+  if (suggestion.targetDeviceIds.length === 0) return suggestion.deviceId;
+  return null;
+}
+
+function canExecuteScriptSuggestion(suggestion: RemediationSuggestion): boolean {
+  return (
+    suggestion.targetType === 'script' &&
+    Boolean(suggestion.scriptId) &&
+    Boolean(singleTargetDeviceId(suggestion)) &&
+    (suggestion.status === 'accepted' || suggestion.status === 'edited') &&
+    !suggestion.scriptExecutionId
+  );
+}
+
 export default function RemediationSuggestionsPanel({ sourceType, sourceId }: RemediationSuggestionsPanelProps) {
   const [suggestions, setSuggestions] = useState<RemediationSuggestion[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [executingId, setExecutingId] = useState<string | null>(null);
   const [error, setError] = useState<string>();
 
   const fetchSuggestions = useCallback(async () => {
@@ -107,6 +129,38 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
       handleActionError(err, 'Could not update suggested fix');
     } finally {
       setUpdatingId(null);
+    }
+  }
+
+  async function executeSuggestion(suggestion: RemediationSuggestion) {
+    const scriptId = suggestion.scriptId;
+    const deviceId = singleTargetDeviceId(suggestion);
+    if (!scriptId || !deviceId) return;
+
+    setExecutingId(suggestion.id);
+    try {
+      const execution = await executeScript(scriptId, [deviceId], suggestion.parameters);
+      const scriptExecutionId = execution.executions[0]?.executionId;
+      if (!scriptExecutionId) {
+        throw new Error('Script execution did not return an execution ID');
+      }
+
+      const result = await runAction<{ data?: RemediationSuggestion }>({
+        request: () => fetchWithAuth(`/remediation-suggestions/${suggestion.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'executed', scriptExecutionId }),
+        }),
+        errorFallback: 'Script queued, but the suggested fix could not be updated',
+        successMessage: 'Script queued and suggested fix updated',
+      });
+      if (result.data) {
+        setSuggestions((current) => current.map((item) => item.id === suggestion.id ? result.data! : item));
+      }
+    } catch (err) {
+      handleActionError(err, 'Could not execute suggested fix');
+    } finally {
+      setExecutingId(null);
     }
   }
 
@@ -176,7 +230,7 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
                 <div className="flex shrink-0 flex-wrap items-center gap-2">
                   <button
                     type="button"
-                    disabled={updatingId === suggestion.id || suggestion.status === 'accepted'}
+                    disabled={updatingId === suggestion.id || executingId === suggestion.id || suggestion.status === 'accepted'}
                     onClick={() => void updateSuggestion(suggestion, 'accepted')}
                     className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                   >
@@ -185,13 +239,24 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
                   </button>
                   <button
                     type="button"
-                    disabled={updatingId === suggestion.id || suggestion.status === 'rejected'}
+                    disabled={updatingId === suggestion.id || executingId === suggestion.id || suggestion.status === 'rejected'}
                     onClick={() => void updateSuggestion(suggestion, 'rejected')}
                     className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <XCircle className="h-4 w-4" />
                     Reject
                   </button>
+                  {canExecuteScriptSuggestion(suggestion) && (
+                    <button
+                      type="button"
+                      disabled={executingId === suggestion.id}
+                      onClick={() => void executeSuggestion(suggestion)}
+                      className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <PlayCircle className="h-4 w-4" />
+                      Execute
+                    </button>
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add an Execute action for accepted/edited single-device script remediation suggestions
- queue execution through the existing /scripts/:id/execute service path, preserving that route's MFA/RBAC/site/maintenance checks
- PATCH the remediation suggestion with the returned scriptExecutionId so lifecycle feedback/evaluation can track execution

## Validation
- pnpm --filter @breeze/web exec vitest run src/components/remediation/RemediationSuggestionsPanel.test.tsx
- pnpm --filter @breeze/web exec vitest run src/components/remediation/RemediationSuggestionsPanel.test.tsx src/services/__tests__/deviceActions.test.ts
- pnpm --filter @breeze/web exec tsc --noEmit
- git diff --check

## Notes
- Script templates, playbooks, and multi-device remediation execution are intentionally deferred; this PR only enables the narrow script/single-device flow where one scriptExecutionId can be linked back to the suggestion.
