### PR TITLE
fix(authenticator): make AssuranceDecision a discriminated union (#1373)

### DIFF
--- a/apps/api/src/services/authenticatorAssurance.test.ts
+++ b/apps/api/src/services/authenticatorAssurance.test.ts
@@ -9,6 +9,7 @@ import {
   resolveApprovalAssurance,
   resolveElevationAssurance,
   assertApprovalAssurance,
+  assertDecisionConsistent,
 } from './authenticatorAssurance';
 import type { AssuranceDecision } from './authenticatorAssurance';
 
@@ -625,5 +626,51 @@ describe('AssuranceDecision type (compile-time invariants)', () => {
     // Reference the bindings so they aren't "unused" (the type errors above are
     // the actual assertions; tsc verifies them).
     expect([badSessionLevel, badSessionDevice, badFactorNoDevice, badFactorLevel1]).toHaveLength(4);
+  });
+});
+
+// #1373: the runtime `assertDecisionConsistent` backstop is now statically
+// unreachable from any typed construction site, so the only way to exercise its
+// fail-closed throw is to forge an inconsistent record via a cast — exactly the
+// `as`-cast / untyped-build path the backstop exists to catch. These lock in
+// that the belt-and-suspenders guard still fires.
+describe('assertDecisionConsistent — runtime backstop (as-cast / untyped builds)', () => {
+  it('throws on a session_tap recorded above L1', () => {
+    const forged = {
+      requiredLevel: 1,
+      decidedVia: 'session_tap',
+      decidedAssuranceLevel: 3,
+      authenticatorDeviceId: null,
+    } as unknown as AssuranceDecision;
+    expect(() => assertDecisionConsistent(forged)).toThrow(/session_tap must be exactly L1/);
+  });
+
+  it('throws on an L2+ factor with a null device id', () => {
+    const forged = {
+      requiredLevel: 2,
+      decidedVia: 'mobile_hw_key',
+      decidedAssuranceLevel: 2,
+      authenticatorDeviceId: null,
+    } as unknown as AssuranceDecision;
+    expect(() => assertDecisionConsistent(forged)).toThrow(/an L2\+ factor must record a device id/);
+  });
+
+  it('accepts the legal session-tap and L2+ shapes', () => {
+    expect(() =>
+      assertDecisionConsistent({
+        requiredLevel: 1,
+        decidedVia: 'session_tap',
+        decidedAssuranceLevel: 1,
+        authenticatorDeviceId: null,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertDecisionConsistent({
+        requiredLevel: 2,
+        decidedVia: 'webauthn_platform',
+        decidedAssuranceLevel: 2,
+        authenticatorDeviceId: 'dev-1',
+      }),
+    ).not.toThrow();
   });
 });

--- a/apps/api/src/services/authenticatorAssurance.test.ts
+++ b/apps/api/src/services/authenticatorAssurance.test.ts
@@ -10,6 +10,7 @@ import {
   resolveElevationAssurance,
   assertApprovalAssurance,
 } from './authenticatorAssurance';
+import type { AssuranceDecision } from './authenticatorAssurance';
 
 vi.mock('../db', () => ({
   db: {
@@ -560,5 +561,69 @@ describe('assertApprovalAssurance — Phase 4 enforcement (partner policy, deny-
     const d = await assertApprovalAssurance({ approvalId: 'a', userId: 'u', riskTier: 'critical', partnerId: null, decision: 'approved' });
     expect(d.decidedAssuranceLevel).toBe(1);
     expect(d.graceDowngrade).toBe(true);
+  });
+});
+
+// #1373: AssuranceDecision is a discriminated union on `decidedVia`, so the
+// factor↔level↔device-id invariants are unrepresentable when illegal. These are
+// COMPILE-TIME assertions — the `@ts-expect-error` lines fail `tsc` (and so the
+// `test-api` typecheck/CI) if a future edit widens the type back into a flat
+// record that permits the contradictory shapes. The runtime body just proves the
+// legal shapes assign and the values round-trip.
+describe('AssuranceDecision type (compile-time invariants)', () => {
+  it('accepts the two legal factor shapes and rejects illegal combinations', () => {
+    // Legal: session tap is exactly L1 with no device id.
+    const sessionTap: AssuranceDecision = {
+      requiredLevel: 3,
+      decidedVia: 'session_tap',
+      decidedAssuranceLevel: 1,
+      authenticatorDeviceId: null,
+    };
+    // Legal: a verified L2+ factor always carries a device id (here L4).
+    const l2Factor: AssuranceDecision = {
+      requiredLevel: 4,
+      decidedVia: 'webauthn_platform',
+      decidedAssuranceLevel: 4,
+      authenticatorDeviceId: 'dev-1',
+      graceDowngrade: false,
+    };
+    expect(sessionTap.decidedAssuranceLevel).toBe(1);
+    expect(l2Factor.authenticatorDeviceId).toBe('dev-1');
+
+    // Illegal: session_tap above L1.
+    // @ts-expect-error session_tap must be exactly L1
+    const badSessionLevel: AssuranceDecision = {
+      requiredLevel: 3,
+      decidedVia: 'session_tap',
+      decidedAssuranceLevel: 3,
+      authenticatorDeviceId: null,
+    };
+    // Illegal: session_tap carrying a device id.
+    // @ts-expect-error session_tap must have no device id
+    const badSessionDevice: AssuranceDecision = {
+      requiredLevel: 1,
+      decidedVia: 'session_tap',
+      decidedAssuranceLevel: 1,
+      authenticatorDeviceId: 'dev-1',
+    };
+    // Illegal: an L2+ factor with a null device id.
+    // @ts-expect-error an L2+ factor must record a device id
+    const badFactorNoDevice: AssuranceDecision = {
+      requiredLevel: 2,
+      decidedVia: 'mobile_hw_key',
+      decidedAssuranceLevel: 2,
+      authenticatorDeviceId: null,
+    };
+    // Illegal: an L2+ factor recorded at L1.
+    // @ts-expect-error an L2+ factor is never level 1
+    const badFactorLevel1: AssuranceDecision = {
+      requiredLevel: 2,
+      decidedVia: 'mobile_hw_key',
+      decidedAssuranceLevel: 1,
+      authenticatorDeviceId: 'dev-1',
+    };
+    // Reference the bindings so they aren't "unused" (the type errors above are
+    // the actual assertions; tsc verifies them).
+    expect([badSessionLevel, badSessionDevice, badFactorNoDevice, badFactorLevel1]).toHaveLength(4);
   });
 });

--- a/apps/api/src/services/authenticatorAssurance.ts
+++ b/apps/api/src/services/authenticatorAssurance.ts
@@ -104,8 +104,11 @@ export type AssuranceDecision = DecidedFactor & AssuranceDecisionShared;
  * at the audit-write boundary rather than recording a self-contradictory
  * forensic row. (#1373: type makes it statically unrepresentable; this keeps the
  * shipped runtime mitigation as belt-and-suspenders.)
+ *
+ * Exported only so the retained backstop keeps direct negative coverage — no
+ * typed caller can drive it to throw now that the union is in place (#1373).
  */
-function assertDecisionConsistent(d: AssuranceDecision): void {
+export function assertDecisionConsistent(d: AssuranceDecision): void {
   const isSession = d.decidedVia === 'session_tap';
   const violations: string[] = [];
   if (isSession !== (d.decidedAssuranceLevel === 1)) violations.push('session_tap must be exactly L1');

--- a/apps/api/src/services/authenticatorAssurance.ts
+++ b/apps/api/src/services/authenticatorAssurance.ts
@@ -53,23 +53,57 @@ export class StepUpRequiredError extends Error {
   }
 }
 
-export interface AssuranceDecision {
+/**
+ * The recorded authentication factor and the level/device-id it implies. These
+ * three fields are NOT independent — the real invariants are:
+ *   - `session_tap` ⟺ L1 ⟺ no device id (the no-proof base case);
+ *   - any verified L2+ factor (`webauthn_platform` / `mobile_hw_key`) always
+ *     carries a device id and a level of 2, 3 or 4 (never 1).
+ * Modelling them as a discriminated union on `decidedVia` makes the compiler
+ * reject the illegal combinations (e.g. `session_tap` at L3, or an L2 factor
+ * with a null device id) that a flat record would silently permit — these
+ * records are persisted verbatim to the audit columns, so an illegal shape is a
+ * corrupt forensic row. See #1373.
+ */
+export type DecidedFactor =
+  | {
+      decidedVia: 'session_tap';
+      decidedAssuranceLevel: 1;
+      authenticatorDeviceId: null;
+    }
+  | {
+      decidedVia: 'webauthn_platform' | 'mobile_hw_key';
+      decidedAssuranceLevel: Exclude<AssuranceLevel, 1>;
+      authenticatorDeviceId: string;
+    };
+
+/** Fields shared by every decision, independent of the recorded factor and
+ * (unlike the factor fields) mutated after the base decision is built — the
+ * partner-policy floor raises `requiredLevel` and the grace path sets
+ * `graceDowngrade`. Kept out of the discriminated union so those post-build
+ * writes stay legal regardless of which factor arm was chosen. */
+export interface AssuranceDecisionShared {
   /** Level the policy would require for this approval (telemetry / future gate). */
   requiredLevel: AssuranceLevel;
-  /** Level actually satisfied by the recorded decision. */
-  decidedAssuranceLevel: AssuranceLevel;
-  /** Factor recorded: 'session_tap' when no proof was presented, else the verified L2 factor. */
-  decidedVia: 'session_tap' | 'mobile_hw_key' | 'webauthn_platform';
-  authenticatorDeviceId: string | null;
   /** Phase 4: under-assured but allowed because enforcement is off / in grace. */
   graceDowngrade?: boolean;
 }
 
 /**
- * Guard the cross-field invariants of a decision before it is persisted to the
- * audit columns: the four fields are independent at the type level, so a future
- * edit to a construction site could write a self-contradictory forensic row.
- * Throws (fail-closed) rather than recording an inconsistent assurance record.
+ * A complete assurance decision: the recorded factor (a discriminated union that
+ * makes the level/device-id invariants unrepresentable when illegal) intersected
+ * with the shared, post-build-mutable fields.
+ */
+export type AssuranceDecision = DecidedFactor & AssuranceDecisionShared;
+
+/**
+ * Defense-in-depth guard before a decision is persisted to the audit columns.
+ * The `DecidedFactor` union now makes the factor↔level↔device-id invariants
+ * unrepresentable at every *typed* construction site, so this can only fire on
+ * an `as`-cast or untyped build — but it stays as a fail-closed runtime backstop
+ * at the audit-write boundary rather than recording a self-contradictory
+ * forensic row. (#1373: type makes it statically unrepresentable; this keeps the
+ * shipped runtime mitigation as belt-and-suspenders.)
  */
 function assertDecisionConsistent(d: AssuranceDecision): void {
   const isSession = d.decidedVia === 'session_tap';
@@ -200,7 +234,10 @@ export async function assertApprovalAssurance(input: {
  * server-derived age (the consume path reads it from Redis; it is never trusted
  * from the route/client). */
 interface VerifiedFactor {
-  decidedVia: AssuranceDecision['decidedVia'];
+  /** A verified factor is always one of the two L2 factors — never a session
+   * tap (the no-proof base case). Narrowing this to the L2-only union lets the
+   * proof branch build the L2+ arm of `DecidedFactor` without a cast. */
+  decidedVia: 'webauthn_platform' | 'mobile_hw_key';
   authenticatorDeviceId: string;
   isPlatformBound: boolean;
   challengeIssuedAt: number;
@@ -217,7 +254,7 @@ function escalateAchievedLevel(
   riskTier: RiskTier,
   factor: VerifiedFactor,
   ctx: { reauthVerified: boolean },
-): AssuranceLevel {
+): Exclude<AssuranceLevel, 1> {
   // low / medium are satisfied by the L2 factor alone.
   if (riskTier !== 'high' && riskTier !== 'critical') return 2;
 


### PR DESCRIPTION
## Summary

Deferred follow-up from the PR #1369 (Breeze Authenticator) review. `AssuranceDecision` (`apps/api/src/services/authenticatorAssurance.ts`) had mutually-independent fields, so the type permitted illegal combinations the real invariants forbid (e.g. `{ decidedVia: 'session_tap', decidedAssuranceLevel: 3 }`, or an L2 factor with a null device id). The invariants lived only in construction code plus the runtime `assertDecisionConsistent()` backstop (`174b4b5b`) — and these records are persisted verbatim to the audit columns, so a future edit to a construction site could silently write a contradictory forensic row.

This turns the convention into a **compile-time** guarantee.

## What changed

- **`AssuranceDecision` is now `DecidedFactor & AssuranceDecisionShared`** where `DecidedFactor` is a discriminated union on `decidedVia`:
  - `{ decidedVia: 'session_tap'; decidedAssuranceLevel: 1; authenticatorDeviceId: null }`
  - `{ decidedVia: 'webauthn_platform' | 'mobile_hw_key'; decidedAssuranceLevel: Exclude<AssuranceLevel, 1>; authenticatorDeviceId: string }`
  - `requiredLevel` / `graceDowngrade` stay in the shared (non-union) half because they are mutated *after* the base decision is built (partner-policy floor raise, grace path) — keeping those post-build writes legal regardless of factor arm.
- **`VerifiedFactor.decidedVia`** narrowed to the two L2 factors, and **`escalateAchievedLevel`** now returns `Exclude<AssuranceLevel, 1>`, so the proof branch builds the L2+ arm of the union with no cast.
- **`assertDecisionConsistent()` retained** as a fail-closed runtime backstop for any `as`-cast / untyped construction at the audit-write boundary (belt-and-suspenders; the type now makes the illegal shapes unrepresentable at every typed site).
- **Compile-time tests** (`@ts-expect-error`) that fail `tsc` — and so CI's `test-api` typecheck — if the type is ever widened back into a flat record that re-permits the contradictory shapes.

Note: the original issue snapshot referenced a `pinVerified` field; the shipped type has no such field (the L3/L4 ladder is derived from the signature + recency + re-auth, not a PIN), so the union is modeled against the current three factor fields. Achieved level for an L2 factor is `2 | 3 | 4` (the shipped `escalateAchievedLevel` reaches L4), not `2 | 3`.

## Test plan

- `pnpm exec vitest run src/services/authenticatorAssurance.test.ts` — 26 passed (25 existing + 1 new compile-time-invariants block).
- `npx tsc --noEmit` (apps/api) — clean. Verified the `@ts-expect-error` guards are load-bearing: removing one surfaces a real `TS2322` (`session_tap` at L3 rejected).
- No runtime behavior change — pure type tightening; consumers (`routes/approvals.ts`, `routes/pam.ts`, audit columns) read the same fields.

Closes #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)