### PR TITLE
fix(ml): gate alert correlation enqueue

### DIFF
--- a/apps/api/src/jobs/alertCorrelation.test.ts
+++ b/apps/api/src/jobs/alertCorrelation.test.ts
@@ -103,9 +103,11 @@ describe('alert correlation queue helpers', () => {
   it('uses a stable BullMQ job id per org/device debounce slot', async () => {
     const jobId = buildAlertCorrelationJobId('org-1', 'device-1');
 
-    await enqueueAlertCorrelation({ orgId: 'org-1', deviceId: 'device-1' });
+    const queuedJobId = await enqueueAlertCorrelation({ orgId: 'org-1', deviceId: 'device-1' });
 
     expect(jobId).toMatch(/^alert-correlation-org-1-device-1-[a-z0-9]+$/);
+    expect(queuedJobId).toBe('queued-correlation-job');
+    expect(shouldProduceMlOutputMock).toHaveBeenCalledWith('org-1', 'ml.alert_correlation.enabled');
     expect(addMock).toHaveBeenCalledWith(
       'correlate-device-alerts',
       expect.objectContaining({ orgId: 'org-1', deviceId: 'device-1' }),
@@ -122,6 +124,17 @@ describe('alert correlation queue helpers', () => {
     const jobId = await enqueueAlertCorrelation({ orgId: 'org-1', deviceId: 'device-1' });
 
     expect(jobId).toBe('existing-correlation-job');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses enqueue work when alert correlation is disabled for the org', async () => {
+    shouldProduceMlOutputMock.mockResolvedValue(false);
+
+    const jobId = await enqueueAlertCorrelation({ orgId: 'org-1', deviceId: 'device-1' });
+
+    expect(jobId).toBeNull();
+    expect(shouldProduceMlOutputMock).toHaveBeenCalledWith('org-1', 'ml.alert_correlation.enabled');
+    expect(getJobMock).not.toHaveBeenCalled();
     expect(addMock).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/jobs/alertCorrelation.ts
+++ b/apps/api/src/jobs/alertCorrelation.ts
@@ -349,7 +349,11 @@ export async function enqueueAlertCorrelation(options: {
   orgId: string;
   deviceId: string;
   windowMinutes?: number;
-}): Promise<string> {
+}): Promise<string | null> {
+  if (!(await shouldProduceMlOutput(options.orgId, 'ml.alert_correlation.enabled'))) {
+    return null;
+  }
+
   const queue = getAlertCorrelationQueue();
   const jobId = buildAlertCorrelationJobId(options.orgId, options.deviceId);
 


### PR DESCRIPTION
## Summary
- Check `ml.alert_correlation.enabled` before creating BullMQ correlation jobs
- Return `null` from the enqueue helper when the producer-side kill switch suppresses work
- Keep the worker-side flag check as defense in depth and add queue-helper regression coverage

## Validation
- `corepack pnpm --filter @breeze/api exec vitest run src/jobs/alertCorrelation.test.ts`
- `corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `corepack pnpm --filter @breeze/api exec eslint src/jobs/alertCorrelation.ts src/jobs/alertCorrelation.test.ts`
- `git diff --check`