### PR TITLE
feat(ml): request remediation elevation approval

### DIFF
--- a/apps/api/src/routes/remediationSuggestions.test.ts
+++ b/apps/api/src/routes/remediationSuggestions.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 
 const dbMocks = vi.hoisted(() => ({
   selectMock: vi.fn(),
+  insertMock: vi.fn(),
   updateMock: vi.fn(),
   writeRouteAuditMock: vi.fn(),
   generateMock: vi.fn(),
@@ -15,6 +16,7 @@ let currentPermissions: { allowedSiteIds?: string[] } | undefined;
 vi.mock('../db', () => ({
   db: {
     select: dbMocks.selectMock,
+    insert: dbMocks.insertMock,
     update: dbMocks.updateMock,
   },
 }));
@@ -40,6 +42,9 @@ vi.mock('../db/schema', () => ({
     requestedAt: 'elevationRequests.requestedAt',
     approvedAt: 'elevationRequests.approvedAt',
     expiresAt: 'elevationRequests.expiresAt',
+  },
+  elevationAudit: {
+    id: 'elevationAudit.id',
   },
   remediationSuggestions: {
     id: 'remediationSuggestions.id',
@@ -177,6 +182,33 @@ function mockElevationLoad(elevation: Record<string, unknown> | undefined) {
   });
 }
 
+function mockDeviceLoad(device: Record<string, unknown> | undefined = {
+  id: baseSuggestion.deviceId,
+  orgId: baseSuggestion.orgId,
+  siteId: '99999999-9999-4999-8999-999999999999',
+}) {
+  dbMocks.selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(device ? [device] : []),
+      }),
+    }),
+  });
+}
+
+function mockInsertReturning(row: Record<string, unknown> | undefined) {
+  const returning = vi.fn().mockResolvedValue(row ? [row] : []);
+  const values = vi.fn().mockReturnValue({ returning });
+  dbMocks.insertMock.mockReturnValueOnce({ values });
+  return { values, returning };
+}
+
+function mockInsertValuesOnly() {
+  const values = vi.fn().mockResolvedValue(undefined);
+  dbMocks.insertMock.mockReturnValueOnce({ values });
+  return { values };
+}
+
 describe('remediation suggestion routes', () => {
   let app: Hono;
 
@@ -241,6 +273,208 @@ describe('remediation suggestion routes', () => {
     }));
     const body = await res.json();
     expect(body.data.status).toBe('accepted');
+  });
+
+  it('creates and links a pending elevation request for accepted high-risk script suggestions', async () => {
+    const accepted = {
+      ...baseSuggestion,
+      status: 'accepted',
+      riskTier: 'high',
+    };
+    const elevationRequestId = '88888888-8888-4888-8888-888888888888';
+    mockSuggestionLoad(accepted);
+    mockDeviceLoad();
+    const elevationInsert = mockInsertReturning({
+      id: elevationRequestId,
+      status: 'pending',
+      expiresAt: null,
+    });
+    const auditInsert = mockInsertValuesOnly();
+    dbMocks.updateMock.mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            ...accepted,
+            elevationRequestId,
+            updatedAt: new Date('2026-06-18T12:05:00.000Z'),
+          }]),
+        }),
+      }),
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/elevation-request`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(201);
+    expect(elevationInsert.values).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: baseSuggestion.orgId,
+      siteId: '99999999-9999-4999-8999-999999999999',
+      deviceId: baseSuggestion.deviceId,
+      flowType: 'tech_jit_admin',
+      subjectUserId: 'user-1',
+      subjectUsername: 'test@example.com',
+      status: 'pending',
+      riskTier: 3,
+      metadata: expect.objectContaining({
+        triggerSource: 'remediation_suggestion',
+        remediationSuggestionId: baseSuggestion.id,
+        scriptId: baseSuggestion.scriptId,
+      }),
+    }));
+    expect(auditInsert.values).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: baseSuggestion.orgId,
+      elevationRequestId,
+      eventType: 'requested',
+      actor: 'technician',
+      actorUserId: 'user-1',
+    }));
+    expect(dbMocks.writeRouteAuditMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'ml.remediation_suggestion.request_elevation',
+      resourceId: baseSuggestion.id,
+    }));
+    const body = await res.json();
+    expect(body.data.elevationRequestId).toBe(elevationRequestId);
+    expect(body.elevationRequest).toEqual({
+      id: elevationRequestId,
+      status: 'pending',
+      expiresAt: null,
+    });
+  });
+
+  it('returns an existing pending linked elevation request idempotently', async () => {
+    const elevationRequestId = '88888888-8888-4888-8888-888888888888';
+    const accepted = {
+      ...baseSuggestion,
+      status: 'accepted',
+      riskTier: 'critical',
+      elevationRequestId,
+    };
+    mockSuggestionLoad(accepted);
+    mockDeviceLoad();
+    mockElevationLoad({
+      id: elevationRequestId,
+      orgId: baseSuggestion.orgId,
+      deviceId: baseSuggestion.deviceId,
+      status: 'pending',
+      expiresAt: null,
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/elevation-request`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+    expect(dbMocks.updateMock).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.data.elevationRequestId).toBe(elevationRequestId);
+    expect(body.elevationRequest).toEqual({
+      id: elevationRequestId,
+      status: 'pending',
+      expiresAt: null,
+    });
+  });
+
+  it('rejects elevation requests for medium-risk suggestions', async () => {
+    mockSuggestionLoad({ ...baseSuggestion, status: 'accepted', riskTier: 'medium' });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/elevation-request`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'Only high-risk remediation suggestions require elevation approval',
+    });
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects elevation requests before acceptance', async () => {
+    mockSuggestionLoad({ ...baseSuggestion, riskTier: 'high' });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/elevation-request`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'Suggestion must be accepted or edited before requesting approval',
+    });
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects elevation requests for multi-device script suggestions', async () => {
+    mockSuggestionLoad({
+      ...baseSuggestion,
+      status: 'accepted',
+      riskTier: 'high',
+      targetDeviceIds: [
+        '44444444-4444-4444-8444-444444444444',
+        '77777777-7777-4777-8777-777777777777',
+      ],
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/elevation-request`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'Remediation approval requires exactly one target device',
+    });
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects elevation requests when the target device is outside site scope', async () => {
+    currentPermissions = { allowedSiteIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'] };
+    mockSuggestionLoad({ ...baseSuggestion, status: 'accepted', riskTier: 'high' });
+    mockDeviceLoad({
+      id: baseSuggestion.deviceId,
+      orgId: baseSuggestion.orgId,
+      siteId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/elevation-request`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Target device not found or access denied' });
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects existing linked elevation requests for another target device', async () => {
+    const elevationRequestId = '88888888-8888-4888-8888-888888888888';
+    mockSuggestionLoad({
+      ...baseSuggestion,
+      status: 'accepted',
+      riskTier: 'high',
+      elevationRequestId,
+    });
+    mockDeviceLoad();
+    mockElevationLoad({
+      id: elevationRequestId,
+      orgId: baseSuggestion.orgId,
+      deviceId: '77777777-7777-4777-8777-777777777777',
+      status: 'pending',
+      expiresAt: null,
+    });
+
+    const res = await app.request(`/remediation-suggestions/${baseSuggestion.id}/elevation-request`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'Elevation request must target the suggested device' });
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
   });
 
   it('rejects execution status without a linked execution rail', async () => {

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { and, desc, eq, gte, inArray, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';
-import { devices, elevationRequests, mlFeedbackEvents, remediationSuggestions, scriptExecutions } from '../db/schema';
+import { devices, elevationAudit, elevationRequests, mlFeedbackEvents, remediationSuggestions, scriptExecutions } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { emitRemediationSuggestionFeedback } from '../services/mlFeedbackEmitters';
@@ -82,6 +82,55 @@ function requiresExecutionApproval(riskTier: string | null | undefined): boolean
   return riskTier === 'high' || riskTier === 'critical';
 }
 
+function remediationApprovalRiskTier(riskTier: string | null | undefined): number | null {
+  if (riskTier === 'high') return 3;
+  if (riskTier === 'critical') return 4;
+  return null;
+}
+
+function reusableElevationStatus(status: string): boolean {
+  return status === 'pending' || status === 'approved' || status === 'auto_approved' || status === 'actuating';
+}
+
+async function loadReusableElevationRequest(options: {
+  elevationRequestId: string;
+  orgId: string;
+  deviceId: string;
+}): Promise<{ id: string; status: string; expiresAt: Date | null } | string> {
+  const [elevation] = await db
+    .select({
+      id: elevationRequests.id,
+      deviceId: elevationRequests.deviceId,
+      status: elevationRequests.status,
+      expiresAt: elevationRequests.expiresAt,
+    })
+    .from(elevationRequests)
+    .where(and(
+      eq(elevationRequests.id, options.elevationRequestId),
+      eq(elevationRequests.orgId, options.orgId),
+    ))
+    .limit(1);
+
+  if (!elevation) {
+    return 'Elevation request not found or access denied';
+  }
+  if (elevation.deviceId !== options.deviceId) {
+    return 'Elevation request must target the suggested device';
+  }
+  if (!reusableElevationStatus(elevation.status)) {
+    return 'Elevation request is no longer reusable';
+  }
+  if (elevation.expiresAt && elevation.expiresAt.getTime() < Date.now()) {
+    return 'Elevation request has expired';
+  }
+
+  return {
+    id: elevation.id,
+    status: elevation.status,
+    expiresAt: elevation.expiresAt,
+  };
+}
+
 async function validateRemediationExecutionApproval(
   existing: typeof remediationSuggestions.$inferSelect,
   deviceId: string,
@@ -126,6 +175,30 @@ async function validateRemediationExecutionApproval(
   }
 
   return null;
+}
+
+async function loadTargetDeviceForSuggestion(
+  existing: typeof remediationSuggestions.$inferSelect,
+  deviceId: string,
+  perms: UserPermissions | undefined,
+): Promise<{ id: string; orgId: string; siteId: string } | string> {
+  const [device] = await db
+    .select({ id: devices.id, orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(and(
+      eq(devices.id, deviceId),
+      eq(devices.orgId, existing.orgId),
+    ))
+    .limit(1);
+
+  if (!device) {
+    return 'Target device not found or access denied';
+  }
+  if (perms?.allowedSiteIds && !canAccessSite(perms, device.siteId)) {
+    return 'Target device not found or access denied';
+  }
+
+  return device;
 }
 
 async function validateLinkedScriptExecution(
@@ -622,6 +695,159 @@ remediationSuggestionRoutes.post(
       skipped: result.skipped,
       data: visible.map(serializeSuggestion),
     }, result.skipped ? 200 : 201);
+  }
+);
+
+remediationSuggestionRoutes.post(
+  '/:id/elevation-request',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.SCRIPTS_EXECUTE.resource, PERMISSIONS.SCRIPTS_EXECUTE.action),
+  requireMfa(),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const id = c.req.param('id') ?? '';
+
+    const conditions: SQL[] = [eq(remediationSuggestions.id, id)];
+    const orgCond = auth.orgCondition(remediationSuggestions.orgId);
+    if (orgCond) conditions.push(orgCond);
+
+    const [existing] = await db
+      .select()
+      .from(remediationSuggestions)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!existing) {
+      return c.json({ error: 'Suggestion not found' }, 404);
+    }
+    if (existing.status !== 'accepted' && existing.status !== 'edited') {
+      return c.json({ error: 'Suggestion must be accepted or edited before requesting approval' }, 400);
+    }
+    if (!requiresExecutionApproval(existing.riskTier)) {
+      return c.json({ error: 'Only high-risk remediation suggestions require elevation approval' }, 400);
+    }
+    if (existing.targetType !== 'script' || !existing.scriptId) {
+      return c.json({ error: 'Only script remediation suggestions can request elevation approval' }, 400);
+    }
+
+    const deviceId = singleTargetDeviceId(existing);
+    if (!deviceId) {
+      return c.json({ error: 'Remediation approval requires exactly one target device' }, 400);
+    }
+
+    const device = await loadTargetDeviceForSuggestion(existing, deviceId, perms);
+    if (typeof device === 'string') {
+      return c.json({ error: device }, 403);
+    }
+
+    if (existing.elevationRequestId) {
+      const elevation = await loadReusableElevationRequest({
+        elevationRequestId: existing.elevationRequestId,
+        orgId: existing.orgId,
+        deviceId,
+      });
+      if (typeof elevation === 'string') {
+        return c.json({ error: elevation }, 409);
+      }
+      return c.json({
+        data: serializeSuggestion(existing),
+        elevationRequest: {
+          id: elevation.id,
+          status: elevation.status,
+          expiresAt: elevation.expiresAt?.toISOString() ?? null,
+        },
+      });
+    }
+
+    const now = new Date();
+    const riskTier = remediationApprovalRiskTier(existing.riskTier);
+    const [elevation] = await db
+      .insert(elevationRequests)
+      .values({
+        orgId: existing.orgId,
+        siteId: device.siteId,
+        partnerId: null,
+        deviceId,
+        flowType: 'tech_jit_admin',
+        subjectUserId: auth.user.id,
+        subjectUsername: auth.user.email ?? auth.user.name ?? auth.user.id,
+        reason: `Remediation suggestion "${existing.title}" requires approval before script execution`,
+        status: 'pending',
+        requestedAt: now,
+        riskTier,
+        metadata: {
+          triggerSource: 'remediation_suggestion',
+          remediationSuggestionId: existing.id,
+          sourceType: existing.sourceType,
+          sourceId: existing.sourceId,
+          scriptId: existing.scriptId,
+          riskTier: existing.riskTier,
+        },
+      })
+      .returning({
+        id: elevationRequests.id,
+        status: elevationRequests.status,
+        expiresAt: elevationRequests.expiresAt,
+      });
+
+    if (!elevation) {
+      return c.json({ error: 'Failed to create elevation request' }, 500);
+    }
+
+    await db.insert(elevationAudit).values({
+      orgId: existing.orgId,
+      elevationRequestId: elevation.id,
+      eventType: 'requested',
+      actor: 'technician',
+      actorUserId: auth.user.id,
+      details: {
+        triggerSource: 'remediation_suggestion',
+        remediationSuggestionId: existing.id,
+        sourceType: existing.sourceType,
+        sourceId: existing.sourceId,
+        scriptId: existing.scriptId,
+      },
+      occurredAt: now,
+    });
+
+    const [updated] = await db
+      .update(remediationSuggestions)
+      .set({
+        elevationRequestId: elevation.id,
+        updatedAt: now,
+      })
+      .where(eq(remediationSuggestions.id, existing.id))
+      .returning();
+
+    if (!updated) {
+      return c.json({ error: 'Failed to link elevation request' }, 500);
+    }
+
+    writeRouteAudit(c, {
+      orgId: updated.orgId,
+      action: 'ml.remediation_suggestion.request_elevation',
+      resourceType: 'remediation_suggestion',
+      resourceId: updated.id,
+      resourceName: updated.title,
+      details: {
+        sourceType: updated.sourceType,
+        sourceId: updated.sourceId,
+        targetType: updated.targetType,
+        scriptId: updated.scriptId,
+        elevationRequestId: updated.elevationRequestId,
+        riskTier: updated.riskTier,
+      },
+    });
+
+    return c.json({
+      data: serializeSuggestion(updated),
+      elevationRequest: {
+        id: elevation.id,
+        status: elevation.status,
+        expiresAt: elevation.expiresAt?.toISOString() ?? null,
+      },
+    }, 201);
   }
 );
 

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -216,30 +216,54 @@ describe('RemediationSuggestionsPanel', () => {
     expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
   });
 
