### PR TITLE
feat(catalog): add TD SYNNEX catalog import

### DIFF
--- a/apps/api/migrations/2026-06-18-td-synnex-digital-bridge.sql
+++ b/apps/api/migrations/2026-06-18-td-synnex-digital-bridge.sql
@@ -1,0 +1,39 @@
+-- TD SYNNEX Digital Bridge catalog integration.
+-- Partner-axis (shape 3) with encrypted credential JSON.
+
+CREATE TABLE IF NOT EXISTS td_synnex_digital_bridge_integrations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id UUID NOT NULL REFERENCES partners(id),
+  environment VARCHAR(20) NOT NULL DEFAULT 'sandbox',
+  region VARCHAR(50) NOT NULL DEFAULT 'US',
+  base_url TEXT NOT NULL,
+  auth_type VARCHAR(20) NOT NULL DEFAULT 'api_key',
+  credentials JSONB NOT NULL DEFAULT '{}'::jsonb,
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  last_test_status VARCHAR(30),
+  last_test_at TIMESTAMP,
+  last_test_error TEXT,
+  last_sync_at TIMESTAMP,
+  last_error TEXT,
+  created_by UUID REFERENCES users(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS td_synnex_digital_bridge_partner_uq
+  ON td_synnex_digital_bridge_integrations (partner_id);
+
+CREATE INDEX IF NOT EXISTS td_synnex_digital_bridge_partner_enabled_idx
+  ON td_synnex_digital_bridge_integrations (partner_id, enabled);
+
+ALTER TABLE td_synnex_digital_bridge_integrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE td_synnex_digital_bridge_integrations FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  CREATE POLICY td_synnex_digital_bridge_partner_access
+    ON td_synnex_digital_bridge_integrations
+    FOR ALL TO breeze_app
+    USING (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id))
+    WITH CHECK (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/api/src/__tests__/integration/catalog-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/catalog-rls.integration.test.ts
@@ -49,6 +49,7 @@ import {
   catalogItems,
   catalogItemOrgPricing,
   catalogBundleComponents,
+  tdSynnexDigitalBridgeIntegrations,
   organizations,
   partners,
 } from '../../db/schema';
@@ -69,6 +70,7 @@ interface Fixture {
   itemA: { id: string };
   componentA: { id: string };
   pricingA: { id: string };
+  tdSynnexA: { id: string };
   partnerBContext: DbAccessContext;
   orgBContext: DbAccessContext;
 }
@@ -124,6 +126,21 @@ async function seedFixture(): Promise<Fixture> {
       .returning({ id: catalogItemOrgPricing.id });
     if (!pricingA) throw new Error('failed to seed org-pricing override A');
 
+    const [tdSynnexA] = await db
+      .insert(tdSynnexDigitalBridgeIntegrations)
+      .values({
+        partnerId: partnerA.id,
+        environment: 'sandbox',
+        region: 'US',
+        baseUrl: 'https://digitalbridge.example.test',
+        authType: 'api_key',
+        credentials: {},
+        settings: {},
+        enabled: true,
+      })
+      .returning({ id: tdSynnexDigitalBridgeIntegrations.id });
+    if (!tdSynnexA) throw new Error('failed to seed TD SYNNEX integration A');
+
     // Partner-scoped context for partner B (mirrors authMiddleware partner scope).
     const partnerBContext: DbAccessContext = {
       scope: 'partner',
@@ -150,6 +167,7 @@ async function seedFixture(): Promise<Fixture> {
       itemA: { id: itemA.id },
       componentA: { id: componentA.id },
       pricingA: { id: pricingA.id },
+      tdSynnexA: { id: tdSynnexA.id },
       partnerBContext,
       orgBContext,
     };
@@ -175,6 +193,9 @@ afterAll(async () => {
     await db
       .delete(catalogItems)
       .where(sql`${catalogItems.partnerId} IN (${partnerList})`);
+    await db
+      .delete(tdSynnexDigitalBridgeIntegrations)
+      .where(sql`${tdSynnexDigitalBridgeIntegrations.partnerId} IN (${partnerList})`);
     await db
       .delete(organizations)
       .where(sql`${organizations.partnerId} IN (${partnerList})`);
@@ -291,5 +312,65 @@ describe('catalog RLS isolation (breeze_app)', () => {
         })
       )
     ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  runDb('partner B context cannot read partner A TD SYNNEX integration', async () => {
+    const { tdSynnexA, partnerBContext } = await seedFixture();
+
+    const rowsB = await withDbAccessContext(partnerBContext, () =>
+      db
+        .select({ id: tdSynnexDigitalBridgeIntegrations.id })
+        .from(tdSynnexDigitalBridgeIntegrations)
+        .where(eq(tdSynnexDigitalBridgeIntegrations.id, tdSynnexA.id))
+    );
+    expect(rowsB).toHaveLength(0);
+  });
+
+  runDb('a forged cross-partner TD SYNNEX integration insert is rejected by RLS', async () => {
+    const { partnerA, partnerBContext } = await seedFixture();
+
+    await expect(
+      withDbAccessContext(partnerBContext, () =>
+        db.insert(tdSynnexDigitalBridgeIntegrations).values({
+          partnerId: partnerA.id,
+          environment: 'sandbox',
+          region: 'US',
+          baseUrl: 'https://digitalbridge.example.test',
+          authType: 'api_key',
+          credentials: {},
+          settings: {},
+          enabled: true,
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  runDb('partner B context UPDATE/DELETE on partner A TD SYNNEX integration affects 0 rows; row survives', async () => {
+    const { tdSynnexA, partnerBContext } = await seedFixture();
+
+    const updateRows = await withDbAccessContext(partnerBContext, () =>
+      db
+        .update(tdSynnexDigitalBridgeIntegrations)
+        .set({ enabled: false, updatedAt: new Date() })
+        .where(eq(tdSynnexDigitalBridgeIntegrations.id, tdSynnexA.id))
+        .returning({ id: tdSynnexDigitalBridgeIntegrations.id })
+    );
+    expect(updateRows).toHaveLength(0);
+
+    const deleteRows = await withDbAccessContext(partnerBContext, () =>
+      db
+        .delete(tdSynnexDigitalBridgeIntegrations)
+        .where(eq(tdSynnexDigitalBridgeIntegrations.id, tdSynnexA.id))
+        .returning({ id: tdSynnexDigitalBridgeIntegrations.id })
+    );
+    expect(deleteRows).toHaveLength(0);
+
+    const surviving = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: tdSynnexDigitalBridgeIntegrations.id, enabled: tdSynnexDigitalBridgeIntegrations.enabled })
+        .from(tdSynnexDigitalBridgeIntegrations)
+        .where(eq(tdSynnexDigitalBridgeIntegrations.id, tdSynnexA.id))
+    );
+    expect(surviving).toEqual([{ id: tdSynnexA.id, enabled: true }]);
   });
 });

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -120,6 +120,7 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   // as an ordinary shape-1 org-tenant table.
   ['catalog_items', 'partner_id'],
   ['catalog_bundle_components', 'partner_id'],
+  ['td_synnex_digital_bridge_integrations', 'partner_id'],
   // Phase 4 email-to-ticket ingest (Shape 3). partner_id is nullable on
   // ticket_email_inbound (only system scope may write null-partner rows);
   // NOT NULL on partner_inbound_domains. Policy:

--- a/apps/api/src/db/schema/catalog.ts
+++ b/apps/api/src/db/schema/catalog.ts
@@ -77,3 +77,28 @@ export const catalogBundleComponents = pgTable('catalog_bundle_components', {
   uniqueIndex('catalog_bundle_components_bundle_comp_uq').on(t.bundleItemId, t.componentItemId),
   index('catalog_bundle_components_partner_idx').on(t.partnerId)
 ]);
+
+// Partner-axis (RLS shape 3). Holds TD SYNNEX Digital Bridge catalog API
+// configuration for a partner. Secret-bearing values live in credentials.
+export const tdSynnexDigitalBridgeIntegrations = pgTable('td_synnex_digital_bridge_integrations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  environment: varchar('environment', { length: 20 }).notNull().default('sandbox'),
+  region: varchar('region', { length: 50 }).notNull().default('US'),
+  baseUrl: text('base_url').notNull(),
+  authType: varchar('auth_type', { length: 20 }).notNull().default('api_key'),
+  credentials: jsonb('credentials').notNull().default({}),
+  settings: jsonb('settings').notNull().default({}),
+  enabled: boolean('enabled').notNull().default(false),
+  lastTestStatus: varchar('last_test_status', { length: 30 }),
+  lastTestAt: timestamp('last_test_at'),
+  lastTestError: text('last_test_error'),
+  lastSyncAt: timestamp('last_sync_at'),
+  lastError: text('last_error'),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (t) => [
+  uniqueIndex('td_synnex_digital_bridge_partner_uq').on(t.partnerId),
+  index('td_synnex_digital_bridge_partner_enabled_idx').on(t.partnerId, t.enabled)
+]);

--- a/apps/api/src/routes/catalog/catalog.test.ts
+++ b/apps/api/src/routes/catalog/catalog.test.ts
@@ -222,6 +222,45 @@ describe('catalog TD SYNNEX distributor routes', () => {
     const body = await res.json();
     expect(body.code).toBe('TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   });
+
+  it('maps a duplicate-SKU CatalogServiceError from import to a 409', async () => {
+    // import drops its own pre-check and relies on createCatalogItem's unique
+    // index, which surfaces a CatalogServiceError the distributor route must map.
+    (tdSvc.importTdSynnexCatalogItem as any).mockRejectedValue(
+      new (svc as any).CatalogServiceError('An item with this SKU already exists', 409, 'DUPLICATE_SKU')
+    );
+    const product = {
+      source: 'td_synnex_digital_bridge', sourceProductId: 'td-1', sku: 'SKU-1',
+      manufacturerPartNumber: null, vendor: null, name: 'Dock', description: null,
+      cost: '100.00', currency: 'USD', availability: null, warehouses: [], raw: {},
+      lastRefreshedAt: new Date().toISOString()
+    };
+    const res = await app().request('/distributors/td-synnex/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ product, item: { name: 'Dock', sku: 'SKU-1', unitPrice: 125, taxable: true } })
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe('DUPLICATE_SKU');
+  });
+
+  it('rejects an oversized raw provider blob on import', async () => {
+    const product = {
+      source: 'td_synnex_digital_bridge', sourceProductId: 'td-1', sku: 'SKU-1',
+      manufacturerPartNumber: null, vendor: null, name: 'Dock', description: null,
+      cost: '100.00', currency: 'USD', availability: null, warehouses: [],
+      raw: { blob: 'x'.repeat(200_001) },
+      lastRefreshedAt: new Date().toISOString()
+    };
+    const res = await app().request('/distributors/td-synnex/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ product, item: { name: 'Dock', unitPrice: 125, taxable: true } })
+    });
+    expect(res.status).toBe(400);
+    expect(tdSvc.importTdSynnexCatalogItem).not.toHaveBeenCalled();
+  });
 });
 
 const ITEM_ID = '11111111-1111-1111-1111-111111111111';

--- a/apps/api/src/routes/catalog/catalog.test.ts
+++ b/apps/api/src/routes/catalog/catalog.test.ts
@@ -16,6 +16,17 @@ vi.mock('../../services/catalogService', () => ({
   }
 }));
 
+vi.mock('../../services/tdSynnexDigitalBridge', () => ({
+  getTdSynnexDigitalBridgeStatus: vi.fn(),
+  saveTdSynnexDigitalBridgeConfig: vi.fn(),
+  testTdSynnexDigitalBridgeConnection: vi.fn(),
+  searchTdSynnexProducts: vi.fn(),
+  importTdSynnexCatalogItem: vi.fn(),
+  TdSynnexDigitalBridgeError: class TdSynnexDigitalBridgeError extends Error {
+    constructor(msg: string, public status = 400, public code?: string) { super(msg); }
+  }
+}));
+
 // Mock auth middleware to inject a partner-scoped actor with catalog perms.
 vi.mock('../../middleware/auth', () => ({
   authMiddleware: async (c: any, next: any) => {
@@ -23,11 +34,13 @@ vi.mock('../../middleware/auth', () => ({
     await next();
   },
   requireScope: () => async (_c: any, next: any) => next(),
-  requirePermission: () => async (_c: any, next: any) => next()
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next()
 }));
 
 import { catalogRoutes } from './index';
 import * as svc from '../../services/catalogService';
+import * as tdSvc from '../../services/tdSynnexDigitalBridge';
 
 function app() {
   // catalogRoutes already applies authMiddleware internally
@@ -78,6 +91,136 @@ describe('catalog routes', () => {
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.code).toBe('DUPLICATE_SKU');
+  });
+});
+
+describe('catalog TD SYNNEX distributor routes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('GET /distributors/td-synnex/status returns masked integration status', async () => {
+    (tdSvc.getTdSynnexDigitalBridgeStatus as any).mockResolvedValue({
+      configured: true,
+      enabled: true,
+      credentials: { apiKey: '********', apiSecret: '********' }
+    });
+    const res = await app().request('/distributors/td-synnex/status', { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.credentials.apiKey).toBe('********');
+    expect(tdSvc.getTdSynnexDigitalBridgeStatus).toHaveBeenCalledOnce();
+  });
+
+  it('PUT /distributors/td-synnex/config validates and saves config', async () => {
+    (tdSvc.saveTdSynnexDigitalBridgeConfig as any).mockResolvedValue({ configured: true, enabled: true });
+    const res = await app().request('/distributors/td-synnex/config', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        enabled: true,
+        environment: 'sandbox',
+        region: 'US',
+        baseUrl: 'https://example.test',
+        authType: 'api_key',
+        credentials: { apiKey: 'key', apiSecret: 'secret' },
+        settings: { searchPath: '/catalog/search', searchMethod: 'GET' }
+      })
+    });
+    expect(res.status).toBe(200);
+    expect(tdSvc.saveTdSynnexDigitalBridgeConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://example.test' }),
+      expect.anything()
+    );
+  });
+
+  it('PUT /distributors/td-synnex/config rejects invalid baseUrl', async () => {
+    const res = await app().request('/distributors/td-synnex/config', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ baseUrl: 'not-a-url' })
+    });
+    expect(res.status).toBe(400);
+    expect(tdSvc.saveTdSynnexDigitalBridgeConfig).not.toHaveBeenCalled();
+  });
+
+  it('PUT /distributors/td-synnex/config rejects internal or non-HTTPS baseUrl values', async () => {
+    const res = await app().request('/distributors/td-synnex/config', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        enabled: true,
+        environment: 'sandbox',
+        region: 'US',
+        baseUrl: 'http://127.0.0.1:8080',
+        authType: 'api_key',
+        credentials: { apiKey: 'key' },
+        settings: { searchPath: '/catalog/search', searchMethod: 'GET' }
+      })
+    });
+    expect(res.status).toBe(400);
+    expect(tdSvc.saveTdSynnexDigitalBridgeConfig).not.toHaveBeenCalled();
+  });
+
+  it('PUT /distributors/td-synnex/config rejects absolute endpoint paths', async () => {
+    const res = await app().request('/distributors/td-synnex/config', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        enabled: true,
+        environment: 'sandbox',
+        region: 'US',
+        baseUrl: 'https://example.test',
+        authType: 'api_key',
+        credentials: { apiKey: 'key' },
+        settings: { searchPath: 'https://evil.example/search', searchMethod: 'GET' }
+      })
+    });
+    expect(res.status).toBe(400);
+    expect(tdSvc.saveTdSynnexDigitalBridgeConfig).not.toHaveBeenCalled();
+  });
+
+  it('GET /distributors/td-synnex/search forwards query and limit', async () => {
+    (tdSvc.searchTdSynnexProducts as any).mockResolvedValue([{ sourceProductId: 'td-1', name: 'Dock' }]);
+    const res = await app().request('/distributors/td-synnex/search?q=dock&limit=10', { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0].name).toBe('Dock');
+    expect(tdSvc.searchTdSynnexProducts).toHaveBeenCalledWith({ q: 'dock', limit: 10 }, expect.anything());
+  });
+
+  it('POST /distributors/td-synnex/import creates a catalog item from a provider product', async () => {
+    (tdSvc.importTdSynnexCatalogItem as any).mockResolvedValue({ id: 'catalog-1', name: 'Dock' });
+    const product = {
+      source: 'td_synnex_digital_bridge',
+      sourceProductId: 'td-1',
+      sku: 'SKU-1',
+      manufacturerPartNumber: 'MPN-1',
+      vendor: 'Vendor',
+      name: 'Dock',
+      description: null,
+      cost: '100.00',
+      currency: 'USD',
+      availability: 4,
+      warehouses: [],
+      raw: {},
+      lastRefreshedAt: new Date().toISOString()
+    };
+    const res = await app().request('/distributors/td-synnex/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ product, item: { name: 'Dock', sku: 'SKU-1', unitPrice: 125, costBasis: 100, taxable: true } })
+    });
+    expect(res.status).toBe(200);
+    expect(tdSvc.importTdSynnexCatalogItem).toHaveBeenCalledOnce();
+  });
+
+  it('maps provider errors to their status code', async () => {
+    (tdSvc.searchTdSynnexProducts as any).mockRejectedValue(
+      new (tdSvc as any).TdSynnexDigitalBridgeError('missing endpoint', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED')
+    );
+    const res = await app().request('/distributors/td-synnex/search?q=dock', { method: 'GET' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   });
 });
 

--- a/apps/api/src/routes/catalog/distributors.ts
+++ b/apps/api/src/routes/catalog/distributors.ts
@@ -1,0 +1,177 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { checkSsrfSafe } from '../../services/ssrfGuard';
+import { catalogActorFrom } from './catalog';
+import {
+  getTdSynnexDigitalBridgeStatus,
+  importTdSynnexCatalogItem,
+  saveTdSynnexDigitalBridgeConfig,
+  searchTdSynnexProducts,
+  testTdSynnexDigitalBridgeConnection,
+  TdSynnexDigitalBridgeError,
+} from '../../services/tdSynnexDigitalBridge';
+
+export const catalogDistributorRoutes = new Hono();
+
+const scopes = requireScope('partner', 'system');
+const readPerm = requirePermission(PERMISSIONS.CATALOG_READ.resource, PERMISSIONS.CATALOG_READ.action);
+const writePerm = requirePermission(PERMISSIONS.CATALOG_WRITE.resource, PERMISSIONS.CATALOG_WRITE.action);
+
+const baseUrlSchema = z.string().url().max(2000).superRefine((value, ctx) => {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return;
+  }
+  if (parsed.username || parsed.password) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Base URL cannot include credentials' });
+    return;
+  }
+  const result = checkSsrfSafe(value, { mode: 'strict-https' });
+  if (!result.ok) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: result.reason ?? 'Base URL is not allowed' });
+  }
+});
+
+const pathSchema = z.string().max(500).optional()
+  .transform((v) => v?.trim() || undefined)
+  .refine(
+    (value) => !value || (
+      value.startsWith('/') &&
+      !value.startsWith('//') &&
+      !value.includes('\\') &&
+      !/[\r\n]/.test(value) &&
+      !/^[a-z][a-z0-9+.-]*:/i.test(value)
+    ),
+    { message: 'Endpoint path must be a relative path beginning with /' }
+  );
+const configSchema = z.object({
+  environment: z.enum(['sandbox', 'production']).default('sandbox'),
+  region: z.string().min(1).max(50).default('US'),
+  baseUrl: baseUrlSchema,
+  authType: z.enum(['api_key', 'bearer', 'basic']).default('api_key'),
+  enabled: z.boolean().default(false),
+  credentials: z.object({
+    apiKey: z.string().max(10_000).nullable().optional(),
+    apiSecret: z.string().max(10_000).nullable().optional(),
+  }).optional(),
+  settings: z.object({
+    accountId: z.string().max(100).optional(),
+    testPath: pathSchema,
+    searchPath: pathSchema,
+    searchMethod: z.enum(['GET', 'POST']).default('GET'),
+    detailsPath: pathSchema,
+    availabilityPath: pathSchema,
+  }).optional()
+});
+
+const searchQuerySchema = z.object({
+  q: z.string().min(2).max(200),
+  limit: z.coerce.number().int().min(1).max(50).default(20)
+});
+
+const productSchema = z.object({
+  source: z.literal('td_synnex_digital_bridge'),
+  sourceProductId: z.string().min(1).max(255),
+  sku: z.string().max(255).nullable(),
+  manufacturerPartNumber: z.string().max(255).nullable(),
+  vendor: z.string().max(255).nullable(),
+  name: z.string().min(1).max(500),
+  description: z.string().max(10_000).nullable(),
+  cost: z.string().max(30).nullable(),
+  currency: z.string().max(10).nullable(),
+  availability: z.number().nullable(),
+  warehouses: z.array(z.record(z.string(), z.unknown())).max(200),
+  raw: z.record(z.string(), z.unknown()),
+  lastRefreshedAt: z.string().max(100)
+});
+
+const money = z.number().nonnegative().max(9_999_999_999.99).multipleOf(0.01);
+const importSchema = z.object({
+  product: productSchema,
+  item: z.object({
+    name: z.string().min(1).max(255),
+    sku: z.string().max(100).nullable().optional(),
+    description: z.string().max(10_000).nullable().optional(),
+    unitPrice: money,
+    costBasis: money.nullable().optional(),
+    markupPercent: z.number().min(0).max(9999.99).multipleOf(0.01).nullable().optional(),
+    taxable: z.boolean().default(true),
+  })
+});
+
+function handleTdSynnexError(c: { json: (body: unknown, status: number) => Response }, err: unknown): Response {
+  if (err instanceof TdSynnexDigitalBridgeError) {
+    return c.json({ error: err.message, code: err.code }, err.status);
+  }
+  throw err;
+}
+
+catalogDistributorRoutes.get('/distributors/td-synnex/status', scopes, readPerm, async (c) => {
+  try {
+    const data = await getTdSynnexDigitalBridgeStatus(catalogActorFrom(c));
+    return c.json({ data });
+  } catch (err) {
+    return handleTdSynnexError(c, err);
+  }
+});
+
+catalogDistributorRoutes.put(
+  '/distributors/td-synnex/config',
+  scopes,
+  writePerm,
+  requireMfa(),
+  zValidator('json', configSchema),
+  async (c) => {
+    try {
+      const data = await saveTdSynnexDigitalBridgeConfig(c.req.valid('json'), catalogActorFrom(c));
+      return c.json({ data });
+    } catch (err) {
+      return handleTdSynnexError(c, err);
+    }
+  }
+);
+
+catalogDistributorRoutes.post('/distributors/td-synnex/test', scopes, writePerm, requireMfa(), async (c) => {
+  try {
+    const data = await testTdSynnexDigitalBridgeConnection(catalogActorFrom(c));
+    return c.json({ data });
+  } catch (err) {
+    return handleTdSynnexError(c, err);
+  }
+});
+
+catalogDistributorRoutes.get(
+  '/distributors/td-synnex/search',
+  scopes,
+  readPerm,
+  zValidator('query', searchQuerySchema),
+  async (c) => {
+    try {
+      const data = await searchTdSynnexProducts(c.req.valid('query'), catalogActorFrom(c));
+      return c.json({ data });
+    } catch (err) {
+      return handleTdSynnexError(c, err);
+    }
+  }
+);
+
+catalogDistributorRoutes.post(
+  '/distributors/td-synnex/import',
+  scopes,
+  writePerm,
+  requireMfa(),
+  zValidator('json', importSchema),
+  async (c) => {
+    try {
+      const data = await importTdSynnexCatalogItem(c.req.valid('json'), catalogActorFrom(c));
+      return c.json({ data });
+    } catch (err) {
+      return handleTdSynnexError(c, err);
+    }
+  }
+);

