### PR TITLE
fix(software): stream multipart upload via busboy to bound peak heap (#1408)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1030.0",
     "@breeze/shared": "workspace:*",
     "@elastic/elasticsearch": "^9.3.2",
+    "@fastify/busboy": "^3.2.0",
     "@googleapis/admin": "^31.0.0",
     "@googleapis/calendar": "^15.0.0",
     "@googleapis/gmail": "^17.0.0",

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 import { softwareRoutes, computeSoftwareDeploymentAggregateStatus } from './software';
 import { db } from '../db';
 import { uploadBinary, isS3Configured } from '../services/s3Storage';
+import { captureException } from '../services/sentry';
+import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
 
 vi.mock('../services', () => ({}));
@@ -90,6 +92,20 @@ vi.mock('../services/s3Storage', () => ({
 vi.mock('./agentWs', () => ({
   sendCommandToAgent: vi.fn(() => true)
 }));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn()
+}));
+
+// Keep the real streaming parser by default; individual tests can override
+// `parseStreamingMultipart` (e.g. to simulate a disk failure).
+vi.mock('../services/streamingUpload', async () => {
+  const actual = await vi.importActual<typeof import('../services/streamingUpload')>(
+    '../services/streamingUpload'
+  );
+  return { ...actual, parseStreamingMultipart: vi.fn(actual.parseStreamingMultipart) };
+});
 
 describe('software routes', () => {
   let app: Hono;
@@ -207,6 +223,29 @@ describe('software routes', () => {
       });
 
       expect(res.status).toBe(400);
+      expect(uploadBinary).not.toHaveBeenCalled();
+    });
+
+    it('maps a non-MultipartError parse failure to a 500 (not a blank crash)', async () => {
+      vi.mocked(isS3Configured).mockReturnValueOnce(true);
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+      );
+      // Simulate an infrastructure failure (e.g. disk full) inside the parser.
+      vi.mocked(parseStreamingMultipart).mockRejectedValueOnce(new Error('ENOSPC: no space left'));
+
+      const fd = new FormData();
+      fd.append('version', '1.0.0');
+      fd.append('file', new File(['payload'], 'pkg.msi'));
+
+      const res = await app.request(`/software/catalog/${catalogId}/versions/upload`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: fd,
+      });
+
+      expect(res.status).toBe(500);
+      expect(captureException).toHaveBeenCalledTimes(1);
       expect(uploadBinary).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -170,6 +170,45 @@ describe('software routes', () => {
       expect(call[2]).toBe(expectedChecksum); // checksum from the streamed hash
       expect(typeof call[0]).toBe('string');  // temp file path, not an in-memory buffer
     });
+
+    it('rejects a disallowed file extension during streaming (400)', async () => {
+      vi.mocked(isS3Configured).mockReturnValueOnce(true);
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+      );
+
+      const fd = new FormData();
+      fd.append('version', '1.0.0');
+      fd.append('file', new File(['payload'], 'evil.sh', { type: 'application/octet-stream' }));
+
+      const res = await app.request(`/software/catalog/${catalogId}/versions/upload`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: fd,
+      });
+
+      expect(res.status).toBe(400);
+      expect(uploadBinary).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when no file part is sent', async () => {
+      vi.mocked(isS3Configured).mockReturnValueOnce(true);
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+      );
+
+      const fd = new FormData();
+      fd.append('version', '1.0.0');
+
+      const res = await app.request(`/software/catalog/${catalogId}/versions/upload`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: fd,
+      });
+
+      expect(res.status).toBe(400);
+      expect(uploadBinary).not.toHaveBeenCalled();
+    });
   });
 
   describe('POST /software/deploy validation', () => {

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -16,11 +16,12 @@ import { writeRouteAudit } from '../services/auditEvents';
 import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
 import { uploadBinary, getPresignedUrl, isS3Configured } from '../services/s3Storage';
 import { sendCommandToAgent, type AgentCommand } from './agentWs';
-import { createHash } from 'node:crypto';
+import {
+  parseStreamingMultipart,
+  MultipartError,
+  type StreamedMultipart,
+} from '../services/streamingUpload';
 import { unlink, mkdir } from 'node:fs/promises';
-import { createWriteStream } from 'node:fs';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -702,71 +703,78 @@ softwareRoutes.post(
       .where(and(eq(softwareCatalog.id, catalogId), eq(softwareCatalog.orgId, orgId)));
     if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
 
-    // Parse multipart form
-    const body = await c.req.parseBody({ all: true });
-    const file = body.file;
-    if (!(file instanceof File)) {
+    // Stream the multipart body straight to a temp file via busboy, hashing as
+    // it arrives, instead of buffering the whole parsed File into the Node heap
+    // (which `c.req.parseBody()` does before the handler runs). Peak heap is now
+    // constant regardless of file size — the OOM vector from #1408. The file's
+    // extension is validated in `onFile` before any bytes are written to disk.
+    const tempDir = join(tmpdir(), 'breeze-uploads');
+    await mkdir(tempDir, { recursive: true });
+    const tempPath = join(tempDir, `${randomUUID()}.upload`);
+
+    let parsed: StreamedMultipart;
+    try {
+      parsed = await parseStreamingMultipart({
+        contentType: c.req.header('content-type'),
+        body: c.req.raw.body,
+        tempPath,
+        maxFileSize: MAX_UPLOAD_SIZE,
+        onFile: ({ filename }) => {
+          // Preserve the route's prior contract: disallowed extension -> 400.
+          const candidate = getFileExtension(filename || 'package');
+          if (!ALLOWED_EXTENSIONS.has(candidate)) {
+            throw new MultipartError(
+              `Unsupported file type: ${candidate}. Allowed: ${[...ALLOWED_EXTENSIONS].join(', ')}`,
+              400,
+            );
+          }
+        },
+      });
+    } catch (err) {
+      if (err instanceof MultipartError) {
+        return c.json({ error: err.message }, err.status);
+      }
+      throw err;
+    }
+
+    const { fields, file } = parsed;
+    if (!file) {
       return c.json({ error: 'file is required' }, 400);
     }
 
-    const version = typeof body.version === 'string' ? body.version.trim() : '';
-    if (!version) return c.json({ error: 'version is required' }, 400);
-
-    // Validate file
-    if (file.size > MAX_UPLOAD_SIZE) {
-      return c.json({ error: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)` }, 413);
-    }
-
-    const originalFileName = file.name || 'package';
-    const ext = getFileExtension(originalFileName);
-    if (!ALLOWED_EXTENSIONS.has(ext)) {
-      return c.json({ error: `Unsupported file type: ${ext}. Allowed: ${[...ALLOWED_EXTENSIONS].join(', ')}` }, 400);
-    }
-
-    const fileType = ext.slice(1); // remove leading dot
-    const architecture = typeof body.architecture === 'string' ? body.architecture : null;
-    const releaseNotes = typeof body.releaseNotes === 'string' ? body.releaseNotes : null;
-    let silentInstallArgs = typeof body.silentInstallArgs === 'string' ? body.silentInstallArgs : null;
-    let silentUninstallArgs = typeof body.silentUninstallArgs === 'string' ? body.silentUninstallArgs : null;
-    const preInstallScript = typeof body.preInstallScript === 'string' ? body.preInstallScript : null;
-    const postInstallScript = typeof body.postInstallScript === 'string' ? body.postInstallScript : null;
-    let supportedOs: string[] | null = null;
-    if (typeof body.supportedOs === 'string') {
-      try { supportedOs = JSON.parse(body.supportedOs); } catch { /* ignore */ }
-    }
-
-    // Auto-detect MSI silent args
-    if (fileType === 'msi' && !silentInstallArgs) {
-      silentInstallArgs = 'msiexec /i "{file}" /qn /norestart';
-    }
-    if (fileType === 'msi' && !silentUninstallArgs) {
-      silentUninstallArgs = 'msiexec /x "{file}" /qn /norestart';
-    }
-
-    // Write to temp file and compute checksum
-    const tempDir = join(tmpdir(), 'breeze-uploads');
-    await mkdir(tempDir, { recursive: true });
-    const tempPath = join(tempDir, `${randomUUID()}${ext}`);
-
     try {
-      // Stream the upload straight to the temp file, hashing incrementally,
-      // instead of buffering the whole file into an ArrayBuffer and again into
-      // a Buffer (~2x the file size, transiently, on top of the parsed body).
-      // Follows the pipeline(stream, hash) pattern in s3Storage.ts. Cuts the
-      // peak transient heap per upload (partially addresses #1408).
-      const hash = createHash('sha256');
-      await pipeline(
-        Readable.fromWeb(file.stream() as Parameters<typeof Readable.fromWeb>[0]),
-        async function* (source) {
-          for await (const chunk of source) {
-            hash.update(chunk as Buffer);
-            yield chunk;
-          }
-        },
-        createWriteStream(tempPath),
-      );
-      const checksum = hash.digest('hex');
-      const fileSize = file.size;
+      const version = typeof fields.version === 'string' ? fields.version.trim() : '';
+      if (!version) return c.json({ error: 'version is required' }, 400);
+
+      const originalFileName = file.filename || 'package';
+      const ext = getFileExtension(originalFileName);
+      // Defensive: onFile already rejected disallowed extensions before writing.
+      if (!ALLOWED_EXTENSIONS.has(ext)) {
+        return c.json({ error: `Unsupported file type: ${ext}. Allowed: ${[...ALLOWED_EXTENSIONS].join(', ')}` }, 400);
+      }
+
+      const fileType = ext.slice(1); // remove leading dot
+      const architecture = typeof fields.architecture === 'string' ? fields.architecture : null;
+      const releaseNotes = typeof fields.releaseNotes === 'string' ? fields.releaseNotes : null;
+      let silentInstallArgs = typeof fields.silentInstallArgs === 'string' ? fields.silentInstallArgs : null;
+      let silentUninstallArgs = typeof fields.silentUninstallArgs === 'string' ? fields.silentUninstallArgs : null;
+      const preInstallScript = typeof fields.preInstallScript === 'string' ? fields.preInstallScript : null;
+      const postInstallScript = typeof fields.postInstallScript === 'string' ? fields.postInstallScript : null;
+      let supportedOs: string[] | null = null;
+      if (typeof fields.supportedOs === 'string') {
+        try { supportedOs = JSON.parse(fields.supportedOs); } catch { /* ignore */ }
+      }
+
+      // Auto-detect MSI silent args
+      if (fileType === 'msi' && !silentInstallArgs) {
+        silentInstallArgs = 'msiexec /i "{file}" /qn /norestart';
+      }
+      if (fileType === 'msi' && !silentUninstallArgs) {
+        silentUninstallArgs = 'msiexec /x "{file}" /qn /norestart';
+      }
+
+      const checksum = file.checksum;
+      const fileSize = file.fileSize;
 
       // Generate version ID for S3 key path
       const versionId = randomUUID();

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -21,6 +21,7 @@ import {
   MultipartError,
   type StreamedMultipart,
 } from '../services/streamingUpload';
+import { captureException, captureMessage } from '../services/sentry';
 import { unlink, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -734,7 +735,12 @@ softwareRoutes.post(
       if (err instanceof MultipartError) {
         return c.json({ error: err.message }, err.status);
       }
-      throw err;
+      // A non-MultipartError is an infrastructure failure (disk full, aborted
+      // body, malformed multipart) with no client status. Don't let it vanish
+      // into a blank 500 — capture it with request context, then surface a
+      // specific message so an out-of-disk condition is diagnosable.
+      captureException(err, c);
+      return c.json({ error: 'Failed to store uploaded package' }, 500);
     }
 
     const { fields, file } = parsed;
@@ -762,7 +768,17 @@ softwareRoutes.post(
       const postInstallScript = typeof fields.postInstallScript === 'string' ? fields.postInstallScript : null;
       let supportedOs: string[] | null = null;
       if (typeof fields.supportedOs === 'string') {
-        try { supportedOs = JSON.parse(fields.supportedOs); } catch { /* ignore */ }
+        try {
+          supportedOs = JSON.parse(fields.supportedOs);
+        } catch {
+          // Malformed supportedOs silently dropped the OS-targeting field on the
+          // created version. Don't fail the upload (matches prior behavior), but
+          // make the discard visible rather than fully silent.
+          captureMessage('software upload: discarded malformed supportedOs', 'warning', {
+            orgId,
+            catalogId,
+          });
+        }
       }
 
       // Auto-detect MSI silent args

--- a/apps/api/src/services/streamingUpload.test.ts
+++ b/apps/api/src/services/streamingUpload.test.ts
@@ -57,6 +57,68 @@ describe('parseStreamingMultipart', () => {
     expect(await readFile(tempPath, 'utf8')).toBe(content);
   });
 
+  it('streams a multi-megabyte file whose disk write outlives parse completion', async () => {
+    // Large enough that the disk-write pipeline almost certainly settles AFTER
+    // busboy emits `finish` — exercising the parsingDone + filePending gate that
+    // the small-payload happy path does not. A regression dropping that gate
+    // would resolve with file === null here.
+    const big = Buffer.alloc(5 * 1024 * 1024, 0x61); // 5 MiB of 'a'
+    const expected = createHash('sha256').update(big).digest('hex');
+    const tempPath = freshTempPath();
+    created.push(tempPath);
+
+    const fd = new FormData();
+    fd.append('file', new File([big], 'big.msi'));
+
+    const { contentType, body } = multipartRequest(fd);
+    const result = await parseStreamingMultipart({
+      contentType,
+      body,
+      tempPath,
+      maxFileSize: 50 * 1024 * 1024,
+    });
+
+    expect(result.file).not.toBeNull();
+    expect(result.file!.fileSize).toBe(big.length);
+    expect(result.file!.checksum).toBe(expected);
+    // The full file must be on disk, not a field-buffered fragment.
+    const onDisk = await readFile(tempPath);
+    expect(onDisk.length).toBe(big.length);
+  });
+
+  it('rejects an over-limit text field with 413 instead of silently truncating', async () => {
+    const tempPath = freshTempPath();
+    const fd = new FormData();
+    fd.append('preInstallScript', 'x'.repeat(2048));
+    fd.append('file', new File(['payload'], 'pkg.msi'));
+
+    const { contentType, body } = multipartRequest(fd);
+    await expect(
+      parseStreamingMultipart({
+        contentType,
+        body,
+        tempPath,
+        maxFileSize: 1024 * 1024,
+        maxFieldSize: 1024,
+      }),
+    ).rejects.toMatchObject({ status: 413 });
+  });
+
+  it('surfaces a disk-write failure as a non-MultipartError and cleans up', async () => {
+    // An un-creatable temp path (parent dir does not exist) makes the file
+    // pipeline reject — the one branch that produces a non-MultipartError.
+    const tempPath = join(tmpdir(), `no-such-dir-${randomUUID()}`, 'out.bin');
+    const fd = new FormData();
+    fd.append('file', new File(['payload-bytes'], 'pkg.msi'));
+
+    const { contentType, body } = multipartRequest(fd);
+    await expect(
+      parseStreamingMultipart({ contentType, body, tempPath, maxFileSize: 1024 * 1024 }),
+    ).rejects.toSatisfy((e: unknown) => e instanceof Error && !(e instanceof MultipartError));
+
+    await expect(stat(tempPath)).rejects.toThrow();
+  });
+
   it('returns file: null when no file part is present', async () => {
     const tempPath = freshTempPath();
     const fd = new FormData();

--- a/apps/api/src/services/streamingUpload.test.ts
+++ b/apps/api/src/services/streamingUpload.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFile, unlink, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import {
+  parseStreamingMultipart,
+  MultipartError,
+  type StreamedMultipart,
+} from './streamingUpload';
+
+function freshTempPath(): string {
+  return join(tmpdir(), `streamingUpload-test-${randomUUID()}.bin`);
+}
+
+function multipartRequest(fd: FormData): { contentType: string; body: ReadableStream<Uint8Array> } {
+  const req = new Request('http://test/', { method: 'POST', body: fd });
+  return {
+    contentType: req.headers.get('content-type')!,
+    body: req.body as ReadableStream<Uint8Array>,
+  };
+}
+
+describe('parseStreamingMultipart', () => {
+  const created: string[] = [];
+  afterEach(async () => {
+    await Promise.all(created.splice(0).map((p) => unlink(p).catch(() => {})));
+  });
+
+  it('streams the file to disk, hashes it, and collects text fields', async () => {
+    const content = 'hello-breeze-package-payload';
+    const expected = createHash('sha256').update(content).digest('hex');
+    const tempPath = freshTempPath();
+    created.push(tempPath);
+
+    const fd = new FormData();
+    fd.append('version', '1.2.3');
+    fd.append('architecture', 'x64');
+    fd.append('file', new File([content], 'pkg.msi', { type: 'application/octet-stream' }));
+
+    const { contentType, body } = multipartRequest(fd);
+    const result: StreamedMultipart = await parseStreamingMultipart({
+      contentType,
+      body,
+      tempPath,
+      maxFileSize: 10 * 1024 * 1024,
+    });
+
+    expect(result.fields.version).toBe('1.2.3');
+    expect(result.fields.architecture).toBe('x64');
+    expect(result.file).not.toBeNull();
+    expect(result.file!.filename).toBe('pkg.msi');
+    expect(result.file!.checksum).toBe(expected);
+    expect(result.file!.fileSize).toBe(Buffer.byteLength(content));
+    // File actually landed on disk with the exact bytes.
+    expect(await readFile(tempPath, 'utf8')).toBe(content);
+  });
+
+  it('returns file: null when no file part is present', async () => {
+    const tempPath = freshTempPath();
+    const fd = new FormData();
+    fd.append('version', '1.0.0');
+
+    const { contentType, body } = multipartRequest(fd);
+    const result = await parseStreamingMultipart({
+      contentType,
+      body,
+      tempPath,
+      maxFileSize: 1024,
+    });
+
+    expect(result.file).toBeNull();
+    expect(result.fields.version).toBe('1.0.0');
+    // No temp file should have been written.
+    await expect(stat(tempPath)).rejects.toThrow();
+  });
+
+  it('rejects an oversized file with a 413 and cleans up the temp file', async () => {
+    const tempPath = freshTempPath();
+    const big = 'x'.repeat(4096);
+    const fd = new FormData();
+    fd.append('file', new File([big], 'big.msi'));
+
+    const { contentType, body } = multipartRequest(fd);
+    await expect(
+      parseStreamingMultipart({ contentType, body, tempPath, maxFileSize: 1024 }),
+    ).rejects.toMatchObject({ status: 413 });
+
+    // Partially-written temp file must be removed on failure.
+    await expect(stat(tempPath)).rejects.toThrow();
+  });
+
+  it('lets onFile reject a disallowed file before bytes are written (415)', async () => {
+    const tempPath = freshTempPath();
+    const fd = new FormData();
+    fd.append('file', new File(['payload'], 'evil.sh'));
+
+    const { contentType, body } = multipartRequest(fd);
+    await expect(
+      parseStreamingMultipart({
+        contentType,
+        body,
+        tempPath,
+        maxFileSize: 1024 * 1024,
+        onFile: ({ filename }) => {
+          if (!filename.endsWith('.msi')) {
+            throw new MultipartError('Unsupported file type', 415);
+          }
+        },
+      }),
+    ).rejects.toMatchObject({ status: 415, message: 'Unsupported file type' });
+
+    await expect(stat(tempPath)).rejects.toThrow();
+  });
+
+  it('rejects a non-multipart content-type with 400', async () => {
+    await expect(
+      parseStreamingMultipart({
+        contentType: 'application/json',
+        body: new Request('http://x', { method: 'POST', body: '{}' }).body as ReadableStream<Uint8Array>,
+        tempPath: freshTempPath(),
+        maxFileSize: 1024,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a missing body with 400', async () => {
+    await expect(
+      parseStreamingMultipart({
+        contentType: 'multipart/form-data; boundary=abc',
+        body: null,
+        tempPath: freshTempPath(),
+        maxFileSize: 1024,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/api/src/services/streamingUpload.ts
+++ b/apps/api/src/services/streamingUpload.ts
@@ -78,6 +78,12 @@ export interface ParseStreamingMultipartOptions {
  * On any error the partially-written temp file is removed before throwing, so
  * the caller never has to clean up after a failed parse. On success the caller
  * owns `tempPath` and must unlink it when done.
+ *
+ * Error contract: a {@link MultipartError} carries a client-facing HTTP status
+ * (400/413/415) the caller should surface directly. Any *other* thrown error
+ * (disk write failure, aborted request body, malformed multipart) is an
+ * infrastructure failure with no status — the caller must log it and map it to
+ * a 500.
  */
 export async function parseStreamingMultipart(
   opts: ParseStreamingMultipartOptions,
@@ -98,6 +104,9 @@ export async function parseStreamingMultipart(
   if (!body) {
     throw new MultipartError('Request body is empty', 400);
   }
+  if (maxFileSize <= 0 || maxFieldSize <= 0 || maxFields <= 0) {
+    throw new Error('parseStreamingMultipart: size/count limits must be positive');
+  }
 
   const fields: Record<string, string> = {};
   let file: StreamedFile | null = null;
@@ -115,16 +124,25 @@ export async function parseStreamingMultipart(
         },
       });
 
+      // Drive the web ReadableStream into busboy.
+      const nodeStream = Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]);
+
       // A single rejection wins; later events after the first failure are ignored.
-      // `close` (parsing done) and the file's disk-write pipeline settle
+      // `finish` (parsing done) and the file's disk-write pipeline settle
       // independently, so only resolve once *both* have finished — otherwise
-      // `close` could fire before the temp file finished writing.
+      // `finish` could fire before the temp file finished writing.
       let settled = false;
       let parsingDone = false;
       let filePending = false;
       const fail = (err: Error) => {
         if (settled) return;
         settled = true;
+        // Tear down the source + parser so no stream outlives the rejected
+        // promise (otherwise the request body keeps draining into a discarded
+        // busboy, and a later stream 'error' would have no live listener).
+        nodeStream.unpipe(bb);
+        nodeStream.destroy();
+        bb.destroy();
         reject(err);
       };
       const maybeSucceed = () => {
@@ -133,8 +151,16 @@ export async function parseStreamingMultipart(
         resolve();
       };
 
-      bb.on('field', (name, value) => {
+      bb.on('field', (name, value, _fieldnameTruncated, valueTruncated) => {
         if (settled) return;
+        // busboy silently truncates an over-`fieldSize` value rather than
+        // erroring. Surface it as 413 instead of persisting a half-value —
+        // the route reads pre/post-install scripts from these fields, and a
+        // silently-cut script is worse than a rejected upload.
+        if (valueTruncated) {
+          fail(new MultipartError(`Field "${name}" too large`, 413));
+          return;
+        }
         fields[name] = value;
       });
 
@@ -176,7 +202,13 @@ export async function parseStreamingMultipart(
         pipeline(stream, dest)
           .then(() => {
             filePending = false;
-            if (truncated || stream.truncated) {
+            // Oversize detection must not rely solely on busboy's soft `limit`
+            // flag: when the cap is hit busboy stops feeding and `pipeline`
+            // resolves *normally* with a partial file on disk. Independently
+            // treat reaching the byte cap as oversize, so a truncated installer
+            // can never slip through as a "success" with a hash over partial
+            // bytes. (busboy's fileSize limit means it stops AT maxFileSize.)
+            if (truncated || stream.truncated || fileSize >= maxFileSize) {
               fail(
                 new MultipartError(
                   `File too large (max ${Math.floor(maxFileSize / 1024 / 1024)}MB)`,
@@ -212,8 +244,6 @@ export async function parseStreamingMultipart(
         maybeSucceed();
       });
 
-      // Drive the web ReadableStream into busboy.
-      const nodeStream = Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]);
       nodeStream.on('error', (err) => fail(err));
       nodeStream.pipe(bb);
     });

--- a/apps/api/src/services/streamingUpload.ts
+++ b/apps/api/src/services/streamingUpload.ts
@@ -1,0 +1,228 @@
+/**
+ * Streaming multipart upload parser.
+ *
+ * Parses a `multipart/form-data` request body incrementally with busboy,
+ * streaming the (single) file part straight to a temp file on disk while it
+ * arrives and hashing it as it goes — so peak heap stays *constant* regardless
+ * of file size.
+ *
+ * This is the streaming counterpart to Hono's `c.req.parseBody()`, which fully
+ * buffers the parsed `File` (the whole upload) into the Node heap before the
+ * route handler runs. For large installer uploads (~500MB) that buffering is a
+ * memory-pressure / OOM vector under concurrency (issue #1408).
+ *
+ * The small text fields (version, architecture, etc.) are still collected into
+ * memory — they're tiny and capped by `maxFieldSize`/`maxFields`.
+ */
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { unlink } from 'node:fs/promises';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { Busboy, type BusboyFileStream } from '@fastify/busboy';
+
+export interface StreamedFile {
+  /** The form field name the file arrived under (e.g. `file`). */
+  fieldName: string;
+  /** The original client-provided filename (may be empty). */
+  filename: string;
+  /** Absolute path to the temp file the upload was streamed to. */
+  tempPath: string;
+  /** Lowercase hex sha256 of the file contents. */
+  checksum: string;
+  /** Number of bytes written to disk. */
+  fileSize: number;
+}
+
+export interface StreamedMultipart {
+  /** Non-file text fields, last value wins on duplicates. */
+  fields: Record<string, string>;
+  /** The single file part, or `null` if none was sent. */
+  file: StreamedFile | null;
+}
+
+export class MultipartError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 413 | 415,
+  ) {
+    super(message);
+    this.name = 'MultipartError';
+  }
+}
+
+export interface ParseStreamingMultipartOptions {
+  /** `content-type` header value (must be `multipart/form-data; boundary=...`). */
+  contentType: string | undefined;
+  /** Web ReadableStream of the raw request body (`c.req.raw.body`). */
+  body: ReadableStream<Uint8Array> | null;
+  /** Absolute path to stream the file part to. Caller owns cleanup on success. */
+  tempPath: string;
+  /** Reject the file as soon as its size exceeds this many bytes. */
+  maxFileSize: number;
+  /**
+   * Optional gate run when the file part first appears (before any bytes are
+   * written), e.g. to reject a disallowed extension early. Throw a
+   * `MultipartError` to abort. Returning normally accepts the part.
+   */
+  onFile?: (info: { fieldName: string; filename: string }) => void;
+  /** Max size of a single non-file field value, in bytes. Default 1MB. */
+  maxFieldSize?: number;
+  /** Max number of non-file fields. Default 50. */
+  maxFields?: number;
+}
+
+/**
+ * Parse a streaming multipart body, writing the first file part to `tempPath`.
+ *
+ * On any error the partially-written temp file is removed before throwing, so
+ * the caller never has to clean up after a failed parse. On success the caller
+ * owns `tempPath` and must unlink it when done.
+ */
+export async function parseStreamingMultipart(
+  opts: ParseStreamingMultipartOptions,
+): Promise<StreamedMultipart> {
+  const {
+    contentType,
+    body,
+    tempPath,
+    maxFileSize,
+    onFile,
+    maxFieldSize = 1024 * 1024,
+    maxFields = 50,
+  } = opts;
+
+  if (!contentType || !contentType.toLowerCase().includes('multipart/form-data')) {
+    throw new MultipartError('Expected multipart/form-data request', 400);
+  }
+  if (!body) {
+    throw new MultipartError('Request body is empty', 400);
+  }
+
+  const fields: Record<string, string> = {};
+  let file: StreamedFile | null = null;
+  let wroteTempFile = false;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const bb = Busboy({
+        headers: { 'content-type': contentType },
+        limits: {
+          fieldSize: maxFieldSize,
+          fields: maxFields,
+          files: 1,
+          fileSize: maxFileSize,
+        },
+      });
+
+      // A single rejection wins; later events after the first failure are ignored.
+      // `close` (parsing done) and the file's disk-write pipeline settle
+      // independently, so only resolve once *both* have finished — otherwise
+      // `close` could fire before the temp file finished writing.
+      let settled = false;
+      let parsingDone = false;
+      let filePending = false;
+      const fail = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        reject(err);
+      };
+      const maybeSucceed = () => {
+        if (settled || !parsingDone || filePending) return;
+        settled = true;
+        resolve();
+      };
+
+      bb.on('field', (name, value) => {
+        if (settled) return;
+        fields[name] = value;
+      });
+
+      bb.on('file', (fieldName, stream: BusboyFileStream, filename) => {
+        if (settled) {
+          stream.resume();
+          return;
+        }
+        // Only the first file part is accepted; busboy is capped to files:1, but
+        // guard defensively in case that changes.
+        if (file || filePending) {
+          stream.resume();
+          return;
+        }
+
+        try {
+          onFile?.({ fieldName, filename });
+        } catch (err) {
+          stream.resume();
+          fail(err instanceof Error ? err : new MultipartError('File rejected', 400));
+          return;
+        }
+
+        const hash = createHash('sha256');
+        let fileSize = 0;
+        let truncated = false;
+
+        stream.on('data', (chunk: Buffer) => {
+          fileSize += chunk.length;
+          hash.update(chunk);
+        });
+        stream.on('limit', () => {
+          truncated = true;
+        });
+
+        wroteTempFile = true;
+        filePending = true;
+        const dest = createWriteStream(tempPath);
+        pipeline(stream, dest)
+          .then(() => {
+            filePending = false;
+            if (truncated || stream.truncated) {
+              fail(
+                new MultipartError(
+                  `File too large (max ${Math.floor(maxFileSize / 1024 / 1024)}MB)`,
+                  413,
+                ),
+              );
+              return;
+            }
+            file = {
+              fieldName,
+              filename: filename ?? '',
+              tempPath,
+              checksum: hash.digest('hex'),
+              fileSize,
+            };
+            maybeSucceed();
+          })
+          .catch((err) => {
+            filePending = false;
+            fail(err instanceof Error ? err : new Error(String(err)));
+          });
+      });
+
+      bb.on('filesLimit', () => {
+        // Extra files beyond the cap are discarded by busboy; not an error.
+      });
+      bb.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
+      // @fastify/busboy signals end-of-parse with the Writable 'finish' event
+      // (not 'close'). The file's disk-write pipeline settles independently, so
+      // `maybeSucceed` only resolves once both have completed.
+      bb.on('finish', () => {
+        parsingDone = true;
+        maybeSucceed();
+      });
+
+      // Drive the web ReadableStream into busboy.
+      const nodeStream = Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]);
+      nodeStream.on('error', (err) => fail(err));
+      nodeStream.pipe(bb);
+    });
+
+    return { fields, file };
+  } catch (err) {
+    if (wroteTempFile) {
+      await unlink(tempPath).catch(() => {});
+    }
+    throw err;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@elastic/elasticsearch':
         specifier: ^9.3.2
         version: 9.4.2
+      '@fastify/busboy':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@googleapis/admin':
         specifier: ^31.0.0
         version: 31.0.0


### PR DESCRIPTION
**Root cause:** The software-package upload route (`POST /software/catalog/:id/versions/upload`) called `c.req.parseBody()`, which fully buffers the parsed `File` — the entire ~500MB upload — into the Node heap *before* the handler runs. PR #1430 (af61655c4) removed the earlier `file.arrayBuffer()` + double-`Buffer` copy, but the `parseBody` buffering remained, so peak heap was still ~filesize per in-flight request. Under concurrent large uploads that's a memory-pressure / OOM vector (the remaining part of #1408 that #1430 explicitly left open).

**Fix:** Replace `parseBody` with a streaming multipart parser. New helper `apps/api/src/services/streamingUpload.ts` (`parseStreamingMultipart`) drives the raw request body (`c.req.raw.body`) through `@fastify/busboy`, writing the single file part straight to a temp file as it arrives and hashing it incrementally. Peak heap is now **constant** regardless of file size.

- `@fastify/busboy@^3.2.0` was already present transitively; now declared explicitly in `apps/api/package.json`.
- Hono's per-path `bodyLimit` middleware takes the content-length fast path for these uploads (no buffering — verified against the Hono source), so it leaves `c.req.raw.body` streamable.
- Disallowed file extensions are rejected in the `onFile` callback **before any bytes hit disk** (preserving the prior 400 contract).
- Oversized files abort mid-stream with a 413; the partially-written temp file is cleaned up on any failure.
- The completion handshake waits for both busboy's `finish` event (note: `@fastify/busboy` emits `finish`, not `close`) **and** the file's disk-write pipeline before resolving.

**Scope:** Focused on the software-package route (the ~500MB production memory vector this issue is titled for). The sibling `devPush.ts` upload (`file.arrayBuffer()`, 150MB dev/internal cap) shares the shape but reorders device-access validation around the parsed fields; adopting the streaming helper there is a deliberate follow-up rather than expanding this PR's blast radius.

**Tests:** `apps/api/src/services/streamingUpload.test.ts` (new, 6 cases: stream+hash+fields, missing file → null, oversized → 413 + cleanup, `onFile` reject → 415 + cleanup, non-multipart → 400, missing body → 400). Extended `software.test.ts` with disallowed-extension (400) and missing-file (400) route cases; the existing #1408 streaming test still passes.

- `vitest run routes/software.test.ts services/streamingUpload.test.ts middleware/bodyLimit.test.ts` → 27 passed
- `tsc --noEmit` clean; `eslint` clean on touched files

Closes #1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)