### PR TITLE
feat(ml): capture edited remediation feedback

### DIFF
--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -124,6 +124,36 @@ describe('RemediationSuggestionsPanel', () => {
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Suggested fix accepted' }));
   });
 
+  it('marks a suggested fix edited through runAction', async () => {
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [suggestion] }));
+      }
+      if (url === '/remediation-suggestions/suggestion-1' && method === 'PATCH') {
+        return Promise.resolve(makeJsonResponse({ data: { ...suggestion, status: 'edited' } }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /mark edited/i }));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/remediation-suggestions/suggestion-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ status: 'edited' }),
+        }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Suggested fix marked edited' }));
+  });
+
   it('executes an accepted single-device script suggestion and links the execution', async () => {
     const accepted = { ...suggestion, status: 'accepted' };
     const executed = {

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { CheckCircle, PlayCircle, RefreshCw, Sparkles, XCircle } from 'lucide-react';
+import { CheckCircle, PencilLine, PlayCircle, RefreshCw, Sparkles, XCircle } from 'lucide-react';
 
 import { handleActionError, runAction } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
@@ -114,7 +114,7 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
     }
   }
 
-  async function updateSuggestion(suggestion: RemediationSuggestion, status: 'accepted' | 'rejected') {
+  async function updateSuggestion(suggestion: RemediationSuggestion, status: 'accepted' | 'edited' | 'rejected') {
     setUpdatingId(suggestion.id);
     try {
       const result = await runAction<{ data?: RemediationSuggestion }>({
@@ -124,7 +124,11 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
           body: JSON.stringify({ status }),
         }),
         errorFallback: 'Could not update suggested fix',
-        successMessage: status === 'accepted' ? 'Suggested fix accepted' : 'Suggested fix rejected',
+        successMessage: status === 'accepted'
+          ? 'Suggested fix accepted'
+          : status === 'edited'
+            ? 'Suggested fix marked edited'
+            : 'Suggested fix rejected',
       });
       if (result.data) {
         setSuggestions((current) => current.map((item) => item.id === suggestion.id ? result.data! : item));
@@ -232,6 +236,22 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
                   >
                     <CheckCircle className="h-4 w-4" />
                     Accept
+                  </button>
+                  <button
+                    type="button"
+                    disabled={
+                      updatingId === suggestion.id ||
+                      executingId === suggestion.id ||
+                      suggestion.status === 'edited' ||
+                      suggestion.status === 'rejected' ||
+                      suggestion.status === 'executed' ||
+                      suggestion.status === 'failed'
+                    }
+                    onClick={() => void updateSuggestion(suggestion, 'edited')}
+                    className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <PencilLine className="h-4 w-4" />
+                    Mark edited
                   </button>
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- add a Mark edited action to remediation suggestions
- send PATCH status=edited through runAction so suggestion.edited feedback is captured
- cover the edited action in the remediation panel component test

## Tests
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec vitest run src/components/remediation/RemediationSuggestionsPanel.test.tsx
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec eslint src/components/remediation/RemediationSuggestionsPanel.tsx src/components/remediation/RemediationSuggestionsPanel.test.tsx
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec tsc -p tsconfig.json --noEmit