### PR TITLE
feat(ml): show remediation suggestions for RCA

### DIFF
--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigat
 
 const fetchMock = vi.mocked(fetchWithAuth);
 
+const ORG_ID = '55555555-5555-4555-8555-555555555555';
 const GROUP_ID = '11111111-1111-4111-8111-111111111111';
 
 const groupPayload = {
@@ -67,6 +68,7 @@ const groupPayload = {
 const rcaPayload = {
   groupId: GROUP_ID,
   scope: {
+    orgId: ORG_ID,
     deviceIds: ['device-1'],
     alertIds: groupPayload.alerts.map((alert) => alert.id),
     windowStart: '2026-06-18T06:00:00.000Z',
@@ -160,6 +162,12 @@ const mlFlags = (rcaEnabled: boolean) => ({
       defaultEnabled: false,
       source: 'org_settings',
     },
+    'ml.remediation_suggestions.enabled': {
+      flag: 'ml.remediation_suggestions.enabled',
+      enabled: true,
+      defaultEnabled: false,
+      source: 'org_settings',
+    },
   },
 });
 
@@ -188,6 +196,33 @@ function mockGroupsResponse(options: { rcaEnabled?: boolean } = {}) {
     }
     if (url === `/alerts/correlations/${GROUP_ID}/feedback` && method === 'POST') {
       return Promise.resolve(makeJsonResponse({ success: true }));
+    }
+    if (url === `/remediation-suggestions?sourceType=rca&sourceId=${GROUP_ID}&limit=5` && method === 'GET') {
+      return Promise.resolve(makeJsonResponse({ data: [] }));
+    }
+    if (url === '/remediation-suggestions/generate' && method === 'POST') {
+      return Promise.resolve(makeJsonResponse({
+        data: [{
+          id: 'suggestion-1',
+          sourceType: 'rca',
+          sourceId: GROUP_ID,
+          deviceId: 'device-1',
+          targetType: 'diagnostic',
+          scriptId: null,
+          scriptTemplateId: null,
+          playbookId: null,
+          title: 'Collect service diagnostics',
+          rationale: 'Matched service restart evidence from the RCA.',
+          expectedAction: 'Run a safe diagnostic collection before changing service state.',
+          riskTier: 'low',
+          status: 'suggested',
+          confidence: 0.8,
+          parameters: {},
+          targetDeviceIds: ['device-1'],
+          elevationRequestId: null,
+          scriptExecutionId: null,
+        }],
+      }, true, 201));
     }
     if (url === '/ticket-categories' && method === 'GET') {
       return Promise.resolve(makeJsonResponse({ data: [] }));
@@ -256,6 +291,26 @@ describe('CorrelatedAlertGroups', () => {
     expect(screen.getByText('Repeated memory service faults 5 occurrences')).toBeInTheDocument();
     expect(screen.getByText('related, 91% confidence')).toBeInTheDocument();
     expect(screen.getByText('No warning/error logs were found in the incident window.')).toBeInTheDocument();
+    expect(await screen.findByText('Suggested Fixes')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^generate$/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/remediation-suggestions/generate',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            sourceType: 'rca',
+            sourceId: GROUP_ID,
+            limit: 3,
+            orgId: ORG_ID,
+            deviceId: 'device-1',
+          }),
+        }),
+      );
+    });
+    expect(await screen.findByText('Collect service diagnostics')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Mark RCA helpful/i }));
 

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -22,6 +22,7 @@ import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 import CreateTicketFromAlertDialog from './CreateTicketFromAlertDialog';
+import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
 
 type AlertItem = {
   id: string;
@@ -76,6 +77,7 @@ type RcaResult = {
   suggestedNextSteps?: RcaSuggestedNextStep[];
   gaps: string[];
   scope: {
+    orgId: string;
     deviceIds: string[];
     alertIds: string[];
     windowStart: string;
@@ -869,6 +871,13 @@ export default function CorrelatedAlertGroups() {
                                   </ul>
                                 </div>
                               )}
+
+                              <RemediationSuggestionsPanel
+                                sourceType="rca"
+                                sourceId={groupRca.groupId}
+                                orgId={groupRca.scope.orgId}
+                                deviceId={groupRca.scope.deviceIds[0]}
+                              />
 
                               <button
                                 type="button"

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -125,6 +125,55 @@ describe('RemediationSuggestionsPanel', () => {
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Suggested fix accepted' }));
   });
 
+  it('includes RCA generation context when provided', async () => {
+    const rcaSuggestion = {
+      ...suggestion,
+      sourceType: 'rca',
+      sourceId: 'rca-1',
+      deviceId: '22222222-2222-4222-8222-222222222222',
+    };
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=rca&sourceId=rca-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === '/remediation-suggestions/generate' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ data: [rcaSuggestion] }, true, 201));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(
+      <RemediationSuggestionsPanel
+        sourceType="rca"
+        sourceId="rca-1"
+        orgId="11111111-1111-4111-8111-111111111111"
+        deviceId="22222222-2222-4222-8222-222222222222"
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /generate/i }));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/remediation-suggestions/generate',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            sourceType: 'rca',
+            sourceId: 'rca-1',
+            limit: 3,
+            orgId: '11111111-1111-4111-8111-111111111111',
+            deviceId: '22222222-2222-4222-8222-222222222222',
+          }),
+        }),
+      );
+    });
+    expect(await screen.findByText('Disk Cleanup')).toBeTruthy();
+  });
+
   it('saves revised suggested fix details through runAction', async () => {
     const edited = {
       ...suggestion,

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -31,6 +31,8 @@ type RemediationSuggestion = {
 type RemediationSuggestionsPanelProps = {
   sourceType: 'alert' | 'anomaly' | 'correlation' | 'rca';
   sourceId: string;
+  orgId?: string;
+  deviceId?: string;
 };
 
 type EditDraft = Pick<RemediationSuggestion, 'title' | 'rationale' | 'expectedAction' | 'riskTier'>;
@@ -73,7 +75,7 @@ function canExecuteScriptSuggestion(suggestion: RemediationSuggestion): boolean 
   return canQueueScriptSuggestion(suggestion) && (!requiresExecutionApproval(suggestion) || Boolean(suggestion.elevationRequestId));
 }
 
-export default function RemediationSuggestionsPanel({ sourceType, sourceId }: RemediationSuggestionsPanelProps) {
+export default function RemediationSuggestionsPanel({ sourceType, sourceId, orgId, deviceId }: RemediationSuggestionsPanelProps) {
   const mlFlags = useMlFeatureFlags();
   const [suggestions, setSuggestions] = useState<RemediationSuggestion[]>([]);
   const [loading, setLoading] = useState(true);
@@ -112,11 +114,18 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId }: Re
     if (remediationSuggestionsDisabled) return;
     setGenerating(true);
     try {
+      const body = {
+        sourceType,
+        sourceId,
+        limit: 3,
+        ...(orgId ? { orgId } : {}),
+        ...(deviceId ? { deviceId } : {}),
+      };
       const result = await runAction<{ data?: RemediationSuggestion[]; skipped?: boolean }>({
         request: () => fetchWithAuth('/remediation-suggestions/generate', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sourceType, sourceId, limit: 3 }),
+          body: JSON.stringify(body),
         }),
         errorFallback: 'Could not generate suggested fixes',
         successMessage: (data) => data.skipped ? 'Suggested fixes are disabled' : 'Suggested fixes generated',


### PR DESCRIPTION
## Summary
- mount suggested fixes in the RCA results panel
- pass RCA org/device context through the remediation suggestions generator
- add coverage for RCA suggestion generation context and the correlations UI integration

## Tests
- corepack pnpm --filter @breeze/web exec vitest run src/components/alerts/CorrelatedAlertGroups.test.tsx src/components/remediation/RemediationSuggestionsPanel.test.tsx
- corepack pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/web exec eslint src/components/alerts/CorrelatedAlertGroups.tsx src/components/alerts/CorrelatedAlertGroups.test.tsx src/components/remediation/RemediationSuggestionsPanel.tsx src/components/remediation/RemediationSuggestionsPanel.test.tsx
- git diff --check