### PR TITLE
fix(ml): site-scope AI risk tools

### DIFF
--- a/apps/api/src/services/aiToolsReliability.test.ts
+++ b/apps/api/src/services/aiToolsReliability.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockListReliabilityDevices = vi.fn();
+const mockListUserRiskScores = vi.fn();
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -78,12 +79,19 @@ vi.mock('./reliabilityScoring', () => ({
   listReliabilityDevices: (...args: unknown[]) => mockListReliabilityDevices(...args),
 }));
 
+vi.mock('./userRiskScoring', () => ({
+  assignSecurityTraining: vi.fn(),
+  getUserRiskDetail: vi.fn(),
+  listUserRiskScores: (...args: unknown[]) => mockListUserRiskScores(...args),
+}));
+
 import { executeTool } from './aiTools';
 
 describe('aiTools get_fleet_health org scoping', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockListReliabilityDevices.mockResolvedValue({ total: 0, rows: [] });
+    mockListUserRiskScores.mockResolvedValue({ total: 0, rows: [] });
   });
 
   it('returns org context error when accessibleOrgIds is empty', async () => {
@@ -128,5 +136,99 @@ describe('aiTools get_fleet_health org scoping', () => {
     );
     expect(parsed.total).toBe(1);
     expect(parsed.summary.averageScore).toBe(44);
+  });
+
+  it('narrows fleet health by allowed sites for site-restricted callers', async () => {
+    const auth = {
+      user: { id: 'user-1' },
+      orgId: 'org-1',
+      scope: 'organization',
+      accessibleOrgIds: ['org-1'],
+      allowedSiteIds: ['site-1', 'site-2'],
+      canAccessOrg: () => true,
+      canAccessSite: (siteId: string | null | undefined) => siteId === 'site-1' || siteId === 'site-2',
+      orgCondition: () => undefined,
+    } as any;
+
+    const result = await executeTool('get_fleet_health', {}, auth);
+    const parsed = JSON.parse(result);
+
+    expect(mockListReliabilityDevices).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgIds: ['org-1'],
+        siteIds: ['site-1', 'site-2'],
+      }),
+    );
+    expect(parsed.total).toBe(0);
+  });
+
+  it('denies explicit fleet health site filters outside caller site access', async () => {
+    const auth = {
+      user: { id: 'user-1' },
+      orgId: 'org-1',
+      scope: 'organization',
+      accessibleOrgIds: ['org-1'],
+      allowedSiteIds: ['site-1'],
+      canAccessOrg: () => true,
+      canAccessSite: (siteId: string | null | undefined) => siteId === 'site-1',
+      orgCondition: () => undefined,
+    } as any;
+
+    const result = await executeTool('get_fleet_health', { siteId: 'site-2' }, auth);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({ error: 'Access denied to this site' });
+    expect(mockListReliabilityDevices).not.toHaveBeenCalled();
+  });
+});
+
+describe('aiTools get_user_risk_scores site scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListReliabilityDevices.mockResolvedValue({ total: 0, rows: [] });
+    mockListUserRiskScores.mockResolvedValue({ total: 0, rows: [] });
+  });
+
+  it('narrows user risk scores by allowed sites for site-restricted callers', async () => {
+    const auth = {
+      user: { id: 'user-1' },
+      orgId: 'org-1',
+      scope: 'organization',
+      accessibleOrgIds: ['org-1'],
+      allowedSiteIds: ['site-1', 'site-2'],
+      canAccessOrg: () => true,
+      canAccessSite: (siteId: string | null | undefined) => siteId === 'site-1' || siteId === 'site-2',
+      orgCondition: () => undefined,
+    } as any;
+
+    const result = await executeTool('get_user_risk_scores', {}, auth);
+    const parsed = JSON.parse(result);
+
+    expect(mockListUserRiskScores).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgIds: ['org-1'],
+        siteIds: ['site-1', 'site-2'],
+      }),
+    );
+    expect(parsed.total).toBe(0);
+  });
+
+  it('denies explicit user risk site filters outside caller site access', async () => {
+    const auth = {
+      user: { id: 'user-1' },
+      orgId: 'org-1',
+      scope: 'organization',
+      accessibleOrgIds: ['org-1'],
+      allowedSiteIds: ['site-1'],
+      canAccessOrg: () => true,
+      canAccessSite: (siteId: string | null | undefined) => siteId === 'site-1',
+      orgCondition: () => undefined,
+    } as any;
+
+    const result = await executeTool('get_user_risk_scores', { siteId: 'site-2' }, auth);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({ error: 'Access denied to this site' });
+    expect(mockListUserRiskScores).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiToolsUserRisk.ts
+++ b/apps/api/src/services/aiToolsUserRisk.ts
@@ -87,6 +87,14 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
           return JSON.stringify({ error: 'Organization context required' });
         }
 
+        const requestedSiteId = typeof input.siteId === 'string' ? input.siteId : undefined;
+        if (requestedSiteId && auth.allowedSiteIds && auth.canAccessSite && !auth.canAccessSite(requestedSiteId)) {
+          return JSON.stringify({ error: 'Access denied to this site' });
+        }
+        const siteIds = !requestedSiteId && auth.allowedSiteIds && auth.canAccessSite
+          ? auth.allowedSiteIds
+          : undefined;
+
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
         const scoreRange = (typeof input.scoreRange === 'string' && ['critical', 'poor', 'fair', 'good'].includes(input.scoreRange))
           ? input.scoreRange as 'critical' | 'poor' | 'fair' | 'good'
@@ -100,7 +108,8 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
 
         const { total, rows } = await listReliabilityDevices({
           orgIds,
-          siteId: typeof input.siteId === 'string' ? input.siteId : undefined,
+          siteId: requestedSiteId,
+          siteIds,
           scoreRange,
           trendDirection,
           issueType,
@@ -169,10 +178,19 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: 'Organization context required' });
       }
 
