### PR TITLE
fix(quotes): show one-time "Due on acceptance" total, not first-period total

### DIFF
--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -10,6 +10,7 @@ import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
 import { markQuoteViewed, declineQuoteByActor } from '../../services/quoteLifecycle';
 import { acceptQuote, emitAcceptInvoiceIssued } from '../../services/quoteAcceptService';
 import { createQuotePayLink } from '../../services/quotePay';
+import { computeQuoteTotals, type QuoteLineForMath } from '../../services/quoteMath';
 import { readQuoteImage } from '../../services/quoteImageStorage';
 import { QuoteServiceError } from '../../services/quoteTypes';
 import { InvoiceServiceError } from '../../services/invoiceTypes';
@@ -39,7 +40,10 @@ quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
   const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
   const lines = (await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible);
   try { await markQuoteViewed(id, auth.user.orgId); } catch (err) { console.error('[portal] quote markViewed failed', { id, err }); }
-  return c.json({ data: { quote, blocks, lines } });
+  // Derive the amount accept actually invoices (one-time only) so the customer
+  // sees an accurate "due on acceptance" instead of the recurring-inclusive total.
+  const dueOnAcceptanceTotal = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null).dueOnAcceptanceTotal;
+  return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal }, blocks, lines } });
 });
 
 // GET /quotes/:id/pdf

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -15,6 +15,7 @@ import { QuoteServiceError } from '../services/quoteTypes';
 import { InvoiceServiceError } from '../services/invoiceTypes';
 import { isQuoteExpired } from '../services/quoteExpiry';
 import { createQuotePayLink } from '../services/quotePay';
+import { computeQuoteTotals, type QuoteLineForMath } from '../services/quoteMath';
 import { captureException } from '../services/sentry';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 
@@ -53,7 +54,10 @@ quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => 
     const [partner] = await db.select({ name: partners.name }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
     const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
     await markQuoteViewed(quote.id, quote.orgId);
-    return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
+    // Derive the amount accept actually invoices (one-time only) so the prospect
+    // sees an accurate "due on acceptance" instead of the recurring-inclusive total.
+    const dueOnAcceptanceTotal = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null).dueOnAcceptanceTotal;
+    return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status, dueOnAcceptanceTotal }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
   }));
   if (!data) return c.json({ error: 'Quote not found' }, 404);
   return c.json({ data });

