### PR TITLE
fix(web): remove dead CSP script-src hash pins + real-browser drift guard (#1232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,12 @@ jobs:
       - name: Build Web
         run: pnpm build --filter=@breeze/web
 
+      - name: Install Chromium for CSP guard
+        run: pnpm --filter @breeze/web exec playwright install --with-deps chromium
+
+      - name: CSP drift guard (real-browser)
+        run: pnpm --filter @breeze/web run csp:guard
+
       - name: Upload Web artifact
         uses: actions/upload-artifact@v7
         with:

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -61,22 +61,18 @@ export default defineConfig({
         "connect-src 'self' https: ws: wss:"
       ],
       scriptDirective: {
-        // Astro auto-hashes its own inline scripts, but is:inline scripts in
-        // Layout.astro and certain hydration bootstrap fragments may not be
-        // covered.  Add their sha256 hashes here so they pass CSP validation.
-        // If a CSP script-src-elem violation appears in the browser console,
-        // copy the suggested sha256 hash from the error into this array.
-        //
-        // ClientRouter swap script: this hash is for the inline script Astro's
-        // <ClientRouter> injects during view-transition swaps (issue #618).
-        // It is constant per Astro version; if you bump astro, re-verify and
-        // update.  Hash-chasing here is a known-fragile workaround --
-        // longer-term we should migrate to a nonce-based CSP.
+        // Astro auto-hashes every build-time inline script it emits (client
+        // islands, hydration bootstrap, is:inline). We carry NO hand-pinned
+        // sha256 hashes here: a 2026-06-19 spike (#1232) proved the previous
+        // two pins were dead on Astro 6.4.7 — removing them and driving real
+        // <ClientRouter> view-transition swaps produced zero CSP violations.
+        // The real-browser CSP drift guard (apps/web/scripts/check-csp-violations.ts,
+        // run in CI) is the safety net: if a future Astro version introduces a
+        // runtime-only inline script needing a hash, the guard fails loudly
+        // instead of breaking silently in production.
         resources: [
           "'self'",
           'https://static.cloudflareinsights.com',
-          "'sha256-dr7co1YqmJP1+caEJBfXkM/oHRwOVAknT+gDygo8nD0='",
-          "'sha256-6wgjuQN80bYuvy8C2/v+mFX1HAEgrfvSs+beElRyx+8='"
         ]
       },
       styleDirective: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "preview": "astro preview",
     "preview:docker": "NODE_ENV=production astro preview --host 0.0.0.0 --port ${PORT:-4321}",
     "prod:docker": "pnpm run build:prod && pnpm run preview:docker",
+    "csp:guard": "node --experimental-strip-types scripts/check-csp-violations.ts",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src",
@@ -52,6 +53,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "playwright": "^1.58.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.20",
     "@testing-library/dom": "^10.4.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
-    "playwright": "^1.58.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.20",
     "@testing-library/dom": "^10.4.1",
@@ -66,6 +65,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "autoprefixer": "^10.5.0",
     "jsdom": "^29.1.1",
+    "playwright": "^1.58.2",
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",

--- a/apps/web/scripts/check-csp-violations.ts
+++ b/apps/web/scripts/check-csp-violations.ts
@@ -33,9 +33,21 @@ async function main(): Promise<void> {
     env: { ...process.env, HOST, PORT: String(PORT) },
     stdio: 'inherit',
   });
+  // Surface early server-boot failures so waitForServer() rejects immediately
+  // rather than spinning the full 30s and throwing a generic timeout.
+  let serverBootError: Error | null = null;
+  server.on('exit', (code) => {
+    serverBootError = new Error(`web server exited during startup (code ${code})`);
+  });
+  server.on('error', (err) => {
+    serverBootError = new Error(`web server process error during startup: ${err.message}`);
+  });
   const violations: Violation[] = [];
   try {
-    await waitForServer();
+    await waitForServer().then(
+      (v) => { if (serverBootError) throw serverBootError; return v; },
+      (err) => { throw serverBootError ?? err; },
+    );
     const browser = await chromium.launch();
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -44,6 +56,9 @@ async function main(): Promise<void> {
     // Only collect inline-script violations (blockedURI === 'inline'); eval
     // violations from Monaco Editor are a separate concern and expected under
     // the current CSP (no 'unsafe-eval' needed for the page shell itself).
+    // Note: addInitScript runs on every full-page load AND persists across
+    // same-document <ClientRouter> view-transition swaps, so both navigation
+    // paths are covered by a single registration.
     await page.addInitScript(() => {
       // @ts-expect-error injected global
       window.__cspViolations = window.__cspViolations || [];
@@ -94,7 +109,8 @@ async function main(): Promise<void> {
       server.once('close', done);
       server.kill('SIGTERM');
       // Fallback: resolve after 5s if the process hasn't exited cleanly.
-      setTimeout(done, 5000);
+      // unref() so this timer doesn't keep the event loop alive after a clean exit.
+      setTimeout(done, 5000).unref();
     });
   }
 

--- a/apps/web/scripts/check-csp-violations.ts
+++ b/apps/web/scripts/check-csp-violations.ts
@@ -1,0 +1,105 @@
+// Boots the production web build and drives a real browser through initial
+// loads AND <ClientRouter> view-transition swaps, failing if any inline script
+// is blocked by CSP. This is the runtime drift guard for #1232 — it sees the
+// swap path a fetch-based guard cannot. No API/DB required (API calls 404,
+// which is fine; we only assert on CSP violations).
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { chromium } from 'playwright';
+
+const HOST = '127.0.0.1';
+const PORT = 14333;
+const BASE = `http://${HOST}:${PORT}`;
+// Public routes that render via ClientRouter layouts (no auth needed).
+const ROUTES = ['/', '/login', '/forgot-password', '/setup'];
+
+type Violation = { blockedURI: string; violatedDirective: string; scriptSample: string; route: string };
+
+async function waitForServer(): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${BASE}/login`, { redirect: 'manual' });
+      if (res.status > 0) return;
+    } catch {
+      /* not up yet */
+    }
+    await sleep(500);
+  }
+  throw new Error('web server did not start within 30s');
+}
+
+async function main(): Promise<void> {
+  const server = spawn('node', ['dist/server/entry.mjs'], {
+    env: { ...process.env, HOST, PORT: String(PORT) },
+    stdio: 'inherit',
+  });
+  const violations: Violation[] = [];
+  try {
+    await waitForServer();
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Register the listener before any page script runs; collect into a global.
+    // Only collect inline-script violations (blockedURI === 'inline'); eval
+    // violations from Monaco Editor are a separate concern and expected under
+    // the current CSP (no 'unsafe-eval' needed for the page shell itself).
+    await page.addInitScript(() => {
+      // @ts-expect-error injected global
+      window.__cspViolations = window.__cspViolations || [];
+      document.addEventListener('securitypolicyviolation', (e) => {
+        if (e.blockedURI !== 'inline') return;
+        // @ts-expect-error injected global
+        window.__cspViolations.push({
+          blockedURI: e.blockedURI,
+          violatedDirective: e.violatedDirective,
+          scriptSample: e.sample,
+        });
+      });
+    });
+
+    const collect = async (route: string) => {
+      const found = await page.evaluate(() => {
+        // @ts-expect-error injected global
+        const v = window.__cspViolations || [];
+        // @ts-expect-error injected global
+        window.__cspViolations = [];
+        return v;
+      });
+      for (const v of found) violations.push({ ...v, route });
+    };
+
+    // Initial loads.
+    for (const route of ROUTES) {
+      await page.goto(BASE + route, { waitUntil: 'networkidle' });
+      await collect(`load ${route}`);
+    }
+    // View-transition swaps: click in-app links so <ClientRouter> performs a
+    // real swap (the path a fetch-based guard cannot observe).
+    await page.goto(BASE + '/login', { waitUntil: 'networkidle' });
+    await page.getByRole('link', { name: 'Forgot password?' }).click();
+    await page.waitForURL('**/forgot-password');
+    await collect('swap /login -> /forgot-password');
+    await page.getByRole('link', { name: 'Sign in' }).click();
+    await page.waitForURL('**/login');
+    await collect('swap /forgot-password -> /login');
+
+    await browser.close();
+  } finally {
+    server.kill('SIGTERM');
+  }
+
+  if (violations.length > 0) {
+    console.error(`[csp-guard] FAIL — ${violations.length} CSP violation(s):`);
+    for (const v of violations) {
+      console.error(`  [${v.route}] ${v.violatedDirective} blocked ${v.blockedURI} sample="${v.scriptSample}"`);
+    }
+    process.exit(1);
+  }
+  console.log(`[csp-guard] OK — no CSP violations across ${ROUTES.length} loads + 2 swaps`);
+}
+
+main().catch((err) => {
+  console.error('[csp-guard] ERROR', err);
+  process.exit(1);
+});

--- a/apps/web/scripts/check-csp-violations.ts
+++ b/apps/web/scripts/check-csp-violations.ts
@@ -79,14 +79,23 @@ async function main(): Promise<void> {
     await page.goto(BASE + '/login', { waitUntil: 'networkidle' });
     await page.getByRole('link', { name: 'Forgot password?' }).click();
     await page.waitForURL('**/forgot-password');
+    await page.waitForLoadState('networkidle');
     await collect('swap /login -> /forgot-password');
     await page.getByRole('link', { name: 'Sign in' }).click();
     await page.waitForURL('**/login');
+    await page.waitForLoadState('networkidle');
     await collect('swap /forgot-password -> /login');
 
     await browser.close();
   } finally {
-    server.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const done = () => resolve();
+      server.once('exit', done);
+      server.once('close', done);
+      server.kill('SIGTERM');
+      // Fallback: resolve after 5s if the process hasn't exited cleanly.
+      setTimeout(done, 5000);
+    });
   }
 
   if (violations.length > 0) {

--- a/docs/superpowers/plans/2026-06-19-csp-script-hash-drift-guard.md
+++ b/docs/superpowers/plans/2026-06-19-csp-script-hash-drift-guard.md
@@ -1,0 +1,447 @@
+# CSP script-hash drift guard (#1232) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the two dead hand-pinned CSP `script-src` hashes and replace them with a real-browser drift guard so the hash-drift class can never ship silently again.
+
+**Architecture:** Astro 6.4.7 auto-hashes every build-time inline script; a spike proved the two hand-pinned hashes are dead (removing them and driving real `<ClientRouter>` view-transition swaps produced zero CSP violations). We delete the pins, add a standalone web-only Playwright guard (boots the prod build, navigates + swaps, fails on any `securitypolicyviolation`) as the primary CI gate, and add a CSP-violation assertion to the authenticated e2e flow for dashboard coverage.
+
+**Tech Stack:** Astro 6.4.7 (`@astrojs/node` standalone), Playwright, Node (TypeScript via `--experimental-strip-types`), Vitest, GitHub Actions.
+
+## Global Constraints
+
+- Repo: `LanternOps/breeze`. Work in an **isolated git worktree off fresh `main`** (per `issue-to-pr`); never edit the shared main working copy in place.
+- Node: prefix all `pnpm`/`node`/`playwright` commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node breaks pnpm engine-strict). Fresh worktrees need `pnpm install`.
+- **The worker never merges and never closes the issue** — stop after the PR + review-summary comment.
+- Astro version is `^6.4.7`; the dead-pin conclusion is version-specific — the guard is the safety net for future bumps.
+- Real agent code is irrelevant here; all work is in `apps/web/` and `e2e-tests/`.
+- The `#1342` fetch-based guard files (`apps/web/scripts/check-csp-hash-drift.ts`, `apps/web/src/__tests__/check-csp-hash-drift.test.ts`) are **not on `main`** — they live only on the unmerged draft PR #1342. Do not recreate them; close #1342 as superseded (Task 4).
+
+---
+
+### Task 1: Standalone web-only CSP drift guard (primary CI gate)
+
+**Files:**
+- Modify: `apps/web/package.json` (add `playwright` devDep + `csp:guard` script)
+- Create: `apps/web/scripts/check-csp-violations.ts`
+- Modify: `.github/workflows/ci.yml` (run the guard in the `build-web` job)
+
+**Interfaces:**
+- Consumes: the production build output `apps/web/dist/server/entry.mjs` (the `@astrojs/node` standalone server), served with CSP enforced by `apps/web/src/middleware.ts` (production is strict by default).
+- Produces: a runnable guard `pnpm --filter @breeze/web run csp:guard` that exits `0` when no inline script is CSP-blocked across initial loads + view-transition swaps, and exits `1` (printing each violation's `blockedURI`/`violatedDirective`/`scriptSample`) otherwise.
+
+- [ ] **Step 1: Add the Playwright dependency and script to `apps/web/package.json`**
+
+Add to `devDependencies` (match the version already used in `e2e-tests/package.json` — check with `node -e "console.log(require('./e2e-tests/package.json').devDependencies.playwright)"` and use that exact string):
+
+```json
+"playwright": "<same version as e2e-tests>"
+```
+
+Add to `scripts`:
+
+```json
+"csp:guard": "node --experimental-strip-types scripts/check-csp-violations.ts"
+```
+
+Then install + fetch the browser:
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm install
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec playwright install chromium
+```
+
+- [ ] **Step 2: Write the guard script**
+
+Create `apps/web/scripts/check-csp-violations.ts`:
+
+```ts
+// Boots the production web build and drives a real browser through initial
+// loads AND <ClientRouter> view-transition swaps, failing if any inline script
+// is blocked by CSP. This is the runtime drift guard for #1232 — it sees the
+// swap path a fetch-based guard cannot. No API/DB required (API calls 404,
+// which is fine; we only assert on CSP violations).
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { chromium } from 'playwright';
+
+const HOST = '127.0.0.1';
+const PORT = 14333;
+const BASE = `http://${HOST}:${PORT}`;
+// Public routes that render via ClientRouter layouts (no auth needed).
+const ROUTES = ['/', '/login', '/forgot-password', '/setup'];
+
+type Violation = { blockedURI: string; violatedDirective: string; scriptSample: string; route: string };
+
+async function waitForServer(): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${BASE}/login`, { redirect: 'manual' });
+      if (res.status > 0) return;
+    } catch {
+      /* not up yet */
+    }
+    await sleep(500);
+  }
+  throw new Error('web server did not start within 30s');
+}
+
+async function main(): Promise<void> {
+  const server = spawn('node', ['dist/server/entry.mjs'], {
+    env: { ...process.env, HOST, PORT: String(PORT) },
+    stdio: 'inherit',
+  });
+  const violations: Violation[] = [];
+  try {
+    await waitForServer();
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Register the listener before any page script runs; collect into a global.
+    await page.addInitScript(() => {
+      // @ts-expect-error injected global
+      window.__cspViolations = window.__cspViolations || [];
+      document.addEventListener('securitypolicyviolation', (e) => {
+        // @ts-expect-error injected global
+        window.__cspViolations.push({
+          blockedURI: e.blockedURI,
+          violatedDirective: e.violatedDirective,
+          scriptSample: e.sample,
+        });
+      });
+    });
+
+    const collect = async (route: string) => {
+      const found = await page.evaluate(() => {
+        // @ts-expect-error injected global
+        const v = window.__cspViolations || [];
+        // @ts-expect-error injected global
+        window.__cspViolations = [];
+        return v;
+      });
+      for (const v of found) violations.push({ ...v, route });
+    };
+
+    // Initial loads.
+    for (const route of ROUTES) {
+      await page.goto(BASE + route, { waitUntil: 'networkidle' });
+      await collect(`load ${route}`);
+    }
+    // View-transition swaps: click in-app links so <ClientRouter> performs a
+    // real swap (the path a fetch-based guard cannot observe).
+    await page.goto(BASE + '/login', { waitUntil: 'networkidle' });
+    await page.getByRole('link', { name: 'Forgot password?' }).click();
+    await page.waitForURL('**/forgot-password');
+    await collect('swap /login -> /forgot-password');
+    await page.getByRole('link', { name: 'Sign in' }).click();
+    await page.waitForURL('**/login');
+    await collect('swap /forgot-password -> /login');
+
+    await browser.close();
+  } finally {
+    server.kill('SIGTERM');
+  }
+
+  if (violations.length > 0) {
+    console.error(`[csp-guard] FAIL — ${violations.length} CSP violation(s):`);
+    for (const v of violations) {
+      console.error(`  [${v.route}] ${v.violatedDirective} blocked ${v.blockedURI} sample="${v.scriptSample}"`);
+    }
+    process.exit(1);
+  }
+  console.log(`[csp-guard] OK — no CSP violations across ${ROUTES.length} loads + 2 swaps`);
+}
+
+main().catch((err) => {
+  console.error('[csp-guard] ERROR', err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Build, then run the guard against the current build (with pins still present) — expect GREEN**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web build
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web run csp:guard
+```
+Expected: `[csp-guard] OK — no CSP violations across 4 loads + 2 swaps` and exit 0.
+
+- [ ] **Step 4: Prove the guard is load-bearing — inject a violation, expect RED**
+
+Temporarily add an unhashed inline script to `apps/web/src/layouts/AuthLayout.astro` (just inside `<body>`), e.g.:
+
+```html
+<script>console.log('csp-guard self-test');</script>
+```
+
+Then rebuild and run:
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web build
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web run csp:guard; echo "exit=$?"
+```
+Expected: `[csp-guard] FAIL — 1 CSP violation(s)` naming `script-src-elem` (or `script-src`) on a `/login` or swap step, exit=1.
+
+**Revert the self-test edit** (`git checkout apps/web/src/layouts/AuthLayout.astro`) and rebuild to confirm GREEN again (Step 3 command).
+
+- [ ] **Step 5: Wire the guard into the `build-web` CI job**
+
+In `.github/workflows/ci.yml`, inside the `build-web` job, **after** the web build step, add steps to install Chromium and run the guard. Match the job's existing pnpm/node setup; add:
+
+```yaml
+      - name: Install Chromium for CSP guard
+        run: pnpm --filter @breeze/web exec playwright install --with-deps chromium
+      - name: CSP drift guard (real-browser)
+        run: pnpm --filter @breeze/web run csp:guard
+```
+(Place these after the step that produces `apps/web/dist`. If `build-web` builds via a turbo/root command, ensure the guard step runs in the same job after that.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/package.json apps/web/scripts/check-csp-violations.ts .github/workflows/ci.yml pnpm-lock.yaml
+git commit -m "test(web): real-browser CSP drift guard for #1232 (loads + ClientRouter swaps)"
+```
+
+---
+
+### Task 2: Authenticated e2e CSP-violation assertion (dashboard coverage)
+
+**Files:**
+- Modify: `e2e-tests/fixtures.ts` (collect `securitypolicyviolation` on both fixtures, assert empty after each test)
+- Create: `e2e-tests/tests/csp-no-violations.spec.ts` (authenticated in-app swap navigation under the listener)
+
+**Interfaces:**
+- Consumes: the existing `authedPage`/`cleanPage` fixtures and `STORAGE_STATE` from `e2e-tests/global-setup.ts`; the running full stack the e2e job already provides.
+- Produces: every e2e test now fails if a CSP violation fires during it; a dedicated spec exercises an authenticated dashboard view-transition swap.
+
+- [ ] **Step 1: Add the violation collector to the fixtures**
+
+Replace `e2e-tests/fixtures.ts` with (keeps existing behavior, adds collection + assertion):
+
+```ts
+import { test as base, expect, type Page, type BrowserContext } from '@playwright/test';
+import { STORAGE_STATE } from './global-setup';
+
+type Fixtures = {
+  authedPage: Page;
+  cleanPage: Page;
+};
+
+type CspViolation = { blockedURI: string; violatedDirective: string; scriptSample: string };
+
+// Register a securitypolicyviolation collector before any page script runs.
+async function withCspCollection(context: BrowserContext): Promise<void> {
+  await context.addInitScript(() => {
+    // @ts-expect-error injected global
+    window.__cspViolations = window.__cspViolations || [];
+    document.addEventListener('securitypolicyviolation', (e) => {
+      // @ts-expect-error injected global
+      window.__cspViolations.push({
+        blockedURI: e.blockedURI,
+        violatedDirective: e.violatedDirective,
+        scriptSample: e.sample,
+      });
+    });
+  });
+}
+
+async function assertNoCspViolations(page: Page): Promise<void> {
+  const violations = (await page.evaluate(() => {
+    // @ts-expect-error injected global
+    return window.__cspViolations || [];
+  })) as CspViolation[];
+  expect(
+    violations,
+    `CSP violations during test:\n${violations
+      .map((v) => `  ${v.violatedDirective} blocked ${v.blockedURI} sample="${v.scriptSample}"`)
+      .join('\n')}`,
+  ).toEqual([]);
+}
+
+export const test = base.extend<Fixtures>({
+  authedPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: STORAGE_STATE });
+    await withCspCollection(ctx);
+    const page = await ctx.newPage();
+    await use(page);
+    await assertNoCspViolations(page);
+    await ctx.close();
+  },
+
+  cleanPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext();
+    await withCspCollection(ctx);
+    const page = await ctx.newPage();
+    await use(page);
+    await assertNoCspViolations(page);
+    await ctx.close();
+  },
+});
+
+export { expect };
+```
+
+- [ ] **Step 2: Add the authenticated swap spec**
+
+Create `e2e-tests/tests/csp-no-violations.spec.ts`. Inspect the sidebar Page Object / `data-testid`s first (`e2e-tests/pages/`) and use real testids for the two links; the structure is:
+
+```ts
+import { test, expect } from '../fixtures';
+
+test.describe('CSP — no violations on authenticated navigation', () => {
+  test('dashboard load + in-app (ClientRouter) navigation emits no CSP violation', async ({ authedPage }) => {
+    await authedPage.goto('/dashboard', { waitUntil: 'networkidle' });
+    // In-app navigation via the sidebar triggers a <ClientRouter> swap (not a
+    // full reload). Use the real data-testid for a sidebar link (e.g. Devices).
+    await authedPage.getByTestId('sidebar-link-devices').click();
+    await authedPage.waitForURL('**/devices');
+    await expect(authedPage).toHaveURL(/\/devices/);
+    // The fixture asserts window.__cspViolations is empty after this test.
+  });
+});
+```
+If no `data-testid` exists on sidebar links, add one in `apps/web/src/components/...Sidebar.tsx` (follow the existing testid convention) as part of this task, since the e2e convention is testid-only.
+
+- [ ] **Step 3: Run the e2e suite (or just this spec) against the stack — expect GREEN**
+
+```bash
+cd e2e-tests
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH PUBLIC_API_URL=http://localhost pnpm exec playwright test csp-no-violations.spec.ts
+```
+Expected: 1 passed. (Requires the local stack up per `e2e-tests/README.md`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e-tests/fixtures.ts e2e-tests/tests/csp-no-violations.spec.ts
+# include the Sidebar testid file if you added one
+git commit -m "test(e2e): fail on CSP violations; assert authenticated ClientRouter swap is clean (#1232)"
+```
+
+---
+
+### Task 3: Delete the dead pins (the #1232 fix)
+
+**Files:**
+- Modify: `apps/web/astro.config.mjs` (remove the two hand-pinned hashes + update comment)
+
+**Interfaces:**
+- Consumes: the green guards from Tasks 1 & 2 (they authorize this deletion).
+- Produces: a `scriptDirective.resources` array carrying no hand-pinned hashes.
+
+- [ ] **Step 1: Remove the two pins and rewrite the comment**
+
+In `apps/web/astro.config.mjs`, change `security.csp.scriptDirective` to:
+
+```js
+      scriptDirective: {
+        // Astro auto-hashes every build-time inline script it emits (client
+        // islands, hydration bootstrap, is:inline). We carry NO hand-pinned
+        // sha256 hashes here: a 2026-06-19 spike (#1232) proved the previous
+        // two pins were dead on Astro 6.4.7 — removing them and driving real
+        // <ClientRouter> view-transition swaps produced zero CSP violations.
+        // The real-browser CSP drift guard (apps/web/scripts/check-csp-violations.ts,
+        // run in CI) is the safety net: if a future Astro version introduces a
+        // runtime-only inline script needing a hash, the guard fails loudly
+        // instead of breaking silently in production.
+        resources: [
+          "'self'",
+          'https://static.cloudflareinsights.com',
+        ]
+      },
+```
+
+- [ ] **Step 2: Rebuild and run the standalone guard — expect GREEN (authorized deletion, part 1)**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web build
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web run csp:guard
+```
+Expected: `[csp-guard] OK` and exit 0. Also confirm the served header no longer contains the pins:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH HOST=127.0.0.1 PORT=14334 node apps/web/dist/server/entry.mjs & sleep 3
+curl -sI http://127.0.0.1:14334/login | grep -io "dr7co1Yq\|6wgjuQN8" || echo "pins absent (good)"
+pkill -f "dist/server/entry.mjs"
+```
+Expected: `pins absent (good)`.
+
+- [ ] **Step 3: Run the authenticated e2e CSP spec — expect GREEN (authorized deletion, part 2 — the dashboard re-verification)**
+
+```bash
+cd e2e-tests
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH PUBLIC_API_URL=http://localhost pnpm exec playwright test csp-no-violations.spec.ts
+```
+Expected: 1 passed. This confirms authenticated dashboard navigation emits no CSP violation without the pins — the gate that authorizes the deletion.
+
+- [ ] **Step 4: Run web unit tests (no regressions)**
+
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/middleware.test.ts src/lib/csp.test.ts
+```
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/astro.config.mjs
+git commit -m "fix(web): remove dead CSP script-src hash pins (#1232)
+
+Spike proved both pins were dead on Astro 6.4.7. Astro auto-hashing covers
+all emitted inline scripts; the real-browser drift guard is the safety net."
+```
+
+---
+
+### Task 4: Retire #1342's fetch-based guard + open the PR
+
+**Files:**
+- (Conditional) Delete: `apps/web/scripts/check-csp-hash-drift.ts`, `apps/web/src/__tests__/check-csp-hash-drift.test.ts`, and their `package.json`/CI wiring — **only if they exist on your base** (they do not on current `main`).
+
+**Interfaces:**
+- Consumes: the merged-or-unmerged state of PR #1342.
+- Produces: a single open PR that `Closes #1232`, with #1342 closed as superseded.
+
+- [ ] **Step 1: Check whether the fetch-guard files exist on your base**
+
+```bash
+ls apps/web/scripts/check-csp-hash-drift.ts apps/web/src/__tests__/check-csp-hash-drift.test.ts 2>/dev/null && echo "EXIST — delete them" || echo "absent — nothing to delete (expected on main)"
+```
+
+- [ ] **Step 2: If they exist, delete them and their wiring; commit**
+
+```bash
+git rm apps/web/scripts/check-csp-hash-drift.ts apps/web/src/__tests__/check-csp-hash-drift.test.ts
+# remove any "check-csp-hash-drift" script from apps/web/package.json and any
+# CI step invoking it in .github/workflows/ci.yml (build-web job)
+git commit -m "chore(web): remove superseded fetch-based CSP drift guard (#1232, supersedes #1342)"
+```
+If Step 1 printed "absent", skip this step.
+
+- [ ] **Step 3: Push, open the PR, and verify (per issue-to-pr)**
+
+```bash
+git push -u origin HEAD
+gh pr create --repo LanternOps/breeze --title "fix(web): remove dead CSP script-src hash pins + real-browser drift guard" \
+  --body "Closes #1232. Supersedes #1342 (close it). Spike (docs/superpowers/specs/2026-06-19-csp-script-hash-drift-guard-design.md) proved both hand-pinned hashes are dead on Astro 6.4.7. Adds a standalone real-browser CSP drift guard (CI build-web) + an authenticated e2e CSP-violation assertion."
+```
+Then run `/pr-review-toolkit:review-pr`, address findings, and post the review-summary comment. Close #1342 as superseded with a one-line reason.
+
+- [ ] **Step 4: Verification checklist before handing off**
+
+- Standalone guard GREEN on the final build; proven RED under an injected inline script (Task 1 Step 4).
+- Authenticated e2e CSP spec GREEN with pins deleted (Task 3 Step 3).
+- Web unit tests GREEN (Task 3 Step 4); `tsc`/`astro check` clean.
+- PR body `Closes #1232`; #1342 closed as superseded.
+- **Do not merge. Do not close #1232.** Hand off with the review summary.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Part 1 (delete pins) → Task 3. Part 2 (standalone web-only guard) → Task 1. Part 3 (authenticated e2e assertion) → Task 2. Part 4 (retire fetch guard) → Task 4. Non-goals (nonce, ClientRouter removal, generator) require no task. Residual caveat (authenticated dashboard re-verification) → Task 3 Step 3, gated explicitly. Covered.
+
+**Placeholder scan:** Two intentional lookups remain because their exact values are environment-specific and must be read at implementation time, not guessed: the `playwright` version string (Task 1 Step 1 — copy verbatim from `e2e-tests/package.json`) and the sidebar link `data-testid` (Task 2 Step 2 — read from `e2e-tests/pages/`). Both include the exact command/file to read and a fallback. No vague "add error handling"-style placeholders.
+
+**Type consistency:** `window.__cspViolations` shape `{ blockedURI, violatedDirective, scriptSample }` is identical in Task 1 and Task 2. The guard script entrypoint `csp:guard` is referenced consistently across Tasks 1, 3. `check-csp-violations.ts` path is consistent throughout.

--- a/docs/superpowers/specs/2026-06-19-csp-script-hash-drift-guard-design.md
+++ b/docs/superpowers/specs/2026-06-19-csp-script-hash-drift-guard-design.md
@@ -1,0 +1,191 @@
+# CSP `script-src` hash-drift: delete dead pins + real-browser drift guard
+
+**Date:** 2026-06-19
+**Issue:** [#1232](https://github.com/LanternOps/breeze/issues/1232) — "Hardcoded CSP `script-src` sha256 hashes drift from emitted inline scripts → blocked Astro hydration + React #418"
+**Supersedes:** the fetch-based partial guard in draft PR #1342 (`fix/1232-csp-hash-drift`)
+
+## Problem
+
+`apps/web/astro.config.mjs` carries two **hand-maintained** sha256 hashes in
+`security.csp.scriptDirective.resources`:
+
+```js
+"'sha256-dr7co1YqmJP1+caEJBfXkM/oHRwOVAknT+gDygo8nD0='",
+"'sha256-6wgjuQN80bYuvy8C2/v+mFX1HAEgrfvSs+beElRyx+8='"
+```
+
+They were added (#618) to authorize an inline script associated with Astro's
+`<ClientRouter>` view-transition **swap** path — content Astro's build-time CSP
+hasher does not cover. Because the hash is constant *per Astro version*, an Astro
+upgrade can change the emitted script, leaving the pinned hash stale. When that
+happens the browser blocks the inline script **at runtime, after deploy** — the
+build still succeeds, so nothing in CI catches it. The original report saw the
+downstream symptom: blocked inline scripts plus `Minified React error #418`
+(hydration mismatch). This is a silent, deploy-time landmine, fragile by
+construction.
+
+## Spike findings (2026-06-19)
+
+A throwaway investigation resolved the two open questions — provenance of the
+hashes, and whether they are still load-bearing — definitively:
+
+1. **The hashes are not a locatable source literal.** Hashing all 387 string
+   literals in Astro's `dist/transitions` + `dist/runtime/server`, plus our
+   layout inline scripts, matched neither pin. (Our theme bootstrap is now an
+   *external* script — `src="/theme-bootstrap.js"` — so it is hashed via `src`,
+   not content.) Any "compute the hash from a source file at build time" approach
+   is therefore not reliably implementable.
+
+2. **The pins are stored as manual `scriptResources`, separate from Astro's
+   auto-computed `scriptHashes`**, and Astro never regenerates them (confirmed in
+   the built `dist/server` CSP config object). They are purely hand-supplied.
+
+3. **Initial-load inline scripts do not need them.** Booting the production build
+   and hashing every inline `<script>` across `/`, `/login`, `/forgot-password`,
+   `/setup`, `/devices` produced three hashes — all of which are already in
+   Astro's auto-generated `scriptHashes`. Neither pin reproduced (0/2).
+
+4. **The pins are dead.** Removing both pins, rebuilding production, serving with
+   CSP enforced, and driving a real Chromium through two `<ClientRouter>`
+   view-transition swaps (`/login` → `/forgot-password` → `/login`) produced
+   **zero CSP violations** (only expected API-404 console errors). On Astro
+   6.4.7 the swap path emits no inline script requiring these hashes; the pins
+   are harmless dead weight that browsers silently ignore.
+
+**Residual caveat:** the browser spike reached only public auth-layout pages;
+`DashboardLayout` routes need a backend + auth to render. The swap script is
+page-agnostic, so the dead-pin conclusion holds — but deletion must be confirmed
+against at least one **authenticated dashboard navigation** before/within the
+implementing PR (covered by the e2e assertion below).
+
+## Decision
+
+Delete the dead pins and prevent the drift class from ever shipping silently
+again with a **real-browser** guard, rather than a generator/derivation/nonce.
+
+### Non-goals (ruled out, with reasons)
+
+- **Per-request nonce** (the issue's headline suggestion): Astro 6.4.7's CSP
+  implementation has **no nonce support** (`dist/core/csp` contains no nonce
+  path). Not implementable without forking Astro.
+- **Remove `<ClientRouter>` / view transitions:** load-bearing across all four
+  layouts and the entire dashboard shell (`Sidebar`, `Header`, `AuthOverlay`,
+  `AdminSessionManager`, `AiChatSidebar`, `HelpPanel`, `ToastContainer` all use
+  `transition:persist`; `navigation.ts` calls `navigate()`). Removing it is a
+  separate SPA-shell rearchitecture, not a fix for this.
+- **Build-time hash generator:** no stable source literal to derive from (finding
+  #1); the only reliable derivation is a headless-browser capture, at which point
+  a *guard* is simpler than a *generator* that must rewrite and commit config.
+- **Keep the fetch-based guard (#1342):** it cannot observe the runtime swap path
+  (it only sees initial-GET HTML), which is the exact vector #1232 describes.
+
+## Design
+
+### Part 1 — Delete the dead pins
+
+In `apps/web/astro.config.mjs`, `security.csp.scriptDirective.resources` becomes:
+
+```js
+resources: [
+  "'self'",
+  'https://static.cloudflareinsights.com',
+]
+```
+
+Update the surrounding comment: explain that Astro auto-hashes all build-time
+inline scripts, that no hand-pinned hashes are carried, and that the drift guard
+(below) is the safety net for any future Astro version that introduces a
+runtime-only inline script.
+
+### Part 2 — Standalone web-only drift guard (primary CI gate)
+
+A dedicated, lightweight check that does not require the API/DB:
+
+- **Boots** the production web build (`node dist/server/entry.mjs`, the
+  `@astrojs/node` standalone adapter) on a test port, CSP enforced (production
+  mode is strict by default via `apps/web/src/middleware.ts`).
+- **Drives Playwright** (already a repo dependency) through:
+  - initial loads of representative public routes (`/`, `/login`,
+    `/forgot-password`, `/setup`), and
+  - **view-transition swaps** between them (click in-app links so `<ClientRouter>`
+    performs a real swap — the path a fetch-based guard cannot see).
+- **Listens for `securitypolicyviolation`** events (and console CSP-refusal
+  errors) and **fails the job** if any inline script is blocked.
+- Runs in the `build-web` CI job, replacing the fetch-based
+  `apps/web/scripts/check-csp-hash-drift.ts` step.
+
+This directly asserts the user-facing invariant ("no inline script is ever
+CSP-blocked") under real runtime conditions, in both drift directions.
+
+### Part 3 — Authenticated e2e assertion (dashboard coverage)
+
+Bolt a CSP-violation listener onto the existing authenticated Playwright e2e
+flow (`e2e-tests/`), which already logs in and reaches real `DashboardLayout`
+pages with their islands and inline scripts. Register a `securitypolicyviolation`
+handler at context/page setup and fail the relevant spec(s) if a violation fires
+during an authenticated session that includes at least one in-app navigation
+(view-transition swap) between dashboard pages.
+
+This closes the residual caveat: it proves the pins are unnecessary on
+authenticated routes too, and guards those routes going forward.
+
+### Part 4 — Retire the fetch-based guard
+
+Remove `apps/web/scripts/check-csp-hash-drift.ts`, its unit test
+(`apps/web/src/__tests__/check-csp-hash-drift.test.ts`), and its `package.json`
+script / CI wiring introduced by #1342. The browser guard supersedes it and
+resolves its self-documented `UNVERIFIED` gap. Draft PR #1342 is closed in favor
+of this work.
+
+## Components & interfaces
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `astro.config.mjs` (edit) | Carry no hand-pinned script hashes; rely on Astro auto-hash | Astro `security.csp` |
+| Standalone guard (new script + CI step) | Boot prod web build, navigate + swap in Playwright, fail on CSP violation | built `dist/`, Playwright, web middleware CSP |
+| e2e CSP assertion (edit to existing spec/fixture) | Fail authenticated e2e on any CSP violation incl. a dashboard swap | `e2e-tests/` harness, running stack |
+| (removed) fetch guard + test | — | — |
+
+## What the guard catches (failure modes)
+
+- **Astro bump introduces a runtime inline script needing a hash** → swap
+  navigation blocks it → `securitypolicyviolation` → **CI red** (vs. today's
+  silent prod breakage). A human then adds the now-required hash (loud, only when
+  actually needed) or revisits.
+- **Any future hand-pinned hash goes stale / dead** → not silently carried,
+  because the guard asserts real script execution rather than the presence of a
+  hash string.
+- **A new app inline script not covered by Astro auto-hash** → blocked on initial
+  load → CI red.
+
+## Testing
+
+- **Standalone guard:** self-test it both ways during implementation — green on a
+  correct build; red when an inline script is deliberately blocked (e.g. a
+  temporary unhashed inline `<script>`), proving the assertion is load-bearing
+  (the failure #1342 could not produce for the swap path).
+- **e2e assertion:** confirm the authenticated flow stays green after pin
+  deletion (this is the authenticated-dashboard re-verification) and goes red
+  under an injected violation.
+- **Existing web unit tests** (`apps/web/src/middleware.test.ts`,
+  `src/lib/csp.test.ts`) must remain green; update any reference to the removed
+  fetch guard.
+
+## Rollout / verification
+
+1. Implement in an isolated worktree off fresh `main` (per `issue-to-pr`).
+2. Delete pins; run the standalone guard locally (build + boot + Playwright) →
+   expect green with zero violations across initial loads and swaps.
+3. Run the authenticated e2e flow with the new assertion against the full stack →
+   confirm no CSP violation on a dashboard view-transition navigation. **This is
+   the gate that authorizes deleting the pins.**
+4. Open PR (`Closes #1232`), close #1342 as superseded.
+5. UI-test hold applies: this is a user-facing CSP change; a human should
+   exercise real navigations in a browser before merge.
+
+## Open questions
+
+None blocking. Route lists for the standalone guard are an implementation detail
+(start with the four public routes exercised in the spike). If a future Astro
+version legitimately requires a runtime hash, adding it back is a one-line,
+CI-gated change — explicitly acceptable.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -833,6 +833,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
+      playwright:
+        specifier: ^1.58.2
+        version: 1.61.0
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -6189,6 +6192,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7896,6 +7904,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -16045,6 +16063,9 @@ snapshots:
   fs.realpath@1.0.0:
     optional: true
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -18409,6 +18430,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:


### PR DESCRIPTION
Closes #1232. Supersedes #1342 (close it).

**Background:** `apps/web/astro.config.mjs` carried two hand-maintained `script-src` sha256 hashes added (#618) for the `<ClientRouter>` view-transition swap script — content Astro's build-time CSP hasher doesn't cover. The hash is constant *per Astro version*, so an Astro bump can leave it stale → the browser blocks the inline script **at runtime, after deploy** (the build still succeeds), surfacing as `Minified React error #418`. A silent, deploy-time landmine.

**Spike finding (the pins are dead on Astro 6.4.7):** removed both pins, rebuilt production, served with CSP enforced, and drove a real Chromium through two `<ClientRouter>` swaps (`/login` → `/forgot-password` → `/login`) — **zero CSP violations**. Astro 6.4.7's auto-hashing already covers every inline script the app emits; the pins were harmless dead weight. Full evidence + design: `docs/superpowers/specs/2026-06-19-csp-script-hash-drift-guard-design.md`.

**Changes:**
- **Delete the two dead pins** from `scriptDirective.resources` (`apps/web/astro.config.mjs`); comment now explains we carry no hand-pinned hashes and points to the guard.
- **Add a standalone real-browser CSP drift guard** (`apps/web/scripts/check-csp-violations.ts`, run as `csp:guard` in the `build-web` CI job). It boots the prod build, drives Playwright through initial loads + view-transition swaps, and **fails CI on any blocked inline script** — catching the runtime swap vector a fetch-based guard can't see. Proven load-bearing: green on a clean build, red when an inline script is injected, green again after revert. Scoped to inline-script violations (`blockedURI === 'inline'`) to exclude Monaco's pre-existing `eval` violations.

**Deliberately NOT done — authenticated-dashboard CSP coverage:** the planned e2e assertion was dropped. The e2e suite runs against a **dev-mode** stack (`docker-compose.override.yml.dev` = `astro dev`), and the web middleware **strips the CSP header in dev** — so a `securitypolicyviolation` assertion there would be vacuous (always green). Residual risk is low: the #1232 vector (the swap script) is page-agnostic and **is** covered by the guard above, and dashboard build-time inline scripts are auto-hashed by Astro exactly like the public pages tested.

**Verification:** `csp:guard` GREEN (4 loads + 2 swaps); served `script-src` confirmed pins-absent; `vitest run src/middleware.test.ts src/lib/csp.test.ts` → 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)