### PR TITLE
fix(ml): address review findings across the ML roadmap

### DIFF
--- a/apps/api/scripts/metric-anomaly-backfill.ts
+++ b/apps/api/scripts/metric-anomaly-backfill.ts
@@ -25,7 +25,13 @@ async function main(): Promise<void> {
     })
   );
 
-  console.log('[metric-anomaly-backfill] Completed.');
+  if (result.skipped) {
+    // Feature flag off for this org — no anomalies were written. Warn loudly on stderr
+    // so an operator does not mistake a no-op for a completed backfill.
+    console.warn('[metric-anomaly-backfill] SKIPPED: metric anomaly detection is disabled for this org; nothing written.');
+  } else {
+    console.log('[metric-anomaly-backfill] Completed.');
+  }
   console.log(JSON.stringify(result, null, 2));
 }
 

--- a/apps/api/scripts/metric-rollup-backfill.ts
+++ b/apps/api/scripts/metric-rollup-backfill.ts
@@ -27,7 +27,13 @@ async function main(): Promise<void> {
     })
   );
 
-  console.log('[metric-rollup-backfill] Completed.');
+  if (result.skipped) {
+    // Feature flag off for this org — no rollups were written. Warn loudly on stderr
+    // so an operator does not mistake a no-op for a completed backfill.
+    console.warn('[metric-rollup-backfill] SKIPPED: metric rollups are disabled for this org; nothing written.');
+  } else {
+    console.log('[metric-rollup-backfill] Completed.');
+  }
   console.log(JSON.stringify(result, null, 2));
 }
 

