### PR TITLE
fix(ml): tighten Phase 4 evaluation labels

### DIFF
--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -556,6 +556,40 @@ describe('ticket triage suggestion routes', () => {
     }));
   });
 
+  it('GET /tickets/triage-evaluation can scope evaluation to one accessible org', async () => {
+    vi.mocked(evaluateTicketTriage).mockResolvedValue({
+      labelWindowDays: 30,
+      totalLabels: 1,
+      acceptedSuggestionLabels: 1,
+      manualOverrideLabels: 0,
+      rejectedSuggestionLabels: 0,
+      categoryLabels: 0,
+      priorityLabels: 1,
+      assigneeLabels: 0,
+      overrideRate: 0,
+    });
+
+    const res = await makeApp().request(`/tickets/triage-evaluation?labelWindowDays=30&orgId=${ORG_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(evaluateTicketTriage)).toHaveBeenCalledWith({
+      orgIds: [ORG_ID],
+      labelWindowDays: 30,
+    });
+  });
+
+  it('GET /tickets/triage-evaluation rejects inaccessible explicit org scope', async () => {
+    authRef.current = {
+      ...DEFAULT_AUTH,
+      canAccessOrg: () => false,
+    };
+
+    const res = await makeApp().request(`/tickets/triage-evaluation?orgId=${ORG_ID}`);
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(evaluateTicketTriage)).not.toHaveBeenCalled();
+  });
+
   it('GET /tickets/:id/triage-suggestion returns a scoped suggestion', async () => {
     dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
     vi.mocked(getTicketTriageSuggestion).mockResolvedValue({
@@ -604,7 +638,18 @@ describe('ticket triage suggestion routes', () => {
     expect(serviceMocks.updateTicketFields).toHaveBeenCalledWith(
       TICKET_ID,
       { priority: 'high' },
-      expect.objectContaining({ userId: 'u-1', triageFeedbackSource: 'suggestion' }),
+      expect.objectContaining({
+        userId: 'u-1',
+        triageFeedbackSource: 'suggestion',
+        triageFeedbackMetadata: {
+          modelVersion: 'ticket-triage-rules-v0',
+          suggestedPriority: 'high',
+          suggestedCategoryId: null,
+          suggestedCategoryName: null,
+          confidence: 0.72,
+          reasons: ['high-impact keywords'],
+        },
+      }),
     );
   });
 

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -30,6 +30,7 @@ export const ticketsRoutes = new Hono();
 const idParam = z.object({ id: z.string().uuid() });
 const triageEvaluationQuerySchema = z.object({
   labelWindowDays: z.coerce.number().int().min(1).max(365).default(90),
+  orgId: z.string().uuid().optional(),
 });
 const applyTriageSuggestionSchema = z.object({
   categoryId: z.string().uuid().nullable().optional(),
@@ -221,9 +222,15 @@ ticketsRoutes.get(
       return c.json({ error: 'Partner context required' }, 403);
     }
 
-    const orgIds = auth.scope === 'organization'
-      ? [auth.orgId as string]
-      : auth.accessibleOrgIds?.length ? auth.accessibleOrgIds : undefined;
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Organization not found or access denied' }, 403);
+    }
+
+    const orgIds = query.orgId
+      ? [query.orgId]
+      : auth.scope === 'organization'
+        ? [auth.orgId as string]
+        : auth.accessibleOrgIds?.length ? auth.accessibleOrgIds : undefined;
 
     const summary = await evaluateTicketTriage({
       orgIds,
@@ -485,6 +492,14 @@ ticketsRoutes.post(
       const ticket = await updateTicketFields(id, body, {
         ...actorFrom(c),
         triageFeedbackSource: 'suggestion',
+        triageFeedbackMetadata: {
+          modelVersion: suggestion.suggestion.modelVersion,
+          suggestedPriority: suggestion.suggestion.priority,
+          suggestedCategoryId: suggestion.suggestion.categoryId,
+          suggestedCategoryName: suggestion.suggestion.categoryName,
+          confidence: suggestion.suggestion.confidence,
+          reasons: suggestion.suggestion.reasons,
+        },
       });
       return c.json({ data: ticket, suggestion: suggestion.suggestion });
     } catch (err) {

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -56,6 +56,7 @@ export interface TicketActor {
   name?: string;
   email?: string;
   triageFeedbackSource?: 'manual' | 'suggestion';
+  triageFeedbackMetadata?: Record<string, unknown>;
 }
 
 // Legacy display identifier (NOT NULL UNIQUE), retry loop dropped when creation
@@ -531,6 +532,7 @@ function ticketTriageFeedbackMetadata(actor: TicketActor, extra: Record<string, 
   return {
     source: acceptedSuggestion ? 'ticket_triage_v0' : 'manual_update',
     acceptedSuggestion,
+    ...(acceptedSuggestion ? actor.triageFeedbackMetadata ?? {} : {}),
     ...extra,
   };
 }

--- a/apps/api/src/services/userRiskScoring.test.ts
+++ b/apps/api/src/services/userRiskScoring.test.ts
@@ -1,10 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  insertMock: vi.fn(),
+  emitSystemMlFeedbackEventMock: vi.fn()
+}));
 
 vi.mock('./eventBus', () => ({
   publishEvent: vi.fn(async () => 'evt-1')
 }));
 
+vi.mock('./mlFeedback', () => ({
+  emitSystemMlFeedbackEvent: dbMocks.emitSystemMlFeedbackEventMock
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: dbMocks.selectMock,
+    insert: dbMocks.insertMock
+  }
+}));
+
 import { publishEvent } from './eventBus';
+import { emitSystemMlFeedbackEvent } from './mlFeedback';
 import {
   classifyUserRiskSeverity,
   computeUserRiskScoreFromFactors,
@@ -12,8 +30,36 @@ import {
   normalizeUserRiskInterventions,
   normalizeUserRiskThresholds,
   normalizeUserRiskWeights,
-  publishUserRiskScoreEvents
+  publishUserRiskScoreEvents,
+  userRiskScoringInternals
 } from './userRiskScoring';
+
+function mockRecentTrainingAssignments(rows: Array<{ id: string }>) {
+  dbMocks.selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows)
+        })
+      })
+    })
+  });
+}
+
+function mockTrainingAssignmentInsert(id: string) {
+  dbMocks.insertMock.mockReturnValueOnce({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id }])
+    })
+  });
+}
+
+beforeEach(() => {
+  dbMocks.selectMock.mockReset();
+  dbMocks.insertMock.mockReset();
+  dbMocks.emitSystemMlFeedbackEventMock.mockReset();
+  vi.mocked(publishEvent).mockClear();
+});
 
 describe('userRiskScoring helpers', () => {
   it('normalizes weights and preserves deterministic scoring', () => {
@@ -116,5 +162,55 @@ describe('publishUserRiskScoreEvents', () => {
     expect(result.publishedHigh).toBe(0);
     expect(result.publishedSpikes).toBe(0);
     expect(vi.mocked(publishEvent)).not.toHaveBeenCalled();
+  });
+});
+
+describe('userRiskScoringInternals.recordTrainingAssignment', () => {
+  it('emits canonical feedback for new auto-assigned training', async () => {
+    mockRecentTrainingAssignments([]);
+    mockTrainingAssignmentInsert('assignment-event-1');
+
+    const result = await userRiskScoringInternals.recordTrainingAssignment({
+      orgId: '00000000-0000-4000-8000-000000000001',
+      userId: '00000000-0000-4000-8000-000000000010',
+      moduleId: 'security-awareness-baseline',
+      assignedBy: null,
+      source: 'user-risk-auto-training',
+      reason: 'Auto-assigned for user risk score 91'
+    });
+
+    expect(result).toMatchObject({ id: 'assignment-event-1', deduplicated: false });
+    expect(emitSystemMlFeedbackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: '00000000-0000-4000-8000-000000000001',
+      sourceType: 'user_risk',
+      sourceId: '00000000-0000-4000-8000-000000000010',
+      eventType: 'training.assigned',
+      outcome: 'assigned',
+      actorUserId: null,
+      metadata: expect.objectContaining({
+        source: 'user-risk-auto-training',
+        assignmentEventId: 'assignment-event-1',
+        moduleId: 'security-awareness-baseline',
+        reason: 'Auto-assigned for user risk score 91',
+        autoAssigned: true
+      })
+    }));
+  });
+
+  it('does not emit canonical feedback for deduplicated auto-training assignments', async () => {
+    mockRecentTrainingAssignments([{ id: 'existing-assignment' }]);
+
+    const result = await userRiskScoringInternals.recordTrainingAssignment({
+      orgId: '00000000-0000-4000-8000-000000000001',
+      userId: '00000000-0000-4000-8000-000000000010',
+      moduleId: 'security-awareness-baseline',
+      assignedBy: null,
+      source: 'user-risk-auto-training',
+      reason: 'Auto-assigned for user risk score 91'
+    });
+
+    expect(result).toEqual({ id: 'existing-assignment', deduplicated: true, eventPublished: false });
+    expect(dbMocks.insertMock).not.toHaveBeenCalled();
+    expect(emitSystemMlFeedbackEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -33,6 +33,7 @@ import {
   type UserRiskPolicyWeights
 } from '../db/schema';
 import { publishEvent } from './eventBus';
+import { emitSystemMlFeedbackEvent } from './mlFeedback';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const HIGH_EVENT_TYPE = 'user.risk_score_high';
@@ -1375,6 +1376,29 @@ async function recordTrainingAssignment(input: RecordTrainingInput): Promise<Rec
     console.error(`[UserRisk] Failed to publish ${TRAINING_ASSIGNED_EVENT_TYPE} for user ${input.userId}:`, error);
   }
 
+  if (input.assignedBy === null) {
+    try {
+      await emitSystemMlFeedbackEvent({
+        orgId: input.orgId,
+        sourceType: 'user_risk',
+        sourceId: input.userId,
+        eventType: 'training.assigned',
+        outcome: 'assigned',
+        actorUserId: null,
+        occurredAt: now,
+        metadata: {
+          source: input.source,
+          assignmentEventId: eventRow?.id ?? null,
+          moduleId: input.moduleId,
+          reason: input.reason ?? null,
+          autoAssigned: true
+        }
+      });
+    } catch (error) {
+      console.error(`[UserRisk] Failed to emit training.assigned feedback for user ${input.userId}:`, error);
+    }
+  }
+
   return {
     id: eventRow?.id ?? '',
     deduplicated: false,
@@ -1551,3 +1575,7 @@ export async function listActiveDeviceSessionsForUserInOrg(input: {
     idleSessions: rows.filter((row) => row.activityState === 'idle' || row.activityState === 'away').length
   };
 }
+
+export const userRiskScoringInternals = {
+  recordTrainingAssignment
+};


### PR DESCRIPTION
## Summary

Tightens Phase 4 evaluation inputs for ticket triage and user-risk training.

## Changes

- Add `orgId` to `/tickets/triage-evaluation` so partner/system callers can evaluate one accessible org.
- Reject explicit ticket-triage evaluation org scopes the caller cannot access.
- Pass accepted ticket triage suggestion context into `ticket.category_changed` and `ticket.priority_changed` feedback metadata.
- Emit canonical `training.assigned` feedback for scorer-driven user-risk auto-training assignments.
- Avoid duplicate canonical training labels when a training assignment is deduplicated, and keep manual assignment labels owned by the route path.

## Validation

- `pnpm --filter=@breeze/api exec vitest run src/routes/tickets/tickets.test.ts`
- `pnpm --filter=@breeze/api exec vitest run src/services/userRiskScoring.test.ts`
- `pnpm --filter=@breeze/api exec eslint src/routes/tickets/tickets.ts src/routes/tickets/tickets.test.ts src/services/ticketService.ts`
- `pnpm --filter=@breeze/api exec eslint src/services/userRiskScoring.ts src/services/userRiskScoring.test.ts`
- `pnpm --filter=@breeze/api exec tsc -p tsconfig.json --noEmit`
