### PR TITLE
feat(ml): add RCA suggested next steps

### DIFF
--- a/apps/api/src/services/alertCorrelationRca.test.ts
+++ b/apps/api/src/services/alertCorrelationRca.test.ts
@@ -252,6 +252,24 @@ describe('alert correlation RCA evidence builder', () => {
       expect.objectContaining({ confidence: 0.58 }),
       expect.objectContaining({ confidence: 0.52 }),
     ]));
+    expect(result.suggestedNextSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        title: 'Validate the leading cause',
+        riskTier: 'low',
+        evidenceIds: expect.arrayContaining([`alert:${ALERT_1}`]),
+      }),
+      expect.objectContaining({
+        title: 'Review recent changes',
+        evidenceIds: ['device_change:change-1'],
+      }),
+      expect.objectContaining({
+        title: 'Inspect aligned error logs',
+      }),
+      expect.objectContaining({
+        title: 'Verify resource pressure',
+        riskTier: 'medium',
+      }),
+    ]));
     expect(result.gaps).toEqual([]);
   });
 

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -34,6 +34,13 @@ export interface RcaRootCauseCandidate {
   supportingEvidenceIds: string[];
 }
 
+export interface RcaSuggestedNextStep {
+  title: string;
+  rationale: string;
+  riskTier: 'low' | 'medium' | 'high';
+  evidenceIds: string[];
+}
+
 export interface AlertCorrelationRcaResult {
   groupId: string;
   scope: {
@@ -45,6 +52,7 @@ export interface AlertCorrelationRcaResult {
   };
   timeline: RcaEvidenceItem[];
   rootCauseCandidates: RcaRootCauseCandidate[];
+  suggestedNextSteps: RcaSuggestedNextStep[];
   gaps: string[];
 }
 
@@ -144,6 +152,73 @@ function buildLogCandidate(evidence: RcaEvidenceItem[]): RcaRootCauseCandidate |
   };
 }
 
+function buildSuggestedNextSteps(
+  evidence: RcaEvidenceItem[],
+  candidates: RcaRootCauseCandidate[],
+  gaps: string[],
+): RcaSuggestedNextStep[] {
+  const steps: RcaSuggestedNextStep[] = [];
+  const firstCandidate = candidates[0];
+  if (firstCandidate) {
+    steps.push({
+      title: 'Validate the leading cause',
+      rationale: 'Review the evidence supporting the highest-confidence candidate before changing device state.',
+      riskTier: 'low',
+      evidenceIds: firstCandidate.supportingEvidenceIds,
+    });
+  }
+
+  const changeEvidence = evidence.find((item) => item.source === 'device_change');
+  if (changeEvidence) {
+    steps.push({
+      title: 'Review recent changes',
+      rationale: 'A configuration, service, software, or patch change overlaps the incident window.',
+      riskTier: 'low',
+      evidenceIds: [changeEvidence.id],
+    });
+  }
+
+  const logEvidence = evidence.find((item) => item.source === 'event_log' || item.source === 'agent_log');
+  if (logEvidence) {
+    steps.push({
+      title: 'Inspect aligned error logs',
+      rationale: 'Warning or error logs line up with the alert burst and may identify the failing service or component.',
+      riskTier: 'low',
+      evidenceIds: [logEvidence.id],
+    });
+  }
+
+  const metricEvidence = evidence.find((item) => item.source === 'metric_rollup');
+  if (metricEvidence) {
+    steps.push({
+      title: 'Verify resource pressure',
+      rationale: 'Metric rollups show elevated utilization during the incident window.',
+      riskTier: 'medium',
+      evidenceIds: [metricEvidence.id],
+    });
+  }
+
+  if (gaps.length > 0) {
+    steps.push({
+      title: 'Fill evidence gaps',
+      rationale: gaps.slice(0, 2).join(' '),
+      riskTier: 'low',
+      evidenceIds: [],
+    });
+  }
+
+  if (steps.length === 0) {
+    steps.push({
+      title: 'Confirm affected scope',
+      rationale: 'No strong supporting evidence was found, so confirm the affected devices and user impact before taking action.',
+      riskTier: 'low',
+      evidenceIds: [],
+    });
+  }
+
+  return steps.slice(0, 4);
+}
+
 export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promise<AlertCorrelationRcaResult> {
   const alertRows = [...options.alerts].sort((a, b) => a.triggeredAt.getTime() - b.triggeredAt.getTime());
   const alertIds = alertRows.map((alert) => alert.id);
@@ -168,6 +243,12 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
       },
       timeline: [],
       rootCauseCandidates: [],
