### PR TITLE
fix(ml): gate reliability scoring outputs

### DIFF
--- a/apps/api/src/services/mlFeatureFlags.integration-notes.md
+++ b/apps/api/src/services/mlFeatureFlags.integration-notes.md
@@ -22,6 +22,7 @@ Future producers should gate the write-producing step, not just UI reads:
 - RCA generation: `ml.rca.enabled`
 - Remediation suggestions: `ml.remediation_suggestions.enabled`
 - Ticket triage suggestions: `ml.ticket_triage.enabled`
+- Device reliability scoring: `ml.device_reliability.enabled`
 - Existing user-risk rules: `ml.user_risk_v0.enabled`
 - Learned user-risk baseline: `ml.user_risk_v1.enabled`
 

--- a/apps/api/src/services/mlFeatureFlags.test.ts
+++ b/apps/api/src/services/mlFeatureFlags.test.ts
@@ -60,6 +60,7 @@ describe('mlFeatureFlags', () => {
     delete process.env.ML_DISABLED_FLAGS;
     delete process.env.ML_RCA_DISABLED;
     delete process.env.ML_ALERT_CORRELATION_DISABLED;
+    delete process.env.ML_DEVICE_RELIABILITY_DISABLED;
   });
 
   afterEach(() => {
@@ -83,6 +84,7 @@ describe('mlFeatureFlags', () => {
       partnerType: 'internal',
     })).toBe(true);
     expect(defaultMlFeatureFlagValue('ml.metric_rollups.enabled', { nodeEnv: 'production' })).toBe(true);
+    expect(defaultMlFeatureFlagValue('ml.device_reliability.enabled', { nodeEnv: 'production' })).toBe(true);
     expect(defaultMlFeatureFlagValue('ml.user_risk_v0.enabled', { nodeEnv: 'production' })).toBe(true);
     expect(defaultMlFeatureFlagValue('ml.rca.enabled', { nodeEnv: 'production' })).toBe(false);
   });
@@ -160,6 +162,14 @@ describe('mlFeatureFlags', () => {
       orgSettings: { mlFeatureFlags: { 'ml.anomalies.enabled': true } },
     })).toMatchObject({
       enabled: false,
+      source: 'global_kill_switch',
+    });
+
+    process.env.ML_DISABLED_FLAGS = '';
+    process.env.ML_DEVICE_RELIABILITY_DISABLED = 'true';
+    expect(resolveMlFeatureFlag('ml.device_reliability.enabled')).toMatchObject({
+      enabled: false,
+      defaultEnabled: true,
       source: 'global_kill_switch',
     });
   });

--- a/apps/api/src/services/mlFeatureFlags.ts
+++ b/apps/api/src/services/mlFeatureFlags.ts
@@ -11,6 +11,7 @@ export const ML_FEATURE_FLAGS = [
   'ml.anomalies.create_alerts',
   'ml.remediation_suggestions.enabled',
   'ml.ticket_triage.enabled',
+  'ml.device_reliability.enabled',
   'ml.user_risk_v0.enabled',
   'ml.user_risk_v1.enabled',
 ] as const;
