### PR TITLE
feat(billing): seller contact info + Terms & Conditions on quotes & invoices

### DIFF
--- a/apps/api/migrations/2026-06-19-quotes-invoices-contact-fields.sql
+++ b/apps/api/migrations/2026-06-19-quotes-invoices-contact-fields.sql
@@ -1,0 +1,20 @@
+-- Seller "From" contact profile on partners + Terms & Conditions block.
+-- Snapshot columns on invoices/quotes mirror the existing bill_to_* snapshot model.
+-- No new tables → no RLS changes (partners/invoices/quotes already have RLS).
+
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_company_name varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_phone varchar(40);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_website varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_line1 varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_line2 varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_city varchar(120);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_region varchar(120);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_postal_code varchar(40);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_country char(2);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_terms_and_conditions text;
+
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS seller_snapshot jsonb;
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS terms_and_conditions text;
+
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS seller_snapshot jsonb;
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS terms_and_conditions text;

--- a/apps/api/src/__tests__/integration/billing-contact-info.integration.test.ts
+++ b/apps/api/src/__tests__/integration/billing-contact-info.integration.test.ts
@@ -1,0 +1,80 @@
+import './setup';
+import { describe, it, expect, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, organizations, users, invoices } from '../../db/schema';
+
+vi.mock('../../services/invoiceEvents', () => ({ emitInvoiceEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../jobs/invoiceWorker', () => ({ enqueueInvoicePdfRender: vi.fn().mockResolvedValue(undefined) }));
+
+import * as svc from '../../services/invoiceService';
+import type { InvoiceActor } from '../../services/invoiceTypes';
+
+interface Fixture { partnerId: string; orgId: string; userId: string }
+
+async function seedFixture(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `Contact MSP ${sfx}`, slug: `contact-msp-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: 'COrg', slug: `co-${sfx}` })
+      .returning({ id: organizations.id });
+    const [u] = await db.insert(users)
+      .values({ partnerId: p!.id, orgId: o!.id, email: `c-${sfx}@x.io`, name: 'C', status: 'active' })
+      .returning({ id: users.id });
+    return { partnerId: p!.id, orgId: o!.id, userId: u!.id };
+  });
+}
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('billing contact info — snapshot at issue', () => {
+  runDb('persists partner seller contact fields', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    await withSystemDbAccessContext(() => svc.updatePartnerBillingSettings({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingCompanyName: 'Acme MSP LLC', billingPhone: '+1 555 0100', billingWebsite: 'acme.test',
+      billingAddressLine1: '1 Main St', billingAddressCity: 'Austin', billingAddressRegion: 'TX',
+      billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+      billingTermsAndConditions: 'Net 30. Late fee 1.5%/mo.',
+    }, actor));
+    const [p] = await withSystemDbAccessContext(() => db.select().from(partners).where(eq(partners.id, f.partnerId)).limit(1));
+    expect(p!.billingCompanyName).toBe('Acme MSP LLC');
+    expect(p!.billingTermsAndConditions).toContain('Net 30');
+  });
+
+  runDb('snapshots seller contact + defaults T&C onto an issued invoice', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    await withSystemDbAccessContext(() => svc.updatePartnerBillingSettings({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingCompanyName: 'Acme MSP LLC', billingAddressLine1: '1 Main St', billingAddressCountry: 'US',
+      billingTermsAndConditions: 'Net 30.',
+    }, actor));
+    const inv = await withSystemDbAccessContext(() => svc.createManualInvoice({ orgId: f.orgId }, actor));
+    await withSystemDbAccessContext(() => svc.addManualLine(inv.id, { description: 'Labor', quantity: 1, unitPrice: 100, taxable: false }, actor));
+    await withSystemDbAccessContext(() => svc.issueInvoice(inv.id, actor));
+    const [issued] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, inv.id)).limit(1));
+    const snap = issued!.sellerSnapshot as { name: string; address: { line1: string } };
+    expect(snap.name).toBe('Acme MSP LLC');
+    expect(snap.address.line1).toBe('1 Main St');
+    expect(issued!.termsAndConditions).toBe('Net 30.');
+  });
+
+  runDb('does not overwrite a draft-supplied T&C with the partner default', async () => {
+    const f = await seedFixture();
+    const actor: InvoiceActor = { userId: f.userId, partnerId: f.partnerId, accessibleOrgIds: [f.orgId] };
+    await withSystemDbAccessContext(() => svc.updatePartnerBillingSettings({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingTermsAndConditions: 'Default terms',
+    }, actor));
+    const inv = await withSystemDbAccessContext(() => svc.createManualInvoice({ orgId: f.orgId, termsAndConditions: 'Custom per-invoice terms' }, actor));
+    await withSystemDbAccessContext(() => svc.addManualLine(inv.id, { description: 'Labor', quantity: 1, unitPrice: 100, taxable: false }, actor));
+    await withSystemDbAccessContext(() => svc.issueInvoice(inv.id, actor));
+    const [issued] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, inv.id)).limit(1));
+    expect(issued!.termsAndConditions).toBe('Custom per-invoice terms');
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
@@ -43,6 +43,32 @@ describe('quote accept → convert', () => {
     expect(inv!.total).toBe('250.00');
   });
 
+  // The auto-issued invoice must carry the quote's frozen seller snapshot, T&C, and
+  // terms footer — the customer signed against a proposal that showed this info;
+  // the invoice they receive must match.
+  runDb('auto-issued invoice carries seller snapshot, termsAndConditions, and terms from the quote', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Onboarding', quantity: 1, unitPrice: 250, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    // Overwrite the snapshot AFTER send — sendQuote unconditionally stamps
+    // buildSellerSnapshot(partnerRow), so we must patch it post-send to simulate
+    // a quote whose frozen seller info differs from the partner's live values.
+    const sellerSnap = { name: 'Acme MSP LLC', address: null, phone: null, email: null, website: null };
+    await withSystemDbAccessContext(() => db.update(quotes).set({
+      sellerSnapshot: sellerSnap,
+      termsAndConditions: 'Net 30 terms',
+      terms: 'Footer line',
+    }).where(eq(quotes.id, created.id)));
+
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane Buyer' }));
+    const [inv] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, res.invoiceId)));
+    expect((inv!.sellerSnapshot as { name: string } | null)?.name).toBe('Acme MSP LLC');
+    expect(inv!.termsAndConditions).toBe('Net 30 terms');
+    expect(inv!.terms).toBe('Footer line');
+  });
+
   // Phase 3 (auto-issue on accept): the converted invoice is ISSUED (status=sent,
   // invoice number, balance = quote one-time total) so the customer can pay it
   // immediately via the existing pay-link — using the accepted quote's locked

--- a/apps/api/src/db/schema/invoices.ts
+++ b/apps/api/src/db/schema/invoices.ts
@@ -48,6 +48,8 @@ export const invoices = pgTable('invoices', {
   billToTaxExempt: boolean('bill_to_tax_exempt').notNull().default(false),
   notes: text('notes'),
   terms: text('terms'),
+  sellerSnapshot: jsonb('seller_snapshot'),
+  termsAndConditions: text('terms_and_conditions'),
   sentAt: timestamp('sent_at'),
   firstViewedAt: timestamp('first_viewed_at'),
   viewedAt: timestamp('viewed_at'),

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -38,6 +38,16 @@ export const partners = pgTable('partners', {
   invoiceNumberPrefix: varchar('invoice_number_prefix', { length: 12 }).notNull().default('INV'),
   invoiceTermsDays: integer('invoice_terms_days').notNull().default(30),
   invoiceFooter: text('invoice_footer'),
+  billingCompanyName: varchar('billing_company_name', { length: 255 }),
+  billingPhone: varchar('billing_phone', { length: 40 }),
+  billingWebsite: varchar('billing_website', { length: 255 }),
+  billingAddressLine1: varchar('billing_address_line1', { length: 255 }),
+  billingAddressLine2: varchar('billing_address_line2', { length: 255 }),
+  billingAddressCity: varchar('billing_address_city', { length: 120 }),
+  billingAddressRegion: varchar('billing_address_region', { length: 120 }),
+  billingAddressPostalCode: varchar('billing_address_postal_code', { length: 40 }),
+  billingAddressCountry: char('billing_address_country', { length: 2 }),
+  billingTermsAndConditions: text('billing_terms_and_conditions'),
   // AI for Office is a per-partner entitlement the platform operator grants
   // (off by default). The session-minting exchange and the /client-ai/admin
   // surface gate on this; it is NOT in settings JSONB because that is

--- a/apps/api/src/db/schema/quotes.ts
+++ b/apps/api/src/db/schema/quotes.ts
@@ -43,6 +43,8 @@ export const quotes = pgTable('quotes', {
   billToTaxId: varchar('bill_to_tax_id', { length: 100 }),
   introNotes: text('intro_notes'),
   terms: text('terms'),
+  sellerSnapshot: jsonb('seller_snapshot'),
+  termsAndConditions: text('terms_and_conditions'),
   declineReason: text('decline_reason'),
   convertedInvoiceId: uuid('converted_invoice_id'),
   pdfDocumentRef: text('pdf_document_ref'),

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -54,11 +54,34 @@ quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
   if (!quote || quote.status === 'draft') return c.json({ error: 'Quote not found' }, 404);
   const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
   const lines = await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder);
-  const [partner] = await db.select().from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+  // partners is a partner-axis RLS table — the portal request runs in ORG scope,
+  // where breeze_has_partner_access is false. A bare read returns 0 rows with NO
+  // error (the #1375 class), causing buildSellerSnapshot(undefined) to produce an
+  // all-null From block on legacy quotes whose seller_snapshot is NULL. Read under
+  // SYSTEM scope, exactly like the sibling portal/invoices.ts pay/settle paths do.
+  const [partner] = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    db.select({
+      name: partners.name,
+      billingCompanyName: partners.billingCompanyName,
+      billingEmail: partners.billingEmail,
+      billingPhone: partners.billingPhone,
+      billingWebsite: partners.billingWebsite,
+      billingAddressLine1: partners.billingAddressLine1,
+      billingAddressLine2: partners.billingAddressLine2,
+      billingAddressCity: partners.billingAddressCity,
+      billingAddressRegion: partners.billingAddressRegion,
+      billingAddressPostalCode: partners.billingAddressPostalCode,
+      billingAddressCountry: partners.billingAddressCountry,
+      invoiceFooter: partners.invoiceFooter,
+      currencyCode: partners.currencyCode,
+    }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1)
+  ));
   const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
   const loadImage = async (imageId: string) => { const img = await readQuoteImage(imageId, id); return img ? { data: img.data } : null; };
   const { renderQuotePdf } = await import('../../services/quotePdf');
-  const quoteForRender = { ...quote, sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partner) };
+  // Legacy/draft docs have no frozen snapshot; synthesize from the live partner so
+  // the From block still renders (issued docs use the frozen column).
+  const quoteForRender = { ...quote, sellerSnapshot: quote.sellerSnapshot ?? (partner ? buildSellerSnapshot(partner) : null) };
   const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, {
     partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
     footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -15,6 +15,7 @@ import { readQuoteImage } from '../../services/quoteImageStorage';
 import { QuoteServiceError } from '../../services/quoteTypes';
 import { InvoiceServiceError } from '../../services/invoiceTypes';
 import { safeContentDispositionFilename } from '../../utils/httpHeaders';
+import { buildSellerSnapshot } from '../../services/sellerSnapshot';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 
 export const quoteRoutes = new Hono();
@@ -53,13 +54,14 @@ quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
   if (!quote || quote.status === 'draft') return c.json({ error: 'Quote not found' }, 404);
   const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
   const lines = await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder);
-  const [partner] = await db.select({ name: partners.name, footer: partners.invoiceFooter, currency: partners.currencyCode }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+  const [partner] = await db.select().from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
   const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
   const loadImage = async (imageId: string) => { const img = await readQuoteImage(imageId, id); return img ? { data: img.data } : null; };
   const { renderQuotePdf } = await import('../../services/quotePdf');
-  const pdf = await renderQuotePdf(quote, blocks, lines, loadImage, {
+  const quoteForRender = { ...quote, sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partner) };
+  const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, {
     partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
-    footer: quote.terms ?? partner?.footer ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? partner?.currency ?? 'USD',
+    footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',
   });
   const filename = safeContentDispositionFilename(`quote-${quote.quoteNumber || quote.id}.pdf`);
   return new Response(new Uint8Array(pdf), { status: 200, headers: { 'Content-Type': 'application/pdf', 'Content-Disposition': `inline; filename="${filename}"`, 'Content-Length': String(pdf.length) } });

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -111,7 +111,9 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
 
     const quoteForRender = {
       ...quote,
-      sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partner),
+      // Legacy/draft docs have no frozen snapshot; synthesize from the live partner so
+      // the From block still renders (issued docs use the frozen column).
+      sellerSnapshot: quote.sellerSnapshot ?? (partner ? buildSellerSnapshot(partner) : null),
     };
 
     // Real image loader: pull bytes from quote_images, constrained to BOTH the

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -18,6 +18,7 @@ import { quoteImages } from '../../db/schema/quotes';
 import { partners } from '../../db/schema/orgs';
 import { portalBranding } from '../../db/schema/portal';
 import { safeContentDispositionFilename } from '../../utils/httpHeaders';
+import { buildSellerSnapshot } from '../../services/sellerSnapshot';
 
 export const quoteCrudRoutes = new Hono();
 const scopes = requireScope('partner', 'system');
@@ -94,7 +95,7 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
     const { quote, blocks, lines } = await getQuote(id, quoteActorFrom(c));
 
     const [partner] = await db
-      .select({ name: partners.name, footer: partners.invoiceFooter, currency: partners.currencyCode })
+      .select()
       .from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
     const [brand] = await db
       .select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText })
@@ -104,8 +105,13 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
       partnerName: partner?.name ?? 'Proposal',
       logoUrl: brand?.logoUrl ?? null,
       primaryColor: brand?.primaryColor ?? null,
-      footer: quote.terms ?? partner?.footer ?? brand?.footerText ?? null,
-      currencyCode: quote.currencyCode ?? partner?.currency ?? 'USD',
+      footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null,
+      currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',
+    };
+
+    const quoteForRender = {
+      ...quote,
+      sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partner),
     };
 
     // Real image loader: pull bytes from quote_images, constrained to BOTH the
@@ -122,7 +128,7 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
     };
 
     const { renderQuotePdf } = await import('../../services/quotePdf');
-    const pdf = await renderQuotePdf(quote, blocks, lines, loadImage, branding);
+    const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, branding);
 
     const filename = safeContentDispositionFilename(`quote-${quote.quoteNumber || quote.id}.pdf`);
     return new Response(new Uint8Array(pdf), {

--- a/apps/api/src/services/invoicePdf.test.ts
+++ b/apps/api/src/services/invoicePdf.test.ts
@@ -140,3 +140,32 @@ describe('renderInvoicePdfBuffer', () => {
     expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Seller From block + T&C tests
+// ---------------------------------------------------------------------------
+
+const sellerSnapshot = {
+  name: 'Acme MSP LLC', phone: '+1 555 0100', email: 'billing@acme.test', website: 'acme.test',
+  address: { line1: '1 Main St', line2: null, city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' },
+};
+
+it('renderInvoiceHtml shows the From block and T&C', () => {
+  const html = renderInvoiceHtml(
+    { invoiceNumber: 'INV-1', currencyCode: 'USD', subtotal: '10', taxTotal: '0', total: '10', amountPaid: '0', balance: '10', billToName: 'Cust', sellerSnapshot, termsAndConditions: 'Net 30 terms' } as never,
+    [],
+    { partnerName: 'Acme MSP LLC' },
+  );
+  expect(html).toContain('From');
+  expect(html).toContain('billing@acme.test');
+  expect(html).toContain('Net 30 terms');
+});
+
+it('renderInvoicePdfBuffer emits a %PDF with a seller snapshot present', async () => {
+  const buf = await renderInvoicePdfBuffer(
+    { invoiceNumber: 'INV-1', currencyCode: 'USD', subtotal: '10', taxTotal: '0', total: '10', amountPaid: '0', balance: '10', billToName: 'Cust', sellerSnapshot, termsAndConditions: 'Net 30' } as never,
+    [],
+    { partnerName: 'Acme MSP LLC' },
+  );
+  expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+});

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -24,6 +24,7 @@ import { getEmailService, buildInvoiceTemplate } from './email';
 import { emitInvoiceEvent } from './invoiceEvents';
 import { InvoiceServiceError } from './invoiceTypes';
 import type { InvoiceActor } from './invoiceTypes';
+import { buildSellerSnapshot, sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
 
 type InvoiceRow = typeof invoices.$inferSelect;
 type InvoiceLineRow = typeof invoiceLines.$inferSelect;
@@ -93,6 +94,8 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
     : '#2563eb';
   const groups = groupVisibleLinesByTicket(lines);
   const billTo = addressLines(invoice.billToAddress as BillToAddress | null);
+  const seller = (invoice.sellerSnapshot as SellerSnapshot | null) ?? null;
+  const sellerLines = sellerAddressLines(seller);
 
   const logoHtml = branding.logoUrl
     ? `<img src="${escapeHtml(branding.logoUrl)}" alt="${escapeHtml(branding.partnerName)}" style="max-height:56px;max-width:220px;" />`
@@ -125,6 +128,14 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
       </div>
       <div style="padding:24px;display:flex;justify-content:space-between;gap:24px;">
         <div>
+          <div style="font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;">From</div>
+          <div style="font-size:14px;font-weight:600;color:#111827;margin-top:4px;">${escapeHtml(seller?.name ?? branding.partnerName)}</div>
+          ${sellerLines.map((l) => `<div style="font-size:13px;color:#4b5563;">${escapeHtml(l)}</div>`).join('')}
+          ${seller?.phone ? `<div style="font-size:12px;color:#6b7280;">${escapeHtml(seller.phone)}</div>` : ''}
+          ${seller?.email ? `<div style="font-size:12px;color:#6b7280;">${escapeHtml(seller.email)}</div>` : ''}
+          ${seller?.website ? `<div style="font-size:12px;color:#6b7280;">${escapeHtml(seller.website)}</div>` : ''}
+        </div>
+        <div>
           <div style="font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;">Bill to</div>
           <div style="font-size:14px;font-weight:600;color:#111827;margin-top:4px;">${escapeHtml(invoice.billToName ?? '')}</div>
           ${billTo.map((l) => `<div style="font-size:13px;color:#4b5563;">${escapeHtml(l)}</div>`).join('')}
@@ -155,6 +166,7 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
         </table>
       </div>
       ${invoice.notes ? `<div style="padding:0 24px 16px;font-size:13px;color:#4b5563;">${escapeHtml(invoice.notes)}</div>` : ''}
+      ${invoice.termsAndConditions ? `<div style="padding:0 24px 16px;font-size:12px;color:#6b7280;"><div style="font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;margin-bottom:4px;">Terms &amp; Conditions</div>${escapeHtml(invoice.termsAndConditions)}</div>` : ''}
       ${(invoice.terms || branding.footerText) ? `<div style="padding:16px 24px;border-top:1px solid #e5e7eb;font-size:12px;color:#9ca3af;">${escapeHtml(invoice.terms ?? branding.footerText ?? '')}</div>` : ''}
     </div>
   </div>
@@ -197,25 +209,34 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       doc.fillColor('#6b7280').fontSize(10).font('Helvetica').text(invoice.invoiceNumber ?? 'DRAFT', left, 74, { width: contentWidth, align: 'right' });
       doc.moveTo(left, 96).lineTo(right, 96).lineWidth(2).strokeColor(primary).stroke();
 
-      // Bill-to block + dates.
+      // From (seller) — left column; Bill To — right column; dates under Bill To.
+      const seller = (invoice.sellerSnapshot as SellerSnapshot | null) ?? null;
+      const rightX = left + contentWidth * 0.55;
+      const rightW = contentWidth * 0.45;
       let y = 112;
-      doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('BILL TO', left, y);
-      doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(invoice.billToName ?? '', left, y + 12);
+
+      doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('FROM', left, y);
+      doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? branding.partnerName, left, y + 12, { width: contentWidth * 0.5 });
+      let fromY = y + 28;
+      doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+      for (const aline of sellerAddressLines(seller)) { doc.text(aline, left, fromY, { width: contentWidth * 0.5 }); fromY += 13; }
+      doc.fillColor('#6b7280').fontSize(9);
+      if (seller?.phone) { doc.text(seller.phone, left, fromY, { width: contentWidth * 0.5 }); fromY += 12; }
+      if (seller?.email) { doc.text(seller.email, left, fromY, { width: contentWidth * 0.5 }); fromY += 12; }
+      if (seller?.website) { doc.text(seller.website, left, fromY, { width: contentWidth * 0.5 }); fromY += 12; }
+
+      doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('BILL TO', rightX, y, { width: rightW });
+      doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(invoice.billToName ?? '', rightX, y + 12, { width: rightW });
       let billY = y + 28;
       doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
-      for (const aline of addressLines(invoice.billToAddress as BillToAddress | null)) {
-        doc.text(aline, left, billY); billY += 13;
-      }
-      if (invoice.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${invoice.billToTaxId}`, left, billY); billY += 13; }
-
-      const dateX = left + contentWidth * 0.6;
-      let dateY = y;
+      for (const aline of addressLines(invoice.billToAddress as BillToAddress | null)) { doc.text(aline, rightX, billY, { width: rightW }); billY += 13; }
+      if (invoice.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${invoice.billToTaxId}`, rightX, billY, { width: rightW }); billY += 13; }
       doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
-      if (invoice.issueDate) { doc.text(`Issued: ${formatDate(invoice.issueDate)}`, dateX, dateY, { width: contentWidth * 0.4, align: 'right' }); dateY += 14; }
-      if (invoice.dueDate) { doc.text(`Due: ${formatDate(invoice.dueDate)}`, dateX, dateY, { width: contentWidth * 0.4, align: 'right' }); dateY += 14; }
+      if (invoice.issueDate) { doc.text(`Issued: ${formatDate(invoice.issueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
+      if (invoice.dueDate) { doc.text(`Due: ${formatDate(invoice.dueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
 
-      // Line table.
-      y = Math.max(billY, dateY) + 20;
+      // Line table starts below the taller of the two columns.
+      y = Math.max(fromY, billY) + 20;
       const colQtyX = left + contentWidth * 0.62;
       const colAmtX = left + contentWidth * 0.80;
       const colDescW = contentWidth * 0.60;
@@ -264,10 +285,17 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
         drawTotal('Balance due', invoice.balance, true);
       }
 
-      // Notes + footer/terms.
+      // Notes (memo) + Terms & Conditions + footer/terms.
       if (invoice.notes) {
         y += 14;
+        doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('NOTES', left, y); y += 12;
         doc.fillColor('#4b5563').fontSize(10).font('Helvetica').text(invoice.notes, left, y, { width: contentWidth });
+        y = doc.y + 8;
+      }
+      if (invoice.termsAndConditions) {
+        y += 6;
+        doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('TERMS & CONDITIONS', left, y); y += 12;
+        doc.fillColor('#6b7280').fontSize(9).font('Helvetica').text(invoice.termsAndConditions, left, y, { width: contentWidth });
         y = doc.y + 8;
       }
       const footer = invoice.terms ?? branding.footerText ?? null;
@@ -291,8 +319,11 @@ async function loadInvoiceForRender(invoiceId: string): Promise<{ invoice: Invoi
   const [invoice] = await db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1);
   if (!invoice) return null;
   const lines = await db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, invoiceId)).orderBy(invoiceLines.sortOrder);
-  const [partner] = await db.select({ name: partners.name, footer: partners.invoiceFooter, currency: partners.currencyCode }).from(partners).where(eq(partners.id, invoice.partnerId)).limit(1);
+  const [partner] = await db.select().from(partners).where(eq(partners.id, invoice.partnerId)).limit(1);
   const [branding] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, invoice.orgId)).limit(1);
+  if (!invoice.sellerSnapshot && partner) {
+    (invoice as { sellerSnapshot: unknown }).sellerSnapshot = buildSellerSnapshot(partner);
+  }
   return {
     invoice,
     lines,
@@ -300,8 +331,8 @@ async function loadInvoiceForRender(invoiceId: string): Promise<{ invoice: Invoi
       partnerName: partner?.name ?? 'Invoice',
       logoUrl: branding?.logoUrl ?? null,
       primaryColor: branding?.primaryColor ?? null,
-      footerText: invoice.terms ?? partner?.footer ?? branding?.footerText ?? null,
-      currencyCode: invoice.currencyCode ?? partner?.currency ?? 'USD',
+      footerText: invoice.terms ?? partner?.invoiceFooter ?? branding?.footerText ?? null,
+      currencyCode: invoice.currencyCode ?? partner?.currencyCode ?? 'USD',
     },
   };
 }

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -321,6 +321,8 @@ async function loadInvoiceForRender(invoiceId: string): Promise<{ invoice: Invoi
   const lines = await db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, invoiceId)).orderBy(invoiceLines.sortOrder);
   const [partner] = await db.select().from(partners).where(eq(partners.id, invoice.partnerId)).limit(1);
   const [branding] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, invoice.orgId)).limit(1);
+  // Legacy/draft docs have no frozen snapshot; synthesize from the live partner so
+  // the From block still renders (issued docs use the frozen column).
   if (!invoice.sellerSnapshot && partner) {
     (invoice as { sellerSnapshot: unknown }).sellerSnapshot = buildSellerSnapshot(partner);
   }

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -238,7 +238,7 @@ export async function deleteDraftInvoice(invoiceId: string, actor: InvoiceActor)
   await db.delete(invoices).where(eq(invoices.id, invoiceId)); // lines cascade
 }
 
-/** Draft-only header edit (notes/site/dueDate). Only provided fields are written;
+/** Draft-only header edit (notes/site/dueDate/termsAndConditions). Only provided fields are written;
  *  siteId can be explicitly set to null to clear it. issue() overwrites dueDate
  *  with issueDate + partner terms, so a draft dueDate is advisory until then. */
 export async function updateInvoice(
@@ -484,7 +484,10 @@ export async function issueInvoice(invoiceId: string, actor: InvoiceActor) {
       issueDate: issueDate.toISOString().slice(0, 10), dueDate: dueDate.toISOString().slice(0, 10),
       taxRate, subtotal, taxTotal, total, balance: total,
       billToName: org?.name ?? null, billToAddress, billToTaxId: org?.taxId ?? null,
-      billToTaxExempt: org?.taxExempt ?? false, terms: partner?.invoiceFooter ?? null,
+      billToTaxExempt: org?.taxExempt ?? false,
+      // `terms` is the small footer line (from partner.invoiceFooter); `termsAndConditions`
+      // is the labeled Terms & Conditions block (from partner.billingTermsAndConditions).
+      terms: partner?.invoiceFooter ?? null,
       sellerSnapshot: buildSellerSnapshot(partner),
       termsAndConditions: inv.termsAndConditions ?? partner?.billingTermsAndConditions ?? null,
       updatedAt: issueDate

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -14,6 +14,7 @@ import { formatInvoiceNumber } from './invoiceNumbers';
 import { emitInvoiceEvent } from './invoiceEvents';
 import { enqueueInvoicePdfRender } from '../jobs/invoiceWorker';
 import { gatherOrgTimeEntries, gatherOrgParts, gatherTicketBillables, type DraftLineSpec } from './invoiceAssembly';
+import { buildSellerSnapshot } from './sellerSnapshot';
 import { InvoiceServiceError } from './invoiceTypes';
 import type { InvoiceActor } from './invoiceTypes';
 import type { ManualLineInput, RecordPaymentInput } from '@breeze/shared';
@@ -39,12 +40,12 @@ function assertDraft(inv: { status: string }): void {
   if (inv.status !== 'draft') throw new InvoiceServiceError('Invoice is not a draft', 409, 'NOT_A_DRAFT');
 }
 
-export async function createManualInvoice(input: { orgId: string; siteId?: string; notes?: string }, actor: InvoiceActor) {
+export async function createManualInvoice(input: { orgId: string; siteId?: string; notes?: string; termsAndConditions?: string }, actor: InvoiceActor) {
   const partnerId = requirePartner(actor);
   requireOrgAccess(actor, input.orgId);
   const rows = await db.insert(invoices).values({
     partnerId, orgId: input.orgId, siteId: input.siteId ?? null, status: 'draft',
-    notes: input.notes ?? null, createdBy: actor.userId
+    notes: input.notes ?? null, termsAndConditions: input.termsAndConditions ?? null, createdBy: actor.userId
   }).returning();
   return rows[0]!;
 }
@@ -242,7 +243,7 @@ export async function deleteDraftInvoice(invoiceId: string, actor: InvoiceActor)
  *  with issueDate + partner terms, so a draft dueDate is advisory until then. */
 export async function updateInvoice(
   invoiceId: string,
-  patch: { notes?: string; siteId?: string | null; dueDate?: string },
+  patch: { notes?: string; siteId?: string | null; dueDate?: string; termsAndConditions?: string | null },
   actor: InvoiceActor
 ) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
@@ -252,6 +253,7 @@ export async function updateInvoice(
   if (patch.notes !== undefined) set.notes = patch.notes;
   if (patch.siteId !== undefined) set.siteId = patch.siteId;     // null clears it
   if (patch.dueDate !== undefined) set.dueDate = patch.dueDate;  // date string
+  if (patch.termsAndConditions !== undefined) set.termsAndConditions = patch.termsAndConditions;
   await db.update(invoices).set(set).where(eq(invoices.id, invoiceId));
   return getOwnedInvoiceOr404(invoiceId);
 }
@@ -304,6 +306,10 @@ export async function updatePartnerBillingSettings(
   patch: {
     currencyCode: string; defaultTaxRate?: number | null; invoiceNumberPrefix: string;
     invoiceTermsDays: number; invoiceFooter?: string | null;
+    billingCompanyName?: string | null; billingPhone?: string | null; billingWebsite?: string | null;
+    billingAddressLine1?: string | null; billingAddressLine2?: string | null; billingAddressCity?: string | null;
+    billingAddressRegion?: string | null; billingAddressPostalCode?: string | null; billingAddressCountry?: string | null;
+    billingTermsAndConditions?: string | null;
   },
   actor: InvoiceActor
 ) {
@@ -318,6 +324,13 @@ export async function updatePartnerBillingSettings(
     set.defaultTaxRate = patch.defaultTaxRate === null ? null : Number(patch.defaultTaxRate).toFixed(3);
   }
   if (patch.invoiceFooter !== undefined) set.invoiceFooter = patch.invoiceFooter;
+  for (const key of [
+    'billingCompanyName', 'billingPhone', 'billingWebsite', 'billingAddressLine1', 'billingAddressLine2',
+    'billingAddressCity', 'billingAddressRegion', 'billingAddressPostalCode', 'billingAddressCountry',
+    'billingTermsAndConditions',
+  ] as const) {
+    if (patch[key] !== undefined) set[key] = patch[key];
+  }
   const [row] = await db.update(partners).set(set).where(eq(partners.id, partnerId)).returning({
     currencyCode: partners.currencyCode, defaultTaxRate: partners.defaultTaxRate,
     invoiceNumberPrefix: partners.invoiceNumberPrefix, invoiceTermsDays: partners.invoiceTermsDays,
@@ -471,7 +484,10 @@ export async function issueInvoice(invoiceId: string, actor: InvoiceActor) {
       issueDate: issueDate.toISOString().slice(0, 10), dueDate: dueDate.toISOString().slice(0, 10),
       taxRate, subtotal, taxTotal, total, balance: total,
       billToName: org?.name ?? null, billToAddress, billToTaxId: org?.taxId ?? null,
-      billToTaxExempt: org?.taxExempt ?? false, terms: partner?.invoiceFooter ?? null, updatedAt: issueDate
+      billToTaxExempt: org?.taxExempt ?? false, terms: partner?.invoiceFooter ?? null,
+      sellerSnapshot: buildSellerSnapshot(partner),
+      termsAndConditions: inv.termsAndConditions ?? partner?.billingTermsAndConditions ?? null,
+      updatedAt: issueDate
     }).where(eq(invoices.id, invoiceId));
 
     // A since-deleted source row makes its `billed` flip a harmless no-op; the

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -187,6 +187,9 @@ export async function acceptQuote(
     issueFields.billToName = quote.billToName ?? null;
     issueFields.billToAddress = quote.billToAddress ?? null;
     issueFields.billToTaxId = quote.billToTaxId ?? null;
+    issueFields.sellerSnapshot = quote.sellerSnapshot ?? null;
+    issueFields.termsAndConditions = quote.termsAndConditions ?? null;
+    issueFields.terms = quote.terms ?? null;
   }
   await db.update(invoices).set(issueFields).where(eq(invoices.id, invoice!.id));
 

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -11,6 +11,7 @@ import { buildQuoteTemplate } from './quoteEmail';
 import { getEmailService } from './email';
 import { resolveBillingEmail } from './invoicePdf';
 import { isQuoteExpired } from './quoteExpiry';
+import { buildSellerSnapshot } from './sellerSnapshot';
 
 type QuoteRow = typeof quotes.$inferSelect;
 
@@ -89,9 +90,15 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
   // Conditional on status='draft' so two concurrent sends can't both flip the
   // quote (the second matches 0 rows and 409s). Counter gaps from the losing
   // send are acceptable, per allocateQuoteCounter's contract (C3).
+  const [partnerRow] = await db.select().from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
   const claimed = await db
     .update(quotes)
-    .set({ status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now })
+    .set({
+      status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now,
+      sellerSnapshot: buildSellerSnapshot(partnerRow),
+      termsAndConditions: quote.termsAndConditions ?? partnerRow?.billingTermsAndConditions ?? null,
+      terms: quote.terms ?? partnerRow?.invoiceFooter ?? null,
+    })
     .where(and(eq(quotes.id, id), eq(quotes.status, 'draft')))
     .returning({ id: quotes.id });
   if (claimed.length === 0) {

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -138,10 +138,12 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
         return img?.data ? { data: img.data } : null;
       };
       const { renderQuotePdf } = await import('./quotePdf');
-      const pdf = await renderQuotePdf({ ...quote, status: 'sent', quoteNumber }, blocks, lines, loadImage, {
-        partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
-        footer: quote.terms ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? 'USD',
-      });
+      const pdf = await renderQuotePdf(
+        { ...quote, status: 'sent', quoteNumber, sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partnerRow) },
+        blocks, lines, loadImage, {
+          partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
+          footer: quote.terms ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? 'USD',
+        });
       const template = buildQuoteTemplate({
         quoteNumber, partnerName: partner?.name ?? 'your provider',
         total: formatMoneyish(quote.total, quote.currencyCode), acceptUrl,

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -81,4 +81,15 @@ describe('renderQuotePdf', () => {
     expect(buf.subarray(0, 4).toString()).toBe('%PDF');
     expect(buf.length).toBeGreaterThan(800);
   });
+
+  it('renderQuotePdf includes the From block and T&C', async () => {
+    const buf = await renderQuotePdf(
+      { id: 'q1', quoteNumber: 'Q-1', currencyCode: 'USD', billToName: 'Cust',
+        sellerSnapshot: { name: 'Acme MSP LLC', phone: null, email: 'billing@acme.test', website: null,
+          address: { line1: '1 Main St', line2: null, city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' } },
+        termsAndConditions: 'Valid 30 days' } as never,
+      [], [], async () => null, { partnerName: 'Acme MSP LLC' },
+    );
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+  });
 });

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -14,6 +14,7 @@
 // route in routes/quotes/quotes.ts supplies the real quote_images loader.
 
 import PDFDocument from 'pdfkit';
+import { sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
 
 // ---------------------------------------------------------------------------
 // Formatting helpers (kept in lock-step with invoicePdf.ts conventions)
@@ -95,6 +96,8 @@ interface QuoteHeader {
   annualRecurringTotal?: string | number | null;
   // Amount invoiced on accept (one-time + one-time tax); derived in getQuote.
   dueOnAcceptanceTotal?: string | number | null;
+  sellerSnapshot?: unknown;
+  termsAndConditions?: string | null;
 }
 
 interface QuoteBlock {
@@ -262,26 +265,36 @@ export async function renderQuotePdf(
   doc.fillColor('#6b7280').fontSize(10).font('Helvetica').text(quote.quoteNumber ?? 'DRAFT', c.left, 74, { width: c.contentWidth, align: 'right' });
   doc.moveTo(c.left, 96).lineTo(c.right, 96).lineWidth(2).strokeColor(primary).stroke();
 
-  // ---- Bill-to block + dates ----------------------------------------------
+  // ---- From (seller) left column; Prepared For + dates right column ---------
   let y = 112;
+  const seller = (quote.sellerSnapshot as SellerSnapshot | null) ?? null;
+  const rightX = c.left + c.contentWidth * 0.55;
+  const rightW = c.contentWidth * 0.45;
+
+  doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('FROM', c.left, y);
+  doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? partnerName, c.left, y + 12, { width: c.contentWidth * 0.5 });
+  let fromY = y + 28;
+  doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+  for (const aline of sellerAddressLines(seller)) { doc.text(aline, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 13; }
+  doc.fillColor('#6b7280').fontSize(9);
+  if (seller?.phone) { doc.text(seller.phone, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
+  if (seller?.email) { doc.text(seller.email, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
+  if (seller?.website) { doc.text(seller.website, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
+
+  let billY = y;
   if (quote.billToName) {
-    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED FOR', c.left, y);
-    doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(quote.billToName, c.left, y + 12);
+    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED FOR', rightX, billY, { width: rightW });
+    doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(quote.billToName, rightX, billY + 12, { width: rightW });
+    billY += 28;
   }
-  let billY = y + (quote.billToName ? 28 : 12);
   doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
-  for (const aline of addressLines(quote.billToAddress as BillToAddress | null)) {
-    doc.text(aline, c.left, billY); billY += 13;
-  }
-  if (quote.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${quote.billToTaxId}`, c.left, billY); billY += 13; }
-
-  const dateX = c.left + c.contentWidth * 0.6;
-  let dateY = y;
+  for (const aline of addressLines(quote.billToAddress as BillToAddress | null)) { doc.text(aline, rightX, billY, { width: rightW }); billY += 13; }
+  if (quote.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${quote.billToTaxId}`, rightX, billY, { width: rightW }); billY += 13; }
   doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
-  if (quote.issueDate) { doc.text(`Issued: ${formatDate(quote.issueDate)}`, dateX, dateY, { width: c.contentWidth * 0.4, align: 'right' }); dateY += 14; }
-  if (quote.expiryDate) { doc.text(`Valid until: ${formatDate(quote.expiryDate)}`, dateX, dateY, { width: c.contentWidth * 0.4, align: 'right' }); dateY += 14; }
+  if (quote.issueDate) { doc.text(`Issued: ${formatDate(quote.issueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
+  if (quote.expiryDate) { doc.text(`Valid until: ${formatDate(quote.expiryDate)}`, rightX, billY, { width: rightW }); billY += 14; }
 
-  y = Math.max(billY, dateY) + 20;
+  y = Math.max(fromY, billY) + 20;
 
   // Intro notes, if any (above the blocks).
   if (quote.introNotes) {
@@ -348,6 +361,14 @@ export async function renderQuotePdf(
 
   // ---- Recurring summary footer -------------------------------------------
   y = renderRecurringSummary(doc, quote, currency, y);
+
+  // ---- Terms & Conditions --------------------------------------------------
+  if (quote.termsAndConditions) {
+    y = ensureSpace(doc, y + 14, 60);
+    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('TERMS & CONDITIONS', c.left, y); y = doc.y + 4;
+    doc.fillColor('#6b7280').fontSize(9).font('Helvetica').text(quote.termsAndConditions, c.left, y, { width: c.contentWidth });
+    y = doc.y;
+  }
 
   // ---- Terms + branding footer --------------------------------------------
   const footer = quote.terms ?? branding.footer ?? null;

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -98,6 +98,7 @@ export async function createQuote(input: CreateQuoteInput, actor: QuoteActor) {
     expiryDate: input.expiryDate ?? null,
     introNotes: input.introNotes ?? null,
     terms: input.terms ?? null,
+    termsAndConditions: input.termsAndConditions ?? null,
     createdBy: actor.userId,
   }).returning();
   return row!;
@@ -148,6 +149,7 @@ export async function updateQuote(id: string, input: UpdateQuoteInput, actor: Qu
   if (input.expiryDate !== undefined) set.expiryDate = input.expiryDate;
   if (input.introNotes !== undefined) set.introNotes = input.introNotes;
   if (input.terms !== undefined) set.terms = input.terms;
+  if (input.termsAndConditions !== undefined) set.termsAndConditions = input.termsAndConditions;
   if (input.billToName !== undefined) set.billToName = input.billToName;
   // Numeric tax_rate takes a fixed-string value; null clears it.
   if (input.taxRate !== undefined) set.taxRate = input.taxRate === null ? null : Number(input.taxRate).toFixed(3);

--- a/apps/api/src/services/sellerSnapshot.test.ts
+++ b/apps/api/src/services/sellerSnapshot.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildSellerSnapshot, sellerAddressLines } from './sellerSnapshot';
+
+const base = {
+  name: 'Acme MSP', billingCompanyName: null, billingEmail: null, billingPhone: null,
+  billingWebsite: null, billingAddressLine1: null, billingAddressLine2: null,
+  billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null,
+  billingAddressCountry: null,
+};
+
+describe('buildSellerSnapshot', () => {
+  it('falls back to partner.name when billingCompanyName is null', () => {
+    expect(buildSellerSnapshot(base).name).toBe('Acme MSP');
+  });
+
+  it('prefers billingCompanyName over name', () => {
+    expect(buildSellerSnapshot({ ...base, billingCompanyName: 'Acme MSP LLC' }).name).toBe('Acme MSP LLC');
+  });
+
+  it('maps contact + address fields', () => {
+    const snap = buildSellerSnapshot({
+      ...base, billingEmail: 'billing@acme.test', billingPhone: '+1 555 0100',
+      billingWebsite: 'acme.test', billingAddressLine1: '1 Main St', billingAddressCity: 'Austin',
+      billingAddressRegion: 'TX', billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+    expect(snap.email).toBe('billing@acme.test');
+    expect(snap.phone).toBe('+1 555 0100');
+    expect(snap.website).toBe('acme.test');
+    expect(snap.address).toMatchObject({ line1: '1 Main St', city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' });
+  });
+});
+
+describe('sellerAddressLines', () => {
+  it('joins city/region/postal and drops empties', () => {
+    const snap = buildSellerSnapshot({
+      ...base, billingAddressLine1: '1 Main St', billingAddressCity: 'Austin',
+      billingAddressRegion: 'TX', billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+    expect(sellerAddressLines(snap)).toEqual(['1 Main St', 'Austin, TX, 78701', 'US']);
+  });
+
+  it('returns [] for a null snapshot', () => {
+    expect(sellerAddressLines(null)).toEqual([]);
+  });
+});

--- a/apps/api/src/services/sellerSnapshot.test.ts
+++ b/apps/api/src/services/sellerSnapshot.test.ts
@@ -39,6 +39,15 @@ describe('sellerAddressLines', () => {
     expect(sellerAddressLines(snap)).toEqual(['1 Main St', 'Austin, TX, 78701', 'US']);
   });
 
+  it('includes line2 when present', () => {
+    const snap = buildSellerSnapshot({
+      ...base, billingAddressLine1: '1 Main St', billingAddressLine2: 'Suite 100',
+      billingAddressCity: 'Austin', billingAddressRegion: 'TX',
+      billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+    expect(sellerAddressLines(snap)).toEqual(['1 Main St', 'Suite 100', 'Austin, TX, 78701', 'US']);
+  });
+
   it('returns [] for a null snapshot', () => {
     expect(sellerAddressLines(null)).toEqual([]);
   });

--- a/apps/api/src/services/sellerSnapshot.ts
+++ b/apps/api/src/services/sellerSnapshot.ts
@@ -3,8 +3,12 @@
 // read the frozen snapshot. The address sub-object uses the SAME keys as
 // billToAddress so the PDF renderers' existing addressLines() helper works for it.
 
+// Intentional duplicate of SellerSnapshot in apps/web/src/components/billing/invoiceTypes.ts
+// and apps/portal/src/lib/api.ts — api/web/portal can't share a package; keep in sync.
 export interface SellerSnapshot {
   name: string | null;
+  // builder never returns null for address, but consumers may receive null from
+  // legacy jsonb rows — the | null is load-bearing for readers; do not remove it.
   address: {
     line1: string | null; line2: string | null; city: string | null;
     region: string | null; postalCode: string | null; country: string | null;

--- a/apps/api/src/services/sellerSnapshot.ts
+++ b/apps/api/src/services/sellerSnapshot.ts
@@ -1,0 +1,53 @@
+// Pure helpers for the seller "From" contact block. buildSellerSnapshot freezes
+// a partner's billing-contact profile onto a document at issue time; renderers
+// read the frozen snapshot. The address sub-object uses the SAME keys as
+// billToAddress so the PDF renderers' existing addressLines() helper works for it.
+
+export interface SellerSnapshot {
+  name: string | null;
+  address: {
+    line1: string | null; line2: string | null; city: string | null;
+    region: string | null; postalCode: string | null; country: string | null;
+  } | null;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+}
+
+interface PartnerContactFields {
+  name?: string | null;
+  billingCompanyName?: string | null;
+  billingEmail?: string | null;
+  billingPhone?: string | null;
+  billingWebsite?: string | null;
+  billingAddressLine1?: string | null;
+  billingAddressLine2?: string | null;
+  billingAddressCity?: string | null;
+  billingAddressRegion?: string | null;
+  billingAddressPostalCode?: string | null;
+  billingAddressCountry?: string | null;
+}
+
+export function buildSellerSnapshot(partner: PartnerContactFields | null | undefined): SellerSnapshot {
+  return {
+    name: partner?.billingCompanyName ?? partner?.name ?? null,
+    address: {
+      line1: partner?.billingAddressLine1 ?? null,
+      line2: partner?.billingAddressLine2 ?? null,
+      city: partner?.billingAddressCity ?? null,
+      region: partner?.billingAddressRegion ?? null,
+      postalCode: partner?.billingAddressPostalCode ?? null,
+      country: partner?.billingAddressCountry ?? null,
+    },
+    phone: partner?.billingPhone ?? null,
+    email: partner?.billingEmail ?? null,
+    website: partner?.billingWebsite ?? null,
+  };
+}
+
+export function sellerAddressLines(snapshot: SellerSnapshot | null | undefined): string[] {
+  const a = snapshot?.address;
+  if (!a) return [];
+  const cityLine = [a.city, a.region, a.postalCode].filter(Boolean).join(', ');
+  return [a.line1, a.line2, cityLine, a.country].filter((s): s is string => !!s && s.trim().length > 0);
+}

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -2,6 +2,7 @@ import { withBase } from '@/lib/basePath';
 import { useEffect, useState } from 'react';
 import { ArrowLeft, AlertCircle, Download, CreditCard } from 'lucide-react';
 import { type InvoiceDetail, type InvoiceStatus, buildPortalApiUrl, portalApi } from '@/lib/api';
+import { sellerLines } from '@/lib/sellerLines';
 import { cn } from '@/lib/utils';
 
 // Invoice statuses that can be paid online (mirrors the API's PAYABLE set).
@@ -110,6 +111,9 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
   const canPay = PAYABLE_STATUSES.has(invoice.status) && Number(invoice.balance) > 0;
+
+  const seller = invoice.sellerSnapshot ?? null;
+  const sellerAddressLines = sellerLines(seller?.address ?? null);
 
   const payInvoice = async () => {
     if (paying) return;
@@ -225,12 +229,25 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{downloadError}</div>
       )}
 
-      {invoice.billToName && (
-        <div className="rounded-lg border p-4">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Bill to</p>
-          <p className="mt-1 text-sm">{invoice.billToName}</p>
-        </div>
-      )}
+      <div className="flex flex-wrap gap-4">
+        {invoice.billToName && (
+          <div className="flex-1 rounded-lg border p-4">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Bill to</p>
+            <p className="mt-1 text-sm">{invoice.billToName}</p>
+          </div>
+        )}
+
+        {seller?.name && (
+          <div className="flex-1 rounded-lg border p-4" data-testid="invoice-from">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">From</p>
+            <p className="mt-1 text-sm font-medium">{seller.name}</p>
+            {sellerAddressLines.map((l, i) => <p key={i} className="text-sm text-muted-foreground">{l}</p>)}
+            {seller.phone && <p className="text-sm text-muted-foreground">{seller.phone}</p>}
+            {seller.email && <p className="text-sm text-muted-foreground">{seller.email}</p>}
+            {seller.website && <p className="text-sm text-muted-foreground">{seller.website}</p>}
+          </div>
+        )}
+      </div>
 
       <div className="overflow-hidden rounded-lg border">
         <table className="w-full">
@@ -267,6 +284,13 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
         <div className="rounded-lg border p-4">
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notes</p>
           <p className="mt-1 whitespace-pre-wrap text-sm">{invoice.notes}</p>
+        </div>
+      )}
+
+      {invoice.termsAndConditions && (
+        <div className="rounded-lg border p-4" data-testid="invoice-terms-conditions">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{invoice.termsAndConditions}</p>
         </div>
       )}
     </div>

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { portalApi, buildPortalApiUrl, type PublicQuoteDetail } from '@/lib/api';
+import { sellerLines } from '@/lib/sellerLines';
 import { cn } from '@/lib/utils';
 import { QuoteBlocks, money } from './quoteBlocks';
 
@@ -37,6 +38,9 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
   const open = status === 'sent' || status === 'viewed';
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+
+  const seller = quote.sellerSnapshot ?? null;
+  const sellerAddressLines = sellerLines(seller?.address ?? null);
 
   const accept = async () => {
     if (busy) return;
@@ -106,6 +110,17 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
         <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">{quote.introNotes}</p>
       )}
 
+      {seller?.name && (
+        <div className="rounded-lg border p-4" data-testid="public-quote-from">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">From</p>
+          <p className="mt-1 text-sm font-medium">{seller.name}</p>
+          {sellerAddressLines.map((l, i) => <p key={i} className="text-sm text-muted-foreground">{l}</p>)}
+          {seller.phone && <p className="text-sm text-muted-foreground">{seller.phone}</p>}
+          {seller.email && <p className="text-sm text-muted-foreground">{seller.email}</p>}
+          {seller.website && <p className="text-sm text-muted-foreground">{seller.website}</p>}
+        </div>
+      )}
+
       <QuoteBlocks
         blocks={blocks}
         lines={lines}
@@ -153,6 +168,13 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
         <div className="rounded-lg border p-4">
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms</p>
           <p className="mt-1 whitespace-pre-wrap text-sm">{quote.terms}</p>
+        </div>
+      )}
+
+      {quote.termsAndConditions && (
+        <div className="rounded-lg border p-4" data-testid="public-quote-terms-conditions">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.termsAndConditions}</p>
         </div>
       )}
 

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ArrowLeft, AlertCircle, Download } from 'lucide-react';
 import { type QuoteDetail, buildPortalApiUrl, portalApi } from '@/lib/api';
+import { sellerLines } from '@/lib/sellerLines';
 import { cn } from '@/lib/utils';
 import { QuoteBlocks, money } from './quoteBlocks';
 
@@ -66,6 +67,9 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
   const open = status === 'sent' || status === 'viewed';
+
+  const seller = quote.sellerSnapshot ?? null;
+  const sellerAddressLines = sellerLines(seller?.address ?? null);
 
   const accept = async () => {
     if (busy) return;
@@ -158,6 +162,17 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
         <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">{quote.introNotes}</p>
       )}
 
+      {seller?.name && (
+        <div className="rounded-lg border p-4" data-testid="quote-from">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">From</p>
+          <p className="mt-1 text-sm font-medium">{seller.name}</p>
+          {sellerAddressLines.map((l, i) => <p key={i} className="text-sm text-muted-foreground">{l}</p>)}
+          {seller.phone && <p className="text-sm text-muted-foreground">{seller.phone}</p>}
+          {seller.email && <p className="text-sm text-muted-foreground">{seller.email}</p>}
+          {seller.website && <p className="text-sm text-muted-foreground">{seller.website}</p>}
+        </div>
+      )}
+
       <QuoteBlocks
         blocks={blocks}
         lines={lines}
@@ -207,6 +222,13 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
         <div className="rounded-lg border p-4">
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms</p>
           <p className="mt-1 whitespace-pre-wrap text-sm">{quote.terms}</p>
+        </div>
+      )}
+
+      {quote.termsAndConditions && (
+        <div className="rounded-lg border p-4" data-testid="quote-terms-conditions">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.termsAndConditions}</p>
         </div>
       )}
 

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -311,6 +311,21 @@ export interface InvoiceSummary {
   balance: string;
 }
 
+export interface SellerSnapshot {
+  name: string | null;
+  address: {
+    line1: string | null;
+    line2: string | null;
+    city: string | null;
+    region: string | null;
+    postalCode: string | null;
+    country: string | null;
+  } | null;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+}
+
 export interface InvoiceLine {
   id: string;
   description: string;
@@ -327,6 +342,8 @@ export interface InvoiceDetail {
     taxRate: string | null;
     billToName: string | null;
     notes: string | null;
+    sellerSnapshot?: SellerSnapshot | null;
+    termsAndConditions?: string | null;
   };
   lines: InvoiceLine[];
 }
@@ -380,6 +397,8 @@ export interface QuoteHeader extends QuoteSummary {
   /** Amount invoiced on accept (one-time + one-time tax); derived server-side. */
   dueOnAcceptanceTotal?: string;
   billToName?: string | null;
+  sellerSnapshot?: SellerSnapshot | null;
+  termsAndConditions?: string | null;
 }
 
 export interface QuoteDetail {

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -311,6 +311,8 @@ export interface InvoiceSummary {
   balance: string;
 }
 
+// Intentional duplicate of SellerSnapshot in apps/api/src/services/sellerSnapshot.ts
+// and apps/web/src/components/billing/invoiceTypes.ts — api/web/portal can't share a package; keep in sync.
 export interface SellerSnapshot {
   name: string | null;
   address: {

--- a/apps/portal/src/lib/sellerLines.test.ts
+++ b/apps/portal/src/lib/sellerLines.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { sellerLines } from './sellerLines';
+
+describe('sellerLines', () => {
+  it('returns [] for null address', () => {
+    expect(sellerLines(null)).toEqual([]);
+  });
+
+  it('joins city/region/postalCode and drops empty fields', () => {
+    const result = sellerLines({
+      line1: '123 Main St',
+      line2: null,
+      city: 'Austin',
+      region: 'TX',
+      postalCode: '78701',
+      country: 'US',
+    });
+    expect(result).toEqual(['123 Main St', 'Austin, TX, 78701', 'US']);
+  });
+
+  it('drops line2 when empty string', () => {
+    const result = sellerLines({
+      line1: '456 Oak Ave',
+      line2: '',
+      city: 'Boston',
+      region: 'MA',
+      postalCode: '02101',
+      country: null,
+    });
+    expect(result).toEqual(['456 Oak Ave', 'Boston, MA, 02101']);
+  });
+
+  it('handles partial city line', () => {
+    const result = sellerLines({
+      line1: null,
+      line2: null,
+      city: 'London',
+      region: null,
+      postalCode: 'EC1A',
+      country: 'UK',
+    });
+    expect(result).toEqual(['London, EC1A', 'UK']);
+  });
+});

--- a/apps/portal/src/lib/sellerLines.ts
+++ b/apps/portal/src/lib/sellerLines.ts
@@ -1,0 +1,9 @@
+import type { SellerSnapshot } from './api';
+
+export function sellerLines(address: SellerSnapshot['address']): string[] {
+  if (!address) return [];
+  const cityLine = [address.city, address.region, address.postalCode].filter(Boolean).join(', ');
+  return [address.line1, address.line2, cityLine, address.country].filter(
+    (s): s is string => !!s && s.trim().length > 0
+  );
+}

--- a/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
@@ -49,7 +49,7 @@ const issued: InvoiceDetailData = {
     id: 'inv-1', invoiceNumber: 'INV-0007', orgId: 'org-1', siteId: null, status: 'sent',
     currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30', sentAt: null, subtotal: '120.00',
     taxRate: '0.000', taxTotal: '0.00', total: '120.00', amountPaid: '0.00', balance: '120.00',
-    billToName: 'Acme', notes: null, createdAt: '2026-06-01T00:00:00Z',
+    billToName: 'Acme', notes: null, termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
   },
   lines,
   stripeConnected: true,

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -42,7 +42,7 @@ const issued: InvoiceDetailData = {
     id: 'inv-1', invoiceNumber: 'INV-0007', orgId: 'org-1', siteId: null, status: 'sent',
     currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30', sentAt: null, subtotal: '120.00',
     taxRate: '0.000', taxTotal: '0.00', total: '120.00', amountPaid: '0.00', balance: '120.00',
-    billToName: 'Acme', notes: null, createdAt: '2026-06-01T00:00:00Z',
+    billToName: 'Acme', notes: null, termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
   },
   lines,
 };

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -15,6 +15,7 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  sellerLines,
 } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -283,6 +284,38 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
               </span>
             </div>
           </div>
+
+          {/* Seller From block */}
+          {invoice.sellerSnapshot && (
+            <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="invoice-detail-from">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">From</h3>
+              <div className="space-y-0.5 text-sm">
+                {invoice.sellerSnapshot.name && (
+                  <p className="font-medium" data-testid="invoice-detail-from-name">{invoice.sellerSnapshot.name}</p>
+                )}
+                {sellerLines(invoice.sellerSnapshot.address).map((line, i) => (
+                  <p key={i} className="text-muted-foreground">{line}</p>
+                ))}
+                {invoice.sellerSnapshot.phone && (
+                  <p className="text-muted-foreground" data-testid="invoice-detail-from-phone">{invoice.sellerSnapshot.phone}</p>
+                )}
+                {invoice.sellerSnapshot.email && (
+                  <p className="text-muted-foreground" data-testid="invoice-detail-from-email">{invoice.sellerSnapshot.email}</p>
+                )}
+                {invoice.sellerSnapshot.website && (
+                  <p className="text-muted-foreground" data-testid="invoice-detail-from-website">{invoice.sellerSnapshot.website}</p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Terms & Conditions */}
+          {invoice.termsAndConditions && (
+            <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="invoice-detail-terms">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+              <p className="whitespace-pre-wrap text-sm text-muted-foreground">{invoice.termsAndConditions}</p>
+            </div>
+          )}
 
           {/* PDF + void */}
           <div className="space-y-2">

--- a/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
@@ -42,7 +42,7 @@ const draft: InvoiceDetail = {
     id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
     currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
     taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
-    notes: '', createdAt: '2026-06-01T00:00:00Z',
+    notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
   },
   lines: [visibleLine],
 };

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -24,13 +24,14 @@ const fetchMock = vi.mocked(fetchWithAuth);
 const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
 
-function draft(lines: InvoiceDetail['lines']): InvoiceDetail {
+function draft(lines: InvoiceDetail['lines'], extra: Partial<InvoiceDetail['invoice']> = {}): InvoiceDetail {
   return {
     invoice: {
       id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
       currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '0.00', taxRate: null,
       taxTotal: '0.00', total: '0.00', amountPaid: '0.00', balance: '0.00', billToName: 'Acme',
-      notes: '', createdAt: '2026-06-01T00:00:00Z',
+      notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+      ...extra,
     },
     lines,
   };
@@ -180,5 +181,31 @@ describe('InvoiceEditor', () => {
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
     // never a success "sent" claim when nothing went out
     expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'Invoice issued and sent' }));
+  });
+
+  it('editing the T&C textarea and blurring issues PATCH /invoices/:id with { termsAndConditions }', async () => {
+    const onChanged = vi.fn();
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') return json({ data: {} });
+      return json({ data: {} });
+    });
+    render(<InvoiceEditor detail={draft([])} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('invoice-terms');
+    fireEvent.change(textarea, { target: { value: 'Net 30' } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      const patchCall = fetchMock.mock.calls.find(
+        (c) => c[0] === '/invoices/inv-1' && (c[1] as RequestInit)?.method === 'PATCH',
+      );
+      expect(patchCall).toBeTruthy();
+      expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toMatchObject({
+        termsAndConditions: 'Net 30',
+      });
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Terms saved' }));
   });
 });

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -34,6 +34,8 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const [issuing, setIssuing] = useState(false);
   const [notes, setNotes] = useState(invoice.notes ?? '');
   const [notesDirty, setNotesDirty] = useState(false);
+  const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
+  const [termsDirty, setTermsDirty] = useState(false);
 
   // Add-line form
   const [addMode, setAddMode] = useState<AddMode>('catalog');
@@ -46,6 +48,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const [pickQty, setPickQty] = useState('1');
 
   useEffect(() => { setNotes(invoice.notes ?? ''); setNotesDirty(false); }, [invoice.notes]);
+  useEffect(() => { setTerms(invoice.termsAndConditions ?? ''); setTermsDirty(false); }, [invoice.termsAndConditions]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });
@@ -174,6 +177,27 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
       setBusy(false);
     }
   }, [busy, notesDirty, notes, invoice.id, refresh]);
+
+  const saveTerms = useCallback(async () => {
+    if (busy || !termsDirty) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}`, {
+          method: 'PATCH', body: JSON.stringify({ termsAndConditions: terms }),
+        }),
+        errorFallback: 'Could not save terms.',
+        successMessage: 'Terms saved',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setTermsDirty(false);
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not save terms.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, termsDirty, terms, invoice.id, refresh]);
 
   const issue = useCallback(async (alsoSend: boolean) => {
     if (busy) return;
@@ -387,6 +411,20 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               rows={3}
               className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
               placeholder="Internal or customer notes…"
+            />
+          </div>
+
+          <div className="rounded-lg border bg-card p-4 shadow-sm">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+            <textarea
+              value={terms}
+              onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
+              onBlur={() => { if (canWrite) void saveTerms(); }}
+              disabled={!canWrite}
+              data-testid="invoice-terms"
+              rows={3}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+              placeholder="Payment terms, warranty clauses, etc."
             />
           </div>
 

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -33,7 +33,7 @@ function invoice(over: Record<string, unknown>) {
       id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
       currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
       taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
-      notes: '', createdAt: '2026-06-01T00:00:00Z', ...over,
+      notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z', ...over,
     },
     lines: [line],
     stripeConnected: false,

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -31,13 +31,13 @@ const INVOICES = [
     id: 'inv-1', invoiceNumber: 'INV-0001', orgId: 'org-1', siteId: null, status: 'overdue',
     currencyCode: 'USD', issueDate: '2026-05-01', dueDate: '2026-05-31', sentAt: null, subtotal: '100.00',
     taxRate: '0.000', taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00',
-    billToName: 'Acme', notes: null, createdAt: '2026-05-01T00:00:00Z',
+    billToName: 'Acme', notes: null, termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-05-01T00:00:00Z',
   },
   {
     id: 'inv-2', invoiceNumber: null, orgId: 'org-2', siteId: null, status: 'draft',
     currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '0.00',
     taxRate: null, taxTotal: '0.00', total: '0.00', amountPaid: '0.00', balance: '0.00',
-    billToName: null, notes: null, createdAt: '2026-06-01T00:00:00Z',
+    billToName: null, notes: null, termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
   },
 ];
 

--- a/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
@@ -63,4 +63,31 @@ describe('PartnerBillingSettings', () => {
       expect(JSON.parse((patch![1] as RequestInit).body as string)).toMatchObject({ defaultTaxRate: 0.07, currencyCode: 'USD' });
     });
   });
+
+  it('uppercases billingAddressCountry and normalizes whitespace-only address fields to null on save', async () => {
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (opts?.method === 'PATCH') return json({ data: {} });
+      return json({
+        currencyCode: 'USD', defaultTaxRate: null, invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+        invoiceFooter: null, billingCompanyName: null, billingPhone: null, billingWebsite: null,
+        billingAddressLine1: '1 Main St', billingAddressLine2: null,
+        billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null,
+        billingAddressCountry: 'us', billingTermsAndConditions: null,
+      });
+    });
+    render(<PartnerBillingSettings />);
+    await waitFor(() => expect(screen.getByTestId('partner-billing-settings')).toBeInTheDocument());
+
+    // Clear addr1 to whitespace-only (should serialize as null); country is uppercased on change
+    fireEvent.change(screen.getByTestId('partner-billing-addr1'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByTestId('partner-billing-save'));
+
+    await waitFor(() => {
+      const patch = fetchMock.mock.calls.find((c) => c[0] === '/partner/billing-settings' && (c[1] as RequestInit)?.method === 'PATCH');
+      expect(patch).toBeTruthy();
+      const body = JSON.parse((patch![1] as RequestInit).body as string);
+      expect(body).toMatchObject({ billingAddressCountry: 'US' });
+      expect(body.billingAddressLine1).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
@@ -16,6 +16,23 @@ const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
 describe('PartnerBillingSettings', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it('loads and shows the seller company name', async () => {
+    fetchMock.mockResolvedValue(json({
+      currencyCode: 'USD', defaultTaxRate: null, invoiceNumberPrefix: 'INV',
+      invoiceTermsDays: 30, invoiceFooter: null,
+      billingCompanyName: 'Acme MSP LLC',
+      billingPhone: null, billingWebsite: null,
+      billingAddressLine1: null, billingAddressLine2: null,
+      billingAddressCity: null, billingAddressRegion: null,
+      billingAddressPostalCode: null, billingAddressCountry: null,
+      billingTermsAndConditions: null,
+    }));
+    render(<PartnerBillingSettings />);
+    await waitFor(() =>
+      expect((screen.getByTestId('partner-billing-company-name') as HTMLInputElement).value).toBe('Acme MSP LLC'),
+    );
+  });
+
   it('loads partner billing and shows the tax rate as a percentage', async () => {
     fetchMock.mockResolvedValue(json({
       currencyCode: 'EUR', defaultTaxRate: '0.085', invoiceNumberPrefix: 'EU',

--- a/apps/web/src/components/billing/PartnerBillingSettings.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.tsx
@@ -13,6 +13,16 @@ interface PartnerBilling {
   invoiceNumberPrefix: string;
   invoiceTermsDays: number;
   invoiceFooter: string | null;
+  billingCompanyName: string | null;
+  billingPhone: string | null;
+  billingWebsite: string | null;
+  billingAddressLine1: string | null;
+  billingAddressLine2: string | null;
+  billingAddressCity: string | null;
+  billingAddressRegion: string | null;
+  billingAddressPostalCode: string | null;
+  billingAddressCountry: string | null;
+  billingTermsAndConditions: string | null;
 }
 
 export default function PartnerBillingSettings() {
@@ -26,6 +36,16 @@ export default function PartnerBillingSettings() {
   const [prefix, setPrefix] = useState('INV');
   const [termsDays, setTermsDays] = useState('30');
   const [footer, setFooter] = useState('');
+  const [companyName, setCompanyName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [website, setWebsite] = useState('');
+  const [addr1, setAddr1] = useState('');
+  const [addr2, setAddr2] = useState('');
+  const [city, setCity] = useState('');
+  const [region, setRegion] = useState('');
+  const [postal, setPostal] = useState('');
+  const [country, setCountry] = useState('');
+  const [terms, setTerms] = useState('');
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -40,6 +60,16 @@ export default function PartnerBillingSettings() {
       setPrefix(p.invoiceNumberPrefix ?? 'INV');
       setTermsDays(String(p.invoiceTermsDays ?? 30));
       setFooter(p.invoiceFooter ?? '');
+      setCompanyName(p.billingCompanyName ?? '');
+      setPhone(p.billingPhone ?? '');
+      setWebsite(p.billingWebsite ?? '');
+      setAddr1(p.billingAddressLine1 ?? '');
+      setAddr2(p.billingAddressLine2 ?? '');
+      setCity(p.billingAddressCity ?? '');
+      setRegion(p.billingAddressRegion ?? '');
+      setPostal(p.billingAddressPostalCode ?? '');
+      setCountry(p.billingAddressCountry ?? '');
+      setTerms(p.billingTermsAndConditions ?? '');
     } catch {
       setLoadError(true);
     } finally {
@@ -64,6 +94,16 @@ export default function PartnerBillingSettings() {
             invoiceNumberPrefix: prefix.trim(),
             invoiceTermsDays: Number(termsDays),
             invoiceFooter: footer.trim() === '' ? null : footer,
+            billingCompanyName: companyName.trim() === '' ? null : companyName.trim(),
+            billingPhone: phone.trim() === '' ? null : phone.trim(),
+            billingWebsite: website.trim() === '' ? null : website.trim(),
+            billingAddressLine1: addr1.trim() === '' ? null : addr1.trim(),
+            billingAddressLine2: addr2.trim() === '' ? null : addr2.trim(),
+            billingAddressCity: city.trim() === '' ? null : city.trim(),
+            billingAddressRegion: region.trim() === '' ? null : region.trim(),
+            billingAddressPostalCode: postal.trim() === '' ? null : postal.trim(),
+            billingAddressCountry: country.trim() === '' ? null : country.trim().toUpperCase(),
+            billingTermsAndConditions: terms.trim() === '' ? null : terms,
           }),
         }),
         errorFallback: 'Failed to save billing settings.',
@@ -76,7 +116,8 @@ export default function PartnerBillingSettings() {
     } finally {
       setSaving(false);
     }
-  }, [saving, currencyCode, taxPercent, prefix, termsDays, footer, load]);
+  }, [saving, currencyCode, taxPercent, prefix, termsDays, footer,
+      companyName, phone, website, addr1, addr2, city, region, postal, country, terms, load]);
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading billing settings…</p>;
   if (loadError) {
@@ -124,11 +165,11 @@ export default function PartnerBillingSettings() {
             />
           </div>
           <div>
-            <label className="text-sm font-medium" htmlFor="pb-terms">Payment terms (days)</label>
+            <label className="text-sm font-medium" htmlFor="pb-terms-days">Payment terms (days)</label>
             <input
-              id="pb-terms" type="number" min={0} max={365} step="1" value={termsDays}
+              id="pb-terms-days" type="number" min={0} max={365} step="1" value={termsDays}
               onChange={(e) => setTermsDays(e.target.value)}
-              data-testid="partner-billing-terms"
+              data-testid="partner-billing-terms-days"
               className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
             />
           </div>
@@ -139,6 +180,108 @@ export default function PartnerBillingSettings() {
             id="pb-footer" rows={3} value={footer}
             onChange={(e) => setFooter(e.target.value)} placeholder="Payment instructions, thank-you note, etc."
             data-testid="partner-billing-footer"
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+      </section>
+
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Company contact</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Shown as the seller on quotes and invoices.
+        </p>
+        <div className="mt-4">
+          <label className="text-sm font-medium" htmlFor="pb-company">Company name</label>
+          <input
+            id="pb-company" type="text" value={companyName}
+            onChange={(e) => setCompanyName(e.target.value)}
+            data-testid="partner-billing-company-name"
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="text-sm font-medium" htmlFor="pb-phone">Phone</label>
+            <input
+              id="pb-phone" type="text" value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              data-testid="partner-billing-phone"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="pb-website">Website</label>
+            <input
+              id="pb-website" type="text" value={website}
+              onChange={(e) => setWebsite(e.target.value)}
+              data-testid="partner-billing-website"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+        </div>
+        <div className="mt-4">
+          <label className="text-sm font-medium" htmlFor="pb-addr1">Address line 1</label>
+          <input
+            id="pb-addr1" type="text" value={addr1}
+            onChange={(e) => setAddr1(e.target.value)}
+            data-testid="partner-billing-addr1"
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="mt-4">
+          <label className="text-sm font-medium" htmlFor="pb-addr2">Address line 2</label>
+          <input
+            id="pb-addr2" type="text" value={addr2}
+            onChange={(e) => setAddr2(e.target.value)}
+            data-testid="partner-billing-addr2"
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="lg:col-span-2">
+            <label className="text-sm font-medium" htmlFor="pb-city">City</label>
+            <input
+              id="pb-city" type="text" value={city}
+              onChange={(e) => setCity(e.target.value)}
+              data-testid="partner-billing-city"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="pb-region">State / region</label>
+            <input
+              id="pb-region" type="text" value={region}
+              onChange={(e) => setRegion(e.target.value)}
+              data-testid="partner-billing-region"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="pb-postal">Postal code</label>
+            <input
+              id="pb-postal" type="text" value={postal}
+              onChange={(e) => setPostal(e.target.value)}
+              data-testid="partner-billing-postal"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+        </div>
+        <div className="mt-4 sm:w-24">
+          <label className="text-sm font-medium" htmlFor="pb-country">Country (2-letter)</label>
+          <input
+            id="pb-country" type="text" maxLength={2} value={country}
+            onChange={(e) => setCountry(e.target.value.toUpperCase())}
+            data-testid="partner-billing-country"
+            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm uppercase"
+          />
+        </div>
+        <div className="mt-4">
+          <label className="text-sm font-medium" htmlFor="pb-tc">Default terms &amp; conditions</label>
+          <textarea
+            id="pb-tc" rows={4} value={terms}
+            onChange={(e) => setTerms(e.target.value)}
+            placeholder="Payment terms, disclaimers, warranty language, etc."
+            data-testid="partner-billing-terms"
             className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
           />
         </div>

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -1,6 +1,30 @@
 // Shared client-side types + helpers for the invoice billing UI.
 // Money fields arrive from the API as numeric(12,2) strings (e.g. '123.40').
 
+/** Snapshot of the seller's contact info captured at invoice/quote creation time.
+ *  Any field may be null if not filled in at the time. */
+export interface SellerSnapshot {
+  name: string | null;
+  address: {
+    line1: string | null;
+    line2: string | null;
+    city: string | null;
+    region: string | null;
+    postalCode: string | null;
+    country: string | null;
+  } | null;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+}
+
+/** Convert a SellerSnapshot address into an array of non-empty display lines. */
+export function sellerLines(a: SellerSnapshot['address'] | null | undefined): string[] {
+  if (!a) return [];
+  const cityLine = [a.city, a.region, a.postalCode].filter(Boolean).join(', ');
+  return [a.line1, a.line2, cityLine, a.country].filter((s): s is string => !!s && s.trim().length > 0);
+}
+
 export type InvoiceStatus =
   | 'draft' | 'sent' | 'partially_paid' | 'overdue' | 'paid' | 'void';
 
@@ -24,6 +48,8 @@ export interface InvoiceSummary {
   balance: string;
   billToName: string | null;
   notes: string | null;
+  termsAndConditions: string | null;
+  sellerSnapshot: SellerSnapshot | null;
   createdAt: string;
 }
 

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -1,6 +1,8 @@
 // Shared client-side types + helpers for the invoice billing UI.
 // Money fields arrive from the API as numeric(12,2) strings (e.g. '123.40').
 
+// Intentional duplicate of SellerSnapshot in apps/api/src/services/sellerSnapshot.ts
+// and apps/portal/src/lib/api.ts — api/web/portal can't share a package; keep in sync.
 /** Snapshot of the seller's contact info captured at invoice/quote creation time.
  *  Any field may be null if not filled in at the time. */
 export interface SellerSnapshot {
@@ -18,6 +20,8 @@ export interface SellerSnapshot {
   website: string | null;
 }
 
+// Intentional duplicate of sellerAddressLines in apps/api/src/services/sellerSnapshot.ts
+// and sellerLines in apps/portal/src/lib/api.ts — api/web/portal can't share a package; keep in sync.
 /** Convert a SellerSnapshot address into an array of non-empty display lines. */
 export function sellerLines(a: SellerSnapshot['address'] | null | undefined): string[] {
   if (!a) return [];

--- a/apps/web/src/components/billing/quotes/QuoteDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.permissions.test.tsx
@@ -32,7 +32,7 @@ const detail: QuoteDetailData = {
     id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
     currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '50.00', taxRate: null,
     taxTotal: '0.00', total: '50.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '50.00',
-    annualRecurringTotal: '0.00', billToName: 'Acme', introNotes: null, terms: null, acceptedAt: null,
+    annualRecurringTotal: '0.00', billToName: 'Acme', introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null,
     declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null,
     viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
   },

--- a/apps/web/src/components/billing/quotes/QuoteDetail.totals.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.totals.test.tsx
@@ -31,7 +31,7 @@ const mixedDetail: QuoteDetailData = {
     currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '1950.00', taxRate: null,
     taxTotal: '0.00', total: '1950.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '1000.00',
     annualRecurringTotal: '450.00', dueOnAcceptanceTotal: '500.00',
-    billToName: 'Acme', introNotes: null, terms: null, acceptedAt: null,
+    billToName: 'Acme', introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null,
     declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null,
     viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
   },

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -13,6 +13,7 @@ import {
   formatDate,
   formatMoney,
   formatRecurrence,
+  sellerLines,
 } from './quoteTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -170,6 +171,38 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
               </>
             )}
           </div>
+
+          {/* Seller From block */}
+          {quote.sellerSnapshot && (
+            <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-detail-from">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">From</h3>
+              <div className="space-y-0.5 text-sm">
+                {quote.sellerSnapshot.name && (
+                  <p className="font-medium" data-testid="quote-detail-from-name">{quote.sellerSnapshot.name}</p>
+                )}
+                {sellerLines(quote.sellerSnapshot.address).map((line, i) => (
+                  <p key={i} className="text-muted-foreground">{line}</p>
+                ))}
+                {quote.sellerSnapshot.phone && (
+                  <p className="text-muted-foreground" data-testid="quote-detail-from-phone">{quote.sellerSnapshot.phone}</p>
+                )}
+                {quote.sellerSnapshot.email && (
+                  <p className="text-muted-foreground" data-testid="quote-detail-from-email">{quote.sellerSnapshot.email}</p>
+                )}
+                {quote.sellerSnapshot.website && (
+                  <p className="text-muted-foreground" data-testid="quote-detail-from-website">{quote.sellerSnapshot.website}</p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Terms & Conditions */}
+          {quote.termsAndConditions && (
+            <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-detail-terms">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+              <p className="whitespace-pre-wrap text-sm text-muted-foreground">{quote.termsAndConditions}</p>
+            </div>
+          )}
 
           {/* Actions */}
           <div className="space-y-2">

--- a/apps/web/src/components/billing/quotes/QuoteEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.permissions.test.tsx
@@ -57,7 +57,7 @@ const detail: QuoteDetailData = {
     id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
     currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '50.00', taxRate: null,
     taxTotal: '0.00', total: '50.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '50.00',
-    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null, acceptedAt: null,
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null,
     declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
     createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
   },

--- a/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  removeLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function draftDetail(extra: Partial<QuoteDetailData['quote']> = {}): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+      termsAndConditions: null, sellerSnapshot: null,
+      acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null,
+      sentAt: null, viewedAt: null, createdBy: null,
+      createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+      ...extra,
+    },
+    blocks: [],
+    lines: [],
+  };
+}
+
+describe('QuoteEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async () => json({ data: {} }));
+  });
+
+  it('editing the T&C textarea and blurring issues PATCH /quotes/:id with { termsAndConditions }', async () => {
+    const onChanged = vi.fn();
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input === '/quotes/q-1' && opts?.method === 'PATCH') return json({ data: {} });
+      return json({ data: {} });
+    });
+    render(<QuoteEditor detail={draftDetail()} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('quote-terms');
+    fireEvent.change(textarea, { target: { value: 'Net 30' } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      const patchCall = fetchMock.mock.calls.find(
+        (c) => c[0] === '/quotes/q-1' && (c[1] as RequestInit)?.method === 'PATCH',
+      );
+      expect(patchCall).toBeTruthy();
+      expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toMatchObject({
+        termsAndConditions: 'Net 30',
+      });
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Terms saved' }));
+  });
+
+  it('renders the T&C textarea pre-filled with existing termsAndConditions', async () => {
+    render(<QuoteEditor detail={draftDetail({ termsAndConditions: 'Payment due in 30 days' })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('quote-terms') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('Payment due in 30 days');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -57,6 +57,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
   const [busy, setBusy] = useState(false);
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
+  const [terms, setTerms] = useState(quote.termsAndConditions ?? '');
+  const [termsDirty, setTermsDirty] = useState(false);
 
   // ---- add-block form ------------------------------------------------------
   const [addType, setAddType] = useState<AddableBlockType>('heading');
@@ -66,7 +68,30 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imageCaption, setImageCaption] = useState('');
 
+  useEffect(() => { setTerms(quote.termsAndConditions ?? ''); setTermsDirty(false); }, [quote.termsAndConditions]);
+
   const refresh = useCallback(() => onChanged(), [onChanged]);
+
+  const saveTerms = useCallback(async () => {
+    if (busy || !termsDirty) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/quotes/${quote.id}`, {
+          method: 'PATCH', body: JSON.stringify({ termsAndConditions: terms }),
+        }),
+        errorFallback: 'Could not save terms.',
+        successMessage: 'Terms saved',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setTermsDirty(false);
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not save terms.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, termsDirty, terms, quote.id, refresh]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });
@@ -395,7 +420,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
           )}
         </div>
 
