### PR TITLE
fix(ml): dedupe user risk signal jobs

### DIFF
--- a/apps/api/src/jobs/userRiskJobs.test.ts
+++ b/apps/api/src/jobs/userRiskJobs.test.ts
@@ -57,6 +57,7 @@ vi.mock('../services/mlFeatureFlags', () => ({
 }));
 
 import {
+  buildUserRiskSignalEventJobId,
   createUserRiskWorker,
   enqueueUserRiskSignalEvent,
   shutdownUserRiskJobs,
@@ -163,6 +164,61 @@ describe('triggerUserRiskRecompute', () => {
     expect(queued.eventType).toHaveLength(128);
     expect(queued.description).toHaveLength(1024);
     expect(queued.details).toBeUndefined();
+    expect(addMock.mock.calls[0]?.[2]).toEqual(expect.objectContaining({
+      jobId: expect.stringMatching(/^user-risk-signal:org-1:user-1:[a-f0-9]{24}$/),
+    }));
+  });
+
+  it('uses a stable BullMQ job id for signal-event ingestion', async () => {
+    const input = {
+      orgId: 'org-1',
+      userId: 'user-1',
+      eventType: 'suspicious_login',
+      severity: 'high' as const,
+      scoreImpact: 12,
+      description: 'Suspicious login',
+      details: { ip: '203.0.113.10', signals: ['new_geo', 'off_hours'] },
+      occurredAt: '2026-03-31T12:00:00.000Z',
+    };
+
+    const first = buildUserRiskSignalEventJobId(input);
+    const second = buildUserRiskSignalEventJobId({
+      ...input,
+      details: { signals: ['new_geo', 'off_hours'], ip: '203.0.113.10' },
+    });
+
+    expect(first).toBe(second);
+    await enqueueUserRiskSignalEvent(input);
+
+    expect(getJobMock).toHaveBeenCalledWith(first);
+    expect(addMock).toHaveBeenCalledWith(
+      'process-signal-event',
+      expect.objectContaining({
+        type: 'process-signal-event',
+        orgId: 'org-1',
+        userId: 'user-1',
+        eventType: 'suspicious_login',
+      }),
+      expect.objectContaining({ jobId: first }),
+    );
+  });
+
+  it('reuses an active signal-event job with the same fingerprint', async () => {
+    getJobMock.mockResolvedValue({
+      id: 'existing-signal-job',
+      getState: vi.fn().mockResolvedValue('active'),
+    });
+
+    const jobId = await enqueueUserRiskSignalEvent({
+      orgId: 'org-1',
+      userId: 'user-1',
+      eventType: 'suspicious_login',
+      description: 'Suspicious login',
+      occurredAt: '2026-03-31T12:00:00.000Z',
+    });
+
+    expect(jobId).toBe('existing-signal-job');
+    expect(addMock).not.toHaveBeenCalled();
   });
 
   it('skips scheduled org recompute output when user-risk v0 is disabled', async () => {

--- a/apps/api/src/jobs/userRiskJobs.ts
+++ b/apps/api/src/jobs/userRiskJobs.ts
@@ -1,5 +1,6 @@
 import { Job, Queue, Worker } from 'bullmq';
 import { sql } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
 
 import * as dbModule from '../db';
 import { organizationUsers } from '../db/schema';
@@ -98,6 +99,28 @@ function sanitizeUserRiskSignalEventInput(
     description: truncateUserRiskString(input.description, USER_RISK_DESCRIPTION_MAX_LEN),
     details: sanitizeUserRiskDetails(input.details),
   };
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableJson(nested)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function buildUserRiskSignalEventJobId(input: Omit<ProcessSignalEventJobData, 'type' | 'queuedAt'>): string {
+  const sanitized = sanitizeUserRiskSignalEventInput(input);
+  const fingerprint = createHash('sha256')
+    .update(stableJson(sanitized))
+    .digest('hex')
+    .slice(0, 24);
+  return `user-risk-signal:${sanitized.orgId}:${sanitized.userId}:${fingerprint}`;
 }
 
 export function getUserRiskQueue(): Queue<UserRiskJobData> {
@@ -349,6 +372,18 @@ export async function triggerUserRiskRecompute(orgId: string): Promise<string> {
 export async function enqueueUserRiskSignalEvent(input: Omit<ProcessSignalEventJobData, 'type' | 'queuedAt'>): Promise<string> {
   const queue = getUserRiskQueue();
   const sanitized = sanitizeUserRiskSignalEventInput(input);
+  const jobId = buildUserRiskSignalEventJobId(sanitized);
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (isReusableState(state)) {
+      return String(existing.id);
+    }
+    await existing.remove().catch((error) => {
+      console.error(`[UserRiskJobs] Failed to remove stale signal-event job ${jobId}:`, error);
+    });
+  }
+
   const job = await queue.add(
     'process-signal-event',
     {
@@ -357,6 +392,7 @@ export async function enqueueUserRiskSignalEvent(input: Omit<ProcessSignalEventJ
       queuedAt: new Date().toISOString()
     },
     {
+      jobId,
       removeOnComplete: { count: 50 },
       removeOnFail: { count: 200 }
     }


### PR DESCRIPTION
## Summary
- add deterministic BullMQ job IDs for user-risk signal event ingestion
- reuse active/reusable signal-event jobs with the same fingerprint
- hash the sanitized signal payload so replayed enqueue calls do not duplicate work

## Verification
- `pnpm --filter @breeze/api exec vitest run src/jobs/userRiskJobs.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `git diff --check`