### PR TITLE
fix(test): exempt partner-axis Pax8 tables from org-tenant RLS coverage check

### DIFF
--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -83,6 +83,17 @@ const ORG_AXIS_POLICY_EXCLUDED_TABLES: ReadonlySet<string> = new Set<string>([
   // quarantined Huntress orgs.
   'huntress_integrations',
   'huntress_org_mappings',
+  // Pax8 sync tables: partner-axis (Shape 3). The MSP partner owns the Pax8
+  // integration; org_id is denormalized (nullable on mappings/snapshots, for the
+  // resolved customer) for FK joins + filtering only — the RLS axis is partner_id
+  // (breeze_has_partner_access, asserted via PARTNER_TENANT_TABLES). Without these
+  // the org_id column makes auto-discovery treat them as shape-1 org-tenant and
+  // demand breeze_has_org_access they intentionally don't have (#1594 added them
+  // to PARTNER_TENANT_TABLES but missed this set). pax8_integrations /
+  // pax8_product_mappings have no org_id, so they're never auto-discovered here.
+  'pax8_company_mappings',
+  'pax8_subscription_snapshots',
+  'pax8_contract_line_links',
 ]);
 
 // Tables whose own `id` column is the tenant identifier (no `org_id`).


### PR DESCRIPTION
**Root cause:** #1594 (Pax8 license sync) shipped `pax8_company_mappings`, `pax8_subscription_snapshots`, and `pax8_contract_line_links` with correct partner-axis RLS (`breeze_has_partner_access(partner_id)`) and added them to `PARTNER_TENANT_TABLES`, but **not** to `ORG_AXIS_POLICY_EXCLUDED_TABLES`. Each table denormalizes a (nullable) `org_id` column, so the org-tenant coverage query auto-discovers them as shape-1 org-tenant tables and demands `breeze_has_org_access` coverage they intentionally don't have.

**Impact:** the `rls-coverage` contract test (Integration Tests job) has been **failing on main and on every open PR** since #1594 merged — `Org-tenant tables missing RLS coverage: [pax8_company_mappings, pax8_subscription_snapshots, pax8_contract_line_links]`. (#1594/#1596 were admin-merged past the red Integration check.)

**Fix:** add the three `org_id`-bearing Pax8 tables to `ORG_AXIS_POLICY_EXCLUDED_TABLES`, alongside `time_entries` and `huntress_*` which follow the identical *partner-axis-with-denormalized-org_id* pattern. `pax8_integrations` / `pax8_product_mappings` have no `org_id`, so they're never auto-discovered here.

**Not a policy/isolation change** — the tables' partner isolation is unchanged and still asserted by the partner-axis coverage check via `PARTNER_TENANT_TABLES` (and the `pax8-rls.integration.test.ts` forge tests from #1594). Test-only, no migration.

This unblocks the `rls-coverage` check for all currently-open PRs once they pick up this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)