### PR TITLE
fix(web): correct stale API version in sidebar footer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -509,13 +509,13 @@ COMPOSE_PROJECT_NAME=breeze
 
 # BREEZE_VERSION pins the Breeze API/web/binaries images. Update this when
 # upgrading — see https://github.com/lanternops/breeze/releases for current.
-BREEZE_VERSION=0.67.1
+BREEZE_VERSION=0.81.0
 
 # Breeze application images. By default these resolve to the tag matching
 # BREEZE_VERSION above. For higher supply-chain assurance, replace the tag
 # (`:${BREEZE_VERSION}`) with a `@sha256:<digest>` ref from the GHCR package
 # page (https://github.com/orgs/lanternops/packages?repo_name=breeze) or via
-# `docker buildx imagetools inspect ghcr.io/lanternops/breeze/api:0.67.1`.
+# `docker buildx imagetools inspect ghcr.io/lanternops/breeze/api:0.81.0`.
 # The strict digest-pinned production deploy path lives in deploy/.env.example
 # and is enforced by scripts/security/check-supply-chain-hardening.sh.
 BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:${BREEZE_VERSION}

--- a/apps/web/src/lib/version.test.ts
+++ b/apps/web/src/lib/version.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('WEB_VERSION', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses PUBLIC_APP_VERSION when set', async () => {
+    vi.stubEnv('PUBLIC_APP_VERSION', '0.81.0');
+    const { WEB_VERSION } = await import('./version');
+    expect(WEB_VERSION).toBe('0.81.0');
+  });
+
+  it('falls back to the non-semver "dev" sentinel when unset (not a fake "0.1.0")', async () => {
+    vi.stubEnv('PUBLIC_APP_VERSION', '');
+    const { WEB_VERSION } = await import('./version');
+    expect(WEB_VERSION).toBe('dev');
+    // A semver-shaped fallback would be flagged stale/red by the footer's
+    // staleness check; the sentinel renders neutral instead.
+    expect(WEB_VERSION).not.toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/apps/web/src/lib/version.ts
+++ b/apps/web/src/lib/version.ts
@@ -1,1 +1,6 @@
-export const WEB_VERSION = import.meta.env.PUBLIC_APP_VERSION || '0.1.0';
+// Baked at build time from the PUBLIC_APP_VERSION build-arg (driven by
+// BREEZE_VERSION). When unset (local dev / an un-versioned build), fall back to
+// the non-semver sentinel 'dev' so the sidebar footer renders a neutral label
+// rather than a misleading fake-old '0.1.0' that the staleness check would flag
+// red as "update available". Mirrors the API fallback (API_VERSION -> 'dev').
+export const WEB_VERSION = import.meta.env.PUBLIC_APP_VERSION || 'dev';


### PR DESCRIPTION
## Confirmed root cause

The sidebar footer (`apps/web/src/components/layout/Sidebar.tsx`) renders **"Web dev · API 0.63.5"**. The version is **fully environment-driven, not a hardcoded literal** — `grep -r "0.63.5"` matches nothing in the tree:

- **API** version comes from `GET /system/version` → `API_VERSION` (`apps/api/src/version.ts`) ← `process.env.APP_VERSION` ← `docker-compose.yml` maps `APP_VERSION: ${BREEZE_VERSION:-dev}`.
- **Web** version is `WEB_VERSION` (`apps/web/src/lib/version.ts`) ← build-time `PUBLIC_APP_VERSION` (baked via Dockerfile ARG).

So **"API 0.63.5" was a stale `BREEZE_VERSION` in the QA host's `.env`**, not a code defect. In fact the footer's `VersionSpan` already handles this correctly: an old version renders **red** with an "update available" tooltip (covered by the existing `Sidebar.staleness.test.tsx`). "Web dev" is the dev-override build-arg (`docker-compose.override.yml.dev`), which has no real version in hot-reload mode.

There were, however, **two genuinely stale in-repo sources** feeding this exact mechanism, which this PR fixes.

## Fix (minimal)

1. **`.env.example` shipped `BREEZE_VERSION=0.67.1`** while the current release is **v0.81.0**. This is the template self-hosters copy to `.env`, and per the deploy flow it drives the footer version directly. Bumped to `0.81.0` and updated the inline `docker buildx imagetools inspect ...:0.67.1` example to match. (Did **not** introduce a VERSION file — version remains git-tag/env driven, per repo convention.)

2. **Web fallback `'0.1.0'` → `'dev'`.** The old fallback was a misleading semver literal: an un-versioned build rendered it as a real-looking old version that the staleness check flags **red ("update available")**. The non-semver sentinel `'dev'` (mirroring the API `API_VERSION` fallback and the dev-override's `PUBLIC_APP_VERSION: dev`) renders **neutral** instead — honest for an unconfigured build.

## Evidence

- `grep -r "0.67.1" .env.example` → no matches after the change.
- New `apps/web/src/lib/version.test.ts` (2 tests): asserts `WEB_VERSION` uses `PUBLIC_APP_VERSION` when set, and falls back to the non-semver `'dev'` sentinel (not a fake `0.1.0`) when unset.
- `pnpm --filter @breeze/web exec vitest run src/lib/version.test.ts src/components/layout/Sidebar.staleness.test.tsx` → **7 passed**.
- `cd apps/web && npx tsc --noEmit` → **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)