### PR TITLE
feat(ml): show alert cluster summaries

### DIFF
--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -98,6 +98,17 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
+  alertCorrelationGroups: {
+    id: 'alertCorrelationGroups.id',
+    status: 'alertCorrelationGroups.status',
+    memberCount: 'alertCorrelationGroups.memberCount',
+    noiseReductionPercent: 'alertCorrelationGroups.noiseReductionPercent',
+  },
+  alertCorrelationMembers: {
+    alertId: 'alertCorrelationMembers.alertId',
+    groupId: 'alertCorrelationMembers.groupId',
+    role: 'alertCorrelationMembers.role',
+  },
   alertRules: {},
   alertTemplates: {},
   alerts: {},
@@ -231,6 +242,20 @@ describe('alert routes', () => {
               })
             })
           })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{
+                alertId: 'alert-1',
+                groupId: 'group-1',
+                role: 'root',
+                groupStatus: 'open',
+                memberCount: 3,
+                noiseReductionPercent: 67
+              }])
+            })
+          })
         } as any);
 
       const res = await app.request('/alerts', {
@@ -242,6 +267,11 @@ describe('alert routes', () => {
       const body = await res.json();
       expect(body.data).toHaveLength(1);
       expect(body.data[0].severity).toBe('high');
+      expect(body.data[0]).toEqual(expect.objectContaining({
+        correlationGroupId: 'group-1',
+        correlationChildCount: 2,
+        noiseReductionPercent: 67
+      }));
       expect(body.pagination.total).toBe(1);
     });
 
@@ -274,6 +304,13 @@ describe('alert routes', () => {
                   })
                 })
               })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([])
             })
           })
         } as any);

--- a/apps/api/src/routes/alerts/alerts.authz.test.ts
+++ b/apps/api/src/routes/alerts/alerts.authz.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../middleware/auth', () => ({
 
 vi.mock('../../db', () => ({ db: {} }));
 vi.mock('../../db/schema', () => ({
+  alertCorrelationGroups: {}, alertCorrelationMembers: {},
   alertRules: {}, alertTemplates: {}, alerts: {}, notificationChannels: {},
   alertNotifications: {}, devices: {}, tickets: {}, ticketAlertLinks: {},
 }));
@@ -61,7 +62,7 @@ vi.mock('./helpers', () => ({
   getAlertWithOrgCheck: vi.fn(),
 }));
 
