### PR TITLE
fix(ml): dedupe remaining feedback callers

### DIFF
--- a/apps/api/src/routes/reliability.test.ts
+++ b/apps/api/src/routes/reliability.test.ts
@@ -322,12 +322,50 @@ describe('public reliability routes', () => {
         orgId: ORG_ID,
         deviceId: DEVICE_ID,
         eventType: 'device.false_alarm',
+        dedupeKey: 'outcome:false_alarm',
         outcome: 'false_alarm',
         actorUserId: 'user-1',
         metadata: expect.objectContaining({
           note: 'Known maintenance window',
           reliabilityScore: 42,
         }),
+      }));
+    });
+
+    it('uses sourceEventId as the reliability feedback replay key when provided', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+        id: DEVICE_ID,
+        orgId: ORG_ID,
+        siteId: 'site-1',
+      } as any);
+      vi.mocked(getDeviceReliability).mockResolvedValue({
+        deviceId: DEVICE_ID,
+        orgId: ORG_ID,
+        reliabilityScore: 42,
+        trendDirection: 'degrading',
+        trendConfidence: 0.8,
+        uptime30d: 96,
+        crashCount30d: 3,
+        hangCount30d: 0,
+        serviceFailureCount30d: 0,
+        hardwareErrorCount30d: 1,
+        mtbfHours: 120,
+        topIssues: [],
+        computedAt: '2026-06-18T12:00:00.000Z',
+      } as any);
+
+      const sourceEventId = '00000000-0000-0000-0000-000000000030';
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ outcome: 'failure_confirmed', sourceEventId }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(vi.mocked(emitDeviceReliabilityFeedback)).toHaveBeenCalledWith(expect.objectContaining({
+        eventType: 'device.failure_confirmed',
+        dedupeKey: `source:${sourceEventId}:failure_confirmed`,
       }));
     });
 

