### PR TITLE
test(web): fix flaky ContractEditor create test (wait for async org option)

### DIFF
--- a/apps/web/src/components/contracts/ContractEditor.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ContractEditor from './ContractEditor';
@@ -53,9 +53,14 @@ describe('ContractEditor (create)', () => {
 
   it('includes the Terms field in the create payload', async () => {
     render(<ContractEditor />);
-    await screen.findByTestId('contract-form-org');
+    const orgSelect = await screen.findByTestId('contract-form-org');
+    // The <option>s populate only after the async /orgs/organizations fetch
+    // resolves. Wait for the option before selecting it — otherwise the
+    // controlled <select> rejects a value with no matching option, orgId stays
+    // empty, canSaveHeader is false, and the save no-ops (flaky under CI load).
+    await within(orgSelect).findByRole('option', { name: 'Acme' });
 
-    fireEvent.change(screen.getByTestId('contract-form-org'), { target: { value: 'org-1' } });
+    fireEvent.change(orgSelect, { target: { value: 'org-1' } });
     fireEvent.change(screen.getByTestId('contract-form-name'), { target: { value: 'Acme MSA' } });
     fireEvent.change(screen.getByTestId('contract-form-terms'), { target: { value: 'Net 30. Auto-renews.' } });
     fireEvent.click(screen.getByTestId('save-contract-btn'));


### PR DESCRIPTION
## Problem

`ContractEditor.test.tsx > ContractEditor (create) > "includes the Terms field in the create payload"` is flaky — it failed once on an unrelated PR's `Test Web` job with `expected "vi.fn()" to be called at least once` (the `waitFor` for `createContract` timed out), while passing locally and on re-run.

## Root cause

The test resolves `await screen.findByTestId('contract-form-org')` and immediately does `fireEvent.change(org, { value: 'org-1' })`. But `findByTestId` resolves on the `<select>` element, which renders right away with only the `<option value="">Select an organization…</option>` placeholder. The real `<option value="org-1">Acme</option>` is appended only after the async `loadOrgs()` (`/orgs/organizations`) fetch resolves and `setOrgs(...)` runs.

Under CI load the `fireEvent.change` can fire before that option exists. A controlled `<select>` rejects a value with no matching option, so `orgId` stays `''`, `canSaveHeader` (`!!orgId && …`) is false, `saveCreate()` early-returns, `createContract` is never called, and the `waitFor` times out.

## Fix

Wait for the `Acme` option to be present before selecting it:

```ts
const orgSelect = await screen.findByTestId('contract-form-org');
await within(orgSelect).findByRole('option', { name: 'Acme' });
fireEvent.change(orgSelect, { target: { value: 'org-1' } });
```

Test-only — `ContractEditor.tsx` is unchanged.

## Verification (node 22.20.0)

- The test passes **5/5** consecutive runs.
- `eslint` clean; `astro check` 0 errors.
