### PR TITLE
fix(agent): harden agent API trust boundary

### DIFF
--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -64,7 +64,12 @@ vi.mock('../db/schema', () => ({
     devicesCompleted: 'scriptExecutionBatches.devicesCompleted',
     devicesFailed: 'scriptExecutionBatches.devicesFailed',
   },
-  backupJobs: {},
+  backupJobs: {
+    id: 'backupJobs.id',
+    orgId: 'backupJobs.orgId',
+    deviceId: 'backupJobs.deviceId',
+    status: 'backupJobs.status',
+  },
   restoreJobs: {
     id: 'restoreJobs.id',
     commandId: 'restoreJobs.commandId',
@@ -114,6 +119,10 @@ vi.mock('../jobs/monitorWorker', () => ({
   recordMonitorCheckResult: vi.fn()
 }));
 
+vi.mock('../jobs/backupWorker', () => ({
+  enqueueBackupResults: vi.fn(),
+}));
+
 vi.mock('../services/redis', () => ({
   isRedisAvailable: vi.fn(() => false),
   getRedis: vi.fn(() => null)
@@ -140,6 +149,10 @@ vi.mock('../services/restoreResultPersistence', () => ({
   updateRestoreJobFromResult: vi.fn((...args: unknown[]) => updateRestoreJobFromResultMock(...(args as []))),
 }));
 
+vi.mock('../services/vaultSyncPersistence', () => ({
+  applyVaultSyncCommandResult: vi.fn(),
+}));
+
 vi.mock('../services/auditService', () => ({
   createAuditLogAsync: vi.fn().mockResolvedValue(undefined),
   createAuditLog: vi.fn().mockResolvedValue(undefined),
@@ -158,6 +171,7 @@ import { db } from '../db';
 import {
   createAgentWsHandlers,
   createAgentWsRoutes,
+  sendCommandToAgent,
   validateAgentToken,
   __resetCrossTenantDropsForTest,
   AGENT_WS_CAPABILITIES,
@@ -166,12 +180,16 @@ import { isAgentTenantActive } from '../services/tenantStatus';
 import { enqueueDiscoveryResults } from '../jobs/discoveryWorker';
 import { enqueueSnmpPollResults } from '../jobs/snmpWorker';
 import { enqueueMonitorCheckResult } from '../jobs/monitorWorker';
+import { enqueueBackupResults } from '../jobs/backupWorker';
 import { getActiveTerminalSession, handleTerminalOutput } from './terminalWs';
 import { registerTunnelOwnership } from './tunnelWs';
 import { processBackupVerificationResult } from './backup/verificationService';
 import { updateRestoreJobFromResult } from '../services/restoreResultPersistence';
 import { rateLimiter } from '../services/rate-limit';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
+import { applyVaultSyncCommandResult } from '../services/vaultSyncPersistence';
+import { isRedisAvailable } from '../services/redis';
+import { publishEvent } from '../services/eventBus';
 
 function wsMock() {
   return {
@@ -324,6 +342,8 @@ describe('agent websocket handshake', () => {
 describe('agent websocket command results', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(isRedisAvailable).mockReturnValue(false);
+    vi.mocked(publishEvent).mockResolvedValue('event-id');
   });
 
   it('rejects cross-device command result updates', async () => {
@@ -515,6 +535,149 @@ describe('agent websocket command results', () => {
     } as any, ws as any);
 
     expect(db.select).not.toHaveBeenCalled();
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  it('rejects orphaned backup results without a dispatch expectation', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const backupJobId = '44444444-4444-4444-8444-444444444444';
+
+    vi.mocked(isRedisAvailable).mockReturnValue(true);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectOwnedCommandResult([]) as any)
+      .mockReturnValueOnce(selectAgentDevice([]) as any)
+      .mockReturnValueOnce(selectWithInnerJoin([
+        {
+          id: backupJobId,
+          orgId: 'org-123',
+          deviceId: 'device-123',
+          agentId: 'agent-123',
+        }
+      ]) as any)
+      // onClose: status lookup before marking offline
+      .mockReturnValueOnce(selectAgentDevice([
+        {
+          id: 'device-123',
+          siteId: 'site-123',
+          status: 'online',
+          hostname: 'host-123',
+        }
+      ]) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: backupJobId,
+        status: 'completed',
+        result: {
+          snapshotId: 'snap-forged',
+          filesBackedUp: 1,
+          bytesBackedUp: 1,
+        }
+      })
+    } as any, ws as any);
+
+    expect(enqueueBackupResults).not.toHaveBeenCalled();
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  it('accepts orphaned backup results only after dispatch records an expectation', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const backupJobId = '55555555-5555-4555-8555-555555555555';
+
+    vi.mocked(isRedisAvailable).mockReturnValue(true);
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+    vi.mocked(db.select)
+      // onOpen: pending commands
+      .mockReturnValueOnce(selectAgentDevice([]) as any)
+      // onOpen: device.online event lookup
+      .mockReturnValueOnce(selectAgentDevice([]) as any)
+      // command result: device_commands lookup
+      .mockReturnValueOnce(selectOwnedCommandResult([]) as any)
+      // command result: discovery job lookup
+      .mockReturnValueOnce(selectAgentDevice([]) as any)
+      // command result: backup job lookup
+      .mockReturnValueOnce(selectWithInnerJoin([
+        {
+          id: backupJobId,
+          orgId: 'org-123',
+          deviceId: 'device-123',
+          agentId: 'agent-123',
+        }
+      ]) as any)
+      // onClose: status lookup before marking offline
+      .mockReturnValueOnce(selectAgentDevice([
+        {
+          id: 'device-123',
+          siteId: 'site-123',
+          status: 'online',
+          hostname: 'host-123',
+        }
+      ]) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onOpen({}, ws as any);
+    expect(sendCommandToAgent('agent-123', {
+      id: backupJobId,
+      type: 'backup_run',
+      payload: { jobId: backupJobId },
+    })).toBe(true);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: backupJobId,
+        status: 'completed',
+        result: {
+          snapshotId: 'snap-real',
+          filesBackedUp: 1,
+          bytesBackedUp: 1,
+        }
+      })
+    } as any, ws as any);
+
+    expect(enqueueBackupResults).toHaveBeenCalledWith(
+      backupJobId,
+      'org-123',
+      'device-123',
+      expect.objectContaining({
+        status: 'completed',
+        snapshotId: 'snap-real',
+      }),
+      expect.objectContaining({
+        actorType: 'agent',
+        actorId: 'agent-123',
+      })
+    );
+
+    await handlers.onClose({}, ws as any);
+  });
+
+  it('rejects vault auto-sync results without a backup-created expectation', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: 'vault-auto-sync-snap-forged',
+        status: 'completed',
+        result: {
+          snapshotId: 'snap-forged',
+          vaultPath: '/vault',
+          manifestVerified: true,
+        }
+      })
+    } as any, ws as any);
+
+    expect(applyVaultSyncCommandResult).not.toHaveBeenCalled();
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
   });
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -488,6 +488,7 @@ const agentPingStates = new Map<string, AgentPingState>();
 const AGENT_PING_INTERVAL_MS = 30_000;
 const AGENT_PONG_TIMEOUT_MS = 10_000;
 const ORPHANED_RESULT_EXPECTATION_TTL_MS = 30 * 60 * 1000;
+const BACKUP_RESULT_EXPECTATION_TTL_MS = 24 * 60 * 60 * 1000;
 const MONITOR_COMMAND_TYPES = new Set(['network_ping', 'network_tcp_check', 'network_http_check', 'network_dns_check']);
 
 type OrphanedResultExpectation =
@@ -500,6 +501,18 @@ type OrphanedResultExpectation =
   | {
       agentId: string;
       kind: 'monitor';
+      targetId: string;
+      expiresAt: number;
+    }
+  | {
+      agentId: string;
+      kind: 'backup';
+      targetId: string;
+      expiresAt: number;
+    }
+  | {
+      agentId: string;
+      kind: 'vault';
       targetId: string;
       expiresAt: number;
     };
@@ -539,7 +552,29 @@ function recordOrphanedResultExpectation(agentId: string, command: AgentCommand)
       targetId: monitorId,
       expiresAt,
     });
+    return;
   }
