### PR TITLE
ci: harden Tauri apt step against slow mirror flake (#1605)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,7 +654,7 @@ jobs:
   rust-check:
     name: Rust Check (Tauri apps)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
 
     steps:
       - name: Checkout
@@ -662,8 +662,31 @@ jobs:
 
       - name: Install Tauri system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          # The Azure apt mirror (azure.archive.ubuntu.com) is intermittently
+          # degraded and can crawl at 1-4 min/package, blowing this job's
+          # timeout before Rust ever compiles — a transient infra flake that
+          # reds `main` and fires main-red-alert with zero code signal (#1605).
+          # Switch to the canonical mirror and retry update+install with
+          # backoff so a slow mirror doesn't masquerade as a build failure.
+          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/*.list \
+            /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+          install_deps() {
+            sudo apt-get update && \
+            sudo apt-get install -y --no-install-recommends \
+              libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "Tauri system dependencies installed (attempt ${attempt})."
+              exit 0
+            fi
+            echo "::warning::apt install failed (attempt ${attempt}/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::Failed to install Tauri system dependencies after 3 attempts."
+          exit 1
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1032,8 +1032,28 @@ jobs:
       - name: Install Linux dependencies
         if: contains(matrix.platform, 'ubuntu')
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          # Harden against a degraded Azure apt mirror (same flake as #1605):
+          # rewrite to the canonical mirror and retry update+install with
+          # backoff so a transient hiccup doesn't fail the release build.
+          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/*.list \
+            /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+          install_deps() {
+            sudo apt-get update && \
+            sudo apt-get install -y --no-install-recommends \
+              libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "Linux dependencies installed (attempt ${attempt})."
+              exit 0
+            fi
+            echo "::warning::apt install failed (attempt ${attempt}/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::Failed to install Linux dependencies after 3 attempts."
+          exit 1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1174,8 +1194,28 @@ jobs:
       - name: Install Linux dependencies
         if: contains(matrix.platform, 'ubuntu')
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          # Harden against a degraded Azure apt mirror (same flake as #1605):
+          # rewrite to the canonical mirror and retry update+install with
+          # backoff so a transient hiccup doesn't fail the release build.
+          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/*.list \
+            /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+          install_deps() {
+            sudo apt-get update && \
+            sudo apt-get install -y --no-install-recommends \
+              libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "Linux dependencies installed (attempt ${attempt})."
+              exit 0
+            fi
+            echo "::warning::apt install failed (attempt ${attempt}/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::Failed to install Linux dependencies after 3 attempts."
+          exit 1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -2017,8 +2057,22 @@ jobs:
             exit 1
           fi
 
-          sudo apt-get update
-          sudo apt-get install -y minisign
+          # Harden against a degraded Azure apt mirror (same flake as #1605).
+          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/*.list \
+            /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+          for attempt in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y --no-install-recommends minisign; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to install minisign after 3 attempts."
+              exit 1
+            fi
+            echo "::warning::apt install failed (attempt ${attempt}/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
 
           key_file="$RUNNER_TEMP/release-manifest.minisign.key"
           printf '%s' "$RELEASE_MANIFEST_MINISIGN_PRIVATE_KEY" > "$key_file"


### PR DESCRIPTION
## Problem

`Rust Check (Tauri apps)` intermittently reds `main`. The failure is **not in Rust** — it's the `Install Tauri system dependencies` step. When the Azure Ubuntu apt mirror (`azure.archive.ubuntu.com`) is degraded, packages crawl at 1–4 min each and blow the job's `timeout-minutes: 25` *before Rust ever compiles*. The cancelled job trips the `CI Success` gate and fires `main-red-alert` — with zero signal of an actual code problem. Most recently hit `main` on 2026-06-18 across three consecutive non-Tauri pushes (#1599).

## Fix

Address the actual flake, not the symptom. Applied to **every** apt install site across both workflows:

- **Mirror fallback** — rewrite `azure.archive.ubuntu.com` → canonical `archive.ubuntu.com` (covers both legacy `.list` and deb822 `.sources` on ubuntu-latest/24.04).
- **Retry with backoff** — wrap `apt-get update && install` in a 3-attempt loop (15/30/45s) so a transient hiccup self-heals.
- **Timeout headroom** (`ci.yml` only) — `timeout-minutes` 25 → 35 so a slow-but-working mirror plus retries don't clip the download.

### Sites hardened
- `ci.yml` — `rust-check` Tauri deps (the red-alert trigger) + timeout bump.
- `release.yml` — `build-viewer` deps, `build-helper` deps, and the `minisign` install in the release-manifest signing step. Same flake fails release builds too, which are far more expensive to re-run.

An inline bash retry loop is used instead of a third-party retry/apt-cache action to avoid adding a new SHA-pinned dependency and the supply-chain review the repo's hardening rules would require.

## Notes

- No untrusted input in any `run:` block — no workflow-injection surface.
- Both workflows YAML-validated locally.

Closes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)