### PR TITLE
fix(web): show loading instead of flash-of-access-denied on partner settings

### DIFF
--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -6,6 +6,7 @@ import PartnerSettingsPage, { runPartnerSave } from './PartnerSettingsPage';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { showToast } from '../shared/Toast';
+import { getJwtClaims } from '../../lib/authScope';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn()
@@ -17,6 +18,14 @@ vi.mock('../../stores/orgStore', () => ({
 
 vi.mock('../shared/Toast', () => ({
   showToast: vi.fn(),
+}));
+
+vi.mock('../../lib/authScope', () => ({
+  getJwtClaims: vi.fn(() => ({ scope: null, orgId: null, partnerId: null })),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
 }));
 
 // Stub the embedded ticketing sub-tab group — we only assert that the Partner
@@ -34,6 +43,7 @@ vi.mock('./TicketingSettingsTabs', () => ({
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 const useOrgStoreMock = vi.mocked(useOrgStore);
 const showToastMock = vi.mocked(showToast);
+const getJwtClaimsMock = vi.mocked(getJwtClaims);
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({
@@ -291,5 +301,89 @@ describe('PartnerSettingsPage Ticketing tab', () => {
     render(<PartnerSettingsPage />);
 
     expect(await screen.findByTestId('stub-ticketing-settings-tabs')).not.toBeNull();
+  });
+});
+
+describe('PartnerSettingsPage access gate (no flash-of-access-denied)', () => {
+  const partnerResponse = {
+    id: 'partner-1',
+    name: 'Acme MSP',
+    slug: 'acme',
+    type: 'partner',
+    plan: 'pro',
+    createdAt: '2026-02-09T00:00:00.000Z',
+    settings: {
+      timezone: 'UTC',
+      dateFormat: 'MM/DD/YYYY',
+      timeFormat: '12h',
+      language: 'en',
+      businessHours: { preset: 'business' },
+      contact: {},
+      address: {},
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    // Default: token claims do NOT confirm partner scope. Individual tests
+    // override this as needed.
+    getJwtClaimsMock.mockReturnValue({ scope: null, orgId: null, partnerId: null });
+  });
+
+  it('shows the loading state (not access-denied) while the partner context is still resolving', () => {
+    // Store is still fetching: currentPartnerId not yet set, isLoading true.
+    useOrgStoreMock.mockReturnValue({
+      currentPartnerId: null,
+      isLoading: true,
+      setPartner: vi.fn(),
+    } as never);
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+
+    render(<PartnerSettingsPage />);
+
+    // Must NOT show the access-denied state during resolution...
+    expect(screen.queryByText('Partner Access Required')).toBeNull();
+    expect(
+      screen.queryByText('Partner settings are only available to partner-level users.')
+    ).toBeNull();
+    // ...it shows the loading affordance instead.
+    expect(screen.getByText('Loading partner settings...')).not.toBeNull();
+  });
+
+  it('renders the settings once a partner user resolves', async () => {
+    useOrgStoreMock.mockReturnValue({
+      currentPartnerId: 'partner-1',
+      isLoading: false,
+      setPartner: vi.fn(),
+    } as never);
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(partnerResponse));
+
+    render(<PartnerSettingsPage />);
+
+    expect(await screen.findByText('Partner Settings')).not.toBeNull();
+    expect(screen.queryByText('Partner Access Required')).toBeNull();
+  });
+
+  it('shows access-denied once resolution confirms a genuine non-partner user', async () => {
+    // Context finished resolving (isLoading false) with no partner, and the JWT
+    // confirms a non-partner scope — the genuine denied case.
+    useOrgStoreMock.mockReturnValue({
+      currentPartnerId: null,
+      isLoading: false,
+      setPartner: vi.fn(),
+    } as never);
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', orgId: 'org-1', partnerId: null });
+
+    render(<PartnerSettingsPage />);
+
+    // The mount effect runs setLoading(false) for the confirmed non-partner
+    // scope, after which the access-denied state must appear.
+    expect(await screen.findByText('Partner Access Required')).not.toBeNull();
+    expect(
+      screen.getByText('Partner settings are only available to partner-level users.')
+    ).not.toBeNull();
+    expect(screen.queryByText('Loading partner settings...')).toBeNull();
   });
 });

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -324,6 +324,26 @@ export default function PartnerSettingsPage() {
     setCustomHours(prev => ({ ...prev, [day]: { ...prev[day], [field]: value } }));
   };
 
+  // Show a loading state while the partner context is still resolving, NOT the
+  // access-denied state. The partner store starts empty (currentPartnerId null)
+  // and only fills after the store fetch or the JWT-seed effect below runs, so
+  // gating "access denied" purely on `!currentPartnerId` flashes the denied UI
+  // for ~1-2s before self-correcting (cousin of the partners.length>0 gating
+  // class). The effect keeps local `loading` true until it has CONFIRMED a
+  // non-partner scope (it calls setLoading(false) only on that branch), so
+  // `loading || contextLoading` is the true "still resolving" signal. Only once
+  // resolution finishes and there is genuinely no partner do we deny access.
+  if (!currentPartnerId && (loading || contextLoading)) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <Loader2 className="h-8 w-8 animate-spin mx-auto text-primary" />
+          <p className="mt-4 text-sm text-muted-foreground">Loading partner settings...</p>
+        </div>
+      </div>
+    );
+  }
+
   if (!currentPartnerId) {
     return (
       <div className="rounded-lg border border-amber-200 bg-amber-50 p-6 text-center dark:border-amber-800 dark:bg-amber-950">


### PR DESCRIPTION
## Root cause

Navigating to `/settings/partner` as a partner-level admin first rendered the full **"Partner Access Required" / "Partner settings are only available to partner-level users."** access-denied state for ~1-2 seconds, then self-corrected to the real partner settings once the partner store resolved. `GET /api/v1/orgs/partners/me` returns **200 the whole time** — the user genuinely IS partner-level.

This is a **gate-before-load / flash-of-access-denied** bug. In `PartnerSettingsPage.tsx` the access-denied gate was evaluated purely on `!currentPartnerId` and ran **before** the loading guard. The partner store (`orgStore`) starts empty (`currentPartnerId === null`) and only fills after the store fetch or the JWT-seed mount effect runs, so the very first render evaluated "denied" against an as-yet-unresolved store. Cousin of the known `partners.length>0` gating class.

## Fix

Gate the access-denied state behind resolution. While the partner context is still resolving — `!currentPartnerId && (loading || contextLoading)` — show the existing loading spinner ("Loading partner settings...") instead of the denied state.

The mount effect already keeps local `loading` true until it has **confirmed** a non-partner scope (it only calls `setLoading(false)` on that branch, after checking JWT claims). So this distinction preserves the **genuine denied case** for real non-partner users (e.g. technicians) — access-denied still renders once resolution finishes with no partner. The fix is scoped to the gating block only; no other page logic changed.

## Test evidence

Added 3 gate cases to `PartnerSettingsPage.test.tsx`:
- (a) partner context still resolving → **loading shown, NOT access-denied**
- (b) resolved partner user → settings render
- (c) resolved genuine non-partner user → access-denied still shown

Verified **non-vacuous**: reverting only the component fix (keeping the new tests) makes case (a) fail (the access-denied heading renders during resolution); restoring the fix makes all pass.

```
pnpm --filter @breeze/web exec vitest run src/components/settings/PartnerSettingsPage.test.tsx
Test Files  1 passed (1)
     Tests  13 passed (13)

pnpm --filter @breeze/web exec tsc --noEmit
EXIT=0  (0 errors)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)