### PR TITLE
fix(ml): gate high-risk remediation execution

### DIFF
--- a/apps/api/src/routes/remediationSuggestions.test.ts
+++ b/apps/api/src/routes/remediationSuggestions.test.ts
@@ -32,6 +32,13 @@ vi.mock('../db/schema', () => ({
     eventType: 'mlFeedbackEvents.eventType',
     occurredAt: 'mlFeedbackEvents.occurredAt',
   },
+  elevationRequests: {
+    id: 'elevationRequests.id',
+    orgId: 'elevationRequests.orgId',
+    deviceId: 'elevationRequests.deviceId',
+    status: 'elevationRequests.status',
+    expiresAt: 'elevationRequests.expiresAt',
+  },
   remediationSuggestions: {
     id: 'remediationSuggestions.id',
     orgId: 'remediationSuggestions.orgId',
@@ -150,6 +157,16 @@ function mockScriptExecutionLoad(execution: Record<string, unknown> | undefined)
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue(execution ? [execution] : []),
+      }),
+    }),
+  });
+}
+
+function mockElevationLoad(elevation: Record<string, unknown> | undefined) {
+  dbMocks.selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(elevation ? [elevation] : []),
       }),
     }),
   });
@@ -440,6 +457,116 @@ describe('remediation suggestion routes', () => {
     expect(body.data.status).toBe('executed');
     expect(body.data.scriptExecutionId).toBe(scriptExecutionId);
     expect(body.execution.executions[0].executionId).toBe(scriptExecutionId);
+  });
+
+  it('blocks high-risk server-side execution without an approved elevation request', async () => {
+    mockSuggestionLoad({
+      ...baseSuggestion,
+      status: 'accepted',
+      riskTier: 'high',
+      elevationRequestId: null,
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: 'High-risk remediation execution requires an approved elevation request',
+    });
+    expect(dbMocks.executeScriptOnDevicesMock).not.toHaveBeenCalled();
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks high-risk server-side execution when the linked elevation is not visible in the same org', async () => {
+    mockSuggestionLoad({
+      ...baseSuggestion,
+      status: 'accepted',
+      riskTier: 'critical',
+      elevationRequestId: '88888888-8888-4888-8888-888888888888',
+    });
+    mockElevationLoad(undefined);
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Elevation request not found or access denied' });
+    expect(dbMocks.executeScriptOnDevicesMock).not.toHaveBeenCalled();
+  });
+
+  it('executes high-risk script suggestions only with an approved same-device elevation request', async () => {
+    const elevationRequestId = '88888888-8888-4888-8888-888888888888';
+    const accepted = {
+      ...baseSuggestion,
+      status: 'accepted',
+      riskTier: 'high',
+      elevationRequestId,
+    };
+    const scriptExecutionId = '66666666-6666-4666-8666-666666666666';
+
+    mockSuggestionLoad(accepted);
+    mockElevationLoad({
+      id: elevationRequestId,
+      orgId: baseSuggestion.orgId,
+      deviceId: baseSuggestion.deviceId,
+      status: 'approved',
+      expiresAt: new Date('2099-01-01T00:00:00.000Z'),
+    });
+    dbMocks.executeScriptOnDevicesMock.mockResolvedValueOnce({
+      ok: true,
+      batchId: null,
+      scriptId: baseSuggestion.scriptId,
+      script: { id: baseSuggestion.scriptId, name: 'Disk Cleanup' },
+      devicesTargeted: 1,
+      maintenanceSuppressedDeviceIds: [],
+      executions: [{
+        executionId: scriptExecutionId,
+        deviceId: baseSuggestion.deviceId,
+        commandId: '77777777-7777-4777-8777-777777777777',
+      }],
+      status: 'queued',
+      triggerType: 'manual',
+      runAs: 'system',
+      auditOrgId: baseSuggestion.orgId,
+    });
+    dbMocks.updateMock.mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            ...accepted,
+            status: 'executed',
+            scriptExecutionId,
+            executedBy: 'user-1',
+            executedAt: new Date('2026-06-18T12:10:00.000Z'),
+          }]),
+        }),
+      }),
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(201);
+    expect(dbMocks.executeScriptOnDevicesMock).toHaveBeenCalledWith(expect.objectContaining({
+      scriptId: baseSuggestion.scriptId,
+      deviceIds: [baseSuggestion.deviceId],
+    }));
+    expect(dbMocks.emitFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'suggestion.executed',
+      metadata: expect.objectContaining({
+        route: 'remediation_suggestions.execute',
+        elevationRequestId,
+        riskTier: 'high',
+        scriptExecutionId,
+      }),
+    }));
   });
 
   it('rejects server-side execution before acceptance', async () => {

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { and, desc, eq, gte, inArray, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';
-import { devices, mlFeedbackEvents, remediationSuggestions, scriptExecutions } from '../db/schema';
+import { devices, elevationRequests, mlFeedbackEvents, remediationSuggestions, scriptExecutions } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { emitRemediationSuggestionFeedback } from '../services/mlFeedbackEmitters';
@@ -75,6 +75,56 @@ function normalizeSuggestionParameters(value: unknown): Record<string, unknown> 
 function singleTargetDeviceId(row: Pick<typeof remediationSuggestions.$inferSelect, 'deviceId' | 'targetDeviceIds'>): string | null {
   if (row.targetDeviceIds.length === 1) return row.targetDeviceIds[0] ?? null;
   if (row.targetDeviceIds.length === 0) return row.deviceId;
+  return null;
+}
+
+function requiresExecutionApproval(riskTier: string | null | undefined): boolean {
+  return riskTier === 'high' || riskTier === 'critical';
+}
+
+async function validateRemediationExecutionApproval(
+  existing: typeof remediationSuggestions.$inferSelect,
+  deviceId: string,
+): Promise<string | null> {
+  if (!requiresExecutionApproval(existing.riskTier)) {
+    return null;
+  }
+
+  if (!existing.elevationRequestId) {
+    return 'High-risk remediation execution requires an approved elevation request';
+  }
+
+  const [elevation] = await db
+    .select({
+      id: elevationRequests.id,
+      orgId: elevationRequests.orgId,
+      deviceId: elevationRequests.deviceId,
+      status: elevationRequests.status,
+      expiresAt: elevationRequests.expiresAt,
+    })
+    .from(elevationRequests)
+    .where(and(
+      eq(elevationRequests.id, existing.elevationRequestId),
+      eq(elevationRequests.orgId, existing.orgId),
+    ))
+    .limit(1);
+
+  if (!elevation) {
+    return 'Elevation request not found or access denied';
+  }
+
+  if (elevation.deviceId !== deviceId) {
+    return 'Elevation request must target the suggested device';
+  }
+
+  if (!['approved', 'auto_approved', 'actuating'].includes(elevation.status)) {
+    return 'Elevation request must be approved before execution';
+  }
+
+  if (elevation.expiresAt && elevation.expiresAt.getTime() < Date.now()) {
+    return 'Elevation request has expired';
+  }
+
   return null;
 }
 
@@ -547,6 +597,11 @@ remediationSuggestionRoutes.post(
       return c.json({ error: 'Remediation script execution requires exactly one target device' }, 400);
     }
 
+    const approvalError = await validateRemediationExecutionApproval(existing, deviceId);
+    if (approvalError) {
+      return c.json({ error: approvalError }, 403);
+    }
+
     const execution = await executeScriptOnDevices({
       scriptId: existing.scriptId,
       deviceIds: [deviceId],
@@ -598,6 +653,8 @@ remediationSuggestionRoutes.post(
         targetType: updated.targetType,
         scriptId: updated.scriptId,
         scriptExecutionId: updated.scriptExecutionId,
+        elevationRequestId: updated.elevationRequestId,
+        riskTier: updated.riskTier,
       },
     });
 
@@ -613,6 +670,8 @@ remediationSuggestionRoutes.post(
         targetType: updated.targetType,
         scriptId: updated.scriptId,
         scriptExecutionId,
+        elevationRequestId: updated.elevationRequestId,
+        riskTier: updated.riskTier,
       },
     });
 


### PR DESCRIPTION
## Summary
- require high/critical remediation script execution to reference an active same-org, same-device PAM elevation decision
- leave low/medium remediation execution behavior unchanged
- include elevation request and risk tier metadata in execution feedback/audit details

## Tests
- pnpm exec vitest run src/routes/remediationSuggestions.test.ts (apps/api)
- pnpm exec eslint src/routes/remediationSuggestions.ts src/routes/remediationSuggestions.test.ts (apps/api)
- pnpm exec tsc -p tsconfig.json --noEmit (apps/api)