### PR TITLE
fix(ml): use rollups for metrics trends

### DIFF
--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -34,6 +34,32 @@ vi.mock('../middleware/auth', () => ({
 
 import { authMiddleware } from '../middleware/auth';
 
+function mockRollupTrendRows(selectMock: ReturnType<typeof vi.fn>, rows: unknown[]) {
+  selectMock.mockReturnValueOnce({
+    from: () => ({
+      where: () => ({
+        groupBy: () => ({
+          orderBy: () => Promise.resolve(rows),
+        }),
+      }),
+    }),
+  });
+}
+
+function mockRawTrendRows(selectMock: ReturnType<typeof vi.fn>, rows: unknown[]) {
+  selectMock.mockReturnValueOnce({
+    from: () => ({
+      innerJoin: () => ({
+        where: () => ({
+          groupBy: () => ({
+            orderBy: () => Promise.resolve(rows),
+          }),
+        }),
+      }),
+    }),
+  });
+}
+
 function getMetricLine(metrics: string, name: string, labels?: Record<string, string>): string | undefined {
   const labelText = labels ? `{${Object.entries(labels).map(([k, v]) => `${k}="${v}"`).join(',')}}` : '';
   return metrics
@@ -99,6 +125,47 @@ describe('metrics routes', () => {
   it('requires auth for metrics endpoints', async () => {
     const res = await app.request('/metrics');
     expect(res.status).toBe(401);
+  });
+
+  it('uses daily metric rollups for trend metrics when available', async () => {
+    const { db } = await import('../db');
+    const selectMock = vi.mocked(db.select);
+    mockRollupTrendRows(selectMock, [
+      { bucket: new Date('2026-06-17T00:00:00.000Z'), metricName: 'cpu_percent', value: 12.4 },
+      { bucket: new Date('2026-06-17T00:00:00.000Z'), metricName: 'ram_percent', value: 66.6 },
+      { bucket: new Date('2026-06-18T00:00:00.000Z'), metricName: 'cpu_percent', value: 20 },
+      { bucket: new Date('2026-06-18T00:00:00.000Z'), metricName: 'ram_percent', value: 70 },
+    ]);
+
+    const res = await app.request('/trends?range=7d', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      { timestamp: '2026-06-17T00:00:00.000Z', cpu: 12, memory: 67 },
+      { timestamp: '2026-06-18T00:00:00.000Z', cpu: 20, memory: 70 },
+    ]);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to raw device metrics for trend metrics when rollups are empty', async () => {
+    const { db } = await import('../db');
+    const selectMock = vi.mocked(db.select);
+    mockRollupTrendRows(selectMock, []);
+    mockRawTrendRows(selectMock, [
+      { bucket: '2026-06-18T00:00:00.000Z', cpu: 21.2, memory: 75.8 },
+    ]);
+
+    const res = await app.request('/trends?range=7d', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      { timestamp: '2026-06-18T00:00:00.000Z', cpu: 21, memory: 76 },
+    ]);
+    expect(selectMock).toHaveBeenCalledTimes(2);
   });
 
   it('requires scrape token for /scrape endpoint', async () => {

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -5,12 +5,12 @@
  */
 
 import { Hono } from 'hono';
-import { avg, and, eq, gte, sql } from 'drizzle-orm';
+import { avg, and, eq, gte, inArray, sql } from 'drizzle-orm';
 import { Counter, Gauge, Histogram, Registry } from 'prom-client';
 import { createHash, timingSafeEqual } from 'crypto';
 
 import { db } from '../db';
-import { deviceMetrics, devices, recoveryReadiness as recoveryReadinessTable, remoteSessions } from '../db/schema';
+import { deviceMetrics, devices, metricRollups, recoveryReadiness as recoveryReadinessTable, remoteSessions } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { PERMISSIONS } from '../services/permissions';
@@ -733,6 +733,47 @@ metricsRoutes.get('/trends', authMiddleware, requireScope('organization', 'partn
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
   try {
+    const rollupOrgCondition =
+      typeof auth?.orgCondition === 'function'
+        ? auth.orgCondition(metricRollups.orgId)
+        : auth?.orgId
+          ? eq(metricRollups.orgId, auth.orgId)
+          : undefined;
+    const rollupCondition = and(
+      eq(metricRollups.sourceTable, 'device_metrics'),
+      eq(metricRollups.bucketSeconds, 86400),
+      inArray(metricRollups.metricName, ['cpu_percent', 'ram_percent']),
+      gte(metricRollups.bucketStart, since),
+      sql`${metricRollups.sampleCount} > 0`,
+      sql`${metricRollups.avgValue} IS NOT NULL`,
+      ...(rollupOrgCondition ? [rollupOrgCondition] : [])
+    );
+    const rollupRows = await db
+      .select({
+        bucket: metricRollups.bucketStart,
+        metricName: metricRollups.metricName,
+        value: sql<number>`sum(${metricRollups.avgValue} * ${metricRollups.sampleCount}) / nullif(sum(${metricRollups.sampleCount}), 0)`
+      })
+      .from(metricRollups)
+      .where(rollupCondition)
+      .groupBy(metricRollups.bucketStart, metricRollups.metricName)
+      .orderBy(metricRollups.bucketStart);
+
+    if (rollupRows.length > 0) {
+      const byBucket = new Map<string, { timestamp: string; cpu: number; memory: number }>();
+      for (const row of rollupRows) {
+        const timestamp = row.bucket instanceof Date ? row.bucket.toISOString() : String(row.bucket);
+        const bucket = byBucket.get(timestamp) ?? { timestamp, cpu: 0, memory: 0 };
+        if (row.metricName === 'cpu_percent') {
+          bucket.cpu = Math.round(Number(row.value ?? 0));
+        } else if (row.metricName === 'ram_percent') {
+          bucket.memory = Math.round(Number(row.value ?? 0));
+        }
+        byBucket.set(timestamp, bucket);
+      }
+      return c.json(Array.from(byBucket.values()));
+    }
+
     const trendsCondition = orgCondition
       ? and(gte(deviceMetrics.timestamp, since), orgCondition)
       : gte(deviceMetrics.timestamp, since);


### PR DESCRIPTION
## Summary
- read daily metric_rollups first for /metrics/trends CPU and memory aggregates
- preserve the existing raw device_metrics fallback when rollups are empty
- add route coverage for rollup-present and rollup-empty paths

## Tests
- corepack pnpm --filter @breeze/api exec vitest run src/routes/metrics.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/api exec eslint src/routes/metrics.ts src/routes/metrics.test.ts
- git diff --check