### PR TITLE
fix(ai): approval poll read 0 rows under RLS — AI tools always "rejected or timed out"

### DIFF
--- a/apps/api/src/__tests__/integration/aiApprovalPollRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiApprovalPollRls.integration.test.ts
@@ -5,13 +5,14 @@
  *
  * Root cause: waitForApproval() (services/aiAgent.ts) polls ai_tool_executions
  * through the bare `db` pool. The AI Agent SDK runs its session OUTSIDE the
- * request's AsyncLocalStorage DB context (by design — runOutsideDbContext, to
- * avoid holding a request txn open for the whole stream), so inside
- * waitForApproval the `db` proxy resolves to the unprivileged `breeze_app`
- * role with NO `breeze.*` GUCs. ai_tool_executions has forced RLS, so the
- * SELECT matched 0 rows and `if (!execution) return false` fired on the first
- * poll (~67ms) — even after the user clicked Approve (which flips the row to
- * 'approved' via the authenticated, context-bound /approvals route).
+ * request's AsyncLocalStorage DB context (by design — the SDK query() is
+ * wrapped in runOutsideDbContext in streamingSessionManager.ts, to avoid
+ * holding a request txn open for the whole stream), so inside waitForApproval
+ * the `db` proxy resolves to the unprivileged `breeze_app` role with NO
+ * `breeze.*` GUCs. ai_tool_executions has forced RLS, so the SELECT matched
+ * 0 rows and `if (!execution) return false` fired on the first poll — even
+ * after the user clicked Approve (which flips the row to 'approved' via the
+ * authenticated, context-bound /approvals route).
  *
  * Same silent-0-row class as #1375; the contextless-write guard doesn't cover
  * SELECT, so nothing surfaced in logs.
@@ -21,8 +22,10 @@
  * (RED) until waitForApproval establishes a system-scope context for its poll.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
 import './setup';
 import { getTestDb } from './setup';
+import { db } from '../../db';
 import { partners, organizations, users } from '../../db/schema';
 import { aiSessions, aiToolExecutions } from '../../db/schema/ai';
 import { waitForApproval } from '../../services/aiAgent';
