### PR TITLE
feat(ml): roll up process samples

### DIFF
--- a/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
-import { devices, deviceMetrics, metricRollups } from '../../db/schema';
+import { devices, deviceMetrics, deviceProcessSamples, metricRollups } from '../../db/schema';
 import { rollupDeviceMetricsRange } from '../../services/metricRollups';
 import { createOrganization, createPartner, createSite } from './db-utils';
 import { getTestDb } from './setup';
@@ -68,6 +68,31 @@ async function insertMetric(options: {
   });
 }
 
+async function insertProcessSample(options: {
+  orgId: string;
+  deviceId: string;
+  timestamp: Date;
+  cpu: number;
+  ramMb: number;
+  diskBps?: number;
+  netBps?: number;
+}): Promise<void> {
+  await getTestDb().insert(deviceProcessSamples).values({
+    orgId: options.orgId,
+    deviceId: options.deviceId,
+    timestamp: options.timestamp,
+    agentTimestamp: options.timestamp,
+    topProcesses: [{
+      name: 'test-process',
+      pid: 42,
+      cpu: options.cpu,
+      ramMb: options.ramMb,
+      diskBps: options.diskBps,
+      netBps: options.netBps,
+    }],
+  });
+}
+
 async function runRollup(orgId: string, from: Date, to: Date): Promise<void> {
   await withSystemDbAccessContext(() =>
     rollupDeviceMetricsRange({
@@ -88,6 +113,20 @@ async function selectCpuRollups(orgId: string, deviceId: string) {
       eq(metricRollups.deviceId, deviceId),
       eq(metricRollups.sourceTable, 'device_metrics'),
       eq(metricRollups.metricName, 'cpu_percent'),
+      eq(metricRollups.bucketSeconds, 300)
+    ))
+    .orderBy(metricRollups.bucketStart);
+}
+
+async function selectProcessRollups(orgId: string, deviceId: string, metricName: string) {
+  return getTestDb()
+    .select()
+    .from(metricRollups)
+    .where(and(
+      eq(metricRollups.orgId, orgId),
+      eq(metricRollups.deviceId, deviceId),
+      eq(metricRollups.sourceTable, 'device_process_samples'),
+      eq(metricRollups.metricName, metricName),
       eq(metricRollups.bucketSeconds, 300)
     ))
     .orderBy(metricRollups.bucketStart);
@@ -148,6 +187,70 @@ describe('metric rollups integration', () => {
     if (!updatedGapBucket) throw new Error('expected replay to preserve the middle bucket');
     expect(updatedGapBucket).toEqual(expect.objectContaining({
       avgValue: 30,
+      sampleCount: 1,
+      gapSeconds: 240,
+    }));
+    expect((updatedGapBucket.metadata as Record<string, unknown>).isGap).toBe(false);
+  });
+
+  it('materializes process sample buckets and replay-updates late process samples', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'process-sample-device' });
+    await insertProcessSample({
+      orgId: orgA,
+      deviceId: device,
+      timestamp: new Date('2026-06-18T12:00:00.000Z'),
+      cpu: 12,
+      ramMb: 512,
+      diskBps: 1000,
+      netBps: 2000,
+    });
+    await insertProcessSample({
+      orgId: orgA,
+      deviceId: device,
+      timestamp: new Date('2026-06-18T12:10:00.000Z'),
+      cpu: 24,
+      ramMb: 768,
+      diskBps: 3000,
+      netBps: 4000,
+    });
+
+    const from = new Date('2026-06-18T12:00:00.000Z');
+    const to = new Date('2026-06-18T12:15:00.000Z');
+    await runRollup(orgA, from, to);
+
+    const cpuSumRollups = await selectProcessRollups(orgA, device, 'top_process_cpu_percent_sum');
+    expect(cpuSumRollups.map((row) => ({
+      bucketStart: row.bucketStart.toISOString(),
+      avgValue: row.avgValue,
+      sampleCount: row.sampleCount,
+      gapSeconds: row.gapSeconds,
+      isGap: (row.metadata as Record<string, unknown>).isGap,
+    }))).toEqual([
+      { bucketStart: '2026-06-18T12:00:00.000Z', avgValue: 12, sampleCount: 1, gapSeconds: 240, isGap: false },
+      { bucketStart: '2026-06-18T12:05:00.000Z', avgValue: null, sampleCount: 0, gapSeconds: 300, isGap: true },
+      { bucketStart: '2026-06-18T12:10:00.000Z', avgValue: 24, sampleCount: 1, gapSeconds: 240, isGap: false },
+    ]);
+
+    const ramMaxRollups = await selectProcessRollups(orgA, device, 'top_process_ram_mb_max');
+    expect(ramMaxRollups.map((row) => row.avgValue)).toEqual([512, null, 768]);
+
+    await insertProcessSample({
+      orgId: orgA,
+      deviceId: device,
+      timestamp: new Date('2026-06-18T12:06:00.000Z'),
+      cpu: 90,
+      ramMb: 2048,
+      diskBps: 5000,
+      netBps: 6000,
+    });
+    await runRollup(orgA, from, to);
+
+    const replayedCpuRollups = await selectProcessRollups(orgA, device, 'top_process_cpu_percent_sum');
+    expect(replayedCpuRollups).toHaveLength(3);
+    const updatedGapBucket = replayedCpuRollups[1];
+    if (!updatedGapBucket) throw new Error('expected replay to preserve the middle process bucket');
+    expect(updatedGapBucket).toEqual(expect.objectContaining({
+      avgValue: 90,
       sampleCount: 1,
       gapSeconds: 240,
     }));

--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -55,12 +55,14 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T13:00:00.000Z'),
     });
 
