### PR TITLE
fix(billing): run Stripe Checkout outside the request DB transaction (#1448)

### DIFF
--- a/apps/api/src/__tests__/authenticated.example.test.ts
+++ b/apps/api/src/__tests__/authenticated.example.test.ts
@@ -46,6 +46,7 @@ vi.mock('../db', () => ({
       where: vi.fn(() => Promise.resolve())
     }))
   },
+  hasDbAccessContext: vi.fn(() => true),
   withDbAccessContext: vi.fn(async (_ctx: any, fn: any) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: any) => fn()),
   runOutsideDbContext: vi.fn((fn: any) => fn()),

--- a/apps/api/src/__tests__/integration/permissionsContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/permissionsContext.integration.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Real-DB regression test for the #1448 blocking finding: the partner pay-link
+ * route (POST /invoices/:id/pay-link) opts out of the auth middleware's auto
+ * request-transaction, so its route-level `requirePermission(INVOICES_SEND)` runs
+ * `getUserPermissions` with NO ambient DB access context.
+ *
+ * Before the fix, those membership/role reads ran on the bare `breeze_app` pool
+ * with no RLS GUCs set → forced RLS filtered them to 0 rows → `getUserPermissions`
+ * returned a spurious `null` → the middleware threw 403, masked only by a warm
+ * in-memory `permissionCache` (so it 403'd on a cold/expired cache). This is the
+ * exact assembled-chain regression the unit tests mock away.
+ *
+ * This test drives the REAL `getUserPermissions` against Postgres with the cache
+ * cleared and NO ambient context (via `runOutsideDbContext`), and asserts it
+ * resolves the partner's real permission set rather than `null`. If the
+ * `withSystemDbAccessContext` self-wrap is removed, this fails (cold-cache 403).
+ */
+import './setup';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db, withSystemDbAccessContext, runOutsideDbContext, hasDbAccessContext } from '../../db';
+import { partners, organizations, users, roles, permissions, rolePermissions, partnerUsers } from '../../db/schema';
+import { getUserPermissions, clearPermissionCache } from '../../services/permissions';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+interface Fixture { partnerId: string; userId: string }
+
+/** Seed a partner, a user, a partner-scope role holding invoices:send, and the
+ *  partner_users membership linking them. All under a system context so the rows
+ *  actually commit (the function under test reads them back with NO context). */
+async function seedPartnerUserWithSendPerm(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `PP ${sfx}`, slug: `pp-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: 'POrg', slug: `po-${sfx}` })
+      .returning({ id: organizations.id });
+    const [u] = await db.insert(users)
+      .values({ partnerId: p!.id, orgId: o!.id, email: `pp-${sfx}@x.io`, name: 'PP', status: 'active' })
+      .returning({ id: users.id });
+    const [r] = await db.insert(roles)
+      .values({ partnerId: p!.id, scope: 'partner', name: `Sender ${sfx}` })
+      .returning({ id: roles.id });
+    const [perm] = await db.insert(permissions)
+      .values({ resource: 'invoices', action: 'send' })
+      .returning({ id: permissions.id });
+    await db.insert(rolePermissions).values({ roleId: r!.id, permissionId: perm!.id });
+    await db.insert(partnerUsers)
+      .values({ partnerId: p!.id, userId: u!.id, roleId: r!.id, orgAccess: 'all' });
+    return { partnerId: p!.id, userId: u!.id };
+  });
+}
+
+describe('getUserPermissions DB access context (breeze_app, real DB, #1448)', () => {
+  beforeEach(async () => {
+    await clearPermissionCache();
+  });
+
+  runDb('resolves the real permission set when called contextless on a cold cache (the pay-link route condition)', async () => {
+    const f = await seedPartnerUserWithSendPerm();
+
+    // Drive it exactly as the contextless pay-link route does: no ambient context,
+    // cold cache. Pre-fix this returned null (→ 403); post-fix it self-wraps.
+    const perms = await runOutsideDbContext(() => {
+      expect(hasDbAccessContext()).toBe(false); // prove we're genuinely contextless
+      return getUserPermissions(f.userId, { partnerId: f.partnerId });
+    });
+
+    expect(perms).not.toBeNull();
+    expect(perms?.scope).toBe('partner');
+    expect(perms?.permissions).toContainEqual({ resource: 'invoices', action: 'send' });
+  });
+
+  runDb('returns null for a user with no membership (genuine no-access, not an RLS artifact)', async () => {
+    // A user that exists but has no partner_users / organization_users row.
+    const orphanId = await withSystemDbAccessContext(async () => {
+      const sfx = Math.random().toString(36).slice(2, 8);
+      const [p] = await db.insert(partners)
+        .values({ name: `OP ${sfx}`, slug: `op-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+        .returning({ id: partners.id });
+      const [u] = await db.insert(users)
+        .values({ partnerId: p!.id, email: `op-${sfx}@x.io`, name: 'OP', status: 'active' })
+        .returning({ id: users.id });
+      return { partnerId: p!.id, userId: u!.id };
+    });
+
+    const perms = await runOutsideDbContext(() =>
+      getUserPermissions(orphanId.userId, { partnerId: orphanId.partnerId }));
+
+    expect(perms).toBeNull();
+  });
+
+  runDb('resolves the same permission set when already inside an ambient context (no-op nest)', async () => {
+    const f = await seedPartnerUserWithSendPerm();
+
+    // Normal-route path: an ambient system context is active; getUserPermissions must
+    // NOT open a second context and must resolve the same row.
+    const perms = await withSystemDbAccessContext(() => {
+      expect(hasDbAccessContext()).toBe(true);
+      return getUserPermissions(f.userId, { partnerId: f.partnerId });
+    });
+
+    expect(perms?.permissions).toContainEqual({ resource: 'invoices', action: 'send' });
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -12,6 +12,7 @@ import { assertActiveTenantContext, TenantInactiveError } from '../services/tena
 import { writeAuditEvent } from '../services/auditEvents';
 import { mfaForcePartnerAdmin } from '../config/env';
 import { ipAllowlistGuard } from './ipAllowlistGuard';
+import { isSelfManagedDbContextRoute } from './selfManagedDbContextRoutes';
 
 export interface AuthContext {
   user: {
@@ -433,10 +434,40 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
   }
   const canAccessSite = siteAccessCheck(allowedSiteIds);
 
+  c.set('auth', {
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      isPlatformAdmin: user.isPlatformAdmin
+    },
+    token: payload,
+    partnerId: payload.partnerId,
+    orgId: payload.orgId,
+    scope: payload.scope,
+    accessibleOrgIds,
+    orgCondition,
+    canAccessOrg,
+    allowedSiteIds,
+    canAccessSite
+  });
+
   // The return value matters: ipAllowlistGuard returns its deny/error
   // Response as a value (it does not throw). Dropping it leaves the Hono
   // context unfinalized — every gated request then 500s with "Context is
   // not finalized" instead of the intended 403/503.
+  const runGuardedHandler = () => ipAllowlistGuard(c, next);
+
+  // #1448 — a small set of routes (the Stripe pay routes) opt OUT of the auto
+  // request-transaction so a slow outbound HTTP call isn't made inside a held
+  // transaction (pinning a pooled connection idle-in-transaction, the #1105
+  // class). They run with NO ambient context and manage their own short DB
+  // access contexts; auth is still set above so requireScope/requirePermission
+  // and the handler's actor still work.
+  if (isSelfManagedDbContextRoute(c.req.method, c.req.path)) {
+    return runGuardedHandler();
+  }
+
   return withDbAccessContext(
     {
       scope: payload.scope,
@@ -450,27 +481,7 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
       // accessiblePartnerIds.
       currentPartnerId: payload.partnerId ?? null
     },
-    async () => {
-      c.set('auth', {
-        user: {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          isPlatformAdmin: user.isPlatformAdmin
-        },
-        token: payload,
-        partnerId: payload.partnerId,
-        orgId: payload.orgId,
-        scope: payload.scope,
-        accessibleOrgIds,
-        orgCondition,
-        canAccessOrg,
-        allowedSiteIds,
-        canAccessSite
-      });
-
-      return ipAllowlistGuard(c, next);
-    }
+    runGuardedHandler
   );
 }
 

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { isSelfManagedDbContextRoute } from './selfManagedDbContextRoutes';
+
+// #1448 — these two routes opt OUT of the auth middleware's auto
+// request-transaction so the Stripe Checkout HTTP call isn't made inside a held
+// DB transaction. The predicate is a security-relevant contract: a route that
+// wrongly matches loses its ambient RLS transaction; a pay route that wrongly
+// fails to match re-pins a pooled connection across the network call.
+describe('isSelfManagedDbContextRoute', () => {
+  const MATCH: ReadonlyArray<[string, string]> = [
+    ['POST', '/api/v1/invoices/abc-123/pay-link'],
+    ['POST', '/api/v1/invoices/abc-123/pay-link/'], // optional trailing slash
+    ['post', '/api/v1/invoices/abc-123/pay-link'], // method is case-insensitive
+    ['POST', '/api/v1/portal/invoices/def-456/pay'],
+    ['POST', '/api/v1/portal/invoices/def-456/pay/'],
+  ];
+
+  const NO_MATCH: ReadonlyArray<[string, string, string]> = [
+    ['GET', '/api/v1/invoices/abc-123/pay-link', 'wrong method (only POST opts out)'],
+    ['GET', '/api/v1/portal/invoices/def-456/pay', 'wrong method'],
+    ['POST', '/api/v1/invoices/abc-123', 'invoice route without /pay-link'],
+    ['POST', '/api/v1/invoices/abc-123/pay', 'partner route has no plain /pay'],
+    ['POST', '/api/v1/portal/invoices/def-456/pay-link', 'portal route has no /pay-link'],
+    ['POST', '/api/v1/invoices/abc-123/pay-link/extra', 'extra path segment must not match'],
+    ['POST', '/api/v1/invoices//pay-link', 'empty id segment must not match'],
+    ['POST', '/api/v1/portal/invoices/def-456/pay/confirm', 'deeper portal path must not match'],
+    ['POST', '/api/v1/invoices', 'collection route'],
+  ];
+
+  it.each(MATCH)('opts out: %s %s', (method, path) => {
+    expect(isSelfManagedDbContextRoute(method, path)).toBe(true);
+  });
+
+  it.each(NO_MATCH)('keeps ambient tx: %s %s (%s)', (method, path) => {
+    expect(isSelfManagedDbContextRoute(method, path)).toBe(false);
+  });
+});

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.ts
@@ -1,0 +1,47 @@
+// #1448 — routes that opt OUT of the auto request-transaction.
+//
+// The auth middlewares (auth.ts, portal/auth.ts) normally wrap the entire
+// route handler in `withDbAccessContext` → `baseDb.transaction`, pinning one
+// pooled PG connection idle-in-transaction for the whole handler. That is fine
+// for handlers that only do DB work, but a handler that makes a slow outbound
+// HTTP call (e.g. Stripe Checkout `sessions.create`, a hundreds-of-ms round
+// trip) inside that held transaction holds the connection idle across the
+// network call — the #1105 pool-poison class.
+//
+// `runOutsideDbContext` alone does NOT help: it only swaps the AsyncLocalStorage
+// `db` proxy reference (pool vs tx); the OUTER `baseDb.transaction` opened by the
+// middleware is still held for the whole handler regardless. The only way to not
+// hold the connection across the HTTP call is to never open the wrapping
+// transaction for these routes — so the middleware consults this predicate and,
+// when it matches, runs the handler with NO ambient context. Those handlers then
+// manage their own short DB access contexts (read in a `withSystemDbAccessContext`,
+// run the HTTP call truly outside any tx, write the result in a fresh short
+// `withSystemDbAccessContext`), keeping the contextless-write guard (#1375) happy
+// while never pinning a connection across the network call.
+//
+// Match against the full request path the middleware sees (`c.req.path`, which
+// includes the `/api/v1` mount prefix and the substituted `:id`), so each entry
+// is a regex over the concrete path, not a literal route pattern.
+interface SelfManagedRoute {
+  method: string;
+  pattern: RegExp;
+}
+
+const SELF_MANAGED_DB_CONTEXT_ROUTES: readonly SelfManagedRoute[] = [
+  // Partner-initiated "Send payment link" — createInvoicePayLink.
+  { method: 'POST', pattern: /^\/api\/v1\/invoices\/[^/]+\/pay-link\/?$/ },
+  // Customer-portal "Pay invoice online".
+  { method: 'POST', pattern: /^\/api\/v1\/portal\/invoices\/[^/]+\/pay\/?$/ },
+];
+
+/**
+ * True when the given request opts out of the auth middleware's auto
+ * request-transaction (it manages its own short DB access contexts so a slow
+ * outbound HTTP call isn't made inside a held transaction — #1448).
+ */
+export function isSelfManagedDbContextRoute(method: string, path: string): boolean {
+  const upper = method.toUpperCase();
+  return SELF_MANAGED_DB_CONTEXT_ROUTES.some(
+    (route) => route.method === upper && route.pattern.test(path)
+  );
+}

--- a/apps/api/src/routes/mcpServer.bearer.test.ts
+++ b/apps/api/src/routes/mcpServer.bearer.test.ts
@@ -49,6 +49,7 @@ vi.mock('../db', () => {
     db: {
       select: () => ({ from: () => ({ where: makeWhere }) }),
     },
+    hasDbAccessContext: vi.fn(() => true),
     withDbAccessContext: vi.fn(),
     withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
     runOutsideDbContext: vi.fn((fn: () => any) => fn()),

--- a/apps/api/src/routes/portal/auth.ts
+++ b/apps/api/src/routes/portal/auth.ts
@@ -41,6 +41,7 @@ import {
   buildPortalUserPayload,
   validatePortalCookieCsrfRequest,
 } from './helpers';
+import { isSelfManagedDbContextRoute } from '../../middleware/selfManagedDbContextRoutes';
 
 export const authRoutes = new Hono();
 const ALLOW_IN_MEMORY_PORTAL_STATE = !PORTAL_USE_REDIS;
@@ -165,6 +166,16 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
   }
 
   c.set('portalAuth', { user, token, authMethod });
+
+  // #1448 — a small set of routes (the Stripe pay route) opt OUT of the auto
+  // request-transaction so a slow outbound HTTP call (Checkout sessions.create)
+  // isn't made inside a held transaction (pinning a pooled connection
+  // idle-in-transaction, the #1105 class). They run with NO ambient context and
+  // manage their own short DB access contexts; portalAuth is still set above so
+  // the handler can read the authenticated org.
+  if (isSelfManagedDbContextRoute(c.req.method, c.req.path)) {
+    return next();
+  }
 
   // Run the protected request under the portal user's organization scope so
   // RLS on every portal-facing table (tickets, devices, assets, profile, ...)

--- a/apps/api/src/routes/portal/invoices.ts
+++ b/apps/api/src/routes/portal/invoices.ts
@@ -137,16 +137,25 @@ invoiceRoutes.get('/invoices/:id/pdf', zValidator('param', ticketParamSchema), a
 });
 
 // POST /portal/invoices/:id/pay — open a Stripe Checkout session on the partner's
-// OWN Stripe account using their stored API key (no Connect). The invoice SELECT and
-// the mapping INSERT run under the customer's org context (RLS-safe as that org); the
-// partner-axis key read escapes to a system sub-context (see below).
+// OWN Stripe account using their stored API key (no Connect).
+//
+// #1448 — this route opts out of the auth middleware's auto request-transaction
+// (see selfManagedDbContextRoutes.ts), so there is NO ambient DB context here.
+// Each DB step opens its own short `withSystemDbAccessContext` and the slow
+// Stripe HTTP call runs OUTSIDE any transaction, so a pooled connection is never
+// held idle across the network round-trip (#1105 class). Tenant isolation does
+// not rely on RLS scope: the invoice SELECT is explicitly filtered to the
+// authenticated `auth.user.orgId`, and the mapping INSERT runs inside a context
+// so it isn't a contextless 0-row no-op (#1375).
 invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), async (c) => {
   const auth = c.get('portalAuth');
   const { id } = c.req.valid('param');
 
-  const [inv] = await db.select().from(invoices)
-    .where(and(eq(invoices.id, id), eq(invoices.orgId, auth.user.orgId), ne(invoices.status, 'draft')))
-    .limit(1);
+  const [inv] = await withSystemDbAccessContext(() =>
+    db.select().from(invoices)
+      .where(and(eq(invoices.id, id), eq(invoices.orgId, auth.user.orgId), ne(invoices.status, 'draft')))
+      .limit(1)
+  );
   if (!inv) return c.json({ error: 'Invoice not found' }, 404);
   if (!PAYABLE.has(inv.status)) return c.json({ error: 'Invoice is not payable' }, 409);
 
@@ -155,16 +164,17 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
   const balanceMinor = toMinorUnits(inv.balance, inv.currencyCode);
   if (balanceMinor <= 0) return c.json({ error: 'Nothing to pay' }, 409);
 
-  // stripe_connect_accounts is a partner-axis table. This handler runs under the
-  // portal user's ORGANIZATION scope (portal/auth.ts), where breeze_has_partner_access
-  // is false — a bare org-scope read would be silently RLS-filtered to 0 rows with no
-  // error (the #1375 class of bug), making the pay route always 409. Read the partner's
-  // key + build their client in a system-scoped sub-context outside the request txn.
+  // partner_stripe_credentials is a partner-axis table. This handler runs with NO
+  // ambient DB context (#1448 opt-out), and even when it did it ran under the portal
+  // user's ORGANIZATION scope, where breeze_has_partner_access is false — a bare read
+  // would be silently RLS-filtered to 0 rows with no error (the #1375 class), making
+  // the pay route always 409. Read the partner's key + build their client in a short
+  // system-scoped context (a no-op nest if a context is somehow already active).
   let stripe: Awaited<ReturnType<typeof getPartnerStripeClient>>['stripe'];
   let stripeAccountId: string;
   try {
-    ({ stripe, stripeAccountId } = await runOutsideDbContext(() =>
-      withSystemDbAccessContext(() => getPartnerStripeClient(inv.partnerId))));
+    ({ stripe, stripeAccountId } = await withSystemDbAccessContext(() =>
+      getPartnerStripeClient(inv.partnerId)));
   } catch (err) {
     // "No key configured" is a benign 409 (partner hasn't set up online payment).
     // A decrypt/unreadable-key fault is a real 500 — don't lie "not available" when
@@ -181,7 +191,9 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
   // Customer-facing portal base URL (mirrors invoicePdf.ts portal-link building).
   const portalBase = (process.env.PUBLIC_APP_URL || process.env.DASHBOARD_URL || 'http://localhost:4321').replace(/\/$/, '');
 
-  const session = await stripe.checkout.sessions.create({
+  // Truly outside any DB context/transaction — no pooled connection is held
+  // across this ~hundreds-of-ms round trip.
+  const session = await runOutsideDbContext(() => stripe.checkout.sessions.create({
     mode: 'payment',
     // v1 is card-only. Restricting payment_method_types keeps the recorded
     // invoice_payments.method ('card') accurate and avoids enabling async/
@@ -209,19 +221,23 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
     // Dedupe double-click / retry: identical (invoice, balance) reuses the same
     // Checkout session instead of creating a second pending mapping row.
     idempotencyKey: `inv_${inv.id}_${balanceMinor}`,
-  });
+  }));
 
-  await db.insert(invoiceStripePayments).values({
-    orgId: inv.orgId,
-    invoiceId: inv.id,
-    stripeAccountId,
-    stripeObjectType: 'checkout_session',
-    stripeObjectId: session.id,
-    stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-    amount: Number(inv.balance).toFixed(2),
-    currency: inv.currencyCode,
-    status: 'pending',
-  });
+  // Fresh short context so the pending-mapping write isn't a contextless 0-row
+  // no-op under forced-RLS breeze_app (#1375).
+  await withSystemDbAccessContext(() =>
+    db.insert(invoiceStripePayments).values({
+      orgId: inv.orgId,
+      invoiceId: inv.id,
+      stripeAccountId,
+      stripeObjectType: 'checkout_session',
+      stripeObjectId: session.id,
+      stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+      amount: Number(inv.balance).toFixed(2),
+      currency: inv.currencyCode,
+      status: 'pending',
+    })
+  );
 
   return c.json({ url: session.url });
 });