+
+  if (command.type === 'backup_run' || PROVIDER_BACKED_BACKUP_COMMAND_TYPES.has(command.type)) {
+    const jobId = typeof payload.jobId === 'string' ? payload.jobId : command.id;
+    if (!jobId) return;
+    orphanedResultExpectations.set(command.id, {
+      agentId,
+      kind: 'backup',
+      targetId: jobId,
+      expiresAt: Date.now() + BACKUP_RESULT_EXPECTATION_TTL_MS,
+    });
+  }
+}
+
+function recordVaultAutoSyncExpectation(agentId: string, snapshotId: string): void {
+  if (!snapshotId) return;
+  orphanedResultExpectations.set(`vault-auto-sync-${snapshotId}`, {
+    agentId,
+    kind: 'vault',
+    targetId: snapshotId,
+    expiresAt: Date.now() + ORPHANED_RESULT_EXPECTATION_TTL_MS,
+  });
 }
 
 function consumeOrphanedResultExpectation(agentId: string, commandId: string): OrphanedResultExpectation | null {
@@ -946,6 +981,15 @@ async function processOrphanedCommandResult(
 
   if (result.commandId.startsWith('vault-auto-sync-')) {
     try {
+      const expectedSnapshotId = result.commandId.slice('vault-auto-sync-'.length);
+      const expectation = consumeOrphanedResultExpectation(agentId, result.commandId);
+      if (!expectation || expectation.kind !== 'vault' || expectation.targetId !== expectedSnapshotId) {
+        console.warn(
+          `[AgentWs] Rejecting unexpected vault auto-sync result ${result.commandId} from agent ${agentId}: ` +
+          `expected=${expectation?.kind === 'vault' ? expectation.targetId : 'none'}`
+        );
+        return;
+      }
       const { normalizedResult, stdout, validationError } = normalizeCriticalResultIfNeeded('vault_sync', result);
       if (validationError) {
         console.warn(`[AgentWs] ${validationError} for orphaned auto-sync ${result.commandId}`);
@@ -955,6 +999,20 @@ async function processOrphanedCommandResult(
           resultStatus: 'failed',
           error: validationError,
         });
+        return;
+      }
+      const structured = normalizedResult.result && typeof normalizedResult.result === 'object'
+        ? normalizedResult.result as Record<string, unknown>
+        : {};
+      if (
+        normalizedResult.status === 'completed' &&
+        typeof structured.snapshotId === 'string' &&
+        structured.snapshotId !== expectedSnapshotId
+      ) {
+        console.warn(
+          `[AgentWs] Rejecting vault auto-sync result ${result.commandId} with mismatched snapshotId ` +
+          `${structured.snapshotId} from agent ${agentId}`
+        );
         return;
       }
       await applyVaultSyncCommandResult({
@@ -1151,6 +1209,14 @@ async function processOrphanedCommandResult(
       console.warn(`[AgentWs] Rejecting backup result for job ${backupJob.id} from unexpected agent ${agentId}`);
       return;
     }
+    const expectation = consumeOrphanedResultExpectation(agentId, result.commandId);
+    if (!expectation || expectation.kind !== 'backup' || expectation.targetId !== backupJob.id) {
+      console.warn(
+        `[AgentWs] Rejecting unexpected backup result ${result.commandId} from agent ${agentId}: ` +
+        `expected=${expectation?.kind === 'backup' ? expectation.targetId : 'none'}`
+      );
+      return;
+    }
     console.log(`[AgentWs] Processing backup result for job ${backupJob.id} from agent ${agentId}`);
     try {
       const parsedBackup = backupCommandResultSchema.safeParse(result.result ?? {});
@@ -1194,6 +1260,10 @@ async function processOrphanedCommandResult(
         if (!persisted.applied) {
           console.warn(`[AgentWs] Ignoring stale inline backup result for job ${backupJob.id} from agent ${agentId}`);
         }
+      }
+      const snapshotId = backupData?.snapshot?.id ?? backupData?.snapshotId;
+      if (result.status === 'completed' && snapshotId) {
+        recordVaultAutoSyncExpectation(agentId, snapshotId);
       }
     } catch (err) {
       console.error(`[AgentWs] Failed to process backup results for ${agentId}:`, err);

--- a/apps/api/src/routes/agents/mtls.test.ts
+++ b/apps/api/src/routes/agents/mtls.test.ts
@@ -169,6 +169,10 @@ vi.mock('../../services/remoteSessionTeardown', () => ({
   TEARDOWN_FAILED: -1,
 }));
 
+vi.mock('../../services/tenantStatus', () => ({
+  isAgentTenantActive: vi.fn(async () => true),
+}));
+
 // Use the real rate-limit helper with the stub above.
 
 // -------------------------------------------------------------------
@@ -177,6 +181,7 @@ vi.mock('../../services/remoteSessionTeardown', () => ({
 
 import { mtlsRoutes } from './mtls';
 import { terminateDeviceRemoteSessions } from '../../services/remoteSessionTeardown';
+import { isAgentTenantActive } from '../../services/tenantStatus';
 
 const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
 const ORG_ID = '22222222-2222-4222-8222-222222222222';
@@ -211,6 +216,7 @@ describe('POST /renew-cert — E4 per-device cooldown', () => {
     issueCertMock.mockReset();
     revokeCertMock.mockReset();
     mockDbUpdateOk();
+    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
   });
 
   it('returns 429 with Retry-After on the 2nd attempt within 30s', async () => {
@@ -264,6 +270,32 @@ describe('POST /renew-cert — E4 per-device cooldown', () => {
     });
     expect(resp.status).toBe(401);
   });
+
+  it('rejects inactive tenants before issuing a certificate', async () => {
+    vi.mocked(isAgentTenantActive).mockResolvedValue(false);
+    mockDeviceLookup({
+      id: DEVICE_ID,
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      hostname: 'host-1',
+      status: 'online',
+      agentTokenHash: TOKEN_HASH,
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+      agentTokenSuspendedAt: null,
+      mtlsCertExpiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+      mtlsCertCfId: null,
+    });
+
+    const resp = await buildApp().request('/agents/renew-cert', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(resp.status).toBe(401);
+    expect(issueCertMock).not.toHaveBeenCalled();
+    expect(isAgentTenantActive).toHaveBeenCalledWith(ORG_ID);
+  });
 });
 
 describe('remote-session teardown wiring on quarantine / deny', () => {
@@ -273,6 +305,7 @@ describe('remote-session teardown wiring on quarantine / deny', () => {
     issueCertMock.mockReset();
     revokeCertMock.mockReset();
     mockDbUpdateOk();
+    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
   });
 
   it('POST /renew-cert quarantine branch tears down live remote sessions', async () => {

--- a/apps/api/src/routes/agents/mtls.ts
+++ b/apps/api/src/routes/agents/mtls.ts
@@ -18,6 +18,7 @@ import { rateLimiter } from '../../services/rate-limit';
 import { encryptSecret } from '../../services/secretCrypto';
 import { isPrivateIp } from '../../services/urlSafety';
 import { terminateDeviceRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
+import { isAgentTenantActive } from '../../services/tenantStatus';
 
 export const mtlsRoutes = new Hono();
 
@@ -155,6 +156,10 @@ mtlsRoutes.post('/renew-cert', async (c) => {
 
   if (device.status === 'quarantined') {
     return c.json({ error: 'Device quarantined', quarantined: true }, 403);
+  }
+
+  if (!(await isAgentTenantActive(device.orgId))) {
+    return c.json({ error: 'Invalid agent credentials' }, 401);
   }
 
   // E4: per-device renewal cooldowns (defense against leaked tokens spamming

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -129,6 +129,10 @@ describe('PUT /agents/:id/patches - third-party fields', () => {
     patchRows = [];
     patchUpsertSet = undefined;
     app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('agent', { role: 'agent', deviceId: DEVICE_ID, agentId: AGENT_ID, orgId: ORG_ID });
+      return next();
+    });
     app.route('/agents', patchesRoutes);
 
     vi.mocked(db.select).mockImplementation(() => ({
@@ -220,6 +224,19 @@ describe('PUT /agents/:id/patches - third-party fields', () => {
     }));
   });
 
+  it('rejects requests without the main agent credential context', async () => {
+    const guardedApp = new Hono();
+    guardedApp.route('/agents', patchesRoutes);
+
+    const res = await guardedApp.request(`/agents/${AGENT_ID}/patches`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patches: [] }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
   it('uses enriched title/vendor/severity from catalog in the upsert', async () => {
     vi.mocked(enrichmentModule.enrichFromCatalog).mockResolvedValue({
       title: 'Mozilla Firefox',
@@ -302,6 +319,10 @@ describe('PUT /agents/:id/patches - ENABLE_AI_PATCH_TESTING gating', () => {
       alreadyExisted: false,
     });
     app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('agent', { role: 'agent', deviceId: DEVICE_ID, agentId: AGENT_ID, orgId: ORG_ID });
+      return next();
+    });
     app.route('/agents', patchesRoutes);
 
     vi.mocked(db.select).mockImplementation(() => ({

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -8,6 +8,7 @@ import { writeAuditEvent } from '../../services/auditEvents';
 import { enrichFromCatalog } from '../../services/thirdPartyEnrichment';
 import { submitPatchesSchema } from './schemas';
 import { inferPatchOsType, parseDate, sanitizeDate } from './helpers';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 // Derive vendor from package id; ignore agent-supplied vendor for winget-style ids.
 function deriveVendor(packageId: string | null | undefined, fallback: string | null | undefined): string | null {
@@ -50,6 +51,7 @@ export async function pruneStaleTombstones(
 }
 
 export const patchesRoutes = new Hono();
+patchesRoutes.use('*', requireAgentRole);
 
 patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async (c) => {
   const agentId = c.req.param('id');

--- a/apps/api/src/routes/agents/security.test.ts
+++ b/apps/api/src/routes/agents/security.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    agentId: 'devices.agentId',
+    managementPosture: 'devices.managementPosture',
+    updatedAt: 'devices.updatedAt',
+  },
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+vi.mock('./helpers', () => ({
+  upsertSecurityStatusForDevice: vi.fn(),
+}));
+
+import { agentSecurityRoutes } from './security';
+
+describe('agent security ingest role gate', () => {
+  it('rejects requests without the main agent credential context', async () => {
+    const app = new Hono();
+    app.route('/agents', agentSecurityRoutes);
+
+    const res = await app.request('/agents/agent-1/security/status', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'windows_defender',
+        realTimeProtection: true,
+      }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/agents/security.ts
+++ b/apps/api/src/routes/agents/security.ts
@@ -6,8 +6,10 @@ import { devices } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { securityStatusIngestSchema, managementPostureIngestSchema } from './schemas';
 import { upsertSecurityStatusForDevice } from './helpers';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 export const agentSecurityRoutes = new Hono();
+agentSecurityRoutes.use('*', requireAgentRole);
 
 agentSecurityRoutes.put('/:id/security/status', zValidator('json', securityStatusIngestSchema), async (c) => {
   const agentId = c.req.param('id');

--- a/apps/web/src/components/logs/LogSearch.test.tsx
+++ b/apps/web/src/components/logs/LogSearch.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { escapeLogCsv } from './LogSearch';
+
+describe('escapeLogCsv', () => {
+  it('neutralizes spreadsheet formula prefixes before CSV quoting', () => {
+    for (const value of ['=cmd', '+cmd', '-cmd', '@cmd', '\tcmd', '\rcmd', '\ncmd']) {
+      expect(escapeLogCsv(value)).toBe(`"'${value.replaceAll('"', '""')}"`);
+    }
+  });
+
+  it('escapes quotes while preserving ordinary values', () => {
+    expect(escapeLogCsv('plain "value"')).toBe('"plain ""value"""');
+  });
+});

--- a/apps/web/src/components/logs/LogSearch.tsx
+++ b/apps/web/src/components/logs/LogSearch.tsx
@@ -48,8 +48,11 @@ function toDatetimeLocalInput(date: Date): string {
   return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
 }
 
-function escapeCsv(value: string): string {
-  const escaped = value.replaceAll('"', '""');
+const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '\r', '\n']);
+
+export function escapeLogCsv(value: string): string {
+  const safeValue = value.length > 0 && FORMULA_PREFIXES.has(value[0]!) ? `'${value}` : value;
+  const escaped = safeValue.replaceAll('"', '""');
   return `"${escaped}"`;
 }
 
@@ -204,7 +207,7 @@ export default function LogSearch() {
     ]);
 
     const csv = [header, ...rows]
-      .map((line) => line.map((value) => escapeCsv(String(value))).join(','))
+      .map((line) => line.map((value) => escapeLogCsv(String(value))).join(','))
       .join('\n');
 
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });


### PR DESCRIPTION
## Summary
- Require main-agent credential context on agent security and patch ingest routes
- Enforce tenant lifecycle checks before mTLS certificate renewal
- Require dispatch expectations before accepting orphaned backup and vault auto-sync WebSocket results
- Neutralize spreadsheet formula prefixes in log CSV exports

## Tests
- pnpm --dir apps/api exec vitest run src/routes/agents/mtls.test.ts src/routes/agents/patches.test.ts src/routes/agents/security.test.ts src/routes/agentWs.test.ts
- pnpm --dir apps/web exec vitest run src/components/logs/LogSearch.test.tsx