### PR TITLE
fix(ml): use rollups for analytics queries

### DIFF
--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -169,6 +169,8 @@ vi.mock('../db/schema', () => ({
     bucketStart: 'metricRollups.bucketStart',
     bucketSeconds: 'metricRollups.bucketSeconds',
     avgValue: 'metricRollups.avgValue',
+    minValue: 'metricRollups.minValue',
+    maxValue: 'metricRollups.maxValue',
     sampleCount: 'metricRollups.sampleCount'
   },
   metricAnomalies: {
@@ -329,6 +331,85 @@ describe('analytics routes', () => {
       expect(body.series).toHaveLength(1);
       expect(body.series[0].metricType).toBe('cpu_usage');
       expect(body.series[0].data).toEqual([]);
+    });
+
+    it('uses metric rollups for hourly averages when available', async () => {
+      mockSelectOnce([
+        { bucket: new Date('2026-06-18T12:00:00.000Z'), value: 42.5 },
+      ]);
+
+      const res = await app.request('/analytics/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceIds: [DEVICE_IN_SCOPE],
+          metricTypes: ['cpu_usage'],
+          startTime: '2026-06-18T00:00:00Z',
+          endTime: '2026-06-19T00:00:00Z',
+          aggregation: 'avg',
+          interval: 'hour'
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.series[0].data).toEqual([
+        { timestamp: '2026-06-18T12:00:00.000Z', value: 42.5 },
+      ]);
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to raw metrics when hourly rollups are empty', async () => {
+      mockSelectOnce([]); // metric_rollups
+      mockSelectOnce([
+        { bucket: new Date('2026-06-18T12:00:00.000Z'), value: 37 },
+      ]); // raw device_metrics
+
+      const res = await app.request('/analytics/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceIds: [DEVICE_IN_SCOPE],
+          metricTypes: ['cpu_usage'],
+          startTime: '2026-06-18T00:00:00Z',
+          endTime: '2026-06-19T00:00:00Z',
+          aggregation: 'avg',
+          interval: 'hour'
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.series[0].data).toEqual([
+        { timestamp: '2026-06-18T12:00:00.000Z', value: 37 },
+      ]);
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses metric rollup sample counts for daily count aggregation', async () => {
+      mockSelectOnce([
+        { bucket: new Date('2026-06-18T00:00:00.000Z'), value: 15 },
+      ]);
+
+      const res = await app.request('/analytics/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceIds: [DEVICE_IN_SCOPE],
+          metricTypes: ['memory_usage'],
+          startTime: '2026-06-18T00:00:00Z',
+          endTime: '2026-06-19T00:00:00Z',
+          aggregation: 'count',
+          interval: 'day'
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.series[0].data).toEqual([
+        { timestamp: '2026-06-18T00:00:00.000Z', value: 15 },
+      ]);
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
     });
 
     it('should validate required fields', async () => {
@@ -940,7 +1021,8 @@ describe('analytics routes', () => {
       it('allows a site-restricted caller when all requested deviceIds are in scope', async () => {
         currentPermissions = { allowedSiteIds: [SITE_ALLOWED] };
         mockSelectOnce(ORG_DEVICE_ROWS); // device resolution
-        mockSelectOnce([]); // metric series query
+        mockSelectOnce([]); // metric_rollups
+        mockSelectOnce([]); // raw metric series query
 
         const res = await app.request('/analytics/query', {
           method: 'POST',
@@ -962,7 +1044,8 @@ describe('analytics routes', () => {
 
       it('does not narrow timeseries for an unrestricted caller', async () => {
         currentPermissions = undefined; // unrestricted — no resolution query
-        mockSelectOnce([]); // metric series query is the first select
+        mockSelectOnce([]); // metric_rollups query is the first select
+        mockSelectOnce([]); // raw metric series query
 
         const res = await app.request('/analytics/query', {
           method: 'POST',

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -128,6 +128,41 @@ function aggregationSql(col: any, agg: string) {
   }
 }
 
+function metricRollupNameForQuery(metricType: string): string | undefined {
+  const normalized = metricType.trim().toLowerCase();
+  if (normalized === 'cpu_usage' || normalized === 'cpu' || normalized === 'cpu utilization') return 'cpu_percent';
+  if (normalized === 'memory_usage' || normalized === 'memory' || normalized === 'ram' || normalized === 'memory utilization') return 'ram_percent';
+  if (normalized === 'ram_used_mb') return 'ram_used_mb';
+  if (normalized === 'disk_usage' || normalized === 'disk' || normalized === 'disk usage') return 'disk_percent';
+  if (normalized === 'disk_used_gb') return 'disk_used_gb';
+  if (normalized === 'network_in' || normalized === 'bandwidth_in') return 'bandwidth_in_bps';
+  if (normalized === 'network_out' || normalized === 'bandwidth_out') return 'bandwidth_out_bps';
+  if (normalized === 'network throughput') return 'bandwidth_in_bps';
+  if (normalized === 'process_count') return 'process_count';
+  return undefined;
+}
+
+function rollupBucketSeconds(interval: string): number | undefined {
+  if (interval === 'hour') return 3600;
+  if (interval === 'day') return 86400;
+  return undefined;
+}
+
+function rollupAggregationSql(agg: string) {
+  switch (agg) {
+    case 'avg':
+      return sql<number>`sum(${metricRollups.avgValue} * ${metricRollups.sampleCount}) / nullif(sum(${metricRollups.sampleCount}), 0)`;
+    case 'min':
+      return sql<number>`min(${metricRollups.minValue})`;
+    case 'max':
+      return sql<number>`max(${metricRollups.maxValue})`;
+    case 'count':
+      return sql<number>`sum(${metricRollups.sampleCount})`;
+    default:
+      return undefined;
+  }
+}
+
 const listDashboardsSchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional(),
@@ -360,6 +395,41 @@ analyticsRoutes.post(
         continue;
       }
 
+      const rollupMetricName = metricRollupNameForQuery(normalizedMetricType);
+      const bucketSeconds = rollupBucketSeconds(interval);
+      const rollupValue = rollupAggregationSql(data.aggregation);
+      let rows: Array<{ bucket: Date | string; value: number | null }> = [];
+
+      if (rollupMetricName && bucketSeconds && rollupValue) {
+        const rollupBucket = metricRollups.bucketStart;
+        const rollupOrgCondition =
+          typeof auth?.orgCondition === 'function'
+            ? auth.orgCondition(metricRollups.orgId)
+            : auth?.orgId
+              ? eq(metricRollups.orgId, auth.orgId)
+              : undefined;
+        rows = await db
+          .select({
+            bucket: rollupBucket,
+            value: rollupValue
+          })
+          .from(metricRollups)
+          .where(
+            and(
+              inArray(metricRollups.deviceId, data.deviceIds),
+              eq(metricRollups.sourceTable, 'device_metrics'),
+              eq(metricRollups.bucketSeconds, bucketSeconds),
+              eq(metricRollups.metricName, rollupMetricName),
+              sql`${metricRollups.sampleCount} > 0`,
+              ...(rollupOrgCondition ? [rollupOrgCondition] : []),
+              gte(metricRollups.bucketStart, startTime),
+              lte(metricRollups.bucketStart, endTime)
+            )
+          )
+          .groupBy(rollupBucket)
+          .orderBy(rollupBucket);
+      }
+
       const bucket = sql<Date>`date_trunc(${interval}, ${deviceMetrics.timestamp})`;
       const value = aggregationSql(metricColumn, data.aggregation);
 
@@ -371,23 +441,25 @@ analyticsRoutes.post(
             ? eq(devices.orgId, auth.orgId)
             : undefined;
 
-      const rows = await db
-        .select({
-          bucket,
-          value
-        })
-        .from(deviceMetrics)
-        .innerJoin(devices, eq(deviceMetrics.deviceId, devices.id))
-        .where(
-          and(
-            inArray(deviceMetrics.deviceId, data.deviceIds),
-            ...(orgCondition ? [orgCondition] : []),
-            gte(deviceMetrics.timestamp, startTime),
-            lte(deviceMetrics.timestamp, endTime)
+      if (rows.length === 0) {
+        rows = await db
+          .select({
+            bucket,
+            value
+          })
+          .from(deviceMetrics)
+          .innerJoin(devices, eq(deviceMetrics.deviceId, devices.id))
+          .where(
+            and(
+              inArray(deviceMetrics.deviceId, data.deviceIds),
+              ...(orgCondition ? [orgCondition] : []),
+              gte(deviceMetrics.timestamp, startTime),
+              lte(deviceMetrics.timestamp, endTime)
+            )
           )
-        )
-        .groupBy(bucket)
-        .orderBy(bucket);
+          .groupBy(bucket)
+          .orderBy(bucket);
+      }
 
       series.push({
         metricType,


### PR DESCRIPTION
## Summary
- use metric_rollups first for /analytics/query hour/day avg, min, max, and count aggregations
- keep raw device_metrics fallback for unsupported rollup shapes or empty rollup reads
- preserve site-scope gating and existing response shape

## Tests
- corepack pnpm --filter @breeze/api exec vitest run src/routes/analytics.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @breeze/api exec eslint src/routes/analytics.ts src/routes/analytics.test.ts
- git diff --check