### PR TITLE
fix(pam): require a distinct approver for elevation requests

### DIFF
--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -46,6 +46,7 @@ vi.mock('../db/schema', () => ({
     approvedAt: 'approvedAt',
     expiresAt: 'expiresAt',
     executionId: 'executionId',
+    subjectUserId: 'subjectUserId',
     approvedByUserId: 'approvedByUserId',
     deniedByUserId: 'deniedByUserId',
     revokedByUserId: 'revokedByUserId',
@@ -580,6 +581,60 @@ describe('POST /pam/elevation-requests/:id/respond', () => {
     expect(auditInserts[0]).toMatchObject({
       details: { assurance_level: 1, factor: 'session_tap' },
     });
+  });
+
+  // Separation-of-duties (maker/checker): the subject who requested a
+  // tech_jit_admin elevation cannot approve their own request. Mirrors the
+  // auditBaselines apply-approval and cisHardening remediation guards (self
+  // APPROVE blocked, self DENY allowed since a denial grants nothing).
+  it('403s when the requester (subject) approves their own elevation', async () => {
+    const { updateSetCalls } = rigTransaction({
+      row: { ...activeRow, flowType: 'tech_jit_admin', subjectUserId: USER_ID },
+      casWins: true,
+    });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve', durationMinutes: 30 }),
+    });
+
+    expect(res.status).toBe(403);
+    // No status flip / approval occurred.
+    expect(updateSetCalls.length).toBe(0);
+    expect(busMocks.publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('lets a DIFFERENT user approve the request (no regression)', async () => {
+    const { updateSetCalls } = rigTransaction({
+      row: { ...activeRow, flowType: 'tech_jit_admin', subjectUserId: 'some-other-user' },
+      casWins: true,
+    });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approve', durationMinutes: 30 }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((updateSetCalls[0] as { status: string }).status).toBe('approved');
+  });
+
+  it('lets the requester (subject) DENY their own elevation (deny grants nothing)', async () => {
+    const { updateSetCalls } = rigTransaction({
+      row: { ...activeRow, flowType: 'tech_jit_admin', subjectUserId: USER_ID },
+      casWins: true,
+    });
+
+    const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'deny', reason: 'changed my mind' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((updateSetCalls[0] as { status: string }).status).toBe('denied');
   });
 });
 

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -588,7 +588,7 @@ describe('POST /pam/elevation-requests/:id/respond', () => {
   // auditBaselines apply-approval and cisHardening remediation guards (self
   // APPROVE blocked, self DENY allowed since a denial grants nothing).
   it('403s when the requester (subject) approves their own elevation', async () => {
-    const { updateSetCalls } = rigTransaction({
+    const { updateSetCalls, auditInserts } = rigTransaction({
       row: { ...activeRow, flowType: 'tech_jit_admin', subjectUserId: USER_ID },
       casWins: true,
     });
@@ -603,6 +603,10 @@ describe('POST /pam/elevation-requests/:id/respond', () => {
     // No status flip / approval occurred.
     expect(updateSetCalls.length).toBe(0);
     expect(busMocks.publishEvent).not.toHaveBeenCalled();
+    // Guard must run BEFORE any audit write — a regression that moved the
+    // self-approval check below the audit insert would write a spurious
+    // `approved`-typed row yet still satisfy the assertions above.
+    expect(auditInserts.length).toBe(0);
   });
 
   it('lets a DIFFERENT user approve the request (no regression)', async () => {

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -431,6 +431,7 @@ pamRoutes.post(
     let result:
       | { kind: 'not_found' }
       | { kind: 'forbidden' }
+      | { kind: 'self_approval' }
       | { kind: 'conflict'; currentStatus: string }
       | {
           kind: 'ok';
@@ -449,6 +450,7 @@ pamRoutes.post(
             status: elevationRequests.status,
             executionId: elevationRequests.executionId,
             riskTier: elevationRequests.riskTier,
+            subjectUserId: elevationRequests.subjectUserId,
           })
           .from(elevationRequests)
           .where(eq(elevationRequests.id, id))
@@ -458,6 +460,17 @@ pamRoutes.post(
         if (!auth.canAccessOrg(row.orgId)) return { kind: 'not_found' as const };
         if (perms && row.siteId && !canAccessSite(perms, row.siteId)) {
           return { kind: 'forbidden' as const };
+        }
+
+        // Separation-of-duties (maker/checker): the subject who requested the
+        // elevation cannot APPROVE their own request. tech_jit_admin sets
+        // subjectUserId to the requesting technician, so without this they could
+        // self-grant JIT admin. Mirrors the auditBaselines apply-approval and
+        // cisHardening remediation guards: only APPROVE is blocked — a self-DENY
+        // grants nothing and stays allowed. uac_intercept rows have a NULL
+        // subjectUserId (end-user OS account), so the guard never fires there.
+        if (approve && row.subjectUserId && row.subjectUserId === auth.user.id) {
+          return { kind: 'self_approval' as const };
         }
 
         // Phase 2/3: verify an optional assertion proof. No proof → L1 session
@@ -585,6 +598,12 @@ pamRoutes.post(
     }
     if (result.kind === 'forbidden') {
       return c.json({ error: 'Site access denied' }, 403);
+    }
+    if (result.kind === 'self_approval') {
+      return c.json(
+        { success: false, error: 'Requester cannot approve their own elevation request' },
+        403,
+      );
     }
     if (result.kind === 'conflict') {
       return c.json(


### PR DESCRIPTION
## Summary

Enforces separation-of-duties (maker/checker) on the PAM elevation respond path (`POST /pam/elevation-requests/:id/respond`). Previously the handler gated on `requirePamExecute` + `requireMfa` + org/site access + assurance/CAS, but never checked that the approver is a different person from the requester. The subject who created an elevation request could therefore approve it themselves.

For `tech_jit_admin` flows the subject is the requesting technician, so this allowed a technician to self-grant JIT admin. The fix rejects an APPROVE when `subject_user_id` matches the authenticated approver (403). A self-DENY remains allowed since it grants nothing. `uac_intercept` rows carry a NULL `subject_user_id` (end-user OS account), so the guard never fires for that flow.

This mirrors the existing guards in `auditBaselines.ts` (apply-approval) and `cisHardening.ts` (remediation approval), both of which block only the approve side.

## Behavior change

This is behavior-changing and should be noted in release notes: a user can no longer approve their own elevation request (they may still deny it). Returns `403 { success: false, error: "Requester cannot approve their own elevation request" }`.

## Tests

Added to `apps/api/src/routes/pam.test.ts`:
- `403s when the requester (subject) approves their own elevation` — asserts 403, no status flip, no event published
- `lets a DIFFERENT user approve the request (no regression)` — asserts 200/approved
- `lets the requester (subject) DENY their own elevation (deny grants nothing)` — asserts 200/denied

`pnpm exec vitest run src/routes/pam.test.ts` → 53 passed (53). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)