### PR TITLE
feat(ml): label remediation approvals in UI

### DIFF
--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -52,6 +52,7 @@ const suggestion = {
   confidence: 0.82,
   parameters: { dryRun: false },
   targetDeviceIds: ['22222222-2222-4222-8222-222222222222'],
+  elevationRequestId: null,
   scriptExecutionId: null,
 };
 
@@ -213,6 +214,32 @@ describe('RemediationSuggestionsPanel', () => {
 
     await screen.findByText('Disk Cleanup');
     expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
+  });
+
+  it('labels high-risk executable suggestions that still need approval', async () => {
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({
+          data: [{
+            ...suggestion,
+            status: 'accepted',
+            riskTier: 'high',
+            elevationRequestId: null,
+          }],
+        }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    const approval = await screen.findByRole('button', { name: /approval required/i });
+    expect(approval).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
+    fireEvent.click(approval);
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/remediation-suggestions/suggestion-1/execute', expect.anything());
   });
 
   it('labels and disables generation when suggested fixes are disabled', async () => {

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { CheckCircle, PencilLine, PlayCircle, RefreshCw, Sparkles, XCircle } from 'lucide-react';
+import { CheckCircle, PencilLine, PlayCircle, RefreshCw, ShieldAlert, Sparkles, XCircle } from 'lucide-react';
 
 import { handleActionError, runAction } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
@@ -24,6 +24,7 @@ type RemediationSuggestion = {
   confidence: number | null;
   parameters: Record<string, unknown>;
   targetDeviceIds: string[];
+  elevationRequestId: string | null;
   scriptExecutionId: string | null;
 };
 
@@ -52,7 +53,7 @@ function singleTargetDeviceId(suggestion: RemediationSuggestion): string | null 
   return null;
 }
 
-function canExecuteScriptSuggestion(suggestion: RemediationSuggestion): boolean {
+function canQueueScriptSuggestion(suggestion: RemediationSuggestion): boolean {
   return (
     suggestion.targetType === 'script' &&
     Boolean(suggestion.scriptId) &&
@@ -60,6 +61,14 @@ function canExecuteScriptSuggestion(suggestion: RemediationSuggestion): boolean 
     (suggestion.status === 'accepted' || suggestion.status === 'edited') &&
     !suggestion.scriptExecutionId
   );
+}
+
+function requiresExecutionApproval(suggestion: RemediationSuggestion): boolean {
+  return suggestion.riskTier === 'high' || suggestion.riskTier === 'critical';
+}
+
+function canExecuteScriptSuggestion(suggestion: RemediationSuggestion): boolean {
+  return canQueueScriptSuggestion(suggestion) && (!requiresExecutionApproval(suggestion) || Boolean(suggestion.elevationRequestId));
 }
 
 export default function RemediationSuggestionsPanel({ sourceType, sourceId }: RemediationSuggestionsPanelProps) {
@@ -271,6 +280,17 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
                     >
                       <PlayCircle className="h-4 w-4" />
                       Execute
+                    </button>
+                  )}
+                  {canQueueScriptSuggestion(suggestion) && requiresExecutionApproval(suggestion) && !suggestion.elevationRequestId && (
+                    <button
+                      type="button"
+                      disabled
+                      title="Approved elevation request required before execution"
+                      className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                      <ShieldAlert className="h-4 w-4" />
+                      Approval required
                     </button>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- add an approval-required state for high/critical remediation suggestions without an elevation link
- prevent the panel from presenting a direct Execute action before approval exists
- cover the approval-required state in the remediation panel test

## Tests
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec vitest run src/components/remediation/RemediationSuggestionsPanel.test.tsx
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec eslint src/components/remediation/RemediationSuggestionsPanel.tsx src/components/remediation/RemediationSuggestionsPanel.test.tsx
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec tsc -p tsconfig.json --noEmit