--- a/apps/api/src/routes/catalog/distributors.ts
+++ b/apps/api/src/routes/catalog/distributors.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { checkSsrfSafe } from '../../services/ssrfGuard';
+import { CatalogServiceError } from '../../services/catalogService';
 import { catalogActorFrom } from './catalog';
 import {
   getTdSynnexDigitalBridgeStatus,
@@ -82,11 +83,17 @@ const productSchema = z.object({
   vendor: z.string().max(255).nullable(),
   name: z.string().min(1).max(500),
   description: z.string().max(10_000).nullable(),
-  cost: z.string().max(30).nullable(),
+  // Normalized money string (matches normalizeTdSynnexProducts' toFixed(2) output).
+  cost: z.string().regex(/^-?\d+\.\d{2}$/).max(30).nullable(),
   currency: z.string().max(10).nullable(),
   availability: z.number().nullable(),
   warehouses: z.array(z.record(z.string(), z.unknown())).max(200),
-  raw: z.record(z.string(), z.unknown()),
+  // Provider passthrough — not persisted, but bound the inbound size so a partner
+  // can't post a multi-MB blob through the import endpoint.
+  raw: z.record(z.string(), z.unknown()).refine(
+    (v) => JSON.stringify(v).length <= 200_000,
+    { message: 'raw product payload is too large' }
+  ),
   lastRefreshedAt: z.string().max(100)
 });
 
@@ -108,6 +115,14 @@ function handleTdSynnexError(c: { json: (body: unknown, status: number) => Respo
   if (err instanceof TdSynnexDigitalBridgeError) {
     return c.json({ error: err.message, code: err.code }, err.status);
   }
+  // createCatalogItem (used by import) surfaces duplicate-SKU / price-range as a
+  // typed CatalogServiceError — map it instead of letting it fall through to a 500.
+  if (err instanceof CatalogServiceError) {
+    return c.json({ error: err.message, code: err.code }, err.status);
+  }
+  // Genuinely unexpected (DB outage, etc.): tag it so the Sentry entry from the
+  // global onError handler is attributable to this integration, then re-throw.
+  console.error('[td-synnex] unexpected error', err);
   throw err;
 }
 

--- a/apps/api/src/routes/catalog/index.ts
+++ b/apps/api/src/routes/catalog/index.ts
@@ -3,11 +3,13 @@ import { authMiddleware } from '../../middleware/auth';
 import { catalogItemRoutes } from './catalog';
 import { catalogPricingRoutes } from './pricing';
 import { catalogBundleRoutes } from './bundles';
+import { catalogDistributorRoutes } from './distributors';
 
 export const catalogRoutes = new Hono();
 
 catalogRoutes.use('*', authMiddleware);
 // pricing + bundles use /:id/<literal> — register before the generic item /:id handlers
+catalogRoutes.route('/', catalogDistributorRoutes);
 catalogRoutes.route('/', catalogPricingRoutes);
 catalogRoutes.route('/', catalogBundleRoutes);
 catalogRoutes.route('/', catalogItemRoutes);

--- a/apps/api/src/services/encryptedColumnRegistry.ts
+++ b/apps/api/src/services/encryptedColumnRegistry.ts
@@ -66,6 +66,7 @@ export const encryptedColumnRegistry: EncryptedColumnSpec[] = [
   { table: 'organizations', column: 'settings', kind: 'json', description: 'organization settings with encrypted log-forwarding secrets' },
   { table: 'partners', column: 'settings', kind: 'json', description: 'partner settings with encrypted remote-access launcher passwords (#716)' },
   { table: 'sites', column: 'settings', kind: 'json', description: 'site-level settings with encrypted overrides' },
+  { table: 'td_synnex_digital_bridge_integrations', column: 'credentials', kind: 'json', description: 'TD SYNNEX Digital Bridge API credentials' },
 ];
 
 const SECRET_JSON_KEYS = new Set([

--- a/apps/api/src/services/tdSynnexDigitalBridge.test.ts
+++ b/apps/api/src/services/tdSynnexDigitalBridge.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+  encryptSecret: vi.fn((value: string | null | undefined) => value ? `enc(${value})` : null),
+  decryptForColumn: vi.fn((_table: string, _column: string, value: string | null | undefined) => value ?? null),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ db: mocks.db }));
+vi.mock('./secretCrypto', () => ({
+  encryptSecret: mocks.encryptSecret,
+  decryptForColumn: mocks.decryptForColumn,
+}));
+vi.mock('./catalogService', () => ({
+  createCatalogItem: mocks.createCatalogItem,
+}));
+
+import {
+  getTdSynnexDigitalBridgeStatus,
+  importTdSynnexCatalogItem,
+  saveTdSynnexDigitalBridgeConfig,
+  normalizeTdSynnexProducts,
+  TD_SYNNEX_MASKED_SECRET,
+  TdSynnexDigitalBridgeError,
+} from './tdSynnexDigitalBridge';
+
+const actor = { userId: 'user-1', partnerId: 'partner-1', accessibleOrgIds: null };
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+function insertChain(returningRows: unknown[]) {
+  return {
+    values: vi.fn().mockReturnThis(),
+    onConflictDoUpdate: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(returningRows),
+  };
+}
+
+describe('tdSynnexDigitalBridge service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('masks credentials when reading integration status', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([{
+      id: 'integration-1',
+      environment: 'sandbox',
+      region: 'US',
+      baseUrl: 'https://digitalbridge.test',
+      authType: 'api_key',
+      enabled: true,
+      credentials: { apiKey: 'enc(key)', apiSecret: 'enc(secret)' },
+      settings: { searchPath: '/search' },
+      lastTestStatus: null,
+      lastTestAt: null,
+      lastTestError: null,
+      lastSyncAt: null,
+      lastError: null,
+    }]));
+
+    const status = await getTdSynnexDigitalBridgeStatus(actor);
+
+    expect(status.configured).toBe(true);
+    expect(status.credentials).toEqual({ apiKey: TD_SYNNEX_MASKED_SECRET, apiSecret: TD_SYNNEX_MASKED_SECRET });
+  });
+
+  it('preserves existing encrypted credentials when masked values are submitted', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([{
+      credentials: { apiKey: 'enc(old-key)', apiSecret: 'enc(old-secret)' },
+      settings: { searchPath: '/old-search' },
+    }]));
+    mocks.db.insert.mockReturnValueOnce(insertChain([{
+      id: 'integration-1',
+      environment: 'sandbox',
+      region: 'US',
+      baseUrl: 'https://digitalbridge.test',
+      authType: 'api_key',
+      enabled: true,
+      credentials: { apiKey: 'enc(old-key)', apiSecret: 'enc(old-secret)' },
+      settings: { searchPath: '/new-search', searchMethod: 'GET' },
+      lastTestStatus: null,
+      lastTestAt: null,
+      lastTestError: null,
+      lastSyncAt: null,
+      lastError: null,
+    }]));
+
+    await saveTdSynnexDigitalBridgeConfig({
+      environment: 'sandbox',
+      region: 'US',
+      baseUrl: 'https://digitalbridge.test',
+      authType: 'api_key',
+      enabled: true,
+      credentials: { apiKey: TD_SYNNEX_MASKED_SECRET, apiSecret: TD_SYNNEX_MASKED_SECRET },
+      settings: { searchPath: '/new-search', searchMethod: 'GET' },
+    }, actor);
+
+    const insert = mocks.db.insert.mock.results[0]!.value;
+    const values = insert.values.mock.calls[0]![0];
+    expect(values.credentials).toEqual({ apiKey: 'enc(old-key)', apiSecret: 'enc(old-secret)' });
+    expect(mocks.encryptSecret).not.toHaveBeenCalledWith(TD_SYNNEX_MASKED_SECRET);
+  });
+
+  it('clears existing encrypted credentials when blank or null values are submitted', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([{
+      credentials: { apiKey: 'enc(old-key)', apiSecret: 'enc(old-secret)' },
+      settings: { searchPath: '/old-search' },
+    }]));
+    mocks.db.insert.mockReturnValueOnce(insertChain([{
+      id: 'integration-1',
+      environment: 'sandbox',
+      region: 'US',
+      baseUrl: 'https://digitalbridge.test',
+      authType: 'api_key',
+      enabled: true,
+      credentials: {},
+      settings: { searchPath: '/new-search', searchMethod: 'GET' },
+      lastTestStatus: null,
+      lastTestAt: null,
+      lastTestError: null,
+      lastSyncAt: null,
+      lastError: null,
+    }]));
+
+    await saveTdSynnexDigitalBridgeConfig({
+      environment: 'sandbox',
+      region: 'US',
+      baseUrl: 'https://digitalbridge.test',
+      authType: 'api_key',
+      enabled: true,
+      credentials: { apiKey: '', apiSecret: null },
+      settings: { searchPath: '/new-search', searchMethod: 'GET' },
+    }, actor);
+
+    const insert = mocks.db.insert.mock.results[0]!.value;
+    const values = insert.values.mock.calls[0]![0];
+    expect(values.credentials).toEqual({});
+  });
+
+  it('rejects import when TD SYNNEX integration is disabled', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([{
+      id: 'integration-1',
+      partnerId: actor.partnerId,
+      enabled: false,
+    }]));
+
+    await expect(importTdSynnexCatalogItem({
+      product: {
+        source: 'td_synnex_digital_bridge',
+        sourceProductId: 'td-1',
+        sku: 'SKU-1',
+        manufacturerPartNumber: null,
+        vendor: null,
+        name: 'Dock',
+        description: null,
+        cost: '100.00',
+        currency: 'USD',
+        availability: null,
+        warehouses: [],
+        raw: {},
+        lastRefreshedAt: new Date().toISOString(),
+      },
+      item: {
+        name: 'Dock',
+        sku: 'SKU-1',
+        unitPrice: 125,
+        taxable: true,
+      },
+    }, actor)).rejects.toThrow(TdSynnexDigitalBridgeError);
+    expect(mocks.createCatalogItem).not.toHaveBeenCalled();
+  });
+
+  it('normalizes common product fields from provider responses', () => {
+    const products = normalizeTdSynnexProducts({
+      products: [{
+        productId: 'p-1',
+        sku: 'SKU-1',
+        manufacturer: 'Lenovo',
+        manufacturerPartNumber: 'MPN-1',
+        productName: 'ThinkPad Dock',
+        netPrice: '99.5',
+        currencyCode: 'USD',
+        availableQuantity: '8',
+        warehouses: [{ code: 'A', quantity: 8 }],
+      }]
+    });
+
+    expect(products[0]).toMatchObject({
+      sourceProductId: 'p-1',
+      sku: 'SKU-1',
+      vendor: 'Lenovo',
+      manufacturerPartNumber: 'MPN-1',
+      cost: '99.50',
+      availability: 8,
+    });
+  });
+});

