### PR TITLE
fix(ml): bound retention worker cleanup

### DIFF
--- a/apps/api/src/jobs/reliabilityRetention.test.ts
+++ b/apps/api/src/jobs/reliabilityRetention.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  withSystemDbAccessContextMock,
+  dbExecuteMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  dbExecuteMock: vi.fn(),
+  capturedWorkerProcessor: { current: null as null | ((job: { data: Record<string, unknown> }) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: { data: Record<string, unknown> }) => Promise<unknown>) {
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    execute: (...args: unknown[]) => dbExecuteMock(...(args as [])),
+  },
+  withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+import {
+  __testOnly,
+  createReliabilityRetentionWorker,
+  extractReliabilityRetentionRowCount,
+  initializeReliabilityRetention,
+  shutdownReliabilityRetention,
+} from './reliabilityRetention';
+
+describe('reliability retention worker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    getRepeatableJobsMock.mockResolvedValue([]);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    addMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    dbExecuteMock.mockResolvedValue({ rowCount: 0 });
+    capturedWorkerProcessor.current = null;
+  });
+
+  afterEach(async () => {
+    await shutdownReliabilityRetention();
+  });
+
+  it('extracts row counts from supported driver result shapes', () => {
+    expect(extractReliabilityRetentionRowCount({ rowCount: 4, count: 2 })).toBe(4);
+    expect(extractReliabilityRetentionRowCount({ count: 3 })).toBe(3);
+    expect(extractReliabilityRetentionRowCount([{}, {}])).toBe(2);
+    expect(extractReliabilityRetentionRowCount({})).toBe(0);
+  });
+
+  it('registers a repeatable pruning job with a stable jobId', async () => {
+    await initializeReliabilityRetention();
+
+    expect(addMock).toHaveBeenCalledWith(
+      __testOnly.JOB_NAME,
+      expect.objectContaining({
+        retentionDays: expect.any(Number),
+        batchSize: __testOnly.BATCH_SIZE,
+        maxBatches: __testOnly.MAX_BATCHES,
+      }),
+      expect.objectContaining({
+        jobId: __testOnly.REPEAT_JOB_ID,
+        repeat: { every: 24 * 60 * 60 * 1000 },
+      }),
+    );
+  });
+
+  it('prunes reliability history in bounded batches inside system DB context', async () => {
+    dbExecuteMock
+      .mockResolvedValueOnce({ rowCount: 4 })
+      .mockResolvedValueOnce({ rowCount: 1 });
+    createReliabilityRetentionWorker();
+
+    const result = await capturedWorkerProcessor.current!({
+      data: { retentionDays: 30, batchSize: 4, maxBatches: 3 },
+    });
+
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      retentionDays: 30,
+      deleted: 5,
+      batches: 2,
+      batchSize: 4,
+      maxBatches: 3,
+      hasMore: false,
+    });
+  });
+
+  it('reports hasMore when every allowed batch is full', async () => {
+    dbExecuteMock
+      .mockResolvedValueOnce({ rowCount: 4 })
+      .mockResolvedValueOnce({ rowCount: 4 });
+    createReliabilityRetentionWorker();
+
+    const result = await capturedWorkerProcessor.current!({
+      data: { retentionDays: 30, batchSize: 4, maxBatches: 2 },
+    });
+
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      deleted: 8,
+      batches: 2,
+      hasMore: true,
+    });
+  });
+});

--- a/apps/api/src/jobs/reliabilityRetention.ts
+++ b/apps/api/src/jobs/reliabilityRetention.ts
@@ -6,10 +6,9 @@
  */
 
 import { Job, Queue, Worker } from 'bullmq';
-import { lt } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 
 import * as dbModule from '../db';
-import { deviceReliabilityHistory } from '../db/schema';
 import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
 
@@ -22,14 +21,70 @@ const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
 };
 
 const QUEUE_NAME = 'reliability-history-retention';
+const JOB_NAME = 'reliability-history-retention';
+const REPEAT_JOB_ID = 'reliability-history-retention';
 const DEFAULT_RETENTION_DAYS = Math.max(30, parseInt(process.env.RELIABILITY_HISTORY_RETENTION_DAYS || '120', 10));
+const BATCH_SIZE = Math.max(1, parseInt(process.env.RELIABILITY_HISTORY_RETENTION_BATCH_SIZE || '10000', 10));
+const MAX_BATCHES = Math.max(1, parseInt(process.env.RELIABILITY_HISTORY_RETENTION_MAX_BATCHES || '50', 10));
 
 type RetentionJobData = {
   retentionDays?: number;
+  batchSize?: number;
+  maxBatches?: number;
 };
 
 let retentionQueue: Queue<RetentionJobData> | null = null;
 let retentionWorker: Worker<RetentionJobData> | null = null;
