### PR TITLE
fix(api): scope-aware org resolution for routing-rule writes (#1633)

### DIFF
--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -46,6 +46,55 @@ export function ensureOrgAccess(orgId: string, auth: { canAccessOrg: (orgId: str
   return auth.canAccessOrg(orgId);
 }
 
+/**
+ * Resolve the org a mutating alerts request should write to, honouring an
+ * explicit (query-param) orgId for partner/system callers.
+ *
+ * Org-scoped callers are pinned to their own org (an explicit orgId that
+ * disagrees is rejected). Partner/system callers select via the request orgId,
+ * which is access-checked; with no orgId, a partner with exactly one accessible
+ * org is disambiguated to it, otherwise the request is genuinely ambiguous (400)
+ * — and an org-scoped caller with no org context is 403. Tenant isolation is
+ * unchanged: the resolved orgId is always canAccessOrg-checked and RLS still
+ * backstops.
+ */
+export function resolveWriteOrgId(
+  auth: {
+    scope: 'system' | 'partner' | 'organization';
+    orgId: string | null;
+    accessibleOrgIds: string[] | null;
+    canAccessOrg: (orgId: string) => boolean;
+  },
+  requestedOrgId?: string
+): { orgId?: string; error?: string; status?: 400 | 403 } {
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) {
+      return { error: 'Organization context required', status: 403 };
+    }
+    if (requestedOrgId && requestedOrgId !== auth.orgId) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: auth.orgId };
+  }
+
+  if (requestedOrgId) {
+    if (!ensureOrgAccess(requestedOrgId, auth)) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: requestedOrgId };
+  }
+
+  if (auth.orgId) {
+    return { orgId: auth.orgId };
+  }
+
+  if (auth.accessibleOrgIds && auth.accessibleOrgIds.length === 1) {
+    return { orgId: auth.accessibleOrgIds[0] };
+  }
+
+  return { error: 'orgId is required when partner has multiple organizations', status: 400 };
+}
+
 export async function getAlertRuleWithOrgCheck(ruleId: string, auth: { canAccessOrg: (orgId: string) => boolean }) {
   const [rule] = await db
     .select()

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -92,7 +92,7 @@ export function resolveWriteOrgId(
     return { orgId: auth.accessibleOrgIds[0] };
   }
 
-  return { error: 'orgId is required when partner has multiple organizations', status: 400 };
+  return { error: 'orgId is required when the caller can access multiple organizations', status: 400 };
 }
 
 export async function getAlertRuleWithOrgCheck(ruleId: string, auth: { canAccessOrg: (orgId: string) => boolean }) {

--- a/apps/api/src/routes/alerts/routing.ts
+++ b/apps/api/src/routes/alerts/routing.ts
@@ -6,7 +6,7 @@ import { notificationRoutingRules } from '../../db/schema';
 import { eq, and, asc, inArray } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { ensureOrgAccess } from './helpers';
+import { ensureOrgAccess, resolveWriteOrgId } from './helpers';
 import { PERMISSIONS } from '../../services/permissions';
 
 const listRoutingRulesSchema = z.object({
@@ -101,10 +101,11 @@ routingRoutes.post(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const resolved = resolveWriteOrgId(auth, c.req.query('orgId'));
+      if (resolved.error) {
+        return c.json({ error: resolved.error }, resolved.status ?? 400);
       }
+      const orgId = resolved.orgId!;
 
       const data = c.req.valid('json');
 
@@ -146,10 +147,11 @@ routingRoutes.patch(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const resolved = resolveWriteOrgId(auth, c.req.query('orgId'));
+      if (resolved.error) {
+        return c.json({ error: resolved.error }, resolved.status ?? 400);
       }
+      const orgId = resolved.orgId!;
 
       const ruleId = c.req.param('id')!;
       const updates = c.req.valid('json');
@@ -202,10 +204,11 @@ routingRoutes.delete(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const orgId = auth.orgId;
-      if (!orgId) {
-        return c.json({ error: 'orgId is required' }, 400);
+      const resolved = resolveWriteOrgId(auth, c.req.query('orgId'));
+      if (resolved.error) {
+        return c.json({ error: resolved.error }, resolved.status ?? 400);
       }
+      const orgId = resolved.orgId!;
 
       const ruleId = c.req.param('id')!;
 

--- a/apps/api/src/routes/alerts/routing.writes.test.ts
+++ b/apps/api/src/routes/alerts/routing.writes.test.ts
@@ -177,4 +177,51 @@ describe('routing-rule writes — partner org resolution (#1633)', () => {
     expect(res.status).toBe(201);
     expect(insertedRef.current?.orgId).toBe('org-1');
   });
+
+  it('org-scoped user: an explicit ?orgId= matching their own org still succeeds', async () => {
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-2', name: 'Olive', email: 'olive@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+    const res = await makeApp().request('/alerts/routing-rules?orgId=org-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(201);
+    expect(insertedRef.current?.orgId).toBe('org-1');
+  });
+
+  it('org-scoped user: smuggling a different ?orgId= is 403 (cannot redirect the write cross-org)', async () => {
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-2', name: 'Olive', email: 'olive@org.example' },
+      // canAccessOrg returns true even for the other org — the org-scope pin must
+      // reject the mismatch on its own, not lean on canAccessOrg.
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+    const res = await makeApp().request('/alerts/routing-rules?orgId=org-2', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(403);
+    expect(insertedRef.current).toBeUndefined();
+  });
+
+  it('system-scoped caller with ?orgId= writes against that org', async () => {
+    authRef.current = {
+      scope: 'system',
+      user: { id: 'u-3', name: 'Sys', email: 'sys@breeze.local' },
+      partnerId: null, orgId: null, accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+    const res = await makeApp().request('/alerts/routing-rules?orgId=org-x', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(201);
+    expect(insertedRef.current?.orgId).toBe('org-x');
+  });
 });

--- a/apps/api/src/routes/alerts/routing.writes.test.ts
+++ b/apps/api/src/routes/alerts/routing.writes.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression for #1633 (write side): POST/PATCH/DELETE /alerts/routing-rules
+// must not hard-require auth.orgId. A partner-scoped user has a null auth.orgId
+// (the active org rides as the ?orgId= query param), so the old
+// `if (!auth.orgId) 400 'orgId is required'` guard blocked them from
+// creating/editing/deleting routing rules entirely. The handlers now resolve
+// the org scope-aware (via resolveWriteOrgId), honouring an access-checked
+// ?orgId= for partner/system callers — mirroring the list fix (#1643).
+
+const { authRef, insertedRef, capturedWhere } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as string,
+      user: { id: 'u-1', name: 'Pat Partner', email: 'pat@partner.example' },
+      partnerId: 'p-1' as string | null,
+      orgId: null as string | null,
+      accessibleOrgIds: ['org-a', 'org-b'] as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  insertedRef: { current: undefined as Record<string, unknown> | undefined },
+  capturedWhere: { current: undefined as unknown },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  // ALERTS_WRITE is exercised separately in routing.authz.test.ts; allow here.
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+const existingRowRef = { current: undefined as Record<string, unknown> | undefined };
+
+vi.mock('../../db', () => {
+  const builder: any = {
+    // insert(...).values(...).returning()
+    values: (vals: Record<string, unknown>) => {
+      insertedRef.current = vals;
+      return builder;
+    },
+    returning: () => Promise.resolve([{ id: 'new-rule', ...(insertedRef.current ?? {}) }]),
+    // update(...).set(...).where(...).returning() and select().from().where().limit()
+    set: () => builder,
+    from: () => builder,
+    where: (cond: unknown) => {
+      capturedWhere.current = cond;
+      return builder;
+    },
+    limit: () => Promise.resolve(existingRowRef.current ? [existingRowRef.current] : []),
+    orderBy: () => Promise.resolve([]),
+  };
+  return {
+    db: {
+      insert: () => builder,
+      update: () => builder,
+      delete: () => ({ where: () => Promise.resolve(undefined) }),
+      select: () => builder,
+    },
+  };
+});
+vi.mock('../../db/schema', () => ({
+  notificationRoutingRules: { id: { name: 'id' }, orgId: { name: 'org_id' } },
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+import { routingRoutes } from './routing';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', routingRoutes);
+  return app;
+}
+
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const CHANNEL_ID = '9a8b7c6d-2222-4333-8444-555566667777';
+const validBody = { name: 'Critical routing', priority: 0, conditions: {}, channelIds: [CHANNEL_ID] };
+
+describe('routing-rule writes — partner org resolution (#1633)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRef.current = undefined;
+    capturedWhere.current = undefined;
+    existingRowRef.current = undefined;
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Pat', email: 'pat@partner.example' },
+      partnerId: 'p-1', orgId: null, accessibleOrgIds: ['org-a', 'org-b'], canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('POST: partner with explicit ?orgId= creates against that org (not 400)', async () => {
+    const res = await makeApp().request('/alerts/routing-rules?orgId=org-a', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(201);
+    expect(insertedRef.current?.orgId).toBe('org-a');
+  });
+
+  it('POST: partner with multiple accessible orgs and no ?orgId= is 400 ambiguous (not 500/crash)', async () => {
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/multiple organizations/);
+  });
+
+  it('POST: partner with exactly one accessible org and no ?orgId= disambiguates to it', async () => {
+    authRef.current = {
+      ...authRef.current,
+      accessibleOrgIds: ['org-only'],
+    } as typeof authRef.current;
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(201);
+    expect(insertedRef.current?.orgId).toBe('org-only');
+  });
+
+  it('POST: explicit ?orgId= the partner cannot access is 403 (cross-tenant rejected)', async () => {
+    authRef.current = {
+      ...authRef.current,
+      canAccessOrg: (id: string) => id !== 'org-forbidden',
+    } as typeof authRef.current;
+    const res = await makeApp().request('/alerts/routing-rules?orgId=org-forbidden', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('PATCH: partner with ?orgId= scopes the lookup to that org (404 when rule absent, not 400)', async () => {
+    existingRowRef.current = undefined; // rule not in that org
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}?orgId=org-a`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'renamed' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE: partner with ?orgId= deletes a rule in that org (not 400)', async () => {
+    existingRowRef.current = { id: RULE_ID, orgId: 'org-a', name: 'r' };
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}?orgId=org-a`, {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: { id: RULE_ID, deleted: true } });
+  });
+
+  it('org-scoped user: write pins to own org without needing ?orgId=', async () => {
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-2', name: 'Olive', email: 'olive@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(201);
+    expect(insertedRef.current?.orgId).toBe('org-1');
+  });
+});


### PR DESCRIPTION
## Summary

`POST`/`PATCH`/`DELETE` `/alerts/routing-rules` hard-required `auth.orgId` and returned `400 {"error":"orgId is required"}` when it was null. A **partner-scoped** user always has a null `auth.orgId` (their active org rides as the `?orgId=` query param), so they could **list** routing rules (fixed by #1643) but still couldn't **create / update / delete** one — the write-side counterpart of the same root cause #1633 called out.

**Fix:** add a shared `resolveWriteOrgId` helper in `alerts/helpers.ts` (mirroring the established `userRisk.ts` / escalation-policies pattern) and use it in all three write handlers, reading the org from `c.req.query('orgId')`:

- **org scope** → pinned to own org; an explicit `?orgId=` that disagrees is `403`.
- **partner/system + `?orgId=`** → access-checked (`canAccessOrg`); cross-tenant is `403`.
- **partner, no `?orgId=`** → a single accessible org is disambiguated to it; otherwise `400` only when genuinely ambiguous.

Tenant isolation is unchanged: the resolved `orgId` is always `canAccessOrg`-checked, the `PATCH`/`DELETE` rule lookups stay `orgId`-scoped (cross-org ⇒ 404), and RLS still backstops.

## Files

- `apps/api/src/routes/alerts/helpers.ts` — new `resolveWriteOrgId` helper.
- `apps/api/src/routes/alerts/routing.ts` — POST/PATCH/DELETE use it instead of the `auth.orgId`-only guard.
- `apps/api/src/routes/alerts/routing.writes.test.ts` — write-side regression (partner explicit/ambiguous/single-org, cross-tenant 403, org-scope pinning).

## Tests

- `routing.writes.test.ts` + `routing.list.test.ts` + `routing.authz.test.ts`: 15 passed.
- Full `src/routes/alerts/` directory: 58 passed.
- `tsc --noEmit` clean.

Closes #1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)