### PR TITLE
fix: GET /alerts/routing-rules should not 400 on load

### DIFF
--- a/apps/api/src/routes/alerts/routing.list.test.ts
+++ b/apps/api/src/routes/alerts/routing.list.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression: GET /alerts/routing-rules must not 400 on load. The Notification
+// Channels page fetches this list on mount with no ?orgId= when no specific org
+// is selected (partner/system scope). The old handler hard-required auth.orgId
+// and 400'd; it now mirrors GET /alerts/channels scope handling and returns an
+// empty list for a clean tenant.
+
+const { authRef, capturedWhere } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as string,
+      user: { id: 'u-1', name: 'Pat Partner', email: 'pat@partner.example' },
+      partnerId: 'p-1' as string | null,
+      orgId: null as string | null,
+      accessibleOrgIds: [] as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  capturedWhere: { current: undefined as unknown },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+// A chainable Drizzle stub: select().from().where().orderBy() resolves to rows
+// and records the where-condition so we can assert what was queried.
+const rowsRef = { current: [] as unknown[] };
+vi.mock('../../db', () => {
+  const builder: any = {
+    from: () => builder,
+    where: (cond: unknown) => {
+      capturedWhere.current = cond;
+      return builder;
+    },
+    orderBy: () => Promise.resolve(rowsRef.current),
+  };
+  return { db: { select: () => builder } };
+});
+vi.mock('../../db/schema', () => ({ notificationRoutingRules: { orgId: { name: 'org_id' } } }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+import { routingRoutes } from './routing';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', routingRoutes);
+  return app;
+}
+
+describe('GET /alerts/routing-rules (list-on-load)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedWhere.current = undefined;
+    rowsRef.current = [];
+  });
+
+  it('returns 200 with an empty list for a partner with no accessible orgs (no orgId)', async () => {
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Pat', email: 'pat@partner.example' },
+      partnerId: 'p-1', orgId: null, accessibleOrgIds: [], canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: [] });
+    // Short-circuited before touching the db — no where-condition captured.
+    expect(capturedWhere.current).toBeUndefined();
+  });
+
+  it('returns 200 (not 400) for a partner with accessible orgs but no orgId selected', async () => {
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Pat', email: 'pat@partner.example' },
+      partnerId: 'p-1', orgId: null, accessibleOrgIds: ['org-a', 'org-b'], canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: [] });
+    // Queried, scoped to the accessible orgs (inArray condition present).
+    expect(capturedWhere.current).toBeDefined();
+  });
+
+  it('returns 200 for an org-scoped user (pinned to own org)', async () => {
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-2', name: 'Olive Org', email: 'olive@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: [] });
+    expect(capturedWhere.current).toBeDefined();
+  });
+
+  it('403 (not 400) for an org-scoped user with no org context', async () => {
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-3', name: 'No Org', email: 'noorg@org.example' },
+      partnerId: null, orgId: null, accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/alerts/routing.ts
+++ b/apps/api/src/routes/alerts/routing.ts
@@ -3,10 +3,15 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { db } from '../../db';
 import { notificationRoutingRules } from '../../db/schema';
-import { eq, and, asc } from 'drizzle-orm';
+import { eq, and, asc, inArray } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { ensureOrgAccess } from './helpers';
 import { PERMISSIONS } from '../../services/permissions';
+
+const listRoutingRulesSchema = z.object({
+  orgId: z.string().guid().optional(),
+});
 
 const createRoutingRuleSchema = z.object({
   name: z.string().min(1).max(255),
@@ -41,18 +46,42 @@ const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, P
 routingRoutes.get(
   '/routing-rules',
   requireScope('organization', 'partner', 'system'),
+  zValidator('query', listRoutingRulesSchema),
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const query = c.req.valid('query');
+
+      // Scope the listing the same way GET /alerts/channels does so the page
+      // can load without a specific org selected. Org-scoped users are pinned to
+      // their own org; partner/system users honour an explicit ?orgId= and
+      // otherwise fall back to all accessible orgs. A clean tenant with no rules
+      // (or a partner with no accessible orgs) returns an empty list — never 400.
+      let orgFilter;
+      if (auth.scope === 'organization') {
+        if (!auth.orgId) {
+          return c.json({ error: 'Organization context required' }, 403);
+        }
+        orgFilter = eq(notificationRoutingRules.orgId, auth.orgId);
+      } else if (query.orgId) {
+        if (!ensureOrgAccess(query.orgId, auth)) {
+          return c.json({ error: 'Access to this organization denied' }, 403);
+        }
+        orgFilter = eq(notificationRoutingRules.orgId, query.orgId);
+      } else if (auth.scope === 'partner') {
+        const orgIds = auth.accessibleOrgIds ?? [];
+        if (orgIds.length === 0) {
+          return c.json({ data: [] });
+        }
+        orgFilter = inArray(notificationRoutingRules.orgId, orgIds);
       }
+      // system scope with no orgId falls through to no filter (sees all rules);
+      // RLS still constrains what breeze_app can read.
 
       const rules = await db
         .select()
         .from(notificationRoutingRules)
-        .where(eq(notificationRoutingRules.orgId, orgId))
+        .where(orgFilter)
         .orderBy(asc(notificationRoutingRules.priority));
 
       return c.json({ data: rules });


### PR DESCRIPTION
## Problem

On the Notification Channels page (`/alerts/channels`), the page fires `GET /api/v1/alerts/routing-rules` on load and it returns **HTTP 400** (logged to the console). The UI degrades gracefully ("0 rules"), so nothing visibly breaks — but a plain list-on-load endpoint 400-ing on a clean/empty tenant is wrong: a GET list should 200 with an empty array.

## Confirmed root cause

The list handler in `apps/api/src/routes/alerts/routing.ts` was naive:

```ts
const orgId = auth.orgId;
if (!orgId) return c.json({ error: 'orgId is required' }, 400);
```

`/alerts/channels` is **not** a global-scope route (`apps/web/src/lib/routeScope.ts`), so `fetchWithAuth` only auto-injects `?orgId=` when a specific org is selected. For a partner/system-scope user with **no org selected** (the default landing state), `auth.orgId` is `null` → the handler 400s.

The sibling on the same page, `GET /alerts/channels` (`apps/api/src/routes/alerts/channels.ts`), is **scope-aware** and 200s in exactly this situation — it scopes partner users to `auth.accessibleOrgIds` and returns `[]` cleanly when empty. `routing-rules` simply never got that treatment. Same class as the `#1636` patches-orgId bug.

## Fix (API side — the smaller, correct side)

Make the **list** handler mirror `GET /alerts/channels` scope handling:

- **organization** scope: pinned to `auth.orgId` (`403` if genuinely absent — unchanged tenant semantics, no longer a 400)
- **partner** scope: honour an explicit, access-checked `?orgId=`; otherwise fall back to `auth.accessibleOrgIds` (empty ⇒ `200 []`), never `400`
- **system** scope: no app filter; RLS still constrains what `breeze_app` can read

Tenant isolation is **not loosened** — org scoping is preserved and an explicit `orgId` is still access-checked via `ensureOrgAccess`. The web caller already passes the scope param it has; the bug was purely the API rejecting the legitimate no-org list. Mutation handlers (`POST`/`PATCH`/`DELETE`) are untouched.

## Test evidence

New unit test `apps/api/src/routes/alerts/routing.list.test.ts` (mirrors the existing `routing.authz.test.ts` style):

- partner, no accessible orgs, no `orgId` → `200 { data: [] }` (short-circuits before DB)
- partner, accessible orgs, no `orgId` selected → `200` (scoped `inArray`), **not 400**
- organization-scoped user → `200`
- organization-scoped user with no org context → `403` (not 400)

```
routing.list.test.ts  ✓ 4 passed
routing.authz.test.ts ✓ 4 passed (no regression)
tsc --noEmit (apps/api) clean (only the pre-existing agents.test.ts / apiKeyAuth.test.ts errors)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)