### PR TITLE
fix(ml): gate user risk output jobs

### DIFF
--- a/apps/api/src/jobs/userRiskJobs.test.ts
+++ b/apps/api/src/jobs/userRiskJobs.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getJobMock, addMock, closeMock } = vi.hoisted(() => ({
+const { getJobMock, addMock, closeMock, workerProcessors } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
   closeMock: vi.fn(),
+  workerProcessors: [] as Array<(job: { data: unknown }) => Promise<unknown>>,
 }));
 
 vi.mock('bullmq', () => ({
@@ -13,6 +14,9 @@ vi.mock('bullmq', () => ({
     close = closeMock;
   },
   Worker: class {
+    constructor(_name: string, processor: (job: { data: unknown }) => Promise<unknown>) {
+      workerProcessors.push(processor);
+    }
     close = closeMock;
     on = vi.fn();
   },
@@ -48,11 +52,24 @@ vi.mock('../services/userRiskSignals', () => ({
   evaluateUserRiskSignalsForOrg: vi.fn(),
 }));
 
+vi.mock('../services/mlFeatureFlags', () => ({
+  shouldProduceMlOutput: vi.fn(),
+}));
+
 import {
+  createUserRiskWorker,
   enqueueUserRiskSignalEvent,
   shutdownUserRiskJobs,
   triggerUserRiskRecompute,
 } from './userRiskJobs';
+import {
+  appendUserRiskSignalEvent,
+  computeAndPersistOrgUserRisk,
+  computeAndPersistUserRiskForUser,
+  publishUserRiskScoreEvents,
+} from '../services/userRiskScoring';
+import { evaluateUserRiskSignalsForOrg } from '../services/userRiskSignals';
+import { shouldProduceMlOutput } from '../services/mlFeatureFlags';
 
 describe('triggerUserRiskRecompute', () => {
   beforeEach(async () => {
@@ -63,6 +80,44 @@ describe('triggerUserRiskRecompute', () => {
     closeMock.mockReset();
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queue-job-1' });
+    workerProcessors.length = 0;
+    vi.mocked(shouldProduceMlOutput).mockReset();
+    vi.mocked(shouldProduceMlOutput).mockResolvedValue(true);
+    vi.mocked(evaluateUserRiskSignalsForOrg).mockReset();
+    vi.mocked(evaluateUserRiskSignalsForOrg).mockResolvedValue({
+      orgId: 'org-1',
+      skipped: false,
+      appended: 0,
+      deduped: 0,
+      candidates: {
+        offHoursMassScripts: 0,
+        remoteSessionBursts: 0,
+        privilegeElevationBursts: 0,
+        newGeographyLogins: 0,
+      },
+    });
+    vi.mocked(computeAndPersistOrgUserRisk).mockReset();
+    vi.mocked(computeAndPersistOrgUserRisk).mockResolvedValue({
+      usersProcessed: 0,
+      changedUsers: [],
+      autoTrainingAssigned: 0,
+      policy: { thresholds: {}, interventions: {} },
+    } as never);
+    vi.mocked(computeAndPersistUserRiskForUser).mockReset();
+    vi.mocked(computeAndPersistUserRiskForUser).mockResolvedValue({
+      usersProcessed: 1,
+      changedUsers: [],
+      autoTrainingAssigned: 0,
+      policy: { thresholds: {}, interventions: {} },
+    } as never);
+    vi.mocked(appendUserRiskSignalEvent).mockReset();
+    vi.mocked(appendUserRiskSignalEvent).mockResolvedValue('event-1');
+    vi.mocked(publishUserRiskScoreEvents).mockReset();
+    vi.mocked(publishUserRiskScoreEvents).mockResolvedValue({
+      publishedHigh: 0,
+      publishedSpikes: 0,
+      failed: 0,
+    });
     await shutdownUserRiskJobs();
   });
 
@@ -108,5 +163,68 @@ describe('triggerUserRiskRecompute', () => {
     expect(queued.eventType).toHaveLength(128);
     expect(queued.description).toHaveLength(1024);
     expect(queued.details).toBeUndefined();
+  });
+
+  it('skips scheduled org recompute output when user-risk v0 is disabled', async () => {
+    vi.mocked(shouldProduceMlOutput).mockResolvedValue(false);
+    createUserRiskWorker();
+
+    const result = await workerProcessors[0]!({
+      data: {
+        type: 'compute-org',
+        orgId: 'org-1',
+        queuedAt: '2026-03-31T12:00:00.000Z',
+      },
+    });
+
+    expect(shouldProduceMlOutput).toHaveBeenCalledWith('org-1', 'ml.user_risk_v0.enabled');
+    expect(evaluateUserRiskSignalsForOrg).not.toHaveBeenCalled();
+    expect(computeAndPersistOrgUserRisk).not.toHaveBeenCalled();
+    expect(publishUserRiskScoreEvents).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      orgId: 'org-1',
+      skipped: true,
+      usersProcessed: 0,
+      changedUsers: 0,
+      autoTrainingAssigned: 0,
+      signalsAppended: 0,
+      signalsDeduped: 0,
+      publishedHigh: 0,
+      publishedSpikes: 0,
+      publishFailures: 0,
+    });
+  });
+
+  it('skips signal-event ingestion and recompute when user-risk v0 is disabled', async () => {
+    vi.mocked(shouldProduceMlOutput).mockResolvedValue(false);
+    createUserRiskWorker();
+
+    const result = await workerProcessors[0]!({
+      data: {
+        type: 'process-signal-event',
+        orgId: 'org-1',
+        userId: 'user-1',
+        eventType: 'suspicious_login',
+        severity: 'high',
+        description: 'Suspicious login',
+        queuedAt: '2026-03-31T12:00:00.000Z',
+      },
+    });
+
+    expect(shouldProduceMlOutput).toHaveBeenCalledWith('org-1', 'ml.user_risk_v0.enabled');
+    expect(appendUserRiskSignalEvent).not.toHaveBeenCalled();
+    expect(computeAndPersistUserRiskForUser).not.toHaveBeenCalled();
+    expect(publishUserRiskScoreEvents).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      orgId: 'org-1',
+      userId: 'user-1',
+      eventId: null,
+      skipped: true,
+      recomputed: false,
+      changedUsers: 0,
+      publishedHigh: 0,
+      publishedSpikes: 0,
+      publishFailures: 0,
+    });
   });
 });

--- a/apps/api/src/jobs/userRiskJobs.ts
+++ b/apps/api/src/jobs/userRiskJobs.ts
@@ -13,6 +13,7 @@ import {
 import { evaluateUserRiskSignalsForOrg } from '../services/userRiskSignals';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
+import { shouldProduceMlOutput } from '../services/mlFeatureFlags';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -142,6 +143,7 @@ async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number 
 
 async function processComputeOrg(data: ComputeOrgJobData): Promise<{
   orgId: string;
+  skipped?: boolean;
   usersProcessed: number;
   changedUsers: number;
   autoTrainingAssigned: number;
@@ -151,6 +153,21 @@ async function processComputeOrg(data: ComputeOrgJobData): Promise<{
   publishedSpikes: number;
   publishFailures: number;
 }> {
+  if (!(await shouldProduceMlOutput(data.orgId, 'ml.user_risk_v0.enabled'))) {
+    return {
+      orgId: data.orgId,
+      skipped: true,
+      usersProcessed: 0,
+      changedUsers: 0,
+      autoTrainingAssigned: 0,
+      signalsAppended: 0,
+      signalsDeduped: 0,
+      publishedHigh: 0,
+      publishedSpikes: 0,
+      publishFailures: 0
+    };
+  }
+
   const signalEvaluation = await evaluateUserRiskSignalsForOrg(data.orgId);
   const result = await computeAndPersistOrgUserRisk(data.orgId);
   const published = await publishUserRiskScoreEvents({
@@ -176,13 +193,28 @@ async function processComputeOrg(data: ComputeOrgJobData): Promise<{
 async function processSignalEvent(data: ProcessSignalEventJobData): Promise<{
   orgId: string;
   userId: string;
-  eventId: string;
+  eventId: string | null;
+  skipped?: boolean;
   recomputed: boolean;
   changedUsers: number;
   publishedHigh: number;
   publishedSpikes: number;
   publishFailures: number;
 }> {
+  if (!(await shouldProduceMlOutput(data.orgId, 'ml.user_risk_v0.enabled'))) {
+    return {
+      orgId: data.orgId,
+      userId: data.userId,
+      eventId: null,
+      skipped: true,
+      recomputed: false,
+      changedUsers: 0,
+      publishedHigh: 0,
+      publishedSpikes: 0,
+      publishFailures: 0
+    };
+  }
+
   const eventId = await appendUserRiskSignalEvent({
     orgId: data.orgId,
     userId: data.userId,


### PR DESCRIPTION
## Summary
- gate scheduled user-risk recompute jobs on ml.user_risk_v0.enabled before signal scanning, score persistence, training assignment, or event publishing
- gate queued user-risk signal-event ingestion on the same flag before appending events or recomputing scores
- add worker processor regressions for disabled scheduled recompute and disabled signal-event ingestion

## Tests
- pnpm --filter @breeze/api exec vitest run src/jobs/userRiskJobs.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit
- git diff --check