### PR TITLE
feat(ml): correlate alerts across a site

### DIFF
--- a/apps/api/src/jobs/alertCorrelation.test.ts
+++ b/apps/api/src/jobs/alertCorrelation.test.ts
@@ -63,6 +63,7 @@ import {
 
 const alertAt = (overrides: Partial<Parameters<typeof buildAlertCorrelationEvidence>[0]['newer']>) => ({
   id: 'alert-1',
+  deviceId: 'device-1',
   triggeredAt: new Date('2026-06-18T12:00:00.000Z'),
   ruleId: null,
   templateId: null,
@@ -147,6 +148,8 @@ describe('alert correlation queue helpers', () => {
       confidence: 0.98,
       metadata: {
         deviceId: 'device-1',
+        parentDeviceId: 'device-1',
+        childDeviceId: 'device-1',
         siteId: 'site-1',
         ruleId: 'rule-1',
         templateId: 'template-1',
@@ -190,6 +193,28 @@ describe('alert correlation queue helpers', () => {
         configPolicyId: 'policy-1',
         configItemName: 'disk-low',
         evidence: ['same_device', 'time_window', 'same_config_policy_item'],
+      },
+    });
+  });
+
+  it('builds same-site evidence for different-device alert pairs', () => {
+    const evidence = buildAlertCorrelationEvidence({
+      older: alertAt({ id: 'older', deviceId: 'device-1', siteId: 'site-1' }),
+      newer: alertAt({ id: 'newer', deviceId: 'device-2', siteId: 'site-1' }),
+      deviceId: 'device-2',
+      timeDiffMs: 3 * 60 * 1000,
+      maxWindowMs: 30 * 60 * 1000,
+    });
+
+    expect(evidence).toMatchObject({
+      correlationType: 'same_site_temporal',
+      confidence: 0.9,
+      metadata: {
+        deviceId: 'device-2',
+        parentDeviceId: 'device-1',
+        childDeviceId: 'device-2',
+        siteId: 'site-1',
+        evidence: ['same_site', 'time_window'],
       },
     });
   });

--- a/apps/api/src/jobs/alertCorrelation.ts
+++ b/apps/api/src/jobs/alertCorrelation.ts
@@ -13,10 +13,11 @@ const ALERT_CORRELATION_QUEUE = 'alert-correlation';
 const DEDUPE_WINDOW_MS = 30 * 1000;
 const DEFAULT_DELAY_MS = 5 * 1000;
 const DEFAULT_WINDOW_MINUTES = 30;
-const MAX_ALERTS_PER_DEVICE_PASS = 50;
+const MAX_ALERTS_PER_SITE_PASS = 50;
 
 type CorrelatableAlert = {
   id: string;
+  deviceId: string;
   triggeredAt: Date;
   ruleId: string | null;
   templateId: string | null;
@@ -29,6 +30,7 @@ type AlertCorrelationEvidenceType =
   | 'same_rule_temporal'
   | 'same_template_temporal'
   | 'same_config_policy_item_temporal'
+  | 'same_site_temporal'
   | 'same_device_temporal';
 
 export type AlertCorrelationJobData = {
@@ -67,9 +69,10 @@ export function buildAlertCorrelationEvidence(options: {
   metadata: Record<string, unknown>;
 } {
   const baseConfidence = Math.round((1 - options.timeDiffMs / options.maxWindowMs) * 100) / 100;
-  let correlationType: AlertCorrelationEvidenceType = 'same_device_temporal';
+  const sameDevice = options.older.deviceId === options.newer.deviceId;
+  let correlationType: AlertCorrelationEvidenceType = sameDevice ? 'same_device_temporal' : 'same_site_temporal';
   let confidence = baseConfidence;
-  const evidence: string[] = ['same_device', 'time_window'];
+  const evidence: string[] = [sameDevice ? 'same_device' : 'same_site', 'time_window'];
 
   if (options.older.ruleId && options.older.ruleId === options.newer.ruleId) {
     correlationType = 'same_rule_temporal';
@@ -96,6 +99,8 @@ export function buildAlertCorrelationEvidence(options: {
     metadata: {
       timeDiffMinutes: Math.round(options.timeDiffMs / 60000),
       deviceId: options.deviceId,
+      parentDeviceId: options.older.deviceId,
+      childDeviceId: options.newer.deviceId,
       siteId: options.newer.siteId ?? options.older.siteId,
       ruleId: options.newer.ruleId ?? options.older.ruleId,
       templateId: options.newer.templateId ?? options.older.templateId,
@@ -155,10 +160,20 @@ export async function runAlertCorrelationForDevice(options: {
 
   const windowMinutes = options.windowMinutes ?? DEFAULT_WINDOW_MINUTES;
   const windowStart = new Date(Date.now() - windowMinutes * 60 * 1000);
+  const [targetDevice] = await db
+    .select({ siteId: devices.siteId })
+    .from(devices)
+    .where(and(eq(devices.id, options.deviceId), eq(devices.orgId, options.orgId)))
+    .limit(1);
+
+  if (!targetDevice) {
+    return { scanned: 0, created: 0 };
+  }
 
   const recentAlerts = await db
     .select({
       id: alerts.id,
+      deviceId: alerts.deviceId,
       triggeredAt: alerts.triggeredAt,
       ruleId: alerts.ruleId,
       templateId: alertRules.templateId,
@@ -171,14 +186,14 @@ export async function runAlertCorrelationForDevice(options: {
     .innerJoin(devices, eq(alerts.deviceId, devices.id))
     .where(
       and(
-        eq(alerts.deviceId, options.deviceId),
         eq(alerts.orgId, options.orgId),
+        eq(devices.siteId, targetDevice.siteId),
         gte(alerts.triggeredAt, windowStart),
         inArray(alerts.status, ['active', 'acknowledged'])
       )
     )
     .orderBy(desc(alerts.triggeredAt))
-    .limit(MAX_ALERTS_PER_DEVICE_PASS);
+    .limit(MAX_ALERTS_PER_SITE_PASS);
 
   if (recentAlerts.length < 2) {
     return { scanned: recentAlerts.length, created: 0 };


### PR DESCRIPTION
## Summary
- broaden alert correlation passes from one device to the triggering device site
- keep each pass bounded while allowing same-site alert pairs across devices
- add same-site correlation evidence and parent/child device metadata

## Verification
- `pnpm --filter @breeze/api exec vitest run src/jobs/alertCorrelation.test.ts`
- `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `git diff --check`