-    expect(result).toMatchObject({ statements: 12, skipped: false });
-    expect(executeMock).toHaveBeenCalledTimes(12);
+    expect(result).toMatchObject({ statements: 21, skipped: false });
+    expect(executeMock).toHaveBeenCalledTimes(21);
     const executedSql = JSON.stringify(executeMock.mock.calls);
     expect(executedSql).toContain('ON CONFLICT');
     expect(executedSql).toContain('percentile_cont(0.95)');
     expect(executedSql).toContain('NULL::double precision');
+    expect(executedSql).toContain('device_process_samples');
+    expect(executedSql).toContain('jsonb_array_elements');
   });
 
   it('materializes regular raw bucket grids so sparse heartbeats create gap buckets', async () => {
@@ -88,11 +90,44 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T13:00:00.000Z'),
     });
 
-    const hourlyStatementSql = JSON.stringify(executeMock.mock.calls[10]);
+    const hourlyStatementSql = JSON.stringify(executeMock.mock.calls[17]);
     expect(hourlyStatementSql).toContain('sum(mr.avg_value * mr.sample_count)');
     expect(hourlyStatementSql).toContain('sum(mr.gap_seconds)');
     expect(hourlyStatementSql).not.toContain('AND mr.sample_count > 0');
     expect(hourlyStatementSql).toContain('HAVING sum(mr.sample_count) > 0');
