### PR TITLE
fix(ml): attach worker observability

### DIFF
--- a/apps/api/src/jobs/metricAnomalies.test.ts
+++ b/apps/api/src/jobs/metricAnomalies.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getJobMock, addMock, closeMock } = vi.hoisted(() => ({
+const { getJobMock, addMock, closeMock, getRepeatableJobsMock, removeRepeatableByKeyMock, attachWorkerObservabilityMock } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
   closeMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  attachWorkerObservabilityMock: vi.fn(),
 }));
 
 vi.mock('bullmq', () => ({
   Queue: class {
     getJob = getJobMock;
     add = addMock;
+    getRepeatableJobs = getRepeatableJobsMock;
+    removeRepeatableByKey = removeRepeatableByKeyMock;
     close = closeMock;
   },
   Worker: class {
@@ -40,9 +45,14 @@ vi.mock('../services/metricAnomalies', () => ({
   detectMetricAnomaliesRange: vi.fn(),
 }));
 
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: attachWorkerObservabilityMock,
+}));
+
 import {
   buildMetricAnomalyJobId,
   enqueueMetricAnomalyBackfill,
+  initializeMetricAnomaliesWorker,
   shutdownMetricAnomaliesWorker,
 } from './metricAnomalies';
 
@@ -53,8 +63,12 @@ describe('metric anomalies queue helpers', () => {
     getJobMock.mockReset();
     addMock.mockReset();
     closeMock.mockReset();
+    getRepeatableJobsMock.mockReset();
+    removeRepeatableByKeyMock.mockReset();
+    attachWorkerObservabilityMock.mockReset();
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queued-anomaly-job' });
+    getRepeatableJobsMock.mockResolvedValue([]);
     await shutdownMetricAnomaliesWorker();
   });
 
@@ -96,5 +110,16 @@ describe('metric anomalies queue helpers', () => {
 
     expect(jobId).toBe('existing-anomaly-job');
     expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('attaches worker observability during initialization', async () => {
+    await initializeMetricAnomaliesWorker();
+
+    expect(attachWorkerObservabilityMock).toHaveBeenCalledWith(expect.anything(), 'metricAnomaliesWorker');
+    expect(addMock).toHaveBeenCalledWith(
+      'scan-orgs',
+      expect.objectContaining({ type: 'scan-orgs' }),
+      expect.objectContaining({ jobId: 'metric-anomalies-scan-orgs' }),
+    );
   });
 });

--- a/apps/api/src/jobs/metricAnomalies.ts
+++ b/apps/api/src/jobs/metricAnomalies.ts
@@ -6,6 +6,7 @@ import { devices } from '../db/schema';
 import { isReusableState } from '../services/bullmqUtils';
 import { detectMetricAnomaliesRange, type MetricAnomalyResult } from '../services/metricAnomalies';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 
 const METRIC_ANOMALIES_QUEUE = 'metric-anomalies';
 const DEFAULT_LOOKBACK_MINUTES = 30;
@@ -143,6 +144,7 @@ async function scheduleMetricAnomaliesScan(): Promise<void> {
 
 export async function initializeMetricAnomaliesWorker(): Promise<void> {
   metricAnomaliesWorker = createMetricAnomaliesWorker();
+  attachWorkerObservability(metricAnomaliesWorker, 'metricAnomaliesWorker');
   metricAnomaliesWorker.on('error', (error) => {
     console.error('[MetricAnomaliesWorker] Worker error:', error);
   });

--- a/apps/api/src/jobs/metricRollups.test.ts
+++ b/apps/api/src/jobs/metricRollups.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getJobMock, addMock, closeMock } = vi.hoisted(() => ({
+const { getJobMock, addMock, closeMock, getRepeatableJobsMock, removeRepeatableByKeyMock, attachWorkerObservabilityMock } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
   closeMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  attachWorkerObservabilityMock: vi.fn(),
 }));
 
 vi.mock('bullmq', () => ({
   Queue: class {
     getJob = getJobMock;
     add = addMock;
+    getRepeatableJobs = getRepeatableJobsMock;
+    removeRepeatableByKey = removeRepeatableByKeyMock;
     close = closeMock;
   },
   Worker: class {
@@ -40,9 +45,14 @@ vi.mock('../services/metricRollups', () => ({
   rollupDeviceMetricsRange: vi.fn(),
 }));
 
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: attachWorkerObservabilityMock,
+}));
+
 import {
   buildMetricRollupJobId,
   enqueueMetricRollupBackfill,
+  initializeMetricRollupsWorker,
   shutdownMetricRollupsWorker,
 } from './metricRollups';
 
@@ -53,8 +63,12 @@ describe('metric rollups queue helpers', () => {
     getJobMock.mockReset();
     addMock.mockReset();
     closeMock.mockReset();
+    getRepeatableJobsMock.mockReset();
+    removeRepeatableByKeyMock.mockReset();
+    attachWorkerObservabilityMock.mockReset();
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queued-rollup-job' });
+    getRepeatableJobsMock.mockResolvedValue([]);
     await shutdownMetricRollupsWorker();
   });
 
@@ -96,5 +110,16 @@ describe('metric rollups queue helpers', () => {
 
     expect(jobId).toBe('existing-rollup-job');
     expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('attaches worker observability during initialization', async () => {
+    await initializeMetricRollupsWorker();
+
+    expect(attachWorkerObservabilityMock).toHaveBeenCalledWith(expect.anything(), 'metricRollupsWorker');
+    expect(addMock).toHaveBeenCalledWith(
+      'scan-orgs',
+      expect.objectContaining({ type: 'scan-orgs' }),
+      expect.objectContaining({ jobId: 'metric-rollups-scan-orgs' }),
+    );
   });
 });

--- a/apps/api/src/jobs/metricRollups.ts
+++ b/apps/api/src/jobs/metricRollups.ts
@@ -6,6 +6,7 @@ import { devices } from '../db/schema';
 import { isReusableState } from '../services/bullmqUtils';
 import { rollupDeviceMetricsRange, type MetricRollupResult } from '../services/metricRollups';
 import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
 
 const METRIC_ROLLUPS_QUEUE = 'metric-rollups';
 const DEFAULT_LOOKBACK_MINUTES = 15;
@@ -143,6 +144,7 @@ async function scheduleMetricRollupsScan(): Promise<void> {
 
 export async function initializeMetricRollupsWorker(): Promise<void> {
   metricRollupsWorker = createMetricRollupsWorker();
+  attachWorkerObservability(metricRollupsWorker, 'metricRollupsWorker');
   metricRollupsWorker.on('error', (error) => {
     console.error('[MetricRollupsWorker] Worker error:', error);
   });


### PR DESCRIPTION
## Summary
- attach shared BullMQ worker observability to metric rollup and metric anomaly workers
- keep existing console handlers while adding the shared Sentry/error hook
- cover worker initialization for both ML workers

## Tests
- pnpm exec vitest run src/jobs/metricRollups.test.ts src/jobs/metricAnomalies.test.ts (apps/api)
- pnpm exec eslint src/jobs/metricRollups.ts src/jobs/metricRollups.test.ts src/jobs/metricAnomalies.ts src/jobs/metricAnomalies.test.ts (apps/api)
- pnpm exec tsc -p tsconfig.json --noEmit (apps/api)