--- a/apps/api/src/routes/portal/invoices.ts
+++ b/apps/api/src/routes/portal/invoices.ts
@@ -164,12 +164,13 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
   const balanceMinor = toMinorUnits(inv.balance, inv.currencyCode);
   if (balanceMinor <= 0) return c.json({ error: 'Nothing to pay' }, 409);
 
-  // partner_stripe_credentials is a partner-axis table. This handler runs with NO
-  // ambient DB context (#1448 opt-out), and even when it did it ran under the portal
-  // user's ORGANIZATION scope, where breeze_has_partner_access is false — a bare read
-  // would be silently RLS-filtered to 0 rows with no error (the #1375 class), making
-  // the pay route always 409. Read the partner's key + build their client in a short
-  // system-scoped context (a no-op nest if a context is somehow already active).
+  // stripe_connect_accounts is a partner-axis table (reused by the #1610 API-key
+  // model). This handler runs with NO ambient DB context (#1448 opt-out), and even
+  // when it did it ran under the portal user's ORGANIZATION scope, where
+  // breeze_has_partner_access is false — a bare read would be silently RLS-filtered
+  // to 0 rows with no error (the #1375 class), making the pay route always 409. Read
+  // the partner's key + build their client in a short system-scoped context (a no-op
+  // nest if a context is somehow already active).
   let stripe: Awaited<ReturnType<typeof getPartnerStripeClient>>['stripe'];
   let stripeAccountId: string;
   try {
@@ -185,6 +186,9 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
     if (err instanceof PartnerStripeError) {
       return c.json({ error: 'Could not initialize payment — please contact support' }, 500);
     }
+    // Unexpected (non-PartnerStripeError) — e.g. a DB/context failure from the
+    // wrapping read. Log it before rethrowing so it isn't an opaque 500.
+    console.error('[portal/invoices] failed to initialize partner Stripe client', { partnerId: inv.partnerId, err });
     throw err;
   }
 

