### PR TITLE
feat(ml): use rollups for AI metric analysis

### DIFF
--- a/apps/api/src/services/aiToolsPerformance.test.ts
+++ b/apps/api/src/services/aiToolsPerformance.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+import { db } from '../db';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { registerPerformanceTools } from './aiToolsPerformance';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const DEVICE_ID = '22222222-2222-4222-8222-222222222222';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function createChain(result: unknown = []) {
+  const chain: Record<string, any> = {};
+  for (const method of ['from', 'where', 'groupBy', 'orderBy', 'limit', 'innerJoin']) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.then = (onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected);
+  return chain;
+}
+
+function mockSelectOnce(result: unknown) {
+  mockDb.select.mockImplementationOnce(() => createChain(result));
+}
+
+function handlerFor(name: string): AiTool['handler'] {
+  const registry = new Map<string, AiTool>();
+  registerPerformanceTools(registry);
+  return registry.get(name)!.handler;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
+    token: {} as AuthContext['token'],
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    canAccessSite: () => true,
+  } as AuthContext;
+}
+
+const DEVICE = {
+  id: DEVICE_ID,
+  orgId: ORG_ID,
+  siteId: 'site-1',
+  hostname: 'host-1',
+  status: 'online',
+};
+
+function rawMetric(timestamp: string, cpuPercent: number) {
+  return {
+    timestamp: new Date(timestamp),
+    cpuPercent,
+    ramPercent: 50,
+    diskPercent: 60,
+    ramUsedMb: 1024,
+    diskUsedGb: 200,
+  };
+}
+
+describe('analyze_metrics AI tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses metric rollups for hourly analysis when available', async () => {
+    mockSelectOnce([DEVICE]);
+    mockSelectOnce([
+      {
+        timestamp: new Date('2026-06-18T11:00:00.000Z'),
+        cpuPercent: 42.125,
+        ramPercent: 55.5,
+        ramUsedMb: 2048,
+        diskPercent: 70.75,
+        diskUsedGb: 250,
+        sampleCount: 12,
+      },
+      {
+        timestamp: new Date('2026-06-18T10:00:00.000Z'),
+        cpuPercent: 21,
+        ramPercent: 40,
+        ramUsedMb: 1024,
+        diskPercent: 65,
+        diskUsedGb: 240,
+        sampleCount: 11,
+      },
+    ]);
+
+    const result = await handlerFor('analyze_metrics')(
+      { deviceId: DEVICE_ID, hoursBack: 72, aggregation: 'hourly' },
+      makeAuth()
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.source).toBe('metric_rollups');
+    expect(parsed.summary.dataPoints).toBe(23);
+    expect(parsed.summary.cpu.current).toBe(42.125);
+    expect(parsed.buckets).toEqual([
+      { period: '2026-06-18T11:00', cpu: 42.13, ram: 55.5, disk: 70.75, count: 12 },
+      { period: '2026-06-18T10:00', cpu: 21, ram: 40, disk: 65, count: 11 },
+    ]);
+    expect(mockDb.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to raw device metrics when hourly rollups are empty', async () => {
+    mockSelectOnce([DEVICE]);
+    mockSelectOnce([]);
+    mockSelectOnce([
+      rawMetric('2026-06-18T11:30:00.000Z', 40),
+      rawMetric('2026-06-18T11:00:00.000Z', 20),
+    ]);
+
+    const result = await handlerFor('analyze_metrics')(
+      { deviceId: DEVICE_ID, hoursBack: 72, aggregation: 'hourly' },
+      makeAuth()
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.source).toBe('device_metrics');
+    expect(parsed.summary.dataPoints).toBe(2);
+    expect(parsed.buckets).toEqual([
+      { period: '2026-06-18T11:00', cpu: 30, ram: 50, disk: 60, count: 2 },
+    ]);
+    expect(mockDb.select).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps raw analysis on raw device metrics', async () => {
+    mockSelectOnce([DEVICE]);
+    mockSelectOnce([
+      rawMetric('2026-06-18T11:30:00.000Z', 40),
+      rawMetric('2026-06-18T11:00:00.000Z', 20),
+    ]);
+
+    const result = await handlerFor('analyze_metrics')(
+      { deviceId: DEVICE_ID, hoursBack: 2, aggregation: 'raw' },
+      makeAuth()
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.metrics).toHaveLength(2);
+    expect(parsed.summary.cpu.current).toBe(40);
+    expect(parsed.source).toBeUndefined();
+    expect(mockDb.select).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/services/aiToolsPerformance.ts
+++ b/apps/api/src/services/aiToolsPerformance.ts
@@ -10,8 +10,8 @@
  */
 
 import { db } from '../db';
-import { devices, deviceMetrics, deviceSessions, deviceBootMetrics } from '../db/schema';
-import { eq, and, desc, gte, SQL } from 'drizzle-orm';
+import { devices, deviceMetrics, deviceSessions, deviceBootMetrics, metricRollups } from '../db/schema';
+import { eq, and, desc, gte, inArray, SQL, sql } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import {
@@ -24,6 +24,23 @@ import {
 } from './startupItems';
 
 type AiToolTier = 1 | 2 | 3 | 4;
+type MetricPoint = {
+  timestamp: Date;
+  cpuPercent: number;
+  ramPercent: number;
+  diskPercent: number;
+  ramUsedMb: number;
+  diskUsedGb: number;
+  sampleCount?: number;
+};
+
+const PERFORMANCE_ROLLUP_METRICS = [
+  'cpu_percent',
+  'ram_percent',
+  'ram_used_mb',
+  'disk_percent',
+  'disk_used_gb',
+] as const;
 
 async function verifyDeviceAccess(
   deviceId: string,
@@ -58,7 +75,7 @@ function computeStats(values: number[]): { min: number; max: number; avg: number
 }
 
 function aggregateMetrics(
-  metrics: Array<{ timestamp: Date; cpuPercent: number; ramPercent: number; diskPercent: number; ramUsedMb: number; diskUsedGb: number }>,
+  metrics: MetricPoint[],
   level: 'hourly' | 'daily'
 ): Array<{ period: string; cpu: number; ram: number; disk: number; count: number }> {
   const bucketMap = new Map<string, { cpu: number[]; ram: number[]; disk: number[]; count: number }>();
@@ -86,6 +103,87 @@ function aggregateMetrics(
     disk: Math.round((b.disk.reduce((a, v) => a + v, 0) / b.disk.length) * 100) / 100,
     count: b.count
   }));
+}
+
+function periodForTimestamp(timestamp: Date, level: 'hourly' | 'daily'): string {
+  const d = new Date(timestamp);
+  return level === 'hourly'
+    ? `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}T${String(d.getUTCHours()).padStart(2, '0')}:00`
+    : `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+function summarizeMetrics(metrics: MetricPoint[]) {
+  return {
+    dataPoints: metrics.reduce((sum, metric) => sum + (metric.sampleCount ?? 1), 0),
+    timeRange: { from: metrics[metrics.length - 1]!.timestamp, to: metrics[0]!.timestamp },
+    cpu: computeStats(metrics.map(m => m.cpuPercent)),
+    ram: computeStats(metrics.map(m => m.ramPercent)),
+    disk: computeStats(metrics.map(m => m.diskPercent)),
+    ramUsedMb: computeStats(metrics.map(m => m.ramUsedMb)),
+    diskUsedGb: computeStats(metrics.map(m => m.diskUsedGb))
+  };
+}
+
+function rollupWeightedAvg(metricName: (typeof PERFORMANCE_ROLLUP_METRICS)[number]) {
+  return sql<number>`
+    coalesce(
+      sum(${metricRollups.avgValue} * ${metricRollups.sampleCount})
+        filter (where ${metricRollups.metricName} = ${metricName})
+      / nullif(
+        sum(${metricRollups.sampleCount})
+          filter (where ${metricRollups.metricName} = ${metricName}),
+        0
+      ),
+      0
+    )
+  `;
+}
+
+function rollupSampleCountSql() {
+  return sql<number>`
+    greatest(
+      coalesce(max(${metricRollups.sampleCount}) filter (where ${metricRollups.metricName} = 'cpu_percent'), 0),
+      coalesce(max(${metricRollups.sampleCount}) filter (where ${metricRollups.metricName} = 'ram_percent'), 0),
+      coalesce(max(${metricRollups.sampleCount}) filter (where ${metricRollups.metricName} = 'disk_percent'), 0)
+    )
+  `;
+}
+
+function rollupBucketSeconds(aggregation: 'hourly' | 'daily'): 3600 | 86400 {
+  return aggregation === 'hourly' ? 3600 : 86400;
+}
+
+async function queryMetricRollupsForAnalysis(
+  orgId: string,
+  deviceId: string,
+  since: Date,
+  aggregation: 'hourly' | 'daily'
+): Promise<MetricPoint[]> {
+  return db
+    .select({
+      timestamp: metricRollups.bucketStart,
+      cpuPercent: rollupWeightedAvg('cpu_percent'),
+      ramPercent: rollupWeightedAvg('ram_percent'),
+      ramUsedMb: rollupWeightedAvg('ram_used_mb'),
+      diskPercent: rollupWeightedAvg('disk_percent'),
+      diskUsedGb: rollupWeightedAvg('disk_used_gb'),
+      sampleCount: rollupSampleCountSql(),
+    })
+    .from(metricRollups)
+    .where(
+      and(
+        eq(metricRollups.orgId, orgId),
+        eq(metricRollups.deviceId, deviceId),
+        eq(metricRollups.sourceTable, 'device_metrics'),
+        eq(metricRollups.bucketSeconds, rollupBucketSeconds(aggregation)),
+        inArray(metricRollups.metricName, [...PERFORMANCE_ROLLUP_METRICS]),
+        sql`${metricRollups.sampleCount} > 0`,
+        gte(metricRollups.bucketStart, since)
+      )
+    )
+    .groupBy(metricRollups.bucketStart)
+    .orderBy(desc(metricRollups.bucketStart))
+    .limit(500);
 }
 
 export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
@@ -123,6 +221,28 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
 
       const hoursBack = Math.min(Math.max(1, Number(input.hoursBack) || 24), 168);
       const since = new Date(Date.now() - hoursBack * 60 * 60 * 1000);
+      const aggregation = input.aggregation || (hoursBack <= 24 ? 'raw' : 'hourly');
+
+      if (aggregation === 'hourly' || aggregation === 'daily') {
+        const rollupMetrics = await queryMetricRollupsForAnalysis(access.device.orgId, deviceId, since, aggregation);
+        if (rollupMetrics.length > 0) {
+          const summary = summarizeMetrics(rollupMetrics);
+          const buckets = rollupMetrics.map((metric) => ({
+            period: periodForTimestamp(metric.timestamp, aggregation),
+            cpu: Math.round(metric.cpuPercent * 100) / 100,
+            ram: Math.round(metric.ramPercent * 100) / 100,
+            disk: Math.round(metric.diskPercent * 100) / 100,
+            count: metric.sampleCount ?? 0,
+          }));
+
+          return JSON.stringify({
+            summary,
+            aggregation,
+            source: 'metric_rollups',
+            buckets
+          }, (_, v) => typeof v === 'bigint' ? Number(v) : v);
+        }
+      }
 
       const metrics = await db
         .select()
@@ -141,19 +261,9 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
       }
 
       // Compute summary statistics
-      const summary = {
-        dataPoints: metrics.length,
-        timeRange: { from: metrics[metrics.length - 1]!.timestamp, to: metrics[0]!.timestamp },
-        cpu: computeStats(metrics.map(m => m.cpuPercent)),
-        ram: computeStats(metrics.map(m => m.ramPercent)),
-        disk: computeStats(metrics.map(m => m.diskPercent)),
-        ramUsedMb: computeStats(metrics.map(m => m.ramUsedMb)),
-        diskUsedGb: computeStats(metrics.map(m => m.diskUsedGb))
-      };
+      const summary = summarizeMetrics(metrics);
 
       // For raw mode, return recent data points (limited to prevent huge responses)
-      const aggregation = input.aggregation || (hoursBack <= 24 ? 'raw' : 'hourly');
-
       if (aggregation === 'raw') {
         return JSON.stringify({
           summary,
@@ -167,6 +277,7 @@ export function registerPerformanceTools(aiTools: Map<string, AiTool>): void {
       return JSON.stringify({
         summary,
         aggregation,
+        source: 'device_metrics',
         buckets
       }, (_, v) => typeof v === 'bigint' ? Number(v) : v);
     }


### PR DESCRIPTION
## Summary
- use hourly/daily `metric_rollups` for the `analyze_metrics` AI tool when rollups are available
- preserve raw `device_metrics` behavior for raw analysis and as fallback when rollups are empty
- add focused service tests for rollup use, raw fallback, and raw-mode preservation

## Validation
- `corepack pnpm --filter @breeze/api exec vitest run src/services/aiToolsPerformance.test.ts`
- `corepack pnpm --filter @breeze/api exec vitest run src/services/aiToolsPerformance.test.ts src/services/aiToolsAnalytics.siteScope.test.ts`
- `corepack pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json`
- `git diff --check`