### PR TITLE
fix(api): resolve routing-rules org scope-aware for partner users (#1633)

### DIFF
--- a/apps/api/src/routes/alerts/routing.orgscope.test.ts
+++ b/apps/api/src/routes/alerts/routing.orgscope.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression for #1633: /alerts/routing-rules must resolve the org scope-aware
+// (honor ?orgId for partner-scoped users whose auth.orgId is null), mirroring the
+// escalation-policies route — instead of always 400ing on auth.orgId.
+
+const { authRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as string,
+      user: { id: 'u-1', name: 'Partner Admin', email: 'admin@breeze.local' },
+      partnerId: 'p-1' as string | null,
+      orgId: null as string | null,
+      accessibleOrgIds: ['org-1', 'org-2'] as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  },
+  // #1633 tests exercise org resolution, not the permission gate — always allow.
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+// Minimal awaitable Drizzle chain: every builder method returns the same chain,
+// and awaiting it resolves to `rows`. Enough to get past the resolution layer.
+const rowsRef = { current: [] as unknown[] };
+function chain(): any {
+  const c: any = {};
+  for (const m of ['select', 'from', 'where', 'orderBy', 'limit', 'insert', 'values', 'returning', 'set', 'update', 'delete']) {
+    c[m] = vi.fn(() => c);
+  }
+  c.then = (resolve: any, reject: any) => Promise.resolve(rowsRef.current).then(resolve, reject);
+  return c;
+}
+vi.mock('../../db', () => ({ db: chain() }));
+vi.mock('../../db/schema', () => ({ notificationRoutingRules: { orgId: 'orgId', priority: 'priority', id: 'id' } }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+import { routingRoutes } from './routing';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', routingRoutes);
+  return app;
+}
+
+const ORG = 'aa0e43c8-1111-4222-8333-444455556666';
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+
+function setAuth(partial: Partial<typeof authRef.current>) {
+  authRef.current = { ...authRef.current, ...partial } as typeof authRef.current;
+}
+
+describe('routing-rules org resolution (#1633)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rowsRef.current = [];
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Partner Admin', email: 'admin@breeze.local' },
+      partnerId: 'p-1', orgId: null, accessibleOrgIds: ['org-1', 'org-2'], canAccessOrg: () => true,
+    };
+  });
+
+  // The headline bug: a partner-scoped user (orgId null) passing ?orgId no longer 400s.
+  it('GET partner-scoped with an accessible ?orgId does not 400', async () => {
+    const res = await makeApp().request(`/alerts/routing-rules?orgId=${ORG}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+  });
+
+  it('GET partner-scoped without ?orgId lists across accessible orgs (no 400)', async () => {
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(200);
+  });
+
+  it('GET partner-scoped with no accessible orgs returns empty', async () => {
+    setAuth({ accessibleOrgIds: [] });
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+  });
+
+  it('GET partner-scoped with an ?orgId outside scope is 403', async () => {
+    setAuth({ canAccessOrg: () => false });
+    const res = await makeApp().request(`/alerts/routing-rules?orgId=${ORG}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET organization-scoped still filters by the auth org', async () => {
+    setAuth({ scope: 'organization', orgId: 'org-1', accessibleOrgIds: null });
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(200);
+  });
+
+  // Writes: partner with multiple orgs and no ?orgId is genuinely ambiguous → 400
+  // (distinct message), but a single accessible org or an explicit ?orgId resolves.
+  it('POST partner-scoped without ?orgId and multiple orgs is 400-ambiguous', async () => {
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r', priority: 0, conditions: {}, channelIds: [RULE_ID] }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/multiple organizations/i);
+  });
+
+  it('POST partner-scoped with an ?orgId outside scope is 403', async () => {
+    setAuth({ canAccessOrg: () => false });
+    const res = await makeApp().request(`/alerts/routing-rules?orgId=${ORG}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r', priority: 0, conditions: {}, channelIds: [RULE_ID] }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('POST partner-scoped with an accessible ?orgId resolves and creates', async () => {
+    rowsRef.current = [{ id: RULE_ID, name: 'r' }];
+    const res = await makeApp().request(`/alerts/routing-rules?orgId=${ORG}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'r', priority: 0, conditions: {}, channelIds: [RULE_ID] }),
+    });
+    expect(res.status).toBe(201);
+  });
+});