--- a/apps/api/src/__tests__/integration/metricAnomalies.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricAnomalies.integration.test.ts
@@ -1,0 +1,401 @@
+import './setup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+
+import { withSystemDbAccessContext } from '../../db';
+import { alerts, devices, metricAnomalies, metricRollups, organizations } from '../../db/schema';
+import { detectMetricAnomaliesRange } from '../../services/metricAnomalies';
+import { promoteMetricAnomalyToAlert } from '../../services/metricAnomalyPromotion';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+// metric_rollups -> metric_anomalies detection requires ml.anomalies.* flags. They
+// default OFF, so each org enables them via settings (root-level flat keys, picked
+// up by flagOverrideFromSettings' flatContainers[0]).
+const ANOMALY_SETTINGS = {
+  'ml.anomalies.enabled': true,
+  'ml.anomalies.create_alerts': true,
+} as const;
+
+const RAW_BUCKET_SECONDS = 300;
+const MIN_BASELINE_BUCKETS = 12;
+const MIN_TREND_BUCKETS = 6;
+
+let agentIdCounter = 0;
+async function insertDevice(options: { orgId: string; siteId: string; hostname: string }): Promise<string> {
+  agentIdCounter++;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId: options.orgId,
+      siteId: options.siteId,
+      agentId: `metric-anomaly-test-${Date.now()}-${agentIdCounter}`,
+      hostname: options.hostname,
+      displayName: options.hostname,
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date('2026-06-18T00:00:00.000Z'),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice returned no row');
+  return row.id;
+}
+
+async function enableAnomalies(orgId: string): Promise<void> {
+  await getTestDb()
+    .update(organizations)
+    .set({ settings: ANOMALY_SETTINGS })
+    .where(eq(organizations.id, orgId));
+}
+
+interface RollupSeed {
+  orgId: string;
+  deviceId: string;
+  sourceTable: 'device_metrics' | 'device_process_samples';
+  metricType: string;
+  metricName: string;
+  bucketStart: Date;
+  avgValue: number;
+  maxValue?: number;
+  sampleCount?: number;
+}
+
+async function insertRollup(seed: RollupSeed): Promise<void> {
+  await getTestDb().insert(metricRollups).values({
+    orgId: seed.orgId,
+    sourceTable: seed.sourceTable,
+    deviceId: seed.deviceId,
+    metricType: seed.metricType,
+    metricName: seed.metricName,
+    bucketStart: seed.bucketStart,
+    bucketSeconds: RAW_BUCKET_SECONDS,
+    avgValue: seed.avgValue,
+    minValue: seed.avgValue,
+    maxValue: seed.maxValue ?? seed.avgValue,
+    p95Value: seed.avgValue,
+    sumValue: seed.avgValue,
+    sampleCount: seed.sampleCount ?? 1,
+    gapSeconds: 0,
+    metadata: { rollupVersion: 'metric-rollups-v1', source: 'raw' },
+  });
+}
+
+function bucketAt(base: Date, offsetBuckets: number): Date {
+  return new Date(base.getTime() + offsetBuckets * RAW_BUCKET_SECONDS * 1000);
+}
+
+async function runDetection(orgId: string, from: Date, to: Date): Promise<void> {
+  await withSystemDbAccessContext(() => detectMetricAnomaliesRange({ orgId, from, to }));
+}
+
+async function selectAnomalies(orgId: string, deviceId: string) {
+  return getTestDb()
+    .select()
+    .from(metricAnomalies)
+    .where(and(eq(metricAnomalies.orgId, orgId), eq(metricAnomalies.deviceId, deviceId)))
+    .orderBy(metricAnomalies.windowStart);
+}
+
+async function selectAnomaliesByType(orgId: string, deviceId: string, anomalyType: string) {
+  return getTestDb()
+    .select()
+    .from(metricAnomalies)
+    .where(
+      and(
+        eq(metricAnomalies.orgId, orgId),
+        eq(metricAnomalies.deviceId, deviceId),
+        eq(metricAnomalies.anomalyType, anomalyType),
+      ),
+    );
+}
+
+describe('metric anomalies integration', () => {
+  let orgA: string;
+  let siteA: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const organizationA = await createOrganization({ partnerId: partner.id, name: 'Anomaly Org A' });
+    orgA = organizationA.id;
+    await enableAnomalies(orgA);
+    siteA = (await createSite({ orgId: orgA, name: 'Anomaly Site A' })).id;
+  });
+
+  it('fires a baseline spike against a zero-stddev baseline via the greatest(...,1) z-score guard', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'zero-stddev-device' });
+
+    // Baseline window: MIN_BASELINE_BUCKETS identical buckets (stddev_samp = 0).
+    // The observed bucket must clear the spike floor of 90 for cpu_percent since
+    // the stddev-derived term collapses to baseline + 3*greatest(0,1) = 13.
+    const anchor = new Date('2026-06-18T18:00:00.000Z');
+    // Baseline buckets must sit in [anchor - 24h, anchor - 15min). Place them 30+ min back.
+    for (let i = 0; i < MIN_BASELINE_BUCKETS + 2; i++) {
+      await insertRollup({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_metrics',
+        metricType: 'cpu',
+        metricName: 'cpu_percent',
+        // 6 buckets (30 min) before the anchor, walking further back.
+        bucketStart: bucketAt(anchor, -(6 + i)),
+        avgValue: 10,
+      });
+    }
+    // Observed bucket inside [from, to): a hard spike well above the 90 floor.
+    await insertRollup({
+      orgId: orgA,
+      deviceId: device,
+      sourceTable: 'device_metrics',
+      metricType: 'cpu',
+      metricName: 'cpu_percent',
+      bucketStart: anchor,
+      avgValue: 99,
+    });
+
+    await runDetection(orgA, anchor, bucketAt(anchor, 1));
+
+    const spikes = await selectAnomaliesByType(orgA, device, 'spike');
+    expect(spikes).toHaveLength(1);
+    const spike = spikes[0]!;
+    expect(spike.observedValue).toBe(99);
+    expect(spike.baselineValue).toBe(10);
+    // z-score guard: |99 - 10| / greatest(0, 1) = 89, never a divide-by-zero.
+    expect(spike.score).toBeCloseTo(89, 5);
+    expect(Number.isFinite(spike.score)).toBe(true);
+    expect((spike.baselineSummary as Record<string, unknown>).baselineStddev).toBe(0);
+  });
+
+  it('does not divide by zero when the baseline collapses to a single distinct value (NULL/zero stddev)', async () => {
+    // A baseline of all-identical values is the realistic stddev-edge: stddev_samp
+    // is 0 (not NULL, since >=2 rows are required to clear MIN_BASELINE_BUCKETS),
+    // and the coalesce(stddev,0)+greatest(...,1) guard keeps the score finite. Here
+    // the observed value stays under threshold, so NO anomaly should be emitted —
+    // proving the guard does not manufacture a spurious spike from a flat baseline.
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'flat-baseline-device' });
+    const anchor = new Date('2026-06-18T18:00:00.000Z');
+    for (let i = 0; i < MIN_BASELINE_BUCKETS + 2; i++) {
+      await insertRollup({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_metrics',
+        metricType: 'cpu',
+        metricName: 'cpu_percent',
+        bucketStart: bucketAt(anchor, -(6 + i)),
+        avgValue: 40,
+      });
+    }
+    // Observed slightly above baseline but below the 90 floor -> no spike.
+    await insertRollup({
+      orgId: orgA,
+      deviceId: device,
+      sourceTable: 'device_metrics',
+      metricType: 'cpu',
+      metricName: 'cpu_percent',
+      bucketStart: anchor,
+      avgValue: 55,
+    });
+
+    await runDetection(orgA, anchor, bucketAt(anchor, 1));
+
+    const anomalies = await selectAnomalies(orgA, device);
+    expect(anomalies).toHaveLength(0);
+  });
+
+  it('detects a growth trend at exactly MIN_TREND_BUCKETS with first_value=0', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'growth-trend-device' });
+    const base = new Date('2026-06-18T18:00:00.000Z');
+
+    // Exactly MIN_TREND_BUCKETS consecutive disk_percent buckets, first_value = 0,
+    // rising past the +15 absolute-growth gate (0 -> 30).
+    const values = [0, 5, 10, 15, 22, 30];
+    expect(values).toHaveLength(MIN_TREND_BUCKETS);
+    for (let i = 0; i < values.length; i++) {
+      await insertRollup({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_metrics',
+        metricType: 'disk',
+        metricName: 'disk_percent',
+        bucketStart: bucketAt(base, i),
+        avgValue: values[i]!,
+      });
+    }
+
+    // The anchor (window end) is the last bucket; scan [base, lastBucket + 1).
+    await runDetection(orgA, base, bucketAt(base, MIN_TREND_BUCKETS));
+
+    const trends = await selectAnomaliesByType(orgA, device, 'disk_growth');
+    expect(trends).toHaveLength(1);
+    const trend = trends[0]!;
+    expect(trend.baselineValue).toBe(0); // first_value
+    expect(trend.observedValue).toBe(30); // last_value
+    expect(trend.score).toBeCloseTo(30, 5);
+    expect((trend.baselineSummary as Record<string, unknown>).trendBuckets).toBe(MIN_TREND_BUCKETS);
+  });
+
+  it('does not fire a growth trend below MIN_TREND_BUCKETS', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'short-trend-device' });
+    const base = new Date('2026-06-18T18:00:00.000Z');
+
+    // One bucket short of MIN_TREND_BUCKETS, even though growth clears the gate.
+    const values = [0, 6, 12, 18, 30];
+    expect(values).toHaveLength(MIN_TREND_BUCKETS - 1);
+    for (let i = 0; i < values.length; i++) {
+      await insertRollup({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_metrics',
+        metricType: 'disk',
+        metricName: 'disk_percent',
+        bucketStart: bucketAt(base, i),
+        avgValue: values[i]!,
+      });
+    }
+
+    await runDetection(orgA, base, bucketAt(base, values.length));
+
+    const trends = await selectAnomaliesByType(orgA, device, 'disk_growth');
+    expect(trends).toHaveLength(0);
+  });
+
+  it('scans interior trend windows across a wide backfill range (per-anchor windowing)', async () => {
+    // Regression for "detectGrowthTrends ignores its from": a wide range must scan
+    // every interior MIN_TREND_BUCKETS window, not only the one ending at `to`.
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'wide-range-device' });
+    const base = new Date('2026-06-18T18:00:00.000Z');
+
+    // First MIN_TREND_BUCKETS buckets grow 0 -> 30 (an interior window). Then flatten
+    // so the window ending at `to` shows no growth. Old code only looked at `to`.
+    const values = [0, 5, 10, 15, 22, 30, 30, 30, 30, 30, 30, 30];
+    for (let i = 0; i < values.length; i++) {
+      await insertRollup({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_metrics',
+        metricType: 'disk',
+        metricName: 'disk_percent',
+        bucketStart: bucketAt(base, i),
+        avgValue: values[i]!,
+      });
+    }
+
+    await runDetection(orgA, base, bucketAt(base, values.length));
+
+    const trends = await selectAnomaliesByType(orgA, device, 'disk_growth');
+    // The interior 0 -> 30 window is caught even though the tail window is flat.
+    expect(trends.length).toBeGreaterThanOrEqual(1);
+    const interior = trends.find((t) => t.baselineValue === 0 && t.observedValue === 30);
+    expect(interior).toBeDefined();
+  });
+
+  it('promotes two metric_name rows of one incident into a single alert', async () => {
+    const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'dedup-promote-device' });
+    const windowStart = new Date('2026-06-18T18:00:00.000Z');
+    const windowEnd = bucketAt(windowStart, 1);
+
+    // Two rows, same device/anomaly_type/window, differing only by metric_name:
+    // the baseline 'network_egress' (bandwidth_out_bps) and the process-runaway
+    // 'network_egress' (top_process_net_bps_sum). Insert directly to mimic both
+    // detectors emitting for the same event.
+    const [baselineRow] = await getTestDb()
+      .insert(metricAnomalies)
+      .values({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_metrics',
+        metricType: 'network',
+        metricName: 'bandwidth_out_bps',
+        anomalyType: 'network_egress',
+        status: 'open',
+        windowStart,
+        windowEnd,
+        bucketSeconds: RAW_BUCKET_SECONDS,
+        observedValue: 5_000_000,
+        baselineValue: 1_000_000,
+        baselineMin: 900_000,
+        baselineMax: 1_100_000,
+        score: 6,
+        confidence: 0.8,
+        sampleCount: 5,
+        baselineSummary: { modelVersion: 'metric-anomalies-v1' },
+        evidence: {},
+      })
+      .returning({ id: metricAnomalies.id });
+
+    const [processRow] = await getTestDb()
+      .insert(metricAnomalies)
+      .values({
+        orgId: orgA,
+        deviceId: device,
+        sourceTable: 'device_process_samples',
+        metricType: 'process',
+        metricName: 'top_process_net_bps_sum',
+        anomalyType: 'network_egress',
+        status: 'open',
+        windowStart,
+        windowEnd,
+        bucketSeconds: RAW_BUCKET_SECONDS,
+        observedValue: 4_800_000,
+        baselineValue: 1_000_000,
+        baselineMin: 900_000,
+        baselineMax: 1_050_000,
+        // Higher confidence so this row is the canonical alert driver.
+        score: 9,
+        confidence: 0.95,
+        sampleCount: 5,
+        baselineSummary: { modelVersion: 'metric-anomalies-v1' },
+        evidence: {},
+      })
+      .returning({ id: metricAnomalies.id });
+
+    if (!baselineRow || !processRow) throw new Error('failed to seed anomaly rows');
+
+    // Promote the first row.
+    const first = await withSystemDbAccessContext(() =>
+      promoteMetricAnomalyToAlert({
+        orgId: orgA,
+        deviceId: device,
+        anomalyId: baselineRow.id,
+        requireCreateAlertsFlag: false,
+      }),
+    );
+    expect(first.status).toBe('promoted');
+    if (first.status !== 'promoted') throw new Error('expected promotion');
+    expect(first.created).toBe(true);
+
+    // Promote the sibling row: must reuse the same alert, not create a second.
+    const second = await withSystemDbAccessContext(() =>
+      promoteMetricAnomalyToAlert({
+        orgId: orgA,
+        deviceId: device,
+        anomalyId: processRow.id,
+        requireCreateAlertsFlag: false,
+      }),
+    );
+    expect(second.status).toBe('promoted');
+    if (second.status !== 'promoted') throw new Error('expected promotion');
+    expect(second.created).toBe(false);
+    expect(second.alertId).toBe(first.alertId);
+
+    // Exactly one alert exists for this device.
+    const deviceAlerts = await getTestDb()
+      .select()
+      .from(alerts)
+      .where(and(eq(alerts.orgId, orgA), eq(alerts.deviceId, device)));
+    expect(deviceAlerts).toHaveLength(1);
+    // The canonical (higher-confidence process) row drove the alert content.
+    const alertContext = deviceAlerts[0]!.context as Record<string, unknown>;
+    expect(alertContext.anomalyId).toBe(processRow.id);
+    expect(alertContext.metricName).toBe('top_process_net_bps_sum');
+
+    // Both anomaly rows are linked to the single alert.
+    const all = await selectAnomalies(orgA, device);
+    expect(all).toHaveLength(2);
+    expect(all.every((a) => a.linkedAlertId === first.alertId)).toBe(true);
+    expect(all.every((a) => a.status === 'promoted')).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/integration/mlOutputRetention.integration.test.ts
+++ b/apps/api/src/__tests__/integration/mlOutputRetention.integration.test.ts
@@ -1,0 +1,173 @@
+import './setup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+
+import { withSystemDbAccessContext } from '../../db';
+import { devices, metricAnomalies, remediationSuggestions } from '../../db/schema';
+import { pruneMlOutputs } from '../../jobs/mlOutputRetention';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+let agentCounter = 0;
+async function insertDevice(orgId: string, siteId: string): Promise<string> {
+  agentCounter++;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `ml-retention-${Date.now()}-${agentCounter}`,
+      hostname: `ml-retention-host-${agentCounter}`,
+      displayName: `ml-retention-host-${agentCounter}`,
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice returned no row');
+  return row.id;
+}
+
+async function insertRemediation(orgId: string, deviceId: string, createdAt: Date): Promise<string> {
+  const [row] = await getTestDb()
+    .insert(remediationSuggestions)
+    .values({
+      orgId,
+      sourceType: 'alert',
+      sourceId: `src-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      deviceId,
+      // 'diagnostic' target needs no script/template/playbook FK
+      // (remediation_suggestions_target_check).
+      targetType: 'diagnostic',
+      title: 'Test remediation',
+      rationale: 'because',
+      expectedAction: 'do the thing',
+      createdAt,
+      updatedAt: createdAt,
+    })
+    .returning({ id: remediationSuggestions.id });
+  if (!row) throw new Error('insertRemediation returned no row');
+  return row.id;
+}
+
+async function insertAnomaly(orgId: string, deviceId: string, detectedAt: Date): Promise<string> {
+  const [row] = await getTestDb()
+    .insert(metricAnomalies)
+    .values({
+      orgId,
+      deviceId,
+      metricType: 'cpu',
+      metricName: 'cpu_percent',
+      anomalyType: 'spike',
+      windowStart: new Date(detectedAt.getTime() - 300_000),
+      windowEnd: detectedAt,
+      observedValue: 99,
+      score: 4.2,
+      confidence: 0.9,
+      detectedAt,
+      updatedAt: detectedAt,
+    })
+    .returning({ id: metricAnomalies.id });
+  if (!row) throw new Error('insertAnomaly returned no row');
+  return row.id;
+}
+
+async function selectRemediationIds(orgId: string) {
+  return (
+    await getTestDb()
+      .select({ id: remediationSuggestions.id })
+      .from(remediationSuggestions)
+      .where(eq(remediationSuggestions.orgId, orgId))
+  ).map((r) => r.id);
+}
+
+async function selectAnomalyIds(orgId: string) {
+  return (
+    await getTestDb()
+      .select({ id: metricAnomalies.id })
+      .from(metricAnomalies)
+      .where(eq(metricAnomalies.orgId, orgId))
+  ).map((r) => r.id);
+}
+
+async function runPrune(retentionDays: number) {
+  return withSystemDbAccessContext(() => pruneMlOutputs({ retentionDays }));
+}
+
+describe('ML output retention pruning integration', () => {
+  let orgId: string;
+  let deviceId: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id, name: 'ML Output Retention Org' });
+    orgId = org.id;
+    const site = await createSite({ orgId, name: 'ML Output Site' });
+    deviceId = await insertDevice(orgId, site.id);
+  });
+
+  it('deletes only rows older than the cutoff by created_at / detected_at', async () => {
+    // retentionDays clamps to a 30-day minimum, so use ages on either side of 30 days.
+    const old = new Date(Date.now() - 45 * DAY_MS);
+    const recent = new Date(Date.now() - 5 * DAY_MS);
+
+    const oldRemediation = await insertRemediation(orgId, deviceId, old);
+    const recentRemediation = await insertRemediation(orgId, deviceId, recent);
+    const oldAnomaly = await insertAnomaly(orgId, deviceId, old);
+    const recentAnomaly = await insertAnomaly(orgId, deviceId, recent);
+
+    const result = await runPrune(30);
+
+    expect(result.deleted).toBe(2);
+    const remediationTable = result.tables.find((t) => t.table === 'remediation_suggestions');
+    const anomalyTable = result.tables.find((t) => t.table === 'metric_anomalies');
+    expect(remediationTable?.deleted).toBe(1);
+    expect(anomalyTable?.deleted).toBe(1);
+
+    const remediationIds = await selectRemediationIds(orgId);
+    expect(remediationIds).toEqual([recentRemediation]);
+    expect(remediationIds).not.toContain(oldRemediation);
+
+    const anomalyIds = await selectAnomalyIds(orgId);
+    expect(anomalyIds).toEqual([recentAnomaly]);
+    expect(anomalyIds).not.toContain(oldAnomaly);
+  });
+
+  it('keeps rows exactly at/after the boundary (just-newer than cutoff survives)', async () => {
+    // Cutoff is now - retentionDays. A row a few minutes newer than the cutoff
+    // must survive; one a few minutes older must be deleted.
+    const retentionDays = 40;
+    const cutoffMs = Date.now() - retentionDays * DAY_MS;
+    const justNewer = new Date(cutoffMs + 5 * 60 * 1000);
+    const justOlder = new Date(cutoffMs - 5 * 60 * 1000);
+
+    const survivor = await insertRemediation(orgId, deviceId, justNewer);
+    const victim = await insertRemediation(orgId, deviceId, justOlder);
+
+    const result = await runPrune(retentionDays);
+
+    const remediationTable = result.tables.find((t) => t.table === 'remediation_suggestions');
+    expect(remediationTable?.deleted).toBe(1);
+    const remaining = await selectRemediationIds(orgId);
+    expect(remaining).toEqual([survivor]);
+    expect(remaining).not.toContain(victim);
+  });
+
+  it('is a no-op when nothing is older than the cutoff', async () => {
+    const recent = new Date(Date.now() - 2 * DAY_MS);
+    await insertRemediation(orgId, deviceId, recent);
+    await insertAnomaly(orgId, deviceId, recent);
+
+    const result = await runPrune(30);
+
+    expect(result.deleted).toBe(0);
+    expect(await selectRemediationIds(orgId)).toHaveLength(1);
+    expect(await selectAnomalyIds(orgId)).toHaveLength(1);
+  });
+});

--- a/apps/api/src/__tests__/integration/reliabilityRetention.integration.test.ts
+++ b/apps/api/src/__tests__/integration/reliabilityRetention.integration.test.ts
@@ -1,0 +1,118 @@
+import './setup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+import { withSystemDbAccessContext } from '../../db';
+import { deviceReliabilityHistory, devices } from '../../db/schema';
+import { pruneReliabilityHistory } from '../../jobs/reliabilityRetention';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+let agentCounter = 0;
+async function insertDevice(orgId: string, siteId: string): Promise<string> {
+  agentCounter++;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `reliability-retention-${Date.now()}-${agentCounter}`,
+      hostname: `reliability-retention-host-${agentCounter}`,
+      displayName: `reliability-retention-host-${agentCounter}`,
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice returned no row');
+  return row.id;
+}
+
+async function insertHistory(orgId: string, deviceId: string, collectedAt: Date): Promise<string> {
+  const [row] = await getTestDb()
+    .insert(deviceReliabilityHistory)
+    .values({
+      orgId,
+      deviceId,
+      collectedAt,
+      uptimeSeconds: 3600,
+      bootTime: new Date(collectedAt.getTime() - 3600 * 1000),
+    })
+    .returning({ id: deviceReliabilityHistory.id });
+  if (!row) throw new Error('insertHistory returned no row');
+  return row.id;
+}
+
+async function selectHistoryIds(orgId: string) {
+  return (
+    await getTestDb()
+      .select({ id: deviceReliabilityHistory.id })
+      .from(deviceReliabilityHistory)
+      .where(eq(deviceReliabilityHistory.orgId, orgId))
+  ).map((r) => r.id);
+}
+
+async function runPrune(retentionDays: number) {
+  return withSystemDbAccessContext(() => pruneReliabilityHistory({ retentionDays }));
+}
+
+describe('reliability history retention pruning integration', () => {
+  let orgId: string;
+  let deviceId: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id, name: 'Reliability Retention Org' });
+    orgId = org.id;
+    const site = await createSite({ orgId, name: 'Reliability Site' });
+    deviceId = await insertDevice(orgId, site.id);
+  });
+
+  it('deletes only history rows older than the cutoff by collected_at', async () => {
+    // retentionDays clamps to a 30-day minimum.
+    const old = new Date(Date.now() - 50 * DAY_MS);
+    const recent = new Date(Date.now() - 3 * DAY_MS);
+
+    const oldId = await insertHistory(orgId, deviceId, old);
+    const recentId = await insertHistory(orgId, deviceId, recent);
+
+    const result = await runPrune(30);
+
+    expect(result.deleted).toBe(1);
+    const remaining = await selectHistoryIds(orgId);
+    expect(remaining).toEqual([recentId]);
+    expect(remaining).not.toContain(oldId);
+  });
+
+  it('keeps a row just-newer than the cutoff and deletes one just-older', async () => {
+    const retentionDays = 45;
+    const cutoffMs = Date.now() - retentionDays * DAY_MS;
+    const justNewer = new Date(cutoffMs + 5 * 60 * 1000);
+    const justOlder = new Date(cutoffMs - 5 * 60 * 1000);
+
+    const survivor = await insertHistory(orgId, deviceId, justNewer);
+    const victim = await insertHistory(orgId, deviceId, justOlder);
+
+    const result = await runPrune(retentionDays);
+
+    expect(result.deleted).toBe(1);
+    const remaining = await selectHistoryIds(orgId);
+    expect(remaining).toEqual([survivor]);
+    expect(remaining).not.toContain(victim);
+  });
+
+  it('is a no-op when nothing is older than the cutoff', async () => {
+    await insertHistory(orgId, deviceId, new Date(Date.now() - 2 * DAY_MS));
+
+    const result = await runPrune(30);
+
+    expect(result.deleted).toBe(0);
+    expect(await selectHistoryIds(orgId)).toHaveLength(1);
+  });
+});

--- a/apps/api/src/__tests__/integration/userRiskRetention.integration.test.ts
+++ b/apps/api/src/__tests__/integration/userRiskRetention.integration.test.ts
@@ -1,0 +1,150 @@
+import './setup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+
+import { withSystemDbAccessContext } from '../../db';
+import { userRiskScores } from '../../db/schema';
+import { compactUserRiskSnapshots } from '../../jobs/userRiskRetention';
+import { createOrganization, createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function insertSnapshot(options: {
+  orgId: string;
+  userId: string;
+  score: number;
+  calculatedAt: Date;
+}): Promise<string> {
+  const [row] = await getTestDb()
+    .insert(userRiskScores)
+    .values({
+      orgId: options.orgId,
+      userId: options.userId,
+      score: options.score,
+      factors: {},
+      trendDirection: 'stable',
+      calculatedAt: options.calculatedAt,
+    })
+    .returning({ id: userRiskScores.id });
+  if (!row) throw new Error('insertSnapshot returned no row');
+  return row.id;
+}
+
+async function selectSnapshots(orgId: string, userId: string) {
+  return getTestDb()
+    .select({ id: userRiskScores.id, calculatedAt: userRiskScores.calculatedAt, score: userRiskScores.score })
+    .from(userRiskScores)
+    .where(and(eq(userRiskScores.orgId, orgId), eq(userRiskScores.userId, userId)))
+    .orderBy(userRiskScores.calculatedAt);
+}
+
+async function runCompaction(options: { retentionDays: number; batchSize?: number; maxBatches?: number }) {
+  return withSystemDbAccessContext(() => compactUserRiskSnapshots(options));
+}
+
+describe('user risk retention compaction integration', () => {
+  let orgId: string;
+  let userId: string;
+  let otherUserId: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id, name: 'User Risk Retention Org' });
+    orgId = org.id;
+    userId = (await createUser({ partnerId: partner.id, orgId, email: `urr-${Date.now()}-a@example.com` })).id;
+    otherUserId = (await createUser({ partnerId: partner.id, orgId, email: `urr-${Date.now()}-b@example.com` })).id;
+  });
+
+  it('keeps the most recent snapshot per (org,user,day) for rows older than the cutoff', async () => {
+    // Three snapshots on the SAME old day — only the latest (12:00) should survive.
+    const oldDay = new Date(Date.now() - 60 * DAY_MS);
+    const morning = new Date(oldDay); morning.setUTCHours(8, 0, 0, 0);
+    const noon = new Date(oldDay); noon.setUTCHours(12, 0, 0, 0);
+    const earlyMorning = new Date(oldDay); earlyMorning.setUTCHours(2, 0, 0, 0);
+
+    await insertSnapshot({ orgId, userId, score: 10, calculatedAt: earlyMorning });
+    await insertSnapshot({ orgId, userId, score: 20, calculatedAt: morning });
+    const survivor = await insertSnapshot({ orgId, userId, score: 30, calculatedAt: noon });
+
+    const result = await runCompaction({ retentionDays: 30 });
+
+    expect(result.deleted).toBe(2);
+    const remaining = await selectSnapshots(orgId, userId);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.id).toBe(survivor);
+    expect(remaining[0]!.score).toBe(30);
+  });
+
+  it('keeps one-per-day across multiple old days and never touches rows newer than the cutoff', async () => {
+    const dayA = new Date(Date.now() - 70 * DAY_MS);
+    const dayB = new Date(Date.now() - 65 * DAY_MS);
+
+    const dayA1 = new Date(dayA); dayA1.setUTCHours(3, 0, 0, 0);
+    const dayA2 = new Date(dayA); dayA2.setUTCHours(21, 0, 0, 0);
+    const dayB1 = new Date(dayB); dayB1.setUTCHours(1, 0, 0, 0);
+    const dayB2 = new Date(dayB); dayB2.setUTCHours(9, 0, 0, 0);
+    const dayB3 = new Date(dayB); dayB3.setUTCHours(23, 0, 0, 0);
+
+    await insertSnapshot({ orgId, userId, score: 1, calculatedAt: dayA1 });
+    const survivorA = await insertSnapshot({ orgId, userId, score: 2, calculatedAt: dayA2 });
+    await insertSnapshot({ orgId, userId, score: 3, calculatedAt: dayB1 });
+    await insertSnapshot({ orgId, userId, score: 4, calculatedAt: dayB2 });
+    const survivorB = await insertSnapshot({ orgId, userId, score: 5, calculatedAt: dayB3 });
+
+    // Two recent snapshots inside the retention window — must be left untouched
+    // even though they are the same day.
+    const recent = new Date(Date.now() - 1 * DAY_MS);
+    const recent1 = new Date(recent); recent1.setUTCHours(6, 0, 0, 0);
+    const recent2 = new Date(recent); recent2.setUTCHours(18, 0, 0, 0);
+    const recentId1 = await insertSnapshot({ orgId, userId, score: 6, calculatedAt: recent1 });
+    const recentId2 = await insertSnapshot({ orgId, userId, score: 7, calculatedAt: recent2 });
+
+    const result = await runCompaction({ retentionDays: 30 });
+
+    // dayA dropped 1, dayB dropped 2 => 3 deleted total.
+    expect(result.deleted).toBe(3);
+    const remaining = await selectSnapshots(orgId, userId);
+    const remainingIds = remaining.map((r) => r.id);
+    expect(remainingIds).toContain(survivorA);
+    expect(remainingIds).toContain(survivorB);
+    expect(remainingIds).toContain(recentId1);
+    expect(remainingIds).toContain(recentId2);
+    expect(remaining).toHaveLength(4);
+  });
+
+  it('partitions per-user so one user\'s duplicates do not affect another', async () => {
+    const oldDay = new Date(Date.now() - 50 * DAY_MS);
+    const t1 = new Date(oldDay); t1.setUTCHours(4, 0, 0, 0);
+    const t2 = new Date(oldDay); t2.setUTCHours(16, 0, 0, 0);
+
+    await insertSnapshot({ orgId, userId, score: 11, calculatedAt: t1 });
+    const userSurvivor = await insertSnapshot({ orgId, userId, score: 12, calculatedAt: t2 });
+    // Other user has a single snapshot the same old day — must survive intact.
+    const otherSurvivor = await insertSnapshot({ orgId, userId: otherUserId, score: 99, calculatedAt: t1 });
+
+    const result = await runCompaction({ retentionDays: 30 });
+
+    expect(result.deleted).toBe(1);
+    const userRows = await selectSnapshots(orgId, userId);
+    expect(userRows.map((r) => r.id)).toEqual([userSurvivor]);
+    const otherRows = await selectSnapshots(orgId, otherUserId);
+    expect(otherRows.map((r) => r.id)).toEqual([otherSurvivor]);
+  });
+
+  it('is a no-op when every old day already has a single snapshot', async () => {
+    const dayA = new Date(Date.now() - 80 * DAY_MS);
+    const dayB = new Date(Date.now() - 75 * DAY_MS);
+    const a = new Date(dayA); a.setUTCHours(10, 0, 0, 0);
+    const b = new Date(dayB); b.setUTCHours(10, 0, 0, 0);
+    await insertSnapshot({ orgId, userId, score: 1, calculatedAt: a });
+    await insertSnapshot({ orgId, userId, score: 2, calculatedAt: b });
+
+    const result = await runCompaction({ retentionDays: 30 });
+
+    expect(result.deleted).toBe(0);
+    const remaining = await selectSnapshots(orgId, userId);
+    expect(remaining).toHaveLength(2);
+  });
+});

--- a/apps/api/src/jobs/alertCorrelation.test.ts
+++ b/apps/api/src/jobs/alertCorrelation.test.ts
@@ -1,13 +1,78 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getJobMock, addMock, closeMock, shouldProduceMlOutputMock, persistGroupsMock, attachWorkerObservabilityMock } = vi.hoisted(() => ({
-  getJobMock: vi.fn(),
-  addMock: vi.fn(),
-  closeMock: vi.fn(),
-  shouldProduceMlOutputMock: vi.fn(),
-  persistGroupsMock: vi.fn(),
-  attachWorkerObservabilityMock: vi.fn(),
-}));
+const {
+  getJobMock,
+  addMock,
+  closeMock,
+  shouldProduceMlOutputMock,
+  persistGroupsMock,
+  attachWorkerObservabilityMock,
+  isFlappingMock,
+  dbState,
+  dbMock,
+} = vi.hoisted(() => {
+  // Minimal stateful db mock supporting the read chain + an insert(...).values(...).returning()
+  // path used by runAlertCorrelationForDevice. `insertReturnsEmpty` simulates an RLS-scoped
+  // write that silently matches 0 rows so the `created` counter must not increment.
+  const dbState = {
+    targetDevice: [] as Array<Record<string, any>>,
+    recentAlerts: [] as Array<Record<string, any>>,
+    existingLinks: [] as Array<Record<string, any>>,
+    recentLogCorrelations: [] as Array<Record<string, any>>,
+    insertReturnsEmpty: false,
+    insertCalls: 0,
+    selectCall: 0,
+  };
+
+  const dbMock = {
+    select: vi.fn(() => {
+      const index = dbState.selectCall;
+      dbState.selectCall += 1;
+      const chain: any = {
+        from: () => chain,
+        leftJoin: () => chain,
+        innerJoin: () => chain,
+        where: () => chain,
+        orderBy: () => chain,
+        limit: () =>
+          // Query order: 0=targetDevice, 1=recentAlerts, 3=recentLogCorrelations (all .limit()).
+          Promise.resolve(
+            index === 0
+              ? dbState.targetDevice
+              : index === 1
+                ? dbState.recentAlerts
+                : index === 3
+                  ? dbState.recentLogCorrelations
+                  : []
+          ),
+        then: (resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) =>
+          // Query order: index 2 = existingLinks (no .limit(); awaited directly).
+          Promise.resolve(dbState.existingLinks).then(resolve, reject),
+      };
+      return chain;
+    }),
+    insert: vi.fn(() => ({
+      values: () => ({
+        returning: () => {
+          dbState.insertCalls += 1;
+          return Promise.resolve(dbState.insertReturnsEmpty ? [] : [{ id: `corr-${dbState.insertCalls}` }]);
+        },
+      }),
+    })),
+  };
+
+  return {
+    getJobMock: vi.fn(),
+    addMock: vi.fn(),
+    closeMock: vi.fn(),
+    shouldProduceMlOutputMock: vi.fn(),
+    persistGroupsMock: vi.fn(),
+    attachWorkerObservabilityMock: vi.fn(),
+    isFlappingMock: vi.fn(),
+    dbState,
+    dbMock,
+  };
+});
 
 vi.mock('bullmq', () => ({
   Queue: class {
@@ -39,7 +104,7 @@ vi.mock('../services/alertCorrelationGroups', () => ({
 }));
 
 vi.mock('../services/alertCooldown', () => ({
-  isFlapping: vi.fn(),
+  isFlapping: isFlappingMock,
 }));
 
 vi.mock('./workerObservability', () => ({
@@ -47,13 +112,17 @@ vi.mock('./workerObservability', () => ({
 }));
 
 vi.mock('../db', () => ({
-  db: {},
+  db: dbMock,
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({
   alerts: {},
-  alertCorrelations: {},
+  alertCorrelations: { id: 'alert_correlations.id', parentAlertId: 'alert_correlations.parentAlertId', childAlertId: 'alert_correlations.childAlertId' },
+  alertRules: {},
+  devices: {},
+  logCorrelationRules: {},
+  logCorrelations: {},
 }));
 
 import {
@@ -89,10 +158,21 @@ describe('alert correlation queue helpers', () => {
     shouldProduceMlOutputMock.mockReset();
     persistGroupsMock.mockReset();
     attachWorkerObservabilityMock.mockReset();
+    isFlappingMock.mockReset();
+    isFlappingMock.mockResolvedValue(false);
     shouldProduceMlOutputMock.mockResolvedValue(true);
     persistGroupsMock.mockResolvedValue({ scanned: 0, groupsWritten: 0, membersWritten: 0 });
     getJobMock.mockResolvedValue(null);
     addMock.mockResolvedValue({ id: 'queued-correlation-job' });
+    dbState.targetDevice = [];
+    dbState.recentAlerts = [];
+    dbState.existingLinks = [];
+    dbState.recentLogCorrelations = [];
+    dbState.insertReturnsEmpty = false;
+    dbState.insertCalls = 0;
+    dbState.selectCall = 0;
+    dbMock.select.mockClear();
+    dbMock.insert.mockClear();
     await shutdownAlertCorrelationWorker();
   });
 
@@ -145,6 +225,34 @@ describe('alert correlation queue helpers', () => {
 
     expect(result).toEqual({ scanned: 0, created: 0 });
     expect(shouldProduceMlOutputMock).toHaveBeenCalledWith('org-1', 'ml.alert_correlation.enabled');
+  });
+
+  it('counts only correlations that the insert actually persisted', async () => {
+    dbState.targetDevice = [{ siteId: 'site-1' }];
+    dbState.recentAlerts = [
+      { id: 'alert-a', deviceId: 'device-1', triggeredAt: new Date('2026-06-18T12:00:00.000Z'), ruleId: 'rule-1', templateId: null, configPolicyId: null, configItemName: null, siteId: 'site-1' },
+      { id: 'alert-b', deviceId: 'device-1', triggeredAt: new Date('2026-06-18T12:01:00.000Z'), ruleId: 'rule-1', templateId: null, configPolicyId: null, configItemName: null, siteId: 'site-1' },
+    ];
+
+    const result = await runAlertCorrelationForDevice({ orgId: 'org-1', deviceId: 'device-1', windowMinutes: 30 });
+
+    expect(dbState.insertCalls).toBe(1);
+    expect(result).toEqual({ scanned: 2, created: 1 });
+    expect(persistGroupsMock).toHaveBeenCalledWith({ orgId: 'org-1', alertIds: ['alert-a', 'alert-b'] });
+  });
+
+  it('does not increment created when an insert silently matches 0 rows (RLS scope drop)', async () => {
+    dbState.targetDevice = [{ siteId: 'site-1' }];
+    dbState.recentAlerts = [
+      { id: 'alert-a', deviceId: 'device-1', triggeredAt: new Date('2026-06-18T12:00:00.000Z'), ruleId: 'rule-1', templateId: null, configPolicyId: null, configItemName: null, siteId: 'site-1' },
+      { id: 'alert-b', deviceId: 'device-1', triggeredAt: new Date('2026-06-18T12:01:00.000Z'), ruleId: 'rule-1', templateId: null, configPolicyId: null, configItemName: null, siteId: 'site-1' },
+    ];
+    dbState.insertReturnsEmpty = true;
+
+    const result = await runAlertCorrelationForDevice({ orgId: 'org-1', deviceId: 'device-1', windowMinutes: 30 });
+
+    expect(dbState.insertCalls).toBe(1);
+    expect(result).toEqual({ scanned: 2, created: 0 });
   });
 
   it('attaches worker observability during initialization', async () => {

--- a/apps/api/src/jobs/alertCorrelation.ts
+++ b/apps/api/src/jobs/alertCorrelation.ts
@@ -504,7 +504,7 @@ export async function runAlertCorrelationForDevice(options: {
       const confidence = evidence.confidence;
       if (confidence < 0.3) continue;
 
-      await db
+      const inserted = await db
         .insert(alertCorrelations)
         .values({
           parentAlertId: older.id,
@@ -512,10 +512,15 @@ export async function runAlertCorrelationForDevice(options: {
           correlationType: evidence.correlationType,
           confidence: String(confidence),
           metadata: evidence.metadata,
-        });
+        })
+        .returning({ id: alertCorrelations.id });
 
       linkedPairs.add(pairKey);
-      created += 1;
+      // Under breeze_app RLS a write that matches no rows throws no error; only count
+      // correlations that were actually persisted so `created` cannot overstate the result.
+      if (inserted.length > 0) {
+        created += 1;
+      }
     }
   }
 

--- a/apps/api/src/jobs/mlOutputRetention.ts
+++ b/apps/api/src/jobs/mlOutputRetention.ts
@@ -187,6 +187,8 @@ export function createMlOutputRetentionWorker(): Worker<RetentionJobData> {
 
 export async function initializeMlOutputRetention(): Promise<void> {
   retentionWorker = createMlOutputRetentionWorker();
+  // attachWorkerObservability already routes 'error'/'failed' to Sentry
+  // (#1379); the handlers below stay console-only to avoid double-reporting (S5).
   attachWorkerObservability(retentionWorker, 'mlOutputRetention');
   retentionWorker.on('error', (error) => {
     console.error('[MlOutputRetention] Worker error:', error);

--- a/apps/api/src/jobs/reliabilityWorker.test.ts
+++ b/apps/api/src/jobs/reliabilityWorker.test.ts
@@ -38,6 +38,7 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
   db: {
     select: selectMock,
   },

--- a/apps/api/src/jobs/reliabilityWorker.ts
+++ b/apps/api/src/jobs/reliabilityWorker.ts
@@ -9,11 +9,21 @@ import { captureException } from '../services/sentry';
 import { isReusableState } from '../services/bullmqUtils';
 
 const { db } = dbModule;
+// #1105 (duration variant): withSystemDbAccessContext holds a DB transaction
+// for the whole callback. compute-org fans out across every device in the org,
+// so the held transaction would pin one pooled connection for the entire scan.
+// Wrap in runOutsideDbContext(() => withSystemDbAccessContext(...)) so the
+// background job opens a fresh context (not an inherited request transaction)
+// and the connection is released promptly when the compute completes.
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   if (typeof dbModule.withSystemDbAccessContext !== 'function') {
     throw new Error('[ReliabilityWorker] withSystemDbAccessContext is not available — DB module may not have loaded correctly');
   }
-  return dbModule.withSystemDbAccessContext(fn);
+  const runOutside = dbModule.runOutsideDbContext;
+  if (typeof runOutside !== 'function') {
+    return dbModule.withSystemDbAccessContext(fn);
+  }
+  return runOutside(() => dbModule.withSystemDbAccessContext(fn));
 };
 
 const RELIABILITY_QUEUE = 'reliability-scoring';
@@ -84,7 +94,9 @@ async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number 
   return { queued: orgRows.length };
 }
 
-async function processComputeOrg(data: ComputeOrgJobData): Promise<{ orgId: string; devicesComputed: number }> {
+async function processComputeOrg(
+  data: ComputeOrgJobData
+): Promise<{ orgId: string; devicesComputed: number; devicesFailed: number }> {
   return computeAndPersistOrgReliability(data.orgId);
 }
 

--- a/apps/api/src/jobs/userRiskJobs.test.ts
+++ b/apps/api/src/jobs/userRiskJobs.test.ts
@@ -64,6 +64,10 @@ vi.mock('../services/mlFeatureFlags', () => ({
   shouldProduceMlOutput: vi.fn(),
 }));
 
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
 import {
   buildUserRiskSignalEventJobId,
   createUserRiskWorker,
@@ -108,6 +112,7 @@ describe('triggerUserRiskRecompute', () => {
       skipped: false,
       appended: 0,
       deduped: 0,
+      failed: 0,
       candidates: {
         offHoursMassScripts: 0,
         remoteSessionBursts: 0,
@@ -183,7 +188,9 @@ describe('triggerUserRiskRecompute', () => {
     expect(queued.description).toHaveLength(1024);
     expect(queued.details).toBeUndefined();
     expect(addMock.mock.calls[0]?.[2]).toEqual(expect.objectContaining({
-      jobId: expect.stringMatching(/^user-risk-signal:org-1:user-1:[a-f0-9]{24}$/),
+      // #1118: jobId uses hyphen separators (0 colons) so BullMQ does not drop
+      // the enqueue — a 3-colon id silently throws.
+      jobId: expect.stringMatching(/^user-risk-signal-org-1-user-1-[a-f0-9]{24}$/),
     }));
   });
 
@@ -206,6 +213,9 @@ describe('triggerUserRiskRecompute', () => {
     });
 
     expect(first).toBe(second);
+    // #1118: BullMQ drops enqueues whose jobId has 1 or 3+ colons. This id must
+    // contain zero colons (hyphen-separated).
+    expect(first).not.toContain(':');
     await enqueueUserRiskSignalEvent(input);
 
     expect(getJobMock).toHaveBeenCalledWith(first);
@@ -328,5 +338,136 @@ describe('triggerUserRiskRecompute', () => {
       publishedSpikes: 0,
       publishFailures: 0,
     });
+  });
+
+  it('computes org user risk and publishes when enabled (happy path)', async () => {
+    vi.mocked(shouldProduceMlOutput).mockResolvedValue(true);
+    vi.mocked(evaluateUserRiskSignalsForOrg).mockResolvedValue({
+      orgId: 'org-1',
+      skipped: false,
+      appended: 2,
+      deduped: 1,
+      failed: 0,
+      candidates: {
+        offHoursMassScripts: 1,
+        remoteSessionBursts: 1,
+        privilegeElevationBursts: 1,
+        newGeographyLogins: 0,
+      },
+    });
+    vi.mocked(computeAndPersistOrgUserRisk).mockResolvedValue({
+      usersProcessed: 5,
+      changedUsers: [{ userId: 'user-1' }],
+      autoTrainingAssigned: 2,
+      policy: { thresholds: { high: 70 }, interventions: {} },
+    } as never);
+    vi.mocked(publishUserRiskScoreEvents).mockResolvedValue({
+      publishedHigh: 1,
+      publishedSpikes: 0,
+      failed: 0,
+    });
+
+    createUserRiskWorker();
+    const result = await workerProcessors[0]!({
+      data: { type: 'compute-org', orgId: 'org-1', queuedAt: '2026-03-31T12:00:00.000Z' },
+    });
+
+    expect(evaluateUserRiskSignalsForOrg).toHaveBeenCalledWith('org-1');
+    expect(computeAndPersistOrgUserRisk).toHaveBeenCalledWith('org-1');
+    expect(publishUserRiskScoreEvents).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      orgId: 'org-1',
+      usersProcessed: 5,
+      changedUsers: 1,
+      autoTrainingAssigned: 2,
+      signalsAppended: 2,
+      signalsDeduped: 1,
+      publishedHigh: 1,
+      publishedSpikes: 0,
+      publishFailures: 0,
+    });
+  });
+
+  it('runs the org DB compute inside runOutsideDbContext, publishes after it closes (#1105)', async () => {
+    const dbModule = await import('../db');
+    const calls: string[] = [];
+    vi.mocked(dbModule.runOutsideDbContext).mockImplementation(((fn: () => unknown) => {
+      calls.push('runOutsideDbContext');
+      return fn();
+    }) as never);
+    vi.mocked(computeAndPersistOrgUserRisk).mockImplementation((async () => {
+      calls.push('computeAndPersistOrgUserRisk');
+      return {
+        usersProcessed: 1,
+        changedUsers: [],
+        autoTrainingAssigned: 0,
+        policy: { thresholds: {}, interventions: {} },
+      };
+    }) as never);
+    vi.mocked(publishUserRiskScoreEvents).mockImplementation((async () => {
+      calls.push('publishUserRiskScoreEvents');
+      return { publishedHigh: 0, publishedSpikes: 0, failed: 0 };
+    }) as never);
+
+    createUserRiskWorker();
+    await workerProcessors[0]!({
+      data: { type: 'compute-org', orgId: 'org-1', queuedAt: '2026-03-31T12:00:00.000Z' },
+    });
+
+    // The DB compute must be wrapped by runOutsideDbContext, and the Redis
+    // publish must happen AFTER (not inside) the held context.
+    expect(calls.indexOf('runOutsideDbContext')).toBeLessThan(calls.indexOf('computeAndPersistOrgUserRisk'));
+    expect(calls.indexOf('computeAndPersistOrgUserRisk')).toBeLessThan(calls.indexOf('publishUserRiskScoreEvents'));
+  });
+
+  it('throws when compute-org publishing partially fails (forces BullMQ retry)', async () => {
+    const { captureException } = await import('../services/sentry');
+    vi.mocked(captureException).mockClear();
+    vi.mocked(publishUserRiskScoreEvents).mockResolvedValue({
+      publishedHigh: 1,
+      publishedSpikes: 0,
+      failed: 2,
+    });
+
+    createUserRiskWorker();
+    await expect(
+      workerProcessors[0]!({
+        data: { type: 'compute-org', orgId: 'org-1', queuedAt: '2026-03-31T12:00:00.000Z' },
+      }),
+    ).rejects.toThrow(/failed to publish 2 risk event/);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when signal-event publishing partially fails (forces BullMQ retry)', async () => {
+    const { captureException } = await import('../services/sentry');
+    vi.mocked(captureException).mockClear();
+    vi.mocked(computeAndPersistUserRiskForUser).mockResolvedValue({
+      usersProcessed: 1,
+      changedUsers: [{ userId: 'user-1' }],
+      autoTrainingAssigned: 0,
+      policy: { thresholds: {}, interventions: {} },
+    } as never);
+    vi.mocked(publishUserRiskScoreEvents).mockResolvedValue({
+      publishedHigh: 0,
+      publishedSpikes: 0,
+      failed: 1,
+    });
+
+    createUserRiskWorker();
+    await expect(
+      workerProcessors[0]!({
+        data: {
+          type: 'process-signal-event',
+          orgId: 'org-1',
+          userId: 'user-1',
+          eventType: 'suspicious_login',
+          severity: 'high',
+          description: 'Suspicious login',
+          queuedAt: '2026-03-31T12:00:00.000Z',
+        },
+      }),
+    ).rejects.toThrow(/failed to publish 1 risk event/);
+    expect(appendUserRiskSignalEvent).toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/jobs/userRiskJobs.ts
+++ b/apps/api/src/jobs/userRiskJobs.ts
@@ -15,11 +15,19 @@ import { evaluateUserRiskSignalsForOrg } from '../services/userRiskSignals';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
 import { shouldProduceMlOutput } from '../services/mlFeatureFlags';
+import { captureException } from '../services/sentry';
 
 const { db } = dbModule;
-const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+// #1105: withSystemDbAccessContext holds a DB transaction (pins a pooled
+// connection) for the whole callback. Wrap the DB compute in
+// runOutsideDbContext(() => withSystemDbAccessContext(...)) and do slow non-DB
+// work (Redis publishes) AFTER the context closes — never inside it.
+const runSystemDbCompute = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
-  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+  const runOutside = dbModule.runOutsideDbContext;
+  if (typeof withSystem !== 'function') return fn();
+  if (typeof runOutside !== 'function') return withSystem(fn);
+  return runOutside(() => withSystem(fn));
 };
 
 const USER_RISK_QUEUE = 'user-risk-scoring';
@@ -120,7 +128,9 @@ export function buildUserRiskSignalEventJobId(input: Omit<ProcessSignalEventJobD
     .update(stableJson(sanitized))
     .digest('hex')
     .slice(0, 24);
-  return `user-risk-signal:${sanitized.orgId}:${sanitized.userId}:${fingerprint}`;
+  // #1118: BullMQ jobIds must contain 0 or exactly 2 colons — 3 colons makes
+  // queue.add() silently throw and the enqueue is dropped. Use hyphen separators.
+  return `user-risk-signal-${sanitized.orgId}-${sanitized.userId}-${fingerprint}`;
 }
 
 export function getUserRiskQueue(): Queue<UserRiskJobData> {
@@ -133,11 +143,17 @@ export function getUserRiskQueue(): Queue<UserRiskJobData> {
 }
 
 async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
-  const orgRows = await db
-    .select({ orgId: organizationUsers.orgId })
-    .from(organizationUsers)
-    .where(sql`${organizationUsers.orgId} is not null`)
-    .groupBy(organizationUsers.orgId);
+  // The org enumeration is a tenant-scoped read; run it under the system
+  // context so RLS lets us see every org (a bare breeze_app read would match
+  // 0 rows, #1375). The result returns before we touch Redis, so the context
+  // is closed by the time we enqueue (#1105).
+  const orgRows = await runSystemDbCompute(() =>
+    db
+      .select({ orgId: organizationUsers.orgId })
+      .from(organizationUsers)
+      .where(sql`${organizationUsers.orgId} is not null`)
+      .groupBy(organizationUsers.orgId)
+  );
 
   if (orgRows.length === 0) {
     return { queued: 0 };
@@ -193,14 +209,29 @@ async function processComputeOrg(data: ComputeOrgJobData): Promise<{
     };
   }
 
-  const signalEvaluation = await evaluateUserRiskSignalsForOrg(data.orgId);
-  const result = await computeAndPersistOrgUserRisk(data.orgId);
+  // #1105: do the DB compute inside the held system context, then RETURN and
+  // run the Redis publishes AFTER the context closes (below) so the open
+  // transaction never spans the per-user publishEvent round-trips.
+  const { signalEvaluation, result } = await runSystemDbCompute(async () => {
+    const signalEvaluation = await evaluateUserRiskSignalsForOrg(data.orgId);
+    const result = await computeAndPersistOrgUserRisk(data.orgId);
+    return { signalEvaluation, result };
+  });
+
   const published = await publishUserRiskScoreEvents({
     orgId: data.orgId,
     changedUsers: result.changedUsers,
     thresholds: result.policy.thresholds,
     interventions: result.policy.interventions
   });
+
+  if (published.failed > 0) {
+    const error = new Error(
+      `[UserRiskJobs] compute-org for org ${data.orgId} failed to publish ${published.failed} risk event(s)`
+    );
+    captureException(error);
+    throw error;
+  }
 
   return {
     orgId: data.orgId,
@@ -240,24 +271,37 @@ async function processSignalEvent(data: ProcessSignalEventJobData): Promise<{
     };
   }
 
-  const eventId = await appendUserRiskSignalEvent({
-    orgId: data.orgId,
-    userId: data.userId,
-    eventType: data.eventType,
-    severity: data.severity,
-    scoreImpact: data.scoreImpact,
-    description: data.description,
-    details: data.details,
-    occurredAt: data.occurredAt ? new Date(data.occurredAt) : undefined
+  // #1105: DB writes inside the held system context; publish after it closes.
+  const { eventId, result } = await runSystemDbCompute(async () => {
+    const eventId = await appendUserRiskSignalEvent({
+      orgId: data.orgId,
+      userId: data.userId,
+      eventType: data.eventType,
+      severity: data.severity,
+      scoreImpact: data.scoreImpact,
+      description: data.description,
+      details: data.details,
+      occurredAt: data.occurredAt ? new Date(data.occurredAt) : undefined
+    });
+
+    const result = await computeAndPersistUserRiskForUser(data.orgId, data.userId);
+    return { eventId, result };
   });
 
-  const result = await computeAndPersistUserRiskForUser(data.orgId, data.userId);
   const published = await publishUserRiskScoreEvents({
     orgId: data.orgId,
     changedUsers: result.changedUsers,
     thresholds: result.policy.thresholds,
     interventions: result.policy.interventions
   });
+
+  if (published.failed > 0) {
+    const error = new Error(
+      `[UserRiskJobs] process-signal-event for org ${data.orgId} user ${data.userId} failed to publish ${published.failed} risk event(s)`
+    );
+    captureException(error);
+    throw error;
+  }
 
   return {
     orgId: data.orgId,
@@ -275,15 +319,16 @@ export function createUserRiskWorker(): Worker<UserRiskJobData> {
   return new Worker<UserRiskJobData>(
     USER_RISK_QUEUE,
     async (job: Job<UserRiskJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        if (job.data.type === 'scan-orgs') {
-          return processScanOrgs(job.data);
-        }
-        if (job.data.type === 'compute-org') {
-          return processComputeOrg(job.data);
-        }
-        return processSignalEvent(job.data);
-      });
+      // Each handler manages its own DB context (#1105): compute inside a
+      // runOutsideDbContext(withSystemDbAccessContext(...)) block and publish
+      // to Redis after it closes. processScanOrgs only reads via the bare pool.
+      if (job.data.type === 'scan-orgs') {
+        return processScanOrgs(job.data);
+      }
+      if (job.data.type === 'compute-org') {
+        return processComputeOrg(job.data);
+      }
+      return processSignalEvent(job.data);
     },
     {
       connection: getBullMQConnection(),
@@ -316,6 +361,9 @@ async function scheduleUserRiskScan(): Promise<void> {
 
 export async function initializeUserRiskJobs(): Promise<void> {
   userRiskWorker = createUserRiskWorker();
+  // attachWorkerObservability already routes both 'error' and 'failed' to
+  // Sentry (#1379); the handlers below are console-only on purpose to avoid
+  // double-reporting (S5).
   attachWorkerObservability(userRiskWorker, 'userRiskWorker');
   userRiskWorker.on('error', (error) => {
     console.error('[UserRiskJobs] Worker error:', error);

--- a/apps/api/src/jobs/userRiskRetention.ts
+++ b/apps/api/src/jobs/userRiskRetention.ts
@@ -142,6 +142,8 @@ export function createUserRiskRetentionWorker(): Worker<RetentionJobData> {
 
 export async function initializeUserRiskRetention(): Promise<void> {
   retentionWorker = createUserRiskRetentionWorker();
+  // attachWorkerObservability already routes 'error'/'failed' to Sentry
+  // (#1379); the handlers below stay console-only to avoid double-reporting (S5).
   attachWorkerObservability(retentionWorker, 'userRiskRetention');
   retentionWorker.on('error', (error) => {
     console.error('[UserRiskRetention] Worker error:', error);

--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -9,6 +9,7 @@ const {
   emitCorrelationFeedbackMock,
   emitRcaFeedbackMock,
   shouldProduceMlOutputMock,
+  captureExceptionMock,
   state,
   tables,
   dbMock,
@@ -61,6 +62,10 @@ const {
     members: [] as Array<Record<string, any>>,
     feedback: [] as Array<Record<string, any>>,
     devices: [] as Array<Record<string, any>>,
+    // Alert ids whose UPDATE should match 0 rows (simulating an RLS-scoped write that the
+    // breeze_app connection silently drops). They still appear in SELECTs so they are read as
+    // "eligible" pre-write, exposing the eligible-vs-written mismatch path.
+    unwritableAlertIds: new Set<string>(),
   };
 
   class SelectQuery {
@@ -102,20 +107,36 @@ const {
     })),
     update: vi.fn((table: unknown) => ({
       set: (values: Record<string, unknown>) => ({
-        where: async (predicate: Predicate) => {
+        where: (predicate: Predicate) => {
           const source = table === tables.alerts
             ? state.alerts
             : table === tables.alertCorrelationGroups
               ? state.groups
               : [];
-          let updated = 0;
+          const written: Array<Record<string, unknown>> = [];
           for (const row of source) {
-            if (evalPredicate(row, predicate)) {
-              Object.assign(row, values);
-              updated += 1;
-            }
+            if (!evalPredicate(row, predicate)) continue;
+            // Simulate an RLS-scoped write silently matching 0 rows for flagged alert ids.
+            if (table === tables.alerts && state.unwritableAlertIds.has(row.id as string)) continue;
+            Object.assign(row, values);
+            written.push(row);
           }
-          return Array.from({ length: updated }, () => ({}));
+          const result = written.map(() => ({}));
+          // Support both `await db.update(...).set(...).where(...)` (returns row stubs) and
+          // `.where(...).returning({ id })` (returns the written ids), matching Drizzle.
+          return {
+            returning: (projection?: Record<string, unknown>) =>
+              Promise.resolve(written.map((row) => {
+                if (!projection) return row;
+                const out: Record<string, unknown> = {};
+                for (const key of Object.keys(projection)) {
+                  out[key] = row[columnKey(projection[key])];
+                }
+                return out;
+              })),
+            then: (resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) =>
+              Promise.resolve(result).then(resolve, reject),
+          };
         },
       }),
     })),
@@ -129,6 +150,7 @@ const {
     emitCorrelationFeedbackMock: vi.fn(),
     emitRcaFeedbackMock: vi.fn(),
     shouldProduceMlOutputMock: vi.fn(),
+    captureExceptionMock: vi.fn(),
     state,
     tables,
     dbMock,
@@ -170,6 +192,7 @@ vi.mock('../../services/alertCorrelationRca', () => ({
   buildAlertCorrelationRca: buildAlertCorrelationRcaMock,
 }));
 vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn(() => Promise.resolve()) }));
+vi.mock('../../services/sentry', () => ({ captureException: captureExceptionMock }));
 vi.mock('../../services/mlFeedbackEmitters', () => ({
   emitAlertStateFeedback: emitAlertStateFeedbackMock,
   emitCorrelationFeedback: emitCorrelationFeedbackMock,
@@ -216,6 +239,7 @@ function seed() {
   state.members = [];
   state.feedback = [];
   state.devices = [{ id: DEVICE_1, hostname: 'server-1' }];
+  state.unwritableAlertIds = new Set();
 }
 
 function seedPersistedGroup() {
@@ -750,5 +774,46 @@ describe('/alerts correlation routes', () => {
       outcome: 'accepted',
       actorUserId: '99999999-9999-4999-8999-999999999999',
     }));
+  });
+
+  it('does not emit alert-state feedback for alerts the UPDATE did not return (RLS 0-row write)', async () => {
+    seedPersistedGroup();
+    // ALERT_2 is read as eligible (still in state) but its UPDATE matches 0 rows, simulating
+    // an RLS-scoped write the breeze_app connection silently drops.
+    state.unwritableAlertIds = new Set([ALERT_2]);
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Only the written alert is counted and gets feedback; the phantom one is suppressed.
+    expect(body.updated).toBe(1);
+    expect(emitAlertStateFeedbackMock).toHaveBeenCalledTimes(1);
+    expect(emitAlertStateFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({ alertId: ALERT_1 }));
+    expect(emitAlertStateFeedbackMock).not.toHaveBeenCalledWith(expect.objectContaining({ alertId: ALERT_2 }));
+    // The eligible-vs-written mismatch is surfaced to Sentry, not silently swallowed.
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits feedback for every alert and reports no mismatch when all writes land', async () => {
+    seedPersistedGroup();
+
+    const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.updated).toBe(2);
+    expect(emitAlertStateFeedbackMock).toHaveBeenCalledTimes(2);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('scopes persisted group status updates to the resolving org', async () => {
+    seedPersistedGroup();
+
+    await makeApp().request(`/alerts/correlations/${GROUP_1}/resolve`, { method: 'POST' });
+
+    const updateCalls = dbMock.update.mock.calls;
+    expect(updateCalls).toContainEqual([tables.alertCorrelationGroups]);
+    expect(state.groups.find((group) => group.id === GROUP_1)?.status).toBe('resolved');
   });
 });

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -9,6 +9,7 @@ import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { buildAlertCorrelationRca } from '../../services/alertCorrelationRca';
 import { publishEvent } from '../../services/eventBus';
+import { captureException } from '../../services/sentry';
 import { emitAlertStateFeedback, emitCorrelationFeedback, emitRcaFeedback } from '../../services/mlFeedbackEmitters';
 import { shouldProduceMlOutput } from '../../services/mlFeatureFlags';
 import { PERMISSIONS } from '../../services/permissions';
@@ -529,11 +530,22 @@ async function getPersistedGroupAlerts(groupId: string, auth: AuthContext): Prom
   return db.select().from(alerts).where(and(eq(alerts.orgId, group.orgId), inArray(alerts.id, alertIds)));
 }
 
-async function updatePersistedGroupStatus(groupId: string, status: 'acknowledged' | 'resolved'): Promise<void> {
-  await db
+async function updatePersistedGroupStatus(
+  groupId: string,
+  orgId: string,
+  status: 'acknowledged' | 'resolved',
+): Promise<void> {
+  const updated = await db
     .update(alertCorrelationGroups)
     .set({ status, updatedAt: new Date() })
-    .where(eq(alertCorrelationGroups.id, groupId));
+    .where(and(eq(alertCorrelationGroups.id, groupId), eq(alertCorrelationGroups.orgId, orgId)))
+    .returning({ id: alertCorrelationGroups.id });
+
+  if (updated.length === 0) {
+    console.warn(
+      `[AlertCorrelationRoute] updatePersistedGroupStatus matched 0 rows for group ${groupId} in org ${orgId} (status=${status}); possible RLS scope mismatch or stale group.`
+    );
+  }
 }
 
 async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'resolve', userId: string) {
@@ -547,14 +559,29 @@ async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'reso
   }
 
   const alertIds = eligible.map((alert) => alert.id);
-  await db
+  const returned = await db
     .update(alerts)
     .set(action === 'acknowledge'
       ? { status: 'acknowledged', acknowledgedAt: now, acknowledgedBy: userId }
       : { status: 'resolved', resolvedAt: now, resolvedBy: userId })
-    .where(inArray(alerts.id, alertIds));
+    .where(inArray(alerts.id, alertIds))
+    .returning({ id: alerts.id });
+
+  // Under breeze_app RLS a write that matches 0 rows throws no error. Emitting ML feedback
+  // for the pre-read `eligible` set would poison correlation-acceptance training with phantom
+  // acknowledgements. Only emit for alerts the UPDATE actually wrote.
+  const writtenIds = new Set(returned.map((row) => row.id));
+  if (writtenIds.size !== eligible.length) {
+    captureException(new Error(
+      `[AlertCorrelationRoute] mutateAlerts ${action} RLS scope mismatch: ` +
+      `${eligible.length} eligible alert(s) but only ${writtenIds.size} written; ` +
+      `suppressing feedback for ${eligible.length - writtenIds.size} unwritten alert(s).`
+    ));
+  }
 
   for (const alert of eligible) {
+    if (!writtenIds.has(alert.id)) continue;
+
     void publishEvent(
       action === 'acknowledge' ? 'alert.acknowledged' : 'alert.resolved',
       alert.orgId,
@@ -584,7 +611,7 @@ async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'reso
     });
   }
 
-  return { updated: eligible.length, skipped: alertRows.length - eligible.length };
+  return { updated: writtenIds.size, skipped: alertRows.length - writtenIds.size };
 }
 
 alertCorrelationRoutes.get(
@@ -793,8 +820,8 @@ alertCorrelationRoutes.post(
     const groupAlertIds = persistedGroupAlerts !== null ? persistedGroupAlerts.map((alert) => alert.id) : group!.alerts.map((alert) => alert.id);
     const groupAlerts = persistedGroupAlerts ?? await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
     const result = await mutateAlerts(groupAlerts, 'acknowledge', auth.user.id);
-    if (persistedGroupAlerts !== null) {
-      await updatePersistedGroupStatus(groupId, 'acknowledged');
+    if (persistedGroupAlerts !== null && groupAlerts[0]) {
+      await updatePersistedGroupStatus(groupId, groupAlerts[0].orgId, 'acknowledged');
     }
 
     writeRouteAudit(c, {
@@ -844,8 +871,8 @@ alertCorrelationRoutes.post(
     const groupAlertIds = persistedGroupAlerts !== null ? persistedGroupAlerts.map((alert) => alert.id) : group!.alerts.map((alert) => alert.id);
     const groupAlerts = persistedGroupAlerts ?? await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
     const result = await mutateAlerts(groupAlerts, 'resolve', auth.user.id);
-    if (persistedGroupAlerts !== null) {
-      await updatePersistedGroupStatus(groupId, 'resolved');
+    if (persistedGroupAlerts !== null && groupAlerts[0]) {
+      await updatePersistedGroupStatus(groupId, groupAlerts[0].orgId, 'resolved');
     }
 
     writeRouteAudit(c, {

--- a/apps/api/src/services/alertCorrelationGroups.test.ts
+++ b/apps/api/src/services/alertCorrelationGroups.test.ts
@@ -42,7 +42,7 @@ const { dbMock, state, tables } = vi.hoisted(() => {
     select: vi.fn(() => ({
       from: (table: unknown) => new SelectQuery(table),
     })),
-    execute: vi.fn(async () => [{ id: '99999999-9999-4999-8999-999999999999' }]),
+    execute: vi.fn(async (_query?: { strings?: TemplateStringsArray; values?: unknown[] }) => [{ id: '99999999-9999-4999-8999-999999999999' }]),
   };
 
   return { dbMock, state, tables };
@@ -95,6 +95,33 @@ describe('alert correlation group materializer', () => {
     expect(result).toEqual({ scanned: 2, groupsWritten: 1, membersWritten: 2 });
     expect(dbMock.execute).toHaveBeenCalledTimes(3);
     expect(JSON.stringify(dbMock.execute.mock.calls)).toContain('ON CONFLICT');
+  });
+
+  it('floors noiseReductionPercent so the suppression claim never overstates (3 members => 66)', async () => {
+    const ALERT_4 = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+    state.alerts = [
+      { id: ALERT_1, orgId: ORG_1, deviceId: 'device-1', ruleId: 'rule-1', status: 'active', severity: 'critical', title: 'CPU high', triggeredAt: new Date('2026-06-18T12:00:00Z'), createdAt: new Date('2026-06-18T12:00:00Z') },
+      { id: ALERT_2, orgId: ORG_1, deviceId: 'device-1', ruleId: 'rule-2', status: 'active', severity: 'high', title: 'Memory high', triggeredAt: new Date('2026-06-18T12:01:00Z'), createdAt: new Date('2026-06-18T12:01:00Z') },
+      { id: ALERT_4, orgId: ORG_1, deviceId: 'device-1', ruleId: 'rule-4', status: 'active', severity: 'medium', title: 'Disk high', triggeredAt: new Date('2026-06-18T12:02:00Z'), createdAt: new Date('2026-06-18T12:02:00Z') },
+    ];
+    state.correlations = [
+      { parentAlertId: ALERT_1, childAlertId: ALERT_2, correlationType: 'same_device_temporal', confidence: '0.91', createdAt: new Date('2026-06-18T12:03:00Z') },
+      { parentAlertId: ALERT_2, childAlertId: ALERT_4, correlationType: 'same_device_temporal', confidence: '0.85', createdAt: new Date('2026-06-18T12:04:00Z') },
+    ];
+
+    const result = await persistAlertCorrelationGroupsForAlerts({
+      orgId: ORG_1,
+      alertIds: [ALERT_1, ALERT_2, ALERT_4],
+    });
+
+    expect(result).toEqual({ scanned: 3, groupsWritten: 1, membersWritten: 3 });
+    // The group upsert is the first execute call; its bound values carry noiseReductionPercent.
+    const groupInsert = dbMock.execute.mock.calls.find((call) =>
+      JSON.stringify(call[0]?.strings ?? []).includes('noise_reduction_percent')
+    );
+    expect(groupInsert).toBeDefined();
+    // (3 - 1) / 3 * 100 = 66.66...; floor => 66 (Math.round would overstate to 67).
+    expect(groupInsert![0]?.values).toContain(66);
   });
 
   it('skips materialization when fewer than two alerts are in scope', async () => {

--- a/apps/api/src/services/alertCorrelationGroups.ts
+++ b/apps/api/src/services/alertCorrelationGroups.ts
@@ -98,7 +98,11 @@ function confidenceForAlert(alertId: string, component: Component): number {
 async function upsertGroup(orgId: string, component: Component): Promise<string> {
   const memberCount = component.alerts.length;
   const score = averageConfidence(component.correlations);
-  const noiseReductionPercent = Math.round(((memberCount - 1) / memberCount) * 100);
+  // Floor (never round up) so the customer-facing noise-reduction claim never overstates
+  // the actual suppression (e.g. 3 members => 66%, not 67%). Guard against a 0-member divide.
+  const noiseReductionPercent = memberCount > 0
+    ? Math.floor(((memberCount - 1) / memberCount) * 100)
+    : 0;
   const firstSeenAt = component.alerts[0]!.triggeredAt;
   const lastSeenAt = component.alerts[memberCount - 1]!.triggeredAt;
   const correlationTypes = [...new Set(component.correlations.map((link) => link.correlationType))];

--- a/apps/api/src/services/alertCorrelationRca.test.ts
+++ b/apps/api/src/services/alertCorrelationRca.test.ts
@@ -528,6 +528,64 @@ describe('alert correlation RCA evidence builder', () => {
     expect(result.gaps).toEqual([]);
   });
 
+  it('keeps high-importance evidence over earlier low-weight noise when truncating', async () => {
+    // Flood the window with many low-weight device_context items that are EARLIER in time than
+    // the single high-weight device_change. An earliest-N truncation would keep the noise and
+    // drop the change; importance-first selection must retain the change.
+    state.correlations = [];
+    state.linkedLogCorrelations = [];
+    state.eventLogs = [];
+    state.agentLogs = [];
+    state.metricRollups = [];
+    state.context = Array.from({ length: 8 }, (_unused, index) => ({
+      id: `ctx-${index}`,
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      contextType: 'issue',
+      summary: `Low-signal context ${index}`,
+      details: null,
+      // All earlier than the change below.
+      createdAt: new Date(`2026-06-18T10:0${index}:00Z`),
+      resolvedAt: null,
+    }));
+    state.changes = [{
+      id: 'change-late',
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      // Latest timestamp in the set — would be dropped by an earliest-N slice.
+      timestamp: new Date('2026-06-18T11:59:00Z'),
+      changeType: 'service',
+      changeAction: 'modified',
+      subject: 'Backup service schedule changed',
+    }];
+
+    const result = await buildAlertCorrelationRca({
+      orgId: ORG_ID,
+      groupId: 'group-1',
+      groupScore: 0.5,
+      windowHours: 4,
+      // Smallest allowed cap (clamped to 5): 1 alert + 1 change + 3 context. The high-weight
+      // change must survive even though 5 of the 8 context items are earlier in time.
+      maxEvidenceItems: 5,
+      alerts: [
+        { id: ALERT_1, orgId: ORG_ID, deviceId: DEVICE_ID, ruleId: 'rule-1', configPolicyId: null, configItemName: null, status: 'active', severity: 'critical', title: 'CPU high', message: 'CPU over 90%', context: {}, triggeredAt: new Date('2026-06-18T12:00:00Z'), acknowledgedAt: null, acknowledgedBy: null, resolvedAt: null, resolvedBy: null, resolutionNote: null, suppressedUntil: null, createdAt: new Date('2026-06-18T12:00:00Z') },
+      ],
+    });
+
+    expect(result.timeline).toHaveLength(5);
+    const sources = result.timeline.map((item) => item.source);
+    expect(sources).toContain('alert');
+    expect(sources).toContain('device_change');
+    expect(result.timeline.find((item) => item.id === 'device_change:change-late')).toBeDefined();
+    // Timeline is still chronologically ordered for display.
+    const timestamps = result.timeline.map((item) => new Date(item.timestamp).getTime());
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => a - b));
+    // The candidate heuristics still find the change in the truncated timeline.
+    expect(result.rootCauseCandidates).toEqual(expect.arrayContaining([
+      expect.objectContaining({ confidence: 0.58, supportingEvidenceIds: ['device_change:change-late'] }),
+    ]));
+  });
+
   it('caps RCA evidence windows relative to old incident time instead of now', async () => {
     state.eventLogs = [
       {

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -317,21 +317,37 @@ function buildAlertMetadata(
   };
 }
 
-function rankEvidence(items: RcaEvidenceItem[]): RcaEvidenceItem[] {
-  const sourceWeight: Record<RcaEvidenceItem['source'], number> = {
-    alert: 100,
-    correlation: 80,
-    device_change: 75,
-    event_log: 70,
-    agent_log: 65,
-    metric_rollup: 55,
-    device_context: 45,
-  };
+const RCA_SOURCE_WEIGHT: Record<RcaEvidenceItem['source'], number> = {
+  alert: 100,
+  correlation: 80,
+  device_change: 75,
+  event_log: 70,
+  agent_log: 65,
+  metric_rollup: 55,
+  device_context: 45,
+};
 
-  return [...items].sort((a, b) => {
+/**
+ * Select the top-N evidence items by importance (sourceWeight), then return those survivors
+ * in chronological order for display. Selecting by importance FIRST (instead of sorting purely
+ * by time and slicing) ensures high-signal evidence — e.g. the alerts and correlation edges —
+ * is not dropped on busy windows where low-weight log/metric noise would otherwise crowd out
+ * the earliest-N. Ties in weight are broken by recency so the most recent high-signal item wins.
+ */
+function rankEvidence(items: RcaEvidenceItem[], maxItems: number): RcaEvidenceItem[] {
+  const byImportance = [...items].sort((a, b) => {
+    const weightDiff = RCA_SOURCE_WEIGHT[b.source] - RCA_SOURCE_WEIGHT[a.source];
+    if (weightDiff !== 0) return weightDiff;
+    // Same source weight: prefer the more recent item.
+    return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+  });
+
+  const survivors = byImportance.slice(0, Math.max(maxItems, 0));
+
+  return survivors.sort((a, b) => {
     const timeDiff = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
     if (timeDiff !== 0) return timeDiff;
-    return sourceWeight[b.source] - sourceWeight[a.source];
+    return RCA_SOURCE_WEIGHT[b.source] - RCA_SOURCE_WEIGHT[a.source];
   });
 }
 
@@ -811,7 +827,7 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
       })),
   ];
 
-  const timeline = rankEvidence(evidence).slice(0, maxEvidenceItems);
+  const timeline = rankEvidence(evidence, maxEvidenceItems);
   const candidates = [
     buildPrimaryAlertCandidate(alertRows, options.groupScore),
     buildCorrelationMetadataCandidate(timeline),

--- a/apps/api/src/services/metricAnomalies.ts
+++ b/apps/api/src/services/metricAnomalies.ts
@@ -53,6 +53,11 @@ function anomalyUpsertAssignments(): SQL {
 
 async function detectBaselineDeviations(options: MetricAnomalyRange): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
+  // bucket_start is timestamp-without-tz; bind ISO strings + ::timestamp so the
+  // comparison stays in tz-free space (matches the rollup writer) and postgres.js
+  // does not bind a raw Date as timestamptz.
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
 
   await db.execute(sql`
     WITH recent AS (
@@ -70,8 +75,8 @@ async function detectBaselineDeviations(options: MetricAnomalyRange): Promise<vo
       WHERE mr.org_id = ${options.orgId}
         AND mr.source_table = 'device_metrics'
         AND mr.bucket_seconds = ${RAW_BUCKET_SECONDS}
-        AND mr.bucket_start >= ${from}
-        AND mr.bucket_start < ${to}
+        AND mr.bucket_start >= ${fromIso}::timestamp
+        AND mr.bucket_start < ${toIso}::timestamp
         AND mr.avg_value IS NOT NULL
         AND mr.sample_count > 0
     ),
@@ -183,9 +188,9 @@ async function detectBaselineDeviations(options: MetricAnomalyRange): Promise<vo
       least(0.99, greatest(0.5, 0.5 + (s.score / 10)))::double precision,
       s.sample_count,
       jsonb_build_object(
-        'modelVersion', ${METRIC_ANOMALY_VERSION},
-        'baselineHours', ${BASELINE_LOOKBACK_HOURS},
-        'baselineGapMinutes', ${BASELINE_GAP_MINUTES},
+        'modelVersion', ${METRIC_ANOMALY_VERSION}::text,
+        'baselineHours', ${BASELINE_LOOKBACK_HOURS}::integer,
+        'baselineGapMinutes', ${BASELINE_GAP_MINUTES}::integer,
         'baselineBuckets', s.baseline_count,
         'baselineStddev', s.baseline_stddev
       ),
@@ -205,9 +210,16 @@ async function detectBaselineDeviations(options: MetricAnomalyRange): Promise<vo
 
 async function detectGrowthTrends(options: MetricAnomalyRange): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
 
   await db.execute(sql`
-    WITH recent AS (
+    WITH anchors AS (
+      -- Every raw bucket in [from, to) is a potential trend-window anchor (the
+      -- window end). Evaluating per-anchor — like detectBaselineDeviations — means
+      -- a wide backfill/catch-up range scans every interior MIN_TREND_BUCKETS slice
+      -- instead of only the single window ending at \`to\`, which silently skipped
+      -- everything before to - MIN_TREND_BUCKETS*RAW_BUCKET_SECONDS.
       SELECT
         mr.org_id,
         mr.device_id,
@@ -215,30 +227,53 @@ async function detectGrowthTrends(options: MetricAnomalyRange): Promise<void> {
         mr.metric_type,
         mr.metric_name,
         mr.bucket_seconds,
-        min(mr.bucket_start) AS window_start,
-        max(mr.bucket_start) AS last_bucket_start,
-        count(*)::integer AS bucket_count,
-        (array_agg(mr.avg_value ORDER BY mr.bucket_start ASC))[1]::double precision AS first_value,
-        (array_agg(mr.avg_value ORDER BY mr.bucket_start DESC))[1]::double precision AS last_value,
-        min(mr.avg_value)::double precision AS min_value,
-        max(mr.avg_value)::double precision AS max_value,
-        sum(mr.sample_count)::integer AS sample_count
+        mr.bucket_start AS anchor_bucket_start
       FROM metric_rollups mr
       WHERE mr.org_id = ${options.orgId}
         AND mr.source_table = 'device_metrics'
         AND mr.bucket_seconds = ${RAW_BUCKET_SECONDS}
-        AND mr.bucket_start >= (${to}::timestamp - (${MIN_TREND_BUCKETS} * ${RAW_BUCKET_SECONDS} * interval '1 second'))
-        AND mr.bucket_start < ${to}
+        AND mr.bucket_start >= ${fromIso}::timestamp
+        AND mr.bucket_start < ${toIso}::timestamp
         AND mr.metric_name IN ('ram_percent', 'ram_used_mb', 'disk_percent', 'disk_used_gb')
         AND mr.avg_value IS NOT NULL
         AND mr.sample_count > 0
+    ),
+    recent AS (
+      SELECT
+        a.org_id,
+        a.device_id,
+        a.source_table,
+        a.metric_type,
+        a.metric_name,
+        a.bucket_seconds,
+        min(w.bucket_start) AS window_start,
+        max(w.bucket_start) AS last_bucket_start,
+        count(*)::integer AS bucket_count,
+        (array_agg(w.avg_value ORDER BY w.bucket_start ASC))[1]::double precision AS first_value,
+        (array_agg(w.avg_value ORDER BY w.bucket_start DESC))[1]::double precision AS last_value,
+        min(w.avg_value)::double precision AS min_value,
+        max(w.avg_value)::double precision AS max_value,
+        sum(w.sample_count)::integer AS sample_count
+      FROM anchors a
+      JOIN metric_rollups w
+        ON w.org_id = a.org_id
+       AND w.device_id = a.device_id
+       AND w.source_table = a.source_table
+       AND w.metric_type = a.metric_type
+       AND w.metric_name = a.metric_name
+       AND w.bucket_seconds = a.bucket_seconds
+       AND w.avg_value IS NOT NULL
+       AND w.sample_count > 0
+       AND w.bucket_start > a.anchor_bucket_start - (${MIN_TREND_BUCKETS}::integer * ${RAW_BUCKET_SECONDS}::integer * interval '1 second')
+       AND w.bucket_start <= a.anchor_bucket_start
       GROUP BY
-        mr.org_id,
-        mr.device_id,
-        mr.source_table,
-        mr.metric_type,
-        mr.metric_name,
-        mr.bucket_seconds
+        a.org_id,
+        a.device_id,
+        a.source_table,
+        a.metric_type,
+        a.metric_name,
+        a.bucket_seconds,
+        a.anchor_bucket_start
     ),
     trend AS (
       SELECT
@@ -298,7 +333,7 @@ async function detectGrowthTrends(options: MetricAnomalyRange): Promise<void> {
       least(0.98, greatest(0.55, 0.55 + (t.score / 100)))::double precision,
       t.sample_count,
       jsonb_build_object(
-        'modelVersion', ${METRIC_ANOMALY_VERSION},
+        'modelVersion', ${METRIC_ANOMALY_VERSION}::text,
         'trendBuckets', t.bucket_count,
         'firstValue', t.first_value,
         'lastValue', t.last_value
@@ -318,6 +353,8 @@ async function detectGrowthTrends(options: MetricAnomalyRange): Promise<void> {
 
 async function detectProcessSampleRunaways(options: MetricAnomalyRange): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
 
   await db.execute(sql`
     WITH recent AS (
@@ -336,8 +373,8 @@ async function detectProcessSampleRunaways(options: MetricAnomalyRange): Promise
       WHERE mr.org_id = ${options.orgId}
         AND mr.source_table = 'device_process_samples'
         AND mr.bucket_seconds = ${RAW_BUCKET_SECONDS}
-        AND mr.bucket_start >= ${from}
-        AND mr.bucket_start < ${to}
+        AND mr.bucket_start >= ${fromIso}::timestamp
+        AND mr.bucket_start < ${toIso}::timestamp
         AND mr.metric_name IN (
           'top_process_cpu_percent_sum',
           'top_process_cpu_percent_max',
@@ -469,9 +506,9 @@ async function detectProcessSampleRunaways(options: MetricAnomalyRange): Promise
       least(0.99, greatest(0.55, 0.55 + (s.score / 10)))::double precision,
       s.sample_count,
       jsonb_build_object(
-        'modelVersion', ${METRIC_ANOMALY_VERSION},
-        'baselineHours', ${BASELINE_LOOKBACK_HOURS},
-        'baselineGapMinutes', ${BASELINE_GAP_MINUTES},
+        'modelVersion', ${METRIC_ANOMALY_VERSION}::text,
+        'baselineHours', ${BASELINE_LOOKBACK_HOURS}::integer,
+        'baselineGapMinutes', ${BASELINE_GAP_MINUTES}::integer,
         'baselineBuckets', s.baseline_count,
         'baselineStddev', s.baseline_stddev,
         'sourceTable', s.source_table

--- a/apps/api/src/services/metricAnomalyPromotion.test.ts
+++ b/apps/api/src/services/metricAnomalyPromotion.test.ts
@@ -19,6 +19,7 @@ const {
 vi.mock('drizzle-orm', () => ({
   and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
   eq: (left: unknown, right: unknown) => ({ type: 'eq', left, right }),
+  ne: (left: unknown, right: unknown) => ({ type: 'ne', left, right }),
 }));
 
 vi.mock('../db', () => ({
@@ -103,6 +104,7 @@ describe('metric anomaly promotion service', () => {
 
   it('creates an alert, links the anomaly, and publishes alert.triggered', async () => {
     selectMock.mockReturnValueOnce(chain([anomaly]));
+    selectMock.mockReturnValueOnce(chain([])); // dedupe siblings lookup
     insertMock.mockReturnValueOnce(chain([{ id: '44444444-4444-4444-8444-444444444444' }]));
     updateMock.mockReturnValueOnce(chain([{ ...anomaly, status: 'promoted', linkedAlertId: '44444444-4444-4444-8444-444444444444' }]));
 
@@ -136,6 +138,50 @@ describe('metric anomaly promotion service', () => {
     );
   });
 
+  it('reuses a sibling anomaly alert instead of creating a duplicate incident', async () => {
+    // network_egress can be emitted twice for one event: once for
+    // bandwidth_out_bps (baseline) and once for top_process_net_bps_sum
+    // (process runaway). Promoting the second one must reuse the first alert.
+    const requested = {
+      ...anomaly,
+      id: '55555555-5555-4555-8555-555555555555',
+      metricName: 'top_process_net_bps_sum',
+      anomalyType: 'network_egress',
+      linkedAlertId: null,
+      status: 'open',
+    };
+    const promotedSibling = {
+      ...anomaly,
+      id: '66666666-6666-4666-8666-666666666666',
+      metricName: 'bandwidth_out_bps',
+      anomalyType: 'network_egress',
+      linkedAlertId: 'alert-from-sibling',
+      status: 'promoted',
+    };
+
+    selectMock.mockReturnValueOnce(chain([requested]));
+    selectMock.mockReturnValueOnce(chain([promotedSibling])); // dedupe siblings lookup
+    updateMock.mockReturnValueOnce(chain([{ ...requested, status: 'promoted', linkedAlertId: 'alert-from-sibling' }]));
+
+    const result = await promoteMetricAnomalyToAlert({
+      orgId: requested.orgId,
+      deviceId: requested.deviceId,
+      anomalyId: requested.id,
+      actorUserId: 'user-1',
+    });
+
+    expect(result).toMatchObject({
+      status: 'promoted',
+      alertId: 'alert-from-sibling',
+      created: false,
+    });
+    // No new alert and no second alert.triggered event for the duplicate row.
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(publishEventMock).not.toHaveBeenCalled();
+    // The duplicate row is still linked + marked promoted.
+    expect(updateMock).toHaveBeenCalledWith(expect.anything());
+  });
+
   it('is idempotent when the anomaly is already linked to an alert', async () => {
     selectMock.mockReturnValueOnce(chain([{ ...anomaly, status: 'promoted', linkedAlertId: 'alert-existing' }]));
 
@@ -158,6 +204,7 @@ describe('metric anomaly promotion service', () => {
 
   it('suppresses alert creation when anomaly alert promotion is disabled', async () => {
     selectMock.mockReturnValueOnce(chain([anomaly]));
+    selectMock.mockReturnValueOnce(chain([])); // dedupe siblings lookup
     shouldProduceMlOutputMock.mockResolvedValue(false);
 
     const result = await promoteMetricAnomalyToAlert({
@@ -174,6 +221,7 @@ describe('metric anomaly promotion service', () => {
 
   it('allows explicit manual promotion even when automatic anomaly alert creation is disabled', async () => {
     selectMock.mockReturnValueOnce(chain([anomaly]));
+    selectMock.mockReturnValueOnce(chain([])); // dedupe siblings lookup
     shouldProduceMlOutputMock.mockResolvedValue(false);
     insertMock.mockReturnValueOnce(chain([{ id: '44444444-4444-4444-8444-444444444444' }]));
     updateMock.mockReturnValueOnce(chain([{ ...anomaly, status: 'promoted', linkedAlertId: '44444444-4444-4444-8444-444444444444' }]));

--- a/apps/api/src/services/metricAnomalyPromotion.ts
+++ b/apps/api/src/services/metricAnomalyPromotion.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 
 import { db } from '../db';
 import { alerts, metricAnomalies } from '../db/schema';
@@ -7,6 +7,40 @@ import { shouldProduceMlOutput } from './mlFeatureFlags';
 import { resolveDeviceSiteId } from './deviceSiteResolver';
 
 type MetricAnomalyRow = typeof metricAnomalies.$inferSelect;
+
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  info: 0,
+};
+
+/**
+ * Two detectors can emit the SAME logical incident under different metric_name
+ * rows: the baseline detector emits anomaly_type='network_egress' for
+ * metric_name='bandwidth_out_bps', while detectProcessSampleRunaways emits the
+ * same 'network_egress' (and a 'process_runaway' CPU/RAM analog) for
+ * metric_name='top_process_net_bps_sum'. The metric_anomalies ON CONFLICT key
+ * includes metric_name, so those rows never collide at write time — one real
+ * event becomes two promotable anomalies.
+ *
+ * We can't dedupe at the detection layer without losing the per-metric evidence,
+ * so we collapse here at promotion: anomalies that share
+ * (deviceId, anomalyType, bucketSeconds, windowStart) are the same incident and
+ * must promote to a SINGLE alert. We pick the higher-severity / higher-confidence
+ * row as the canonical one driving the alert, and link every sibling to that one
+ * alert so a second promotion is a no-op reuse instead of a duplicate incident.
+ */
+function isHigherPriority(candidate: MetricAnomalyRow, current: MetricAnomalyRow): boolean {
+  const candidateRank = SEVERITY_RANK[severityForAnomaly(candidate)] ?? -1;
+  const currentRank = SEVERITY_RANK[severityForAnomaly(current)] ?? -1;
+  if (candidateRank !== currentRank) return candidateRank > currentRank;
+  if (candidate.confidence !== current.confidence) return candidate.confidence > current.confidence;
+  if (candidate.score !== current.score) return candidate.score > current.score;
+  // Stable tiebreak so the canonical row is deterministic across re-promotions.
+  return candidate.id < current.id;
+}
 
 export type MetricAnomalyPromotionResult =
   | {
@@ -65,6 +99,30 @@ function anomalyIdentityWhere(options: PromoteMetricAnomalyToAlertOptions) {
   );
 }
 
+/**
+ * Find anomalies in the same incident group as `anomaly` — same device,
+ * anomaly_type, bucket window — but a DIFFERENT metric_name (and a different
+ * row). Used to collapse the double-emitted-anomaly case into a single alert.
+ */
+async function findDedupeSiblings(
+  orgId: string,
+  anomaly: MetricAnomalyRow,
+): Promise<MetricAnomalyRow[]> {
+  return db
+    .select()
+    .from(metricAnomalies)
+    .where(
+      and(
+        eq(metricAnomalies.orgId, orgId),
+        eq(metricAnomalies.deviceId, anomaly.deviceId),
+        eq(metricAnomalies.anomalyType, anomaly.anomalyType),
+        eq(metricAnomalies.bucketSeconds, anomaly.bucketSeconds),
+        eq(metricAnomalies.windowStart, anomaly.windowStart),
+        ne(metricAnomalies.id, anomaly.id),
+      ),
+    );
+}
+
 export async function promoteMetricAnomalyToAlert(
   options: PromoteMetricAnomalyToAlertOptions,
 ): Promise<MetricAnomalyPromotionResult> {
@@ -107,6 +165,33 @@ export async function promoteMetricAnomalyToAlert(
     };
   }
 
+  // Collapse the double-emitted-anomaly case: if a sibling row (same device /
+  // anomaly_type / window, different metric_name) already drove an alert, reuse
+  // that alert instead of opening a second incident for the same event.
+  const siblings = await findDedupeSiblings(anomaly.orgId, anomaly);
+  const promotedSibling = siblings.find((s) => s.linkedAlertId);
+  if (promotedSibling?.linkedAlertId) {
+    const reusedAlertId = promotedSibling.linkedAlertId;
+    const now = new Date();
+    const [updated] = await db
+      .update(metricAnomalies)
+      .set({
+        status: 'promoted',
+        linkedAlertId: reusedAlertId,
+        resolvedAt: null,
+        updatedAt: now,
+      })
+      .where(anomalyIdentityWhere(options))
+      .returning();
+
+    return {
+      status: 'promoted',
+      anomaly: updated ?? { ...anomaly, status: 'promoted', linkedAlertId: reusedAlertId, resolvedAt: null, updatedAt: now },
+      alertId: reusedAlertId,
+      created: false,
+    };
+  }
+
   if (
     options.requireCreateAlertsFlag !== false
     && !(await shouldProduceMlOutput(anomaly.orgId, 'ml.anomalies.create_alerts'))
@@ -114,32 +199,41 @@ export async function promoteMetricAnomalyToAlert(
     return { status: 'disabled', anomaly };
   }
 
-  const severity = severityForAnomaly(anomaly);
-  const title = titleForAnomaly(anomaly);
-  const message = messageForAnomaly(anomaly);
+  // Pick the highest-severity / highest-confidence row in the incident group to
+  // drive the single alert, so the de-duped incident keeps the strongest signal.
+  let canonical = anomaly;
+  for (const sibling of siblings) {
+    if (isHigherPriority(sibling, canonical)) {
+      canonical = sibling;
+    }
+  }
+
+  const severity = severityForAnomaly(canonical);
+  const title = titleForAnomaly(canonical);
+  const message = messageForAnomaly(canonical);
   const now = new Date();
 
   const [alert] = await db
     .insert(alerts)
     .values({
       ruleId: null,
-      deviceId: anomaly.deviceId,
-      orgId: anomaly.orgId,
+      deviceId: canonical.deviceId,
+      orgId: canonical.orgId,
       status: 'active',
       severity,
       title,
       message,
       context: {
         source: 'metric_anomaly',
-        anomalyId: anomaly.id,
-        metricName: anomaly.metricName,
-        metricType: anomaly.metricType,
-        anomalyType: anomaly.anomalyType,
-        observedValue: anomaly.observedValue,
-        baselineValue: anomaly.baselineValue,
-        confidence: anomaly.confidence,
-        score: anomaly.score,
-        modelVersion: (anomaly.baselineSummary as { modelVersion?: unknown } | null)?.modelVersion ?? null,
+        anomalyId: canonical.id,
+        metricName: canonical.metricName,
+        metricType: canonical.metricType,
+        anomalyType: canonical.anomalyType,
+        observedValue: canonical.observedValue,
+        baselineValue: canonical.baselineValue,
+        confidence: canonical.confidence,
+        score: canonical.score,
+        modelVersion: (canonical.baselineSummary as { modelVersion?: unknown } | null)?.modelVersion ?? null,
       },
       triggeredAt: now,
     })
@@ -159,6 +253,26 @@ export async function promoteMetricAnomalyToAlert(
     })
     .where(anomalyIdentityWhere(options))
     .returning();
+
+  // Link every sibling to the same alert so a later promotion of any of them is
+  // a no-op reuse, not a duplicate incident.
+  for (const sibling of siblings) {
+    await db
+      .update(metricAnomalies)
+      .set({
+        status: 'promoted',
+        linkedAlertId: alert.id,
+        resolvedAt: null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(metricAnomalies.id, sibling.id),
+          eq(metricAnomalies.orgId, anomaly.orgId),
+          eq(metricAnomalies.deviceId, anomaly.deviceId),
+        ),
+      );
+  }
 
   const siteId = await resolveDeviceSiteId(anomaly.deviceId);
   await publishEvent(

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -104,7 +104,12 @@ export interface MetricRollupResult {
 
 function bucketStartSql(timestampSql: SQL, bucketSeconds: number): SQL<Date> {
   const bucketSecondsSql = sql.raw(String(bucketSeconds));
-  return sql<Date>`to_timestamp(floor(extract(epoch from ${timestampSql}) / ${bucketSecondsSql}) * ${bucketSecondsSql})::timestamp`;
+  // Bucket entirely in timestamp-without-tz space via date_bin (Postgres 14+).
+  // The previous to_timestamp(...)::timestamp round-trip shifted buckets by the
+  // session TZ offset on any non-UTC DB session, diverging from the raw path
+  // (generate_series over ::timestamp). date_bin never converts to/from timestamptz,
+  // so it stays aligned with the raw grid regardless of the session timezone.
+  return sql<Date>`date_bin(make_interval(secs => ${bucketSecondsSql}), ${timestampSql}, timestamp 'epoch')`;
 }
 
 function upsertAssignments(): SQL {

--- a/apps/api/src/services/mlFeedbackEmitters.test.ts
+++ b/apps/api/src/services/mlFeedbackEmitters.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture every payload handed to the underlying writer so we can assert shape
+// and the actorUserIdOrNull normalization without exporting the helper.
+const emitMlFeedbackEvent = vi.fn();
+
+vi.mock('./mlFeedback', () => ({
+  emitMlFeedbackEvent: (...args: unknown[]) => emitMlFeedbackEvent(...args),
+}));
+
+import {
+  emitAlertStateFeedback,
+  emitCorrelationFeedback,
+  emitAnomalyFeedback,
+  emitRcaFeedback,
+  emitRemediationSuggestionFeedback,
+  emitDeviceReliabilityFeedback,
+  emitTicketTriageFeedback,
+  emitUserRiskFeedback,
+} from './mlFeedbackEmitters';
+
+const VALID_UUID = '11111111-2222-4333-8444-555566667777';
+
+function lastPayload(): Record<string, unknown> {
+  return emitMlFeedbackEvent.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+}
+
+describe('mlFeedbackEmitters', () => {
+  beforeEach(() => {
+    emitMlFeedbackEvent.mockReset();
+    emitMlFeedbackEvent.mockResolvedValue({ id: 'evt-1', inserted: true });
+  });
+
+  describe('payload shape per emitter', () => {
+    it('emitAlertStateFeedback maps to the alert source type', async () => {
+      await emitAlertStateFeedback({
+        orgId: 'org-1',
+        alertId: 'alert-1',
+        eventType: 'alert.acknowledged',
+        outcome: 'acknowledged',
+        actorUserId: VALID_UUID,
+        metadata: { foo: 'bar' },
+      });
+      expect(lastPayload()).toMatchObject({
+        orgId: 'org-1',
+        sourceType: 'alert',
+        sourceId: 'alert-1',
+        eventType: 'alert.acknowledged',
+        outcome: 'acknowledged',
+        actorUserId: VALID_UUID,
+        metadata: { foo: 'bar' },
+      });
+      expect(lastPayload().occurredAt).toBeInstanceOf(Date);
+    });
+
+    it('emitCorrelationFeedback maps to the correlation source type', async () => {
+      await emitCorrelationFeedback({
+        orgId: 'org-1', correlationId: 'corr-1',
+        eventType: 'correlation.accepted', outcome: 'accepted',
+      });
+      expect(lastPayload()).toMatchObject({ sourceType: 'correlation', sourceId: 'corr-1', eventType: 'correlation.accepted' });
+    });
+
+    it('emitAnomalyFeedback maps to the anomaly source type', async () => {
+      await emitAnomalyFeedback({
+        orgId: 'org-1', anomalyId: 'an-1',
+        eventType: 'anomaly.promoted', outcome: 'promoted',
+      });
+      expect(lastPayload()).toMatchObject({ sourceType: 'anomaly', sourceId: 'an-1', eventType: 'anomaly.promoted' });
+    });
+
+    it('emitRcaFeedback maps to the rca source type', async () => {
+      await emitRcaFeedback({
+        orgId: 'org-1', rcaId: 'rca-1',
+        eventType: 'rca.helpful', outcome: 'helpful',
+      });
+      expect(lastPayload()).toMatchObject({ sourceType: 'rca', sourceId: 'rca-1', eventType: 'rca.helpful' });
+    });
+
+    it('emitRemediationSuggestionFeedback maps to the remediation source type', async () => {
+      await emitRemediationSuggestionFeedback({
+        orgId: 'org-1', suggestionId: 'sg-1',
+        eventType: 'suggestion.accepted', outcome: 'accepted',
+      });
+      expect(lastPayload()).toMatchObject({ sourceType: 'remediation', sourceId: 'sg-1', eventType: 'suggestion.accepted' });
+    });
+
+    it('emitDeviceReliabilityFeedback maps to the device source type', async () => {
+      await emitDeviceReliabilityFeedback({
+        orgId: 'org-1', deviceId: 'dev-1',
+        eventType: 'device.failure_confirmed', outcome: 'failure_confirmed',
+      });
+      expect(lastPayload()).toMatchObject({ sourceType: 'device', sourceId: 'dev-1', eventType: 'device.failure_confirmed' });
+    });
+
+    it('emitTicketTriageFeedback maps to the ticket source type', async () => {
+      await emitTicketTriageFeedback({
+        orgId: 'org-1', ticketId: 'tk-1',
+        eventType: 'ticket.priority_changed', outcome: 'priority_changed',
+      });
+      expect(lastPayload()).toMatchObject({ sourceType: 'ticket', sourceId: 'tk-1', eventType: 'ticket.priority_changed' });
+    });
+
+    it('emitUserRiskFeedback maps to the user_risk source type', async () => {
+      await emitUserRiskFeedback({
+        orgId: 'org-1', userId: 'usr-1',
+        eventType: 'user_risk.true_positive', outcome: 'true_positive',
+      });
+      expect(lastPayload()).toMatchObject({ sourceType: 'user_risk', sourceId: 'usr-1', eventType: 'user_risk.true_positive' });
+    });
+  });
+
+  describe('actorUserIdOrNull normalization', () => {
+    it('passes through a well-formed RFC UUID', async () => {
+      await emitAlertStateFeedback({
+        orgId: 'org-1', alertId: 'a', eventType: 'alert.resolved', outcome: 'resolved',
+        actorUserId: VALID_UUID,
+      });
+      expect(lastPayload().actorUserId).toBe(VALID_UUID);
+    });
+
+    it('nulls out a malformed actor id', async () => {
+      await emitAlertStateFeedback({
+        orgId: 'org-1', alertId: 'a', eventType: 'alert.resolved', outcome: 'resolved',
+        actorUserId: 'not-a-uuid',
+      });
+      expect(lastPayload().actorUserId).toBeNull();
+    });
+
+    it('nulls out the all-zero nil sentinel (version nibble is 0, fails [1-5])', async () => {
+      await emitAlertStateFeedback({
+        orgId: 'org-1', alertId: 'a', eventType: 'alert.resolved', outcome: 'resolved',
+        actorUserId: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(lastPayload().actorUserId).toBeNull();
+    });
+
+    it('nulls out undefined/null actor ids (system actor)', async () => {
+      await emitAlertStateFeedback({
+        orgId: 'org-1', alertId: 'a', eventType: 'alert.resolved', outcome: 'resolved',
+      });
+      expect(lastPayload().actorUserId).toBeNull();
+    });
+  });
+
+  describe('emitFeedbackBestEffort error boundary', () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
+
+    it('swallows a throwing underlying write on best-effort emitters and logs it', async () => {
+      emitMlFeedbackEvent.mockRejectedValueOnce(new Error('db exploded'));
+      await expect(emitAlertStateFeedback({
+        orgId: 'org-1', alertId: 'a', eventType: 'alert.resolved', outcome: 'resolved',
+      })).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[MlFeedback] Failed to emit alert.resolved'),
+        expect.any(Error),
+      );
+    });
+
+    it('propagates errors from the non-best-effort device emitter (intentional)', async () => {
+      emitMlFeedbackEvent.mockRejectedValueOnce(new Error('db exploded'));
+      await expect(emitDeviceReliabilityFeedback({
+        orgId: 'org-1', deviceId: 'dev-1', eventType: 'device.replaced', outcome: 'replaced',
+      })).rejects.toThrow('db exploded');
+    });
+
+    it('propagates errors from the non-best-effort user-risk emitter (intentional)', async () => {
+      emitMlFeedbackEvent.mockRejectedValueOnce(new Error('db exploded'));
+      await expect(emitUserRiskFeedback({
+        orgId: 'org-1', userId: 'usr-1', eventType: 'user_risk.false_positive', outcome: 'false_positive',
+      })).rejects.toThrow('db exploded');
+    });
+  });
+});

--- a/apps/api/src/services/reliabilityScoring.featureFlag.test.ts
+++ b/apps/api/src/services/reliabilityScoring.featureFlag.test.ts
@@ -53,6 +53,7 @@ describe('reliability scoring feature flag gates', () => {
     await expect(computeAndPersistOrgReliability('org-1')).resolves.toEqual({
       orgId: 'org-1',
       devicesComputed: 0,
+      devicesFailed: 0,
     });
 
     expect(mocks.shouldProduceMlOutput).toHaveBeenCalledWith('org-1', 'ml.device_reliability.enabled');

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { and, asc, desc, eq, gt, gte, inArray, lte, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';
@@ -9,6 +11,7 @@ import {
   type ReliabilityTopIssue,
 } from '../db/schema';
 import { shouldProduceMlOutput } from './mlFeatureFlags';
+import { captureException } from './sentry';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RELIABILITY_FACTOR_WEIGHTS = {
@@ -632,7 +635,17 @@ function computeTopIssues(input: {
 function buildReliabilityDrivers(details: unknown): ReliabilityFactorDriver[] {
   const root = asObject(details);
   const factors = asObject(root?.factors);
-  if (!factors) return [];
+  if (!factors) {
+    // Distinguish a genuine "no factors" from a malformed/parse-failure payload:
+    // if `details` carried a `factors` key but it didn't parse as an object,
+    // that's a data-shape bug worth surfacing rather than silently returning [].
+    if (root && 'factors' in root) {
+      console.warn(
+        '[ReliabilityScoring] buildReliabilityDrivers: details.factors present but not an object — returning no drivers'
+      );
+    }
+    return [];
+  }
 
   const configs: Array<{ factor: ReliabilityFactorName; label: string }> = [
     { factor: 'uptime', label: 'Uptime' },
@@ -1002,16 +1015,24 @@ async function runConcurrently<T>(
         succeeded++;
       } else {
         failed++;
-        console.error('[ReliabilityScoring] device computation failed:', result.reason);
+        const errorId = randomUUID();
+        console.error(`[ReliabilityScoring] device computation failed (errorId=${errorId}):`, result.reason);
+        captureException(
+          result.reason instanceof Error
+            ? result.reason
+            : new Error(`[ReliabilityScoring] device computation failed (errorId=${errorId}): ${String(result.reason)}`)
+        );
       }
     }
   }
   return { succeeded, failed };
 }
 
-export async function computeAndPersistOrgReliability(orgId: string): Promise<{ orgId: string; devicesComputed: number }> {
+export async function computeAndPersistOrgReliability(
+  orgId: string
+): Promise<{ orgId: string; devicesComputed: number; devicesFailed: number }> {
   if (!(await shouldProduceMlOutput(orgId, 'ml.device_reliability.enabled'))) {
-    return { orgId, devicesComputed: 0 };
+    return { orgId, devicesComputed: 0, devicesFailed: 0 };
   }
 
   const orgDevices = await db
@@ -1019,15 +1040,15 @@ export async function computeAndPersistOrgReliability(orgId: string): Promise<{ 
     .from(devices)
     .where(and(eq(devices.orgId, orgId), sql`${devices.status} <> 'decommissioned'`));
 
-  if (orgDevices.length === 0) return { orgId, devicesComputed: 0 };
+  if (orgDevices.length === 0) return { orgId, devicesComputed: 0, devicesFailed: 0 };
 
-  const { succeeded } = await runConcurrently(
+  const { succeeded, failed } = await runConcurrently(
     orgDevices,
     10,
     (device) => computeAndPersistDeviceReliability(device.id).then(() => undefined)
   );
 
-  return { orgId, devicesComputed: succeeded };
+  return { orgId, devicesComputed: succeeded, devicesFailed: failed };
 }
 
 export async function listReliabilityDevices(filter: ReliabilityListFilter): Promise<{ total: number; rows: ReliabilityListItem[] }> {

--- a/apps/api/src/services/remediationSuggestions.test.ts
+++ b/apps/api/src/services/remediationSuggestions.test.ts
@@ -1,6 +1,112 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-import { __testOnly } from './remediationSuggestions';
+// Hoisted so the vi.mock factories (which are themselves hoisted) can read them.
+const h = vi.hoisted(() => {
+  const TABLE = '__table__';
+  const tbl = (name: string, extra: Record<string, string> = {}) => ({ [TABLE]: name, ...extra });
+  return {
+    TABLE,
+    insertedRows: [] as Array<Record<string, unknown>>,
+    tables: {
+      alertCorrelationGroups: tbl('alertCorrelationGroups'),
+      alerts: tbl('alerts'),
+      devices: tbl('devices'),
+      metricAnomalies: tbl('metricAnomalies'),
+      playbookDefinitions: tbl('playbookDefinitions', { id: 'p', name: 'p', description: 'p', category: 'p', isBuiltIn: 'p', isActive: 'p', orgId: 'p' }),
+      remediationSuggestions: tbl('remediationSuggestions', { orgId: 'r', sourceType: 'r', sourceId: 'r', targetType: 'r', scriptId: 'r', scriptTemplateId: 'r', playbookId: 'r' }),
+      scripts: tbl('scripts', { id: 's', name: 's', description: 's', category: 's', runAs: 's', deletedAt: 's', isSystem: 's', orgId: 's', updatedAt: 's' }),
+      scriptTemplates: tbl('scriptTemplates', { id: 't', name: 't', description: 't', category: 't', rating: 't', downloads: 't' }),
+    },
+  };
+});
+
+const insertedRows = h.insertedRows;
+
+vi.mock('../db', () => {
+  // Chainable query builder; the resolved value depends on the `from` table.
+  function makeSelectChain() {
+    let table: string | undefined;
+    const chain: Record<string, unknown> = {};
+    const passthrough = () => chain;
+    chain.from = (t: Record<string, string>) => { table = t?.[h.TABLE]; return chain; };
+    chain.where = passthrough;
+    chain.orderBy = passthrough;
+    chain.limit = passthrough;
+    chain.then = (resolve: (v: unknown) => unknown) => {
+      // Source-context lookups + candidate lists + existing all resolve empty
+      // so generateRemediationSuggestions falls through to the fallback nudge.
+      if (table === 'metricAnomalies') {
+        return resolve([{
+          id: 'anomaly-1', orgId: 'org-1', deviceId: 'dev-1', linkedAlertId: null,
+          linkedCorrelationGroupId: null, anomalyType: 'zzz_no_match', metricType: 'zzz',
+          metricName: 'zzz_metric', evidence: {},
+        }]);
+      }
+      return resolve([]);
+    };
+    return chain;
+  }
+
+  return {
+    db: {
+      select: () => makeSelectChain(),
+      insert: () => ({
+        values: (vals: Record<string, unknown>) => ({
+          returning: () => {
+            const row = { id: `sugg-${h.insertedRows.length + 1}`, ...vals };
+            h.insertedRows.push(row);
+            return Promise.resolve([row]);
+          },
+        }),
+      }),
+    },
+  };
+});
+
+vi.mock('../db/schema', () => h.tables);
+
+vi.mock('./mlFeatureFlags', () => ({
+  shouldProduceMlOutput: vi.fn().mockResolvedValue(true),
+}));
+
+import { __testOnly, generateRemediationSuggestions } from './remediationSuggestions';
+import { shouldProduceMlOutput } from './mlFeatureFlags';
+
+describe('generateRemediationSuggestions fallback tagging', () => {
+  beforeEach(() => {
+    insertedRows.length = 0;
+    vi.mocked(shouldProduceMlOutput).mockResolvedValue(true);
+  });
+
+  it('tags the persisted fallback row and sets usedFallback when nothing matches', async () => {
+    const result = await generateRemediationSuggestions({
+      sourceType: 'anomaly',
+      sourceId: 'anomaly-1',
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.usedFallback).toBe(true);
+    expect(result.suggestions).toHaveLength(1);
+
+    const persisted = insertedRows[0];
+    expect(persisted).toBeDefined();
+    expect(persisted!.targetType).toBe('diagnostic');
+    expect(persisted!.evidence).toMatchObject({ fallback: true, reason: 'no_term_match' });
+  });
+
+  it('reports usedFallback=false and no rows when ML output is disabled', async () => {
+    vi.mocked(shouldProduceMlOutput).mockResolvedValue(false);
+    const result = await generateRemediationSuggestions({
+      sourceType: 'anomaly',
+      sourceId: 'anomaly-1',
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.usedFallback).toBe(false);
+    expect(result.suggestions).toEqual([]);
+    expect(insertedRows).toHaveLength(0);
+  });
+});
 
 describe('remediation suggestion heuristics', () => {
   it('maps network egress anomalies to network/security remediation terms', () => {

--- a/apps/api/src/services/remediationSuggestions.ts
+++ b/apps/api/src/services/remediationSuggestions.ts
@@ -31,6 +31,12 @@ export interface RemediationSuggestionGenerateResult {
   sourceId: string;
   orgId: string;
   skipped: boolean;
+  /**
+   * True when no real script/template/playbook matched and the only persisted
+   * suggestion is the canned "collect diagnostics" fallback nudge. Lets callers
+   * and eval distinguish "found a real fix" from "found nothing".
+   */
+  usedFallback: boolean;
   suggestions: Array<typeof remediationSuggestions.$inferSelect>;
 }
 
@@ -62,6 +68,8 @@ interface Candidate {
   confidence: number;
   expectedAction: string;
   matchedTerms: string[];
+  /** Set only on the canned diagnostic nudge pushed when nothing else matched. */
+  fallback?: boolean;
 }
 
 function sourceTextParts(...parts: Array<string | null | undefined>): string {
@@ -304,6 +312,7 @@ async function listCandidates(ctx: SourceContext, limit: number): Promise<Candid
       confidence: 0.35,
       expectedAction: 'Use existing diagnostic commands or playbooks to gather more evidence before changing the device.',
       matchedTerms: terms.slice(0, 3),
+      fallback: true,
     });
   }
 
@@ -333,6 +342,7 @@ export async function generateRemediationSuggestions(
       sourceId: input.sourceId,
       orgId: ctx.orgId,
       skipped: true,
+      usedFallback: false,
       suggestions: [],
     };
   }
@@ -347,6 +357,7 @@ export async function generateRemediationSuggestions(
     ));
 
   const candidates = await listCandidates(ctx, Math.min(Math.max(input.limit ?? 3, 1), 10));
+  const usedFallback = candidates.some((candidate) => candidate.fallback === true);
   const created: Array<typeof remediationSuggestions.$inferSelect> = [];
   for (const candidate of candidates) {
     const prior = existing.find((row) => sameTarget(row, candidate));
@@ -384,6 +395,9 @@ export async function generateRemediationSuggestions(
           category: candidate.category,
           metricName: ctx.metricName,
           anomalyType: ctx.anomalyType,
+          // Tag the canned "collect diagnostics" nudge so eval/consumers can tell
+          // it apart from a real script/template/playbook match.
+          ...(candidate.fallback ? { fallback: true, reason: 'no_term_match' } : {}),
         },
       })
       .returning();
@@ -395,6 +409,7 @@ export async function generateRemediationSuggestions(
     sourceId: input.sourceId,
     orgId: ctx.orgId,
     skipped: false,
+    usedFallback,
     suggestions: created,
   };
 }

--- a/apps/api/src/services/ticketTriage.test.ts
+++ b/apps/api/src/services/ticketTriage.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Categories returned by the mocked db.select chain; mutated per-test.
+let categoryRows: Array<{ id: string; name: string; defaultPriority: string | null }> = [];
 
 vi.mock('../db', () => ({
-  db: {},
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(categoryRows),
+      }),
+    }),
+  },
 }));
 
 vi.mock('../db/schema', () => ({
@@ -14,7 +23,45 @@ vi.mock('./mlFeatureFlags', () => ({
   resolveMlFeatureFlagForOrg: vi.fn(),
 }));
 
-import { ticketTriageInternals } from './ticketTriage';
+import { getTicketTriageSuggestion, ticketTriageInternals } from './ticketTriage';
+import { resolveMlFeatureFlagForOrg } from './mlFeatureFlags';
+
+const baseTicket = {
+  id: 'ticket-1',
+  orgId: 'org-1',
+  partnerId: 'partner-1',
+  subject: 'VPN is down for the whole office',
+  description: 'Nobody can connect to the VPN',
+  source: 'email',
+  priority: 'normal',
+  categoryId: null,
+} as unknown as Parameters<typeof getTicketTriageSuggestion>[0];
+
+describe('getTicketTriageSuggestion — empty-category explanation', () => {
+  beforeEach(() => {
+    categoryRows = [];
+    vi.mocked(resolveMlFeatureFlagForOrg).mockResolvedValue({ enabled: true, source: 'test' } as never);
+  });
+
+  it('records no_partner_categories when the ticket has no partner', async () => {
+    const result = await getTicketTriageSuggestion({ ...baseTicket, partnerId: null } as never);
+    expect(result.suggestion).not.toBeNull();
+    expect(result.suggestion?.reasons).toContain('no_partner_categories');
+    expect(result.suggestion?.categoryId).toBeNull();
+  });
+
+  it('records no_active_partner_categories when the partner has no active categories', async () => {
+    categoryRows = [];
+    const result = await getTicketTriageSuggestion(baseTicket);
+    expect(result.suggestion?.reasons).toContain('no_active_partner_categories');
+  });
+
+  it('records no_category_keyword_match when categories exist but none match', async () => {
+    categoryRows = [{ id: 'cat-backup', name: 'Backup', defaultPriority: null }];
+    const result = await getTicketTriageSuggestion(baseTicket);
+    expect(result.suggestion?.reasons).toContain('no_category_keyword_match');
+  });
+});
 
 describe('ticketTriageInternals', () => {
   it('suggests urgent priority for outage/security language', () => {

--- a/apps/api/src/services/ticketTriage.ts
+++ b/apps/api/src/services/ticketTriage.ts
@@ -124,7 +124,18 @@ export async function getTicketTriageSuggestion(ticket: TicketRow): Promise<Tick
   const category = chooseTicketCategory(text, categories);
   const suggestedPriority = category?.defaultPriority ?? prioritySuggestion.priority;
   const reasons = [prioritySuggestion.reason];
-  if (category) reasons.push(`matched ${category.name}`);
+  if (category) {
+    reasons.push(`matched ${category.name}`);
+  } else if (!ticket.partnerId) {
+    // No partner on the ticket means we never loaded any categories, so a
+    // category suggestion is structurally impossible. Record the skip so an
+    // empty/priority-only result is explained rather than silently empty.
+    reasons.push('no_partner_categories');
+  } else if (categories.length === 0) {
+    reasons.push('no_active_partner_categories');
+  } else {
+    reasons.push('no_category_keyword_match');
+  }
 
   const changesPriority = suggestedPriority !== ticket.priority;
   const changesCategory = Boolean(category && category.id !== ticket.categoryId);

--- a/apps/api/src/services/userRiskScoring.test.ts
+++ b/apps/api/src/services/userRiskScoring.test.ts
@@ -21,6 +21,10 @@ vi.mock('../db', () => ({
   }
 }));
 
+vi.mock('./sentry', () => ({
+  captureException: vi.fn()
+}));
+
 import { publishEvent } from './eventBus';
 import { emitSystemMlFeedbackEvent } from './mlFeedback';
 import {

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -34,6 +34,7 @@ import {
 } from '../db/schema';
 import { publishEvent } from './eventBus';
 import { emitSystemMlFeedbackEvent } from './mlFeedback';
+import { captureException } from './sentry';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const HIGH_EVENT_TYPE = 'user.risk_score_high';
@@ -844,16 +845,33 @@ function buildChangedUsers(
 
 async function persistUserRiskSnapshots(computedRows: ComputedUserRisk[], calculatedAt: Date): Promise<void> {
   if (computedRows.length === 0) return;
-  await db.insert(userRiskScores).values(
-    computedRows.map((row) => ({
-      orgId: row.orgId,
-      userId: row.userId,
-      score: row.score,
-      factors: row.factors,
-      trendDirection: row.trendDirection,
-      calculatedAt
-    }))
-  );
+  // Verify the write actually landed. Under forced RLS a context/policy gap
+  // makes an INSERT match 0 rows with NO error (#1375 silent-write class), so
+  // we must compare returned rows to what we intended to persist rather than
+  // trust the call succeeded.
+  const inserted = await db
+    .insert(userRiskScores)
+    .values(
+      computedRows.map((row) => ({
+        orgId: row.orgId,
+        userId: row.userId,
+        score: row.score,
+        factors: row.factors,
+        trendDirection: row.trendDirection,
+        calculatedAt
+      }))
+    )
+    .returning({ userId: userRiskScores.userId });
+
+  if (inserted.length !== computedRows.length) {
+    const orgId = computedRows[0]?.orgId;
+    const error = new Error(
+      `[UserRiskScoring] persistUserRiskSnapshots persisted ${inserted.length} of ${computedRows.length} ` +
+        `user risk snapshots for org ${orgId ?? 'unknown'} — possible RLS context/policy gap (#1375)`
+    );
+    captureException(error);
+    throw error;
+  }
 }
 
 export async function computeAndPersistOrgUserRisk(orgId: string): Promise<UserRiskRecomputeResult> {

--- a/apps/api/src/services/userRiskSignals.ts
+++ b/apps/api/src/services/userRiskSignals.ts
@@ -43,6 +43,11 @@ export type UserRiskSignalEvaluationResult = {
   skipped: boolean;
   appended: number;
   deduped: number;
+  /** Signals whose append threw and were skipped (S4 — distinct from deduped). */
+  failed: number;
+  // NOTE: `candidates` are DETECTION counts (how many rows each query matched),
+  // NOT persisted counts. The persisted total is `appended`; `appended + deduped
+  // + failed` should equal the sum of candidate counts.
   candidates: {
     offHoursMassScripts: number;
     remoteSessionBursts: number;
@@ -135,6 +140,7 @@ export async function evaluateUserRiskSignalsForOrg(
       skipped: true,
       appended: 0,
       deduped: 0,
+      failed: 0,
       candidates: {
         offHoursMassScripts: 0,
         remoteSessionBursts: 0,
@@ -225,15 +231,25 @@ export async function evaluateUserRiskSignalsForOrg(
 
   let appended = 0;
   let deduped = 0;
-  const record = async (result: 'appended' | 'deduped') => {
-    if (result === 'appended') appended += 1;
-    else deduped += 1;
+  let failed = 0;
+  // S4: a single signal append failing must not abort evaluation of the rest of
+  // the org's candidates. Count the failure and continue; the count is surfaced
+  // in the result (and `appended` stays an honest persisted count).
+  const recordSignal = async (build: () => Promise<'appended' | 'deduped'>): Promise<void> => {
+    try {
+      const result = await build();
+      if (result === 'appended') appended += 1;
+      else deduped += 1;
+    } catch (error) {
+      failed += 1;
+      console.error(`[UserRiskSignals] Failed to append signal for org ${orgId}:`, error);
+    }
   };
 
   for (const row of scriptRows) {
     const devicesTargeted = toInt(row.devices_targeted);
     const occurredAt = toDate(row.created_at);
-    await record(await appendDedupedSignal({
+    await recordSignal(() => appendDedupedSignal({
       orgId,
       userId: row.user_id,
       eventType: 'script.off_hours_mass_execution',
@@ -257,7 +273,7 @@ export async function evaluateUserRiskSignalsForOrg(
     const count = toInt(row.session_count);
     const latestAt = toDate(row.latest_at);
     const key = windowKey(latestAt, lookbackHours);
-    await record(await appendDedupedSignal({
+    await recordSignal(() => appendDedupedSignal({
       orgId,
       userId: row.user_id,
       eventType: 'remote_session_burst',
@@ -280,7 +296,7 @@ export async function evaluateUserRiskSignalsForOrg(
     const approvedCount = toInt(row.approved_count);
     const latestAt = toDate(row.latest_at);
     const key = windowKey(latestAt, lookbackHours);
-    await record(await appendDedupedSignal({
+    await recordSignal(() => appendDedupedSignal({
       orgId,
       userId: row.user_id,
       eventType: 'privilege_elevation_burst',
@@ -308,7 +324,7 @@ export async function evaluateUserRiskSignalsForOrg(
       : typeof row.previous_countries === 'string'
         ? row.previous_countries.replace(/[{}"]/g, '').split(',').filter(Boolean)
         : [];
-    await record(await appendDedupedSignal({
+    await recordSignal(() => appendDedupedSignal({
       orgId,
       userId: row.user_id,
       eventType: 'auth.login.new_geography',
@@ -334,6 +350,7 @@ export async function evaluateUserRiskSignalsForOrg(
     skipped: false,
     appended,
     deduped,
+    failed,
     candidates: {
       offHoursMassScripts: scriptRows.length,
       remoteSessionBursts: remoteRows.length,

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -275,6 +275,101 @@ describe('CorrelatedAlertGroups', () => {
     });
   });
 
+  it('toasts an error when acknowledging the group fails (non-2xx)', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(mlFlags(true)));
+      }
+      if (url === '/alerts/correlations' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ groups: [groupPayload] }));
+      }
+      if (url === `/alerts/correlations/${GROUP_ID}/acknowledge` && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<CorrelatedAlertGroups />);
+
+    const groupTitle = (await screen.findAllByText('High CPU on SRV-01'))[0];
+    const section = groupTitle.closest('section')!;
+    fireEvent.click(within(section).getByRole('button', { name: /Acknowledge group/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('toasts an error when resolving the group fails (non-2xx)', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(mlFlags(true)));
+      }
+      if (url === '/alerts/correlations' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ groups: [groupPayload] }));
+      }
+      if (url === `/alerts/correlations/${GROUP_ID}/resolve` && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<CorrelatedAlertGroups />);
+
+    const groupTitle = (await screen.findAllByText('High CPU on SRV-01'))[0];
+    const section = groupTitle.closest('section')!;
+    fireEvent.click(within(section).getByRole('button', { name: /Resolve group/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('shows the error state (not the empty state) when the groups envelope is malformed', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(mlFlags(true)));
+      }
+      if (url === '/alerts/correlations' && method === 'GET') {
+        // Malformed: neither groups nor data is an array.
+        return Promise.resolve(makeJsonResponse({ groups: { nope: true } }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<CorrelatedAlertGroups />);
+
+    expect(await screen.findByText('Failed to load alert groups')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.queryByText('No correlated alert groups found.')).toBeNull();
+  });
+
+  it('renders the empty state when the API returns zero groups', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse(mlFlags(true)));
+      }
+      if (url === '/alerts/correlations' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ groups: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<CorrelatedAlertGroups />);
+
+    expect(await screen.findByText('No correlated alert groups found.')).toBeInTheDocument();
+  });
+
   it('runs explicit RCA and records feedback', async () => {
     mockGroupsResponse();
 

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -371,7 +371,11 @@ export default function CorrelatedAlertGroups() {
       }
 
       const data = await response.json();
-      const nextGroups = (data.groups ?? data.data ?? []) as AlertGroup[];
+      const rawGroups = data?.groups ?? data?.data;
+      if (!Array.isArray(rawGroups)) {
+        throw new Error('Failed to load alert groups');
+      }
+      const nextGroups = rawGroups as AlertGroup[];
       setGroups(nextGroups);
       setExpandedGroups((previous) => {
         const stillValid = new Set([...previous].filter((id) => nextGroups.some((group) => group.id === id)));

--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
@@ -270,6 +270,123 @@ describe('DeviceAnomaliesPanel', () => {
     expect(screen.getByText('200.0 KB/s')).toBeTruthy();
   });
 
+  it('warns when a promote succeeds without an alert link', async () => {
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(anomalyFlags(true)));
+      if (url === '/devices/dev-1/anomalies?status=open&limit=5') {
+        return Promise.resolve(makeJsonResponse({
+          data: [
+            {
+              id: 'anomaly-1',
+              metricType: 'system',
+              metricName: 'cpu_percent',
+              anomalyType: 'spike',
+              status: 'open',
+              windowStart: '2026-06-18T12:00:00.000Z',
+              windowEnd: '2026-06-18T12:05:00.000Z',
+              observedValue: 96.4,
+              baselineValue: 42.2,
+              score: 8.1,
+              confidence: 0.91,
+              sampleCount: 5,
+              linkedAlertId: null,
+              detectedAt: '2026-06-18T12:05:00.000Z',
+            },
+          ],
+        }));
+      }
+      if (url === '/devices/dev-1/anomalies/anomaly-1/status' && method === 'PATCH') {
+        // Promote succeeds but the backend returns no linkedAlertId.
+        return Promise.resolve(makeJsonResponse({
+          data: { id: 'anomaly-1', status: 'promoted', linkedAlertId: null },
+        }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<DeviceAnomaliesPanel deviceId="dev-1" compact />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /promote/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'warning',
+        message: 'Anomaly promoted but no alert link returned',
+      }));
+    });
+    // No "promoted to alert" success banner, and the row is gone.
+    expect(screen.queryByText('Anomaly promoted to alert')).toBeNull();
+    await waitFor(() => expect(screen.queryByText('Spike')).toBeNull());
+  });
+
+  it('toasts an error when a status update fails (non-2xx)', async () => {
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(anomalyFlags(true)));
+      if (url === '/devices/dev-1/anomalies?status=open&limit=5') {
+        return Promise.resolve(makeJsonResponse({
+          data: [
+            {
+              id: 'anomaly-1',
+              metricType: 'system',
+              metricName: 'cpu_percent',
+              anomalyType: 'spike',
+              status: 'open',
+              windowStart: '2026-06-18T12:00:00.000Z',
+              windowEnd: '2026-06-18T12:05:00.000Z',
+              observedValue: 96.4,
+              baselineValue: 42.2,
+              score: 8.1,
+              confidence: 0.91,
+              sampleCount: 5,
+              linkedAlertId: null,
+              detectedAt: '2026-06-18T12:05:00.000Z',
+            },
+          ],
+        }));
+      }
+      if (url === '/devices/dev-1/anomalies/anomaly-1/status' && method === 'PATCH') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<DeviceAnomaliesPanel deviceId="dev-1" compact />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    // The row stays put because the mutation failed.
+    expect(screen.getByText('Spike')).toBeTruthy();
+  });
+
+  it('renders an error state with a working Retry when the load fails', async () => {
+    let attempt = 0;
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(anomalyFlags(true)));
+      if (url === '/devices/dev-1/anomalies?status=open&limit=25') {
+        attempt += 1;
+        if (attempt === 1) return Promise.resolve(makeJsonResponse({ error: 'down' }, false, 500));
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
+
+    render(<DeviceAnomaliesPanel deviceId="dev-1" />);
+
+    expect(await screen.findByText('Failed to load metric anomalies')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await screen.findByText('No open anomalies');
+    expect(attempt).toBe(2);
+  });
+
   it('labels the panel disabled and does not load anomalies when anomaly output is disabled', async () => {
     fetchWithAuthMock.mockImplementation((input) => {
       const url = String(input);

--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, CheckCircle, ExternalLink, RefreshCw, TrendingUp, XCircl
 
 import { runAction, handleActionError } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
 import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
@@ -165,12 +166,19 @@ export default function DeviceAnomaliesPanel({ deviceId, compact = false, focuse
             ? 'Anomaly promoted'
             : 'Anomaly resolved',
       });
-      if (status === 'promoted' && result.data?.linkedAlertId) {
-        setPromotedAlert({
-          alertId: result.data.linkedAlertId,
-          metricName: anomaly.metricName,
-          anomalyType: anomaly.anomalyType,
-        });
+      if (status === 'promoted') {
+        if (result.data?.linkedAlertId) {
+          setPromotedAlert({
+            alertId: result.data.linkedAlertId,
+            metricName: anomaly.metricName,
+            anomalyType: anomaly.anomalyType,
+          });
+        } else {
+          // The promote succeeded but the backend returned no alert link, so the
+          // row is about to disappear with no way to reach the created alert.
+          // Surface a distinct warning so this is not mistaken for a clean promote.
+          showToast({ message: 'Anomaly promoted but no alert link returned', type: 'warning' });
+        }
       }
       setAnomalies((current) => current.filter((item) => item.id !== anomaly.id));
     } catch (err) {

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -130,6 +130,53 @@ describe('DeviceReliabilityPanel', () => {
     }));
   });
 
+  it('toasts an error when feedback submission fails (non-2xx)', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          snapshot: {
+            deviceId: 'dev-1',
+            reliabilityScore: 65,
+            trendDirection: 'stable',
+            trendConfidence: 0.4,
+            uptime30d: 99.1,
+            crashCount30d: 0,
+            hangCount30d: 1,
+            serviceFailureCount30d: 0,
+            hardwareErrorCount30d: 0,
+            mtbfHours: null,
+            topIssues: [],
+            drivers: [],
+            computedAt: '2026-06-18T12:00:00.000Z',
+          },
+          history: [],
+        }),
+      )
+      .mockResolvedValueOnce(makeJsonResponse({ error: 'boom' }, false, 500));
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /false alarm/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('renders an error state with a working Retry when the load fails', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse({ error: 'down' }, false, 500))
+      .mockResolvedValueOnce(makeJsonResponse({ error: 'No snapshot' }, false, 404));
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    expect(await screen.findByText('Failed to load reliability score')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await screen.findByText('No reliability snapshot available yet.');
+  });
+
   it('renders an empty state when no snapshot exists yet', async () => {
     fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ error: 'No snapshot' }, false, 404));
 

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -342,6 +342,165 @@ describe('RemediationSuggestionsPanel', () => {
     expect(screen.queryByRole('button', { name: /execute/i })).toBeNull();
   });
 
+  it('rejects a suggestion through runAction', async () => {
+    const rejected = { ...suggestion, status: 'rejected' };
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [suggestion] }));
+      }
+      if (url === '/remediation-suggestions/suggestion-1' && method === 'PATCH') {
+        return Promise.resolve(makeJsonResponse({ data: rejected }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /reject/i }));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/remediation-suggestions/suggestion-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ status: 'rejected' }),
+        }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Suggested fix rejected' }));
+    expect(await screen.findByText('Status: rejected')).toBeTruthy();
+  });
+
+  it('toasts an error when generation fails (non-2xx)', async () => {
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === '/remediation-suggestions/generate' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /generate/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('toasts an error when an update fails (non-2xx)', async () => {
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [suggestion] }));
+      }
+      if (url === '/remediation-suggestions/suggestion-1' && method === 'PATCH') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /accept/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+  });
+
+  it('toasts an error when execution fails (non-2xx)', async () => {
+    const accepted = { ...suggestion, status: 'accepted' };
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [accepted] }));
+      }
+      if (url === '/remediation-suggestions/suggestion-1/execute' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /execute/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('toasts an error when an approval request fails (non-2xx)', async () => {
+    const accepted = { ...suggestion, status: 'accepted', riskTier: 'high', elevationRequestId: null };
+    fetchWithAuthMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [accepted] }));
+      }
+      if (url === '/remediation-suggestions/suggestion-1/elevation-request' && method === 'POST') {
+        return Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /request approval/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('renders the empty state when no suggestions exist', async () => {
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    expect(await screen.findByText('No suggested fixes yet.')).toBeTruthy();
+  });
+
+  it('shows an inline error when loading suggestions fails', async () => {
+    fetchWithAuthMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/config/ml-feature-flags') return Promise.resolve(makeJsonResponse(remediationFlags(true)));
+      if (url === '/remediation-suggestions?sourceType=anomaly&sourceId=anomaly-1&limit=5') {
+        return Promise.resolve(makeJsonResponse({ error: 'down' }, false, 500));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${url}` }, false, 404));
+    });
+
+    render(<RemediationSuggestionsPanel sourceType="anomaly" sourceId="anomaly-1" />);
+
+    expect(await screen.findByText('Failed to load suggested fixes')).toBeTruthy();
+  });
+
   it('labels and disables generation when suggested fixes are disabled', async () => {
     fetchWithAuthMock.mockImplementation((input) => {
       const url = String(input);

--- a/apps/web/src/components/security/UserRiskPage.test.tsx
+++ b/apps/web/src/components/security/UserRiskPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import UserRiskPage from './UserRiskPage';
@@ -149,6 +149,120 @@ describe('UserRiskPage', () => {
       type: 'success',
       message: 'False positive label saved',
     }));
+  });
+
+  it('posts true-positive feedback through runAction and refetches scores', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(flagsPayload(true)))
+      .mockResolvedValueOnce(response(scorePayload))
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(detailPayload))
+      .mockResolvedValueOnce(response({ success: true })) // feedback POST
+      .mockResolvedValueOnce(response(scorePayload)) // refetch scores
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(detailPayload));
+
+    render(<UserRiskPage />);
+
+    const button = await screen.findByRole('button', { name: /true positive/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/user-risk/users/00000000-0000-4000-8000-000000000010/feedback',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            orgId: '00000000-0000-4000-8000-000000000001',
+            outcome: 'true_positive',
+            score: 88,
+          }),
+        }),
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'True positive label saved',
+    }));
+    // loadScores runs again after a successful label.
+    const scoreCalls = fetchWithAuthMock.mock.calls.filter(([url]) => url === '/user-risk/scores?limit=25&minScore=50');
+    expect(scoreCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('toasts an error when saving a label fails (non-2xx)', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(flagsPayload(true)))
+      .mockResolvedValueOnce(response(scorePayload))
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(detailPayload))
+      .mockResolvedValueOnce(response({ error: 'boom' }, false, 500));
+
+    render(<UserRiskPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /false positive/i }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('shows a detail-panel error inline without blanking the page, and retries just the detail load', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(flagsPayload(true)))
+      .mockResolvedValueOnce(response(scorePayload))
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response({ error: 'detail down' }, false, 500)) // detail load fails
+      .mockResolvedValueOnce(response(detailPayload)); // detail retry succeeds
+
+    render(<UserRiskPage />);
+
+    // The page itself still renders (list + metrics), only the detail panel errors.
+    await screen.findByTestId('user-risk-page');
+    expect(await screen.findByTestId('user-risk-detail-error')).toBeTruthy();
+    expect(screen.getByText('Failed to load user risk detail')).toBeTruthy();
+    // The list is still present — the page was NOT replaced by the page-level error.
+    expect(screen.getAllByText('Alice Admin').length).toBeGreaterThanOrEqual(1);
+
+    const detailError = screen.getByTestId('user-risk-detail-error');
+    fireEvent.click(within(detailError).getByRole('button', { name: /retry/i }));
+
+    expect(await screen.findByText('Multiple failed sign-in attempts')).toBeTruthy();
+    expect(screen.queryByTestId('user-risk-detail-error')).toBeNull();
+    // The detail retry did NOT refetch the scores list.
+    const scoreCalls = fetchWithAuthMock.mock.calls.filter(([url]) => url === '/user-risk/scores?limit=25&minScore=50');
+    expect(scoreCalls.length).toBe(1);
+  });
+
+  it('renders the page-level error with Retry when the scores list fails to load', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(flagsPayload(true)))
+      .mockResolvedValueOnce(response({ error: 'down' }, false, 500)) // scores fail
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(scorePayload)) // retry scores
+      .mockResolvedValueOnce(response(evaluationPayload))
+      .mockResolvedValueOnce(response(detailPayload));
+
+    render(<UserRiskPage />);
+
+    expect(await screen.findByText('Failed to load user risk scores')).toBeTruthy();
+    expect(screen.queryByTestId('user-risk-page')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await screen.findByTestId('user-risk-page');
+  });
+
+  it('renders the empty list state when no users are above threshold', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(flagsPayload(true)))
+      .mockResolvedValueOnce(response({ data: [] }))
+      .mockResolvedValueOnce(response(evaluationPayload));
+
+    render(<UserRiskPage />);
+
+    expect(await screen.findByText('No users are above the current risk threshold.')).toBeTruthy();
+    expect(screen.getByText('Select a user to inspect risk evidence.')).toBeTruthy();
   });
 
   it('shows disabled state and does not fetch stale scores when user-risk v0 is disabled', async () => {

--- a/apps/web/src/components/security/UserRiskPage.tsx
+++ b/apps/web/src/components/security/UserRiskPage.tsx
@@ -102,6 +102,8 @@ export default function UserRiskPage() {
   const [loading, setLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [detailReloadKey, setDetailReloadKey] = useState(0);
   const [labeling, setLabeling] = useState<'true_positive' | 'false_positive' | null>(null);
   const userRiskDisabled = mlFlags.isDisabled('ml.user_risk_v0.enabled');
 
@@ -149,15 +151,18 @@ export default function UserRiskPage() {
   useEffect(() => {
     if (userRiskDisabled) {
       setDetail(null);
+      setDetailError(null);
       return;
     }
     if (!selected) {
       setDetail(null);
+      setDetailError(null);
       return;
     }
 
     let active = true;
     setDetailLoading(true);
+    setDetailError(null);
     fetchWithAuth(`/user-risk/users/${selected.userId}?orgId=${selected.orgId}`)
       .then(async (response) => {
         if (!response.ok) throw new Error('Failed to load user risk detail');
@@ -165,7 +170,10 @@ export default function UserRiskPage() {
         if (active) setDetail(json?.data ?? null);
       })
       .catch((err) => {
-        if (active) setError(err instanceof Error ? err.message : 'Failed to load user risk detail');
+        if (active) {
+          setDetail(null);
+          setDetailError(err instanceof Error ? err.message : 'Failed to load user risk detail');
+        }
       })
       .finally(() => {
         if (active) setDetailLoading(false);
@@ -174,7 +182,7 @@ export default function UserRiskPage() {
     return () => {
       active = false;
     };
-  }, [selected, userRiskDisabled]);
+  }, [selected, userRiskDisabled, detailReloadKey]);
 
   const factors = useMemo(() => (
     Object.entries(detail?.latestScore.factors ?? selected?.factors ?? {})
@@ -317,6 +325,26 @@ export default function UserRiskPage() {
                   {detail?.latestScore.severity ?? 'score'} {detail?.latestScore.score ?? selected.score}
                 </span>
               </div>
+
+              {detailError && (
+                <div
+                  className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+                  data-testid="user-risk-detail-error"
+                >
+                  <div className="flex items-center gap-2">
+                    <AlertTriangle className="h-4 w-4" />
+                    <span>{detailError}</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setDetailReloadKey((key) => key + 1)}
+                    className="mt-3 inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+                  >
+                    <RefreshCw className="h-4 w-4" />
+                    Retry
+                  </button>
+                </div>
+              )}
 
               <div className="flex flex-wrap gap-2">
                 <button

--- a/apps/web/src/hooks/useMlFeatureFlags.test.ts
+++ b/apps/web/src/hooks/useMlFeatureFlags.test.ts
@@ -1,0 +1,93 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useMlFeatureFlags } from './useMlFeatureFlags';
+import { fetchWithAuth } from '../stores/auth';
+
+vi.mock('../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const disabledFlag = {
+  flag: 'ml.anomalies.enabled' as const,
+  enabled: false,
+  defaultEnabled: false,
+  source: 'org_settings',
+};
+
+describe('useMlFeatureFlags', () => {
+  beforeEach(() => {
+    fetchWithAuthMock.mockReset();
+  });
+
+  it('parses the mlFeatureFlags response shape', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ mlFeatureFlags: { 'ml.anomalies.enabled': disabledFlag } }),
+    );
+
+    const { result } = renderHook(() => useMlFeatureFlags());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(result.current.flags['ml.anomalies.enabled']?.enabled).toBe(false);
+    expect(result.current.isDisabled('ml.anomalies.enabled')).toBe(true);
+    expect(result.current.isDisabled('ml.rca.enabled')).toBe(false);
+  });
+
+  it('parses the alternative data response shape', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeJsonResponse({ data: { 'ml.anomalies.enabled': disabledFlag } }),
+    );
+
+    const { result } = renderHook(() => useMlFeatureFlags());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.flags['ml.anomalies.enabled']?.enabled).toBe(false);
+    expect(result.current.isDisabled('ml.anomalies.enabled')).toBe(true);
+  });
+
+  it('fails OPEN on a non-ok response: records the error but leaves every flag enabled', async () => {
+    // INTENTIONAL fail-open contract: when the flag endpoint errors we set
+    // loaded=true with no flags, so isDisabled(...) returns false for every
+    // flag and ML features stay visible rather than disappearing on a transient
+    // config-load failure. This test pins that behavior so a future change that
+    // flips it to fail-closed is a conscious decision, not an accident.
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ error: 'boom' }, false, 500));
+
+    const { result } = renderHook(() => useMlFeatureFlags());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.error).toContain('500');
+    expect(result.current.flags).toEqual({});
+    expect(result.current.isDisabled('ml.anomalies.enabled')).toBe(false);
+  });
+
+  it('fails OPEN when the request rejects', async () => {
+    fetchWithAuthMock.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useMlFeatureFlags());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.error).toBe('network down');
+    expect(result.current.isDisabled('ml.device_reliability.enabled')).toBe(false);
+  });
+
+  it('treats flags as not-disabled until loaded resolves', () => {
+    fetchWithAuthMock.mockReturnValueOnce(new Promise<Response>(() => {}));
+
+    const { result } = renderHook(() => useMlFeatureFlags());
+
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.isDisabled('ml.anomalies.enabled')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -69,6 +69,7 @@ const TARGET_GLOBS = [
   'src/components/contracts/ContractDetail.tsx',
   'src/components/billing/quotes/QuotesPage.tsx',
   'src/components/billing/quotes/QuoteEditor.tsx',
+  'src/components/alerts/CorrelatedAlertGroups.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -260,7 +261,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(41);
+    expect(absoluteFiles.length).toBe(42);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/runActionAllowlist.ts
+++ b/apps/web/src/lib/runActionAllowlist.ts
@@ -29,5 +29,5 @@ export const RUN_ACTION_MIGRATION_BACKLOG: ReadonlyArray<string> = [
   'apps/web/src/components/alerts/AlertTemplateEditor.tsx',
   'apps/web/src/components/alerts/AlertTemplateList.tsx',
   // AlertsPage.tsx migrated to runAction (#1300) — now in TARGET_GLOBS.
-  'apps/web/src/components/alerts/CorrelatedAlertGroups.tsx',
+  // CorrelatedAlertGroups.tsx migrated to runAction — now in TARGET_GLOBS.
 ];

--- a/packages/shared/src/validators/mlFeedback.test.ts
+++ b/packages/shared/src/validators/mlFeedback.test.ts
@@ -79,4 +79,55 @@ describe('mlFeedbackEventSchema', () => {
     expect(() => mlFeedbackEventSchema.parse({ ...validEvent, confidence: 1.1 })).toThrow();
     expect(() => mlFeedbackEventSchema.parse({ ...validEvent, confidence: -0.1 })).toThrow();
   });
+
+  const NIL_UUID = '00000000-0000-0000-0000-000000000000';
+
+  describe('nil-UUID sentinel handling (.guid lenient, not strict-RFC .uuid)', () => {
+    it('accepts the nil-UUID sentinel for orgId so system labels are never silently 400-rejected', () => {
+      const parsed = mlFeedbackEventSchema.parse({ ...validEvent, orgId: NIL_UUID });
+      expect(parsed.orgId).toBe(NIL_UUID);
+    });
+
+    it('accepts the nil-UUID sentinel for actorUserId (system actor)', () => {
+      const parsed = mlFeedbackEventSchema.parse({ ...validEvent, actorUserId: NIL_UUID });
+      expect(parsed.actorUserId).toBe(NIL_UUID);
+    });
+
+    it('still rejects a non-UUID-shaped orgId', () => {
+      expect(() => mlFeedbackEventSchema.parse({ ...validEvent, orgId: 'not-a-uuid' })).toThrow();
+    });
+
+    it('still rejects a non-UUID-shaped actorUserId', () => {
+      expect(() => mlFeedbackEventSchema.parse({ ...validEvent, actorUserId: 'nope' })).toThrow();
+    });
+  });
+
+  describe('enum rejection', () => {
+    it('rejects an unknown sourceType', () => {
+      expect(() => mlFeedbackEventSchema.parse({ ...validEvent, sourceType: 'spaceship' })).toThrow();
+    });
+
+    it('rejects an unknown eventType', () => {
+      expect(() => mlFeedbackEventSchema.parse({ ...validEvent, eventType: 'alert.exploded' })).toThrow();
+    });
+
+    it('rejects an unknown outcome', () => {
+      expect(() => mlFeedbackEventSchema.parse({ ...validEvent, outcome: 'vaporized' })).toThrow();
+    });
+  });
+
+  describe('sourceId length boundaries', () => {
+    it('rejects an empty sourceId', () => {
+      expect(() => mlFeedbackEventSchema.parse({ ...validEvent, sourceId: '' })).toThrow();
+    });
+
+    it('accepts a sourceId at the 255-char ceiling', () => {
+      const parsed = mlFeedbackEventSchema.parse({ ...validEvent, sourceId: 'a'.repeat(255) });
+      expect(parsed.sourceId).toHaveLength(255);
+    });
+
+    it('rejects a sourceId one char over the ceiling', () => {
+      expect(() => mlFeedbackEventSchema.parse({ ...validEvent, sourceId: 'a'.repeat(256) })).toThrow();
+    });
+  });
 });

--- a/packages/shared/src/validators/mlFeedback.ts
+++ b/packages/shared/src/validators/mlFeedback.ts
@@ -95,12 +95,18 @@ export const mlFeedbackMetadataSchema = z.record(z.string(), z.unknown()).refine
 );
 
 export const mlFeedbackEventSchema = z.object({
-  orgId: z.string().uuid(),
+  // `.guid()` (lenient) rather than `.uuid()` (strict-RFC): Zod v4's strict UUID
+  // check can reject the all-zero nil sentinel `00000000-0000-0000-0000-000000000000`
+  // across minor versions. orgId is always a real tenant UUID and actorUserId is
+  // normalized to null for system actors (see actorUserIdOrNull in
+  // mlFeedbackEmitters.ts), but emitting a nil sentinel must never be silently
+  // 400-rejected here. `.guid()` accepts any well-formed UUID-shaped string.
+  orgId: z.string().guid(),
   sourceType: z.enum(ML_FEEDBACK_SOURCE_TYPES),
   sourceId: z.string().min(1).max(255),
   eventType: z.enum(ML_FEEDBACK_EVENT_TYPES),
   dedupeKey: z.string().trim().min(1).max(255).nullable().optional(),
-  actorUserId: z.string().uuid().nullable().optional(),
+  actorUserId: z.string().guid().nullable().optional(),
   outcome: z.enum(ML_FEEDBACK_OUTCOMES),
   confidence: z.number().min(0).max(1).nullable().optional(),
   metadata: mlFeedbackMetadataSchema.default({}),


### PR DESCRIPTION
Follow-up to the merged **ML roadmap** (#1588 · #1595 · #1597 · #1598 · #1600), implementing the fixes from a multi-agent review of that work. Every functional finding and substantive suggestion is addressed; the test gaps that let these ship are closed too.

**296 tests pass** (152 API unit · 111 web · 17 shared · 16 new integration) · typecheck clean across api/web/shared · no schema/migration changes.

## Critical
- **ML feedback training poisoning** — `routes/alerts/correlations.ts`: `mutateAlerts` now `.returning()` and emits `emitAlertStateFeedback`/`publishEvent` only for alerts the UPDATE actually wrote. Under `breeze_app` RLS a 0-row write throws no error (#1375/#1591 class), so the old code emitted phantom acknowledgements into correlation-acceptance training. Sentry-captures on scope mismatch. `updatePersistedGroupStatus` is now org-scoped + verified.
- **Timezone-dependent rollup corruption** — `services/metricRollups.ts`: replaced the `to_timestamp(floor(epoch/n)*n)::timestamp` round-trip (which shifts derived buckets by the session TZ offset on any non-UTC DB session) with tz-free `date_bin`, so derived hour/day rollups align with the raw 5-min grid.
- **Silently-dropped enqueues** — `jobs/userRiskJobs.ts`: 3-colon BullMQ jobId → hyphen separators (#1118).

## Important — #1105 pool-poison (extends the #1597 fix to the remaining workers)
- `userRiskJobs` & `reliabilityWorker` run DB compute inside `runOutsideDbContext(withSystemDbAccessContext(...))` and publish/fan-out **after** the context closes — no transaction held across Redis or whole-org device loops (dangerous against the US 25-connection ceiling).
- `userRiskScoring.persistUserRiskSnapshots` verifies its write with `.returning()`; `reliabilityScoring` surfaces `devicesFailed` and routes failures to Sentry instead of `console.error`.

## Important — ML correctness
- `metricAnomalies.detectGrowthTrends` scans the full `[from, to)` range per-anchor (was hardcoded to the last 6 buckets — backfills silently skipped interiors).
- `metricAnomalyPromotion` de-dupes cross-source anomalies (baseline vs process-sample `network_egress`/CPU) by `(device, anomaly_type, window)` — one event no longer promotes to two incidents.
- `alertCorrelationRca` ranks evidence by importance **before** truncation, then sorts chronologically (was earliest-N, dropping high-signal evidence).
- `alertCorrelationGroups.noiseReductionPercent` floors (never overstates the customer-facing claim).
- `remediationSuggestions` tags the no-match fallback row (`usedFallback` + `evidence.fallback`).
- Backfill scripts warn loudly on a feature-flag SKIPPED no-op.

## Web
- `UserRiskPage` isolates per-user detail-load errors from the page (own inline retry).
- `DeviceAnomaliesPanel` warns on a link-less promote; `CorrelatedAlertGroups` guards malformed envelopes; stale `runActionAllowlist` entry removed and the component added to the `no-silent-mutations` guard.

## Tests (closing the gaps that let these ship)
- New `mlFeedbackEmitters` unit tests (error-swallow boundary, actor-id null path).
- New integration tests: `metricAnomalies` math (stddev=0 guard, growth boundaries, promotion dedup) and retention boundaries (userRisk keep-one-per-day partition, mlOutput + reliability cutoffs).
- Mutation-failure + empty/error-state tests across all 5 ML panels; `useMlFeatureFlags` fail-open pinned; `mlFeedback` validator nil-UUID → `.guid()`.

## Notes / deliberate non-changes
- **Reviewed finding "ml_feedback_events forge test goes vacuous" — false positive.** That test runs under `vitest.config.rls-coverage.ts`, which is setup-less (no per-test TRUNCATE), so the memoized fixture is correct. Verified by running the block (the rejected-INSERT case proves RLS is live). Left unchanged.
- **Two soft file-split suggestions held** (`alertCorrelationRca.ts` 837 lines, `CorrelatedAlertGroups.tsx` 924 lines). CLAUDE.md explicitly discourages line-count-driven splits and the review rated these the lowest-priority, skip-unless-touched items; splitting would add risk/noise with no functional benefit. Happy to do them if wanted.
- **Pre-existing bugs surfaced but out of scope** (filed separately): `routes/analytics.ts` bare `catch {}` returning fabricated all-zero data as HTTP 200, and the unmounted `AlertCorrelationView.tsx` silent bulk-ack. Not introduced by the ML PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)