### PR TITLE
feat(integrations): Pax8 distributor UI + TD SYNNEX moved to Integrations hub

### DIFF
--- a/apps/web/src/components/integrations/IntegrationsPage.test.tsx
+++ b/apps/web/src/components/integrations/IntegrationsPage.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let scope: 'system' | 'partner' | 'organization' | null = 'partner';
+
+// Mock authScope so we can drive the Distributors-tab scope gate.
+vi.mock('../../lib/authScope', () => ({
+  getJwtClaims: () => ({ scope, orgId: null, partnerId: 'partner-1' }),
+  loginPathWithNext: () => '/login'
+}));
+
+// Stub the heavy child panels so the test stays focused on tab/sub-tab wiring.
+vi.mock('../webhooks/WebhooksPage', () => ({ default: () => <div data-testid="stub-webhooks" /> }));
+vi.mock('../psa/PsaConnectionsPage', () => ({ default: () => <div data-testid="stub-psa" /> }));
+vi.mock('./SecurityIntegration', () => ({ default: () => <div data-testid="stub-security" /> }));
+vi.mock('./HuntressIntegration', () => ({ default: () => <div data-testid="stub-huntress" /> }));
+vi.mock('./MonitoringIntegration', () => ({ default: () => <div data-testid="stub-monitoring" /> }));
+vi.mock('./GoogleWorkspaceIntegration', () => ({ default: () => <div data-testid="stub-google" /> }));
+vi.mock('./M365Integration', () => ({ default: () => <div data-testid="stub-m365" /> }));
+vi.mock('./Pax8Integration', () => ({ default: () => <div data-testid="stub-pax8" /> }));
+vi.mock('../settings/TdSynnexCatalogPanel', () => ({ default: () => <div data-testid="stub-tdsynnex" /> }));
+
+import IntegrationsPage from './IntegrationsPage';
+
+describe('IntegrationsPage — Distributors tab', () => {
+  beforeEach(() => {
+    scope = 'partner';
+  });
+
+  it('shows a Distributors top-level tab', () => {
+    render(<IntegrationsPage />);
+    expect(screen.getByRole('button', { name: /Distributors/i })).toBeTruthy();
+  });
+
+  it('renders Pax8 by default and TD SYNNEX when the sub-tab is selected (partner scope)', () => {
+    render(<IntegrationsPage />);
+    fireEvent.click(screen.getByRole('button', { name: /Distributors/i }));
+
+    // pax8 is the default sub-tab
+    expect(screen.getByTestId('stub-pax8')).toBeTruthy();
+    expect(screen.queryByTestId('stub-tdsynnex')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'TD SYNNEX' }));
+    expect(screen.getByTestId('stub-tdsynnex')).toBeTruthy();
+    expect(screen.queryByTestId('stub-pax8')).toBeNull();
+  });
+
+  it('lets a system-scope user use the Distributors tab', () => {
+    scope = 'system';
+    render(<IntegrationsPage />);
+    fireEvent.click(screen.getByRole('button', { name: /Distributors/i }));
+    expect(screen.getByTestId('stub-pax8')).toBeTruthy();
+    expect(screen.queryByTestId('distributors-org-scope')).toBeNull();
+  });
+
+  it('gates the Distributors tab for org-scope users with a partner-only message', () => {
+    scope = 'organization';
+    render(<IntegrationsPage />);
+    fireEvent.click(screen.getByRole('button', { name: /Distributors/i }));
+
+    expect(screen.getByTestId('distributors-org-scope')).toBeTruthy();
+    // No panels and no sub-tab bar for org-scope users.
+    expect(screen.queryByTestId('stub-pax8')).toBeNull();
+    expect(screen.queryByTestId('stub-tdsynnex')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'TD SYNNEX' })).toBeNull();
+  });
+});

--- a/apps/web/src/components/integrations/IntegrationsPage.tsx
+++ b/apps/web/src/components/integrations/IntegrationsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
   Activity,
+  Boxes,
   Plug,
   Shield,
   Users,
@@ -13,10 +14,14 @@ import HuntressIntegration from './HuntressIntegration';
 import MonitoringIntegration from './MonitoringIntegration';
 import GoogleWorkspaceIntegration from './GoogleWorkspaceIntegration';
 import M365Integration from './M365Integration';
+import Pax8Integration from './Pax8Integration';
+import TdSynnexCatalogPanel from '../settings/TdSynnexCatalogPanel';
+import { getJwtClaims } from '../../lib/authScope';
 
-type TabId = 'webhooks' | 'psa' | 'security' | 'monitoring' | 'identity';
+type TabId = 'webhooks' | 'psa' | 'security' | 'monitoring' | 'identity' | 'distributors';
 type SecuritySubTab = 'sentinelone' | 'huntress';
 type IdentitySubTab = 'google' | 'm365';
