### PR TITLE
feat(ml): surface anomaly context on alerts

### DIFF
--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -232,6 +232,18 @@ describe('alert routes', () => {
                           severity: 'high',
                           title: 'CPU usage high',
                           message: 'CPU over threshold',
+                          context: {
+                            source: 'metric_anomaly',
+                            anomalyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                            metricName: 'cpu.usage',
+                            metricType: 'gauge',
+                            anomalyType: 'spike',
+                            observedValue: 97.3,
+                            baselineValue: 42.1,
+                            confidence: 0.92,
+                            score: 8.4,
+                            modelVersion: 'rollup-v0',
+                          },
                           deviceHostname: 'device-1',
                           ruleName: 'CPU Alert'
                         }
@@ -267,6 +279,18 @@ describe('alert routes', () => {
       const body = await res.json();
       expect(body.data).toHaveLength(1);
       expect(body.data[0].severity).toBe('high');
+      expect(body.data[0].contextData).toEqual(expect.objectContaining({
+        source: 'metric_anomaly',
+        anomalyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        metricName: 'cpu.usage',
+      }));
+      expect(body.data[0].anomalyContext).toEqual(expect.objectContaining({
+        source: 'metric_anomaly',
+        anomalyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        metricName: 'cpu.usage',
+        anomalyType: 'spike',
+        confidence: 0.92,
+      }));
       expect(body.data[0]).toEqual(expect.objectContaining({
         correlationGroupId: 'group-1',
         correlationChildCount: 2,

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -48,7 +48,36 @@ type AlertCorrelationSummaryRow = {
   noiseReductionPercent: number | string | null;
 };
 
-export function attachAlertCorrelationSummaries<T extends { id: string }>(
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function normalizeMetricAnomalyContext(context: unknown) {
+  const record = asRecord(context);
+  if (record.source !== 'metric_anomaly') return null;
+  return {
+    source: 'metric_anomaly',
+    anomalyId: typeof record.anomalyId === 'string' ? record.anomalyId : null,
+    metricName: typeof record.metricName === 'string' ? record.metricName : null,
+    metricType: typeof record.metricType === 'string' ? record.metricType : null,
+    anomalyType: typeof record.anomalyType === 'string' ? record.anomalyType : null,
+    observedValue: typeof record.observedValue === 'number' ? record.observedValue : null,
+    baselineValue: typeof record.baselineValue === 'number' ? record.baselineValue : null,
+    confidence: typeof record.confidence === 'number' ? record.confidence : null,
+    score: typeof record.score === 'number' ? record.score : null,
+    modelVersion: typeof record.modelVersion === 'string' ? record.modelVersion : null,
+  };
+}
+
+function withMlAlertContext<T extends { context?: unknown }>(alert: T) {
+  return {
+    ...alert,
+    contextData: alert.context ?? null,
+    anomalyContext: normalizeMetricAnomalyContext(alert.context),
+  };
+}
+
+export function attachAlertCorrelationSummaries<T extends { id: string; context?: unknown }>(
   alertRows: T[],
   correlationRows: AlertCorrelationSummaryRow[]
 ) {
@@ -64,7 +93,7 @@ export function attachAlertCorrelationSummaries<T extends { id: string }>(
   return alertRows.map((alert) => {
     const correlation = correlationByAlertId.get(alert.id);
     if (!correlation) {
-      return {
+      return withMlAlertContext({
         ...alert,
         correlationGroupId: null,
         correlationRole: null,
@@ -72,13 +101,13 @@ export function attachAlertCorrelationSummaries<T extends { id: string }>(
         correlationMemberCount: 0,
         correlationChildCount: 0,
         noiseReductionPercent: null,
-      };
+      });
     }
 
     const memberCount = Number(correlation.memberCount ?? 0);
     const noiseReductionPercent = Number(correlation.noiseReductionPercent ?? 0);
 
-    return {
+    return withMlAlertContext({
       ...alert,
       correlationGroupId: correlation.groupId,
       correlationRole: correlation.role,
@@ -86,7 +115,7 @@ export function attachAlertCorrelationSummaries<T extends { id: string }>(
       correlationMemberCount: Number.isFinite(memberCount) ? memberCount : 0,
       correlationChildCount: Math.max((Number.isFinite(memberCount) ? memberCount : 0) - 1, 0),
       noiseReductionPercent: Number.isFinite(noiseReductionPercent) ? noiseReductionPercent : null,
-    };
+    });
   });
 }
 
@@ -779,7 +808,7 @@ alertsRoutes.get(
       .where(eq(alertNotifications.alertId, alertId))
       .orderBy(desc(alertNotifications.createdAt));
 
-    return c.json({
+    return c.json(withMlAlertContext({
       ...alert,
       device: device ? {
         id: device.id,
@@ -796,7 +825,7 @@ alertsRoutes.get(
         isActive: rule.isActive
       } : null,
       notifications
-    });
+    }));
   }
 );
 

--- a/apps/web/src/components/alerts/AlertDetailPage.tsx
+++ b/apps/web/src/components/alerts/AlertDetailPage.tsx
@@ -15,6 +15,13 @@ import {
 import CreateTicketFromAlertDialog from './CreateTicketFromAlertDialog';
 import type { TicketStatus, TicketPriority } from '../tickets/ticketConfig';
 import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
+import {
+  formatAnomalyConfidence,
+  formatAnomalyType,
+  formatAnomalyValue,
+  normalizeMetricAnomalyContext,
+  type MetricAnomalyAlertContext,
+} from './alertMlContext';
 
 type Alert = {
   id: string;
@@ -31,7 +38,9 @@ type Alert = {
   acknowledgedBy?: string;
   resolvedAt?: string;
   resolvedBy?: string;
+  context?: Record<string, unknown>;
   contextData?: Record<string, unknown>;
+  anomalyContext?: MetricAnomalyAlertContext | null;
 };
 
 type LinkedTicket = {
@@ -87,6 +96,8 @@ export default function AlertDetailPage({ alertId }: AlertDetailPageProps) {
         deviceName: data.device?.hostname || data.deviceName || 'Unknown Device',
         ruleName: data.rule?.name || data.ruleName,
         ruleId: data.rule?.id || data.ruleId,
+        contextData: data.contextData ?? data.context,
+        anomalyContext: data.anomalyContext ?? normalizeMetricAnomalyContext(data.contextData ?? data.context),
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch alert');
@@ -288,6 +299,47 @@ export default function AlertDetailPage({ alertId }: AlertDetailPageProps) {
       </div>
 
       <RemediationSuggestionsPanel sourceType="alert" sourceId={alert.id} />
+
+      {alert.anomalyContext && (
+        <div className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-6 shadow-sm">
+          <h3 className="text-sm font-semibold text-muted-foreground mb-4">ML Anomaly Evidence</h3>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <p className="text-xs text-muted-foreground">Metric</p>
+              <p className="text-sm font-medium">{alert.anomalyContext.metricName ?? 'Unknown metric'}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Type</p>
+              <p className="text-sm font-medium capitalize">{formatAnomalyType(alert.anomalyContext.anomalyType)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Confidence</p>
+              <p className="text-sm font-medium tabular-nums">{formatAnomalyConfidence(alert.anomalyContext.confidence)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Observed</p>
+              <p className="text-sm font-medium tabular-nums">{formatAnomalyValue(alert.anomalyContext.observedValue)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Baseline</p>
+              <p className="text-sm font-medium tabular-nums">{formatAnomalyValue(alert.anomalyContext.baselineValue)}</p>
+            </div>
+            {alert.anomalyContext.modelVersion && (
+              <div>
+                <p className="text-xs text-muted-foreground">Model</p>
+                <p className="text-sm font-medium">{alert.anomalyContext.modelVersion}</p>
+              </div>
+            )}
+          </div>
+          <a
+            href={`/devices/${alert.deviceId}#anomalies`}
+            className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-sky-700 hover:underline"
+          >
+            Open device anomalies
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      )}
 
       {/* Linked Tickets */}
       {(linkedTickets.length > 0 || linkedError) && (

--- a/apps/web/src/components/alerts/AlertDetails.tsx
+++ b/apps/web/src/components/alerts/AlertDetails.tsx
@@ -26,6 +26,7 @@ import {
 } from './alertConfig';
 import type { Alert } from './AlertList';
 import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
+import { formatAnomalyConfidence, formatAnomalyType, formatAnomalyValue } from './alertMlContext';
 
 export type NotificationHistory = {
   id: string;
@@ -174,6 +175,47 @@ export default function AlertDetails({
           </div>
 
           <RemediationSuggestionsPanel sourceType="alert" sourceId={alert.id} />
+
+          {alert.anomalyContext && (
+            <div className="rounded-md border border-sky-500/30 bg-sky-500/10 p-4">
+              <h3 className="text-sm font-semibold mb-3">ML Anomaly Evidence</h3>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <p className="text-xs text-muted-foreground">Metric</p>
+                  <p className="text-sm font-medium">{alert.anomalyContext.metricName ?? 'Unknown metric'}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Type</p>
+                  <p className="text-sm font-medium capitalize">{formatAnomalyType(alert.anomalyContext.anomalyType)}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Observed</p>
+                  <p className="text-sm font-medium tabular-nums">{formatAnomalyValue(alert.anomalyContext.observedValue)}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Baseline</p>
+                  <p className="text-sm font-medium tabular-nums">{formatAnomalyValue(alert.anomalyContext.baselineValue)}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Confidence</p>
+                  <p className="text-sm font-medium tabular-nums">{formatAnomalyConfidence(alert.anomalyContext.confidence)}</p>
+                </div>
+                {alert.anomalyContext.modelVersion && (
+                  <div>
+                    <p className="text-xs text-muted-foreground">Model</p>
+                    <p className="text-sm font-medium">{alert.anomalyContext.modelVersion}</p>
+                  </div>
+                )}
+              </div>
+              <a
+                href={`/devices/${alert.deviceId}#anomalies`}
+                className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-sky-700 hover:underline"
+              >
+                Open device anomalies
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+          )}
 
           {/* Device Info */}
           <div className="rounded-md border p-4">

--- a/apps/web/src/components/alerts/AlertList.tsx
+++ b/apps/web/src/components/alerts/AlertList.tsx
@@ -11,6 +11,7 @@ import {
   ExternalLink,
   Calendar,
   GitBranch,
+  Activity,
   SlidersHorizontal,
   X,
   Loader2
@@ -23,6 +24,11 @@ import {
   type AlertSeverity,
   type AlertStatus,
 } from './alertConfig';
+import {
+  formatAnomalyConfidence,
+  formatAnomalyType,
+  type MetricAnomalyAlertContext,
+} from './alertMlContext';
 
 export type { AlertSeverity, AlertStatus };
 
@@ -41,7 +47,9 @@ export type Alert = {
   acknowledgedBy?: string;
   resolvedAt?: string;
   resolvedBy?: string;
+  context?: Record<string, unknown>;
   contextData?: Record<string, unknown>;
+  anomalyContext?: MetricAnomalyAlertContext | null;
   correlationGroupId?: string | null;
   correlationRole?: string | null;
   correlationGroupStatus?: string | null;
@@ -452,6 +460,17 @@ export default function AlertList({
                                 : ''}
                             </span>
                           </a>
+                        )}
+                        {alert.anomalyContext && (
+                          <span
+                            className="mt-1 inline-flex max-w-full items-center gap-1 rounded-md border border-sky-500/30 bg-sky-500/10 px-1.5 py-0.5 text-[11px] font-medium text-sky-700"
+                            title="Promoted metric anomaly"
+                          >
+                            <Activity className="h-3 w-3 shrink-0" />
+                            <span className="truncate">
+                              ML anomaly: {alert.anomalyContext.metricName ?? 'metric'} · {formatAnomalyType(alert.anomalyContext.anomalyType)} · {formatAnomalyConfidence(alert.anomalyContext.confidence)}
+                            </span>
+                          </span>
                         )}
                       </div>
                     </td>

--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -274,4 +274,58 @@ describe('AlertsPage — acknowledge in-flight feedback', () => {
     expect(await screen.findByText('Grouped incident: 3 related · 75% noise cut')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /SRV-01/i })).toHaveAttribute('href', '/devices/device-1');
   });
+
+  it('renders promoted metric anomaly context in the alert list and details panel', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({
+          data: [{
+            ...activeAlert,
+            context: {
+              source: 'metric_anomaly',
+              anomalyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+              metricName: 'cpu.usage',
+              metricType: 'gauge',
+              anomalyType: 'spike',
+              observedValue: 97.3,
+              baselineValue: 42.1,
+              confidence: 0.92,
+              score: 8.4,
+              modelVersion: 'rollup-v0',
+            },
+          }]
+        }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === `/alerts/${ALERT_ID}` && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ statusHistory: [], notificationHistory: [] }));
+      }
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      }
+      if (url === `/remediation-suggestions?sourceType=alert&sourceId=${ALERT_ID}&limit=5` && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<AlertsPage />);
+
+    expect(await screen.findByText('ML anomaly: cpu.usage · spike · 92%')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('High CPU on SRV-01'));
+    const dialog = await screen.findByRole('dialog');
+
+    expect(within(dialog).getByText('ML Anomaly Evidence')).toBeInTheDocument();
+    expect(within(dialog).getByText('cpu.usage')).toBeInTheDocument();
+    expect(within(dialog).getByText('spike')).toBeInTheDocument();
+    expect(within(dialog).getByText('97.30')).toBeInTheDocument();
+    expect(within(dialog).getByText('42.10')).toBeInTheDocument();
+    expect(within(dialog).getByText('92%')).toBeInTheDocument();
+    expect(within(dialog).getByRole('link', { name: /Open device anomalies/i })).toHaveAttribute('href', '/devices/device-1#anomalies');
+  });
 });

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -12,15 +12,20 @@ import { DeviceFilterBar } from '../filters/DeviceFilterBar';
 import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
 import { runAction, ActionError } from '../../lib/runAction';
+import { normalizeMetricAnomalyContext } from './alertMlContext';
 
 type Device = { id: string; name: string };
 
 function normalizeAlertRows(rows: Record<string, unknown>[]): Alert[] {
   return rows.map((row) => {
     const deviceName = row.deviceName ?? row.deviceHostname ?? row.hostname ?? 'Unknown device';
+    const contextData = row.contextData ?? row.context;
+    const anomalyContext = row.anomalyContext ?? normalizeMetricAnomalyContext(contextData);
     return {
       ...row,
       deviceName: String(deviceName),
+      contextData,
+      anomalyContext,
       correlationMemberCount: Number(row.correlationMemberCount ?? 0),
       correlationChildCount: Number(row.correlationChildCount ?? 0),
       noiseReductionPercent: row.noiseReductionPercent == null ? null : Number(row.noiseReductionPercent),

--- a/apps/web/src/components/alerts/alertMlContext.ts
+++ b/apps/web/src/components/alerts/alertMlContext.ts
@@ -1,0 +1,56 @@
+export type MetricAnomalyAlertContext = {
+  source: 'metric_anomaly';
+  anomalyId: string | null;
+  metricName: string | null;
+  metricType: string | null;
+  anomalyType: string | null;
+  observedValue: number | null;
+  baselineValue: number | null;
+  confidence: number | null;
+  score: number | null;
+  modelVersion: string | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+export function normalizeMetricAnomalyContext(value: unknown): MetricAnomalyAlertContext | null {
+  const context = asRecord(value);
+  if (context.source !== 'metric_anomaly') return null;
+
+  return {
+    source: 'metric_anomaly',
+    anomalyId: stringOrNull(context.anomalyId),
+    metricName: stringOrNull(context.metricName),
+    metricType: stringOrNull(context.metricType),
+    anomalyType: stringOrNull(context.anomalyType),
+    observedValue: numberOrNull(context.observedValue),
+    baselineValue: numberOrNull(context.baselineValue),
+    confidence: numberOrNull(context.confidence),
+    score: numberOrNull(context.score),
+    modelVersion: stringOrNull(context.modelVersion),
+  };
+}
+
+export function formatAnomalyType(value: string | null): string {
+  return value ? value.replace(/_/g, ' ') : 'anomaly';
+}
+
+export function formatAnomalyValue(value: number | null): string {
+  if (value === null) return 'n/a';
+  return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(2);
+}
+
+export function formatAnomalyConfidence(value: number | null): string {
+  if (value === null) return 'n/a';
+  return `${Math.round(value * 100)}%`;
+}


### PR DESCRIPTION
## Summary
- add `contextData` compatibility and normalized `anomalyContext` payloads to alert API responses
- show promoted metric anomaly context in the alert list
- add typed ML anomaly evidence panels to alert slide-over and full detail views

## Verification
- `pnpm --filter @breeze/api exec vitest run src/routes/alerts.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @breeze/web exec vitest run src/components/alerts/AlertsPage.test.tsx`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`
- `git diff --check`