### PR TITLE
fix(web): preserve set theme on auth pages

### DIFF
--- a/apps/web/src/layouts/AuthLayout.astro
+++ b/apps/web/src/layouts/AuthLayout.astro
@@ -16,6 +16,12 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Breeze RMM - Remote Monitoring and Management" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <!--
+      Apply persisted appearance preferences before first paint. Auth pages can
+      be reached by hard redirects after token expiry, so they cannot rely on
+      the main app layout having installed the theme swap listener.
+    -->
+    <script is:inline src="/theme-bootstrap.js"></script>
     <title>{title} | Breeze RMM</title>
     <ClientRouter />
   </head>

--- a/apps/web/src/layouts/AuthShellBranded.astro
+++ b/apps/web/src/layouts/AuthShellBranded.astro
@@ -22,6 +22,12 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <!--
+      Apply persisted appearance preferences before first paint. Auth pages can
+      be reached by hard redirects after token expiry, so they cannot rely on
+      the main app layout having installed the theme swap listener.
+    -->
+    <script is:inline src="/theme-bootstrap.js"></script>
     <title>{title} | Breeze RMM</title>
     <ClientRouter />
   </head>

--- a/apps/web/src/layouts/themeBootstrap.test.ts
+++ b/apps/web/src/layouts/themeBootstrap.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+function readLayout(name: string): string {
+  return readFileSync(join(process.cwd(), 'src/layouts', name), 'utf8');
+}
+
+describe('auth layout theme bootstrap', () => {
+  it.each(['AuthShellBranded.astro', 'AuthLayout.astro'])(
+    '%s applies persisted appearance before first paint',
+    (layoutName) => {
+      const source = readLayout(layoutName);
+
+      expect(source).toContain('<script is:inline src="/theme-bootstrap.js"></script>');
+      expect(source.indexOf('src="/theme-bootstrap.js"')).toBeLessThan(source.indexOf('<ClientRouter />'));
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- Loads the persisted theme bootstrap script in auth layouts before first paint.
- Keeps logged-out redirects on the login/auth pages consistent with set theme.
- Adds a focused layout test to prevent regressions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Testing

- [ ] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [ ] Manual testing (describe below)

Targeted verification run:

- `git diff --check`
- `pnpm --filter @breeze/web exec vitest run src/components/auth/LoginPage.test.tsx src/layouts/themeBootstrap.test.ts`
- `pnpm --filter @breeze/web lint`
- `pnpm --filter @breeze/web build`

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included