### PR TITLE
fix(auth): hard-reject refresh tokens without a fam claim (#917 L-1)

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1076,7 +1076,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-1'
+        jti: 'refresh-jti-1',
+        fam: 'family-id-mock'
       });
       vi.mocked(db.select)
         .mockReturnValueOnce({
@@ -1183,7 +1184,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-2'
+        jti: 'refresh-jti-2',
+        fam: 'family-id-mock'
       });
 
       const res = await app.request('/auth/refresh', {
@@ -1214,7 +1216,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-race'
+        jti: 'refresh-jti-race',
+        fam: 'family-id-mock'
       });
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
@@ -1264,7 +1267,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-graced'
+        jti: 'refresh-jti-graced',
+        fam: 'family-id-mock'
       });
 
       const res = await app.request('/auth/refresh', {
@@ -1301,7 +1305,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-stolen'
+        jti: 'refresh-jti-stolen',
+        fam: 'fam-attacked'
       });
 
       const res = await app.request('/auth/refresh', {
@@ -1331,7 +1336,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-winner'
+        jti: 'refresh-jti-winner',
+        fam: 'family-id-mock'
       });
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
@@ -1376,7 +1382,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-3'
+        jti: 'refresh-jti-3',
+        fam: 'family-id-mock'
       });
       vi.mocked(db.select)
         .mockReturnValueOnce({
@@ -1450,7 +1457,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-tenant'
+        jti: 'refresh-jti-tenant',
+        fam: 'family-id-mock'
       });
       vi.mocked(assertActiveTenantContext).mockRejectedValue(new TenantInactiveError('Partner is not active'));
       vi.mocked(db.select)