--- a/apps/api/src/routes/alerts/routing.ts
+++ b/apps/api/src/routes/alerts/routing.ts
@@ -3,10 +3,55 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { db } from '../../db';
 import { notificationRoutingRules } from '../../db/schema';
-import { eq, and, asc } from 'drizzle-orm';
+import { eq, and, asc, inArray, type SQL } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
+import { ensureOrgAccess } from './helpers';
+
+const listRoutingRulesSchema = z.object({
+  orgId: z.string().guid().optional(),
+});
+
+type RoutingAuth = {
+  scope: string;
+  orgId: string | null;
+  accessibleOrgIds: string[] | null;
+  canAccessOrg: (orgId: string) => boolean;
+};
+
+// Resolve the single org a write (create/update/delete) targets, scope-aware.
+// Mirrors the escalation-policies route (policies.ts) so partner-scoped users —
+// whose auth.orgId is null and who select an org per request — can manage routing
+// rules via the ?orgId query param instead of always 400ing (issue #1633).
+// RLS still backstops tenant isolation; this just resolves a valid orgId to write.
+function resolveWriteOrgId(
+  auth: RoutingAuth,
+  requestedOrgId: string | undefined,
+): { orgId: string } | { error: string; status: 400 | 403 } {
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) return { error: 'Organization context required', status: 403 };
+    return { orgId: auth.orgId };
+  }
+  if (auth.scope === 'partner') {
+    let orgId = requestedOrgId;
+    if (!orgId) {
+      const orgs = auth.accessibleOrgIds ?? [];
+      if (orgs.length === 1 && orgs[0]) {
+        orgId = orgs[0];
+      } else {
+        return { error: 'orgId is required when partner has multiple organizations', status: 400 };
+      }
+    }
+    if (!ensureOrgAccess(orgId, auth)) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId };
+  }
+  // system
+  if (!requestedOrgId) return { error: 'orgId is required', status: 400 };
+  return { orgId: requestedOrgId };
+}
 
 const createRoutingRuleSchema = z.object({
   name: z.string().min(1).max(255),
@@ -41,18 +86,44 @@ const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, P
 routingRoutes.get(
   '/routing-rules',
   requireScope('organization', 'partner', 'system'),
+  zValidator('query', listRoutingRulesSchema),
   async (c) => {
     try {
-      const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const auth = c.get('auth') as RoutingAuth;
+      const query = c.req.valid('query');
+
+      // Build the org filter the same way the policies list does, so partner-scoped
+      // users (auth.orgId null) can list by the selected ?orgId or across all their
+      // accessible orgs, instead of always 400ing (issue #1633).
+      const conditions: SQL[] = [];
+      if (auth.scope === 'organization') {
+        if (!auth.orgId) {
+          return c.json({ error: 'Organization context required' }, 403);
+        }
+        conditions.push(eq(notificationRoutingRules.orgId, auth.orgId));
+      } else if (auth.scope === 'partner') {
+        if (query.orgId) {
+          if (!ensureOrgAccess(query.orgId, auth)) {
+            return c.json({ error: 'Access to this organization denied' }, 403);
+          }
+          conditions.push(eq(notificationRoutingRules.orgId, query.orgId));
+        } else {
+          const orgIds = auth.accessibleOrgIds ?? [];
+          if (orgIds.length === 0) {
+            return c.json({ data: [] });
+          }
+          conditions.push(inArray(notificationRoutingRules.orgId, orgIds));
+        }
+      } else if (auth.scope === 'system' && query.orgId) {
+        conditions.push(eq(notificationRoutingRules.orgId, query.orgId));
       }
+
+      const whereCondition = conditions.length === 1 ? conditions[0] : and(...conditions);
 
       const rules = await db
         .select()
         .from(notificationRoutingRules)
-        .where(eq(notificationRoutingRules.orgId, orgId))
+        .where(whereCondition)
         .orderBy(asc(notificationRoutingRules.priority));
 
       return c.json({ data: rules });
@@ -71,11 +142,12 @@ routingRoutes.post(
   zValidator('json', createRoutingRuleSchema),
   async (c) => {
     try {
-      const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const auth = c.get('auth') as RoutingAuth;
+      const resolved = resolveWriteOrgId(auth, c.req.query('orgId') || undefined);
+      if ('error' in resolved) {
+        return c.json({ error: resolved.error }, resolved.status);
       }
+      const orgId = resolved.orgId;
 
       const data = c.req.valid('json');
 
@@ -116,11 +188,12 @@ routingRoutes.patch(
   zValidator('json', updateRoutingRuleSchema),
   async (c) => {
     try {
-      const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const auth = c.get('auth') as RoutingAuth;
+      const resolved = resolveWriteOrgId(auth, c.req.query('orgId') || undefined);
+      if ('error' in resolved) {
+        return c.json({ error: resolved.error }, resolved.status);
       }
+      const orgId = resolved.orgId;
 
       const ruleId = c.req.param('id')!;
       const updates = c.req.valid('json');
@@ -172,11 +245,12 @@ routingRoutes.delete(
   requireMfa(),
   async (c) => {
     try {
-      const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const auth = c.get('auth') as RoutingAuth;
+      const resolved = resolveWriteOrgId(auth, c.req.query('orgId') || undefined);
+      if ('error' in resolved) {
+        return c.json({ error: resolved.error }, resolved.status);
       }
+      const orgId = resolved.orgId;
 
       const ruleId = c.req.param('id')!;
 


### PR DESCRIPTION
## Problem

Closes #1633. `GET /api/v1/alerts/routing-rules` returns `400 {"error":"orgId is required"}` for **partner-scoped** users (`partner_id` set, `org_id` null) — breaking the Notification Channels page — **even when the client passes `?orgId=…`**. The handler resolved the org only from `auth.orgId` (null for partner users, whose reach is partner-wide and resolved per-request via the selected org) and ignored the query param. The same `auth.orgId`-only guard was on POST/PATCH/DELETE, so create/edit/delete of routing rules were broken for partner users too.

## Fix

Resolve the org **scope-aware**, mirroring the sibling escalation-policies route (`policies.ts`):

- **organization** scope → use `auth.orgId` (403 if missing).
- **partner** scope → honor `?orgId` (validated within the caller's accessible orgs via `ensureOrgAccess`, **403** on cross-tenant); fall back to the single accessible org; only **400** when genuinely ambiguous (multiple orgs, no `orgId`).
- **system** scope → optional `?orgId` filter.

`GET` lists by the selected org or across all accessible orgs (a new `?orgId` query validator); the three write verbs share a small `resolveWriteOrgId` helper. RLS still backstops tenant isolation — this only resolves a valid `orgId` for partner-scoped callers. No web change needed (the client already sends `orgId`).

## Tests

New `routing.orgscope.test.ts` (8 cases): partner GET with an accessible `?orgId` (no 400), without `?orgId` (lists across accessible), with no accessible orgs (empty), with an out-of-scope `?orgId` (403), org-scope GET; and POST ambiguous→400 / out-of-scope→403 / resolved→201. Existing `routing.authz.test.ts` (permission gate) still passes — **12/12**.

## Verification (node 22.20.0)

- `vitest` routing.orgscope + routing.authz: **12/12 pass**
- `tsc --noEmit -p apps/api`: clean
- `eslint` on changed files: clean