-  it('labels high-risk executable suggestions that still need approval', async () => {
-    fetchWithAuthMock.mockImplementation((input) => {
+  it('requests approval for high-risk executable suggestions before execution', async () => {
+    const accepted = {
+      ...suggestion,
+      status: 'accepted',
+      riskTier: 'high',
+      elevationRequestId: null,
+    };
+    const withApproval = {
+      ...accepted,
+      elevationRequestId: '44444444-4444-4444-8444-444444444444',
+    };
+    fetchWithAuthMock.mockImplementation((input, init) => {
       const url = String(input);
+      const method = init?.method ?? 'GET';
       if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
       if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
         return Promise.resolve(makeJsonResponse({
-          data: [{
-            ...suggestion,
-            status: 'accepted',
-            riskTier: 'high',
-            elevationRequestId: null,
-          }],
+          data: [accepted],
         }));
       }
-      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+      if (url === '/remediation-suggestions/suggestion-1/elevation-request' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({
+          data: withApproval,
+          elevationRequest: {
+            id: withApproval.elevationRequestId,
+            status: 'pending',
+            expiresAt: null,
+          },
+        }, true, 201));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
     });
 
     render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
 
-    const approval = await screen.findByRole('button', { name: /approval required/i });
-    expect(approval).toBeDisabled();
+    const approval = await screen.findByRole('button', { name: /request approval/i });
     expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
     fireEvent.click(approval);
-    expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/remediation-suggestions/suggestion-1/execute', expect.anything());
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/remediation-suggestions/suggestion-1/elevation-request',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Approval requested' }));
+    expect(await screen.findByRole('button', { name: /approval pending/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
   });
 
   it('labels and disables generation when suggested fixes are disabled', async () => {

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -78,6 +78,8 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
   const [generating, setGenerating] = useState(false);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [executingId, setExecutingId] = useState<string | null>(null);
+  const [requestingApprovalId, setRequestingApprovalId] = useState<string | null>(null);
+  const [approvalStatuses, setApprovalStatuses] = useState<Record<string, string>>({});
   const [error, setError] = useState<string>();
 
   const fetchSuggestions = useCallback(async () => {
@@ -172,6 +174,38 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
     }
   }
 
+  async function requestApproval(suggestion: RemediationSuggestion) {
+    if (!canQueueScriptSuggestion(suggestion) || !requiresExecutionApproval(suggestion) || suggestion.elevationRequestId) return;
+
+    setRequestingApprovalId(suggestion.id);
+    try {
+      const result = await runAction<{
+        data?: RemediationSuggestion;
+        elevationRequest?: { id: string; status: string; expiresAt: string | null };
+      }>({
+        request: () => fetchWithAuth(`/remediation-suggestions/${suggestion.id}/elevation-request`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        errorFallback: 'Could not request approval',
+        successMessage: 'Approval requested',
+      });
+      if (result.data) {
+        setSuggestions((current) => current.map((item) => item.id === suggestion.id ? result.data! : item));
+      }
+      if (result.elevationRequest?.status) {
+        setApprovalStatuses((current) => ({
+          ...current,
+          [suggestion.id]: result.elevationRequest!.status,
+        }));
+      }
+    } catch (err) {
+      handleActionError(err, 'Could not request approval');
+    } finally {
+      setRequestingApprovalId(null);
+    }
+  }
+
   if (loading) {
     return (
       <div className="mt-4 rounded-md border border-dashed p-4">
@@ -216,87 +250,103 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
         <p className="mt-3 text-sm text-muted-foreground">No suggested fixes yet.</p>
       ) : (
         <div className="mt-3 space-y-3">
-          {suggestions.map((suggestion) => (
-            <div key={suggestion.id} className="rounded-md border p-3">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-semibold">{suggestion.title}</span>
-                    <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">{targetLabel(suggestion)}</span>
-                    <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${riskClasses[suggestion.riskTier]}`}>
-                      {suggestion.riskTier}
-                    </span>
-                    {suggestion.confidence != null && (
-                      <span className="text-xs text-muted-foreground">{Math.round(suggestion.confidence * 100)}%</span>
+          {suggestions.map((suggestion) => {
+            const approvalStatus = approvalStatuses[suggestion.id];
+            const approvalPending = requiresExecutionApproval(suggestion) && suggestion.elevationRequestId && approvalStatus === 'pending';
+            return (
+              <div key={suggestion.id} className="rounded-md border p-3">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-semibold">{suggestion.title}</span>
+                      <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">{targetLabel(suggestion)}</span>
+                      <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${riskClasses[suggestion.riskTier]}`}>
+                        {suggestion.riskTier}
+                      </span>
+                      {suggestion.confidence != null && (
+                        <span className="text-xs text-muted-foreground">{Math.round(suggestion.confidence * 100)}%</span>
+                      )}
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">{suggestion.rationale}</p>
+                    <p className="mt-2 text-sm">{suggestion.expectedAction}</p>
+                    {suggestion.status !== 'suggested' && (
+                      <p className="mt-2 text-xs font-medium text-muted-foreground">Status: {suggestion.status}</p>
                     )}
                   </div>
-                  <p className="mt-2 text-sm text-muted-foreground">{suggestion.rationale}</p>
-                  <p className="mt-2 text-sm">{suggestion.expectedAction}</p>
-                  {suggestion.status !== 'suggested' && (
-                    <p className="mt-2 text-xs font-medium text-muted-foreground">Status: {suggestion.status}</p>
-                  )}
-                </div>
-                <div className="flex shrink-0 flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    disabled={updatingId === suggestion.id || executingId === suggestion.id || suggestion.status === 'accepted'}
-                    onClick={() => void updateSuggestion(suggestion, 'accepted')}
-                    className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <CheckCircle className="h-4 w-4" />
-                    Accept
-                  </button>
-                  <button
-                    type="button"
-                    disabled={
-                      updatingId === suggestion.id ||
-                      executingId === suggestion.id ||
-                      suggestion.status === 'edited' ||
-                      suggestion.status === 'rejected' ||
-                      suggestion.status === 'executed' ||
-                      suggestion.status === 'failed'
-                    }
-                    onClick={() => void updateSuggestion(suggestion, 'edited')}
-                    className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <PencilLine className="h-4 w-4" />
-                    Mark edited
-                  </button>
-                  <button
-                    type="button"
-                    disabled={updatingId === suggestion.id || executingId === suggestion.id || suggestion.status === 'rejected'}
-                    onClick={() => void updateSuggestion(suggestion, 'rejected')}
-                    className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <XCircle className="h-4 w-4" />
-                    Reject
-                  </button>
-                  {canExecuteScriptSuggestion(suggestion) && (
+                  <div className="flex shrink-0 flex-wrap items-center gap-2">
                     <button
                       type="button"
-                      disabled={executingId === suggestion.id}
-                      onClick={() => void executeSuggestion(suggestion)}
-                      className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                      disabled={updatingId === suggestion.id || executingId === suggestion.id || suggestion.status === 'accepted'}
+                      onClick={() => void updateSuggestion(suggestion, 'accepted')}
+                      className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      <PlayCircle className="h-4 w-4" />
-                      Execute
+                      <CheckCircle className="h-4 w-4" />
+                      Accept
                     </button>
-                  )}
-                  {canQueueScriptSuggestion(suggestion) && requiresExecutionApproval(suggestion) && !suggestion.elevationRequestId && (
                     <button
                       type="button"
-                      disabled
-                      title="Approved elevation request required before execution"
-                      className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground disabled:cursor-not-allowed disabled:opacity-70"
+                      disabled={
+                        updatingId === suggestion.id ||
+                        executingId === suggestion.id ||
+                        suggestion.status === 'edited' ||
+                        suggestion.status === 'rejected' ||
+                        suggestion.status === 'executed' ||
+                        suggestion.status === 'failed'
+                      }
+                      onClick={() => void updateSuggestion(suggestion, 'edited')}
+                      className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      <ShieldAlert className="h-4 w-4" />
-                      Approval required
+                      <PencilLine className="h-4 w-4" />
+                      Mark edited
                     </button>
-                  )}
+                    <button
+                      type="button"
+                      disabled={updatingId === suggestion.id || executingId === suggestion.id || suggestion.status === 'rejected'}
+                      onClick={() => void updateSuggestion(suggestion, 'rejected')}
+                      className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <XCircle className="h-4 w-4" />
+                      Reject
+                    </button>
+                    {canExecuteScriptSuggestion(suggestion) && !approvalPending && (
+                      <button
+                        type="button"
+                        disabled={executingId === suggestion.id || requestingApprovalId === suggestion.id}
+                        onClick={() => void executeSuggestion(suggestion)}
+                        className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        <PlayCircle className="h-4 w-4" />
+                        Execute
+                      </button>
+                    )}
+                    {canQueueScriptSuggestion(suggestion) && requiresExecutionApproval(suggestion) && !suggestion.elevationRequestId && (
+                      <button
+                        type="button"
+                        disabled={requestingApprovalId === suggestion.id || updatingId === suggestion.id || executingId === suggestion.id}
+                        onClick={() => void requestApproval(suggestion)}
+                        title="Request PAM approval before execution"
+                        className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        <ShieldAlert className="h-4 w-4" />
+                        {requestingApprovalId === suggestion.id ? 'Requesting...' : 'Request approval'}
+                      </button>
+                    )}
+                    {approvalPending && (
+                      <button
+                        type="button"
+                        disabled
+                        title="Waiting for PAM approval"
+                        className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground disabled:cursor-not-allowed disabled:opacity-70"
+                      >
+                        <ShieldAlert className="h-4 w-4" />
+                        Approval pending
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Adds a remediation-specific approval request path so high/critical script suggestions can create and link a PAM elevation request from the suggestion card.

## Changes

- Add `POST /remediation-suggestions/:id/elevation-request` for accepted/edited high-risk script suggestions.
- Validate org, target device, site scope, single-device target shape, and reusable existing elevation requests before linking.
- Create a pending `tech_jit_admin` PAM elevation request plus elevation audit row, then link it back to the suggestion.
- Replace the disabled high-risk UI label with a `Request approval` action and local `Approval pending` state.

## Validation

- `pnpm --filter=@breeze/api exec vitest run src/routes/remediationSuggestions.test.ts`
- `pnpm --filter=@breeze/web exec vitest run src/components/remediation/RemediationSuggestionsPanel.test.tsx`
- `pnpm --filter=@breeze/api exec eslint src/routes/remediationSuggestions.ts src/routes/remediationSuggestions.test.ts`
- `pnpm --filter=@breeze/web exec eslint src/components/remediation/RemediationSuggestionsPanel.tsx src/components/remediation/RemediationSuggestionsPanel.test.tsx`
- `pnpm --filter=@breeze/api exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter=@breeze/web exec tsc -p tsconfig.json --noEmit`
