### PR TITLE
feat(ml): use rollups for device metric history

### DIFF
--- a/apps/api/src/routes/devices/metrics.test.ts
+++ b/apps/api/src/routes/devices/metrics.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const DEVICE_ID = '33333333-3333-4333-8333-333333333333';
+const SITE_ID = '44444444-4444-4444-8444-444444444444';
+
+let allowedSiteIds: string[] | undefined;
+
+vi.mock('../../db', () => {
+  const createChain = (result: unknown = []) => {
+    const chain: Record<string, any> = {};
+    for (const method of ['from', 'where', 'groupBy', 'orderBy', 'limit']) {
+      chain[method] = vi.fn(() => chain);
+    }
+    chain.then = (onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
+      Promise.resolve(result).then(onFulfilled, onRejected);
+    return chain;
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => createChain([])),
+    },
+  };
+});
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: '11111111-1111-4111-8111-111111111111',
+      partnerId: null,
+      accessibleOrgIds: ['11111111-1111-4111-8111-111111111111'],
+      canAccessOrg: (orgId: string) => orgId === '11111111-1111-4111-8111-111111111111',
+      user: { id: '22222222-2222-4222-8222-222222222222', email: 'test@example.com' },
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    c.set('permissions', {
+      permissions: [{ resource: 'devices', action: 'read' }],
+      orgId: '11111111-1111-4111-8111-111111111111',
+      roleId: 'role-1',
+      scope: 'organization',
+      ...(allowedSiteIds ? { allowedSiteIds } : {}),
+    });
+    return next();
+  }),
+}));
+
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+  },
+  canAccessSite: (permissions: { allowedSiteIds?: string[] } | undefined, siteId: string) =>
+    !permissions?.allowedSiteIds || permissions.allowedSiteIds.includes(siteId),
+}));
+
+import { db } from '../../db';
+import { metricsRoutes } from './metrics';
+
+function createChain(result: unknown = []) {
+  const chain: Record<string, any> = {};
+  for (const method of ['from', 'where', 'groupBy', 'orderBy', 'limit']) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.then = (onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected);
+  return chain;
+}
+
+function mockSelectOnce(result: unknown) {
+  vi.mocked(db.select).mockImplementationOnce(() => createChain(result) as never);
+}
+
+const DEVICE = {
+  id: DEVICE_ID,
+  orgId: ORG_ID,
+  siteId: SITE_ID,
+  hostname: 'host-1',
+  osType: 'linux',
+  status: 'online',
+};
+
+const SITE = {
+  timezone: 'America/Denver',
+};
+
+function rawMetricBucket(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    bucket: new Date('2026-06-18T12:00:00.000Z'),
+    avgCpuPercent: 11.125,
+    avgRamPercent: 22.25,
+    avgRamUsedMb: 1024,
+    avgDiskPercent: 33.375,
+    avgDiskUsedGb: 44.5,
+    diskActivityAvailable: true,
+    totalDiskReadBytes: 1000n,
+    totalDiskWriteBytes: 2000n,
+    avgDiskReadBps: 300,
+    avgDiskWriteBps: 400,
+    totalDiskReadOps: 5n,
+    totalDiskWriteOps: 6n,
+    totalNetworkIn: 7000n,
+    totalNetworkOut: 8000n,
+    avgBandwidthIn: 900,
+    avgBandwidthOut: 1000,
+    avgProcessCount: 101,
+    ...overrides,
+  };
+}
+
+describe('device metrics route', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allowedSiteIds = undefined;
+    app = new Hono();
+    app.route('/devices', metricsRoutes);
+  });
+
+  it('uses hourly metric rollups for long-range device history when available', async () => {
+    mockSelectOnce([DEVICE]);
+    mockSelectOnce([SITE]);
+    mockSelectOnce([rawMetricBucket({
+      avgCpuPercent: 42.678,
+      totalDiskReadBytes: 0n,
+      totalDiskWriteBytes: 0n,
+      totalDiskReadOps: 0n,
+      totalDiskWriteOps: 0n,
+      totalNetworkIn: 0n,
+      totalNetworkOut: 0n,
+    })]);
+
+    const res = await app.request(
+      `/devices/${DEVICE_ID}/metrics?range=7d&endDate=2026-06-19T00:00:00.000Z`,
+      { method: 'GET', headers: { Authorization: 'Bearer t' } }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.interval).toBe('1h');
+    expect(body.timezone).toBe('America/Denver');
+    expect(body.data).toEqual([
+      {
+        timestamp: '2026-06-18T12:00:00.000Z',
+        cpu: 42.68,
+        ram: 22.25,
+        ramUsedMb: 1024,
+        disk: 33.38,
+        diskUsedGb: 44.5,
+        diskActivityAvailable: true,
+        diskReadBytes: 0,
+        diskWriteBytes: 0,
+        diskReadBps: 300,
+        diskWriteBps: 400,
+        diskReadOps: 0,
+        diskWriteOps: 0,
+        networkIn: 0,
+        networkOut: 0,
+        bandwidthInBps: 900,
+        bandwidthOutBps: 1000,
+        processCount: 101,
+      },
+    ]);
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to raw device metrics when requested rollups are empty', async () => {
+    mockSelectOnce([DEVICE]);
+    mockSelectOnce([SITE]);
+    mockSelectOnce([]);
+    mockSelectOnce([rawMetricBucket()]);
+
+    const res = await app.request(
+      `/devices/${DEVICE_ID}/metrics?range=7d&endDate=2026-06-19T00:00:00.000Z`,
+      { method: 'GET', headers: { Authorization: 'Bearer t' } }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({
+      timestamp: '2026-06-18T12:00:00.000Z',
+      cpu: 11.13,
+      diskReadBytes: 1000,
+      networkIn: 7000,
+    });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(4);
+  });
+
+  it('keeps one-minute requests on raw metrics', async () => {
+    mockSelectOnce([DEVICE]);
+    mockSelectOnce([SITE]);
+    mockSelectOnce([rawMetricBucket()]);
+
+    const res = await app.request(
+      `/devices/${DEVICE_ID}/metrics?interval=1m&startDate=2026-06-18T00:00:00.000Z&endDate=2026-06-19T00:00:00.000Z`,
+      { method: 'GET', headers: { Authorization: 'Bearer t' } }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.interval).toBe('1m');
+    expect(body.data[0].diskReadBytes).toBe(1000);
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not query metrics when site scope denies the device', async () => {
+    allowedSiteIds = ['55555555-5555-4555-8555-555555555555'];
+    mockSelectOnce([DEVICE]);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/metrics?range=7d`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Access to this site denied' });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/routes/devices/metrics.ts
+++ b/apps/api/src/routes/devices/metrics.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, gte, lte, sql, asc } from 'drizzle-orm';
+import { and, eq, gte, inArray, lte, sql, asc } from 'drizzle-orm';
 import { db } from '../../db';
-import { deviceMetrics, sites } from '../../db/schema';
+import { deviceMetrics, metricRollups, sites } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
@@ -12,28 +12,153 @@ export const metricsRoutes = new Hono();
 
 metricsRoutes.use('*', authMiddleware);
 
+type DeviceMetricBucket = {
+  bucket: Date;
+  avgCpuPercent: number;
+  avgRamPercent: number;
+  avgRamUsedMb: number;
+  avgDiskPercent: number;
+  avgDiskUsedGb: number;
+  diskActivityAvailable: boolean;
+  totalDiskReadBytes: bigint;
+  totalDiskWriteBytes: bigint;
+  avgDiskReadBps: number;
+  avgDiskWriteBps: number;
+  totalDiskReadOps: bigint;
+  totalDiskWriteOps: bigint;
+  totalNetworkIn: bigint;
+  totalNetworkOut: bigint;
+  avgBandwidthIn: number;
+  avgBandwidthOut: number;
+  avgProcessCount: number;
+};
+
+const ROLLUP_METRIC_NAMES = [
+  'cpu_percent',
+  'ram_percent',
+  'ram_used_mb',
+  'disk_percent',
+  'disk_used_gb',
+  'disk_read_bps',
+  'disk_write_bps',
+  'bandwidth_in_bps',
+  'bandwidth_out_bps',
+  'process_count',
+] as const;
+
+function rollupWeightedAvg(metricName: (typeof ROLLUP_METRIC_NAMES)[number]) {
+  return sql<number>`
+    sum(${metricRollups.avgValue} * ${metricRollups.sampleCount})
+      filter (where ${metricRollups.metricName} = ${metricName})
+    / nullif(
+      sum(${metricRollups.sampleCount})
+        filter (where ${metricRollups.metricName} = ${metricName}),
+      0
+    )
+  `;
+}
+
+function rollupBucketSeconds(interval: '1m' | '5m' | '1h' | '1d'): 3600 | 86400 | undefined {
+  if (interval === '1h') return 3600;
+  if (interval === '1d') return 86400;
+  return undefined;
+}
+
+async function queryMetricRollups(
+  orgId: string,
+  deviceId: string,
+  startDate: Date,
+  endDate: Date,
+  interval: '1m' | '5m' | '1h' | '1d'
+): Promise<DeviceMetricBucket[]> {
+  const bucketSeconds = rollupBucketSeconds(interval);
+  if (!bucketSeconds) return [];
+
+  return db
+    .select({
+      bucket: metricRollups.bucketStart,
+      avgCpuPercent: rollupWeightedAvg('cpu_percent'),
+      avgRamPercent: rollupWeightedAvg('ram_percent'),
+      avgRamUsedMb: rollupWeightedAvg('ram_used_mb'),
+      avgDiskPercent: rollupWeightedAvg('disk_percent'),
+      avgDiskUsedGb: rollupWeightedAvg('disk_used_gb'),
+      diskActivityAvailable: sql<boolean>`
+        coalesce(
+          sum(${metricRollups.sampleCount})
+            filter (where ${metricRollups.metricName} in ('disk_read_bps', 'disk_write_bps')),
+          0
+        ) > 0
+      `,
+      totalDiskReadBytes: sql<bigint>`0::bigint`,
+      totalDiskWriteBytes: sql<bigint>`0::bigint`,
+      avgDiskReadBps: rollupWeightedAvg('disk_read_bps'),
+      avgDiskWriteBps: rollupWeightedAvg('disk_write_bps'),
+      totalDiskReadOps: sql<bigint>`0::bigint`,
+      totalDiskWriteOps: sql<bigint>`0::bigint`,
+      totalNetworkIn: sql<bigint>`0::bigint`,
+      totalNetworkOut: sql<bigint>`0::bigint`,
+      avgBandwidthIn: rollupWeightedAvg('bandwidth_in_bps'),
+      avgBandwidthOut: rollupWeightedAvg('bandwidth_out_bps'),
+      avgProcessCount: rollupWeightedAvg('process_count'),
+    })
+    .from(metricRollups)
+    .where(
+      and(
+        eq(metricRollups.orgId, orgId),
+        eq(metricRollups.deviceId, deviceId),
+        eq(metricRollups.sourceTable, 'device_metrics'),
+        eq(metricRollups.bucketSeconds, bucketSeconds),
+        inArray(metricRollups.metricName, [...ROLLUP_METRIC_NAMES]),
+        sql`${metricRollups.sampleCount} > 0`,
+        gte(metricRollups.bucketStart, startDate),
+        lte(metricRollups.bucketStart, endDate)
+      )
+    )
+    .groupBy(metricRollups.bucketStart)
+    .orderBy(asc(metricRollups.bucketStart));
+}
+
+async function queryRawMetricBuckets(
+  deviceId: string,
+  startDate: Date,
+  endDate: Date
+): Promise<DeviceMetricBucket[]> {
+  return db
+    .select({
+      bucket: sql<Date>`date_trunc('minute', ${deviceMetrics.timestamp})`,
+      avgCpuPercent: sql<number>`avg(${deviceMetrics.cpuPercent})`,
+      avgRamPercent: sql<number>`avg(${deviceMetrics.ramPercent})`,
+      avgRamUsedMb: sql<number>`avg(${deviceMetrics.ramUsedMb})`,
+      avgDiskPercent: sql<number>`avg(${deviceMetrics.diskPercent})`,
+      avgDiskUsedGb: sql<number>`avg(${deviceMetrics.diskUsedGb})`,
+      diskActivityAvailable: sql<boolean>`bool_or(coalesce(${deviceMetrics.diskActivityAvailable}, false))`,
+      totalDiskReadBytes: sql<bigint>`sum(${deviceMetrics.diskReadBytes})`,
+      totalDiskWriteBytes: sql<bigint>`sum(${deviceMetrics.diskWriteBytes})`,
+      avgDiskReadBps: sql<number>`avg(${deviceMetrics.diskReadBps})::float8`,
+      avgDiskWriteBps: sql<number>`avg(${deviceMetrics.diskWriteBps})::float8`,
+      totalDiskReadOps: sql<bigint>`sum(${deviceMetrics.diskReadOps})`,
+      totalDiskWriteOps: sql<bigint>`sum(${deviceMetrics.diskWriteOps})`,
+      totalNetworkIn: sql<bigint>`sum(${deviceMetrics.networkInBytes})`,
+      totalNetworkOut: sql<bigint>`sum(${deviceMetrics.networkOutBytes})`,
+      avgBandwidthIn: sql<number>`avg(${deviceMetrics.bandwidthInBps})::float8`,
+      avgBandwidthOut: sql<number>`avg(${deviceMetrics.bandwidthOutBps})::float8`,
+      avgProcessCount: sql<number>`avg(${deviceMetrics.processCount})`
+    })
+    .from(deviceMetrics)
+    .where(
+      and(
+        eq(deviceMetrics.deviceId, deviceId),
+        gte(deviceMetrics.timestamp, startDate),
+        lte(deviceMetrics.timestamp, endDate)
+      )
+    )
+    .groupBy(sql`date_trunc('minute', ${deviceMetrics.timestamp})`)
+    .orderBy(asc(sql`date_trunc('minute', ${deviceMetrics.timestamp})`));
+}
+
 // Helper function to aggregate metrics by interval
 function aggregateMetricsByInterval(
-  data: Array<{
-    bucket: Date;
-    avgCpuPercent: number;
-    avgRamPercent: number;
-    avgRamUsedMb: number;
-    avgDiskPercent: number;
-    avgDiskUsedGb: number;
-    diskActivityAvailable: boolean;
-    totalDiskReadBytes: bigint;
-    totalDiskWriteBytes: bigint;
-    avgDiskReadBps: number;
-    avgDiskWriteBps: number;
-    totalDiskReadOps: bigint;
-    totalDiskWriteOps: bigint;
-    totalNetworkIn: bigint;
-    totalNetworkOut: bigint;
-    avgBandwidthIn: number;
-    avgBandwidthOut: number;
-    avgProcessCount: number;
-  }>,
+  data: DeviceMetricBucket[],
   interval: string,
   bucketSeconds: number
 ): Array<{
@@ -231,38 +356,10 @@ metricsRoutes.get(
 
     const bucketSeconds = intervalSeconds[interval] ?? 300; // default to 5 minutes
 
-    // Query with time bucket aggregation
-    const metricsData = await db
-      .select({
-        bucket: sql<Date>`date_trunc('minute', ${deviceMetrics.timestamp})`,
-        avgCpuPercent: sql<number>`avg(${deviceMetrics.cpuPercent})`,
-        avgRamPercent: sql<number>`avg(${deviceMetrics.ramPercent})`,
-        avgRamUsedMb: sql<number>`avg(${deviceMetrics.ramUsedMb})`,
-        avgDiskPercent: sql<number>`avg(${deviceMetrics.diskPercent})`,
-        avgDiskUsedGb: sql<number>`avg(${deviceMetrics.diskUsedGb})`,
-        diskActivityAvailable: sql<boolean>`bool_or(coalesce(${deviceMetrics.diskActivityAvailable}, false))`,
-        totalDiskReadBytes: sql<bigint>`sum(${deviceMetrics.diskReadBytes})`,
-        totalDiskWriteBytes: sql<bigint>`sum(${deviceMetrics.diskWriteBytes})`,
-        avgDiskReadBps: sql<number>`avg(${deviceMetrics.diskReadBps})::float8`,
-        avgDiskWriteBps: sql<number>`avg(${deviceMetrics.diskWriteBps})::float8`,
-        totalDiskReadOps: sql<bigint>`sum(${deviceMetrics.diskReadOps})`,
-        totalDiskWriteOps: sql<bigint>`sum(${deviceMetrics.diskWriteOps})`,
-        totalNetworkIn: sql<bigint>`sum(${deviceMetrics.networkInBytes})`,
-        totalNetworkOut: sql<bigint>`sum(${deviceMetrics.networkOutBytes})`,
-        avgBandwidthIn: sql<number>`avg(${deviceMetrics.bandwidthInBps})::float8`,
-        avgBandwidthOut: sql<number>`avg(${deviceMetrics.bandwidthOutBps})::float8`,
-        avgProcessCount: sql<number>`avg(${deviceMetrics.processCount})`
-      })
-      .from(deviceMetrics)
-      .where(
-        and(
-          eq(deviceMetrics.deviceId, deviceId),
-          gte(deviceMetrics.timestamp, startDate),
-          lte(deviceMetrics.timestamp, endDate)
-        )
-      )
-      .groupBy(sql`date_trunc('minute', ${deviceMetrics.timestamp})`)
-      .orderBy(asc(sql`date_trunc('minute', ${deviceMetrics.timestamp})`));
+    let metricsData = await queryMetricRollups(device.orgId, deviceId, startDate, endDate, interval);
+    if (metricsData.length === 0) {
+      metricsData = await queryRawMetricBuckets(deviceId, startDate, endDate);
+    }
 
     // Further aggregate based on requested interval
     const aggregatedData = aggregateMetricsByInterval(metricsData, interval, bucketSeconds);


### PR DESCRIPTION
## Summary
- read hourly and daily device metric history from `metric_rollups` when available
- keep one-minute and five-minute history on raw `device_metrics` and fall back to raw data when rollups are empty
- add route tests for rollup use, raw fallback, raw one-minute requests, and site-scope denial

## Validation
- `corepack pnpm --filter @breeze/api exec vitest run src/routes/devices/metrics.test.ts`
- `corepack pnpm --filter @breeze/api exec vitest run src/routes/devices/metrics.test.ts src/routes/devices/core.permissions.test.ts`
- `corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `git diff --check`

## Notes
Rollups do not currently include monotonic byte and operation counters, so the rollup path preserves the response shape with zero counter totals and still returns rolled rate/utilization fields. Raw fallback preserves full counter values when rollups are absent.