### PR TITLE
fix(web): render access-denied on 403 instead of "session expired" (#1629 follow-up)

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -316,6 +316,29 @@ describe('DevicesPage — network-arm fetch failure handling (#1322)', () => {
   });
 });
 
+// #1629 follow-up: a 403 on the devices load is a permission denial, not an
+// expired session. The web fetcher throws the raw Response on a non-OK status,
+// so DevicesPage catches a 403 Response and must render the access-denied state
+// (no misleading "session expired / try again"), not the generic error banner.
+describe('DevicesPage — 403 renders access-denied (not session expired)', () => {
+  it('renders AccessDenied when the devices fetch returns 403', async () => {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce(null);
+    // fetchAllDevices throws the raw Response on a non-OK status (its contract).
+    vi.mocked(fetchAllDevices).mockRejectedValueOnce(new Response(null, { status: 403 }));
+
+    render(<DevicesPage />);
+
+    expect(await screen.findByTestId('access-denied')).toBeTruthy();
+    expect(screen.getByText('Access denied')).toBeTruthy();
+    expect(screen.getByText("You don't have permission to view devices.")).toBeTruthy();
+    // Must NOT show the session-expired copy or a retry on a permission denial.
+    expect(screen.queryByText('Session expired')).toBeNull();
+    expect(screen.queryByText('Try again')).toBeNull();
+    expect(screen.queryByTestId(`device-card-${DEV_1}`)).toBeNull();
+  });
+});
+
 // Regression: multi-select "Run Script" sent an EMPTY deviceIds array → the API
 // rejected it with 400 "Array must contain at least one item". Root cause: the
 // ScriptPickerModal called onSelect() then onClose(), and onClose

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -21,7 +21,8 @@ import { useOrgStore } from '../../stores/orgStore';
 import { PageScopeIndicator } from '../layout/PageScopeIndicator';
 import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
-import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
+import { getErrorMessage, getErrorTitle, isAccessDenied } from '@/lib/errorMessages';
+import AccessDenied from '../shared/AccessDenied';
 import { asRecord, toPercent } from '@/lib/deviceUtils';
 import { ENABLE_NETWORK_DEVICES_IN_LIST } from '@/lib/featureFlags';
 import ProgressBar from '../shared/ProgressBar';
@@ -823,6 +824,12 @@ export default function DevicesPage() {
         </div>
       </div>
     );
+  }
+
+  // A 403 is a permission denial, not a transient load failure — render the
+  // access-denied state (no misleading "session expired / try again" UI).
+  if (error && isAccessDenied(error)) {
+    return <AccessDenied message="You don't have permission to view devices." />;
   }
 
   if (error) {

--- a/apps/web/src/components/layout/Sidebar.rbac.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.rbac.test.tsx
@@ -53,6 +53,13 @@ function has(container: HTMLElement, href: string): boolean {
   return container.querySelector(`a[href="${href}"]`) !== null;
 }
 
+// A collapsible section header is a <button> whose first <span> is the label.
+function hasSectionHeader(container: HTMLElement, label: string): boolean {
+  return [...container.querySelectorAll('button')].some(
+    (b) => b.querySelector('span')?.textContent === label,
+  );
+}
+
 beforeEach(() => {
   fetchWithAuthMock.mockReset();
   fetchWithAuthMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) } as Response);
