### PR TITLE
fix(ml): capture CF redirect login country

### DIFF
--- a/apps/api/src/routes/auth/cfAccessRedirectLogin.test.ts
+++ b/apps/api/src/routes/auth/cfAccessRedirectLogin.test.ts
@@ -310,6 +310,7 @@ describe('GET /cf-access-login', () => {
         iss: `https://${envState.teamDomain}`,
         exp: 999,
         iat: 1,
+        country: 'CA',
       },
     };
     dbState.userRow = { ...activeUser };
@@ -319,7 +320,10 @@ describe('GET /cf-access-login', () => {
     expect(cookieState.set).toBe('refresh-tok');
     expect(auditState.audits[0]).toMatchObject({
       action: 'user.login',
-      details: expect.objectContaining({ method: 'cf_access_jwt_redirect' }),
+      details: expect.objectContaining({
+        method: 'cf_access_jwt_redirect',
+        cfAccessCountry: 'CA',
+      }),
     });
   });
 

--- a/apps/api/src/routes/auth/cfAccessRedirectLogin.ts
+++ b/apps/api/src/routes/auth/cfAccessRedirectLogin.ts
@@ -206,6 +206,7 @@ cfAccessRedirectLoginRoutes.get('/cf-access-login', async (c) => {
       mfa: mfaSatisfied,
       scope: context.scope,
       cfAccessSub: claims.sub,
+      cfAccessCountry: claims.country ?? null,
     },
     ipAddress: getClientIP(c),
     userAgent: c.req.header('user-agent'),


### PR DESCRIPTION
## Summary
- Include `cfAccessCountry` in Cloudflare Access redirect-login audit details
- Align redirect-login audit metadata with the JSON CF Access login middleware
- Extend the redirect success test so user-risk new-geography signals can consume trusted CF country data from both login paths

## Validation
- `corepack pnpm --filter @breeze/api exec vitest run src/routes/auth/cfAccessRedirectLogin.test.ts`
- `corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `corepack pnpm --filter @breeze/api exec eslint src/routes/auth/cfAccessRedirectLogin.ts src/routes/auth/cfAccessRedirectLogin.test.ts`
- `git diff --check`