--- a/apps/api/src/routes/reliability.ts
+++ b/apps/api/src/routes/reliability.ts
@@ -49,6 +49,7 @@ const evaluationQuerySchema = z.object({
 const feedbackBodySchema = z.object({
   outcome: z.enum(['failure_confirmed', 'replaced', 'false_alarm']),
   occurredAt: z.coerce.date().optional(),
+  sourceEventId: z.string().uuid().optional(),
   metadata: z.record(z.string(), z.unknown()).default({}),
 });
 
@@ -267,6 +268,7 @@ reliabilityRoutes.post(
       orgId: device.orgId,
       deviceId,
       eventType,
+      dedupeKey: body.sourceEventId ? `source:${body.sourceEventId}:${body.outcome}` : `outcome:${body.outcome}`,
       outcome: body.outcome,
       actorUserId: auth.user?.id,
       occurredAt: body.occurredAt,

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -5,12 +5,13 @@ const valuesMock = vi.fn();
 const setMock = vi.fn();
 const whereMock = vi.fn();
 
-const { emitMock, auditMock, allocateMock, dbMocks, configMocks } = vi.hoisted(() => {
+const { emitMock, emitTriageFeedbackMock, auditMock, allocateMock, dbMocks, configMocks } = vi.hoisted(() => {
   const insertReturning = vi.fn();
   const updateReturning = vi.fn();
   const selectResult = vi.fn();
   return {
     emitMock: vi.fn().mockResolvedValue(undefined),
+    emitTriageFeedbackMock: vi.fn().mockResolvedValue(undefined),
     auditMock: vi.fn().mockResolvedValue(undefined),
     allocateMock: vi.fn().mockResolvedValue('T-2026-0042'),
     dbMocks: { insertReturning, updateReturning, selectResult },
@@ -24,6 +25,7 @@ const { emitMock, auditMock, allocateMock, dbMocks, configMocks } = vi.hoisted((
 });
 
 vi.mock('./ticketEvents', () => ({ emitTicketEvent: emitMock }));
+vi.mock('./mlFeedbackEmitters', () => ({ emitTicketTriageFeedback: emitTriageFeedbackMock }));
 vi.mock('./auditService', () => ({ createAuditLogAsync: auditMock }));
 vi.mock('./ticketNumbers', () => ({ allocateInternalTicketNumber: allocateMock }));
 vi.mock('./ticketConfigService', () => ({
@@ -505,6 +507,10 @@ describe('assignTicket', () => {
       type: 'ticket.assigned',
       payload: expect.objectContaining({ assigneeId: 'u-2' })
     }));
+    expect(emitTriageFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'ticket.assignee_changed',
+      dedupeKey: 'assignedTo:null:"u-2"',
+    }));
   });
 
   it('throws 409 on concurrent modification and does NOT write a feed entry or emit', async () => {
@@ -821,6 +827,10 @@ describe('updateTicketFields', () => {
       partnerId: 'p-1',
       actorUserId: 'u-1',
       payload: { changed: ['subject', 'priority'] }
+    }));
+    expect(emitTriageFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'ticket.priority_changed',
+      dedupeKey: 'priority:"normal":"high"',
     }));
     expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
       orgId: 'o-1',

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -537,6 +537,10 @@ function ticketTriageFeedbackMetadata(actor: TicketActor, extra: Record<string, 
   };
 }
 
+function ticketTriageDedupeKey(field: string, oldValue: unknown, newValue: unknown): string {
+  return `${field}:${JSON.stringify(oldValue ?? null)}:${JSON.stringify(newValue ?? null)}`;
+}
+
 export async function updateTicketFields(
   ticketId: string,
   fields: UpdateTicketFieldsInput,
@@ -622,6 +626,7 @@ export async function updateTicketFields(
       orgId: ticket.orgId,
       ticketId,
       eventType: 'ticket.category_changed',
+      dedupeKey: ticketTriageDedupeKey('categoryId', ticket.categoryId ?? null, updated[0]?.categoryId ?? null),
       outcome: 'category_changed',
       actorUserId: actor.userId,
       metadata: ticketTriageFeedbackMetadata(actor, {
@@ -635,6 +640,7 @@ export async function updateTicketFields(
       orgId: ticket.orgId,
       ticketId,
       eventType: 'ticket.priority_changed',
+      dedupeKey: ticketTriageDedupeKey('priority', ticket.priority, updated[0]?.priority ?? null),
       outcome: 'priority_changed',
       actorUserId: actor.userId,
       metadata: ticketTriageFeedbackMetadata(actor, {
@@ -704,6 +710,7 @@ export async function assignTicket(ticketId: string, assigneeId: string | null, 
     orgId: ticket.orgId,
     ticketId,
     eventType: 'ticket.assignee_changed',
+    dedupeKey: ticketTriageDedupeKey('assignedTo', prevAssignedTo ?? null, assigneeId),
     outcome: 'assignee_changed',
     actorUserId: actor.userId,
     metadata: ticketTriageFeedbackMetadata(actor, {


### PR DESCRIPTION
## Summary

- Add semantic feedback dedupe keys for ticket category/priority/assignee labels emitted from `ticketService`.
- Add reliability feedback replay keys, including an optional `sourceEventId` for event-backed labels.
- Cover the new keys in focused ticket service and reliability route tests.

## Why

PR #1542 introduced canonical semantic dedupe support and PR #1543 wired the main route callers. Ticket service field-change labels and reliability feedback were the remaining launched feedback producers that could still retry with a fresh `occurredAt` and double-count evaluation labels.

## Validation

- `pnpm --filter @breeze/api exec vitest run src/services/ticketService.test.ts src/routes/reliability.test.ts src/services/mlFeedback.test.ts`
- `pnpm --filter @breeze/api exec vitest run src/routes/reliability.test.ts src/services/ticketService.test.ts`
- `pnpm --filter @breeze/api lint`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