--- a/apps/api/src/services/tdSynnexDigitalBridge.test.ts
+++ b/apps/api/src/services/tdSynnexDigitalBridge.test.ts
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-  db: {
-    select: vi.fn(),
-    insert: vi.fn(),
-    update: vi.fn(),
-  },
-  encryptSecret: vi.fn((value: string | null | undefined) => value ? `enc(${value})` : null),
-  decryptForColumn: vi.fn((_table: string, _column: string, value: string | null | undefined) => value ?? null),
-  createCatalogItem: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  class SsrfBlockedError extends Error {}
+  return {
+    db: {
+      select: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+    },
+    encryptSecret: vi.fn((value: string | null | undefined) => value ? `enc(${value})` : null),
+    decryptForColumn: vi.fn((_table: string, _column: string, value: string | null | undefined) => value ?? null),
+    createCatalogItem: vi.fn(),
+    safeFetch: vi.fn(),
+    SsrfBlockedError,
+  };
+});
 
 vi.mock('../db', () => ({ db: mocks.db }));
 vi.mock('./secretCrypto', () => ({
@@ -19,12 +24,19 @@ vi.mock('./secretCrypto', () => ({
 vi.mock('./catalogService', () => ({
   createCatalogItem: mocks.createCatalogItem,
 }));
+vi.mock('./urlSafety', () => ({
+  safeFetch: mocks.safeFetch,
+  SsrfBlockedError: mocks.SsrfBlockedError,
+}));
 
 import {
   getTdSynnexDigitalBridgeStatus,
   importTdSynnexCatalogItem,
   saveTdSynnexDigitalBridgeConfig,
+  searchTdSynnexProducts,
   normalizeTdSynnexProducts,
+  normalizeTdSynnexBaseUrl,
+  normalizeTdSynnexEndpointPath,
   TD_SYNNEX_MASKED_SECRET,
   TdSynnexDigitalBridgeError,
 } from './tdSynnexDigitalBridge';
@@ -46,6 +58,32 @@ function insertChain(returningRows: unknown[]) {
     returning: vi.fn().mockResolvedValue(returningRows),
   };
 }
+
+// db.update(...).set(...).where(...) — `where` is awaited directly on the search
+// path and `.returning()` is chained on the test-connection path.
+function updateChain(returningRows: unknown[] = []) {
+  return {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(returningRows),
+    returning: vi.fn().mockResolvedValue(returningRows),
+  };
+}
+
+function fakeResponse(status: number, body: string) {
+  return { status, ok: status >= 200 && status < 300, text: async () => body } as unknown as Response;
+}
+
+const enabledRow = {
+  id: 'integration-1',
+  partnerId: actor.partnerId,
+  environment: 'sandbox',
+  region: 'US',
+  baseUrl: 'https://digitalbridge.example.test',
+  authType: 'api_key',
+  enabled: true,
+  credentials: { apiKey: 'enc(key)' },
+  settings: { searchPath: '/search' },
+};
 
 describe('tdSynnexDigitalBridge service', () => {
   beforeEach(() => {
@@ -204,5 +242,199 @@ describe('tdSynnexDigitalBridge service', () => {
       cost: '99.50',
       availability: 8,
     });
+  });
+
+  it('detects products across array/products/items/results/data shapes', () => {
+    const one = { id: 'a', name: 'A' };
+    expect(normalizeTdSynnexProducts([one])).toHaveLength(1);
+    expect(normalizeTdSynnexProducts({ products: [one] })).toHaveLength(1);
+    expect(normalizeTdSynnexProducts({ items: [one] })).toHaveLength(1);
+    expect(normalizeTdSynnexProducts({ results: [one] })).toHaveLength(1);
+    expect(normalizeTdSynnexProducts({ data: [one] })).toHaveLength(1);
+  });
+
+  it('returns [] for garbage / unexpected payload shapes', () => {
+    expect(normalizeTdSynnexProducts(null)).toEqual([]);
+    expect(normalizeTdSynnexProducts({})).toEqual([]);
+    expect(normalizeTdSynnexProducts({ products: 'nope' })).toEqual([]);
+    expect(normalizeTdSynnexProducts('garbage')).toEqual([]);
+  });
+
+  it('skips provider rows with no usable identifier instead of fabricating ids', () => {
+    const products = normalizeTdSynnexProducts([
+      { name: 'No identifier' },           // no id, no sku -> skipped
+      {},                                  // empty -> skipped
+      { sku: 'ONLY-SKU', name: 'Has SKU' } // sku becomes the sourceProductId
+    ]);
+    expect(products).toHaveLength(1);
+    expect(products[0]).toMatchObject({ sourceProductId: 'ONLY-SKU', sku: 'ONLY-SKU' });
+  });
+
+  it('formats numeric cost to a 2-decimal string', () => {
+    const [product] = normalizeTdSynnexProducts([{ id: 'p', name: 'P', price: 99.5 }]);
+    expect(product!.cost).toBe('99.50');
+  });
+
+  it('rejects partner-less actors before touching the database', async () => {
+    await expect(getTdSynnexDigitalBridgeStatus({ ...actor, partnerId: null }))
+      .rejects.toMatchObject({ code: 'TD_SYNNEX_PARTNER_REQUIRED', status: 400 });
+    expect(mocks.db.select).not.toHaveBeenCalled();
+  });
+
+  it('encrypts a freshly submitted credential (trimmed)', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([{ credentials: {}, settings: {} }]));
+    mocks.db.insert.mockReturnValueOnce(insertChain([{ ...enabledRow, credentials: { apiKey: 'enc(new-key)' } }]));
+
+    await saveTdSynnexDigitalBridgeConfig({
+      environment: 'sandbox', region: 'US', baseUrl: 'https://digitalbridge.example.test',
+      authType: 'api_key', enabled: true,
+      credentials: { apiKey: '  new-key  ' },
+      settings: { searchPath: '/search', searchMethod: 'GET' },
+    }, actor);
+
+    const values = mocks.db.insert.mock.results[0]!.value.values.mock.calls[0]![0];
+    expect(values.credentials.apiKey).toBe('enc(new-key)');
+    expect(mocks.encryptSecret).toHaveBeenCalledWith('new-key');
+  });
+
+  it('never emits stored ciphertext or plaintext in masked status', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([{
+      ...enabledRow, credentials: { apiKey: 'enc(supersecret)', apiSecret: 'enc(topsecret)' },
+    }]));
+    const status = await getTdSynnexDigitalBridgeStatus(actor);
+    const serialized = JSON.stringify(status);
+    expect(serialized).not.toContain('supersecret');
+    expect(serialized).not.toContain('enc(');
+  });
+
+  it('requires the secret for basic auth before reporting configured', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([{
+      ...enabledRow, authType: 'basic', credentials: { apiKey: 'enc(key)' },
+    }]));
+    const status = await getTdSynnexDigitalBridgeStatus(actor);
+    expect(status.configured).toBe(false);
+  });
+
+  describe('normalizeTdSynnexBaseUrl', () => {
+    it('accepts and trims a valid https url', () => {
+      expect(normalizeTdSynnexBaseUrl('https://digitalbridge.example.test/v1/?x=1#frag'))
+        .toBe('https://digitalbridge.example.test/v1');
+    });
+
+    it.each([
+      ['not-a-url'],
+      ['http://digitalbridge.example.test'],     // not https
+      ['https://user:pass@digitalbridge.example.test'], // embedded credentials
+      ['https://127.0.0.1'],                     // internal address
+      ['https://localhost'],
+    ])('rejects %s', (value) => {
+      expect(() => normalizeTdSynnexBaseUrl(value))
+        .toThrow(expect.objectContaining({ code: 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED' }));
+    });
+  });
+
+  describe('normalizeTdSynnexEndpointPath', () => {
+    it('accepts a relative path', () => {
+      expect(normalizeTdSynnexEndpointPath('/v1/search')).toBe('/v1/search');
+    });
+
+    it.each([
+      ['search'],            // no leading slash
+      ['//evil.example'],    // protocol-relative
+      ['/a\\b'],             // backslash
+      ['/a\r\nb'],           // CRLF
+      ['https://evil.test'], // absolute url / scheme
+      ['javascript:alert(1)'],
+    ])('rejects %s', (value) => {
+      expect(() => normalizeTdSynnexEndpointPath(value))
+        .toThrow(expect.objectContaining({ code: 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED' }));
+    });
+  });
+
+  describe('requestDigitalBridge error mapping (via search)', () => {
+    beforeEach(() => {
+      mocks.db.select.mockReturnValue(selectChain([enabledRow]));
+      mocks.db.update.mockReturnValue(updateChain());
+    });
+
+    it('maps a 401 response to TD_SYNNEX_AUTH_FAILED and records lastError', async () => {
+      mocks.safeFetch.mockResolvedValueOnce(fakeResponse(401, ''));
+      await expect(searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor))
+        .rejects.toMatchObject({ code: 'TD_SYNNEX_AUTH_FAILED', status: 401 });
+      const setArg = mocks.db.update.mock.results[0]!.value.set.mock.calls[0]![0];
+      expect(setArg.lastError).toContain('credentials');
+    });
+
+    it('maps a non-ok response to TD_SYNNEX_PROVIDER_ERROR (502)', async () => {
+      mocks.safeFetch.mockResolvedValueOnce(fakeResponse(500, '{}'));
+      await expect(searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor))
+        .rejects.toMatchObject({ code: 'TD_SYNNEX_PROVIDER_ERROR', status: 502 });
+    });
+
+    it('maps invalid JSON to TD_SYNNEX_PROVIDER_ERROR', async () => {
+      mocks.safeFetch.mockResolvedValueOnce(fakeResponse(200, '{not json'));
+      await expect(searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor))
+        .rejects.toMatchObject({ code: 'TD_SYNNEX_PROVIDER_ERROR' });
+    });
+
+    it('maps a timeout to TD_SYNNEX_PROVIDER_ERROR', async () => {
+      const abort = new Error('aborted'); abort.name = 'AbortError';
+      mocks.safeFetch.mockRejectedValueOnce(abort);
+      await expect(searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor))
+        .rejects.toMatchObject({ code: 'TD_SYNNEX_PROVIDER_ERROR' });
+    });
+
+    it('maps an SSRF block to TD_SYNNEX_ENDPOINT_NOT_CONFIGURED', async () => {
+      mocks.safeFetch.mockRejectedValueOnce(new mocks.SsrfBlockedError('blocked'));
+      await expect(searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor))
+        .rejects.toMatchObject({ code: 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED' });
+    });
+
+    it('returns normalized products and clears lastError on success', async () => {
+      mocks.safeFetch.mockResolvedValueOnce(fakeResponse(200, JSON.stringify({ products: [{ id: 'p-1', name: 'Dock' }] })));
+      const products = await searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor);
+      expect(products).toHaveLength(1);
+      const setArg = mocks.db.update.mock.results[0]!.value.set.mock.calls[0]![0];
+      expect(setArg.lastError).toBeNull();
+    });
+  });
+
+  it('fails loudly when stored credentials are a corrupt non-string', async () => {
+    mocks.db.select.mockReturnValue(selectChain([{ ...enabledRow, credentials: { apiKey: 123 } }]));
+    mocks.db.update.mockReturnValue(updateChain());
+    await expect(searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor))
+      .rejects.toMatchObject({ code: 'TD_SYNNEX_CREDENTIALS_INVALID', status: 400 });
+  });
+
+  it('maps a configured base path through to the resolved endpoint url', async () => {
+    mocks.db.select.mockReturnValue(selectChain([{
+      ...enabledRow, baseUrl: 'https://digitalbridge.example.test/digitalbridge/v1', settings: { searchPath: '/products/search' },
+    }]));
+    mocks.db.update.mockReturnValue(updateChain());
+    mocks.safeFetch.mockResolvedValueOnce(fakeResponse(200, JSON.stringify({ products: [] })));
+    await searchTdSynnexProducts({ q: 'dock', limit: 20 }, actor);
+    const calledUrl = mocks.safeFetch.mock.calls[0]![0] as string;
+    // base path prefix must be preserved, not dropped by absolute-path resolution
+    expect(calledUrl).toContain('/digitalbridge/v1/products/search');
+  });
+
+  it('imports a provider product mapping distributor metadata into attributes', async () => {
+    mocks.db.select.mockReturnValueOnce(selectChain([enabledRow]));
+    mocks.createCatalogItem.mockResolvedValueOnce({ id: 'catalog-1' });
+    await importTdSynnexCatalogItem({
+      product: {
+        source: 'td_synnex_digital_bridge', sourceProductId: 'td-1', sku: 'SKU-1',
+        manufacturerPartNumber: 'MPN-1', vendor: 'Lenovo', name: 'Dock', description: 'desc',
+        cost: '100.00', currency: 'USD', availability: 4, warehouses: [{ code: 'A' }],
+        raw: { anything: true }, lastRefreshedAt: new Date().toISOString(),
+      },
+      item: { name: 'Dock', sku: 'SKU-1', unitPrice: 125, taxable: true },
+    }, actor);
+    const input = mocks.createCatalogItem.mock.calls[0]![0];
+    expect(input.attributes.distributor).toMatchObject({
+      provider: 'td_synnex_digital_bridge', sourceProductId: 'td-1', vendor: 'Lenovo',
+    });
+    // raw provider blob must NOT be persisted into the catalog item
+    expect(input.attributes.distributor).not.toHaveProperty('raw');
   });
 });

