### PR TITLE
fix(web): give FormData uploads a 10-minute timeout, not the 30s API default (#1601)

### DIFF
--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -81,6 +81,59 @@ describe('auth store fetchWithAuth', () => {
     expect(headers.get('Content-Type')).toBeNull();
   });
 
+  it('aborts a JSON request at the 30s default timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      useAuthStore.getState().login(baseUser, baseTokens);
+      let captured: AbortSignal | undefined;
+      const fetchMock = vi.fn().mockImplementation((_url: string, opts: RequestInit) => {
+        captured = opts.signal as AbortSignal;
+        return new Promise<Response>(() => {}); // never resolves so the timeout stays pending
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      void fetchWithAuth('/devices', { method: 'GET' });
+      await Promise.resolve();
+      expect(captured?.aborted).toBe(false);
+
+      vi.advanceTimersByTime(30_000);
+      expect(captured?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('gives FormData uploads a 10-minute ceiling, not the 30s default (issue #1601)', async () => {
+    // A large installer (hundreds of MB) takes far longer than 30s to send. The
+    // old blanket 30s timeout aborted the in-flight upload — surfacing "signal is
+    // aborted without reason" — even though the server received the file. Uploads
+    // must survive well past 30s.
+    vi.useFakeTimers();
+    try {
+      useAuthStore.getState().login(baseUser, baseTokens);
+      let captured: AbortSignal | undefined;
+      const fetchMock = vi.fn().mockImplementation((_url: string, opts: RequestInit) => {
+        captured = opts.signal as AbortSignal;
+        return new Promise<Response>(() => {});
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const form = new FormData();
+      form.append('file', new Blob(['x'], { type: 'application/octet-stream' }), 'big.msi');
+      void fetchWithAuth('/software/catalog/c1/versions/upload', { method: 'POST', body: form });
+      await Promise.resolve();
+      expect(captured?.aborted).toBe(false);
+
+      vi.advanceTimersByTime(30_000);
+      expect(captured?.aborted).toBe(false); // still alive past the JSON cap
+
+      vi.advanceTimersByTime(10 * 60_000);
+      expect(captured?.aborted).toBe(true); // aborts only at the upload ceiling
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('strips only exact /api prefix while preserving /api-* routes', async () => {
     useAuthStore.getState().login(baseUser, baseTokens);
     const fetchMock = vi

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -421,6 +421,11 @@ export async function bootstrapFromCfAccessRedirect(): Promise<boolean> {
   return true;
 }
 
+// Default request timeout for JSON API calls. Uploads get a much longer ceiling
+// (see UPLOAD_TIMEOUT_MS) because large installer files take far longer to send.
+const DEFAULT_TIMEOUT_MS = 30_000;
+const UPLOAD_TIMEOUT_MS = 10 * 60_000;
+
 export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): Promise<Response> {
   // Auto-inject orgId from the org store so partner/system users always scope API calls
   let url = rawUrl;
@@ -457,10 +462,15 @@ export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): 
     headers.set('Content-Type', 'application/json');
   }
 
-  // Use caller-provided signal or create a 30-second timeout to prevent indefinite hangs
+  // Use caller-provided signal or create a default timeout to prevent indefinite hangs.
+  // FormData bodies are file uploads (software installers can be hundreds of MB); a 30s
+  // cap aborts an in-flight upload the server then completes anyway, surfacing the
+  // confusing "signal is aborted without reason" DOMException even though the file
+  // landed (issue #1601). Give uploads a much longer ceiling while keeping it bounded.
   const externalSignal = options.signal;
+  const timeoutMs = options.body instanceof FormData ? UPLOAD_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
   const controller = !externalSignal ? new AbortController() : null;
-  const timeout = controller ? setTimeout(() => controller.abort(), 30_000) : null;
+  const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
   const signal = externalSignal ?? controller!.signal;
 
   let response: Response;


### PR DESCRIPTION
## Problem

Closes #1601. Uploading a large software-package version (reporter tested a ~190 MB MSI) shows the error **"signal is aborted without reason"**, yet the file actually uploads successfully and appears in the version manager. The UI failure state is misleading — the upload completed.

## Root cause

The upload (`SoftwareVersionManager` → `fetchWithAuth('/software/catalog/:id/versions/upload', { body: formData })`) passes no `signal`, so `fetchWithAuth` (`apps/web/src/stores/auth.ts`) applies its blanket **30-second** `AbortController` timeout:

```ts
const controller = !externalSignal ? new AbortController() : null;
const timeout = controller ? setTimeout(() => controller.abort(), 30_000) : null;
```

A multi-hundred-MB installer takes far longer than 30s to send. The timer fires `controller.abort()` **with no argument** — which is exactly what throws `DOMException: signal is aborted without reason` — while the server has already received and committed the file. Server side is fine (the body finished and the version was created); only the client's wait was cut off, so the user sees an error for an upload that succeeded.

The 30s default is sensible for JSON API calls but wrong for any multipart upload. The same latent bug exists in every other FormData upload path that doesn't pass its own signal (avatar, branding logo, quote attachments) — they just rarely exceed 30s because the files are small.

## Fix

Make the timeout body-aware in `fetchWithAuth`: FormData bodies (file uploads) get a much longer but still bounded ceiling (10 minutes); JSON requests keep the 30s default. One shared change fixes the reported software upload and the latent avatar/logo/quote cases, preserves the indefinite-hang guard, and touches no call sites.

```ts
const timeoutMs = options.body instanceof FormData ? UPLOAD_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
```

This is the client-side complement to the earlier server-side large-upload work (body-limit carve-out / streaming) — those are why the file now lands; this stops the client from falsely reporting failure.

## Tests

Two new cases in `auth.test.ts` (fake timers + a never-resolving fetch to capture the request signal):
- a JSON request aborts at the 30s default;
- a FormData upload survives past 30s and aborts only at the 10-minute upload ceiling (issue #1601).

## Local verification (node 22.20.0, matching CI `.nvmrc`)

- `vitest src/stores/auth.test.ts`: **22/22 pass** (2 new + 20 existing)
- `astro check` (apps/web): **0 errors**
- `eslint` on both changed files: clean
- No dependency changes; web-only.