--- a/apps/api/src/services/invoiceCheckout.ts
+++ b/apps/api/src/services/invoiceCheckout.ts
@@ -43,9 +43,10 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
   if (balanceMinor <= 0) throw new InvoiceServiceError('Nothing to pay', 409, 'NOTHING_TO_PAY');
 
   // The partner charges on their OWN Stripe account using their stored key (no
-  // platform/Connect). partner_stripe_credentials is a partner-axis table, so read
-  // it in a short system-scoped context (#1448 — there is no ambient request tx
-  // here). One read returns both the client and the account id (for the mapping row).
+  // platform/Connect). stripe_connect_accounts is a partner-axis table (reused by
+  // the #1610 API-key model), so read it in a short system-scoped context (#1448 —
+  // there is no ambient request tx here). One read returns both the client and the
+  // account id (for the mapping row).
   let stripe, stripeAccountId: string;
   try {
     ({ stripe, stripeAccountId } = await withSystemDbAccessContext(() =>
@@ -57,6 +58,10 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
     if (err instanceof PartnerStripeError && err.code === 'NO_STRIPE_KEY') {
       throw new InvoiceServiceError('Online payment is not available — connect Stripe first', 409, 'STRIPE_NOT_CONNECTED');
     }
+    // Log at this layer too: a non-NO_STRIPE_KEY error here may be an unreadable key
+    // (already logged in partnerStripe) OR an unexpected DB/context failure from the
+    // wrapping read — don't let the latter collapse into a generic 500 with no trace.
+    console.error('[invoiceCheckout] failed to initialize partner Stripe client', { partnerId: inv.partnerId, err });
     throw new InvoiceServiceError('Could not initialize payment — please contact support', 500, 'STRIPE_INIT_FAILED');
   }
 

--- a/apps/api/src/services/invoiceCheckout.ts
+++ b/apps/api/src/services/invoiceCheckout.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { invoices, invoiceStripePayments } from '../db/schema';
 import { getPartnerStripeClient, PartnerStripeError } from './partnerStripe';
 import { toMinorUnits } from './stripeMoney';
@@ -18,13 +18,22 @@ const PAYABLE = new Set(['sent', 'partially_paid', 'overdue']);
  * idempotently via the `invoice_stripe_payments` mapping, so this only creates
  * the session + a pending mapping row.
  *
- * Twin of the customer-driven POST /portal/invoices/:id/pay. This handler runs
- * under a partner/system request scope, so the partner-axis connection row is
- * RLS-visible directly (no system sub-context escape needed, unlike the portal's
- * org scope).
+ * Twin of the customer-driven POST /portal/invoices/:id/pay.
+ *
+ * #1448 — this route opts out of the auth middleware's auto request-transaction
+ * (see selfManagedDbContextRoutes.ts), so there is NO ambient DB context here.
+ * Each DB step opens its own short `withSystemDbAccessContext` and the slow
+ * Stripe HTTP call runs OUTSIDE any transaction — a pooled connection is never
+ * held idle across the network round-trip (#1105 class). Tenant isolation does
+ * not rely on RLS scope here: the explicit `requireOrgAccess(actor, inv.orgId)`
+ * app-layer guard blocks cross-tenant access regardless of the read scope, and
+ * the mapping INSERT runs inside a context so it isn't a contextless 0-row
+ * no-op (#1375).
  */
 export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActor): Promise<{ url: string }> {
-  const [inv] = await db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1);
+  const [inv] = await withSystemDbAccessContext(() =>
+    db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1)
+  );
   if (!inv) throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
   requireOrgAccess(actor, inv.orgId);
   if (!PAYABLE.has(inv.status)) throw new InvoiceServiceError('Invoice is not payable', 409, 'NOT_PAYABLE');
@@ -34,11 +43,13 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
   if (balanceMinor <= 0) throw new InvoiceServiceError('Nothing to pay', 409, 'NOTHING_TO_PAY');
 
   // The partner charges on their OWN Stripe account using their stored key (no
-  // platform/Connect). One read returns both the client and the account id (for the
-  // mapping row).
+  // platform/Connect). partner_stripe_credentials is a partner-axis table, so read
+  // it in a short system-scoped context (#1448 — there is no ambient request tx
+  // here). One read returns both the client and the account id (for the mapping row).
   let stripe, stripeAccountId: string;
   try {
-    ({ stripe, stripeAccountId } = await getPartnerStripeClient(inv.partnerId));
+    ({ stripe, stripeAccountId } = await withSystemDbAccessContext(() =>
+      getPartnerStripeClient(inv.partnerId)));
   } catch (err) {
     // Only "no key configured" is a benign 409. A decrypt/unreadable-key fault is an
     // internal error — surface it as such (and let it be logged) instead of lying
@@ -51,7 +62,9 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
 
   const portalBase = (process.env.PUBLIC_APP_URL || process.env.DASHBOARD_URL || 'http://localhost:4321').replace(/\/$/, '');
 
-  const session = await stripe.checkout.sessions.create({
+  // Truly outside any DB context/transaction — no pooled connection is held
+  // across this ~hundreds-of-ms round trip.
+  const session = await runOutsideDbContext(() => stripe.checkout.sessions.create({
     mode: 'payment',
     payment_method_types: ['card'],
     line_items: [{
@@ -77,21 +90,25 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
     // Identical (invoice, balance) reuses the session instead of creating a
     // second pending mapping — safe for repeated "send link" clicks.
     idempotencyKey: `inv_${inv.id}_${balanceMinor}`,
-  });
+  }));
 
   if (!session.url) throw new InvoiceServiceError('Stripe did not return a checkout URL', 500, 'STRIPE_NO_URL');
 
-  await db.insert(invoiceStripePayments).values({
-    orgId: inv.orgId,
-    invoiceId: inv.id,
-    stripeAccountId,
-    stripeObjectType: 'checkout_session',
-    stripeObjectId: session.id,
-    stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-    amount: Number(inv.balance).toFixed(2),
-    currency: inv.currencyCode,
-    status: 'pending',
-  });
+  // Fresh short context so the pending-mapping write isn't a contextless 0-row
+  // no-op under forced-RLS breeze_app (#1375).
+  await withSystemDbAccessContext(() =>
+    db.insert(invoiceStripePayments).values({
+      orgId: inv.orgId,
+      invoiceId: inv.id,
+      stripeAccountId,
+      stripeObjectType: 'checkout_session',
+      stripeObjectId: session.id,
+      stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+      amount: Number(inv.balance).toFixed(2),
+      currency: inv.currencyCode,
+      status: 'pending',
+    })
+  );
 
   return { url: session.url };
 }

--- a/apps/api/src/services/permissions.test.ts
+++ b/apps/api/src/services/permissions.test.ts
@@ -1,9 +1,18 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+// hasDbAccessContext defaults to false (simulating a contextless caller, e.g. the
+// #1448 self-managed-DB-context pay routes whose permission read runs with no
+// ambient transaction). withSystemDbAccessContext is a transparent pass-through so
+// the wrapped reads still run against the mocked db. Individual tests can override
+// hasDbAccessContext to assert the no-op-nest path when a context is already active.
+const mockHasDbAccessContext = vi.fn(() => false);
+const mockWithSystemDbAccessContext = vi.fn(<T>(fn: () => Promise<T>) => fn());
 vi.mock('../db', () => ({
   db: {
     select: vi.fn()
-  }
+  },
+  hasDbAccessContext: () => mockHasDbAccessContext(),
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => mockWithSystemDbAccessContext(fn)
 }));
 
 vi.mock('../db/schema', () => ({
@@ -54,6 +63,8 @@ describe('permissions service', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.mocked(getRedis).mockReturnValue(null);
+    mockHasDbAccessContext.mockReturnValue(false);
+    mockWithSystemDbAccessContext.mockImplementation(<T>(fn: () => Promise<T>) => fn());
     await clearPermissionCache();
   });
 
@@ -395,6 +406,67 @@ describe('permissions service', () => {
 
       await clearPermissionCache('user-123');
       expect(redis.incr).toHaveBeenCalledWith('permission-cache:user-version:user-123');
+    });
+  });
+
+  describe('getUserPermissions DB access context (#1448)', () => {
+    function mockMembershipAndRoleReads() {
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ roleId: 'role-reader', siteIds: null }])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ resource: 'devices', action: 'read' }])
+            })
+          })
+        } as any);
+    }
+
+    it('establishes a system context for its RLS-protected reads when none is active (the #1448 pay-route path)', async () => {
+      // The self-managed-DB-context pay routes run requirePermission with NO ambient
+      // transaction. Without the wrapper the membership reads would RLS-filter to 0
+      // rows under breeze_app → null → 403 (the #1375 class). Assert it wraps instead.
+      mockHasDbAccessContext.mockReturnValue(false);
+      mockMembershipAndRoleReads();
+
+      const perms = await getUserPermissions('user-123', { orgId: 'org-123' });
+
+      expect(perms).not.toBeNull();
+      expect(perms?.permissions).toEqual([{ resource: 'devices', action: 'read' }]);
+      expect(mockWithSystemDbAccessContext).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT open a redundant context when one is already active (no-op nest on normal routes)', async () => {
+      // Normal routes already run inside an org/partner withDbAccessContext; opening a
+      // second system context there would override the request scope. Assert pass-through.
+      mockHasDbAccessContext.mockReturnValue(true);
+      mockMembershipAndRoleReads();
+
+      const perms = await getUserPermissions('user-123', { orgId: 'org-123' });
+
+      expect(perms?.permissions).toEqual([{ resource: 'devices', action: 'read' }]);
+      expect(mockWithSystemDbAccessContext).not.toHaveBeenCalled();
+    });
+
+    it('returns null (→ 403) when the user has no membership, regardless of context', async () => {
+      mockHasDbAccessContext.mockReturnValue(false);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+
+      const perms = await getUserPermissions('user-orphan', { orgId: 'org-123' });
+
+      expect(perms).toBeNull();
     });
   });
 