--- a/apps/api/src/services/tdSynnexDigitalBridge.ts
+++ b/apps/api/src/services/tdSynnexDigitalBridge.ts
@@ -1,0 +1,509 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { catalogItems, tdSynnexDigitalBridgeIntegrations } from '../db/schema';
+import { encryptSecret, decryptForColumn } from './secretCrypto';
+import { createCatalogItem, type CatalogActor } from './catalogService';
+import type { CreateCatalogItemInput } from '@breeze/shared';
+import { checkSsrfSafe } from './ssrfGuard';
+import { safeFetch, SsrfBlockedError } from './urlSafety';
+
+const TABLE = 'td_synnex_digital_bridge_integrations';
+const CREDENTIALS_COLUMN = 'credentials';
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const MIN_REQUEST_TIMEOUT_MS = 1_000;
+const MAX_REQUEST_TIMEOUT_MS = 60_000;
+export const TD_SYNNEX_MASKED_SECRET = '********';
+
+type AuthType = 'api_key' | 'bearer' | 'basic';
+type HttpMethod = 'GET' | 'POST';
+
+export interface TdSynnexDigitalBridgeSettings {
+  accountId?: string;
+  testPath?: string;
+  searchPath?: string;
+  searchMethod?: HttpMethod;
+  detailsPath?: string;
+  availabilityPath?: string;
+}
+
+export interface TdSynnexDigitalBridgeCredentials {
+  apiKey?: string | null;
+  apiSecret?: string | null;
+}
+
+export interface TdSynnexDigitalBridgeConfigInput {
+  environment: 'sandbox' | 'production';
+  region: string;
+  baseUrl: string;
+  authType: AuthType;
+  enabled: boolean;
+  credentials?: TdSynnexDigitalBridgeCredentials;
+  settings?: TdSynnexDigitalBridgeSettings;
+}
+
+export interface TdSynnexProduct {
+  source: 'td_synnex_digital_bridge';
+  sourceProductId: string;
+  sku: string | null;
+  manufacturerPartNumber: string | null;
+  vendor: string | null;
+  name: string;
+  description: string | null;
+  cost: string | null;
+  currency: string | null;
+  availability: number | null;
+  warehouses: Array<Record<string, unknown>>;
+  raw: Record<string, unknown>;
+  lastRefreshedAt: string;
+}
+
+export class TdSynnexDigitalBridgeError extends Error {
+  constructor(
+    message: string,
+    public status: 400 | 401 | 404 | 409 | 502 = 400,
+    public code:
+      | 'TD_SYNNEX_NOT_CONFIGURED'
+      | 'TD_SYNNEX_DISABLED'
+      | 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED'
+      | 'TD_SYNNEX_AUTH_FAILED'
+      | 'TD_SYNNEX_PROVIDER_ERROR'
+      | 'TD_SYNNEX_NO_RESULTS'
+      | 'TD_SYNNEX_DUPLICATE_SKU' = 'TD_SYNNEX_PROVIDER_ERROR'
+  ) {
+    super(message);
+    this.name = 'TdSynnexDigitalBridgeError';
+  }
+}
+
+function requirePartner(actor: CatalogActor): string {
+  if (!actor.partnerId) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX integration is partner-scoped', 400, 'TD_SYNNEX_NOT_CONFIGURED');
+  }
+  return actor.partnerId;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function asMethod(value: unknown): HttpMethod {
+  return value === 'POST' ? 'POST' : 'GET';
+}
+
+function asAuthType(value: unknown): AuthType {
+  return value === 'bearer' || value === 'basic' ? value : 'api_key';
+}
+
+function decryptCredential(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return decryptForColumn(TABLE, CREDENTIALS_COLUMN, value);
+}
+
+function mergeCredentialField(output: Record<string, unknown>, key: 'apiKey' | 'apiSecret', value: unknown) {
+  if (value === undefined || value === TD_SYNNEX_MASKED_SECRET) return;
+  if (value === null || (typeof value === 'string' && value.trim().length === 0)) {
+    delete output[key];
+    return;
+  }
+  if (typeof value === 'string') {
+    output[key] = encryptSecret(value.trim());
+  }
+}
+
+function mergeCredentials(existing: unknown, next: TdSynnexDigitalBridgeCredentials | undefined): Record<string, unknown> {
+  const current = asRecord(existing);
+  const output: Record<string, unknown> = { ...current };
+  if (!next) return output;
+  mergeCredentialField(output, 'apiKey', next.apiKey);
+  mergeCredentialField(output, 'apiSecret', next.apiSecret);
+  return output;
+}
+
+export function normalizeTdSynnexBaseUrl(rawUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL must be a valid URL', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL cannot include credentials', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+  }
+
+  const ssrf = checkSsrfSafe(parsed.toString(), { mode: 'strict-https' });
+  if (!ssrf.ok) {
+    throw new TdSynnexDigitalBridgeError(`TD SYNNEX base URL rejected: ${ssrf.reason}`, 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+  }
+
+  parsed.hash = '';
+  parsed.search = '';
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+export function normalizeTdSynnexEndpointPath(path: string): string {
+  const value = path.trim();
+  if (!value.startsWith('/') || value.startsWith('//') || value.includes('\\') || /[\r\n]/.test(value) || /^[a-z][a-z0-9+.-]*:/i.test(value)) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX endpoint paths must be relative paths beginning with /', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+  }
+  return value;
+}
+
+function requestTimeoutMs(): number {
+  const parsed = Number.parseInt(process.env.TD_SYNNEX_DIGITAL_BRIDGE_TIMEOUT_MS ?? '', 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_REQUEST_TIMEOUT_MS;
+  return Math.min(MAX_REQUEST_TIMEOUT_MS, Math.max(MIN_REQUEST_TIMEOUT_MS, parsed));
+}
+
+function maskConfig(row: typeof tdSynnexDigitalBridgeIntegrations.$inferSelect | null) {
+  if (!row) {
+    return { configured: false, enabled: false };
+  }
+  const credentials = asRecord(row.credentials);
+  const hasApiKey = typeof credentials.apiKey === 'string' && credentials.apiKey.length > 0;
+  const hasApiSecret = typeof credentials.apiSecret === 'string' && credentials.apiSecret.length > 0;
+  return {
+    configured: hasApiKey,
+    id: row.id,
+    environment: row.environment,
+    region: row.region,
+    baseUrl: row.baseUrl,
+    authType: row.authType,
+    enabled: row.enabled,
+    credentials: {
+      apiKey: hasApiKey ? TD_SYNNEX_MASKED_SECRET : '',
+      apiSecret: hasApiSecret ? TD_SYNNEX_MASKED_SECRET : ''
+    },
+    settings: asRecord(row.settings),
+    lastTestStatus: row.lastTestStatus,
+    lastTestAt: row.lastTestAt,
+    lastTestError: row.lastTestError,
+    lastSyncAt: row.lastSyncAt,
+    lastError: row.lastError
+  };
+}
+
+export async function getTdSynnexDigitalBridgeStatus(actor: CatalogActor) {
+  const partnerId = requirePartner(actor);
+  const [row] = await db
+    .select()
+    .from(tdSynnexDigitalBridgeIntegrations)
+    .where(eq(tdSynnexDigitalBridgeIntegrations.partnerId, partnerId))
+    .limit(1);
+  return maskConfig(row ?? null);
+}
+
+export async function saveTdSynnexDigitalBridgeConfig(input: TdSynnexDigitalBridgeConfigInput, actor: CatalogActor) {
+  const partnerId = requirePartner(actor);
+  const baseUrl = normalizeTdSynnexBaseUrl(input.baseUrl);
+  const existing = await db
+    .select()
+    .from(tdSynnexDigitalBridgeIntegrations)
+    .where(eq(tdSynnexDigitalBridgeIntegrations.partnerId, partnerId))
+    .limit(1);
+  const current = existing[0] ?? null;
+  const credentials = mergeCredentials(current?.credentials, input.credentials);
+  const settings = {
+    ...asRecord(current?.settings),
+    ...asRecord(input.settings),
+    searchMethod: asMethod(input.settings?.searchMethod)
+  };
+
+  const rows = await db
+    .insert(tdSynnexDigitalBridgeIntegrations)
+    .values({
+      partnerId,
+      environment: input.environment,
+      region: input.region,
+      baseUrl,
+      authType: input.authType,
+      credentials,
+      settings,
+      enabled: input.enabled,
+      createdBy: actor.userId,
+      updatedAt: new Date()
+    })
+    .onConflictDoUpdate({
+      target: tdSynnexDigitalBridgeIntegrations.partnerId,
+      set: {
+        environment: input.environment,
+        region: input.region,
+        baseUrl,
+        authType: input.authType,
+        credentials,
+        settings,
+        enabled: input.enabled,
+        updatedAt: new Date()
+      }
+    })
+    .returning();
+
+  return maskConfig(rows[0] ?? null);
+}
+
+async function getActiveIntegration(actor: CatalogActor) {
+  const partnerId = requirePartner(actor);
+  const [row] = await db
+    .select()
+    .from(tdSynnexDigitalBridgeIntegrations)
+    .where(eq(tdSynnexDigitalBridgeIntegrations.partnerId, partnerId))
+    .limit(1);
+  if (!row) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX Digital Bridge is not configured', 404, 'TD_SYNNEX_NOT_CONFIGURED');
+  }
+  if (!row.enabled) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX Digital Bridge is disabled', 400, 'TD_SYNNEX_DISABLED');
+  }
+  return row;
+}
+
+function endpointUrl(baseUrl: string, path: string, params?: Record<string, string | number | undefined>): string {
+  const safeBaseUrl = normalizeTdSynnexBaseUrl(baseUrl);
+  const safePath = normalizeTdSynnexEndpointPath(path);
+  const url = new URL(safePath, safeBaseUrl.endsWith('/') ? safeBaseUrl : `${safeBaseUrl}/`);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value !== undefined && String(value).length > 0) url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+function authHeaders(row: typeof tdSynnexDigitalBridgeIntegrations.$inferSelect): HeadersInit {
+  const credentials = asRecord(row.credentials);
+  const apiKey = decryptCredential(credentials.apiKey);
+  const apiSecret = decryptCredential(credentials.apiSecret);
+  const authType = asAuthType(row.authType);
+  if (!apiKey) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX API key is not configured', 400, 'TD_SYNNEX_NOT_CONFIGURED');
+  }
+
+  if (authType === 'bearer') {
+    return { authorization: `Bearer ${apiKey}` };
+  }
+  if (authType === 'basic') {
+    const auth = Buffer.from(`${apiKey}:${apiSecret ?? ''}`).toString('base64');
+    return { authorization: `Basic ${auth}` };
+  }
+  return {
+    'x-api-key': apiKey,
+    ...(apiSecret ? { 'x-api-secret': apiSecret } : {})
+  };
+}
+
+async function requestDigitalBridge(row: typeof tdSynnexDigitalBridgeIntegrations.$inferSelect, path: string, options: {
+  method?: HttpMethod;
+  query?: Record<string, string | number | undefined>;
+  body?: Record<string, unknown>;
+}) {
+  const method = options.method ?? 'GET';
+  const url = endpointUrl(row.baseUrl, path, method === 'GET' ? options.query : undefined);
+  let response: Response;
+  try {
+    response = await safeFetch(url, {
+      method,
+      headers: {
+        accept: 'application/json',
+        ...(method === 'POST' ? { 'content-type': 'application/json' } : {}),
+        ...authHeaders(row)
+      },
+      body: method === 'POST' ? JSON.stringify(options.body ?? {}) : undefined,
+      timeoutMs: requestTimeoutMs()
+    });
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL resolved to a blocked address', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+    }
+    const isTimeout = err instanceof Error && (err.name === 'AbortError' || err.message.toLowerCase().includes('timed out'));
+    throw new TdSynnexDigitalBridgeError(
+      isTimeout ? 'TD SYNNEX request timed out' : 'TD SYNNEX request failed',
+      502,
+      'TD_SYNNEX_PROVIDER_ERROR'
+    );
+  }
+  if (response.status === 401 || response.status === 403) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX rejected the configured credentials', 401, 'TD_SYNNEX_AUTH_FAILED');
+  }
+  const text = await response.text();
+  let parsed: unknown = null;
+  try {
+    parsed = text ? JSON.parse(text) as unknown : null;
+  } catch {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX returned an invalid JSON response', 502, 'TD_SYNNEX_PROVIDER_ERROR');
+  }
+  if (!response.ok) {
+    throw new TdSynnexDigitalBridgeError(`TD SYNNEX request failed with HTTP ${response.status}`, 502, 'TD_SYNNEX_PROVIDER_ERROR');
+  }
+  return parsed;
+}
+
+function pickNumber(record: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.trim() && Number.isFinite(Number(value))) return Number(value);
+  }
+  return null;
+}
+
+function pickString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = asString(record[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function pickArray(record: Record<string, unknown>, keys: string[]): Array<Record<string, unknown>> {
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) return value.filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object' && !Array.isArray(entry));
+  }
+  return [];
+}
+
+function productArray(payload: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(payload)) return payload.filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object' && !Array.isArray(entry));
+  const record = asRecord(payload);
+  for (const key of ['products', 'items', 'results', 'data']) {
+    const value = record[key];
+    if (Array.isArray(value)) return productArray(value);
+  }
+  return [];
+}
+
+export function normalizeTdSynnexProducts(payload: unknown): TdSynnexProduct[] {
+  const now = new Date().toISOString();
+  return productArray(payload).map((product, index) => {
+    const sourceProductId = pickString(product, ['id', 'productId', 'itemId', 'tdSynnexItemId', 'sku', 'partNumber']) ?? `result-${index}`;
+    const sku = pickString(product, ['sku', 'tdSku', 'tdSynnexSku', 'itemNumber', 'partNumber']);
+    const name = pickString(product, ['name', 'title', 'productName', 'description']) ?? sku ?? sourceProductId;
+    const cost = pickNumber(product, ['cost', 'price', 'netPrice', 'dealerPrice', 'unitCost']);
+    return {
+      source: 'td_synnex_digital_bridge',
+      sourceProductId,
+      sku,
+      manufacturerPartNumber: pickString(product, ['manufacturerPartNumber', 'mfrPartNumber', 'mpn', 'vendorPartNumber']),
+      vendor: pickString(product, ['vendor', 'manufacturer', 'brand']),
+      name,
+      description: pickString(product, ['description', 'longDescription', 'shortDescription']),
+      cost: cost === null ? null : cost.toFixed(2),
+      currency: pickString(product, ['currency', 'currencyCode']) ?? 'USD',
+      availability: pickNumber(product, ['availability', 'availableQuantity', 'quantityAvailable', 'stock']),
+      warehouses: pickArray(product, ['warehouses', 'warehouseAvailability', 'inventory']),
+      raw: product,
+      lastRefreshedAt: now
+    };
+  });
+}
+
+export async function testTdSynnexDigitalBridgeConnection(actor: CatalogActor) {
+  const row = await getActiveIntegration(actor);
+  const settings = asRecord(row.settings);
+  const testPath = asString(settings.testPath);
+  if (!testPath) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX test endpoint path is not configured', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+  }
+  try {
+    await requestDigitalBridge(row, testPath, { method: 'GET', query: { region: row.region } });
+    const [updated] = await db
+      .update(tdSynnexDigitalBridgeIntegrations)
+      .set({ lastTestStatus: 'success', lastTestAt: new Date(), lastTestError: null, updatedAt: new Date() })
+      .where(eq(tdSynnexDigitalBridgeIntegrations.id, row.id))
+      .returning();
+    return maskConfig(updated ?? row);
+  } catch (err) {
+    await db
+      .update(tdSynnexDigitalBridgeIntegrations)
+      .set({
+        lastTestStatus: 'failed',
+        lastTestAt: new Date(),
+        lastTestError: err instanceof Error ? err.message : 'Connection test failed',
+        updatedAt: new Date()
+      })
+      .where(eq(tdSynnexDigitalBridgeIntegrations.id, row.id));
+    throw err;
+  }
+}
+
+export async function searchTdSynnexProducts(query: { q: string; limit: number }, actor: CatalogActor) {
+  const row = await getActiveIntegration(actor);
+  const settings = asRecord(row.settings);
+  const searchPath = asString(settings.searchPath);
+  if (!searchPath) {
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX search endpoint path is not configured', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+  }
+  const accountId = asString(settings.accountId);
+  const method = asMethod(settings.searchMethod);
+  const payload = await requestDigitalBridge(row, searchPath, {
+    method,
+    query: { q: query.q, query: query.q, limit: query.limit, region: row.region, accountId },
+    body: { q: query.q, query: query.q, limit: query.limit, region: row.region, accountId }
+  });
+  const products = normalizeTdSynnexProducts(payload).slice(0, query.limit);
+  await db
+    .update(tdSynnexDigitalBridgeIntegrations)
+    .set({ lastSyncAt: new Date(), lastError: null, updatedAt: new Date() })
+    .where(eq(tdSynnexDigitalBridgeIntegrations.id, row.id));
+  return products;
+}
+
+export interface ImportTdSynnexCatalogItemInput {
+  product: TdSynnexProduct;
+  item: {
+    name: string;
+    sku?: string | null;
+    description?: string | null;
+    unitPrice: number;
+    costBasis?: number | null;
+    markupPercent?: number | null;
+    taxable: boolean;
+  };
+}
+
+export async function importTdSynnexCatalogItem(input: ImportTdSynnexCatalogItemInput, actor: CatalogActor) {
+  const partnerId = requirePartner(actor);
+  await getActiveIntegration(actor);
+  const existingSku = input.item.sku?.trim();
+  if (existingSku) {
+    const existing = await db
+      .select({ id: catalogItems.id })
+      .from(catalogItems)
+      .where(and(eq(catalogItems.partnerId, partnerId), eq(catalogItems.sku, existingSku)))
+      .limit(1);
+    if (existing.length > 0) {
+      throw new TdSynnexDigitalBridgeError('An item with this SKU already exists', 409, 'TD_SYNNEX_DUPLICATE_SKU');
+    }
+  }
+  const catalogInput: CreateCatalogItemInput = {
+    itemType: 'hardware',
+    name: input.item.name,
+    sku: existingSku || null,
+    description: input.item.description ?? input.product.description ?? null,
+    billingType: 'one_time',
+    unitPrice: input.item.unitPrice,
+    costBasis: input.item.costBasis ?? null,
+    markupPercent: input.item.markupPercent ?? null,
+    unitOfMeasure: 'each',
+    taxable: input.item.taxable,
+    taxCategory: null,
+    isBundle: false,
+    attributes: {
+      distributor: {
+        provider: 'td_synnex_digital_bridge',
+        sourceProductId: input.product.sourceProductId,
+        sku: input.product.sku,
+        manufacturerPartNumber: input.product.manufacturerPartNumber,
+        vendor: input.product.vendor,
+        currency: input.product.currency,
+        availability: input.product.availability,
+        warehouses: input.product.warehouses,
+        lastRefreshedAt: input.product.lastRefreshedAt
+      }
+    }
+  };
+  return createCatalogItem(catalogInput, actor);
+}

--- a/apps/api/src/services/tdSynnexDigitalBridge.ts
+++ b/apps/api/src/services/tdSynnexDigitalBridge.ts
@@ -1,6 +1,6 @@
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { db } from '../db';
-import { catalogItems, tdSynnexDigitalBridgeIntegrations } from '../db/schema';
+import { tdSynnexDigitalBridgeIntegrations } from '../db/schema';
 import { encryptSecret, decryptForColumn } from './secretCrypto';
 import { createCatalogItem, type CatalogActor } from './catalogService';
 import type { CreateCatalogItemInput } from '@breeze/shared';
@@ -57,27 +57,38 @@ export interface TdSynnexProduct {
   lastRefreshedAt: string;
 }
 
+// Single source of truth for the HTTP status each error code maps to. Coupling
+// the status to the code here makes incoherent pairs (e.g. a 502 duplicate-SKU)
+// unrepresentable and removes the old misleading 400/PROVIDER_ERROR default.
+const TD_SYNNEX_ERROR_STATUS = {
+  TD_SYNNEX_PARTNER_REQUIRED: 400,
+  TD_SYNNEX_NOT_CONFIGURED: 404,
+  TD_SYNNEX_DISABLED: 400,
+  TD_SYNNEX_ENDPOINT_NOT_CONFIGURED: 400,
+  TD_SYNNEX_CREDENTIALS_INVALID: 400,
+  TD_SYNNEX_AUTH_FAILED: 401,
+  TD_SYNNEX_PROVIDER_ERROR: 502,
+  TD_SYNNEX_NO_RESULTS: 404,
+  TD_SYNNEX_DUPLICATE_SKU: 409,
+} as const;
+
+export type TdSynnexDigitalBridgeErrorCode = keyof typeof TD_SYNNEX_ERROR_STATUS;
+
 export class TdSynnexDigitalBridgeError extends Error {
+  public readonly status: number;
   constructor(
     message: string,
-    public status: 400 | 401 | 404 | 409 | 502 = 400,
-    public code:
-      | 'TD_SYNNEX_NOT_CONFIGURED'
-      | 'TD_SYNNEX_DISABLED'
-      | 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED'
-      | 'TD_SYNNEX_AUTH_FAILED'
-      | 'TD_SYNNEX_PROVIDER_ERROR'
-      | 'TD_SYNNEX_NO_RESULTS'
-      | 'TD_SYNNEX_DUPLICATE_SKU' = 'TD_SYNNEX_PROVIDER_ERROR'
+    public readonly code: TdSynnexDigitalBridgeErrorCode = 'TD_SYNNEX_PROVIDER_ERROR'
   ) {
     super(message);
     this.name = 'TdSynnexDigitalBridgeError';
+    this.status = TD_SYNNEX_ERROR_STATUS[code];
   }
 }
 
 function requirePartner(actor: CatalogActor): string {
   if (!actor.partnerId) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX integration is partner-scoped', 400, 'TD_SYNNEX_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX integration is partner-scoped', 'TD_SYNNEX_PARTNER_REQUIRED');
   }
   return actor.partnerId;
 }
