### PR TITLE
feat(ml): label disabled ML actions

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -667,7 +667,7 @@ async function resolveFallbackOrgId(c: Context, path: string): Promise<string | 
 api.use('*', async (c, next) => {
   const path = c.req.path;
   if (path.startsWith('/api/v1/auth')) return next();
-  if (path === '/api/v1/config' || path.startsWith('/api/v1/config/')) return next();
+  if (path === '/api/v1/config' || path === '/api/v1/config/') return next();
   if (path.startsWith('/api/v1/users/me')) return next();
   if (path === '/api/v1/partner/me' || path.startsWith('/api/v1/partner/me/')) return next();
   if (path.startsWith('/api/v1/agents/')) return next();

--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -1,5 +1,28 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+
+const mocks = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      orgId: '11111111-1111-4111-8111-111111111111',
+      canAccessOrg: (orgId: string) => orgId === '11111111-1111-4111-8111-111111111111',
+    },
+  },
+  resolveAllMlFeatureFlagsForOrg: vi.fn(),
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', mocks.authRef.current);
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../services/mlFeatureFlags', () => ({
+  resolveAllMlFeatureFlagsForOrg: mocks.resolveAllMlFeatureFlagsForOrg,
+}));
+
 import { configRoutes } from './config';
 
 describe('GET /config', () => {
@@ -9,6 +32,25 @@ describe('GET /config', () => {
   beforeEach(() => {
     delete process.env.BREEZE_BILLING_URL;
     delete process.env.ENABLE_REGISTRATION;
+    mocks.authRef.current = {
+      orgId: '11111111-1111-4111-8111-111111111111',
+      canAccessOrg: (orgId: string) => orgId === '11111111-1111-4111-8111-111111111111',
+    };
+    mocks.resolveAllMlFeatureFlagsForOrg.mockReset();
+    mocks.resolveAllMlFeatureFlagsForOrg.mockResolvedValue({
+      'ml.rca.enabled': {
+        flag: 'ml.rca.enabled',
+        enabled: false,
+        defaultEnabled: false,
+        source: 'org_settings',
+      },
+      'ml.remediation_suggestions.enabled': {
+        flag: 'ml.remediation_suggestions.enabled',
+        enabled: true,
+        defaultEnabled: false,
+        source: 'org_settings',
+      },
+    });
   });
 
   afterEach(() => {
@@ -58,5 +100,25 @@ describe('GET /config', () => {
     process.env.ENABLE_REGISTRATION = 'false';
     const { body } = await request();
     expect(body.registration).toEqual({ enabled: false });
+  });
+
+  it('returns authenticated org-scoped ML feature flag resolutions', async () => {
+    const app = new Hono().route('/config', configRoutes);
+    const res = await app.request('/config/ml-feature-flags');
+
+    expect(res.status).toBe(200);
+    expect(mocks.resolveAllMlFeatureFlagsForOrg).toHaveBeenCalledWith('11111111-1111-4111-8111-111111111111');
+    const body = await res.json();
+    expect(body.orgId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(body.mlFeatureFlags['ml.rca.enabled']).toMatchObject({ enabled: false, source: 'org_settings' });
+    expect(body.data).toEqual(body.mlFeatureFlags);
+  });
+
+  it('rejects ML feature flag requests for inaccessible orgs', async () => {
+    const app = new Hono().route('/config', configRoutes);
+    const res = await app.request('/config/ml-feature-flags?orgId=22222222-2222-4222-8222-222222222222');
+
+    expect(res.status).toBe(403);
+    expect(mocks.resolveAllMlFeatureFlagsForOrg).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,8 +1,16 @@
 import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
 import { cfAccessTrustEnabled } from '../config/env';
 import { envFlag } from '../utils/envFlag';
+import { authMiddleware, requireScope, type AuthContext } from '../middleware/auth';
+import { resolveAllMlFeatureFlagsForOrg } from '../services/mlFeatureFlags';
 
 export const configRoutes = new Hono();
+
+const mlFeatureFlagsQuerySchema = z.object({
+  orgId: z.string().uuid().optional(),
+});
 
 // GET /api/v1/config — returns feature flags for the UI. No auth required;
 // flags are derived purely from server env, not user state, so self-hosted
@@ -28,3 +36,25 @@ configRoutes.get('/', (c) => {
     },
   });
 });
+
+configRoutes.get(
+  '/ml-feature-flags',
+  authMiddleware,
+  requireScope('organization', 'partner', 'system'),
+  zValidator('query', mlFeatureFlagsQuerySchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const query = c.req.valid('query');
+    const orgId = query.orgId ?? auth.orgId;
+
+    if (!orgId) {
+      return c.json({ error: 'Organization context required' }, 400);
+    }
+    if (!auth.canAccessOrg(orgId)) {
+      return c.json({ error: 'Organization not found or access denied' }, 403);
+    }
+
+    const flags = await resolveAllMlFeatureFlagsForOrg(orgId);
+    return c.json({ orgId, mlFeatureFlags: flags, data: flags });
+  }
+);

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -108,10 +108,25 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
     json: vi.fn().mockResolvedValue(payload)
   }) as unknown as Response;
 
-function mockGroupsResponse() {
+const mlFlags = (rcaEnabled: boolean) => ({
+  mlFeatureFlags: {
+    'ml.rca.enabled': {
+      flag: 'ml.rca.enabled',
+      enabled: rcaEnabled,
+      defaultEnabled: false,
+      source: 'org_settings',
+    },
+  },
+});
+
+function mockGroupsResponse(options: { rcaEnabled?: boolean } = {}) {
+  const rcaEnabled = options.rcaEnabled ?? true;
   fetchMock.mockImplementation((input, init) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
+    if (url === '/config/ml-feature-flags' && method === 'GET') {
+      return Promise.resolve(makeJsonResponse(mlFlags(rcaEnabled)));
+    }
     if (url === '/alerts/correlations' && method === 'GET') {
       return Promise.resolve(makeJsonResponse({ groups: [groupPayload] }));
     }
@@ -190,6 +205,22 @@ describe('CorrelatedAlertGroups', () => {
         })
       );
     });
+  });
+
+  it('labels and disables RCA when the feature is disabled', async () => {
+    mockGroupsResponse({ rcaEnabled: false });
+
+    render(<CorrelatedAlertGroups />);
+
+    await screen.findAllByText('High CPU on SRV-01');
+    const disabledButton = await screen.findByRole('button', { name: /RCA disabled/i });
+    expect(disabledButton).toBeDisabled();
+    fireEvent.click(disabledButton);
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      `/alerts/correlations/${GROUP_ID}/explain`,
+      expect.anything(),
+    );
   });
 
   it('marks the correlations tab active on the correlations route', () => {

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -19,6 +19,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import type { AlertSeverity, AlertStatus } from './AlertList';
 import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
+import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 type AlertItem = {
   id: string;
@@ -121,6 +122,7 @@ function evidenceLabel(source: string) {
 }
 
 export default function CorrelatedAlertGroups() {
+  const mlFlags = useMlFeatureFlags();
   const [groups, setGroups] = useState<AlertGroup[]>([]);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [rcaByGroup, setRcaByGroup] = useState<Record<string, RcaResult | undefined>>({});
@@ -138,6 +140,7 @@ export default function CorrelatedAlertGroups() {
       : groups.reduce((sum, group) => sum + (group.noiseReductionPercent ?? 0), 0) / groups.length;
     return { incidentCount, memberCount, suppressedAlerts, avgReduction };
   }, [groups]);
+  const rcaDisabled = mlFlags.isDisabled('ml.rca.enabled');
 
   const fetchGroups = useCallback(async () => {
     setIsLoading(true);
@@ -388,11 +391,12 @@ export default function CorrelatedAlertGroups() {
                       <button
                         type="button"
                         onClick={() => void handleExplainGroup(group)}
-                        disabled={isBusy || isExplaining}
+                        disabled={isBusy || isExplaining || rcaDisabled}
+                        title={rcaDisabled ? 'RCA is disabled for this organization' : undefined}
                         className="inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
                       >
                         {isExplaining ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Brain className="h-3.5 w-3.5" />}
-                        Explain incident
+                        {rcaDisabled ? 'RCA disabled' : 'Explain incident'}
                       </button>
                       <button
                         type="button"

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -24,6 +24,17 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
     json: vi.fn().mockResolvedValue(payload),
   }) as unknown as Response;
 
+const remediationFlags = (enabled: boolean) => ({
+  mlFeatureFlags: {
+    'ml.remediation_suggestions.enabled': {
+      flag: 'ml.remediation_suggestions.enabled',
+      enabled,
+      defaultEnabled: false,
+      source: 'org_settings',
+    },
+  },
+});
+
 const suggestion = {
   id: 'suggestion-1',
   sourceType: 'anomaly',
@@ -51,7 +62,14 @@ describe('RemediationSuggestionsPanel', () => {
   });
 
   it('lists suggested fixes for a source', async () => {
-    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [suggestion] }));
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [suggestion] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
 
     render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
 
@@ -62,10 +80,21 @@ describe('RemediationSuggestionsPanel', () => {
   });
 
   it('generates suggestions and accepts a suggestion through runAction', async () => {
-    fetchWithAuthMock
-      .mockResolvedValueOnce(makeJsonResponse({ data: [] }))
-      .mockResolvedValueOnce(makeJsonResponse({ data: [suggestion] }, true, 201))
-      .mockResolvedValueOnce(makeJsonResponse({ data: { ...suggestion, status: 'accepted' } }));
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === '/remediation-suggestions/generate' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ data: [suggestion] }, true, 201));
+      }
+      if (url === '/remediation-suggestions/suggestion-1' && method === 'PATCH') {
+        return Promise.resolve(makeJsonResponse({ data: { ...suggestion, status: 'accepted' } }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
 
     render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
 
@@ -102,9 +131,18 @@ describe('RemediationSuggestionsPanel', () => {
       status: 'executed',
       scriptExecutionId: '33333333-3333-4333-8333-333333333333',
     };
-    fetchWithAuthMock
-      .mockResolvedValueOnce(makeJsonResponse({ data: [accepted] }))
-      .mockResolvedValueOnce(makeJsonResponse({ data: executed }));
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [accepted] }));
+      }
+      if (url === '/remediation-suggestions/suggestion-1/execute' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ data: executed }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
 
     render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
 
@@ -123,20 +161,45 @@ describe('RemediationSuggestionsPanel', () => {
   });
 
   it('does not show execute for multi-device script suggestions', async () => {
-    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({
-      data: [{
-        ...suggestion,
-        status: 'accepted',
-        targetDeviceIds: [
-          '22222222-2222-4222-8222-222222222222',
-          '33333333-3333-4333-8333-333333333333',
-        ],
-      }],
-    }));
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({
+          data: [{
+            ...suggestion,
+            status: 'accepted',
+            targetDeviceIds: [
+              '22222222-2222-4222-8222-222222222222',
+              '33333333-3333-4333-8333-333333333333',
+            ],
+          }],
+        }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
 
     render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
 
     await screen.findByText('Disk Cleanup');
     expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
+  });
+
+  it('labels and disables generation when suggested fixes are disabled', async () => {
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(false)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    const disabledButton = await screen.findByRole('button', { name: /suggestions disabled/i });
+    expect(disabledButton).toBeDisabled();
+    fireEvent.click(disabledButton);
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/remediation-suggestions/generate', expect.anything());
   });
 });

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -3,6 +3,7 @@ import { CheckCircle, PlayCircle, RefreshCw, Sparkles, XCircle } from 'lucide-re
 
 import { handleActionError, runAction } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
+import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 type SuggestionStatus = 'suggested' | 'accepted' | 'edited' | 'rejected' | 'executed' | 'failed';
 
@@ -62,6 +63,7 @@ function canExecuteScriptSuggestion(suggestion: RemediationSuggestion): boolean 
 }
 
 export default function RemediationSuggestionsPanel({ sourceType, sourceId }: RemediationSuggestionsPanelProps) {
+  const mlFlags = useMlFeatureFlags();
   const [suggestions, setSuggestions] = useState<RemediationSuggestion[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
@@ -89,7 +91,10 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
     void fetchSuggestions();
   }, [fetchSuggestions]);
 