--- a/apps/api/src/services/quoteMath.test.ts
+++ b/apps/api/src/services/quoteMath.test.ts
@@ -21,6 +21,38 @@ describe('computeQuoteTotals', () => {
     // tax applies only to taxable lines (1000 + 220 = 1220) * 0.1 = 122.00
     expect(r.taxTotal).toBe('122.00');
     expect(r.total).toBe('2542.00');
+    // dueOnAcceptanceTotal = what accept actually invoices: one-time subtotal +
+    // tax on ONLY the one-time taxable lines (1000 + 1000*0.1 = 1100), NOT the
+    // recurring-inclusive total (2542) the UI used to mis-advertise.
+    expect(r.dueOnAcceptanceTotal).toBe('1100.00');
+    expect(r.dueOnAcceptanceTotal).not.toBe(r.total);
+  });
+
+  it('dueOnAcceptanceTotal = one-time subtotal + tax on one-time lines, excluding recurring (the bug)', () => {
+    // A quote mixing a $500 one-time line with recurring lines: accept invoices
+    // only the $500 (+ its tax). The recurring-inclusive `total` must NOT be the
+    // advertised "due on acceptance" figure.
+    const r = computeQuoteTotals([
+      line({ quantity: '1', unitPrice: '500', recurrence: 'one_time', taxable: false }),  // 500 one-time
+      line({ quantity: '1', unitPrice: '1000', recurrence: 'monthly', taxable: false }),  // 1000/mo
+      line({ quantity: '1', unitPrice: '450', recurrence: 'annual', taxable: false }),    // 450/yr
+    ], null);
+    expect(r.oneTimeTotal).toBe('500.00');
+    expect(r.total).toBe('1950.00');             // 500 + 1000 + 450 (first period of each)
+    expect(r.dueOnAcceptanceTotal).toBe('500.00'); // only the one-time, no tax
+    expect(r.dueOnAcceptanceTotal).toBe(r.oneTimeTotal);
+    expect(r.dueOnAcceptanceTotal).not.toBe(r.total);
+  });
+
+  it('dueOnAcceptanceTotal taxes only one-time taxable lines, not recurring taxable lines', () => {
+    const r = computeQuoteTotals([
+      line({ quantity: '1', unitPrice: '500', recurrence: 'one_time', taxable: true }),   // 500 one-time, taxable
+      line({ quantity: '1', unitPrice: '1000', recurrence: 'monthly', taxable: true }),   // 1000/mo, taxable
+    ], 0.1);
+    // Whole-quote tax includes the monthly line: (500 + 1000) * 0.1 = 150.
+    expect(r.taxTotal).toBe('150.00');
+    // Due-on-accept tax is on the one-time line ONLY: 500 * 0.1 = 50 → 550 due.
+    expect(r.dueOnAcceptanceTotal).toBe('550.00');
   });
 
   it('excludes non-customer-visible lines from totals', () => {

--- a/apps/api/src/services/quoteMath.ts
+++ b/apps/api/src/services/quoteMath.ts
@@ -15,10 +15,20 @@ export interface QuoteTotals {
   oneTimeTotal: string;
   monthlyRecurringTotal: string;
   annualRecurringTotal: string;
+  /**
+   * The amount actually invoiced when the customer accepts the quote. Accept
+   * auto-issues a one-time-only invoice (recurring lines are deferred to the
+   * Phase 4 recurring contract — see quoteAcceptService.ts), so this is the
+   * one-time subtotal PLUS tax on just the taxable one-time lines. It mirrors
+   * quoteAcceptService's `computeInvoiceTotals(oneTimeLines, taxRate)` exactly,
+   * and is the figure the UI must advertise as "due on acceptance" — NOT
+   * `total`, which also rolls in the first monthly + annual period.
+   */
+  dueOnAcceptanceTotal: string;
 }
 
 export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | null): QuoteTotals {
-  let oneTime = 0, monthly = 0, annual = 0, taxableBasis = 0;
+  let oneTime = 0, monthly = 0, annual = 0, taxableBasis = 0, oneTimeTaxableBasis = 0;
   for (const l of lines) {
     if (!l.customerVisible) continue;
     // Route through the canonical billing helpers so quote per-line cents equal
@@ -28,14 +38,19 @@ export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | 
     if (l.recurrence === 'monthly') monthly += lineCents;
     else if (l.recurrence === 'annual') annual += lineCents;
     else oneTime += lineCents;
-    if (l.taxable) taxableBasis += lineCents;
+    if (l.taxable) {
+      taxableBasis += lineCents;
+      if (l.recurrence === 'one_time') oneTimeTaxableBasis += lineCents;
+    }
   }
-  // First-invoice basis: one-time + first monthly period + first annual period.
+  // First-period basis: one-time + first monthly period + first annual period.
   const subtotal = oneTime + monthly + annual;
   // Match invoiceMath.computeInvoiceTotals' round-half-up; nullish so a 0 rate
   // and null both yield 0 tax.
   const rate = taxRate ?? 0;
   const taxCents = Math.floor(taxableBasis * rate + 0.5);
+  // Tax on ONLY the one-time taxable lines — what accept actually invoices.
+  const oneTimeTaxCents = Math.floor(oneTimeTaxableBasis * rate + 0.5);
   return {
     subtotal: fromCents(subtotal),
     taxTotal: fromCents(taxCents),
@@ -43,5 +58,6 @@ export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | 
     oneTimeTotal: fromCents(oneTime),
     monthlyRecurringTotal: fromCents(monthly),
     annualRecurringTotal: fromCents(annual),
+    dueOnAcceptanceTotal: fromCents(oneTime + oneTimeTaxCents),
   };
 }

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -63,4 +63,22 @@ describe('renderQuotePdf', () => {
     // A multi-line, multi-section document should be non-trivial in size.
     expect(buf.length).toBeGreaterThan(1500);
   });
+
+  it('renders the due-on-acceptance + first-period summary rows for a recurring quote', async () => {
+    // Quote with recurring revenue: the summary draws a bold "Due on acceptance"
+    // (one-time + one-time tax) plus a "First-period total (incl. recurring)" row.
+    const buf = await renderQuotePdf(
+      {
+        id: 'q1', quoteNumber: 'Q-4',
+        oneTimeTotal: '500.00', monthlyRecurringTotal: '1000.00', annualRecurringTotal: '450.00',
+        dueOnAcceptanceTotal: '500.00', total: '1950.00', currencyCode: 'USD',
+      },
+      [{ id: 'b1', blockType: 'line_items', sortOrder: 0, content: {} }],
+      [{ id: 'l1', blockId: 'b1', description: 'Setup', quantity: '1', unitPrice: '500', lineTotal: '500.00', recurrence: 'one_time' }],
+      async () => null,
+      {},
+    );
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+    expect(buf.length).toBeGreaterThan(800);
+  });
 });

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -93,6 +93,8 @@ interface QuoteHeader {
   oneTimeTotal?: string | number | null;
   monthlyRecurringTotal?: string | number | null;
   annualRecurringTotal?: string | number | null;
+  // Amount invoiced on accept (one-time + one-time tax); derived in getQuote.
+  dueOnAcceptanceTotal?: string | number | null;
 }
 
 interface QuoteBlock {
@@ -185,10 +187,14 @@ function renderLineTable(doc: PDFKit.PDFDocument, lines: QuoteLine[], currency: 
 }
 
 // ---------------------------------------------------------------------------
-// Recurring summary footer: One-time / Monthly / Annual / first-invoice total,
-// drawn from the quote header buckets. The "first invoice total" is the quote's
-// `total` (one-time charges + the first recurring period), matching how the
-// header total is computed in quoteMath.
+// Recurring summary footer: One-time / Monthly / Annual / due-on-acceptance,
+// drawn from the quote header buckets. The bold "Due on acceptance" figure is
+// what accept actually invoices (one-time charges + tax on the one-time lines —
+// quote.dueOnAcceptanceTotal); recurring lines bill later via the contract, so
+// they are NOT in that figure. When there is recurring revenue we also show the
+// `total` as a secondary "first-period total (incl. recurring)" line so the
+// recurring-inclusive number is still visible but not presented as the invoiced
+// amount.
 // ---------------------------------------------------------------------------
 
 function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, startY: number): number {
@@ -213,7 +219,14 @@ function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, cur
   if (quote.taxTotal != null && Number(quote.taxTotal) > 0) {
     drawRow(`Tax${quote.taxRate ? ` (${(Number(quote.taxRate) * 100).toFixed(2)}%)` : ''}`, quote.taxTotal, '');
   }
-  drawRow('First invoice total', quote.total, '', true);
+  const hasRecurring =
+    Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+  // Bold primary figure = what accept invoices now. Fall back to the one-time
+  // total if the derived field is somehow absent.
+  drawRow('Due on acceptance', quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, '', true);
+  if (hasRecurring) {
+    drawRow('First-period total (incl. recurring)', quote.total, '');
+  }
   return y;
 }
 

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -109,7 +109,13 @@ export async function getQuote(id: string, actor: QuoteActor) {
   assertOrg(actor, q.orgId);
   const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
   const lines = await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder);