-import { alertsRoutes } from './alerts';
+import { alertsRoutes, attachAlertCorrelationSummaries } from './alerts';
 
 function makeApp() {
   const app = new Hono();
@@ -130,5 +131,43 @@ describe('alert state-change authz (Finding #6)', () => {
       body: JSON.stringify({}),
     });
     expect(res.status).not.toBe(403);
+  });
+});
+
+describe('attachAlertCorrelationSummaries', () => {
+  it('adds group child count and noise reduction fields to visible alert rows', () => {
+    const [alert] = attachAlertCorrelationSummaries(
+      [{ id: ALERT_ID, title: 'High CPU' }],
+      [{
+        alertId: ALERT_ID,
+        groupId: '6f5e4d3c-2222-4333-8444-555566667777',
+        role: 'root',
+        groupStatus: 'open',
+        memberCount: 4,
+        noiseReductionPercent: 75,
+      }]
+    );
+
+    expect(alert).toEqual(expect.objectContaining({
+      correlationGroupId: '6f5e4d3c-2222-4333-8444-555566667777',
+      correlationRole: 'root',
+      correlationGroupStatus: 'open',
+      correlationMemberCount: 4,
+      correlationChildCount: 3,
+      noiseReductionPercent: 75,
+    }));
+  });
+
+  it('returns explicit empty correlation fields when an alert is not grouped', () => {
+    const [alert] = attachAlertCorrelationSummaries([{ id: ALERT_ID, title: 'High CPU' }], []);
+
+    expect(alert).toEqual(expect.objectContaining({
+      correlationGroupId: null,
+      correlationRole: null,
+      correlationGroupStatus: null,
+      correlationMemberCount: 0,
+      correlationChildCount: 0,
+      noiseReductionPercent: null,
+    }));
   });
 });

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 import { and, or, eq, sql, desc, gte, lte, inArray, isNull, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import {
+  alertCorrelationGroups,
+  alertCorrelationMembers,
   alertRules,
   alertTemplates,
   alerts,
@@ -36,6 +38,57 @@ const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, P
 const requireAlertAcknowledge = requirePermission(PERMISSIONS.ALERTS_ACKNOWLEDGE.resource, PERMISSIONS.ALERTS_ACKNOWLEDGE.action);
 
 const alertIdParamSchema = z.object({ id: z.string().uuid() });
+
+type AlertCorrelationSummaryRow = {
+  alertId: string;
+  groupId: string;
+  role: string;
+  groupStatus: string;
+  memberCount: number | string | null;
+  noiseReductionPercent: number | string | null;
+};
+
+export function attachAlertCorrelationSummaries<T extends { id: string }>(
+  alertRows: T[],
+  correlationRows: AlertCorrelationSummaryRow[]
+) {
+  const correlationByAlertId = new Map<string, AlertCorrelationSummaryRow>();
+
+  for (const row of correlationRows) {
+    const existing = correlationByAlertId.get(row.alertId);
+    if (!existing || row.role === 'root') {
+      correlationByAlertId.set(row.alertId, row);
+    }
+  }
+
+  return alertRows.map((alert) => {
+    const correlation = correlationByAlertId.get(alert.id);
+    if (!correlation) {
+      return {
+        ...alert,
+        correlationGroupId: null,
+        correlationRole: null,
+        correlationGroupStatus: null,
+        correlationMemberCount: 0,
+        correlationChildCount: 0,
+        noiseReductionPercent: null,
+      };
+    }
+
+    const memberCount = Number(correlation.memberCount ?? 0);
+    const noiseReductionPercent = Number(correlation.noiseReductionPercent ?? 0);
+
+    return {
+      ...alert,
+      correlationGroupId: correlation.groupId,
+      correlationRole: correlation.role,
+      correlationGroupStatus: correlation.groupStatus,
+      correlationMemberCount: Number.isFinite(memberCount) ? memberCount : 0,
+      correlationChildCount: Math.max((Number.isFinite(memberCount) ? memberCount : 0) - 1, 0),
+      noiseReductionPercent: Number.isFinite(noiseReductionPercent) ? noiseReductionPercent : null,
+    };
+  });
+}
 
 // GET /alerts - List alerts with filters
 alertsRoutes.get(
@@ -170,8 +223,24 @@ alertsRoutes.get(
       .limit(limit)
       .offset(offset);
 
+    const alertIds = alertsList.map((alert) => alert.id);
+    const correlationRows = alertIds.length > 0
+      ? await db
+        .select({
+          alertId: alertCorrelationMembers.alertId,
+          groupId: alertCorrelationMembers.groupId,
+          role: alertCorrelationMembers.role,
+          groupStatus: alertCorrelationGroups.status,
+          memberCount: alertCorrelationGroups.memberCount,
+          noiseReductionPercent: alertCorrelationGroups.noiseReductionPercent,
+        })
+        .from(alertCorrelationMembers)
+        .innerJoin(alertCorrelationGroups, eq(alertCorrelationMembers.groupId, alertCorrelationGroups.id))
+        .where(inArray(alertCorrelationMembers.alertId, alertIds))
+      : [];
+
     return c.json({
-      data: alertsList,
+      data: attachAlertCorrelationSummaries(alertsList, correlationRows),
       pagination: { page, limit, total }
     });
   }

--- a/apps/web/src/components/alerts/AlertList.tsx
+++ b/apps/web/src/components/alerts/AlertList.tsx
@@ -10,6 +10,7 @@ import {
   MoreHorizontal,
   ExternalLink,
   Calendar,
+  GitBranch,
   SlidersHorizontal,
   X,
   Loader2
@@ -41,6 +42,12 @@ export type Alert = {
   resolvedAt?: string;
   resolvedBy?: string;
   contextData?: Record<string, unknown>;
+  correlationGroupId?: string | null;
+  correlationRole?: string | null;
+  correlationGroupStatus?: string | null;
+  correlationMemberCount?: number;
+  correlationChildCount?: number;
+  noiseReductionPercent?: number | null;
 };
 
 type AlertListProps = {
@@ -391,6 +398,9 @@ export default function AlertList({
             ) : (
               paginatedAlerts.map(alert => {
                 const isSubmitting = submittingId === alert.id;
+                const correlationChildCount =
+                  alert.correlationChildCount ?? Math.max((alert.correlationMemberCount ?? 0) - 1, 0);
+                const hasCorrelationSummary = Boolean(alert.correlationGroupId && correlationChildCount > 0);
                 return (
                   <tr
                     key={alert.id}
@@ -427,6 +437,22 @@ export default function AlertList({
                         <p className="text-xs text-muted-foreground truncate max-w-xs">
                           {alert.message}
                         </p>
+                        {hasCorrelationSummary && (
+                          <a
+                            href="/alerts/correlations"
+                            onClick={e => e.stopPropagation()}
+                            className="mt-1 inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/5 px-1.5 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/10"
+                            title={`Open incident group ${alert.correlationGroupId}`}
+                          >
+                            <GitBranch className="h-3 w-3 shrink-0" />
+                            <span className="truncate">
+                              Grouped incident: {correlationChildCount} related
+                              {alert.noiseReductionPercent != null
+                                ? ` · ${alert.noiseReductionPercent}% noise cut`
+                                : ''}
+                            </span>
+                          </a>
+                        )}
                       </div>
                     </td>
                     <td className="px-4 py-3">

--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -180,4 +180,35 @@ describe('AlertsPage — acknowledge in-flight feedback', () => {
     });
     expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
   });
+
+  it('shows grouped incident count and noise reduction in the alert list', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({
+          data: [{
+            ...activeAlert,
+            deviceName: undefined,
+            deviceHostname: 'SRV-01',
+            correlationGroupId: '6f5e4d3c-2222-4333-8444-555566667777',
+            correlationRole: 'root',
+            correlationGroupStatus: 'open',
+            correlationMemberCount: 4,
+            correlationChildCount: 3,
+            noiseReductionPercent: 75,
+          }]
+        }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: 'unexpected' }, false, 404));
+    });
+
+    render(<AlertsPage />);
+
+    expect(await screen.findByText('Grouped incident: 3 related · 75% noise cut')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /SRV-01/i })).toHaveAttribute('href', '/devices/device-1');
+  });
 });

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -15,6 +15,19 @@ import { runAction, ActionError } from '../../lib/runAction';
 
 type Device = { id: string; name: string };
 
+function normalizeAlertRows(rows: Record<string, unknown>[]): Alert[] {
+  return rows.map((row) => {
+    const deviceName = row.deviceName ?? row.deviceHostname ?? row.hostname ?? 'Unknown device';
+    return {
+      ...row,
+      deviceName: String(deviceName),
+      correlationMemberCount: Number(row.correlationMemberCount ?? 0),
+      correlationChildCount: Number(row.correlationChildCount ?? 0),
+      noiseReductionPercent: row.noiseReductionPercent == null ? null : Number(row.noiseReductionPercent),
+    } as Alert;
+  });
+}
+
 export default function AlertsPage() {
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [devices, setDevices] = useState<Device[]>([]);
@@ -51,7 +64,8 @@ export default function AlertsPage() {
         throw new Error('Failed to fetch alerts');
       }
       const data = await response.json();
-      setAlerts(data.data ?? data.alerts ?? (Array.isArray(data) ? data : []));
+      const raw: Record<string, unknown>[] = data.data ?? data.alerts ?? (Array.isArray(data) ? data : []);
+      setAlerts(normalizeAlertRows(raw));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {


### PR DESCRIPTION
## Summary
- enrich GET /alerts rows with correlation group metadata for already-visible alerts
- show grouped incident child count and noise-reduction on the alert list
- normalize API alert device names before rendering the list

## Tests
- pnpm exec vitest run src/routes/alerts.test.ts src/routes/alerts/alerts.authz.test.ts (apps/api)
- pnpm exec vitest run src/components/alerts/AlertsPage.test.tsx (apps/web)
- pnpm exec eslint src/routes/alerts.ts src/routes/alerts.test.ts src/routes/alerts/alerts.authz.test.ts (apps/api)
- pnpm exec eslint src/components/alerts/AlertList.tsx src/components/alerts/AlertsPage.tsx src/components/alerts/AlertsPage.test.tsx (apps/web)
- pnpm exec tsc -p tsconfig.json --noEmit (apps/api)
- pnpm exec tsc -p tsconfig.json --noEmit (apps/web)