### PR TITLE
fix(ml): label disabled user risk surface

### DIFF
--- a/apps/web/src/components/security/UserRiskPage.test.tsx
+++ b/apps/web/src/components/security/UserRiskPage.test.tsx
@@ -23,6 +23,17 @@ const response = (payload: unknown, ok = true, status = ok ? 200 : 500): Respons
   json: vi.fn().mockResolvedValue(payload),
 }) as unknown as Response;
 
+const flagsPayload = (enabled: boolean) => ({
+  mlFeatureFlags: {
+    'ml.user_risk_v0.enabled': {
+      flag: 'ml.user_risk_v0.enabled',
+      enabled,
+      defaultEnabled: true,
+      source: 'org_settings',
+    },
+  },
+});
+
 const scorePayload = {
   data: [
     {
@@ -83,12 +94,13 @@ const detailPayload = {
 
 describe('UserRiskPage', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    fetchWithAuthMock.mockReset();
     showToast.mockReset();
   });
 
   it('renders scores, evaluation metrics, and selected user evidence', async () => {
     fetchWithAuthMock
+      .mockResolvedValueOnce(response(flagsPayload(true)))
       .mockResolvedValueOnce(response(scorePayload))
       .mockResolvedValueOnce(response(evaluationPayload))
       .mockResolvedValueOnce(response(detailPayload));
@@ -98,7 +110,7 @@ describe('UserRiskPage', () => {
     await screen.findByTestId('user-risk-page');
     expect(screen.getAllByText('Alice Admin')).toHaveLength(2);
     expect(screen.getByText('75%')).toBeTruthy();
-    expect(screen.getByText('Multiple failed sign-in attempts')).toBeTruthy();
+    expect(await screen.findByText('Multiple failed sign-in attempts')).toBeTruthy();
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/user-risk/scores?limit=25&minScore=50');
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/user-risk/evaluation?days=30');
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/user-risk/users/00000000-0000-4000-8000-000000000010?orgId=00000000-0000-4000-8000-000000000001');
@@ -106,6 +118,7 @@ describe('UserRiskPage', () => {
 
   it('posts false-positive feedback through runAction', async () => {
     fetchWithAuthMock
+      .mockResolvedValueOnce(response(flagsPayload(true)))
       .mockResolvedValueOnce(response(scorePayload))
       .mockResolvedValueOnce(response(evaluationPayload))
       .mockResolvedValueOnce(response(detailPayload))
@@ -136,5 +149,17 @@ describe('UserRiskPage', () => {
       type: 'success',
       message: 'False positive label saved',
     }));
+  });
+
+  it('shows disabled state and does not fetch stale scores when user-risk v0 is disabled', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(response(flagsPayload(false)));
+
+    render(<UserRiskPage />);
+
+    await screen.findByTestId('user-risk-disabled');
+    expect(screen.getByText('User risk scoring is disabled for this organization.')).toBeTruthy();
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/config/ml-feature-flags');
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/user-risk/scores?limit=25&minScore=50');
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/user-risk/evaluation?days=30');
   });
 });

--- a/apps/web/src/components/security/UserRiskPage.tsx
+++ b/apps/web/src/components/security/UserRiskPage.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, ShieldAlert, UserCheck
 
 import { runAction, handleActionError } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
+import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 type UserRiskScore = {
   orgId: string;
@@ -93,6 +94,7 @@ const formatFactor = (value: string): string => (
 );
 
 export default function UserRiskPage() {
+  const mlFlags = useMlFeatureFlags();
   const [scores, setScores] = useState<UserRiskScore[]>([]);
   const [detail, setDetail] = useState<UserRiskDetail | null>(null);
   const [evaluation, setEvaluation] = useState<Evaluation | null>(null);
@@ -101,8 +103,13 @@ export default function UserRiskPage() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [labeling, setLabeling] = useState<'true_positive' | 'false_positive' | null>(null);
+  const userRiskDisabled = mlFlags.isDisabled('ml.user_risk_v0.enabled');
 
   const loadScores = useCallback(async () => {
+    if (!mlFlags.loaded || userRiskDisabled) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -123,13 +130,27 @@ export default function UserRiskPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [mlFlags.loaded, userRiskDisabled]);
 
   useEffect(() => {
+    if (!mlFlags.loaded) return;
+    if (userRiskDisabled) {
+      setScores([]);
+      setEvaluation(null);
+      setSelected(null);
+      setDetail(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
     void loadScores();
-  }, [loadScores]);
+  }, [loadScores, mlFlags.loaded, userRiskDisabled]);
 
   useEffect(() => {
+    if (userRiskDisabled) {
+      setDetail(null);
+      return;
+    }
     if (!selected) {
       setDetail(null);
       return;
@@ -153,7 +174,7 @@ export default function UserRiskPage() {
     return () => {
       active = false;
     };
-  }, [selected]);
+  }, [selected, userRiskDisabled]);
 
   const factors = useMemo(() => (
     Object.entries(detail?.latestScore.factors ?? selected?.factors ?? {})
@@ -190,6 +211,26 @@ export default function UserRiskPage() {
     return (
       <div className="flex min-h-[420px] items-center justify-center" data-testid="user-risk-loading">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (userRiskDisabled) {
+    return (
+      <div className="space-y-5" data-testid="user-risk-page">
+        <header>
+          <h1 className="text-2xl font-semibold tracking-normal">User Risk</h1>
+          <p className="text-sm text-muted-foreground">Review rules-v0 risk scores, evidence, and evaluation labels.</p>
+        </header>
+        <section className="rounded-lg border bg-card p-6" data-testid="user-risk-disabled">
+          <div className="flex items-start gap-3">
+            <ShieldAlert className="mt-0.5 h-5 w-5 text-muted-foreground" />
+            <div>
+              <h2 className="text-sm font-semibold">User risk scoring is disabled for this organization.</h2>
+              <p className="mt-1 text-sm text-muted-foreground">Scores, evidence, and labels will appear here when the user-risk v0 producer is enabled.</p>
+            </div>
+          </div>
+        </section>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- gate the User Risk page on `ml.user_risk_v0.enabled`
- show a clear disabled state when the rules-v0 producer is off
- avoid fetching stale user-risk scores/evaluation/detail while disabled

## Verification
- `pnpm --filter @breeze/web exec vitest run src/components/security/UserRiskPage.test.tsx`
- `pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json`
- `git diff --check`