### PR TITLE
feat(ml): roll up linked SNMP metrics

### DIFF
--- a/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
-import { devices, deviceMetrics, deviceProcessSamples, metricRollups } from '../../db/schema';
+import { discoveredAssets, devices, deviceMetrics, deviceProcessSamples, metricRollups, snmpDevices, snmpMetrics } from '../../db/schema';
 import { rollupDeviceMetricsRange } from '../../services/metricRollups';
 import { createOrganization, createPartner, createSite } from './db-utils';
 import { getTestDb } from './setup';
@@ -93,6 +93,70 @@ async function insertProcessSample(options: {
   });
 }
 
+let ipCounter = 10;
+async function insertSnmpDevice(options: {
+  orgId: string;
+  siteId?: string;
+  linkedDeviceId?: string | null;
+  name: string;
+}): Promise<string> {
+  ipCounter++;
+  let assetId: string | null = null;
+  if (options.siteId) {
+    const [asset] = await getTestDb()
+      .insert(discoveredAssets)
+      .values({
+        orgId: options.orgId,
+        siteId: options.siteId,
+        ipAddress: `10.60.0.${ipCounter}`,
+        hostname: options.name,
+        assetType: 'switch',
+        approvalStatus: 'approved',
+        isOnline: true,
+        linkedDeviceId: options.linkedDeviceId ?? null,
+        discoveryMethods: ['snmp'],
+      })
+      .returning({ id: discoveredAssets.id });
+    if (!asset) throw new Error('insert discovered asset returned no row');
+    assetId = asset.id;
+  }
+
+  const [device] = await getTestDb()
+    .insert(snmpDevices)
+    .values({
+      orgId: options.orgId,
+      assetId,
+      name: options.name,
+      ipAddress: `10.60.0.${ipCounter}`,
+      snmpVersion: '2c',
+      port: 161,
+      pollingInterval: 300,
+      isActive: true,
+    })
+    .returning({ id: snmpDevices.id });
+  if (!device) throw new Error('insert SNMP device returned no row');
+  return device.id;
+}
+
+async function insertSnmpMetric(options: {
+  orgId: string;
+  snmpDeviceId: string;
+  oid: string;
+  name: string;
+  value: string;
+  timestamp: Date;
+}): Promise<void> {
+  await getTestDb().insert(snmpMetrics).values({
+    orgId: options.orgId,
+    deviceId: options.snmpDeviceId,
+    oid: options.oid,
+    name: options.name,
+    value: options.value,
+    valueType: 'Gauge',
+    timestamp: options.timestamp,
+  });
+}
+
 async function runRollup(orgId: string, from: Date, to: Date): Promise<void> {
   await withSystemDbAccessContext(() =>
     rollupDeviceMetricsRange({
@@ -127,6 +191,20 @@ async function selectProcessRollups(orgId: string, deviceId: string, metricName:
       eq(metricRollups.deviceId, deviceId),
       eq(metricRollups.sourceTable, 'device_process_samples'),
       eq(metricRollups.metricName, metricName),
+      eq(metricRollups.bucketSeconds, 300)
+    ))
+    .orderBy(metricRollups.bucketStart);
+}
+
+async function selectSnmpRollups(orgId: string, deviceId: string) {
+  return getTestDb()
+    .select()
+    .from(metricRollups)
+    .where(and(
+      eq(metricRollups.orgId, orgId),
+      eq(metricRollups.deviceId, deviceId),
+      eq(metricRollups.sourceTable, 'snmp_metrics'),
+      eq(metricRollups.metricType, 'snmp'),
       eq(metricRollups.bucketSeconds, 300)
     ))
     .orderBy(metricRollups.bucketStart);
@@ -255,6 +333,113 @@ describe('metric rollups integration', () => {
       gapSeconds: 240,
     }));
     expect((updatedGapBucket.metadata as Record<string, unknown>).isGap).toBe(false);
+  });
+
+  it('materializes linked SNMP metric buckets and ignores unlinked or non-numeric SNMP series', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'snmp-linked-device' });
+    const linkedSnmpDevice = await insertSnmpDevice({
+      orgId: orgA,
+      siteId: siteA,
+      linkedDeviceId: device,
+      name: 'linked-switch',
+    });
+    const unlinkedSnmpDevice = await insertSnmpDevice({
+      orgId: orgA,
+      siteId: siteA,
+      linkedDeviceId: null,
+      name: 'unlinked-switch',
+    });
+    const assetlessSnmpDevice = await insertSnmpDevice({
+      orgId: orgA,
+      name: 'assetless-switch',
+    });
+
+    await insertSnmpMetric({
+      orgId: orgA,
+      snmpDeviceId: linkedSnmpDevice,
+      oid: '1.3.6.1.2.1.25.3.3.1.2',
+      name: 'hrProcessorLoad',
+      value: '12.5',
+      timestamp: new Date('2026-06-18T12:00:00.000Z'),
+    });
+    await insertSnmpMetric({
+      orgId: orgA,
+      snmpDeviceId: linkedSnmpDevice,
+      oid: '1.3.6.1.2.1.25.3.3.1.2',
+      name: 'hrProcessorLoad',
+      value: '40',
+      timestamp: new Date('2026-06-18T12:10:00.000Z'),
+    });
+    await insertSnmpMetric({
+      orgId: orgA,
+      snmpDeviceId: linkedSnmpDevice,
+      oid: '1.3.6.1.2.1.1.5.0',
+      name: 'sysName',
+      value: 'switch-a',
+      timestamp: new Date('2026-06-18T12:00:00.000Z'),
+    });
+    await insertSnmpMetric({
+      orgId: orgA,
+      snmpDeviceId: unlinkedSnmpDevice,
+      oid: '1.3.6.1.2.1.25.3.3.1.2',
+      name: 'hrProcessorLoad',
+      value: '99',
+      timestamp: new Date('2026-06-18T12:00:00.000Z'),
+    });
+    await insertSnmpMetric({
+      orgId: orgA,
+      snmpDeviceId: assetlessSnmpDevice,
+      oid: '1.3.6.1.2.1.25.3.3.1.2',
+      name: 'hrProcessorLoad',
+      value: '88',
+      timestamp: new Date('2026-06-18T12:00:00.000Z'),
+    });
+
+    const from = new Date('2026-06-18T12:00:00.000Z');
+    const to = new Date('2026-06-18T12:15:00.000Z');
+    await runRollup(orgA, from, to);
+
+    const rollups = await selectSnmpRollups(orgA, device);
+    expect(rollups.map((row) => ({
+      bucketStart: row.bucketStart.toISOString(),
+      avgValue: row.avgValue,
+      sampleCount: row.sampleCount,
+      gapSeconds: row.gapSeconds,
+      isGap: (row.metadata as Record<string, unknown>).isGap,
+      oid: (row.metadata as Record<string, unknown>).oid,
+      displayName: (row.metadata as Record<string, unknown>).displayName,
+    }))).toEqual([
+      {
+        bucketStart: '2026-06-18T12:00:00.000Z',
+        avgValue: 12.5,
+        sampleCount: 1,
+        gapSeconds: 240,
+        isGap: false,
+        oid: '1.3.6.1.2.1.25.3.3.1.2',
+        displayName: 'hrProcessorLoad',
+      },
+      {
+        bucketStart: '2026-06-18T12:05:00.000Z',
+        avgValue: null,
+        sampleCount: 0,
+        gapSeconds: 300,
+        isGap: true,
+        oid: '1.3.6.1.2.1.25.3.3.1.2',
+        displayName: 'hrProcessorLoad',
+      },
+      {
+        bucketStart: '2026-06-18T12:10:00.000Z',
+        avgValue: 40,
+        sampleCount: 1,
+        gapSeconds: 240,
+        isGap: false,
+        oid: '1.3.6.1.2.1.25.3.3.1.2',
+        displayName: 'hrProcessorLoad',
+      },
+    ]);
+
+    expect(rollups.every((row) => row.metricName.startsWith('hrProcessorLoad:'))).toBe(true);
+    expect(rollups.some((row) => (row.metadata as Record<string, unknown>).displayName === 'sysName')).toBe(false);
   });
 
   it('enforces org RLS for metric rollup reads and forged writes', async () => {

--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -55,13 +55,14 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T13:00:00.000Z'),
     });
 
