### PR TITLE
fix(security): multi-tenant authz hardening from security review #1

### DIFF
--- a/apps/api/migrations/2026-06-23-sec-review-1-fk-child-rls-backstop.sql
+++ b/apps/api/migrations/2026-06-23-sec-review-1-fk-child-rls-backstop.sql
@@ -1,0 +1,187 @@
+-- Security review #1 (multi-tenant isolation): RLS backstop for five tenant
+-- child tables that shipped with NO row-level security. Each reaches its tenant
+-- only through a parent FK (no org_id column), so the org_id auto-discovery in
+-- rls-coverage.integration.test.ts never surfaced them and they were never
+-- backstopped. They are contained today by app-layer parent org-checks in every
+-- request path, but CLAUDE.md mandates RLS as the source of truth ("no
+-- app-layer-only fallback"): a future code path that reads/writes these by their
+-- child id without re-checking the parent would silently cross tenants on the
+-- bare breeze_app pool.
+--
+-- Shape follows the canonical FK-child pattern in 2026-05-30-fk-child-tables-rls.sql:
+-- four per-command PERMISSIVE policies, each a single-table `FROM <parent>` EXISTS
+-- (no JOIN — the contract test matches `FROM <parent>` literally). The
+-- config_policy_* children reach their org through a 2–3 hop chain, expressed as
+-- scalar subqueries so the EXISTS still has a single-table `FROM configuration_policies`.
+-- The chain terminates at configuration_policies (org_id NOT NULL, no OR branch),
+-- so it is #1016-safe under bound parameters.
+--
+-- Matching PARENT_FK_JOIN_POLICY_TABLES allowlist entries are added in the same PR.
+-- Idempotent: ENABLE/FORCE are no-ops on re-apply; every policy is DROP IF EXISTS
+-- then CREATE. No inner BEGIN/COMMIT (autoMigrate wraps each file in a txn).
+
+-- ── config_policy_sensitive_data_settings ──────────────────────────────────
+-- feature_link_id → config_policy_feature_links → configuration_policies.org_id
+ALTER TABLE config_policy_sensitive_data_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_sensitive_data_settings FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_sensitive_data_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_sensitive_data_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_sensitive_data_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_sensitive_data_settings;
+CREATE POLICY breeze_org_isolation_select ON config_policy_sensitive_data_settings FOR SELECT USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON config_policy_sensitive_data_settings FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON config_policy_sensitive_data_settings FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON config_policy_sensitive_data_settings FOR DELETE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+
+-- ── config_policy_monitoring_settings ──────────────────────────────────────
+-- feature_link_id → config_policy_feature_links → configuration_policies.org_id
+ALTER TABLE config_policy_monitoring_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_monitoring_settings FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_monitoring_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_monitoring_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_monitoring_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_monitoring_settings;
+CREATE POLICY breeze_org_isolation_select ON config_policy_monitoring_settings FOR SELECT USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON config_policy_monitoring_settings FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON config_policy_monitoring_settings FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON config_policy_monitoring_settings FOR DELETE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND public.breeze_has_org_access(cp.org_id))
+);
+
+-- ── config_policy_monitoring_watches ───────────────────────────────────────
+-- settings_id → config_policy_monitoring_settings → config_policy_feature_links
+--   → configuration_policies.org_id
+ALTER TABLE config_policy_monitoring_watches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_monitoring_watches FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_monitoring_watches;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_monitoring_watches;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_monitoring_watches;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_monitoring_watches;
+CREATE POLICY breeze_org_isolation_select ON config_policy_monitoring_watches FOR SELECT USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON config_policy_monitoring_watches FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON config_policy_monitoring_watches FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND public.breeze_has_org_access(cp.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON config_policy_monitoring_watches FOR DELETE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND public.breeze_has_org_access(cp.org_id))
+);
+
+-- ── dashboard_widgets ──────────────────────────────────────────────────────
+-- dashboard_id → analytics_dashboards.org_id
+ALTER TABLE dashboard_widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dashboard_widgets FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON dashboard_widgets;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON dashboard_widgets;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON dashboard_widgets;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON dashboard_widgets;
+CREATE POLICY breeze_org_isolation_select ON dashboard_widgets FOR SELECT USING (
+  EXISTS (SELECT 1 FROM analytics_dashboards d WHERE d.id = dashboard_widgets.dashboard_id AND public.breeze_has_org_access(d.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON dashboard_widgets FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM analytics_dashboards d WHERE d.id = dashboard_widgets.dashboard_id AND public.breeze_has_org_access(d.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON dashboard_widgets FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM analytics_dashboards d WHERE d.id = dashboard_widgets.dashboard_id AND public.breeze_has_org_access(d.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM analytics_dashboards d WHERE d.id = dashboard_widgets.dashboard_id AND public.breeze_has_org_access(d.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON dashboard_widgets FOR DELETE USING (
+  EXISTS (SELECT 1 FROM analytics_dashboards d WHERE d.id = dashboard_widgets.dashboard_id AND public.breeze_has_org_access(d.org_id))
+);
+
+-- ── backup_snapshot_files ──────────────────────────────────────────────────
+-- snapshot_db_id → backup_snapshots.org_id
+ALTER TABLE backup_snapshot_files ENABLE ROW LEVEL SECURITY;
+ALTER TABLE backup_snapshot_files FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON backup_snapshot_files;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON backup_snapshot_files;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON backup_snapshot_files;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON backup_snapshot_files;
+CREATE POLICY breeze_org_isolation_select ON backup_snapshot_files FOR SELECT USING (
+  EXISTS (SELECT 1 FROM backup_snapshots s WHERE s.id = backup_snapshot_files.snapshot_db_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON backup_snapshot_files FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM backup_snapshots s WHERE s.id = backup_snapshot_files.snapshot_db_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON backup_snapshot_files FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM backup_snapshots s WHERE s.id = backup_snapshot_files.snapshot_db_id AND public.breeze_has_org_access(s.org_id))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM backup_snapshots s WHERE s.id = backup_snapshot_files.snapshot_db_id AND public.breeze_has_org_access(s.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON backup_snapshot_files FOR DELETE USING (
+  EXISTS (SELECT 1 FROM backup_snapshots s WHERE s.id = backup_snapshot_files.snapshot_db_id AND public.breeze_has_org_access(s.org_id))
+);

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -227,6 +227,21 @@ const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new
   ['plugin_logs', ['plugin_installations']],
   ['report_runs', ['reports']],
   ['maintenance_occurrences', ['maintenance_windows']],
+  // 2026-06-23 security-review #1 backstop: five tenant child tables that
+  // shipped with NO rls and reach their org only through a parent FK. The three
+  // config_policy_* children reach the org via a 2–3 hop chain expressed as
+  // scalar subqueries, so the org-bearing parent in their EXISTS `FROM` is
+  // configuration_policies. See 2026-06-23-sec-review-1-fk-child-rls-backstop.sql.
+  ['config_policy_sensitive_data_settings', ['configuration_policies']],
+  ['config_policy_monitoring_settings', ['configuration_policies']],
+  ['config_policy_monitoring_watches', ['configuration_policies']],
+  ['dashboard_widgets', ['analytics_dashboards']],
+  ['backup_snapshot_files', ['backup_snapshots']],
+  // psa_ticket_mappings already shipped a correct single-table-join policy
+  // (2026-04-11-bucket-c-dead-cleanup-rls.sql) but had no org_id column and was
+  // never allowlisted, so the contract test couldn't see it. Register it so a
+  // future regression that drops/weakens the policy is caught.
+  ['psa_ticket_mappings', ['psa_connections']],
 ]);
 
 // Tables scoped to the calling user via breeze_current_user_id().

--- a/apps/api/src/routes/accessReviews.test.ts
+++ b/apps/api/src/routes/accessReviews.test.ts
@@ -62,7 +62,8 @@ vi.mock('../middleware/auth', () => ({
     });
     return next();
   }),
-  requirePermission: vi.fn(() => (c: any, next: any) => next())
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (c: any, next: any) => next())
 }));
 
 vi.mock('../services/tokenRevocation', () => ({

--- a/apps/api/src/routes/accessReviews.ts
+++ b/apps/api/src/routes/accessReviews.ts
@@ -15,7 +15,7 @@ import {
   organizationUsers,
   organizations
 } from '../db/schema';
-import { authMiddleware, requirePermission } from '../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
 import { clearPermissionCache, PERMISSIONS } from '../services/permissions';
 import { writeRouteAudit } from '../services/auditEvents';
 import { revokeAllUserTokens } from '../services/tokenRevocation';
@@ -123,6 +123,7 @@ accessReviewRoutes.get(
 accessReviewRoutes.post(
   '/',
   requirePermission(PERMISSIONS.USERS_WRITE.resource, PERMISSIONS.USERS_WRITE.action),
+  requireMfa(),
   zValidator('json', createReviewSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -303,6 +304,7 @@ accessReviewRoutes.get(
 accessReviewRoutes.patch(
   '/:id/items/:itemId',
   requirePermission(PERMISSIONS.USERS_WRITE.resource, PERMISSIONS.USERS_WRITE.action),
+  requireMfa(),
   zValidator('json', updateItemSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -392,6 +394,7 @@ accessReviewRoutes.patch(
 accessReviewRoutes.post(
   '/:id/complete',
   requirePermission(PERMISSIONS.USERS_WRITE.resource, PERMISSIONS.USERS_WRITE.action),
+  requireMfa(),
   async (c) => {
     const auth = c.get('auth');
     const scopeContext = getScopeContext(auth);

--- a/apps/api/src/routes/cisHardening.ts
+++ b/apps/api/src/routes/cisHardening.ts
@@ -795,6 +795,7 @@ cisHardeningRoutes.post(
         deviceId: cisRemediationActions.deviceId,
         status: cisRemediationActions.status,
         approvalStatus: cisRemediationActions.approvalStatus,
+        requestedBy: cisRemediationActions.requestedBy,
       })
       .from(cisRemediationActions)
       .where(and(...conditions));
@@ -850,6 +851,23 @@ cisHardeningRoutes.post(
         error: 'No pending remediation actions eligible for approval update',
         skippedIds,
       }, 400);
+    }
+
+    // Maker/checker: the requester cannot approve their own pending actions.
+    // CIS remediation queues hardening/rollback commands to endpoints, so the
+    // pending_approval → approved transition is a separation-of-duties control.
+    // Mirror the auditBaselines apply-approval guard. (Denials are skipped on
+    // an approval; an explicit rejection by the requester is still allowed.)
+    if (body.approved) {
+      const selfApprovedIds = actions
+        .filter((action) => pendingIds.includes(action.id) && action.requestedBy === auth.user.id)
+        .map((action) => action.id);
+      if (selfApprovedIds.length > 0) {
+        return c.json({
+          error: 'Requester cannot approve their own remediation actions',
+          selfApprovedIds,
+        }, 403);
+      }
     }
 
     const now = new Date();

--- a/apps/api/src/routes/cisHardening_remediate.test.ts
+++ b/apps/api/src/routes/cisHardening_remediate.test.ts
@@ -339,6 +339,52 @@ describe('CIS hardening routes', () => {
       expect(body.queued).toBe(1);
     });
 
+    it('blocks the requester from approving their own actions (security review #1)', async () => {
+      // The action was requested by the same user now approving it — maker/checker
+      // must reject the self-approval before any status flip or command dispatch.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: ACTION_ID, orgId: ORG_ID, status: 'pending_approval', approvalStatus: 'pending', requestedBy: 'user-1' },
+          ]),
+        }),
+      } as any);
+
+      const res = await app.request('/cis/remediate/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ actionIds: [ACTION_ID], approved: true }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.selfApprovedIds).toEqual([ACTION_ID]);
+      // No remediation was dispatched.
+      expect(vi.mocked(scheduleCisRemediationWithResult)).not.toHaveBeenCalled();
+    });
+
+    it('lets the requester REJECT their own actions (denials are not self-approval)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: ACTION_ID, orgId: ORG_ID, status: 'pending_approval', approvalStatus: 'pending', requestedBy: 'user-1' },
+          ]),
+        }),
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      } as any);
+
+      const res = await app.request('/cis/remediate/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ actionIds: [ACTION_ID], approved: false }),
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).approved).toBe(false);
+    });
+
     it('rejects remediation actions', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/filters.ts
+++ b/apps/api/src/routes/filters.ts
@@ -164,7 +164,7 @@ filterRoutes.post(
       for (const orgId of orgIds) {
         const result = await evaluateFilter(
           conditions as unknown as FilterConditionGroup,
-          { orgId }
+          { orgId, allowedSiteIds: auth.allowedSiteIds }
         );
         deviceIds.push(...result.deviceIds);
       }
@@ -196,7 +196,7 @@ filterRoutes.post(
     for (const orgId of orgIds) {
       const preview = await evaluateFilterWithPreview(
         conditions as unknown as FilterConditionGroup,
-        { orgId, previewLimit: limit }
+        { orgId, previewLimit: limit, allowedSiteIds: auth.allowedSiteIds }
       );
       totalCount += preview.totalCount;
       allDevices.push(...preview.devices);
@@ -452,7 +452,7 @@ filterRoutes.post(
 
     const preview = await evaluateFilterWithPreview(
       filter.conditions as FilterConditionGroup,
-      { orgId: filter.orgId, previewLimit: query.limit }
+      { orgId: filter.orgId, previewLimit: query.limit, allowedSiteIds: auth.allowedSiteIds }
     );
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -167,6 +167,21 @@ async function getGroupWithAccess(
   return group;
 }
 
+/**
+ * Site-axis gate for an existing group. RLS only defends the org axis, so a
+ * site-restricted org user could otherwise mutate/delete a group bound to a
+ * site outside their allowlist (same org). Org-wide groups (siteId null) stay
+ * accessible, matching the read (GET) visibility model. Empty/unset allowlist
+ * (partner/system scope) = full access.
+ */
+export function groupSiteAllowed(
+  group: { siteId: string | null },
+  perms: UserPermissions | undefined
+): boolean {
+  if (!perms?.allowedSiteIds) return true;
+  return group.siteId === null || canAccessSite(perms, group.siteId);
+}
+
 async function getDeviceCountForGroup(groupId: string): Promise<number> {
   const [result] = await db
     .select({ count: sql<number>`count(*)` })
@@ -503,6 +518,11 @@ groupRoutes.patch(
       return c.json({ error: 'Group not found' }, 404);
     }
 
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (!groupSiteAllowed(group, perms)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+
     // Validate parent group if provided
     if (payload.parentId) {
       if (payload.parentId === id) {
@@ -521,6 +541,11 @@ groupRoutes.patch(
       const validSite = await siteBelongsToOrg(payload.siteId, group.orgId);
       if (!validSite) {
         return c.json({ error: 'Site not found or belongs to different organization' }, 400);
+      }
+      // A site-restricted caller cannot re-point a group into a site outside
+      // their allowlist either.
+      if (perms?.allowedSiteIds && !canAccessSite(perms, payload.siteId)) {
+        return c.json({ error: 'Access to this site denied' }, 403);
       }
     }
 
@@ -602,6 +627,10 @@ groupRoutes.delete(
     const group = await getGroupWithAccess(id, auth);
     if (!group) {
       return c.json({ error: 'Group not found' }, 404);
+    }
+
+    if (!groupSiteAllowed(group, c.get('permissions') as UserPermissions | undefined)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
     }
 
     // Check for child groups

--- a/apps/api/src/routes/monitors.ts
+++ b/apps/api/src/routes/monitors.ts
@@ -95,11 +95,12 @@ async function requireMonitorAccess(auth: AuthContext, monitorId: string, permis
   return { monitor } as const;
 }
 
-async function requireAlertRuleAccess(auth: AuthContext, ruleId: string) {
+async function requireAlertRuleAccess(auth: AuthContext, ruleId: string, permissions?: UserPermissions) {
   const [row] = await db
     .select({
       rule: networkMonitorAlertRules,
-      monitorOrgId: networkMonitors.orgId
+      monitorOrgId: networkMonitors.orgId,
+      monitorAssetId: networkMonitors.assetId
     })
     .from(networkMonitorAlertRules)
     .innerJoin(networkMonitors, eq(networkMonitorAlertRules.monitorId, networkMonitors.id))
@@ -113,6 +114,15 @@ async function requireAlertRuleAccess(auth: AuthContext, ruleId: string) {
     if (row.monitorOrgId !== auth.orgId) return { error: 'Alert rule not found.', status: 404 } as const;
   } else {
     if (!auth.canAccessOrg(row.monitorOrgId)) return { error: 'Access denied', status: 403 } as const;
+  }
+
+  // Site-axis re-check: RLS only defends the org axis. A site-restricted user
+  // could otherwise edit/delete alert rules on a monitor in a site outside
+  // their allowlist (same org). Mirror requireMonitorAccess's site gate — the
+  // create path (POST /alerts) already goes through it. Empty/unset allowlist
+  // (partner/system scope) = full access.
+  if (!(await hasMonitorSiteAccess({ orgId: row.monitorOrgId, assetId: row.monitorAssetId }, permissions))) {
+    return { error: 'Access to this site denied', status: 403 } as const;
   }
 
   return row;
@@ -812,7 +822,7 @@ monitorRoutes.patch(
     const auth = c.get('auth') as AuthContext;
     const { id: ruleId } = c.req.valid('param');
     const payload = c.req.valid('json');
-    const accessResult = await requireAlertRuleAccess(auth, ruleId);
+    const accessResult = await requireAlertRuleAccess(auth, ruleId, c.get('permissions') as UserPermissions | undefined);
     if ('error' in accessResult) return c.json({ error: accessResult.error }, accessResult.status);
 
     const [updated] = await db.update(networkMonitorAlertRules)
@@ -844,7 +854,7 @@ monitorRoutes.delete(
   async (c) => {
     const auth = c.get('auth') as AuthContext;
     const { id: ruleId } = c.req.valid('param');
-    const accessResult = await requireAlertRuleAccess(auth, ruleId);
+    const accessResult = await requireAlertRuleAccess(auth, ruleId, c.get('permissions') as UserPermissions | undefined);
     if ('error' in accessResult) return c.json({ error: accessResult.error }, accessResult.status);
 
     const [removed] = await db.delete(networkMonitorAlertRules)

--- a/apps/api/src/routes/remediationSuggestions.test.ts
+++ b/apps/api/src/routes/remediationSuggestions.test.ts
@@ -95,7 +95,32 @@ vi.mock('../services/scriptExecution', () => ({
   executeScriptOnDevices: dbMocks.executeScriptOnDevicesMock,
 }));
 
-import { remediationSuggestionRoutes } from './remediationSuggestions';
+import { remediationSuggestionRoutes, resolvePatchedRiskTier } from './remediationSuggestions';
+
+describe('resolvePatchedRiskTier (security review #1: execution-approval downgrade guard)', () => {
+  it('keeps the stored tier when the client omits riskTier', () => {
+    expect(resolvePatchedRiskTier('critical', undefined)).toBe('critical');
+    expect(resolvePatchedRiskTier('high', null)).toBe('high');
+  });
+
+  it('refuses to LOWER the stored tier (the bypass)', () => {
+    // critical→low downgrade would make /execute skip the elevation approval.
+    expect(resolvePatchedRiskTier('critical', 'low')).toBe('critical');
+    expect(resolvePatchedRiskTier('high', 'medium')).toBe('high');
+    expect(resolvePatchedRiskTier('medium', 'low')).toBe('medium');
+  });
+
+  it('allows RAISING the tier (more approval is always safe)', () => {
+    expect(resolvePatchedRiskTier('low', 'critical')).toBe('critical');
+    expect(resolvePatchedRiskTier('medium', 'high')).toBe('high');
+  });
+
+  it('keeps equal tiers and treats an unknown stored tier as lowest rank', () => {
+    expect(resolvePatchedRiskTier('high', 'high')).toBe('high');
+    // unknown stored tier (rank -1) → any valid requested tier is a raise.
+    expect(resolvePatchedRiskTier('weird', 'low')).toBe('low');
+  });
+});
 
 const baseSuggestion = {
   id: '22222222-2222-4222-8222-222222222222',

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -86,6 +86,26 @@ function requiresExecutionApproval(riskTier: string | null | undefined): boolean
   return riskTier === 'high' || riskTier === 'critical';
 }
 
+const RISK_TIER_RANK: Record<string, number> = { low: 0, medium: 1, high: 2, critical: 3 };
+
+/**
+ * Resolve the riskTier to persist on a PATCH. A caller may RAISE the tier
+ * (asking for more approval) but must never LOWER it: the /execute approval
+ * gate (validateRemediationExecutionApproval) reads the STORED riskTier, so a
+ * downgrade (e.g. critical→low) on a non-MFA PATCH would let a SCRIPTS_EXECUTE
+ * user skip the elevation-approval rail entirely. Clamp to the higher of the
+ * stored and requested tiers so the gate can never be weakened from the client.
+ */
+export function resolvePatchedRiskTier(
+  existing: string,
+  requested: string | null | undefined
+): string {
+  if (requested == null) return existing;
+  const existingRank = RISK_TIER_RANK[existing] ?? -1;
+  const requestedRank = RISK_TIER_RANK[requested] ?? -1;
+  return requestedRank >= existingRank ? requested : existing;
+}
+
 function remediationApprovalRiskTier(riskTier: string | null | undefined): number | null {
   if (riskTier === 'high') return 3;
   if (riskTier === 'critical') return 4;
@@ -978,7 +998,7 @@ remediationSuggestionRoutes.patch(
         title: input.title ?? existing.title,
         rationale: input.rationale ?? existing.rationale,
         expectedAction: input.expectedAction ?? existing.expectedAction,
-        riskTier: input.riskTier ?? existing.riskTier,
+        riskTier: resolvePatchedRiskTier(existing.riskTier, input.riskTier),
         parameters: input.parameters ?? existing.parameters,
         elevationRequestId: input.elevationRequestId === undefined ? existing.elevationRequestId : input.elevationRequestId,
         toolExecutionId: input.toolExecutionId === undefined ? existing.toolExecutionId : input.toolExecutionId,

--- a/apps/api/src/routes/tickets/export.ts
+++ b/apps/api/src/routes/tickets/export.ts
@@ -18,7 +18,14 @@ ticketExportRoutes.get(
   zValidator('query', billablesExportQuerySchema),
   async (c) => {
     const q = c.req.valid('query');
-    const rows = await listBillables(q.from, q.to, q.orgId);
+    const auth = c.get('auth');
+    // A requested orgId must be in the caller's accessible set; otherwise confine
+    // the export to the caller's org allowlist (time_entries is partner-axis RLS,
+    // so omitting orgId would otherwise leak every org under the partner).
+    if (q.orgId && !auth.canAccessOrg(q.orgId)) {
+      return c.json({ error: 'Access to this organization denied' }, 403);
+    }
+    const rows = await listBillables(q.from, q.to, q.orgId, auth.accessibleOrgIds);
     const lines = [CSV_HEADERS.join(',')];
     for (const r of rows) {
       lines.push(csvRow([

--- a/apps/api/src/routes/timeEntries/timeEntries.ts
+++ b/apps/api/src/routes/timeEntries/timeEntries.ts
@@ -101,7 +101,13 @@ timeEntriesApiRoutes.get('/', scopes, readPerm, zValidator('query', listTimeEntr
   const q = c.req.valid('query');
   const actor = timeActorFrom(c);
   // D5: non-admins see only their own entries through the standalone list.
-  const filters = { ...q, userId: actor.manageAll ? q.userId : actor.userId };
+  // Org-axis allowlist confines partner-scope admins to granted orgs (the
+  // partner-axis time_entries RLS does not). (#sec-review-1)
+  const filters = {
+    ...q,
+    userId: actor.manageAll ? q.userId : actor.userId,
+    accessibleOrgIds: actor.accessibleOrgIds,
+  };
   const { entries, total } = await listTimeEntries(filters);
   return c.json({ data: entries, total, limit: q.limit, offset: q.offset });
 });

--- a/apps/api/src/services/filterEngine.ts
+++ b/apps/api/src/services/filterEngine.ts
@@ -462,6 +462,27 @@ export interface EvaluateFilterOptions {
   orgId: string;
   limit?: number;
   offset?: number;
+  /**
+   * Site-axis allowlist (auth.allowedSiteIds). When provided (non-null), results
+   * are additionally confined to these sites. RLS does NOT enforce the site
+   * axis, so a site-restricted caller (org scope) MUST pass it — otherwise the
+   * preview returns the whole org's devices regardless of site restriction.
+   * Omit/null = unrestricted (system/partner scope and the dynamic-group /
+   * deployment / automation back-ends, which run with no per-user site scope).
+   * Empty array = caller has no accessible sites → matches nothing.
+   * (#sec-review-1)
+   */
+  allowedSiteIds?: string[] | null;
+}
+
+/**
+ * Optional site-axis predicate for the devices query. See
+ * EvaluateFilterOptions.allowedSiteIds.
+ */
+function siteScopeCondition(allowedSiteIds: string[] | null | undefined): SQL | undefined {
+  if (allowedSiteIds == null) return undefined;
+  if (allowedSiteIds.length === 0) return sql`false`;
+  return inArray(devices.siteId, allowedSiteIds);
 }
 
 // The `matches` operator emits a Postgres regex (`~`). `MAX_REGEX_PATTERN_LENGTH`
@@ -501,6 +522,7 @@ export async function evaluateFilter(
   options: EvaluateFilterOptions
 ): Promise<FilterEvaluationResult> {
   const { orgId, limit, offset } = options;
+  const siteScope = siteScopeCondition(options.allowedSiteIds);
 
   // Determine which tables we need to join
   const fieldsUsed = extractFieldsFromFilter(filter);
@@ -519,7 +541,7 @@ export async function evaluateFilter(
     tx
       .select({ id: devices.id })
       .from(devices)
-      .where(and(eq(devices.orgId, orgId), filterSQL))
+      .where(and(eq(devices.orgId, orgId), siteScope, filterSQL))
   );
 
   return {
@@ -537,6 +559,7 @@ export async function evaluateFilterWithPreview(
   options: EvaluateFilterOptions & { previewLimit?: number }
 ): Promise<FilterPreviewResult> {
   const { orgId, previewLimit = 10 } = options;
+  const siteScope = siteScopeCondition(options.allowedSiteIds);
 
   const filterSQL = buildGroupSQL(filter);
 
@@ -545,7 +568,7 @@ export async function evaluateFilterWithPreview(
     const [countResult] = await tx
       .select({ count: sql<number>`count(*)` })
       .from(devices)
-      .where(and(eq(devices.orgId, orgId), filterSQL));
+      .where(and(eq(devices.orgId, orgId), siteScope, filterSQL));
 
     // Get preview devices
     const previewDevices = await tx
@@ -558,7 +581,7 @@ export async function evaluateFilterWithPreview(
         lastSeenAt: devices.lastSeenAt
       })
       .from(devices)
-      .where(and(eq(devices.orgId, orgId), filterSQL))
+      .where(and(eq(devices.orgId, orgId), siteScope, filterSQL))
       .limit(previewLimit);
 
     return { countResult, previewDevices };

--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -102,8 +102,31 @@ vi.mock('../db/schema', () => ({
 import {
   computeDurationMinutes, createTimeEntry, startTimer, stopTimer,
   updateTimeEntry, deleteTimeEntry, approveTimeEntries, addTicketPart,
-  getTimesheet, getTicketBillingSummary, listBillables
+  getTimesheet, getTicketBillingSummary, listBillables, entryOrgAllowed
 } from './timeEntryService';
+
+describe('entryOrgAllowed (security review #1: time_entries org-axis allowlist)', () => {
+  it('system scope (accessibleOrgIds null) sees every entry', () => {
+    expect(entryOrgAllowed({ orgId: 'o-1' }, null)).toBe(true);
+    expect(entryOrgAllowed({ orgId: null }, null)).toBe(true);
+  });
+
+  it('confines partner scope to its granted orgs (the cross-org leak)', () => {
+    // orgAccess='selected' admin granted only o-1: an o-9 entry under the same
+    // partner must look "not found" even though partner-axis RLS would return it.
+    expect(entryOrgAllowed({ orgId: 'o-1' }, ['o-1', 'o-2'])).toBe(true);
+    expect(entryOrgAllowed({ orgId: 'o-9' }, ['o-1', 'o-2'])).toBe(false);
+  });
+
+  it('null-org (unlinked) entries carry no org to leak and stay in scope', () => {
+    expect(entryOrgAllowed({ orgId: null }, ['o-1'])).toBe(true);
+    expect(entryOrgAllowed({ orgId: null }, [])).toBe(true);
+  });
+
+  it('empty allowlist denies every org-bound entry', () => {
+    expect(entryOrgAllowed({ orgId: 'o-1' }, [])).toBe(false);
+  });
+});
 
 // accessibleOrgIds null = unrestricted within partner (orgAccess='all' / system).
 // Existing fixtures use 'o-1'/'o-9' etc., so null keeps prior tests passing.

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, isNull, lt, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNull, lt, lte, or, sql, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { timeEntries, ticketParts, tickets, ticketCategories, organizations, users, ticketComments } from '../db/schema';
 import { emitTimeEntryEvent } from './timeEntryEvents';
@@ -372,11 +372,37 @@ export async function stopTimer(input: { description?: string; isBillable?: bool
 
 // ── Update / Delete ──────────────────────────────────────────────────────
 
-async function getEntryOr404(id: string) {
-  // RLS (partner-axis) scopes this read in the request context.
+/**
+ * Org-axis SQL predicate for the partner-axis `time_entries` table. RLS scopes
+ * this table by partner only (Shape 3) — a partner user with orgAccess='selected'
+ * is NOT confined to their granted orgs by RLS, so the org allowlist must be
+ * applied at the app layer (mirrors resolveTicketLink's existing check, which
+ * only fires on the ticket-link path). `null` accessibleOrgIds = system scope
+ * (no filter). Null-org (unlinked) entries carry no org to leak and stay in
+ * scope. (#sec-review-1)
+ */
+function orgAxisSql(accessibleOrgIds: string[] | null): SQL | undefined {
+  if (accessibleOrgIds === null) return undefined;
+  if (accessibleOrgIds.length === 0) return isNull(timeEntries.orgId);
+  return or(isNull(timeEntries.orgId), inArray(timeEntries.orgId, accessibleOrgIds));
+}
+
+/** In-memory counterpart of orgAxisSql for an already-fetched row. */
+export function entryOrgAllowed(entry: { orgId: string | null }, accessibleOrgIds: string[] | null): boolean {
+  if (accessibleOrgIds === null) return true;
+  if (entry.orgId === null) return true;
+  return accessibleOrgIds.includes(entry.orgId);
+}
+
+async function getEntryOr404(id: string, actor: TimeEntryActor) {
+  // RLS (partner-axis) scopes this read to the actor's partner; the org-axis
+  // allowlist is enforced here because RLS does not constrain it.
   const rows = await db.select().from(timeEntries).where(eq(timeEntries.id, id)).limit(1);
   const entry = rows[0];
   if (!entry) throw new TimeEntryServiceError('Time entry not found', 404, 'ENTRY_NOT_FOUND');
+  if (!entryOrgAllowed(entry, actor.accessibleOrgIds)) {
+    throw new TimeEntryServiceError('Time entry not found', 404, 'ENTRY_NOT_FOUND');
+  }
   return entry;
 }
 
@@ -390,7 +416,7 @@ function assertCanMutate(entry: { userId: string; isApproved: boolean }, actor: 
 }
 
 export async function updateTimeEntry(id: string, input: UpdateTimeEntryInput, actor: TimeEntryActor) {
-  const entry = await getEntryOr404(id);
+  const entry = await getEntryOr404(id, actor);
   assertCanMutate(entry, actor);
 
   const startedAt = input.startedAt ?? entry.startedAt;
@@ -447,7 +473,7 @@ export async function updateTimeEntry(id: string, input: UpdateTimeEntryInput, a
 }
 
 export async function deleteTimeEntry(id: string, actor: TimeEntryActor) {
-  const entry = await getEntryOr404(id);
+  const entry = await getEntryOr404(id, actor);
   assertCanMutate(entry, actor);
   await db.delete(timeEntries).where(eq(timeEntries.id, id));
 
@@ -479,11 +505,15 @@ export async function approveTimeEntries(ids: string[], approve: boolean, actor:
   if (!actor.manageAll) {
     throw new TimeEntryServiceError('Approving time entries requires an admin role', 403, 'ADMIN_REQUIRED');
   }
-  // RLS scopes to the actor's partner — out-of-partner ids look "missing", by design.
+  // RLS scopes to the actor's partner — out-of-partner ids look "missing", by
+  // design. The org-axis allowlist is applied here too (RLS is partner-axis
+  // only), so an orgAccess='selected' admin can't approve entries in a
+  // non-granted org under the same partner — those ids also look "missing".
+  const orgAxis = orgAxisSql(actor.accessibleOrgIds);
   const candidates = await db
     .select({ id: timeEntries.id, endedAt: timeEntries.endedAt, partnerId: timeEntries.partnerId, ticketId: timeEntries.ticketId })
     .from(timeEntries)
-    .where(inArray(timeEntries.id, ids));
+    .where(orgAxis ? and(inArray(timeEntries.id, ids), orgAxis) : inArray(timeEntries.id, ids));
 
   const found = new Map(candidates.map((c) => [c.id, c]));
   const skippedReasons: Partial<Record<TimeEntryServiceErrorCode, number>> = {};
@@ -590,6 +620,13 @@ export interface ListTimeEntriesFilters {
   userId?: string;
   ticketId?: string;
   orgId?: string;
+  /**
+   * The caller's org-axis allowlist (auth.accessibleOrgIds). `null`/omitted =
+   * system scope (no org filter). For partner scope this confines the
+   * partner-axis time_entries list to the caller's granted orgs — RLS does not
+   * do it. (#sec-review-1)
+   */
+  accessibleOrgIds?: string[] | null;
   from?: Date;
   to?: Date;
   running?: boolean;
@@ -632,6 +669,13 @@ function listConditions(filters: ListTimeEntriesFilters) {
   if (filters.userId) conditions.push(eq(timeEntries.userId, filters.userId));
   if (filters.ticketId) conditions.push(eq(timeEntries.ticketId, filters.ticketId));
   if (filters.orgId) conditions.push(eq(timeEntries.orgId, filters.orgId));
+  // Org-axis allowlist (partner scope): RLS is partner-axis only, so confine
+  // the list to the caller's granted orgs here. Skipped for system scope
+  // (accessibleOrgIds null/undefined) and when a specific in-scope orgId is set.
+  if (!filters.orgId && filters.accessibleOrgIds != null) {
+    const orgAxis = orgAxisSql(filters.accessibleOrgIds);
+    if (orgAxis) conditions.push(orgAxis);
+  }
   if (filters.from) conditions.push(gte(timeEntries.startedAt, filters.from));
   if (filters.to) conditions.push(lt(timeEntries.startedAt, filters.to));
   if (filters.running !== undefined) {
@@ -770,7 +814,19 @@ const toFinite = (v: string | null): number | null => {
   return n;
 };
 
-export async function listBillables(from: Date, to: Date, orgId?: string): Promise<BillableRow[]> {
+export async function listBillables(
+  from: Date,
+  to: Date,
+  orgId?: string,
+  accessibleOrgIds?: string[] | null
+): Promise<BillableRow[]> {
+  // Org-axis allowlist for the partner-axis time_entries half. RLS scopes
+  // time_entries by partner only, so without this an orgAccess='selected'
+  // partner admin omitting `orgId` would export billing data for every org
+  // under the partner. ticket_parts carries a direct org_id and is already
+  // org-axis RLS-scoped, but we constrain it too for defense-in-depth.
+  // `accessibleOrgIds` null/undefined = system scope (no filter). (#sec-review-1)
+  const applyOrgAxis = !orgId && accessibleOrgIds != null;
   const timeConditions = [
     eq(timeEntries.isBillable, true),
     sql`${timeEntries.endedAt} IS NOT NULL`,
@@ -778,6 +834,10 @@ export async function listBillables(from: Date, to: Date, orgId?: string): Promi
     lte(timeEntries.startedAt, to)
   ];
   if (orgId) timeConditions.push(eq(timeEntries.orgId, orgId));
+  if (applyOrgAxis) {
+    const orgAxis = orgAxisSql(accessibleOrgIds);
+    if (orgAxis) timeConditions.push(orgAxis);
+  }
 
   const timeRows = await db
     .select({
@@ -804,6 +864,10 @@ export async function listBillables(from: Date, to: Date, orgId?: string): Promi
     lte(ticketParts.createdAt, to)
   ];
   if (orgId) partConditions.push(eq(ticketParts.orgId, orgId));
+  if (applyOrgAxis && accessibleOrgIds != null) {
+    // ticket_parts.org_id is NOT NULL; an empty allowlist matches nothing.
+    partConditions.push(inArray(ticketParts.orgId, accessibleOrgIds));
+  }
 
   const partRows = await db
     .select({


### PR DESCRIPTION
## Summary

Findings from the **DEEP multi-tenant isolation + authz security review** (playbook entry #1) of all API route groups. No cross-MSP/cross-tenant breach was found — RLS org/partner isolation holds across the surface. The fixes here address an exploitable privilege-escalation, a partner-axis cross-org leak, several site-axis app-layer gaps, two separation-of-duties/step-up gaps, and three tenant child tables that shipped with no RLS backstop.

Each finding was generated and then independently adversarially re-verified (dropped anything < 8 confidence).

## Findings fixed

| Sev | Finding | Fix |
|-----|---------|-----|
| **HIGH** | `remediationSuggestions` PATCH lets a `scripts:execute` user downgrade `riskTier` (no MFA, no clamp) so `/execute` skips the elevation-approval gate (which reads the **stored** tier) | Clamp `riskTier` on PATCH: may raise, never lower (`resolvePatchedRiskTier`) |
| MEDIUM | `time_entries` is **partner-axis** RLS — an `orgAccess='selected'` partner admin could mutate/approve/delete/list/export time-entries + billables for **non-granted orgs** under the same partner | Apply the org-axis allowlist in `getEntryOr404` / `approveTimeEntries` / `listTimeEntries` / `listBillables` + the billables CSV export (mirrors `resolveTicketLink`) |
| MEDIUM | CIS `/remediate/approve` had no requester≠approver guard before dispatching hardening/rollback commands | Add the maker/checker self-approval guard (mirrors `auditBaselines`) |
| MEDIUM | `accessReviews` create / item-decision / **complete** (mass membership delete + token revoke) lacked `requireMfa()` — every sibling membership mutation requires it | Add `requireMfa()` to all three |
| MEDIUM | Site-axis (`allowedSiteIds`) is **app-layer only** — a site-restricted org user could act cross-site within their org via group PATCH/DELETE, monitor alert-rule PATCH/DELETE, and filter preview | Add the site gate the GET/POST siblings already enforce (`groups`, `monitors.requireAlertRuleAccess`, opt-in `allowedSiteIds` in the filter engine) |
| LOW (DiD) | `config_policy_sensitive_data_settings`, `config_policy_monitoring_settings`, `config_policy_monitoring_watches`, `dashboard_widgets`, `backup_snapshot_files` shipped with **no RLS** (contained today by app-layer parent checks, but CLAUDE.md mandates RLS as the source of truth, and they were invisible to the coverage contract test) | New idempotent migration adds ENABLE+FORCE + parent-FK-join policies; register them (+ the already-correct `psa_ticket_mappings`) in `PARENT_FK_JOIN_POLICY_TABLES` |

## Deferred (follow-up)

Deployment-target and `policyManagement` remediation **site-axis narrowing** require threading user site-scope through shared background engines (`deploymentEngine` / `automationRuntime`), where site-scope is semantically a user-only concern — handled separately to avoid breaking background runs. Same class as the items above (intra-org, cross-site, MEDIUM).

## Verification

- `tsc --noEmit` clean.
- Unit tests: `riskTier` clamp, `time_entries` org-axis (`entryOrgAllowed`); route tests: CIS self-approval (403 + no dispatch), MFA mock added. All touched suites green (single-fork).
- Migration: deparse + allowlist parent-name match validated against Postgres (`pg_policies.qual` renders single-table `FROM configuration_policies`); follows the canonical `2026-05-30-fk-child-tables-rls.sql` pattern; ordering regression test (`autoMigrate.test.ts`) green.

> ℹ️ The `Integration Tests` job runs the `rls-coverage` contract test that validates the migration + allowlist; it runs on this PR after `lint`/`typecheck` pass (also triggered via `workflow_dispatch` on the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)