### PR TITLE
fix(web): permission-gate sidebar nav + access-denied for billing roles

### DIFF
--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -115,4 +115,20 @@ describe('InvoicesPage', () => {
 
     await waitFor(() => expect(navigateTo).toHaveBeenCalledWith('/billing/invoices/inv-new'));
   });
+
+  it('renders the access-denied state (not the retryable error) on a 403', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/invoices')) return json({ error: 'forbidden' }, false, 403);
+      return json({}, false, 404);
+    });
+    render(<InvoicesPage />);
+
+    await waitFor(() => expect(screen.getByTestId('access-denied')).toBeInTheDocument());
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to view invoices.")).toBeInTheDocument();
+    // The generic data-load-failure UI must NOT appear for a 403.
+    expect(screen.queryByTestId('invoices-error')).not.toBeInTheDocument();
+    expect(screen.queryByText('Try again')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -4,6 +4,7 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { Dialog } from '../shared/Dialog';
+import AccessDenied from '../shared/AccessDenied';
 import {
   type InvoiceStatus,
   type InvoiceSummary,
@@ -77,6 +78,9 @@ export default function InvoicesPage() {
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  // A 403 from the invoices route is a permission denial, not a load failure,
+  // so it renders the access-denied state rather than the retryable error.
+  const [forbidden, setForbidden] = useState(false);
   const [filters, setFilters] = useState<Filters>(() => readFilters());
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
@@ -108,6 +112,7 @@ export default function InvoicesPage() {
     try {
       setLoading(true);
       setError(undefined);
+      setForbidden(false);
       const params = new URLSearchParams();
       if (f.orgId) params.set('orgId', f.orgId);
       if (f.status) params.set('status', f.status);
@@ -116,6 +121,7 @@ export default function InvoicesPage() {
       const qs = params.toString();
       const res = await fetchWithAuth(`/invoices${qs ? `?${qs}` : ''}`);
       if (res.status === 401) return UNAUTHORIZED();
+      if (res.status === 403) { setForbidden(true); return; }
       if (!res.ok) throw new Error('Failed to load invoices');
       const body = (await res.json()) as { data: InvoiceSummary[] };
       setInvoices(body.data ?? []);
@@ -253,6 +259,14 @@ export default function InvoicesPage() {
       </button>
     </th>
   );
+
+  if (forbidden) {
+    return (
+      <div className="space-y-5" data-testid="invoices-page">
+        <AccessDenied message="You don't have permission to view invoices." />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-5" data-testid="invoices-page">

--- a/apps/web/src/components/layout/Sidebar.rbac.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.rbac.test.tsx
@@ -1,0 +1,145 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Permission-aware nav regression (#1454): the dedicated billing roles must only
+// see the items their grants allow. Before the fix, items like Devices, Users,
+// Roles, and the Security section carried no `requiredPermission`, so a
+// "Partner Billing" role (billing grants only) saw the full admin sidebar.
+
+type Perm = { resource: string; action: string };
+
+const state = vi.hoisted(() => ({
+  user: { isPlatformAdmin: false, permissions: [] as Perm[] },
+}));
+const fetchWithAuthMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: fetchWithAuthMock,
+  useAuthStore: Object.assign(
+    (selector: (s: { user: typeof state.user }) => unknown) => selector({ user: state.user }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('../../stores/uiStore', () => ({
+  useUiStore: () => ({ isMobileMenuOpen: false, closeMobileMenu: vi.fn() }),
+}));
+// Partner scope so partnerScopeOnly items aren't hidden by scope — the
+// permission gate is what we're exercising here.
+vi.mock('../../lib/authScope', () => ({ getJwtClaims: () => ({ scope: 'partner' }) }));
+vi.mock('./BrandHeader', () => ({ default: () => null }));
+
+import Sidebar from './Sidebar';
+
+// The seeded role grant sets (apps/api/src/db/seed.ts).
+const PARTNER_BILLING: Perm[] = [
+  { resource: 'catalog', action: 'read' }, { resource: 'catalog', action: 'write' }, { resource: 'catalog', action: 'delete' },
+  { resource: 'quotes', action: 'read' }, { resource: 'quotes', action: 'write' }, { resource: 'quotes', action: 'send' },
+  { resource: 'invoices', action: 'read' }, { resource: 'invoices', action: 'write' }, { resource: 'invoices', action: 'send' }, { resource: 'invoices', action: 'export' },
+  { resource: 'contracts', action: 'read' }, { resource: 'contracts', action: 'write' }, { resource: 'contracts', action: 'manage' },
+];
+const PARTNER_TECHNICIAN: Perm[] = [
+  { resource: 'backup', action: 'read' }, { resource: 'backup', action: 'write' },
+  { resource: 'devices', action: 'read' }, { resource: 'devices', action: 'execute' },
+  { resource: 'scripts', action: 'read' }, { resource: 'scripts', action: 'execute' },
+  { resource: 'alerts', action: 'read' }, { resource: 'alerts', action: 'acknowledge' },
+  { resource: 'tickets', action: 'read' },
+  { resource: 'reports', action: 'read' }, { resource: 'reports', action: 'write' },
+  { resource: 'sites', action: 'read' },
+  { resource: 'organizations', action: 'read' },
+];
+const ADMIN: Perm[] = [{ resource: '*', action: '*' }];
+
+function has(container: HTMLElement, href: string): boolean {
+  return container.querySelector(`a[href="${href}"]`) !== null;
+}
+
+beforeEach(() => {
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) } as Response);
+  state.user.isPlatformAdmin = false;
+  state.user.permissions = [];
+  localStorage.clear();
+  localStorage.setItem('sidebar-mode', 'open');
+  // Expand every section so collapsed children don't hide hrefs.
+  localStorage.setItem(
+    'sidebar-sections',
+    JSON.stringify({ 'ai-fleet': true, monitoring: true, security: true, operations: true, backup: true, reporting: true, settings: true }),
+  );
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false, media: query,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(),
+    dispatchEvent: vi.fn(), onchange: null,
+  })) as unknown as typeof window.matchMedia;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('Sidebar — permission-aware nav for billing vs technician vs admin', () => {
+  it('Partner Billing sees only its billing items, not the admin/fleet sidebar', async () => {
+    state.user.permissions = PARTNER_BILLING;
+    const { container } = render(<Sidebar currentPath="/fleet" />);
+    await waitFor(() => expect(has(container, '/billing/invoices')).toBe(true));
+
+    // Billing surfaces it CAN access:
+    expect(has(container, '/billing/invoices')).toBe(true);
+    expect(has(container, '/billing/quotes')).toBe(true);
+    expect(has(container, '/contracts')).toBe(true);
+    expect(has(container, '/settings/catalog')).toBe(true);
+
+    // Admin / fleet surfaces it must NOT see (the #1454 regression):
+    expect(has(container, '/settings/users')).toBe(false);
+    expect(has(container, '/settings/roles')).toBe(false);
+    expect(has(container, '/devices')).toBe(false);
+    expect(has(container, '/security')).toBe(false);
+    expect(has(container, '/scripts')).toBe(false);
+    expect(has(container, '/backup')).toBe(false);
+    expect(has(container, '/reports')).toBe(false);
+  });
+
+  it('Partner Technician sees fleet/ops items but no billing and no user/role admin', async () => {
+    state.user.permissions = PARTNER_TECHNICIAN;
+    const { container } = render(<Sidebar currentPath="/fleet" />);
+    await waitFor(() => expect(has(container, '/devices')).toBe(true));
+
+    // Technician surfaces it CAN access:
+    expect(has(container, '/devices')).toBe(true);
+    expect(has(container, '/scripts')).toBe(true);
+    expect(has(container, '/alerts')).toBe(true);
+    expect(has(container, '/tickets')).toBe(true);
+    expect(has(container, '/reports')).toBe(true);
+    expect(has(container, '/backup')).toBe(true);
+    expect(has(container, '/security')).toBe(true); // gated on devices:read, which it holds
+
+    // No billing grants → billing nav hidden:
+    expect(has(container, '/billing/invoices')).toBe(false);
+    expect(has(container, '/billing/quotes')).toBe(false);
+    expect(has(container, '/contracts')).toBe(false);
+    expect(has(container, '/settings/catalog')).toBe(false);
+
+    // No users grant → user/role admin hidden:
+    expect(has(container, '/settings/users')).toBe(false);
+    expect(has(container, '/settings/roles')).toBe(false);
+  });
+
+  it('Admin wildcard sees everything across billing, fleet, and settings', async () => {
+    state.user.permissions = ADMIN;
+    const { container } = render(<Sidebar currentPath="/fleet" />);
+    await waitFor(() => expect(has(container, '/devices')).toBe(true));
+
+    expect(has(container, '/devices')).toBe(true);
+    expect(has(container, '/billing/invoices')).toBe(true);
+    expect(has(container, '/settings/users')).toBe(true);
+    expect(has(container, '/settings/roles')).toBe(true);
+    expect(has(container, '/security')).toBe(true);
+    expect(has(container, '/reports')).toBe(true);
+    expect(has(container, '/backup')).toBe(true);
+  });
+
+  it('Dashboard stays visible regardless of permissions (ungated landing page)', async () => {
+    state.user.permissions = PARTNER_BILLING;
+    const { container } = render(<Sidebar currentPath="/fleet" />);
+    await waitFor(() => expect(has(container, '/billing/invoices')).toBe(true));
+    expect(has(container, '/')).toBe(true);
+  });
+});

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -109,15 +109,20 @@ type NavItem = {
 // ---------------------------------------------------------------------------
 // Top-level items (always visible, 6-8 max)
 // ---------------------------------------------------------------------------
+// Each item maps to the permission its backing route enforces (see the
+// requirePermission calls in apps/api/src/routes/*). Gating the nav on the same
+// grant keeps a permission-scoped role (e.g. "Partner Billing", which holds only
+// catalog/invoices/quotes/contracts) from seeing items it has no access to.
+// Dashboard is ungated — it's the always-available landing page.
 const topLevelNav: NavItem[] = [
   { name: 'Dashboard', href: '/', icon: LayoutDashboard },
-  { name: 'Devices', href: '/devices', icon: Monitor },
-  { name: 'Alerts', href: '/alerts', icon: Bell },
-  { name: 'Tickets', href: '/tickets', icon: Ticket },
-  { name: 'Incidents', href: '/incidents', icon: ShieldAlert },
-  { name: 'Remote Access', href: '/remote', icon: Terminal },
-  { name: 'Scripts', href: '/scripts', icon: FileCode },
-  { name: 'Patches', href: '/patches', icon: Download },
+  { name: 'Devices', href: '/devices', icon: Monitor, requiredPermission: { resource: 'devices', action: 'read' } },
+  { name: 'Alerts', href: '/alerts', icon: Bell, requiredPermission: { resource: 'alerts', action: 'read' } },
+  { name: 'Tickets', href: '/tickets', icon: Ticket, requiredPermission: { resource: 'tickets', action: 'read' } },
+  { name: 'Incidents', href: '/incidents', icon: ShieldAlert, requiredPermission: { resource: 'alerts', action: 'read' } },
+  { name: 'Remote Access', href: '/remote', icon: Terminal, requiredPermission: { resource: 'remote', action: 'access' } },
+  { name: 'Scripts', href: '/scripts', icon: FileCode, requiredPermission: { resource: 'scripts', action: 'read' } },
+  { name: 'Patches', href: '/patches', icon: Download, requiredPermission: { resource: 'devices', action: 'read' } },
 ];
 
 // ---------------------------------------------------------------------------
@@ -146,25 +151,28 @@ export const navSections: NavSection[] = [
     id: 'monitoring',
     label: 'Monitoring',
     icon: Activity,
+    // Both surfaces read device/network state, gated on devices:read server-side.
     items: [
-      { name: 'Network Monitor', href: '/monitoring', icon: Activity },
-      { name: 'Network Discovery', href: '/discovery', icon: Network },
+      { name: 'Network Monitor', href: '/monitoring', icon: Activity, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'Network Discovery', href: '/discovery', icon: Network, requiredPermission: { resource: 'devices', action: 'read' } },
     ],
   },
   {
     id: 'security',
     label: 'Security',
     icon: ShieldCheck,
+    // The security suite is built on device posture/scan data (devices:read).
+    // A billing-only role has no devices:read grant, so the whole section hides.
     items: [
-      { name: 'Security', href: '/security', icon: ShieldCheck },
-      { name: 'DNS Security', href: '/dns-security', icon: Network },
-      { name: 'PAM', href: '/pam', icon: KeyRound },
-      { name: 'User Risk', href: '/security/user-risk', icon: UserCheck },
-      { name: 'Sensitive Data', href: '/sensitive-data', icon: ScanSearch },
-      { name: 'Peripherals', href: '/peripherals', icon: Usb },
-      { name: 'AI Risk Engine', href: '/ai-risk', icon: BrainCircuit },
-      { name: 'CIS Benchmarks', href: '/cis-hardening', icon: ClipboardCheck },
-      { name: 'Compliance Baselines', href: '/audit-baselines', icon: ListChecks },
+      { name: 'Security', href: '/security', icon: ShieldCheck, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'DNS Security', href: '/dns-security', icon: Network, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'PAM', href: '/pam', icon: KeyRound, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'User Risk', href: '/security/user-risk', icon: UserCheck, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'Sensitive Data', href: '/sensitive-data', icon: ScanSearch, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'Peripherals', href: '/peripherals', icon: Usb, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'AI Risk Engine', href: '/ai-risk', icon: BrainCircuit, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'CIS Benchmarks', href: '/cis-hardening', icon: ClipboardCheck, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'Compliance Baselines', href: '/audit-baselines', icon: ListChecks, requiredPermission: { resource: 'devices', action: 'read' } },
     ],
   },
   {
@@ -176,9 +184,9 @@ export const navSections: NavSection[] = [
       { name: 'Invoices', href: '/billing/invoices', icon: Receipt, partnerScopeOnly: true, requiredPermission: { resource: 'invoices', action: 'read' } },
       { name: 'Contracts', href: '/contracts', icon: FileSignature, partnerScopeOnly: true, requiredPermission: { resource: 'contracts', action: 'read' } },
       { name: 'Product Catalog', href: '/settings/catalog', icon: Tags, partnerScopeOnly: true, requiredPermission: { resource: 'catalog', action: 'read' } },
-      { name: 'Software Library', href: '/software', icon: Package },
-      { name: 'Software Policies', href: '/software-inventory', icon: Package },
-      { name: 'Config Policies', href: '/configuration-policies', icon: Layers },
+      { name: 'Software Library', href: '/software', icon: Package, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'Software Policies', href: '/software-inventory', icon: Package, requiredPermission: { resource: 'devices', action: 'read' } },
+      { name: 'Config Policies', href: '/configuration-policies', icon: Layers, requiredPermission: { resource: 'devices', action: 'read' } },
       { name: 'Integrations', href: '/integrations', icon: Plug },
     ],
   },
@@ -186,10 +194,11 @@ export const navSections: NavSection[] = [
     id: 'backup',
     label: 'Backup',
     icon: HardDrive,
+    // Backup/recovery surfaces are gated on the backup:read grant.
     items: [
-      { name: 'Backup', href: '/backup', icon: HardDrive },
-      { name: 'Cloud Backup', href: '/c2c', icon: Cloud },
-      { name: 'Disaster Recovery', href: '/dr', icon: ShieldEllipsis },
+      { name: 'Backup', href: '/backup', icon: HardDrive, requiredPermission: { resource: 'backup', action: 'read' } },
+      { name: 'Cloud Backup', href: '/c2c', icon: Cloud, requiredPermission: { resource: 'backup', action: 'read' } },
+      { name: 'Disaster Recovery', href: '/dr', icon: ShieldEllipsis, requiredPermission: { resource: 'backup', action: 'read' } },
     ],
   },
   {
@@ -197,10 +206,10 @@ export const navSections: NavSection[] = [
     label: 'Reporting',
     icon: BarChart3,
     items: [
-      { name: 'Reports', href: '/reports', icon: FileText },
-      { name: 'Analytics', href: '/analytics', icon: BarChart3 },
-      { name: 'Audit Trail', href: '/audit', icon: FileText },
-      { name: 'Event Logs', href: '/logs', icon: ScrollText },
+      { name: 'Reports', href: '/reports', icon: FileText, requiredPermission: { resource: 'reports', action: 'read' } },
+      { name: 'Analytics', href: '/analytics', icon: BarChart3, requiredPermission: { resource: 'reports', action: 'read' } },
+      { name: 'Audit Trail', href: '/audit', icon: FileText, requiredPermission: { resource: 'audit', action: 'read' } },
+      { name: 'Event Logs', href: '/logs', icon: ScrollText, requiredPermission: { resource: 'audit', action: 'read' } },
     ],
   },
   {
@@ -208,14 +217,15 @@ export const navSections: NavSection[] = [
     label: 'Settings',
     icon: Building,
     items: [
-      { name: 'Partner', href: '/settings/partner', icon: Building },
-      { name: 'Organizations', href: '/settings/organizations', icon: Building2 },
-      { name: 'AI Usage & Budget', href: '/settings/ai-usage', icon: BrainCircuit },
-      { name: 'Custom Fields', href: '/settings/custom-fields', icon: ListChecks },
+      { name: 'Partner', href: '/settings/partner', icon: Building, partnerScopeOnly: true },
+      { name: 'Organizations', href: '/settings/organizations', icon: Building2, requiredPermission: { resource: 'organizations', action: 'read' } },
+      { name: 'AI Usage & Budget', href: '/settings/ai-usage', icon: BrainCircuit, partnerScopeOnly: true },
+      { name: 'Custom Fields', href: '/settings/custom-fields', icon: ListChecks, requiredPermission: { resource: 'organizations', action: 'read' } },
       { name: 'Saved Filters', href: '/settings/filters', icon: Filter },
-      { name: 'Users', href: '/settings/users', icon: Users },
-      { name: 'Roles', href: '/settings/roles', icon: KeyRound },
-      { name: 'Enrollment Keys', href: '/settings/enrollment-keys', icon: Key },
+      // Users + Roles are both served by the users routes (users:read).
+      { name: 'Users', href: '/settings/users', icon: Users, requiredPermission: { resource: 'users', action: 'read' } },
+      { name: 'Roles', href: '/settings/roles', icon: KeyRound, requiredPermission: { resource: 'users', action: 'read' } },
+      { name: 'Enrollment Keys', href: '/settings/enrollment-keys', icon: Key, requiredPermission: { resource: 'devices', action: 'read' } },
       { name: 'Deletion requests', href: '/admin/account-deletion-requests', icon: UserX, badgeKind: 'deletion-requests', platformAdminOnly: true },
     ],
   },

--- a/apps/web/src/components/settings/RolesPage.test.tsx
+++ b/apps/web/src/components/settings/RolesPage.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RolesPage from './RolesPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+describe('RolesPage — access control on the roles list', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the access-denied state (not the retryable error) on a 403', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/roles') return json({ error: 'forbidden' }, false, 403);
+      return json({}, false, 404);
+    });
+    render(<RolesPage />);
+
+    await waitFor(() => expect(screen.getByTestId('access-denied')).toBeInTheDocument());
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to manage roles.")).toBeInTheDocument();
+    // A 403 must NOT offer a misleading "Try again" retry.
+    expect(screen.queryByText('Try again')).not.toBeInTheDocument();
+  });
+
+  it('renders the retryable error (with Try again) on a non-403 load failure', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/roles') return json({}, false, 500);
+      return json({}, false, 404);
+    });
+    render(<RolesPage />);
+
+    await waitFor(() => expect(screen.getByText('Try again')).toBeInTheDocument());
+    expect(screen.queryByTestId('access-denied')).not.toBeInTheDocument();
+  });
+
+  it('renders the roles list on a successful load', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/roles') {
+        return json({ data: [{ id: 'r1', name: 'Partner Admin', description: null, scope: 'partner', isSystem: true, userCount: 1, createdAt: '2026-01-01', updatedAt: '2026-01-01' }] });
+      }
+      if (input === '/permissions/catalog') return json({ permissions: [], resourceLabels: {}, actionLabels: {} });
+      return json({}, false, 404);
+    });
+    render(<RolesPage />);
+
+    await waitFor(() => expect(screen.getByText('Partner Admin')).toBeInTheDocument());
+    expect(screen.queryByTestId('access-denied')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/RolesPage.tsx
+++ b/apps/web/src/components/settings/RolesPage.tsx
@@ -11,6 +11,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
+import AccessDenied from '../shared/AccessDenied';
 
 type ModalMode = 'closed' | 'create' | 'edit' | 'clone' | 'delete' | 'users';
 
@@ -25,6 +26,9 @@ export default function RolesPage() {
   const [roles, setRoles] = useState<Role[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  // Distinct from `error`: a 403 is a permission denial, not a transient load
+  // failure, so it renders the access-denied state (no misleading retry button).
+  const [forbidden, setForbidden] = useState(false);
   const [modalMode, setModalMode] = useState<ModalMode>('closed');
   const [selectedRole, setSelectedRole] = useState<Role | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -36,10 +40,15 @@ export default function RolesPage() {
     try {
       setLoading(true);
       setError(undefined);
+      setForbidden(false);
       const response = await fetchWithAuth('/roles');
       if (!response.ok) {
         if (response.status === 401) {
           void navigateTo('/login', { replace: true });
+          return;
+        }
+        if (response.status === 403) {
+          setForbidden(true);
           return;
         }
         throw new Error('Failed to fetch roles');
@@ -345,6 +354,10 @@ export default function RolesPage() {
         </div>
       </div>
     );
+  }
+
+  if (forbidden) {
+    return <AccessDenied message="You don't have permission to manage roles." />;
   }
 
   if (error && roles.length === 0) {

--- a/apps/web/src/components/shared/AccessDenied.test.tsx
+++ b/apps/web/src/components/shared/AccessDenied.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import AccessDenied from './AccessDenied';
+
+describe('AccessDenied', () => {
+  it('renders the default permission-denied message', () => {
+    render(<AccessDenied />);
+    expect(screen.getByTestId('access-denied')).toBeInTheDocument();
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to view this.")).toBeInTheDocument();
+    // It is an alert, not a retry surface — no retry button.
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a custom message and testId', () => {
+    render(<AccessDenied message="You don't have permission to view invoices." testId="invoices-denied" />);
+    expect(screen.getByTestId('invoices-denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to view invoices.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shared/AccessDenied.tsx
+++ b/apps/web/src/components/shared/AccessDenied.tsx
@@ -1,0 +1,41 @@
+import { ShieldX } from 'lucide-react';
+
+interface AccessDeniedProps {
+  /**
+   * Optional, resource-specific message. Falls back to a generic
+   * permission-denied sentence. Keep it user-facing — never leak the raw
+   * resource:action grant string.
+   */
+  message?: string;
+  /** data-testid for e2e/unit assertions. Defaults to `access-denied`. */
+  testId?: string;
+}
+
+/**
+ * Distinct "you lack permission" state, rendered when an API call returns 403.
+ *
+ * This is deliberately NOT the generic "Failed to load / Try again" UI — a 403
+ * is not a transient failure, so offering a retry button is misleading (it will
+ * 403 again). Server-side `requirePermission` is the real gate; this component
+ * just gives a permission-scoped user (e.g. "Partner Billing" landing on /roles)
+ * a clear explanation instead of a confusing error.
+ */
+export default function AccessDenied({
+  message = "You don't have permission to view this.",
+  testId = 'access-denied',
+}: AccessDeniedProps) {
+  return (
+    <div
+      className="rounded-lg border border-border bg-muted/30 p-8 text-center"
+      data-testid={testId}
+      role="alert"
+    >
+      <ShieldX className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
+      <h2 className="mt-4 text-base font-semibold">Access denied</h2>
+      <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">{message}</p>
+      <p className="mx-auto mt-3 max-w-sm text-xs text-muted-foreground">
+        If you believe you should have access, contact your administrator.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
**Found by:** internal Playwright UI QA sweep of unreleased changes since v0.81.0 (2026-06-19); evidence in `docs/testing/FEATURE_TEST_LOG.md`. Relates to the billing roles from #1454.

**Symptom:** API authorization was correct (Partner Billing → 403 on `/roles`, Partner Technician → 403 on `/invoices`), but the **"Partner Billing" role saw the full admin sidebar** (Users, Roles, Devices, Security). Gated routes also rendered a generic "Failed to load / Try again" instead of an access-denied state.

**Root cause:** The nav-filter mechanism (`Sidebar.tsx:472-476`, `hasPermission`) worked, but only the **billing** items carried a `requiredPermission`. Admin/fleet items (Devices, Users, Roles, the Security section, Reporting, Backup) had none, so they rendered for everyone — which is why the technician's billing nav hid correctly but Partner Billing still saw admin items.

**Fix:** Added a server-aligned `requiredPermission` to every permissioned nav item (each mapped to the `requirePermission(...)` the matching API route enforces, all verified present in `packages/shared/src/constants/permissions.ts`), so the sidebar reflects the user's effective grants. Added a reusable `AccessDenied` component (`apps/web/src/components/shared/AccessDenied.tsx`, no retry — a 403 isn't transient) and wired it into `RolesPage` and `InvoicesPage` on 403; non-403 failures keep the retryable error.

**Verified:** new `Sidebar.rbac.test.tsx` (4), `AccessDenied.test.tsx` (2), `RolesPage.test.tsx` (3), extended `InvoicesPage.test.tsx`; existing Sidebar tests (11) still pass; `tsc --noEmit` clean. **Pending:** a live multi-role browser pass (admin/billing/tech sidebars) — queued behind the in-progress Patching sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)