### PR TITLE
feat(ml): add anomaly backfill command

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "dev": "tsx watch src/index.ts",
     "lint": "eslint src",
     "oauth:gen-keys": "tsx scripts/oauth-gen-keys.ts",
+    "metric-anomalies:backfill": "tsx scripts/metric-anomaly-backfill.ts",
     "metric-rollups:backfill": "tsx scripts/metric-rollup-backfill.ts",
     "recover:stuck-agents": "tsx scripts/recover-stuck-agents.ts",
     "recover:stuck-agents:prod": "node dist/scripts/recover-stuck-agents.cjs",

--- a/apps/api/scripts/metric-anomaly-backfill.lib.ts
+++ b/apps/api/scripts/metric-anomaly-backfill.lib.ts
@@ -1,0 +1,70 @@
+export const MAX_ANOMALY_BACKFILL_DAYS = 31;
+
+export interface MetricAnomalyBackfillOptions {
+  orgId: string;
+  from: Date;
+  to: Date;
+  dryRun: boolean;
+}
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  pnpm metric-anomalies:backfill -- --org-id <uuid> --from <iso> --to <iso> [--dry-run]',
+    '',
+    `The time range must be positive and no longer than ${MAX_ANOMALY_BACKFILL_DAYS} days.`,
+    'Run metric-rollups:backfill for the same org/time range first if rollups are missing.',
+  ].join('\n');
+}
+
+function readOption(args: string[], name: string): string | undefined {
+  const equalsPrefix = `${name}=`;
+  const equalsValue = args.find((arg) => arg.startsWith(equalsPrefix));
+  if (equalsValue) return equalsValue.slice(equalsPrefix.length);
+
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  return args[index + 1];
+}
+
+function parseDateOption(value: string | undefined, name: string): Date {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} is required\n\n${usage()}`);
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${name} must be a valid ISO timestamp`);
+  }
+  return parsed;
+}
+
+export function parseMetricAnomalyBackfillArgs(args: string[]): MetricAnomalyBackfillOptions {
+  if (args.includes('--help') || args.includes('-h')) {
+    throw new Error(usage());
+  }
+
+  const orgId = readOption(args, '--org-id');
+  if (!orgId || orgId.startsWith('--')) {
+    throw new Error(`--org-id is required\n\n${usage()}`);
+  }
+
+  const from = parseDateOption(readOption(args, '--from'), '--from');
+  const to = parseDateOption(readOption(args, '--to'), '--to');
+  if (from >= to) {
+    throw new Error('--from must be before --to');
+  }
+
+  const rangeMs = to.getTime() - from.getTime();
+  const maxRangeMs = MAX_ANOMALY_BACKFILL_DAYS * 24 * 60 * 60 * 1000;
+  if (rangeMs > maxRangeMs) {
+    throw new Error(`Backfill range must be ${MAX_ANOMALY_BACKFILL_DAYS} days or less`);
+  }
+
+  return {
+    orgId,
+    from,
+    to,
+    dryRun: args.includes('--dry-run'),
+  };
+}

