### PR TITLE
fix(ml): avoid DB context during metric worker fanout

### DIFF
--- a/apps/api/src/jobs/metricAnomalies.test.ts
+++ b/apps/api/src/jobs/metricAnomalies.test.ts
@@ -13,6 +13,8 @@ const {
   whereMock,
   groupByMock,
   workerProcessorMock,
+  runOutsideDbContextMock,
+  withSystemDbAccessContextMock,
 } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
@@ -26,6 +28,8 @@ const {
   whereMock: vi.fn(),
   groupByMock: vi.fn(),
   workerProcessorMock: vi.fn(),
+  runOutsideDbContextMock: vi.fn(<T>(fn: () => T) => fn()),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('bullmq', () => ({
@@ -58,7 +62,8 @@ vi.mock('../services/bullmqUtils', () => ({
 
 vi.mock('../db', () => ({
   db: { select: selectMock },
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: runOutsideDbContextMock,
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
 }));
 
 vi.mock('../db/schema', () => ({
@@ -96,6 +101,10 @@ describe('metric anomalies queue helpers', () => {
     whereMock.mockReset();
     groupByMock.mockReset();
     workerProcessorMock.mockReset();
+    runOutsideDbContextMock.mockClear();
+    withSystemDbAccessContextMock.mockClear();
+    runOutsideDbContextMock.mockImplementation(<T>(fn: () => T) => fn());
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queued-anomaly-job' });
     addBulkMock.mockResolvedValue([]);
@@ -187,6 +196,40 @@ describe('metric anomalies queue helpers', () => {
           jobId: 'metric-anomalies-org-1-20260618T115500000Z-20260618T122500000Z',
         }),
       }),
+    ]);
+  });
+
+  it('does not hold system DB context while scan fan-out enqueues BullMQ jobs', async () => {
+    const callOrder: string[] = [];
+    runOutsideDbContextMock.mockImplementation(<T>(fn: () => T): T => {
+      callOrder.push('runOutsideDbContext');
+      return fn();
+    });
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => {
+      callOrder.push('withSystemDbAccessContext:start');
+      const result = await fn();
+      callOrder.push('withSystemDbAccessContext:end');
+      return result;
+    });
+    addBulkMock.mockImplementation(async () => {
+      callOrder.push('addBulk');
+      return [];
+    });
+
+    await initializeMetricAnomaliesWorker();
+    addBulkMock.mockClear();
+    await workerProcessorMock({
+      data: {
+        type: 'scan-orgs',
+        lookbackMinutes: 30,
+      },
+    });
+
+    expect(callOrder).toEqual([
+      'runOutsideDbContext',
+      'withSystemDbAccessContext:start',
+      'withSystemDbAccessContext:end',
+      'addBulk',
     ]);
   });
 });

--- a/apps/api/src/jobs/metricAnomalies.ts
+++ b/apps/api/src/jobs/metricAnomalies.ts
@@ -1,7 +1,7 @@
 import { Job, Queue, Worker } from 'bullmq';
 import { sql } from 'drizzle-orm';
 
-import { db, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices } from '../db/schema';
 import { isReusableState } from '../services/bullmqUtils';
 import { detectMetricAnomaliesRange, type MetricAnomalyResult } from '../services/metricAnomalies';
@@ -55,12 +55,18 @@ function recentWindow(now = new Date(), lookbackMinutes = DEFAULT_LOOKBACK_MINUT
   return { from, to };
 }
 
-async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
-  const orgRows = await db
+async function findAnomalyOrgRows(): Promise<Array<{ orgId: string }>> {
+  return db
     .select({ orgId: devices.orgId })
     .from(devices)
     .where(sql`${devices.status} <> 'decommissioned'`)
     .groupBy(devices.orgId);
+}
+
+async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
+  const orgRows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() => findAnomalyOrgRows())
+  );
 
   if (orgRows.length === 0) {
     return { queued: 0 };
@@ -102,13 +108,15 @@ async function processDetectOrgRange(data: DetectOrgRangeJobData): Promise<Metri
 export function createMetricAnomaliesWorker(): Worker<MetricAnomalyJobData> {
   return new Worker<MetricAnomalyJobData>(
     METRIC_ANOMALIES_QUEUE,
-    async (job: Job<MetricAnomalyJobData>) =>
-      withSystemDbAccessContext(async () => {
-        if (job.data.type === 'scan-orgs') {
-          return processScanOrgs(job.data);
-        }
-        return processDetectOrgRange(job.data);
-      }),
+    async (job: Job<MetricAnomalyJobData>) => {
+      if (job.data.type === 'scan-orgs') {
+        return processScanOrgs(job.data);
+      }
+      const data = job.data;
+      return runOutsideDbContext(() =>
+        withSystemDbAccessContext(() => processDetectOrgRange(data))
+      );
+    },
     {
       connection: getBullMQConnection(),
       concurrency: 2,

--- a/apps/api/src/jobs/metricRollups.test.ts
+++ b/apps/api/src/jobs/metricRollups.test.ts
@@ -13,6 +13,8 @@ const {
   whereMock,
   groupByMock,
   workerProcessorMock,
+  runOutsideDbContextMock,
+  withSystemDbAccessContextMock,
 } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
@@ -26,6 +28,8 @@ const {
   whereMock: vi.fn(),
   groupByMock: vi.fn(),
   workerProcessorMock: vi.fn(),
+  runOutsideDbContextMock: vi.fn(<T>(fn: () => T) => fn()),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('bullmq', () => ({
@@ -58,7 +62,8 @@ vi.mock('../services/bullmqUtils', () => ({
 
 vi.mock('../db', () => ({
   db: { select: selectMock },
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: runOutsideDbContextMock,
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
 }));
 
 vi.mock('../db/schema', () => ({
@@ -96,6 +101,10 @@ describe('metric rollups queue helpers', () => {
     whereMock.mockReset();
     groupByMock.mockReset();
     workerProcessorMock.mockReset();
+    runOutsideDbContextMock.mockClear();
+    withSystemDbAccessContextMock.mockClear();
+    runOutsideDbContextMock.mockImplementation(<T>(fn: () => T) => fn());
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queued-rollup-job' });
     addBulkMock.mockResolvedValue([]);
@@ -187,6 +196,40 @@ describe('metric rollups queue helpers', () => {
           jobId: 'metric-rollups-org-1-20260618T121000000Z-20260618T122500000Z',
         }),
       }),
+    ]);
+  });
+
+  it('does not hold system DB context while scan fan-out enqueues BullMQ jobs', async () => {
+    const callOrder: string[] = [];
+    runOutsideDbContextMock.mockImplementation(<T>(fn: () => T): T => {
+      callOrder.push('runOutsideDbContext');
+      return fn();
+    });
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => {
+      callOrder.push('withSystemDbAccessContext:start');
+      const result = await fn();
+      callOrder.push('withSystemDbAccessContext:end');
+      return result;
+    });
+    addBulkMock.mockImplementation(async () => {
+      callOrder.push('addBulk');
+      return [];
+    });
+
+    await initializeMetricRollupsWorker();
+    addBulkMock.mockClear();
+    await workerProcessorMock({
+      data: {
+        type: 'scan-orgs',
+        lookbackMinutes: 15,
+      },
+    });
+
+    expect(callOrder).toEqual([
+      'runOutsideDbContext',
+      'withSystemDbAccessContext:start',
+      'withSystemDbAccessContext:end',
+      'addBulk',
     ]);
   });
 });

--- a/apps/api/src/jobs/metricRollups.ts
+++ b/apps/api/src/jobs/metricRollups.ts
@@ -1,7 +1,7 @@
 import { Job, Queue, Worker } from 'bullmq';
 import { sql } from 'drizzle-orm';
 
-import { db, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices } from '../db/schema';
 import { isReusableState } from '../services/bullmqUtils';
 import { rollupDeviceMetricsRange, type MetricRollupResult } from '../services/metricRollups';
@@ -55,12 +55,18 @@ function recentWindow(now = new Date(), lookbackMinutes = DEFAULT_LOOKBACK_MINUT
   return { from, to };
 }
 
-async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
-  const orgRows = await db
+async function findRollupOrgRows(): Promise<Array<{ orgId: string }>> {
+  return db
     .select({ orgId: devices.orgId })
     .from(devices)
     .where(sql`${devices.status} <> 'decommissioned'`)
     .groupBy(devices.orgId);
+}
+
+async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
+  const orgRows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() => findRollupOrgRows())
+  );
 
   if (orgRows.length === 0) {
     return { queued: 0 };
@@ -102,13 +108,15 @@ async function processRollupOrgRange(data: RollupOrgRangeJobData): Promise<Metri
 export function createMetricRollupsWorker(): Worker<MetricRollupJobData> {
   return new Worker<MetricRollupJobData>(
     METRIC_ROLLUPS_QUEUE,
-    async (job: Job<MetricRollupJobData>) =>
-      withSystemDbAccessContext(async () => {
-        if (job.data.type === 'scan-orgs') {
-          return processScanOrgs(job.data);
-        }
-        return processRollupOrgRange(job.data);
-      }),
+    async (job: Job<MetricRollupJobData>) => {
+      if (job.data.type === 'scan-orgs') {
+        return processScanOrgs(job.data);
+      }
+      const data = job.data;
+      return runOutsideDbContext(() =>
+        withSystemDbAccessContext(() => processRollupOrgRange(data))
+      );
+    },
     {
       connection: getBullMQConnection(),
       concurrency: 2,


### PR DESCRIPTION
## Summary
- run metric rollup/anomaly DB work through runOutsideDbContext + system DB context
- keep BullMQ scan fan-out outside the held DB context
- add worker tests proving queue fan-out happens after the system DB context closes

## Verification
- corepack pnpm --filter @breeze/api exec vitest run src/jobs/metricRollups.test.ts src/jobs/metricAnomalies.test.ts
- corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json
- git diff --check