### PR TITLE
feat(ml): show RCA evidence metadata in correlations UI

### DIFF
--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -84,7 +84,7 @@ const rcaPayload = {
       title: 'Review recent changes',
       rationale: 'A service change overlaps the incident window.',
       riskTier: 'low',
-      evidenceIds: ['device_change:1']
+      evidenceIds: ['device_change:1', 'correlation:1']
     }
   ],
   timeline: [
@@ -95,6 +95,50 @@ const rcaPayload = {
       timestamp: '2026-06-18T11:55:00.000Z',
       title: 'Service restart',
       summary: 'Restarted API service before the incident.'
+    },
+    {
+      id: 'correlation:1',
+      source: 'correlation',
+      type: 'flapping_temporal',
+      timestamp: '2026-06-18T12:01:00.000Z',
+      title: 'Correlation: flapping temporal',
+      summary: 'Alerts share flapping and log correlation evidence.',
+      metadata: {
+        evidence: ['same_device', 'shared_log_correlation', 'flapping_suppression'],
+        ruleId: 'rule-1',
+        templateId: 'template-1',
+        logCorrelationRuleNames: ['Service crash burst'],
+        logPatterns: ['service crashed'],
+        logOccurrences: 7,
+        logSeverity: 'error',
+        flappingDetected: true,
+        flappingRuleIds: ['rule-1'],
+        flappingDeviceIds: ['device-1']
+      }
+    },
+    {
+      id: 'alert:1',
+      source: 'alert',
+      type: 'config_policy_alert',
+      timestamp: '2026-06-18T12:05:00.000Z',
+      title: 'Service timeout on SRV-01',
+      summary: 'Triggered via config policy rule "Memory threshold".',
+      metadata: {
+        configSource: {
+          configPolicyAlertRuleName: 'Memory threshold',
+          configurationPolicyName: 'Server monitoring baseline',
+          itemName: 'ram_percent'
+        },
+        linkedLogCorrelations: [{
+          ruleName: 'Repeated memory service faults',
+          occurrences: 5
+        }],
+        correlationMember: {
+          role: 'related',
+          confidence: 0.91
+        },
+        contextSummary: '{"threshold":90,"observed":94}'
+      }
     }
   ],
   gaps: ['No warning/error logs were found in the incident window.']
@@ -195,6 +239,16 @@ describe('CorrelatedAlertGroups', () => {
     expect(screen.getByText('Review recent changes')).toBeInTheDocument();
     expect(screen.getByText('A service change overlaps the incident window.')).toBeInTheDocument();
     expect(screen.getByText('Restarted API service before the incident.')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Open evidence Service restart/i })[0]).toHaveAttribute('href', '#rca-evidence-device_change-1');
+    expect(screen.getByRole('link', { name: /Open evidence Correlation: flapping temporal/i })).toHaveAttribute('href', '#rca-evidence-correlation-1');
+    expect(screen.getByText('Shared evidence')).toBeInTheDocument();
+    expect(screen.getByText('same device, shared log correlation, flapping suppression')).toBeInTheDocument();
+    expect(screen.getByText('rules Service crash burst; patterns service crashed; 7 occurrences; severity error')).toBeInTheDocument();
+    expect(screen.getByText('rules rule-1; devices device-1')).toBeInTheDocument();
+    expect(screen.getByText('Config source')).toBeInTheDocument();
+    expect(screen.getByText('Memory threshold / Server monitoring baseline / ram_percent')).toBeInTheDocument();
+    expect(screen.getByText('Repeated memory service faults 5 occurrences')).toBeInTheDocument();
+    expect(screen.getByText('related, 91% confidence')).toBeInTheDocument();
     expect(screen.getByText('No warning/error logs were found in the incident window.')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Mark RCA helpful/i }));
