### PR TITLE
feat(ml): suggest RCA next steps from correlation metadata

### DIFF
--- a/apps/api/src/services/alertCorrelationRca.test.ts
+++ b/apps/api/src/services/alertCorrelationRca.test.ts
@@ -517,11 +517,12 @@ describe('alert correlation RCA evidence builder', () => {
         evidenceIds: ['device_change:change-1'],
       }),
       expect.objectContaining({
-        title: 'Inspect aligned error logs',
+        title: 'Review flapping suppression',
+        riskTier: 'low',
+        evidenceIds: [`correlation:${ALERT_1}:${ALERT_2}`],
       }),
       expect.objectContaining({
-        title: 'Verify resource pressure',
-        riskTier: 'medium',
+        title: 'Inspect aligned error logs',
       }),
     ]));
     expect(result.gaps).toEqual([]);

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -469,6 +469,25 @@ function buildSuggestedNextSteps(
     });
   }
 
+  const correlationEvidence = evidence.find((item) => item.source === 'correlation' && item.metadata);
+  const correlationMetadata = metadataRecord(correlationEvidence?.metadata);
+  const logCorrelationRuleNames = metadataStringArray(correlationMetadata, 'logCorrelationRuleNames', 3);
+  if (correlationMetadata.flappingDetected === true && correlationEvidence) {
+    steps.push({
+      title: 'Review flapping suppression',
+      rationale: 'Correlation evidence indicates repeated alert state changes; verify whether the underlying rule should be tuned or the device state is oscillating.',
+      riskTier: 'low',
+      evidenceIds: [correlationEvidence.id],
+    });
+  } else if (logCorrelationRuleNames.length > 0 && correlationEvidence) {
+    steps.push({
+      title: 'Inspect correlated log pattern',
+      rationale: `Log-correlation evidence matched ${logCorrelationRuleNames.slice(0, 2).join(', ')} during the alert burst.`,
+      riskTier: 'low',
+      evidenceIds: [correlationEvidence.id],
+    });
+  }
+
   const logEvidence = evidence.find((item) => item.source === 'event_log' || item.source === 'agent_log');
   if (logEvidence) {
     steps.push({


### PR DESCRIPTION
## Summary
- add RCA next-step recommendations from enriched correlation metadata
- surface flapping review when correlation evidence identifies flapping suppression
- fall back to correlated log-pattern inspection when log-correlation metadata is present

## Tests
- pnpm --filter @breeze/api exec vitest run src/services/alertCorrelationRca.test.ts
- pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- git diff --check