### PR TITLE
fix(oauth): honor org client blocks for partner bearers

### DIFF
--- a/apps/api/src/middleware/bearerTokenAuth.test.ts
+++ b/apps/api/src/middleware/bearerTokenAuth.test.ts
@@ -447,6 +447,27 @@ describe('bearerTokenAuthMiddleware', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
+  it('rejects org-scoped bearer tokens for an actively blocked OAuth client', async () => {
+    dbState.rows = [[{ orgId }]];
+    const token = await mintToken({
+      sub: userId,
+      partner_id: partnerId,
+      org_id: orgId,
+      scope: 'mcp:read',
+      jti: 'org-blocked-client-jti',
+      client_id: 'client-blocked-for-org',
+    });
+    const next = vi.fn();
+
+    await expect(
+      bearerTokenAuthMiddleware(createContext({ Authorization: `Bearer ${token}` }), next)
+    ).rejects.toMatchObject({
+      status: 403,
+      message: 'oauth client blocked for this organization',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('preserves grant_id for stable MCP session and rate-limit ownership', async () => {
     const token = await mintToken({
       sub: userId,
@@ -522,6 +543,44 @@ describe('bearerTokenAuthMiddleware', () => {
     const facts = collectPredicateFacts(orgPredicate);
     expect(facts.columns).toEqual(expect.arrayContaining(['partner_id', 'status', 'deleted_at']));
     expect(facts.params).toEqual(expect.arrayContaining(['active', 'trial']));
+  });
+
+  it('removes orgs with active OAuth client blocks from partner-scope bearer access', async () => {
+    const blockedOrg = '44444444-4444-4444-8444-444444444444';
+    const allowedOrg = '55555555-5555-5555-8555-555555555555';
+    dbState.rows = [
+      [{ orgAccess: 'all', orgIds: null }],
+      [{ id: blockedOrg }, { id: allowedOrg }],
+      [{ orgId: blockedOrg }],
+    ];
+
+    const token = await mintToken({
+      sub: userId,
+      partner_id: partnerId,
+      org_id: null,
+      scope: 'mcp:read',
+      jti: 'partner-blocked-client-jti',
+      client_id: 'client-blocked-in-one-org',
+    });
+    const c = createContext({ Authorization: `Bearer ${token}` });
+    const next = vi.fn();
+
+    await bearerTokenAuthMiddleware(c, next);
+
+    expect(c.get('apiKey')).toMatchObject({
+      id: 'oauth:partner-blocked-client-jti',
+      orgId: null,
+      partnerId,
+      oauthClientId: 'client-blocked-in-one-org',
+    });
+    expect(withDbAccessContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'partner',
+        accessibleOrgIds: [allowedOrg],
+      }),
+      expect.any(Function)
+    );
+    expect(next).toHaveBeenCalledOnce();
   });
 
   it('passes [] (not null) for partner-scope tokens whose partner has no orgs (M-B1)', async () => {

--- a/apps/api/src/middleware/bearerTokenAuth.ts
+++ b/apps/api/src/middleware/bearerTokenAuth.ts
@@ -1,10 +1,10 @@
 import type { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyResult } from 'jose';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNull, or } from 'drizzle-orm';
 import { OAUTH_ISSUER, OAUTH_RESOURCE_URL } from '../config/env';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
-import { organizations, partnerUsers } from '../db/schema';
+import { oauthClientBlocks, organizations, partnerUsers } from '../db/schema';
 import { isGrantRevoked, isJtiRevoked } from '../oauth/revocationCache';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 
@@ -18,6 +18,7 @@ interface OAuthApiKeyContext {
   rateLimit: number;
   createdBy: string;
   oauthGrantId?: string;
+  oauthClientId?: string;
 }
 
 let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
@@ -175,6 +176,27 @@ export async function resolvePartnerAccessibleOrgIds(
 // Exported for unit tests that exercise the partner-scope resolution path.
 export const _resolvePartnerAccessibleOrgIdsForTests = resolvePartnerAccessibleOrgIds;
 
+async function filterBlockedOAuthClientOrgIds(orgIds: string[], clientId: string | undefined): Promise<string[]> {
+  if (!clientId || orgIds.length === 0) return orgIds;
+
+  return withSystemDbAccessContext(async () => {
+    const now = new Date();
+    const rows = await db
+      .select({ orgId: oauthClientBlocks.orgId })
+      .from(oauthClientBlocks)
+      .where(
+        and(
+          eq(oauthClientBlocks.clientId, clientId),
+          inArray(oauthClientBlocks.orgId, orgIds),
+          or(isNull(oauthClientBlocks.blockedUntil), gt(oauthClientBlocks.blockedUntil, now)),
+        ),
+      );
+    if (rows.length === 0) return orgIds;
+    const blocked = new Set(rows.map((row) => row.orgId));
+    return orgIds.filter((orgId) => !blocked.has(orgId));
+  });
+}
+
 export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
   if (!OAUTH_ISSUER || !OAUTH_RESOURCE_URL) {
     throw new HTTPException(500, { message: 'OAuth not configured: OAUTH_ISSUER and OAUTH_RESOURCE_URL must be set' });
@@ -223,17 +245,20 @@ export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
   if (typeof payload.grant_id === 'string' && await isGrantRevoked(payload.grant_id)) {
     throw new HTTPException(401, { message: 'token revoked' });
   }
+  const clientIdClaim = typeof (payload as { client_id?: unknown }).client_id === 'string'
+    ? (payload as { client_id?: string }).client_id
+    : typeof (payload as { azp?: unknown }).azp === 'string'
+      ? (payload as { azp?: string }).azp
+      : undefined;
+
   // Org-wide OAuth client block: covers the "no Cursor in Acme Corp for the
-  // next 30 days" admin lever. Cheap one-row check, only runs when an org
-  // is in scope (org_id claim present). System-context lookup; the table is
-  // org-tenant RLS but this middleware is the authorization point.
-  if (typeof payload.org_id === 'string' && typeof (payload as { client_id?: unknown }).client_id === 'string') {
-    const { isOauthClientBlockedForOrg } = await import('../routes/lifecycle');
-    const blocked = await isOauthClientBlockedForOrg(
-      payload.org_id,
-      (payload as { client_id: string }).client_id
-    );
-    if (blocked) {
+  // next 30 days" admin lever. Org-scoped bearers are rejected outright.
+  // Partner-scoped bearers are filtered below so a block removes only the
+  // blocked org from the partner-wide allowlist while preserving access to
+  // other orgs under the partner.
+  if (typeof payload.org_id === 'string' && clientIdClaim) {
+    const unblocked = await filterBlockedOAuthClientOrgIds([payload.org_id], clientIdClaim);
+    if (unblocked.length === 0) {
       throw new HTTPException(403, { message: 'oauth client blocked for this organization' });
     }
   }
@@ -265,11 +290,6 @@ export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
   }
 
   const oauthScopes = (payload.scope ?? '').split(' ').filter(Boolean);
-  const clientIdClaim = typeof (payload as { client_id?: unknown }).client_id === 'string'
-    ? (payload as { client_id?: string }).client_id
-    : typeof (payload as { azp?: unknown }).azp === 'string'
-      ? (payload as { azp?: string }).azp
-      : undefined;
   const effectiveScopes = expandOAuthScopes(oauthScopes, clientIdClaim);
 
   (c.set as (key: 'apiKey', value: OAuthApiKeyContext) => void)('apiKey', {
@@ -282,6 +302,7 @@ export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
     rateLimit: 1000,
     createdBy: payload.sub,
     ...(typeof payload.grant_id === 'string' ? { oauthGrantId: payload.grant_id } : {}),
+    ...(clientIdClaim ? { oauthClientId: clientIdClaim } : {}),
   });
   if (payload.org_id) c.set('apiKeyOrgId', payload.org_id);
 
@@ -292,7 +313,10 @@ export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
   // leaning entirely on RLS. See resolvePartnerAccessibleOrgIds() above.
   const partnerAccessibleOrgIds = payload.org_id
     ? null
-    : await resolvePartnerAccessibleOrgIds(payload.partner_id, payload.sub);
+    : await filterBlockedOAuthClientOrgIds(
+        await resolvePartnerAccessibleOrgIds(payload.partner_id, payload.sub),
+        clientIdClaim,
+      );
 
   await withDbAccessContext(
     payload.org_id


### PR DESCRIPTION
## Summary
- Filters partner-scoped OAuth bearer accessible orgs by active org-wide OAuth client blocks
- Keeps org-scoped bearer behavior fail-closed for blocked clients without importing lifecycle routes
- Carries the OAuth client id in the MCP apiKey context for audit/debug context

## Security finding
Partner-scoped OAuth bearers have no org_id claim, so the existing org-wide connected-app block check did not run for them. Because MCP builds a partner org allowlist for these tokens, a blocked client could still reach the blocked org through partner-scope MCP access. The middleware now subtracts blocked orgs from the partner allowlist, and still rejects org-scoped tokens outright.

## Tests
- pnpm --dir apps/api exec vitest run src/middleware/bearerTokenAuth.test.ts
- pnpm --dir apps/api exec vitest run src/routes/mcpServer.bearer.test.ts --testTimeout=15000
- pnpm --dir apps/api exec vitest run src/routes/mcpServer.streamable.test.ts --testTimeout=15000
- pnpm --dir apps/api exec vitest run src/routes/mcpServer.effectiveTier.test.ts --testTimeout=15000
- pnpm --dir apps/api exec vitest run src/routes/oauth.test.ts src/routes/oauth.rate-limit.test.ts --testTimeout=15000
- pnpm --dir apps/api exec vitest run src/routes/oauth.revocation.test.ts --testTimeout=15000
- pnpm --dir apps/api exec vitest run src/routes/oauthInteraction.test.ts --testTimeout=15000
- pnpm --dir apps/api exec vitest run src/routes/connectedApps.test.ts --testTimeout=15000
- pnpm --dir apps/api exec vitest run src/routes/lifecycle.test.ts --testTimeout=15000
- pnpm --dir apps/api exec tsc --noEmit --pretty false

Note: running several OAuth/MCP suites in one shared Vitest process produced mock/env timeouts, so the route suites above were verified as isolated invocations.