### PR TITLE
fix(ml): manage output rows on device lifecycle

### DIFF
--- a/apps/api/src/routes/devices/cascadeDelete.test.ts
+++ b/apps/api/src/routes/devices/cascadeDelete.test.ts
@@ -156,6 +156,14 @@ describe('device hard-delete table coverage contract', () => {
     expect(DEVICE_CASCADE_DELETE_TABLES).not.toContain('tickets');
   });
 
+  it('deletes ML output rows before anomaly parent rows during device hard-delete', () => {
+    expect(DEVICE_CASCADE_DELETE_TABLES).toContain('remediation_suggestions');
+    expect(DEVICE_CASCADE_DELETE_TABLES).toContain('metric_anomalies');
+    expect(DEVICE_CASCADE_DELETE_TABLES.indexOf('remediation_suggestions')).toBeLessThan(
+      DEVICE_CASCADE_DELETE_TABLES.indexOf('metric_anomalies'),
+    );
+  });
+
   it('includes every table whose linked_device_id FK references devices.id', () => {
     const linkedSet = new Set<string>(DEVICE_LINKED_DEVICE_ID_TABLES);
     const missing: string[] = [];

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -109,9 +109,9 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
   'elevation_requests',
   'group_membership_log',
   'huntress_agents', 'huntress_incidents', 'hyperv_vms', 'local_vaults',
-  'metric_rollups',
+  'metric_anomalies', 'metric_rollups',
   'peripheral_events', 'playbook_executions', 'provision_credential_handles',
-  'recovery_readiness', 'recovery_tokens', 'remote_sessions', 'restore_jobs',
+  'recovery_readiness', 'recovery_tokens', 'remediation_suggestions', 'remote_sessions', 'restore_jobs',
   's1_actions', 's1_agents', 's1_threats',
   'script_executions',
   'security_posture_snapshots', 'security_scans', 'security_status',
@@ -202,7 +202,7 @@ export const DEVICE_CASCADE_DELETE_TABLES = [
   // Analytics & reliability
   'device_reliability_history', 'device_reliability',
   'playbook_executions', 'time_series_metrics', 'capacity_predictions',
-  'device_process_samples', 'metric_rollups',
+  'device_process_samples', 'remediation_suggestions', 'metric_anomalies', 'metric_rollups',
   // Portal & integrations (tickets are detached, not deleted —
   // see DEVICE_DETACH_DEVICE_ID_TABLES)
   'psa_ticket_mappings', 'asset_checkouts',

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -120,6 +120,11 @@ describe('DEVICE_ORG_DENORMALIZED_TABLES coverage', () => {
         `DEVICE_CASCADE_DELETE_TABLES and DEVICE_DETACH_DEVICE_ID_TABLES.`,
     ).toEqual([]);
   });
+
+  it('includes ML output tables so device moves do not strand old-org rows', () => {
+    expect(DEVICE_ORG_DENORMALIZED_TABLES).toContain('metric_anomalies');
+    expect(DEVICE_ORG_DENORMALIZED_TABLES).toContain('remediation_suggestions');
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

Ensures Phase 3 ML output rows follow device lifecycle operations.

## Changes

- Add `metric_anomalies` and `remediation_suggestions` to device org-denormalized rewrite coverage so move-org rewrites their `org_id`.
- Add both tables to the hard-delete cascade list, with remediation suggestions before anomaly rows.
- Add explicit lifecycle contract tests for the ML output tables.

## Validation

- `pnpm --filter=@breeze/api exec vitest run src/routes/devices/cascadeDelete.test.ts src/routes/devices/moveOrg.coverage.test.ts`
- `pnpm --filter=@breeze/api exec eslint src/routes/devices/core.ts src/routes/devices/cascadeDelete.test.ts src/routes/devices/moveOrg.coverage.test.ts`
- `pnpm --filter=@breeze/api exec tsc -p tsconfig.json --noEmit`
