### PR TITLE
fix(ml): use execution time for reliability scans

### DIFF
--- a/apps/api/src/jobs/reliabilityWorker.test.ts
+++ b/apps/api/src/jobs/reliabilityWorker.test.ts
@@ -1,18 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getJobMock, addMock, closeMock } = vi.hoisted(() => ({
+const { getJobMock, addMock, addBulkMock, closeMock, selectMock, fromMock, whereMock, groupByMock, workerProcessors } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
+  addBulkMock: vi.fn(),
   closeMock: vi.fn(),
+  selectMock: vi.fn(),
+  fromMock: vi.fn(),
+  whereMock: vi.fn(),
+  groupByMock: vi.fn(),
+  workerProcessors: [] as Array<(job: { data: unknown }) => Promise<unknown>>,
 }));
 
 vi.mock('bullmq', () => ({
   Queue: class {
     getJob = getJobMock;
     add = addMock;
+    addBulk = addBulkMock;
     close = closeMock;
   },
   Worker: class {
+    constructor(_name: string, processor: (job: { data: unknown }) => Promise<unknown>) {
+      workerProcessors.push(processor);
+    }
+
     close = closeMock;
     on = vi.fn();
   },
@@ -27,11 +38,13 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  db: {},
+  db: {
+    select: selectMock,
+  },
 }));
 
 vi.mock('../db/schema', () => ({
-  devices: {},
+  devices: { orgId: 'devices.orgId', status: 'devices.status' },
 }));
 
 vi.mock('../services/reliabilityScoring', () => ({
@@ -44,6 +57,7 @@ vi.mock('../services/sentry', () => ({
 }));
 
 import {
+  createReliabilityWorker,
   enqueueDeviceReliabilityComputation,
   shutdownReliabilityWorker,
 } from './reliabilityWorker';
@@ -54,9 +68,20 @@ describe('enqueueDeviceReliabilityComputation', () => {
     vi.setSystemTime(new Date('2026-03-31T12:00:00.000Z'));
     getJobMock.mockReset();
     addMock.mockReset();
+    addBulkMock.mockReset();
     closeMock.mockReset();
+    selectMock.mockReset();
+    fromMock.mockReset();
+    whereMock.mockReset();
+    groupByMock.mockReset();
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queue-job-1' });
+    addBulkMock.mockResolvedValue([]);
+    selectMock.mockReturnValue({ from: fromMock });
+    fromMock.mockReturnValue({ where: whereMock });
+    whereMock.mockReturnValue({ groupBy: groupByMock });
+    groupByMock.mockResolvedValue([{ orgId: 'org-1' }]);
+    workerProcessors.length = 0;
     await shutdownReliabilityWorker();
   });
 
@@ -86,5 +111,33 @@ describe('enqueueDeviceReliabilityComputation', () => {
 
     expect(jobId).toBe('existing-job');
     expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('uses worker execution time when scheduled scans fan out org recompute jobs', async () => {
+    vi.setSystemTime(new Date('2026-03-31T02:00:00.000Z'));
+    createReliabilityWorker();
+
+    vi.setSystemTime(new Date('2026-04-01T02:05:00.000Z'));
+    const result = await workerProcessors[0]!({
+      data: {
+        type: 'scan-orgs',
+        queuedAt: '2026-03-31T02:00:00.000Z',
+      },
+    });
+
+    expect(result).toEqual({ queued: 1 });
+    expect(addBulkMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: 'compute-org',
+        data: expect.objectContaining({
+          type: 'compute-org',
+          orgId: 'org-1',
+          queuedAt: '2026-04-01T02:05:00.000Z',
+        }),
+        opts: expect.objectContaining({
+          jobId: 'reliability-org-1-2026-04-01T02',
+        }),
+      }),
+    ]);
   });
 });

--- a/apps/api/src/jobs/reliabilityWorker.ts
+++ b/apps/api/src/jobs/reliabilityWorker.ts
@@ -21,7 +21,7 @@ const ON_DEMAND_RELIABILITY_DEDUPE_WINDOW_MS = 30 * 1000;
 
 type ScanOrgsJobData = {
   type: 'scan-orgs';
-  queuedAt: string;
+  queuedAt?: string;
 };
 
 type ComputeOrgJobData = {
@@ -62,14 +62,16 @@ async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number 
   }
 
   const queue = getReliabilityQueue();
-  const slotKey = data.queuedAt.slice(0, 13);
+  const scannedAt = new Date();
+  const queuedAt = scannedAt.toISOString();
+  const slotKey = queuedAt.slice(0, 13);
   await queue.addBulk(
     orgRows.map((row) => ({
       name: 'compute-org',
       data: {
         type: 'compute-org' as const,
         orgId: row.orgId,
-        queuedAt: data.queuedAt,
+        queuedAt,
       },
       opts: {
         jobId: `reliability-${row.orgId}-${slotKey}`,
@@ -128,7 +130,6 @@ async function scheduleReliabilityScan(): Promise<void> {
     'scan-orgs',
     {
       type: 'scan-orgs',
-      queuedAt: new Date().toISOString(),
     },
     {
       jobId: 'reliability-scan-orgs',


### PR DESCRIPTION
## Summary
- compute reliability repeat-scan fan-out timestamps at worker execution time instead of repeatable-job registration time
- keep stale queuedAt payloads backwards-compatible while generating fresh hourly child job ids
- add worker-level coverage for the scheduled scan fan-out path

## Tests
- corepack pnpm --filter @breeze/api exec vitest run src/jobs/reliabilityWorker.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/api exec eslint src/jobs/reliabilityWorker.ts src/jobs/reliabilityWorker.test.ts
- git diff --check