### PR TITLE
feat(ml): include correlation member evidence in RCA

### DIFF
--- a/apps/api/src/services/alertCorrelationRca.test.ts
+++ b/apps/api/src/services/alertCorrelationRca.test.ts
@@ -29,6 +29,15 @@ const { dbMock, state, tables } = vi.hoisted(() => {
       metadata: 'alert_correlations.metadata',
       createdAt: 'alert_correlations.createdAt',
     },
+    alertCorrelationMembers: {
+      orgId: 'alertCorrelationMembers.orgId',
+      groupId: 'alertCorrelationMembers.groupId',
+      alertId: 'alertCorrelationMembers.alertId',
+      role: 'alertCorrelationMembers.role',
+      confidence: 'alertCorrelationMembers.confidence',
+      evidence: 'alertCorrelationMembers.evidence',
+      updatedAt: 'alertCorrelationMembers.updatedAt',
+    },
     brainDeviceContext: {
       id: 'brainDeviceContext.id',
       orgId: 'brainDeviceContext.orgId',
@@ -135,6 +144,7 @@ const { dbMock, state, tables } = vi.hoisted(() => {
     devices: [] as Array<Record<string, any>>,
     alertRuleSources: [] as Array<Record<string, any>>,
     correlations: [] as Array<Record<string, any>>,
+    memberEvidence: [] as Array<Record<string, any>>,
     configPolicySources: [] as Array<Record<string, any>>,
     context: [] as Array<Record<string, any>>,
     changes: [] as Array<Record<string, any>>,
@@ -162,19 +172,21 @@ const { dbMock, state, tables } = vi.hoisted(() => {
           ? state.alertRuleSources
           : this.table === tables.alertCorrelations
             ? state.correlations
-            : this.table === tables.configPolicyAlertRules
-              ? state.configPolicySources
-              : this.table === tables.brainDeviceContext
-                ? state.context
-                : this.table === tables.logCorrelations
-                  ? state.linkedLogCorrelations
-                  : this.table === tables.deviceChangeLog
-                    ? state.changes
-                    : this.table === tables.deviceEventLogs
-                      ? state.eventLogs
-                      : this.table === tables.agentLogs
-                        ? state.agentLogs
-                        : state.metricRollups;
+            : this.table === tables.alertCorrelationMembers
+              ? state.memberEvidence
+              : this.table === tables.configPolicyAlertRules
+                ? state.configPolicySources
+                : this.table === tables.brainDeviceContext
+                  ? state.context
+                  : this.table === tables.logCorrelations
+                    ? state.linkedLogCorrelations
+                    : this.table === tables.deviceChangeLog
+                      ? state.changes
+                      : this.table === tables.deviceEventLogs
+                        ? state.eventLogs
+                        : this.table === tables.agentLogs
+                          ? state.agentLogs
+                          : state.metricRollups;
       const filtered = source.filter((row) => evalPredicate(row, this.predicate));
       if (!this.projection) return filtered;
       return filtered.map((row) => {
@@ -210,6 +222,7 @@ vi.mock('drizzle-orm', () => ({
 vi.mock('../db', () => ({ db: dbMock }));
 vi.mock('../db/schema', () => ({
   agentLogs: tables.agentLogs,
+  alertCorrelationMembers: tables.alertCorrelationMembers,
   alertCorrelations: tables.alertCorrelations,
   alertRules: tables.alertRules,
   alertTemplates: tables.alertTemplates,
@@ -273,6 +286,26 @@ describe('alert correlation RCA evidence builder', () => {
       },
       createdAt: new Date('2026-06-18T12:03:00Z'),
     }];
+    state.memberEvidence = [
+      {
+        orgId: ORG_ID,
+        groupId: 'group-1',
+        alertId: ALERT_1,
+        role: 'root',
+        confidence: '1.00',
+        evidence: { version: 'alert-correlation-groups-v1', source: 'component-root' },
+        updatedAt: new Date('2026-06-18T12:04:00Z'),
+      },
+      {
+        orgId: ORG_ID,
+        groupId: 'group-1',
+        alertId: ALERT_2,
+        role: 'related',
+        confidence: '0.91',
+        evidence: { version: 'alert-correlation-groups-v1', source: 'same-device' },
+        updatedAt: new Date('2026-06-18T12:04:30Z'),
+      },
+    ];
     state.configPolicySources = [{
       orgId: ORG_ID,
       configPolicyAlertRuleId: 'cpar-1',
@@ -419,6 +452,12 @@ describe('alert correlation RCA evidence builder', () => {
         isBuiltIn: false,
         cooldownMinutes: 10,
       },
+      correlationMember: {
+        role: 'root',
+        confidence: 1,
+        evidenceVersion: 'alert-correlation-groups-v1',
+        updatedAt: '2026-06-18T12:04:00.000Z',
+      },
     });
     const configAlertEvidence = result.timeline.find((item) => item.id === `alert:${ALERT_2}`);
     expect(configAlertEvidence?.summary).toContain('via config policy rule "Memory threshold"');
@@ -450,6 +489,12 @@ describe('alert correlation RCA evidence builder', () => {
         affectedDevices: [{ deviceId: DEVICE_ID, hostname: 'server-1', count: 5 }],
         sampleLogIds: ['sample-log-1'],
       }],
+      correlationMember: {
+        role: 'related',
+        confidence: 0.91,
+        evidenceVersion: 'alert-correlation-groups-v1',
+        updatedAt: '2026-06-18T12:04:30.000Z',
+      },
     });
     expect(result.rootCauseCandidates).toEqual(expect.arrayContaining([
       expect.objectContaining({ confidence: 0.91 }),

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
 import { db } from '../db';
 import {
   agentLogs,
+  alertCorrelationMembers,
   alertCorrelations,
   alertRules,
   alertTemplates,
@@ -62,6 +63,14 @@ type LinkedLogCorrelation = {
   occurrences: number;
   affectedDevices: unknown;
   sampleLogs: unknown;
+};
+
+type CorrelationMemberEvidence = {
+  alertId: string;
+  role: string;
+  confidence: string | null;
+  evidence: unknown;
+  updatedAt: Date;
 };
 
 export interface RcaEvidenceItem {
@@ -245,7 +254,9 @@ function buildAlertMetadata(
   ruleSource: AlertRuleSource | undefined,
   configSource: ConfigPolicyAlertSource | undefined,
   linkedLogCorrelations: LinkedLogCorrelation[],
+  memberEvidence: CorrelationMemberEvidence | undefined,
 ): Record<string, unknown> {
+  const memberEvidenceRecord = metadataRecord(memberEvidence?.evidence);
   return {
     alertId: alert.id,
     status: alert.status,
@@ -296,6 +307,13 @@ function buildAlertMetadata(
       affectedDevices: compactAffectedDevices(correlation.affectedDevices),
       sampleLogIds: compactSampleLogIds(correlation.sampleLogs),
     })),
+    correlationMember: memberEvidence ? {
+      role: memberEvidence.role,
+      confidence: Number(memberEvidence.confidence ?? 0),
+      evidenceVersion: metadataString(memberEvidenceRecord, 'version'),
+      evidence: memberEvidenceRecord,
+      updatedAt: toIso(asDate(memberEvidence.updatedAt)),
+    } : null,
   };
 }
 
@@ -323,12 +341,14 @@ function buildAlertEvidence(
   ruleSources: Map<string, AlertRuleSource>,
   configSources: Map<string, ConfigPolicyAlertSource>,
   linkedLogCorrelations: Map<string, LinkedLogCorrelation[]>,
+  memberEvidenceByAlertId: Map<string, CorrelationMemberEvidence>,
 ): RcaEvidenceItem[] {
   return alertRows.map((alert) => {
     const device = deviceNames.get(alert.deviceId);
     const ruleSource = alert.ruleId ? ruleSources.get(alert.ruleId) : undefined;
     const configSource = alert.configPolicyId ? configSources.get(alert.configPolicyId) : undefined;
     const alertLinkedLogCorrelations = linkedLogCorrelations.get(alert.id) ?? [];
+    const memberEvidence = memberEvidenceByAlertId.get(alert.id);
     const sourceSummary = ruleSource?.ruleName
       ? ` via rule "${ruleSource.ruleName}"`
       : configSource?.configPolicyAlertRuleName
@@ -349,7 +369,7 @@ function buildAlertEvidence(
       severity: alert.severity,
       title: alert.title,
       summary: `${alert.severity.toUpperCase()} alert on ${device?.hostname ?? alert.deviceId}${sourceSummary}${linkedLogSummary}: ${alert.message ?? alert.title}`,
-      metadata: buildAlertMetadata(alert, ruleSource, configSource, alertLinkedLogCorrelations),
+      metadata: buildAlertMetadata(alert, ruleSource, configSource, alertLinkedLogCorrelations, memberEvidence),
     };
   });
 }
@@ -570,6 +590,24 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
     rows.push(correlation);
     linkedLogCorrelationsByAlertId.set(correlation.alertId, rows);
   }
+  const memberEvidenceRows: CorrelationMemberEvidence[] = alertIds.length > 0
+    ? await db
+        .select({
+          alertId: alertCorrelationMembers.alertId,
+          role: alertCorrelationMembers.role,
+          confidence: alertCorrelationMembers.confidence,
+          evidence: alertCorrelationMembers.evidence,
+          updatedAt: alertCorrelationMembers.updatedAt,
+        })
+        .from(alertCorrelationMembers)
+        .where(and(
+          eq(alertCorrelationMembers.orgId, options.orgId),
+          eq(alertCorrelationMembers.groupId, options.groupId),
+          inArray(alertCorrelationMembers.alertId, alertIds)
+        ))
+        .limit(alertIds.length)
+    : [];
+  const memberEvidenceByAlertId = new Map(memberEvidenceRows.map((row) => [row.alertId, row]));
 
   const correlationRows = alertIds.length > 1
     ? await db
@@ -648,7 +686,14 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
   if (metricRows.length === 0) gaps.push('No 5-minute metric rollups were available in the incident window.');
 
   const evidence: RcaEvidenceItem[] = [
-    ...buildAlertEvidence(alertRows, deviceNames, ruleSources, configSources, linkedLogCorrelationsByAlertId),
+    ...buildAlertEvidence(
+      alertRows,
+      deviceNames,
+      ruleSources,
+      configSources,
+      linkedLogCorrelationsByAlertId,
+      memberEvidenceByAlertId
+    ),
     ...correlationRows.map((link) => ({
       id: `correlation:${link.parentAlertId}:${link.childAlertId}`,
       source: 'correlation' as const,


### PR DESCRIPTION
## Summary
- attach persisted alert_correlation_members role/confidence/evidence to RCA alert timeline metadata
- scope member lookup by org, group, and alert ids with a bounded limit
- cover root and related member metadata in the RCA evidence builder test

## Tests
- pnpm --filter @breeze/api exec vitest run src/services/alertCorrelationRca.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- git diff --check