### PR TITLE
fix(web): auto-derive organization slug from name

### DIFF
--- a/apps/web/src/components/settings/OrganizationForm.test.tsx
+++ b/apps/web/src/components/settings/OrganizationForm.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import OrganizationForm, { slugifyOrganizationName } from './OrganizationForm';
+
+describe('slugifyOrganizationName', () => {
+  it('lowercases, hyphenates, and trims punctuation', () => {
+    expect(slugifyOrganizationName('Acme Corp')).toBe('acme-corp');
+    expect(slugifyOrganizationName('  Globex, Inc. ')).toBe('globex-inc');
+    expect(slugifyOrganizationName('Foo & Bar 42')).toBe('foo-bar-42');
+  });
+});
+
+describe('OrganizationForm slug auto-derive', () => {
+  it('auto-populates the slug from the name as the user types', async () => {
+    const user = userEvent.setup();
+    render(<OrganizationForm />);
+
+    const nameInput = screen.getByLabelText('Organization name');
+    const slugInput = screen.getByLabelText('Slug') as HTMLInputElement;
+
+    await user.type(nameInput, 'Acme Corp');
+
+    expect(slugInput.value).toBe('acme-corp');
+  });
+
+  it('submits successfully with only the name filled (derived slug is valid)', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<OrganizationForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Organization name'), 'Acme Corp');
+    await user.click(screen.getByRole('button', { name: 'Save organization' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      name: 'Acme Corp',
+      slug: 'acme-corp'
+    });
+  });
+
+  it('stops syncing once the slug is manually edited', async () => {
+    const user = userEvent.setup();
+    render(<OrganizationForm />);
+
+    const nameInput = screen.getByLabelText('Organization name');
+    const slugInput = screen.getByLabelText('Slug') as HTMLInputElement;
+
+    await user.type(nameInput, 'Acme');
+    expect(slugInput.value).toBe('acme');
+
+    // User overrides the slug by hand.
+    await user.clear(slugInput);
+    await user.type(slugInput, 'custom-slug');
+    expect(slugInput.value).toBe('custom-slug');
+
+    // Changing the name again must NOT overwrite the manual slug.
+    await user.type(nameInput, ' Corporation');
+    expect(slugInput.value).toBe('custom-slug');
+  });
+
+  it('does not overwrite an existing slug supplied via defaultValues (edit mode)', async () => {
+    const user = userEvent.setup();
+    render(<OrganizationForm defaultValues={{ name: 'Acme', slug: 'existing-slug' }} />);
+
+    const nameInput = screen.getByLabelText('Organization name');
+    const slugInput = screen.getByLabelText('Slug') as HTMLInputElement;
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Renamed Org');
+
+    expect(slugInput.value).toBe('existing-slug');
+  });
+});

--- a/apps/web/src/components/settings/OrganizationForm.tsx
+++ b/apps/web/src/components/settings/OrganizationForm.tsx
@@ -1,7 +1,17 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+
+// Derive a URL-safe slug from an organization name. Matches the slug schema
+// (^[a-z0-9-]+$) and the existing setup-wizard slugify behavior.
+export function slugifyOrganizationName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 100);
+}
 
 const organizationSchema = z
   .object({
@@ -65,6 +75,7 @@ export default function OrganizationForm({
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, isSubmitting }
   } = useForm<z.input<typeof organizationSchema>, unknown, z.output<typeof organizationSchema>>({
     resolver: zodResolver(organizationSchema),
@@ -82,6 +93,14 @@ export default function OrganizationForm({
 
   const isLoading = useMemo(() => loading ?? isSubmitting, [loading, isSubmitting]);
 
+  // Keep the slug linked to the name until the user manually edits the slug.
+  // If the form was seeded with an existing slug (edit mode), treat it as
+  // already manually set so we never overwrite it.
+  const slugManuallyEdited = useRef<boolean>(Boolean(defaultValues?.slug));
+
+  const nameField = register('name');
+  const slugField = register('slug');
+
   return (
     <form
       onSubmit={handleSubmit(async values => {
@@ -98,7 +117,15 @@ export default function OrganizationForm({
             id="organization-name"
             placeholder="Acme Corp"
             className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            {...register('name')}
+            {...nameField}
+            onChange={event => {
+              nameField.onChange(event);
+              if (!slugManuallyEdited.current) {
+                setValue('slug', slugifyOrganizationName(event.target.value), {
+                  shouldValidate: true
+                });
+              }
+            }}
           />
           {errors.name && <p className="text-sm text-destructive">{errors.name.message}</p>}
         </div>
@@ -111,7 +138,12 @@ export default function OrganizationForm({
             id="organization-slug"
             placeholder="acme-corp"
             className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            {...register('slug')}
+            {...slugField}
+            onChange={event => {
+              // Once the user touches the slug, stop syncing it from the name.
+              slugManuallyEdited.current = true;
+              slugField.onChange(event);
+            }}
           />
           {errors.slug && <p className="text-sm text-destructive">{errors.slug.message}</p>}
         </div>


### PR DESCRIPTION
## Root cause

On **Settings -> Organizations** (`/settings/organizations`), the "Add organization" form pairs a **name** field (`Acme Corp`) with a **slug** field whose placeholder (`acme-corp`) implies the slug auto-derives from the name. It did not. Submitting a name-only form failed Zod validation with **"Slug is required"**, forcing the user to hand-type the slug.

This was inconsistent with **Settings -> Custom Fields**, where the **Field Key auto-derives from the Display Name** as you type (e.g. `QA Asset Tag` -> `qa_asset_tag`).

The slug `<input>` was a bare `register('slug')` field with no link to the name, so the server-required slug was never populated client-side.

## Fix

`apps/web/src/components/settings/OrganizationForm.tsx`:

- Added `slugifyOrganizationName(name)` — lowercases, hyphenates non-alphanumerics, trims leading/trailing hyphens, caps at 100 chars. Matches the slug schema (`^[a-z0-9-]+$`) and the existing setup-wizard `slugify` in `OrganizationSetupStep.tsx`.
- The **name** input's `onChange` now derives the slug via `setValue('slug', ...)` — but only while the user hasn't manually edited the slug (standard "linked until manually overridden" UX, like Custom Fields).
- A `useRef` tracks manual slug edits: once the user touches the **slug** field, name changes stop overwriting it.
- Edit mode: a slug seeded via `defaultValues.slug` is treated as already-manual, so it's never clobbered.
- Slug field stays fully editable; **server-side validation is unchanged** — the slug is still required on submit, we just auto-fill a sensible default.

## Test evidence

New `apps/web/src/components/settings/OrganizationForm.test.tsx` (5 tests, all passing):
- `slugifyOrganizationName` lowercases/hyphenates/trims punctuation
- typing a name auto-populates the slug
- name-only submit succeeds with a valid derived slug
- editing the slug by hand stops name->slug syncing (manual slug preserved)
- `defaultValues.slug` (edit mode) is not overwritten on rename

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

`pnpm --filter @breeze/web exec tsc --noEmit` -> 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)