### PR TITLE
feat(ml): show reliability disabled state

### DIFF
--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -5,9 +5,14 @@ import DeviceReliabilityPanel from './DeviceReliabilityPanel';
 import { fetchWithAuth } from '../../stores/auth';
 
 const showToast = vi.fn();
+const useMlFeatureFlagsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../../hooks/useMlFeatureFlags', () => ({
+  useMlFeatureFlags: useMlFeatureFlagsMock,
 }));
 
 vi.mock('../shared/Toast', () => ({
@@ -28,6 +33,13 @@ describe('DeviceReliabilityPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     showToast.mockReset();
+    useMlFeatureFlagsMock.mockReturnValue({
+      flags: {},
+      loaded: true,
+      error: null,
+      isDisabled: () => false,
+      reload: vi.fn(),
+    });
   });
 
   it('renders reliability score drivers for a device', async () => {
@@ -121,5 +133,28 @@ describe('DeviceReliabilityPanel', () => {
     render(<DeviceReliabilityPanel deviceId="dev-1" />);
 
     await screen.findByText('No reliability snapshot available yet.');
+  });
+
+  it('shows a disabled state without fetching reliability when the feature flag is off', async () => {
+    useMlFeatureFlagsMock.mockReturnValue({
+      flags: {
+        'ml.device_reliability.enabled': {
+          flag: 'ml.device_reliability.enabled',
+          enabled: false,
+          defaultEnabled: true,
+          source: 'org_settings',
+        },
+      },
+      loaded: true,
+      error: null,
+      isDisabled: (flag: string) => flag === 'ml.device_reliability.enabled',
+      reload: vi.fn(),
+    });
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    expect(await screen.findByText('Reliability scoring is disabled for this organization.')).toBeTruthy();
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/reliability/dev-1');
+    expect(screen.queryByRole('button', { name: /false alarm/i })).toBeNull();
   });
 });

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, CheckCircle, RefreshCw, ShieldCheck, Wrench, XCircle } f
 
 import { runAction, handleActionError } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
+import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 type ReliabilityTopIssue = {
   type: 'crashes' | 'hangs' | 'services' | 'hardware' | 'uptime';
@@ -81,10 +82,12 @@ function formatEvidenceValue(key: string, value: number): string {
 }
 
 export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPanelProps) {
+  const mlFlags = useMlFeatureFlags();
   const [snapshot, setSnapshot] = useState<ReliabilitySnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [labeling, setLabeling] = useState<string | null>(null);
+  const reliabilityDisabled = mlFlags.isDisabled('ml.device_reliability.enabled');
 
   const fetchReliability = useCallback(async () => {
     setLoading(true);
@@ -106,8 +109,15 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
   }, [deviceId]);
 
   useEffect(() => {
+    if (!mlFlags.loaded) return;
+    if (reliabilityDisabled) {
+      setSnapshot(null);
+      setError(undefined);
+      setLoading(false);
+      return;
+    }
     void fetchReliability();
-  }, [fetchReliability]);
+  }, [fetchReliability, mlFlags.loaded, reliabilityDisabled]);
 
   const drivers = useMemo(() => (snapshot?.drivers ?? []).slice(0, 3), [snapshot?.drivers]);
 
@@ -157,6 +167,20 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
             <RefreshCw className="h-4 w-4" />
             Retry
           </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (reliabilityDisabled) {
+    return (
+      <div className="rounded-lg border bg-card p-5 shadow-sm">
+        <div className="flex items-center gap-3">
+          <ShieldCheck className="h-5 w-5 text-muted-foreground" />
+          <div>
+            <h3 className="text-base font-semibold">Reliability</h3>
+            <p className="text-sm text-muted-foreground">Reliability scoring is disabled for this organization.</p>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- have the device reliability panel respect `ml.device_reliability.enabled`
- show an explicit disabled state instead of fetching or displaying active reliability scores when the flag is off
- hide reliability feedback buttons while reliability scoring is disabled

## Tests
- `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceReliabilityPanel.test.tsx`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`