### PR TITLE
feat(ml): include correlation metadata in RCA evidence

### DIFF
--- a/apps/api/src/services/alertCorrelationRca.test.ts
+++ b/apps/api/src/services/alertCorrelationRca.test.ts
@@ -4,10 +4,12 @@ const { dbMock, state, tables } = vi.hoisted(() => {
   const tables = {
     devices: { id: 'devices.id', orgId: 'devices.orgId', hostname: 'devices.hostname', osType: 'devices.osType' },
     alertCorrelations: {
+      id: 'alert_correlations.id',
       parentAlertId: 'alert_correlations.parentAlertId',
       childAlertId: 'alert_correlations.childAlertId',
       correlationType: 'alert_correlations.correlationType',
       confidence: 'alert_correlations.confidence',
+      metadata: 'alert_correlations.metadata',
       createdAt: 'alert_correlations.createdAt',
     },
     brainDeviceContext: {
@@ -164,10 +166,25 @@ describe('alert correlation RCA evidence builder', () => {
     vi.clearAllMocks();
     state.devices = [{ id: DEVICE_ID, orgId: ORG_ID, hostname: 'server-1', osType: 'windows' }];
     state.correlations = [{
+      id: 'correlation-1',
       parentAlertId: ALERT_1,
       childAlertId: ALERT_2,
       correlationType: 'same_device_temporal',
       confidence: '0.91',
+      metadata: {
+        evidence: ['same_device', 'time_window', 'same_rule', 'shared_log_correlation', 'flapping_suppression'],
+        ruleId: 'rule-1',
+        templateId: 'template-1',
+        logCorrelationIds: ['log-correlation-1'],
+        logCorrelationRuleIds: ['log-rule-1'],
+        logCorrelationRuleNames: ['Service crash burst'],
+        logPatterns: ['service crashed'],
+        logOccurrences: 7,
+        logSeverity: 'critical',
+        flappingDetected: true,
+        flappingRuleIds: ['rule-1'],
+        flappingDeviceIds: [DEVICE_ID],
+      },
       createdAt: new Date('2026-06-18T12:03:00Z'),
     }];
     state.context = [{
@@ -247,6 +264,27 @@ describe('alert correlation RCA evidence builder', () => {
       'agent_log',
       'metric_rollup',
     ]));
+    const correlationEvidence = result.timeline.find((item) => item.source === 'correlation');
+    expect(correlationEvidence?.summary).toContain('shared_log_correlation');
+    expect(correlationEvidence?.summary).toContain('Service crash burst');
+    expect(correlationEvidence?.summary).toContain('service crashed');
+    expect(correlationEvidence?.summary).toContain('Flapping detected');
+    expect(correlationEvidence?.metadata).toMatchObject({
+      correlationId: 'correlation-1',
+      parentAlertId: ALERT_1,
+      childAlertId: ALERT_2,
+      confidence: 0.91,
+      evidence: ['same_device', 'time_window', 'same_rule', 'shared_log_correlation', 'flapping_suppression'],
+      ruleId: 'rule-1',
+      templateId: 'template-1',
+      logCorrelationIds: ['log-correlation-1'],
+      logCorrelationRuleNames: ['Service crash burst'],
+      logPatterns: ['service crashed'],
+      logOccurrences: 7,
+      flappingDetected: true,
+      flappingRuleIds: ['rule-1'],
+      flappingDeviceIds: [DEVICE_ID],
+    });
     expect(result.rootCauseCandidates).toEqual(expect.arrayContaining([
       expect.objectContaining({ confidence: 0.91 }),
       expect.objectContaining({ confidence: 0.58 }),

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -26,6 +26,7 @@ export interface RcaEvidenceItem {
   severity?: string;
   title: string;
   summary: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface RcaRootCauseCandidate {
@@ -83,6 +84,90 @@ function summarizeJson(value: unknown, maxLength = 180): string {
   if (value == null) return '';
   const raw = typeof value === 'string' ? value : JSON.stringify(value);
   return raw.length > maxLength ? `${raw.slice(0, maxLength)}...` : raw;
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function metadataStringArray(metadata: Record<string, unknown>, key: string, maxItems = 5): string[] {
+  const value = metadata[key];
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string' && item.length > 0)
+    .slice(0, maxItems);
+}
+
+function metadataString(metadata: Record<string, unknown>, key: string): string | null {
+  const value = metadata[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function buildCorrelationSummary(link: CorrelationRow): string {
+  const metadata = metadataRecord(link.metadata);
+  const details: string[] = [];
+  const evidence = metadataStringArray(metadata, 'evidence');
+  const sourceIds = [
+    metadataString(metadata, 'ruleId') ? `rule ${metadataString(metadata, 'ruleId')}` : null,
+    metadataString(metadata, 'templateId') ? `template ${metadataString(metadata, 'templateId')}` : null,
+    metadataString(metadata, 'configPolicyId') && metadataString(metadata, 'configItemName')
+      ? `config item ${metadataString(metadata, 'configPolicyId')}/${metadataString(metadata, 'configItemName')}`
+      : null,
+  ].filter((item): item is string => Boolean(item));
+  const logRuleNames = metadataStringArray(metadata, 'logCorrelationRuleNames');
+  const logPatterns = metadataStringArray(metadata, 'logPatterns', 3);
+  const logOccurrences = typeof metadata.logOccurrences === 'number' ? metadata.logOccurrences : null;
+  const logSeverity = metadataString(metadata, 'logSeverity');
+  const flappingRuleIds = metadataStringArray(metadata, 'flappingRuleIds');
+  const flappingDeviceIds = metadataStringArray(metadata, 'flappingDeviceIds');
+
+  if (evidence.length > 0) details.push(`Evidence: ${evidence.join(', ')}`);
+  if (sourceIds.length > 0) details.push(`Sources: ${sourceIds.join(', ')}`);
+  if (logRuleNames.length > 0 || logPatterns.length > 0) {
+    const logDetails = [
+      logRuleNames.length > 0 ? `rules ${logRuleNames.join(', ')}` : null,
+      logPatterns.length > 0 ? `patterns ${logPatterns.join(', ')}` : null,
+      logOccurrences != null ? `${logOccurrences} occurrence${logOccurrences === 1 ? '' : 's'}` : null,
+      logSeverity ? `severity ${logSeverity}` : null,
+    ].filter((item): item is string => Boolean(item));
+    details.push(`Log correlation: ${logDetails.join('; ')}`);
+  }
+  if (metadata.flappingDetected === true) {
+    const flappingDetails = [
+      flappingRuleIds.length > 0 ? `rules ${flappingRuleIds.join(', ')}` : null,
+      flappingDeviceIds.length > 0 ? `devices ${flappingDeviceIds.join(', ')}` : null,
+    ].filter((item): item is string => Boolean(item));
+    details.push(`Flapping detected${flappingDetails.length > 0 ? ` on ${flappingDetails.join('; ')}` : ''}`);
+  }
+
+  const base = `Alert ${link.parentAlertId} is correlated with ${link.childAlertId} at confidence ${Number(link.confidence ?? 0).toFixed(2)}.`;
+  return details.length > 0 ? `${base} ${details.join('. ')}.` : base;
+}
+
+function buildCorrelationMetadata(link: CorrelationRow): Record<string, unknown> {
+  const metadata = metadataRecord(link.metadata);
+  return {
+    correlationId: link.id,
+    parentAlertId: link.parentAlertId,
+    childAlertId: link.childAlertId,
+    confidence: Number(link.confidence ?? 0),
+    evidence: metadataStringArray(metadata, 'evidence'),
+    ruleId: metadataString(metadata, 'ruleId'),
+    templateId: metadataString(metadata, 'templateId'),
+    configPolicyId: metadataString(metadata, 'configPolicyId'),
+    configItemName: metadataString(metadata, 'configItemName'),
+    logCorrelationIds: metadataStringArray(metadata, 'logCorrelationIds'),
+    logCorrelationRuleIds: metadataStringArray(metadata, 'logCorrelationRuleIds'),
+    logCorrelationRuleNames: metadataStringArray(metadata, 'logCorrelationRuleNames'),
+    logPatterns: metadataStringArray(metadata, 'logPatterns', 3),
+    logOccurrences: typeof metadata.logOccurrences === 'number' ? metadata.logOccurrences : null,
+    logSeverity: metadataString(metadata, 'logSeverity'),
+    flappingDetected: metadata.flappingDetected === true,
+    flappingRuleIds: metadataStringArray(metadata, 'flappingRuleIds'),
+    flappingDeviceIds: metadataStringArray(metadata, 'flappingDeviceIds'),
+    flappingConfigPolicyIds: metadataStringArray(metadata, 'flappingConfigPolicyIds'),
+  };
 }
 
 function rankEvidence(items: RcaEvidenceItem[]): RcaEvidenceItem[] {
@@ -346,7 +431,8 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
       timestamp: toIso(asDate(link.createdAt)),
       alertId: link.parentAlertId,
       title: `Correlation: ${link.correlationType}`,
-      summary: `Alert ${link.parentAlertId} is correlated with ${link.childAlertId} at confidence ${Number(link.confidence ?? 0).toFixed(2)}.`,
+      summary: buildCorrelationSummary(link),
+      metadata: buildCorrelationMetadata(link),
     })),
     ...contextRows.map((row) => ({
       id: `device_context:${row.id}`,


### PR DESCRIPTION
## Summary
- enrich RCA correlation evidence summaries with edge metadata from alert_correlations
- expose bounded structured metadata on correlation timeline items for richer RCA clients
- cover log/flapping/source metadata in the RCA evidence builder test

## Tests
- pnpm --filter @breeze/api exec vitest run src/services/alertCorrelationRca.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- git diff --check