### PR TITLE
fix(ml): harden roadmap v0 controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,13 +744,14 @@ jobs:
   # without mocks). BLOCKING on PRs and main — it lived inside the
   # non-blocking smoke-test job until 2026-06, which let two breakages
   # (#1042's RBAC gate, #1092's org-scope lockout) merge "green" and keep
-  # main red for 8 days. ~2-3 min: no Docker image builds, just the
-  # docker-compose.test.yml stack (postgres + redis pulls).
+  # main red for 8 days. No Docker image builds, but the real-DB suite plus
+  # RLS coverage regularly needs more than 15 minutes as the migration/test
+  # surface grows.
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [lint, typecheck]
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/apps/api/migrations/2026-06-18-n-metric-rollups-partitions.sql
+++ b/apps/api/migrations/2026-06-18-n-metric-rollups-partitions.sql
@@ -1,0 +1,85 @@
+-- Bootstrap metric_rollups monthly partitions so fresh installs are not left on
+-- the default partition until the maintenance worker runs. Idempotent
+-- throughout. autoMigrate wraps this file in a transaction.
+
+DO $$
+DECLARE
+  anchor_month TIMESTAMP := date_trunc('month', now() AT TIME ZONE 'UTC');
+  offset_months INTEGER;
+  partition_start TIMESTAMP;
+  partition_end TIMESTAMP;
+  partition_name TEXT;
+BEGIN
+  FOR offset_months IN -1..3 LOOP
+    partition_start := anchor_month + make_interval(months => offset_months);
+    partition_end := partition_start + interval '1 month';
+    partition_name := format(
+      'metric_rollups_y%sm%s',
+      to_char(partition_start, 'YYYY'),
+      to_char(partition_start, 'MM')
+    );
+
+    BEGIN
+      EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I PARTITION OF metric_rollups FOR VALUES FROM (%L) TO (%L)',
+        partition_name,
+        partition_start,
+        partition_end
+      );
+    EXCEPTION WHEN check_violation THEN
+      IF SQLERRM LIKE '%updated partition constraint for default partition%'
+        AND SQLERRM LIKE '%would be violated by some row%' THEN
+        RAISE WARNING
+          'Skipping %, metric_rollups_default already contains rows for [% - %)',
+          partition_name,
+          partition_start,
+          partition_end;
+        CONTINUE;
+      END IF;
+      RAISE;
+    END;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_inherits
+      JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+      JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+      JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+      JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+      WHERE child.relname = partition_name
+        AND child_ns.nspname = 'public'
+        AND parent.relname = 'metric_rollups'
+        AND parent_ns.nspname = 'public'
+    ) THEN
+      RAISE EXCEPTION '% exists but is not attached as a metric_rollups partition', partition_name;
+    END IF;
+
+    -- PARTITION OF inherits parent checks and partitioned indexes. RLS policies
+    -- and grants are relation-local, so converge them here for each child.
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', partition_name);
+    EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', partition_name);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_select ON %I', partition_name);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_insert ON %I', partition_name);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_update ON %I', partition_name);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_delete ON %I', partition_name);
+
+    EXECUTE format(
+      'CREATE POLICY breeze_org_isolation_select ON %I FOR SELECT USING (public.breeze_has_org_access(org_id))',
+      partition_name
+    );
+    EXECUTE format(
+      'CREATE POLICY breeze_org_isolation_insert ON %I FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))',
+      partition_name
+    );
+    EXECUTE format(
+      'CREATE POLICY breeze_org_isolation_update ON %I FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id))',
+      partition_name
+    );
+    EXECUTE format(
+      'CREATE POLICY breeze_org_isolation_delete ON %I FOR DELETE USING (public.breeze_has_org_access(org_id))',
+      partition_name
+    );
+
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I TO breeze_app', partition_name);
+  END LOOP;
+END $$;

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -147,7 +147,11 @@ export async function setupIntegrationTests() {
   testClient = postgres(DATABASE_URL, {
     max: 10,
     idle_timeout: 20,
-    connect_timeout: 10
+    connect_timeout: 10,
+    // cleanupDatabase() intentionally uses TRUNCATE ... CASCADE on beforeEach.
+    // PostgreSQL emits one NOTICE per cascaded table, which can flood CI logs
+    // enough for the integration job to hit its wall-clock timeout.
+    onnotice: () => {}
   });
 
   testDb = drizzle(testClient, { schema });
@@ -194,6 +198,23 @@ export async function teardownIntegrationTests() {
   }
 }
 
