### PR TITLE
feat(ml): add ticket triage category override

### DIFF
--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -395,6 +395,38 @@ describe('TicketWorkbench ML triage suggestions', () => {
     }));
   });
 
+  it('lets a tech override the ticket category from the workbench', async () => {
+    mockTicketApi({
+      'tk-1': makeTicket({ id: 'tk-1', categoryId: 'cat-hardware' }),
+    });
+
+    render(
+      <TicketWorkbench
+        ticketId="tk-1"
+        assignees={[]}
+        categories={[
+          { id: 'cat-hardware', name: 'Hardware' },
+          { id: 'cat-network', name: 'Network' },
+        ]}
+      />,
+    );
+
+    const categorySelect = await screen.findByTestId('ticket-workbench-category');
+    expect(categorySelect).toHaveValue('cat-hardware');
+
+    fireEvent.change(categorySelect, { target: { value: 'cat-network' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ categoryId: 'cat-network' }),
+        }),
+      );
+    });
+  });
+
   it('hides the suggestion strip when triage is disabled', async () => {
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -440,6 +440,29 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
           >
             {PRIORITY_OPTIONS.map((p) => <option key={p} value={p}>{priorityLabel(config, p)}</option>)}
           </select>
+          {categories.length > 0 && (
+            <select
+              value={ticket.categoryId ?? ''}
+              onChange={(e) => {
+                const categoryId = e.target.value || null;
+                if (categoryId === (ticket.categoryId ?? null)) return;
+                void runAction({
+                  request: () => fetchWithAuth(`/tickets/${ticketId}`, { method: 'PATCH', body: JSON.stringify({ categoryId }) }),
+                  errorFallback: 'Category update failed. Retry.',
+                  onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+                }).then(() => afterMutation({ categoryId })).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+              }}
+              className="max-w-[180px] rounded-md border bg-background px-2 py-1 text-xs text-foreground"
+              data-testid="ticket-workbench-category"
+              aria-label="Category"
+            >
+              <option value="">No category</option>
+              {ticket.categoryId && !categories.some((category) => category.id === ticket.categoryId) && (
+                <option value={ticket.categoryId}>Current category</option>
+              )}
+              {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+            </select>
+          )}
           {assignees !== null ? (
             <select
               value={ticket.assignedTo ?? ''}


### PR DESCRIPTION
## Summary
- add a category picker to the ticket workbench when category options are available
- send manual category overrides through the existing ticket PATCH path so `ticket.category_changed` feedback is captured as manual override data
- cover the category override flow in the workbench test suite

## Tests
- `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
- `pnpm --filter @breeze/web exec tsc --noEmit`
- `git diff --check`