### PR TITLE
feat(ml): record user risk training completion

### DIFF
--- a/apps/api/src/routes/userRisk.test.ts
+++ b/apps/api/src/routes/userRisk.test.ts
@@ -243,6 +243,72 @@ describe('userRiskRoutes', () => {
     expect(emitUserRiskFeedback).not.toHaveBeenCalled();
   });
 
+  it('POST /users/:userId/training-completed records a completion label', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(true);
+    vi.mocked(emitUserRiskFeedback).mockResolvedValue(undefined);
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}/training-completed`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        moduleId: 'security-awareness-baseline',
+        assignmentEventId: '00000000-0000-0000-0000-000000000020',
+        completedAt: '2026-06-18T12:00:00.000Z'
+      })
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, eventType: 'training.completed' });
+    expect(emitUserRiskFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_ID,
+      userId: USER_ID,
+      eventType: 'training.completed',
+      outcome: 'completed',
+      actorUserId: '00000000-0000-0000-0000-000000000099',
+      metadata: expect.objectContaining({
+        source: 'user_risk_training_completion',
+        moduleId: 'security-awareness-baseline',
+        assignmentEventId: '00000000-0000-0000-0000-000000000020',
+        completedAt: '2026-06-18T12:00:00.000Z'
+      })
+    }));
+  });
+
+  it('POST /users/:userId/training-completed returns 404 for a user outside the org', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(false);
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}/training-completed`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({})
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'User not found in this organization' });
+    expect(emitUserRiskFeedback).not.toHaveBeenCalled();
+  });
+
+  it('POST /users/:userId/training-completed rejects inaccessible orgs before membership lookup', async () => {
+    const app = buildApp({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (id) => id === ORG_ID
+    });
+    const res = await app.request(`/user-risk/users/${USER_ID}/training-completed`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orgId: ORG_ID_2 })
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Access denied to this organization' });
+    expect(getUserRiskOrgMembership).not.toHaveBeenCalled();
+    expect(emitUserRiskFeedback).not.toHaveBeenCalled();
+  });
+
   it('PUT /policy updates policy', async () => {
     vi.mocked(updateUserRiskPolicy).mockResolvedValue({
       orgId: ORG_ID,

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -65,6 +65,14 @@ const assignTrainingSchema = z.object({
   reason: z.string().min(1).max(500).optional()
 });
 
+const completeTrainingSchema = z.object({
+  orgId: z.string().uuid().optional(),
+  moduleId: z.string().min(1).max(120).optional(),
+  assignmentEventId: z.string().uuid().optional(),
+  completedAt: z.string().datetime().optional(),
+  note: z.string().trim().max(1000).optional()
+});
+
 const feedbackPayloadSchema = z.object({
   orgId: z.string().uuid().optional(),
   outcome: z.enum(['true_positive', 'false_positive']),
@@ -296,6 +304,56 @@ userRiskRoutes.get(
     });
 
     return c.json({ data: evaluation });
+  }
+);
+
+userRiskRoutes.post(
+  '/users/:userId/training-completed',
+  requirePermission('users', 'write'),
+  zValidator('param', detailParamSchema),
+  zValidator('json', completeTrainingSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { userId } = c.req.valid('param');
+    const payload = c.req.valid('json');
+
+    const resolved = resolveWriteOrgId(auth, payload.orgId);
+    if (!resolved.orgId) {
+      return c.json({ error: resolved.error ?? 'Organization resolution failed' }, resolved.status ?? 400);
+    }
+
+    const isMember = await getUserRiskOrgMembership(userId, resolved.orgId);
+    if (!isMember) {
+      return c.json({ error: 'User not found in this organization' }, 404);
+    }
+
+    await emitUserRiskFeedback({
+      orgId: resolved.orgId,
+      userId,
+      eventType: 'training.completed',
+      outcome: 'completed',
+      actorUserId: auth.user.id,
+      metadata: {
+        source: 'user_risk_training_completion',
+        moduleId: payload.moduleId ?? null,
+        assignmentEventId: payload.assignmentEventId ?? null,
+        completedAt: payload.completedAt ?? new Date().toISOString(),
+        note: payload.note ?? null
+      }
+    });
+
+    writeRouteAudit(c, {
+      orgId: resolved.orgId,
+      action: 'user_risk.training.complete',
+      resourceType: 'user',
+      resourceId: userId,
+      details: {
+        moduleId: payload.moduleId ?? null,
+        assignmentEventId: payload.assignmentEventId ?? null
+      }
+    });
+
+    return c.json({ success: true, eventType: 'training.completed' });
   }
 );
 


### PR DESCRIPTION
## Summary
- add a scoped admin/manual endpoint to mark user-risk training completed
- emit the existing training.completed feedback label so evaluation completion metrics can move
- guard completion labels by org access and user membership

## Tests
- pnpm exec vitest run src/routes/userRisk.test.ts (apps/api)
- pnpm exec eslint src/routes/userRisk.ts src/routes/userRisk.test.ts (apps/api)
- pnpm exec tsc -p tsconfig.json --noEmit (apps/api)