### PR TITLE
fix(ml): gate RCA empty-state action

### DIFF
--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -239,9 +239,16 @@ describe('CorrelatedAlertGroups', () => {
     render(<CorrelatedAlertGroups />);
 
     await screen.findAllByText('High CPU on SRV-01');
-    const disabledButton = await screen.findByRole('button', { name: /RCA disabled/i });
-    expect(disabledButton).toBeDisabled();
-    fireEvent.click(disabledButton);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /RCA disabled/i })).toHaveLength(2));
+    for (const button of screen.getAllByRole('button', { name: /RCA disabled/i })) {
+      expect(button).toBeDisabled();
+      fireEvent.click(button);
+    }
+
+    const rcaPanel = screen.getByText('Evidence is gathered on demand.').closest('.rounded-md') as HTMLElement;
+    const emptyStateButton = within(rcaPanel).getByRole('button', { name: /RCA disabled/i });
+    expect(emptyStateButton).toBeDisabled();
+    fireEvent.click(emptyStateButton);
 
     expect(fetchMock).not.toHaveBeenCalledWith(
       `/alerts/correlations/${GROUP_ID}/explain`,

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -225,6 +225,8 @@ export default function CorrelatedAlertGroups() {
   };
 
   const handleExplainGroup = async (group: AlertGroup) => {
+    if (rcaDisabled) return;
+
     setLoadingRcaGroupId(group.id);
     try {
       const result = await runAction<{ data?: RcaResult; rca?: RcaResult }>({
@@ -515,11 +517,12 @@ export default function CorrelatedAlertGroups() {
                               <button
                                 type="button"
                                 onClick={() => void handleExplainGroup(group)}
-                                disabled={isExplaining}
+                                disabled={isExplaining || rcaDisabled}
+                                title={rcaDisabled ? 'RCA is disabled for this organization' : undefined}
                                 className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                               >
                                 {isExplaining ? <Loader2 className="h-4 w-4 animate-spin" /> : <Brain className="h-4 w-4" />}
-                                Explain incident
+                                {rcaDisabled ? 'RCA disabled' : 'Explain incident'}
                               </button>
                             </div>
                           ) : (


### PR DESCRIPTION
## Summary
- Gates the expanded Incident RCA empty-state action when `ml.rca.enabled` is disabled.
- Mirrors the row-level disabled label/title and adds a handler guard so disabled RCA cannot post an explain request.
- Extends the correlated alert groups test to assert both disabled RCA controls do not call `/explain`.

## Why
The top-level RCA action already respected the feature flag, but the empty-state button inside an expanded group still rendered as `Explain incident` and could call the RCA endpoint.

## Validation
- `NODE_OPTIONS="--localstorage-file=/tmp/breeze-vitest-localstorage-rca" pnpm exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx` from `apps/web`
- `pnpm --filter @breeze/web lint`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`