+  });
+
+  it('rolls up top process sample metrics from JSON process payloads', async () => {
+    await rollupDeviceMetricsRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    const processStatementSql = JSON.stringify(executeMock.mock.calls[10]);
+    expect(processStatementSql).toContain('device_process_samples');
+    expect(processStatementSql).toContain('process_devices');
+    expect(processStatementSql).toContain('sample_values');
+    expect(processStatementSql).toContain('top_process_count');
+    expect(processStatementSql).toContain('jsonb_array_length(dps.top_processes)');
+    expect(processStatementSql).toContain("'process'");
+
+    const processCpuStatementSql = JSON.stringify(executeMock.mock.calls[11]);
+    expect(processCpuStatementSql).toContain('top_process_cpu_percent_sum');
+    expect(processCpuStatementSql).toContain('jsonb_array_elements(dps.top_processes)');
+    expect(processCpuStatementSql).toContain("proc.value -> 'cpu'");
+
+    const processCpuMaxStatementSql = JSON.stringify(executeMock.mock.calls[12]);
+    expect(processCpuMaxStatementSql).toContain('top_process_cpu_percent_max');
+    expect(processCpuMaxStatementSql).toContain('max(');
+
+    const processRamMaxStatementSql = JSON.stringify(executeMock.mock.calls[14]);
+    expect(processRamMaxStatementSql).toContain('top_process_ram_mb_max');
+    expect(processRamMaxStatementSql).toContain("proc.value -> 'ramMb'");
+
+    const processHourlyStatementSql = JSON.stringify(executeMock.mock.calls[19]);
+    expect(processHourlyStatementSql).toContain('device_process_samples');
+    expect(processHourlyStatementSql).toContain('sourceBucketSeconds');
   });
 
   it('rejects invalid ranges before executing writes', async () => {

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -26,6 +26,67 @@ const DEVICE_METRIC_ROLLUP_SOURCES = [
   { metricType: 'process', metricName: 'process_count', column: 'process_count' },
 ] as const;
 
+const PROCESS_SAMPLE_ROLLUP_SOURCES = [
+  {
+    metricName: 'top_process_count',
+    valueSql: 'jsonb_array_length(dps.top_processes)::double precision',
+  },
+  {
+    metricName: 'top_process_cpu_percent_sum',
+    valueSql: `(SELECT coalesce(sum(
+      CASE WHEN jsonb_typeof(proc.value -> 'cpu') = 'number'
+        THEN (proc.value ->> 'cpu')::double precision
+        ELSE 0
+      END
+    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
+  },
+  {
+    metricName: 'top_process_cpu_percent_max',
+    valueSql: `(SELECT coalesce(max(
+      CASE WHEN jsonb_typeof(proc.value -> 'cpu') = 'number'
+        THEN (proc.value ->> 'cpu')::double precision
+        ELSE NULL
+      END
+    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
+  },
+  {
+    metricName: 'top_process_ram_mb_sum',
+    valueSql: `(SELECT coalesce(sum(
+      CASE WHEN jsonb_typeof(proc.value -> 'ramMb') = 'number'
+        THEN (proc.value ->> 'ramMb')::double precision
+        ELSE 0
+      END
+    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
+  },
+  {
+    metricName: 'top_process_ram_mb_max',
+    valueSql: `(SELECT coalesce(max(
+      CASE WHEN jsonb_typeof(proc.value -> 'ramMb') = 'number'
+        THEN (proc.value ->> 'ramMb')::double precision
+        ELSE NULL
+      END
+    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
+  },
+  {
+    metricName: 'top_process_disk_bps_sum',
+    valueSql: `(SELECT coalesce(sum(
+      CASE WHEN jsonb_typeof(proc.value -> 'diskBps') = 'number'
+        THEN (proc.value ->> 'diskBps')::double precision
+        ELSE 0
+      END
+    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
+  },
+  {
+    metricName: 'top_process_net_bps_sum',
+    valueSql: `(SELECT coalesce(sum(
+      CASE WHEN jsonb_typeof(proc.value -> 'netBps') = 'number'
+        THEN (proc.value ->> 'netBps')::double precision
+        ELSE 0
+      END
+    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
+  },
+] as const;
+
 export interface MetricRollupRange {
   orgId: string;
   from: Date;
@@ -149,7 +210,101 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
   `);
 }
 
-async function rollupDerivedDeviceMetrics(options: MetricRollupRange, sourceBucketSeconds: MetricRollupBucketSeconds, targetBucketSeconds: MetricRollupBucketSeconds): Promise<void> {
+async function rollupRawProcessSampleMetric(options: MetricRollupRange, metric: (typeof PROCESS_SAMPLE_ROLLUP_SOURCES)[number]): Promise<void> {
+  const { from, to } = normalizeRange(options.from, options.to);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
+  const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
+  const valueSql = sql.raw(metric.valueSql);
+
+  await db.execute(sql`
+    WITH process_devices AS (
+      SELECT DISTINCT dps.org_id, dps.device_id
+      FROM device_process_samples dps
+      WHERE dps.org_id = ${options.orgId}
+        AND dps.timestamp >= ${fromIso}::timestamp
+        AND dps.timestamp < ${toIso}::timestamp
+    ),
+    buckets AS (
+      SELECT generate_series(
+        ${fromIso}::timestamp,
+        ${toIso}::timestamp - interval '1 second' * ${RAW_BUCKET_SECONDS},
+        interval '1 second' * ${RAW_BUCKET_SECONDS}
+      )::timestamp AS bucket_start
+    ),
+    bucket_grid AS (
+      SELECT pd.org_id, pd.device_id, buckets.bucket_start
+      FROM process_devices pd
+      CROSS JOIN buckets
+    ),
+    sample_values AS (
+      SELECT
+        dps.org_id,
+        dps.device_id,
+        dps.timestamp,
+        ${valueSql} AS metric_value
+      FROM device_process_samples dps
+      WHERE dps.org_id = ${options.orgId}
+        AND dps.timestamp >= ${fromIso}::timestamp
+        AND dps.timestamp < ${toIso}::timestamp
+    )
+    INSERT INTO metric_rollups (
+      org_id,
+      source_table,
+      device_id,
+      metric_type,
+      metric_name,
+      bucket_start,
+      bucket_seconds,
+      avg_value,
+      min_value,
+      max_value,
+      p95_value,
+      sum_value,
+      sample_count,
+      gap_seconds,
+      metadata
+    )
+    SELECT
+      bg.org_id,
+      'device_process_samples',
+      bg.device_id,
+      'process',
+      ${metric.metricName},
+      bg.bucket_start,
+      ${RAW_BUCKET_SECONDS},
+      avg(sv.metric_value)::double precision,
+      min(sv.metric_value)::double precision,
+      max(sv.metric_value)::double precision,
+      percentile_cont(0.95) within group (order by sv.metric_value)::double precision,
+      sum(sv.metric_value)::double precision,
+      count(sv.metric_value)::integer,
+      greatest(${RAW_BUCKET_SECONDS} - (count(sv.metric_value)::integer * ${expectedSampleSeconds}), 0)::integer,
+      jsonb_build_object(
+        'rollupVersion', ${METRIC_ROLLUP_VERSION}::text,
+        'source', 'raw',
+        'sourceTable', 'device_process_samples',
+        'expectedSampleSeconds', ${expectedSampleSeconds}::integer,
+        'isGap', count(sv.metric_value) = 0
+      )
+    FROM bucket_grid bg
+    LEFT JOIN sample_values sv
+      ON sv.org_id = bg.org_id
+      AND sv.device_id = bg.device_id
+      AND sv.timestamp >= bg.bucket_start
+      AND sv.timestamp < bg.bucket_start + (interval '1 second' * ${RAW_BUCKET_SECONDS})
+    GROUP BY bg.org_id, bg.device_id, bg.bucket_start
+    ON CONFLICT (org_id, source_table, device_id, metric_type, metric_name, bucket_seconds, bucket_start)
+    DO UPDATE SET ${upsertAssignments()}
+  `);
+}
+
+async function rollupDerivedMetricSource(
+  options: MetricRollupRange,
+  sourceTable: 'device_metrics' | 'device_process_samples',
+  sourceBucketSeconds: MetricRollupBucketSeconds,
+  targetBucketSeconds: MetricRollupBucketSeconds,
+): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
   const fromIso = from.toISOString();
   const toIso = to.toISOString();
@@ -195,7 +350,7 @@ async function rollupDerivedDeviceMetrics(options: MetricRollupRange, sourceBuck
       )
     FROM metric_rollups mr
     WHERE mr.org_id = ${options.orgId}
-      AND mr.source_table = 'device_metrics'
+      AND mr.source_table = ${sourceTable}
       AND mr.bucket_seconds = ${sourceBucketSeconds}
       AND mr.bucket_start >= ${fromIso}::timestamp
       AND mr.bucket_start < ${toIso}::timestamp
@@ -224,9 +379,18 @@ export async function rollupDeviceMetricsRange(options: MetricRollupRange): Prom
     statements += 1;
   }
 
-  await rollupDerivedDeviceMetrics(options, RAW_BUCKET_SECONDS, HOUR_BUCKET_SECONDS);
+  for (const metric of PROCESS_SAMPLE_ROLLUP_SOURCES) {
+    await rollupRawProcessSampleMetric(options, metric);
+    statements += 1;
+  }
+
+  await rollupDerivedMetricSource(options, 'device_metrics', RAW_BUCKET_SECONDS, HOUR_BUCKET_SECONDS);
   statements += 1;
-  await rollupDerivedDeviceMetrics(options, HOUR_BUCKET_SECONDS, DAY_BUCKET_SECONDS);
+  await rollupDerivedMetricSource(options, 'device_metrics', HOUR_BUCKET_SECONDS, DAY_BUCKET_SECONDS);
+  statements += 1;
+  await rollupDerivedMetricSource(options, 'device_process_samples', RAW_BUCKET_SECONDS, HOUR_BUCKET_SECONDS);
+  statements += 1;
+  await rollupDerivedMetricSource(options, 'device_process_samples', HOUR_BUCKET_SECONDS, DAY_BUCKET_SECONDS);
   statements += 1;
 
   return {


### PR DESCRIPTION
## Summary

Extends the Phase 1 metric rollup worker beyond `device_metrics` by adding rollups for `device_process_samples`.

## Changes

- Add raw 5-minute rollups for top-process count, CPU sum/max, RAM sum/max, disk throughput sum, and network throughput sum.
- Preserve regular bucket grids and gap metadata for sparse process samples.
- Generalize derived hourly/daily rollups so both `device_metrics` and `device_process_samples` are materialized.
- Leave SNMP rollups out of this slice because `snmp_metrics.device_id` targets `snmp_devices.id`, while `metric_rollups.device_id` currently FKs to agent `devices.id`.

## Validation

- `pnpm --filter=@breeze/api exec vitest run src/services/metricRollups.test.ts`
- `pnpm --filter=@breeze/api exec eslint src/services/metricRollups.ts src/services/metricRollups.test.ts`
- `pnpm --filter=@breeze/api exec tsc -p tsconfig.json --noEmit`
