### PR TITLE
fix(auth): harden password-change session invalidation

### DIFF
--- a/apps/api/src/__tests__/authenticated.example.test.ts
+++ b/apps/api/src/__tests__/authenticated.example.test.ts
@@ -76,6 +76,7 @@ vi.mock('../services/tenantStatus', () => ({
 vi.mock('../services/tokenRevocation', () => ({
   isUserTokenRevoked: vi.fn(async () => false),
   revokeUserTokens: vi.fn(async () => {}),
+  isTokenIssuedBeforePasswordChange: vi.fn(() => false),
 }));
 
 import { db } from '../db';

--- a/apps/api/src/__tests__/devices.endpoints.test.ts
+++ b/apps/api/src/__tests__/devices.endpoints.test.ts
@@ -54,6 +54,7 @@ vi.mock('../services/tenantStatus', () => ({
 vi.mock('../services/tokenRevocation', () => ({
   isUserTokenRevoked: vi.fn(async () => false),
   revokeUserTokens: vi.fn(async () => {}),
+  isTokenIssuedBeforePasswordChange: vi.fn(() => false),
 }));
 
 vi.mock('../db', () => ({

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -19,7 +19,8 @@ vi.mock('../services/permissions', () => ({
 }));
 
 vi.mock('../services/tokenRevocation', () => ({
-  isUserTokenRevoked: vi.fn().mockResolvedValue(false)
+  isUserTokenRevoked: vi.fn().mockResolvedValue(false),
+  isTokenIssuedBeforePasswordChange: vi.fn(() => false)
 }));
 
 vi.mock('../services/tenantStatus', () => ({
@@ -58,6 +59,7 @@ vi.mock('../db/schema', () => ({
     email: 'email',
     name: 'name',
     status: 'status',
+    passwordChangedAt: 'passwordChangedAt',
     mfaEnabled: 'mfaEnabled',
     isPlatformAdmin: 'isPlatformAdmin'
   },
@@ -86,7 +88,7 @@ vi.mock('../db/schema', () => ({
 import { Hono } from 'hono';
 import { authMiddleware, requireScope, requirePermission, requireMfa, requireOrg, requirePartner, requireOrgAccess, resolveOrgAccess, AuthContext } from './auth';
 import { verifyToken } from '../services/jwt';
-import { isUserTokenRevoked } from '../services/tokenRevocation';
+import { isTokenIssuedBeforePasswordChange, isUserTokenRevoked } from '../services/tokenRevocation';
 import { db, withDbAccessContext } from '../db';
 import { getUserPermissions, hasPermission, canAccessOrg } from '../services/permissions';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
@@ -99,7 +101,8 @@ const basePayload = {
   partnerId: 'partner-123',
   scope: 'organization' as const,
   type: 'access' as const,
-  mfa: false
+  mfa: false,
+  iat: 1_700_000_000
 };
 
 const activeUser = {
@@ -107,6 +110,7 @@ const activeUser = {
   email: 'test@example.com',
   name: 'Test User',
   status: 'active',
+  passwordChangedAt: null,
   // Default to enrolled so existing tests don't pick up the new role-MFA
   // gate; the gate-specific tests below override this explicitly.
   mfaEnabled: true,
@@ -176,6 +180,7 @@ describe('authMiddleware', () => {
     vi.mocked(db.select).mockReset();
     vi.mocked(verifyToken).mockReset();
     vi.mocked(isUserTokenRevoked).mockResolvedValue(false);
+    vi.mocked(isTokenIssuedBeforePasswordChange).mockReturnValue(false);
     vi.mocked(assertActiveTenantContext).mockResolvedValue(undefined);
   });
 
@@ -234,6 +239,24 @@ describe('authMiddleware', () => {
     });
 
     expect(res.status).toBe(403);
+  });
+
+  it('rejects when the token predates the current password change', async () => {
+    const app = buildAuthApp();
+    const passwordChangedAt = new Date('2026-06-19T10:00:00Z');
+    vi.mocked(verifyToken).mockResolvedValue(basePayload);
+    vi.mocked(isTokenIssuedBeforePasswordChange).mockReturnValue(true);
+    mockUserSelect([{ ...activeUser, passwordChangedAt }]);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(401);
+    expect(isTokenIssuedBeforePasswordChange).toHaveBeenCalledWith(
+      basePayload.iat,
+      passwordChangedAt
+    );
   });
 
   it('sets auth context for valid token', async () => {

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -110,7 +110,7 @@ const activeUser = {
   email: 'test@example.com',
   name: 'Test User',
   status: 'active',
-  passwordChangedAt: null,
+  passwordChangedAt: null as Date | null,
   // Default to enrolled so existing tests don't pick up the new role-MFA
   // gate; the gate-specific tests below override this explicitly.
   mfaEnabled: true,

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { verifyToken, TokenPayload } from '../services/jwt';
 import { getUserPermissions, hasPermission, canAccessOrg, canAccessSite, UserPermissions } from '../services/permissions';
-import { isUserTokenRevoked } from '../services/tokenRevocation';
+import { isTokenIssuedBeforePasswordChange, isUserTokenRevoked } from '../services/tokenRevocation';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
 import { users, partnerUsers, organizationUsers, organizations, roles } from '../db/schema';
 import { and, eq, inArray, isNull, SQL } from 'drizzle-orm';
@@ -323,6 +323,7 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
         email: users.email,
         name: users.name,
         status: users.status,
+        passwordChangedAt: users.passwordChangedAt,
         mfaEnabled: users.mfaEnabled,
         isPlatformAdmin: users.isPlatformAdmin
       })
@@ -337,6 +338,10 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
 
   if (user.status !== 'active') {
     throw new HTTPException(403, { message: 'Account is not active' });
+  }
+
+  if (isTokenIssuedBeforePasswordChange(payload.iat, user.passwordChangedAt)) {
+    throw new HTTPException(401, { message: 'Invalid or expired token' });
   }
 
   try {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -23,7 +23,9 @@ vi.mock('../services', () => ({
   invalidateSession: vi.fn(),
   invalidateAllUserSessions: vi.fn(),
   isUserTokenRevoked: vi.fn().mockResolvedValue(false),
+  isTokenIssuedBeforePasswordChange: vi.fn(() => false),
   revokeAllUserTokens: vi.fn().mockResolvedValue(undefined),
+  revokeAllRefreshTokenFamiliesForUser: vi.fn().mockResolvedValue(undefined),
   isRefreshTokenJtiRevoked: vi.fn().mockResolvedValue(false),
   revokeRefreshTokenJti: vi.fn().mockResolvedValue(true),
   // #1107: rotation-grace helpers. Default mock = "not recently rotated" so
@@ -173,7 +175,9 @@ import {
   generateRecoveryCodes,
   invalidateAllUserSessions,
   isUserTokenRevoked,
+  isTokenIssuedBeforePasswordChange,
   revokeAllUserTokens,
+  revokeAllRefreshTokenFamiliesForUser,
   isRefreshTokenJtiRevoked,
   revokeRefreshTokenJti,
   markRefreshTokenJtiRotated,
@@ -216,6 +220,8 @@ describe('auth routes', () => {
       email: 'test@example.com',
     });
     vi.mocked(isUserTokenRevoked).mockResolvedValue(false);
+    vi.mocked(isTokenIssuedBeforePasswordChange).mockReturnValue(false);
+    vi.mocked(revokeAllRefreshTokenFamiliesForUser).mockResolvedValue(undefined);
     vi.mocked(isRefreshTokenJtiRevoked).mockResolvedValue(false);
     // #1107: reset rotation-grace + family helpers to the happy-path baseline.
     vi.mocked(revokeRefreshTokenJti).mockResolvedValue(true);

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../db/schema', () => ({
     email: 'users.email',
     passwordHash: 'users.passwordHash',
     status: 'users.status',
+    passwordChangedAt: 'users.passwordChangedAt',
     lastLoginAt: 'users.lastLoginAt',
   },
 }));
@@ -43,6 +44,7 @@ vi.mock('../../services', () => ({
   revokeFamily: vi.fn(async () => undefined),
   isFamilyRevoked: vi.fn(async () => false),
   touchFamilyLastUsed: vi.fn(async () => undefined),
+  isTokenIssuedBeforePasswordChange: vi.fn(() => false),
   mintRefreshTokenFamily: vi.fn(async () => 'family-id'),
   bindRefreshJtiToFamily: vi.fn(async () => undefined),
   recordAccountFailure: vi.fn(async () => ({ count: 1, newlyLocked: false })),
@@ -148,6 +150,7 @@ import {
   revokeFamily,
   revokeRefreshTokenJti,
   bindRefreshJtiToFamily,
+  isTokenIssuedBeforePasswordChange,
 } from '../../services';
 import { enforceIpAllowlist } from '../../services/ipAllowlist';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
@@ -272,6 +275,7 @@ describe('POST /login — inactive-tenant observability signal (#719)', () => {
     process.env.NODE_ENV = 'test';
     process.env.E2E_MODE = 'true';
     vi.mocked(enforceIpAllowlist).mockResolvedValue({ decision: 'allow' });
+    vi.mocked(isTokenIssuedBeforePasswordChange).mockReturnValue(false);
     vi.mocked(db.update).mockReturnValue(updateChain() as any);
   });
 
@@ -296,7 +300,9 @@ describe('POST /login — inactive-tenant observability signal (#719)', () => {
     // Generic body — no account/tenant status leaks.
     expect(body).toMatchObject({ error: 'Invalid email or password' });
     expect(JSON.stringify(body)).not.toContain('suspended');
-    expect(recordFailedLogin).toHaveBeenCalledWith('account_inactive');
+    await vi.waitFor(() => {
+      expect(recordFailedLogin).toHaveBeenCalledWith('account_inactive');
+    });
     // Exactly once — a single inactive-account attempt must not double-count.
     // The metric is emitted ONLY via auditUserLoginFailure's internal
     // recordFailedLogin call; login.ts must not add its own (#719 regression).
@@ -329,7 +335,9 @@ describe('POST /login — inactive-tenant observability signal (#719)', () => {
     expect(res.status).toBe(401);
     const body = await res.json() as Record<string, unknown>;
     expect(body).toMatchObject({ error: 'Invalid email or password' });
-    expect(recordFailedLogin).toHaveBeenCalledWith('tenant_inactive');
+    await vi.waitFor(() => {
+      expect(recordFailedLogin).toHaveBeenCalledWith('tenant_inactive');
+    });
     // Exactly once — a single inactive-tenant attempt must not double-count.
     // The metric is emitted ONLY via auditUserLoginFailure's internal
     // recordFailedLogin call; login.ts must not add its own (#719 regression).

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -19,6 +19,7 @@ import {
   revokeFamily,
   isFamilyRevoked,
   touchFamilyLastUsed,
+  isTokenIssuedBeforePasswordChange,
   mintRefreshTokenFamily,
   bindRefreshJtiToFamily,
   recordAccountFailure,
@@ -686,13 +687,23 @@ loginRoutes.post('/refresh', async (c) => {
   // Check if user still exists and is active — pre-auth, wrap in system scope.
   const [user] = await withSystemDbAccessContext(async () =>
     db
-      .select({ id: users.id, email: users.email, status: users.status })
+      .select({
+        id: users.id,
+        email: users.email,
+        status: users.status,
+        passwordChangedAt: users.passwordChangedAt,
+      })
       .from(users)
       .where(eq(users.id, payload.sub))
       .limit(1)
   );
 
   if (!user || user.status !== 'active') {
+    clearRefreshTokenCookie(c);
+    return c.json({ error: 'Invalid refresh token' }, 401);
+  }
+
+  if (isTokenIssuedBeforePasswordChange(payload.iat, user.passwordChangedAt)) {
     clearRefreshTokenCookie(c);
     return c.json({ error: 'Invalid refresh token' }, 401);
   }

--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -8,6 +8,7 @@ const {
   getEligibilityMock,
   getEligibilityForUserMock,
   revokeOauthArtifactsMock,
+  revokeRefreshFamiliesMock,
   revokeAllUserTokensMock,
   recordFailedLoginMock,
 } = vi.hoisted(() => ({
@@ -18,6 +19,7 @@ const {
   getEligibilityMock: vi.fn(),
   getEligibilityForUserMock: vi.fn(),
   revokeOauthArtifactsMock: vi.fn(async () => ({ grantsRevoked: 0, refreshTokensRevoked: 0, jtisRevoked: 0 })),
+  revokeRefreshFamiliesMock: vi.fn(async () => undefined),
   revokeAllUserTokensMock: vi.fn(async () => undefined),
   recordFailedLoginMock: vi.fn(),
 }));
@@ -53,6 +55,7 @@ vi.mock('../../services', () => ({
     getdel: getdelMock,
   })),
   invalidateAllUserSessions: vi.fn(async () => undefined),
+  revokeAllRefreshTokenFamiliesForUser: revokeRefreshFamiliesMock,
   revokeAllUserTokens: revokeAllUserTokensMock,
 }));
 
@@ -149,6 +152,8 @@ describe('password reset eligibility (#719)', () => {
     getEligibilityForUserMock.mockReset();
     revokeOauthArtifactsMock.mockReset();
     revokeOauthArtifactsMock.mockResolvedValue({ grantsRevoked: 0, refreshTokensRevoked: 0, jtisRevoked: 0 });
+    revokeRefreshFamiliesMock.mockReset();
+    revokeRefreshFamiliesMock.mockResolvedValue(undefined);
     revokeAllUserTokensMock.mockReset();
     revokeAllUserTokensMock.mockResolvedValue(undefined);
     recordFailedLoginMock.mockReset();
@@ -313,6 +318,7 @@ describe('password reset eligibility (#719)', () => {
       // Stolen MCP OAuth refresh tokens must be revoked on reset, not just
       // first-party JWTs.
       expect(revokeOauthArtifactsMock).toHaveBeenCalledWith('u-pending');
+      expect(revokeRefreshFamiliesMock).toHaveBeenCalledWith('u-pending', 'password-reset');
       expect(writeAuthAudit).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -344,6 +350,7 @@ describe('password reset eligibility (#719)', () => {
       const body = await res.json() as { success: boolean };
       expect(body.success).toBe(true);
       expect(revokeAllUserTokensMock).toHaveBeenCalledWith('u-pending');
+      expect(revokeRefreshFamiliesMock).toHaveBeenCalledWith('u-pending', 'password-reset');
       expect(revokeOauthArtifactsMock).toHaveBeenCalledWith('u-pending');
     });
 
@@ -382,6 +389,7 @@ describe('password reset eligibility (#719)', () => {
 
       expect(res.status).toBe(400);
       expect(revokeOauthArtifactsMock).not.toHaveBeenCalled();
+      expect(revokeRefreshFamiliesMock).not.toHaveBeenCalled();
     });
 
     it('refuses reset completion if partner became suspended after token issue', async () => {
@@ -476,6 +484,7 @@ describe('password reset eligibility (#719)', () => {
       expect(body.success).toBe(true);
       // A previously authorized MCP OAuth refresh token must be revoked on a
       // password change, not just first-party JWTs.
+      expect(revokeRefreshFamiliesMock).toHaveBeenCalledWith('u-1', 'password-change');
       expect(revokeOauthArtifactsMock).toHaveBeenCalledWith('u-1');
     });
 
@@ -493,6 +502,7 @@ describe('password reset eligibility (#719)', () => {
       const body = await res.json() as { success: boolean };
       expect(body.success).toBe(true);
       expect(revokeAllUserTokensMock).toHaveBeenCalledWith('u-1');
+      expect(revokeRefreshFamiliesMock).toHaveBeenCalledWith('u-1', 'password-change');
       expect(revokeOauthArtifactsMock).toHaveBeenCalledWith('u-1');
     });
 

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -11,6 +11,7 @@ import {
   forgotPasswordLimiter,
   getRedis,
   invalidateAllUserSessions,
+  revokeAllRefreshTokenFamiliesForUser,
   revokeAllUserTokens
 } from '../../services';
 import { getEmailService } from '../../services/email';
@@ -241,6 +242,9 @@ passwordRoutes.post('/reset-password', zValidator('json', resetPasswordSchema), 
   await revokeAllUserTokens(userId).catch((error) =>
     console.error('[auth] Failed to revoke JWTs after password reset:', error),
   );
+  await revokeAllRefreshTokenFamiliesForUser(userId, 'password-reset').catch((error) =>
+    console.error('[auth] Failed to revoke refresh-token families after password reset:', error),
+  );
   await revokeAllUserOauthArtifacts(userId).catch((error) =>
     console.error('[auth] Failed to revoke OAuth artifacts after password reset:', error),
   );
@@ -315,6 +319,9 @@ passwordRoutes.post('/change-password', authMiddleware, zValidator('json', chang
   // failure (e.g. a Redis blip), which is the exact window this revoke closes.
   await revokeAllUserTokens(auth.user.id).catch((error) =>
     console.error('[auth] Failed to revoke JWTs after password change:', error),
+  );
+  await revokeAllRefreshTokenFamiliesForUser(auth.user.id, 'password-change').catch((error) =>
+    console.error('[auth] Failed to revoke refresh-token families after password change:', error),
   );
   await revokeCurrentRefreshTokenJti(c, auth.user.id).catch((error) =>
     console.error('[auth] Failed to revoke current refresh token after password change:', error),

--- a/apps/api/src/services/tokenRevocation.test.ts
+++ b/apps/api/src/services/tokenRevocation.test.ts
@@ -1,15 +1,31 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Redis } from 'ioredis';
 
+const dbMocks = vi.hoisted(() => ({
+  update: vi.fn(),
+  set: vi.fn(),
+  where: vi.fn(),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn())
+}));
+
 // Mock the redis module before importing the module under test
 vi.mock('./redis', () => ({
   getRedis: vi.fn()
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    update: dbMocks.update
+  },
+  withSystemDbAccessContext: dbMocks.withSystemDbAccessContext
 }));
 
 import { getRedis } from './redis';
 import {
   isUserTokenRevoked,
   revokeAllUserTokens,
+  revokeAllRefreshTokenFamiliesForUser,
+  isTokenIssuedBeforePasswordChange,
   isRefreshTokenJtiRevoked,
   revokeRefreshTokenJti,
   markRefreshTokenJtiRotated,
@@ -40,6 +56,10 @@ describe('tokenRevocation', () => {
   beforeEach(() => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
+    dbMocks.where.mockResolvedValue(undefined);
+    dbMocks.set.mockReturnValue({ where: dbMocks.where });
+    dbMocks.update.mockReturnValue({ set: dbMocks.set });
+    dbMocks.withSystemDbAccessContext.mockImplementation(async (fn: () => Promise<unknown>) => fn());
   });
 
   afterEach(() => {
@@ -263,6 +283,38 @@ describe('tokenRevocation', () => {
         expect.stringContaining('Failed to revoke user tokens'),
         expect.any(Error)
       );
+    });
+  });
+
+  describe('revokeAllRefreshTokenFamiliesForUser', () => {
+    it('revokes every refresh-token family for the user under system DB context', async () => {
+      await revokeAllRefreshTokenFamiliesForUser('user-1', 'password-reset');
+
+      expect(dbMocks.withSystemDbAccessContext).toHaveBeenCalledWith(expect.any(Function));
+      expect(dbMocks.update).toHaveBeenCalled();
+      expect(dbMocks.set).toHaveBeenCalledWith({
+        revokedAt: expect.anything(),
+        revokedReason: expect.anything(),
+      });
+      expect(dbMocks.where).toHaveBeenCalled();
+    });
+  });
+
+  describe('isTokenIssuedBeforePasswordChange', () => {
+    it('rejects tokens issued before passwordChangedAt', () => {
+      expect(
+        isTokenIssuedBeforePasswordChange(1_700_000_000, new Date(1_700_000_010_000))
+      ).toBe(true);
+    });
+
+    it('allows tokens issued in the same second as passwordChangedAt', () => {
+      expect(
+        isTokenIssuedBeforePasswordChange(1_700_000_010, new Date(1_700_000_010_500))
+      ).toBe(false);
+    });
+
+    it('fails closed for missing iat after a password change', () => {
+      expect(isTokenIssuedBeforePasswordChange(undefined, new Date())).toBe(true);
     });
   });
 

--- a/apps/api/src/services/tokenRevocation.ts
+++ b/apps/api/src/services/tokenRevocation.ts
@@ -137,6 +137,51 @@ export async function revokeAllUserTokens(userId: string): Promise<void> {
   }
 }
 
+/**
+ * Durable backstop for password reset/change invalidation. Redis revocation is
+ * still the hot path for access tokens, but password changes must also survive a
+ * Redis outage or flush. Revoking every refresh-token family for the user makes
+ * existing refresh cookies fail through `isFamilyRevoked()`'s Postgres check.
+ */
+export async function revokeAllRefreshTokenFamiliesForUser(
+  userId: string,
+  reason: string
+): Promise<void> {
+  const truncatedReason = reason.length > 64 ? reason.slice(0, 64) : reason;
+
+  await dbModule.withSystemDbAccessContext(async () => {
+    await dbModule.db
+      .update(refreshTokenFamilies)
+      .set({
+        revokedAt: sql`COALESCE(revoked_at, now())`,
+        revokedReason: sql`COALESCE(revoked_reason, ${truncatedReason})`,
+      })
+      .where(eq(refreshTokenFamilies.userId, userId));
+  });
+}
+
+export function isTokenIssuedBeforePasswordChange(
+  tokenIssuedAt: number | undefined,
+  passwordChangedAt: Date | string | null | undefined
+): boolean {
+  if (!passwordChangedAt) return false;
+
+  const changedAtMs = passwordChangedAt instanceof Date
+    ? passwordChangedAt.getTime()
+    : new Date(passwordChangedAt).getTime();
+  if (!Number.isFinite(changedAtMs)) return false;
+
+  // A token with no sane iat cannot prove it was minted after the password
+  // changed, so fail closed once passwordChangedAt is set.
+  if (typeof tokenIssuedAt !== 'number' || !Number.isFinite(tokenIssuedAt)) {
+    return true;
+  }
+
+  // JWT iat is second-granularity. Use a strict comparison so a legitimate
+  // immediate re-login in the same second as the password change is not rejected.
+  return tokenIssuedAt < Math.floor(changedAtMs / 1000);
+}
+
 export async function isRefreshTokenJtiRevoked(jti: string): Promise<boolean> {
   const redis = getRedis();
   if (!redis) {


### PR DESCRIPTION
## Summary
- Add a Postgres-backed revocation path for all refresh-token families after password reset/change.
- Reject access and refresh JWTs whose `iat` predates the user's `passwordChangedAt` timestamp.
- Update auth route and token-revocation tests for the durable invalidation path.

## Tests
- `pnpm --filter @breeze/api lint`
- `pnpm exec vitest run src/services/tokenRevocation.test.ts src/middleware/auth.test.ts src/routes/auth/login.test.ts src/routes/auth/password.test.ts src/routes/auth.test.ts`