@@ -99,7 +110,13 @@ function asAuthType(value: unknown): AuthType {
 }
 
 function decryptCredential(value: unknown): string | null {
-  if (typeof value !== 'string' || value.length === 0) return null;
+  if (value === undefined || value === null) return null;
+  // A present-but-non-string credential means the stored JSONB is corrupt — fail
+  // loudly with an actionable code instead of silently treating it as "absent".
+  if (typeof value !== 'string') {
+    throw new TdSynnexDigitalBridgeError('Stored TD SYNNEX credentials are corrupt — please re-enter and save them', 'TD_SYNNEX_CREDENTIALS_INVALID');
+  }
+  if (value.length === 0) return null;
   return decryptForColumn(TABLE, CREDENTIALS_COLUMN, value);
 }
 
@@ -128,16 +145,16 @@ export function normalizeTdSynnexBaseUrl(rawUrl: string): string {
   try {
     parsed = new URL(rawUrl);
   } catch {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL must be a valid URL', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL must be a valid URL', 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   }
 
   if (parsed.username || parsed.password) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL cannot include credentials', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL cannot include credentials', 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   }
 
   const ssrf = checkSsrfSafe(parsed.toString(), { mode: 'strict-https' });
   if (!ssrf.ok) {
-    throw new TdSynnexDigitalBridgeError(`TD SYNNEX base URL rejected: ${ssrf.reason}`, 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError(`TD SYNNEX base URL rejected: ${ssrf.reason}`, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   }
 
   parsed.hash = '';
@@ -149,7 +166,7 @@ export function normalizeTdSynnexBaseUrl(rawUrl: string): string {
 export function normalizeTdSynnexEndpointPath(path: string): string {
   const value = path.trim();
   if (!value.startsWith('/') || value.startsWith('//') || value.includes('\\') || /[\r\n]/.test(value) || /^[a-z][a-z0-9+.-]*:/i.test(value)) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX endpoint paths must be relative paths beginning with /', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX endpoint paths must be relative paths beginning with /', 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   }
   return value;
 }
@@ -167,8 +184,11 @@ function maskConfig(row: typeof tdSynnexDigitalBridgeIntegrations.$inferSelect |
   const credentials = asRecord(row.credentials);
   const hasApiKey = typeof credentials.apiKey === 'string' && credentials.apiKey.length > 0;
   const hasApiSecret = typeof credentials.apiSecret === 'string' && credentials.apiSecret.length > 0;
+  // basic auth needs both key and secret to authenticate; key-only auth modes
+  // (api_key headers / bearer) are configured with just the key.
+  const requiresSecret = asAuthType(row.authType) === 'basic';
   return {
-    configured: hasApiKey,
+    configured: hasApiKey && (!requiresSecret || hasApiSecret),
     id: row.id,
     environment: row.environment,
     region: row.region,
@@ -254,10 +274,10 @@ async function getActiveIntegration(actor: CatalogActor) {
     .where(eq(tdSynnexDigitalBridgeIntegrations.partnerId, partnerId))
     .limit(1);
   if (!row) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX Digital Bridge is not configured', 404, 'TD_SYNNEX_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX Digital Bridge is not configured', 'TD_SYNNEX_NOT_CONFIGURED');
   }
   if (!row.enabled) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX Digital Bridge is disabled', 400, 'TD_SYNNEX_DISABLED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX Digital Bridge is disabled', 'TD_SYNNEX_DISABLED');
   }
   return row;
 }
@@ -265,20 +285,41 @@ async function getActiveIntegration(actor: CatalogActor) {
 function endpointUrl(baseUrl: string, path: string, params?: Record<string, string | number | undefined>): string {
   const safeBaseUrl = normalizeTdSynnexBaseUrl(baseUrl);
   const safePath = normalizeTdSynnexEndpointPath(path);
-  const url = new URL(safePath, safeBaseUrl.endsWith('/') ? safeBaseUrl : `${safeBaseUrl}/`);
+  // Resolve the endpoint path RELATIVE to the base so a base URL carrying a path
+  // prefix (e.g. https://host/digitalbridge/v1) is preserved. `new URL('/x', base)`
+  // treats the leading slash as origin-absolute and silently drops the prefix, so
+  // strip it and resolve against a trailing-slashed base instead.
+  const base = safeBaseUrl.endsWith('/') ? safeBaseUrl : `${safeBaseUrl}/`;
+  const url = new URL(safePath.replace(/^\/+/, ''), base);
   for (const [key, value] of Object.entries(params ?? {})) {
     if (value !== undefined && String(value).length > 0) url.searchParams.set(key, String(value));
+  }
+  // Re-validate the fully-resolved URL: the path/param join must not escape the
+  // SSRF-vetted https origin.
+  const ssrf = checkSsrfSafe(url.toString(), { mode: 'strict-https' });
+  if (!ssrf.ok) {
+    throw new TdSynnexDigitalBridgeError(`TD SYNNEX endpoint rejected: ${ssrf.reason}`, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   }
   return url.toString();
 }
 
 function authHeaders(row: typeof tdSynnexDigitalBridgeIntegrations.$inferSelect): HeadersInit {
   const credentials = asRecord(row.credentials);
-  const apiKey = decryptCredential(credentials.apiKey);
-  const apiSecret = decryptCredential(credentials.apiSecret);
+  let apiKey: string | null;
+  let apiSecret: string | null;
+  try {
+    apiKey = decryptCredential(credentials.apiKey);
+    apiSecret = decryptCredential(credentials.apiSecret);
+  } catch (err) {
+    // decryptCredential throws a typed error for corrupt JSONB; decryptForColumn
+    // throws a plain Error for an undecryptable blob (rotated key / truncated
+    // ciphertext). Both are actionable "re-enter credentials" situations, not 500s.
+    if (err instanceof TdSynnexDigitalBridgeError) throw err;
+    throw new TdSynnexDigitalBridgeError('Stored TD SYNNEX credentials could not be decrypted — please re-enter and save them', 'TD_SYNNEX_CREDENTIALS_INVALID');
+  }
   const authType = asAuthType(row.authType);
   if (!apiKey) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX API key is not configured', 400, 'TD_SYNNEX_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX API key is not configured', 'TD_SYNNEX_CREDENTIALS_INVALID');
   }
 
   if (authType === 'bearer') {
@@ -301,41 +342,43 @@ async function requestDigitalBridge(row: typeof tdSynnexDigitalBridgeIntegration
 }) {
   const method = options.method ?? 'GET';
   const url = endpointUrl(row.baseUrl, path, method === 'GET' ? options.query : undefined);
+  // Build headers (which decrypt credentials) BEFORE the try so a typed
+  // credential error surfaces as-is instead of being remapped to PROVIDER_ERROR.
+  const headers = {
+    accept: 'application/json',
+    ...(method === 'POST' ? { 'content-type': 'application/json' } : {}),
+    ...authHeaders(row)
+  };
   let response: Response;
   try {
     response = await safeFetch(url, {
       method,
-      headers: {
-        accept: 'application/json',
-        ...(method === 'POST' ? { 'content-type': 'application/json' } : {}),
-        ...authHeaders(row)
-      },
+      headers,
       body: method === 'POST' ? JSON.stringify(options.body ?? {}) : undefined,
       timeoutMs: requestTimeoutMs()
     });
   } catch (err) {
     if (err instanceof SsrfBlockedError) {
-      throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL resolved to a blocked address', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+      throw new TdSynnexDigitalBridgeError('TD SYNNEX base URL resolved to a blocked address', 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
     }
     const isTimeout = err instanceof Error && (err.name === 'AbortError' || err.message.toLowerCase().includes('timed out'));
     throw new TdSynnexDigitalBridgeError(
       isTimeout ? 'TD SYNNEX request timed out' : 'TD SYNNEX request failed',
-      502,
       'TD_SYNNEX_PROVIDER_ERROR'
     );
   }
   if (response.status === 401 || response.status === 403) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX rejected the configured credentials', 401, 'TD_SYNNEX_AUTH_FAILED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX rejected the configured credentials', 'TD_SYNNEX_AUTH_FAILED');
   }
   const text = await response.text();
   let parsed: unknown = null;
   try {
     parsed = text ? JSON.parse(text) as unknown : null;
   } catch {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX returned an invalid JSON response', 502, 'TD_SYNNEX_PROVIDER_ERROR');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX returned an invalid JSON response', 'TD_SYNNEX_PROVIDER_ERROR');
   }
   if (!response.ok) {
-    throw new TdSynnexDigitalBridgeError(`TD SYNNEX request failed with HTTP ${response.status}`, 502, 'TD_SYNNEX_PROVIDER_ERROR');
+    throw new TdSynnexDigitalBridgeError(`TD SYNNEX request failed with HTTP ${response.status}`, 'TD_SYNNEX_PROVIDER_ERROR');
   }
   return parsed;
 }
@@ -377,14 +420,20 @@ function productArray(payload: unknown): Array<Record<string, unknown>> {
 
 export function normalizeTdSynnexProducts(payload: unknown): TdSynnexProduct[] {
   const now = new Date().toISOString();
-  return productArray(payload).map((product, index) => {
-    const sourceProductId = pickString(product, ['id', 'productId', 'itemId', 'tdSynnexItemId', 'sku', 'partNumber']) ?? `result-${index}`;
+  const products: TdSynnexProduct[] = [];
+  for (const product of productArray(payload)) {
+    const sourceProductId = pickString(product, ['id', 'productId', 'itemId', 'tdSynnexItemId', 'sku', 'partNumber']);
     const sku = pickString(product, ['sku', 'tdSku', 'tdSynnexSku', 'itemNumber', 'partNumber']);
-    const name = pickString(product, ['name', 'title', 'productName', 'description']) ?? sku ?? sourceProductId;
+    // Require a stable identifier. Fabricating `result-${index}` ids collides
+    // across searches (React keys, distributor.sourceProductId) and lets garbage
+    // provider rows import as meaningless catalog items — skip them instead.
+    const resolvedId = sourceProductId ?? sku;
+    if (!resolvedId) continue;
+    const name = pickString(product, ['name', 'title', 'productName', 'description']) ?? sku ?? resolvedId;
     const cost = pickNumber(product, ['cost', 'price', 'netPrice', 'dealerPrice', 'unitCost']);
-    return {
+    products.push({
       source: 'td_synnex_digital_bridge',
-      sourceProductId,
+      sourceProductId: resolvedId,
       sku,
       manufacturerPartNumber: pickString(product, ['manufacturerPartNumber', 'mfrPartNumber', 'mpn', 'vendorPartNumber']),
       vendor: pickString(product, ['vendor', 'manufacturer', 'brand']),
@@ -396,8 +445,9 @@ export function normalizeTdSynnexProducts(payload: unknown): TdSynnexProduct[] {
       warehouses: pickArray(product, ['warehouses', 'warehouseAvailability', 'inventory']),
       raw: product,
       lastRefreshedAt: now
-    };
-  });
+    });
+  }
+  return products;
 }
 
 export async function testTdSynnexDigitalBridgeConnection(actor: CatalogActor) {
@@ -405,7 +455,7 @@ export async function testTdSynnexDigitalBridgeConnection(actor: CatalogActor) {
   const settings = asRecord(row.settings);
   const testPath = asString(settings.testPath);
   if (!testPath) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX test endpoint path is not configured', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX test endpoint path is not configured', 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   }
   try {
     await requestDigitalBridge(row, testPath, { method: 'GET', query: { region: row.region } });
@@ -434,15 +484,26 @@ export async function searchTdSynnexProducts(query: { q: string; limit: number }
   const settings = asRecord(row.settings);
   const searchPath = asString(settings.searchPath);
   if (!searchPath) {
-    throw new TdSynnexDigitalBridgeError('TD SYNNEX search endpoint path is not configured', 400, 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
+    throw new TdSynnexDigitalBridgeError('TD SYNNEX search endpoint path is not configured', 'TD_SYNNEX_ENDPOINT_NOT_CONFIGURED');
   }
   const accountId = asString(settings.accountId);
   const method = asMethod(settings.searchMethod);
-  const payload = await requestDigitalBridge(row, searchPath, {
-    method,
-    query: { q: query.q, query: query.q, limit: query.limit, region: row.region, accountId },
-    body: { q: query.q, query: query.q, limit: query.limit, region: row.region, accountId }
-  });
+  let payload: unknown;
+  try {
+    payload = await requestDigitalBridge(row, searchPath, {
+      method,
+      query: { q: query.q, query: query.q, limit: query.limit, region: row.region, accountId },
+      body: { q: query.q, query: query.q, limit: query.limit, region: row.region, accountId }
+    });
+  } catch (err) {
+    // Record the failure so the status panel reflects an unhealthy integration
+    // instead of a stale "last sync succeeded" — mirrors the test-connection path.
+    await db
+      .update(tdSynnexDigitalBridgeIntegrations)
+      .set({ lastError: err instanceof Error ? err.message : 'TD SYNNEX search failed', updatedAt: new Date() })
+      .where(eq(tdSynnexDigitalBridgeIntegrations.id, row.id));
+    throw err;
+  }
   const products = normalizeTdSynnexProducts(payload).slice(0, query.limit);
   await db
     .update(tdSynnexDigitalBridgeIntegrations)
@@ -465,19 +526,11 @@ export interface ImportTdSynnexCatalogItemInput {
 }
 
 export async function importTdSynnexCatalogItem(input: ImportTdSynnexCatalogItemInput, actor: CatalogActor) {
-  const partnerId = requirePartner(actor);
   await getActiveIntegration(actor);
   const existingSku = input.item.sku?.trim();
-  if (existingSku) {
-    const existing = await db
-      .select({ id: catalogItems.id })
-      .from(catalogItems)
-      .where(and(eq(catalogItems.partnerId, partnerId), eq(catalogItems.sku, existingSku)))
-      .limit(1);
-    if (existing.length > 0) {
-      throw new TdSynnexDigitalBridgeError('An item with this SKU already exists', 409, 'TD_SYNNEX_DUPLICATE_SKU');
-    }
-  }
+  // Duplicate-SKU is enforced authoritatively by createCatalogItem's partial
+  // unique index (it throws CatalogServiceError DUPLICATE_SKU/409, mapped by the
+  // route). A pre-check here would only add a TOCTOU race and a second error code.
   const catalogInput: CreateCatalogItemInput = {
     itemType: 'hardware',
     name: input.item.name,

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -29,7 +29,7 @@ interface ExpandState {
   economics: BundleEconomics | null;
 }
 
-export default function CatalogItemsTab() {
+export default function CatalogItemsTab({ reloadKey = 0 }: { reloadKey?: number }) {
   const [items, setItems] = useState<CatalogItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -71,7 +71,7 @@ export default function CatalogItemsTab() {
     }
   }, []);
 
-  useEffect(() => { void load(view); }, [load, view]);
+  useEffect(() => { void load(view); }, [load, view, reloadKey]);
 
   const openCreate = () => { setEditItem(null); setDrawerOpen(true); };
   const openEdit = (it: CatalogItem) => { setEditItem(it); setDrawerOpen(true); };

--- a/apps/web/src/components/settings/CatalogSettingsPage.tsx
+++ b/apps/web/src/components/settings/CatalogSettingsPage.tsx
@@ -1,7 +1,10 @@
 import { getJwtClaims } from '../../lib/authScope';
 import CatalogItemsTab from './CatalogItemsTab';
+import TdSynnexCatalogPanel from './TdSynnexCatalogPanel';
+import { useState } from 'react';
 
 export default function CatalogSettingsPage() {
+  const [reloadKey, setReloadKey] = useState(0);
   // Catalog routes enforce requireScope('partner','system') server-side. Gate
   // the page client-side so org-scope users get a clear "partner accounts only"
   // message instead of a misleading load error. getJwtClaims returns null scope
@@ -33,7 +36,8 @@ export default function CatalogSettingsPage() {
           Manage hardware, software, and service items used across quotes, contracts, and invoices.
         </p>
       </div>
-      <CatalogItemsTab />
+      <TdSynnexCatalogPanel onImported={() => setReloadKey((key) => key + 1)} />
+      <CatalogItemsTab reloadKey={reloadKey} />
     </div>
   );
 }

--- a/apps/web/src/components/settings/TdSynnexCatalogPanel.test.tsx
+++ b/apps/web/src/components/settings/TdSynnexCatalogPanel.test.tsx
@@ -125,4 +125,41 @@ describe('TdSynnexCatalogPanel', () => {
     });
     expect(onImported).toHaveBeenCalledOnce();
   });
+
+  it('surfaces an import failure and does not fire the imported callback', async () => {
+    const onImported = vi.fn();
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonResponse(statusPayload))
+      .mockResolvedValueOnce(jsonResponse({ data: [product] }))
+      .mockResolvedValueOnce(jsonResponse({ error: 'An item with this SKU already exists', code: 'DUPLICATE_SKU' }, 409));
+
+    render(<TdSynnexCatalogPanel onImported={onImported} />);
+    await screen.findByTestId('td-synnex-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-search-query'), { target: { value: 'dock' } });
+    fireEvent.click(screen.getByTestId('td-synnex-search'));
+    fireEvent.click(await screen.findByTestId('td-synnex-import-open-td-1'));
+    fireEvent.change(screen.getByTestId('td-synnex-import-price'), { target: { value: '125.00' } });
+    fireEvent.click(screen.getByTestId('td-synnex-import-save'));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(onImported).not.toHaveBeenCalled();
+  });
+
+  it('treats an HTTP-200 { success:false } search body as a failure', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonResponse(statusPayload))
+      .mockResolvedValueOnce(jsonResponse({ success: false, error: 'Search backend down' }, 200));
+
+    render(<TdSynnexCatalogPanel />);
+    await screen.findByTestId('td-synnex-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-search-query'), { target: { value: 'dock' } });
+    fireEvent.click(screen.getByTestId('td-synnex-search'));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(screen.queryByText('ThinkPad Dock')).toBeNull();
+  });
 });

--- a/apps/web/src/components/settings/TdSynnexCatalogPanel.test.tsx
+++ b/apps/web/src/components/settings/TdSynnexCatalogPanel.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+const showToast = vi.fn();
+const navigateTo = vi.fn();
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
+vi.mock('../shared/Toast', () => ({ showToast: (...args: unknown[]) => showToast(...args) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+vi.mock('../../lib/authScope', () => ({ loginPathWithNext: () => '/login?next=/settings/catalog' }));
+
+import TdSynnexCatalogPanel from './TdSynnexCatalogPanel';
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const statusPayload = {
+  data: {
+    configured: true,
+    enabled: true,
+    environment: 'sandbox',
+    region: 'US',
+    baseUrl: 'https://digitalbridge.test',
+    authType: 'api_key',
+    credentials: { apiKey: '********', apiSecret: '********' },
+    settings: {
+      accountId: 'acct-1',
+      testPath: '/health',
+      searchPath: '/catalog/search',
+      searchMethod: 'GET',
+    },
+    lastTestStatus: null,
+  },
+};
+
+const product = {
+  source: 'td_synnex_digital_bridge',
+  sourceProductId: 'td-1',
+  sku: 'SKU-1',
+  manufacturerPartNumber: 'MPN-1',
+  vendor: 'Lenovo',
+  name: 'ThinkPad Dock',
+  description: 'USB-C dock',
+  cost: '100.00',
+  currency: 'USD',
+  availability: 5,
+  warehouses: [],
+  raw: {},
+  lastRefreshedAt: '2026-06-18T00:00:00.000Z',
+};
+
+describe('TdSynnexCatalogPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuth.mockResolvedValue(jsonResponse(statusPayload));
+  });
+
+  it('loads and renders masked credential status', async () => {
+    render(<TdSynnexCatalogPanel />);
+
+    expect(await screen.findByTestId('td-synnex-panel')).toBeTruthy();
+    expect((screen.getByTestId('td-synnex-api-key') as HTMLInputElement).value).toBe('********');
+    expect(screen.getByTestId('td-synnex-status-label').textContent).toContain('Configured');
+  });
+
+  it('saves configuration with runAction', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonResponse(statusPayload))
+      .mockResolvedValueOnce(jsonResponse(statusPayload));
+
+    render(<TdSynnexCatalogPanel />);
+    await screen.findByTestId('td-synnex-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-base-url'), { target: { value: 'https://digitalbridge.example.test' } });
+    fireEvent.click(screen.getByTestId('td-synnex-save'));
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        '/catalog/distributors/td-synnex/config',
+        expect.objectContaining({ method: 'PUT' })
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('searches and renders pricing and availability', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonResponse(statusPayload))
+      .mockResolvedValueOnce(jsonResponse({ data: [product] }));
+
+    render(<TdSynnexCatalogPanel />);
+    await screen.findByTestId('td-synnex-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-search-query'), { target: { value: 'dock' } });
+    fireEvent.click(screen.getByTestId('td-synnex-search'));
+
+    expect(await screen.findByText('ThinkPad Dock')).toBeTruthy();
+    expect(screen.getByText('USD 100.00')).toBeTruthy();
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('imports a selected product and calls the imported callback', async () => {
+    const onImported = vi.fn();
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonResponse(statusPayload))
+      .mockResolvedValueOnce(jsonResponse({ data: [product] }))
+      .mockResolvedValueOnce(jsonResponse({ data: { id: 'catalog-1' } }));
+
+    render(<TdSynnexCatalogPanel onImported={onImported} />);
+    await screen.findByTestId('td-synnex-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-search-query'), { target: { value: 'dock' } });
+    fireEvent.click(screen.getByTestId('td-synnex-search'));
+    fireEvent.click(await screen.findByTestId('td-synnex-import-open-td-1'));
+    fireEvent.change(screen.getByTestId('td-synnex-import-price'), { target: { value: '125.00' } });
+    fireEvent.click(screen.getByTestId('td-synnex-import-save'));
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        '/catalog/distributors/td-synnex/import',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+    expect(onImported).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/settings/TdSynnexCatalogPanel.tsx
+++ b/apps/web/src/components/settings/TdSynnexCatalogPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CheckCircle2, Plug, Search } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { isApiFailure, extractApiError } from '../../lib/apiError';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
@@ -146,7 +147,8 @@ export default function TdSynnexCatalogPanel({ onImported }: { onImported?: () =
       const body = (await res.json()) as { data: IntegrationStatus };
       setStatus(body.data);
       setConfig(configFromStatus(body.data));
-    } catch {
+    } catch (err) {
+      console.error('[td-synnex] status load failed', err);
       showToast({ message: 'TD SYNNEX settings failed to load.', type: 'error' });
     } finally {
       setLoading(false);
@@ -229,7 +231,11 @@ export default function TdSynnexCatalogPanel({ onImported }: { onImported?: () =
         return;
       }
       const body = await res.json().catch(() => null) as { data?: TdSynnexProduct[]; error?: string } | null;
-      if (!res.ok) throw new Error(body?.error ?? 'Search failed');
+      // Honor the runAction failure contract: a non-2xx status OR an HTTP-200
+      // { success:false } body both count as failures (CLAUDE.md no-silent-mutations).
+      if (isApiFailure(body, res.status)) {
+        throw new Error(extractApiError(body, 'TD SYNNEX search failed.'));
+      }
       setProducts(body?.data ?? []);
     } catch (err) {
       showToast({ message: err instanceof Error ? err.message : 'TD SYNNEX search failed.', type: 'error' });

--- a/apps/web/src/components/settings/TdSynnexCatalogPanel.tsx
+++ b/apps/web/src/components/settings/TdSynnexCatalogPanel.tsx
@@ -1,0 +1,572 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, Plug, Search } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+
+const MASKED = '********';
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+interface IntegrationStatus {
+  configured: boolean;
+  enabled: boolean;
+  environment?: 'sandbox' | 'production';
+  region?: string;
+  baseUrl?: string;
+  authType?: 'api_key' | 'bearer' | 'basic';
+  credentials?: { apiKey?: string; apiSecret?: string };
+  settings?: {
+    accountId?: string;
+    testPath?: string;
+    searchPath?: string;
+    searchMethod?: 'GET' | 'POST';
+    detailsPath?: string;
+    availabilityPath?: string;
+  };
+  lastTestStatus?: string | null;
+  lastTestAt?: string | null;
+  lastTestError?: string | null;
+}
+
+interface ConfigForm {
+  enabled: boolean;
+  environment: 'sandbox' | 'production';
+  region: string;
+  baseUrl: string;
+  authType: 'api_key' | 'bearer' | 'basic';
+  apiKey: string;
+  apiSecret: string;
+  accountId: string;
+  testPath: string;
+  searchPath: string;
+  searchMethod: 'GET' | 'POST';
+}
+
+interface TdSynnexProduct {
+  source: 'td_synnex_digital_bridge';
+  sourceProductId: string;
+  sku: string | null;
+  manufacturerPartNumber: string | null;
+  vendor: string | null;
+  name: string;
+  description: string | null;
+  cost: string | null;
+  currency: string | null;
+  availability: number | null;
+  warehouses: Array<Record<string, unknown>>;
+  raw: Record<string, unknown>;
+  lastRefreshedAt: string;
+}
+
+interface ImportForm {
+  name: string;
+  sku: string;
+  description: string;
+  unitPrice: string;
+  costBasis: string;
+  markupPercent: string;
+  taxable: boolean;
+}
+
+const EMPTY_CONFIG: ConfigForm = {
+  enabled: false,
+  environment: 'sandbox',
+  region: 'US',
+  baseUrl: '',
+  authType: 'api_key',
+  apiKey: '',
+  apiSecret: '',
+  accountId: '',
+  testPath: '',
+  searchPath: '',
+  searchMethod: 'GET',
+};
+
+function configFromStatus(status: IntegrationStatus | null): ConfigForm {
+  if (!status?.configured && !status?.baseUrl) return EMPTY_CONFIG;
+  return {
+    enabled: status.enabled,
+    environment: status.environment ?? 'sandbox',
+    region: status.region ?? 'US',
+    baseUrl: status.baseUrl ?? '',
+    authType: status.authType ?? 'api_key',
+    apiKey: status.credentials?.apiKey ?? '',
+    apiSecret: status.credentials?.apiSecret ?? '',
+    accountId: status.settings?.accountId ?? '',
+    testPath: status.settings?.testPath ?? '',
+    searchPath: status.settings?.searchPath ?? '',
+    searchMethod: status.settings?.searchMethod ?? 'GET',
+  };
+}
+
+function productImportDefaults(product: TdSynnexProduct): ImportForm {
+  const cost = product.cost ?? '';
+  return {
+    name: product.name,
+    sku: product.sku ?? product.manufacturerPartNumber ?? '',
+    description: product.description ?? '',
+    unitPrice: cost,
+    costBasis: cost,
+    markupPercent: '',
+    taxable: true,
+  };
+}
+
+function toMoney(value: string): number | null {
+  if (!value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Number(parsed.toFixed(2)) : null;
+}
+
+export default function TdSynnexCatalogPanel({ onImported }: { onImported?: () => void }) {
+  const [status, setStatus] = useState<IntegrationStatus | null>(null);
+  const [config, setConfig] = useState<ConfigForm>(EMPTY_CONFIG);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [query, setQuery] = useState('');
+  const [products, setProducts] = useState<TdSynnexProduct[]>([]);
+  const [draftProduct, setDraftProduct] = useState<TdSynnexProduct | null>(null);
+  const [importForm, setImportForm] = useState<ImportForm | null>(null);
+  const [importing, setImporting] = useState(false);
+  const endpointReady = config.searchPath.trim().length > 0;
+
+  const loadStatus = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth('/catalog/distributors/td-synnex/status');
+      if (res.status === 401) {
+        UNAUTHORIZED();
+        return;
+      }
+      if (!res.ok) throw new Error('failed');
+      const body = (await res.json()) as { data: IntegrationStatus };
+      setStatus(body.data);
+      setConfig(configFromStatus(body.data));
+    } catch {
+      showToast({ message: 'TD SYNNEX settings failed to load.', type: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadStatus(); }, [loadStatus]);
+
+  const connectionLabel = useMemo(() => {
+    if (status?.lastTestStatus === 'success') return 'Last test succeeded';
+    if (status?.lastTestStatus === 'failed') return status.lastTestError ?? 'Last test failed';
+    if (status?.configured) return 'Configured';
+    return 'Not configured';
+  }, [status]);
+
+  const saveConfig = useCallback(async () => {
+    setSaving(true);
+    try {
+      const result = await runAction<{ data: IntegrationStatus }>({
+        request: () => fetchWithAuth('/catalog/distributors/td-synnex/config', {
+          method: 'PUT',
+          body: JSON.stringify({
+            enabled: config.enabled,
+            environment: config.environment,
+            region: config.region.trim(),
+            baseUrl: config.baseUrl.trim(),
+            authType: config.authType,
+            credentials: {
+              apiKey: config.apiKey.trim(),
+              apiSecret: config.apiSecret.trim(),
+            },
+            settings: {
+              accountId: config.accountId.trim() || undefined,
+              testPath: config.testPath.trim() || undefined,
+              searchPath: config.searchPath.trim() || undefined,
+              searchMethod: config.searchMethod,
+            },
+          }),
+        }),
+        errorFallback: 'TD SYNNEX settings failed to save.',
+        successMessage: 'TD SYNNEX settings saved',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setStatus(result.data);
+      setConfig(configFromStatus(result.data));
+    } catch (err) {
+      handleActionError(err, 'TD SYNNEX settings failed to save.');
+    } finally {
+      setSaving(false);
+    }
+  }, [config]);
+
+  const testConnection = useCallback(async () => {
+    setTesting(true);
+    try {
+      const result = await runAction<{ data: IntegrationStatus }>({
+        request: () => fetchWithAuth('/catalog/distributors/td-synnex/test', { method: 'POST' }),
+        errorFallback: 'TD SYNNEX connection test failed.',
+        successMessage: 'TD SYNNEX connection test succeeded',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setStatus(result.data);
+      setConfig(configFromStatus(result.data));
+    } catch (err) {
+      handleActionError(err, 'TD SYNNEX connection test failed.');
+      void loadStatus();
+    } finally {
+      setTesting(false);
+    }
+  }, [loadStatus]);
+
+  const searchProducts = useCallback(async () => {
+    if (!query.trim()) return;
+    setSearching(true);
+    setProducts([]);
+    try {
+      const res = await fetchWithAuth(`/catalog/distributors/td-synnex/search?q=${encodeURIComponent(query.trim())}&limit=20`);
+      if (res.status === 401) {
+        UNAUTHORIZED();
+        return;
+      }
+      const body = await res.json().catch(() => null) as { data?: TdSynnexProduct[]; error?: string } | null;
+      if (!res.ok) throw new Error(body?.error ?? 'Search failed');
+      setProducts(body?.data ?? []);
+    } catch (err) {
+      showToast({ message: err instanceof Error ? err.message : 'TD SYNNEX search failed.', type: 'error' });
+    } finally {
+      setSearching(false);
+    }
+  }, [query]);
+
+  const openImport = (product: TdSynnexProduct) => {
+    setDraftProduct(product);
+    setImportForm(productImportDefaults(product));
+  };
+
+  const importProduct = useCallback(async () => {
+    if (!draftProduct || !importForm) return;
+    const unitPrice = toMoney(importForm.unitPrice);
+    if (unitPrice === null) {
+      showToast({ message: 'Enter a valid sell price.', type: 'error' });
+      return;
+    }
+    setImporting(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/catalog/distributors/td-synnex/import', {
+          method: 'POST',
+          body: JSON.stringify({
+            product: draftProduct,
+            item: {
+              name: importForm.name.trim(),
+              sku: importForm.sku.trim() || null,
+              description: importForm.description.trim() || null,
+              unitPrice,
+              costBasis: toMoney(importForm.costBasis),
+              markupPercent: toMoney(importForm.markupPercent),
+              taxable: importForm.taxable,
+            },
+          }),
+        }),
+        errorFallback: 'TD SYNNEX item import failed.',
+        successMessage: `Imported ${importForm.name.trim()}`,
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setDraftProduct(null);
+      setImportForm(null);
+      if (onImported) onImported();
+    } catch (err) {
+      handleActionError(err, 'TD SYNNEX item import failed.');
+    } finally {
+      setImporting(false);
+    }
+  }, [draftProduct, importForm, onImported]);
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground" data-testid="td-synnex-loading">Loading TD SYNNEX.</p>;
+  }
+
+  return (
+    <section className="space-y-4 border-t pt-6" data-testid="td-synnex-panel">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 text-lg font-semibold">
+            <Plug className="h-4 w-4" aria-hidden="true" />
+            TD SYNNEX
+          </h2>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Connect Digital Bridge to search real-time distributor catalog data and import hardware into Breeze.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground" data-testid="td-synnex-status-label">
+          {status?.lastTestStatus === 'success' && <CheckCircle2 className="h-4 w-4 text-green-600" aria-hidden="true" />}
+          {connectionLabel}
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <label className="text-xs font-medium">
+          Base URL
+          <input
+            value={config.baseUrl}
+            onChange={(e) => setConfig((f) => ({ ...f, baseUrl: e.target.value }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            placeholder="https://..."
+            data-testid="td-synnex-base-url"
+          />
+        </label>
+        <label className="text-xs font-medium">
+          Region
+          <input
+            value={config.region}
+            onChange={(e) => setConfig((f) => ({ ...f, region: e.target.value }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            data-testid="td-synnex-region"
+          />
+        </label>
+        <label className="text-xs font-medium">
+          Environment
+          <select
+            value={config.environment}
+            onChange={(e) => setConfig((f) => ({ ...f, environment: e.target.value as ConfigForm['environment'] }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            data-testid="td-synnex-environment"
+          >
+            <option value="sandbox">Sandbox</option>
+            <option value="production">Production</option>
+          </select>
+        </label>
+        <label className="text-xs font-medium">
+          Auth type
+          <select
+            value={config.authType}
+            onChange={(e) => setConfig((f) => ({ ...f, authType: e.target.value as ConfigForm['authType'] }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            data-testid="td-synnex-auth-type"
+          >
+            <option value="api_key">API key headers</option>
+            <option value="bearer">Bearer token</option>
+            <option value="basic">Basic auth</option>
+          </select>
+        </label>
+        <label className="text-xs font-medium">
+          API key
+          <input
+            value={config.apiKey}
+            onChange={(e) => setConfig((f) => ({ ...f, apiKey: e.target.value }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            placeholder={MASKED}
+            data-testid="td-synnex-api-key"
+          />
+        </label>
+        <label className="text-xs font-medium">
+          API secret
+          <input
+            value={config.apiSecret}
+            onChange={(e) => setConfig((f) => ({ ...f, apiSecret: e.target.value }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            placeholder={MASKED}
+            type="password"
+            data-testid="td-synnex-api-secret"
+          />
+        </label>
+        <label className="text-xs font-medium">
+          Account ID
+          <input
+            value={config.accountId}
+            onChange={(e) => setConfig((f) => ({ ...f, accountId: e.target.value }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            data-testid="td-synnex-account-id"
+          />
+        </label>
+        <label className="text-xs font-medium">
+          Test path
+          <input
+            value={config.testPath}
+            onChange={(e) => setConfig((f) => ({ ...f, testPath: e.target.value }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            placeholder="/..."
+            data-testid="td-synnex-test-path"
+          />
+        </label>
+        <label className="text-xs font-medium">
+          Search path
+          <input
+            value={config.searchPath}
+            onChange={(e) => setConfig((f) => ({ ...f, searchPath: e.target.value }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            placeholder="/..."
+            data-testid="td-synnex-search-path"
+          />
+        </label>
+        <label className="text-xs font-medium">
+          Search method
+          <select
+            value={config.searchMethod}
+            onChange={(e) => setConfig((f) => ({ ...f, searchMethod: e.target.value as ConfigForm['searchMethod'] }))}
+            className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            data-testid="td-synnex-search-method"
+          >
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={config.enabled}
+            onChange={(e) => setConfig((f) => ({ ...f, enabled: e.target.checked }))}
+            data-testid="td-synnex-enabled"
+          />
+          Enabled
+        </label>
+        <button
+          type="button"
+          onClick={() => void saveConfig()}
+          disabled={saving || !config.baseUrl.trim()}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+          data-testid="td-synnex-save"
+        >
+          {saving ? 'Saving.' : 'Save settings'}
+        </button>
+        <button
+          type="button"
+          onClick={() => void testConnection()}
+          disabled={testing || !config.enabled || !config.testPath.trim()}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          data-testid="td-synnex-test"
+        >
+          {testing ? 'Testing.' : 'Test connection'}
+        </button>
+      </div>
+
+      <div className="space-y-3 border-t pt-4">
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void searchProducts();
+              }}
+              className="w-full rounded-md border bg-background py-1.5 pl-8 pr-2.5 text-sm"
+              placeholder="Search by SKU, manufacturer part number, or product name"
+              data-testid="td-synnex-search-query"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => void searchProducts()}
+            disabled={searching || !query.trim() || !status?.enabled || !endpointReady}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            data-testid="td-synnex-search"
+          >
+            {searching ? 'Searching.' : 'Search products'}
+          </button>
+        </div>
+
+        {products.length > 0 && (
+          <table className="min-w-full divide-y text-sm" data-testid="td-synnex-results">
+            <thead>
+              <tr className="text-left text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Product</th>
+                <th className="px-3 py-2 font-medium">SKU</th>
+                <th className="px-3 py-2 font-medium">Cost</th>
+                <th className="px-3 py-2 font-medium">Available</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {products.map((product) => (
+                <tr key={product.sourceProductId} data-testid={`td-synnex-result-${product.sourceProductId}`}>
+                  <td className="px-3 py-2">
+                    <div className="font-medium">{product.name}</div>
+                    <div className="text-xs text-muted-foreground">{product.vendor ?? 'Unknown vendor'}</div>
+                  </td>
+                  <td className="px-3 py-2">{product.sku ?? product.manufacturerPartNumber ?? 'N/A'}</td>
+                  <td className="px-3 py-2">{product.cost ? `${product.currency ?? 'USD'} ${product.cost}` : 'N/A'}</td>
+                  <td className="px-3 py-2">{product.availability ?? 'N/A'}</td>
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => openImport(product)}
+                      className="text-sm text-primary hover:underline"
+                      data-testid={`td-synnex-import-open-${product.sourceProductId}`}
+                    >
+                      Import
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {draftProduct && importForm && (
+          <div className="space-y-3 rounded-md border bg-muted/30 p-4" data-testid="td-synnex-import-editor">
+            <div>
+              <h3 className="text-sm font-semibold">Import product</h3>
+              <p className="mt-1 text-xs text-muted-foreground">{draftProduct.name}</p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="text-xs font-medium">
+                Name
+                <input value={importForm.name} onChange={(e) => setImportForm((f) => f && ({ ...f, name: e.target.value }))} className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="td-synnex-import-name" />
+              </label>
+              <label className="text-xs font-medium">
+                SKU
+                <input value={importForm.sku} onChange={(e) => setImportForm((f) => f && ({ ...f, sku: e.target.value }))} className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="td-synnex-import-sku" />
+              </label>
+              <label className="text-xs font-medium">
+                Sell price
+                <input value={importForm.unitPrice} onChange={(e) => setImportForm((f) => f && ({ ...f, unitPrice: e.target.value }))} inputMode="decimal" className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="td-synnex-import-price" />
+              </label>
+              <label className="text-xs font-medium">
+                Cost basis
+                <input value={importForm.costBasis} onChange={(e) => setImportForm((f) => f && ({ ...f, costBasis: e.target.value }))} inputMode="decimal" className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="td-synnex-import-cost" />
+              </label>
+              <label className="text-xs font-medium">
+                Markup percent
+                <input value={importForm.markupPercent} onChange={(e) => setImportForm((f) => f && ({ ...f, markupPercent: e.target.value }))} inputMode="decimal" className="mt-1 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="td-synnex-import-markup" />
+              </label>
+              <label className="flex items-end gap-2 text-sm">
+                <input type="checkbox" checked={importForm.taxable} onChange={(e) => setImportForm((f) => f && ({ ...f, taxable: e.target.checked }))} data-testid="td-synnex-import-taxable" />
+                Taxable
+              </label>
+              <label className="text-xs font-medium md:col-span-2">
+                Description
+                <textarea value={importForm.description} onChange={(e) => setImportForm((f) => f && ({ ...f, description: e.target.value }))} className="mt-1 min-h-20 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="td-synnex-import-description" />
+              </label>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => void importProduct()}
+                disabled={importing || !importForm.name.trim() || toMoney(importForm.unitPrice) === null}
+                className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                data-testid="td-synnex-import-save"
+              >
+                {importing ? 'Importing.' : 'Import item'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setDraftProduct(null);
+                  setImportForm(null);
+                }}
+                className="rounded-md border px-3 py-1.5 text-sm font-medium"
+                data-testid="td-synnex-import-cancel"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a v1 TD SYNNEX Digital Bridge catalog import integration for partner-scoped catalog management.

## What Changed

- Added partner-scoped TD SYNNEX Digital Bridge integration storage with encrypted credentials and RLS coverage.
- Added API routes for status, config, connection test, search, and import under `/catalog/distributors/td-synnex/*`.
- Added a provider adapter with credential masking/preservation, safe outbound URL handling, `safeFetch` transport, timeouts, product normalization, and catalog import metadata.
- Added a Product Catalog TD SYNNEX panel for setup, test, search, preview, and import using `runAction` for mutations.
- Added focused API, RLS, and web tests.

## Validation

- `pnpm --dir apps/api exec vitest run src/routes/catalog/catalog.test.ts src/services/tdSynnexDigitalBridge.test.ts`
- `pnpm --dir apps/web exec vitest run src/components/settings/TdSynnexCatalogPanel.test.tsx`
- `pnpm --dir apps/api exec eslint src/routes/catalog/distributors.ts src/services/tdSynnexDigitalBridge.ts src/services/tdSynnexDigitalBridge.test.ts src/routes/catalog/catalog.test.ts`
- `pnpm --dir apps/web exec eslint src/components/settings/TdSynnexCatalogPanel.tsx src/components/settings/TdSynnexCatalogPanel.test.tsx src/components/settings/CatalogSettingsPage.tsx src/components/settings/CatalogItemsTab.tsx`
- `pnpm --dir apps/api exec tsc --noEmit`
- `pnpm --dir apps/web exec tsc --noEmit`

## Notes

External TD SYNNEX sandbox acceptance still requires real Digital Bridge credentials and the portal-provided endpoint paths.
