### PR TITLE
fix(ml): prune retained output rows

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -157,6 +157,7 @@ import {
   shutdownMetricRollupMaintenanceWorker,
 } from './jobs/metricRollupMaintenance';
 import { initializeMetricAnomaliesWorker, shutdownMetricAnomaliesWorker } from './jobs/metricAnomalies';
+import { initializeMlOutputRetention, shutdownMlOutputRetention } from './jobs/mlOutputRetention';
 import { initializeIPHistoryRetention, shutdownIPHistoryRetention } from './jobs/ipHistoryRetention';
 import { initializeChangeLogRetention, shutdownChangeLogRetention } from './jobs/changeLogRetention';
 import { initializeOauthCleanupWorker, shutdownOauthCleanupWorker } from './jobs/oauthCleanup';
@@ -1054,6 +1055,7 @@ async function initializeWorkers(): Promise<void> {
     ['metricRollupsWorker', initializeMetricRollupsWorker],
     ['metricRollupMaintenance', initializeMetricRollupMaintenanceWorker],
     ['metricAnomaliesWorker', initializeMetricAnomaliesWorker],
+    ['mlOutputRetention', initializeMlOutputRetention],
     ['offlineDetector', initializeOfflineDetector],
     ['notificationDispatcher', initializeNotificationDispatcher],
     ['webhookDelivery', initializeWebhookDeliveryWorker],
@@ -1247,6 +1249,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownLogCorrelationWorker,
     shutdownAgentLogRetention,
     shutdownIPHistoryRetention,
+    shutdownMlOutputRetention,
     shutdownReliabilityRetention,
     shutdownProcessSampleRetention,
     shutdownChangeLogRetention,

--- a/apps/api/src/jobs/mlOutputRetention.test.ts
+++ b/apps/api/src/jobs/mlOutputRetention.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  withSystemDbAccessContextMock,
+  dbExecuteMock,
+  attachWorkerObservabilityMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  dbExecuteMock: vi.fn(),
+  attachWorkerObservabilityMock: vi.fn(),
+  capturedWorkerProcessor: { current: null as null | ((job: { data: Record<string, unknown> }) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: { data: Record<string, unknown> }) => Promise<unknown>) {
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    execute: (...args: unknown[]) => dbExecuteMock(...(args as [])),
+  },
+  withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: (...args: unknown[]) => attachWorkerObservabilityMock(...(args as [])),
+}));
+
+import {
+  __testOnly,
+  createMlOutputRetentionWorker,
+  extractMlOutputRetentionRowCount,
+  initializeMlOutputRetention,
+  shutdownMlOutputRetention,
+} from './mlOutputRetention';
+
+describe('ML output retention worker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    getRepeatableJobsMock.mockResolvedValue([]);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    addMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    dbExecuteMock.mockResolvedValue({ rowCount: 0 });
+    capturedWorkerProcessor.current = null;
+  });
+
+  afterEach(async () => {
+    await shutdownMlOutputRetention();
+  });
+
+  it('extracts row counts from supported driver result shapes', () => {
+    expect(extractMlOutputRetentionRowCount({ rowCount: 4, count: 2 })).toBe(4);
+    expect(extractMlOutputRetentionRowCount({ count: 3 })).toBe(3);
+    expect(extractMlOutputRetentionRowCount([{}, {}])).toBe(2);
+    expect(extractMlOutputRetentionRowCount({})).toBe(0);
+  });
+
+  it('registers a repeatable pruning job with a stable jobId', async () => {
+    await initializeMlOutputRetention();
+
+    expect(attachWorkerObservabilityMock).toHaveBeenCalledWith(expect.anything(), 'mlOutputRetention');
+    expect(addMock).toHaveBeenCalledWith(
+      __testOnly.JOB_NAME,
+      expect.objectContaining({
+        retentionDays: __testOnly.DEFAULT_RETENTION_DAYS,
+        batchSize: __testOnly.BATCH_SIZE,
+        maxBatches: __testOnly.MAX_BATCHES,
+      }),
+      expect.objectContaining({
+        jobId: __testOnly.REPEAT_JOB_ID,
+        repeat: { every: __testOnly.RETENTION_INTERVAL_MS },
+      }),
+    );
+  });
+
+  it('prunes remediation suggestions and metric anomalies in bounded ctid batches inside system DB context', async () => {
+    dbExecuteMock
+      .mockResolvedValueOnce({ rowCount: 4 })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 0 });
+    createMlOutputRetentionWorker();
+
+    const result = await capturedWorkerProcessor.current!({
+      data: { retentionDays: 30, batchSize: 4, maxBatches: 3 },
+    });
+
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    expect(dbExecuteMock).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(dbExecuteMock.mock.calls)).toContain('DELETE FROM remediation_suggestions');
+    expect(JSON.stringify(dbExecuteMock.mock.calls)).toContain('DELETE FROM metric_anomalies');
+    expect(JSON.stringify(dbExecuteMock.mock.calls)).toContain('SELECT ctid');
+    expect(JSON.stringify(dbExecuteMock.mock.calls)).toContain('created_at <');
+    expect(JSON.stringify(dbExecuteMock.mock.calls)).toContain('detected_at <');
+    expect(JSON.stringify(dbExecuteMock.mock.calls)).toContain('LIMIT');
+    expect(result).toMatchObject({
+      retentionDays: 30,
+      deleted: 5,
+      batchSize: 4,
+      maxBatches: 3,
+      hasMore: false,
+      tables: [
+        { table: 'remediation_suggestions', deleted: 5, batches: 2, hasMore: false },
+        { table: 'metric_anomalies', deleted: 0, batches: 1, hasMore: false },
+      ],
+    });
+  });
+
+  it('reports hasMore when any output table exhausts the configured batch cap', async () => {
+    dbExecuteMock
+      .mockResolvedValueOnce({ rowCount: 4 })
+      .mockResolvedValueOnce({ rowCount: 4 })
+      .mockResolvedValueOnce({ rowCount: 1 });
+    createMlOutputRetentionWorker();
+
+    const result = await capturedWorkerProcessor.current!({
+      data: { retentionDays: 30, batchSize: 4, maxBatches: 2 },
+    });
+
+    expect(dbExecuteMock).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({
+      deleted: 9,
+      hasMore: true,
+      tables: [
+        { table: 'remediation_suggestions', deleted: 8, batches: 2, hasMore: true },
+        { table: 'metric_anomalies', deleted: 1, batches: 1, hasMore: false },
+      ],
+    });
+  });
+});

