### PR TITLE
fix(scripts): preserve Monaco theme colors across View-Transition swap (#1589)

### DIFF
--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -120,6 +120,73 @@ describe('ScriptForm Monaco lifecycle (issue #1186)', () => {
   });
 });
 
+describe('ScriptForm Monaco theme preservation across View-Transition swap (issue #1589)', () => {
+  afterEach(() => {
+    document.head.querySelectorAll('style.monaco-colors').forEach(el => el.remove());
+    vi.clearAllMocks();
+  });
+
+  // Monaco appends its theme colors (token colors, selection background) as a
+  // runtime <style class="monaco-colors"> in document.head — distinct from the
+  // structural editor.main.css link the #1186 fix made swap-safe. Astro rebuilds
+  // <head> from the new page's markup on a swap, dropping that runtime style, and
+  // Monaco's singleton theme service won't re-inject it for the recreated editor.
+  // ScriptForm must clone the live style into the incoming document so the colors
+  // survive the swap (otherwise: white text, invisible selection until refresh).
+  it('clones the live monaco-colors style into the incoming document on astro:before-swap', () => {
+    render(<ScriptForm />);
+    // Simulate Monaco's runtime theme injection into the current <head>.
+    const live = document.createElement('style');
+    live.className = 'monaco-colors';
+    live.textContent = '.monaco-editor { color: #d4d4d4; }';
+    document.head.appendChild(live);
+
+    const newDocument = document.implementation.createHTMLDocument('');
+    const event = Object.assign(new Event('astro:before-swap'), { newDocument });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    const cloned = newDocument.head.querySelector('style.monaco-colors');
+    expect(cloned).not.toBeNull();
+    expect(cloned?.textContent).toBe('.monaco-editor { color: #d4d4d4; }');
+  });
+
+  it('does not duplicate the style when the incoming document already carries one', () => {
+    render(<ScriptForm />);
+    const live = document.createElement('style');
+    live.className = 'monaco-colors';
+    live.textContent = '.monaco-editor { color: #d4d4d4; }';
+    document.head.appendChild(live);
+
+    const newDocument = document.implementation.createHTMLDocument('');
+    const carried = newDocument.createElement('style');
+    carried.className = 'monaco-colors';
+    carried.textContent = '/* already present */';
+    newDocument.head.appendChild(carried);
+
+    const event = Object.assign(new Event('astro:before-swap'), { newDocument });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(newDocument.head.querySelectorAll('style.monaco-colors')).toHaveLength(1);
+    expect(newDocument.head.querySelector('style.monaco-colors')?.textContent).toBe('/* already present */');
+  });
+
+  it('no-ops when no monaco-colors style is present (editor never mounted)', () => {
+    render(<ScriptForm />);
+    const newDocument = document.implementation.createHTMLDocument('');
+    const event = Object.assign(new Event('astro:before-swap'), { newDocument });
+    expect(() => {
+      act(() => {
+        document.dispatchEvent(event);
+      });
+    }).not.toThrow();
+    expect(newDocument.head.querySelector('style.monaco-colors')).toBeNull();
+  });
+});
+
 describe('ScriptForm availability picker — partner-scope gate', () => {
   beforeEach(() => {
     editorInstances.length = 0;

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -121,6 +121,35 @@ export default function ScriptForm({
     return () => document.removeEventListener('astro:page-load', forceLayout);
   }, []);
 
+  // Preserve Monaco's theme colors across View Transition swaps (issue #1589,
+  // follow-up to #1186). The #1186 fix made Monaco's *structural* stylesheet
+  // (editor.main.css) a build-time <link> so it survives Astro rebuilding <head>
+  // from the new page's server markup. But Monaco injects its *theme* colors
+  // (vs-dark token colors, selection background) as a separate runtime <style
+  // class="monaco-colors"> appended to document.head — that one is still dropped
+  // by the swap. Monaco's standalone theme service is a module singleton that
+  // survives SPA navigation, and it only creates that global style element once
+  // (`if (!this._globalStyleElement)`) and short-circuits setTheme when the theme
+  // is unchanged (`this._theme === desiredTheme`), so the recreated editor never
+  // re-injects it. The editor then renders un-themed (white text, invisible
+  // selection) until a full refresh. Clone the live style into the incoming
+  // document on `astro:before-swap` so the rebuilt <head> keeps the colors.
+  useEffect(() => {
+    const preserveMonacoColors = (event: Event) => {
+      const newDocument = (event as Event & { newDocument?: Document }).newDocument;
+      if (!newDocument) return;
+      if (newDocument.head.querySelector('style.monaco-colors')) return;
+      const live = document.head.querySelector('style.monaco-colors');
+      if (!live) return;
+      const clone = newDocument.createElement('style');
+      clone.className = 'monaco-colors';
+      clone.textContent = live.textContent;
+      newDocument.head.appendChild(clone);
+    };
+    document.addEventListener('astro:before-swap', preserveMonacoColors);
+    return () => document.removeEventListener('astro:before-swap', preserveMonacoColors);
+  }, []);
+
   const {
     register,
     handleSubmit,


### PR DESCRIPTION
## Problem

Closes #1589. Navigating between scripts in the editor (scripts list → edit A → list → edit B) left the Monaco editor un-themed — text rendered white and text selection was invisible — until a full page refresh restored it. Reported on v0.81.0.

## Root cause (verified against `monaco-editor` 0.55.1 source)

Monaco splits its CSS into two runtime pieces injected into `document.head`:

1. **Structural** styles (`editor.main.css`). #1186 already fixed these by statically importing the stylesheet so Astro bundles it as a build-time `<link>` that's part of every editor route's server markup — so it survives Astro rebuilding `<head>` from the new page on a View-Transition swap.
2. **Theme colors** — the vs-dark token colors and selection background — are generated at runtime and appended by the standalone theme service as a separate `<style class="monaco-colors">` in `document.head` (`createStyleSheet(undefined, …)` → `mainWindow.document.head.appendChild`). This one is **still dropped** when Astro rebuilds `<head>` on the swap.

Monaco's standalone theme service is a module-level singleton that survives SPA navigation, and it can't re-inject the dropped style for the recreated editor:

- `_registerRegularEditorContainer()` creates the global theme `<style>` **only once** — `if (!this._globalStyleElement)`. After the first mount the ref is set (pointing at the now-detached node), so subsequent editors don't re-create it.
- `_updateActualTheme()` short-circuits when the theme is unchanged — `if (!desiredTheme || this._theme === desiredTheme) return;`. The recreated editor's `theme="vs-dark"` is already current, so `setTheme` is a no-op and never rewrites/re-attaches the style.

Net: after a swap the editor has structural CSS (the #1186 `<link>`) but no theme colors → white text, invisible selection. A full refresh re-inits the module (`_globalStyleElement` is null again) and re-injects into the fresh `<head>`.

## Fix

Mirror the #1186 philosophy (make Monaco's head-injected CSS survive the swap) for the remaining theme `<style>`. On `astro:before-swap`, clone the live `style.monaco-colors` into the incoming document's `<head>` so the rebuilt head keeps the colors. Purely additive DOM, no reliance on Monaco internals, no new dependencies. Guarded to no-op when the editor never mounted or the incoming document already carries the style.

## Tests

New `describe('… issue #1589')` block in `ScriptForm.test.tsx` (3 cases): clones the style into the incoming document on `astro:before-swap`; does not duplicate when one is already present; no-ops when no `monaco-colors` style exists.

## Local verification

- `astro check` (apps/web): **0 errors**
- `vitest src/components/scripts/ScriptForm.test.tsx`: **12/12 pass** (3 new + 9 existing #1186 / partner-gate)
- `eslint` on both changed files: clean
- No dependency changes.
