### PR TITLE
feat(ml): record ticket triage rejection feedback

### DIFF
--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -190,6 +190,7 @@ import { ticketsRoutes } from './index';
 // instanceof check in the route works against errors thrown by the mocks.
 import { TicketServiceError } from '../../services/ticketService';
 import { evaluateTicketTriage, getTicketTriageSuggestion } from '../../services/ticketTriage';
+import { emitTicketTriageFeedback } from '../../services/mlFeedbackEmitters';
 
 const TICKET_ID = '3f2f1d8e-1111-4222-8333-444455556666';
 const ORG_ID    = '3f2f1d8e-1111-4222-8333-444455556666';
@@ -539,6 +540,7 @@ describe('ticket triage suggestion routes', () => {
       totalLabels: 3,
       acceptedSuggestionLabels: 1,
       manualOverrideLabels: 2,
+      rejectedSuggestionLabels: 0,
       categoryLabels: 1,
       priorityLabels: 1,
       assigneeLabels: 1,
@@ -628,6 +630,47 @@ describe('ticket triage suggestion routes', () => {
     });
 
     expect(res.status).toBe(409);
+    expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
+  });
+
+  it('POST /tickets/:id/triage-suggestion/reject records explicit rejection feedback', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    vi.mocked(getTicketTriageSuggestion).mockResolvedValue({
+      enabled: true,
+      flagSource: 'org_settings',
+      suggestion: {
+        modelVersion: 'ticket-triage-rules-v0',
+        confidence: 0.72,
+        priority: 'high',
+        categoryId: '00000000-0000-4000-8000-000000000123',
+        categoryName: 'Hardware',
+        reasons: ['matched Hardware'],
+      },
+    });
+    vi.mocked(emitTicketTriageFeedback).mockResolvedValue(undefined);
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/triage-suggestion/reject`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ note: 'Wrong queue' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(emitTicketTriageFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: STUB_TICKET.orgId,
+      ticketId: TICKET_ID,
+      eventType: 'ticket.triage_rejected',
+      outcome: 'rejected',
+      actorUserId: 'u-1',
+      metadata: expect.objectContaining({
+        acceptedSuggestion: false,
+        rejectedSuggestion: true,
+        modelVersion: 'ticket-triage-rules-v0',
+        suggestedPriority: 'high',
+        suggestedCategoryId: '00000000-0000-4000-8000-000000000123',
+        note: 'Wrong queue',
+      }),
+    }));
     expect(serviceMocks.updateTicketFields).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -20,6 +20,7 @@ import {
   evaluateTicketTriage,
   getTicketTriageSuggestion,
 } from '../../services/ticketTriage';
+import { emitTicketTriageFeedback } from '../../services/mlFeedbackEmitters';
 import type { AuthContext } from '../../middleware/auth';
 
 // NOTE: authMiddleware is applied by the hub router in ./index.ts (alerts pattern) —
@@ -35,6 +36,9 @@ const applyTriageSuggestionSchema = z.object({
   priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
 }).refine((value) => value.categoryId !== undefined || value.priority !== undefined, {
   message: 'At least one suggested field is required',
+});
+const rejectTriageSuggestionSchema = z.object({
+  note: z.string().trim().max(500).optional(),
 });
 
 const OPEN_STATUSES = ['new', 'open', 'pending', 'on_hold'] as const;
@@ -486,6 +490,55 @@ ticketsRoutes.post(
     } catch (err) {
       return handleServiceError(c, err);
     }
+  }
+);
+
+ticketsRoutes.post(
+  '/:id/triage-suggestion/reject',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('param', idParam),
+  zValidator('json', rejectTriageSuggestionSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+    const body = c.req.valid('json');
+
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const ticket = await getScopedTicketOr404(auth, id);
+    if (!ticket) return c.json({ error: 'Ticket not found' }, 404);
+
+    const suggestion = await getTicketTriageSuggestion(ticket);
+    if (!suggestion.enabled) {
+      return c.json({ error: 'Ticket triage suggestions are disabled' }, 409);
+    }
+    if (!suggestion.suggestion) {
+      return c.json({ error: 'No ticket triage suggestion is currently available' }, 409);
+    }
+
+    await emitTicketTriageFeedback({
+      orgId: ticket.orgId,
+      ticketId: id,
+      eventType: 'ticket.triage_rejected',
+      outcome: 'rejected',
+      actorUserId: auth.user.id,
+      metadata: {
+        source: 'ticket_triage_v0',
+        acceptedSuggestion: false,
+        rejectedSuggestion: true,
+        modelVersion: suggestion.suggestion.modelVersion,
+        suggestedPriority: suggestion.suggestion.priority,
+        suggestedCategoryId: suggestion.suggestion.categoryId,
+        suggestedCategoryName: suggestion.suggestion.categoryName,
+        confidence: suggestion.suggestion.confidence,
+        reasons: suggestion.suggestion.reasons,
+        note: body.note,
+      },
+    });
+
+    return c.json({ success: true, suggestion: suggestion.suggestion });
   }
 );
 

--- a/apps/api/src/services/mlFeedbackEmitters.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.ts
@@ -144,8 +144,8 @@ export async function emitDeviceReliabilityFeedback(options: {
 export async function emitTicketTriageFeedback(options: {
   orgId: string;
   ticketId: string;
-  eventType: 'ticket.category_changed' | 'ticket.priority_changed' | 'ticket.assignee_changed' | 'ticket.resolved' | 'ticket.reopened';
-  outcome: 'category_changed' | 'priority_changed' | 'assignee_changed' | 'resolved' | 'reopened';
+  eventType: 'ticket.category_changed' | 'ticket.priority_changed' | 'ticket.assignee_changed' | 'ticket.triage_rejected' | 'ticket.resolved' | 'ticket.reopened';
+  outcome: 'category_changed' | 'priority_changed' | 'assignee_changed' | 'rejected' | 'resolved' | 'reopened';
   actorUserId?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;

--- a/apps/api/src/services/ticketTriage.test.ts
+++ b/apps/api/src/services/ticketTriage.test.ts
@@ -41,16 +41,18 @@ describe('ticketTriageInternals', () => {
       { eventType: 'ticket.priority_changed', metadata: { acceptedSuggestion: true } },
       { eventType: 'ticket.category_changed', metadata: { acceptedSuggestion: false } },
       { eventType: 'ticket.assignee_changed', metadata: { source: 'manual_update' } },
+      { eventType: 'ticket.triage_rejected', metadata: { acceptedSuggestion: false } },
     ], 90);
 
     expect(summary).toEqual(expect.objectContaining({
-      totalLabels: 3,
+      totalLabels: 4,
       acceptedSuggestionLabels: 1,
-      manualOverrideLabels: 2,
+      manualOverrideLabels: 3,
+      rejectedSuggestionLabels: 1,
       categoryLabels: 1,
       priorityLabels: 1,
       assigneeLabels: 1,
-      overrideRate: 0.67,
+      overrideRate: 0.75,
     }));
   });
 });

--- a/apps/api/src/services/ticketTriage.ts
+++ b/apps/api/src/services/ticketTriage.ts
@@ -36,6 +36,7 @@ export interface TicketTriageEvaluationSummary {
   totalLabels: number;
   acceptedSuggestionLabels: number;
   manualOverrideLabels: number;
+  rejectedSuggestionLabels: number;
   categoryLabels: number;
   priorityLabels: number;
   assigneeLabels: number;
@@ -156,6 +157,7 @@ export function computeTicketTriageEvaluationSummary(
 ): TicketTriageEvaluationSummary {
   let acceptedSuggestionLabels = 0;
   let manualOverrideLabels = 0;
+  let rejectedSuggestionLabels = 0;
   let categoryLabels = 0;
   let priorityLabels = 0;
   let assigneeLabels = 0;
@@ -165,8 +167,14 @@ export function computeTicketTriageEvaluationSummary(
     if (label.eventType === 'ticket.category_changed') categoryLabels += 1;
     if (label.eventType === 'ticket.priority_changed') priorityLabels += 1;
     if (label.eventType === 'ticket.assignee_changed') assigneeLabels += 1;
-    if (metadata.acceptedSuggestion === true) acceptedSuggestionLabels += 1;
-    else manualOverrideLabels += 1;
+    if (label.eventType === 'ticket.triage_rejected') {
+      rejectedSuggestionLabels += 1;
+      manualOverrideLabels += 1;
+    } else if (metadata.acceptedSuggestion === true) {
+      acceptedSuggestionLabels += 1;
+    } else {
+      manualOverrideLabels += 1;
+    }
   }
 
   const denominator = acceptedSuggestionLabels + manualOverrideLabels;
@@ -175,6 +183,7 @@ export function computeTicketTriageEvaluationSummary(
     totalLabels: labels.length,
     acceptedSuggestionLabels,
     manualOverrideLabels,
+    rejectedSuggestionLabels,
     categoryLabels,
     priorityLabels,
     assigneeLabels,
@@ -187,7 +196,7 @@ export async function evaluateTicketTriage(input: TicketTriageEvaluationInput = 
   const since = new Date(Date.now() - labelWindowDays * DAY_MS);
   const conditions = [
     eq(mlFeedbackEvents.sourceType, 'ticket'),
-    inArray(mlFeedbackEvents.eventType, ['ticket.category_changed', 'ticket.priority_changed', 'ticket.assignee_changed']),
+    inArray(mlFeedbackEvents.eventType, ['ticket.category_changed', 'ticket.priority_changed', 'ticket.assignee_changed', 'ticket.triage_rejected']),
     gte(mlFeedbackEvents.occurredAt, since),
   ];
   if (input.orgIds && input.orgIds.length > 0) {

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -427,6 +427,58 @@ describe('TicketWorkbench ML triage suggestions', () => {
     });
   });
 
+  it('records explicit rejection feedback for a triage suggestion', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1', priority: 'normal', categoryId: null }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({
+          enabled: true,
+          flagSource: 'org_settings',
+          suggestion: {
+            modelVersion: 'ticket-triage-rules-v0',
+            confidence: 0.72,
+            priority: 'high',
+            categoryId: 'cat-hardware',
+            categoryName: 'Hardware',
+            reasons: ['matched Hardware'],
+          },
+        });
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(
+      <TicketWorkbench
+        ticketId="tk-1"
+        assignees={[]}
+        categories={[{ id: 'cat-hardware', name: 'Hardware' }]}
+      />,
+    );
+
+    await screen.findByTestId('ticket-triage-suggestion');
+    fireEvent.click(screen.getByTestId('ticket-triage-reject'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/triage-suggestion/reject',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({}),
+        }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'Ticket triage feedback saved',
+    }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-triage-suggestion')).toBeNull();
+    });
+  });
+
   it('hides the suggestion strip when triage is disabled', async () => {
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -65,6 +65,7 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   const [triageSuggestion, setTriageSuggestion] = useState<TicketTriageSuggestion | null>(null);
   const [triageLoading, setTriageLoading] = useState(false);
   const [applyingTriage, setApplyingTriage] = useState(false);
+  const [rejectingTriage, setRejectingTriage] = useState(false);
 
   // null = picker hidden (no USERS_READ etc.); degrade to a label + unassign-only button.
   const [fetchedAssignees, setFetchedAssignees] = useState<Array<{ id: string; name: string | null; email: string }> | null>(null);
@@ -269,6 +270,27 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       setApplyingTriage(false);
     }
   }, [afterMutation, applyingTriage, ticketId, triageSuggestion]);
+
+  const rejectTriageSuggestion = useCallback(async () => {
+    if (!triageSuggestion || rejectingTriage) return;
+    setRejectingTriage(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/tickets/${ticketId}/triage-suggestion/reject`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        }),
+        errorFallback: 'Could not save ticket triage feedback.',
+        successMessage: 'Ticket triage feedback saved',
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+      setTriageSuggestion(null);
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setRejectingTriage(false);
+    }
+  }, [rejectingTriage, ticketId, triageSuggestion]);
 
   // Fallback path: option values are the six core enums; POST {status}.
   const onStatusChange = useCallback(async (status: TicketStatus) => {
@@ -528,15 +550,26 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
                 ) : null}
               </div>
               {triageSuggestion && (
-                <button
-                  type="button"
-                  onClick={() => void applyTriageSuggestion()}
-                  disabled={applyingTriage}
-                  className="inline-flex shrink-0 items-center justify-center rounded-md border px-2.5 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
-                  data-testid="ticket-triage-apply"
-                >
-                  {applyingTriage ? 'Applying…' : 'Apply'}
-                </button>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void rejectTriageSuggestion()}
+                    disabled={applyingTriage || rejectingTriage}
+                    className="inline-flex items-center justify-center rounded-md border px-2.5 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                    data-testid="ticket-triage-reject"
+                  >
+                    {rejectingTriage ? 'Saving…' : 'Not right'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void applyTriageSuggestion()}
+                    disabled={applyingTriage || rejectingTriage}
+                    className="inline-flex items-center justify-center rounded-md border px-2.5 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                    data-testid="ticket-triage-apply"
+                  >
+                    {applyingTriage ? 'Applying…' : 'Apply'}
+                  </button>
+                </div>
               )}
             </div>
           </div>

