### PR TITLE
feat(docs): site-wide CTA banner pointing back to the product

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -11,6 +11,10 @@ export default defineConfig({
       },
       favicon: '/favicon.svg',
       customCss: ['./src/styles/custom.css'],
+      components: {
+        // Site-wide CTA that points docs readers back to the product.
+        Banner: './src/components/DocsCTABanner.astro',
+      },
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/LanternOps/breeze' },
       ],

--- a/apps/docs/src/components/DocsCTABanner.astro
+++ b/apps/docs/src/components/DocsCTABanner.astro
@@ -1,0 +1,77 @@
+---
+// Site-wide CTA banner. Overrides Starlight's default <Banner/> component so it
+// renders on every docs page. Analytics (PostHog) show docs is the #2 traffic
+// destination but rarely funnels readers back to the product to convert, so this
+// strip points self-hosting readers at the managed Cloud beta and pricing.
+---
+
+<aside class="breeze-cta-banner" aria-label="Breeze Cloud">
+  <p class="breeze-cta-banner__text">
+    <strong>Rather not self-host?</strong> Breeze Cloud runs the full platform for you — public beta, US &amp; EU.
+  </p>
+  <div class="breeze-cta-banner__actions">
+    <a class="breeze-cta-banner__btn breeze-cta-banner__btn--primary" href="https://breezermm.com/#cloud-signup">Start Cloud free</a>
+    <a class="breeze-cta-banner__btn" href="https://breezermm.com/pricing/">See pricing</a>
+  </div>
+</aside>
+
+<style>
+  .breeze-cta-banner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem 1.25rem;
+    margin-bottom: 1.5rem;
+    padding: 0.7rem 0.9rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    background:
+      linear-gradient(
+        0deg,
+        color-mix(in srgb, var(--sl-color-accent) 8%, transparent),
+        color-mix(in srgb, var(--sl-color-accent) 8%, transparent)
+      ),
+      var(--sl-color-bg-nav);
+  }
+  .breeze-cta-banner__text {
+    margin: 0;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-text);
+  }
+  .breeze-cta-banner__text strong {
+    color: var(--sl-color-white);
+  }
+  .breeze-cta-banner__actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+  .breeze-cta-banner__btn {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+    font-size: var(--sl-text-sm);
+    font-weight: 600;
+    line-height: 1;
+    padding: 0.5rem 0.85rem;
+    border-radius: 0.4rem;
+    border: 1px solid var(--sl-color-hairline);
+    color: var(--sl-color-text);
+    text-decoration: none;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .breeze-cta-banner__btn:hover {
+    border-color: var(--sl-color-accent);
+  }
+  .breeze-cta-banner__btn--primary {
+    background: var(--sl-color-accent);
+    border-color: var(--sl-color-accent);
+    color: #0b0e12;
+  }
+  .breeze-cta-banner__btn--primary:hover {
+    background: var(--sl-color-accent-high);
+    border-color: var(--sl-color-accent-high);
+    color: #0b0e12;
+  }
+</style>


### PR DESCRIPTION
## What

Overrides Starlight's `Banner` component so every docs page renders a persistent CTA strip linking readers to the Cloud beta and pricing on breezermm.com.

- New `apps/docs/src/components/DocsCTABanner.astro` (themed with Starlight `--sl-color-*` tokens, works in light/dark)
- Wired via `components.Banner` in `apps/docs/astro.config.mjs`

## Why

PostHog shows docs is the **#2 traffic destination** for the marketing funnel, but it rarely funnels readers back to convert — `outbound_docs_click` (299/mo) far outweighs every conversion event. Docs traffic currently dead-ends in the documentation. This gives every docs page a path back to the product.

## Notes

- No docs page uses `banner:` frontmatter today, so overriding the default Banner is non-destructive.
- Verified: `npm run build` succeeds and the banner renders into built HTML across pages (index, getting-started, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)