### PR TITLE
feat(ml): capture correlation correction feedback

### DIFF
--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -596,6 +596,125 @@ describe('/alerts correlation routes', () => {
     }));
   });
 
+  it('records split correction feedback for a visible persisted correlation group', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'correlation.split',
+        outcome: 'split',
+        alertIds: [ALERT_2, ALERT_1],
+        note: 'These alerts are unrelated.',
+        metadata: { surface: 'test' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(emitCorrelationFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_1,
+      correlationId: GROUP_1,
+      eventType: 'correlation.split',
+      dedupeKey: `split:${[ALERT_1, ALERT_2].sort().join(',')}`,
+      outcome: 'split',
+      actorUserId: '99999999-9999-4999-8999-999999999999',
+      metadata: expect.objectContaining({
+        groupId: GROUP_1,
+        rootAlertId: ALERT_1,
+        alertIds: [ALERT_2, ALERT_1],
+        note: 'These alerts are unrelated.',
+        surface: 'test',
+      }),
+    }));
+  });
+
+  it('records dismissed and merged correction feedback with stable replay keys', async () => {
+    seedPersistedGroup();
+    const targetGroupId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+    const dismissed = await makeApp().request(`/alerts/correlations/${GROUP_1}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'correlation.dismissed',
+        outcome: 'dismissed',
+      }),
+    });
+    expect(dismissed.status).toBe(200);
+
+    const merged = await makeApp().request(`/alerts/correlations/${GROUP_1}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'correlation.merged',
+        outcome: 'merged',
+        targetGroupId,
+      }),
+    });
+    expect(merged.status).toBe(200);
+
+    expect(emitCorrelationFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'correlation.dismissed',
+      dedupeKey: 'correction:dismissed',
+      outcome: 'dismissed',
+    }));
+    expect(emitCorrelationFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'correlation.merged',
+      dedupeKey: `merge:${targetGroupId}`,
+      outcome: 'merged',
+      metadata: expect.objectContaining({ targetGroupId }),
+    }));
+  });
+
+  it('rejects invalid correlation correction feedback', async () => {
+    seedPersistedGroup();
+
+    const badOutcome = await makeApp().request(`/alerts/correlations/${GROUP_1}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'correlation.split',
+        outcome: 'dismissed',
+      }),
+    });
+    expect(badOutcome.status).toBe(400);
+
+    const missingMergeTarget = await makeApp().request(`/alerts/correlations/${GROUP_1}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'correlation.merged',
+        outcome: 'merged',
+      }),
+    });
+    expect(missingMergeTarget.status).toBe(400);
+
+    expect(emitCorrelationFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('does not record correction feedback for an inaccessible correlation group', async () => {
+    seedPersistedGroup();
+    authRef.current = {
+      ...authRef.current,
+      orgId: ORG_2,
+      canAccessOrg: (orgId: string) => orgId === ORG_2,
+    };
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'correlation.dismissed',
+        outcome: 'dismissed',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(emitCorrelationFeedbackMock).not.toHaveBeenCalled();
+  });
+
   it('rejects inconsistent RCA feedback event/outcome pairs', async () => {
     seedPersistedGroup();
 

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -38,6 +38,30 @@ const rcaFeedbackSchema = z.object({
     });
   }
 });
