### PR TITLE
fix(installer): avoid host-derived install script URLs

### DIFF
--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -183,6 +183,35 @@ describe('GET /install.sh — generated installer script', () => {
     return res.text();
   }
 
+  it('does not derive the production server URL from the request host', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalBreezeServer = process.env.BREEZE_SERVER;
+    const originalPublicApiUrl = process.env.PUBLIC_API_URL;
+    const originalApiUrl = process.env.API_URL;
+    try {
+      process.env.NODE_ENV = 'production';
+      delete process.env.BREEZE_SERVER;
+      delete process.env.PUBLIC_API_URL;
+      delete process.env.API_URL;
+
+      const res = await downloadRoutes.request('https://attacker.example/install.sh');
+      const body = await res.text();
+
+      expect(res.status).toBe(503);
+      expect(body).not.toContain('attacker.example');
+      expect(body).not.toContain('https://attacker.example');
+    } finally {
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
+      if (originalBreezeServer === undefined) delete process.env.BREEZE_SERVER;
+      else process.env.BREEZE_SERVER = originalBreezeServer;
+      if (originalPublicApiUrl === undefined) delete process.env.PUBLIC_API_URL;
+      else process.env.PUBLIC_API_URL = originalPublicApiUrl;
+      if (originalApiUrl === undefined) delete process.env.API_URL;
+      else process.env.API_URL = originalApiUrl;
+    }
+  });
+
   it('is valid bash (bash -n syntax check)', async () => {
     const script = await fetchScript();
     const tmp = mkdtempSync(join(tmpdir(), 'breeze-install-sh-'));

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -288,11 +288,28 @@ downloadRoutes.get('/download/helper/:os/:arch', async (c) => {
 // Install Script (public, no auth)
 // ============================================
 
-downloadRoutes.get('/install.sh', async (c) => {
-  const serverUrl =
+function resolveInstallScriptServerUrl(requestUrl: string): string | null {
+  const configured =
     process.env.BREEZE_SERVER ||
     process.env.PUBLIC_API_URL ||
-    new URL(c.req.url).origin;
+    process.env.API_URL;
+  if (configured) return configured.replace(/\/$/, '');
+
+  if (process.env.NODE_ENV === 'production') {
+    return null;
+  }
+
+  return new URL(requestUrl).origin.replace(/\/$/, '');
+}
+
+downloadRoutes.get('/install.sh', async (c) => {
+  const serverUrl = resolveInstallScriptServerUrl(c.req.url);
+  if (!serverUrl) {
+    return c.json(
+      { error: 'Installer script unavailable: server URL is not configured' },
+      503
+    );
+  }
 
   const script = generateInstallScript(serverUrl);
 


### PR DESCRIPTION
## Summary
- stop unauthenticated install.sh from deriving production server URLs from the request host
- require an explicit BREEZE_SERVER, PUBLIC_API_URL, or API_URL in production
- keep local/dev request-origin fallback for tests and development

## Tests
- pnpm --dir apps/api exec vitest run src/routes/agents/download.test.ts
- pnpm --dir apps/api exec tsc --noEmit --pretty false

Draft while security-review playbook follow-up continues.