-    expect(result).toMatchObject({ statements: 21, skipped: false });
-    expect(executeMock).toHaveBeenCalledTimes(21);
+    expect(result).toMatchObject({ statements: 24, skipped: false });
+    expect(executeMock).toHaveBeenCalledTimes(24);
     const executedSql = JSON.stringify(executeMock.mock.calls);
     expect(executedSql).toContain('ON CONFLICT');
     expect(executedSql).toContain('percentile_cont(0.95)');
     expect(executedSql).toContain('NULL::double precision');
     expect(executedSql).toContain('device_process_samples');
+    expect(executedSql).toContain('snmp_metrics');
     expect(executedSql).toContain('jsonb_array_elements');
   });
 
@@ -90,7 +91,7 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T13:00:00.000Z'),
     });
 
-    const hourlyStatementSql = JSON.stringify(executeMock.mock.calls[17]);
+    const hourlyStatementSql = JSON.stringify(executeMock.mock.calls[18]);
     expect(hourlyStatementSql).toContain('sum(mr.avg_value * mr.sample_count)');
     expect(hourlyStatementSql).toContain('sum(mr.gap_seconds)');
     expect(hourlyStatementSql).not.toContain('AND mr.sample_count > 0');
@@ -125,9 +126,33 @@ describe('metric rollups service', () => {
     expect(processRamMaxStatementSql).toContain('top_process_ram_mb_max');
     expect(processRamMaxStatementSql).toContain("proc.value -> 'ramMb'");
 
-    const processHourlyStatementSql = JSON.stringify(executeMock.mock.calls[19]);
+    const processHourlyStatementSql = JSON.stringify(executeMock.mock.calls[20]);
     expect(processHourlyStatementSql).toContain('device_process_samples');
     expect(processHourlyStatementSql).toContain('sourceBucketSeconds');
+  });
+
+  it('rolls up numeric SNMP metrics for SNMP assets linked to managed devices', async () => {
+    await rollupDeviceMetricsRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    const snmpStatementSql = JSON.stringify(executeMock.mock.calls[17]);
+    expect(snmpStatementSql).toContain('snmp_metrics');
+    expect(snmpStatementSql).toContain('snmp_devices');
+    expect(snmpStatementSql).toContain('discovered_assets');
+    expect(snmpStatementSql).toContain('da.linked_device_id');
+    expect(snmpStatementSql).toContain('JOIN devices');
+    expect(snmpStatementSql).toContain("btrim(sm.value) ~ '^-?[0-9]+");
+    expect(snmpStatementSql).toContain("'snmp_metrics'");
+    expect(snmpStatementSql).toContain("'snmp'");
+    expect(snmpStatementSql).toContain('snmpDeviceId');
+    expect(snmpStatementSql).toContain('displayName');
+
+    const snmpHourlyStatementSql = JSON.stringify(executeMock.mock.calls[22]);
+    expect(snmpHourlyStatementSql).toContain('snmp_metrics');
+    expect(snmpHourlyStatementSql).toContain('sourceBucketSeconds');
   });
 
   it('rejects invalid ranges before executing writes', async () => {

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -299,9 +299,137 @@ async function rollupRawProcessSampleMetric(options: MetricRollupRange, metric: 
   `);
 }
 
+async function rollupRawSnmpMetrics(options: MetricRollupRange): Promise<void> {
+  const { from, to } = normalizeRange(options.from, options.to);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
+  const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
+
+  await db.execute(sql`
+    WITH snmp_values AS (
+      SELECT
+        sm.org_id,
+        da.linked_device_id AS device_id,
+        sm.device_id AS snmp_device_id,
+        sm.oid,
+        sm.name,
+        left(
+          regexp_replace(coalesce(nullif(sm.name, ''), sm.oid), '[^a-zA-Z0-9_.:-]+', '_', 'g')
+            || ':' || md5(sm.device_id::text || ':' || sm.oid),
+          120
+        ) AS metric_name,
+        CASE
+          WHEN btrim(sm.value) ~ '^-?[0-9]+(\\.[0-9]+)?$'
+            THEN btrim(sm.value)::double precision
+          ELSE NULL
+        END AS metric_value,
+        sm.timestamp
+      FROM snmp_metrics sm
+      JOIN snmp_devices sd
+        ON sd.id = sm.device_id
+        AND sd.org_id = sm.org_id
+      JOIN discovered_assets da
+        ON da.id = sd.asset_id
+        AND da.org_id = sm.org_id
+        AND da.linked_device_id IS NOT NULL
+      JOIN devices d
+        ON d.id = da.linked_device_id
+        AND d.org_id = sm.org_id
+      WHERE sm.org_id = ${options.orgId}
+        AND sm.timestamp >= ${fromIso}::timestamp
+        AND sm.timestamp < ${toIso}::timestamp
+    ),
+    snmp_series AS (
+      SELECT DISTINCT
+        org_id,
+        device_id,
+        snmp_device_id,
+        oid,
+        name,
+        metric_name
+      FROM snmp_values
+      WHERE metric_value IS NOT NULL
+    ),
+    buckets AS (
+      SELECT generate_series(
+        ${fromIso}::timestamp,
+        ${toIso}::timestamp - interval '1 second' * ${RAW_BUCKET_SECONDS},
+        interval '1 second' * ${RAW_BUCKET_SECONDS}
+      )::timestamp AS bucket_start
+    ),
+    bucket_grid AS (
+      SELECT
+        ss.org_id,
+        ss.device_id,
+        ss.snmp_device_id,
+        ss.oid,
+        ss.name,
+        ss.metric_name,
+        buckets.bucket_start
+      FROM snmp_series ss
+      CROSS JOIN buckets
+    )
+    INSERT INTO metric_rollups (
+      org_id,
+      source_table,
+      device_id,
+      metric_type,
+      metric_name,
+      bucket_start,
+      bucket_seconds,
+      avg_value,
+      min_value,
+      max_value,
+      p95_value,
+      sum_value,
+      sample_count,
+      gap_seconds,
+      metadata
+    )
+    SELECT
+      bg.org_id,
+      'snmp_metrics',
+      bg.device_id,
+      'snmp',
+      bg.metric_name,
+      bg.bucket_start,
+      ${RAW_BUCKET_SECONDS},
+      avg(sv.metric_value)::double precision,
+      min(sv.metric_value)::double precision,
+      max(sv.metric_value)::double precision,
+      percentile_cont(0.95) within group (order by sv.metric_value)::double precision,
+      sum(sv.metric_value)::double precision,
+      count(sv.metric_value)::integer,
+      greatest(${RAW_BUCKET_SECONDS} - (count(sv.metric_value)::integer * ${expectedSampleSeconds}), 0)::integer,
+      jsonb_build_object(
+        'rollupVersion', ${METRIC_ROLLUP_VERSION}::text,
+        'source', 'raw',
+        'sourceTable', 'snmp_metrics',
+        'expectedSampleSeconds', ${expectedSampleSeconds}::integer,
+        'isGap', count(sv.metric_value) = 0,
+        'snmpDeviceId', bg.snmp_device_id,
+        'oid', bg.oid,
+        'displayName', bg.name
+      )
+    FROM bucket_grid bg
+    LEFT JOIN snmp_values sv
+      ON sv.org_id = bg.org_id
+      AND sv.device_id = bg.device_id
+      AND sv.snmp_device_id = bg.snmp_device_id
+      AND sv.oid = bg.oid
+      AND sv.metric_name = bg.metric_name
+      AND sv.timestamp >= bg.bucket_start
+      AND sv.timestamp < bg.bucket_start + (interval '1 second' * ${RAW_BUCKET_SECONDS})
+      AND sv.metric_value IS NOT NULL
+    GROUP BY bg.org_id, bg.device_id, bg.snmp_device_id, bg.oid, bg.name, bg.metric_name, bg.bucket_start
+    ON CONFLICT (org_id, source_table, device_id, metric_type, metric_name, bucket_seconds, bucket_start)
+    DO UPDATE SET ${upsertAssignments()}
+  `);
+}
+
 async function rollupDerivedMetricSource(
   options: MetricRollupRange,
-  sourceTable: 'device_metrics' | 'device_process_samples',
+  sourceTable: 'device_metrics' | 'device_process_samples' | 'snmp_metrics',
   sourceBucketSeconds: MetricRollupBucketSeconds,
   targetBucketSeconds: MetricRollupBucketSeconds,
 ): Promise<void> {
@@ -384,6 +512,9 @@ export async function rollupDeviceMetricsRange(options: MetricRollupRange): Prom
     statements += 1;
   }
 
+  await rollupRawSnmpMetrics(options);
+  statements += 1;
+
   await rollupDerivedMetricSource(options, 'device_metrics', RAW_BUCKET_SECONDS, HOUR_BUCKET_SECONDS);
   statements += 1;
   await rollupDerivedMetricSource(options, 'device_metrics', HOUR_BUCKET_SECONDS, DAY_BUCKET_SECONDS);
@@ -391,6 +522,10 @@ export async function rollupDeviceMetricsRange(options: MetricRollupRange): Prom
   await rollupDerivedMetricSource(options, 'device_process_samples', RAW_BUCKET_SECONDS, HOUR_BUCKET_SECONDS);
   statements += 1;
   await rollupDerivedMetricSource(options, 'device_process_samples', HOUR_BUCKET_SECONDS, DAY_BUCKET_SECONDS);
+  statements += 1;
+  await rollupDerivedMetricSource(options, 'snmp_metrics', RAW_BUCKET_SECONDS, HOUR_BUCKET_SECONDS);
+  statements += 1;
+  await rollupDerivedMetricSource(options, 'snmp_metrics', HOUR_BUCKET_SECONDS, DAY_BUCKET_SECONDS);
   statements += 1;
 
   return {


### PR DESCRIPTION
## Summary

Completes the Phase 1 metric rollup source coverage for SNMP metrics where SNMP devices can be safely mapped to managed Breeze devices.

## Changes

- Add raw 5-minute rollups for numeric `snmp_metrics` values.
- Bridge SNMP readings through `snmp_devices -> discovered_assets.linked_device_id -> devices` so `metric_rollups.device_id` remains a managed device ID.
- Store SNMP identity in rollup metadata (`snmpDeviceId`, `oid`, `displayName`) and skip nonnumeric SNMP values.
- Derive hourly/daily rollups for `snmp_metrics` alongside `device_metrics` and `device_process_samples`.
- Cover linked, unlinked, assetless, and nonnumeric SNMP inputs in integration tests.

## Notes

Standalone SNMP devices without a linked managed device are intentionally not rolled up in this slice. Supporting those cleanly needs a broader subject model because `metric_rollups.device_id` currently FKs to `devices.id`.

## Validation

- `pnpm --filter=@breeze/api exec vitest run src/services/metricRollups.test.ts`
- `pnpm --filter=@breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/metricRollups.integration.test.ts`
- `pnpm --filter=@breeze/api exec eslint src/services/metricRollups.ts src/services/metricRollups.test.ts src/__tests__/integration/metricRollups.integration.test.ts`
- `pnpm --filter=@breeze/api exec tsc -p tsconfig.json --noEmit`
