### PR TITLE
fix(ml): scope reliability feedback dedupe to snapshots

### DIFF
--- a/apps/api/src/routes/reliability.test.ts
+++ b/apps/api/src/routes/reliability.test.ts
@@ -322,7 +322,7 @@ describe('public reliability routes', () => {
         orgId: ORG_ID,
         deviceId: DEVICE_ID,
         eventType: 'device.false_alarm',
-        dedupeKey: 'outcome:false_alarm',
+        dedupeKey: 'snapshot:2026-06-18T12:00:00.000Z:false_alarm',
         outcome: 'false_alarm',
         actorUserId: 'user-1',
         metadata: expect.objectContaining({

--- a/apps/api/src/routes/reliability.ts
+++ b/apps/api/src/routes/reliability.ts
@@ -50,6 +50,7 @@ const feedbackBodySchema = z.object({
   outcome: z.enum(['failure_confirmed', 'replaced', 'false_alarm']),
   occurredAt: z.coerce.date().optional(),
   sourceEventId: z.string().uuid().optional(),
+  snapshotComputedAt: z.string().datetime().optional(),
   metadata: z.record(z.string(), z.unknown()).default({}),
 });
 
@@ -66,6 +67,17 @@ function parseScoreRange(value: string | undefined): ReliabilityScoreRange | und
   if (normalized === '71-85') return 'fair';
   if (normalized === '86-100') return 'good';
   return undefined;
+}
+
+function reliabilityFeedbackDedupeKey(options: {
+  outcome: 'failure_confirmed' | 'replaced' | 'false_alarm';
+  sourceEventId?: string;
+  snapshotComputedAt?: string;
+}): string {
+  if (options.sourceEventId) {
+    return `source:${options.sourceEventId}:${options.outcome}`;
+  }
+  return `snapshot:${options.snapshotComputedAt ?? 'unknown'}:${options.outcome}`;
 }
 
 export const reliabilityRoutes = new Hono();
@@ -268,7 +280,11 @@ reliabilityRoutes.post(
       orgId: device.orgId,
       deviceId,
       eventType,
-      dedupeKey: body.sourceEventId ? `source:${body.sourceEventId}:${body.outcome}` : `outcome:${body.outcome}`,
+      dedupeKey: reliabilityFeedbackDedupeKey({
+        outcome: body.outcome,
+        sourceEventId: body.sourceEventId,
+        snapshotComputedAt: body.snapshotComputedAt ?? snapshot.computedAt,
+      }),
       outcome: body.outcome,
       actorUserId: auth.user?.id,
       occurredAt: body.occurredAt,

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -117,7 +117,10 @@ describe('DeviceReliabilityPanel', () => {
         '/reliability/dev-1/feedback',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ outcome: 'false_alarm' }),
+          body: JSON.stringify({
+            outcome: 'false_alarm',
+            snapshotComputedAt: '2026-06-18T12:00:00.000Z',
+          }),
         }),
       );
     });

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -128,7 +128,7 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
         request: () => fetchWithAuth(`/reliability/${deviceId}/feedback`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ outcome }),
+          body: JSON.stringify({ outcome, snapshotComputedAt: snapshot?.computedAt }),
         }),
         errorFallback: 'Could not save reliability feedback',
         successMessage: outcome === 'false_alarm'


### PR DESCRIPTION
## Summary
- scope reliability feedback replay keys to the labeled reliability snapshot when no source event is provided
- keep sourceEventId as the strongest explicit dedupe key
- include the displayed snapshot timestamp in web reliability feedback submissions

## Verification
- `pnpm --filter @breeze/api exec vitest run src/routes/reliability.test.ts`
- `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceReliabilityPanel.test.tsx`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`
- `git diff --check`