### PR TITLE
fix(ml): allow manual anomaly promotion

### DIFF
--- a/apps/api/src/routes/devices/anomalies.test.ts
+++ b/apps/api/src/routes/devices/anomalies.test.ts
@@ -145,6 +145,7 @@ describe('device anomaly routes', () => {
       deviceId: device.id,
       anomalyId: anomaly.id,
       actorUserId: 'user-1',
+      requireCreateAlertsFlag: false,
     });
     expect(updateMock).not.toHaveBeenCalled();
     expect(emitAnomalyFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/api/src/routes/devices/anomalies.ts
+++ b/apps/api/src/routes/devices/anomalies.ts
@@ -117,6 +117,7 @@ anomaliesRoutes.patch(
         deviceId,
         anomalyId,
         actorUserId: auth.user.id,
+        requireCreateAlertsFlag: false,
       });
 
       if (result.status === 'not_found') {

--- a/apps/api/src/services/metricAnomalyPromotion.test.ts
+++ b/apps/api/src/services/metricAnomalyPromotion.test.ts
@@ -171,4 +171,29 @@ describe('metric anomaly promotion service', () => {
     expect(updateMock).not.toHaveBeenCalled();
     expect(publishEventMock).not.toHaveBeenCalled();
   });
+
+  it('allows explicit manual promotion even when automatic anomaly alert creation is disabled', async () => {
+    selectMock.mockReturnValueOnce(chain([anomaly]));
+    shouldProduceMlOutputMock.mockResolvedValue(false);
+    insertMock.mockReturnValueOnce(chain([{ id: '44444444-4444-4444-8444-444444444444' }]));
+    updateMock.mockReturnValueOnce(chain([{ ...anomaly, status: 'promoted', linkedAlertId: '44444444-4444-4444-8444-444444444444' }]));
+
+    const result = await promoteMetricAnomalyToAlert({
+      orgId: anomaly.orgId,
+      deviceId: anomaly.deviceId,
+      anomalyId: anomaly.id,
+      actorUserId: 'user-1',
+      requireCreateAlertsFlag: false,
+    });
+
+    expect(result).toMatchObject({
+      status: 'promoted',
+      alertId: '44444444-4444-4444-8444-444444444444',
+      created: true,
+    });
+    expect(shouldProduceMlOutputMock).not.toHaveBeenCalled();
+    expect(insertMock).toHaveBeenCalledWith(expect.anything());
+    expect(updateMock).toHaveBeenCalledWith(expect.anything());
+    expect(publishEventMock).toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/services/metricAnomalyPromotion.ts
+++ b/apps/api/src/services/metricAnomalyPromotion.ts
@@ -28,6 +28,7 @@ export type PromoteMetricAnomalyToAlertOptions = {
   deviceId: string;
   anomalyId: string;
   actorUserId?: string | null;
+  requireCreateAlertsFlag?: boolean;
 };
 
 function titleForAnomaly(anomaly: MetricAnomalyRow): string {
@@ -106,7 +107,10 @@ export async function promoteMetricAnomalyToAlert(
     };
   }
 
-  if (!(await shouldProduceMlOutput(anomaly.orgId, 'ml.anomalies.create_alerts'))) {
+  if (
+    options.requireCreateAlertsFlag !== false
+    && !(await shouldProduceMlOutput(anomaly.orgId, 'ml.anomalies.create_alerts'))
+  ) {
     return { status: 'disabled', anomaly };
   }
 


### PR DESCRIPTION
## Summary
- allow explicit user-initiated anomaly promotion to create/link an alert even when automatic anomaly alert creation is disabled
- keep automatic anomaly alert creation gated by `ml.anomalies.create_alerts` by default
- cover the manual override path in service and device anomaly route tests

## Tests
- `pnpm --filter @breeze/api exec vitest run src/services/metricAnomalyPromotion.test.ts src/routes/devices/anomalies.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit`
- `git diff --check`