+
+export function extractReliabilityRetentionRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? result.length : 0;
+}
+
+export async function pruneReliabilityHistory(options: {
+  retentionDays: number;
+  batchSize?: number;
+  maxBatches?: number;
+}) {
+  const retentionDays = Math.max(30, options.retentionDays);
+  const batchSize = Math.max(1, options.batchSize ?? BATCH_SIZE);
+  const maxBatches = Math.max(1, options.maxBatches ?? MAX_BATCHES);
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+  const startedAt = Date.now();
+
+  let deleted = 0;
+  let batches = 0;
+  let lastBatchDeleted = 0;
+
+  while (batches < maxBatches) {
+    const result = await db.execute(sql`
+      DELETE FROM device_reliability_history
+      WHERE ctid IN (
+        SELECT ctid
+        FROM device_reliability_history
+        WHERE collected_at < ${cutoff}::timestamptz
+        LIMIT ${batchSize}
+      )
+    `);
+    lastBatchDeleted = extractReliabilityRetentionRowCount(result);
+    deleted += lastBatchDeleted;
+    batches += 1;
+    if (lastBatchDeleted < batchSize) break;
+  }
+
+  const durationMs = Date.now() - startedAt;
+  return {
+    retentionDays,
+    deleted,
+    batches,
+    batchSize,
+    maxBatches,
+    hasMore: batches >= maxBatches && lastBatchDeleted >= batchSize,
+    durationMs,
+  };
+}
 
 export function getReliabilityRetentionQueue(): Queue<RetentionJobData> {
   if (!retentionQueue) {
@@ -45,17 +100,15 @@ export function createReliabilityRetentionWorker(): Worker<RetentionJobData> {
     QUEUE_NAME,
     async (job: Job<RetentionJobData>) => {
       return runWithSystemDbAccess(async () => {
-        const retentionDays = Math.max(30, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS);
-        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
-        const startedAt = Date.now();
-
-        await db
-          .delete(deviceReliabilityHistory)
-          .where(lt(deviceReliabilityHistory.collectedAt, cutoff));
-
-        const durationMs = Date.now() - startedAt;
-        console.log(`[ReliabilityRetention] Pruned reliability history older than ${retentionDays} days in ${durationMs}ms`);
-        return { retentionDays, durationMs };
+        const result = await pruneReliabilityHistory({
+          retentionDays: job.data.retentionDays ?? DEFAULT_RETENTION_DAYS,
+          batchSize: job.data.batchSize,
+          maxBatches: job.data.maxBatches,
+        });
+        console.log(
+          `[ReliabilityRetention] Pruned ${result.deleted} reliability history rows older than ${result.retentionDays} days (batches=${result.batches}, hasMore=${result.hasMore}) in ${result.durationMs}ms`
+        );
+        return result;
       });
     },
     {
@@ -84,9 +137,10 @@ export async function initializeReliabilityRetention(): Promise<void> {
     }
 
     await queue.add(
-      'cleanup',
-      { retentionDays: DEFAULT_RETENTION_DAYS },
+      JOB_NAME,
+      { retentionDays: DEFAULT_RETENTION_DAYS, batchSize: BATCH_SIZE, maxBatches: MAX_BATCHES },
       {
+        jobId: REPEAT_JOB_ID,
         repeat: { every: 24 * 60 * 60 * 1000 },
         removeOnComplete: { count: 5 },
         removeOnFail: { count: 10 }
@@ -110,3 +164,12 @@ export async function shutdownReliabilityRetention(): Promise<void> {
     retentionQueue = null;
   }
 }
+
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  BATCH_SIZE,
+  MAX_BATCHES,
+  DEFAULT_RETENTION_DAYS,
+};

--- a/apps/api/src/jobs/userRiskRetention.test.ts
+++ b/apps/api/src/jobs/userRiskRetention.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  withSystemDbAccessContextMock,
+  dbExecuteMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  dbExecuteMock: vi.fn(),
+  capturedWorkerProcessor: { current: null as null | ((job: { data: Record<string, unknown> }) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: { data: Record<string, unknown> }) => Promise<unknown>) {
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    execute: (...args: unknown[]) => dbExecuteMock(...(args as [])),
+  },
+  withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: vi.fn(),
+}));
+
+import {
+  __testOnly,
+  createUserRiskRetentionWorker,
+  extractUserRiskRetentionRowCount,
+  initializeUserRiskRetention,
+  shutdownUserRiskRetention,
+} from './userRiskRetention';
+
+describe('user risk retention worker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    getRepeatableJobsMock.mockResolvedValue([]);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    addMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    dbExecuteMock.mockResolvedValue({ rowCount: 0 });
+    capturedWorkerProcessor.current = null;
+  });
+
+  afterEach(async () => {
+    await shutdownUserRiskRetention();
+  });
+
+  it('extracts row counts from supported driver result shapes', () => {
+    expect(extractUserRiskRetentionRowCount({ rowCount: 4, count: 2 })).toBe(4);
+    expect(extractUserRiskRetentionRowCount({ count: 3 })).toBe(3);
+    expect(extractUserRiskRetentionRowCount([{}, {}])).toBe(2);
+    expect(extractUserRiskRetentionRowCount({})).toBe(0);
+  });
+
+  it('registers a repeatable compaction job with a stable jobId', async () => {
+    await initializeUserRiskRetention();
+
+    expect(addMock).toHaveBeenCalledWith(
+      __testOnly.JOB_NAME,
+      expect.objectContaining({
+        retentionDays: expect.any(Number),
+        batchSize: __testOnly.BATCH_SIZE,
+        maxBatches: __testOnly.MAX_BATCHES,
+      }),
+      expect.objectContaining({
+        jobId: __testOnly.REPEAT_JOB_ID,
+        repeat: { every: __testOnly.DEFAULT_RETENTION_INTERVAL_MS },
+      }),
+    );
+  });
+
+  it('compacts old snapshots in bounded batches inside system DB context', async () => {
+    dbExecuteMock
+      .mockResolvedValueOnce({ rowCount: 5 })
+      .mockResolvedValueOnce({ rowCount: 2 });
+    createUserRiskRetentionWorker();
+
+    const result = await capturedWorkerProcessor.current!({
+      data: { retentionDays: 30, batchSize: 5, maxBatches: 3 },
+    });
+
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      retentionDays: 30,
+      deleted: 7,
+      batches: 2,
+      batchSize: 5,
+      maxBatches: 3,
+      hasMore: false,
+    });
+  });
+
+  it('reports hasMore when every allowed batch is full', async () => {
+    dbExecuteMock
+      .mockResolvedValueOnce({ rowCount: 5 })
+      .mockResolvedValueOnce({ rowCount: 5 });
+    createUserRiskRetentionWorker();
+
+    const result = await capturedWorkerProcessor.current!({
+      data: { retentionDays: 30, batchSize: 5, maxBatches: 2 },
+    });
+
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      deleted: 10,
+      batches: 2,
+      hasMore: true,
+    });
+  });
+});