+  const remediationSuggestionsDisabled = mlFlags.isDisabled('ml.remediation_suggestions.enabled');
+
   async function generateSuggestions() {
+    if (remediationSuggestionsDisabled) return;
     setGenerating(true);
     try {
       const result = await runAction<{ data?: RemediationSuggestion[]; skipped?: boolean }>({
@@ -181,12 +186,13 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
           </button>
           <button
             type="button"
-            disabled={generating}
+            disabled={generating || remediationSuggestionsDisabled}
             onClick={() => void generateSuggestions()}
+            title={remediationSuggestionsDisabled ? 'Suggested fixes are disabled for this organization' : undefined}
             className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Sparkles className="h-4 w-4" />
-            Generate
+            {remediationSuggestionsDisabled ? 'Suggestions disabled' : 'Generate'}
           </button>
         </div>
       </div>

--- a/apps/web/src/hooks/useMlFeatureFlags.ts
+++ b/apps/web/src/hooks/useMlFeatureFlags.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../stores/auth';
+
+export type MlFeatureFlagName =
+  | 'ml.alert_correlation.enabled'
+  | 'ml.rca.enabled'
+  | 'ml.metric_rollups.enabled'
+  | 'ml.anomalies.enabled'
+  | 'ml.anomalies.create_alerts'
+  | 'ml.remediation_suggestions.enabled'
+  | 'ml.ticket_triage.enabled'
+  | 'ml.user_risk_v0.enabled'
+  | 'ml.user_risk_v1.enabled';
+
+export type MlFeatureFlagResolution = {
+  flag: MlFeatureFlagName;
+  enabled: boolean;
+  defaultEnabled: boolean;
+  source: string;
+};
+
+type MlFeatureFlagsResponse = {
+  mlFeatureFlags?: Partial<Record<MlFeatureFlagName, MlFeatureFlagResolution>>;
+  data?: Partial<Record<MlFeatureFlagName, MlFeatureFlagResolution>>;
+};
+
+export function useMlFeatureFlags() {
+  const [flags, setFlags] = useState<Partial<Record<MlFeatureFlagName, MlFeatureFlagResolution>>>({});
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetchWithAuth('/config/ml-feature-flags');
+      if (!response.ok) {
+        throw new Error(`Failed to load ML feature flags (${response.status})`);
+      }
+      const body = await response.json() as MlFeatureFlagsResponse;
+      setFlags(body.mlFeatureFlags ?? body.data ?? {});
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load ML feature flags');
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const isDisabled = useCallback((flag: MlFeatureFlagName) => loaded && flags[flag]?.enabled === false, [flags, loaded]);
+
+  return { flags, loaded, error, isDisabled, reload: load };
+}


### PR DESCRIPTION
## Summary
- add authenticated /config/ml-feature-flags for org-scoped ML flag resolutions
- keep the public /config root unauthenticated while restoring partner-guard coverage for config subroutes
- add a shared web hook for ML feature flags
- label and disable RCA explain and remediation suggestion generation before action when their flags are off

## Tests
- pnpm --filter @breeze/api exec vitest run src/routes/config.test.ts
- pnpm --filter @breeze/web exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx src/components/remediation/RemediationSuggestionsPanel.test.tsx
- pnpm --filter @breeze/api exec tsc --noEmit
- pnpm --filter @breeze/web exec tsc --noEmit
- git diff --check