--- a/apps/api/src/services/permissions.ts
+++ b/apps/api/src/services/permissions.ts
@@ -1,4 +1,4 @@
-import { db } from '../db';
+import { db, hasDbAccessContext, withSystemDbAccessContext } from '../db';
 import { roles, permissions, rolePermissions, partnerUsers, organizationUsers } from '../db/schema';
 import { eq, and } from 'drizzle-orm';
 import { getRedis } from './redis';
@@ -96,79 +96,100 @@ export async function getUserPermissions(
     return cached.userPerms;
   }
 
-  let roleId: string | null = null;
-  let scope: 'system' | 'partner' | 'organization' = 'system';
-  let orgAccess: 'all' | 'selected' | 'none' | undefined;
-  let allowedOrgIds: string[] | undefined;
-  let allowedSiteIds: string[] | undefined;
+  // The membership/role reads below hit RLS-protected tables (organization_users,
+  // partner_users, role_permissions). They must run under an RLS access context or
+  // the unprivileged breeze_app role silently filters them to 0 rows — returning a
+  // spurious `null` (→ 403) instead of the real permission set (the #1375 class).
+  // Most callers (normal routes via authMiddleware) already have an org/partner
+  // context active, in which case this is a no-op nest that keeps that context.
+  // The self-managed-DB-context pay routes (#1448) run requirePermission with NO
+  // ambient context, so without this wrapper getUserPermissions would 403 on a
+  // cold/expired permission cache. The explicit userId + orgId/partnerId equality
+  // filters mean a system-scope read returns the same single row a narrower scope
+  // would, so widening the read scope here doesn't change the result set.
+  const wrap = hasDbAccessContext()
+    ? <T>(fn: () => Promise<T>) => fn()
+    : withSystemDbAccessContext;
 