--- a/apps/api/src/jobs/userRiskRetention.ts
+++ b/apps/api/src/jobs/userRiskRetention.ts
@@ -19,6 +19,10 @@ const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
 };
 
 const QUEUE_NAME = 'user-risk-retention';
+const JOB_NAME = 'user-risk-retention';
+const REPEAT_JOB_ID = 'user-risk-retention';
+const BATCH_SIZE = parsePositiveIntEnv('USER_RISK_RETENTION_BATCH_SIZE', 5000);
+const MAX_BATCHES = parsePositiveIntEnv('USER_RISK_RETENTION_MAX_BATCHES', 50);
 
 function parsePositiveIntEnv(name: string, defaultValue: number): number {
   const raw = process.env[name];
@@ -36,10 +40,73 @@ const DEFAULT_RETENTION_INTERVAL_MS = parsePositiveIntEnv('USER_RISK_RETENTION_I
 
 type RetentionJobData = {
   retentionDays?: number;
+  batchSize?: number;
+  maxBatches?: number;
 };
 
 let retentionQueue: Queue<RetentionJobData> | null = null;
 let retentionWorker: Worker<RetentionJobData> | null = null;
+
+export function extractUserRiskRetentionRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? result.length : 0;
+}
+
+export async function compactUserRiskSnapshots(options: {
+  retentionDays: number;
+  batchSize?: number;
+  maxBatches?: number;
+}) {
+  const retentionDays = Math.max(30, options.retentionDays);
+  const batchSize = Math.max(1, options.batchSize ?? BATCH_SIZE);
+  const maxBatches = Math.max(1, options.maxBatches ?? MAX_BATCHES);
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+  const start = Date.now();
+
+  let deleted = 0;
+  let batches = 0;
+  let lastBatchDeleted = 0;
+
+  while (batches < maxBatches) {
+    const result = await db.execute(sql`
+      WITH ranked AS (
+        SELECT
+          ctid,
+          ROW_NUMBER() OVER (
+            PARTITION BY org_id, user_id, DATE(calculated_at)
+            ORDER BY calculated_at DESC
+          ) AS rn
+        FROM user_risk_scores
+        WHERE calculated_at < ${cutoff}::timestamptz
+      ),
+      victims AS (
+        SELECT ctid
+        FROM ranked
+        WHERE rn > 1
+        LIMIT ${batchSize}
+      )
+      DELETE FROM user_risk_scores
+      WHERE ctid IN (SELECT ctid FROM victims)
+    `);
+    lastBatchDeleted = extractUserRiskRetentionRowCount(result);
+    deleted += lastBatchDeleted;
+    batches += 1;
+    if (lastBatchDeleted < batchSize) break;
+  }
+
+  const durationMs = Date.now() - start;
+  return {
+    retentionDays,
+    deleted,
+    batches,
+    batchSize,
+    maxBatches,
+    hasMore: batches >= maxBatches && lastBatchDeleted >= batchSize,
+    durationMs,
+  };
+}
 
 export function getUserRiskRetentionQueue(): Queue<RetentionJobData> {
   if (!retentionQueue) {
@@ -55,35 +122,15 @@ export function createUserRiskRetentionWorker(): Worker<RetentionJobData> {
     QUEUE_NAME,
     async (job: Job<RetentionJobData>) => {
       return runWithSystemDbAccess(async () => {
-        const retentionDays = Math.max(30, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS);
-        // postgres-js does not coerce JS Date in template-literal params; pass an ISO string.
-        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
-        const start = Date.now();
-
-        const result = await db.execute(sql`
-          WITH ranked AS (
-            SELECT
-              id,
-              ROW_NUMBER() OVER (
-                PARTITION BY org_id, user_id, DATE(calculated_at)
-                ORDER BY calculated_at DESC
-              ) AS rn
-            FROM user_risk_scores
-            WHERE calculated_at < ${cutoff}
-          )
-          DELETE FROM user_risk_scores urs
-          USING ranked r
-          WHERE urs.id = r.id
-            AND r.rn > 1
-        `);
-
-        const durationMs = Date.now() - start;
-        const raw = result as unknown as { rowCount?: number };
-        const deleted = typeof raw.rowCount === 'number' ? raw.rowCount : 'unknown';
+        const result = await compactUserRiskSnapshots({
+          retentionDays: job.data.retentionDays ?? DEFAULT_RETENTION_DAYS,
+          batchSize: job.data.batchSize,
+          maxBatches: job.data.maxBatches,
+        });
         console.log(
-          `[UserRiskRetention] Compacted user risk snapshots older than ${retentionDays} days (deleted=${deleted}) in ${durationMs}ms`
+          `[UserRiskRetention] Compacted user risk snapshots older than ${result.retentionDays} days (deleted=${result.deleted}, batches=${result.batches}, hasMore=${result.hasMore}) in ${result.durationMs}ms`
         );
-        return { retentionDays, deleted, durationMs };
+        return result;
       });
     },
     {
@@ -110,9 +157,10 @@ export async function initializeUserRiskRetention(): Promise<void> {
   }
 
   await queue.add(
-    'cleanup',
-    { retentionDays: DEFAULT_RETENTION_DAYS },
+    JOB_NAME,
+    { retentionDays: DEFAULT_RETENTION_DAYS, batchSize: BATCH_SIZE, maxBatches: MAX_BATCHES },
     {
+      jobId: REPEAT_JOB_ID,
       repeat: { every: DEFAULT_RETENTION_INTERVAL_MS },
       removeOnComplete: { count: 5 },
       removeOnFail: { count: 20 }
@@ -132,3 +180,13 @@ export async function shutdownUserRiskRetention(): Promise<void> {
     retentionQueue = null;
   }
 }
+
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  BATCH_SIZE,
+  MAX_BATCHES,
+  DEFAULT_RETENTION_DAYS,
+  DEFAULT_RETENTION_INTERVAL_MS,
+};


### PR DESCRIPTION
## Summary
- make user-risk snapshot compaction run in bounded ctid batches with deleted counts and hasMore reporting
- make reliability history retention use bounded ctid batches instead of broad deletes
- register both retention repeat jobs with stable jobIds for multi-replica dedupe

## Tests
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec vitest run src/jobs/userRiskRetention.test.ts src/jobs/reliabilityRetention.test.ts
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec eslint src/jobs/userRiskRetention.ts src/jobs/userRiskRetention.test.ts src/jobs/reliabilityRetention.ts src/jobs/reliabilityRetention.test.ts
- PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/toddhebebrand/.cargo/bin:/Users/toddhebebrand/.codex/tmp/arg0/codex-arg0sDkBDJ:/Applications/Codex.app/Contents/Resources /usr/local/bin/corepack pnpm exec tsc -p tsconfig.json --noEmit