### PR TITLE
feat(ml): report remediation approval latency

### DIFF
--- a/apps/api/src/routes/remediationSuggestions.test.ts
+++ b/apps/api/src/routes/remediationSuggestions.test.ts
@@ -37,6 +37,8 @@ vi.mock('../db/schema', () => ({
     orgId: 'elevationRequests.orgId',
     deviceId: 'elevationRequests.deviceId',
     status: 'elevationRequests.status',
+    requestedAt: 'elevationRequests.requestedAt',
+    approvedAt: 'elevationRequests.approvedAt',
     expiresAt: 'elevationRequests.expiresAt',
   },
   remediationSuggestions: {
@@ -47,6 +49,9 @@ vi.mock('../db/schema', () => ({
     deviceId: 'remediationSuggestions.deviceId',
     status: 'remediationSuggestions.status',
     createdAt: 'remediationSuggestions.createdAt',
+    acceptedAt: 'remediationSuggestions.acceptedAt',
+    executedAt: 'remediationSuggestions.executedAt',
+    elevationRequestId: 'remediationSuggestions.elevationRequestId',
   },
   scriptExecutions: {
     id: 'scriptExecutions.id',
@@ -597,6 +602,20 @@ describe('remediation suggestion routes', () => {
       { eventType: 'suggestion.executed', count: 1 },
       { eventType: 'suggestion.failed', count: 1 },
     ]);
+    mockSelectOnce([
+      {
+        acceptedAt: new Date('2026-06-18T12:05:00.000Z'),
+        executedAt: new Date('2026-06-18T12:20:00.000Z'),
+        elevationRequestedAt: new Date('2026-06-18T12:00:00.000Z'),
+        elevationApprovedAt: new Date('2026-06-18T12:10:00.000Z'),
+      },
+      {
+        acceptedAt: new Date('2026-06-18T12:30:00.000Z'),
+        executedAt: new Date('2026-06-18T13:10:00.000Z'),
+        elevationRequestedAt: new Date('2026-06-18T12:00:00.000Z'),
+        elevationApprovedAt: new Date('2026-06-18T12:45:00.000Z'),
+      },
+    ]);
 
     const res = await app.request('/remediation-suggestions/evaluation?days=30', {
       method: 'GET',
@@ -627,6 +646,18 @@ describe('remediation suggestion routes', () => {
       executed: 1,
       failed: 1,
     });
+    expect(body.latency).toEqual({
+      approval: {
+        sampleSize: 2,
+        averageMinutes: 27.5,
+        p95Minutes: 45,
+      },
+      execution: {
+        sampleSize: 2,
+        averageMinutes: 27.5,
+        p95Minutes: 40,
+      },
+    });
     expect(body.window.days).toBe(30);
   });
 
@@ -643,6 +674,7 @@ describe('remediation suggestion routes', () => {
   it('returns zero rates when no suggestions match', async () => {
     mockSelectOnce([]);
     mockSelectOnce([]);
+    mockSelectOnce([]);
 
     const res = await app.request('/remediation-suggestions/evaluation?days=7', {
       method: 'GET',
@@ -654,6 +686,8 @@ describe('remediation suggestion routes', () => {
     expect(body.total).toBe(0);
     expect(body.rates).toEqual({ acceptRate: 0, rejectRate: 0, executeRate: 0, failureRate: 0 });
     expect(body.feedback.total).toBe(0);
+    expect(body.latency.approval).toEqual({ sampleSize: 0, averageMinutes: null, p95Minutes: null });
+    expect(body.latency.execution).toEqual({ sampleSize: 0, averageMinutes: null, p95Minutes: null });
   });
 
   it('returns 403 when a site-restricted caller drills into an out-of-scope deviceId', async () => {
@@ -675,6 +709,7 @@ describe('remediation suggestion routes', () => {
     mockSelectOnce([{ id: baseSuggestion.deviceId, siteId: '22222222-2222-4222-8222-222222222222' }]);
     mockSelectOnce([{ status: 'accepted', count: 1 }]);
     mockSelectOnce([{ eventType: 'suggestion.accepted', count: 1 }]);
+    mockSelectOnce([]);
 
     const res = await app.request('/remediation-suggestions/evaluation?days=90', {
       method: 'GET',

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -274,6 +274,47 @@ function zeroEvaluationResponse(options: {
       executed: 0,
       failed: 0,
     },
+    latency: {
+      approval: emptyLatencySummary(),
+      execution: emptyLatencySummary(),
+    },
+  };
+}
+
+function emptyLatencySummary() {
+  return {
+    sampleSize: 0,
+    averageMinutes: null,
+    p95Minutes: null,
+  };
+}
+
+function dateValue(value: Date | string | null | undefined): number | null {
+  if (!value) return null;
+  const timestamp = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function latencyMinutes(later: Date | string | null | undefined, earlier: Date | string | null | undefined): number | null {
+  const laterMs = dateValue(later);
+  const earlierMs = dateValue(earlier);
+  if (laterMs === null || earlierMs === null || laterMs < earlierMs) return null;
+  return (laterMs - earlierMs) / 60_000;
+}
+
+function roundLatency(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function summarizeLatencyMinutes(values: number[]) {
+  if (values.length === 0) return emptyLatencySummary();
+  const sorted = [...values].sort((a, b) => a - b);
+  const total = sorted.reduce((sum, value) => sum + value, 0);
+  const p95Index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1);
+  return {
+    sampleSize: sorted.length,
+    averageMinutes: roundLatency(total / sorted.length),
+    p95Minutes: roundLatency(sorted[p95Index] ?? sorted[sorted.length - 1] ?? 0),
   };
 }
 
@@ -456,6 +497,23 @@ remediationSuggestionRoutes.get(
       ))
       .groupBy(mlFeedbackEvents.eventType);
 
+    const latencyRows = await db
+      .select({
+        acceptedAt: remediationSuggestions.acceptedAt,
+        executedAt: remediationSuggestions.executedAt,
+        elevationRequestedAt: elevationRequests.requestedAt,
+        elevationApprovedAt: elevationRequests.approvedAt,
+      })
+      .from(remediationSuggestions)
+      .innerJoin(
+        elevationRequests,
+        and(
+          eq(elevationRequests.id, remediationSuggestions.elevationRequestId),
+          eq(elevationRequests.orgId, remediationSuggestions.orgId),
+        ),
+      )
+      .where(and(...suggestionFilters));
+
     const status = {
       suggested: 0,
       accepted: 0,
@@ -490,6 +548,13 @@ remediationSuggestionRoutes.get(
     }
     feedback.total = feedback.accepted + feedback.edited + feedback.rejected + feedback.executed + feedback.failed;
 
+    const approvalLatencies = latencyRows
+      .map((row) => latencyMinutes(row.elevationApprovedAt, row.elevationRequestedAt))
+      .filter((value): value is number => value !== null);
+    const executionLatencies = latencyRows
+      .map((row) => latencyMinutes(row.executedAt, row.acceptedAt))
+      .filter((value): value is number => value !== null);
+
     return c.json({
       window: {
         days: query.days,
@@ -509,6 +574,10 @@ remediationSuggestionRoutes.get(
         failureRate: total > 0 ? status.failed / total : 0,
       },
       feedback,
+      latency: {
+        approval: summarizeLatencyMinutes(approvalLatencies),
+        execution: summarizeLatencyMinutes(executionLatencies),
+      },
     });
   }
 );


### PR DESCRIPTION
## Summary
- add approval and execution latency summaries to remediation suggestion evaluation output
- compute approval latency from linked elevation request requested/approved timestamps
- cover populated and empty evaluation windows in route tests

## Tests
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec vitest run src/routes/remediationSuggestions.test.ts
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec eslint src/routes/remediationSuggestions.ts src/routes/remediationSuggestions.test.ts
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec tsc -p tsconfig.json --noEmit