### PR TITLE
fix(mobile): surface SecureStore wipe failures on logout teardown (#1625)

### DIFF
--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react-native';
 
 import { useAppSelector, useAppDispatch } from '../store';
 import { setCredentials, logout, logoutAsync } from '../store/authSlice';
-import { getStoredToken, getStoredUser, clearAuthData } from '../services/auth';
+import { getStoredToken, getStoredUser, clearAuthData, SecureWipeError } from '../services/auth';
 import { getCurrentUser, onDeviceBlocked } from '../services/api';
 import { spacing, type } from '../theme';
 import { identify as analyticsIdentify, reset as analyticsReset } from '../lib/analytics';
@@ -20,6 +20,27 @@ import { ApprovalGate } from './ApprovalGate';
 import { OnboardingScreen } from '../screens/onboarding/OnboardingScreen';
 import { Spinner } from '../components/Spinner';
 import { palette } from '../theme';
+
+/**
+ * Clear local auth state, tolerating a partial secure-wipe failure.
+ *
+ * A `SecureWipeError` is already reported to Sentry inside `clearAuthData`, so
+ * we swallow only that specific error here — it must not abort the redux logout
+ * that follows. Any *other* throw (a genuinely novel failure) is re-reported and
+ * re-thrown rather than silently dropped, so we don't reintroduce a silent
+ * failure of an unrelated kind (the exact trap #1625 fixed).
+ */
+async function clearAuthDataTolerant(): Promise<void> {
+  try {
+    await clearAuthData();
+  } catch (err) {
+    if (err instanceof SecureWipeError || (err as { name?: string } | null)?.name === 'SecureWipeError') {
+      return; // already reported to Sentry inside clearAuthData
+    }
+    Sentry.captureException(err, { tags: { area: 'auth-teardown-nav' } });
+    throw err;
+  }
+}
 
 export function RootNavigator() {
   const dispatch = useAppDispatch();
@@ -98,9 +119,10 @@ export function RootNavigator() {
           const status = (err as { statusCode?: number } | null)?.statusCode;
           if (status === 401 || status === 403) {
             // A failed secure wipe (SecureWipeError) is already reported to
-            // Sentry inside clearAuthData; don't let it abort the redux logout
-            // or fall through to the outer catch and double-wipe.
-            await clearAuthData().catch(() => {});
+            // Sentry inside clearAuthData; clearAuthDataTolerant swallows only
+            // that so it can't abort the redux logout or fall through to the
+            // outer catch and double-wipe. Other failures still surface.
+            await clearAuthDataTolerant();
             dispatch(logout());
           }
           // Other failures (network down, 5xx) intentionally leave the
@@ -109,7 +131,7 @@ export function RootNavigator() {
         }
       } catch (error) {
         console.error('Error checking auth:', error);
-        await clearAuthData().catch(() => {});
+        await clearAuthDataTolerant();
         dispatch(logout());
       } finally {
         setIsCheckingAuth(false);

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -97,7 +97,10 @@ export function RootNavigator() {
         } catch (err) {
           const status = (err as { statusCode?: number } | null)?.statusCode;
           if (status === 401 || status === 403) {
-            await clearAuthData();
+            // A failed secure wipe (SecureWipeError) is already reported to
+            // Sentry inside clearAuthData; don't let it abort the redux logout
+            // or fall through to the outer catch and double-wipe.
+            await clearAuthData().catch(() => {});
             dispatch(logout());
           }
           // Other failures (network down, 5xx) intentionally leave the
@@ -106,7 +109,7 @@ export function RootNavigator() {
         }
       } catch (error) {
         console.error('Error checking auth:', error);
-        await clearAuthData();
+        await clearAuthData().catch(() => {});
         dispatch(logout());
       } finally {
         setIsCheckingAuth(false);

--- a/apps/mobile/src/services/approvalCache.test.ts
+++ b/apps/mobile/src/services/approvalCache.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  APPROVAL_CACHE_KEY,
+  clearApprovalCache,
+  clearApprovalCacheOrThrow,
+} from './approvalCache';
+
+const secureStore = {
+  deleteItemAsync: vi.fn(),
+};
+vi.mock('expo-secure-store', () => ({
+  deleteItemAsync: (...a: unknown[]) => secureStore.deleteItemAsync(...a),
+}));
+
+beforeEach(() => {
+  secureStore.deleteItemAsync.mockReset().mockResolvedValue(undefined);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('clearApprovalCacheOrThrow', () => {
+  it('deletes the approvals cache key', async () => {
+    await clearApprovalCacheOrThrow();
+    expect(secureStore.deleteItemAsync).toHaveBeenCalledWith(APPROVAL_CACHE_KEY);
+  });
+
+  it('propagates SecureStore errors (used on the security-teardown path)', async () => {
+    secureStore.deleteItemAsync.mockRejectedValue(new Error('keychain locked'));
+    await expect(clearApprovalCacheOrThrow()).rejects.toThrow('keychain locked');
+  });
+});
+
+describe('clearApprovalCache (best-effort variant)', () => {
+  it('swallows SecureStore errors for graceful-degradation callers', async () => {
+    secureStore.deleteItemAsync.mockRejectedValue(new Error('keychain locked'));
+    await expect(clearApprovalCache()).resolves.toBeUndefined();
+  });
+});

--- a/apps/mobile/src/services/approvalCache.ts
+++ b/apps/mobile/src/services/approvalCache.ts
@@ -1,13 +1,27 @@
 import * as SecureStore from 'expo-secure-store';
 import type { ApprovalRequest } from './approvals';
 
-const KEY = 'breeze.approvals.cache.v1';
+export const APPROVAL_CACHE_KEY = 'breeze.approvals.cache.v1';
+const KEY = APPROVAL_CACHE_KEY;
 
 // Cache last /pending response so cold open with no network still renders the queue.
 
+/**
+ * Delete the persisted approvals cache, propagating any SecureStore error.
+ *
+ * Use this on the security-teardown path (sign-out) where a failed wipe must be
+ * surfaced rather than swallowed — leaving the prior session's approvals cache
+ * on-device is the cross-session leak #1415 closed. The swallowing
+ * `clearApprovalCache` below is for best-effort/graceful-degradation callers
+ * (e.g. resetting a corrupt cache) where a failure is non-sensitive.
+ */
+export async function clearApprovalCacheOrThrow(): Promise<void> {
+  await SecureStore.deleteItemAsync(KEY);
+}
+
 export async function clearApprovalCache(): Promise<void> {
   try {
-    await SecureStore.deleteItemAsync(KEY);
+    await clearApprovalCacheOrThrow();
   } catch (err) {
     console.warn('[approvalCache] clear failed', err);
   }

--- a/apps/mobile/src/services/auth.test.ts
+++ b/apps/mobile/src/services/auth.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { clearAuthData } from './auth';
+import { clearAuthData, SecureWipeError } from './auth';
 
 const secureStore = {
   deleteItemAsync: vi.fn(),
@@ -9,8 +9,16 @@ vi.mock('expo-secure-store', () => ({
   deleteItemAsync: (...a: unknown[]) => secureStore.deleteItemAsync(...a),
 }));
 
+const sentry = {
+  captureException: vi.fn(),
+};
+vi.mock('@sentry/react-native', () => ({
+  captureException: (...a: unknown[]) => sentry.captureException(...a),
+}));
+
 beforeEach(() => {
   secureStore.deleteItemAsync.mockReset().mockResolvedValue(undefined);
+  sentry.captureException.mockReset();
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -26,19 +34,57 @@ describe('clearAuthData', () => {
     expect(keys).toContain('breeze.approvals.cache.v1');
   });
 
+  it('does not call Sentry or throw when every wipe succeeds', async () => {
+    await expect(clearAuthData()).resolves.toBeUndefined();
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
   it('attempts every delete (no short-circuit) when one SecureStore entry is locked', async () => {
     // A locked-keychain failure on one key must not stop the other deletes from
-    // being attempted. The helpers swallow their own errors, so clearAuthData
-    // resolves; the load-bearing assertion is that all three deletes were still
-    // dispatched — i.e. nobody refactors this into a short-circuiting sequence.
+    // being attempted (allSettled, not a short-circuiting sequence).
     secureStore.deleteItemAsync.mockImplementation(async (key: string) => {
       if (key === 'breeze_auth_token') throw new Error('keychain locked');
     });
 
-    await expect(clearAuthData()).resolves.toBeUndefined();
+    await expect(clearAuthData()).rejects.toBeInstanceOf(SecureWipeError);
 
     const keys = secureStore.deleteItemAsync.mock.calls.map((c) => c[0]);
     expect(keys).toContain('breeze_user');
     expect(keys).toContain('breeze.approvals.cache.v1');
+  });
+
+  it('surfaces a partial-wipe failure instead of swallowing it', async () => {
+    // Regression for #1625: a sensitive-key delete failure must be *surfaced*
+    // (thrown + reported to telemetry), not silently swallowed, or the
+    // surviving token/cache re-opens the cross-session leak #1415 closed.
+    const cause = new Error('keychain locked');
+    secureStore.deleteItemAsync.mockImplementation(async (key: string) => {
+      if (key === 'breeze.approvals.cache.v1') throw cause;
+    });
+
+    await expect(clearAuthData()).rejects.toMatchObject({
+      name: 'SecureWipeError',
+      failedKeys: ['breeze.approvals.cache.v1'],
+    });
+
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+    const [reported, context] = sentry.captureException.mock.calls[0];
+    expect(reported).toBeInstanceOf(SecureWipeError);
+    expect((context as { extra?: { failedKeys?: string[] } }).extra?.failedKeys).toEqual([
+      'breeze.approvals.cache.v1',
+    ]);
+  });
+
+  it('reports every surviving key when multiple deletes fail', async () => {
+    secureStore.deleteItemAsync.mockImplementation(async (key: string) => {
+      if (key === 'breeze_auth_token' || key === 'breeze_user') {
+        throw new Error('keychain locked');
+      }
+    });
+
+    await expect(clearAuthData()).rejects.toMatchObject({
+      failedKeys: ['breeze_auth_token', 'breeze_user'],
+    });
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -1,6 +1,7 @@
 import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
 import type { User } from './api';
-import { clearApprovalCache } from './approvalCache';
+import { APPROVAL_CACHE_KEY, clearApprovalCacheOrThrow } from './approvalCache';
 
 const TOKEN_KEY = 'breeze_auth_token';
 const USER_KEY = 'breeze_user';
@@ -85,6 +86,24 @@ export async function removeUser(): Promise<void> {
 }
 
 /**
+ * Error thrown when one or more sensitive entries could not be wiped during
+ * `clearAuthData`. Carries the list of keys that survived so callers / Sentry
+ * can see exactly what leaked.
+ */
+export class SecureWipeError extends Error {
+  readonly failedKeys: string[];
+
+  constructor(failedKeys: string[], cause?: unknown) {
+    super(`Failed to wipe sensitive SecureStore entries: ${failedKeys.join(', ')}`);
+    this.name = 'SecureWipeError';
+    this.failedKeys = failedKeys;
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/**
  * Clear all authentication data.
  *
  * Also clears the persistent approvals cache (`breeze.approvals.cache.v1`).
@@ -94,13 +113,48 @@ export async function removeUser(): Promise<void> {
  * on the same device would read the prior session's cached approvals — the
  * same cross-session leak the Redux logout reset in `store/resettable.ts`
  * closes for in-memory state.
+ *
+ * This is a security teardown, so a *partial* wipe must not be silently
+ * swallowed: if a SecureStore delete throws (locked keychain, decrypt failure)
+ * the surviving token / cache re-opens the cross-session leak while the user
+ * lands on the signed-out screen. We therefore:
+ *   - attempt every delete (no short-circuit), via `Promise.allSettled`;
+ *   - report any failure to Sentry so it's observable on production builds
+ *     where `console.*` goes nowhere a developer sees;
+ *   - throw a `SecureWipeError` naming the surviving keys so callers can react
+ *     (e.g. retry on next keychain-unlock) instead of assuming a clean wipe.
  */
 export async function clearAuthData(): Promise<void> {
-  await Promise.all([
-    removeToken(),
-    removeUser(),
-    clearApprovalCache(),
-  ]);
+  const deletions: Array<{ key: string; run: () => Promise<unknown> }> = [
+    { key: TOKEN_KEY, run: () => SecureStore.deleteItemAsync(TOKEN_KEY) },
+    { key: USER_KEY, run: () => SecureStore.deleteItemAsync(USER_KEY) },
+    { key: APPROVAL_CACHE_KEY, run: () => clearApprovalCacheOrThrow() },
+  ];
+
+  const results = await Promise.allSettled(deletions.map((d) => d.run()));
+
+  const failures = results
+    .map((result, i) => ({ result, key: deletions[i].key }))
+    .filter(
+      (entry): entry is { result: PromiseRejectedResult; key: string } =>
+        entry.result.status === 'rejected'
+    );
+
+  if (failures.length === 0) return;
+
+  const failedKeys = failures.map((f) => f.key);
+  const firstReason = failures[0].result.reason;
+  const error = new SecureWipeError(failedKeys, firstReason);
+
+  // Surface to telemetry — on a production RN build the per-helper console.*
+  // logs go nowhere a developer sees, so without this the partial wipe is
+  // invisible. Sentry is initialized in App.tsx.
+  Sentry.captureException(error, {
+    tags: { area: 'auth-teardown' },
+    extra: { failedKeys },
+  });
+
+  throw error;
 }
 
 /**

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -34,17 +34,6 @@ export async function getStoredToken(): Promise<string | null> {
 }
 
 /**
- * Remove the stored authentication token
- */
-export async function removeToken(): Promise<void> {
-  try {
-    await SecureStore.deleteItemAsync(TOKEN_KEY);
-  } catch (error) {
-    console.error('Error removing token:', error);
-  }
-}
-
-/**
  * Store user data securely
  */
 export async function storeUser(user: User): Promise<void> {
@@ -75,31 +64,26 @@ export async function getStoredUser(): Promise<User | null> {
 }
 
 /**
- * Remove the stored user data
- */
-export async function removeUser(): Promise<void> {
-  try {
-    await SecureStore.deleteItemAsync(USER_KEY);
-  } catch (error) {
-    console.error('Error removing user:', error);
-  }
-}
-
-/**
  * Error thrown when one or more sensitive entries could not be wiped during
  * `clearAuthData`. Carries the list of keys that survived so callers / Sentry
  * can see exactly what leaked.
+ *
+ * Only ever constructed for a non-empty failure set — the `[string, ...string[]]`
+ * parameter type makes `new SecureWipeError([])` a compile error, so an
+ * "empty failure" instance is unrepresentable. We branch on `.name` rather than
+ * `instanceof` at call sites because subclass `instanceof` is unreliable across
+ * RN/Hermes bundles; `.name` is set explicitly here to keep that contract sound.
  */
 export class SecureWipeError extends Error {
-  readonly failedKeys: string[];
+  readonly failedKeys: readonly string[];
 
-  constructor(failedKeys: string[], cause?: unknown) {
-    super(`Failed to wipe sensitive SecureStore entries: ${failedKeys.join(', ')}`);
+  constructor(failedKeys: readonly [string, ...string[]], cause?: unknown) {
+    super(
+      `Failed to wipe sensitive SecureStore entries: ${failedKeys.join(', ')}`,
+      cause !== undefined ? { cause } : undefined
+    );
     this.name = 'SecureWipeError';
-    this.failedKeys = failedKeys;
-    if (cause !== undefined) {
-      (this as { cause?: unknown }).cause = cause;
-    }
+    this.failedKeys = [...failedKeys]; // defensive snapshot — not shared with the Sentry payload
   }
 }
 
@@ -140,11 +124,16 @@ export async function clearAuthData(): Promise<void> {
         entry.result.status === 'rejected'
     );
 
-  if (failures.length === 0) return;
+  const [firstFailure, ...restFailures] = failures;
+  if (firstFailure === undefined) return;
 
-  const failedKeys = failures.map((f) => f.key);
-  const firstReason = failures[0].result.reason;
-  const error = new SecureWipeError(failedKeys, firstReason);
+  // Non-empty by construction (firstFailure is defined), so this satisfies the
+  // SecureWipeError `[string, ...string[]]` non-empty tuple contract.
+  const failedKeys: [string, ...string[]] = [
+    firstFailure.key,
+    ...restFailures.map((f) => f.key),
+  ];
+  const error = new SecureWipeError(failedKeys, firstFailure.result.reason);
 
   // Surface to telemetry — on a production RN build the per-helper console.*
   // logs go nowhere a developer sees, so without this the partial wipe is

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+
+// Mock the service layer so importing authSlice never pulls expo-secure-store
+// (the node-only vitest runtime can't parse the native modules) and so we can
+// drive the four logoutAsync outcomes deterministically.
+const api = {
+  logout: vi.fn(),
+  login: vi.fn(),
+  verifyMfa: vi.fn(),
+};
+vi.mock('../services/api', () => ({
+  login: (...a: unknown[]) => api.login(...a),
+  logout: (...a: unknown[]) => api.logout(...a),
+  verifyMfa: (...a: unknown[]) => api.verifyMfa(...a),
+}));
+
+const auth = {
+  clearAuthData: vi.fn(),
+  storeToken: vi.fn(),
+  storeUser: vi.fn(),
+};
+vi.mock('../services/auth', () => ({
+  clearAuthData: (...a: unknown[]) => auth.clearAuthData(...a),
+  storeToken: (...a: unknown[]) => auth.storeToken(...a),
+  storeUser: (...a: unknown[]) => auth.storeUser(...a),
+}));
+
+const sentry = { captureException: vi.fn() };
+vi.mock('@sentry/react-native', () => ({
+  captureException: (...a: unknown[]) => sentry.captureException(...a),
+}));
+
+import authReducer, { logoutAsync } from './authSlice';
+
+function makeStore() {
+  return configureStore({ reducer: { auth: authReducer } });
+}
+
+beforeEach(() => {
+  api.logout.mockReset().mockResolvedValue(undefined);
+  auth.clearAuthData.mockReset().mockResolvedValue(undefined);
+  sentry.captureException.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('logoutAsync', () => {
+  it('API ok + wipe ok → fulfilled, wipe runs exactly once', async () => {
+    const store = makeStore();
+    const result = await store.dispatch(logoutAsync());
+
+    expect(result.type).toBe('auth/logout/fulfilled');
+    expect(auth.clearAuthData).toHaveBeenCalledTimes(1);
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(store.getState().auth.token).toBeNull();
+    expect(store.getState().auth.user).toBeNull();
+  });
+
+  it('API fails + wipe ok → rejected with the api message, still signs out', async () => {
+    api.logout.mockRejectedValue(new Error('network down'));
+    const store = makeStore();
+
+    const result = await store.dispatch(logoutAsync());
+
+    expect(result.type).toBe('auth/logout/rejected');
+    expect(result.payload).toBe('network down');
+    // wipe still runs exactly once even though the server logout failed
+    expect(auth.clearAuthData).toHaveBeenCalledTimes(1);
+    // api failure is reported to telemetry
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+    // session is reset regardless
+    expect(store.getState().auth.token).toBeNull();
+  });
+
+  it('API ok + wipe fails → rejected with the wipe message', async () => {
+    auth.clearAuthData.mockRejectedValue(new Error('Secure wipe failed: x'));
+    const store = makeStore();
+
+    const result = await store.dispatch(logoutAsync());
+
+    expect(result.type).toBe('auth/logout/rejected');
+    expect(result.payload).toBe('Secure wipe failed: x');
+    expect(auth.clearAuthData).toHaveBeenCalledTimes(1);
+    expect(store.getState().auth.user).toBeNull();
+  });
+
+  it('API fails + wipe fails → rejected with both messages merged', async () => {
+    api.logout.mockRejectedValue(new Error('network down'));
+    auth.clearAuthData.mockRejectedValue(new Error('Secure wipe failed: x'));
+    const store = makeStore();
+
+    const result = await store.dispatch(logoutAsync());
+
+    expect(result.type).toBe('auth/logout/rejected');
+    expect(result.payload).toBe('network down; Secure wipe failed: x');
+    expect(auth.clearAuthData).toHaveBeenCalledTimes(1);
+    expect(store.getState().auth.token).toBeNull();
+  });
+});

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import * as Sentry from '@sentry/react-native';
 
 import {
   login as apiLogin,
@@ -77,6 +78,10 @@ export const logoutAsync = createAsyncThunk(
       await apiLogout();
     } catch (error: unknown) {
       apiErrorMessage = (error as { message?: string }).message || 'Logout failed';
+      // A failed server-side logout may leave the session token live on the
+      // backend — security-relevant, and the rejected reducer discards the
+      // message (state.error is reset), so report it to telemetry here.
+      Sentry.captureException(error, { tags: { area: 'auth-logout-api' } });
     }
 
     // Local secure wipe runs exactly once. `clearAuthData` now throws a

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -70,14 +70,29 @@ export const verifyMfaAsync = createAsyncThunk(
 export const logoutAsync = createAsyncThunk(
   'auth/logout',
   async (_, { rejectWithValue }) => {
+    // Best-effort server logout; we tear down local state regardless of its
+    // outcome so the user always leaves the authenticated surface.
+    let apiErrorMessage: string | undefined;
     try {
       await apiLogout();
+    } catch (error: unknown) {
+      apiErrorMessage = (error as { message?: string }).message || 'Logout failed';
+    }
+
+    // Local secure wipe runs exactly once. `clearAuthData` now throws a
+    // SecureWipeError (already reported to Sentry) if any sensitive entry
+    // survived; surface that as a rejection rather than letting it escape the
+    // thunk unhandled — the Redux session reset still happens via the
+    // logout/rejected reducers, so the user is signed out either way.
+    try {
       await clearAuthData();
     } catch (error: unknown) {
-      // Clear local data even if API call fails
-      await clearAuthData();
-      const apiError = error as { message?: string };
-      return rejectWithValue(apiError.message || 'Logout failed');
+      const wipeMessage = (error as { message?: string }).message || 'Secure wipe failed';
+      return rejectWithValue(apiErrorMessage ? `${apiErrorMessage}; ${wipeMessage}` : wipeMessage);
+    }
+
+    if (apiErrorMessage) {
+      return rejectWithValue(apiErrorMessage);
     }
   }
 );

--- a/apps/mobile/src/store/logoutResetContract.test.ts
+++ b/apps/mobile/src/store/logoutResetContract.test.ts
@@ -11,6 +11,12 @@ vi.mock('expo-secure-store', () => ({
   setItemAsync: vi.fn(),
   deleteItemAsync: vi.fn(),
 }));
+// authSlice now also imports @sentry/react-native (logout telemetry); mock it
+// so importing the slice doesn't pull the react-native runtime into the
+// node-only vitest environment.
+vi.mock('@sentry/react-native', () => ({
+  captureException: vi.fn(),
+}));
 
 import { LOGOUT_ACTION_TYPES } from './resettable';
 import { logout, logoutAsync } from './authSlice';


### PR DESCRIPTION
**Closes #1625.** Follow-up to PR #1415 (mobile cross-session data-leak fix).

**Root cause:** `clearAuthData()` (`apps/mobile/src/services/auth.ts`) ran `removeToken()` / `removeUser()` / `clearApprovalCache()` in a `Promise.all`, but each helper swallowed its own SecureStore error (`console.warn`/`error`) before resolving. The `Promise.all` therefore resolved `void` even when **zero** deletes succeeded. On a production RN build those console logs go nowhere a developer sees, so a partial wipe (locked keychain / decrypt failure) silently left the auth token and/or the persisted approvals cache (`breeze.approvals.cache.v1`) on-device while the user landed on the signed-out screen — re-opening the exact cross-session leak #1415 closed.

**Fix:**
- `clearAuthData` now runs the three deletes via `Promise.allSettled` (still no short-circuit — every key is attempted), aggregates the surviving keys, **reports them to Sentry**, and throws a `SecureWipeError` naming the leaked keys so callers can react instead of assuming a clean wipe.
- The issue listed "no mobile error reporter is wired today (Sentry is API-only)" as a blocker — that's **stale**: `@sentry/react-native` is a dependency and `Sentry.init` runs in `App.tsx` (and `RootNavigator` already calls `Sentry.setUser`). So telemetry surfacing is available now.
- Added `clearApprovalCacheOrThrow()` (propagating) for the teardown path while keeping the swallowing `clearApprovalCache()` for graceful-degradation callers (corrupt-cache reset, etc.); exported `APPROVAL_CACHE_KEY` for diagnostics.
- Hardened the three callers (`authSlice.logoutAsync`, `RootNavigator` auth-check x2) so a `SecureWipeError` is surfaced (`rejectWithValue` / Sentry) **without** aborting the redux logout or double-wiping. The session reset runs on both the `fulfilled` and `rejected` reducers, so the user is signed out regardless of wipe outcome.

**Out of scope (left for separate tracked work, per the issue):** the optional "pending secure wipe" retry-on-next-keychain-unlock flag.

**Tests** (`apps/mobile`, vitest):
- `auth.test.ts`: a sensitive-key delete failure is *surfaced* (throws `SecureWipeError` + `Sentry.captureException` called with the failed keys), every delete still attempted on partial failure, multi-failure aggregation, and clean happy-path (no throw / no Sentry).
- `approvalCache.test.ts`: the propagate-vs-swallow contract for `clearApprovalCacheOrThrow` vs `clearApprovalCache`.
- 8/8 passed single-file; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)