### PR TITLE
feat(ml): expose edited RCA feedback

### DIFF
--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -205,6 +205,32 @@ describe('CorrelatedAlertGroups', () => {
         })
       );
     });
+
+    fireEvent.click(screen.getByRole('button', { name: /Mark edited/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/alerts/correlations/${GROUP_ID}/rca-feedback`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('rca.edited')
+        })
+      );
+    });
+    const editedRequest = fetchMock.mock.calls.find(([url, init]) =>
+      url === `/alerts/correlations/${GROUP_ID}/rca-feedback` &&
+      String(init?.body ?? '').includes('rca.edited')
+    );
+    expect(JSON.parse(String(editedRequest?.[1]?.body))).toEqual(expect.objectContaining({
+      eventType: 'rca.edited',
+      outcome: 'edited',
+      metadata: expect.objectContaining({
+        source: 'correlated_alert_groups_ui',
+        candidateCount: 1,
+        evidenceCount: 1,
+        gapCount: 1
+      })
+    }));
   });
 
   it('labels and disables RCA when the feature is disabled', async () => {

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -8,6 +8,7 @@ import {
   ExternalLink,
   FileText,
   Loader2,
+  Pencil,
   RefreshCw,
   ThumbsDown,
   ThumbsUp,
@@ -248,16 +249,22 @@ export default function CorrelatedAlertGroups() {
     }
   };
 
-  const sendRcaFeedback = async (group: AlertGroup, eventType: 'rca.helpful' | 'rca.not_helpful' | 'rca.used_in_ticket') => {
-    const outcome = eventType.replace('rca.', '') as 'helpful' | 'not_helpful' | 'used_in_ticket';
+  const sendRcaFeedback = async (group: AlertGroup, eventType: 'rca.helpful' | 'rca.not_helpful' | 'rca.edited' | 'rca.used_in_ticket') => {
+    const outcome = eventType.replace('rca.', '') as 'helpful' | 'not_helpful' | 'edited' | 'used_in_ticket';
     try {
+      const rca = rcaByGroup[group.id];
       await runAction({
         request: () => fetchWithAuth(`/alerts/correlations/${group.id}/rca-feedback`, {
           method: 'POST',
           body: JSON.stringify({
             eventType,
             outcome,
-            metadata: { source: 'correlated_alert_groups_ui' }
+            metadata: {
+              source: 'correlated_alert_groups_ui',
+              candidateCount: rca?.rootCauseCandidates.length ?? null,
+              evidenceCount: rca?.timeline.length ?? null,
+              gapCount: rca?.gaps.length ?? null,
+            }
           })
         }),
         errorFallback: 'Failed to record RCA feedback',
@@ -593,6 +600,14 @@ export default function CorrelatedAlertGroups() {
                               >
                                 <FileText className="h-4 w-4" />
                                 Used in ticket
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => void sendRcaFeedback(group, 'rca.edited')}
+                                className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+                              >
+                                <Pencil className="h-4 w-4" />
+                                Mark edited
                               </button>
                             </div>
                           )}


### PR DESCRIPTION
## Summary
- add a Mark edited control to the incident RCA panel
- send rca.edited / edited feedback through the existing correlation RCA feedback endpoint
- include minimal RCA shape metadata for downstream evaluation

## Tests
- pnpm exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx (apps/web)
- pnpm exec eslint src/components/alerts/CorrelatedAlertGroups.tsx src/components/alerts/CorrelatedAlertGroups.test.tsx (apps/web)
- pnpm exec tsc -p tsconfig.json --noEmit (apps/web)