@@ -230,7 +284,7 @@ describe('CorrelatedAlertGroups', () => {
       metadata: expect.objectContaining({
         source: 'correlated_alert_groups_ui',
         candidateCount: 1,
-        evidenceCount: 1,
+        evidenceCount: 3,
         gapCount: 1
       })
     }));

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -52,6 +52,7 @@ type RcaEvidenceItem = {
   title: string;
   summary: string;
   severity?: string;
+  metadata?: Record<string, unknown>;
 };
 
 type RcaCandidate = {
@@ -120,6 +121,169 @@ function formatDateTime(value: string | undefined) {
 
 function evidenceLabel(source: string) {
   return source.replace(/_/g, ' ');
+}
+
+function evidenceDomId(evidenceId: string) {
+  return `rca-evidence-${evidenceId.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function metadataRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(metadataRecord).filter((item): item is Record<string, unknown> => Boolean(item));
+}
+
+function metadataString(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function metadataStringArray(record: Record<string, unknown>, key: string, maxItems = 4): string[] {
+  const value = record[key];
+  if (!Array.isArray(value)) return [];
+  return value.map(metadataString).filter((item): item is string => Boolean(item)).slice(0, maxItems);
+}
+
+function metadataNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function compactDetail(value: string, maxLength = 140): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}...` : value;
+}
+
+function appendDetail(details: Array<{ label: string; value: string }>, label: string, value: string | null | undefined) {
+  if (!value) return;
+  details.push({ label, value: compactDetail(value) });
+}
+
+function formatEvidenceList(values: string[]) {
+  return values.map(evidenceLabel).join(', ');
+}
+
+function formatMetadataConfidence(value: number | null) {
+  return value == null ? null : `${formatPercent(value * 100)} confidence`;
+}
+
+function buildCorrelationMetadataDetails(metadata: Record<string, unknown>) {
+  const details: Array<{ label: string; value: string }> = [];
+  const evidence = metadataStringArray(metadata, 'evidence', 5);
+  const logRuleNames = metadataStringArray(metadata, 'logCorrelationRuleNames', 3);
+  const logPatterns = metadataStringArray(metadata, 'logPatterns', 2);
+  const logOccurrences = metadataNumber(metadata, 'logOccurrences');
+  const logSeverity = metadataString(metadata.logSeverity);
+  const flappingRuleIds = metadataStringArray(metadata, 'flappingRuleIds', 3);
+  const flappingDeviceIds = metadataStringArray(metadata, 'flappingDeviceIds', 3);
+  const sourceParts = [
+    metadataString(metadata.ruleId) ? `rule ${metadataString(metadata.ruleId)}` : null,
+    metadataString(metadata.templateId) ? `template ${metadataString(metadata.templateId)}` : null,
+    metadataString(metadata.configPolicyId) && metadataString(metadata.configItemName)
+      ? `config ${metadataString(metadata.configPolicyId)} / ${metadataString(metadata.configItemName)}`
+      : null,
+  ].filter((item): item is string => Boolean(item));
+
+  appendDetail(details, 'Shared evidence', evidence.length > 0 ? formatEvidenceList(evidence) : null);
+  appendDetail(details, 'Source match', sourceParts.length > 0 ? sourceParts.join(', ') : null);
+
+  const logParts = [
+    logRuleNames.length > 0 ? `rules ${logRuleNames.join(', ')}` : null,
+    logPatterns.length > 0 ? `patterns ${logPatterns.join(', ')}` : null,
+    logOccurrences != null ? `${logOccurrences} occurrence${logOccurrences === 1 ? '' : 's'}` : null,
+    logSeverity ? `severity ${logSeverity}` : null,
+  ].filter((item): item is string => Boolean(item));
+  appendDetail(details, 'Log correlation', logParts.length > 0 ? logParts.join('; ') : null);
+
+  if (metadata.flappingDetected === true) {
+    const flappingParts = [
+      flappingRuleIds.length > 0 ? `rules ${flappingRuleIds.join(', ')}` : null,
+      flappingDeviceIds.length > 0 ? `devices ${flappingDeviceIds.join(', ')}` : null,
+    ].filter((item): item is string => Boolean(item));
+    appendDetail(details, 'Flapping', flappingParts.length > 0 ? flappingParts.join('; ') : 'detected');
+  }
+
+  return details;
+}
+
+function buildAlertMetadataDetails(metadata: Record<string, unknown>) {
+  const details: Array<{ label: string; value: string }> = [];
+  const rule = metadataRecord(metadata.rule);
+  const template = metadataRecord(metadata.template);
+  const configSource = metadataRecord(metadata.configSource);
+  const correlationMember = metadataRecord(metadata.correlationMember);
+  const linkedLogCorrelations = metadataRecordArray(metadata.linkedLogCorrelations);
+
+  appendDetail(details, 'Alert rule', metadataString(rule?.name));
+  appendDetail(details, 'Template', metadataString(template?.name));
+
+  if (configSource) {
+    const configParts = [
+      metadataString(configSource.configPolicyAlertRuleName),
+      metadataString(configSource.configurationPolicyName),
+      metadataString(configSource.itemName),
+    ].filter((item): item is string => Boolean(item));
+    appendDetail(details, 'Config source', configParts.length > 0 ? configParts.join(' / ') : metadataString(configSource.configPolicyAlertRuleId));
+  }
+
+  if (linkedLogCorrelations.length > 0) {
+    const logDetails = linkedLogCorrelations.slice(0, 2).map((correlation) => {
+      const name = metadataString(correlation.ruleName) ?? metadataString(correlation.detectedPattern) ?? metadataString(correlation.rulePattern);
+      const occurrences = metadataNumber(correlation, 'occurrences');
+      return [name, occurrences != null ? `${occurrences} occurrence${occurrences === 1 ? '' : 's'}` : null]
+        .filter((item): item is string => Boolean(item))
+        .join(' ');
+    }).filter(Boolean);
+    appendDetail(details, 'Linked logs', logDetails.length > 0 ? logDetails.join('; ') : null);
+  }
+
+  if (correlationMember) {
+    const memberParts = [
+      metadataString(correlationMember.role),
+      formatMetadataConfidence(metadataNumber(correlationMember, 'confidence')),
+    ].filter((item): item is string => Boolean(item));
+    appendDetail(details, 'Group member', memberParts.length > 0 ? memberParts.join(', ') : null);
+  }
+
+  appendDetail(details, 'Alert context', metadataString(metadata.contextSummary));
+  return details;
+}
+
+function evidenceMetadataDetails(item: RcaEvidenceItem) {
+  const metadata = metadataRecord(item.metadata);
+  if (!metadata) return [];
+  if (item.source === 'correlation') return buildCorrelationMetadataDetails(metadata).slice(0, 5);
+  if (item.source === 'alert') return buildAlertMetadataDetails(metadata).slice(0, 5);
+  return [];
+}
+
+function EvidenceLinks({ evidenceIds, timeline }: { evidenceIds: string[]; timeline: RcaEvidenceItem[] }) {
+  const linkedItems = evidenceIds
+    .map((id) => timeline.find((item) => item.id === id))
+    .filter((item): item is RcaEvidenceItem => Boolean(item));
+
+  if (linkedItems.length === 0) return null;
+
+  return (
+    <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1.5 text-xs">
+      <span className="text-muted-foreground">Evidence</span>
+      {linkedItems.map((item) => (
+        <a
+          key={item.id}
+          href={`#${evidenceDomId(item.id)}`}
+          className="inline-flex max-w-full items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label={`Open evidence ${item.title}`}
+        >
+          <FileText className="h-3 w-3 shrink-0" />
+          <span className="truncate">{item.title}</span>
+        </a>
+      ))}
+    </div>
+  );
 }
 
 export default function CorrelatedAlertGroups() {
@@ -589,6 +753,7 @@ export default function CorrelatedAlertGroups() {
                                         </span>
                                       </div>
                                       <p className="mt-1 text-sm text-muted-foreground">{candidate.summary}</p>
+                                      <EvidenceLinks evidenceIds={candidate.supportingEvidenceIds} timeline={groupRca.timeline} />
                                     </div>
                                   ))
                                 )}