@@ -72,6 +75,22 @@ async function seedExecution(status: 'pending' | 'approved' | 'rejected'): Promi
 }
 
 describe('waitForApproval — polls ai_tool_executions with RLS context (SDK path)', () => {
+  // Self-defense against a vacuous environment. The "approved → true" assertion
+  // below only proves the fix if forced RLS is actually filtering — i.e. the app
+  // `db` pool is the non-bypass `breeze_app` role. On a misconfigured BYPASSRLS
+  // connection (e.g. a fresh worktree missing the .env.test symlink) the poll
+  // would find the row and pass even with the fix reverted. This probe makes
+  // that misconfiguration fail loudly instead: a contextless bare-pool read
+  // MUST be hidden by RLS.
+  it('forced RLS actually hides the row from a contextless bare-pool read', async () => {
+    const executionId = await seedExecution('approved');
+    const rows = await db
+      .select({ id: aiToolExecutions.id })
+      .from(aiToolExecutions)
+      .where(eq(aiToolExecutions.id, executionId));
+    expect(rows).toHaveLength(0);
+  });
+
   it('returns true for an approved execution when called with no ambient DB context', async () => {
     const executionId = await seedExecution('approved');
 
@@ -95,5 +114,24 @@ describe('waitForApproval — polls ai_tool_executions with RLS context (SDK pat
     controller.abort();
     const approved = await waitForApproval(executionId, 5_000, controller.signal);
     expect(approved).toBe(false);
+  });
+
+  it('marks a never-approved execution rejected on timeout (the wrapped timeout write)', async () => {
+    // The timeout-path UPDATE was the same silent-0-row class as the SELECT:
+    // pre-fix it ran on the bare pool and matched 0 rows under RLS, leaving the
+    // row stuck 'pending'. With the wrap it must now flip to 'rejected'. Short
+    // timeout so the poll exhausts quickly; assert on terminal row state (read
+    // back on the superuser conn) rather than tight timing.
+    const executionId = await seedExecution('pending');
+
+    const approved = await waitForApproval(executionId, 250);
+    expect(approved).toBe(false);
+
+    const [after] = await getTestDb()
+      .select({ status: aiToolExecutions.status, errorMessage: aiToolExecutions.errorMessage })
+      .from(aiToolExecutions)
+      .where(eq(aiToolExecutions.id, executionId));
+    expect(after!.status).toBe('rejected');
+    expect(after!.errorMessage).toBe('Approval timed out');
   });
 });

--- a/apps/api/src/__tests__/integration/aiApprovalPollRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiApprovalPollRls.integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression: the AI agent could not run ANY approval-gated tool on US prod
+ * (every execute_command returned "Tool execution was rejected or timed out",
+ * including read-only list_processes). Users had to manually flag the chat.
+ *
+ * Root cause: waitForApproval() (services/aiAgent.ts) polls ai_tool_executions
+ * through the bare `db` pool. The AI Agent SDK runs its session OUTSIDE the
+ * request's AsyncLocalStorage DB context (by design — runOutsideDbContext, to
+ * avoid holding a request txn open for the whole stream), so inside
+ * waitForApproval the `db` proxy resolves to the unprivileged `breeze_app`
+ * role with NO `breeze.*` GUCs. ai_tool_executions has forced RLS, so the
+ * SELECT matched 0 rows and `if (!execution) return false` fired on the first
+ * poll (~67ms) — even after the user clicked Approve (which flips the row to
+ * 'approved' via the authenticated, context-bound /approvals route).
+ *
+ * Same silent-0-row class as #1375; the contextless-write guard doesn't cover
+ * SELECT, so nothing surfaced in logs.
+ *
+ * These tests run against a real DB as `breeze_app` (forced RLS) and call
+ * waitForApproval with NO ambient context, exactly as the SDK does. They fail
+ * (RED) until waitForApproval establishes a system-scope context for its poll.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import './setup';
+import { getTestDb } from './setup';
+import { partners, organizations, users } from '../../db/schema';
+import { aiSessions, aiToolExecutions } from '../../db/schema/ai';
+import { waitForApproval } from '../../services/aiAgent';
+
+let orgId: string;
+let userId: string;
+let sessionId: string;
+
+beforeEach(async () => {
+  // Seed on the superuser test connection (bypasses RLS). setup.ts TRUNCATEs
+  // users/partners CASCADE per test, clearing the ai_* rows transitively.
+  const tdb = getTestDb();
+  const sfx = `${Date.now()}-${Math.floor(performance.now())}`;
+  const [p] = await tdb
+    .insert(partners)
+    .values({ name: 'AI Approval RLS', slug: `ai-appr-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+    .returning({ id: partners.id });
+  const [o] = await tdb
+    .insert(organizations)
+    .values({ partnerId: p!.id, name: 'AI Approval Org', slug: `ai-appr-org-${sfx}` })
+    .returning({ id: organizations.id });
+  orgId = o!.id;
+  const [u] = await tdb
+    .insert(users)
+    .values({ partnerId: p!.id, email: `ai-appr-${sfx}@test.local`, name: 'Approver', status: 'active' })
+    .returning({ id: users.id });
+  userId = u!.id;
+  const [s] = await tdb
+    .insert(aiSessions)
+    .values({ orgId, userId, type: 'general' })
+    .returning({ id: aiSessions.id });
+  sessionId = s!.id;
+});
+
+async function seedExecution(status: 'pending' | 'approved' | 'rejected'): Promise<string> {
+  const tdb = getTestDb();
+  const [row] = await tdb
+    .insert(aiToolExecutions)
+    .values({
+      sessionId,
+      toolName: 'execute_command',
+      toolInput: { deviceId: 'd', commandType: 'list_processes' },
+      status,
+    })
+    .returning({ id: aiToolExecutions.id });
+  return row!.id;
+}
+
+describe('waitForApproval — polls ai_tool_executions with RLS context (SDK path)', () => {
+  it('returns true for an approved execution when called with no ambient DB context', async () => {
+    const executionId = await seedExecution('approved');
+
+    // No withDbAccessContext wrapper — mirrors the SDK session loop, which runs
+    // outside the request context. Before the fix this resolved to breeze_app
+    // with no GUC, saw 0 rows under forced RLS, and returned false.
+    const approved = await waitForApproval(executionId, 5_000);
+
+    expect(approved).toBe(true);
+  });
+
+  it('returns false for a rejected execution (genuine reject, not a 0-row miss)', async () => {
+    const executionId = await seedExecution('rejected');
+    const approved = await waitForApproval(executionId, 5_000);
+    expect(approved).toBe(false);
+  });
+
+  it('respects an already-aborted signal without touching the DB', async () => {
+    const executionId = await seedExecution('pending');
+    const controller = new AbortController();
+    controller.abort();
+    const approved = await waitForApproval(executionId, 5_000, controller.signal);
+    expect(approved).toBe(false);
+  });
+});

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -247,9 +247,11 @@ export async function getSessionMessages(sessionId: string, auth: AuthContext) {
  * Polls the DB with exponential backoff.
  *
  * Each query is wrapped in `withSystemDbAccessContext`. The AI Agent SDK runs
- * its session OUTSIDE the request's AsyncLocalStorage DB context (see
- * aiAgentSdk.ts — runOutsideDbContext), so a bare `db` query here resolves to
- * the unprivileged `breeze_app` role with no RLS GUCs. `ai_tool_executions`
+ * its session OUTSIDE the request's AsyncLocalStorage DB context (the SDK
+ * query() is wrapped in runOutsideDbContext in streamingSessionManager.ts;
+ * aiAgentSdk.ts documents the same constraint), so a bare `db` query here
+ * resolves to the unprivileged `breeze_app` role with no RLS GUCs.
+ * `ai_tool_executions`
  * has forced RLS, so that read matched 0 rows and the poll returned `false`
  * on the first iteration — every approval-gated tool reported "rejected or
  * timed out" even after the user approved it. System scope lets the internal

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -6,7 +6,7 @@
  * via streamingSessionManager.ts and aiAgentSdkTools.ts.
  */
 
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { aiSessions, aiMessages, aiToolExecutions, delegantM365Connections, devices } from '../db/schema';
 import { eq, and, desc, sql, type SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
@@ -245,6 +245,16 @@ export async function getSessionMessages(sessionId: string, auth: AuthContext) {
 /**
  * Wait for a tool execution to be approved or rejected.
  * Polls the DB with exponential backoff.
+ *
+ * Each query is wrapped in `withSystemDbAccessContext`. The AI Agent SDK runs
+ * its session OUTSIDE the request's AsyncLocalStorage DB context (see
+ * aiAgentSdk.ts — runOutsideDbContext), so a bare `db` query here resolves to
+ * the unprivileged `breeze_app` role with no RLS GUCs. `ai_tool_executions`
+ * has forced RLS, so that read matched 0 rows and the poll returned `false`
+ * on the first iteration — every approval-gated tool reported "rejected or
+ * timed out" even after the user approved it. System scope lets the internal
+ * poll resolve the row by its PK. Wrapping per-query (not the whole loop)
+ * keeps each txn short so we never hold a connection idle across the sleeps.
  */
 export async function waitForApproval(executionId: string, timeoutMs: number, signal?: AbortSignal): Promise<boolean> {
   const startTime = Date.now();
@@ -255,11 +265,13 @@ export async function waitForApproval(executionId: string, timeoutMs: number, si
     if (signal?.aborted) return false;
 
     try {
-      const [execution] = await db
-        .select({ status: aiToolExecutions.status })
-        .from(aiToolExecutions)
-        .where(eq(aiToolExecutions.id, executionId))
-        .limit(1);
+      const [execution] = await withSystemDbAccessContext(() =>
+        db
+          .select({ status: aiToolExecutions.status })
+          .from(aiToolExecutions)
+          .where(eq(aiToolExecutions.id, executionId))
+          .limit(1)
+      );
 
       consecutiveErrors = 0;
 
@@ -272,10 +284,12 @@ export async function waitForApproval(executionId: string, timeoutMs: number, si
       console.error(`[AI] Approval poll error (attempt ${consecutiveErrors}):`, err);
       if (consecutiveErrors >= 5) {
         try {
-          await db
-            .update(aiToolExecutions)
-            .set({ status: 'rejected', errorMessage: 'Polling failed' })
-            .where(eq(aiToolExecutions.id, executionId));
+          await withSystemDbAccessContext(() =>
+            db
+              .update(aiToolExecutions)
+              .set({ status: 'rejected', errorMessage: 'Polling failed' })
+              .where(eq(aiToolExecutions.id, executionId))
+          );
         } catch (cleanupErr) {
           console.error('[AI] Failed to cleanup polling-failed execution:', cleanupErr);
         }
@@ -289,10 +303,12 @@ export async function waitForApproval(executionId: string, timeoutMs: number, si
 
   // Timeout - mark as rejected
   try {
-    await db
-      .update(aiToolExecutions)
-      .set({ status: 'rejected', errorMessage: 'Approval timed out' })
-      .where(eq(aiToolExecutions.id, executionId));
+    await withSystemDbAccessContext(() =>
+      db
+        .update(aiToolExecutions)
+        .set({ status: 'rejected', errorMessage: 'Approval timed out' })
+        .where(eq(aiToolExecutions.id, executionId))
+    );
   } catch (err) {
     console.error('[AI] Failed to mark timed-out execution:', err);
   }


### PR DESCRIPTION
## Problem
Reported on US prod: the AI agent could not run **any** tool. Every `execute_command` (including read-only `list_processes`) returned `{"error":"Tool execution was rejected or timed out"}` — even after the user clicked Approve — so users gave up and manually flagged the chat.

Evidence from the flagged session: each `execute_command` returned the error in **~67 ms**, yet `ai_tool_executions.status = approved` and `approval_requests.status = expired`. A `waitForApproval(300_000)` cannot return by timeout in 67 ms.

## Root cause
`waitForApproval()` (`services/aiAgent.ts`) polls `ai_tool_executions` through the bare `db` pool. The AI Agent SDK runs its session **outside** the request's AsyncLocalStorage DB context (`aiAgentSdk.ts`, via `runOutsideDbContext` — so a long stream never holds a request txn open). So the `db` proxy in `waitForApproval` resolves to the unprivileged **`breeze_app`** role (`rolbypassrls = f`) with **no `breeze.*` GUCs**. `ai_tool_executions` is RLS **enabled + forced**, so the poll's SELECT matched **0 rows** → `if (!execution) return false` fired on the first iteration. The user's Approve hit the context-bound `/approvals` route (which set `status = approved`), but the SDK had already given up.

Surfaced once `DATABASE_URL_APP=breeze_app` was set on US (RLS-enforcement rollout); previously the bare pool was `doadmin` (BYPASSRLS), so the poll happened to work. Same silent-0-row class as #1375 — and the contextless-write guard only covers `insert/update/delete`, so the SELECT was completely silent.

## Fix
Wrap each poll query (and the timeout / poll-failure status writes) in `withSystemDbAccessContext` — **per-query, not around the loop**, so each txn stays short and no connection is held idle across the backoff sleeps. When an ambient context already exists (the non-SDK chat path), it's reused unchanged.

## Test
Adds a real-DB integration test (`aiApprovalPollRls.integration.test.ts`) that calls `waitForApproval` with **no** ambient context (as the SDK does) and asserts an approved execution resolves to `true`. Fails before the fix (`expected false to be true`), passes after. Existing `approval-system-scope` integration test and `aiAgentSdk`/`aiAgent` unit tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)