### PR TITLE
feat(ml): add source evidence to alert correlation

### DIFF
--- a/apps/api/src/jobs/alertCorrelation.test.ts
+++ b/apps/api/src/jobs/alertCorrelation.test.ts
@@ -53,12 +53,24 @@ vi.mock('../db/schema', () => ({
 }));
 
 import {
+  buildAlertCorrelationEvidence,
   buildAlertCorrelationJobId,
   enqueueAlertCorrelation,
   initializeAlertCorrelationWorker,
   runAlertCorrelationForDevice,
   shutdownAlertCorrelationWorker,
 } from './alertCorrelation';
+
+const alertAt = (overrides: Partial<Parameters<typeof buildAlertCorrelationEvidence>[0]['newer']>) => ({
+  id: 'alert-1',
+  triggeredAt: new Date('2026-06-18T12:00:00.000Z'),
+  ruleId: null,
+  templateId: null,
+  configPolicyId: null,
+  configItemName: null,
+  siteId: 'site-1',
+  ...overrides,
+});
 
 describe('alert correlation queue helpers', () => {
   beforeEach(async () => {
@@ -119,5 +131,66 @@ describe('alert correlation queue helpers', () => {
     await initializeAlertCorrelationWorker();
 
     expect(attachWorkerObservabilityMock).toHaveBeenCalledWith(expect.anything(), 'alertCorrelationWorker');
+  });
+
+  it('builds stronger evidence for alerts from the same rule', () => {
+    const evidence = buildAlertCorrelationEvidence({
+      older: alertAt({ id: 'older', ruleId: 'rule-1', templateId: 'template-1' }),
+      newer: alertAt({ id: 'newer', ruleId: 'rule-1', templateId: 'template-1' }),
+      deviceId: 'device-1',
+      timeDiffMs: 5 * 60 * 1000,
+      maxWindowMs: 30 * 60 * 1000,
+    });
+
+    expect(evidence).toMatchObject({
+      correlationType: 'same_rule_temporal',
+      confidence: 0.98,
+      metadata: {
+        deviceId: 'device-1',
+        siteId: 'site-1',
+        ruleId: 'rule-1',
+        templateId: 'template-1',
+        evidence: ['same_device', 'time_window', 'same_rule'],
+      },
+    });
+  });
+
+  it('falls back to same-template evidence when rule ids differ', () => {
+    const evidence = buildAlertCorrelationEvidence({
+      older: alertAt({ id: 'older', ruleId: 'rule-1', templateId: 'template-1' }),
+      newer: alertAt({ id: 'newer', ruleId: 'rule-2', templateId: 'template-1' }),
+      deviceId: 'device-1',
+      timeDiffMs: 6 * 60 * 1000,
+      maxWindowMs: 30 * 60 * 1000,
+    });
+
+    expect(evidence).toMatchObject({
+      correlationType: 'same_template_temporal',
+      confidence: 0.9,
+      metadata: {
+        templateId: 'template-1',
+        evidence: ['same_device', 'time_window', 'same_template'],
+      },
+    });
+  });
+
+  it('captures config-policy item evidence for policy alerts', () => {
+    const evidence = buildAlertCorrelationEvidence({
+      older: alertAt({ id: 'older', configPolicyId: 'policy-1', configItemName: 'disk-low' }),
+      newer: alertAt({ id: 'newer', configPolicyId: 'policy-1', configItemName: 'disk-low' }),
+      deviceId: 'device-1',
+      timeDiffMs: 9 * 60 * 1000,
+      maxWindowMs: 30 * 60 * 1000,
+    });
+
+    expect(evidence).toMatchObject({
+      correlationType: 'same_config_policy_item_temporal',
+      confidence: 0.8,
+      metadata: {
+        configPolicyId: 'policy-1',
+        configItemName: 'disk-low',
+        evidence: ['same_device', 'time_window', 'same_config_policy_item'],
+      },
+    });
   });
 });

--- a/apps/api/src/jobs/alertCorrelation.ts
+++ b/apps/api/src/jobs/alertCorrelation.ts
@@ -2,7 +2,7 @@ import { Job, Queue, Worker } from 'bullmq';
 import { and, desc, eq, gte, inArray } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
-import { alertCorrelations, alerts } from '../db/schema';
+import { alertCorrelations, alertRules, alerts, devices } from '../db/schema';
 import { persistAlertCorrelationGroupsForAlerts } from '../services/alertCorrelationGroups';
 import { isReusableState } from '../services/bullmqUtils';
 import { shouldProduceMlOutput } from '../services/mlFeatureFlags';
@@ -14,6 +14,22 @@ const DEDUPE_WINDOW_MS = 30 * 1000;
 const DEFAULT_DELAY_MS = 5 * 1000;
 const DEFAULT_WINDOW_MINUTES = 30;
 const MAX_ALERTS_PER_DEVICE_PASS = 50;
+
+type CorrelatableAlert = {
+  id: string;
+  triggeredAt: Date;
+  ruleId: string | null;
+  templateId: string | null;
+  configPolicyId: string | null;
+  configItemName: string | null;
+  siteId: string | null;
+};
+
+type AlertCorrelationEvidenceType =
+  | 'same_rule_temporal'
+  | 'same_template_temporal'
+  | 'same_config_policy_item_temporal'
+  | 'same_device_temporal';
 
 export type AlertCorrelationJobData = {
   orgId: string;
@@ -37,6 +53,57 @@ export function getAlertCorrelationQueue(): Queue<AlertCorrelationJobData> {
 export function buildAlertCorrelationJobId(orgId: string, deviceId: string, now = Date.now()): string {
   const slot = Math.floor(now / DEDUPE_WINDOW_MS).toString(36);
   return ['alert-correlation', orgId, deviceId, slot].join('-');
+}
+
+export function buildAlertCorrelationEvidence(options: {
+  older: CorrelatableAlert;
+  newer: CorrelatableAlert;
+  deviceId: string;
+  timeDiffMs: number;
+  maxWindowMs: number;
+}): {
+  correlationType: AlertCorrelationEvidenceType;
+  confidence: number;
+  metadata: Record<string, unknown>;
+} {
+  const baseConfidence = Math.round((1 - options.timeDiffMs / options.maxWindowMs) * 100) / 100;
+  let correlationType: AlertCorrelationEvidenceType = 'same_device_temporal';
+  let confidence = baseConfidence;
+  const evidence: string[] = ['same_device', 'time_window'];
+
+  if (options.older.ruleId && options.older.ruleId === options.newer.ruleId) {
+    correlationType = 'same_rule_temporal';
+    confidence = Math.min(0.99, Math.round((confidence + 0.15) * 100) / 100);
+    evidence.push('same_rule');
+  } else if (options.older.templateId && options.older.templateId === options.newer.templateId) {
+    correlationType = 'same_template_temporal';
+    confidence = Math.min(0.99, Math.round((confidence + 0.1) * 100) / 100);
+    evidence.push('same_template');
+  } else if (
+    options.older.configPolicyId &&
+    options.older.configPolicyId === options.newer.configPolicyId &&
+    options.older.configItemName &&
+    options.older.configItemName === options.newer.configItemName
+  ) {
+    correlationType = 'same_config_policy_item_temporal';
+    confidence = Math.min(0.99, Math.round((confidence + 0.1) * 100) / 100);
+    evidence.push('same_config_policy_item');
+  }
+
+  return {
+    correlationType,
+    confidence,
+    metadata: {
+      timeDiffMinutes: Math.round(options.timeDiffMs / 60000),
+      deviceId: options.deviceId,
+      siteId: options.newer.siteId ?? options.older.siteId,
+      ruleId: options.newer.ruleId ?? options.older.ruleId,
+      templateId: options.newer.templateId ?? options.older.templateId,
+      configPolicyId: options.newer.configPolicyId ?? options.older.configPolicyId,
+      configItemName: options.newer.configItemName ?? options.older.configItemName,
+      evidence,
+    },
+  };
 }
 
 export async function enqueueAlertCorrelation(options: {
@@ -90,8 +157,18 @@ export async function runAlertCorrelationForDevice(options: {
   const windowStart = new Date(Date.now() - windowMinutes * 60 * 1000);
 
   const recentAlerts = await db
-    .select({ id: alerts.id, triggeredAt: alerts.triggeredAt })
+    .select({
+      id: alerts.id,
+      triggeredAt: alerts.triggeredAt,
+      ruleId: alerts.ruleId,
+      templateId: alertRules.templateId,
+      configPolicyId: alerts.configPolicyId,
+      configItemName: alerts.configItemName,
+      siteId: devices.siteId,
+    })
     .from(alerts)
+    .leftJoin(alertRules, eq(alerts.ruleId, alertRules.id))
+    .innerJoin(devices, eq(alerts.deviceId, devices.id))
     .where(
       and(
         eq(alerts.deviceId, options.deviceId),
@@ -135,7 +212,14 @@ export async function runAlertCorrelationForDevice(options: {
       if (linkedPairs.has(pairKey)) continue;
 
       const timeDiffMs = Math.abs(newer.triggeredAt.getTime() - older.triggeredAt.getTime());
-      const confidence = Math.round((1 - timeDiffMs / maxWindowMs) * 100) / 100;
+      const evidence = buildAlertCorrelationEvidence({
+        older,
+        newer,
+        deviceId: options.deviceId,
+        timeDiffMs,
+        maxWindowMs,
+      });
+      const confidence = evidence.confidence;
       if (confidence < 0.3) continue;
 
       await db
@@ -143,12 +227,9 @@ export async function runAlertCorrelationForDevice(options: {
         .values({
           parentAlertId: older.id,
           childAlertId: newer.id,
-          correlationType: 'same_device_temporal',
+          correlationType: evidence.correlationType,
           confidence: String(confidence),
-          metadata: {
-            timeDiffMinutes: Math.round(timeDiffMs / 60000),
-            deviceId: options.deviceId,
-          },
+          metadata: evidence.metadata,
         });
 
       linkedPairs.add(pairKey);


### PR DESCRIPTION
## Summary
- select rule/template/config-policy/site context during alert correlation passes
- emit stronger correlation types for same-rule, same-template, and same config-policy item alert pairs
- include source evidence in alert correlation metadata for grouping/RCA consumers

## Verification
- `pnpm --filter @breeze/api exec vitest run src/jobs/alertCorrelation.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `git diff --check`