### PR TITLE
fix(api): reject empty-authority portal URL in quote acceptUrl (#1630 follow-up)

### DIFF
--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -51,6 +51,27 @@ describe('quoteLifecycle portal URL', () => {
     expect(new URL(url).hostname).not.toBe('');
   });
 
+  it('SKIPS the empty-authority triple-slash form (`https:///portal`) rather than emitting a dead link', () => {
+    // #1630 follow-up: PUBLIC_PORTAL_URL="https:///portal" (host var didn't
+    // interpolate). `new URL('https:///portal').hostname === 'portal'` — Node
+    // reinterprets the first path segment as the host, so the parsed-hostname
+    // guard wrongly passes and we'd ship `https:///portal/quote/<token>`.
+    process.env.PUBLIC_PORTAL_URL = 'https:///portal';
+    process.env.PUBLIC_APP_URL = 'https://app.example.com';
+    const url = buildPublicQuoteAcceptUrl('tok');
+    expect(url).not.toMatch(/^https?:\/\/\//); // no empty-authority `://[/]`
+    expect(url).not.toContain('https:///portal');
+    expect(new URL(url).hostname).toBe('app.example.com'); // fell through to next valid candidate
+    expect(url).toBe('https://app.example.com/quote/tok');
+  });
+
+  it('preserves a valid host + /portal base path (not over-eagerly skipped)', () => {
+    process.env.PUBLIC_PORTAL_URL = 'https://example.com/portal';
+    const base = portalBase();
+    expect(base).toBe('https://example.com/portal'); // returned as-is, base path intact
+    expect(new URL(base).hostname).toBe('example.com');
+  });
+
   it('falls through an empty PUBLIC_PORTAL_URL to PUBLIC_APP_URL', () => {
     process.env.PUBLIC_PORTAL_URL = '';
     process.env.PUBLIC_APP_URL = 'https://app.example.com';
@@ -68,9 +89,9 @@ describe('quoteLifecycle portal URL', () => {
     // monkeypatching: not possible via env since the fallback is a constant, so
     // we assert the happy-path host invariant instead — portalBase always yields
     // a parseable URL with a hostname.
-    process.env.PUBLIC_PORTAL_URL = 'not-a-url';
-    process.env.PUBLIC_APP_URL = 'https://'; // empty host
-    process.env.DASHBOARD_URL = '   ';        // blank
+    process.env.PUBLIC_PORTAL_URL = 'https:///portal'; // empty-authority triple-slash
+    process.env.PUBLIC_APP_URL = 'https://';           // empty host
+    process.env.DASHBOARD_URL = '   ';                 // blank
     const base = portalBase();
     expect(new URL(base).hostname).toBe('localhost'); // last good fallback
   });

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -22,11 +22,11 @@ type QuoteRow = typeof quotes.$inferSelect;
  * invoicePdf.ts. The public quote route lives at `<portalBase>/quote/<token>`.
  *
  * Hardening (malformed `https:///quote/...` accept links): a configured value
- * that is empty or parses to an empty host (e.g. a bare `https://`) must NEVER
- * silently produce an empty-host URL in a customer-facing email. We walk the
- * configured chain and, if none yields a usable host, throw loudly so the
- * caller's best-effort email swallow records the failure rather than mailing a
- * dead link.
+ * that is empty, an empty-authority triple-slash form (`https:///portal`), or
+ * otherwise parses to an empty host (e.g. a bare `https://`) must NEVER silently
+ * produce an empty-host URL in a customer-facing email. We walk the configured
+ * chain and, if none yields a usable host, throw loudly so the caller's
+ * best-effort email swallow records the failure rather than mailing a dead link.
  */
 export function portalBase(): string {
   const candidates = [
@@ -39,6 +39,14 @@ export function portalBase(): string {
   for (const candidate of candidates) {
     const trimmed = candidate?.trim();
     if (!trimmed) continue;
+    // Reject the empty-authority triple-slash form before parsing: `https:///portal`
+    // (a templating accident where the host var didn't interpolate) has an empty
+    // authority, but `new URL('https:///portal').hostname` reinterprets the first
+    // path segment (`portal`) as the host — so the parsed-hostname guard below would
+    // wrongly pass and we'd emit a dead `https:///portal/quote/...` link. Treat any
+    // value whose authority component (between `://` and the next `/`, `?`, `#`, or
+    // end) is empty as malformed and skip it.
+    if (/^[a-z][a-z0-9+.-]*:\/\/(?=[/?#]|$)/i.test(trimmed)) continue;
     let parsed: URL;
     try {
       parsed = new URL(trimmed);


### PR DESCRIPTION
## Root cause

`portalBase()` in `apps/api/src/services/quoteLifecycle.ts` walks the candidate chain `[PUBLIC_PORTAL_URL, PUBLIC_APP_URL, DASHBOARD_URL, 'http://localhost:4321/portal']`, parses each with `new URL()`, and guarded malformed values only with `if (!parsed.hostname) continue;`.

That guard has a hole for the **empty-authority triple-slash form** `https:///portal` — a common templating accident where the host variable didn't interpolate. `new URL('https:///portal').hostname === 'portal'`: Node reinterprets the empty authority's first path segment as the host. So `!parsed.hostname` is **false**, the guard passes, and the function returns the raw `https:///portal`. `buildPublicQuoteAcceptUrl()` then emits `https:///portal/quote/<token>` — a triple-slash dead link that browsers/email clients resolve to the nonexistent host `portal`.

Verified live (PR #1630 follow-up): the send response returned `acceptUrl: "https:///portal/quote/<token>"`.

## Fix

Before parsing, detect when the authority component (between `://` and the next `/`, `?`, `#`, or end of string) is empty in the raw trimmed value, using `/^[a-z][a-z0-9+.-]*:\/\/(?=[/?#]|$)/i`, and `continue` past such candidates as malformed. The chain then falls through to `PUBLIC_APP_URL` / `DASHBOARD_URL`, or throws loudly if none is usable — matching the function's stated hardening intent (never mail an empty-host link).

- Genuinely valid values (`https://example.com/portal`, `http://localhost:4321/portal`) still pass and are returned trimmed, so the `/portal` base path is preserved.
- The candidate set and order are unchanged; `buildPublicQuoteAcceptUrl` is unchanged.

## Test evidence

Added/updated cases in `quoteLifecycle.test.ts`:
- `https:///portal` -> skipped -> falls through to the next valid candidate (`https://app.example.com`); asserts the result is **not** `https:///portal` and has a real host.
- `https://example.com/portal` -> `portalBase()` returns it as-is (host + `/portal` base path preserved).
- Folded the triple-slash form into the all-malformed -> fall-through-to-localhost contract case.

Scoped run:
```
PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/quoteLifecycle.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)