+      suggestedNextSteps: [{
+        title: 'Confirm affected scope',
+        rationale: 'No alerts were attached, so confirm the incident group membership before taking action.',
+        riskTier: 'low',
+        evidenceIds: [],
+      }],
       gaps: ['No alerts were attached to this correlation group.'],
     };
   }
@@ -324,6 +405,7 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
     buildChangeCandidate(timeline),
     buildLogCandidate(timeline),
   ].filter((candidate): candidate is RcaRootCauseCandidate => Boolean(candidate));
+  const suggestedNextSteps = buildSuggestedNextSteps(timeline, candidates, gaps);
 
   return {
     groupId: options.groupId,
@@ -336,6 +418,7 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
     },
     timeline,
     rootCauseCandidates: candidates,
+    suggestedNextSteps,
     gaps,
   };
 }

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -79,6 +79,14 @@ const rcaPayload = {
       supportingEvidenceIds: ['device_change:1']
     }
   ],
+  suggestedNextSteps: [
+    {
+      title: 'Review recent changes',
+      rationale: 'A service change overlaps the incident window.',
+      riskTier: 'low',
+      evidenceIds: ['device_change:1']
+    }
+  ],
   timeline: [
     {
       id: 'device_change:1',
@@ -166,6 +174,8 @@ describe('CorrelatedAlertGroups', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /Explain incident/i })[0]);
 
     expect(await screen.findByText('A recent service restart lines up with the alert burst.')).toBeInTheDocument();
+    expect(screen.getByText('Review recent changes')).toBeInTheDocument();
+    expect(screen.getByText('A service change overlaps the incident window.')).toBeInTheDocument();
     expect(screen.getByText('Restarted API service before the incident.')).toBeInTheDocument();
     expect(screen.getByText('No warning/error logs were found in the incident window.')).toBeInTheDocument();
 

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -58,10 +58,18 @@ type RcaCandidate = {
   supportingEvidenceIds: string[];
 };
 
+type RcaSuggestedNextStep = {
+  title: string;
+  rationale: string;
+  riskTier: 'low' | 'medium' | 'high';
+  evidenceIds: string[];
+};
+
 type RcaResult = {
   groupId: string;
   timeline: RcaEvidenceItem[];
   rootCauseCandidates: RcaCandidate[];
+  suggestedNextSteps?: RcaSuggestedNextStep[];
   gaps: string[];
   scope: {
     deviceIds: string[];
@@ -522,6 +530,28 @@ export default function CorrelatedAlertGroups() {
                                   ))
                                 )}
                               </div>
+
+                              {groupRca.suggestedNextSteps && groupRca.suggestedNextSteps.length > 0 && (
+                                <div>
+                                  <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                                    <FileText className="h-4 w-4" />
+                                    Suggested next steps
+                                  </div>
+                                  <div className="space-y-2">
+                                    {groupRca.suggestedNextSteps.map((step) => (
+                                      <div key={step.title} className="rounded-md border bg-muted/20 px-3 py-2">
+                                        <div className="flex flex-wrap items-center justify-between gap-2">
+                                          <p className="text-sm font-medium">{step.title}</p>
+                                          <span className="rounded-full border bg-background px-2 py-0.5 text-[11px] capitalize text-muted-foreground">
+                                            {step.riskTier} risk
+                                          </span>
+                                        </div>
+                                        <p className="mt-1 text-xs text-muted-foreground">{step.rationale}</p>
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
 
                               <div>
                                 <div className="mb-2 flex items-center gap-2 text-sm font-medium">


### PR DESCRIPTION
## Summary
- add conservative diagnostic suggested next steps to RCA results
- derive steps from leading candidates, changes, logs, metric evidence, and gaps
- render suggested next steps in the correlated alert group RCA panel

## Tests
- `pnpm --filter @breeze/api exec vitest run src/services/alertCorrelationRca.test.ts`
- `pnpm --filter @breeze/web exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx`
- `pnpm --filter @breeze/api exec tsc --noEmit`
- `pnpm --filter @breeze/web exec tsc --noEmit`
- `git diff --check`