### PR TITLE
fix(web): use hash (not query param) for Monitoring/Discovery tab state

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -434,7 +434,7 @@ export default function DevicesPage() {
     // (per-type overview pages are deferred to a #1322 follow-up). Route to
     // the existing Discovery asset view, deep-linked to this asset.
     if ((device.deviceClass ?? 'agent') === 'network') {
-      void navigateTo(`/discovery?tab=assets&asset=${device.id}`);
+      void navigateTo(`/discovery?asset=${device.id}#assets`);
       return;
     }
     void navigateTo(`/devices/${device.id}`);

--- a/apps/web/src/components/discovery/DiscoveryPage.test.tsx
+++ b/apps/web/src/components/discovery/DiscoveryPage.test.tsx
@@ -85,7 +85,38 @@ function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500):
 describe('DiscoveryPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    window.history.pushState({}, '', '/discovery?tab=profiles');
+    window.history.pushState({}, '', '/discovery#profiles');
+  });
+
+  it('derives the initial tab from window.location.hash', async () => {
+    window.history.pushState({}, '', '/discovery#topology');
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+
+    render(<DiscoveryPage />);
+
+    expect(await screen.findByText('Topology tab')).toBeInTheDocument();
+  });
+
+  it('defaults to the Assets tab when there is no hash', async () => {
+    window.history.pushState({}, '', '/discovery');
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+
+    render(<DiscoveryPage />);
+
+    expect(await screen.findByText('Assets tab')).toBeInTheDocument();
+  });
+
+  it('updates the hash when a tab is clicked', async () => {
+    window.history.pushState({}, '', '/discovery');
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+
+    render(<DiscoveryPage />);
+    await screen.findByText('Assets tab');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Topology' }));
+
+    expect(window.location.hash).toBe('#topology');
+    expect(await screen.findByText('Topology tab')).toBeInTheDocument();
   });
 
   it('toasts and shows a per-profile loading state while queuing a scan', async () => {

--- a/apps/web/src/components/discovery/DiscoveryPage.tsx
+++ b/apps/web/src/components/discovery/DiscoveryPage.tsx
@@ -234,36 +234,24 @@ function mapProfileToDisplay(profile: ApiDiscoveryProfile): DiscoveryProfile {
   };
 }
 
-function getTabFromURL(): DiscoveryTab {
+function getTabFromHash(): DiscoveryTab {
   if (typeof window === 'undefined') return 'assets';
-  const params = new URLSearchParams(window.location.search);
-  const tab = params.get('tab');
-  if (tab && (DISCOVERY_TABS as readonly string[]).includes(tab)) {
-    return tab as DiscoveryTab;
+  const hash = window.location.hash.replace('#', '');
+  if (hash && (DISCOVERY_TABS as readonly string[]).includes(hash)) {
+    return hash as DiscoveryTab;
   }
   return 'assets';
-}
-
-function pushTabToURL(tab: DiscoveryTab) {
-  if (typeof window === 'undefined') return;
-  const url = new URL(window.location.href);
-  if (tab === 'assets') {
-    url.searchParams.delete('tab');
-  } else {
-    url.searchParams.set('tab', tab);
-  }
-  window.history.pushState({ tab }, '', url.toString());
 }
 
 export default function DiscoveryPage() {
   const [activeTab, setActiveTab] = useState<DiscoveryTab>('assets');
 
-  // Sync tab from URL after hydration + listen for back/forward
+  // Sync tab from the hash after hydration + listen for hash changes.
   useEffect(() => {
-    setActiveTab(getTabFromURL());
-    const onPopState = () => setActiveTab(getTabFromURL());
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
+    setActiveTab(getTabFromHash());
+    const onHashChange = () => setActiveTab(getTabFromHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
   const [profiles, setProfiles] = useState<ApiDiscoveryProfile[]>([]);
   const [profilesLoading, setProfilesLoading] = useState(true);
@@ -550,8 +538,8 @@ export default function DiscoveryPage() {
   };
 
   const navigateToTab = useCallback((tab: DiscoveryTab) => {
+    if (typeof window !== 'undefined') window.location.hash = tab;
     setActiveTab(tab);
-    pushTabToURL(tab);
   }, []);
 
   const handleNavigateToJobs = useCallback((profileId: string) => {

--- a/apps/web/src/components/monitoring/MonitoringAssetsDashboard.tsx
+++ b/apps/web/src/components/monitoring/MonitoringAssetsDashboard.tsx
@@ -710,7 +710,7 @@ function EditMonitoringModal({
                   Add network check
                 </button>
                 <a
-                  href={`/monitoring?tab=checks&assetId=${encodeURIComponent(asset.id)}`}
+                  href={`/monitoring?assetId=${encodeURIComponent(asset.id)}#checks`}
                   className="inline-flex items-center h-8 rounded-md border px-3 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
                   Open checks

--- a/apps/web/src/components/monitoring/MonitoringPage.test.tsx
+++ b/apps/web/src/components/monitoring/MonitoringPage.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MonitoringPage from './MonitoringPage';
+
+vi.mock('./MonitoringAssetsDashboard', () => ({
+  default: () => <div>Assets tab</div>
+}));
+
+vi.mock('../monitors/NetworkMonitorList', () => ({
+  default: () => <div>Checks tab</div>
+}));
+
+vi.mock('../snmp/SNMPTemplateList', () => ({
+  default: () => <div>Templates list</div>
+}));
+
+vi.mock('../snmp/SNMPTemplateEditor', () => ({
+  default: () => <div>Templates editor</div>
+}));
+
+describe('MonitoringPage', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/monitoring');
+  });
+
+  it('derives the initial tab from window.location.hash', () => {
+    window.history.pushState({}, '', '/monitoring#checks');
+
+    render(<MonitoringPage />);
+
+    expect(screen.getByText('Checks tab')).toBeInTheDocument();
+  });
+
+  it('defaults to the Assets tab when there is no hash', () => {
+    window.history.pushState({}, '', '/monitoring');
+
+    render(<MonitoringPage />);
+
+    expect(screen.getByText('Assets tab')).toBeInTheDocument();
+  });
+
+  it('updates the hash and switches tabs when a tab is clicked', () => {
+    window.history.pushState({}, '', '/monitoring');
+
+    render(<MonitoringPage />);
+    expect(screen.getByText('Assets tab')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'SNMP Templates' }));
+
+    expect(window.location.hash).toBe('#templates');
+    expect(screen.getByText('Templates list')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/monitoring/MonitoringPage.tsx
+++ b/apps/web/src/components/monitoring/MonitoringPage.tsx
@@ -7,38 +7,26 @@ import SNMPTemplateEditor from '../snmp/SNMPTemplateEditor';
 const MONITORING_TABS = ['assets', 'checks', 'templates'] as const;
 type MonitoringTab = (typeof MONITORING_TABS)[number];
 
-function getTabFromURL(): MonitoringTab {
+function getTabFromHash(): MonitoringTab {
   if (typeof window === 'undefined') return 'assets';
-  const params = new URLSearchParams(window.location.search);
-  const tab = params.get('tab');
-  if (tab && (MONITORING_TABS as readonly string[]).includes(tab)) {
-    return tab as MonitoringTab;
+  const hash = window.location.hash.replace('#', '');
+  if (hash && (MONITORING_TABS as readonly string[]).includes(hash)) {
+    return hash as MonitoringTab;
   }
   return 'assets';
 }
 
-function pushTabToURL(tab: MonitoringTab) {
-  if (typeof window === 'undefined') return;
-  const url = new URL(window.location.href);
-  if (tab === 'assets') {
-    url.searchParams.delete('tab');
-  } else {
-    url.searchParams.set('tab', tab);
-  }
-  window.history.pushState({ tab }, '', url.toString());
-}
-
 export default function MonitoringPage() {
-  const [activeTab, setActiveTab] = useState<MonitoringTab>(getTabFromURL);
+  const [activeTab, setActiveTab] = useState<MonitoringTab>(getTabFromHash);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | undefined>(undefined);
   const [templateRefreshToken, setTemplateRefreshToken] = useState(0);
   const [initialAssetId, setInitialAssetId] = useState<string | null>(null);
 
-  // Sync active tab when the user navigates back/forward.
+  // Sync active tab when the hash changes (e.g. back/forward navigation).
   useEffect(() => {
-    const onPopState = () => setActiveTab(getTabFromURL());
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
+    const onHashChange = () => setActiveTab(getTabFromHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
 
   useEffect(() => {
@@ -61,8 +49,8 @@ export default function MonitoringPage() {
   const tabButtons = MONITORING_TABS.map((id) => ({ id, label: tabLabels[id] }));
 
   const navigateToTab = useCallback((tab: MonitoringTab) => {
+    if (typeof window !== 'undefined') window.location.hash = tab;
     setActiveTab(tab);
-    pushTabToURL(tab);
   }, []);
 
   return (


### PR DESCRIPTION
## Root cause

The **Network Monitor** (`/monitoring`) and **Network Discovery** (`/discovery`) pages stored their active-tab UI state in a **query param** (`?tab=checks`, `?tab=templates`, etc.). This contradicts the project convention in `CLAUDE.md` ("URL State in Components"):

> Use `window.location.hash` (`#value`) for client-side UI state like selected tabs… Do **not** use query params (`?key=value`) for transient UI state — keep the pattern consistent.

The canonical implementations are `DeviceDetails.tsx` and `OrganizationsPage.tsx` (Backup/Partner settings pages also use `#hash` tabs).

## Fix

Converted both pages to the DeviceDetails hash pattern:
- Read the initial tab from `window.location.hash` on mount via `useState(getTabFromHash)`, defaulting to the first tab (`assets`) when there is no hash.
- Write `window.location.hash` on tab change (replacing `history.pushState` + `?tab=` mutation).
- Listen to `hashchange` instead of `popstate` to keep the active tab in sync.

Deep-link query params that carry **data** are preserved (`?assetId=` on Monitoring, `?asset=` on Discovery) — only the transient `tab` selector moved to the hash.

Updated the two inbound deep-links that pointed at `?tab=`:
- `MonitoringAssetsDashboard` "Open checks" → `/monitoring?assetId=…#checks`
- `DevicesPage` network-device routing → `/discovery?asset=…#assets`

**Out of scope:** the Patches page also uses `?tab=` and is intentionally left untouched, per the task.

## Test evidence

- New `MonitoringPage.test.tsx`: initial tab from hash, default tab with no hash, hash update on tab click.
- Extended `DiscoveryPage.test.tsx` with the same three hash cases (and migrated the existing `beforeEach` from `?tab=profiles` to `#profiles`).

```
Test Files  2 passed (2)
     Tests  10 passed (10)
```

`pnpm --filter @breeze/web exec tsc --noEmit` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)