+type DistributorSubTab = 'pax8' | 'tdsynnex';
 
 const tabs: { id: TabId; label: string; icon: typeof Activity }[] = [
   { id: 'webhooks', label: 'Webhooks', icon: Webhook },
@@ -24,6 +29,7 @@ const tabs: { id: TabId; label: string; icon: typeof Activity }[] = [
   { id: 'security', label: 'Security', icon: Shield },
   { id: 'monitoring', label: 'Monitoring', icon: Activity },
   { id: 'identity', label: 'Identity', icon: Users },
+  { id: 'distributors', label: 'Distributors', icon: Boxes },
 ];
 
 const securitySubTabs: { id: SecuritySubTab; label: string }[] = [
@@ -36,6 +42,11 @@ const identitySubTabs: { id: IdentitySubTab; label: string }[] = [
   { id: 'm365', label: 'Microsoft 365' },
 ];
 
+const distributorSubTabs: { id: DistributorSubTab; label: string }[] = [
+  { id: 'pax8', label: 'Pax8' },
+  { id: 'tdsynnex', label: 'TD SYNNEX' },
+];
+
 interface IntegrationsPageProps {
   initialTab?: TabId;
 }
@@ -44,6 +55,15 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
   const [activeTab, setActiveTab] = useState<TabId>(initialTab);
   const [securitySubTab, setSecuritySubTab] = useState<SecuritySubTab>('sentinelone');
   const [identitySubTab, setIdentitySubTab] = useState<IdentitySubTab>('google');
+  const [distributorSubTab, setDistributorSubTab] = useState<DistributorSubTab>('pax8');
+
+  // Pax8 and TD SYNNEX APIs both enforce requireScope('partner','system'). Gate
+  // the Distributors tab on the JWT scope (never on useOrgStore().partners.length,
+  // which is empty for real partner users — a known broken anti-pattern here) so
+  // org-scope users get a clear message instead of 403 errors. getJwtClaims returns
+  // null scope on a missing/undecodable token, so only a confirmed 'organization'
+  // scope is blocked; everything else falls through to the server's own check.
+  const isOrgScoped = getJwtClaims().scope === 'organization';
 
   return (
     <div className="space-y-6">
@@ -125,6 +145,29 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
         </div>
       )}
 
+      {/* Distributor sub-tabs (hidden for org-scope users, who can't use these APIs) */}
+      {activeTab === 'distributors' && !isOrgScoped && (
+        <div className="flex gap-2">
+          {distributorSubTabs.map((sub) => {
+            const isActive = sub.id === distributorSubTab;
+            return (
+              <button
+                key={sub.id}
+                type="button"
+                onClick={() => setDistributorSubTab(sub.id)}
+                className={`rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                  isActive
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border bg-background text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {sub.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       {/* Tab content */}
       {activeTab === 'webhooks' && <WebhooksPage />}
       {activeTab === 'psa' && <PsaConnectionsPage />}
@@ -133,6 +176,16 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
       {activeTab === 'monitoring' && <MonitoringIntegration />}
       {activeTab === 'identity' && identitySubTab === 'google' && <GoogleWorkspaceIntegration />}
       {activeTab === 'identity' && identitySubTab === 'm365' && <M365Integration />}
+      {activeTab === 'distributors' && isOrgScoped && (
+        <p
+          className="py-12 text-center text-sm text-muted-foreground"
+          data-testid="distributors-org-scope"
+        >
+          Distributor integrations (Pax8 and TD SYNNEX) are available to partner accounts only.
+        </p>
+      )}
+      {activeTab === 'distributors' && !isOrgScoped && distributorSubTab === 'pax8' && <Pax8Integration />}
+      {activeTab === 'distributors' && !isOrgScoped && distributorSubTab === 'tdsynnex' && <TdSynnexCatalogPanel />}
     </div>
   );
 }

--- a/apps/web/src/components/integrations/Pax8Integration.test.tsx
+++ b/apps/web/src/components/integrations/Pax8Integration.test.tsx
@@ -1,0 +1,278 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+const showToast = vi.fn();
+const navigateTo = vi.fn();
+let scope: 'system' | 'partner' | 'organization' | null = 'partner';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
+vi.mock('../shared/Toast', () => ({ showToast: (...args: unknown[]) => showToast(...args) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+vi.mock('../../lib/authScope', () => ({
+  loginPathWithNext: () => '/login?next=/integrations',
+  getJwtClaims: () => ({ scope, orgId: null, partnerId: 'partner-1' })
+}));
+
+import Pax8Integration from './Pax8Integration';
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const existingIntegration = {
+  id: 'pax8-1',
+  partnerId: 'partner-1',
+  name: 'Production Pax8',
+  apiBaseUrl: 'https://api.pax8.com',
+  tokenUrl: 'https://login.pax8.com/oauth/token',
+  isActive: true,
+  lastSyncAt: '2026-06-18T12:00:00.000Z',
+  lastSyncStatus: 'success',
+  lastSyncError: null,
+  hasClientId: true,
+  hasClientSecret: true,
+  hasWebhookSecret: false
+};
+
+const breezeOrg = { id: '00000000-0000-4000-8000-000000000001', name: 'Acme Corp' };
+
+const company = {
+  pax8CompanyId: 'pax8-co-1',
+  pax8CompanyName: 'Acme Pax8',
+  status: 'active',
+  mappedOrgId: null,
+  mappedOrgName: null,
+  ignored: false,
+  lastSeenAt: null,
+  updatedAt: null
+};
+
+const subscription = {
+  id: 'sub-1',
+  pax8SubscriptionId: 'pax8-sub-1',
+  pax8CompanyId: 'pax8-co-1',
+  pax8CompanyName: 'Acme Pax8',
+  orgId: null,
+  productId: 'prod-1',
+  productName: 'Microsoft 365 Business',
+  vendorName: 'Microsoft',
+  status: 'active',
+  billingTerm: 'monthly',
+  quantity: 12,
+  unitPrice: '20.00',
+  unitCost: '15.00',
+  currencyCode: 'USD',
+  contractLineId: null,
+  syncEnabled: null
+};
+
+/** Mock the load fan-out: integration + (when configured) companies/subscriptions/orgs. */
+function mockLoad(options: { integration?: typeof existingIntegration | null; companies?: unknown[]; subscriptions?: unknown[] } = {}) {
+  const integration = options.integration === undefined ? null : options.integration;
+  fetchWithAuth.mockImplementation(async (url: string) => {
+    if (url === '/pax8/integration') return jsonResponse({ data: integration });
+    if (url === '/pax8/companies') return jsonResponse({ data: options.companies ?? [] });
+    if (url.startsWith('/pax8/subscriptions')) return jsonResponse({ data: options.subscriptions ?? [] });
+    if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+    return jsonResponse({}, 404);
+  });
+}
+
+describe('Pax8Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scope = 'partner';
+  });
+
+  it('renders the connect form (not connected) when no integration exists', async () => {
+    mockLoad({ integration: null });
+    render(<Pax8Integration />);
+
+    expect(await screen.findByTestId('pax8-panel')).toBeTruthy();
+    expect(screen.getByTestId('pax8-status-disconnected')).toBeTruthy();
+    expect(screen.getByText('Connect Pax8')).toBeTruthy();
+    // Test / Sync only show once configured.
+    expect(screen.queryByTestId('pax8-test')).toBeNull();
+    expect(screen.queryByTestId('pax8-sync')).toBeNull();
+    // Save is disabled until both credentials are entered for a fresh integration.
+    expect((screen.getByTestId('pax8-save') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows configured indicators and sync status when an integration exists', async () => {
+    mockLoad({ integration: existingIntegration });
+    render(<Pax8Integration />);
+
+    expect(await screen.findByTestId('pax8-status-connected')).toBeTruthy();
+    expect(screen.getByTestId('pax8-has-client-id')).toBeTruthy();
+    expect(screen.getByTestId('pax8-has-client-secret')).toBeTruthy();
+    expect(screen.getByTestId('pax8-sync-status')).toBeTruthy();
+    expect(screen.getByTestId('pax8-sync-status-value').textContent).toContain('success');
+    // Secrets are never re-populated into the inputs.
+    expect((screen.getByTestId('pax8-client-id') as HTMLInputElement).value).toBe('');
+    expect((screen.getByTestId('pax8-client-secret') as HTMLInputElement).value).toBe('');
+  });
+
+  it('connects a fresh integration via runAction with both credentials', async () => {
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/pax8/integration' && init?.method === 'POST') {
+        return jsonResponse({ ...existingIntegration, lastSyncStatus: null, lastSyncAt: null }, 201);
+      }
+      if (url === '/pax8/integration') return jsonResponse({ data: null });
+      if (url === '/pax8/companies') return jsonResponse({ data: [] });
+      if (url.startsWith('/pax8/subscriptions')) return jsonResponse({ data: [] });
+      if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+      return jsonResponse({}, 404);
+    });
+
+    render(<Pax8Integration />);
+    await screen.findByTestId('pax8-panel');
+
+    fireEvent.change(screen.getByTestId('pax8-client-id'), { target: { value: 'client-abc' } });
+    fireEvent.change(screen.getByTestId('pax8-client-secret'), { target: { value: 'secret-xyz' } });
+    fireEvent.click(screen.getByTestId('pax8-save'));
+
+    await waitFor(() => {
+      expect(fetchWithAuth.mock.calls.some(([url, init]) => url === '/pax8/integration' && init?.method === 'POST')).toBe(true);
+    });
+    const postCall = fetchWithAuth.mock.calls.find(([url, init]) => url === '/pax8/integration' && init?.method === 'POST');
+    expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({ name: 'Pax8', clientId: 'client-abc', clientSecret: 'secret-xyz' });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('updates an existing integration without re-sending secrets when fields are blank', async () => {
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/pax8/integration' && init?.method === 'POST') return jsonResponse(existingIntegration, 200);
+      if (url === '/pax8/integration') return jsonResponse({ data: existingIntegration });
+      if (url === '/pax8/companies') return jsonResponse({ data: [] });
+      if (url.startsWith('/pax8/subscriptions')) return jsonResponse({ data: [] });
+      if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+      return jsonResponse({}, 404);
+    });
+
+    render(<Pax8Integration />);
+    await screen.findByTestId('pax8-status-connected');
+
+    const save = screen.getByTestId('pax8-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(false); // existing integration may save with blank credentials
+    fireEvent.click(save);
+
+    await waitFor(() => {
+      expect(fetchWithAuth.mock.calls.some(([url, init]) => url === '/pax8/integration' && init?.method === 'POST')).toBe(true);
+    });
+    const postCall = fetchWithAuth.mock.calls.find(([url, init]) => url === '/pax8/integration' && init?.method === 'POST');
+    const body = JSON.parse(String(postCall?.[1]?.body));
+    expect(body).not.toHaveProperty('clientId');
+    expect(body).not.toHaveProperty('clientSecret');
+    expect(body).toMatchObject({ name: 'Production Pax8' });
+  });
+
+  it('surfaces a successful connection test', async () => {
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/pax8/integration/test' && init?.method === 'POST') return jsonResponse({ success: true, data: {} });
+      if (url === '/pax8/integration') return jsonResponse({ data: existingIntegration });
+      if (url === '/pax8/companies') return jsonResponse({ data: [] });
+      if (url.startsWith('/pax8/subscriptions')) return jsonResponse({ data: [] });
+      if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+      return jsonResponse({}, 404);
+    });
+
+    render(<Pax8Integration />);
+    await screen.findByTestId('pax8-status-connected');
+    fireEvent.click(screen.getByTestId('pax8-test'));
+
+    expect(await screen.findByTestId('pax8-test-result')).toHaveTextContent('Connection test succeeded.');
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('surfaces a failed connection test (HTTP 502)', async () => {
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/pax8/integration/test' && init?.method === 'POST') {
+        return jsonResponse({ success: false, error: 'Invalid Pax8 credentials' }, 502);
+      }
+      if (url === '/pax8/integration') return jsonResponse({ data: existingIntegration });
+      if (url === '/pax8/companies') return jsonResponse({ data: [] });
+      if (url.startsWith('/pax8/subscriptions')) return jsonResponse({ data: [] });
+      if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+      return jsonResponse({}, 404);
+    });
+
+    render(<Pax8Integration />);
+    await screen.findByTestId('pax8-status-connected');
+    fireEvent.click(screen.getByTestId('pax8-test'));
+
+    await waitFor(() => expect(screen.getByTestId('pax8-test-result')).toHaveTextContent('Invalid Pax8 credentials'));
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('triggers a sync via runAction and surfaces success', async () => {
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/pax8/sync' && init?.method === 'POST') return jsonResponse({ queued: true, jobId: 'job-1' });
+      if (url === '/pax8/integration') return jsonResponse({ data: existingIntegration });
+      if (url === '/pax8/companies') return jsonResponse({ data: [] });
+      if (url.startsWith('/pax8/subscriptions')) return jsonResponse({ data: [] });
+      if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+      return jsonResponse({}, 404);
+    });
+
+    render(<Pax8Integration />);
+    await screen.findByTestId('pax8-status-connected');
+    fireEvent.click(screen.getByTestId('pax8-sync'));
+
+    await waitFor(() => {
+      expect(fetchWithAuth.mock.calls.some(([url, init]) => url === '/pax8/sync' && init?.method === 'POST')).toBe(true);
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('maps a Pax8 company to a Breeze org and posts the mapping', async () => {
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/pax8/companies/map' && init?.method === 'POST') {
+        return jsonResponse({ data: { ...company, mappedOrgId: breezeOrg.id, mappedOrgName: breezeOrg.name } });
+      }
+      if (url === '/pax8/integration') return jsonResponse({ data: existingIntegration });
+      if (url === '/pax8/companies') return jsonResponse({ data: [company] });
+      if (url.startsWith('/pax8/subscriptions')) return jsonResponse({ data: [] });
+      if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+      return jsonResponse({}, 404);
+    });
+
+    render(<Pax8Integration />);
+    await screen.findByTestId('pax8-companies-table');
+
+    fireEvent.change(screen.getByTestId('pax8-company-map-pax8-co-1'), { target: { value: breezeOrg.id } });
+
+    await waitFor(() => {
+      expect(fetchWithAuth.mock.calls.some(([url, init]) => url === '/pax8/companies/map' && init?.method === 'POST')).toBe(true);
+    });
+    const mapCall = fetchWithAuth.mock.calls.find(([url, init]) => url === '/pax8/companies/map' && init?.method === 'POST');
+    expect(JSON.parse(String(mapCall?.[1]?.body))).toMatchObject({
+      integrationId: 'pax8-1',
+      pax8CompanyId: 'pax8-co-1',
+      orgId: breezeOrg.id
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('renders the read-only subscriptions list', async () => {
+    mockLoad({ integration: existingIntegration, subscriptions: [subscription] });
+    render(<Pax8Integration />);
+
+    expect(await screen.findByTestId('pax8-subscriptions-table')).toBeTruthy();
+    expect(screen.getByText('Microsoft 365 Business')).toBeTruthy();
+    expect(screen.getByText('USD 15.00')).toBeTruthy();
+  });
+
+  it('shows a partner-scope-only message for org-scope users and never calls the API', async () => {
+    scope = 'organization';
+    mockLoad({ integration: existingIntegration });
+    render(<Pax8Integration />);
+
+    expect(await screen.findByTestId('pax8-org-scope')).toBeTruthy();
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/integrations/Pax8Integration.tsx
+++ b/apps/web/src/components/integrations/Pax8Integration.tsx
@@ -1,0 +1,617 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AlertTriangle,
+  Boxes,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  Loader2,
+  Plug,
+  RefreshCw,
+  Save,
+  Unplug
+} from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext, getJwtClaims } from '../../lib/authScope';
+
+// ── Types mirrored from apps/api/src/routes/pax8.ts ────────────────────────
+interface Pax8Integration {
+  id: string;
+  partnerId: string;
+  name: string;
+  apiBaseUrl: string;
+  tokenUrl: string;
+  isActive: boolean;
+  lastSyncAt: string | null;
+  lastSyncStatus: string | null;
+  lastSyncError: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  hasClientId: boolean;
+  hasClientSecret: boolean;
+  hasWebhookSecret: boolean;
+}
+
+interface Pax8Company {
+  pax8CompanyId: string;
+  pax8CompanyName: string | null;
+  status: string | null;
+  mappedOrgId: string | null;
+  mappedOrgName: string | null;
+  ignored: boolean;
+  lastSeenAt: string | null;
+  updatedAt: string | null;
+}
+
+interface Pax8Subscription {
+  id: string;
+  pax8SubscriptionId: string;
+  pax8CompanyId: string | null;
+  pax8CompanyName: string | null;
+  orgId: string | null;
+  productId: string | null;
+  productName: string | null;
+  vendorName: string | null;
+  status: string | null;
+  billingTerm: string | null;
+  quantity: number | null;
+  unitPrice: string | null;
+  unitCost: string | null;
+  currencyCode: string | null;
+  contractLineId: string | null;
+  syncEnabled: boolean | null;
+}
+
+interface OrgOption {
+  id: string;
+  name: string;
+}
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+const MFA_HINT = 'This change requires MFA. Set up or verify MFA in your profile, then retry.';
+
+/** Pax8 writes are MFA-gated server-side; a 403 "MFA required" should read as a
+ *  setup hint, not a raw permission error. */
+function isMfaError(err: unknown): boolean {
+  return err instanceof ActionError && err.status === 403 && /mfa required/i.test(err.message);
+}
+
+export default function Pax8Integration() {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [integration, setIntegration] = useState<Pax8Integration | null>(null);
+
+  // Config form
+  const [name, setName] = useState('Pax8');
+  const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [webhookSecret, setWebhookSecret] = useState('');
+  const [showSecret, setShowSecret] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  // Companies + subscriptions
+  const [companies, setCompanies] = useState<Pax8Company[]>([]);
+  const [subscriptions, setSubscriptions] = useState<Pax8Subscription[]>([]);
+  const [orgOptions, setOrgOptions] = useState<OrgOption[]>([]);
+  const [mappingCompanyId, setMappingCompanyId] = useState<string | null>(null);
+
+  const claims = getJwtClaims();
+  const isOrgScoped = claims.scope === 'organization';
+
+  const isConfigured = !!integration;
+  // A fresh integration needs both credentials; an existing one may save with
+  // either field blank to keep the stored secret (the API keeps existing if omitted).
+  const canSave =
+    name.trim().length > 0 &&
+    (isConfigured || (clientId.trim().length > 0 && clientSecret.trim().length > 0));
+
+  const fetchIntegration = useCallback(async () => {
+    const res = await fetchWithAuth('/pax8/integration');
+    if (res.status === 401) {
+      UNAUTHORIZED();
+      return null;
+    }
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(
+        `Failed to load Pax8 integration (${res.status}): ${(json as Record<string, unknown>).error ?? res.statusText}`
+      );
+    }
+    const data = (json as { data: Pax8Integration | null }).data;
+    setIntegration(data);
+    if (data) setName(data.name);
+    return data;
+  }, []);
+
+  const fetchCompaniesAndSubs = useCallback(async () => {
+    const [companiesRes, subsRes, orgsRes] = await Promise.all([
+      fetchWithAuth('/pax8/companies'),
+      fetchWithAuth('/pax8/subscriptions?limit=100'),
+      fetchWithAuth('/orgs/organizations')
+    ]);
+    const companiesJson = await companiesRes.json().catch(() => ({}));
+    const subsJson = await subsRes.json().catch(() => ({}));
+    const orgsJson = await orgsRes.json().catch(() => ({}));
+    if (companiesRes.ok) setCompanies((companiesJson as { data?: Pax8Company[] }).data ?? []);
+    if (subsRes.ok) setSubscriptions((subsJson as { data?: Pax8Subscription[] }).data ?? []);
+    if (orgsRes.ok) {
+      const data = (orgsJson as { data?: OrgOption[] }).data;
+      setOrgOptions(Array.isArray(data) ? data : []);
+    }
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const data = await fetchIntegration();
+      if (data) await fetchCompaniesAndSubs();
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to load Pax8 integration');
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchIntegration, fetchCompaniesAndSubs]);
+
+  useEffect(() => {
+    if (isOrgScoped) {
+      setLoading(false);
+      return;
+    }
+    void load();
+  }, [load, isOrgScoped]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setTestResult(null);
+    try {
+      // Only include secrets the user actually entered so an update keeps the
+      // stored credential when the field is left blank.
+      const body: Record<string, unknown> = { name: name.trim() };
+      if (clientId.trim()) body.clientId = clientId.trim();
+      if (clientSecret.trim()) body.clientSecret = clientSecret.trim();
+      if (webhookSecret.trim()) body.webhookSecret = webhookSecret.trim();
+
+      const result = await runAction<Pax8Integration & { syncWarning?: string }>({
+        request: () =>
+          fetchWithAuth('/pax8/integration', { method: 'POST', body: JSON.stringify(body) }),
+        errorFallback: 'Failed to save the Pax8 integration.',
+        successMessage: isConfigured ? 'Pax8 integration updated' : 'Pax8 integration connected',
+        onUnauthorized: UNAUTHORIZED
+      });
+      setIntegration(result);
+      setName(result.name);
+      setClientId('');
+      setClientSecret('');
+      setWebhookSecret('');
+      await fetchCompaniesAndSubs();
+    } catch (err) {
+      if (isMfaError(err)) setLoadError(MFA_HINT);
+      handleActionError(err, 'Failed to save the Pax8 integration.');
+    } finally {
+      setSaving(false);
+    }
+  }, [name, clientId, clientSecret, webhookSecret, isConfigured, fetchCompaniesAndSubs]);
+
+  const handleTest = useCallback(async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/pax8/integration/test', { method: 'POST', body: JSON.stringify({}) }),
+        errorFallback: 'Pax8 connection test failed.',
+        successMessage: 'Pax8 connection test succeeded',
+        onUnauthorized: UNAUTHORIZED
+      });
+      setTestResult({ ok: true, message: 'Connection test succeeded.' });
+    } catch (err) {
+      const message = isMfaError(err)
+        ? MFA_HINT
+        : err instanceof ActionError
+          ? err.message
+          : 'Pax8 connection test failed.';
+      setTestResult({ ok: false, message });
+      handleActionError(err, 'Pax8 connection test failed.');
+    } finally {
+      setTesting(false);
+    }
+  }, []);
+
+  const handleSync = useCallback(async () => {
+    setSyncing(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/pax8/sync', { method: 'POST', body: JSON.stringify({}) }),
+        errorFallback: 'Failed to schedule a Pax8 sync.',
+        successMessage: 'Pax8 sync scheduled',
+        onUnauthorized: UNAUTHORIZED
+      });
+      // Re-load to surface lastSync* once the worker finishes; the immediate
+      // re-fetch may still show the prior status (sync runs in the background).
+      await fetchIntegration();
+      await fetchCompaniesAndSubs();
+    } catch (err) {
+      if (isMfaError(err)) setLoadError(MFA_HINT);
+      handleActionError(err, 'Failed to schedule a Pax8 sync.');
+    } finally {
+      setSyncing(false);
+    }
+  }, [fetchIntegration, fetchCompaniesAndSubs]);
+
+  const mapCompany = useCallback(
+    async (company: Pax8Company, orgId: string | null) => {
+      if (!integration) return;
+      setMappingCompanyId(company.pax8CompanyId);
+      try {
+        const result = await runAction<{ data: Pax8Company }>({
+          request: () =>
+            fetchWithAuth('/pax8/companies/map', {
+              method: 'POST',
+              body: JSON.stringify({
+                integrationId: integration.id,
+                pax8CompanyId: company.pax8CompanyId,
+                orgId
+              })
+            }),
+          errorFallback: 'Failed to map the Pax8 company.',
+          successMessage: orgId ? 'Pax8 company mapped' : 'Pax8 company unmapped',
+          onUnauthorized: UNAUTHORIZED
+        });
+        const mapped = result.data;
+        setCompanies((prev) =>
+          prev.map((c) => (c.pax8CompanyId === company.pax8CompanyId ? { ...c, ...mapped } : c))
+        );
+      } catch (err) {
+        handleActionError(err, 'Failed to map the Pax8 company.');
+      } finally {
+        setMappingCompanyId(null);
+      }
+    },
+    [integration]
+  );
+
+  if (isOrgScoped) {
+    return (
+      <div className="space-y-6" data-testid="pax8-panel">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Boxes className="h-5 w-5" />
+          </div>
+          <h1 className="text-2xl font-semibold">Pax8</h1>
+        </div>
+        <p className="text-center text-sm text-muted-foreground" data-testid="pax8-org-scope">
+          The Pax8 distributor integration is available to partner accounts only.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20" data-testid="pax8-loading">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const syncStatusColor =
+    integration?.lastSyncStatus === 'success'
+      ? 'text-emerald-600'
+      : integration?.lastSyncStatus === 'error' || integration?.lastSyncStatus === 'failed'
+        ? 'text-red-600'
+        : 'text-muted-foreground';
+
+  return (
+    <div className="space-y-6" data-testid="pax8-panel">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Boxes className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold">Pax8</h1>
+          <p className="text-sm text-muted-foreground">
+            Connect Pax8 to sync companies and license subscriptions into Breeze, then map each Pax8
+            company to a Breeze organization for license billing.
+          </p>
+        </div>
+        {isConfigured ? (
+          <span
+            className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-700"
+            data-testid="pax8-status-connected"
+          >
+            <CheckCircle2 className="h-3.5 w-3.5" /> Connected
+          </span>
+        ) : (
+          <span
+            className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600"
+            data-testid="pax8-status-disconnected"
+          >
+            <Unplug className="h-3.5 w-3.5" /> Not connected
+          </span>
+        )}
+      </div>
+
+      {loadError && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700" data-testid="pax8-load-error">
+          {loadError}
+        </div>
+      )}
+
+      {/* Connection card */}
+      <div className="rounded-xl border bg-card p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Connection</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Enter your Pax8 OAuth client credentials. Secrets are stored encrypted and never returned;
+          leave a field blank when updating to keep the stored value. Saving requires MFA verification.
+        </p>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="md:col-span-2">
+            <label className="mb-1 block text-sm font-medium">Display name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Pax8"
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              data-testid="pax8-name"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              Client ID
+              {integration?.hasClientId && (
+                <span className="ml-1 inline-flex items-center gap-1 text-xs text-emerald-600" data-testid="pax8-has-client-id">
+                  <CheckCircle2 className="h-3 w-3" /> configured
+                </span>
+              )}
+            </label>
+            <input
+              type="text"
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              placeholder={integration?.hasClientId ? '•••••••••• (stored)' : 'Pax8 client ID'}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              data-testid="pax8-client-id"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              Client secret
+              {integration?.hasClientSecret && (
+                <span className="ml-1 inline-flex items-center gap-1 text-xs text-emerald-600" data-testid="pax8-has-client-secret">
+                  <CheckCircle2 className="h-3 w-3" /> configured
+                </span>
+              )}
+            </label>
+            <div className="relative">
+              <input
+                type={showSecret ? 'text' : 'password'}
+                value={clientSecret}
+                onChange={(e) => setClientSecret(e.target.value)}
+                placeholder={integration?.hasClientSecret ? '•••••••••• (stored)' : 'Pax8 client secret'}
+                className="h-10 w-full rounded-md border bg-background px-3 pr-10 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                data-testid="pax8-client-secret"
+              />
+              <button
+                type="button"
+                onClick={() => setShowSecret(!showSecret)}
+                className="absolute right-2 top-2.5 text-muted-foreground hover:text-foreground"
+                aria-label={showSecret ? 'Hide secret' : 'Show secret'}
+              >
+                {showSecret ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+
+          <div className="md:col-span-2">
+            <label className="mb-1 block text-sm font-medium">
+              Webhook secret <span className="text-xs text-muted-foreground">(optional)</span>
+              {integration?.hasWebhookSecret && (
+                <span className="ml-1 inline-flex items-center gap-1 text-xs text-emerald-600" data-testid="pax8-has-webhook-secret">
+                  <CheckCircle2 className="h-3 w-3" /> configured
+                </span>
+              )}
+            </label>
+            <input
+              type="password"
+              value={webhookSecret}
+              onChange={(e) => setWebhookSecret(e.target.value)}
+              placeholder={integration?.hasWebhookSecret ? '•••••••••• (stored)' : 'Pax8 webhook signing secret'}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              data-testid="pax8-webhook-secret"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={!canSave || saving}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            data-testid="pax8-save"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            {isConfigured ? 'Update connection' : 'Connect Pax8'}
+          </button>
+          {isConfigured && (
+            <>
+              <button
+                type="button"
+                onClick={() => void handleTest()}
+                disabled={testing}
+                className="inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                data-testid="pax8-test"
+              >
+                {testing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plug className="h-4 w-4" />}
+                Test connection
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleSync()}
+                disabled={syncing}
+                className="inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                data-testid="pax8-sync"
+              >
+                {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                Sync now
+              </button>
+            </>
+          )}
+          {testResult && (
+            <span
+              className={`inline-flex items-center gap-1 text-sm ${testResult.ok ? 'text-emerald-600' : 'text-red-600'}`}
+              data-testid="pax8-test-result"
+            >
+              {testResult.ok ? <CheckCircle2 className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
+              {testResult.message}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Sync status */}
+      {isConfigured && (
+        <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="pax8-sync-status">
+          <h2 className="text-lg font-semibold">Sync status</h2>
+          <div className="mt-4 space-y-2 text-sm">
+            <div className="flex justify-between text-muted-foreground">
+              <span>Last sync</span>
+              <span className="text-foreground">
+                {integration?.lastSyncAt ? new Date(integration.lastSyncAt).toLocaleString() : 'Never'}
+              </span>
+            </div>
+            <div className="flex justify-between text-muted-foreground">
+              <span>Status</span>
+              <span className={syncStatusColor} data-testid="pax8-sync-status-value">
+                {integration?.lastSyncStatus ?? 'Not yet run'}
+              </span>
+            </div>
+            {integration?.lastSyncError && (
+              <div className="flex justify-between gap-4 text-muted-foreground">
+                <span>Last error</span>
+                <span className="text-right text-red-600" data-testid="pax8-sync-error">
+                  {integration.lastSyncError}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Company mapping */}
+      {isConfigured && (
+        <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="pax8-companies">
+          <h2 className="text-lg font-semibold">Company mapping</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Map each Pax8 company to a Breeze organization. Subscriptions sync to the mapped org for
+            license billing.
+          </p>
+          {companies.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="pax8-companies-empty">
+              No Pax8 companies yet. Run a sync to pull companies from Pax8.
+            </p>
+          ) : (
+            <table className="min-w-full divide-y text-sm" data-testid="pax8-companies-table">
+              <thead>
+                <tr className="text-left text-muted-foreground">
+                  <th className="px-3 py-2 font-medium">Pax8 company</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Breeze organization</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {companies.map((company) => (
+                  <tr key={company.pax8CompanyId} data-testid={`pax8-company-${company.pax8CompanyId}`}>
+                    <td className="px-3 py-2">
+                      <div className="font-medium">{company.pax8CompanyName ?? company.pax8CompanyId}</div>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">{company.status ?? '—'}</td>
+                    <td className="px-3 py-2">
+                      <select
+                        value={company.mappedOrgId ?? ''}
+                        disabled={mappingCompanyId === company.pax8CompanyId}
+                        onChange={(e) => void mapCompany(company, e.target.value || null)}
+                        className="h-9 w-full rounded-md border bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+                        data-testid={`pax8-company-map-${company.pax8CompanyId}`}
+                        aria-label={`Map ${company.pax8CompanyName ?? company.pax8CompanyId} to a Breeze organization`}
+                      >
+                        <option value="">Unmapped</option>
+                        {orgOptions.map((org) => (
+                          <option key={org.id} value={org.id}>
+                            {org.name}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {/* Subscriptions (read-only) */}
+      {isConfigured && (
+        <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="pax8-subscriptions">
+          <h2 className="text-lg font-semibold">Subscriptions</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            License subscriptions pulled from Pax8. Link a subscription to a contract line from the
+            organization&apos;s contract to sync quantities automatically.
+          </p>
+          {subscriptions.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="pax8-subscriptions-empty">
+              No subscriptions yet. Run a sync to pull subscriptions from Pax8.
+            </p>
+          ) : (
+            <table className="min-w-full divide-y text-sm" data-testid="pax8-subscriptions-table">
+              <thead>
+                <tr className="text-left text-muted-foreground">
+                  <th className="px-3 py-2 font-medium">Product</th>
+                  <th className="px-3 py-2 font-medium">Company</th>
+                  <th className="px-3 py-2 font-medium">Qty</th>
+                  <th className="px-3 py-2 font-medium">Unit cost</th>
+                  <th className="px-3 py-2 font-medium">Linked</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {subscriptions.map((sub) => (
+                  <tr key={sub.id} data-testid={`pax8-subscription-${sub.id}`}>
+                    <td className="px-3 py-2">
+                      <div className="font-medium">{sub.productName ?? sub.productId ?? sub.pax8SubscriptionId}</div>
+                      <div className="text-xs text-muted-foreground">{sub.vendorName ?? ''}</div>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">{sub.pax8CompanyName ?? sub.pax8CompanyId ?? '—'}</td>
+                    <td className="px-3 py-2">{sub.quantity ?? '—'}</td>
+                    <td className="px-3 py-2">
+                      {sub.unitCost ? `${sub.currencyCode ?? 'USD'} ${sub.unitCost}` : '—'}
+                    </td>
+                    <td className="px-3 py-2">
+                      {sub.contractLineId ? (
+                        <span className="inline-flex items-center gap-1 text-xs text-emerald-600">
+                          <CheckCircle2 className="h-3 w-3" /> {sub.syncEnabled ? 'syncing' : 'linked'}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">Not linked</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/CatalogSettingsPage.tsx
+++ b/apps/web/src/components/settings/CatalogSettingsPage.tsx
@@ -1,10 +1,7 @@
 import { getJwtClaims } from '../../lib/authScope';
 import CatalogItemsTab from './CatalogItemsTab';
-import TdSynnexCatalogPanel from './TdSynnexCatalogPanel';
-import { useState } from 'react';
 
 export default function CatalogSettingsPage() {
-  const [reloadKey, setReloadKey] = useState(0);
   // Catalog routes enforce requireScope('partner','system') server-side. Gate
   // the page client-side so org-scope users get a clear "partner accounts only"
   // message instead of a misleading load error. getJwtClaims returns null scope
@@ -34,10 +31,10 @@ export default function CatalogSettingsPage() {
         <h1 className="text-xl font-semibold">Product Catalog</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Manage hardware, software, and service items used across quotes, contracts, and invoices.
+          Connect distributors (Pax8, TD SYNNEX) under Integrations &rarr; Distributors.
         </p>
       </div>
-      <TdSynnexCatalogPanel onImported={() => setReloadKey((key) => key + 1)} />
-      <CatalogItemsTab reloadKey={reloadKey} />
+      <CatalogItemsTab />
     </div>
   );
 }


### PR DESCRIPTION
**Why:** Pax8 (#1594) shipped a complete API + background sync worker but **no web UI** — it was unusable from the app. TD SYNNEX (#1596) had a UI but it was buried under Settings → Catalog. This surfaces both distributor integrations on the **Integrations** page.

**What:**
- New **Distributors** tab on the Integrations page (mirrors the Identity sub-tab pattern), with **Pax8** and **TD SYNNEX** sub-tabs. Gated on JWT scope (`getJwtClaims().scope`, NOT `partners.length` — the known broken anti-pattern); org-scope users get a clear "partner accounts only" message.
- New **`Pax8Integration`** panel against the existing `/pax8` API: connect/config (write-only secrets with "configured" indicators), **Test connection**, **Sync now** (surfaces `lastSyncAt`/`lastSyncStatus`/`lastSyncError`), and **Pax8-company → Breeze-org mapping**. All mutations use `runAction`; an MFA-required 403 surfaces a friendly hint.
- **TD SYNNEX** now renders under Integrations → Distributors and is **removed from Settings → Catalog** (`CatalogItemsTab` retained there; a pointer to the new location added).

**Deferred (noted):** in-UI **subscription linking** (`POST /pax8/subscriptions/link`) needs a contract-line picker scoped to the mapped org's contract — subscriptions are shown read-only for now.

**Verified:** new `Pax8Integration.test.tsx` + `IntegrationsPage.test.tsx` (14); with `TdSynnexCatalogPanel.test.tsx` + `no-silent-mutations.test.ts` → **76 passed**. `tsc --noEmit` clean; `astro check` 0 errors. Live Pax8 OAuth round-trip + visual layout not verified without a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)