-        {/* ── live totals ────────────────────────────────────────────── */}
+        {/* ── live totals + terms ────────────────────────────────────── */}
         <div className="space-y-4">
           <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-live-totals">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live totals</h3>
@@ -436,6 +461,20 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 </p>
               </>
             )}
+          </div>
+
+          <div className="rounded-lg border bg-card p-4 shadow-sm">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+            <textarea
+              value={terms}
+              onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
+              onBlur={() => { if (canWrite) void saveTerms(); }}
+              disabled={!canWrite}
+              data-testid="quote-terms"
+              rows={3}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+              placeholder="Payment terms, warranty clauses, etc."
+            />
           </div>
         </div>
       </div>

--- a/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
@@ -28,7 +28,7 @@ const QUOTES = [
     id: 'q-1', quoteNumber: 'Q-0001', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
     currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null, taxTotal: '0.00',
     total: '150.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '50.00', annualRecurringTotal: '0.00',
-    billToName: null, introNotes: null, terms: null, acceptedAt: null, declinedAt: null, convertedAt: null,
+    billToName: null, introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null, convertedAt: null,
     convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
     createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
   },

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -2,6 +2,10 @@
 // Mirrors invoiceTypes.ts. Money fields arrive from the API as numeric(12,2)
 // strings (e.g. '123.40'); tax rate is a numeric(6,3) FRACTION string ('0.07').
 
