### PR TITLE
fix(psa): route provider requests through safeFetch

### DIFF
--- a/apps/api/src/routes/psa.test.ts
+++ b/apps/api/src/routes/psa.test.ts
@@ -192,6 +192,27 @@ describe('psa route security gates', () => {
     expect(insertMock).toHaveBeenCalled();
   });
 
+  it('rejects unsafe PSA credential base URLs before storing credentials', async () => {
+    const res = await app.request('/psa/connections', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'jira',
+        name: 'Metadata PSA',
+        credentials: {
+          baseUrl: 'https://169.254.169.254/latest/meta-data',
+          apiKey: 'secret',
+        },
+        settings: {},
+      }),
+    });
+
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('credentials.baseUrl rejected');
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
   it('requires MFA before testing or deleting existing PSA credentials', async () => {
     mfaGate.deny = true;
 

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -7,6 +7,7 @@ import { db } from '../db';
 import { devices, psaConnections as psaConnectionsTable, psaTicketMappings } from '../db/schema';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { validatePsaBaseUrl } from '../services/psa/http';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 
 export const psaRoutes = new Hono();
@@ -76,6 +77,17 @@ async function ensureOrgAccess(
 
 function encryptCredentials(credentials: Record<string, unknown>): string | null {
   return encryptSecret(JSON.stringify(credentials));
+}
+
+function validatePsaCredentialBaseUrl(credentials: Record<string, unknown>): string | null {
+  const baseUrl = credentials.baseUrl;
+  if (baseUrl === undefined) return null;
+  if (typeof baseUrl !== 'string' || baseUrl.trim().length === 0) {
+    return 'credentials.baseUrl must be a non-empty URL';
+  }
+
+  const rejectionReason = validatePsaBaseUrl(baseUrl.trim());
+  return rejectionReason ? `credentials.baseUrl rejected: ${rejectionReason}` : null;
 }
 
 function decryptCredentials(value: unknown): Record<string, unknown> | null {
@@ -349,6 +361,11 @@ psaRoutes.post(
       return c.json({ error: 'orgId is required for system scope' }, 400);
     }
 
+    const baseUrlError = validatePsaCredentialBaseUrl(data.credentials);
+    if (baseUrlError) {
+      return c.json({ error: baseUrlError }, 400);
+    }
+
     const credentialsEncrypted = encryptCredentials(data.credentials);
     if (!credentialsEncrypted) {
       return c.json({ error: 'Failed to encrypt credentials' }, 500);
@@ -452,6 +469,11 @@ psaRoutes.patch(
     }
 
     if (data.credentials !== undefined) {
+      const baseUrlError = validatePsaCredentialBaseUrl(data.credentials);
+      if (baseUrlError) {
+        return c.json({ error: baseUrlError }, 400);
+      }
+
       const encrypted = encryptCredentials(data.credentials);
       if (!encrypted) {
         return c.json({ error: 'Failed to encrypt credentials' }, 500);

--- a/apps/api/src/services/psa/autotask.ts
+++ b/apps/api/src/services/psa/autotask.ts
@@ -1,4 +1,5 @@
 import { PSACompany, PSAConnectionTest, PSAProvider, PSATicket, PSATicketCreate, PSATicketUpdate } from './types';
+import { psaFetch } from './http';
 
 export interface AutotaskCredentials {
   baseUrl: string;
@@ -50,7 +51,7 @@ export class AutotaskProvider implements PSAProvider {
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
+    const response = await psaFetch(`${this.baseUrl}${path}`, {
       method,
       headers: {
         ...this.getHeaders(),

--- a/apps/api/src/services/psa/connectwise.ts
+++ b/apps/api/src/services/psa/connectwise.ts
@@ -1,4 +1,5 @@
 import { PSACompany, PSAConnectionTest, PSAProvider, PSATicket, PSATicketCreate, PSATicketUpdate } from './types';
+import { psaFetch } from './http';
 
 export interface ConnectWiseCredentials {
   baseUrl: string;
@@ -51,7 +52,7 @@ export class ConnectWiseProvider implements PSAProvider {
     body?: unknown,
     contentType = 'application/json'
   ): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
+    const response = await psaFetch(`${this.baseUrl}${path}`, {
       method,
       headers: {
         'Authorization': this.getAuthHeader(),

--- a/apps/api/src/services/psa/freshservice.ts
+++ b/apps/api/src/services/psa/freshservice.ts
@@ -1,4 +1,5 @@
 import { PSACompany, PSAConnectionTest, PSAProvider, PSATicket, PSATicketCreate, PSATicketUpdate } from './types';
+import { psaFetch } from './http';
 
 export interface FreshserviceCredentials {
   baseUrl: string;
@@ -42,7 +43,7 @@ export class FreshserviceProvider implements PSAProvider {
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
+    const response = await psaFetch(`${this.baseUrl}${path}`, {
       method,
       headers: {
         'Authorization': this.getAuthHeader(),

--- a/apps/api/src/services/psa/http.test.ts
+++ b/apps/api/src/services/psa/http.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { psaFetch, validatePsaBaseUrl } from './http';
+import { safeFetch, SsrfBlockedError } from '../urlSafety';
+
+vi.mock('../urlSafety', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../urlSafety')>();
+  return {
+    ...actual,
+    safeFetch: vi.fn(async () => new Response('{}', { status: 200 })),
+  };
+});
+
+describe('PSA HTTP safety', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects unsafe PSA base URLs before dialing', async () => {
+    expect(validatePsaBaseUrl('http://psa.example.com/api')).toBe('URL must use https://');
+    expect(validatePsaBaseUrl('https://169.254.169.254/latest/meta-data')).toContain('cloud-metadata');
+
+    await expect(psaFetch('https://169.254.169.254/latest/meta-data')).rejects.toBeInstanceOf(SsrfBlockedError);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it('uses safeFetch with conservative PSA defaults for public HTTPS URLs', async () => {
+    await psaFetch('https://psa.example.com/api', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(safeFetch).toHaveBeenCalledWith(
+      'https://psa.example.com/api',
+      expect.objectContaining({
+        timeoutMs: 20_000,
+        redirect: 'error',
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      })
+    );
+  });
+});

--- a/apps/api/src/services/psa/http.test.ts
+++ b/apps/api/src/services/psa/http.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { psaFetch, validatePsaBaseUrl } from './http';
 import { safeFetch, SsrfBlockedError } from '../urlSafety';
+import * as env from '../../config/env';
 
 vi.mock('../urlSafety', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../urlSafety')>();
@@ -13,6 +14,14 @@ vi.mock('../urlSafety', async (importOriginal) => {
 describe('PSA HTTP safety', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default the suite to hosted-SaaS (strict) unless a test opts into self-host.
+    vi.spyOn(env, 'isHosted').mockReturnValue(true);
+    process.env.IS_HOSTED = 'true';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.IS_HOSTED;
   });
 
   it('rejects unsafe PSA base URLs before dialing', async () => {
@@ -33,10 +42,59 @@ describe('PSA HTTP safety', () => {
       'https://psa.example.com/api',
       expect.objectContaining({
         timeoutMs: 20_000,
-        redirect: 'error',
         method: 'POST',
         headers: { Authorization: 'Bearer token' },
       })
     );
+  });
+
+  it('keeps hosted SaaS strict: no allowPrivateNetwork on the safeFetch call', async () => {
+    await psaFetch('https://psa.example.com/api');
+
+    expect(safeFetch).toHaveBeenCalledWith(
+      'https://psa.example.com/api',
+      expect.objectContaining({ allowPrivateNetwork: false })
+    );
+  });
+
+  describe('on-prem (self-hosted) PSA base URLs', () => {
+    it('ALLOWS http + RFC1918 PSA URLs when self-hosted', async () => {
+      vi.spyOn(env, 'isHosted').mockReturnValue(false);
+      process.env.IS_HOSTED = 'false';
+
+      // Static write-time validation accepts http:// and private IPs.
+      expect(validatePsaBaseUrl('http://10.0.0.5/api')).toBeNull();
+      expect(validatePsaBaseUrl('https://jira.corp.local/rest')).toBeNull();
+
+      // Call-time path threads allowPrivateNetwork through to safeFetch so
+      // DNS-resolved RFC1918 targets aren't blocked.
+      await psaFetch('http://10.0.0.5/api');
+      expect(safeFetch).toHaveBeenCalledWith(
+        'http://10.0.0.5/api',
+        expect.objectContaining({ allowPrivateNetwork: true })
+      );
+    });
+
+    it('BLOCKS http + RFC1918 PSA URLs when hosted SaaS', async () => {
+      vi.spyOn(env, 'isHosted').mockReturnValue(true);
+      process.env.IS_HOSTED = 'true';
+
+      expect(validatePsaBaseUrl('http://10.0.0.5/api')).toBe('URL must use https://');
+      expect(validatePsaBaseUrl('https://10.0.0.5/api')).toContain('private/RFC1918');
+
+      await expect(psaFetch('http://10.0.0.5/api')).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(safeFetch).not.toHaveBeenCalled();
+    });
+
+    it('fails closed: garbage IS_HOSTED stays strict', async () => {
+      // isHosted() (envFlag) returns false for unrecognized values, but the
+      // private-network gate must NOT open without an affirmative self-host signal.
+      vi.spyOn(env, 'isHosted').mockReturnValue(false);
+      process.env.IS_HOSTED = 'banana';
+
+      expect(validatePsaBaseUrl('http://10.0.0.5/api')).toBe('URL must use https://');
+      await expect(psaFetch('http://10.0.0.5/api')).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(safeFetch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/services/psa/http.ts
+++ b/apps/api/src/services/psa/http.ts
@@ -1,0 +1,23 @@
+import { checkSsrfSafe } from '../ssrfGuard';
+import { safeFetch, SsrfBlockedError, type SafeFetchInit } from '../urlSafety';
+
+const DEFAULT_PSA_TIMEOUT_MS = 20_000;
+
+export function validatePsaBaseUrl(rawUrl: string): string | null {
+  const result = checkSsrfSafe(rawUrl, { mode: 'strict-https' });
+  return result.ok ? null : result.reason ?? 'URL is not safe';
+}
+
+export async function psaFetch(input: string | URL, init: SafeFetchInit = {}): Promise<Response> {
+  const rawUrl = String(input);
+  const staticError = validatePsaBaseUrl(rawUrl);
+  if (staticError) {
+    throw new SsrfBlockedError(`PSA URL rejected: ${staticError}`);
+  }
+
+  return safeFetch(rawUrl, {
+    timeoutMs: DEFAULT_PSA_TIMEOUT_MS,
+    redirect: 'error',
+    ...init,
+  });
+}

--- a/apps/api/src/services/psa/http.ts
+++ b/apps/api/src/services/psa/http.ts
@@ -1,10 +1,34 @@
-import { checkSsrfSafe } from '../ssrfGuard';
+import { isHosted } from '../../config/env';
+import { checkSsrfSafe, type SsrfMode } from '../ssrfGuard';
 import { safeFetch, SsrfBlockedError, type SafeFetchInit } from '../urlSafety';
 
 const DEFAULT_PSA_TIMEOUT_MS = 20_000;
 
+// On-prem PSAs (ConnectWise / Autotask / ServiceNow / Jira Data Center, etc.)
+// legitimately live on the customer LAN, so on SELF-HOSTED deployments their
+// base URL may be plain http:// and/or an RFC1918/ULA address. Hosted SaaS stays
+// strict (HTTPS-only, no private networking) because a private IP is genuinely
+// unreachable from us and is a real SSRF target. Loopback, link-local, cloud
+// metadata, and CGNAT remain blocked in BOTH modes (see ssrfGuard +
+// urlSafety.isAlwaysBlockedIp).
+//
+// Fail closed: only open http/RFC1918 when self-host is AFFIRMATIVELY declared
+// (IS_HOSTED explicitly set to a recognized non-truthy value: 'false'/'0'/'no'/
+// 'off'). Unset/empty/garbage IS_HOSTED => strict, mirroring the #570 hardening
+// lesson and the dnsProviders precedent (an unmapped IS_HOSTED must never
+// silently weaken security). `!isHosted()` is implied by falsey-set membership
+// but kept explicit so the truthy/falsey vocabularies can never drift apart.
+function psaAllowsPrivateNetwork(): boolean {
+  const isHostedRaw = (process.env.IS_HOSTED ?? '').trim().toLowerCase();
+  const recognizedSelfHostSignal = new Set(['0', 'false', 'no', 'off']).has(isHostedRaw);
+  return recognizedSelfHostSignal && !isHosted();
+}
+
 export function validatePsaBaseUrl(rawUrl: string): string | null {
-  const result = checkSsrfSafe(rawUrl, { mode: 'strict-https' });
+  // Self-hosted operators own both ends, so permit http + RFC1918/ULA via the
+  // on-prem mode. Hosted SaaS keeps the strict HTTPS-only, no-private-IP mode.
+  const mode: SsrfMode = psaAllowsPrivateNetwork() ? 'on-prem-http' : 'strict-https';
+  const result = checkSsrfSafe(rawUrl, { mode });
   return result.ok ? null : result.reason ?? 'URL is not safe';
 }
 
@@ -17,7 +41,9 @@ export async function psaFetch(input: string | URL, init: SafeFetchInit = {}): P
 
   return safeFetch(rawUrl, {
     timeoutMs: DEFAULT_PSA_TIMEOUT_MS,
-    redirect: 'error',
+    // Self-hosters may legitimately reach RFC1918/ULA PSAs; metadata/loopback/
+    // link-local/CGNAT stay blocked even when this is true. Hosted SaaS: strict.
+    allowPrivateNetwork: psaAllowsPrivateNetwork(),
     ...init,
   });
 }

--- a/apps/api/src/services/psa/jira.ts
+++ b/apps/api/src/services/psa/jira.ts
@@ -3,6 +3,7 @@
  *
  * Supports both Jira Cloud and Jira Server/Data Center
  */
+import { psaFetch } from './http';
 
 export interface JiraCredentials {
   type: 'cloud' | 'server';
@@ -100,7 +101,7 @@ class JiraClient {
   ): Promise<T> {
     const url = `${this.credentials.baseUrl}/rest/api/3${path}`;
 
-    const response = await fetch(url, {
+    const response = await psaFetch(url, {
       method,
       headers: {
         'Authorization': this.getAuthHeader(),

--- a/apps/api/src/services/psa/servicenow.ts
+++ b/apps/api/src/services/psa/servicenow.ts
@@ -1,4 +1,5 @@
 import { PSACompany, PSAConnectionTest, PSAProvider, PSATicket, PSATicketCreate, PSATicketUpdate } from './types';
+import { psaFetch } from './http';
 
 export interface ServiceNowCredentials {
   baseUrl: string;
@@ -53,7 +54,7 @@ export class ServiceNowProvider implements PSAProvider {
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
+    const response = await psaFetch(`${this.baseUrl}${path}`, {
       method,
       headers: {
         'Authorization': this.getAuthHeader(),

--- a/apps/api/src/services/psa/zendesk.ts
+++ b/apps/api/src/services/psa/zendesk.ts
@@ -1,4 +1,5 @@
 import { PSACompany, PSAConnectionTest, PSAProvider, PSATicket, PSATicketCreate, PSATicketUpdate } from './types';
+import { psaFetch } from './http';
 
 export interface ZendeskCredentials {
   baseUrl: string;
@@ -45,7 +46,7 @@ export class ZendeskProvider implements PSAProvider {
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
+    const response = await psaFetch(`${this.baseUrl}${path}`, {
       method,
       headers: {
         'Authorization': this.getAuthHeader(),


### PR DESCRIPTION
## Summary
- add a PSA HTTP wrapper that validates tenant-supplied PSA URLs and routes provider calls through safeFetch
- reject unsafe credentials.baseUrl values on PSA connection create/update
- cover route rejection and runtime wrapper behavior with focused tests

## Tests
- pnpm --dir apps/api exec vitest run src/services/psa/http.test.ts src/routes/psa.test.ts
- pnpm --dir apps/api exec tsc --noEmit --pretty false

Draft while security-review playbook follow-up continues.