### PR TITLE
feat(ml): show ticket triage reason codes

### DIFF
--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -359,7 +359,7 @@ describe('TicketWorkbench ML triage suggestions', () => {
             priority: 'high',
             categoryId: 'cat-hardware',
             categoryName: 'Hardware',
-            reasons: ['matched Hardware'],
+            reasons: ['high-impact keywords', 'matched Hardware'],
           },
         });
       }
@@ -377,6 +377,9 @@ describe('TicketWorkbench ML triage suggestions', () => {
     await screen.findByTestId('ticket-triage-suggestion');
     expect(screen.getByText(/Priority: High/i)).toBeInTheDocument();
     expect(screen.getByText(/Category: Hardware/i)).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-triage-reasons')).toBeInTheDocument();
+    expect(screen.getByText('high-impact keywords')).toBeInTheDocument();
+    expect(screen.getByText('matched Hardware')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('ticket-triage-apply'));
 

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -383,6 +383,7 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   const suggestedCategoryName = triageSuggestion?.categoryId
     ? (categories.find((category) => category.id === triageSuggestion.categoryId)?.name ?? triageSuggestion.categoryName ?? 'Suggested category')
     : null;
+  const triageReasons = triageSuggestion?.reasons.filter((reason) => reason.trim().length > 0) ?? [];
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="ticket-workbench" aria-busy={loading || undefined}>
@@ -542,11 +543,25 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
                 {triageLoading ? (
                   <p className="mt-1 text-xs text-muted-foreground">Checking ticket signals…</p>
                 ) : triageSuggestion ? (
-                  <div className="mt-1 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
-                    {triageSuggestion.priority && <span>Priority: {priorityLabel(config, triageSuggestion.priority)}</span>}
-                    {suggestedCategoryName && <span>Category: {suggestedCategoryName}</span>}
-                    <span>{Math.round(triageSuggestion.confidence * 100)}% confidence</span>
-                  </div>
+                  <>
+                    <div className="mt-1 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
+                      {triageSuggestion.priority && <span>Priority: {priorityLabel(config, triageSuggestion.priority)}</span>}
+                      {suggestedCategoryName && <span>Category: {suggestedCategoryName}</span>}
+                      <span>{Math.round(triageSuggestion.confidence * 100)}% confidence</span>
+                    </div>
+                    {triageReasons.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1.5" data-testid="ticket-triage-reasons">
+                        {triageReasons.map((reason) => (
+                          <span
+                            key={reason}
+                            className="rounded border bg-background px-1.5 py-0.5 text-xs text-muted-foreground"
+                          >
+                            {reason}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </>
                 ) : null}
               </div>
               {triageSuggestion && (


### PR DESCRIPTION
## Summary
- render ticket triage reason strings as compact evidence chips in the workbench suggestion strip
- keep existing priority/category/confidence summary and apply/reject flow unchanged
- cover reason visibility in the TicketWorkbench ML triage test

## Verification
- `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`
- `git diff --check`