### PR TITLE
fix(api): surface analytics query failures instead of fake-empty 200 (#1608)

### DIFF
--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -551,6 +551,61 @@ describe('analytics routes', () => {
       expect(body.data.devices).toEqual({ total: 3, online: 2, offline: 1, pending: 0 });
       expect(body.data.highlights).toEqual([]);
     });
+
+    it('returns 500 (not a zeroed 200) when the query fails (issue #1608)', async () => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(db.select).mockImplementationOnce(() => {
+        throw new Error('too many clients already');
+      });
+
+      const res = await app.request('/analytics/executive-summary?periodType=monthly', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to load executive summary' });
+      // The old behavior returned a fully-zeroed success body; assert we no longer do.
+      expect(body.data).toBeUndefined();
+      errSpy.mockRestore();
+    });
+  });
+
+  describe('GET /analytics/os-distribution', () => {
+    it('returns the OS distribution on success', async () => {
+      mockSelectOnce([
+        { osType: 'Windows', osVersion: '11', count: 4 },
+        { osType: 'Linux', osVersion: 'Ubuntu 24.04', count: 1 }
+      ]);
+
+      const res = await app.request('/analytics/os-distribution', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([
+        { name: 'Windows 11', value: 4 },
+        { name: 'Linux Ubuntu 24.04', value: 1 }
+      ]);
+    });
+
+    it('returns 500 (not an empty 200) when the query fails (issue #1608)', async () => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(db.select).mockImplementationOnce(() => {
+        throw new Error('query timeout');
+      });
+
+      const res = await app.request('/analytics/os-distribution', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'Failed to load OS distribution' });
+      errSpy.mockRestore();
+    });
   });
 
   describe('dashboards and widgets', () => {

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -18,6 +18,7 @@ import {
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
+import { captureException } from '../services/sentry';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 
 export const analyticsRoutes = new Hono();
@@ -1670,19 +1671,13 @@ analyticsRoutes.get(
           metrics: [],
         },
       });
-    } catch {
-      return c.json({
-        data: {
-          devices: { total: 0, online: 0, offline: 0, pending: 0 },
-          totalDevices: 0,
-          onlineDevices: 0,
-          offlineDevices: 0,
-          pendingDevices: 0,
-          trendData: [],
-          highlights: [],
-          metrics: [],
-        },
-      });
+    } catch (err) {
+      // Previously this swallowed every error and returned a fully-zeroed body
+      // as HTTP 200, making a failed dashboard indistinguishable from a genuinely
+      // empty org (no alert, no log). Surface the failure instead (issue #1608).
+      captureException(err, c);
+      console.error('[Analytics] executive-summary failed for org %s:', auth?.orgId ?? 'unknown', err);
+      return c.json({ error: 'Failed to load executive summary' }, 500);
     }
   }
 );
@@ -1730,8 +1725,12 @@ analyticsRoutes.get(
       }
 
       return c.json([]);
-    } catch {
-      return c.json([]);
+    } catch (err) {
+      // The success path already returns [] for a genuinely-empty result, so this
+      // catch only ever masked real failures as an empty-but-OK 200 (issue #1608).
+      captureException(err, c);
+      console.error('[Analytics] os-distribution failed for org %s:', auth?.orgId ?? 'unknown', err);
+      return c.json({ error: 'Failed to load OS distribution' }, 500);
     }
   }
 );


### PR DESCRIPTION
## Problem

Closes #1608. Two analytics handlers had bare `catch {}` blocks that swallowed every error and returned a **success-shaped body as HTTP 200**:

- `GET /analytics/executive-summary` (`analytics.ts:~1673`) — returned a fully-zeroed dashboard (`devices: {total:0,…}`, empty `trendData`/`highlights`/`metrics`).
- `GET /analytics/os-distribution` (`analytics.ts:~1733`) — returned `[]`.

A real failure (pool exhaustion / transient "too many clients", RLS `42501`, query timeout) was therefore **indistinguishable from a genuinely empty org**, with no error binding, no log, and no Sentry capture — nobody is paged, the dashboard just silently shows zeros.

## Fix

Bind the error, report it (`captureException(err, c)` + `console.error` with the `orgId`), and return **500**. The genuinely-empty cases are unaffected — they're already handled on the success paths (executive-summary computes real zeros from the query; os-distribution returns `[]` when there are no rows), so only the failure path changes.

Matches the existing error convention in the codebase (e.g. `routes/devices/core.ts`).

## Tests

`analytics.test.ts`: added failure-path cases for both handlers asserting **500** (not a zeroed/empty 200), plus an os-distribution success case. **28/28 pass.**

## Local verification (node 22.20.0, matching `.nvmrc`)

- `vitest src/routes/analytics.test.ts`: 28/28 pass
- `tsc --noEmit -p apps/api`: clean
- `eslint` on both changed files: clean

## Scope

Limited to the two live analytics handlers (the main bug). The related `AlertCorrelationView.handleBulkAcknowledge` item noted in the issue is intentionally left for the `RUN_ACTION_MIGRATION_BACKLOG` as described there — it's not currently mounted, so not a live user-facing bug.