+import type { SellerSnapshot } from '../invoiceTypes';
+export type { SellerSnapshot } from '../invoiceTypes';
+export { sellerLines } from '../invoiceTypes';
+
 export type QuoteStatus =
   | 'draft' | 'sent' | 'viewed' | 'accepted' | 'declined' | 'expired' | 'converted';
 
@@ -37,6 +41,8 @@ export interface Quote {
   billToName: string | null;
   introNotes: string | null;
   terms: string | null;
+  termsAndConditions: string | null;
+  sellerSnapshot: SellerSnapshot | null;
   acceptedAt: string | null;
   declinedAt: string | null;
   convertedAt: string | null;

--- a/docs/superpowers/plans/2026-06-19-quotes-invoices-contact-info.md
+++ b/docs/superpowers/plans/2026-06-19-quotes-invoices-contact-info.md
@@ -1,0 +1,1179 @@
+# Quotes & Invoices — Seller Contact Info, Terms & Conditions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a seller/MSP "From" contact block and a combined "Terms & Conditions" block (payment terms + disclaimers) to quotes and invoices, snapshotted at issue and rendered across PDF, email HTML, web, and portal — reusing the existing memo (`notes`/`introNotes`) and footer (`terms`) columns.
+
+**Architecture:** New partner-level contact fields are the editable source of truth. At issue time both documents snapshot the seller contact into a `sellerSnapshot` jsonb column and default `termsAndConditions` from the partner — mirroring the existing `billTo*` snapshot model. A single pure helper builds the snapshot; all renderers read the frozen snapshot (falling back to a live partner build for draft previews).
+
+**Tech Stack:** PostgreSQL + Drizzle ORM, Hono + Zod (`@hono/zod-validator`), pdfkit, React (apps/web + apps/portal), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-quotes-invoices-contact-info-design.md`
+
+## Global Constraints
+
+- **Node:** prefix every pnpm/vitest command with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict).
+- **Fresh worktree:** run `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm install` once before building/testing (this worktree was created fresh).
+- **API tests:** run a single file with `PATH=… pnpm --filter @breeze/api exec vitest run <path>` (the `test -- <file>` script runs the whole suite — do not use it).
+- **Shared package:** has no build step; verify with `PATH=… pnpm --filter @breeze/shared exec vitest run <path>` and `pnpm --filter @breeze/shared typecheck`.
+- **Migrations:** hand-written SQL in `apps/api/migrations/`, idempotent (`ADD COLUMN IF NOT EXISTS`), no inner `BEGIN/COMMIT`, filename `2026-06-19-<slug>.sql`. Never edit a shipped migration.
+- **No new tables → no RLS policy changes and no `rls-coverage` allowlist edits.** All three tables (`partners`, `invoices`, `quotes`) already have RLS.
+- **Snapshot semantics:** seller contact + terms + footer are frozen at issue; never re-resolved from the partner afterwards.
+- **Seller snapshot shape (canonical, used everywhere):**
+  ```ts
+  interface SellerSnapshot {
+    name: string | null;
+    address: { line1: string | null; line2: string | null; city: string | null; region: string | null; postalCode: string | null; country: string | null } | null;
+    phone: string | null;
+    email: string | null;
+    website: string | null;
+  }
+  ```
+  The `address` sub-object intentionally uses the **same keys** as `billToAddress` so the existing `addressLines()` helpers in both PDF renderers work unchanged.
+
+---
+
+### Task 1: DB schema + migration
+
+**Files:**
+- Modify: `apps/api/src/db/schema/orgs.ts:10-46` (partners)
+- Modify: `apps/api/src/db/schema/invoices.ts:28-76` (invoices)
+- Modify: `apps/api/src/db/schema/quotes.ts:21-63` (quotes)
+- Create: `apps/api/migrations/2026-06-19-quotes-invoices-contact-fields.sql`
+
+**Interfaces:**
+- Produces: new columns `partners.billingCompanyName|billingPhone|billingWebsite|billingAddressLine1|billingAddressLine2|billingAddressCity|billingAddressRegion|billingAddressPostalCode|billingAddressCountry|billingTermsAndConditions`; `invoices.sellerSnapshot (jsonb)`, `invoices.termsAndConditions (text)`; `quotes.sellerSnapshot (jsonb)`, `quotes.termsAndConditions (text)`.
+
+- [ ] **Step 1: Add partner columns to the Drizzle schema**
+
+In `apps/api/src/db/schema/orgs.ts`, inside the `partners` table definition, immediately after `invoiceFooter: text('invoice_footer'),` (line 40) add:
+
+```ts
+  billingCompanyName: varchar('billing_company_name', { length: 255 }),
+  billingPhone: varchar('billing_phone', { length: 40 }),
+  billingWebsite: varchar('billing_website', { length: 255 }),
+  billingAddressLine1: varchar('billing_address_line1', { length: 255 }),
+  billingAddressLine2: varchar('billing_address_line2', { length: 255 }),
+  billingAddressCity: varchar('billing_address_city', { length: 120 }),
+  billingAddressRegion: varchar('billing_address_region', { length: 120 }),
+  billingAddressPostalCode: varchar('billing_address_postal_code', { length: 40 }),
+  billingAddressCountry: char('billing_address_country', { length: 2 }),
+  billingTermsAndConditions: text('billing_terms_and_conditions'),
+```
+
+(`varchar`, `char`, `text` are already imported in this file — confirm at the top; the existing `organizations` table uses all three.)
+
+- [ ] **Step 2: Add invoice columns**
+
+In `apps/api/src/db/schema/invoices.ts`, in the `invoices` table after `terms: text('terms'),` (line 50) add:
+
+```ts
+  sellerSnapshot: jsonb('seller_snapshot'),
+  termsAndConditions: text('terms_and_conditions'),
+```
+
+(`jsonb` and `text` are already imported — `billToAddress: jsonb(...)` exists at line 46.)
+
+- [ ] **Step 3: Add quote columns**
+
+In `apps/api/src/db/schema/quotes.ts`, in the `quotes` table after `terms: text('terms'),` (line 45) add:
+
+```ts
+  sellerSnapshot: jsonb('seller_snapshot'),
+  termsAndConditions: text('terms_and_conditions'),
+```
+
+- [ ] **Step 4: Write the migration**
+
+Create `apps/api/migrations/2026-06-19-quotes-invoices-contact-fields.sql`:
+
+```sql
+-- Seller "From" contact profile on partners + Terms & Conditions block.
+-- Snapshot columns on invoices/quotes mirror the existing bill_to_* snapshot model.
+-- No new tables → no RLS changes (partners/invoices/quotes already have RLS).
+
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_company_name varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_phone varchar(40);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_website varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_line1 varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_line2 varchar(255);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_city varchar(120);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_region varchar(120);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_postal_code varchar(40);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_address_country char(2);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS billing_terms_and_conditions text;
+
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS seller_snapshot jsonb;
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS terms_and_conditions text;
+
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS seller_snapshot jsonb;
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS terms_and_conditions text;
+```
+
+- [ ] **Step 5: Verify schema/migration drift is clean**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+```
+Expected: no drift reported (schema matches migrations). If drift is reported, reconcile column names/types until clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/db/schema/orgs.ts apps/api/src/db/schema/invoices.ts apps/api/src/db/schema/quotes.ts apps/api/migrations/2026-06-19-quotes-invoices-contact-fields.sql
+git commit -m "feat(billing): schema + migration for seller contact, T&C on quotes/invoices"
+```
+
+---
+
+### Task 2: Seller snapshot helper
+
+**Files:**
+- Create: `apps/api/src/services/sellerSnapshot.ts`
+- Test: `apps/api/src/services/sellerSnapshot.test.ts`
+
+**Interfaces:**
+- Consumes: a partner row (Drizzle `typeof partners.$inferSelect`, or any object with the `billing*`/`name` fields).
+- Produces: `buildSellerSnapshot(partner): SellerSnapshot`, the `SellerSnapshot` type, and `sellerAddressLines(snapshot): string[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/sellerSnapshot.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildSellerSnapshot, sellerAddressLines } from './sellerSnapshot';
+
+const base = {
+  name: 'Acme MSP', billingCompanyName: null, billingEmail: null, billingPhone: null,
+  billingWebsite: null, billingAddressLine1: null, billingAddressLine2: null,
+  billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null,
+  billingAddressCountry: null,
+};
+
+describe('buildSellerSnapshot', () => {
+  it('falls back to partner.name when billingCompanyName is null', () => {
+    expect(buildSellerSnapshot(base).name).toBe('Acme MSP');
+  });
+
+  it('prefers billingCompanyName over name', () => {
+    expect(buildSellerSnapshot({ ...base, billingCompanyName: 'Acme MSP LLC' }).name).toBe('Acme MSP LLC');
+  });
+
+  it('maps contact + address fields', () => {
+    const snap = buildSellerSnapshot({
+      ...base, billingEmail: 'billing@acme.test', billingPhone: '+1 555 0100',
+      billingWebsite: 'acme.test', billingAddressLine1: '1 Main St', billingAddressCity: 'Austin',
+      billingAddressRegion: 'TX', billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+    expect(snap.email).toBe('billing@acme.test');
+    expect(snap.phone).toBe('+1 555 0100');
+    expect(snap.website).toBe('acme.test');
+    expect(snap.address).toMatchObject({ line1: '1 Main St', city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' });
+  });
+});
+
+describe('sellerAddressLines', () => {
+  it('joins city/region/postal and drops empties', () => {
+    const snap = buildSellerSnapshot({
+      ...base, billingAddressLine1: '1 Main St', billingAddressCity: 'Austin',
+      billingAddressRegion: 'TX', billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+    expect(sellerAddressLines(snap)).toEqual(['1 Main St', 'Austin, TX, 78701', 'US']);
+  });
+
+  it('returns [] for a null snapshot', () => {
+    expect(sellerAddressLines(null)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/sellerSnapshot.test.ts`
+Expected: FAIL — cannot find module `./sellerSnapshot`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/api/src/services/sellerSnapshot.ts`:
+
+```ts
+// Pure helpers for the seller "From" contact block. buildSellerSnapshot freezes
+// a partner's billing-contact profile onto a document at issue time; renderers
+// read the frozen snapshot. The address sub-object uses the SAME keys as
+// billToAddress so the PDF renderers' existing addressLines() helper works for it.
+
+export interface SellerSnapshot {
+  name: string | null;
+  address: {
+    line1: string | null; line2: string | null; city: string | null;
+    region: string | null; postalCode: string | null; country: string | null;
+  } | null;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+}
+
+interface PartnerContactFields {
+  name?: string | null;
+  billingCompanyName?: string | null;
+  billingEmail?: string | null;
+  billingPhone?: string | null;
+  billingWebsite?: string | null;
+  billingAddressLine1?: string | null;
+  billingAddressLine2?: string | null;
+  billingAddressCity?: string | null;
+  billingAddressRegion?: string | null;
+  billingAddressPostalCode?: string | null;
+  billingAddressCountry?: string | null;
+}
+
+export function buildSellerSnapshot(partner: PartnerContactFields | null | undefined): SellerSnapshot {
+  return {
+    name: partner?.billingCompanyName ?? partner?.name ?? null,
+    address: {
+      line1: partner?.billingAddressLine1 ?? null,
+      line2: partner?.billingAddressLine2 ?? null,
+      city: partner?.billingAddressCity ?? null,
+      region: partner?.billingAddressRegion ?? null,
+      postalCode: partner?.billingAddressPostalCode ?? null,
+      country: partner?.billingAddressCountry ?? null,
+    },
+    phone: partner?.billingPhone ?? null,
+    email: partner?.billingEmail ?? null,
+    website: partner?.billingWebsite ?? null,
+  };
+}
+
+export function sellerAddressLines(snapshot: SellerSnapshot | null | undefined): string[] {
+  const a = snapshot?.address;
+  if (!a) return [];
+  const cityLine = [a.city, a.region, a.postalCode].filter(Boolean).join(', ');
+  return [a.line1, a.line2, cityLine, a.country].filter((s): s is string => !!s && s.trim().length > 0);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/sellerSnapshot.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/sellerSnapshot.ts apps/api/src/services/sellerSnapshot.test.ts
+git commit -m "feat(billing): buildSellerSnapshot helper + tests"
+```
+
+---
+
+### Task 3: Shared validators + inferred types
+
+**Files:**
+- Modify: `packages/shared/src/validators/invoices.ts` (partner billing settings, create/update invoice schemas)
+- Modify: `packages/shared/src/validators/quotes.ts` (create/update quote schemas)
+- Test: `packages/shared/src/validators/invoices.test.ts`, `packages/shared/src/validators/quotes.test.ts` (create if absent)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `partnerBillingSettingsSchema` accepts the new partner contact fields + `billingTermsAndConditions`; `createManualInvoiceSchema`/`updateInvoiceSchema`/`createQuoteSchema`/`updateQuoteSchema` accept `termsAndConditions`. Inferred types (`PartnerBillingSettingsInput`, etc.) gain the new optional fields automatically.
+
+- [ ] **Step 1: Write the failing validator tests**
+
+Append to `packages/shared/src/validators/invoices.test.ts` (create the file with the standard header if it does not exist):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { partnerBillingSettingsSchema, createManualInvoiceSchema, updateInvoiceSchema } from './invoices';
+
+describe('partnerBillingSettingsSchema — contact fields', () => {
+  it('accepts the new seller contact + T&C fields', () => {
+    const parsed = partnerBillingSettingsSchema.parse({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingCompanyName: 'Acme MSP LLC', billingPhone: '+1 555 0100', billingWebsite: 'acme.test',
+      billingAddressLine1: '1 Main St', billingAddressCity: 'Austin', billingAddressRegion: 'TX',
+      billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+      billingTermsAndConditions: 'Net 30. Late fee 1.5%/mo.',
+    });
+    expect(parsed.billingCompanyName).toBe('Acme MSP LLC');
+    expect(parsed.billingAddressCountry).toBe('US');
+  });
+
+  it('rejects a 3-letter country code', () => {
+    expect(() => partnerBillingSettingsSchema.parse({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, billingAddressCountry: 'USA',
+    })).toThrow();
+  });
+});
+
+describe('invoice T&C field', () => {
+  it('create accepts termsAndConditions', () => {
+    const p = createManualInvoiceSchema.parse({ orgId: '00000000-0000-0000-0000-000000000000', termsAndConditions: 'Net 30' });
+    expect(p.termsAndConditions).toBe('Net 30');
+  });
+  it('update accepts termsAndConditions', () => {
+    const p = updateInvoiceSchema.parse({ termsAndConditions: 'Net 15' });
+    expect(p.termsAndConditions).toBe('Net 15');
+  });
+});
+```
+
+Append to `packages/shared/src/validators/quotes.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createQuoteSchema, updateQuoteSchema } from './quotes';
+
+describe('quote T&C field', () => {
+  it('create accepts termsAndConditions', () => {
+    const p = createQuoteSchema.parse({ orgId: '00000000-0000-0000-0000-000000000000', termsAndConditions: 'Valid 30 days' });
+    expect(p.termsAndConditions).toBe('Valid 30 days');
+  });
+  it('update accepts termsAndConditions (nullable to clear)', () => {
+    expect(updateQuoteSchema.parse({ termsAndConditions: null }).termsAndConditions).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared exec vitest run src/validators/invoices.test.ts src/validators/quotes.test.ts`
+Expected: FAIL — unknown keys stripped / assertions fail (the schemas don't include the new fields yet).
+
+- [ ] **Step 3: Extend the schemas**
+
+In `packages/shared/src/validators/invoices.ts`, replace `partnerBillingSettingsSchema` (lines 75-81) with:
+
+```ts
+export const partnerBillingSettingsSchema = z.object({
+  currencyCode: z.string().length(3),
+  defaultTaxRate: taxRate.nullable().optional(),
+  invoiceNumberPrefix: z.string().min(1).max(12),
+  invoiceTermsDays: z.number().int().min(0).max(365),
+  invoiceFooter: z.string().max(5000).nullable().optional(),
+  // Seller "From" contact profile (snapshotted onto each document at issue).
+  billingCompanyName: z.string().max(255).nullable().optional(),
+  billingPhone: z.string().max(40).nullable().optional(),
+  billingWebsite: z.string().max(255).nullable().optional(),
+  billingAddressLine1: z.string().max(255).nullable().optional(),
+  billingAddressLine2: z.string().max(255).nullable().optional(),
+  billingAddressCity: z.string().max(120).nullable().optional(),
+  billingAddressRegion: z.string().max(120).nullable().optional(),
+  billingAddressPostalCode: z.string().max(40).nullable().optional(),
+  billingAddressCountry: z.string().length(2).nullable().optional(),
+  billingTermsAndConditions: z.string().max(20_000).nullable().optional(),
+});
+```
+
+In the same file, add `termsAndConditions` to the invoice schemas:
+
+```ts
+export const createManualInvoiceSchema = z.object({
+  orgId: z.string().guid(),
+  siteId: z.string().guid().optional(),
+  notes: z.string().max(5000).optional(),
+  termsAndConditions: z.string().max(20_000).optional()
+});
+
+export const updateInvoiceSchema = z.object({
+  notes: z.string().max(5000).optional(),
+  siteId: z.string().guid().nullable().optional(),
+  dueDate: isoDate.optional(),
+  termsAndConditions: z.string().max(20_000).nullable().optional()
+});
+```
+
+In `packages/shared/src/validators/quotes.ts`, add `termsAndConditions` to both schemas:
+
+```ts
+export const createQuoteSchema = z.object({
+  orgId: z.string().guid(),
+  siteId: z.string().guid().optional(),
+  currencyCode: z.string().length(3).default('USD'),
+  expiryDate: isoDate.optional(),
+  introNotes: z.string().max(5000).optional(),
+  terms: z.string().max(20_000).optional(),
+  termsAndConditions: z.string().max(20_000).optional(),
+});
+
+export const updateQuoteSchema = z.object({
+  siteId: z.string().guid().nullable().optional(),
+  expiryDate: isoDate.nullable().optional(),
+  introNotes: z.string().max(5000).nullable().optional(),
+  terms: z.string().max(20_000).nullable().optional(),
+  termsAndConditions: z.string().max(20_000).nullable().optional(),
+  taxRate: taxRate.nullable().optional(),
+  billToName: z.string().max(255).nullable().optional(),
+});
+```
+
+> Note: `z.string().length(2)` for country mirrors the `char(2)` column. The inferred types (`z.infer<...>`) update automatically — no separate type edits needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared exec vitest run src/validators/invoices.test.ts src/validators/quotes.test.ts`
+Expected: PASS. Then `PATH=… pnpm --filter @breeze/shared typecheck` — expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/invoices.ts packages/shared/src/validators/quotes.ts packages/shared/src/validators/invoices.test.ts packages/shared/src/validators/quotes.test.ts
+git commit -m "feat(billing): validators accept seller contact + T&C fields"
+```
+
+---
+
+### Task 4: API service wiring (settings, create/update, issue snapshot)
+
+**Files:**
+- Modify: `apps/api/src/services/invoiceService.ts` (`updatePartnerBillingSettings`, `createManualInvoice`, `updateInvoice`, `issueInvoice`)
+- Modify: `apps/api/src/services/quoteService.ts` (`createQuote`, `updateQuote`)
+- Modify: `apps/api/src/services/quoteLifecycle.ts` (`sendQuote`)
+- Test: `apps/api/src/__tests__/integration/billing-contact-info.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `buildSellerSnapshot` (Task 2); new columns (Task 1); validated payloads (Task 3).
+- Produces: issued invoices/quotes carry `sellerSnapshot` + `termsAndConditions`; partner settings persist contact fields.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `apps/api/src/__tests__/integration/billing-contact-info.integration.test.ts`. Follow the existing integration harness conventions in this directory (real `breeze_app` DB, autoMigrate + per-test TRUNCATE, seed fresh per `it`). Model the seed/actor setup on a neighboring invoice integration test (e.g. `invoicePdf.integration.test.ts` or `invoices.integration.test.ts`) — reuse its helpers for creating a partner, org, and `InvoiceActor`.
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+// Reuse the integration bootstrap + seed helpers from a neighboring spec in this dir.
+import { db } from '../../db';
+import { partners, invoices } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+import { updatePartnerBillingSettings, createManualInvoice, issueInvoice } from '../../services/invoiceService';
+// ...import the local seed helpers (seedPartnerOrg, makeActor, addVisibleLine) used by sibling tests...
+
+describe('billing contact info — snapshot at issue', () => {
+  beforeEach(async () => { /* TRUNCATE per harness */ });
+
+  it('persists partner seller contact fields', async () => {
+    const { actor, partnerId } = await seedPartnerOrg();
+    await updatePartnerBillingSettings({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingCompanyName: 'Acme MSP LLC', billingPhone: '+1 555 0100', billingWebsite: 'acme.test',
+      billingAddressLine1: '1 Main St', billingAddressCity: 'Austin', billingAddressRegion: 'TX',
+      billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+      billingTermsAndConditions: 'Net 30. Late fee 1.5%/mo.',
+    }, actor);
+    const [p] = await db.select().from(partners).where(eq(partners.id, partnerId)).limit(1);
+    expect(p!.billingCompanyName).toBe('Acme MSP LLC');
+    expect(p!.billingTermsAndConditions).toContain('Net 30');
+  });
+
+  it('snapshots seller contact + defaults T&C onto an issued invoice', async () => {
+    const { actor, orgId, partnerId } = await seedPartnerOrg();
+    await updatePartnerBillingSettings({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingCompanyName: 'Acme MSP LLC', billingAddressLine1: '1 Main St', billingAddressCountry: 'US',
+      billingTermsAndConditions: 'Net 30.',
+    }, actor);
+    const inv = await createManualInvoice({ orgId }, actor);
+    await addVisibleLine(inv.id, orgId); // a customer-visible line so issue is allowed
+    await issueInvoice(inv.id, actor);
+    const [issued] = await db.select().from(invoices).where(eq(invoices.id, inv.id)).limit(1);
+    const snap = issued!.sellerSnapshot as { name: string; address: { line1: string } };
+    expect(snap.name).toBe('Acme MSP LLC');
+    expect(snap.address.line1).toBe('1 Main St');
+    expect(issued!.termsAndConditions).toBe('Net 30.');
+  });
+
+  it('does not overwrite a draft-supplied T&C with the partner default', async () => {
+    const { actor, orgId } = await seedPartnerOrg();
+    await updatePartnerBillingSettings({ currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, billingTermsAndConditions: 'Default terms' }, actor);
+    const inv = await createManualInvoice({ orgId, termsAndConditions: 'Custom per-invoice terms' }, actor);
+    await addVisibleLine(inv.id, orgId);
+    await issueInvoice(inv.id, actor);
+    const [issued] = await db.select().from(invoices).where(eq(invoices.id, inv.id)).limit(1);
+    expect(issued!.termsAndConditions).toBe('Custom per-invoice terms');
+  });
+});
+```
+
+> The `seedPartnerOrg`, `makeActor`, and `addVisibleLine` helpers must match the patterns the sibling integration specs already use. If a neighboring spec exposes reusable seed helpers, import them; otherwise inline the same insert sequence those specs use.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/billing-contact-info.integration.test.ts`
+Expected: FAIL — `createManualInvoice` rejects `termsAndConditions`, snapshot/T&C columns are null.
+
+- [ ] **Step 3: Wire `updatePartnerBillingSettings`**
+
+In `apps/api/src/services/invoiceService.ts`, extend the `patch` type and the write in `updatePartnerBillingSettings` (lines 303-328). Add to the `patch` parameter type the optional fields, then after the existing `if (patch.invoiceFooter !== undefined) ...` (line 320) add:
+
+```ts
+  for (const key of [
+    'billingCompanyName', 'billingPhone', 'billingWebsite', 'billingAddressLine1', 'billingAddressLine2',
+    'billingAddressCity', 'billingAddressRegion', 'billingAddressPostalCode', 'billingAddressCountry',
+    'billingTermsAndConditions',
+  ] as const) {
+    if (patch[key] !== undefined) set[key] = patch[key];
+  }
+```
+
+Update the `patch` type to:
+```ts
+  patch: {
+    currencyCode: string; defaultTaxRate?: number | null; invoiceNumberPrefix: string;
+    invoiceTermsDays: number; invoiceFooter?: string | null;
+    billingCompanyName?: string | null; billingPhone?: string | null; billingWebsite?: string | null;
+    billingAddressLine1?: string | null; billingAddressLine2?: string | null; billingAddressCity?: string | null;
+    billingAddressRegion?: string | null; billingAddressPostalCode?: string | null; billingAddressCountry?: string | null;
+    billingTermsAndConditions?: string | null;
+  },
+```
+
+(The `.returning(...)` projection can stay as-is; the route returns the service result and the settings UI reloads via `GET /partners/me`, which already returns the full row.)
+
+- [ ] **Step 4: Wire invoice create/update for T&C**
+
+In `createManualInvoice` (lines 42-50) extend the input type and insert:
+
+```ts
+export async function createManualInvoice(input: { orgId: string; siteId?: string; notes?: string; termsAndConditions?: string }, actor: InvoiceActor) {
+  const partnerId = requirePartner(actor);
+  requireOrgAccess(actor, input.orgId);
+  const rows = await db.insert(invoices).values({
+    partnerId, orgId: input.orgId, siteId: input.siteId ?? null, status: 'draft',
+    notes: input.notes ?? null, termsAndConditions: input.termsAndConditions ?? null, createdBy: actor.userId
+  }).returning();
+  return rows[0]!;
+}
+```
+
+In `updateInvoice` (lines 243-257) extend the `patch` type with `termsAndConditions?: string | null` and add after the `notes` line:
+
+```ts
+  if (patch.termsAndConditions !== undefined) set.termsAndConditions = patch.termsAndConditions;
+```
+
+- [ ] **Step 5: Snapshot in `issueInvoice`**
+
+In `apps/api/src/services/invoiceService.ts`, add the import at the top:
+```ts
+import { buildSellerSnapshot } from './sellerSnapshot';
+```
+In `issueInvoice`, in the final `db.update(invoices).set({...})` (lines 465-475), add two fields to the set object (the full `partner` row is in scope from line 427, and `inv` from line 407):
+
+```ts
+      sellerSnapshot: buildSellerSnapshot(partner),
+      termsAndConditions: inv.termsAndConditions ?? partner?.billingTermsAndConditions ?? null,
+```
+
+(Leave the existing `terms: partner?.invoiceFooter ?? null` line unchanged — that is the footer snapshot.)
+
+- [ ] **Step 6: Wire quote create/update for T&C**
+
+In `apps/api/src/services/quoteService.ts`, in `createQuote` (lines 90-104) add to the insert values:
+```ts
+    termsAndConditions: input.termsAndConditions ?? null,
+```
+In `updateQuote` (lines 144-158) add after the `terms` line:
+```ts
+  if (input.termsAndConditions !== undefined) set.termsAndConditions = input.termsAndConditions;
+```
+(`CreateQuoteInput`/`UpdateQuoteInput` already gain `termsAndConditions` from Task 3's inferred types.)
+
+- [ ] **Step 7: Snapshot in `sendQuote`**
+
+In `apps/api/src/services/quoteLifecycle.ts`, add the import:
+```ts
+import { buildSellerSnapshot } from './sellerSnapshot';
+```
+Before the claim `db.update(quotes).set(...)` (lines 92-96), fetch the full partner row and include the snapshot/defaults in the set:
+
+```ts
+  const [partnerRow] = await db.select().from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+  const claimed = await db
+    .update(quotes)
+    .set({
+      status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now,
+      sellerSnapshot: buildSellerSnapshot(partnerRow),
+      termsAndConditions: quote.termsAndConditions ?? partnerRow?.billingTermsAndConditions ?? null,
+      terms: quote.terms ?? partnerRow?.invoiceFooter ?? null,
+    })
+    .where(and(eq(quotes.id, id), eq(quotes.status, 'draft')))
+    .returning({ id: quotes.id });
+```
+
+(`partners` is already imported in this file — line 4. `quote` comes from `getQuote` at line 76 and carries `terms`/`termsAndConditions`.)
+
+- [ ] **Step 8: Run the integration test to verify it passes**
+
+Run the Step 2 command. Expected: PASS (all three cases). Also run the existing invoice + quote service unit tests to confirm no regression:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/routes/invoices/settings.test.ts
+```
+Expected: PASS (existing settings route test still green — the schema additions are optional).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/services/invoiceService.ts apps/api/src/services/quoteService.ts apps/api/src/services/quoteLifecycle.ts apps/api/src/__tests__/integration/billing-contact-info.integration.test.ts
+git commit -m "feat(billing): snapshot seller contact + default T&C at issue (invoice + quote)"
+```
+
+---
+
+### Task 5: PDF + email-HTML renderers (From block + T&C)
+
+**Files:**
+- Modify: `apps/api/src/services/invoicePdf.ts` (`renderInvoiceHtml`, `renderInvoicePdfBuffer`, `loadInvoiceForRender`)
+- Modify: `apps/api/src/services/quotePdf.ts` (`renderQuotePdf`, `QuoteHeader`)
+- Modify: `apps/api/src/services/quoteLifecycle.ts` + `apps/api/src/routes/quotes/quotes.ts` + `apps/api/src/routes/portal/quotes.ts` (pass `sellerSnapshot` to the quote PDF — it already passes the full `quote`, so confirm the header type carries it)
+- Test: `apps/api/src/services/invoicePdf.test.ts`, `apps/api/src/services/quotePdf.test.ts`
+
+**Interfaces:**
+- Consumes: `invoice.sellerSnapshot`/`invoice.termsAndConditions`, `quote.sellerSnapshot`/`quote.termsAndConditions`, `buildSellerSnapshot`, `sellerAddressLines`.
+- Produces: rendered From + T&C in PDF and email HTML; draft previews build a live snapshot when `sellerSnapshot` is null.
+
+- [ ] **Step 1: Write failing renderer tests**
+
+Append to `apps/api/src/services/invoicePdf.test.ts`:
+
+```ts
+import { renderInvoiceHtml, renderInvoicePdfBuffer } from './invoicePdf';
+
+const sellerSnapshot = {
+  name: 'Acme MSP LLC', phone: '+1 555 0100', email: 'billing@acme.test', website: 'acme.test',
+  address: { line1: '1 Main St', line2: null, city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' },
+};
+
+it('renderInvoiceHtml shows the From block and T&C', () => {
+  const html = renderInvoiceHtml(
+    { invoiceNumber: 'INV-1', currencyCode: 'USD', subtotal: '10', taxTotal: '0', total: '10', amountPaid: '0', balance: '10', billToName: 'Cust', sellerSnapshot, termsAndConditions: 'Net 30 terms' } as never,
+    [],
+    { partnerName: 'Acme MSP LLC' },
+  );
+  expect(html).toContain('From');
+  expect(html).toContain('billing@acme.test');
+  expect(html).toContain('Net 30 terms');
+});
+
+it('renderInvoicePdfBuffer emits a %PDF with a seller snapshot present', async () => {
+  const buf = await renderInvoicePdfBuffer(
+    { invoiceNumber: 'INV-1', currencyCode: 'USD', subtotal: '10', taxTotal: '0', total: '10', amountPaid: '0', balance: '10', billToName: 'Cust', sellerSnapshot, termsAndConditions: 'Net 30' } as never,
+    [],
+    { partnerName: 'Acme MSP LLC' },
+  );
+  expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+});
+```
+
+Append to `apps/api/src/services/quotePdf.test.ts`:
+
+```ts
+it('renderQuotePdf includes the From block and T&C', async () => {
+  const buf = await renderQuotePdf(
+    { id: 'q1', quoteNumber: 'Q-1', currencyCode: 'USD', billToName: 'Cust',
+      sellerSnapshot: { name: 'Acme MSP LLC', phone: null, email: 'billing@acme.test', website: null,
+        address: { line1: '1 Main St', line2: null, city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' } },
+      termsAndConditions: 'Valid 30 days' } as never,
+    [], [], async () => null, { partnerName: 'Acme MSP LLC' },
+  );
+  expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/invoicePdf.test.ts src/services/quotePdf.test.ts`
+Expected: FAIL — `renderInvoiceHtml` output lacks "From"/email; type errors on `sellerSnapshot`/`termsAndConditions` until the header types are widened.
+
+- [ ] **Step 3: Add a shared seller-address helper import + types to invoicePdf.ts**
+
+At the top of `apps/api/src/services/invoicePdf.ts` add:
+```ts
+import { buildSellerSnapshot, sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
+```
+(The `InvoiceRow` type already includes `sellerSnapshot`/`termsAndConditions` after Task 1, since it is `typeof invoices.$inferSelect`.)
+
+- [ ] **Step 4: Render From + T&C in `renderInvoiceHtml`**
+
+In `renderInvoiceHtml` (line 89+), compute the seller lines near `const billTo = ...` (line 95):
+```ts
+  const seller = (invoice.sellerSnapshot as SellerSnapshot | null) ?? null;
+  const sellerLines = sellerAddressLines(seller);
+```
+Add a "From" column inside the existing `display:flex` header block. Replace the bill-to/dates block (lines 126-137) so the row has three parts — From (left), Bill To (middle), dates (right):
+
+```ts
+      <div style="padding:24px;display:flex;justify-content:space-between;gap:24px;">
+        <div>
+          <div style="font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;">From</div>
+          <div style="font-size:14px;font-weight:600;color:#111827;margin-top:4px;">${escapeHtml(seller?.name ?? branding.partnerName)}</div>
+          ${sellerLines.map((l) => `<div style="font-size:13px;color:#4b5563;">${escapeHtml(l)}</div>`).join('')}
+          ${seller?.phone ? `<div style="font-size:12px;color:#6b7280;">${escapeHtml(seller.phone)}</div>` : ''}
+          ${seller?.email ? `<div style="font-size:12px;color:#6b7280;">${escapeHtml(seller.email)}</div>` : ''}
+          ${seller?.website ? `<div style="font-size:12px;color:#6b7280;">${escapeHtml(seller.website)}</div>` : ''}
+        </div>
+        <div>
+          <div style="font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;">Bill to</div>
+          <div style="font-size:14px;font-weight:600;color:#111827;margin-top:4px;">${escapeHtml(invoice.billToName ?? '')}</div>
+          ${billTo.map((l) => `<div style="font-size:13px;color:#4b5563;">${escapeHtml(l)}</div>`).join('')}
+          ${invoice.billToTaxId ? `<div style="font-size:12px;color:#6b7280;margin-top:4px;">Tax ID: ${escapeHtml(invoice.billToTaxId)}</div>` : ''}
+        </div>
+        <div style="text-align:right;font-size:13px;color:#4b5563;">
+          ${invoice.issueDate ? `<div>Issued: ${escapeHtml(formatDate(invoice.issueDate))}</div>` : ''}
+          ${invoice.dueDate ? `<div>Due: ${escapeHtml(formatDate(invoice.dueDate))}</div>` : ''}
+        </div>
+      </div>
+```
+
+Add the T&C block between the notes block (line 157) and the footer block (line 158):
+
+```ts
+      ${invoice.termsAndConditions ? `<div style="padding:0 24px 16px;font-size:12px;color:#6b7280;"><div style="font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;margin-bottom:4px;">Terms &amp; Conditions</div>${escapeHtml(invoice.termsAndConditions)}</div>` : ''}
+```
+
+- [ ] **Step 5: Render From + T&C in `renderInvoicePdfBuffer`**
+
+In `renderInvoicePdfBuffer` (line 179+), after the header rule (line 198) and before the bill-to block, draw the From block on the left and move Bill To to the right column. Replace lines 200-216 with:
+
+```ts
+      // From (seller) — left column; Bill To — right column; dates under Bill To.
+      const seller = (invoice.sellerSnapshot as SellerSnapshot | null) ?? null;
+      const rightX = left + contentWidth * 0.55;
+      const rightW = contentWidth * 0.45;
+      let y = 112;
+
+      doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('FROM', left, y);
+      doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? branding.partnerName, left, y + 12, { width: contentWidth * 0.5 });
+      let fromY = y + 28;
+      doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+      for (const aline of sellerAddressLines(seller)) { doc.text(aline, left, fromY, { width: contentWidth * 0.5 }); fromY += 13; }
+      doc.fillColor('#6b7280').fontSize(9);
+      if (seller?.phone) { doc.text(seller.phone, left, fromY, { width: contentWidth * 0.5 }); fromY += 12; }
+      if (seller?.email) { doc.text(seller.email, left, fromY, { width: contentWidth * 0.5 }); fromY += 12; }
+      if (seller?.website) { doc.text(seller.website, left, fromY, { width: contentWidth * 0.5 }); fromY += 12; }
+
+      doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('BILL TO', rightX, y, { width: rightW });
+      doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(invoice.billToName ?? '', rightX, y + 12, { width: rightW });
+      let billY = y + 28;
+      doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+      for (const aline of addressLines(invoice.billToAddress as BillToAddress | null)) { doc.text(aline, rightX, billY, { width: rightW }); billY += 13; }
+      if (invoice.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${invoice.billToTaxId}`, rightX, billY, { width: rightW }); billY += 13; }
+      doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+      if (invoice.issueDate) { doc.text(`Issued: ${formatDate(invoice.issueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
+      if (invoice.dueDate) { doc.text(`Due: ${formatDate(invoice.dueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
+
+      // Line table starts below the taller of the two columns.
+      y = Math.max(fromY, billY) + 20;
+```
+
+> This replaces the old `let y = 112; ...` bill-to/date block and the subsequent `y = Math.max(billY, dateY) + 20;` (line 218). Remove the now-dead `dateX`/`dateY` lines (211-215) and the old line-table `y =` reassignment at 218 — the new block ends with the correct `y`.
+
+Add the T&C block in the notes/footer area. Replace lines 267-276 with:
+
+```ts
+      // Notes (memo) + Terms & Conditions + footer/terms.
+      if (invoice.notes) {
+        y += 14;
+        doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('NOTES', left, y); y += 12;
+        doc.fillColor('#4b5563').fontSize(10).font('Helvetica').text(invoice.notes, left, y, { width: contentWidth });
+        y = doc.y + 8;
+      }
+      if (invoice.termsAndConditions) {
+        y += 6;
+        doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('TERMS & CONDITIONS', left, y); y += 12;
+        doc.fillColor('#6b7280').fontSize(9).font('Helvetica').text(invoice.termsAndConditions, left, y, { width: contentWidth });
+        y = doc.y + 8;
+      }
+      const footer = invoice.terms ?? branding.footerText ?? null;
+      if (footer) {
+        doc.fillColor('#9ca3af').fontSize(9).font('Helvetica').text(footer, left, Math.max(y, doc.page.height - 110), { width: contentWidth });
+      }
+```
+
+- [ ] **Step 6: Draft-preview fallback in `loadInvoiceForRender`**
+
+In `loadInvoiceForRender` (lines 290-307), the partner is already selected at line 294 — widen that select to include the contact fields, then fill a live snapshot when the invoice has none (draft preview). Change the partner select to:
+
+```ts
+  const [partner] = await db.select().from(partners).where(eq(partners.id, invoice.partnerId)).limit(1);
+```
+and before the `return`, add:
+```ts
+  if (!invoice.sellerSnapshot && partner) {
+    (invoice as { sellerSnapshot: unknown }).sellerSnapshot = buildSellerSnapshot(partner);
+  }
+```
+(Keep the existing `branding` object; it still reads `partner.name`/`partner.invoiceFooter`/`partner.currencyCode`, which the full-row select still provides.)
+
+- [ ] **Step 7: Render From + T&C in the quote PDF**
+
+In `apps/api/src/services/quotePdf.ts`:
+
+Add to the top:
+```ts
+import { sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
+```
+Widen `QuoteHeader` (lines 77-98) by adding:
+```ts
+  sellerSnapshot?: unknown;
+  termsAndConditions?: string | null;
+```
+
+In `renderQuotePdf`, replace the PREPARED FOR / dates block (lines 265-284) with a two-column From / Prepared-For layout:
+
+```ts
+  // ---- From (seller) left column; Prepared For + dates right column ---------
+  let y = 112;
+  const seller = (quote.sellerSnapshot as SellerSnapshot | null) ?? null;
+  const rightX = c.left + c.contentWidth * 0.55;
+  const rightW = c.contentWidth * 0.45;
+
+  doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('FROM', c.left, y);
+  doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? partnerName, c.left, y + 12, { width: c.contentWidth * 0.5 });
+  let fromY = y + 28;
+  doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+  for (const aline of sellerAddressLines(seller)) { doc.text(aline, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 13; }
+  doc.fillColor('#6b7280').fontSize(9);
+  if (seller?.phone) { doc.text(seller.phone, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
+  if (seller?.email) { doc.text(seller.email, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
+  if (seller?.website) { doc.text(seller.website, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
+
+  let billY = y;
+  if (quote.billToName) {
+    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED FOR', rightX, billY, { width: rightW });
+    doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(quote.billToName, rightX, billY + 12, { width: rightW });
+    billY += 28;
+  }
+  doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+  for (const aline of addressLines(quote.billToAddress as BillToAddress | null)) { doc.text(aline, rightX, billY, { width: rightW }); billY += 13; }
+  if (quote.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${quote.billToTaxId}`, rightX, billY, { width: rightW }); billY += 13; }
+  doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+  if (quote.issueDate) { doc.text(`Issued: ${formatDate(quote.issueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
+  if (quote.expiryDate) { doc.text(`Valid until: ${formatDate(quote.expiryDate)}`, rightX, billY, { width: rightW }); billY += 14; }
+
+  y = Math.max(fromY, billY) + 20;
+```
+
+(Delete the old `dateX`/`dateY` lines 278-282 and the `y = Math.max(billY, dateY) + 20;` at line 284 — the new block sets `y`.)
+
+Add the T&C block after the recurring summary, before the footer. Between line 350 (`y = renderRecurringSummary(...)`) and line 352 (`const footer = ...`) insert:
+
+```ts
+  // ---- Terms & Conditions --------------------------------------------------
+  if (quote.termsAndConditions) {
+    y = ensureSpace(doc, y + 14, 60);
+    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('TERMS & CONDITIONS', c.left, y); y = doc.y + 4;
+    doc.fillColor('#6b7280').fontSize(9).font('Helvetica').text(quote.termsAndConditions, c.left, y, { width: c.contentWidth });
+    y = doc.y;
+  }
+```
+
+- [ ] **Step 8: Pass a live snapshot for quote draft previews**
+
+The quote PDF route(s) build the `quote` object passed to `renderQuotePdf`. In `apps/api/src/routes/quotes/quotes.ts` (around line 90-107) and `apps/api/src/routes/portal/quotes.ts` (around line 56), where the partner row is selected for branding, widen that select to the full partner row and set a fallback before calling `renderQuotePdf`:
+
+```ts
+  const [partner] = await db.select().from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+  const quoteForRender = {
+    ...quote,
+    sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partner),
+  };
+```
+Pass `quoteForRender` instead of `quote` to `renderQuotePdf`, and keep `footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null` in the branding arg. Add `import { buildSellerSnapshot } from '../../services/sellerSnapshot';` to each route file. (`sendQuote` already snapshots at issue, so the emailed PDF needs no fallback — but adding `sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partnerRow)` to its `renderQuotePdf` call at line 134 is harmless and covers any legacy already-sent quote re-render.)
+
+- [ ] **Step 9: Run renderer tests + verify pass**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/invoicePdf.test.ts src/services/quotePdf.test.ts`
+Expected: PASS. Then typecheck the API: `PATH=… pnpm --filter @breeze/api exec tsc --noEmit` — expected: no new errors (pre-existing errors in `agents.test.ts`/`apiKeyAuth.test.ts` are known).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/api/src/services/invoicePdf.ts apps/api/src/services/quotePdf.ts apps/api/src/services/quoteLifecycle.ts apps/api/src/routes/quotes/quotes.ts apps/api/src/routes/portal/quotes.ts apps/api/src/services/invoicePdf.test.ts apps/api/src/services/quotePdf.test.ts
+git commit -m "feat(billing): render seller From block + T&C in invoice/quote PDFs + email HTML"
+```
+
+---
+
+### Task 6: Partner billing settings web UI
+
+**Files:**
+- Modify: `apps/web/src/components/billing/PartnerBillingSettings.tsx`
+- Test: `apps/web/src/components/billing/PartnerBillingSettings.test.tsx` (extend if present, else create)
+
+**Interfaces:**
+- Consumes: `GET /orgs/partners/me` (full partner row — already returns new columns), `PATCH /partner/billing-settings` (Task 3/4 payload).
+- Produces: editable company-name/address/phone/website + default T&C fields.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create/extend `apps/web/src/components/billing/PartnerBillingSettings.test.tsx`. Mock `fetchWithAuth` to resolve `GET /orgs/partners/me` with a partner that has `billingCompanyName: 'Acme MSP LLC'` and assert it renders, and that Save posts the field. Follow the existing apps/web test setup (jsdom, `@testing-library/react`). Minimal assertion:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import PartnerBillingSettings from './PartnerBillingSettings';
+// mock ../../lib/fetchWithAuth + runAction per existing tests in this dir
+
+it('loads and shows the seller company name', async () => {
+  // arrange fetchWithAuth GET to return { currencyCode:'USD', invoiceNumberPrefix:'INV', invoiceTermsDays:30, billingCompanyName:'Acme MSP LLC', ... }
+  render(<PartnerBillingSettings />);
+  await waitFor(() => expect((screen.getByTestId('partner-billing-company-name') as HTMLInputElement).value).toBe('Acme MSP LLC'));
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/billing/PartnerBillingSettings.test.tsx`
+Expected: FAIL — `partner-billing-company-name` testid not found.
+
+- [ ] **Step 3: Extend the `PartnerBilling` type + state**
+
+In `PartnerBillingSettings.tsx`, extend the interface (lines 10-16) and add state + load wiring:
+
+```tsx
+interface PartnerBilling {
+  currencyCode: string;
+  defaultTaxRate: string | null;
+  invoiceNumberPrefix: string;
+  invoiceTermsDays: number;
+  invoiceFooter: string | null;
+  billingCompanyName: string | null;
+  billingPhone: string | null;
+  billingWebsite: string | null;
+  billingAddressLine1: string | null;
+  billingAddressLine2: string | null;
+  billingAddressCity: string | null;
+  billingAddressRegion: string | null;
+  billingAddressPostalCode: string | null;
+  billingAddressCountry: string | null;
+  billingTermsAndConditions: string | null;
+}
+```
+
+Add `useState` hooks for each new field (string state, default `''`), e.g.:
+```tsx
+const [companyName, setCompanyName] = useState('');
+const [phone, setPhone] = useState('');
+const [website, setWebsite] = useState('');
+const [addr1, setAddr1] = useState('');
+const [addr2, setAddr2] = useState('');
+const [city, setCity] = useState('');
+const [region, setRegion] = useState('');
+const [postal, setPostal] = useState('');
+const [country, setCountry] = useState('');
+const [terms, setTerms] = useState('');
+```
+
+In `load` (after line 42 `setFooter(...)`), populate them:
+```tsx
+setCompanyName(p.billingCompanyName ?? '');
+setPhone(p.billingPhone ?? '');
+setWebsite(p.billingWebsite ?? '');
+setAddr1(p.billingAddressLine1 ?? '');
+setAddr2(p.billingAddressLine2 ?? '');
+setCity(p.billingAddressCity ?? '');
+setRegion(p.billingAddressRegion ?? '');
+setPostal(p.billingAddressPostalCode ?? '');
+setCountry(p.billingAddressCountry ?? '');
+setTerms(p.billingTermsAndConditions ?? '');
+```
+
+- [ ] **Step 4: Send the new fields on Save**
+
+In `save` (the `JSON.stringify({...})` body, lines 60-67), add (use `null` for empty optional text, matching the existing `invoiceFooter` pattern — the billing UI↔Zod payload caution):
+
+```tsx
+          billingCompanyName: companyName.trim() === '' ? null : companyName.trim(),
+          billingPhone: phone.trim() === '' ? null : phone.trim(),
+          billingWebsite: website.trim() === '' ? null : website.trim(),
+          billingAddressLine1: addr1.trim() === '' ? null : addr1.trim(),
+          billingAddressLine2: addr2.trim() === '' ? null : addr2.trim(),
+          billingAddressCity: city.trim() === '' ? null : city.trim(),
+          billingAddressRegion: region.trim() === '' ? null : region.trim(),
+          billingAddressPostalCode: postal.trim() === '' ? null : postal.trim(),
+          billingAddressCountry: country.trim() === '' ? null : country.trim().toUpperCase(),
+          billingTermsAndConditions: terms.trim() === '' ? null : terms,
+```
+
+Add the field dependencies to the `save` `useCallback` deps array.
+
+- [ ] **Step 5: Add the form inputs**
+
+Add a "Company contact (shown on quotes & invoices)" section before or after the footer field, following the existing field pattern (lines 136-144). Include a `data-testid="partner-billing-company-name"` input for company name, text inputs for phone/website/address parts (2-letter `maxLength={2}` country), and a `<textarea>` for default T&C with `data-testid="partner-billing-terms"`. Example for two fields (repeat the pattern for the rest):
+
+```tsx
+<div className="mt-4">
+  <label className="text-sm font-medium" htmlFor="pb-company">Company name</label>
+  <input id="pb-company" value={companyName} onChange={(e) => setCompanyName(e.target.value)}
+    data-testid="partner-billing-company-name"
+    className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm" />
+</div>
+<div className="mt-4">
+  <label className="text-sm font-medium" htmlFor="pb-terms">Default terms &amp; conditions</label>
+  <textarea id="pb-terms" rows={4} value={terms} onChange={(e) => setTerms(e.target.value)}
+    placeholder="Payment terms, disclaimers, warranty language, etc."
+    data-testid="partner-billing-terms"
+    className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm" />
+</div>
+```
+
+- [ ] **Step 6: Run to verify pass**
+
+Run the Step 2 command. Expected: PASS. Then `PATH=… pnpm --filter @breeze/web exec astro check` (or the web typecheck script) — expected: no new type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/billing/PartnerBillingSettings.tsx apps/web/src/components/billing/PartnerBillingSettings.test.tsx
+git commit -m "feat(web): edit seller contact profile + default T&C in partner billing settings"
+```
+
+---
+
+### Task 7: Web invoice & quote editor/detail (T&C edit + From display)
+
+**Files:**
+- Modify: `apps/web/src/components/billing/InvoiceEditor.tsx` (add T&C textarea + save)
+- Modify: `apps/web/src/components/billing/InvoiceDetail.tsx` (show From + T&C)
+- Modify: `apps/web/src/components/billing/quotes/QuoteEditor.tsx` (add T&C textarea + save) and `QuoteDetail.tsx` (show From + T&C)
+- Test: extend the corresponding `*.test.tsx` where present
+
+**Interfaces:**
+- Consumes: `PATCH /invoices/:id` + `PATCH /quotes/:id` with `termsAndConditions`; the invoice/quote row's `sellerSnapshot`/`termsAndConditions`.
+- Produces: draft editors can set T&C; detail views show the From block (from snapshot) + T&C.
+
+- [ ] **Step 1: Write the failing test (invoice editor T&C save)**
+
+In `apps/web/src/components/billing/InvoiceEditor.test.tsx` (extend/create), assert that editing the T&C textarea and saving issues `PATCH /invoices/:id` with `{ termsAndConditions: 'Net 30' }`. Mirror the existing notes-save test in that file.
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/billing/InvoiceEditor.test.tsx`
+Expected: FAIL — no T&C textarea / PATCH not sent.
+
+- [ ] **Step 3: Add T&C edit to `InvoiceEditor.tsx`**
+
+Mirror the existing notes pattern (state at lines 35-36, `saveNotes` at 157-176). Add:
+```tsx
+const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
+const [termsDirty, setTermsDirty] = useState(false);
+```
+and a `saveTerms` callback identical to `saveNotes` but with body `JSON.stringify({ termsAndConditions: terms })` and success message `'Terms saved'`. Render a labelled `<textarea data-testid="invoice-terms">` near the notes textarea, wired to `setTerms`/`setTermsDirty` and `saveTerms`.
+
+- [ ] **Step 4: Show From + T&C in `InvoiceDetail.tsx`**
+
+Add a read-only From block (from `invoice.sellerSnapshot`) near the Bill To area and a T&C block near where notes render. Use the same `SellerSnapshot` shape; render `name`, address lines, phone/email/website, and `invoice.termsAndConditions` when present. (Define a small local `sellerLines(snapshot)` mirroring `sellerAddressLines`, or import the shape; the web app cannot import the API service, so inline a 4-line helper.)
+
+- [ ] **Step 5: Mirror for quotes**
+
+In `QuoteEditor.tsx` add the same T&C textarea (`data-testid="quote-terms"`) wired to `PATCH /quotes/:id` with `{ termsAndConditions }`. In `QuoteDetail.tsx` show the From block + T&C from `quote.sellerSnapshot`/`quote.termsAndConditions`.
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run the Step 2 command (plus the quote editor test). Expected: PASS. Then web typecheck — expected: no new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/billing/InvoiceEditor.tsx apps/web/src/components/billing/InvoiceDetail.tsx apps/web/src/components/billing/quotes/QuoteEditor.tsx apps/web/src/components/billing/quotes/QuoteDetail.tsx apps/web/src/components/billing/**/*.test.tsx
+git commit -m "feat(web): edit T&C + show seller From block on invoice/quote editor + detail"
+```
+
+---
+
+### Task 8: Portal customer views (From block + T&C)
+
+**Files:**
+- Modify: `apps/portal/src/components/portal/InvoiceDetailView.tsx`
+- Modify: `apps/portal/src/components/portal/QuoteDetailView.tsx`
+- Test: extend the corresponding portal `*.test.tsx` if present
+
+**Interfaces:**
+- Consumes: the portal invoice/quote payload (already returns the full row → includes `sellerSnapshot`, `termsAndConditions`).
+- Produces: customer-facing From block + T&C block.
+
+- [ ] **Step 1: Write the failing test**
+
+In the portal invoice view test (create/extend), render `InvoiceDetailView` with an `invoice` that has a `sellerSnapshot` + `termsAndConditions` and assert "From", the seller email, and the T&C text appear. Mirror the existing bill-to/notes rendering tests.
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/portal exec vitest run src/components/portal/InvoiceDetailView.test.tsx`
+Expected: FAIL — From/T&C not rendered.
+
+- [ ] **Step 3: Add From + T&C to `InvoiceDetailView.tsx`**
+
+Add a local seller-lines helper and render a From card beside the existing Bill To card (lines 228-232), plus a T&C card near the Notes card (lines 266-271):
+
+```tsx
+const seller = invoice.sellerSnapshot as
+  | { name: string | null; phone: string | null; email: string | null; website: string | null;
+      address: { line1: string|null; line2: string|null; city: string|null; region: string|null; postalCode: string|null; country: string|null } | null }
+  | null;
+const sellerLines = (() => {
+  const a = seller?.address; if (!a) return [] as string[];
+  const cityLine = [a.city, a.region, a.postalCode].filter(Boolean).join(', ');
+  return [a.line1, a.line2, cityLine, a.country].filter((s): s is string => !!s && s.trim().length > 0);
+})();
+```
+
+```tsx
+{seller?.name && (
+  <div className="rounded-lg border p-4">
+    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">From</p>
+    <p className="mt-1 text-sm font-medium">{seller.name}</p>
+    {sellerLines.map((l, i) => <p key={i} className="text-sm text-muted-foreground">{l}</p>)}
+    {seller.phone && <p className="text-sm text-muted-foreground">{seller.phone}</p>}
+    {seller.email && <p className="text-sm text-muted-foreground">{seller.email}</p>}
+    {seller.website && <p className="text-sm text-muted-foreground">{seller.website}</p>}
+  </div>
+)}
+```
+
+```tsx
+{invoice.termsAndConditions && (
+  <div className="rounded-lg border p-4">
+    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</p>
+    <p className="mt-1 whitespace-pre-wrap text-sm">{invoice.termsAndConditions}</p>
+  </div>
+)}
+```
+
+(Add `sellerSnapshot`/`termsAndConditions` to the portal `Invoice` TypeScript type used by this component.)
+
+- [ ] **Step 4: Mirror for `QuoteDetailView.tsx`**
+
+Add the same From card near the quote header and a T&C card near the Terms card (lines 206-211). Add the fields to the portal `Quote` type.
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run the Step 2 command (plus the quote view test). Expected: PASS. Then the portal typecheck/`astro check` — expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/portal/src/components/portal/InvoiceDetailView.tsx apps/portal/src/components/portal/QuoteDetailView.tsx apps/portal/src/components/portal/**/*.test.tsx
+git commit -m "feat(portal): show seller From block + T&C on customer invoice/quote views"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full billing-related API suites single-fork:
+  ```bash
+  PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/invoicePdf.test.ts src/services/quotePdf.test.ts src/services/sellerSnapshot.test.ts src/routes/invoices/settings.test.ts
+  PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/billing-contact-info.integration.test.ts
+  ```
+- [ ] Run shared + web + portal billing tests (commands in their tasks).
+- [ ] `pnpm db:check-drift` clean.
+- [ ] Manual smoke (optional, local docker): set seller contact in partner billing settings, create + issue an invoice and a quote, confirm the From block + T&C appear in the web detail, the portal view, and the downloaded PDF.
+
+## Notes for the implementer
+
+- **Snapshot, never live (after issue):** the renderers read `sellerSnapshot`/`termsAndConditions` off the row. The only live-build fallback is for **draft previews** (Task 5 Steps 6 & 8). Do not make issued documents re-resolve from the partner.
+- **Footer vs T&C:** `terms` is the footer (unchanged); `termsAndConditions` is the new block. Don't conflate them.
+- **Memo:** `invoices.notes` / `quotes.introNotes` already exist and already render — Task 5/7/8 only relabel/position them ("Notes"); no schema change.
+- **Money/optional payload caution:** for new optional text fields send `null` (not `undefined`/empty string) when cleared, matching the existing `invoiceFooter` handling — this class of UI↔Zod mismatch has bitten billing before.
+```

--- a/docs/superpowers/specs/2026-06-19-quotes-invoices-contact-info-design.md
+++ b/docs/superpowers/specs/2026-06-19-quotes-invoices-contact-info-design.md
@@ -1,0 +1,131 @@
+# Quotes & Invoices — Seller Contact Info, Memo, Terms & Footer
+
+**Date:** 2026-06-19
+**Status:** Design approved, pending spec review
+**Scope:** Add a seller/MSP "From" contact block and a "Terms & Conditions" block (payment terms + disclaimers) to both quotes and invoices, and surface the existing memo + footer consistently across both. The customer "Bill To" block already exists and is unchanged.
+
+## Problem
+
+Quotes and invoices render the customer ("Bill To" / "Prepared For") at the top, but there is **no seller/MSP "From" block** — the `partners` table has only `name` + `billingEmail`, no address/phone/website. There is also no dedicated place for **payment terms or disclaimers**. A customer receiving a document can't see who it's from, how to reach them, or the terms that apply.
+
+## What already exists (confirmed in code)
+
+| Concept | Invoices | Quotes | Default source |
+|---|---|---|---|
+| Customer "Bill To" | `billToName`, `billToAddress` (jsonb), `billToTaxId`, `billToTaxExempt` | `billToName`, `billToAddress`, `billToTaxId` | snapshot at issue |
+| Memo (note above footer) | `notes` (`invoicePdf.ts:157,268`) | `introNotes` (`quotePdf.ts:287`) | none (per-doc) |
+| Footer (bottom line) | `terms` — used as `footer = terms ?? branding.footer` (`invoicePdf.ts:273,303`); snapshotted from `partner.invoiceFooter` at issue (`invoiceService.ts:474`) | `terms` — `footer = terms ?? branding.footer` (`quotePdf.ts:353`); falls back to `partner.invoiceFooter` live at render (`quotes.ts:107`), not snapshotted | `partner.invoiceFooter` |
+
+> Naming note: the doc column `terms` is, despite its name, the **footer** line. We keep it as-is (renaming a shipped column is churn + data risk) and give the new Terms & Conditions block its own clearly-named column.
+
+## Goals
+
+1. A seller "From" block at the top of every quote and invoice: company name, address, phone, email, website.
+2. A "Terms & Conditions" block (payment terms + disclaimers combined into one free-text block), with a reusable partner-level default, editable per document, on both doc types.
+3. Memo and footer surfaced **consistently** (uniform label + placement) across quotes and invoices — reusing the existing columns, no duplicates.
+
+## Non-goals
+
+- Seller tax/VAT/registration ID (declined — only the customer's tax ID appears, in Bill To).
+- Per-customer / per-document overrides of the seller profile (partner-level only).
+- A separate structured payment-terms mechanism — the existing `partner.invoiceTermsDays` → `dueDate` is unchanged; the new T&C block is supplementary free text.
+- Retroactively backfilling a From block onto already-issued documents (snapshot semantics).
+- Logo handling — already provided via branding; the From block is text-only.
+- A new `memo` column — both docs already have a memo-equivalent column (`invoices.notes`, `quotes.introNotes`); we relabel/reposition rather than add schema.
+
+## Key design decision: snapshot at issue
+
+The seller "From" details, the Terms & Conditions block, and the footer are **copied onto the document when it is issued**, exactly as `billTo*` already works. They are not rendered live from the current partner profile after issue.
+
+Rationale: consistency with the existing Bill To snapshot model, and historical accuracy (if an MSP later changes its address or terms, previously-issued documents stay faithful to what the customer received).
+
+Consequences:
+- Documents issued before this ships have no `sellerSnapshot`/`termsAndConditions` and won't gain them retroactively; renderers degrade gracefully when a snapshot or any field is absent.
+- Quote footer becomes snapshot-at-issue too (today it falls back live at render). At issue we set `terms` from `partner.invoiceFooter` when empty, mirroring invoices — making both doc types consistent.
+
+## Data model
+
+### `partners` — editable source of truth (`apps/api/src/db/schema/orgs.ts`)
+New fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `billingCompanyName` | `varchar(255)` null | Legal/billing name; falls back to `partners.name` |
+| `billingPhone` | `varchar(40)` null | |
+| `billingWebsite` | `varchar(255)` null | |
+| `billingAddressLine1` | `varchar(255)` null | |
+| `billingAddressLine2` | `varchar(255)` null | |
+| `billingAddressCity` | `varchar(120)` null | |
+| `billingAddressRegion` | `varchar(120)` null | |
+| `billingAddressPostalCode` | `varchar(40)` null | |
+| `billingAddressCountry` | `char(2)` null | ISO-3166 alpha-2 |
+| `billingTermsAndConditions` | `text` null | Partner default for the T&C block |
+
+Reused as-is: `billingEmail`, `invoiceFooter` (footer default), `invoiceTermsDays`.
+
+### `invoices` and `quotes` (`schema/invoices.ts`, `schema/quotes.ts`)
+Add to **both**:
+
+| Field | Type | Notes |
+|---|---|---|
+| `sellerSnapshot` | `jsonb` null | `{ name, addressLine1, addressLine2, city, region, postalCode, country, phone, email, website }` captured at issue (single jsonb, mirrors `billToAddress`) |
+| `termsAndConditions` | `text` null | The T&C block; defaulted from `partner.billingTermsAndConditions` at issue, editable per doc |
+
+Unchanged/reused: memo (`invoices.notes` / `quotes.introNotes`), footer (`terms` on both).
+
+### Migration
+Single date-prefixed migration `apps/api/migrations/2026-06-19-quotes-invoices-contact-fields.sql`:
+- Idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for all new columns on `partners`, `invoices`, `quotes`.
+- **No new tables → no RLS policy changes and no `rls-coverage` allowlist edits** (all three tables already have RLS).
+- No data backfill. Run `pnpm db:check-drift` after.
+
+## Behavior
+
+### At issue time (invoice + quote lifecycle)
+1. Build `sellerSnapshot` from the partner profile (`billingCompanyName ?? name`, address parts, phone, `billingEmail`, website); store only present fields.
+2. Default `termsAndConditions` from `partner.billingTermsAndConditions` when the doc's value is empty.
+3. Default footer (`terms`) from `partner.invoiceFooter` when empty — now for quotes too (was live fallback).
+4. Memo (`notes` / `introNotes`) is whatever the user typed; no default.
+
+After issue these are frozen — not re-resolved from the partner.
+
+### Draft create/update
+- Continue accepting memo (`notes` / `introNotes`).
+- Accept `termsAndConditions` in create/update payloads; editor pre-fills it from `partner.billingTermsAndConditions` as a starting point.
+
+## Rendering surfaces
+
+Document layout (all surfaces): **From** top-left (beneath logo), **Bill To / Prepared For** top-right → line items → totals → **Memo** ("Notes") → **Terms & Conditions** → **footer** at the very bottom. Each block renders only the fields present.
+
+| Surface | File(s) | Change |
+|---|---|---|
+| Invoice PDF/HTML | `apps/api/src/services/invoicePdf.ts` | Add From block + T&C block (memo + footer already render) |
+| Quote PDF | `apps/api/src/services/quotePdf.ts` | Add From block + T&C block (introNotes + footer already render) |
+| Web invoice | `apps/web/src/components/billing/InvoiceDetail.tsx`, `InvoiceEditor.tsx` | Show From; add T&C field; memo relabeled "Memo" |
+| Web quote | `apps/web/src/components/billing/quotes/QuoteEditor.tsx` + quote view | Same |
+| Portal (customer) | `apps/portal/src/components/portal/InvoiceDetailView.tsx`, `quoteBlocks.tsx` | Show From / Bill To / memo / T&C / footer |
+
+Drafts (web/editor) show a **live preview** of the From block from the current partner profile (no snapshot yet); issued documents render the frozen `sellerSnapshot`.
+
+### Partner settings UI
+Extend the existing partner billing settings (where `invoiceNumberPrefix`, `invoiceFooter`, `defaultTaxRate` already live) with the company-contact fields and the `billingTermsAndConditions` default. Single place the MSP maintains its From details, default footer, and default terms.
+
+## API & shared
+
+- **Partner settings update route** + Zod validator: accept new `billing*` contact fields + `billingTermsAndConditions` (`packages/shared/src/validators/`).
+- **Issue logic** (`invoiceService.ts`, `quoteLifecycle.ts`): build `sellerSnapshot`; default `termsAndConditions` + footer as above.
+- **Invoice/quote create/update**: accept `termsAndConditions`.
+- **Shared types** (`packages/shared/src/types/`): seller-snapshot shape + new partner/invoice/quote fields.
+
+> Billing UI↔Zod payload caution (prior billing lesson): keep editor payloads consistent with validator expectations (`undefined` vs `null` for optional text) and add a test exercising the real payload — a class of bug that has bitten billing twice and slipped past unit tests.
+
+## Testing
+
+- **Validators**: new partner contact fields, `termsAndConditions` accepted/rejected correctly.
+- **Issue logic** (real-DB integration, `src/__tests__/integration/*.integration.test.ts`): `sellerSnapshot` built from partner; `termsAndConditions` + footer defaulted only when empty; none re-resolved after issue (frozen); quote footer now snapshotted.
+- **Renderers**: From / T&C appear on web + portal; absent fields degrade gracefully; issued docs use the snapshot, drafts use the live partner preview.
+- Follow `breeze-testing` conventions; tests alongside source.
+
+## Rollout
+
+Ships dark-compatible: existing issued documents simply lack From/T&C until reissued; nothing breaks. No env vars, no new tables, no RLS changes.

--- a/packages/shared/src/validators/invoices.test.ts
+++ b/packages/shared/src/validators/invoices.test.ts
@@ -35,3 +35,36 @@ describe('partnerBillingSettingsSchema', () => {
     expect(partnerBillingSettingsSchema.safeParse({ currencyCode: 'USD', defaultTaxRate: 0.085, invoiceNumberPrefix: 'INV', invoiceTermsDays: 30 }).success).toBe(true);
   });
 });
+
+import { createManualInvoiceSchema, updateInvoiceSchema } from './invoices';
+
+describe('partnerBillingSettingsSchema — contact fields', () => {
+  it('accepts the new seller contact + T&C fields', () => {
+    const parsed = partnerBillingSettingsSchema.parse({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingCompanyName: 'Acme MSP LLC', billingPhone: '+1 555 0100', billingWebsite: 'acme.test',
+      billingAddressLine1: '1 Main St', billingAddressCity: 'Austin', billingAddressRegion: 'TX',
+      billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+      billingTermsAndConditions: 'Net 30. Late fee 1.5%/mo.',
+    });
+    expect(parsed.billingCompanyName).toBe('Acme MSP LLC');
+    expect(parsed.billingAddressCountry).toBe('US');
+  });
+
+  it('rejects a 3-letter country code', () => {
+    expect(() => partnerBillingSettingsSchema.parse({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, billingAddressCountry: 'USA',
+    })).toThrow();
+  });
+});
+
+describe('invoice T&C field', () => {
+  it('create accepts termsAndConditions', () => {
+    const p = createManualInvoiceSchema.parse({ orgId: '00000000-0000-0000-0000-000000000000', termsAndConditions: 'Net 30' });
+    expect(p.termsAndConditions).toBe('Net 30');
+  });
+  it('update accepts termsAndConditions', () => {
+    const p = updateInvoiceSchema.parse({ termsAndConditions: 'Net 15' });
+    expect(p.termsAndConditions).toBe('Net 15');
+  });
+});

--- a/packages/shared/src/validators/invoices.test.ts
+++ b/packages/shared/src/validators/invoices.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   assembleFromOrgSchema, manualLineSchema, recordPaymentSchema,
-  partnerBillingSettingsSchema, orgBillingSettingsSchema
+  partnerBillingSettingsSchema, orgBillingSettingsSchema,
+  createManualInvoiceSchema, updateInvoiceSchema
 } from './invoices';
 
 describe('assembleFromOrgSchema', () => {
@@ -36,7 +37,6 @@ describe('partnerBillingSettingsSchema', () => {
   });
 });
 
-import { createManualInvoiceSchema, updateInvoiceSchema } from './invoices';
 
 describe('partnerBillingSettingsSchema — contact fields', () => {
   it('accepts the new seller contact + T&C fields', () => {

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -41,13 +41,15 @@ export const updateLineSchema = z.object({
 export const createManualInvoiceSchema = z.object({
   orgId: z.string().guid(),
   siteId: z.string().guid().optional(),
-  notes: z.string().max(5000).optional()
+  notes: z.string().max(5000).optional(),
+  termsAndConditions: z.string().max(20_000).optional()
 });
 
 export const updateInvoiceSchema = z.object({
   notes: z.string().max(5000).optional(),
   siteId: z.string().guid().nullable().optional(),
-  dueDate: isoDate.optional()
+  dueDate: isoDate.optional(),
+  termsAndConditions: z.string().max(20_000).nullable().optional()
 });
 
 export const recordPaymentSchema = z.object({
@@ -77,7 +79,18 @@ export const partnerBillingSettingsSchema = z.object({
   defaultTaxRate: taxRate.nullable().optional(),
   invoiceNumberPrefix: z.string().min(1).max(12),
   invoiceTermsDays: z.number().int().min(0).max(365),
-  invoiceFooter: z.string().max(5000).nullable().optional()
+  invoiceFooter: z.string().max(5000).nullable().optional(),
+  // Seller "From" contact profile (snapshotted onto each document at issue).
+  billingCompanyName: z.string().max(255).nullable().optional(),
+  billingPhone: z.string().max(40).nullable().optional(),
+  billingWebsite: z.string().max(255).nullable().optional(),
+  billingAddressLine1: z.string().max(255).nullable().optional(),
+  billingAddressLine2: z.string().max(255).nullable().optional(),
+  billingAddressCity: z.string().max(120).nullable().optional(),
+  billingAddressRegion: z.string().max(120).nullable().optional(),
+  billingAddressPostalCode: z.string().max(40).nullable().optional(),
+  billingAddressCountry: z.string().length(2).nullable().optional(),
+  billingTermsAndConditions: z.string().max(20_000).nullable().optional(),
 });
 
 export const orgBillingSettingsSchema = z.object({

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -46,3 +46,15 @@ describe('declineQuoteSchema', () => {
     expect(declineQuoteSchema.safeParse({ reason: 'x'.repeat(5001) }).success).toBe(false);
   });
 });
+
+import { updateQuoteSchema } from './quotes';
+
+describe('quote T&C field', () => {
+  it('create accepts termsAndConditions', () => {
+    const p = createQuoteSchema.parse({ orgId: '00000000-0000-0000-0000-000000000000', termsAndConditions: 'Valid 30 days' });
+    expect(p.termsAndConditions).toBe('Valid 30 days');
+  });
+  it('update accepts termsAndConditions (nullable to clear)', () => {
+    expect(updateQuoteSchema.parse({ termsAndConditions: null }).termsAndConditions).toBeNull();
+  });
+});

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createQuoteSchema, quoteLineInputSchema, quoteBlockInputSchema, listQuotesQuerySchema,
   acceptQuoteSchema, declineQuoteSchema,
+  updateQuoteSchema,
 } from './quotes';
 
 describe('quote validators', () => {
@@ -47,7 +48,6 @@ describe('declineQuoteSchema', () => {
   });
 });
 
-import { updateQuoteSchema } from './quotes';
 
 describe('quote T&C field', () => {
   it('create accepts termsAndConditions', () => {

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -61,6 +61,7 @@ export const createQuoteSchema = z.object({
   expiryDate: isoDate.optional(),
   introNotes: z.string().max(5000).optional(),
   terms: z.string().max(20_000).optional(),
+  termsAndConditions: z.string().max(20_000).optional(),
 });
 
 export const updateQuoteSchema = z.object({
@@ -68,6 +69,7 @@ export const updateQuoteSchema = z.object({
   expiryDate: isoDate.nullable().optional(),
   introNotes: z.string().max(5000).nullable().optional(),
   terms: z.string().max(20_000).nullable().optional(),
+  termsAndConditions: z.string().max(20_000).nullable().optional(),
   taxRate: taxRate.nullable().optional(),
   billToName: z.string().max(255).nullable().optional(),
 });


### PR DESCRIPTION
## Summary

Adds a seller/MSP **"From" contact block** and a combined **"Terms & Conditions"** block (payment terms + disclaimers) to quotes and invoices, and surfaces the existing memo + footer consistently. The customer "Bill To" side already existed and is unchanged.

**Design:** partner-level contact fields are the editable source of truth. At issue time the seller contact is frozen into a `seller_snapshot` jsonb column and `terms_and_conditions` is defaulted from the partner — mirroring the existing `bill_to_*` snapshot model (historical accuracy: documents never change if the MSP later edits its profile).

Spec: `docs/superpowers/specs/2026-06-19-quotes-invoices-contact-info-design.md`
Plan: `docs/superpowers/plans/2026-06-19-quotes-invoices-contact-info.md`

## What changed

- **Schema/migration:** new `partners` billing-contact columns + `billing_terms_and_conditions`; `seller_snapshot (jsonb)` + `terms_and_conditions (text)` on `invoices` and `quotes`. Idempotent migration; **no new tables → no RLS/allowlist changes**.
- **Snapshot at issue:** `issueInvoice`, `sendQuote`, **and** the quote-accept conversion (`quoteAcceptService`) all freeze the seller contact + default T&C/footer onto the row. T&C defaults only when the doc value is empty; the existing footer (`terms`) line is untouched.
- **Reuse, not duplication:** memo reuses `invoices.notes` / `quotes.intro_notes`; footer reuses `terms`. One shared `buildSellerSnapshot` helper (API) and one `sellerLines` helper (web/portal).
- **Rendering (all customer-facing surfaces):** invoice & quote PDFs (two-column From / Bill-To), invoice email HTML, web (MSP) editor + detail, and **three** portal customer views — `InvoiceDetailView`, `QuoteDetailView`, and the public quote-accept page `PublicQuoteView`.
- **Settings UI:** partner billing settings gains the company-contact fields + default T&C.

## Testing

- TDD throughout; **108 feature tests green**: shared validators (18), API unit incl. both PDF renderers + settings (25), API real-DB integration incl. snapshot-freeze + draft-T&C-not-overwritten + quote-accept carry (12), web billing suite (49), portal helper (4).
- `db:check-drift` clean; typecheck / `astro check` clean.

## Review

Built via 8 subagent-driven tasks, each independently spec+quality reviewed. A final whole-branch review caught one Critical (the quote-accept auto-issued invoice dropped the snapshot) — **fixed in `ee508ce9`** with a covering integration assertion. Remaining findings triaged non-blocking.

## Note

UI-facing feature — **held for in-browser UI verification before merge** (not auto-merged). Repo uses squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)