### PR TITLE
fix(web): calm "not enabled" state for disabled identity integrations

### DIFF
--- a/apps/web/src/components/integrations/GoogleWorkspaceIntegration.test.tsx
+++ b/apps/web/src/components/integrations/GoogleWorkspaceIntegration.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import GoogleWorkspaceIntegration from './GoogleWorkspaceIntegration';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn()
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: vi.fn().mockResolvedValue(payload)
+  } as unknown as Response;
+}
+
+describe('GoogleWorkspaceIntegration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a calm not-enabled state (no red error, no connect form) when the feature flag is off (404 not enabled)', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeResponse({ error: 'Google Workspace integration is not enabled' }, false, 404)
+    );
+
+    render(<GoogleWorkspaceIntegration />);
+
+    // Calm not-enabled empty state is shown.
+    await waitFor(() =>
+      expect(screen.getByTestId('google-workspace-not-enabled')).toBeInTheDocument()
+    );
+    expect(
+      screen.getByText(/Google Workspace integration is not enabled on this instance/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/GOOGLE_WORKSPACE_ENABLED/)).toBeInTheDocument();
+
+    // The red "Failed to load connection" error is NOT rendered.
+    expect(screen.queryByText(/Failed to load connection/i)).not.toBeInTheDocument();
+
+    // The connect form (service-account JSON paste) is hidden.
+    expect(screen.queryByText(/Service-account JSON key/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Save & verify/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the red error UI for a genuine (non-404) load failure', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeResponse({ error: 'Boom' }, false, 500));
+
+    render(<GoogleWorkspaceIntegration />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to load connection \(500\): Boom/i)).toBeInTheDocument()
+    );
+    // Not swallowed into the calm state.
+    expect(screen.queryByTestId('google-workspace-not-enabled')).not.toBeInTheDocument();
+    // Connect form still renders for a real error (defect was only the not-enabled case).
+    expect(screen.getByRole('button', { name: /Save & verify/i })).toBeInTheDocument();
+  });
+
+  it('keeps the red error UI for a network error', async () => {
+    fetchWithAuthMock.mockRejectedValue(new Error('Network down'));
+
+    render(<GoogleWorkspaceIntegration />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to load connection: Network down/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('google-workspace-not-enabled')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/integrations/GoogleWorkspaceIntegration.tsx
+++ b/apps/web/src/components/integrations/GoogleWorkspaceIntegration.tsx
@@ -40,6 +40,7 @@ const GOOGLE_DWD_SCOPES_CSV = [
 export default function GoogleWorkspaceIntegration() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [notEnabled, setNotEnabled] = useState(false);
   const [connection, setConnection] = useState<Connection | null>(null);
 
   const [customerDomain, setCustomerDomain] = useState('');
@@ -62,6 +63,14 @@ export default function GoogleWorkspaceIntegration() {
       const res = await fetchWithAuth('/google/connection');
       if (!res.ok) {
         const json = await res.json().catch(() => ({}));
+        const errorText = String((json as Record<string, unknown>).error ?? '');
+        // A disabled feature flag (GOOGLE_WORKSPACE_ENABLED off) darks the whole
+        // /google route group with a 404 "...is not enabled" body. That is a
+        // normal state, not a failure — render a calm empty state, not a red error.
+        if (res.status === 404 && /not enabled/i.test(errorText)) {
+          setNotEnabled(true);
+          return;
+        }
         setLoadError(
           `Failed to load connection (${res.status}): ${(json as Record<string, unknown>).error ?? res.statusText}`
         );
@@ -140,6 +149,38 @@ export default function GoogleWorkspaceIntegration() {
     return (
       <div className="flex items-center justify-center py-20">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (notEnabled) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Users className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold">Google Workspace</h1>
+            <p className="text-sm text-muted-foreground">
+              Connect a Workspace domain so the AI assistant can manage users and groups for this
+              organization.
+            </p>
+          </div>
+        </div>
+        <div
+          className="rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+          data-testid="google-workspace-not-enabled"
+        >
+          <p className="font-medium text-foreground">
+            Google Workspace integration is not enabled on this instance.
+          </p>
+          <p className="mt-1">
+            An administrator enables it by setting{' '}
+            <code className="rounded bg-muted px-1">GOOGLE_WORKSPACE_ENABLED</code> on the API server,
+            then reloading this page.
+          </p>
+        </div>
       </div>
     );
   }

--- a/apps/web/src/components/integrations/M365Integration.test.tsx
+++ b/apps/web/src/components/integrations/M365Integration.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import M365Integration from './M365Integration';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn()
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: vi.fn().mockResolvedValue(payload)
+  } as unknown as Response;
+}
+
+describe('M365Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a calm not-enabled state (no red error, no connect form) when the feature flag is off (404 not enabled)', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeResponse({ error: 'Microsoft 365 integration is not enabled' }, false, 404)
+    );
+
+    render(<M365Integration />);
+
+    await waitFor(() => expect(screen.getByTestId('m365-not-enabled')).toBeInTheDocument());
+    expect(
+      screen.getByText(/Microsoft 365 integration is not enabled on this instance/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/M365_ENABLED/)).toBeInTheDocument();
+
+    // The red "Failed to load connection" error is NOT rendered.
+    expect(screen.queryByText(/Failed to load connection/i)).not.toBeInTheDocument();
+
+    // The connect form (client secret) is hidden.
+    expect(screen.queryByText(/Client secret/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Save & verify/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the red error UI for a genuine (non-404) load failure', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeResponse({ error: 'Boom' }, false, 500));
+
+    render(<M365Integration />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to load connection \(500\): Boom/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('m365-not-enabled')).not.toBeInTheDocument();
+    // Connect form still renders for a real error.
+    expect(screen.getByRole('button', { name: /Save & verify/i })).toBeInTheDocument();
+  });
+
+  it('keeps the red error UI for a network error', async () => {
+    fetchWithAuthMock.mockRejectedValue(new Error('Network down'));
+
+    render(<M365Integration />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to load connection: Network down/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('m365-not-enabled')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/integrations/M365Integration.tsx
+++ b/apps/web/src/components/integrations/M365Integration.tsx
@@ -25,6 +25,7 @@ type SaveState = { status: 'idle' | 'saving' | 'saved' | 'error'; message?: stri
 export default function M365Integration() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [notEnabled, setNotEnabled] = useState(false);
   const [connection, setConnection] = useState<Connection | null>(null);
 
   const [tenantId, setTenantId] = useState('');
@@ -45,6 +46,14 @@ export default function M365Integration() {
       const res = await fetchWithAuth('/m365/connection');
       if (!res.ok) {
         const json = await res.json().catch(() => ({}));
+        const errorText = String((json as Record<string, unknown>).error ?? '');
+        // A disabled feature flag (M365_ENABLED off) darks the whole /m365 route
+        // group with a 404 "...is not enabled" body. That is a normal state, not
+        // a failure — render a calm empty state, not a red error.
+        if (res.status === 404 && /not enabled/i.test(errorText)) {
+          setNotEnabled(true);
+          return;
+        }
         setLoadError(
           `Failed to load connection (${res.status}): ${(json as Record<string, unknown>).error ?? res.statusText}`
         );
@@ -123,6 +132,38 @@ export default function M365Integration() {
     return (
       <div className="flex items-center justify-center py-20">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (notEnabled) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Building2 className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold">Microsoft 365</h1>
+            <p className="text-sm text-muted-foreground">
+              Connect an Entra (Azure AD) app registration so the AI assistant can manage users and
+              groups for this organization's tenant.
+            </p>
+          </div>
+        </div>
+        <div
+          className="rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+          data-testid="m365-not-enabled"
+        >
+          <p className="font-medium text-foreground">
+            Microsoft 365 integration is not enabled on this instance.
+          </p>
+          <p className="mt-1">
+            An administrator enables it by setting{' '}
+            <code className="rounded bg-muted px-1">M365_ENABLED</code> on the API server, then
+            reloading this page.
+          </p>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
**Found by:** internal review while investigating a reported error on Integrations → Identity → Google Workspace (2026-06-19).

**Symptom:** The Google Workspace and Microsoft 365 tabs render the full connect UI and then a raw red **"Failed to load connection (404): Google Workspace integration is not enabled"**. But a disabled feature flag is a normal state, not a failure.

**Root cause:** `GOOGLE_WORKSPACE_ENABLED` / `M365_ENABLED` default OFF (`apps/api/src/config/env.ts:13,18`), so the route groups return `404 {error: "...integration is not enabled"}` (`google.ts:39`, `m365.ts:39`). The web components turned any load failure — including this expected 404 — into the red error banner (`GoogleWorkspaceIntegration.tsx:66`, `M365Integration.tsx:49`).

**Fix:** Both components detect the not-enabled case defensively (`res.status === 404 && /not enabled/i.test(errorText)`) and render a calm empty state (mirroring the existing `clientAi/OrgsTab.tsx` precedent) that replaces the connect form and notes an admin enables it via the server flag. **All other failures (non-404, 500, network) keep the existing red error UI** — only the not-enabled 404 is intercepted.

**Verified:** new `GoogleWorkspaceIntegration.test.tsx` + `M365Integration.test.tsx` (6 tests) assert the calm state on a 404 "not enabled" (form hidden, red error absent), and that a 500 / network error still renders the red error with the form present. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)