### PR TITLE
feat(ml): detect process sample runaways

### DIFF
--- a/apps/api/src/services/metricAnomalies.test.ts
+++ b/apps/api/src/services/metricAnomalies.test.ts
@@ -70,8 +70,11 @@ describe('metric anomalies service', () => {
     expect(processStatementSql).toContain('top_process_cpu_percent_max');
     expect(processStatementSql).toContain('top_process_ram_mb_sum');
     expect(processStatementSql).toContain('top_process_ram_mb_max');
+    expect(processStatementSql).toContain('top_process_disk_bps_sum');
+    expect(processStatementSql).toContain('top_process_net_bps_sum');
     expect(processStatementSql).toContain('process_sample_runaway');
     expect(processStatementSql).toContain('process_runaway');
+    expect(processStatementSql).toContain('network_egress');
   });
 
   it('rejects invalid ranges before executing writes', async () => {

--- a/apps/api/src/services/metricAnomalies.test.ts
+++ b/apps/api/src/services/metricAnomalies.test.ts
@@ -48,21 +48,30 @@ describe('metric anomalies service', () => {
     expect(executeMock).not.toHaveBeenCalled();
   });
 
-  it('upserts baseline deviations and growth trends idempotently', async () => {
+  it('upserts baseline deviations, growth trends, and process sample runaways idempotently', async () => {
     const result = await detectMetricAnomaliesRange({
       orgId: '11111111-1111-1111-1111-111111111111',
       from: new Date('2026-06-18T12:00:00.000Z'),
       to: new Date('2026-06-18T12:30:00.000Z'),
     });
 
-    expect(result).toMatchObject({ statements: 2, skipped: false });
-    expect(executeMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ statements: 3, skipped: false });
+    expect(executeMock).toHaveBeenCalledTimes(3);
     const executedSql = JSON.stringify(executeMock.mock.calls);
     expect(executedSql).toContain('INSERT INTO metric_anomalies');
     expect(executedSql).toContain('ON CONFLICT');
     expect(executedSql).toContain("WHERE metric_anomalies.status = 'open'");
     expect(executedSql).toContain('network_egress');
     expect(executedSql).toContain('memory_growth');
+
+    const processStatementSql = JSON.stringify(executeMock.mock.calls[2]);
+    expect(processStatementSql).toContain("mr.source_table = 'device_process_samples'");
+    expect(processStatementSql).toContain('top_process_cpu_percent_sum');
+    expect(processStatementSql).toContain('top_process_cpu_percent_max');
+    expect(processStatementSql).toContain('top_process_ram_mb_sum');
+    expect(processStatementSql).toContain('top_process_ram_mb_max');
+    expect(processStatementSql).toContain('process_sample_runaway');
+    expect(processStatementSql).toContain('process_runaway');
   });
 
   it('rejects invalid ranges before executing writes', async () => {

--- a/apps/api/src/services/metricAnomalies.ts
+++ b/apps/api/src/services/metricAnomalies.ts
@@ -342,7 +342,9 @@ async function detectProcessSampleRunaways(options: MetricAnomalyRange): Promise
           'top_process_cpu_percent_sum',
           'top_process_cpu_percent_max',
           'top_process_ram_mb_sum',
-          'top_process_ram_mb_max'
+          'top_process_ram_mb_max',
+          'top_process_disk_bps_sum',
+          'top_process_net_bps_sum'
         )
         AND mr.avg_value IS NOT NULL
         AND mr.sample_count > 0
@@ -414,6 +416,14 @@ async function detectProcessSampleRunaways(options: MetricAnomalyRange): Promise
               1024
             )
           )
+          OR (
+            b.metric_name IN ('top_process_disk_bps_sum', 'top_process_net_bps_sum')
+            AND b.avg_value >= greatest(
+              coalesce(b.baseline_value, 0) + (4 * greatest(coalesce(b.baseline_stddev, 0), 1)),
+              coalesce(b.baseline_value, 0) * 3,
+              1000000
+            )
+          )
         )
     )
     INSERT INTO metric_anomalies (
@@ -443,7 +453,10 @@ async function detectProcessSampleRunaways(options: MetricAnomalyRange): Promise
       s.source_table,
       s.metric_type,
       s.metric_name,
-      'process_runaway',
+      CASE
+        WHEN s.metric_name = 'top_process_net_bps_sum' THEN 'network_egress'
+        ELSE 'process_runaway'
+      END,
       'open',
       s.bucket_start,
       s.bucket_start + (${RAW_BUCKET_SECONDS} * interval '1 second'),

--- a/apps/api/src/services/metricAnomalies.ts
+++ b/apps/api/src/services/metricAnomalies.ts
@@ -316,6 +316,167 @@ async function detectGrowthTrends(options: MetricAnomalyRange): Promise<void> {
   `);
 }
 
+async function detectProcessSampleRunaways(options: MetricAnomalyRange): Promise<void> {
+  const { from, to } = normalizeRange(options.from, options.to);
+
+  await db.execute(sql`
+    WITH recent AS (
+      SELECT
+        mr.org_id,
+        mr.device_id,
+        mr.source_table,
+        mr.metric_type,
+        mr.metric_name,
+        mr.bucket_start,
+        mr.bucket_seconds,
+        mr.avg_value,
+        mr.max_value,
+        mr.sample_count
+      FROM metric_rollups mr
+      WHERE mr.org_id = ${options.orgId}
+        AND mr.source_table = 'device_process_samples'
+        AND mr.bucket_seconds = ${RAW_BUCKET_SECONDS}
+        AND mr.bucket_start >= ${from}
+        AND mr.bucket_start < ${to}
+        AND mr.metric_name IN (
+          'top_process_cpu_percent_sum',
+          'top_process_cpu_percent_max',
+          'top_process_ram_mb_sum',
+          'top_process_ram_mb_max'
+        )
+        AND mr.avg_value IS NOT NULL
+        AND mr.sample_count > 0
+    ),
+    baseline AS (
+      SELECT
+        r.org_id,
+        r.device_id,
+        r.source_table,
+        r.metric_type,
+        r.metric_name,
+        r.bucket_start,
+        r.bucket_seconds,
+        r.avg_value,
+        r.max_value,
+        r.sample_count,
+        avg(b.avg_value)::double precision AS baseline_value,
+        min(b.avg_value)::double precision AS baseline_min,
+        max(b.avg_value)::double precision AS baseline_max,
+        stddev_samp(b.avg_value)::double precision AS baseline_stddev,
+        count(*)::integer AS baseline_count
+      FROM recent r
+      JOIN metric_rollups b
+        ON b.org_id = r.org_id
+       AND b.device_id = r.device_id
+       AND b.source_table = r.source_table
+       AND b.metric_type = r.metric_type
+       AND b.metric_name = r.metric_name
+       AND b.bucket_seconds = r.bucket_seconds
+       AND b.avg_value IS NOT NULL
+       AND b.sample_count > 0
+       AND b.bucket_start >= r.bucket_start - (${BASELINE_LOOKBACK_HOURS} * interval '1 hour')
+       AND b.bucket_start < r.bucket_start - (${BASELINE_GAP_MINUTES} * interval '1 minute')
+      GROUP BY
+        r.org_id,
+        r.device_id,
+        r.source_table,
+        r.metric_type,
+        r.metric_name,
+        r.bucket_start,
+        r.bucket_seconds,
+        r.avg_value,
+        r.max_value,
+        r.sample_count
+    ),
+    scored AS (
+      SELECT
+        b.*,
+        (
+          abs(b.avg_value - coalesce(b.baseline_value, b.avg_value))
+          / greatest(coalesce(b.baseline_stddev, 0), 1)
+        )::double precision AS score
+      FROM baseline b
+      WHERE b.baseline_count >= ${MIN_BASELINE_BUCKETS}
+        AND (
+          (
+            b.metric_name IN ('top_process_cpu_percent_sum', 'top_process_cpu_percent_max')
+            AND b.avg_value >= greatest(
+              coalesce(b.baseline_value, 0) + (3 * greatest(coalesce(b.baseline_stddev, 0), 1)),
+              coalesce(b.baseline_value, 0) * 2,
+              80
+            )
+          )
+          OR (
+            b.metric_name IN ('top_process_ram_mb_sum', 'top_process_ram_mb_max')
+            AND b.avg_value >= greatest(
+              coalesce(b.baseline_value, 0) + (3 * greatest(coalesce(b.baseline_stddev, 0), 1)),
+              coalesce(b.baseline_value, 0) * 1.75,
+              1024
+            )
+          )
+        )
+    )
+    INSERT INTO metric_anomalies (
+      org_id,
+      device_id,
+      source_table,
+      metric_type,
+      metric_name,
+      anomaly_type,
+      status,
+      window_start,
+      window_end,
+      bucket_seconds,
+      observed_value,
+      baseline_value,
+      baseline_min,
+      baseline_max,
+      score,
+      confidence,
+      sample_count,
+      baseline_summary,
+      evidence
+    )
+    SELECT
+      s.org_id,
+      s.device_id,
+      s.source_table,
+      s.metric_type,
+      s.metric_name,
+      'process_runaway',
+      'open',
+      s.bucket_start,
+      s.bucket_start + (${RAW_BUCKET_SECONDS} * interval '1 second'),
+      s.bucket_seconds,
+      s.avg_value,
+      s.baseline_value,
+      s.baseline_min,
+      s.baseline_max,
+      greatest(s.score, 0),
+      least(0.99, greatest(0.55, 0.55 + (s.score / 10)))::double precision,
+      s.sample_count,
+      jsonb_build_object(
+        'modelVersion', ${METRIC_ANOMALY_VERSION},
+        'baselineHours', ${BASELINE_LOOKBACK_HOURS},
+        'baselineGapMinutes', ${BASELINE_GAP_MINUTES},
+        'baselineBuckets', s.baseline_count,
+        'baselineStddev', s.baseline_stddev,
+        'sourceTable', s.source_table
+      ),
+      jsonb_build_object(
+        'kind', 'process_sample_runaway',
+        'metricName', s.metric_name,
+        'observedValue', s.avg_value,
+        'baselineValue', s.baseline_value,
+        'baselineMax', s.baseline_max
+      )
+    FROM scored s
+    ON CONFLICT (org_id, device_id, metric_name, anomaly_type, bucket_seconds, window_start)
+    DO UPDATE SET ${anomalyUpsertAssignments()}
+    WHERE metric_anomalies.status = 'open'
+  `);
+}
+
 export async function detectMetricAnomaliesRange(options: MetricAnomalyRange): Promise<MetricAnomalyResult> {
   const { from, to } = normalizeRange(options.from, options.to);
   if (!(await shouldProduceMlOutput(options.orgId, 'ml.anomalies.enabled'))) {
@@ -330,12 +491,13 @@ export async function detectMetricAnomaliesRange(options: MetricAnomalyRange): P
 
   await detectBaselineDeviations(options);
   await detectGrowthTrends(options);
+  await detectProcessSampleRunaways(options);
 
   return {
     orgId: options.orgId,
     from: from.toISOString(),
     to: to.toISOString(),
-    statements: 2,
+    statements: 3,
     skipped: false,
   };
 }

--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
@@ -61,7 +61,7 @@ describe('DeviceAnomaliesPanel', () => {
     expect(screen.getByText('CPU')).toBeTruthy();
     expect(screen.getByText('96.4%')).toBeTruthy();
     expect(screen.getByText('42.2%')).toBeTruthy();
-    expect(screen.getByText('91%')).toBeTruthy();
+    expect(screen.getAllByText('91%').length).toBeGreaterThanOrEqual(1);
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1/anomalies?status=open&limit=25');
   });
 
@@ -107,5 +107,37 @@ describe('DeviceAnomaliesPanel', () => {
     });
     await waitFor(() => expect(screen.queryByText('Network egress')).toBeNull());
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Anomaly dismissed' }));
+  });
+
+  it('renders process-sample anomaly metric labels', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'anomaly-process-1',
+            metricType: 'process',
+            metricName: 'top_process_net_bps_sum',
+            anomalyType: 'network_egress',
+            status: 'open',
+            windowStart: '2026-06-18T12:00:00.000Z',
+            windowEnd: '2026-06-18T12:05:00.000Z',
+            observedValue: 1500000,
+            baselineValue: 200000,
+            score: 8.2,
+            confidence: 0.93,
+            sampleCount: 3,
+            linkedAlertId: null,
+            detectedAt: '2026-06-18T12:05:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    render(<DeviceAnomaliesPanel deviceId="dev-1" />);
+
+    await screen.findByText('Network egress');
+    expect(screen.getByText('Top process network I/O')).toBeTruthy();
+    expect(screen.getByText('1.5 MB/s')).toBeTruthy();
+    expect(screen.getByText('200.0 KB/s')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
@@ -40,6 +40,13 @@ const metricLabels: Record<string, string> = {
   bandwidth_in_bps: 'Network in',
   bandwidth_out_bps: 'Network out',
   process_count: 'Processes',
+  top_process_count: 'Top processes',
+  top_process_cpu_percent_sum: 'Top process CPU total',
+  top_process_cpu_percent_max: 'Top process CPU peak',
+  top_process_ram_mb_sum: 'Top process RAM total',
+  top_process_ram_mb_max: 'Top process RAM peak',
+  top_process_disk_bps_sum: 'Top process disk I/O',
+  top_process_net_bps_sum: 'Top process network I/O',
 };
 
 const anomalyLabels: Record<string, string> = {
@@ -55,7 +62,7 @@ const anomalyLabels: Record<string, string> = {
 function formatMetricValue(metricName: string, value: number): string {
   if (!Number.isFinite(value)) return '0';
   if (metricName.endsWith('_percent')) return `${value.toFixed(1)}%`;
-  if (metricName.endsWith('_bps')) {
+  if (metricName.includes('_bps')) {
     if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)} GB/s`;
     if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)} MB/s`;
     if (value >= 1_000) return `${(value / 1_000).toFixed(1)} KB/s`;


### PR DESCRIPTION
## Summary

Adds the Phase 3 process-runaway detector backed by `device_process_samples` rollups, with UI labels for process-sample anomaly metrics.

## Changes

- Add a `device_process_samples` anomaly detector for top-process CPU and RAM sum/max rollups.
- Include top-process disk and network byte-rate rollups in the process-sample detector.
- Emit `network_egress` for top-process network spikes and `process_runaway` for the other process-sample spikes.
- Surface process-sample metric labels and byte-rate formatting in the device anomalies panel.
- Keep anomaly writes behind the existing `ml.anomalies.enabled` producer flag.

## Validation

- `pnpm --filter=@breeze/api exec vitest run src/services/metricAnomalies.test.ts`
- `pnpm --filter=@breeze/web exec vitest run src/components/devices/DeviceAnomaliesPanel.test.tsx`
- `pnpm --filter=@breeze/api exec eslint src/services/metricAnomalies.ts src/services/metricAnomalies.test.ts`
- `pnpm --filter=@breeze/web exec eslint src/components/devices/DeviceAnomaliesPanel.tsx src/components/devices/DeviceAnomaliesPanel.test.tsx`
- `pnpm --filter=@breeze/api exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter=@breeze/web exec tsc -p tsconfig.json --noEmit`
