### PR TITLE
feat(ml): draft tickets from RCA evidence

### DIFF
--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -1264,15 +1264,26 @@ describe('alert routes', () => {
       const res = await app.request(`/alerts/${ALERT_ID}/create-ticket`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ subject: 'Custom subject', priority: 'urgent' })
+        body: JSON.stringify({ subject: 'Custom subject', description: 'RCA note draft', priority: 'urgent' })
       });
 
       expect(res.status).toBe(201);
       expect(createTicketFromAlertMock).toHaveBeenCalledWith(
         ALERT_ID,
         expect.objectContaining({ userId: 'user-123' }),
-        expect.objectContaining({ subject: 'Custom subject', priority: 'urgent' })
+        expect.objectContaining({ subject: 'Custom subject', description: 'RCA note draft', priority: 'urgent' })
       );
+    });
+
+    it('rejects overlong ticket descriptions', async () => {
+      const res = await app.request(`/alerts/${ALERT_ID}/create-ticket`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: 'x'.repeat(5001) })
+      });
+
+      expect(res.status).toBe(400);
+      expect(createTicketFromAlertMock).not.toHaveBeenCalled();
     });
 
     it('returns 404 for out-of-site alert devices (site-restricted caller)', async () => {

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -837,6 +837,7 @@ alertsRoutes.post(
   zValidator('param', alertIdParamSchema),
   zValidator('json', z.object({
     subject: z.string().min(1).max(255).optional(),
+    description: z.string().max(5000).optional(),
     categoryId: z.string().uuid().optional(),
     priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
     assigneeId: z.string().uuid().optional()

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -189,6 +189,12 @@ function mockGroupsResponse(options: { rcaEnabled?: boolean } = {}) {
     if (url === `/alerts/correlations/${GROUP_ID}/feedback` && method === 'POST') {
       return Promise.resolve(makeJsonResponse({ success: true }));
     }
+    if (url === '/ticket-categories' && method === 'GET') {
+      return Promise.resolve(makeJsonResponse({ data: [] }));
+    }
+    if (url === `/alerts/${groupPayload.rootCause.id}/create-ticket` && method === 'POST') {
+      return Promise.resolve(makeJsonResponse({ data: { id: 'ticket-1', internalNumber: 'T-2026-0101' } }, true, 201));
+    }
     return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
   });
 }
@@ -288,6 +294,32 @@ describe('CorrelatedAlertGroups', () => {
         gapCount: 1
       })
     }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Create ticket from RCA/i }));