+const correlationFeedbackSchema = z.object({
+  eventType: z.enum(['correlation.split', 'correlation.merged', 'correlation.dismissed']),
+  outcome: z.enum(['split', 'merged', 'dismissed']),
+  alertIds: z.array(z.string().uuid()).max(100).optional().default([]),
+  targetGroupId: z.string().uuid().optional(),
+  note: z.string().trim().max(1000).optional(),
+  metadata: z.record(z.unknown()).optional().default({}),
+}).superRefine((value, ctx) => {
+  const expectedOutcome = value.eventType.replace('correlation.', '') as typeof value.outcome;
+  if (value.outcome !== expectedOutcome) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'outcome must match eventType',
+      path: ['outcome'],
+    });
+  }
+  if (value.eventType === 'correlation.merged' && !value.targetGroupId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'targetGroupId is required for merge feedback',
+      path: ['targetGroupId'],
+    });
+  }
+});
 
 async function parseOptionalExplainBody(c: Context) {
   const contentType = c.req.header('content-type') ?? '';
@@ -355,6 +379,13 @@ function rcaFeedbackDedupeKey(
   return typeof metadata.editId === 'string' ? `edit:${metadata.editId}` : undefined;
 }
 
+function correlationFeedbackDedupeKey(body: z.infer<typeof correlationFeedbackSchema>): string {
+  if (body.eventType === 'correlation.dismissed') return 'correction:dismissed';
+  if (body.eventType === 'correlation.merged') return `merge:${body.targetGroupId}`;
+  const alertIds = [...body.alertIds].sort();
+  return alertIds.length > 0 ? `split:${alertIds.join(',')}` : 'split';
+}
+
 async function getCorrelationFeedbackCounts(auth: AuthContext, since: Date) {
   const feedbackOrgConditions = feedbackOrgConditionsForAuth(auth);
   if (feedbackOrgConditions === null) {
@@ -648,6 +679,55 @@ alertCorrelationRoutes.post(
     });
 
     return c.json({ rca, data: rca });
+  }
+);
+
+alertCorrelationRoutes.post(
+  '/correlations/:groupId/feedback',
+  requireScope('organization', 'partner', 'system'),
+  requireAlertRead,
+  zValidator('param', groupIdParamSchema),
+  zValidator('json', correlationFeedbackSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { groupId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const group = await getAccessiblePersistedGroup(groupId, auth);
+    if (!group) {
+      return c.json({ error: 'Correlation group not found' }, 404);
+    }
+
+    await emitCorrelationFeedback({
+      orgId: group.orgId,
+      correlationId: group.id,
+      eventType: body.eventType,
+      dedupeKey: correlationFeedbackDedupeKey(body),
+      outcome: body.outcome,
+      actorUserId: auth.user.id,
+      metadata: {
+        ...body.metadata,
+        groupId: group.id,
+        rootAlertId: group.rootAlertId,
+        alertIds: body.alertIds,
+        targetGroupId: body.targetGroupId ?? null,
+        note: body.note ?? null,
+      },
+    });
+
+    writeRouteAudit(c, {
+      orgId: group.orgId,
+      action: 'alert_correlation.feedback',
+      resourceType: 'alert_correlation',
+      resourceId: group.id,
+      details: {
+        eventType: body.eventType,
+        outcome: body.outcome,
+        alertIds: body.alertIds,
+        targetGroupId: body.targetGroupId ?? null,
+      },
+    });
+
+    return c.json({ success: true });
   }
 );
 

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -142,6 +142,9 @@ function mockGroupsResponse(options: { rcaEnabled?: boolean } = {}) {
     if (url === `/alerts/correlations/${GROUP_ID}/rca-feedback` && method === 'POST') {
       return Promise.resolve(makeJsonResponse({ success: true }));
     }
+    if (url === `/alerts/correlations/${GROUP_ID}/feedback` && method === 'POST') {
+      return Promise.resolve(makeJsonResponse({ success: true }));
+    }
     return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
   });
 }
