### PR TITLE
fix(ml): emit alert feedback from alternate action callers

### DIFF
--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { mobileRoutes } from './mobile';
 
-const { publishEventMock, setCooldownMock, rateLimitState, authState } = vi.hoisted(() => ({
+const { publishEventMock, setCooldownMock, emitAlertStateFeedbackMock, rateLimitState, authState } = vi.hoisted(() => ({
   publishEventMock: vi.fn().mockResolvedValue('event-1'),
   setCooldownMock: vi.fn().mockResolvedValue(undefined),
+  emitAlertStateFeedbackMock: vi.fn().mockResolvedValue(undefined),
   rateLimitState: { allowed: true },
   authState: { permissions: undefined as { allowedSiteIds?: string[] } | undefined }
 }));
@@ -61,6 +62,10 @@ vi.mock('../services/eventBus', () => ({
 
 vi.mock('../services/alertCooldown', () => ({
   setCooldown: setCooldownMock
+}));
+
+vi.mock('../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: emitAlertStateFeedbackMock
 }));
 
 vi.mock('../middleware/userRateLimit', () => ({
@@ -609,6 +614,7 @@ describe('mobile routes', () => {
       });
 
       expect(res.status).toBe(404);
+      expect(emitAlertStateFeedbackMock).not.toHaveBeenCalled();
     });
 
     it('should reject non-active alerts', async () => {
@@ -623,12 +629,13 @@ describe('mobile routes', () => {
       });
 
       expect(res.status).toBe(400);
+      expect(emitAlertStateFeedbackMock).not.toHaveBeenCalled();
     });
 
-    it('should acknowledge active alert', async () => {
+    it('should acknowledge active alert and emit feedback', async () => {
       vi.mocked(db.select).mockReturnValue(
         mockSelectLimitChain([
-          { id: 'alert-1', status: 'active', orgId: 'org-123' }
+          { id: 'alert-1', status: 'active', orgId: 'org-123', ruleId: 'rule-1', deviceId: 'device-1' }
         ]) as any
       );
       vi.mocked(db.update).mockReturnValue(
@@ -644,6 +651,17 @@ describe('mobile routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.status).toBe('acknowledged');
+      expect(emitAlertStateFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+        orgId: 'org-123',
+        alertId: 'alert-1',
+        eventType: 'alert.acknowledged',
+        outcome: 'acknowledged',
+        actorUserId: 'user-123',
+        metadata: {
+          source: 'mobile.alerts',
+          previousStatus: 'active',
+        },
+      }));
     });
   });
 
@@ -658,6 +676,7 @@ describe('mobile routes', () => {
       });
 
       expect(res.status).toBe(404);
+      expect(emitAlertStateFeedbackMock).not.toHaveBeenCalled();
     });
 
     it('should reject already resolved alerts', async () => {
@@ -674,9 +693,10 @@ describe('mobile routes', () => {
       });
 
       expect(res.status).toBe(400);
+      expect(emitAlertStateFeedbackMock).not.toHaveBeenCalled();
     });
 
-    it('should resolve alert with note', async () => {
+    it('should resolve alert with note and emit feedback', async () => {
       vi.mocked(db.select).mockReturnValue(
         mockSelectLimitChain([
           { id: 'alert-1', status: 'acknowledged', orgId: 'org-123' }
@@ -697,6 +717,18 @@ describe('mobile routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.status).toBe('resolved');
+      expect(emitAlertStateFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+        orgId: 'org-123',
+        alertId: 'alert-1',
+        eventType: 'alert.resolved',
+        outcome: 'resolved',
+        actorUserId: 'user-123',
+        metadata: {
+          source: 'mobile.alerts',
+          previousStatus: 'acknowledged',
+          hasResolutionNote: true,
+        },
+      }));
     });
   });
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -24,6 +24,7 @@ import { publishEvent } from '../services/eventBus';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { dispatchWake } from '../services/wakeOnLan';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
+import { emitAlertStateFeedback } from '../services/mlFeedbackEmitters';
 
 export const mobileRoutes = new Hono();
 const requireMobileAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
@@ -670,11 +671,12 @@ mobileRoutes.post(
       return c.json({ error: `Cannot acknowledge alert with status: ${alert.status}` }, 400);
     }
 
+    const acknowledgedAt = new Date();
     const [updated] = await db
       .update(alerts)
       .set({
         status: 'acknowledged',
-        acknowledgedAt: new Date(),
+        acknowledgedAt,
         acknowledgedBy: auth.user.id
       })
       .where(eq(alerts.id, alertId))
@@ -696,6 +698,19 @@ mobileRoutes.post(
     } catch (error) {
       console.error('[MobileRoutes] Failed to publish alert.acknowledged event:', error);
     }
+
+    await emitAlertStateFeedback({
+      orgId: alert.orgId,
+      alertId: updated?.id ?? alertId,
+      eventType: 'alert.acknowledged',
+      outcome: 'acknowledged',
+      actorUserId: auth.user.id,
+      occurredAt: acknowledgedAt,
+      metadata: {
+        source: 'mobile.alerts',
+        previousStatus: alert.status,
+      },
+    });
 
     writeRouteAudit(c, {
       orgId: alert.orgId,
@@ -729,11 +744,12 @@ mobileRoutes.post(
       return c.json({ error: 'Alert is already resolved' }, 400);
     }
 
+    const resolvedAt = new Date();
     const [updated] = await db
       .update(alerts)
       .set({
         status: 'resolved',
-        resolvedAt: new Date(),
+        resolvedAt,
         resolvedBy: auth.user.id,
         resolutionNote: data.note
       })
@@ -786,6 +802,20 @@ mobileRoutes.post(
     } catch (error) {
       console.error('[MobileRoutes] Failed to publish alert.resolved event:', error);
     }
+
+    await emitAlertStateFeedback({
+      orgId: alert.orgId,
+      alertId: updated?.id ?? alertId,
+      eventType: 'alert.resolved',
+      outcome: 'resolved',
+      actorUserId: auth.user.id,
+      occurredAt: resolvedAt,
+      metadata: {
+        source: 'mobile.alerts',
+        previousStatus: alert.status,
+        hasResolutionNote: Boolean(data.note),
+      },
+    });
 
     writeRouteAudit(c, {
       orgId: alert.orgId,

--- a/apps/api/src/services/aiToolsAlerts.feedback.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.feedback.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dbSelect: vi.fn(),
+  dbUpdate: vi.fn(),
+  emitAlertStateFeedback: vi.fn().mockResolvedValue(undefined),
+  publishEvent: vi.fn().mockResolvedValue('event-1'),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: mocks.dbSelect,
+    update: mocks.dbUpdate,
+  },
+}));
+
+vi.mock('./eventBus', () => ({
+  publishEvent: mocks.publishEvent,
+}));
+
+vi.mock('./mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: mocks.emitAlertStateFeedback,
+}));
+
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { registerAlertTools } from './aiToolsAlerts';
+
+const ALERT = {
+  id: 'alert-1',
+  orgId: 'org-1',
+  ruleId: 'rule-1',
+  deviceId: 'device-1',
+  status: 'active',
+  title: 'CPU hot',
+};
+
+function handlerFor(name: string): AiTool['handler'] {
+  const registry = new Map<string, AiTool>();
+  registerAlertTools(registry);
+  return registry.get(name)!.handler;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: '11111111-1111-4111-8111-111111111111', email: 'user@example.com', name: 'User', isPlatformAdmin: false },
+    token: {} as never,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: (orgId) => orgId === 'org-1',
+  };
+}
+
+function mockAlertLookup(row: unknown | null) {
+  mocks.dbSelect.mockReturnValueOnce({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn().mockResolvedValue(row ? [row] : []),
+      })),
+    })),
+  });
+}
+
+function mockUpdate() {
+  mocks.dbUpdate.mockReturnValueOnce({
+    set: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue(undefined),
+    })),
+  });
+}
+
+describe('manage_alerts feedback emission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('acknowledge emits alert state feedback with actor and previous status', async () => {
+    mockAlertLookup(ALERT);
+    mockUpdate();
+
+    const result = JSON.parse(await handlerFor('manage_alerts')(
+      { action: 'acknowledge', alertId: ALERT.id },
+      makeAuth()
+    ));
+
+    expect(result.success).toBe(true);
+    expect(mocks.emitAlertStateFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ALERT.orgId,
+      alertId: ALERT.id,
+      eventType: 'alert.acknowledged',
+      outcome: 'acknowledged',
+      actorUserId: '11111111-1111-4111-8111-111111111111',
+      metadata: {
+        source: 'ai_tools.manage_alerts',
+        previousStatus: 'active',
+      },
+    }));
+  });
+
+  it('resolve emits alert state feedback with note metadata', async () => {
+    mockAlertLookup({ ...ALERT, status: 'acknowledged' });
+    mockUpdate();
+
+    const result = JSON.parse(await handlerFor('manage_alerts')(
+      { action: 'resolve', alertId: ALERT.id, resolutionNote: 'fixed' },
+      makeAuth()
+    ));
+
+    expect(result.success).toBe(true);
+    expect(mocks.emitAlertStateFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ALERT.orgId,
+      alertId: ALERT.id,
+      eventType: 'alert.resolved',
+      outcome: 'resolved',
+      actorUserId: '11111111-1111-4111-8111-111111111111',
+      metadata: {
+        source: 'ai_tools.manage_alerts',
+        previousStatus: 'acknowledged',
+        hasResolutionNote: true,
+      },
+    }));
+  });
+
+  it('suppress emits alert state feedback with stable suppression dedupe key', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T10:00:00.000Z'));
+    try {
+      mockAlertLookup(ALERT);
+      mockUpdate();
+
+      const result = JSON.parse(await handlerFor('manage_alerts')(
+        { action: 'suppress', alertId: ALERT.id, suppressDuration: 2 },
+        makeAuth()
+      ));
+
+      expect(result.success).toBe(true);
+      expect(mocks.emitAlertStateFeedback).toHaveBeenCalledWith(expect.objectContaining({
+        orgId: ALERT.orgId,
+        alertId: ALERT.id,
+        eventType: 'alert.suppressed',
+        dedupeKey: 'suppress:2026-06-18T12:00:00.000Z',
+        outcome: 'suppressed',
+        actorUserId: '11111111-1111-4111-8111-111111111111',
+        metadata: {
+          source: 'ai_tools.manage_alerts',
+          previousStatus: 'active',
+          suppressedUntil: '2026-06-18T12:00:00.000Z',
+          durationHours: 2,
+        },
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not emit feedback when the alert is missing', async () => {
+    mockAlertLookup(null);
+
+    const result = JSON.parse(await handlerFor('manage_alerts')(
+      { action: 'acknowledge', alertId: ALERT.id },
+      makeAuth()
+    ));
+
+    expect(result.error).toContain('not found');
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(mocks.emitAlertStateFeedback).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -13,6 +13,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
 import { deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { emitAlertStateFeedback } from './mlFeedbackEmitters';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -138,11 +139,12 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         const alert = await findAlertWithAccess(input.alertId as string, auth);
         if (!alert) return JSON.stringify({ error: 'Alert not found or access denied' });
 
+        const acknowledgedAt = new Date();
         await db
           .update(alerts)
           .set({
             status: 'acknowledged',
-            acknowledgedAt: new Date(),
+            acknowledgedAt,
             acknowledgedBy: auth.user.id
           })
           .where(eq(alerts.id, input.alertId as string));
@@ -166,6 +168,19 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
           eventWarning = 'Alert was acknowledged but event notification may be delayed';
         }
 
+        await emitAlertStateFeedback({
+          orgId: alert.orgId,
+          alertId: alert.id,
+          eventType: 'alert.acknowledged',
+          outcome: 'acknowledged',
+          actorUserId: auth.user.id,
+          occurredAt: acknowledgedAt,
+          metadata: {
+            source: 'ai_tools.manage_alerts',
+            previousStatus: alert.status,
+          },
+        });
+
         return JSON.stringify({ success: true, message: `Alert "${alert.title}" acknowledged`, warning: eventWarning });
       }
 
@@ -175,13 +190,15 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         const alert = await findAlertWithAccess(input.alertId as string, auth);
         if (!alert) return JSON.stringify({ error: 'Alert not found or access denied' });
 
+        const resolvedAt = new Date();
+        const resolutionNote = (input.resolutionNote as string) ?? 'Resolved via AI assistant';
         await db
           .update(alerts)
           .set({
             status: 'resolved',
-            resolvedAt: new Date(),
+            resolvedAt,
             resolvedBy: auth.user.id,
-            resolutionNote: (input.resolutionNote as string) ?? 'Resolved via AI assistant'
+            resolutionNote
           })
           .where(eq(alerts.id, input.alertId as string));
 
@@ -195,7 +212,7 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
               ruleId: alert.ruleId,
               deviceId: alert.deviceId,
               resolvedBy: auth.user.id,
-              resolutionNote: (input.resolutionNote as string) ?? 'Resolved via AI assistant'
+              resolutionNote
             },
             'ai-tools',
             { userId: auth.user.id }
@@ -204,6 +221,20 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
           console.error('[AiTools] Failed to publish alert.resolved event:', error);
           resolveEventWarning = 'Alert was resolved but event notification may be delayed';
         }
+
+        await emitAlertStateFeedback({
+          orgId: alert.orgId,
+          alertId: alert.id,
+          eventType: 'alert.resolved',
+          outcome: 'resolved',
+          actorUserId: auth.user.id,
+          occurredAt: resolvedAt,
+          metadata: {
+            source: 'ai_tools.manage_alerts',
+            previousStatus: alert.status,
+            hasResolutionNote: Boolean(input.resolutionNote),
+          },
+        });
 
         return JSON.stringify({ success: true, message: `Alert "${alert.title}" resolved`, warning: resolveEventWarning });
       }
@@ -216,13 +247,15 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
 
         const durationHours = Math.min(Math.max(1, Number(input.suppressDuration) || 24), 720);
         const suppressedUntil = new Date(Date.now() + durationHours * 60 * 60 * 1000);
+        const occurredAt = new Date();
+        const resolutionNote = (input.resolutionNote as string) ?? `Suppressed for ${durationHours}h via AI assistant`;
 
         await db
           .update(alerts)
           .set({
             status: 'suppressed',
             suppressedUntil,
-            resolutionNote: (input.resolutionNote as string) ?? `Suppressed for ${durationHours}h via AI assistant`
+            resolutionNote
           })
           .where(eq(alerts.id, input.alertId as string));
 
@@ -246,6 +279,22 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
           console.error('[AiTools] Failed to publish alert.suppressed event:', error);
           suppressEventWarning = 'Alert was suppressed but event notification may be delayed';
         }
+
+        await emitAlertStateFeedback({
+          orgId: alert.orgId,
+          alertId: alert.id,
+          eventType: 'alert.suppressed',
+          dedupeKey: `suppress:${suppressedUntil.toISOString()}`,
+          outcome: 'suppressed',
+          actorUserId: auth.user.id,
+          occurredAt,
+          metadata: {
+            source: 'ai_tools.manage_alerts',
+            previousStatus: alert.status,
+            suppressedUntil: suppressedUntil.toISOString(),
+            durationHours,
+          },
+        });
 
         return JSON.stringify({
           success: true,


### PR DESCRIPTION
## Summary
- emit alert state feedback from AI `manage_alerts` acknowledge/resolve/suppress actions
- emit alert state feedback from mobile acknowledge/resolve alert actions
- cover success and no-emission failure paths for AI/mobile callers

## Tests
- `pnpm --filter @breeze/api exec vitest run src/services/aiToolsAlerts.feedback.test.ts src/services/aiToolsAlerts.siteScope.test.ts src/routes/mobile.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`