-  return { quote: q, blocks, lines };
+  // dueOnAcceptanceTotal is a derived (non-persisted) figure: the amount accept
+  // actually invoices (one-time lines only — recurring is deferred to the Phase 4
+  // contract). Computed from the canonical quoteMath so it stays penny-consistent
+  // with quoteAcceptService's invoice, and so the UI can advertise an accurate
+  // "due on acceptance" instead of the recurring-inclusive `total` (see #bug).
+  const totals = computeQuoteTotals(lines as QuoteLineForMath[], q.taxRate ? parseFloat(q.taxRate) : null);
+  return { quote: { ...q, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal }, blocks, lines };
 }
 
 export async function listQuotes(query: ListQuotesQuery, actor: QuoteActor) {

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -133,9 +133,20 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
           </div>
         )}
         <div className="flex justify-between border-t pt-1 font-semibold">
-          <span>{hasRecurring ? 'First invoice total' : 'Total'}</span>
-          <span>{money(quote.total, currency)}</span>
+          <span>{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
+          <span>{money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}</span>
         </div>
+        {hasRecurring && (
+          <>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>First-period total (incl. recurring)</span>
+              <span>{money(quote.total, currency)}</span>
+            </div>
+            <p className="pt-1 text-xs text-muted-foreground">
+              Accepting invoices only the one-time charges now. Recurring lines bill on their own schedule.
+            </p>
+          </>
+        )}
       </div>
 
       {quote.terms && (

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -187,9 +187,20 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
           </>
         )}
         <div className="flex justify-between border-t pt-1 font-semibold">
-          <span>{hasRecurring ? 'First invoice total' : 'Total'}</span>
-          <span>{money(quote.total, currency)}</span>
+          <span>{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
+          <span>{money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}</span>
         </div>
+        {hasRecurring && (
+          <>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>First-period total (incl. recurring)</span>
+              <span>{money(quote.total, currency)}</span>
+            </div>
+            <p className="pt-1 text-xs text-muted-foreground">
+              Accepting invoices only the one-time charges now. Recurring lines bill on their own schedule.
+            </p>
+          </>
+        )}
       </div>
 
       {quote.terms && (

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -377,6 +377,8 @@ export interface QuoteHeader extends QuoteSummary {
   oneTimeTotal?: string;
   monthlyRecurringTotal?: string;
   annualRecurringTotal?: string;
+  /** Amount invoiced on accept (one-time + one-time tax); derived server-side. */
+  dueOnAcceptanceTotal?: string;
   billToName?: string | null;
 }
 

--- a/apps/web/src/components/billing/quotes/QuoteDetail.totals.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.totals.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import { formatMoney, type QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// Regression for the "First-invoice total" mislabel: accept auto-issues a
+// ONE-TIME-only invoice, so the prominent figure must advertise what is invoiced
+// on accept (dueOnAcceptanceTotal == one-time + one-time tax), NOT the
+// recurring-inclusive `total`. The recurring-inclusive number is shown separately
+// as "First-period total (incl. recurring)".
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [{ resource: 'quotes', action: 'read' }] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+// A quote mixing a $500 one-time line with recurring revenue: total = 1950 (first
+// period of each cadence), but only $500 is invoiced on accept.
+const mixedDetail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: 'Q-1', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '1950.00', taxRate: null,
+    taxTotal: '0.00', total: '1950.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '1000.00',
+    annualRecurringTotal: '450.00', dueOnAcceptanceTotal: '500.00',
+    billToName: 'Acme', introNotes: null, terms: null, acceptedAt: null,
+    declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null,
+    viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'quotes', action: 'read' }];
+});
+
+describe('QuoteDetail — totals labelling', () => {
+  it('prominent figure is the due-on-acceptance amount (one-time), NOT the recurring-inclusive total', async () => {
+    render(<QuoteDetail detail={mixedDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    const due = screen.getByTestId('quote-detail-due-on-acceptance');
+    expect(due).toHaveTextContent(formatMoney('500.00', 'USD'));
+    // It must equal the one-time total, never the recurring-inclusive total.
+    expect(due).toHaveTextContent(formatMoney(mixedDetail.quote.oneTimeTotal, 'USD'));
+    expect(due).not.toHaveTextContent(formatMoney(mixedDetail.quote.total, 'USD'));
+
+    // The recurring-inclusive total is still shown, but labelled as first-period.
+    const firstPeriod = screen.getByTestId('quote-detail-first-period');
+    expect(firstPeriod).toHaveTextContent(formatMoney('1950.00', 'USD'));
+
+    // The misleading "First-invoice total" testid is gone.
+    expect(screen.queryByTestId('quote-detail-total')).not.toBeInTheDocument();
+  });
+
+  it('falls back to oneTimeTotal when the derived dueOnAcceptanceTotal is absent', async () => {
+    const noDerived: QuoteDetailData = {
+      ...mixedDetail,
+      quote: { ...mixedDetail.quote, dueOnAcceptanceTotal: undefined },
+    };
+    render(<QuoteDetail detail={noDerived} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-detail-due-on-acceptance')).toHaveTextContent(formatMoney('500.00', 'USD'));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -155,13 +155,19 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
               )}
             </dl>
             <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">First-invoice total</span>
-              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-detail-total">{formatMoney(quote.total, currency)}</span>
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
+              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-detail-due-on-acceptance">{formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}</span>
             </div>
             {hasRecurring && (
-              <p className="mt-2 text-xs text-muted-foreground">
-                First-invoice total combines one-time charges with the first period of each recurring cadence (monthly + annual).
-              </p>
+              <>
+                <div className="mt-2 flex justify-between text-sm tabular-nums">
+                  <span className="text-muted-foreground">First-period total (incl. recurring)</span>
+                  <span className="font-medium" data-testid="quote-detail-first-period">{formatMoney(quote.total, currency)}</span>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their own schedule via the contract. The first-period total combines the one-time charges with the first period of each recurring cadence.
+                </p>
+              </>
             )}
           </div>
 

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -420,15 +420,21 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
               )}
             </dl>
             <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">First-invoice total</span>
-              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-total-first-invoice">
-                {formatMoney(quote.total, currency)}
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
+              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-total-due-on-acceptance">
+                {formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}
               </span>
             </div>
             {hasRecurring && (
-              <p className="mt-2 text-xs text-muted-foreground" data-testid="quote-totals-recurring-hint">
-                First-invoice total combines one-time charges with the first period of each recurring cadence (monthly + annual).
-              </p>
+              <>
+                <div className="mt-2 flex items-baseline justify-between text-sm tabular-nums">
+                  <span className="text-muted-foreground">First-period total (incl. recurring)</span>
+                  <span className="font-medium" data-testid="quote-total-first-period">{formatMoney(quote.total, currency)}</span>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground" data-testid="quote-totals-recurring-hint">
+                  Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their own schedule via the contract. The first-period total combines the one-time charges with the first period of each recurring cadence.
+                </p>
+              </>
             )}
           </div>
         </div>

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -27,6 +27,13 @@ export interface Quote {
   oneTimeTotal: string;
   monthlyRecurringTotal: string;
   annualRecurringTotal: string;
+  /**
+   * Amount actually invoiced on accept = one-time subtotal + tax on one-time
+   * taxable lines (recurring is deferred to the Phase 4 contract). Derived
+   * server-side in `getQuote`, so it's present on `GET /quotes/:id` but absent
+   * from the list endpoint. The UI shows this as "Due on acceptance"; `total`
+   * is the recurring-inclusive first-period figure shown separately. */
+  dueOnAcceptanceTotal?: string;
   billToName: string | null;
   introNotes: string | null;
   terms: string | null;


### PR DESCRIPTION
**Found by:** internal Playwright UI QA sweep of unreleased changes since v0.81.0 (2026-06-19); evidence in `docs/testing/FEATURE_TEST_LOG.md`.

**Symptom:** A quote advertised a "First-invoice total" of e.g. **$1,950**, but on accept the auto-issued invoice was **$500**. Confusing/misleading to the customer who clicks Accept.

**Root cause:** The prominent figure was bound to `quote.total`, which `computeQuoteTotals` (`apps/api/src/services/quoteMath.ts:33`) defines as one-time **+ first monthly + first annual period**. But accept auto-issues a **one-time-only** invoice (`quoteAcceptService.ts:103-104` — recurring lines are deferred to the Phase 4 recurring contract). The two definitions of "first invoice" disagreed. The invoice ($500) is correct; the label/value was the defect.

**Fix:** Added a derived `dueOnAcceptanceTotal` (one-time subtotal + tax on only the taxable one-time lines, mirroring `computeInvoiceTotals(oneTimeLines, taxRate)` to the penny) and bound the prominent figure to it under the label **"Due on acceptance"**. Demoted `quote.total` to a clearly-labelled **"First-period total (incl. recurring)"** row. Applied consistently across the internal editor/detail (`QuoteEditor.tsx`, `QuoteDetail.tsx`), the **customer-facing portal** (`PublicQuoteView.tsx`, `QuoteDetailView.tsx`), and the **quote PDF** (`quotePdf.ts`). Accept/invoice logic untouched. No migration.

**Verified:** API `quoteMath`/`quotePdf` suites (10) incl. the exact `$500` vs `$1,950` scenario asserting `dueOnAcceptanceTotal === oneTimeTotal !== total`; full API quote suite (30); web quote component tests (10). `tsc --noEmit` clean for api/web/portal; `astro check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)