--- a/packages/shared/src/validators/mlFeedback.test.ts
+++ b/packages/shared/src/validators/mlFeedback.test.ts
@@ -49,6 +49,20 @@ describe('mlFeedbackEventSchema', () => {
     expect(parsed.eventType).toBe('anomaly.promoted');
   });
 
+  it('accepts explicit ticket triage rejection feedback', () => {
+    const parsed = mlFeedbackEventSchema.parse({
+      ...validEvent,
+      sourceType: 'ticket',
+      sourceId: 'ticket-1',
+      eventType: 'ticket.triage_rejected',
+      outcome: 'rejected',
+      metadata: { modelVersion: 'ticket-triage-rules-v0' },
+    });
+
+    expect(parsed.sourceType).toBe('ticket');
+    expect(parsed.eventType).toBe('ticket.triage_rejected');
+  });
+
   it('rejects metadata over the byte cap', () => {
     const oversized = { notes: 'x'.repeat(ML_FEEDBACK_METADATA_MAX_BYTES + 1) };
     expect(getJsonByteLength(oversized)).toBeGreaterThan(ML_FEEDBACK_METADATA_MAX_BYTES);

--- a/packages/shared/src/validators/mlFeedback.ts
+++ b/packages/shared/src/validators/mlFeedback.ts
@@ -38,6 +38,7 @@ export const ML_FEEDBACK_EVENT_TYPES = [
   'ticket.category_changed',
   'ticket.priority_changed',
   'ticket.assignee_changed',
+  'ticket.triage_rejected',
   'ticket.resolved',
   'ticket.reopened',
   'device.failure_confirmed',


### PR DESCRIPTION
## Summary
- add canonical `ticket.triage_rejected` feedback events for explicit triage suggestion rejection
- expose `POST /tickets/:id/triage-suggestion/reject` and include rejected counts in ticket triage evaluation
- add a `Not right` action in the ticket workbench suggestion strip

## Tests
- `pnpm --filter @breeze/api exec vitest run src/routes/tickets/tickets.test.ts src/services/ticketTriage.test.ts`
- `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
- `pnpm --filter @breeze/shared exec vitest run src/validators/mlFeedback.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit`
- `pnpm --filter @breeze/web exec tsc --noEmit`
- `git diff --check`

## Notes
- `pnpm --filter @breeze/shared exec tsc --noEmit` currently fails on an unrelated existing strictness issue in `packages/shared/src/validators/ticketConfig.test.ts:105` (object possibly undefined).