### PR TITLE
feat(ml): label disabled anomaly UI

### DIFF
--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
@@ -24,6 +24,17 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
     json: vi.fn().mockResolvedValue(payload),
   }) as unknown as Response;
 
+const anomalyFlags = (enabled: boolean) => ({
+  mlFeatureFlags: {
+    'ml.anomalies.enabled': {
+      flag: 'ml.anomalies.enabled',
+      enabled,
+      defaultEnabled: false,
+      source: 'org_settings',
+    },
+  },
+});
+
 describe('DeviceAnomaliesPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -31,28 +42,33 @@ describe('DeviceAnomaliesPanel', () => {
   });
 
   it('renders open metric anomalies for a device', async () => {
-    fetchWithAuthMock.mockResolvedValue(
-      makeJsonResponse({
-        data: [
-          {
-            id: 'anomaly-1',
-            metricType: 'cpu',
-            metricName: 'cpu_percent',
-            anomalyType: 'spike',
-            status: 'open',
-            windowStart: '2026-06-18T12:00:00.000Z',
-            windowEnd: '2026-06-18T12:05:00.000Z',
-            observedValue: 96.4,
-            baselineValue: 42.2,
-            score: 8.1,
-            confidence: 0.91,
-            sampleCount: 5,
-            linkedAlertId: null,
-            detectedAt: '2026-06-18T12:05:00.000Z',
-          },
-        ],
-      }),
-    );
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(anomalyFlags(true)));
+      if (url === '/devices/dev-1/anomalies?status=open&limit=25') {
+        return Promise.resolve(makeJsonResponse({
+          data: [
+            {
+              id: 'anomaly-1',
+              metricType: 'cpu',
+              metricName: 'cpu_percent',
+              anomalyType: 'spike',
+              status: 'open',
+              windowStart: '2026-06-18T12:00:00.000Z',
+              windowEnd: '2026-06-18T12:05:00.000Z',
+              observedValue: 96.4,
+              baselineValue: 42.2,
+              score: 8.1,
+              confidence: 0.91,
+              sampleCount: 5,
+              linkedAlertId: null,
+              detectedAt: '2026-06-18T12:05:00.000Z',
+            },
+          ],
+        }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
 
     render(<DeviceAnomaliesPanel deviceId="dev-1" />);
 
@@ -66,9 +82,12 @@ describe('DeviceAnomaliesPanel', () => {
   });
 
   it('uses runAction for status updates and removes the updated row', async () => {
-    fetchWithAuthMock
-      .mockResolvedValueOnce(
-        makeJsonResponse({
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(anomalyFlags(true)));
+      if (url === '/devices/dev-1/anomalies?status=open&limit=5') {
+        return Promise.resolve(makeJsonResponse({
           data: [
             {
               id: 'anomaly-1',
@@ -87,9 +106,13 @@ describe('DeviceAnomaliesPanel', () => {
               detectedAt: '2026-06-18T12:05:00.000Z',
             },
           ],
-        }),
-      )
-      .mockResolvedValueOnce(makeJsonResponse({ data: { id: 'anomaly-1', status: 'dismissed' } }));
+        }));
+      }
+      if (url === '/devices/dev-1/anomalies/anomaly-1/status' && method === 'PATCH') {
+        return Promise.resolve(makeJsonResponse({ data: { id: 'anomaly-1', status: 'dismissed' } }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
 
     render(<DeviceAnomaliesPanel deviceId="dev-1" compact />);
 
@@ -110,28 +133,33 @@ describe('DeviceAnomaliesPanel', () => {
   });
 
   it('renders process-sample anomaly metric labels', async () => {
-    fetchWithAuthMock.mockResolvedValue(
-      makeJsonResponse({
-        data: [
-          {
-            id: 'anomaly-process-1',
-            metricType: 'process',
-            metricName: 'top_process_net_bps_sum',
-            anomalyType: 'network_egress',
-            status: 'open',
-            windowStart: '2026-06-18T12:00:00.000Z',
-            windowEnd: '2026-06-18T12:05:00.000Z',
-            observedValue: 1500000,
-            baselineValue: 200000,
-            score: 8.2,
-            confidence: 0.93,
-            sampleCount: 3,
-            linkedAlertId: null,
-            detectedAt: '2026-06-18T12:05:00.000Z',
-          },
-        ],
-      }),
-    );
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(anomalyFlags(true)));
+      if (url === '/devices/dev-1/anomalies?status=open&limit=25') {
+        return Promise.resolve(makeJsonResponse({
+          data: [
+            {
+              id: 'anomaly-process-1',
+              metricType: 'process',
+              metricName: 'top_process_net_bps_sum',
+              anomalyType: 'network_egress',
+              status: 'open',
+              windowStart: '2026-06-18T12:00:00.000Z',
+              windowEnd: '2026-06-18T12:05:00.000Z',
+              observedValue: 1500000,
+              baselineValue: 200000,
+              score: 8.2,
+              confidence: 0.93,
+              sampleCount: 3,
+              linkedAlertId: null,
+              detectedAt: '2026-06-18T12:05:00.000Z',
+            },
+          ],
+        }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
 
     render(<DeviceAnomaliesPanel deviceId="dev-1" />);
 
@@ -139,5 +167,19 @@ describe('DeviceAnomaliesPanel', () => {
     expect(screen.getByText('Top process network I/O')).toBeTruthy();
     expect(screen.getByText('1.5 MB/s')).toBeTruthy();
     expect(screen.getByText('200.0 KB/s')).toBeTruthy();
+  });
+
+  it('labels the panel disabled and does not load anomalies when anomaly output is disabled', async () => {
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(anomalyFlags(false)));
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
+
+    render(<DeviceAnomaliesPanel deviceId="dev-1" />);
+
+    await screen.findByText('Anomaly detection disabled');
+    expect(screen.getByText('Anomaly detection is disabled for this organization.')).toBeTruthy();
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/devices/dev-1/anomalies?status=open&limit=25');
   });
 });

--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, CheckCircle, ExternalLink, RefreshCw, TrendingUp, XCircl
 import { runAction, handleActionError } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
 import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
+import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 type AnomalyStatus = 'open' | 'dismissed' | 'promoted' | 'resolved';
 
@@ -93,10 +94,12 @@ function labelForAnomaly(type: string): string {
 }
 
 export default function DeviceAnomaliesPanel({ deviceId, compact = false }: DeviceAnomaliesPanelProps) {
+  const mlFlags = useMlFeatureFlags();
   const [anomalies, setAnomalies] = useState<MetricAnomaly[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const anomaliesDisabled = mlFlags.isDisabled('ml.anomalies.enabled');
 
   const fetchAnomalies = useCallback(async () => {
     setLoading(true);
@@ -114,8 +117,15 @@ export default function DeviceAnomaliesPanel({ deviceId, compact = false }: Devi
   }, [compact, deviceId]);
 
   useEffect(() => {
+    if (!mlFlags.loaded) return;
+    if (anomaliesDisabled) {
+      setAnomalies([]);
+      setError(undefined);
+      setLoading(false);
+      return;
+    }
     void fetchAnomalies();
-  }, [fetchAnomalies]);
+  }, [anomaliesDisabled, fetchAnomalies, mlFlags.loaded]);
 
   const sorted = useMemo(
     () => [...anomalies].sort((a, b) => b.confidence - a.confidence || b.score - a.score),
@@ -169,6 +179,26 @@ export default function DeviceAnomaliesPanel({ deviceId, compact = false }: Devi
             <RefreshCw className="h-4 w-4" />
             Retry
           </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (anomaliesDisabled) {
+    return (
+      <div className={`rounded-lg border bg-card shadow-sm ${compact ? 'p-4' : 'p-6'}`}>
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-muted-foreground" />
+          <div>
+            <h3 className="text-lg font-semibold">Metric Anomalies</h3>
+            {!compact && (
+              <p className="text-sm text-muted-foreground">Anomaly detection is disabled for this organization.</p>
+            )}
+          </div>
+        </div>
+        <div className="mt-5 rounded-md border border-dashed p-6 text-center">
+          <CheckCircle className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">Anomaly detection disabled</p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Labels the device anomaly panel as disabled when `ml.anomalies.enabled` is off for the organization.

## Changes

- Load org-scoped ML feature flags before fetching device anomalies.
- Render an explicit disabled state instead of calling the anomalies endpoint when anomaly output is disabled.
- Add panel tests for enabled fetches, compact status updates, process metric labels, and the disabled state.

## Validation

- `pnpm --filter=@breeze/web exec vitest run src/components/devices/DeviceAnomaliesPanel.test.tsx`
- `pnpm --filter=@breeze/web exec eslint src/components/devices/DeviceAnomaliesPanel.tsx src/components/devices/DeviceAnomaliesPanel.test.tsx`
- `pnpm --filter=@breeze/web exec tsc -p tsconfig.json --noEmit`
