### PR TITLE
feat(ml): execute remediation suggestions server-side

### DIFF
--- a/apps/api/src/routes/remediationSuggestions.test.ts
+++ b/apps/api/src/routes/remediationSuggestions.test.ts
@@ -7,6 +7,7 @@ const dbMocks = vi.hoisted(() => ({
   writeRouteAuditMock: vi.fn(),
   generateMock: vi.fn(),
   emitFeedbackMock: vi.fn(),
+  executeScriptOnDevicesMock: vi.fn(),
 }));
 
 let currentPermissions: { allowedSiteIds?: string[] } | undefined;
@@ -40,6 +41,12 @@ vi.mock('../db/schema', () => ({
     status: 'remediationSuggestions.status',
     createdAt: 'remediationSuggestions.createdAt',
   },
+  scriptExecutions: {
+    id: 'scriptExecutions.id',
+    orgId: 'scriptExecutions.orgId',
+    scriptId: 'scriptExecutions.scriptId',
+    deviceId: 'scriptExecutions.deviceId',
+  },
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -58,6 +65,7 @@ vi.mock('../middleware/auth', () => ({
   }),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
 vi.mock('../services/auditEvents', () => ({
@@ -70,6 +78,10 @@ vi.mock('../services/remediationSuggestions', () => ({
 
 vi.mock('../services/mlFeedbackEmitters', () => ({
   emitRemediationSuggestionFeedback: dbMocks.emitFeedbackMock,
+}));
+
+vi.mock('../services/scriptExecution', () => ({
+  executeScriptOnDevices: dbMocks.executeScriptOnDevicesMock,
 }));
 
 import { remediationSuggestionRoutes } from './remediationSuggestions';
@@ -128,6 +140,16 @@ function mockSuggestionLoad(suggestion: Record<string, unknown>) {
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue([suggestion]),
+      }),
+    }),
+  });
+}
+
+function mockScriptExecutionLoad(execution: Record<string, unknown> | undefined) {
+  dbMocks.selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(execution ? [execution] : []),
       }),
     }),
   });
