### PR TITLE
fix(ml): add feedback semantic dedupe keys

### DIFF
--- a/apps/api/migrations/2026-06-18-zzzz-ml-feedback-dedupe-key.sql
+++ b/apps/api/migrations/2026-06-18-zzzz-ml-feedback-dedupe-key.sql
@@ -1,0 +1,10 @@
+-- Add optional semantic idempotency keys for canonical ML feedback events.
+-- Existing append-only timestamp dedupe remains unchanged for callers without
+-- a stable domain key.
+
+ALTER TABLE ml_feedback_events
+  ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(255);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ml_feedback_events_semantic_dedupe_uq
+  ON ml_feedback_events (org_id, source_type, source_id, event_type, dedupe_key)
+  WHERE dedupe_key IS NOT NULL;

--- a/apps/api/src/db/schema/mlFeedback.ts
+++ b/apps/api/src/db/schema/mlFeedback.ts
@@ -1,4 +1,7 @@
 import {
+  sql,
+} from 'drizzle-orm';
+import {
   index,
   jsonb,
   pgTable,
@@ -22,6 +25,7 @@ export const mlFeedbackEvents = pgTable('ml_feedback_events', {
   sourceType: varchar('source_type', { length: 40 }).$type<MlFeedbackEventSourceType>().notNull(),
   sourceId: varchar('source_id', { length: 255 }).notNull(),
   eventType: varchar('event_type', { length: 80 }).$type<MlFeedbackEventType>().notNull(),
+  dedupeKey: varchar('dedupe_key', { length: 255 }),
   actorUserId: uuid('actor_user_id').references(() => users.id, { onDelete: 'set null' }),
   outcome: varchar('outcome', { length: 60 }).$type<MlFeedbackEventOutcome>().notNull(),
   confidence: real('confidence'),
@@ -35,6 +39,9 @@ export const mlFeedbackEvents = pgTable('ml_feedback_events', {
     table.eventType,
     table.occurredAt,
   ),
+  semanticDedupeIdx: uniqueIndex('ml_feedback_events_semantic_dedupe_uq')
+    .on(table.orgId, table.sourceType, table.sourceId, table.eventType, table.dedupeKey)
+    .where(sql`${table.dedupeKey} IS NOT NULL`),
   orgOccurredIdx: index('ml_feedback_events_org_occurred_idx').on(table.orgId, table.occurredAt),
   orgEventIdx: index('ml_feedback_events_org_event_idx').on(table.orgId, table.eventType, table.occurredAt),
   sourceIdx: index('ml_feedback_events_source_idx').on(table.sourceType, table.sourceId, table.occurredAt),

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -705,6 +705,7 @@ describe('ticket triage suggestion routes', () => {
       orgId: STUB_TICKET.orgId,
       ticketId: TICKET_ID,
       eventType: 'ticket.triage_rejected',
+      dedupeKey: 'reject:ticket-triage-rules-v0:high:00000000-0000-4000-8000-000000000123',
       outcome: 'rejected',
       actorUserId: 'u-1',
       metadata: expect.objectContaining({

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -42,6 +42,16 @@ const rejectTriageSuggestionSchema = z.object({
   note: z.string().trim().max(500).optional(),
 });
 
+function triageSuggestionDedupeKey(suggestion: Awaited<ReturnType<typeof getTicketTriageSuggestion>>['suggestion']): string | undefined {
+  if (!suggestion) return undefined;
+  return [
+    'reject',
+    suggestion.modelVersion,
+    suggestion.priority ?? 'none',
+    suggestion.categoryId ?? 'none',
+  ].join(':');
+}
+
 const OPEN_STATUSES = ['new', 'open', 'pending', 'on_hold'] as const;
 const CLOSED_STATUSES = ['resolved', 'closed'] as const;
 
@@ -537,6 +547,7 @@ ticketsRoutes.post(
       orgId: ticket.orgId,
       ticketId: id,
       eventType: 'ticket.triage_rejected',
+      dedupeKey: triageSuggestionDedupeKey(suggestion.suggestion),
       outcome: 'rejected',
       actorUserId: auth.user.id,
       metadata: {

--- a/apps/api/src/routes/userRisk.test.ts
+++ b/apps/api/src/routes/userRisk.test.ts
@@ -225,7 +225,29 @@ describe('userRiskRoutes', () => {
       userId: USER_ID,
       eventType: 'user_risk.true_positive',
       outcome: 'true_positive',
+      dedupeKey: undefined,
       actorUserId: '00000000-0000-0000-0000-000000000099'
+    }));
+  });
+
+  it('POST /users/:userId/feedback uses source event id as a replay key', async () => {
+    vi.mocked(getUserRiskOrgMembership).mockResolvedValue(true);
+    vi.mocked(emitUserRiskFeedback).mockResolvedValue(undefined);
+
+    const app = buildApp();
+    const res = await app.request(`/user-risk/users/${USER_ID}/feedback`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        outcome: 'false_positive',
+        sourceEventId: '00000000-0000-0000-0000-000000000030'
+      })
+    });
+
+    expect(res.status).toBe(200);
+    expect(emitUserRiskFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'user_risk.false_positive',
+      dedupeKey: 'review:00000000-0000-0000-0000-000000000030:false_positive'
     }));
   });
 
@@ -264,8 +286,10 @@ describe('userRiskRoutes', () => {
       orgId: ORG_ID,
       userId: USER_ID,
       eventType: 'training.completed',
+      dedupeKey: 'assignment:00000000-0000-0000-0000-000000000020',
       outcome: 'completed',
       actorUserId: '00000000-0000-0000-0000-000000000099',
+      occurredAt: new Date('2026-06-18T12:00:00.000Z'),
       metadata: expect.objectContaining({
         source: 'user_risk_training_completion',
         moduleId: 'security-awareness-baseline',

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -82,6 +82,12 @@ const feedbackPayloadSchema = z.object({
   reason: z.string().trim().max(120).optional()
 });
 
+function trainingCompletionDedupeKey(payload: z.infer<typeof completeTrainingSchema>, completedAt: Date): string {
+  if (payload.assignmentEventId) return `assignment:${payload.assignmentEventId}`;
+  if (payload.moduleId) return `module:${payload.moduleId}`;
+  return `completed:${completedAt.toISOString()}`;
+}
+
 function resolveWriteOrgId(
   auth: {
     scope: 'system' | 'partner' | 'organization';
@@ -327,17 +333,21 @@ userRiskRoutes.post(
       return c.json({ error: 'User not found in this organization' }, 404);
     }
 
+    const completedAt = payload.completedAt ? new Date(payload.completedAt) : new Date();
+
     await emitUserRiskFeedback({
       orgId: resolved.orgId,
       userId,
       eventType: 'training.completed',
+      dedupeKey: trainingCompletionDedupeKey(payload, completedAt),
       outcome: 'completed',
       actorUserId: auth.user.id,
+      occurredAt: completedAt,
       metadata: {
         source: 'user_risk_training_completion',
         moduleId: payload.moduleId ?? null,
         assignmentEventId: payload.assignmentEventId ?? null,
-        completedAt: payload.completedAt ?? new Date().toISOString(),
+        completedAt: completedAt.toISOString(),
         note: payload.note ?? null
       }
     });
@@ -385,6 +395,7 @@ userRiskRoutes.post(
       orgId: resolved.orgId,
       userId,
       eventType,
+      dedupeKey: payload.sourceEventId ? `review:${payload.sourceEventId}:${payload.outcome}` : undefined,
       outcome: payload.outcome,
       actorUserId: auth.user.id,
       metadata: {

--- a/apps/api/src/services/mlFeedback.test.ts
+++ b/apps/api/src/services/mlFeedback.test.ts
@@ -58,6 +58,7 @@ describe('mlFeedback service', () => {
       orgId: validEvent.orgId,
       sourceType: 'alert',
       eventType: 'alert.acknowledged',
+      dedupeKey: null,
       actorUserId: validEvent.actorUserId,
       confidence: 0.9,
       metadata: { route: 'alerts.acknowledge' },
@@ -73,6 +74,25 @@ describe('mlFeedback service', () => {
 
     expect(result).toEqual({ id: null, inserted: false });
     expect(dbMocks.onConflictDoNothingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a semantic dedupe key when the emitter provides one', async () => {
+    dbMocks.returningMock.mockResolvedValue([]);
+
+    const result = await emitMlFeedbackEvent({
+      ...validEvent,
+      dedupeKey: 'ack:user-action-123',
+      occurredAt: new Date('2026-06-18T12:01:00.000Z'),
+    });
+
+    expect(result).toEqual({ id: null, inserted: false });
+    expect(dbMocks.valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+      dedupeKey: 'ack:user-action-123',
+      occurredAt: new Date('2026-06-18T12:01:00.000Z'),
+    }));
+    const conflictConfig = dbMocks.onConflictDoNothingMock.mock.calls[0]?.[0];
+    expect(conflictConfig?.target).toHaveLength(5);
+    expect(conflictConfig?.where).toBeDefined();
   });
 
   it('rejects oversized metadata before issuing a database write', async () => {

--- a/apps/api/src/services/mlFeedback.ts
+++ b/apps/api/src/services/mlFeedback.ts
@@ -1,4 +1,7 @@
 import {
+  sql,
+} from 'drizzle-orm';
+import {
   ML_FEEDBACK_METADATA_MAX_BYTES,
   getJsonByteLength,
   mlFeedbackEventSchema,
@@ -27,6 +30,25 @@ export async function emitMlFeedbackEvent(
 ): Promise<EmitMlFeedbackResult> {
   const event = mlFeedbackEventSchema.parse(input);
   assertMlFeedbackMetadataWithinLimit(event.metadata);
+  const conflictConfig = event.dedupeKey
+    ? {
+        target: [
+          mlFeedbackEvents.orgId,
+          mlFeedbackEvents.sourceType,
+          mlFeedbackEvents.sourceId,
+          mlFeedbackEvents.eventType,
+          mlFeedbackEvents.dedupeKey,
+        ],
+        where: sql`${mlFeedbackEvents.dedupeKey} IS NOT NULL`,
+      }
+    : {
+        target: [
+          mlFeedbackEvents.sourceType,
+          mlFeedbackEvents.sourceId,
+          mlFeedbackEvents.eventType,
+          mlFeedbackEvents.occurredAt,
+        ],
+      };
 
   const rows = await database
     .insert(mlFeedbackEvents)
@@ -35,20 +57,14 @@ export async function emitMlFeedbackEvent(
       sourceType: event.sourceType,
       sourceId: event.sourceId,
       eventType: event.eventType,
+      dedupeKey: event.dedupeKey ?? null,
       actorUserId: event.actorUserId ?? null,
       outcome: event.outcome,
       confidence: event.confidence ?? null,
       metadata: event.metadata,
       occurredAt: event.occurredAt,
     })
-    .onConflictDoNothing({
-      target: [
-        mlFeedbackEvents.sourceType,
-        mlFeedbackEvents.sourceId,
-        mlFeedbackEvents.eventType,
-        mlFeedbackEvents.occurredAt,
-      ],
-    })
+    .onConflictDoNothing(conflictConfig)
     .returning({ id: mlFeedbackEvents.id });
 
   const row = rows[0];

--- a/apps/api/src/services/mlFeedbackEmitters.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.ts
@@ -21,6 +21,7 @@ export async function emitAlertStateFeedback(options: {
   eventType: 'alert.acknowledged' | 'alert.resolved' | 'alert.suppressed' | 'alert.dismissed' | 'alert.reopened';
   outcome: 'acknowledged' | 'resolved' | 'suppressed' | 'dismissed' | 'reopened';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -29,6 +30,7 @@ export async function emitAlertStateFeedback(options: {
     sourceType: 'alert',
     sourceId: options.alertId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},
@@ -42,6 +44,7 @@ export async function emitCorrelationFeedback(options: {
   eventType: 'correlation.accepted' | 'correlation.split' | 'correlation.merged' | 'correlation.dismissed';
   outcome: 'accepted' | 'split' | 'merged' | 'dismissed';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -50,6 +53,7 @@ export async function emitCorrelationFeedback(options: {
     sourceType: 'correlation',
     sourceId: options.correlationId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},
@@ -63,6 +67,7 @@ export async function emitAnomalyFeedback(options: {
   eventType: 'anomaly.dismissed' | 'anomaly.promoted' | 'anomaly.resolved';
   outcome: 'dismissed' | 'promoted' | 'resolved';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -71,6 +76,7 @@ export async function emitAnomalyFeedback(options: {
     sourceType: 'anomaly',
     sourceId: options.anomalyId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},
@@ -84,6 +90,7 @@ export async function emitRcaFeedback(options: {
   eventType: 'rca.helpful' | 'rca.not_helpful' | 'rca.edited' | 'rca.used_in_ticket';
   outcome: 'helpful' | 'not_helpful' | 'edited' | 'used_in_ticket';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -92,6 +99,7 @@ export async function emitRcaFeedback(options: {
     sourceType: 'rca',
     sourceId: options.rcaId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},
@@ -105,6 +113,7 @@ export async function emitRemediationSuggestionFeedback(options: {
   eventType: 'suggestion.accepted' | 'suggestion.edited' | 'suggestion.rejected' | 'suggestion.executed' | 'suggestion.failed';
   outcome: 'accepted' | 'edited' | 'rejected' | 'executed' | 'failed';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -113,6 +122,7 @@ export async function emitRemediationSuggestionFeedback(options: {
     sourceType: 'remediation',
     sourceId: options.suggestionId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},
@@ -126,6 +136,7 @@ export async function emitDeviceReliabilityFeedback(options: {
   eventType: 'device.failure_confirmed' | 'device.replaced' | 'device.false_alarm';
   outcome: 'failure_confirmed' | 'replaced' | 'false_alarm';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -134,6 +145,7 @@ export async function emitDeviceReliabilityFeedback(options: {
     sourceType: 'device',
     sourceId: options.deviceId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},
@@ -147,6 +159,7 @@ export async function emitTicketTriageFeedback(options: {
   eventType: 'ticket.category_changed' | 'ticket.priority_changed' | 'ticket.assignee_changed' | 'ticket.triage_rejected' | 'ticket.resolved' | 'ticket.reopened';
   outcome: 'category_changed' | 'priority_changed' | 'assignee_changed' | 'rejected' | 'resolved' | 'reopened';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -155,6 +168,7 @@ export async function emitTicketTriageFeedback(options: {
     sourceType: 'ticket',
     sourceId: options.ticketId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},
@@ -168,6 +182,7 @@ export async function emitUserRiskFeedback(options: {
   eventType: 'user_risk.true_positive' | 'user_risk.false_positive' | 'training.assigned' | 'training.completed';
   outcome: 'true_positive' | 'false_positive' | 'assigned' | 'completed';
   actorUserId?: string | null;
+  dedupeKey?: string | null;
   occurredAt?: Date;
   metadata?: Record<string, unknown>;
 }): Promise<void> {
@@ -176,6 +191,7 @@ export async function emitUserRiskFeedback(options: {
     sourceType: 'user_risk',
     sourceId: options.userId,
     eventType: options.eventType,
+    dedupeKey: options.dedupeKey ?? undefined,
     outcome: options.outcome,
     actorUserId: actorUserIdOrNull(options.actorUserId),
     metadata: options.metadata ?? {},

--- a/packages/shared/src/validators/mlFeedback.test.ts
+++ b/packages/shared/src/validators/mlFeedback.test.ts
@@ -56,11 +56,17 @@ describe('mlFeedbackEventSchema', () => {
       sourceId: 'ticket-1',
       eventType: 'ticket.triage_rejected',
       outcome: 'rejected',
+      dedupeKey: 'suggestion:ticket-triage-rules-v0:high:hardware',
       metadata: { modelVersion: 'ticket-triage-rules-v0' },
     });
 
     expect(parsed.sourceType).toBe('ticket');
     expect(parsed.eventType).toBe('ticket.triage_rejected');
+    expect(parsed.dedupeKey).toBe('suggestion:ticket-triage-rules-v0:high:hardware');
+  });
+
+  it('rejects empty semantic dedupe keys', () => {
+    expect(() => mlFeedbackEventSchema.parse({ ...validEvent, dedupeKey: '' })).toThrow();
   });
 
   it('rejects metadata over the byte cap', () => {

--- a/packages/shared/src/validators/mlFeedback.ts
+++ b/packages/shared/src/validators/mlFeedback.ts
@@ -99,6 +99,7 @@ export const mlFeedbackEventSchema = z.object({
   sourceType: z.enum(ML_FEEDBACK_SOURCE_TYPES),
   sourceId: z.string().min(1).max(255),
   eventType: z.enum(ML_FEEDBACK_EVENT_TYPES),
+  dedupeKey: z.string().trim().min(1).max(255).nullable().optional(),
   actorUserId: z.string().uuid().nullable().optional(),
   outcome: z.enum(ML_FEEDBACK_OUTCOMES),
   confidence: z.number().min(0).max(1).nullable().optional(),


### PR DESCRIPTION
## Summary

- Add optional semantic `dedupeKey` support to canonical ML feedback events.
- Back it with a partial unique index on `(org_id, source_type, source_id, event_type, dedupe_key)` when `dedupe_key` is present.
- Thread dedupe keys through ML feedback emitters and use stable keys for user-risk training/review feedback and ticket triage rejection feedback.

## Why

The existing canonical feedback service deduped exact timestamp replays, but route retries that generated a fresh `occurredAt` could still create duplicate labels. Those duplicates would skew downstream ML evaluation metrics.

## Validation

- `pnpm --filter @breeze/shared exec vitest run src/validators/mlFeedback.test.ts`
- `pnpm --filter @breeze/api exec vitest run src/services/mlFeedback.test.ts src/routes/userRisk.test.ts src/routes/tickets/tickets.test.ts`
- `pnpm --filter @breeze/api lint`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- Disposable DB migration + `pnpm --filter @breeze/api db:check-drift`

Note: `pnpm --filter @breeze/shared exec tsc --noEmit -p tsconfig.json` currently fails on unrelated `src/validators/ticketConfig.test.ts(105,28): Object is possibly 'undefined'`.
