### PR TITLE
fix(web): wrap alert detail mutations in runAction

### DIFF
--- a/apps/web/src/components/alerts/AlertDetailPage.tsx
+++ b/apps/web/src/components/alerts/AlertDetailPage.tsx
@@ -4,6 +4,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { cn } from '@/lib/utils';
 import { useAiStore } from '@/stores/aiStore';
 import { navigateTo } from '@/lib/navigation';
+import { ActionError, handleActionError, runAction } from '../../lib/runAction';
 import Breadcrumbs from '../layout/Breadcrumbs';
 import {
   severityConfig,
@@ -145,13 +146,18 @@ export default function AlertDetailPage({ alertId }: AlertDetailPageProps) {
     if (!alert || actionInProgress) return;
     try {
       setActionInProgress(true);
-      const response = await fetchWithAuth(`/alerts/${alertId}/acknowledge`, {
-        method: 'POST'
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/${alertId}/acknowledge`, { method: 'POST' }),
+        errorFallback: 'Failed to acknowledge alert',
+        successMessage: 'Alert acknowledged',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-      if (!response.ok) throw new Error('Failed to acknowledge alert');
       await fetchAlert();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to acknowledge alert');
+      handleActionError(err, 'Failed to acknowledge alert');
+      if (!(err instanceof ActionError && err.status === 401)) {
+        setError(err instanceof Error ? err.message : 'Failed to acknowledge alert');
+      }
     } finally {
       setActionInProgress(false);
     }
@@ -161,13 +167,18 @@ export default function AlertDetailPage({ alertId }: AlertDetailPageProps) {
     if (!alert || actionInProgress) return;
     try {
       setActionInProgress(true);
-      const response = await fetchWithAuth(`/alerts/${alertId}/resolve`, {
-        method: 'POST'
+      await runAction({
+        request: () => fetchWithAuth(`/alerts/${alertId}/resolve`, { method: 'POST' }),
+        errorFallback: 'Failed to resolve alert',
+        successMessage: 'Alert resolved',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-      if (!response.ok) throw new Error('Failed to resolve alert');
       await fetchAlert();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to resolve alert');
+      handleActionError(err, 'Failed to resolve alert');
+      if (!(err instanceof ActionError && err.status === 401)) {
+        setError(err instanceof Error ? err.message : 'Failed to resolve alert');
+      }
     } finally {
       setActionInProgress(false);
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -30,6 +30,7 @@ const REPO_ROOT = resolve(WEB_ROOT, '../../..');
 const TARGET_GLOBS = [
   'src/components/alerts/NotificationChannelsPage.tsx',
   'src/components/alerts/AlertsPage.tsx',
+  'src/components/alerts/AlertDetailPage.tsx',
   'src/components/settings/PartnerSettingsPage.tsx',
   'src/components/patches/PatchesPage.tsx',
   'src/components/settings/RolesPage.tsx',
@@ -262,7 +263,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(43);
+    expect(absoluteFiles.length).toBe(44);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/runActionAllowlist.ts
+++ b/apps/web/src/lib/runActionAllowlist.ts
@@ -23,7 +23,6 @@ export const RUN_ACTION_MIGRATION_BACKLOG: ReadonlyArray<string> = [
   'apps/web/src/components/devices/DeviceSettingsModal.tsx',
   'apps/web/src/components/devices/DeviceWarrantyCard.tsx',
   'apps/web/src/components/alerts/AlertCorrelationView.tsx',
-  'apps/web/src/components/alerts/AlertDetailPage.tsx',
   'apps/web/src/components/alerts/AlertRuleEditor.tsx',
   'apps/web/src/components/alerts/AlertRulesPage.tsx',
   'apps/web/src/components/alerts/AlertTemplateEditor.tsx',


### PR DESCRIPTION
## Summary
- wrap Alert detail acknowledge/resolve mutations in runAction so API failures produce user feedback
- add AlertDetailPage to the no-silent-mutations targeted set
- remove AlertDetailPage from the runAction migration backlog

## Security review
- Covers playbook #7 web app runAction mutation hardening. Exact DOM injection search found no production uses of dangerouslySetInnerHTML/innerHTML/etc.

## Tests
- pnpm --dir apps/web exec vitest run src/lib/__tests__/no-silent-mutations.test.ts
- pnpm --dir apps/web exec tsc --noEmit --pretty false