### PR TITLE
fix(web): scope ML feature-flag fetch to active org + SSR-safe alerts tabs

### DIFF
--- a/apps/web/src/components/alerts/AlertRulesPage.tsx
+++ b/apps/web/src/components/alerts/AlertRulesPage.tsx
@@ -188,7 +188,7 @@ export default function AlertRulesPage() {
 
   return (
     <div className="space-y-6">
-      <AlertsTabStrip />
+      <AlertsTabStrip currentPath="/alerts/rules" />
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Alert Rules</h1>

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -361,7 +361,7 @@ export default function AlertsPage() {
 
   return (
     <div className="space-y-5">
-      <AlertsTabStrip />
+      <AlertsTabStrip currentPath="/alerts" />
       <div>
         <h1 className="text-xl font-bold tracking-tight">Alerts</h1>
         <p className="text-sm text-muted-foreground mt-1">

--- a/apps/web/src/components/alerts/AlertsTabStrip.tsx
+++ b/apps/web/src/components/alerts/AlertsTabStrip.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
 const TABS = [
@@ -8,17 +8,39 @@ const TABS = [
   { href: '/alerts/channels', label: 'Channels' },
 ] as const;
 
-export default function AlertsTabStrip() {
+interface AlertsTabStripProps {
+  // SSR-correct current path supplied by the rendering page/component so the
+  // server and client first paint agree on the active tab (no hydration mismatch).
+  currentPath?: string;
+}
+
+// Seed from the prop (SSR-stable) and update after mount so the active tab
+// stays correct across Astro View Transitions and back/forward navigation.
+// Mirrors useCurrentPath in components/layout/Sidebar.tsx.
+function useCurrentPath(initialPath: string): string {
+  const [path, setPath] = useState(initialPath);
+  useEffect(() => {
+    const update = () => setPath(window.location.pathname);
+    document.addEventListener('astro:after-swap', update);
+    window.addEventListener('popstate', update);
+    return () => {
+      document.removeEventListener('astro:after-swap', update);
+      window.removeEventListener('popstate', update);
+    };
+  }, []);
+  return path;
+}
+
+export default function AlertsTabStrip({ currentPath = '/alerts' }: AlertsTabStripProps) {
   const mlFlags = useMlFeatureFlags();
   const alertCorrelationDisabled = mlFlags.isDisabled('ml.alert_correlation.enabled');
+  const path = useCurrentPath(currentPath);
   const activeHref = useMemo(() => {
-    if (typeof window === 'undefined') return '/alerts';
-    const path = window.location.pathname;
     if (path.startsWith('/alerts/correlations')) return '/alerts/correlations';
     if (path.startsWith('/alerts/channels')) return '/alerts/channels';
     if (path.startsWith('/alerts/rules')) return '/alerts/rules';
     return '/alerts';
-  }, []);
+  }, [path]);
 
   return (
     <nav className="flex gap-1 border-b text-sm" aria-label="Alerts sections">

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.test.tsx
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CorrelatedAlertGroups from './CorrelatedAlertGroups';
 import AlertsTabStrip from './AlertsTabStrip';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 vi.mock('../../stores/auth', () => ({
-  fetchWithAuth: vi.fn()
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn()
 }));
 
 const showToast = vi.fn();
@@ -244,6 +246,9 @@ function mockGroupsResponse(options: { rcaEnabled?: boolean; alertCorrelationEna
 describe('CorrelatedAlertGroups', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // useMlFeatureFlags only fetches when an org is active; seed one so the
+    // flag-driven (enabled/disabled) branches resolve under test.
+    useOrgStore.setState({ currentOrgId: 'org-1' });
   });
 
   it('renders grouped alert summary and expanded members', async () => {
@@ -578,15 +583,12 @@ describe('CorrelatedAlertGroups', () => {
   });
 
   it('marks the correlations tab active on the correlations route', () => {
-    window.history.pushState({}, '', '/alerts/correlations');
-
-    render(<AlertsTabStrip />);
+    render(<AlertsTabStrip currentPath="/alerts/correlations" />);
 
     expect(screen.getByRole('link', { name: 'Correlations' })).toHaveAttribute('aria-current', 'page');
   });
 
   it('labels the correlations tab as disabled when alert correlation is disabled', async () => {
-    window.history.pushState({}, '', '/alerts');
     fetchMock.mockImplementation((input, init) => {
       const url = String(input);
       const method = init?.method ?? 'GET';
@@ -596,7 +598,7 @@ describe('CorrelatedAlertGroups', () => {
       return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
     });
 
-    render(<AlertsTabStrip />);
+    render(<AlertsTabStrip currentPath="/alerts" />);
 
     expect(await screen.findByText('Correlations disabled')).toHaveAttribute('aria-disabled', 'true');
     expect(screen.queryByRole('link', { name: 'Correlations' })).toBeNull();

--- a/apps/web/src/components/alerts/NotificationChannelsPage.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelsPage.tsx
@@ -464,7 +464,7 @@ export default function NotificationChannelsPage() {
 
   return (
     <div className="space-y-6">
-      <AlertsTabStrip />
+      <AlertsTabStrip currentPath="/alerts/channels" />
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Notification Channels</h1>

--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.test.tsx
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DeviceAnomaliesPanel from './DeviceAnomaliesPanel';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 const showToast = vi.fn();
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
 }));
 
 vi.mock('../shared/Toast', () => ({
@@ -39,6 +41,9 @@ describe('DeviceAnomaliesPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     showToast.mockReset();
+    // useMlFeatureFlags only fetches when an org is active; seed one so the
+    // flag-driven (enabled/disabled) branches resolve under test.
+    useOrgStore.setState({ currentOrgId: 'org-1' });
   });
 
   it('renders open metric anomalies for a device', async () => {

--- a/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
+++ b/apps/web/src/components/remediation/RemediationSuggestionsPanel.test.tsx
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RemediationSuggestionsPanel from './RemediationSuggestionsPanel';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 const showToast = vi.fn();
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
 }));
 
 vi.mock('../shared/Toast', () => ({
@@ -60,6 +62,9 @@ describe('RemediationSuggestionsPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     showToast.mockReset();
+    // useMlFeatureFlags only fetches when an org is active; seed one so the
+    // flag-driven (enabled/disabled) branches resolve under test.
+    useOrgStore.setState({ currentOrgId: 'org-1' });
   });
 
   it('lists suggested fixes for a source', async () => {

--- a/apps/web/src/components/security/UserRiskPage.test.tsx
+++ b/apps/web/src/components/security/UserRiskPage.test.tsx
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import UserRiskPage from './UserRiskPage';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 const showToast = vi.fn();
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
 }));
 
 vi.mock('../shared/Toast', () => ({
@@ -96,6 +98,10 @@ describe('UserRiskPage', () => {
   beforeEach(() => {
     fetchWithAuthMock.mockReset();
     showToast.mockReset();
+    // useMlFeatureFlags only fetches /config/ml-feature-flags when an org is
+    // active; seed one so the flag request is the first call, matching the
+    // ordered mockResolvedValueOnce chains below.
+    useOrgStore.setState({ currentOrgId: 'org-1' });
   });
 
   it('renders scores, evaluation metrics, and selected user evidence', async () => {

--- a/apps/web/src/components/security/UserRiskPage.tsx
+++ b/apps/web/src/components/security/UserRiskPage.tsx
@@ -69,6 +69,15 @@ const scoreBarClass = (score: number): string => {
   return 'bg-emerald-500';
 };
 
+// Risk-factor (driver) bars represent how much a factor *contributes* to risk,
+// so they use a warm risk palette and never green — a low contribution is still
+// risk, not "good" (which an emerald bar would imply on a high-risk user).
+const driverBarClass = (value: number): string => {
+  if (value >= 25) return 'bg-red-500';
+  if (value >= 15) return 'bg-orange-500';
+  return 'bg-amber-500';
+};
+
 const severityClass = (severity: string | null): string => {
   if (severity === 'critical') return 'border-red-500/40 bg-red-500/10 text-red-700';
   if (severity === 'high') return 'border-orange-500/40 bg-orange-500/10 text-orange-700';
@@ -377,7 +386,7 @@ export default function UserRiskPage() {
                         <span className="font-medium">{value}</span>
                       </div>
                       <div className="h-2 rounded-full bg-muted">
-                        <div className={`h-2 rounded-full ${scoreBarClass(value)}`} style={{ width: `${value}%` }} />
+                        <div className={`h-2 rounded-full ${driverBarClass(value)}`} style={{ width: `${value}%` }} />
                       </div>
                     </div>
                   ))}

--- a/apps/web/src/hooks/useMlFeatureFlags.test.ts
+++ b/apps/web/src/hooks/useMlFeatureFlags.test.ts
@@ -3,12 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useMlFeatureFlags } from './useMlFeatureFlags';
 import { fetchWithAuth } from '../stores/auth';
+import { useOrgStore } from '../stores/orgStore';
 
 vi.mock('../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
 }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const setCurrentOrgId = (orgId: string | null) => {
+  useOrgStore.setState({ currentOrgId: orgId });
+};
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({
@@ -28,6 +34,9 @@ const disabledFlag = {
 describe('useMlFeatureFlags', () => {
   beforeEach(() => {
     fetchWithAuthMock.mockReset();
+    // Default to an active org so the fetch path runs; the no-org case is
+    // exercised explicitly below.
+    setCurrentOrgId('org-1');
   });
 
   it('parses the mlFeatureFlags response shape', async () => {
@@ -80,6 +89,18 @@ describe('useMlFeatureFlags', () => {
     await waitFor(() => expect(result.current.loaded).toBe(true));
     expect(result.current.error).toBe('network down');
     expect(result.current.isDisabled('ml.device_reliability.enabled')).toBe(false);
+  });
+
+  it('skips the request when there is no active org (All-orgs scope)', async () => {
+    setCurrentOrgId(null);
+
+    const { result } = renderHook(() => useMlFeatureFlags());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+    expect(result.current.flags).toEqual({});
+    expect(result.current.isDisabled('ml.anomalies.enabled')).toBe(false);
   });
 
   it('treats flags as not-disabled until loaded resolves', () => {

--- a/apps/web/src/hooks/useMlFeatureFlags.ts
+++ b/apps/web/src/hooks/useMlFeatureFlags.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../stores/auth';
+import { useOrgStore } from '../stores/orgStore';
 
 export type MlFeatureFlagName =
   | 'ml.alert_correlation.enabled'
@@ -29,8 +30,20 @@ export function useMlFeatureFlags() {
   const [flags, setFlags] = useState<Partial<Record<MlFeatureFlagName, MlFeatureFlagResolution>>>({});
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The /config/ml-feature-flags endpoint resolves flags per organization and
+  // returns 400 without an org context, so scope the request to the active org.
+  const currentOrgId = useOrgStore((state) => state.currentOrgId);
 
   const load = useCallback(async () => {
+    // No active org (e.g. the "All orgs" scope) → there's nothing to resolve
+    // flags against. Skip the request rather than firing one that 400s, and
+    // treat it as loaded with no overrides (every flag stays enabled).
+    if (!currentOrgId) {
+      setFlags({});
+      setError(null);
+      setLoaded(true);
+      return;
+    }
     try {
       const response = await fetchWithAuth('/config/ml-feature-flags');
       if (!response.ok) {
@@ -44,7 +57,7 @@ export function useMlFeatureFlags() {
     } finally {
       setLoaded(true);
     }
-  }, []);
+  }, [currentOrgId]);
 
   useEffect(() => {
     void load();

--- a/apps/web/src/pages/alerts/correlations.astro
+++ b/apps/web/src/pages/alerts/correlations.astro
@@ -2,11 +2,13 @@
 import DashboardLayout from '../../layouts/DashboardLayout.astro';
 import AlertsTabStrip from '../../components/alerts/AlertsTabStrip';
 import CorrelatedAlertGroups from '../../components/alerts/CorrelatedAlertGroups';
+
+const currentPath = Astro.url.pathname;
 ---
 
 <DashboardLayout title="Alert Correlations">
   <div class="space-y-5">
-    <AlertsTabStrip client:load />
+    <AlertsTabStrip currentPath={currentPath} client:load />
     <div>
       <h1 class="text-xl font-bold tracking-tight">Alert Correlations</h1>
       <p class="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
Two ML-surface UI bugs surfaced during a Playwright QA sweep of the ML features (User Risk, Anomalies, Alert Correlations/RCA, Capacity Forecast), plus a small UX fix. All verified live against the local stack.

## 1. `useMlFeatureFlags` fired the flag request with no org context (Medium)
`apps/web/src/hooks/useMlFeatureFlags.ts` called `GET /config/ml-feature-flags` with no `orgId`. That endpoint resolves flags **per-organization** and returns `400 "Organization context required"` without one — so:
- every ML page logged a **console 400** on load, and
- the swallowed error left `flags = {}`, so `isDisabled()` returned `false` for **every** flag → the intended "disabled" UI states could never render through the hook.

Server-side enforcement of the flags was always intact, so this was a UI-gating/console-noise bug, not a data exposure.

**Fix:** the hook reads the active org from `orgStore`, **skips** the request when there's no active org (e.g. the "All orgs" scope) rather than firing one that 400s, and re-fetches when the org changes.

**Verified live:** `/security/user-risk` now calls `…/ml-feature-flags?orgId=…` and renders with **0 console errors** (was a 400 on every load).

## 2. `AlertsTabStrip` hydration mismatch (Low)
The component derived the active tab from `window.location` during render, so SSR (no `window`) and the client first paint disagreed → React hydration-mismatch warning on `/alerts/correlations`.

**Fix:** it now takes an SSR-correct `currentPath` prop, mirroring the existing `Sidebar` / `useCurrentPath` pattern. `pages/alerts/correlations.astro` passes `Astro.url.pathname`; the three React pages that nest the strip pass their own static route.

**Verified live:** `/alerts/correlations` hydrates with **0 console errors**.

## 3. User Risk "Top drivers" bars colored as "good" (UX nit)
The driver bars reused the risk-**score** color scale, which returns green for any value < 50 — so on a critical-risk user the risk-contribution bars all rendered green ("good"). Added a dedicated warm driver palette (amber → orange → red, never green).

## Tests
Because the hook now transitively imports `orgStore` (which calls `registerOrgIdProvider` at import time), the affected component tests add that export to their `stores/auth` mock and seed `useOrgStore.currentOrgId` so the flag-driven enabled/disabled branches resolve. Full affected suites green:

```
src/hooks/useMlFeatureFlags.test.ts
src/components/alerts/**            (incl. CorrelatedAlertGroups)
src/components/security/UserRiskPage.test.tsx
src/components/devices/DeviceAnomaliesPanel.test.tsx
src/components/remediation/RemediationSuggestionsPanel.test.tsx
→ 285 passed
```

## QA evidence
Manually verified each ML surface end-to-end (empty, disabled, and with-data states, plus mobile) via Playwright, including the on-demand RCA "Explain incident" flow. Notes + screenshots recorded in `docs/testing/FEATURE_TEST_LOG.md` (kept local, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)