@@ -95,6 +102,19 @@ describe('Sidebar — permission-aware nav for billing vs technician vs admin', 
     expect(has(container, '/scripts')).toBe(false);
     expect(has(container, '/backup')).toBe(false);
     expect(has(container, '/reports')).toBe(false);
+
+    // #1629 follow-up: a section whose items are ALL permission-filtered out
+    // must hide its header entirely — no empty "Monitoring/Security/Backup/
+    // Reporting" group that expands to nothing.
+    expect(hasSectionHeader(container, 'Monitoring')).toBe(false);
+    expect(hasSectionHeader(container, 'Security')).toBe(false);
+    expect(hasSectionHeader(container, 'Backup')).toBe(false);
+    expect(hasSectionHeader(container, 'Reporting')).toBe(false);
+    // Sections that still have at least one visible item keep their header:
+    // Operations holds the billing items it can access, and AI & Fleet has the
+    // always-visible Fleet landing item.
+    expect(hasSectionHeader(container, 'Operations')).toBe(true);
+    expect(hasSectionHeader(container, 'AI & Fleet')).toBe(true);
   });
 
   it('Partner Technician sees fleet/ops items but no billing and no user/role admin', async () => {
@@ -134,6 +154,12 @@ describe('Sidebar — permission-aware nav for billing vs technician vs admin', 
     expect(has(container, '/security')).toBe(true);
     expect(has(container, '/reports')).toBe(true);
     expect(has(container, '/backup')).toBe(true);
+
+    // Admin sees every section header (nothing filtered out).
+    expect(hasSectionHeader(container, 'Monitoring')).toBe(true);
+    expect(hasSectionHeader(container, 'Security')).toBe(true);
+    expect(hasSectionHeader(container, 'Backup')).toBe(true);
+    expect(hasSectionHeader(container, 'Reporting')).toBe(true);
   });
 
   it('Dashboard stays visible regardless of permissions (ungated landing page)', async () => {

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -472,18 +472,28 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
   const deletionRequestsCount = useDeletionRequestsBadge(isPlatformAdmin);
 
   // --- Render a single nav item -------------------------------------------
-  const renderNavItem = (item: NavItem, forMobileOverlay = false) => {
-    if (item.requiresAiForOffice && !aiForOfficeEnabled) return null;
-    if (item.platformAdminOnly && !isPlatformAdmin) return null;
+  // Whether a nav item passes all visibility gates (feature flag, platform
+  // admin, partner scope, permission). Kept in sync with the early returns in
+  // `renderNavItem` below so section-header visibility (renderCollapsibleSection)
+  // matches what actually renders — a section whose items are all filtered out
+  // must not show an empty header that expands to nothing.
+  const isNavItemVisible = (item: NavItem): boolean => {
+    if (item.requiresAiForOffice && !aiForOfficeEnabled) return false;
+    if (item.platformAdminOnly && !isPlatformAdmin) return false;
     if (item.partnerScopeOnly) {
       const { scope } = getJwtClaims();
-      if (scope !== null && scope !== 'partner') return null;
+      if (scope !== null && scope !== 'partner') return false;
     }
     if (item.requiredPermission) {
       if (!hasPermission(permissions, item.requiredPermission.resource, item.requiredPermission.action)) {
-        return null;
+        return false;
       }
     }
+    return true;
+  };
+
+  const renderNavItem = (item: NavItem, forMobileOverlay = false) => {
+    if (!isNavItemVisible(item)) return null;
     const isActive = item.href === activeHref;
     const labels = forMobileOverlay ? true : showLabels;
     const narrow = forMobileOverlay ? false : isNarrow;
@@ -518,6 +528,11 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
 
   // --- Render a collapsible section ----------------------------------------
   const renderCollapsibleSection = (section: NavSection, forMobileOverlay = false) => {
+    // Hide the whole section (header + divider) when every item is filtered out
+    // by permissions/scope/flags — otherwise a permission-limited user sees an
+    // empty group header that expands to nothing (#1629 follow-up).
+    if (!section.items.some(isNavItemVisible)) return null;
+
     const expanded = isSectionExpanded(section.id);
     const labels = forMobileOverlay ? true : showLabels;
 

--- a/apps/web/src/components/reports/DashboardWidgets.test.tsx
+++ b/apps/web/src/components/reports/DashboardWidgets.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DashboardWidgets from './DashboardWidgets';
+import { fetchWithAuth } from '../../stores/auth';
+
+// #1629 follow-up: the per-widget fetches swallow their own errors and degrade
+// to empty data. A 403, however, is a permission denial — it must surface as the
+// access-denied state instead of silently rendering zeroes, and must NOT show a
+// "session expired" message or a misleading Retry.
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const resp = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+describe('DashboardWidgets — 403 renders access-denied (not empty data / retry)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders AccessDenied when a widget endpoint returns 403', async () => {
+    fetchMock.mockImplementation(async () => resp({ error: 'forbidden' }, 403));
+
+    render(<DashboardWidgets showDeviceStatus showAlertCounts={false} showCompliance={false} showResources={false} />);
+
+    await waitFor(() => expect(screen.getByTestId('access-denied')).toBeInTheDocument());
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to view this dashboard data.")).toBeInTheDocument();
+    // No misleading retry, no "session expired" copy, and no silently-zeroed widget.
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+    expect(screen.queryByText(/session expired/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Total Devices')).not.toBeInTheDocument();
+  });
+
+  it('renders the widget data on a successful load (no access-denied)', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (String(url).startsWith('/reports/data/device-inventory')) return resp({ total: 7 });
+      if (String(url).startsWith('/devices')) {
+        return resp({ summary: { online: 5, offline: 1, maintenance: 1 } });
+      }
+      return resp({});
+    });
+
+    render(<DashboardWidgets showDeviceStatus showAlertCounts={false} showCompliance={false} showResources={false} />);
+
+    await waitFor(() => expect(screen.getByText('Total Devices')).toBeInTheDocument());
+    expect(screen.queryByTestId('access-denied')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/reports/DashboardWidgets.tsx
+++ b/apps/web/src/components/reports/DashboardWidgets.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { cn, widthPercentClass } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
+import AccessDenied from '../shared/AccessDenied';
 
 type DeviceStatusData = {
   total: number;
@@ -82,22 +83,41 @@ export default function DashboardWidgets({
   const [resources, setResources] = useState<ResourceData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  // Distinct from `error`: a 403 is a permission denial, not a transient load
+  // failure, so it renders the access-denied state (no misleading retry button).
+  const [forbidden, setForbidden] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
 
   const fetchData = useCallback(async () => {
     setError(undefined);
+    setForbidden(false);
+    // The per-widget fetches below swallow their own errors and degrade to
+    // empty data. A 403, however, means the user lacks permission for the
+    // dashboard data — surface it as the access-denied state instead of
+    // silently showing zeroes. `parseOrFlag403` records the denial and
+    // re-throws so the widget's own `.catch` still runs (no half state).
+    let sawForbidden = false;
+    const parseOrFlag403 = (res: Response): Promise<unknown> => {
+      if (res.status === 403) {
+        sawForbidden = true;
+        throw res;
+      }
+      return res.json();
+    };
     try {
       const promises: Promise<void>[] = [];
 
       if (showDeviceStatus) {
         promises.push(
           fetchWithAuth('/reports/data/device-inventory?limit=1')
-            .then(res => res.json())
-            .then(data => {
+            .then(parseOrFlag403)
+            .then((raw) => {
+              const data = raw as { total?: number };
               // Get status counts from devices endpoint
               return fetchWithAuth('/devices?limit=1')
-                .then(res => res.json())
-                .then(devData => {
+                .then(parseOrFlag403)
+                .then((rawDev) => {
+                  const devData = rawDev as { summary?: { online?: number; offline?: number; maintenance?: number } };
                   // Calculate from the data or use summary if available
                   setDeviceStatus({
                     total: data.total || 0,
@@ -117,8 +137,9 @@ export default function DashboardWidgets({
       if (showAlertCounts) {
         promises.push(
           fetchWithAuth('/reports/data/alerts-summary')
-            .then(res => res.json())
-            .then(data => {
+            .then(parseOrFlag403)
+            .then((raw) => {
+              const data = raw as { data?: { bySeverity?: Record<string, number> } };
               setAlertCounts({
                 critical: data.data?.bySeverity?.critical || 0,
                 high: data.data?.bySeverity?.high || 0,
@@ -136,12 +157,23 @@ export default function DashboardWidgets({
       if (showCompliance) {
         promises.push(
           fetchWithAuth('/reports/data/compliance')
-            .then(res => res.json())
-            .then(data => {
+            .then(parseOrFlag403)
+            .then((raw) => {
+              const data = raw as {
+                data?: {
+                  overview?: {
+                    complianceScore?: number;
+                    totalDevices?: number;
+                    onlineDevices?: number;
+                    maintenanceDevices?: number;
+                  };
+                  issues?: unknown[];
+                };
+              };
               setCompliance({
                 complianceScore: data.data?.overview?.complianceScore || 100,
                 totalDevices: data.data?.overview?.totalDevices || 0,
-                compliantDevices: data.data?.overview?.onlineDevices + data.data?.overview?.maintenanceDevices || 0,
+                compliantDevices: (data.data?.overview?.onlineDevices ?? 0) + (data.data?.overview?.maintenanceDevices ?? 0),
                 issueCount: data.data?.issues?.length || 0
               });
             })
@@ -154,8 +186,16 @@ export default function DashboardWidgets({
       if (showResources) {
         promises.push(
           fetchWithAuth('/reports/data/metrics')
-            .then(res => res.json())
-            .then(data => {
+            .then(parseOrFlag403)
+            .then((raw) => {
+              const data = raw as {
+                data?: {
+                  averages?: { cpu: number; ram: number; disk: number };
+                  topCpu?: TopResourceDevice[];
+                  topRam?: TopResourceDevice[];
+                  topDisk?: TopResourceDevice[];
+                };
+              };
               setResources({
                 averages: data.data?.averages || { cpu: 0, ram: 0, disk: 0 },
                 topCpu: data.data?.topCpu || [],
@@ -175,6 +215,7 @@ export default function DashboardWidgets({
       }
 
       await Promise.all(promises);
+      if (sawForbidden) setForbidden(true);
       setLastUpdated(new Date());
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load dashboard data');
@@ -209,6 +250,12 @@ export default function DashboardWidgets({
         ))}
       </div>
     );
+  }
+
+  // A 403 is a permission denial, not a transient load failure — render the
+  // access-denied state (no misleading retry) instead of a generic error card.
+  if (forbidden) {
+    return <AccessDenied message="You don't have permission to view this dashboard data." />;
   }
 
   if (error) {

--- a/apps/web/src/components/settings/UsersPage.test.tsx
+++ b/apps/web/src/components/settings/UsersPage.test.tsx
@@ -107,3 +107,36 @@ describe('UsersPage — handleEditSubmit role-change contract', () => {
     expect(roleCalls.length).toBe(0);
   });
 });
+
+// #1629 follow-up: a 403 on the users list is a permission denial, not a
+// transient "Failed to fetch users" error — it must render AccessDenied with
+// no misleading "Try again" retry.
+describe('UsersPage — 403 renders access-denied (not the retryable error)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders AccessDenied on a 403 from /users', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === '/users') return jsonResponse({ error: 'forbidden' }, 403);
+      return jsonResponse({}, 404);
+    });
+    render(<UsersPage />);
+
+    await waitFor(() => expect(screen.getByTestId('access-denied')).toBeInTheDocument());
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to view users.")).toBeInTheDocument();
+    // No misleading retry on a permission denial, and no "session expired" copy.
+    expect(screen.queryByText('Try again')).not.toBeInTheDocument();
+    expect(screen.queryByText('Failed to fetch users')).not.toBeInTheDocument();
+  });
+
+  it('renders the retryable error (with Try again) on a non-403 load failure', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === '/users') return jsonResponse({}, 500);
+      return jsonResponse({}, 404);
+    });
+    render(<UsersPage />);
+
+    await waitFor(() => expect(screen.getByText('Try again')).toBeInTheDocument());
+    expect(screen.queryByTestId('access-denied')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/UsersPage.tsx
+++ b/apps/web/src/components/settings/UsersPage.tsx
@@ -4,6 +4,7 @@ import UserInviteForm, { type RoleOption } from './UserInviteForm';
 import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { navigateTo } from '@/lib/navigation';
+import AccessDenied from '../shared/AccessDenied';
 
 type ModalMode = 'closed' | 'invite' | 'edit' | 'remove';
 
@@ -29,6 +30,9 @@ export default function UsersPage() {
   const [roles, setRoles] = useState<RoleOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  // Distinct from `error`: a 403 is a permission denial, not a transient load
+  // failure, so it renders the access-denied state (no misleading retry button).
+  const [forbidden, setForbidden] = useState(false);
   const [modalMode, setModalMode] = useState<ModalMode>('closed');
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -46,10 +50,15 @@ export default function UsersPage() {
     try {
       setLoading(true);
       setError(undefined);
+      setForbidden(false);
       const response = await fetchWithAuth('/users');
       if (!response.ok) {
         if (response.status === 401) {
           void navigateTo('/login', { replace: true });
+          return;
+        }
+        if (response.status === 403) {
+          setForbidden(true);
           return;
         }
         throw new Error('Failed to fetch users');
@@ -264,6 +273,10 @@ export default function UsersPage() {
         </div>
       </div>
     );
+  }
+
+  if (forbidden) {
+    return <AccessDenied message="You don't have permission to view users." />;
   }
 
   if (error && users.length === 0) {

--- a/apps/web/src/lib/errorMessages.test.ts
+++ b/apps/web/src/lib/errorMessages.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { getErrorMessage, getErrorTitle, isAccessDenied } from './errorMessages';
+
+// #1629 follow-up: a 403 is a permission denial, NOT an expired session. Before
+// the fix, both 401 and 403 mapped to "Session expired / Please sign in again",
+// so a validly-signed-in but permission-limited user was told to sign in again.
+describe('errorMessages — 401 vs 403 distinction', () => {
+  // A real Response so the `error instanceof Response` branch is exercised.
+  const resp = (status: number): Response => new Response(null, { status });
+
+  it('401 (Response) → "Session expired" / "sign in again"', () => {
+    const err = resp(401);
+    expect(getErrorTitle(err)).toBe('Session expired');
+    expect(getErrorMessage(err)).toBe('Your session has expired. Please sign in again.');
+    expect(isAccessDenied(err)).toBe(false);
+  });
+
+  it('403 (Response) → "Access denied" / permission message, NOT session expired', () => {
+    const err = resp(403);
+    expect(getErrorTitle(err)).toBe('Access denied');
+    expect(getErrorMessage(err)).toBe("You don't have permission to view this.");
+    // The two must produce different titles + messages (the core bug).
+    expect(getErrorTitle(err)).not.toBe(getErrorTitle(resp(401)));
+    expect(getErrorMessage(err)).not.toBe(getErrorMessage(resp(401)));
+    expect(isAccessDenied(err)).toBe(true);
+  });
+
+  it('treats any error object carrying status === 403 as access-denied (e.g. ActionError)', () => {
+    const actionLike = Object.assign(new Error('forbidden'), { status: 403 });
+    expect(isAccessDenied(actionLike)).toBe(true);
+    expect(getErrorTitle(actionLike)).toBe('Access denied');
+    expect(getErrorMessage(actionLike)).toBe("You don't have permission to view this.");
+
+    const actionLike401 = Object.assign(new Error('unauthorized'), { status: 401 });
+    expect(isAccessDenied(actionLike401)).toBe(false);
+    expect(getErrorTitle(actionLike401)).toBe('Session expired');
+  });
+
+  it('5xx still maps to a server error and is not access-denied', () => {
+    const err = resp(503);
+    expect(getErrorTitle(err)).toBe('Server error');
+    expect(getErrorMessage(err)).toBe("Something went wrong on our end. We're looking into it.");
+    expect(isAccessDenied(err)).toBe(false);
+  });
+
+  it('network/fetch failures are unchanged and not access-denied', () => {
+    const err = new TypeError('Failed to fetch');
+    expect(getErrorTitle(err)).toBe('Connection error');
+    expect(getErrorMessage(err)).toBe('Unable to reach the server. Check your connection and try again.');
+    expect(isAccessDenied(err)).toBe(false);
+  });
+
+  it('a plain non-status error is not access-denied', () => {
+    expect(isAccessDenied(new Error('boom'))).toBe(false);
+    expect(isAccessDenied('boom')).toBe(false);
+    expect(isAccessDenied(null)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/errorMessages.ts
+++ b/apps/web/src/lib/errorMessages.ts
@@ -1,15 +1,47 @@
 /**
+ * Reads an HTTP status off a thrown error, whether it's a `Response` (the
+ * contract used by `fetchAll*` helpers, which `throw resp` on non-OK) or an
+ * app error object that carries a numeric `.status` (e.g. `ActionError` from
+ * `runAction`). Returns `undefined` when no status can be determined.
+ */
+function getErrorStatus(error: unknown): number | undefined {
+  if (error instanceof Response) return error.status;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    typeof (error as { status: unknown }).status === 'number'
+  ) {
+    return (error as { status: number }).status;
+  }
+  return undefined;
+}
+
+/**
+ * True when an error represents an HTTP 403 (permission denied). A 403 is a
+ * permission denial, not a transient load failure or an expired session, so
+ * callers should render the access-denied state (no misleading "session
+ * expired / try again" UI). Robust to both `Response` and any app error object
+ * carrying `status === 403`.
+ */
+export function isAccessDenied(error: unknown): boolean {
+  return getErrorStatus(error) === 403;
+}
+
+/**
  * Maps fetch errors to user-friendly messages based on error type.
  */
 export function getErrorMessage(error: unknown): string {
   if (error instanceof TypeError && error.message.includes('fetch')) {
     return 'Unable to reach the server. Check your connection and try again.';
   }
-  if (error instanceof Response) {
-    if (error.status === 401 || error.status === 403)
-      return 'Your session has expired. Please sign in again.';
-    if (error.status >= 500)
-      return "Something went wrong on our end. We're looking into it.";
+  const status = getErrorStatus(error);
+  if (status !== undefined) {
+    // 403 is a permission denial, not an expired session — keep them distinct
+    // so we don't tell a validly-signed-in user to "sign in again."
+    if (status === 403) return "You don't have permission to view this.";
+    if (status === 401) return 'Your session has expired. Please sign in again.';
+    if (status >= 500) return "Something went wrong on our end. We're looking into it.";
   }
   const msg = error instanceof Error ? error.message : String(error);
   if (
@@ -29,9 +61,11 @@ export function getErrorTitle(error: unknown): string {
   if (error instanceof TypeError && error.message.includes('fetch')) {
     return 'Connection error';
   }
-  if (error instanceof Response) {
-    if (error.status === 401 || error.status === 403) return 'Session expired';
-    if (error.status >= 500) return 'Server error';
+  const status = getErrorStatus(error);
+  if (status !== undefined) {
+    if (status === 403) return 'Access denied';
+    if (status === 401) return 'Session expired';
+    if (status >= 500) return 'Server error';
   }
   const msg = error instanceof Error ? error.message : String(error);
   if (


### PR DESCRIPTION
## Problem

PR #1629 added permission-gated sidebar nav + an `AccessDenied` component, but the access-denied state was **never shown on an HTTP 403**. A validly-signed-in but permission-limited user (e.g. a Partner-Billing role landing on the Dashboard, `/devices`, or `/settings/users`) saw misleading states instead of a clear "you don't have permission" message.

## Root cause

`apps/web/src/lib/errorMessages.ts` mapped **both** 401 and 403 to "Session expired" / "Your session has expired. Please sign in again." So a 403 (valid session, missing permission) told the user to sign in again. The affected pages either rendered that copy (`DevicesPage`, `DashboardWidgets`) or a generic "Failed to fetch users / Try again" (`UsersPage`) — none rendered the existing `AccessDenied` component, which was only wired into `RolesPage` + `InvoicesPage`. Separately, `Sidebar.renderCollapsibleSection` always rendered a section header even when every item in it was permission-filtered out.

## Changes

1. **`errorMessages.ts`** — distinguish 403 from 401. 401 keeps "Session expired"; 403 now → title **"Access denied"** / message **"You don't have permission to view this."** Added an `isAccessDenied(error)` helper that reads `.status` off both a `Response` and any app error object carrying `status === 403` (e.g. `ActionError` from `runAction`).
2. **Render `AccessDenied` on 403** in:
   - `DevicesPage` — the devices fetch throws the raw `Response`; `isAccessDenied(error)` short-circuits to `AccessDenied` before the generic error banner.
   - `UsersPage` — new `forbidden` state (mirroring `RolesPage`); the `/users` 403 branch renders `AccessDenied` instead of throwing "Failed to fetch users".
   - `DashboardWidgets` — the per-widget fetches swallow their own errors and degrade to empty data, so a 403 was silently rendering zeroes. A small `parseOrFlag403` helper records a 403 and surfaces the access-denied state (no Retry).
   None of these offer a misleading "Try again" / "sign in again" retry on a permission denial.
3. **`Sidebar.tsx`** — hide a collapsible section header entirely when every item is permission-filtered out (no more empty "Monitoring / Security / Backup / Reporting" group headers that expand to nothing). Extracted an `isNavItemVisible` predicate kept in sync with `renderNavItem`'s existing gates; sections with at least one visible item and the always-present top-level items are unaffected.

## Tests

- New `errorMessages.test.ts`: 401 vs 403 produce different titles/messages; `ActionError`-like `status === 403`; `isAccessDenied`; 5xx + network unchanged.
- New `DashboardWidgets.test.tsx`: 403 → `AccessDenied` (no silent zeroes, no Retry/session-expired); success path still renders widget data.
- `DevicesPage.test.tsx` + `UsersPage.test.tsx`: 403 → `AccessDenied`; non-403 load failure still shows the retryable error.
- `Sidebar.rbac.test.tsx`: empty section headers hidden for Partner Billing; all headers shown for admin.

```
pnpm --filter @breeze/web exec vitest run <affected files + no-silent-mutations>
Test Files  7 passed (7)
     Tests  87 passed (87)
```

`tsc --noEmit` clean (0 errors across apps/web). `no-silent-mutations` green (changes don't touch mutation handlers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)