### PR TITLE
feat(ml): surface alert remediation suggestions

### DIFF
--- a/apps/web/src/components/alerts/AlertDetailPage.tsx
+++ b/apps/web/src/components/alerts/AlertDetailPage.tsx
@@ -14,6 +14,7 @@ import {
 } from './alertConfig';
 import CreateTicketFromAlertDialog from './CreateTicketFromAlertDialog';
 import type { TicketStatus, TicketPriority } from '../tickets/ticketConfig';
+import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
 
 type Alert = {
   id: string;
@@ -285,6 +286,8 @@ export default function AlertDetailPage({ alertId }: AlertDetailPageProps) {
         <h3 className="text-sm font-semibold text-muted-foreground mb-2">Message</h3>
         <p className="text-sm">{alert.message}</p>
       </div>
+
+      <RemediationSuggestionsPanel sourceType="alert" sourceId={alert.id} />
 
       {/* Linked Tickets */}
       {(linkedTickets.length > 0 || linkedError) && (

--- a/apps/web/src/components/alerts/AlertDetails.tsx
+++ b/apps/web/src/components/alerts/AlertDetails.tsx
@@ -25,6 +25,7 @@ import {
   type AlertStatus,
 } from './alertConfig';
 import type { Alert } from './AlertList';
+import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
 
 export type NotificationHistory = {
   id: string;
@@ -171,6 +172,8 @@ export default function AlertDetails({
           <div className="rounded-md border bg-muted/20 p-4">
             <p className="text-sm">{alert.message}</p>
           </div>
+
+          <RemediationSuggestionsPanel sourceType="alert" sourceId={alert.id} />
 
           {/* Device Info */}
           <div className="rounded-md border p-4">

--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -49,6 +49,17 @@ const activeAlert = {
   triggeredAt: new Date().toISOString()
 };
 
+const remediationFlags = (enabled: boolean) => ({
+  mlFeatureFlags: {
+    'ml.remediation_suggestions.enabled': {
+      flag: 'ml.remediation_suggestions.enabled',
+      enabled,
+      defaultEnabled: false,
+      source: 'org_settings',
+    },
+  },
+});
+
 /** A promise we can resolve from the test body to simulate a slow ack. */
 function deferred<T>() {
   let resolve!: (v: T) => void;
@@ -126,6 +137,12 @@ describe('AlertsPage — acknowledge in-flight feedback', () => {
         // Detail-panel fetch (status/notification history).
         return Promise.resolve(makeJsonResponse({ statusHistory: [], notificationHistory: [] }));
       }
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      }
+      if (url === `/remediation-suggestions?sourceType=alert&sourceId=${ALERT_ID}&limit=5` && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
       if (url === `/alerts/${ALERT_ID}/acknowledge` && method === 'POST') {
         return ackDeferred.promise;
       }
@@ -152,6 +169,52 @@ describe('AlertsPage — acknowledge in-flight feedback', () => {
     ackDeferred.resolve(makeJsonResponse({ success: true }));
     await waitFor(() => {
       expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    });
+  });
+
+  it('loads and generates suggested fixes from the selected alert', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [activeAlert] }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === `/alerts/${ALERT_ID}` && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ statusHistory: [], notificationHistory: [] }));
+      }
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      }
+      if (url === `/remediation-suggestions?sourceType=alert&sourceId=${ALERT_ID}&limit=5` && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === '/remediation-suggestions/generate' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<AlertsPage />);
+
+    fireEvent.click(await screen.findByText('High CPU on SRV-01'));
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText('Suggested Fixes');
+    expect(fetchMock).toHaveBeenCalledWith(`/remediation-suggestions?sourceType=alert&sourceId=${ALERT_ID}&limit=5`);
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Generate$/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/remediation-suggestions/generate',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ sourceType: 'alert', sourceId: ALERT_ID, limit: 3 }),
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Mounts `RemediationSuggestionsPanel` on both alert detail surfaces with `sourceType="alert"`.
- Extends alert page coverage so opening an alert fetches suggested fixes for the alert source and Generate posts the alert source payload.

## Why
The remediation backend already supports alert-sourced suggestions, but alert triage UI only exposed the feature through anomaly contexts. This makes suggested fixes available directly from alert details and the alert list slide-over.

## Validation
- `NODE_OPTIONS="--localstorage-file=/tmp/breeze-vitest-localstorage" pnpm exec vitest run src/components/alerts/AlertsPage.test.tsx` from `apps/web`
- `pnpm --filter @breeze/web lint`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`

Note: `pnpm --filter @breeze/web test -- AlertsPage.test.tsx` was attempted first, but the package script treated it as a broad run and unrelated tests failed before execution due to Node localStorage being unavailable without `--localstorage-file`.