+    const description = await screen.findByTestId('alert-ticket-description') as HTMLTextAreaElement;
+    expect(description.value).toContain('RCA draft for correlated alert group');
+    expect(description.value).toContain('A recent service restart lines up with the alert burst.');
+    expect(description.value).toContain('Review recent changes');
+    fireEvent.click(screen.getByTestId('alert-ticket-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/alerts/${groupPayload.rootCause.id}/create-ticket`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('RCA draft for correlated alert group')
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/alerts/correlations/${GROUP_ID}/rca-feedback`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('rca.used_in_ticket')
+        })
+      );
+    });
   });
 
   it('records correlation correction feedback from group controls', async () => {

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -21,6 +21,7 @@ import type { AlertSeverity, AlertStatus } from './AlertList';
 import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
+import CreateTicketFromAlertDialog from './CreateTicketFromAlertDialog';
 
 type AlertItem = {
   id: string;
@@ -155,7 +156,9 @@ function metadataNumber(record: Record<string, unknown>, key: string): number | 
 }
 
 function compactDetail(value: string, maxLength = 140): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}...` : value;
+  if (value.length <= maxLength) return value;
+  if (maxLength <= 3) return value.slice(0, maxLength);
+  return `${value.slice(0, maxLength - 3)}...`;
 }
 
 function appendDetail(details: Array<{ label: string; value: string }>, label: string, value: string | null | undefined) {
@@ -286,11 +289,52 @@ function EvidenceLinks({ evidenceIds, timeline }: { evidenceIds: string[]; timel
   );
 }
 
+function buildRcaTicketNote(group: AlertGroup, rca: RcaResult) {
+  const lines = [
+    `RCA draft for correlated alert group ${group.id}`,
+    `Root alert: ${group.rootCause.title}`,
+    `Device: ${group.rootCause.device}`,
+    `Window: ${formatDateTime(rca.scope.windowStart)} - ${formatDateTime(rca.scope.windowEnd)}`,
+    '',
+    'Likely causes:',
+  ];
+
+  if (rca.rootCauseCandidates.length === 0) {
+    lines.push('- No likely cause candidates were found.');
+  } else {
+    for (const candidate of rca.rootCauseCandidates.slice(0, 3)) {
+      lines.push(`- ${candidate.summary} (${formatPercent(candidate.confidence * 100)} confidence)`);
+    }
+  }
+
+  if (rca.suggestedNextSteps && rca.suggestedNextSteps.length > 0) {
+    lines.push('', 'Suggested next steps:');
+    for (const step of rca.suggestedNextSteps.slice(0, 4)) {
+      lines.push(`- ${step.title}: ${step.rationale} (${step.riskTier} risk)`);
+    }
+  }
+
+  if (rca.timeline.length > 0) {
+    lines.push('', 'Evidence summary:');
+    for (const item of rca.timeline.slice(0, 6)) {
+      lines.push(`- ${item.title}: ${item.summary}`);
+    }
+  }
+
+  if (rca.gaps.length > 0) {
+    lines.push('', 'Evidence gaps:');
+    for (const gap of rca.gaps.slice(0, 3)) lines.push(`- ${gap}`);
+  }
+
+  return compactDetail(lines.join('\n'), 5000);
+}
+
 export default function CorrelatedAlertGroups() {
   const mlFlags = useMlFeatureFlags();
   const [groups, setGroups] = useState<AlertGroup[]>([]);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [rcaByGroup, setRcaByGroup] = useState<Record<string, RcaResult | undefined>>({});
+  const [ticketGroup, setTicketGroup] = useState<AlertGroup | null>(null);
   const [loadingRcaGroupId, setLoadingRcaGroupId] = useState<string | null>(null);
   const [busyGroupId, setBusyGroupId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -500,6 +544,8 @@ export default function CorrelatedAlertGroups() {
       </div>
     );
   }
+
+  const ticketGroupRca = ticketGroup ? rcaByGroup[ticketGroup.id] : undefined;
 
   return (
     <div className="space-y-5">
@@ -826,11 +872,11 @@ export default function CorrelatedAlertGroups() {
 
                               <button
                                 type="button"
-                                onClick={() => void sendRcaFeedback(group, 'rca.used_in_ticket')}
+                                onClick={() => setTicketGroup(group)}
                                 className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
                               >
                                 <FileText className="h-4 w-4" />
-                                Used in ticket
+                                Create ticket from RCA
                               </button>
                               <button
                                 type="button"
@@ -852,6 +898,21 @@ export default function CorrelatedAlertGroups() {
           )}
         </div>
       </div>
+      {ticketGroup && ticketGroupRca && (
+        <CreateTicketFromAlertDialog
+          alertId={ticketGroup.rootCause.id}
+          alertTitle={ticketGroup.rootCause.title}
+          alertSeverity={ticketGroup.rootCause.severity}
+          initialDescription={buildRcaTicketNote(ticketGroup, ticketGroupRca)}
+          openTicketNumber={null}
+          onClose={() => setTicketGroup(null)}
+          onCreated={() => {
+            const createdFromGroup = ticketGroup;
+            setTicketGroup(null);
+            void sendRcaFeedback(createdFromGroup, 'rca.used_in_ticket');
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/alerts/CreateTicketFromAlertDialog.test.tsx
+++ b/apps/web/src/components/alerts/CreateTicketFromAlertDialog.test.tsx
@@ -88,6 +88,20 @@ describe('CreateTicketFromAlertDialog', () => {
     expect(body).toEqual({ subject: 'CPU pegged on SRV-01', priority: 'urgent', categoryId: CAT_ID });
   });
 
+  it('prefills and POSTs an editable description', async () => {
+    mockApi();
+    render(<CreateTicketFromAlertDialog {...baseProps} initialDescription="Initial RCA note" />);
+    expect((screen.getByTestId('alert-ticket-description') as HTMLTextAreaElement).value).toBe('Initial RCA note');
+    fireEvent.change(screen.getByTestId('alert-ticket-description'), { target: { value: 'Edited RCA note' } });
+    fireEvent.click(screen.getByTestId('alert-ticket-submit'));
+
+    await waitFor(() => expect(baseProps.onCreated).toHaveBeenCalled());
+    const postCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(JSON.parse(String(postCall![1]!.body))).toEqual(expect.objectContaining({
+      description: 'Edited RCA note'
+    }));
+  });
+
   it('omits categoryId when none selected', async () => {
     mockApi();
     render(<CreateTicketFromAlertDialog {...baseProps} />);

--- a/apps/web/src/components/alerts/CreateTicketFromAlertDialog.tsx
+++ b/apps/web/src/components/alerts/CreateTicketFromAlertDialog.tsx
@@ -48,6 +48,7 @@ type CreateTicketFromAlertDialogProps = {
   alertId: string;
   alertTitle: string;
   alertSeverity: string;
+  initialDescription?: string;
   /** internalNumber of an open linked ticket, if one exists — shows a duplicate warning. */
   openTicketNumber: string | null;
   /** True when the linked-tickets fetch failed — "no warning" must not read as "no duplicates". */
@@ -57,9 +58,10 @@ type CreateTicketFromAlertDialogProps = {
 };
 
 export default function CreateTicketFromAlertDialog({
-  alertId, alertTitle, alertSeverity, openTicketNumber, duplicateCheckFailed = false, onClose, onCreated
+  alertId, alertTitle, alertSeverity, initialDescription = '', openTicketNumber, duplicateCheckFailed = false, onClose, onCreated
 }: CreateTicketFromAlertDialogProps) {
   const [subject, setSubject] = useState(alertTitle);
+  const [description, setDescription] = useState(initialDescription);
   const [priority, setPriority] = useState<Priority>(SEVERITY_TO_PRIORITY[alertSeverity] ?? 'normal');
   const [categoryId, setCategoryId] = useState('');
   const [categories, setCategories] = useState<CategoryOption[]>([]);
@@ -93,6 +95,7 @@ export default function CreateTicketFromAlertDialog({
           method: 'POST',
           body: JSON.stringify({
             subject: subject.trim(),
+            ...(description.trim() ? { description: description.trim() } : {}),
             priority,
             ...(categoryId ? { categoryId } : {})
           })
@@ -107,7 +110,7 @@ export default function CreateTicketFromAlertDialog({
     } finally {
       setSubmitting(false);
     }
-  }, [subject, priority, categoryId, submitting, alertId, onCreated]);
+  }, [subject, description, priority, categoryId, submitting, alertId, onCreated]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" data-testid="alert-ticket-dialog">
@@ -147,6 +150,18 @@ export default function CreateTicketFromAlertDialog({
               maxLength={255}
               className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
               data-testid="alert-ticket-subject"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="alert-ticket-description">Description</label>
+            <textarea
+              id="alert-ticket-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={5000}
+              rows={initialDescription ? 8 : 4}
+              className="mt-1 w-full resize-y rounded-md border bg-background px-3 py-1.5 text-sm"
+              data-testid="alert-ticket-description"
             />
           </div>
           <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary
- allow alert create-ticket requests to pass a bounded ticket description
- let alert ticket dialogs prefill and submit editable descriptions
- add a Create ticket from RCA action that drafts a ticket description from RCA candidates, next steps, evidence, and gaps, then records rca.used_in_ticket after creation

## Tests
- corepack pnpm --filter @breeze/web exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx src/components/alerts/CreateTicketFromAlertDialog.test.tsx
- corepack pnpm --filter @breeze/api exec vitest run src/routes/alerts.test.ts
- corepack pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/web exec eslint src/components/alerts/CorrelatedAlertGroups.tsx src/components/alerts/CorrelatedAlertGroups.test.tsx src/components/alerts/CreateTicketFromAlertDialog.tsx src/components/alerts/CreateTicketFromAlertDialog.test.tsx
- corepack pnpm --filter @breeze/api exec eslint src/routes/alerts/alerts.ts src/routes/alerts.test.ts
- git diff --check