+      const requestedSiteId = typeof input.siteId === 'string' ? input.siteId : undefined;
+      if (requestedSiteId && auth.allowedSiteIds && auth.canAccessSite && !auth.canAccessSite(requestedSiteId)) {
+        return JSON.stringify({ error: 'Access denied to this site' });
+      }
+      const siteIds = !requestedSiteId && auth.allowedSiteIds && auth.canAccessSite
+        ? auth.allowedSiteIds
+        : undefined;
+
       const limit = Math.min(Math.max(1, Number(input.limit) || 25), 200);
       const result = await listUserRiskScores({
         orgIds,
-        siteId: typeof input.siteId === 'string' ? input.siteId : undefined,
+        siteId: requestedSiteId,
+        siteIds,
         minScore: typeof input.minScore === 'number' ? input.minScore : undefined,
         maxScore: typeof input.maxScore === 'number' ? input.maxScore : undefined,
         trendDirection: (typeof input.trendDirection === 'string'

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -59,6 +59,7 @@ export interface ReliabilityListFilter {
   orgId?: string;
   orgIds?: string[];
   siteId?: string;
+  siteIds?: string[];
   minScore?: number;
   maxScore?: number;
   scoreRange?: ReliabilityScoreRange;
@@ -1038,6 +1039,8 @@ export async function listReliabilityDevices(filter: ReliabilityListFilter): Pro
   }
   if (filter.siteId) {
     conditions.push(eq(devices.siteId, filter.siteId));
+  } else if (filter.siteIds && filter.siteIds.length > 0) {
+    conditions.push(inArray(devices.siteId, filter.siteIds));
   }
 
   const [rangeMin, rangeMax] = filter.scoreRange ? scoreRangeBounds(filter.scoreRange) : [undefined, undefined];

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -266,6 +266,7 @@ export type UserRiskScoreListFilter = {
   orgIds?: string[];
   orgId?: string;
   siteId?: string;
+  siteIds?: string[];
   minScore?: number;
   maxScore?: number;
   trendDirection?: 'up' | 'down' | 'stable';
@@ -950,6 +951,9 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
   }
   if (filter.siteId) {
     conditions.push(sql`${organizationUsers.siteIds} @> ARRAY[${filter.siteId}]::uuid[]`);
+  } else if (filter.siteIds && filter.siteIds.length > 0) {
+    const allowedSiteIds = sql.join(filter.siteIds.map((siteId) => sql`${siteId}::uuid`), sql`, `);
+    conditions.push(sql`${organizationUsers.siteIds} && ARRAY[${allowedSiteIds}]`);
   }
 
   const whereClause = and(...conditions);


### PR DESCRIPTION
## Summary
- deny explicit forbidden site filters in AI fleet health and user-risk score tools
- narrow broad site-restricted AI calls by the caller's allowed site IDs
- add multi-site filters in reliability and user-risk scoring service reads

## Tests
- corepack pnpm --filter @breeze/api exec vitest run src/services/aiToolsReliability.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/api exec eslint src/services/aiToolsUserRisk.ts src/services/reliabilityScoring.ts src/services/userRiskScoring.ts src/services/aiToolsReliability.test.ts
- git diff --check