@@ -257,6 +279,11 @@ describe('remediation suggestion routes', () => {
   it('marks accepted suggestions executed when a script execution is linked', async () => {
     const scriptExecutionId = '66666666-6666-4666-8666-666666666666';
     mockSuggestionLoad({ ...baseSuggestion, status: 'accepted' });
+    mockScriptExecutionLoad({
+      orgId: baseSuggestion.orgId,
+      scriptId: baseSuggestion.scriptId,
+      deviceId: baseSuggestion.deviceId,
+    });
     dbMocks.updateMock.mockReturnValueOnce({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -289,6 +316,144 @@ describe('remediation suggestion routes', () => {
     const body = await res.json();
     expect(body.data.status).toBe('executed');
     expect(body.data.scriptExecutionId).toBe(scriptExecutionId);
+  });
+
+  it('rejects linked script executions from another organization', async () => {
+    const scriptExecutionId = '66666666-6666-4666-8666-666666666666';
+    mockSuggestionLoad({ ...baseSuggestion, status: 'accepted' });
+    mockScriptExecutionLoad({
+      orgId: '77777777-7777-4777-8777-777777777777',
+      scriptId: baseSuggestion.scriptId,
+      deviceId: baseSuggestion.deviceId,
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'executed', scriptExecutionId }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Linked script execution must belong to the same organization');
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects linked script executions for another script', async () => {
+    const scriptExecutionId = '66666666-6666-4666-8666-666666666666';
+    mockSuggestionLoad({ ...baseSuggestion, status: 'accepted' });
+    mockScriptExecutionLoad({
+      orgId: baseSuggestion.orgId,
+      scriptId: '77777777-7777-4777-8777-777777777777',
+      deviceId: baseSuggestion.deviceId,
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'executed', scriptExecutionId }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Linked script execution must run the suggested script');
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects linked script executions for another target device', async () => {
+    const scriptExecutionId = '66666666-6666-4666-8666-666666666666';
+    mockSuggestionLoad({ ...baseSuggestion, status: 'accepted' });
+    mockScriptExecutionLoad({
+      orgId: baseSuggestion.orgId,
+      scriptId: baseSuggestion.scriptId,
+      deviceId: '77777777-7777-4777-8777-777777777777',
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'executed', scriptExecutionId }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Linked script execution must target the suggested device');
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+  });
+
+  it('executes accepted script suggestions through the server-side script rail', async () => {
+    const accepted = { ...baseSuggestion, status: 'accepted' };
+    const scriptExecutionId = '66666666-6666-4666-8666-666666666666';
+    mockSuggestionLoad(accepted);
+    dbMocks.executeScriptOnDevicesMock.mockResolvedValueOnce({
+      ok: true,
+      batchId: null,
+      scriptId: baseSuggestion.scriptId,
+      script: { id: baseSuggestion.scriptId, name: 'Disk Cleanup' },
+      devicesTargeted: 1,
+      maintenanceSuppressedDeviceIds: [],
+      executions: [{
+        executionId: scriptExecutionId,
+        deviceId: baseSuggestion.deviceId,
+        commandId: '77777777-7777-4777-8777-777777777777',
+      }],
+      status: 'queued',
+      triggerType: 'manual',
+      runAs: 'system',
+      auditOrgId: baseSuggestion.orgId,
+    });
+    dbMocks.updateMock.mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            ...accepted,
+            status: 'executed',
+            scriptExecutionId,
+            executedBy: 'user-1',
+            executedAt: new Date('2026-06-18T12:10:00.000Z'),
+          }]),
+        }),
+      }),
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(201);
+    expect(dbMocks.executeScriptOnDevicesMock).toHaveBeenCalledWith(expect.objectContaining({
+      scriptId: baseSuggestion.scriptId,
+      deviceIds: [baseSuggestion.deviceId],
+      parameters: baseSuggestion.parameters,
+      triggerType: 'manual',
+    }));
+    expect(dbMocks.emitFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'suggestion.executed',
+      outcome: 'executed',
+      metadata: expect.objectContaining({
+        route: 'remediation_suggestions.execute',
+        scriptExecutionId,
+      }),
+    }));
+    const body = await res.json();
+    expect(body.data.status).toBe('executed');
+    expect(body.data.scriptExecutionId).toBe(scriptExecutionId);
+    expect(body.execution.executions[0].executionId).toBe(scriptExecutionId);
+  });
+
+  it('rejects server-side execution before acceptance', async () => {
+    mockSuggestionLoad(baseSuggestion);
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Suggestion must be accepted or edited before it can be executed');
+    expect(dbMocks.executeScriptOnDevicesMock).not.toHaveBeenCalled();
   });
 
   it('returns remediation status rates and lifecycle feedback counts', async () => {

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -4,12 +4,13 @@ import { z } from 'zod';
 import { and, desc, eq, gte, inArray, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';
-import { devices, mlFeedbackEvents, remediationSuggestions } from '../db/schema';
-import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
+import { devices, mlFeedbackEvents, remediationSuggestions, scriptExecutions } from '../db/schema';
+import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { emitRemediationSuggestionFeedback } from '../services/mlFeedbackEmitters';
 import { generateRemediationSuggestions } from '../services/remediationSuggestions';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { executeScriptOnDevices } from '../services/scriptExecution';
 
 export const remediationSuggestionRoutes = new Hono();
 
@@ -64,6 +65,55 @@ function hasExecutionLink(input: {
   playbookExecutionId: string | null;
 }): boolean {
   return Boolean(input.toolExecutionId || input.scriptExecutionId || input.playbookExecutionId);
+}
+
+function normalizeSuggestionParameters(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function singleTargetDeviceId(row: Pick<typeof remediationSuggestions.$inferSelect, 'deviceId' | 'targetDeviceIds'>): string | null {
+  if (row.targetDeviceIds.length === 1) return row.targetDeviceIds[0] ?? null;
+  if (row.targetDeviceIds.length === 0) return row.deviceId;
+  return null;
+}
+
+async function validateLinkedScriptExecution(
+  existing: typeof remediationSuggestions.$inferSelect,
+  scriptExecutionId: string | null | undefined,
+): Promise<string | null> {
+  if (!scriptExecutionId) return null;
+
+  const [execution] = await db
+    .select({
+      orgId: scriptExecutions.orgId,
+      scriptId: scriptExecutions.scriptId,
+      deviceId: scriptExecutions.deviceId,
+    })
+    .from(scriptExecutions)
+    .where(eq(scriptExecutions.id, scriptExecutionId))
+    .limit(1);
+
+  if (!execution) {
+    return 'Linked script execution not found';
+  }
+  if (execution.orgId !== existing.orgId) {
+    return 'Linked script execution must belong to the same organization';
+  }
+  if (existing.scriptId && execution.scriptId !== existing.scriptId) {
+    return 'Linked script execution must run the suggested script';
+  }
+
+  const targetDeviceIds = existing.targetDeviceIds.length > 0
+    ? existing.targetDeviceIds
+    : existing.deviceId
+      ? [existing.deviceId]
+      : [];
+  if (targetDeviceIds.length > 0 && !targetDeviceIds.includes(execution.deviceId)) {
+    return 'Linked script execution must target the suggested device';
+  }
+
+  return null;
 }
 
 function validateSuggestionLifecycleUpdate(
@@ -456,6 +506,132 @@ remediationSuggestionRoutes.post(
   }
 );
 
+remediationSuggestionRoutes.post(
+  '/:id/execute',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.SCRIPTS_EXECUTE.resource, PERMISSIONS.SCRIPTS_EXECUTE.action),
+  requireMfa(),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const id = c.req.param('id') ?? '';
+
+    const conditions: SQL[] = [eq(remediationSuggestions.id, id)];
+    const orgCond = auth.orgCondition(remediationSuggestions.orgId);
+    if (orgCond) conditions.push(orgCond);
+
+    const [existing] = await db
+      .select()
+      .from(remediationSuggestions)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!existing) {
+      return c.json({ error: 'Suggestion not found' }, 404);
+    }
+    if (!(await siteAllowedForSuggestion(existing, perms))) {
+      return c.json({ error: 'Suggestion not found or access denied' }, 403);
+    }
+    if (existing.status !== 'accepted' && existing.status !== 'edited') {
+      return c.json({ error: 'Suggestion must be accepted or edited before it can be executed' }, 400);
+    }
+    if (existing.scriptExecutionId) {
+      return c.json({ error: 'Suggestion already has a linked script execution' }, 409);
+    }
+    if (existing.targetType !== 'script' || !existing.scriptId) {
+      return c.json({ error: 'Only script remediation suggestions can be executed' }, 400);
+    }
+
+    const deviceId = singleTargetDeviceId(existing);
+    if (!deviceId) {
+      return c.json({ error: 'Remediation script execution requires exactly one target device' }, 400);
+    }
+
+    const execution = await executeScriptOnDevices({
+      scriptId: existing.scriptId,
+      deviceIds: [deviceId],
+      parameters: normalizeSuggestionParameters(existing.parameters),
+      triggerType: 'manual',
+      auth,
+      permissions: perms,
+    });
+
+    if (!execution.ok) {
+      return c.json({
+        error: execution.error,
+        maintenanceSuppressedDeviceIds: execution.maintenanceSuppressedDeviceIds,
+      }, execution.status);
+    }
+
+    const scriptExecutionId = execution.executions[0]?.executionId;
+    if (!scriptExecutionId) {
+      return c.json({ error: 'Script execution did not return an execution ID' }, 500);
+    }
+
+    const now = new Date();
+    const [updated] = await db
+      .update(remediationSuggestions)
+      .set({
+        status: 'executed',
+        scriptExecutionId,
+        executedBy: auth.user.id,
+        executedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(remediationSuggestions.id, existing.id))
+      .returning();
+
+    if (!updated) {
+      return c.json({ error: 'Failed to update suggestion' }, 500);
+    }
+
+    await emitRemediationSuggestionFeedback({
+      orgId: updated.orgId,
+      suggestionId: updated.id,
+      eventType: 'suggestion.executed',
+      outcome: 'executed',
+      actorUserId: auth.user.id,
+      metadata: {
+        route: 'remediation_suggestions.execute',
+        sourceType: updated.sourceType,
+        sourceId: updated.sourceId,
+        targetType: updated.targetType,
+        scriptId: updated.scriptId,
+        scriptExecutionId: updated.scriptExecutionId,
+      },
+    });
+
+    writeRouteAudit(c, {
+      orgId: updated.orgId,
+      action: 'ml.remediation_suggestion.execute',
+      resourceType: 'remediation_suggestion',
+      resourceId: updated.id,
+      resourceName: updated.title,
+      details: {
+        sourceType: updated.sourceType,
+        sourceId: updated.sourceId,
+        targetType: updated.targetType,
+        scriptId: updated.scriptId,
+        scriptExecutionId,
+      },
+    });
+
+    return c.json({
+      data: serializeSuggestion(updated),
+      execution: {
+        batchId: execution.batchId,
+        scriptId: execution.scriptId,
+        devicesTargeted: execution.devicesTargeted,
+        maintenanceSuppressedDeviceIds: execution.maintenanceSuppressedDeviceIds.length > 0
+          ? execution.maintenanceSuppressedDeviceIds
+          : undefined,
+        executions: execution.executions,
+        status: execution.status,
+      },
+    }, 201);
+  }
+);
+
 remediationSuggestionRoutes.patch(
   '/:id',
   requireScope('organization', 'partner', 'system'),
@@ -487,6 +663,13 @@ remediationSuggestionRoutes.patch(
     const validationError = validateSuggestionLifecycleUpdate(existing, input);
     if (validationError) {
       return c.json({ error: validationError }, 400);
+    }
+    if (input.status === 'executed' || input.status === 'failed') {
+      const scriptExecutionId = input.scriptExecutionId === undefined ? existing.scriptExecutionId : input.scriptExecutionId;
+      const linkedExecutionError = await validateLinkedScriptExecution(existing, scriptExecutionId);
+      if (linkedExecutionError) {
+        return c.json({ error: linkedExecutionError }, 400);
+      }
     }
 
     const now = new Date();

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -8,19 +8,13 @@ import { db } from '../db';
 import {
   scripts,
   scriptExecutions,
-  scriptExecutionBatches,
   devices,
   deviceCommands
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
-import { sendCommandToAgent } from './agentWs';
 import { writeRouteAudit } from '../services/auditEvents';
-import { checkDeviceMaintenanceWindow } from '../services/featureConfigResolver';
-import {
-  claimPendingCommandForDelivery,
-  releaseClaimedCommandDelivery,
-} from '../services/commandDispatch';
+import { executeScriptOnDevices } from '../services/scriptExecution';
 
 export const scriptRoutes = new Hono();
 
@@ -634,201 +628,47 @@ scriptRoutes.post(
     const { id: scriptId } = c.req.valid('param');
     const data = c.req.valid('json');
 
-    const script = await getScriptWithOrgCheck(scriptId, auth);
-    if (!script) {
-      return c.json({ error: 'Script not found' }, 404);
-    }
+    const result = await executeScriptOnDevices({
+      scriptId,
+      deviceIds: data.deviceIds,
+      parameters: data.parameters,
+      triggerType: data.triggerType,
+      runAs: data.runAs,
+      auth,
+      permissions: c.get('permissions') as UserPermissions | undefined,
+    });
 
-    // Validate device access
-    const deviceRecords = await db
-      .select()
-      .from(devices)
-      .where(inArray(devices.id, data.deviceIds));
-
-    if (deviceRecords.length === 0) {
-      return c.json({ error: 'No valid devices found' }, 400);
-    }
-
-    // Check access to each device's org
-    const validDevices: typeof deviceRecords = [];
-    const siteDeniedDeviceIds: string[] = [];
-    for (const device of deviceRecords) {
-      const hasAccess = ensureOrgAccess(device.orgId, auth);
-      if (hasAccess) {
-        if (!canAccessDeviceSite(device.siteId, c.get('permissions') as UserPermissions | undefined)) {
-          siteDeniedDeviceIds.push(device.id);
-          continue;
-        }
-        // Also check OS compatibility
-        if (script.osTypes.includes(device.osType)) {
-          // Don't execute on decommissioned devices
-          if (device.status !== 'decommissioned') {
-            validDevices.push(device);
-          }
-        }
-      }
-    }
-
-    if (siteDeniedDeviceIds.length > 0) {
-      return c.json({ error: 'Access to one or more device sites denied' }, 403);
-    }
-
-    if (validDevices.length === 0) {
-      return c.json({ error: 'No accessible or compatible devices found' }, 400);
-    }
-
-    // Filter out devices where script execution is suppressed by a maintenance window
-    const maintenanceSuppressedDeviceIds: string[] = [];
-    const executableDevices: typeof validDevices = [];
-    for (const device of validDevices) {
-      const maintenanceStatus = await checkDeviceMaintenanceWindow(device.id);
-      if (maintenanceStatus.active && maintenanceStatus.suppressScripts) {
-        maintenanceSuppressedDeviceIds.push(device.id);
-      } else {
-        executableDevices.push(device);
-      }
-    }
-
-    if (executableDevices.length === 0) {
+    if (!result.ok) {
       return c.json({
-        error: 'All target devices are in a maintenance window with script execution suppressed',
-        maintenanceSuppressedDeviceIds,
-      }, 409);
-    }
-
-    const triggerType = data.triggerType ?? 'manual';
-    const parameters = data.parameters ?? {};
-    const runAs = data.runAs ?? script.runAs;
-
-    // Create batch if multiple devices
-    let batchId: string | null = null;
-    if (executableDevices.length > 1) {
-      // Denormalize the executing org onto the batch (RLS tenant axis). All
-      // executableDevices passed ensureOrgAccess above; for a built-in/system
-      // script (scripts.org_id is NULL) this is the only tenant linkage.
-      const batchOrgId = executableDevices[0]!.orgId;
-      const [batch] = await db
-        .insert(scriptExecutionBatches)
-        .values({
-          scriptId,
-          orgId: batchOrgId,
-          triggeredBy: auth.user.id,
-          triggerType,
-          parameters,
-          devicesTargeted: executableDevices.length,
-          status: 'pending'
-        })
-        .returning();
-      if (!batch) {
-        throw new Error('Failed to create batch');
-      }
-      batchId = batch.id;
-    }
-
-    // Create executions and queue commands for each device
-    const executions: Array<{ executionId: string; deviceId: string; commandId: string }> = [];
-
-    for (const device of executableDevices) {
-      // Create execution record
-      const [execution] = await db
-        .insert(scriptExecutions)
-        .values({
-          scriptId,
-          deviceId: device.id,
-          orgId: device.orgId,
-          triggeredBy: auth.user.id,
-          triggerType,
-          parameters,
-          status: 'pending'
-        })
-        .returning();
-
-      if (!execution) {
-        throw new Error('Failed to create execution');
-      }
-
-      // Queue command for device
-      const [command] = await db
-        .insert(deviceCommands)
-        .values({
-          deviceId: device.id,
-          type: 'script',
-          payload: {
-            scriptId,
-            executionId: execution.id,
-            batchId,
-            language: script.language,
-            content: script.content,
-            parameters,
-            timeoutSeconds: script.timeoutSeconds,
-            runAs
-          },
-          status: 'pending',
-          createdBy: auth.user.id
-        })
-        .returning();
-
-      if (!command) {
-        throw new Error('Failed to create command');
-      }
-
-      // Push command via WebSocket for immediate execution
-      if (device.agentId) {
-        const claimed = await claimPendingCommandForDelivery(command.id);
-        if (claimed) {
-          const sent = sendCommandToAgent(device.agentId, {
-            id: command.id,
-            type: 'script',
-            payload: command.payload as Record<string, unknown>
-          });
-          if (sent) {
-            await db
-              .update(scriptExecutions)
-              .set({ status: 'running', startedAt: claimed.executedAt })
-              .where(eq(scriptExecutions.id, execution.id));
-          } else {
-            await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
-          }
-        }
-      }
-
-      executions.push({
-        executionId: execution.id,
-        deviceId: device.id,
-        commandId: command.id
-      });
-    }
-
-    // Update batch status to queued
-    if (batchId) {
-      await db
-        .update(scriptExecutionBatches)
-        .set({ status: 'queued' })
-        .where(eq(scriptExecutionBatches.id, batchId));
+        error: result.error,
+        maintenanceSuppressedDeviceIds: result.maintenanceSuppressedDeviceIds,
+      }, result.status);
     }
 
     writeRouteAudit(c, {
-      orgId: resolveScriptAuditOrgId(auth, script.orgId, executableDevices[0]?.orgId ?? null),
+      orgId: result.auditOrgId,
       action: 'script.execute',
       resourceType: 'script',
-      resourceId: script.id,
-      resourceName: script.name,
+      resourceId: result.script.id,
+      resourceName: result.script.name,
       details: {
-        batchId,
-        devicesTargeted: executableDevices.length,
-        maintenanceSuppressedDeviceIds,
-        triggerType,
-        runAs
+        batchId: result.batchId,
+        devicesTargeted: result.devicesTargeted,
+        maintenanceSuppressedDeviceIds: result.maintenanceSuppressedDeviceIds,
+        triggerType: result.triggerType,
+        runAs: result.runAs,
       }
     });
 
     return c.json({
-      batchId,
+      batchId: result.batchId,
       scriptId,
-      devicesTargeted: executableDevices.length,
-      maintenanceSuppressedDeviceIds: maintenanceSuppressedDeviceIds.length > 0 ? maintenanceSuppressedDeviceIds : undefined,
-      executions,
-      status: 'queued'
+      devicesTargeted: result.devicesTargeted,
+      maintenanceSuppressedDeviceIds: result.maintenanceSuppressedDeviceIds.length > 0
+        ? result.maintenanceSuppressedDeviceIds
+        : undefined,
+      executions: result.executions,
+      status: result.status,
     }, 201);
   }
 );

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -1,0 +1,258 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+
+import { db } from '../db';
+import {
+  deviceCommands,
+  devices,
+  scriptExecutionBatches,
+  scriptExecutions,
+  scripts,
+} from '../db/schema';
+import {
+  claimPendingCommandForDelivery,
+  releaseClaimedCommandDelivery,
+} from './commandDispatch';
+import { checkDeviceMaintenanceWindow } from './featureConfigResolver';
+import { canAccessSite, type UserPermissions } from './permissions';
+import { sendCommandToAgent } from '../routes/agentWs';
+
+type ScriptExecutionAuth = {
+  user: { id: string };
+  orgId: string | null;
+  canAccessOrg: (orgId: string) => boolean;
+};
+
+type ExecuteScriptOnDevicesInput = {
+  scriptId: string;
+  deviceIds: string[];
+  parameters?: Record<string, unknown>;
+  triggerType?: 'manual' | 'scheduled' | 'alert' | 'policy';
+  runAs?: 'system' | 'user';
+  auth: ScriptExecutionAuth;
+  permissions?: UserPermissions;
+};
+
+type ExecuteScriptOnDevicesFailure = {
+  ok: false;
+  status: 400 | 403 | 404 | 409;
+  error: string;
+  maintenanceSuppressedDeviceIds?: string[];
+};
+
+type ExecuteScriptOnDevicesSuccess = {
+  ok: true;
+  batchId: string | null;
+  scriptId: string;
+  script: typeof scripts.$inferSelect;
+  devicesTargeted: number;
+  maintenanceSuppressedDeviceIds: string[];
+  executions: Array<{ executionId: string; deviceId: string; commandId: string }>;
+  status: 'queued';
+  triggerType: 'manual' | 'scheduled' | 'alert' | 'policy';
+  runAs: string;
+  auditOrgId: string | null;
+};
+
+export type ExecuteScriptOnDevicesResult = ExecuteScriptOnDevicesSuccess | ExecuteScriptOnDevicesFailure;
+
+function ensureOrgAccess(orgId: string, auth: Pick<ScriptExecutionAuth, 'canAccessOrg'>) {
+  return auth.canAccessOrg(orgId);
+}
+
+async function getScriptWithOrgCheck(scriptId: string, auth: Pick<ScriptExecutionAuth, 'canAccessOrg'>) {
+  const [script] = await db
+    .select()
+    .from(scripts)
+    .where(and(eq(scripts.id, scriptId), isNull(scripts.deletedAt)))
+    .limit(1);
+
+  if (!script) return null;
+  if (script.isSystem) return script;
+  if (script.orgId && !ensureOrgAccess(script.orgId, auth)) return null;
+  return script;
+}
+
+function canAccessDeviceSite(siteId: string | null | undefined, userPerms: UserPermissions | undefined): boolean {
+  if (!userPerms?.allowedSiteIds) return true;
+  return typeof siteId === 'string' && canAccessSite(userPerms, siteId);
+}
+
+function resolveScriptAuditOrgId(
+  auth: { orgId: string | null },
+  scriptOrgId?: string | null,
+  deviceOrgId?: string | null,
+): string | null {
+  return scriptOrgId ?? deviceOrgId ?? auth.orgId ?? null;
+}
+
+export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput): Promise<ExecuteScriptOnDevicesResult> {
+  const script = await getScriptWithOrgCheck(input.scriptId, input.auth);
+  if (!script) {
+    return { ok: false, status: 404, error: 'Script not found' };
+  }
+
+  const deviceRecords = await db
+    .select()
+    .from(devices)
+    .where(inArray(devices.id, input.deviceIds));
+
+  if (deviceRecords.length === 0) {
+    return { ok: false, status: 400, error: 'No valid devices found' };
+  }
+
+  const validDevices: typeof deviceRecords = [];
+  const siteDeniedDeviceIds: string[] = [];
+  for (const device of deviceRecords) {
+    if (!ensureOrgAccess(device.orgId, input.auth)) continue;
+    if (!canAccessDeviceSite(device.siteId, input.permissions)) {
+      siteDeniedDeviceIds.push(device.id);
+      continue;
+    }
+    if (script.osTypes.includes(device.osType) && device.status !== 'decommissioned') {
+      validDevices.push(device);
+    }
+  }
+
+  if (siteDeniedDeviceIds.length > 0) {
+    return { ok: false, status: 403, error: 'Access to one or more device sites denied' };
+  }
+
+  if (validDevices.length === 0) {
+    return { ok: false, status: 400, error: 'No accessible or compatible devices found' };
+  }
+
+  const maintenanceSuppressedDeviceIds: string[] = [];
+  const executableDevices: typeof validDevices = [];
+  for (const device of validDevices) {
+    const maintenanceStatus = await checkDeviceMaintenanceWindow(device.id);
+    if (maintenanceStatus.active && maintenanceStatus.suppressScripts) {
+      maintenanceSuppressedDeviceIds.push(device.id);
+    } else {
+      executableDevices.push(device);
+    }
+  }
+
+  if (executableDevices.length === 0) {
+    return {
+      ok: false,
+      status: 409,
+      error: 'All target devices are in a maintenance window with script execution suppressed',
+      maintenanceSuppressedDeviceIds,
+    };
+  }
+
+  const triggerType = input.triggerType ?? 'manual';
+  const parameters = input.parameters ?? {};
+  const runAs = input.runAs ?? script.runAs;
+
+  let batchId: string | null = null;
+  if (executableDevices.length > 1) {
+    const batchOrgId = executableDevices[0]!.orgId;
+    const [batch] = await db
+      .insert(scriptExecutionBatches)
+      .values({
+        scriptId: input.scriptId,
+        orgId: batchOrgId,
+        triggeredBy: input.auth.user.id,
+        triggerType,
+        parameters,
+        devicesTargeted: executableDevices.length,
+        status: 'pending',
+      })
+      .returning();
+    if (!batch) {
+      throw new Error('Failed to create batch');
+    }
+    batchId = batch.id;
+  }
+
+  const executions: Array<{ executionId: string; deviceId: string; commandId: string }> = [];
+  for (const device of executableDevices) {
+    const [execution] = await db
+      .insert(scriptExecutions)
+      .values({
+        scriptId: input.scriptId,
+        deviceId: device.id,
+        orgId: device.orgId,
+        triggeredBy: input.auth.user.id,
+        triggerType,
+        parameters,
+        status: 'pending',
+      })
+      .returning();
+
+    if (!execution) {
+      throw new Error('Failed to create execution');
+    }
+
+    const [command] = await db
+      .insert(deviceCommands)
+      .values({
+        deviceId: device.id,
+        type: 'script',
+        payload: {
+          scriptId: input.scriptId,
+          executionId: execution.id,
+          batchId,
+          language: script.language,
+          content: script.content,
+          parameters,
+          timeoutSeconds: script.timeoutSeconds,
+          runAs,
+        },
+        status: 'pending',
+        createdBy: input.auth.user.id,
+      })
+      .returning();
+
+    if (!command) {
+      throw new Error('Failed to create command');
+    }
+
+    if (device.agentId) {
+      const claimed = await claimPendingCommandForDelivery(command.id);
+      if (claimed) {
+        const sent = sendCommandToAgent(device.agentId, {
+          id: command.id,
+          type: 'script',
+          payload: command.payload as Record<string, unknown>,
+        });
+        if (sent) {
+          await db
+            .update(scriptExecutions)
+            .set({ status: 'running', startedAt: claimed.executedAt })
+            .where(eq(scriptExecutions.id, execution.id));
+        } else {
+          await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
+        }
+      }
+    }
+
+    executions.push({
+      executionId: execution.id,
+      deviceId: device.id,
+      commandId: command.id,
+    });
+  }
+
+  if (batchId) {
+    await db
+      .update(scriptExecutionBatches)
+      .set({ status: 'queued' })
+      .where(eq(scriptExecutionBatches.id, batchId));
+  }
+
+  return {
+    ok: true,
+    batchId,
+    scriptId: input.scriptId,
+    script,
+    devicesTargeted: executableDevices.length,
+    maintenanceSuppressedDeviceIds,
+    executions,
+    status: 'queued',
+    triggerType,
+    runAs,
+    auditOrgId: resolveScriptAuditOrgId(input.auth, script.orgId, executableDevices[0]?.orgId ?? null),
+  };
+}

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RemediationSuggestionsPanel from './RemediationSuggestionsPanel';
-import { executeScript } from '../../services/deviceActions';
 import { fetchWithAuth } from '../../stores/auth';
 
 const showToast = vi.fn();
@@ -11,16 +10,11 @@ vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
-vi.mock('../../services/deviceActions', () => ({
-  executeScript: vi.fn(),
-}));
-
 vi.mock('../shared/Toast', () => ({
   showToast: (input: unknown) => showToast(input),
 }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
-const executeScriptMock = vi.mocked(executeScript);
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({
@@ -111,39 +105,17 @@ describe('RemediationSuggestionsPanel', () => {
     fetchWithAuthMock
       .mockResolvedValueOnce(makeJsonResponse({ data: [accepted] }))
       .mockResolvedValueOnce(makeJsonResponse({ data: executed }));
-    executeScriptMock.mockResolvedValueOnce({
-      batchId: null,
-      scriptId: suggestion.scriptId,
-      devicesTargeted: 1,
-      executions: [{
-        executionId: '33333333-3333-4333-8333-333333333333',
-        deviceId: suggestion.deviceId,
-        commandId: '44444444-4444-4444-8444-444444444444',
-      }],
-      status: 'queued',
-    });
 
     render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
 
     fireEvent.click(await screen.findByRole('button', { name: /execute/i }));
 
     await waitFor(() => {
-      expect(executeScriptMock).toHaveBeenCalledWith(
-        suggestion.scriptId,
-        [suggestion.deviceId],
-        suggestion.parameters,
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/remediation-suggestions/suggestion-1/execute',
+        expect.objectContaining({ method: 'POST' }),
       );
     });
-    expect(fetchWithAuthMock).toHaveBeenCalledWith(
-      '/remediation-suggestions/suggestion-1',
-      expect.objectContaining({
-        method: 'PATCH',
-        body: JSON.stringify({
-          status: 'executed',
-          scriptExecutionId: '33333333-3333-4333-8333-333333333333',
-        }),
-      }),
-    );
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
       type: 'success',
       message: 'Script queued and suggested fix updated',

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { CheckCircle, PlayCircle, RefreshCw, Sparkles, XCircle } from 'lucide-react';
 
 import { handleActionError, runAction } from '../../lib/runAction';
-import { executeScript } from '../../services/deviceActions';
 import { fetchWithAuth } from '../../stores/auth';
 
 type SuggestionStatus = 'suggested' | 'accepted' | 'edited' | 'rejected' | 'executed' | 'failed';
@@ -133,25 +132,16 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
   }
 
   async function executeSuggestion(suggestion: RemediationSuggestion) {
-    const scriptId = suggestion.scriptId;
-    const deviceId = singleTargetDeviceId(suggestion);
-    if (!scriptId || !deviceId) return;
+    if (!canExecuteScriptSuggestion(suggestion)) return;
 
     setExecutingId(suggestion.id);
     try {
-      const execution = await executeScript(scriptId, [deviceId], suggestion.parameters);
-      const scriptExecutionId = execution.executions[0]?.executionId;
-      if (!scriptExecutionId) {
-        throw new Error('Script execution did not return an execution ID');
-      }
-
       const result = await runAction<{ data?: RemediationSuggestion }>({
-        request: () => fetchWithAuth(`/remediation-suggestions/${suggestion.id}`, {
-          method: 'PATCH',
+        request: () => fetchWithAuth(`/remediation-suggestions/${suggestion.id}/execute`, {
+          method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ status: 'executed', scriptExecutionId }),
         }),
-        errorFallback: 'Script queued, but the suggested fix could not be updated',
+        errorFallback: 'Could not execute suggested fix',
         successMessage: 'Script queued and suggested fix updated',
       });
       if (result.data) {


### PR DESCRIPTION
## Summary
- extract the shared script execution path into an API service
- add POST /remediation-suggestions/:id/execute so accepted script suggestions are validated, queued, linked, audited, and feedback-emitted server-side
- validate direct terminal remediation updates against the linked script execution org, script, and target device
- update the remediation suggestions panel to call the server-side execution endpoint

## Tests
- pnpm --filter @breeze/api exec vitest run src/routes/remediationSuggestions.test.ts
- pnpm --filter @breeze/web exec vitest run src/components/remediation/RemediationSuggestionsPanel.test.tsx
- pnpm --filter @breeze/api exec vitest run src/routes/scripts.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit
- pnpm --filter @breeze/web exec tsc --noEmit
- git diff --check