-  // Check organization-level access first
-  if (context.orgId) {
-    const [orgUser] = await db
-      .select()
-      .from(organizationUsers)
-      .where(
-        and(
-          eq(organizationUsers.userId, userId),
-          eq(organizationUsers.orgId, context.orgId)
+  const userPerms = await wrap(async (): Promise<UserPermissions | null> => {
+    let roleId: string | null = null;
+    let scope: 'system' | 'partner' | 'organization' = 'system';
+    let orgAccess: 'all' | 'selected' | 'none' | undefined;
+    let allowedOrgIds: string[] | undefined;
+    let allowedSiteIds: string[] | undefined;
+
+    // Check organization-level access first
+    if (context.orgId) {
+      const [orgUser] = await db
+        .select()
+        .from(organizationUsers)
+        .where(
+          and(
+            eq(organizationUsers.userId, userId),
+            eq(organizationUsers.orgId, context.orgId)
+          )
         )
-      )
-      .limit(1);
+        .limit(1);
 
-    if (orgUser) {
-      roleId = orgUser.roleId;
-      scope = 'organization';
-      allowedSiteIds = orgUser.siteIds || undefined;
+      if (orgUser) {
+        roleId = orgUser.roleId;
+        scope = 'organization';
+        allowedSiteIds = orgUser.siteIds || undefined;
+      }
     }
-  }
 
-  // Check partner-level access
-  if (!roleId && context.partnerId) {
-    const [partnerUser] = await db
-      .select()
-      .from(partnerUsers)
-      .where(
-        and(
-          eq(partnerUsers.userId, userId),
-          eq(partnerUsers.partnerId, context.partnerId)
+    // Check partner-level access
+    if (!roleId && context.partnerId) {
+      const [partnerUser] = await db
+        .select()
+        .from(partnerUsers)
+        .where(
+          and(
+            eq(partnerUsers.userId, userId),
+            eq(partnerUsers.partnerId, context.partnerId)
+          )
         )
-      )
-      .limit(1);
+        .limit(1);
 
-    if (partnerUser) {
-      roleId = partnerUser.roleId;
-      scope = 'partner';
-      orgAccess = partnerUser.orgAccess;
-      allowedOrgIds = partnerUser.orgIds || undefined;
+      if (partnerUser) {
+        roleId = partnerUser.roleId;
+        scope = 'partner';
+        orgAccess = partnerUser.orgAccess;
+        allowedOrgIds = partnerUser.orgIds || undefined;
+      }
     }
-  }
 
-  if (!roleId) {
+    if (!roleId) {
+      return null;
+    }
+
+    // Get role permissions
+    const rolePerms = await db
+      .select({
+        resource: permissions.resource,
+        action: permissions.action
+      })
+      .from(rolePermissions)
+      .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
+      .where(eq(rolePermissions.roleId, roleId));
+
+    const perms = rolePerms.map(p => ({ resource: p.resource, action: p.action }));
+
+    return {
+      permissions: perms,
+      partnerId: context.partnerId || null,
+      orgId: context.orgId || null,
+      roleId,
+      scope,
+      orgAccess,
+      allowedOrgIds,
+      allowedSiteIds
+    };
+  });
+
+  if (!userPerms) {
     return null;
   }
-
-  // Get role permissions
-  const rolePerms = await db
-    .select({
-      resource: permissions.resource,
-      action: permissions.action
-    })
-    .from(rolePermissions)
-    .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
-    .where(eq(rolePermissions.roleId, roleId));
-
-  const perms = rolePerms.map(p => ({ resource: p.resource, action: p.action }));
-
-  const userPerms = {
-    permissions: perms,
-    partnerId: context.partnerId || null,
-    orgId: context.orgId || null,
-    roleId,
-    scope,
-    orgAccess,
-    allowedOrgIds,
-    allowedSiteIds
-  };
 
   // Cache the result
   permissionCache.set(cacheKey, {


### PR DESCRIPTION
## Problem

`createInvoicePayLink` (`apps/api/src/services/invoiceCheckout.ts`) and its twin `POST /portal/invoices/:id/pay` (`apps/api/src/routes/portal/invoices.ts`) call `stripe.checkout.sessions.create(...)` — a hundreds-of-ms HTTP round-trip — **inside** the request DB transaction. The auth middlewares wrap the whole handler in `withDbAccessContext` → `baseDb.transaction(...)`, so one pooled PG connection is held *idle-in-transaction* across the Stripe call (the #1105 pool-poison class, milder here: a one-shot, low-frequency action).

`runOutsideDbContext` alone can't fix it — it only swaps the AsyncLocalStorage `db` proxy reference; the **outer** middleware transaction is held for the whole handler regardless.

## Fix

**1 — Opt the two pay routes out of the auto request-transaction.** A small self-managed-DB-context route registry (`selfManagedDbContextRoutes.ts`) lists them. `authMiddleware` / `portalAuthMiddleware` set the auth context first (so `requireScope`/`requirePermission`/the handler actor still work), then for a self-managed route run the handler with **no ambient DB context** (skip the wrapping transaction). The handlers manage their own short contexts:
- read invoice + partner Stripe client in `withSystemDbAccessContext` (the `partner_stripe_credentials` read is partner-axis — an org-scope read would be RLS-filtered to 0 rows, the #1375 class),
- run `checkout.sessions.create` truly **outside** any tx via `runOutsideDbContext`,
- write the pending `invoice_stripe_payments` mapping in a fresh short `withSystemDbAccessContext` (so it isn't a contextless 0-row no-op under forced-RLS `breeze_app`, #1375).

A pooled connection is never held across the network round-trip. Tenant isolation is preserved without the ambient RLS transaction: the portal route filters the invoice SELECT by the authenticated `auth.user.orgId`; the partner route enforces `requireOrgAccess(actor, inv.orgId)` at the app layer.

**2 — Self-establish a DB context for the permission read (fixes the blocking finding from the prior review).** Opting the handler chain out of context also stripped context from the route-level `requirePermission(INVOICES_SEND)` that runs *before* the partner pay-link handler. `getUserPermissions()` does RLS-protected reads on `organization_users` / `partner_users` / `role_permissions`; contextless under forced-RLS those filter to 0 rows → `null` → **HTTP 403** (masked by the warm `permissionCache`, 403 on cold/expired). Rather than re-wire the route, `getUserPermissions` now wraps its reads in a short `withSystemDbAccessContext` when no context is active, and is a no-op pass-through when one already is (the common case). Its explicit `userId` + `orgId`/`partnerId` equality filters mean a system-scope read returns the same single row a narrower scope would — no result-set change for existing callers; correct for any contextless caller.

**Rebased onto current `main`** (post-#1610 per-partner Stripe API-key model, post-#1620, post-#1621), re-expressing the change on top of #1610's key-based `getPartnerStripeClient` flow (replaces the old Connect `getConnection`).

## Tests

- New table-driven unit test for `isSelfManagedDbContextRoute` (14 cases): the two POST pay routes opt out; wrong method, sibling paths, extra/empty segments, unrelated routes keep the ambient transaction.
- New `getUserPermissions` context cases: contextless caller establishes a system context and resolves perms (the regression); active context is a no-op nest; orphaned user still → `null`/403.
- Affected unit suites green (permissions, auth middleware, selfManagedDbContextRoutes, invoices/stripe, portal/invoices): 110 passed. `tsc --noEmit` clean.
- `invoiceCheckout` + `quotePay` integration tests green against the real RLS-enforcing `breeze_app` DB (9 passed).

## Affected
- `apps/api/src/middleware/auth.ts`
- `apps/api/src/middleware/selfManagedDbContextRoutes.ts` (new) + test
- `apps/api/src/routes/portal/auth.ts`
- `apps/api/src/routes/portal/invoices.ts`
- `apps/api/src/services/invoiceCheckout.ts`
- `apps/api/src/services/permissions.ts` + test

Closes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)