@@ -101,7 +102,11 @@ export function defaultMlFeatureFlagValue(
 ): boolean {
   assertMlFeatureFlagName(flag);
 
-  if (flag === 'ml.metric_rollups.enabled' || flag === 'ml.user_risk_v0.enabled') {
+  if (
+    flag === 'ml.metric_rollups.enabled'
+    || flag === 'ml.device_reliability.enabled'
+    || flag === 'ml.user_risk_v0.enabled'
+  ) {
     return true;
   }
 

--- a/apps/api/src/services/reliabilityScoring.featureFlag.test.ts
+++ b/apps/api/src/services/reliabilityScoring.featureFlag.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const limit = vi.fn();
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+
+  return {
+    dbSelect: vi.fn(() => ({ from })),
+    dbInsert: vi.fn(),
+    from,
+    limit,
+    shouldProduceMlOutput: vi.fn(),
+    where,
+  };
+});
+
+vi.mock('../db', () => ({
+  db: {
+    select: mocks.dbSelect,
+    insert: mocks.dbInsert,
+  },
+}));
+
+vi.mock('./mlFeatureFlags', () => ({
+  shouldProduceMlOutput: mocks.shouldProduceMlOutput,
+}));
+
+import {
+  computeAndPersistDeviceReliability,
+  computeAndPersistOrgReliability,
+} from './reliabilityScoring';
+
+describe('reliability scoring feature flag gates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips device reliability writes when the org flag is disabled', async () => {
+    mocks.limit.mockResolvedValueOnce([{ id: 'device-1', orgId: 'org-1' }]);
+    mocks.shouldProduceMlOutput.mockResolvedValueOnce(false);
+
+    await expect(computeAndPersistDeviceReliability('device-1')).resolves.toBe(false);
+
+    expect(mocks.shouldProduceMlOutput).toHaveBeenCalledWith('org-1', 'ml.device_reliability.enabled');
+    expect(mocks.dbSelect).toHaveBeenCalledTimes(1);
+    expect(mocks.dbInsert).not.toHaveBeenCalled();
+  });
+
+  it('skips org reliability scans before selecting devices when the org flag is disabled', async () => {
+    mocks.shouldProduceMlOutput.mockResolvedValueOnce(false);
+
+    await expect(computeAndPersistOrgReliability('org-1')).resolves.toEqual({
+      orgId: 'org-1',
+      devicesComputed: 0,
+    });
+
+    expect(mocks.shouldProduceMlOutput).toHaveBeenCalledWith('org-1', 'ml.device_reliability.enabled');
+    expect(mocks.dbSelect).not.toHaveBeenCalled();
+    expect(mocks.dbInsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -8,6 +8,7 @@ import {
   mlFeedbackEvents,
   type ReliabilityTopIssue,
 } from '../db/schema';
+import { shouldProduceMlOutput } from './mlFeatureFlags';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RELIABILITY_FACTOR_WEIGHTS = {
@@ -797,6 +798,9 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
     .limit(1);
 
   if (!device) return false;
+  if (!(await shouldProduceMlOutput(device.orgId, 'ml.device_reliability.enabled'))) {
+    return false;
+  }
 
   const now = new Date();
   const lookbackStart = getSince(90);
@@ -1005,6 +1009,10 @@ async function runConcurrently<T>(
 }
 
 export async function computeAndPersistOrgReliability(orgId: string): Promise<{ orgId: string; devicesComputed: number }> {
+  if (!(await shouldProduceMlOutput(orgId, 'ml.device_reliability.enabled'))) {
+    return { orgId, devicesComputed: 0 };
+  }
+
   const orgDevices = await db
     .select({ id: devices.id })
     .from(devices)

--- a/apps/web/src/hooks/useMlFeatureFlags.ts
+++ b/apps/web/src/hooks/useMlFeatureFlags.ts
@@ -9,6 +9,7 @@ export type MlFeatureFlagName =
   | 'ml.anomalies.create_alerts'
   | 'ml.remediation_suggestions.enabled'
   | 'ml.ticket_triage.enabled'
+  | 'ml.device_reliability.enabled'
   | 'ml.user_risk_v0.enabled'
   | 'ml.user_risk_v1.enabled';
 


### PR DESCRIPTION
## Summary
- add `ml.device_reliability.enabled` to the typed ML feature-flag surface
- default reliability scoring on to preserve current behavior while supporting org/global kill switches
- stop device/org reliability scoring before writes when the flag is disabled

## Tests
- `pnpm --filter @breeze/api exec vitest run src/services/mlFeatureFlags.test.ts src/services/reliabilityScoring.featureFlag.test.ts src/routes/config.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`