--- a/apps/api/scripts/metric-anomaly-backfill.test.ts
+++ b/apps/api/scripts/metric-anomaly-backfill.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_ANOMALY_BACKFILL_DAYS, parseMetricAnomalyBackfillArgs } from './metric-anomaly-backfill.lib';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('parseMetricAnomalyBackfillArgs', () => {
+  it('parses a bounded org/time-range backfill request', () => {
+    const options = parseMetricAnomalyBackfillArgs([
+      '--org-id',
+      ORG_ID,
+      '--from',
+      '2026-06-18T00:00:00.000Z',
+      '--to',
+      '2026-06-19T00:00:00.000Z',
+      '--dry-run',
+    ]);
+
+    expect(options).toEqual({
+      orgId: ORG_ID,
+      from: new Date('2026-06-18T00:00:00.000Z'),
+      to: new Date('2026-06-19T00:00:00.000Z'),
+      dryRun: true,
+    });
+  });
+
+  it('accepts equals-style arguments for shell-friendly use', () => {
+    const options = parseMetricAnomalyBackfillArgs([
+      `--org-id=${ORG_ID}`,
+      '--from=2026-06-18T00:00:00.000Z',
+      '--to=2026-06-18T01:00:00.000Z',
+    ]);
+
+    expect(options.orgId).toBe(ORG_ID);
+    expect(options.from.toISOString()).toBe('2026-06-18T00:00:00.000Z');
+    expect(options.to.toISOString()).toBe('2026-06-18T01:00:00.000Z');
+    expect(options.dryRun).toBe(false);
+  });
+
+  it('rejects ranges longer than the bounded backfill limit', () => {
+    expect(() =>
+      parseMetricAnomalyBackfillArgs([
+        '--org-id',
+        ORG_ID,
+        '--from',
+        '2026-06-01T00:00:00.000Z',
+        '--to',
+        new Date(Date.UTC(2026, 5, 1 + MAX_ANOMALY_BACKFILL_DAYS, 0, 0, 1)).toISOString(),
+      ])
+    ).toThrow(`${MAX_ANOMALY_BACKFILL_DAYS} days or less`);
+  });
+
+  it('rejects invalid and inverted ranges before any database work', () => {
+    expect(() =>
+      parseMetricAnomalyBackfillArgs([
+        '--org-id',
+        ORG_ID,
+        '--from',
+        'not-a-date',
+        '--to',
+        '2026-06-18T01:00:00.000Z',
+      ])
+    ).toThrow('--from must be a valid ISO timestamp');
+
+    expect(() =>
+      parseMetricAnomalyBackfillArgs([
+        '--org-id',
+        ORG_ID,
+        '--from',
+        '2026-06-18T02:00:00.000Z',
+        '--to',
+        '2026-06-18T01:00:00.000Z',
+      ])
+    ).toThrow('--from must be before --to');
+  });
+
+  it('requires org and timestamps', () => {
+    expect(() => parseMetricAnomalyBackfillArgs([])).toThrow('--org-id is required');
+    expect(() => parseMetricAnomalyBackfillArgs(['--org-id', ORG_ID])).toThrow('--from is required');
+  });
+});

--- a/apps/api/scripts/metric-anomaly-backfill.ts
+++ b/apps/api/scripts/metric-anomaly-backfill.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env tsx
+import { closeDb, withSystemDbAccessContext } from '../src/db';
+import { detectMetricAnomaliesRange } from '../src/services/metricAnomalies';
+import { parseMetricAnomalyBackfillArgs } from './metric-anomaly-backfill.lib';
+
+async function main(): Promise<void> {
+  const options = parseMetricAnomalyBackfillArgs(process.argv.slice(2));
+  const summary = {
+    orgId: options.orgId,
+    from: options.from.toISOString(),
+    to: options.to.toISOString(),
+  };
+
+  if (options.dryRun) {
+    console.log('[metric-anomaly-backfill] Dry run; no anomalies written.');
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  const result = await withSystemDbAccessContext(() =>
+    detectMetricAnomaliesRange({
+      orgId: options.orgId,
+      from: options.from,
+      to: options.to,
+    })
+  );
+
+  console.log('[metric-anomaly-backfill] Completed.');
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error('[metric-anomaly-backfill] Failed:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/docs/runbooks/ml-operations.md
+++ b/docs/runbooks/ml-operations.md
@@ -186,6 +186,8 @@ Metric rollups:
 Anomalies:
 - Keep `ml.anomalies.create_alerts` off until dismiss/promote rates are acceptable.
 - Review anomaly status counts before increasing sensitivity.
+- For a bounded manual replay after rollups are present, run:
+  `pnpm --filter @breeze/api metric-anomalies:backfill -- --org-id <org-id> --from <iso> --to <iso>`.
 
 Remediation suggestions:
 - Suggestions should reference existing scripts/templates where possible.


### PR DESCRIPTION
## Summary
- add a bounded `metric-anomalies:backfill` API script for one org/time range
- run anomaly detection directly inside system DB context for operator/debug replay
- add parser coverage and document the command in the ML operations runbook

## Tests
- corepack pnpm --filter @breeze/api exec vitest run scripts/metric-anomaly-backfill.test.ts scripts/metric-rollup-backfill.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze corepack pnpm --filter @breeze/api metric-anomalies:backfill -- --org-id 11111111-1111-4111-8111-111111111111 --from 2026-06-18T00:00:00.000Z --to 2026-06-18T01:00:00.000Z --dry-run
- git diff --check

Note: `corepack pnpm --filter @breeze/api exec eslint scripts/metric-anomaly-backfill.ts scripts/metric-anomaly-backfill.lib.ts scripts/metric-anomaly-backfill.test.ts` exits 0, but the current API ESLint config ignores `apps/api/scripts/*` and reports warnings only.