### PR TITLE
fix(ml): site-scope reliability summaries

### DIFF
--- a/apps/api/src/routes/reliability.test.ts
+++ b/apps/api/src/routes/reliability.test.ts
@@ -39,12 +39,14 @@ import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './devices/help
 const ORG_ID = '00000000-0000-0000-0000-000000000001';
 const ORG_ID_2 = '00000000-0000-0000-0000-000000000002';
 const DEVICE_ID = '00000000-0000-0000-0000-000000000010';
+const SITE_ID = '00000000-0000-0000-0000-000000000020';
 
 type AuthOverrides = {
   scope?: 'organization' | 'partner' | 'system';
   orgId?: string | null;
   accessibleOrgIds?: string[] | null;
   canAccessOrg?: (id: string) => boolean;
+  allowedSiteIds?: string[];
 };
 
 function buildApp(overrides: AuthOverrides = {}): Hono {
@@ -58,7 +60,7 @@ function buildApp(overrides: AuthOverrides = {}): Hono {
       accessibleOrgIds: 'accessibleOrgIds' in overrides ? overrides.accessibleOrgIds : [ORG_ID],
       canAccessOrg: overrides.canAccessOrg ?? ((id: string) => id === ORG_ID),
     });
-    c.set('permissions', { allowedSiteIds: undefined });
+    c.set('permissions', { allowedSiteIds: overrides.allowedSiteIds });
     await next();
   };
   const app = new Hono();
@@ -181,6 +183,37 @@ describe('public reliability routes', () => {
       const body = await res.json();
       expect(body.summary).toEqual(summary);
       expect(body.worstDevices).toEqual([]);
+    });
+
+    it('scopes summary and worst devices to allowed sites for site-restricted users', async () => {
+      const summary = {
+        orgId: ORG_ID,
+        devices: 1,
+        averageScore: 48,
+        criticalDevices: 1,
+        poorDevices: 0,
+        fairDevices: 0,
+        goodDevices: 0,
+        degradingDevices: 1,
+        topIssues: [{ type: 'crashes' as const, count: 2 }],
+      };
+      vi.mocked(getOrgReliabilitySummary).mockResolvedValue(summary);
+      vi.mocked(listReliabilityDevices).mockResolvedValue({ total: 1, rows: [{ deviceId: DEVICE_ID }] as any });
+
+      const app = buildApp({ allowedSiteIds: [SITE_ID] });
+      const res = await app.request(`/reliability/org/${ORG_ID}/summary`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.summary).toEqual(summary);
+      expect(body.worstDevices).toEqual([{ deviceId: DEVICE_ID }]);
+      expect(vi.mocked(getOrgReliabilitySummary)).toHaveBeenCalledWith(ORG_ID, { siteIds: [SITE_ID] });
+      expect(vi.mocked(listReliabilityDevices)).toHaveBeenCalledWith({
+        orgId: ORG_ID,
+        siteIds: [SITE_ID],
+        limit: 10,
+        offset: 0,
+      });
     });
   });
 

--- a/apps/api/src/routes/reliability.ts
+++ b/apps/api/src/routes/reliability.ts
@@ -206,9 +206,11 @@ reliabilityRoutes.get(
       return c.json({ error: 'Access denied to this organization' }, 403);
     }
 
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    const siteIds = permissions?.allowedSiteIds;
     const [summary, worstDevices] = await Promise.all([
-      getOrgReliabilitySummary(orgId),
-      listReliabilityDevices({ orgId, limit: 10, offset: 0 }),
+      getOrgReliabilitySummary(orgId, { siteIds }),
+      listReliabilityDevices({ orgId, siteIds, limit: 10, offset: 0 }),
     ]);
 
     return c.json({

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -1039,8 +1039,8 @@ export async function listReliabilityDevices(filter: ReliabilityListFilter): Pro
   }
   if (filter.siteId) {
     conditions.push(eq(devices.siteId, filter.siteId));
-  } else if (filter.siteIds && filter.siteIds.length > 0) {
-    conditions.push(inArray(devices.siteId, filter.siteIds));
+  } else if (filter.siteIds) {
+    conditions.push(filter.siteIds.length > 0 ? inArray(devices.siteId, filter.siteIds) : sql`false`);
   }
 
   const [rangeMin, rangeMax] = filter.scoreRange ? scoreRangeBounds(filter.scoreRange) : [undefined, undefined];
@@ -1324,7 +1324,7 @@ export async function getDeviceReliabilityHistory(deviceId: string, days: number
     });
 }
 
-export async function getOrgReliabilitySummary(orgId: string): Promise<{
+export async function getOrgReliabilitySummary(orgId: string, options: { siteIds?: string[] } = {}): Promise<{
   orgId: string;
   devices: number;
   averageScore: number;
@@ -1335,6 +1335,11 @@ export async function getOrgReliabilitySummary(orgId: string): Promise<{
   degradingDevices: number;
   topIssues: Array<{ type: ReliabilityTopIssue['type']; count: number }>;
 }> {
+  const conditions: SQL[] = [eq(deviceReliability.orgId, orgId)];
+  if (options.siteIds) {
+    conditions.push(options.siteIds.length > 0 ? inArray(devices.siteId, options.siteIds) : sql`false`);
+  }
+
   const rows = await db
     .select({
       reliabilityScore: deviceReliability.reliabilityScore,
@@ -1346,7 +1351,8 @@ export async function getOrgReliabilitySummary(orgId: string): Promise<{
       uptime30d: deviceReliability.uptime30d,
     })
     .from(deviceReliability)
-    .where(eq(deviceReliability.orgId, orgId));
+    .innerJoin(devices, eq(deviceReliability.deviceId, devices.id))
+    .where(and(...conditions));
 
   const total = rows.length;
   const averageScore = total > 0

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -951,9 +951,13 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
   }
   if (filter.siteId) {
     conditions.push(sql`${organizationUsers.siteIds} @> ARRAY[${filter.siteId}]::uuid[]`);
-  } else if (filter.siteIds && filter.siteIds.length > 0) {
-    const allowedSiteIds = sql.join(filter.siteIds.map((siteId) => sql`${siteId}::uuid`), sql`, `);
-    conditions.push(sql`${organizationUsers.siteIds} && ARRAY[${allowedSiteIds}]`);
+  } else if (filter.siteIds) {
+    if (filter.siteIds.length === 0) {
+      conditions.push(sql`false`);
+    } else {
+      const allowedSiteIds = sql.join(filter.siteIds.map((siteId) => sql`${siteId}::uuid`), sql`, `);
+      conditions.push(sql`${organizationUsers.siteIds} && ARRAY[${allowedSiteIds}]`);
+    }
   }
 
   const whereClause = and(...conditions);


### PR DESCRIPTION
## Summary
- scope reliability org summaries and worst-device lists to allowed site IDs
- make empty allowed-site sets fail closed in reliability and user-risk multi-site filters
- add route regression coverage for site-restricted reliability summaries

## Tests
- corepack pnpm --filter @breeze/api exec vitest run src/routes/reliability.test.ts src/services/aiToolsReliability.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/api exec eslint src/routes/reliability.ts src/routes/reliability.test.ts src/services/reliabilityScoring.ts src/services/userRiskScoring.ts
- git diff --check