@@ -229,6 +232,70 @@ describe('CorrelatedAlertGroups', () => {
         candidateCount: 1,
         evidenceCount: 1,
         gapCount: 1
+      })
+    }));
+  });
+
+  it('records correlation correction feedback from group controls', async () => {
+    mockGroupsResponse();
+
+    render(<CorrelatedAlertGroups />);
+
+    const groupTitle = (await screen.findAllByText('High CPU on SRV-01'))[0];
+    const section = groupTitle.closest('section')!;
+
+    fireEvent.click(within(section).getByRole('button', { name: /Mark wrong group/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/alerts/correlations/${GROUP_ID}/feedback`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('correlation.split')
+        })
+      );
+    });
+    const splitRequest = fetchMock.mock.calls.find(([url, init]) =>
+      url === `/alerts/correlations/${GROUP_ID}/feedback` &&
+      String(init?.body ?? '').includes('correlation.split')
+    );
+    expect(JSON.parse(String(splitRequest?.[1]?.body))).toEqual(expect.objectContaining({
+      eventType: 'correlation.split',
+      outcome: 'split',
+      alertIds: groupPayload.alerts.map((alert) => alert.id),
+      metadata: expect.objectContaining({
+        source: 'correlated_alert_groups_ui',
+        memberCount: 3,
+        correlationScore: 0.88,
+        noiseReductionPercent: 67
+      })
+    }));
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Marked group as incorrect' }));
+    });
+
+    fireEvent.click(within(section).getByRole('button', { name: /Dismiss grouping/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/alerts/correlations/${GROUP_ID}/feedback`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('correlation.dismissed')
+        })
+      );
+    });
+    const dismissedRequest = fetchMock.mock.calls.find(([url, init]) =>
+      url === `/alerts/correlations/${GROUP_ID}/feedback` &&
+      String(init?.body ?? '').includes('correlation.dismissed')
+    );
+    expect(JSON.parse(String(dismissedRequest?.[1]?.body))).toEqual(expect.objectContaining({
+      eventType: 'correlation.dismissed',
+      outcome: 'dismissed',
+      alertIds: [],
+      metadata: expect.objectContaining({
+        source: 'correlated_alert_groups_ui',
+        memberCount: 3
       })
     }));
   });

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -278,6 +278,37 @@ export default function CorrelatedAlertGroups() {
     }
   };
 
+  const sendCorrelationFeedback = async (group: AlertGroup, eventType: 'correlation.split' | 'correlation.dismissed') => {
+    const outcome = eventType.replace('correlation.', '') as 'split' | 'dismissed';
+    const isSplit = eventType === 'correlation.split';
+    setBusyGroupId(group.id);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/correlations/${group.id}/feedback`, {
+          method: 'POST',
+          body: JSON.stringify({
+            eventType,
+            outcome,
+            alertIds: isSplit ? group.alerts.map((alert) => alert.id) : [],
+            metadata: {
+              source: 'correlated_alert_groups_ui',
+              memberCount: group.memberCount ?? group.alerts.length,
+              correlationScore: group.correlationScore,
+              noiseReductionPercent: group.noiseReductionPercent ?? null,
+            }
+          })
+        }),
+        errorFallback: 'Failed to record correlation feedback',
+        successMessage: isSplit ? 'Marked group as incorrect' : 'Dismissed correlation group',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+    } catch (err) {
+      handleActionError(err, 'Failed to record correlation feedback');
+    } finally {
+      setBusyGroupId(null);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="rounded-lg border bg-card p-6 shadow-sm">
@@ -424,6 +455,24 @@ export default function CorrelatedAlertGroups() {
                       >
                         {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
                         Resolve group
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void sendCorrelationFeedback(group, 'correlation.split')}
+                        disabled={isBusy || isExplaining}
+                        className="inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                      >
+                        {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ThumbsDown className="h-3.5 w-3.5" />}
+                        Mark wrong group
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void sendCorrelationFeedback(group, 'correlation.dismissed')}
+                        disabled={isBusy || isExplaining}
+                        className="inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                      >
+                        {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
+                        Dismiss grouping
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- add a correlation feedback endpoint for split, merged, and dismissed correction labels
- add group-card controls to mark incorrect groupings and dismiss correlation groupings through `runAction`
- cover validation, access denial, dedupe keys, and UI feedback requests

## Tests
- `pnpm --filter @breeze/api exec vitest run src/routes/alerts/correlations.test.ts`
- `pnpm --filter @breeze/web exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx src/lib/__tests__/no-silent-mutations.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`