--- a/apps/api/src/jobs/mlOutputRetention.ts
+++ b/apps/api/src/jobs/mlOutputRetention.ts
@@ -1,0 +1,237 @@
+/**
+ * ML Output Retention Worker
+ *
+ * Prunes model output rows while preserving long-lived feedback labels.
+ * Default retention: 365 days (configurable via ML_OUTPUT_RETENTION_DAYS).
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
+
+const { db } = dbModule;
+
+const QUEUE_NAME = 'ml-output-retention';
+const JOB_NAME = 'ml-output-retention';
+const REPEAT_JOB_ID = 'ml-output-retention';
+const DEFAULT_RETENTION_DAYS = Math.max(30, parsePositiveIntEnv('ML_OUTPUT_RETENTION_DAYS', 365));
+const BATCH_SIZE = parsePositiveIntEnv('ML_OUTPUT_RETENTION_BATCH_SIZE', 5000);
+const MAX_BATCHES = parsePositiveIntEnv('ML_OUTPUT_RETENTION_MAX_BATCHES', 50);
+const RETENTION_INTERVAL_MS = parsePositiveIntEnv('ML_OUTPUT_RETENTION_INTERVAL_MS', 24 * 60 * 60 * 1000);
+
+type RetentionJobData = {
+  retentionDays?: number;
+  batchSize?: number;
+  maxBatches?: number;
+};
+
+type PrunedTable = {
+  table: 'remediation_suggestions' | 'metric_anomalies';
+  deleted: number;
+  batches: number;
+  hasMore: boolean;
+};
+
+let retentionQueue: Queue<RetentionJobData> | null = null;
+let retentionWorker: Worker<RetentionJobData> | null = null;
+
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`[MlOutputRetention] Invalid ${name}="${raw}", using default ${defaultValue}`);
+    return defaultValue;
+  }
+  return parsed;
+}
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error('[MlOutputRetention] withSystemDbAccessContext is not available — DB module may not have loaded correctly');
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+export function extractMlOutputRetentionRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? result.length : 0;
+}
+
+async function pruneRemediationSuggestions(cutoff: string, batchSize: number, maxBatches: number): Promise<PrunedTable> {
+  let deleted = 0;
+  let batches = 0;
+  let lastBatchDeleted = 0;
+
+  while (batches < maxBatches) {
+    const result = await db.execute(sql`
+      DELETE FROM remediation_suggestions
+      WHERE ctid IN (
+        SELECT ctid
+        FROM remediation_suggestions
+        WHERE created_at < ${cutoff}::timestamptz
+        LIMIT ${batchSize}
+      )
+    `);
+    lastBatchDeleted = extractMlOutputRetentionRowCount(result);
+    deleted += lastBatchDeleted;
+    batches += 1;
+    if (lastBatchDeleted < batchSize) break;
+  }
+
+  return {
+    table: 'remediation_suggestions',
+    deleted,
+    batches,
+    hasMore: batches >= maxBatches && lastBatchDeleted >= batchSize,
+  };
+}
+
+async function pruneMetricAnomalies(cutoff: string, batchSize: number, maxBatches: number): Promise<PrunedTable> {
+  let deleted = 0;
+  let batches = 0;
+  let lastBatchDeleted = 0;
+
+  while (batches < maxBatches) {
+    const result = await db.execute(sql`
+      DELETE FROM metric_anomalies
+      WHERE ctid IN (
+        SELECT ctid
+        FROM metric_anomalies
+        WHERE detected_at < ${cutoff}::timestamptz
+        LIMIT ${batchSize}
+      )
+    `);
+    lastBatchDeleted = extractMlOutputRetentionRowCount(result);
+    deleted += lastBatchDeleted;
+    batches += 1;
+    if (lastBatchDeleted < batchSize) break;
+  }
+
+  return {
+    table: 'metric_anomalies',
+    deleted,
+    batches,
+    hasMore: batches >= maxBatches && lastBatchDeleted >= batchSize,
+  };
+}
+
+export async function pruneMlOutputs(options: {
+  retentionDays: number;
+  batchSize?: number;
+  maxBatches?: number;
+}) {
+  const retentionDays = Math.max(30, options.retentionDays);
+  const batchSize = Math.max(1, options.batchSize ?? BATCH_SIZE);
+  const maxBatches = Math.max(1, options.maxBatches ?? MAX_BATCHES);
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+  const startedAt = Date.now();
+
+  const tables = [
+    await pruneRemediationSuggestions(cutoff, batchSize, maxBatches),
+    await pruneMetricAnomalies(cutoff, batchSize, maxBatches),
+  ];
+  const durationMs = Date.now() - startedAt;
+
+  return {
+    retentionDays,
+    cutoff,
+    batchSize,
+    maxBatches,
+    tables,
+    deleted: tables.reduce((sum, table) => sum + table.deleted, 0),
+    hasMore: tables.some((table) => table.hasMore),
+    durationMs,
+  };
+}
+
+export function getMlOutputRetentionQueue(): Queue<RetentionJobData> {
+  if (!retentionQueue) {
+    retentionQueue = new Queue<RetentionJobData>(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return retentionQueue;
+}
+
+export function createMlOutputRetentionWorker(): Worker<RetentionJobData> {
+  return new Worker<RetentionJobData>(
+    QUEUE_NAME,
+    async (job: Job<RetentionJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        const result = await pruneMlOutputs({
+          retentionDays: job.data.retentionDays ?? DEFAULT_RETENTION_DAYS,
+          batchSize: job.data.batchSize,
+          maxBatches: job.data.maxBatches,
+        });
+        const detail = result.tables
+          .map((table) => `${table.table}=${table.deleted}/${table.batches}${table.hasMore ? '+' : ''}`)
+          .join(' ');
+        console.log(
+          `[MlOutputRetention] Pruned ${result.deleted} ML output rows older than ${result.retentionDays} days (${detail}) in ${result.durationMs}ms`,
+        );
+        return result;
+      });
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+}
+
+export async function initializeMlOutputRetention(): Promise<void> {
+  retentionWorker = createMlOutputRetentionWorker();
+  attachWorkerObservability(retentionWorker, 'mlOutputRetention');
+  retentionWorker.on('error', (error) => {
+    console.error('[MlOutputRetention] Worker error:', error);
+  });
+  retentionWorker.on('failed', (job, error) => {
+    console.error(`[MlOutputRetention] Job ${job?.id} failed after ${job?.attemptsMade} attempts:`, error);
+  });
+
+  const queue = getMlOutputRetentionQueue();
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    await queue.removeRepeatableByKey(job.key);
+  }
+
+  await queue.add(
+    JOB_NAME,
+    { retentionDays: DEFAULT_RETENTION_DAYS, batchSize: BATCH_SIZE, maxBatches: MAX_BATCHES },
+    {
+      jobId: REPEAT_JOB_ID,
+      repeat: { every: RETENTION_INTERVAL_MS },
+      removeOnComplete: { count: 5 },
+      removeOnFail: { count: 20 },
+    },
+  );
+
+  console.log('[MlOutputRetention] Retention worker initialized');
+}
+
+export async function shutdownMlOutputRetention(): Promise<void> {
+  if (retentionWorker) {
+    await retentionWorker.close();
+    retentionWorker = null;
+  }
+  if (retentionQueue) {
+    await retentionQueue.close();
+    retentionQueue = null;
+  }
+}
+
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  DEFAULT_RETENTION_DAYS,
+  BATCH_SIZE,
+  MAX_BATCHES,
+  RETENTION_INTERVAL_MS,
+};

--- a/docs/runbooks/ml-operations.md
+++ b/docs/runbooks/ml-operations.md
@@ -139,8 +139,10 @@ Expected queue names include:
 | Queue | Purpose |
 | --- | --- |
 | `metric-rollups` | Metric rollup computation |
+| `metric-rollup-maintenance` | Rollup partition upkeep and rollup retention |
 | `alert-correlation` | Alert grouping and clustering |
 | `metric-anomalies` | Anomaly detection |
+| `ml-output-retention` | Bounded pruning for metric anomalies and remediation suggestions |
 | `reliability-scoring` | Device reliability score computation |
 | `user-risk-scoring` | User-risk scoring and signal ingestion |
 
@@ -150,6 +152,23 @@ idempotent for that queue.
 
 Remediation suggestions are generated on demand through the remediation
 suggestion route/service. They do not currently have a dedicated BullMQ queue.
+
+## Retention
+
+Feedback labels in `ml_feedback_events` are long-lived evaluation assets and
+are not pruned by the ML output retention worker. Model output rows are bounded:
+
+| Data | Default | Environment knobs |
+| --- | --- | --- |
+| `metric_anomalies` | 365 days by `detected_at` | `ML_OUTPUT_RETENTION_DAYS`, `ML_OUTPUT_RETENTION_BATCH_SIZE`, `ML_OUTPUT_RETENTION_MAX_BATCHES` |
+| `remediation_suggestions` | 365 days by `created_at` | same as above |
+| `metric_rollups` | tier-specific in rollup maintenance | `METRIC_ROLLUP_RETENTION_*` / maintenance settings |
+| user-risk score snapshots | compacted after 90 days | `USER_RISK_RETENTION_*` |
+
+The ML output worker deletes in bounded `ctid` batches and reports whether more
+rows remain after the configured batch cap. If it repeatedly reports `hasMore`,
+increase `ML_OUTPUT_RETENTION_MAX_BATCHES` temporarily or run the queue more
+often rather than issuing an unbounded manual `DELETE`.
 
 ## Debugging By Surface
 


### PR DESCRIPTION
## Summary
- Adds an `ml-output-retention` BullMQ worker that prunes `remediation_suggestions` and `metric_anomalies` in bounded `ctid` batches.
- Wires the worker into API startup/shutdown with a stable repeat job ID.
- Documents ML output retention defaults and tuning knobs in the ML operations runbook.

## Why
The ML roadmap requires each output table to have documented retention and bounded cleanup. Metric anomalies and remediation suggestions were tenant-cascade covered, but they did not have normal retention cleanup. Feedback labels remain long-lived in `ml_feedback_events`.

## Validation
- `pnpm --filter @breeze/api exec vitest run src/jobs/mlOutputRetention.test.ts`
- `pnpm --filter @breeze/api lint`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
