### PR TITLE
fix(web): multi-select "Run Script" sent empty deviceIds (400 "Array must contain at least one item")

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -77,7 +77,34 @@ vi.mock('./filterUrl', () => ({
 }));
 
 // Presentational/heavy children — not under test.
-vi.mock('./ScriptPickerModal', () => ({ default: () => null }));
+// ScriptPickerModal is stubbed to expose the real modal's select→close
+// sequence: it calls onSelect(...) and then onClose() (mirroring
+// ScriptPickerModal.handleSelect for a parameterless script). This is the
+// exact ordering that regressed multi-select run-script — onClose wiped the
+// target devices before the confirm dialog executed.
+vi.mock('./ScriptPickerModal', () => ({
+  default: ({
+    isOpen,
+    onSelect,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onSelect: (script: { id: string; name: string }, runAs: string, parameters?: unknown) => void;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <button
+        type="button"
+        data-testid="pick-script"
+        onClick={() => {
+          onSelect({ id: 'script-1', name: 'Test Script' }, 'system', undefined);
+          onClose();
+        }}
+      >
+        pick
+      </button>
+    ) : null,
+}));
 vi.mock('./DeviceSettingsModal', () => ({ default: () => null }));
 vi.mock('./AddDeviceModal', () => ({ default: () => null }));
 vi.mock('./CreateGroupModal', () => ({ default: () => null }));
@@ -106,7 +133,7 @@ vi.mock('./DeviceList', () => ({
       data-filter-ids={serverFilterIds ? [...serverFilterIds].sort().join(',') : ''}
       data-watchdog-versions={devices.map(d => d.watchdogVersion ?? '').join(',')}
     >
-      {['maintenance-on', 'maintenance-off', 'decommission', 'reboot'].map(action => (
+      {['maintenance-on', 'maintenance-off', 'decommission', 'reboot', 'run-script'].map(action => (
         <button
           key={action}
           type="button"
@@ -286,6 +313,50 @@ describe('DevicesPage — network-arm fetch failure handling (#1322)', () => {
     expect(await screen.findByTestId('device-list')).toBeTruthy();
     expect(screen.queryByText('Session expired')).toBeNull();
     expect(screen.queryByText('Failed to load')).toBeNull();
+  });
+});
+
+// Regression: multi-select "Run Script" sent an EMPTY deviceIds array → the API
+// rejected it with 400 "Array must contain at least one item". Root cause: the
+// ScriptPickerModal called onSelect() then onClose(), and onClose
+// (closeScriptPicker) reset scriptTargetDevices to [] BEFORE the confirm
+// dialog's doExecuteScript read it. The selected devices must be captured into
+// pendingScriptRun so execution is independent of the wiped state.
+describe('DevicesPage — multi-select run script keeps its target devices', () => {
+  async function renderAgentFleet() {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValue(null); // no advanced filter
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    await waitFor(() => expect(list.getAttribute('data-device-count')).toBe('3'));
+    return list;
+  }
+
+  it('executes with the originally-selected device ids, not an empty array', async () => {
+    const { executeScript } = await import('../../services/deviceActions');
+    vi.mocked(executeScript).mockResolvedValue({
+      batchId: 'batch-1',
+      scriptId: 'script-1',
+      devicesTargeted: 3,
+      executions: [],
+      status: 'queued',
+    } as never);
+
+    await renderAgentFleet();
+
+    // Bulk "run script" over the full fleet → opens the (stubbed) picker.
+    fireEvent.click(screen.getByTestId('bulk-run-script'));
+    // Selecting a script fires onSelect + onClose, then the confirm dialog shows.
+    fireEvent.click(await screen.findByTestId('pick-script'));
+    // Confirm the scope-gated run.
+    fireEvent.click(await screen.findByTestId('confirm-fleet-action'));
+
+    await waitFor(() => {
+      expect(vi.mocked(executeScript)).toHaveBeenCalledTimes(1);
+    });
+    const [scriptId, deviceIds] = vi.mocked(executeScript).mock.calls[0];
+    expect(scriptId).toBe('script-1');
+    expect([...(deviceIds as string[])].sort()).toEqual([DEV_1, DEV_2, DEV_3].sort());
   });
 });
 

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -348,6 +348,12 @@ describe('DevicesPage — multi-select run script keeps its target devices', () 
     fireEvent.click(screen.getByTestId('bulk-run-script'));
     // Selecting a script fires onSelect + onClose, then the confirm dialog shows.
     fireEvent.click(await screen.findByTestId('pick-script'));
+
+    // The scope-confirm message is computed from pendingScriptRun.devices too —
+    // a regression back to the wiped scriptTargetDevices would render
+    // "0 devices". Assert the real count is shown before confirming.
+    expect(await screen.findByText(/on 3 devices/i)).toBeTruthy();
+
     // Confirm the scope-gated run.
     fireEvent.click(await screen.findByTestId('confirm-fleet-action'));
 

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -77,7 +77,7 @@ export default function DevicesPage() {
   });
   const [scriptPickerOpen, setScriptPickerOpen] = useState(false);
   const [scriptTargetDevices, setScriptTargetDevices] = useState<Device[]>([]);
-  type PendingScriptRun = { script: Script; runAs: ScriptRunAsSelection; parameters?: Record<string, unknown> };
+  type PendingScriptRun = { script: Script; runAs: ScriptRunAsSelection; parameters?: Record<string, unknown>; devices: Device[] };
   const [pendingScriptRun, setPendingScriptRun] = useState<PendingScriptRun | null>(null);
   const [settingsDevice, setSettingsDevice] = useState<Device | null>(null);
   // v2 chip bar seeds its filter from the URL hash so a filtered view is
@@ -454,20 +454,24 @@ export default function DevicesPage() {
   };
 
   const handleScriptSelect = (script: Script, runAs: ScriptRunAsSelection, parameters?: Record<string, unknown>) => {
-    // Gate script execution behind a scope-naming confirm dialog.
-    setPendingScriptRun({ script, runAs, parameters });
+    // Gate script execution behind a scope-naming confirm dialog. Capture the
+    // target devices now: ScriptPickerModal calls onClose() right after
+    // onSelect(), and closeScriptPicker() resets scriptTargetDevices to [] —
+    // so doExecuteScript can't read that state later or it sends an empty
+    // deviceIds array (API 400 "Array must contain at least one item").
+    setPendingScriptRun({ script, runAs, parameters, devices: scriptTargetDevices });
   };
 
   const doExecuteScript = async (pending: PendingScriptRun) => {
     if (actionInProgress) return;
     try {
       setActionInProgress(true);
-      const { script, runAs, parameters } = pending;
-      const deviceIds = scriptTargetDevices.map(d => d.id);
+      const { script, runAs, parameters, devices } = pending;
+      const deviceIds = devices.map(d => d.id);
       const result = await executeScript(script.id, deviceIds, parameters, runAs);
 
-      if (scriptTargetDevices.length === 1) {
-        showToast({ type: 'success', message: `Script "${script.name}" queued for ${scriptTargetDevices[0].hostname}` });
+      if (devices.length === 1) {
+        showToast({ type: 'success', message: `Script "${script.name}" queued for ${devices[0].hostname}` });
       } else {
         showToast({ type: 'success', message: `Script "${script.name}" queued for ${result.devicesTargeted} devices` });
       }
@@ -988,7 +992,7 @@ export default function DevicesPage() {
       />
 
       {pendingScriptRun && (() => {
-        const distinctOrgIds = [...new Set(scriptTargetDevices.map(d => d.orgId).filter(Boolean))];
+        const distinctOrgIds = [...new Set(pendingScriptRun.devices.map(d => d.orgId).filter(Boolean))];
         const scriptOrgNames = distinctOrgIds.length > 0
           ? distinctOrgIds.map(id => orgStoreOrgs.find(o => o.id === id)?.name ?? id)
           : ['the selected organization'];
@@ -1007,7 +1011,7 @@ export default function DevicesPage() {
             confirmTestId="confirm-fleet-action"
             message={scopeConfirmMessage({
               action: `Run ${pendingScriptRun.script.name}`,
-              deviceCount: scriptTargetDevices.length,
+              deviceCount: pendingScriptRun.devices.length,
               orgNames: scriptOrgNames,
             })}
             isLoading={actionInProgress}


### PR DESCRIPTION
## Problem
Reported on US prod: selecting multiple devices and running a script fails. The browser shows a 400 with body `"Array must contain at least one item"`, and `POST /scripts/{id}/execute` returns 400 every time.

## Root cause
`ScriptPickerModal` calls `onSelect(...)` and then **`onClose()`** when a script is picked (`ScriptPickerModal.tsx:150-151` / `169-170`). `onClose` is `closeScriptPicker`, which resets `scriptTargetDevices` to `[]` (`DevicesPage.tsx`). The scope-confirm dialog then runs `doExecuteScript`, which read the now-empty `scriptTargetDevices` and POSTed `deviceIds: []` — rejected by `executeScriptSchema` (`deviceIds: z.array(...).min(1)`). The confirm dialog itself also showed a 0-device count for the same reason.

**Not a Zod-version issue** — Zod is v3.25 and the schema is correct. This is a React state-lifetime bug introduced by the confirm-dialog gate.

Single-device runs from `DeviceDetailPage` were unaffected — they pass `[device.id]` directly — which is why only multi-select from the devices list broke.

## Fix
Capture the selected devices into `pendingScriptRun` at select time, so execution and the confirm message are independent of the wiped picker state.

## Test
Adds a regression test driving bulk run-script → pick → confirm and asserting `executeScript` receives the originally-selected ids. Fails before the fix (`expected [] to deeply equal [3 ids]`), passes after. Full `DevicesPage.test.tsx` suite green (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)