### PR TITLE
feat(ml): include alert source metadata in RCA evidence

### DIFF
--- a/apps/api/src/services/alertCorrelationRca.test.ts
+++ b/apps/api/src/services/alertCorrelationRca.test.ts
@@ -3,6 +3,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { dbMock, state, tables } = vi.hoisted(() => {
   const tables = {
     devices: { id: 'devices.id', orgId: 'devices.orgId', hostname: 'devices.hostname', osType: 'devices.osType' },
+    alertRules: {
+      id: 'alertRules.ruleId',
+      orgId: 'alertRules.orgId',
+      templateId: 'alertRules.templateId',
+      name: 'alertRules.ruleName',
+      targetType: 'alertRules.ruleTargetType',
+      targetId: 'alertRules.ruleTargetId',
+      isActive: 'alertRules.ruleIsActive',
+    },
+    alertTemplates: {
+      id: 'alertTemplates.templateIdValue',
+      name: 'alertTemplates.templateName',
+      category: 'alertTemplates.templateCategory',
+      severity: 'alertTemplates.templateSeverity',
+      isBuiltIn: 'alertTemplates.templateIsBuiltIn',
+      cooldownMinutes: 'alertTemplates.templateCooldownMinutes',
+    },
     alertCorrelations: {
       id: 'alert_correlations.id',
       parentAlertId: 'alert_correlations.parentAlertId',
@@ -61,6 +78,24 @@ const { dbMock, state, tables } = vi.hoisted(() => {
       avgValue: 'metricRollups.avgValue',
       maxValue: 'metricRollups.maxValue',
     },
+    configPolicyAlertRules: {
+      id: 'configPolicyAlertRules.configPolicyAlertRuleId',
+      featureLinkId: 'configPolicyAlertRules.featureLinkId',
+      name: 'configPolicyAlertRules.configPolicyAlertRuleName',
+      severity: 'configPolicyAlertRules.configPolicyAlertSeverity',
+      cooldownMinutes: 'configPolicyAlertRules.configPolicyAlertCooldownMinutes',
+    },
+    configPolicyFeatureLinks: {
+      id: 'configPolicyFeatureLinks.featureLinkId',
+      configPolicyId: 'configPolicyFeatureLinks.configurationPolicyId',
+      featureType: 'configPolicyFeatureLinks.featureType',
+    },
+    configurationPolicies: {
+      id: 'configurationPolicies.configurationPolicyId',
+      orgId: 'configurationPolicies.orgId',
+      name: 'configurationPolicies.configurationPolicyName',
+      status: 'configurationPolicies.configurationPolicyStatus',
+    },
   };
 
   type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
@@ -80,7 +115,9 @@ const { dbMock, state, tables } = vi.hoisted(() => {
 
   const state = {
     devices: [] as Array<Record<string, any>>,
+    alertRuleSources: [] as Array<Record<string, any>>,
     correlations: [] as Array<Record<string, any>>,
+    configPolicySources: [] as Array<Record<string, any>>,
     context: [] as Array<Record<string, any>>,
     changes: [] as Array<Record<string, any>>,
     eventLogs: [] as Array<Record<string, any>>,
@@ -92,6 +129,8 @@ const { dbMock, state, tables } = vi.hoisted(() => {
     private predicate: Predicate;
     constructor(private table: unknown, private projection?: Record<string, unknown>) {}
     where(predicate: Predicate) { this.predicate = predicate; return this; }
+    leftJoin() { return this; }
+    innerJoin() { return this; }
     orderBy() { return this; }
     limit(limit: number) { return Promise.resolve(this.rows().slice(0, limit)); }
     then(resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) {
@@ -100,17 +139,21 @@ const { dbMock, state, tables } = vi.hoisted(() => {
     private rows() {
       const source = this.table === tables.devices
         ? state.devices
-        : this.table === tables.alertCorrelations
-          ? state.correlations
-          : this.table === tables.brainDeviceContext
-            ? state.context
-            : this.table === tables.deviceChangeLog
-              ? state.changes
-              : this.table === tables.deviceEventLogs
-                ? state.eventLogs
-                : this.table === tables.agentLogs
-                  ? state.agentLogs
-                  : state.metricRollups;
+        : this.table === tables.alertRules
+          ? state.alertRuleSources
+          : this.table === tables.alertCorrelations
+            ? state.correlations
+            : this.table === tables.configPolicyAlertRules
+              ? state.configPolicySources
+              : this.table === tables.brainDeviceContext
+                ? state.context
+                : this.table === tables.deviceChangeLog
+                  ? state.changes
+                  : this.table === tables.deviceEventLogs
+                    ? state.eventLogs
+                    : this.table === tables.agentLogs
+                      ? state.agentLogs
+                      : state.metricRollups;
       const filtered = source.filter((row) => evalPredicate(row, this.predicate));
       if (!this.projection) return filtered;
       return filtered.map((row) => {
@@ -147,7 +190,12 @@ vi.mock('../db', () => ({ db: dbMock }));
 vi.mock('../db/schema', () => ({
   agentLogs: tables.agentLogs,
   alertCorrelations: tables.alertCorrelations,
+  alertRules: tables.alertRules,
+  alertTemplates: tables.alertTemplates,
   brainDeviceContext: tables.brainDeviceContext,
+  configPolicyAlertRules: tables.configPolicyAlertRules,
+  configPolicyFeatureLinks: tables.configPolicyFeatureLinks,
+  configurationPolicies: tables.configurationPolicies,
   deviceChangeLog: tables.deviceChangeLog,
   deviceEventLogs: tables.deviceEventLogs,
   devices: tables.devices,
@@ -165,6 +213,21 @@ describe('alert correlation RCA evidence builder', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.devices = [{ id: DEVICE_ID, orgId: ORG_ID, hostname: 'server-1', osType: 'windows' }];
+    state.alertRuleSources = [{
+      orgId: ORG_ID,
+      ruleId: 'rule-1',
+      templateId: 'template-1',
+      ruleName: 'CPU threshold',
+      ruleTargetType: 'device',
+      ruleTargetId: DEVICE_ID,
+      ruleIsActive: true,
+      templateIdValue: 'template-1',
+      templateName: 'Resource saturation',
+      templateCategory: 'performance',
+      templateSeverity: 'critical',
+      templateIsBuiltIn: false,
+      templateCooldownMinutes: 10,
+    }];
     state.correlations = [{
       id: 'correlation-1',
       parentAlertId: ALERT_1,
@@ -186,6 +249,18 @@ describe('alert correlation RCA evidence builder', () => {
         flappingDeviceIds: [DEVICE_ID],
       },
       createdAt: new Date('2026-06-18T12:03:00Z'),
+    }];
+    state.configPolicySources = [{
+      orgId: ORG_ID,
+      configPolicyAlertRuleId: 'cpar-1',
+      configPolicyAlertRuleName: 'Memory threshold',
+      configPolicyAlertSeverity: 'high',
+      configPolicyAlertCooldownMinutes: 15,
+      featureLinkId: 'feature-link-1',
+      featureType: 'alerts',
+      configurationPolicyId: 'policy-1',
+      configurationPolicyName: 'Server monitoring baseline',
+      configurationPolicyStatus: 'active',
     }];
     state.context = [{
       id: 'ctx-1',
@@ -246,8 +321,8 @@ describe('alert correlation RCA evidence builder', () => {
       windowHours: 4,
       maxEvidenceItems: 20,
       alerts: [
-        { id: ALERT_1, orgId: ORG_ID, deviceId: DEVICE_ID, ruleId: 'rule-1', configPolicyId: null, configItemName: null, status: 'active', severity: 'critical', title: 'CPU high', message: 'CPU over 90%', context: {}, triggeredAt: new Date('2026-06-18T12:00:00Z'), acknowledgedAt: null, acknowledgedBy: null, resolvedAt: null, resolvedBy: null, resolutionNote: null, suppressedUntil: null, createdAt: new Date('2026-06-18T12:00:00Z') },
-        { id: ALERT_2, orgId: ORG_ID, deviceId: DEVICE_ID, ruleId: 'rule-2', configPolicyId: null, configItemName: null, status: 'active', severity: 'high', title: 'Memory high', message: 'RAM over 90%', context: {}, triggeredAt: new Date('2026-06-18T12:02:00Z'), acknowledgedAt: null, acknowledgedBy: null, resolvedAt: null, resolvedBy: null, resolutionNote: null, suppressedUntil: null, createdAt: new Date('2026-06-18T12:02:00Z') },
+        { id: ALERT_1, orgId: ORG_ID, deviceId: DEVICE_ID, ruleId: 'rule-1', configPolicyId: null, configItemName: null, status: 'active', severity: 'critical', title: 'CPU high', message: 'CPU over 90%', context: { threshold: 90, observed: 96 }, triggeredAt: new Date('2026-06-18T12:00:00Z'), acknowledgedAt: null, acknowledgedBy: null, resolvedAt: null, resolvedBy: null, resolutionNote: null, suppressedUntil: null, createdAt: new Date('2026-06-18T12:00:00Z') },
+        { id: ALERT_2, orgId: ORG_ID, deviceId: DEVICE_ID, ruleId: null, configPolicyId: 'cpar-1', configItemName: 'ram_percent', status: 'active', severity: 'high', title: 'Memory high', message: 'RAM over 90%', context: { threshold: 90, observed: 94 }, triggeredAt: new Date('2026-06-18T12:02:00Z'), acknowledgedAt: null, acknowledgedBy: null, resolvedAt: null, resolvedBy: null, resolutionNote: null, suppressedUntil: null, createdAt: new Date('2026-06-18T12:02:00Z') },
       ],
     });
 
@@ -284,6 +359,43 @@ describe('alert correlation RCA evidence builder', () => {
       flappingDetected: true,
       flappingRuleIds: ['rule-1'],
       flappingDeviceIds: [DEVICE_ID],
+    });
+    const legacyAlertEvidence = result.timeline.find((item) => item.id === `alert:${ALERT_1}`);
+    expect(legacyAlertEvidence?.summary).toContain('via rule "CPU threshold"');
+    expect(legacyAlertEvidence?.metadata).toMatchObject({
+      contextSummary: '{"threshold":90,"observed":96}',
+      rule: {
+        id: 'rule-1',
+        name: 'CPU threshold',
+        targetType: 'device',
+        targetId: DEVICE_ID,
+        isActive: true,
+      },
+      template: {
+        id: 'template-1',
+        name: 'Resource saturation',
+        category: 'performance',
+        severity: 'critical',
+        isBuiltIn: false,
+        cooldownMinutes: 10,
+      },
+    });
+    const configAlertEvidence = result.timeline.find((item) => item.id === `alert:${ALERT_2}`);
+    expect(configAlertEvidence?.summary).toContain('via config policy rule "Memory threshold"');
+    expect(configAlertEvidence?.metadata).toMatchObject({
+      contextSummary: '{"threshold":90,"observed":94}',
+      configSource: {
+        configPolicyAlertRuleId: 'cpar-1',
+        configPolicyAlertRuleName: 'Memory threshold',
+        severity: 'high',
+        cooldownMinutes: 15,
+        featureLinkId: 'feature-link-1',
+        featureType: 'alerts',
+        configurationPolicyId: 'policy-1',
+        configurationPolicyName: 'Server monitoring baseline',
+        configurationPolicyStatus: 'active',
+        itemName: 'ram_percent',
+      },
     });
     expect(result.rootCauseCandidates).toEqual(expect.arrayContaining([
       expect.objectContaining({ confidence: 0.91 }),

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -4,8 +4,13 @@ import { db } from '../db';
 import {
   agentLogs,
   alertCorrelations,
+  alertRules,
+  alertTemplates,
   alerts,
   brainDeviceContext,
+  configPolicyAlertRules,
+  configPolicyFeatureLinks,
+  configurationPolicies,
   deviceChangeLog,
   deviceEventLogs,
   devices,
@@ -15,6 +20,32 @@ import {
 type AlertRow = typeof alerts.$inferSelect;
 type CorrelationRow = typeof alertCorrelations.$inferSelect;
 type DeviceRow = Pick<typeof devices.$inferSelect, 'id' | 'hostname' | 'osType'>;
+
+type AlertRuleSource = {
+  ruleId: string;
+  ruleName: string;
+  ruleTargetType: string;
+  ruleTargetId: string;
+  ruleIsActive: boolean;
+  templateId: string | null;
+  templateName: string | null;
+  templateCategory: string | null;
+  templateSeverity: string | null;
+  templateIsBuiltIn: boolean | null;
+  templateCooldownMinutes: number | null;
+};
+
+type ConfigPolicyAlertSource = {
+  configPolicyAlertRuleId: string;
+  configPolicyAlertRuleName: string;
+  configPolicyAlertSeverity: string;
+  configPolicyAlertCooldownMinutes: number;
+  featureLinkId: string;
+  featureType: string;
+  configurationPolicyId: string;
+  configurationPolicyName: string;
+  configurationPolicyStatus: string;
+};
 
 export interface RcaEvidenceItem {
   id: string;
@@ -170,6 +201,51 @@ function buildCorrelationMetadata(link: CorrelationRow): Record<string, unknown>
   };
 }
 
+function buildAlertMetadata(
+  alert: AlertRow,
+  ruleSource: AlertRuleSource | undefined,
+  configSource: ConfigPolicyAlertSource | undefined,
+): Record<string, unknown> {
+  return {
+    alertId: alert.id,
+    status: alert.status,
+    ruleId: alert.ruleId,
+    configPolicyId: alert.configPolicyId,
+    configItemName: alert.configItemName,
+    contextSummary: summarizeJson(alert.context, 500) || null,
+    rule: ruleSource ? {
+      id: ruleSource.ruleId,
+      name: ruleSource.ruleName,
+      targetType: ruleSource.ruleTargetType,
+      targetId: ruleSource.ruleTargetId,
+      isActive: ruleSource.ruleIsActive,
+    } : null,
+    template: ruleSource?.templateId ? {
+      id: ruleSource.templateId,
+      name: ruleSource.templateName,
+      category: ruleSource.templateCategory,
+      severity: ruleSource.templateSeverity,
+      isBuiltIn: ruleSource.templateIsBuiltIn,
+      cooldownMinutes: ruleSource.templateCooldownMinutes,
+    } : null,
+    configSource: configSource ? {
+      configPolicyAlertRuleId: configSource.configPolicyAlertRuleId,
+      configPolicyAlertRuleName: configSource.configPolicyAlertRuleName,
+      severity: configSource.configPolicyAlertSeverity,
+      cooldownMinutes: configSource.configPolicyAlertCooldownMinutes,
+      featureLinkId: configSource.featureLinkId,
+      featureType: configSource.featureType,
+      configurationPolicyId: configSource.configurationPolicyId,
+      configurationPolicyName: configSource.configurationPolicyName,
+      configurationPolicyStatus: configSource.configurationPolicyStatus,
+      itemName: alert.configItemName,
+    } : alert.configPolicyId ? {
+      configPolicyAlertRuleId: alert.configPolicyId,
+      itemName: alert.configItemName,
+    } : null,
+  };
+}
+
 function rankEvidence(items: RcaEvidenceItem[]): RcaEvidenceItem[] {
   const sourceWeight: Record<RcaEvidenceItem['source'], number> = {
     alert: 100,
@@ -188,9 +264,23 @@ function rankEvidence(items: RcaEvidenceItem[]): RcaEvidenceItem[] {
   });
 }
 
-function buildAlertEvidence(alertRows: AlertRow[], deviceNames: Map<string, DeviceRow>): RcaEvidenceItem[] {
+function buildAlertEvidence(
+  alertRows: AlertRow[],
+  deviceNames: Map<string, DeviceRow>,
+  ruleSources: Map<string, AlertRuleSource>,
+  configSources: Map<string, ConfigPolicyAlertSource>,
+): RcaEvidenceItem[] {
   return alertRows.map((alert) => {
     const device = deviceNames.get(alert.deviceId);
+    const ruleSource = alert.ruleId ? ruleSources.get(alert.ruleId) : undefined;
+    const configSource = alert.configPolicyId ? configSources.get(alert.configPolicyId) : undefined;
+    const sourceSummary = ruleSource?.ruleName
+      ? ` via rule "${ruleSource.ruleName}"`
+      : configSource?.configPolicyAlertRuleName
+        ? ` via config policy rule "${configSource.configPolicyAlertRuleName}"`
+        : alert.configPolicyId
+          ? ` via config policy item "${alert.configItemName ?? alert.configPolicyId}"`
+        : '';
     return {
       id: `alert:${alert.id}`,
       source: 'alert',
@@ -200,7 +290,8 @@ function buildAlertEvidence(alertRows: AlertRow[], deviceNames: Map<string, Devi
       alertId: alert.id,
       severity: alert.severity,
       title: alert.title,
-      summary: `${alert.severity.toUpperCase()} alert on ${device?.hostname ?? alert.deviceId}: ${alert.message ?? alert.title}`,
+      summary: `${alert.severity.toUpperCase()} alert on ${device?.hostname ?? alert.deviceId}${sourceSummary}: ${alert.message ?? alert.title}`,
+      metadata: buildAlertMetadata(alert, ruleSource, configSource),
     };
   });
 }
@@ -345,6 +436,52 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
         .where(and(eq(devices.orgId, options.orgId), inArray(devices.id, deviceIds)))
     : [];
   const deviceNames = new Map(deviceRows.map((device) => [device.id, device]));
+  const ruleIds = [...new Set(alertRows.map((alert) => alert.ruleId).filter((id): id is string => Boolean(id)))];
+  const ruleSourceRows: AlertRuleSource[] = ruleIds.length > 0
+    ? await db
+        .select({
+          ruleId: alertRules.id,
+          ruleName: alertRules.name,
+          ruleTargetType: alertRules.targetType,
+          ruleTargetId: alertRules.targetId,
+          ruleIsActive: alertRules.isActive,
+          templateId: alertTemplates.id,
+          templateName: alertTemplates.name,
+          templateCategory: alertTemplates.category,
+          templateSeverity: alertTemplates.severity,
+          templateIsBuiltIn: alertTemplates.isBuiltIn,
+          templateCooldownMinutes: alertTemplates.cooldownMinutes,
+        })
+        .from(alertRules)
+        .leftJoin(alertTemplates, eq(alertRules.templateId, alertTemplates.id))
+        .where(and(eq(alertRules.orgId, options.orgId), inArray(alertRules.id, ruleIds)))
+    : [];
+  const ruleSources = new Map(ruleSourceRows.map((row) => [row.ruleId, row]));
+  const configPolicyAlertRuleIds = [
+    ...new Set(alertRows.map((alert) => alert.configPolicyId).filter((id): id is string => Boolean(id)))
+  ];
+  const configSourceRows: ConfigPolicyAlertSource[] = configPolicyAlertRuleIds.length > 0
+    ? await db
+        .select({
+          configPolicyAlertRuleId: configPolicyAlertRules.id,
+          configPolicyAlertRuleName: configPolicyAlertRules.name,
+          configPolicyAlertSeverity: configPolicyAlertRules.severity,
+          configPolicyAlertCooldownMinutes: configPolicyAlertRules.cooldownMinutes,
+          featureLinkId: configPolicyFeatureLinks.id,
+          featureType: configPolicyFeatureLinks.featureType,
+          configurationPolicyId: configurationPolicies.id,
+          configurationPolicyName: configurationPolicies.name,
+          configurationPolicyStatus: configurationPolicies.status,
+        })
+        .from(configPolicyAlertRules)
+        .innerJoin(configPolicyFeatureLinks, eq(configPolicyAlertRules.featureLinkId, configPolicyFeatureLinks.id))
+        .innerJoin(configurationPolicies, eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id))
+        .where(and(
+          eq(configurationPolicies.orgId, options.orgId),
+          inArray(configPolicyAlertRules.id, configPolicyAlertRuleIds)
+        ))
+    : [];
+  const configSources = new Map(configSourceRows.map((row) => [row.configPolicyAlertRuleId, row]));
 
   const correlationRows = alertIds.length > 1
     ? await db
@@ -423,7 +560,7 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
   if (metricRows.length === 0) gaps.push('No 5-minute metric rollups were available in the incident window.');
 
   const evidence: RcaEvidenceItem[] = [
-    ...buildAlertEvidence(alertRows, deviceNames),
+    ...buildAlertEvidence(alertRows, deviceNames, ruleSources, configSources),
     ...correlationRows.map((link) => ({
       id: `correlation:${link.parentAlertId}:${link.childAlertId}`,
       source: 'correlation' as const,


### PR DESCRIPTION
## Summary
- attach bounded alert context and source metadata to RCA alert timeline items
- resolve legacy alert rule/template source details at RCA read time
- resolve config-policy alert rule source details through policy feature links without persisting broad config payloads

## Tests
- pnpm --filter @breeze/api exec vitest run src/services/alertCorrelationRca.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- git diff --check