@@ -2086,7 +2094,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-sec'
+        jti: 'refresh-jti-sec',
+        fam: 'family-id-mock'
       });
       vi.mocked(db.select)
         .mockReturnValueOnce({
@@ -2139,7 +2148,8 @@ describe('auth routes', () => {
         type: 'refresh',
         mfa: false,
         iat: 123456,
-        jti: 'refresh-jti-no-sec'
+        jti: 'refresh-jti-no-sec',
+        fam: 'family-id-mock'
       });
       vi.mocked(db.select)
         .mockReturnValueOnce({

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -38,7 +38,8 @@ vi.mock('../../services', () => ({
   isRefreshTokenJtiRevoked: vi.fn(async () => false),
   revokeAllUserTokens: vi.fn(async () => undefined),
   revokeRefreshTokenJti: vi.fn(async () => true),
-  getFamilyForJti: vi.fn(async () => null),
+  markRefreshTokenJtiRotated: vi.fn(async () => undefined),
+  wasRefreshTokenJtiRecentlyRotated: vi.fn(async () => false),
   revokeFamily: vi.fn(async () => undefined),
   isFamilyRevoked: vi.fn(async () => false),
   touchFamilyLastUsed: vi.fn(async () => undefined),
@@ -139,11 +140,23 @@ vi.mock('../../services/sentry', () => ({
 
 import { loginRoutes } from './login';
 import { db, withSystemDbAccessContext } from '../../db';
-import { createTokenPair } from '../../services';
+import {
+  createTokenPair,
+  verifyToken,
+  isRefreshTokenJtiRevoked,
+  revokeFamily,
+  revokeRefreshTokenJti,
+  bindRefreshJtiToFamily,
+} from '../../services';
 import { enforceIpAllowlist } from '../../services/ipAllowlist';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { TenantInactiveError } from '../../services/tenantStatus';
-import { resolveCurrentUserTokenContext } from './helpers';
+import {
+  resolveCurrentUserTokenContext,
+  resolveRefreshToken,
+  validateCookieCsrfRequest,
+  clearRefreshTokenCookie,
+} from './helpers';
 
 function selectChain(rows: unknown[]) {
   return {
@@ -373,5 +386,75 @@ describe('POST /login — last_login_at write runs under system DB context (#137
     expect(res.status).toBe(200);
     expect(db.update).toHaveBeenCalled();
     expect(updateRanInsideContext).toBe(true);
+  });
+});
+
+describe('POST /refresh — hard-reject fam-less legacy tokens (#917 L-1)', () => {
+  async function postRefresh() {
+    return loginRoutes.request('/refresh', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env.E2E_MODE = 'true'; // skip the Redis rate-limit branch
+    // A valid refresh cookie + passing CSRF so execution reaches the fam check.
+    vi.mocked(resolveRefreshToken).mockReturnValue('refresh-token');
+    vi.mocked(validateCookieCsrfRequest).mockReturnValue(null);
+    // Active user for the success path.
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'admin@msp.com',
+      status: 'active',
+    }]) as any);
+    vi.mocked(isRefreshTokenJtiRevoked).mockResolvedValue(false);
+    vi.mocked(revokeRefreshTokenJti).mockResolvedValue(true);
+    vi.mocked(resolveCurrentUserTokenContext).mockResolvedValue({
+      roleId: 'role-1',
+      partnerId: 'partner-1',
+      orgId: null,
+      scope: 'partner',
+    } as any);
+  });
+
+  it('rejects a verified refresh token that has no fam claim with 401 and clears the cookie', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({
+      sub: 'user-1',
+      email: 'admin@msp.com',
+      type: 'refresh',
+      jti: 'jti-legacy',
+      // no `fam` — pre-rollout token
+    } as any);
+
+    const res = await postRefresh();
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: 'Invalid refresh token' });
+    expect(clearRefreshTokenCookie).toHaveBeenCalled();
+    // Must bail before reuse-detection / minting — no family work, no new pair.
+    expect(isRefreshTokenJtiRevoked).not.toHaveBeenCalled();
+    expect(createTokenPair).not.toHaveBeenCalled();
+  });
+
+  it('accepts a refresh token carrying a fam claim and mints a new pair under that family', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({
+      sub: 'user-1',
+      email: 'admin@msp.com',
+      type: 'refresh',
+      jti: 'jti-current',
+      fam: 'family-42',
+    } as any);
+
+    const res = await postRefresh();
+
+    expect(res.status).toBe(200);
+    expect(createTokenPair).toHaveBeenCalledTimes(1);
+    // Family propagates into the rotated token and the jti→family binding.
+    expect(vi.mocked(createTokenPair).mock.calls[0]?.[1]).toEqual({ refreshFam: 'family-42' });
+    expect(bindRefreshJtiToFamily).toHaveBeenCalledWith('refresh-jti', 'family-42');
+    expect(revokeFamily).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -434,8 +434,13 @@ describe('POST /refresh — hard-reject fam-less legacy tokens (#917 L-1)', () =
     expect(res.status).toBe(401);
     expect(await res.json()).toMatchObject({ error: 'Invalid refresh token' });
     expect(clearRefreshTokenCookie).toHaveBeenCalled();
-    // Must bail before reuse-detection / minting — no family work, no new pair.
+    // Observability: the legacy-token cohort must be countable in prod so the
+    // "compat window has closed" assumption is verifiable (#917 L-1 review).
+    expect(recordFailedLogin).toHaveBeenCalledWith('refresh_fam_missing');
+    // Must bail before reuse-detection / minting — no family work, no new pair,
+    // no Redis jti mutation (guards against a refactor reordering the fam check).
     expect(isRefreshTokenJtiRevoked).not.toHaveBeenCalled();
+    expect(revokeRefreshTokenJti).not.toHaveBeenCalled();
     expect(createTokenPair).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -16,7 +16,6 @@ import {
   revokeRefreshTokenJti,
   markRefreshTokenJtiRotated,
   wasRefreshTokenJtiRecentlyRotated,
-  getFamilyForJti,
   revokeFamily,
   isFamilyRevoked,
   touchFamilyLastUsed,
@@ -583,6 +582,18 @@ loginRoutes.post('/refresh', async (c) => {
     return c.json({ error: 'Invalid refresh token' }, 401);
   }
 
+  // #917 L-1: hard-reject refresh tokens minted before the family/reuse-detection
+  // rollout (Task 7). A token without a `fam` claim pre-dates families and would
+  // silently skip family-wide reuse-detection — an attacker replaying a stolen
+  // legacy token could keep refreshing undetected. The backwards-compat window
+  // was time-gated to one refresh-token TTL (7d) past the rollout; that window
+  // has now elapsed, so every still-valid refresh token carries a `fam`. Reject
+  // the claimless remainder rather than fall through to the legacy per-jti path.
+  if (!payload.fam) {
+    clearRefreshTokenCookie(c);
+    return c.json({ error: 'Invalid refresh token' }, 401);
+  }
+
   // Rate limit per user — 10 refreshes per minute
   const e2eMode = process.env.E2E_MODE === '1' || process.env.E2E_MODE === 'true';
   if (!e2eMode) {
@@ -600,17 +611,11 @@ loginRoutes.post('/refresh', async (c) => {
     }
   }
 
-  // Task 7: resolve the family for this jti. Prefer the verified JWT claim
-  // (`fam`) — it's cryptographically signed and can't be tampered with. Fall
-  // back to the Redis jti→family map for tokens that pre-date this rollout
-  // (legacy: claim absent → only `refresh-jti-fam:<jti>` may know the
-  // family). When BOTH are missing we treat the token as legacy and skip the
-  // family-revocation checks — backwards-compat for sessions issued before
-  // this PR. The per-jti revocation check below still gates those.
-  let familyId: string | null = payload.fam ?? null;
-  if (!familyId) {
-    familyId = await getFamilyForJti(payload.jti);
-  }
+  // Task 7: the family id comes from the verified JWT claim (`fam`) — it's
+  // cryptographically signed and can't be tampered with. The claimless legacy
+  // path was retired in #917 L-1 (rejected above), so every token reaching here
+  // carries a family and the Redis jti→family fallback is no longer needed.
+  const familyId: string = payload.fam;
 
   // Reuse detection: if this jti has already been revoked AND we have a
   // family id, this is a replay of an old (rotated) refresh token. Kill the
@@ -632,24 +637,22 @@ loginRoutes.post('/refresh', async (c) => {
     if (await wasRefreshTokenJtiRecentlyRotated(payload.jti)) {
       return c.json({ error: 'Refresh already in progress', reason: 'refresh_raced' }, 401);
     }
-    if (familyId) {
-      await revokeFamily(familyId, 'reuse-detected');
-      createAuditLogAsync({
-        actorType: 'user',
-        actorId: payload.sub,
-        actorEmail: payload.email,
-        action: 'auth.refresh.reuse_detected',
-        resourceType: 'refresh_token_family',
-        resourceId: familyId,
-        details: {
-          replayedJti: payload.jti,
-          reason: 'Revoked refresh-token JTI replayed — entire family revoked',
-        },
-        ipAddress: getClientIP(c),
-        userAgent: c.req.header('user-agent'),
-        result: 'denied',
-      });
-    }
+    await revokeFamily(familyId, 'reuse-detected');
+    createAuditLogAsync({
+      actorType: 'user',
+      actorId: payload.sub,
+      actorEmail: payload.email,
+      action: 'auth.refresh.reuse_detected',
+      resourceType: 'refresh_token_family',
+      resourceId: familyId,
+      details: {
+        replayedJti: payload.jti,
+        reason: 'Revoked refresh-token JTI replayed — entire family revoked',
+      },
+      ipAddress: getClientIP(c),
+      userAgent: c.req.header('user-agent'),
+      result: 'denied',
+    });
     clearRefreshTokenCookie(c);
     return c.json({ error: 'Invalid refresh token' }, 401);
   }
@@ -657,7 +660,7 @@ loginRoutes.post('/refresh', async (c) => {
   // Family-revoked sentinel check: covers the descendant case. If a sibling
   // refresh on this family already triggered reuse-detection, this token —
   // although its own jti hasn't been revoked — must also fail.
-  if (familyId && (await isFamilyRevoked(familyId))) {
+  if (await isFamilyRevoked(familyId)) {
     clearRefreshTokenCookie(c);
     return c.json({ error: 'Invalid refresh token' }, 401);
   }
@@ -720,9 +723,8 @@ loginRoutes.post('/refresh', async (c) => {
     return c.json({ error: 'Refresh already in progress', reason: 'refresh_raced' }, 401);
   }
 
-  // Create new token pair. Inherit the family from the verified claim (or
-  // the looked-up familyId from Redis for legacy tokens that didn't carry
-  // the claim but we still know the family for).
+  // Create new token pair. The rotated refresh token inherits the family from
+  // the verified `fam` claim so reuse-detection follows the whole chain.
   const tokens = await createTokenPair({
     sub: user.id,
     email: user.email,
@@ -735,17 +737,15 @@ loginRoutes.post('/refresh', async (c) => {
     // token. Deliberately NOT re-read from the header — a refresh must not be
     // able to drop the binding by omitting it.
     mdid: carryForwardBinding(payload)
-  }, familyId ? { refreshFam: familyId } : {});
+  }, { refreshFam: familyId });
 
-  if (familyId) {
-    // Map the newly-minted jti to the same family so a future replay of THIS
-    // jti can also be detected via Redis. Best-effort; the JWT `fam` claim
-    // is the primary record.
-    await bindRefreshJtiToFamily(tokens.refreshJti, familyId);
-    // Telemetry: bump lastUsedAt on the family row. Fire-and-forget — never
-    // blocks the refresh.
-    void touchFamilyLastUsed(familyId);
-  }
+  // Map the newly-minted jti to the same family so a future replay of THIS
+  // jti can also be detected via Redis. Best-effort; the JWT `fam` claim
+  // is the primary record.
+  await bindRefreshJtiToFamily(tokens.refreshJti, familyId);
+  // Telemetry: bump lastUsedAt on the family row. Fire-and-forget — never
+  // blocks the refresh.
+  void touchFamilyLastUsed(familyId);
 
   setRefreshTokenCookie(c, tokens.refreshToken);
   return c.json({ tokens: toPublicTokens(tokens) });

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -589,7 +589,15 @@ loginRoutes.post('/refresh', async (c) => {
   // was time-gated to one refresh-token TTL (7d) past the rollout; that window
   // has now elapsed, so every still-valid refresh token carries a `fam`. Reject
   // the claimless remainder rather than fall through to the legacy per-jti path.
+  //
+  // Emit a counter so the cohort is observable: this rejection's safety rests on
+  // the compat window having fully closed. A non-trivial `refresh_fam_missing`
+  // rate in production would mean that assumption is wrong (clock skew, a late-
+  // upgraded self-hosted instance) and real users are being silently logged out
+  // — this metric is the only signal that distinguishes that from ordinary
+  // expiry, since the response is a generic 401 like every other invalid token.
   if (!payload.fam) {
+    recordFailedLogin('refresh_fam_missing');
     clearRefreshTokenCookie(c);
     return c.json({ error: 'Invalid refresh token' }, 401);
   }


### PR DESCRIPTION
## Summary

Closes the last remaining sub-item of the #917 hardening cluster: **L-1 — refresh tokens without a `fam` claim silently skip family reuse-detection.**

Refresh tokens minted before the family/reuse-detection rollout (Task 7) carry no `fam` claim. On `/refresh`, the handler treated those as legacy and fell back to the per-jti path, **skipping family-wide reuse-detection**. A replayed stolen legacy token could therefore keep refreshing undetected.

The issue body time-gated the hard-reject to one refresh-token TTL (7d) past the rollout — **2026-06-15** — to avoid force-logging-out still-valid pre-rollout sessions. That window has now elapsed (today is past the gate, prod TTL is `7d`), so every still-valid refresh token already carries a `fam`.

## Change

`apps/api/src/routes/auth/login.ts` — `POST /refresh`:

- After JWT verification, **reject any token without `payload.fam`** with `401 Invalid refresh token` + cookie clear, before reuse-detection or minting.
- Drop the now-dead Redis `getFamilyForJti` legacy fallback (unused import removed) and the always-true `familyId` guards downstream. `familyId` is now a non-null `string` sourced from the verified claim.

**Safe across all auth flows:** every refresh-token mint site — login, SSO (`sso.ts`), passkeys, cfAccess, invite, register, MFA — passes `refreshFam` via `mintRefreshTokenFamily`, so only genuine pre-rollout tokens lack `fam`. No active-session regression.

## Tests

New `POST /refresh — hard-reject fam-less legacy tokens (#917 L-1)` describe block in `login.test.ts`:
- fam-less token → 401, cookie cleared, **bails before** reuse-detection/mint (asserts `isRefreshTokenJtiRevoked`/`createTokenPair` not called).
- fam-bearing token → 200, family propagates into the rotated token (`refreshFam`) + jti→family binding.

`vitest run routes/auth/login.test.ts` → **9 passed**. `tsc --noEmit` clean.

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)