+function isUndefinedTableError(error: unknown): boolean {
+  const code = (error as { code?: string; cause?: { code?: string } } | undefined)?.code
+    ?? (error as { cause?: { code?: string } } | undefined)?.cause?.code;
+  return code === '42P01';
+}
+
+async function cleanupAppendOnlyMlFeedbackEvents() {
+  try {
+    await testClient.begin(async (tx) => {
+      await tx`SET LOCAL breeze.allow_audit_retention = '1'`;
+      await tx`DELETE FROM ml_feedback_events`;
+    });
+  } catch (error) {
+    if (!isUndefinedTableError(error)) throw error;
+  }
+}
+
 export async function cleanupDatabase() {
   if (!testDb) return;
 
@@ -201,6 +222,11 @@ export async function cleanupDatabase() {
   // again here in case a future caller invokes cleanupDatabase outside the
   // normal beforeAll path. Wiping a prod/dev DB must require deliberate opt-in.
   assertTestDatabase(DATABASE_URL, 'cleanupDatabase');
+
+  // ml_feedback_events is append-only production data. Clean it explicitly
+  // through the retention/erasure bypass GUC instead of relying on an implicit
+  // organizations TRUNCATE CASCADE side effect.
+  await cleanupAppendOnlyMlFeedbackEvents();
 
   // Truncate all tables in reverse dependency order
   // This ensures we don't hit foreign key constraints

--- a/apps/api/src/__tests__/integration/tenantCascade.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantCascade.integration.test.ts
@@ -47,9 +47,16 @@ describe('Tenant cascade list contract', () => {
       FROM information_schema.columns c
       JOIN information_schema.tables t
         ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+      JOIN pg_class cls
+        ON cls.relname = c.table_name
+      JOIN pg_namespace n
+        ON n.oid = cls.relnamespace AND n.nspname = c.table_schema
+      LEFT JOIN pg_inherits inh
+        ON inh.inhrelid = cls.oid
       WHERE c.table_schema = 'public'
         AND c.column_name = 'org_id'
         AND t.table_type = 'BASE TABLE'
+        AND inh.inhrelid IS NULL
       ORDER BY c.table_name;
     `)) as unknown as Array<{ table_name: string }>;
 

--- a/apps/api/src/db/migration-metric-rollups-partitions.test.ts
+++ b/apps/api/src/db/migration-metric-rollups-partitions.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('metric_rollups partition bootstrap migration', () => {
+  const migrationsDir = resolve(__dirname, '../../migrations');
+  const foundationMigration = '2026-06-18-metric-rollups.sql';
+  const partitionMigration = '2026-06-18-n-metric-rollups-partitions.sql';
+  const sql = readFileSync(join(migrationsDir, partitionMigration), 'utf8');
+
+  it('sorts after the metric_rollups foundation migration', () => {
+    const files = readdirSync(migrationsDir)
+      .filter((name) => name.endsWith('.sql'))
+      .sort((a, b) => a.localeCompare(b));
+
+    expect(files).toContain(foundationMigration);
+    expect(files).toContain(partitionMigration);
+    expect(files.indexOf(partitionMigration)).toBeGreaterThan(files.indexOf(foundationMigration));
+  });
+
+  it('pre-creates a rolling monthly partition window at migration time', () => {
+    expect(sql).toContain('FOR offset_months IN -1..3 LOOP');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS %I PARTITION OF metric_rollups');
+    expect(sql).toContain('FOR VALUES FROM (%L) TO (%L)');
+    expect(sql).toContain('metric_rollups_y%sm%s');
+  });
+
+  it('hardens each child partition with RLS policies and breeze_app grants', () => {
+    expect(sql).toContain('ALTER TABLE %I ENABLE ROW LEVEL SECURITY');
+    expect(sql).toContain('ALTER TABLE %I FORCE ROW LEVEL SECURITY');
+    expect(sql).toContain('FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))');
+    expect(sql).toContain('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I TO breeze_app');
+  });
+
+  it('verifies an existing same-name relation is attached to metric_rollups', () => {
+    expect(sql).toContain('FROM pg_inherits');
+    expect(sql).toContain("parent.relname = 'metric_rollups'");
+    expect(sql).toContain('is not attached as a metric_rollups partition');
+  });
+});

--- a/apps/web/src/components/alerts/AlertList.tsx
+++ b/apps/web/src/components/alerts/AlertList.tsx
@@ -68,6 +68,7 @@ type AlertListProps = {
   onBulkAction?: (action: string, alerts: Alert[]) => void;
   submittingId?: string | null;
   pageSize?: number;
+  alertCorrelationDisabled?: boolean;
 };
 
 export default function AlertList({
@@ -79,7 +80,8 @@ export default function AlertList({
   onSuppress,
   onBulkAction,
   submittingId,
-  pageSize = 25
+  pageSize = 25,
+  alertCorrelationDisabled = false
 }: AlertListProps) {
   const [query, setQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
@@ -445,7 +447,19 @@ export default function AlertList({
                         <p className="text-xs text-muted-foreground truncate max-w-xs">
                           {alert.message}
                         </p>
-                        {hasCorrelationSummary && (
+                        {hasCorrelationSummary && alertCorrelationDisabled && (
+                          <span
+                            className="mt-1 inline-flex max-w-full cursor-not-allowed items-center gap-1 rounded-md border border-muted-foreground/30 bg-muted/40 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground"
+                            title="Alert correlation is disabled for this organization"
+                            aria-disabled="true"
+                          >
+                            <GitBranch className="h-3 w-3 shrink-0" />
+                            <span className="truncate">
+                              Grouped incident unavailable: alert correlation disabled
+                            </span>
+                          </span>
+                        )}
+                        {hasCorrelationSummary && !alertCorrelationDisabled && (
                           <a
                             href="/alerts/correlations"
                             onClick={e => e.stopPropagation()}

--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -49,8 +49,14 @@ const activeAlert = {
   triggeredAt: new Date().toISOString()
 };
 
-const remediationFlags = (enabled: boolean) => ({
+const remediationFlags = (enabled: boolean, alertCorrelationEnabled = true) => ({
   mlFeatureFlags: {
+    'ml.alert_correlation.enabled': {
+      flag: 'ml.alert_correlation.enabled',
+      enabled: alertCorrelationEnabled,
+      defaultEnabled: false,
+      source: 'org_settings',
+    },
     'ml.remediation_suggestions.enabled': {
       flag: 'ml.remediation_suggestions.enabled',
       enabled,
@@ -273,6 +279,39 @@ describe('AlertsPage — acknowledge in-flight feedback', () => {
 
     expect(await screen.findByText('Grouped incident: 3 related · 75% noise cut')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /SRV-01/i })).toHaveAttribute('href', '/devices/device-1');
+  });
+
+  it('labels grouped incidents without linking when alert correlation is disabled', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(remediationFlags(true, false)));
+      }
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({
+          data: [{
+            ...activeAlert,
+            correlationGroupId: '6f5e4d3c-2222-4333-8444-555566667777',
+            correlationRole: 'root',
+            correlationGroupStatus: 'open',
+            correlationMemberCount: 4,
+            correlationChildCount: 3,
+            noiseReductionPercent: 75,
+          }]
+        }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<AlertsPage />);
+
+    const disabledBadge = (await screen.findByText('Grouped incident unavailable: alert correlation disabled')).closest('[aria-disabled]');
+    expect(disabledBadge).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.queryByRole('link', { name: /Grouped incident/i })).toBeNull();
   });
 
   it('renders promoted metric anomaly context in the alert list and details panel', async () => {

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -13,6 +13,7 @@ import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
 import { runAction, ActionError } from '../../lib/runAction';
 import { normalizeMetricAnomalyContext } from './alertMlContext';
+import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 type Device = { id: string; name: string };
 
@@ -34,6 +35,7 @@ function normalizeAlertRows(rows: Record<string, unknown>[]): Alert[] {
 }
 
 export default function AlertsPage() {
+  const mlFlags = useMlFeatureFlags();
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [devices, setDevices] = useState<Device[]>([]);
   const [loading, setLoading] = useState(true);
@@ -55,6 +57,7 @@ export default function AlertsPage() {
   // null (global route); this just makes the page refetch instead of showing
   // the previous scope.
   const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const alertCorrelationDisabled = mlFlags.isDisabled('ml.alert_correlation.enabled');
 
   const fetchAlerts = useCallback(async () => {
     try {
@@ -441,6 +444,7 @@ export default function AlertsPage() {
           onSuppress={handleSuppress}
           onBulkAction={handleBulkAction}
           submittingId={submittingId}
+          alertCorrelationDisabled={alertCorrelationDisabled}
         />
       )}
 

--- a/apps/web/src/components/alerts/AlertsTabStrip.tsx
+++ b/apps/web/src/components/alerts/AlertsTabStrip.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 const TABS = [
   { href: '/alerts', label: 'Alerts' },
@@ -8,6 +9,8 @@ const TABS = [
 ] as const;
 
 export default function AlertsTabStrip() {
+  const mlFlags = useMlFeatureFlags();
+  const alertCorrelationDisabled = mlFlags.isDisabled('ml.alert_correlation.enabled');
   const activeHref = useMemo(() => {
     if (typeof window === 'undefined') return '/alerts';
     const path = window.location.pathname;
@@ -21,6 +24,23 @@ export default function AlertsTabStrip() {
     <nav className="flex gap-1 border-b text-sm" aria-label="Alerts sections">
       {TABS.map((tab) => {
         const isActive = tab.href === activeHref;
+        const isDisabled = tab.href === '/alerts/correlations' && alertCorrelationDisabled;
+        if (isDisabled) {
+          return (
+            <span
+              key={tab.href}
+              className={
+                'inline-flex h-10 cursor-not-allowed items-center px-4 -mb-px border-b-2 text-muted-foreground opacity-70 ' +
+                (isActive ? 'border-muted-foreground/40 font-semibold' : 'border-transparent')
+              }
+              aria-current={isActive ? 'page' : undefined}
+              aria-disabled="true"
+              title="Alert correlation is disabled for this organization"
+            >
+              Correlations disabled
+            </span>
+          );
+        }
         return (
           <a
             key={tab.href}

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -154,8 +154,14 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
     json: vi.fn().mockResolvedValue(payload)
   }) as unknown as Response;
 
-const mlFlags = (rcaEnabled: boolean) => ({
+const mlFlags = (rcaEnabled: boolean, alertCorrelationEnabled = true) => ({
   mlFeatureFlags: {
+    'ml.alert_correlation.enabled': {
+      flag: 'ml.alert_correlation.enabled',
+      enabled: alertCorrelationEnabled,
+      defaultEnabled: false,
+      source: 'org_settings',
+    },
     'ml.rca.enabled': {
       flag: 'ml.rca.enabled',
       enabled: rcaEnabled,
@@ -171,13 +177,14 @@ const mlFlags = (rcaEnabled: boolean) => ({
   },
 });
 
-function mockGroupsResponse(options: { rcaEnabled?: boolean } = {}) {
+function mockGroupsResponse(options: { rcaEnabled?: boolean; alertCorrelationEnabled?: boolean } = {}) {
   const rcaEnabled = options.rcaEnabled ?? true;
+  const alertCorrelationEnabled = options.alertCorrelationEnabled ?? true;
   fetchMock.mockImplementation((input, init) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
     if (url === '/config/ml-feature-flags' && method === 'GET') {
-      return Promise.resolve(makeJsonResponse(mlFlags(rcaEnabled)));
+      return Promise.resolve(makeJsonResponse(mlFlags(rcaEnabled, alertCorrelationEnabled)));
     }
     if (url === '/alerts/correlations' && method === 'GET') {
       return Promise.resolve(makeJsonResponse({ groups: [groupPayload] }));
@@ -464,11 +471,39 @@ describe('CorrelatedAlertGroups', () => {
     );
   });
 
+  it('shows a disabled correlation state without fetching groups when alert correlation is disabled', async () => {
+    mockGroupsResponse({ alertCorrelationEnabled: false });
+
+    render(<CorrelatedAlertGroups />);
+
+    expect(await screen.findByText('Alert correlation disabled')).toBeInTheDocument();
+    expect(screen.getByText('Correlated alert groups are hidden because alert correlation is disabled for this organization.')).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith('/alerts/correlations');
+    expect(screen.queryByText('High CPU on SRV-01')).toBeNull();
+  });
+
   it('marks the correlations tab active on the correlations route', () => {
     window.history.pushState({}, '', '/alerts/correlations');
 
     render(<AlertsTabStrip />);
 
     expect(screen.getByRole('link', { name: 'Correlations' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('labels the correlations tab as disabled when alert correlation is disabled', async () => {
+    window.history.pushState({}, '', '/alerts');
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(mlFlags(true, false)));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<AlertsTabStrip />);
+
+    expect(await screen.findByText('Correlations disabled')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.queryByRole('link', { name: 'Correlations' })).toBeNull();
   });
 });

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -352,6 +352,7 @@ export default function CorrelatedAlertGroups() {
     return { incidentCount, memberCount, suppressedAlerts, avgReduction };
   }, [groups]);
   const rcaDisabled = mlFlags.isDisabled('ml.rca.enabled');
+  const alertCorrelationDisabled = mlFlags.isDisabled('ml.alert_correlation.enabled');
 
   const fetchGroups = useCallback(async () => {
     setIsLoading(true);
@@ -385,8 +386,16 @@ export default function CorrelatedAlertGroups() {
   }, []);
 
   useEffect(() => {
+    if (!mlFlags.loaded) return;
+    if (alertCorrelationDisabled) {
+      setGroups([]);
+      setExpandedGroups(new Set());
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
     void fetchGroups();
-  }, [fetchGroups]);
+  }, [alertCorrelationDisabled, fetchGroups, mlFlags.loaded]);
 
   const toggleGroup = (groupId: string) => {
     setExpandedGroups(prev => {
@@ -524,6 +533,20 @@ export default function CorrelatedAlertGroups() {
       <div className="rounded-lg border bg-card p-6 shadow-sm">
         <div className="flex h-48 items-center justify-center">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      </div>
+    );
+  }
+
+  if (alertCorrelationDisabled) {
+    return (
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <div className="flex min-h-48 flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+          <Brain className="h-8 w-8" />
+          <h2 className="text-base font-semibold text-foreground">Alert correlation disabled</h2>
+          <p className="max-w-md text-sm">
+            Correlated alert groups are hidden because alert correlation is disabled for this organization.
+          </p>
         </div>
       </div>
     );

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RemediationSuggestionsPanel from './RemediationSuggestionsPanel';
@@ -246,7 +246,14 @@ describe('RemediationSuggestionsPanel', () => {
 
     render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
 
-    fireEvent.click(await screen.findByRole('button', { name: /execute/i }));
+    const preview = (await screen.findByText('Execution preview')).closest('div') as HTMLElement;
+    expect(within(preview).getByText('Script: script 11111111-1111-4111-8111-111111111111')).toBeTruthy();
+    expect(within(preview).getByText('device 22222222-2222-4222-8222-222222222222')).toBeTruthy();
+    expect(within(preview).getByText('Matched disk cleanup terms.')).toBeTruthy();
+    expect(within(preview).getByText('Run script "Disk Cleanup" through the existing script execution flow.')).toBeTruthy();
+    expect(within(preview).getByText(/"dryRun": false/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /execute/i }));
 
     await waitFor(() => {
       expect(fetchWithAuthMock).toHaveBeenCalledWith(

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.tsx
@@ -51,6 +51,32 @@ function targetLabel(suggestion: RemediationSuggestion): string {
   return 'Diagnostic';
 }
 
+function targetIdentifier(suggestion: RemediationSuggestion): string {
+  if (suggestion.targetType === 'script') return suggestion.scriptId ? `script ${suggestion.scriptId}` : 'script without a script ID';
+  if (suggestion.targetType === 'script_template') {
+    return suggestion.scriptTemplateId ? `template ${suggestion.scriptTemplateId}` : 'template without a template ID';
+  }
+  if (suggestion.targetType === 'playbook') return suggestion.playbookId ? `playbook ${suggestion.playbookId}` : 'playbook without a playbook ID';
+  return 'diagnostic action';
+}
+
+function targetDeviceLabel(suggestion: RemediationSuggestion): string {
+  const ids = suggestion.targetDeviceIds.length > 0
+    ? suggestion.targetDeviceIds
+    : suggestion.deviceId
+      ? [suggestion.deviceId]
+      : [];
+
+  if (ids.length === 0) return 'No target device in this suggestion';
+  if (ids.length === 1) return `device ${ids[0]}`;
+  return `${ids.length} devices: ${ids.join(', ')}`;
+}
+
+function parametersPreview(suggestion: RemediationSuggestion): string | null {
+  if (!suggestion.parameters || Object.keys(suggestion.parameters).length === 0) return null;
+  return JSON.stringify(suggestion.parameters, null, 2);
+}
+
 function singleTargetDeviceId(suggestion: RemediationSuggestion): string | null {
   if (suggestion.targetDeviceIds.length === 1) return suggestion.targetDeviceIds[0] ?? null;
   if (suggestion.targetDeviceIds.length === 0) return suggestion.deviceId;
@@ -317,6 +343,8 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId, orgI
             const approvalStatus = approvalStatuses[suggestion.id];
             const approvalPending = requiresExecutionApproval(suggestion) && suggestion.elevationRequestId && approvalStatus === 'pending';
             const editing = editingId === suggestion.id && editDraft;
+            const executionPreview = suggestion.status === 'accepted' || suggestion.status === 'edited';
+            const parameterJson = parametersPreview(suggestion);
             return (
               <div key={suggestion.id} className="rounded-md border p-3">
                 {editing ? (
@@ -400,6 +428,43 @@ export default function RemediationSuggestionsPanel({ sourceType, sourceId, orgI
                       <p className="mt-2 text-sm">{suggestion.expectedAction}</p>
                       {suggestion.status !== 'suggested' && (
                         <p className="mt-2 text-xs font-medium text-muted-foreground">Status: {suggestion.status}</p>
+                      )}
+                      {executionPreview && (
+                        <div className="mt-3 rounded-md border bg-muted/30 p-3">
+                          <p className="text-xs font-semibold text-foreground">Execution preview</p>
+                          <dl className="mt-2 grid gap-2 text-xs sm:grid-cols-2">
+                            <div className="min-w-0">
+                              <dt className="font-medium text-muted-foreground">Will run</dt>
+                              <dd className="break-words text-foreground">{targetLabel(suggestion)}: {targetIdentifier(suggestion)}</dd>
+                            </div>
+                            <div className="min-w-0">
+                              <dt className="font-medium text-muted-foreground">Where</dt>
+                              <dd className="break-words text-foreground">{targetDeviceLabel(suggestion)}</dd>
+                            </div>
+                            <div className="min-w-0">
+                              <dt className="font-medium text-muted-foreground">Source</dt>
+                              <dd className="break-words text-foreground">{suggestion.sourceType} {suggestion.sourceId}</dd>
+                            </div>
+                            <div className="min-w-0">
+                              <dt className="font-medium text-muted-foreground">Risk</dt>
+                              <dd className="break-words text-foreground">{suggestion.riskTier}</dd>
+                            </div>
+                            <div className="min-w-0 sm:col-span-2">
+                              <dt className="font-medium text-muted-foreground">Why</dt>
+                              <dd className="break-words text-foreground">{suggestion.rationale}</dd>
+                            </div>
+                            <div className="min-w-0 sm:col-span-2">
+                              <dt className="font-medium text-muted-foreground">Expected action</dt>
+                              <dd className="break-words text-foreground">{suggestion.expectedAction}</dd>
+                            </div>
+                          </dl>
+                          {parameterJson && (
+                            <div className="mt-2">
+                              <p className="text-xs font-medium text-muted-foreground">Parameters</p>
+                              <pre className="mt-1 max-h-36 overflow-auto rounded-md border bg-background p-2 text-xs text-foreground">{parameterJson}</pre>
+                            </div>
+                          )}
+                        </div>
                       )}
                     </div>
                     <div className="flex shrink-0 flex-wrap items-center gap-2">

--- a/docs/runbooks/ml-operations.md
+++ b/docs/runbooks/ml-operations.md
@@ -114,6 +114,22 @@ Key metrics:
 | Ticket triage | Override rate for category/priority/assignee |
 | User risk | True-positive rate, training completion, repeat signal rate |
 
+## V1 Promotion Baselines
+
+Before enabling a learned v1 model, compare it to the active v0 rule/heuristic
+over the same org cohort and evaluation window. The v1 candidate must beat the
+v0 metric below before rollout:
+
+| Future v1 surface | v0 metric to beat |
+| --- | --- |
+| Alert correlation | Lower correction rate from `feedback.totalCorrections` while preserving `compressionRatio` |
+| RCA | Higher helpful rate from `rcaFeedback.helpful` versus `rcaFeedback.notHelpful` and `rcaFeedback.edited` |
+| Anomalies | Lower `rates.dismissRate`; use `rates.promoteRate` and `rates.resolveRate` as guardrails |
+| Remediation | Higher `rates.acceptRate` with no worse `rates.failureRate` |
+| Reliability | Higher `precision` from `/api/reliability/evaluation` |
+| Ticket triage | Lower `overrideRate` from `/api/tickets/triage-evaluation` |
+| User risk | Higher `precision` from `/api/user-risk/evaluation` |
+
 ## Feedback Labels
 
 Canonical labels live in `ml_feedback_events`. They are append-only and deduped


### PR DESCRIPTION
## Summary
- pre-create a rolling metric_rollups partition window with child RLS/grants so fresh installs do not sit on the default partition until maintenance runs
- explicitly clean append-only ml_feedback_events in integration setup and document v1 promotion baselines for each ML surface
- hide/label alert correlation UI when disabled and add a clearer remediation execution preview

## Verification
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- corepack pnpm --dir apps/api exec vitest run --testTimeout=20000 src/db/migration-metric-rollups-partitions.test.ts src/db/autoMigrate.test.ts
- corepack pnpm --dir apps/web exec vitest run src/components/remediation/RemediationSuggestionsPanel.test.tsx src/components/alerts/CorrelatedAlertGroups.test.tsx src/components/alerts/AlertsPage.test.tsx
- corepack pnpm --filter @breeze/web exec tsc --noEmit -p tsconfig.json
- git diff --check

## Notes
This follows the merged ML roadmap carrier PR #1433 and closes the concrete v0 hardening gaps found in the post-merge audit. Later model improvements such as LLM ticket triage, impossible-travel scoring, and learned reliability v1 remain follow-up work.