### PR TITLE
fix(ml): dedupe anomaly feedback replays

### DIFF
--- a/apps/api/src/routes/devices/anomalies.test.ts
+++ b/apps/api/src/routes/devices/anomalies.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
 const {
+  selectMock,
   updateMock,
   emitAnomalyFeedbackMock,
   promoteMetricAnomalyToAlertMock,
   getDeviceWithOrgAndSiteCheckMock,
 } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
   updateMock: vi.fn(),
   emitAnomalyFeedbackMock: vi.fn(),
   promoteMetricAnomalyToAlertMock: vi.fn(),
@@ -17,11 +19,12 @@ vi.mock('drizzle-orm', () => ({
   and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
   desc: (column: unknown) => ({ type: 'desc', column }),
   eq: (left: unknown, right: unknown) => ({ type: 'eq', left, right }),
+  ne: (left: unknown, right: unknown) => ({ type: 'ne', left, right }),
 }));
 
 vi.mock('../../db', () => ({
   db: {
-    select: vi.fn(),
+    select: selectMock,
     update: updateMock,
   },
 }));
@@ -114,6 +117,16 @@ function updateChain(result: unknown) {
   };
 }
 
+function selectChain(result: unknown) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  };
+}
+
 describe('device anomaly routes', () => {
   let app: Hono;
 
@@ -151,6 +164,7 @@ describe('device anomaly routes', () => {
     expect(emitAnomalyFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
       eventType: 'anomaly.promoted',
       outcome: 'promoted',
+      occurredAt: anomaly.updatedAt,
       metadata: expect.objectContaining({
         linkedAlertId: '44444444-4444-4444-8444-444444444444',
         createdAlert: true,
@@ -178,7 +192,8 @@ describe('device anomaly routes', () => {
   });
 
   it('keeps dismissed status updates on the existing direct update path', async () => {
-    updateMock.mockReturnValueOnce(updateChain([{ ...anomaly, status: 'dismissed', updatedAt: new Date('2026-06-18T12:10:00.000Z') }]));
+    const transitionAt = new Date('2026-06-18T12:10:00.000Z');
+    updateMock.mockReturnValueOnce(updateChain([{ ...anomaly, status: 'dismissed', updatedAt: transitionAt }]));
 
     const res = await app.request(`/devices/${device.id}/anomalies/${anomaly.id}/status`, {
       method: 'PATCH',
@@ -192,6 +207,29 @@ describe('device anomaly routes', () => {
     expect(emitAnomalyFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
       eventType: 'anomaly.dismissed',
       outcome: 'dismissed',
+      occurredAt: transitionAt,
     }));
+  });
+
+  it('returns an existing same-status anomaly without emitting duplicate feedback', async () => {
+    const existingDismissed = {
+      ...anomaly,
+      status: 'dismissed',
+      updatedAt: new Date('2026-06-18T12:10:00.000Z'),
+    };
+    updateMock.mockReturnValueOnce(updateChain([]));
+    selectMock.mockReturnValueOnce(selectChain([existingDismissed]));
+
+    const res = await app.request(`/devices/${device.id}/anomalies/${anomaly.id}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ status: 'dismissed' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(emitAnomalyFeedbackMock).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.data.status).toBe('dismissed');
+    expect(body.data.updatedAt).toBe('2026-06-18T12:10:00.000Z');
   });
 });

--- a/apps/api/src/routes/devices/anomalies.ts
+++ b/apps/api/src/routes/devices/anomalies.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, ne } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { metricAnomalies } from '../../db/schema';
@@ -133,6 +133,7 @@ anomaliesRoutes.patch(
         eventType: 'anomaly.promoted',
         outcome: 'promoted',
         actorUserId: auth.user.id,
+        occurredAt: result.anomaly.updatedAt,
         metadata: {
           route: 'devices.anomalies.status',
           metricName: result.anomaly.metricName,
@@ -158,11 +159,24 @@ anomaliesRoutes.patch(
         eq(metricAnomalies.id, anomalyId),
         eq(metricAnomalies.orgId, device.orgId),
         eq(metricAnomalies.deviceId, deviceId),
+        ne(metricAnomalies.status, input.status),
       ))
       .returning();
 
     if (!updated) {
-      return c.json({ error: 'Anomaly not found' }, 404);
+      const [existing] = await db
+        .select()
+        .from(metricAnomalies)
+        .where(and(
+          eq(metricAnomalies.id, anomalyId),
+          eq(metricAnomalies.orgId, device.orgId),
+          eq(metricAnomalies.deviceId, deviceId),
+        ))
+        .limit(1);
+      if (!existing) {
+        return c.json({ error: 'Anomaly not found' }, 404);
+      }
+      return c.json({ data: serializeAnomaly(existing) });
     }
 
     await emitAnomalyFeedback({
@@ -171,6 +185,7 @@ anomaliesRoutes.patch(
       eventType: `anomaly.${input.status}`,
       outcome: input.status,
       actorUserId: auth.user.id,
+      occurredAt: updated.updatedAt,
       metadata: {
         route: 'devices.anomalies.status',
         metricName: updated.metricName,


### PR DESCRIPTION
## Summary

Makes anomaly status feedback safer under request retries and replayed PATCHes.

## Changes

- Pass the anomaly transition timestamp as `occurredAt` for promoted, dismissed, and resolved feedback events.
- Avoid rewriting an anomaly when the requested status is already current.
- Return the existing anomaly for same-status replayed requests without emitting duplicate feedback.

## Validation

- `pnpm --filter=@breeze/api exec vitest run src/routes/devices/anomalies.test.ts`
- `pnpm --filter=@breeze/api exec eslint src/routes/devices/anomalies.ts src/routes/devices/anomalies.test.ts`
- `pnpm --filter=@breeze/api exec tsc -p tsconfig.json --noEmit`
