### PR TITLE
fix(rls): exclude partner-axis pax8 tables from org-axis coverage check (#1612)

### DIFF
--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -83,6 +83,18 @@ const ORG_AXIS_POLICY_EXCLUDED_TABLES: ReadonlySet<string> = new Set<string>([
   // quarantined Huntress orgs.
   'huntress_integrations',
   'huntress_org_mappings',
+  // Pax8 billing-sync tables are partner-axis (Shape 3) — a Pax8 integration
+  // belongs to a partner (MSP); the routes reject organization scope outright
+  // ("managed at partner scope") and gate on breeze_has_partner_access. The
+  // org_id column is a mapping target only (which Breeze org a Pax8 company /
+  // subscription / contract line resolves to), pinned to the same partner by
+  // the composite FK (org_id, partner_id) → organizations(id, partner_id), and
+  // is NULL until mapped on the snapshot/company tables. The RLS axis is
+  // partner_id (see PARTNER_TENANT_TABLES), not org. pax8_integrations and
+  // pax8_product_mappings carry no org_id and are not auto-discovered here.
+  'pax8_company_mappings',
+  'pax8_subscription_snapshots',
+  'pax8_contract_line_links',
 ]);
 
 // Tables whose own `id` column is the tenant identifier (no `org_id`).


### PR DESCRIPTION
## Problem

CI is red on `main` (issue #1612, run at `ef0426d6`). The **Integration Tests** job fails the `rls-coverage` contract test:

```
Org-tenant tables missing RLS coverage:
[
  { "table": "pax8_company_mappings",        "rls_on": true, "missing_cmds": ["SELECT","INSERT","UPDATE","DELETE"] },
  { "table": "pax8_subscription_snapshots",  "rls_on": true, "missing_cmds": ["SELECT","INSERT","UPDATE","DELETE"] },
  { "table": "pax8_contract_line_links",     "rls_on": true, "missing_cmds": ["SELECT","INSERT","UPDATE","DELETE"] }
]
```

**Root cause:** The Pax8 license-sync PR (#1594) added these three tables to `PARTNER_TENANT_TABLES` but not to `ORG_AXIS_POLICY_EXCLUDED_TABLES`. All three carry an `org_id` column, so the org-axis assertion auto-discovers them as shape-1 org-tenant tables and demands `breeze_has_org_access` policies they intentionally don't have. Their RLS axis is `partner_id`.

The **Integration Tests** job is skipped on `pull_request` (runs only on main push / `workflow_dispatch`), so #1594's PR CI never ran this check and it landed red on main.

## Why partner-axis is correct (not a real isolation gap)

These are partner-scoped billing-integration tables (Shape 3):
- `apps/api/src/routes/pax8.ts` rejects organization scope outright — *"Pax8 billing integrations are managed at partner scope"* — and gates on `breeze_has_partner_access` / partner-or-system scope.
- The `org_id` column is a **mapping target only** (which Breeze org a Pax8 company/subscription/contract line resolves to), pinned to the same partner by the composite FK `(org_id, partner_id) → organizations(id, partner_id)`, and is NULL until mapped on the snapshot/company tables.
- The partner-axis `breeze_has_partner_access(partner_id)` policies are already installed by the migration and pass the partner-axis assertion.

This mirrors the existing `time_entries` / `huntress_integrations` / `huntress_org_mappings` exclusions exactly.

## Fix

Add the three `org_id`-carrying pax8 tables to `ORG_AXIS_POLICY_EXCLUDED_TABLES` with a documenting comment. **No migration needed** — the policies are already correct. `pax8_integrations` and `pax8_product_mappings` carry no `org_id` and are not auto-discovered.

## Verification

Ran against the CI test DB (`docker-compose.test.yml` + `autoMigrate`), confirming the pax8 tables are present and carry `breeze_has_partner_access` policies:

```
test:rls-coverage → Test Files 1 passed (1) | Tests 45 passed (45)
```

Closes #1612

🤖 Generated with [Claude Code](https://claude.com/claude-code)