@@ -610,6 +775,7 @@ export default function CorrelatedAlertGroups() {
                                           </span>
                                         </div>
                                         <p className="mt-1 text-xs text-muted-foreground">{step.rationale}</p>
+                                        <EvidenceLinks evidenceIds={step.evidenceIds} timeline={groupRca.timeline} />
                                       </div>
                                     ))}
                                   </div>
@@ -622,17 +788,30 @@ export default function CorrelatedAlertGroups() {
                                   Evidence timeline
                                 </div>
                                 <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
-                                  {groupRca.timeline.map((item) => (
-                                    <div key={item.id} className="rounded-md border px-3 py-2">
-                                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                                        <span>{formatDateTime(item.timestamp)}</span>
-                                        <span className="rounded-full border bg-muted px-2 py-0.5">{evidenceLabel(item.source)}</span>
-                                        <span>{item.type}</span>
+                                  {groupRca.timeline.map((item) => {
+                                    const metadataDetails = evidenceMetadataDetails(item);
+                                    return (
+                                      <div key={item.id} id={evidenceDomId(item.id)} className="scroll-mt-4 rounded-md border px-3 py-2">
+                                        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                          <span>{formatDateTime(item.timestamp)}</span>
+                                          <span className="rounded-full border bg-muted px-2 py-0.5">{evidenceLabel(item.source)}</span>
+                                          <span>{item.type}</span>
+                                        </div>
+                                        <p className="mt-1 text-sm font-medium">{item.title}</p>
+                                        <p className="mt-0.5 text-xs text-muted-foreground">{item.summary}</p>
+                                        {metadataDetails.length > 0 && (
+                                          <dl className="mt-2 grid gap-1 text-xs sm:grid-cols-2">
+                                            {metadataDetails.map((detail) => (
+                                              <div key={`${item.id}:${detail.label}`} className="min-w-0">
+                                                <dt className="font-medium text-foreground">{detail.label}</dt>
+                                                <dd className="truncate text-muted-foreground" title={detail.value}>{detail.value}</dd>
+                                              </div>
+                                            ))}
+                                          </dl>
+                                        )}
                                       </div>
-                                      <p className="mt-1 text-sm font-medium">{item.title}</p>
-                                      <p className="mt-0.5 text-xs text-muted-foreground">{item.summary}</p>
-                                    </div>
-                                  ))}
+                                    );
+                                  })}
                                 </div>
                               </div>
 


### PR DESCRIPTION
## Summary
- render bounded RCA evidence metadata for correlation and alert timeline items
- add in-panel links from RCA candidates and suggested next steps to supporting timeline evidence
- extend correlated alert group UI coverage for flapping/log/config/member evidence details

## Tests
- corepack pnpm --filter @breeze/web exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx
- corepack pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/web exec eslint src/components/alerts/CorrelatedAlertGroups.tsx src/components/alerts/CorrelatedAlertGroups.test.tsx
- git diff --check