### PR TITLE
feat(ml): enrich RCA remediation context

### DIFF
--- a/apps/api/src/services/remediationSuggestions.test.ts
+++ b/apps/api/src/services/remediationSuggestions.test.ts
@@ -47,4 +47,38 @@ describe('remediation suggestion heuristics', () => {
     expect(__testOnly.riskTierForCandidate(context, 'delete temp cleanup')).toBe('high');
     expect(__testOnly.riskTierForCandidate(context, 'restart service')).toBe('medium');
   });
+
+  it('builds RCA suggestion context from correlation group metadata', () => {
+    const context = __testOnly.rcaContextFromCorrelationGroup({
+      id: 'group-1',
+      orgId: 'org-1',
+      rootAlertId: 'alert-1',
+      groupKey: 'site:server-room',
+      status: 'open',
+      metadata: {
+        logCorrelationRuleNames: ['Service crash burst'],
+        logPatterns: ['service crashed'],
+        flappingDetected: true,
+      },
+    }, {
+      sourceType: 'rca',
+      sourceId: 'group-1',
+      orgId: 'org-1',
+      deviceId: 'dev-1',
+    });
+
+    expect(context).toMatchObject({
+      sourceType: 'rca',
+      sourceId: 'group-1',
+      orgId: 'org-1',
+      deviceId: 'dev-1',
+      alertId: 'alert-1',
+      correlationGroupId: 'group-1',
+      rcaId: 'group-1',
+      title: 'RCA for correlation group site:server-room',
+    });
+    expect(context.text).toContain('service crash burst');
+    expect(context.text).toContain('service crashed');
+    expect(context.text).toContain('flappingdetected');
+  });
 });

--- a/apps/api/src/services/remediationSuggestions.ts
+++ b/apps/api/src/services/remediationSuggestions.ts
@@ -117,6 +117,24 @@ function riskTierForCandidate(ctx: SourceContext, candidateText: string): Candid
   return 'low';
 }
 
+function rcaContextFromCorrelationGroup(
+  row: Pick<typeof alertCorrelationGroups.$inferSelect, 'id' | 'orgId' | 'rootAlertId' | 'groupKey' | 'status' | 'metadata'>,
+  input: GenerateRemediationSuggestionsInput,
+): SourceContext {
+  return {
+    sourceType: 'rca',
+    sourceId: input.sourceId,
+    orgId: row.orgId,
+    deviceId: input.deviceId ?? null,
+    alertId: row.rootAlertId,
+    anomalyId: null,
+    correlationGroupId: row.id,
+    rcaId: input.sourceId,
+    title: `RCA for correlation group ${row.groupKey}`,
+    text: sourceTextParts(row.groupKey, row.status, JSON.stringify(row.metadata ?? {}), input.sourceId),
+  };
+}
+
 async function resolveSourceContext(input: GenerateRemediationSuggestionsInput): Promise<SourceContext | null> {
   if (input.sourceType === 'anomaly') {
     const [row] = await db.select().from(metricAnomalies).where(eq(metricAnomalies.id, input.sourceId)).limit(1);
@@ -170,6 +188,11 @@ async function resolveSourceContext(input: GenerateRemediationSuggestionsInput):
       title: `Correlation group ${row.groupKey}`,
       text: sourceTextParts(row.groupKey, row.status, JSON.stringify(row.metadata ?? {})),
     };
+  }
+
+  if (input.sourceType === 'rca') {
+    const [row] = await db.select().from(alertCorrelationGroups).where(eq(alertCorrelationGroups.id, input.sourceId)).limit(1);
+    if (row) return rcaContextFromCorrelationGroup(row, input);
   }
 
   if (!input.orgId) return null;
@@ -380,4 +403,5 @@ export const __testOnly = {
   termsForSource,
   scoreCandidate,
   riskTierForCandidate,
+  rcaContextFromCorrelationGroup,
 };


### PR DESCRIPTION
## Summary
- resolve RCA remediation suggestions from alert correlation groups before falling back to generic context
- include correlation group metadata, status, root alert, and group key in the suggestion source context
- add service coverage for RCA context construction from correlation metadata

## Tests
- corepack pnpm --filter @breeze/api exec vitest run src/services/remediationSuggestions.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/api exec eslint src/services/remediationSuggestions.ts src/services/remediationSuggestions.test.ts
- git diff --check