### PR TITLE
fix(alerts): enforce site-axis scope on correlation and bulk endpoints

### DIFF
--- a/apps/api/src/routes/alerts/alerts.authz.test.ts
+++ b/apps/api/src/routes/alerts/alerts.authz.test.ts
@@ -9,7 +9,7 @@ import { Hono } from 'hono';
 const { authRef, grantedRef, state, tables, dbMock } = vi.hoisted(() => {
   const tables = {
     alerts: { id: 'alerts.id', orgId: 'alerts.orgId', deviceId: 'alerts.deviceId', status: 'alerts.status' },
-    devices: { id: 'devices.id', siteId: 'devices.siteId' },
+    devices: { id: 'devices.id', siteId: 'devices.siteId', orgId: 'devices.orgId' },
     tickets: { id: 'tickets.id', deviceId: 'tickets.deviceId' },
   };
 
@@ -172,7 +172,7 @@ describe('alert state-change authz (Finding #6)', () => {
     authRef.current = {
       scope: 'organization',
       user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
-      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, allowedSiteIds: undefined, canAccessOrg: () => true,
     } as typeof authRef.current;
   });
 
@@ -248,8 +248,8 @@ describe('POST /alerts/bulk site-axis scope (T3)', () => {
       allowedSiteIds: undefined, canAccessOrg: () => true,
     } as typeof authRef.current;
     state.devices = [
-      { id: DEVICE_A, siteId: SITE_A },
-      { id: DEVICE_B, siteId: SITE_B },
+      { id: DEVICE_A, siteId: SITE_A, orgId: ORG },
+      { id: DEVICE_B, siteId: SITE_B, orgId: ORG },
     ];
     state.alerts = [
       { id: ALERT_A, orgId: ORG, deviceId: DEVICE_A, status: 'active', ruleId: 'r-a' },
@@ -269,6 +269,21 @@ describe('POST /alerts/bulk site-axis scope (T3)', () => {
 
     expect(res.status).toBe(200);
     expect(state.alerts.find((a) => a.id === ALERT_A)?.status).toBe('acknowledged');
+    expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('active');
+  });
+
+  it('returns 404 (no writes) when every alertId is out-of-site for a SITE_A-restricted user', async () => {
+    authRef.current = { ...authRef.current, allowedSiteIds: [SITE_A] } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertIds: [ALERT_B], action: 'acknowledge' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'No accessible alerts found' });
+    // No alert was mutated.
     expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('active');
   });
 

--- a/apps/api/src/routes/alerts/alerts.authz.test.ts
+++ b/apps/api/src/routes/alerts/alerts.authz.test.ts
@@ -6,18 +6,103 @@ import { Hono } from 'hono';
 // addition to scope tier. acknowledge -> ALERTS_ACKNOWLEDGE; resolve/suppress/
 // bulk -> ALERTS_WRITE (mirrors the mobile alert routes).
 
-const { authRef, grantedRef } = vi.hoisted(() => ({
-  authRef: {
-    current: {
-      scope: 'organization' as string,
-      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
-      partnerId: null as string | null,
-      orgId: 'org-1' as string | null,
-      accessibleOrgIds: null as string[] | null,
-      canAccessOrg: (_id: string) => true as boolean,
+const { authRef, grantedRef, state, tables, dbMock } = vi.hoisted(() => {
+  const tables = {
+    alerts: { id: 'alerts.id', orgId: 'alerts.orgId', deviceId: 'alerts.deviceId', status: 'alerts.status' },
+    devices: { id: 'devices.id', siteId: 'devices.siteId' },
+    tickets: { id: 'tickets.id', deviceId: 'tickets.deviceId' },
+  };
+
+  type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
+  const columnKey = (col: unknown) => String(col).split('.').pop()!;
+  const evalPredicate = (row: Record<string, unknown>, predicate: Predicate): boolean => {
+    if (!predicate) return true;
+    if (predicate.op === 'eq') return row[columnKey(predicate.col)] === predicate.val;
+    if (predicate.op === 'inArray') return (predicate.vals ?? []).includes(row[columnKey(predicate.col)]);
+    if (predicate.op === 'and') return (predicate.args ?? []).every((arg) => evalPredicate(row, arg));
+    if (predicate.op === 'or') return (predicate.args ?? []).some((arg) => evalPredicate(row, arg));
+    return true;
+  };
+
+  const state = {
+    alerts: [] as Array<Record<string, any>>,
+    devices: [] as Array<Record<string, any>>,
+  };
+
+  class SelectQuery {
+    private predicate: Predicate;
+    constructor(private table: unknown, private projection?: Record<string, unknown>) {}
+    where(predicate: Predicate) { this.predicate = predicate; return this; }
+    orderBy() { return this; }
+    limit(limit: number) { return Promise.resolve(this.rows().slice(0, limit)); }
+    then(resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) {
+      return Promise.resolve(this.rows()).then(resolve, reject);
+    }
+    private rows() {
+      const source = this.table === tables.alerts ? state.alerts : state.devices;
+      const filtered = source.filter((row) => evalPredicate(row, this.predicate));
+      if (!this.projection) return filtered;
+      return filtered.map((row) => {
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(this.projection!)) out[key] = row[columnKey(this.projection![key])];
+        return out;
+      });
+    }
+  }
+
+  const dbMock = {
+    select: vi.fn((projection?: Record<string, unknown>) => ({
+      from: (table: unknown) => new SelectQuery(table, projection),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (predicate: Predicate) => {
+          const source = table === tables.alerts ? state.alerts : [];
+          const written: Array<Record<string, unknown>> = [];
+          for (const row of source) {
+            if (!evalPredicate(row, predicate)) continue;
+            Object.assign(row, values);
+            written.push(row);
+          }
+          return {
+            returning: () => Promise.resolve(written),
+            then: (resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) =>
+              Promise.resolve(written.map(() => ({}))).then(resolve, reject),
+          };
+        },
+      }),
+    })),
+  };
+
+  return {
+    authRef: {
+      current: {
+        scope: 'organization' as string,
+        user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+        partnerId: null as string | null,
+        orgId: 'org-1' as string | null,
+        accessibleOrgIds: null as string[] | null,
+        allowedSiteIds: undefined as string[] | undefined,
+        canAccessOrg: (_id: string) => true as boolean,
+      },
     },
-  },
-  grantedRef: { current: new Set<string>() },
+    grantedRef: { current: new Set<string>() },
+    state,
+    tables,
+    dbMock,
+  };
+});
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  gte: (col: unknown, val: unknown) => ({ op: 'gte', col, val }),
+  lte: (col: unknown, val: unknown) => ({ op: 'lte', col, val }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  or: (...args: unknown[]) => ({ op: 'or', args }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  sql: Object.assign(() => ({ op: 'sql' }), { raw: () => ({ op: 'sql' }) }),
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -31,17 +116,23 @@ vi.mock('../../middleware/auth', () => ({
     if (!grantedRef.current.has(`${resource}:${action}`)) {
       return c.json({ error: 'Forbidden' }, 403);
     }
-    c.set('permissions', {});
+    c.set('permissions', { allowedSiteIds: authRef.current?.allowedSiteIds });
     await next();
   },
   requireMfa: () => async (_c: any, next: any) => next(),
+  // Used by filterAlertsBySiteScope / deviceInSiteScope (real ../tickets/siteScope).
+  siteAccessCheck: (allowedSiteIds?: string[]) => (siteId: string | null | undefined) => {
+    if (!allowedSiteIds) return true;
+    if (!siteId) return false;
+    return allowedSiteIds.includes(siteId);
+  },
 }));
 
-vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db', () => ({ db: dbMock }));
 vi.mock('../../db/schema', () => ({
   alertCorrelationGroups: {}, alertCorrelationMembers: {},
-  alertRules: {}, alertTemplates: {}, alerts: {}, notificationChannels: {},
-  alertNotifications: {}, devices: {}, tickets: {}, ticketAlertLinks: {},
+  alertRules: {}, alertTemplates: {}, alerts: tables.alerts, notificationChannels: {},
+  alertNotifications: {}, devices: tables.devices, tickets: tables.tickets, ticketAlertLinks: {},
 }));
 vi.mock('../../services/alertCooldown', () => ({
   setCooldown: vi.fn(), markConfigPolicyRuleCooldown: vi.fn(),
@@ -131,6 +222,80 @@ describe('alert state-change authz (Finding #6)', () => {
       body: JSON.stringify({}),
     });
     expect(res.status).not.toBe(403);
+  });
+});
+
+// Site-axis enforcement on POST /alerts/bulk (T3, #1051 class). RLS does NOT
+// enforce site scope; a site-restricted org user must not bulk ack/resolve
+// alerts on devices outside their allowed sites.
+describe('POST /alerts/bulk site-axis scope (T3)', () => {
+  const ORG = 'org-1';
+  const SITE_A = '5a5a5a5a-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SITE_B = '5b5b5b5b-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const DEVICE_A = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd';
+  const DEVICE_B = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd';
+  const ALERT_A = 'a1a1a1a1-1111-4111-8111-111111111111';
+  const ALERT_B = 'a2a2a2a2-2222-4222-8222-222222222222';
+  const ALERT_ORGWIDE = 'a3a3a3a3-3333-4333-8333-333333333333';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>(['alerts:write']);
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: ORG, accessibleOrgIds: null,
+      allowedSiteIds: undefined, canAccessOrg: () => true,
+    } as typeof authRef.current;
+    state.devices = [
+      { id: DEVICE_A, siteId: SITE_A },
+      { id: DEVICE_B, siteId: SITE_B },
+    ];
+    state.alerts = [
+      { id: ALERT_A, orgId: ORG, deviceId: DEVICE_A, status: 'active', ruleId: 'r-a' },
+      { id: ALERT_B, orgId: ORG, deviceId: DEVICE_B, status: 'active', ruleId: 'r-b' },
+      { id: ALERT_ORGWIDE, orgId: ORG, deviceId: null, status: 'active', ruleId: 'r-org' },
+    ];
+  });
+
+  it('does not acknowledge a SITE_B alert for a SITE_A-restricted user', async () => {
+    authRef.current = { ...authRef.current, allowedSiteIds: [SITE_A] } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertIds: [ALERT_A, ALERT_B], action: 'acknowledge' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(state.alerts.find((a) => a.id === ALERT_A)?.status).toBe('acknowledged');
+    expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('active');
+  });
+
+  it('still acknowledges org-wide (deviceless) alerts for a SITE_A-restricted user', async () => {
+    authRef.current = { ...authRef.current, allowedSiteIds: [SITE_A] } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertIds: [ALERT_ORGWIDE, ALERT_B], action: 'acknowledge' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(state.alerts.find((a) => a.id === ALERT_ORGWIDE)?.status).toBe('acknowledged');
+    expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('active');
+  });
+
+  it('acknowledges alerts across all sites for an unrestricted user (no regression)', async () => {
+    const res = await makeApp().request('/alerts/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alertIds: [ALERT_A, ALERT_B], action: 'acknowledge' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(state.alerts.find((a) => a.id === ALERT_A)?.status).toBe('acknowledged');
+    expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('acknowledged');
   });
 });
 

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -24,7 +24,7 @@ import { listAlertsSchema, resolveAlertSchema, suppressAlertSchema, bulkAlertAct
 import { getPagination, ensureOrgAccess, getAlertWithOrgCheck } from './helpers';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
 import { createTicketFromAlert, TicketServiceError } from '../../services/ticketService';
-import { deviceInSiteScope } from '../tickets/siteScope';
+import { deviceInSiteScope, filterAlertsBySiteScope } from '../tickets/siteScope';
 
 export const alertsRoutes = new Hono();
 
@@ -393,7 +393,7 @@ alertsRoutes.post(
           ? inArray(alerts.orgId, auth.accessibleOrgIds)
           : undefined;
 
-    const accessible = await db
+    const orgScoped = await db
       .select()
       .from(alerts)
       .where(
@@ -401,6 +401,11 @@ alertsRoutes.post(
           ? and(inArray(alerts.id, alertIds), orgCondition)
           : inArray(alerts.id, alertIds)
       );
+
+    // Site axis (RLS does NOT enforce it): drop alerts on devices outside the
+    // caller's allowed sites before mutating. Deviceless (org-wide) alerts stay,
+    // matching the GET /alerts narrowing. No-op for unrestricted callers.
+    const accessible = await filterAlertsBySiteScope(auth, orgScoped);
 
     if (accessible.length === 0) {
       return c.json({ error: 'No accessible alerts found' }, 404);

--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -40,7 +40,7 @@ const {
       sourceId: 'ml_feedback_events.sourceId', eventType: 'ml_feedback_events.eventType',
       outcome: 'ml_feedback_events.outcome', occurredAt: 'ml_feedback_events.occurredAt',
     },
-    devices: { id: 'devices.id', hostname: 'devices.hostname' },
+    devices: { id: 'devices.id', hostname: 'devices.hostname', siteId: 'devices.siteId' },
   };
 
   type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
@@ -176,6 +176,12 @@ vi.mock('../../middleware/auth', () => ({
     if (!grantedRef.current.has(`${resource}:${action}`)) return _c.json({ error: 'Forbidden' }, 403);
     await next();
   },
+  // Used by filterAlertsBySiteScope / deviceInSiteScope (real ../tickets/siteScope).
+  siteAccessCheck: (allowedSiteIds?: string[]) => (siteId: string | null | undefined) => {
+    if (!allowedSiteIds) return true;
+    if (!siteId) return false;
+    return allowedSiteIds.includes(siteId);
+  },
 }));
 
 vi.mock('../../db', () => ({ db: dbMock }));
@@ -186,6 +192,8 @@ vi.mock('../../db/schema', () => ({
   alertCorrelations: tables.alertCorrelations,
   devices: tables.devices,
   mlFeedbackEvents: tables.mlFeedbackEvents,
+  // Referenced by the real ../tickets/siteScope module (ticketSiteScopeCondition).
+  tickets: { id: 'tickets.id', deviceId: 'tickets.deviceId' },
 }));
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../../services/alertCorrelationRca', () => ({
@@ -218,6 +226,11 @@ const ALERT_2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 const ALERT_3 = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const DEVICE_1 = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 const GROUP_1 = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+// Site-axis (T2 #1051 class) fixtures: two devices in two sites within ORG_1.
+const SITE_A = '5a5a5a5a-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_B = '5b5b5b5b-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const DEVICE_2 = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd';
+const ALERT_4 = 'a4a4a4a4-4444-4444-8444-444444444444';
 
 function makeApp() {
   const app = new Hono();
@@ -238,7 +251,10 @@ function seed() {
   state.groups = [];
   state.members = [];
   state.feedback = [];
-  state.devices = [{ id: DEVICE_1, hostname: 'server-1' }];
+  state.devices = [
+    { id: DEVICE_1, hostname: 'server-1', siteId: SITE_A },
+    { id: DEVICE_2, hostname: 'server-2', siteId: SITE_B },
+  ];
   state.unwritableAlertIds = new Set();
 }
 
@@ -815,5 +831,124 @@ describe('/alerts correlation routes', () => {
     const updateCalls = dbMock.update.mock.calls;
     expect(updateCalls).toContainEqual([tables.alertCorrelationGroups]);
     expect(state.groups.find((group) => group.id === GROUP_1)?.status).toBe('resolved');
+  });
+
+  // Site-axis enforcement (T2, #1051 class). Site scope is an app-layer-only
+  // authz axis RLS does NOT enforce; a SITE_A-restricted ORG_1 user must not
+  // read or mutate alert/correlation state for SITE_B devices in the same org.
+  describe('site-axis scope (T2)', () => {
+    // Persisted group spanning a SITE_A alert (ALERT_1/DEVICE_1) and a SITE_B
+    // alert (ALERT_4/DEVICE_2), both in ORG_1, linked under GROUP_1.
+    function seedSiteScopedGroup() {
+      state.alerts.push({
+        id: ALERT_4, orgId: ORG_1, deviceId: DEVICE_2, status: 'active', severity: 'high',
+        title: 'Other site', ruleId: 'rule-4',
+        triggeredAt: new Date('2026-06-18T12:05:00Z'), createdAt: new Date('2026-06-18T12:05:00Z'),
+      });
+      state.correlations.push({
+        id: '44444444-aaaa-4aaa-8aaa-444444444444',
+        parentAlertId: ALERT_1, childAlertId: ALERT_4,
+        correlationType: 'same_device_temporal', confidence: '0.80',
+        createdAt: new Date('2026-06-18T12:06:00Z'),
+      });
+      state.groups = [{
+        id: GROUP_1, orgId: ORG_1, groupKey: `root:${ALERT_1}`, rootAlertId: ALERT_1,
+        status: 'open', score: '0.90', noiseReductionPercent: 50, memberCount: 2,
+        firstSeenAt: new Date('2026-06-18T12:00:00Z'), lastSeenAt: new Date('2026-06-18T12:05:00Z'),
+        metadata: {}, createdAt: new Date('2026-06-18T12:06:00Z'),
+      }];
+      state.members = [
+        { id: 'eeeeeeee-0001-4eee-8eee-eeeeeeeeeeee', orgId: ORG_1, groupId: GROUP_1, alertId: ALERT_1, role: 'root', confidence: '1.00', createdAt: new Date('2026-06-18T12:06:00Z') },
+        { id: 'eeeeeeee-0004-4eee-8eee-eeeeeeeeeeee', orgId: ORG_1, groupId: GROUP_1, alertId: ALERT_4, role: 'related', confidence: '0.80', createdAt: new Date('2026-06-18T12:06:00Z') },
+      ];
+    }
+
+    function restrictToSiteA() {
+      authRef.current = { ...authRef.current, allowedSiteIds: [SITE_A] };
+    }
+
+    it('filters out a SITE_B alert from a persisted group detail for a SITE_A-restricted user', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const res = await makeApp().request(`/alerts/correlations/${GROUP_1}`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const ids = body.group.alerts.map((a: { id: string }) => a.id);
+      expect(ids).toContain(ALERT_1);
+      expect(ids).not.toContain(ALERT_4);
+    });
+
+    it('does not acknowledge a SITE_B alert when a SITE_A-restricted user acks the group', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/acknowledge`, { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_1)?.status).toBe('acknowledged');
+      expect(state.alerts.find((a) => a.id === ALERT_4)?.status).toBe('active');
+    });
+
+    it('does not resolve a SITE_B alert when a SITE_A-restricted user resolves the group', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const res = await makeApp().request(`/alerts/correlations/${GROUP_1}/resolve`, { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_1)?.status).toBe('resolved');
+      expect(state.alerts.find((a) => a.id === ALERT_4)?.status).toBe('active');
+    });
+
+    it('returns 404 on GET /:alertId/correlations for a SITE_B alert to a SITE_A-restricted user', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const res = await makeApp().request(`/alerts/${ALERT_4}/correlations`);
+      expect(res.status).toBe(404);
+    });
+
+    it('filters SITE_B related alerts out of GET /:alertId/correlations for a SITE_A-restricted user', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const res = await makeApp().request(`/alerts/${ALERT_1}/correlations`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const relatedIds = body.relatedAlerts.map((a: { id: string }) => a.id);
+      expect(relatedIds).not.toContain(ALERT_4);
+    });
+
+    it('does not acknowledge a SITE_B related alert via POST /:alertId/correlations/acknowledge', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const res = await makeApp().request(`/alerts/${ALERT_1}/correlations/acknowledge`, { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_1)?.status).toBe('acknowledged');
+      expect(state.alerts.find((a) => a.id === ALERT_4)?.status).toBe('active');
+    });
+
+    it('returns 404 on POST /:alertId/correlations/acknowledge for a SITE_B alert to a SITE_A-restricted user', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const res = await makeApp().request(`/alerts/${ALERT_4}/correlations/acknowledge`, { method: 'POST' });
+      expect(res.status).toBe(404);
+    });
+
+    it('leaves an unrestricted user able to see and acknowledge the whole group (no regression)', async () => {
+      seedSiteScopedGroup();
+      // No allowedSiteIds → unrestricted.
+
+      const detail = await makeApp().request(`/alerts/correlations/${GROUP_1}`);
+      const detailBody = await detail.json();
+      const ids = detailBody.group.alerts.map((a: { id: string }) => a.id);
+      expect(ids).toEqual(expect.arrayContaining([ALERT_1, ALERT_4]));
+
+      const ack = await makeApp().request(`/alerts/correlations/${GROUP_1}/acknowledge`, { method: 'POST' });
+      expect(ack.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_1)?.status).toBe('acknowledged');
+      expect(state.alerts.find((a) => a.id === ALERT_4)?.status).toBe('acknowledged');
+    });
   });
 });

--- a/apps/api/src/routes/alerts/correlations.test.ts
+++ b/apps/api/src/routes/alerts/correlations.test.ts
@@ -40,7 +40,7 @@ const {
       sourceId: 'ml_feedback_events.sourceId', eventType: 'ml_feedback_events.eventType',
       outcome: 'ml_feedback_events.outcome', occurredAt: 'ml_feedback_events.occurredAt',
     },
-    devices: { id: 'devices.id', hostname: 'devices.hostname', siteId: 'devices.siteId' },
+    devices: { id: 'devices.id', hostname: 'devices.hostname', siteId: 'devices.siteId', orgId: 'devices.orgId' },
   };
 
   type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
@@ -231,6 +231,9 @@ const SITE_A = '5a5a5a5a-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const SITE_B = '5b5b5b5b-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 const DEVICE_2 = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd';
 const ALERT_4 = 'a4a4a4a4-4444-4444-8444-444444444444';
+// Deviceless (org-wide) alert: not site-bound, must stay visible/ackable to a
+// site-restricted caller.
+const ALERT_5 = 'a5a5a5a5-5555-4555-8555-555555555555';
 
 function makeApp() {
   const app = new Hono();
@@ -252,8 +255,8 @@ function seed() {
   state.members = [];
   state.feedback = [];
   state.devices = [
-    { id: DEVICE_1, hostname: 'server-1', siteId: SITE_A },
-    { id: DEVICE_2, hostname: 'server-2', siteId: SITE_B },
+    { id: DEVICE_1, hostname: 'server-1', siteId: SITE_A, orgId: ORG_1 },
+    { id: DEVICE_2, hostname: 'server-2', siteId: SITE_B, orgId: ORG_1 },
   ];
   state.unwritableAlertIds = new Set();
 }
@@ -845,21 +848,34 @@ describe('/alerts correlation routes', () => {
         title: 'Other site', ruleId: 'rule-4',
         triggeredAt: new Date('2026-06-18T12:05:00Z'), createdAt: new Date('2026-06-18T12:05:00Z'),
       });
+      // Deviceless (org-wide) member: not site-bound, stays visible/ackable.
+      state.alerts.push({
+        id: ALERT_5, orgId: ORG_1, deviceId: null, status: 'active', severity: 'high',
+        title: 'Org-wide', ruleId: 'rule-5',
+        triggeredAt: new Date('2026-06-18T12:07:00Z'), createdAt: new Date('2026-06-18T12:07:00Z'),
+      });
       state.correlations.push({
         id: '44444444-aaaa-4aaa-8aaa-444444444444',
         parentAlertId: ALERT_1, childAlertId: ALERT_4,
         correlationType: 'same_device_temporal', confidence: '0.80',
         createdAt: new Date('2026-06-18T12:06:00Z'),
       });
+      state.correlations.push({
+        id: '55555555-aaaa-4aaa-8aaa-555555555555',
+        parentAlertId: ALERT_1, childAlertId: ALERT_5,
+        correlationType: 'same_device_temporal', confidence: '0.75',
+        createdAt: new Date('2026-06-18T12:07:00Z'),
+      });
       state.groups = [{
         id: GROUP_1, orgId: ORG_1, groupKey: `root:${ALERT_1}`, rootAlertId: ALERT_1,
-        status: 'open', score: '0.90', noiseReductionPercent: 50, memberCount: 2,
-        firstSeenAt: new Date('2026-06-18T12:00:00Z'), lastSeenAt: new Date('2026-06-18T12:05:00Z'),
+        status: 'open', score: '0.90', noiseReductionPercent: 50, memberCount: 3,
+        firstSeenAt: new Date('2026-06-18T12:00:00Z'), lastSeenAt: new Date('2026-06-18T12:07:00Z'),
         metadata: {}, createdAt: new Date('2026-06-18T12:06:00Z'),
       }];
       state.members = [
         { id: 'eeeeeeee-0001-4eee-8eee-eeeeeeeeeeee', orgId: ORG_1, groupId: GROUP_1, alertId: ALERT_1, role: 'root', confidence: '1.00', createdAt: new Date('2026-06-18T12:06:00Z') },
         { id: 'eeeeeeee-0004-4eee-8eee-eeeeeeeeeeee', orgId: ORG_1, groupId: GROUP_1, alertId: ALERT_4, role: 'related', confidence: '0.80', createdAt: new Date('2026-06-18T12:06:00Z') },
+        { id: 'eeeeeeee-0005-4eee-8eee-eeeeeeeeeeee', orgId: ORG_1, groupId: GROUP_1, alertId: ALERT_5, role: 'related', confidence: '0.75', createdAt: new Date('2026-06-18T12:07:00Z') },
       ];
     }
 
@@ -877,6 +893,24 @@ describe('/alerts correlation routes', () => {
       const ids = body.group.alerts.map((a: { id: string }) => a.id);
       expect(ids).toContain(ALERT_1);
       expect(ids).not.toContain(ALERT_4);
+    });
+
+    it('keeps a deviceless (org-wide) group member visible and ackable to a SITE_A-restricted user', async () => {
+      seedSiteScopedGroup();
+      restrictToSiteA();
+
+      const detail = await makeApp().request(`/alerts/correlations/${GROUP_1}`);
+      expect(detail.status).toBe(200);
+      const detailBody = await detail.json();
+      const ids = detailBody.group.alerts.map((a: { id: string }) => a.id);
+      expect(ids).toContain(ALERT_1);
+      expect(ids).toContain(ALERT_5);
+      expect(ids).not.toContain(ALERT_4);
+
+      const ack = await makeApp().request(`/alerts/correlations/${GROUP_1}/acknowledge`, { method: 'POST' });
+      expect(ack.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_5)?.status).toBe('acknowledged');
+      expect(state.alerts.find((a) => a.id === ALERT_4)?.status).toBe('active');
     });
 
     it('does not acknowledge a SITE_B alert when a SITE_A-restricted user acks the group', async () => {

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -839,7 +839,10 @@ alertCorrelationRoutes.post(
     }
 
     const groupAlertIds = persistedGroupAlerts !== null ? persistedGroupAlerts.map((alert) => alert.id) : group!.alerts.map((alert) => alert.id);
-    const groupAlerts = persistedGroupAlerts ?? await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
+    // Defense-in-depth: persistedGroupAlerts is already site-filtered, but the
+    // in-memory fallback re-fetches by id unfiltered, so re-apply the site axis
+    // (RLS does NOT enforce it). No-op for in-scope ids / unrestricted callers.
+    const groupAlerts = persistedGroupAlerts ?? await filterAlertsBySiteScope(auth, await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds)));
     const result = await mutateAlerts(groupAlerts, 'acknowledge', auth.user.id);
     if (persistedGroupAlerts !== null && groupAlerts[0]) {
       await updatePersistedGroupStatus(groupId, groupAlerts[0].orgId, 'acknowledged');
@@ -890,7 +893,10 @@ alertCorrelationRoutes.post(
     }
 
     const groupAlertIds = persistedGroupAlerts !== null ? persistedGroupAlerts.map((alert) => alert.id) : group!.alerts.map((alert) => alert.id);
-    const groupAlerts = persistedGroupAlerts ?? await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds));
+    // Defense-in-depth: persistedGroupAlerts is already site-filtered, but the
+    // in-memory fallback re-fetches by id unfiltered, so re-apply the site axis
+    // (RLS does NOT enforce it). No-op for in-scope ids / unrestricted callers.
+    const groupAlerts = persistedGroupAlerts ?? await filterAlertsBySiteScope(auth, await db.select().from(alerts).where(inArray(alerts.id, groupAlertIds)));
     const result = await mutateAlerts(groupAlerts, 'resolve', auth.user.id);
     if (persistedGroupAlerts !== null && groupAlerts[0]) {
       await updatePersistedGroupStatus(groupId, groupAlerts[0].orgId, 'resolved');

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -13,6 +13,7 @@ import { captureException } from '../../services/sentry';
 import { emitAlertStateFeedback, emitCorrelationFeedback, emitRcaFeedback } from '../../services/mlFeedbackEmitters';
 import { shouldProduceMlOutput } from '../../services/mlFeatureFlags';
 import { PERMISSIONS } from '../../services/permissions';
+import { deviceInSiteScope, filterAlertsBySiteScope } from '../tickets/siteScope';
 
 export const alertCorrelationRoutes = new Hono();
 
@@ -87,6 +88,9 @@ type AuthContext = {
   accessibleOrgIds?: string[] | null;
   user: { id: string };
   canAccessOrg: (orgId: string) => boolean;
+  // Site-axis allowlist (sub-org restriction). Undefined = unrestricted. RLS
+  // does NOT enforce this axis, so every alert read/mutation below narrows by it.
+  allowedSiteIds?: string[];
 };
 
 type AlertRow = typeof alerts.$inferSelect;
@@ -144,6 +148,13 @@ async function getAccessibleAlert(alertId: string, auth: AuthContext): Promise<A
     return null;
   }
 
+  // Site axis: a site-restricted caller must not see/act on an alert whose
+  // device is outside their allowed sites. Out-of-site → not found (no oracle),
+  // matching the alerts.ts by-id paths. Deviceless alerts stay visible.
+  if (alert.deviceId && !(await deviceInSiteScope(auth, alert.deviceId))) {
+    return null;
+  }
+
   return alert;
 }
 
@@ -152,10 +163,12 @@ async function listAccessibleAlerts(auth: AuthContext): Promise<AlertRow[]> {
   if (orgConditions === null) {
     return [];
   }
-  if (orgConditions.length === 0) {
-    return db.select().from(alerts);
-  }
-  return db.select().from(alerts).where(and(...orgConditions));
+  const rows = orgConditions.length === 0
+    ? await db.select().from(alerts)
+    : await db.select().from(alerts).where(and(...orgConditions));
+  // Site axis (RLS does NOT enforce it): drop alerts on out-of-site devices so
+  // correlation grouping/listing/evaluation never expose another site's alerts.
+  return filterAlertsBySiteScope(auth, rows);
 }
 
 function alertDisplayDevice(alert: AlertRow & { deviceHostname?: string | null }) {
@@ -321,9 +334,11 @@ async function buildPersistedCorrelationGroups(auth: AuthContext, groupId?: stri
     .where(inArray(alertCorrelationMembers.groupId, groupIds));
 
   const alertIds = [...new Set(members.map((member) => member.alertId))];
-  const memberAlerts = alertIds.length > 0
+  const memberAlertsRaw = alertIds.length > 0
     ? await db.select().from(alerts).where(inArray(alerts.id, alertIds))
     : [];
+  // Site axis: hide member alerts on out-of-site devices from a restricted caller.
+  const memberAlerts = await filterAlertsBySiteScope(auth, memberAlertsRaw);
   const alertById = new Map(memberAlerts.map((alert) => [alert.id, alert]));
 
   const deviceIds = [...new Set(memberAlerts.map((alert) => alert.deviceId))];
@@ -527,7 +542,13 @@ async function getPersistedGroupAlerts(groupId: string, auth: AuthContext): Prom
   if (members.length === 0) return [];
 
   const alertIds = members.map((member) => member.alertId);
-  return db.select().from(alerts).where(and(eq(alerts.orgId, group.orgId), inArray(alerts.id, alertIds)));
+  const groupAlerts = await db
+    .select()
+    .from(alerts)
+    .where(and(eq(alerts.orgId, group.orgId), inArray(alerts.id, alertIds)));
+  // Site axis: a restricted caller acking/resolving a group must not mutate
+  // members on out-of-site devices.
+  return filterAlertsBySiteScope(auth, groupAlerts);
 }
 
 async function updatePersistedGroupStatus(
@@ -932,9 +953,11 @@ alertCorrelationRoutes.get(
     const relatedIds = [...new Set(links.map((link) =>
       link.parentAlertId === alertId ? link.childAlertId : link.parentAlertId
     ))];
-    const relatedAlerts = relatedIds.length > 0
+    const relatedAlertsRaw = relatedIds.length > 0
       ? await db.select().from(alerts).where(and(eq(alerts.orgId, alert.orgId), inArray(alerts.id, relatedIds)))
       : [];
+    // Site axis: drop related alerts on out-of-site devices from a restricted caller.
+    const relatedAlerts = await filterAlertsBySiteScope(auth, relatedAlertsRaw);
     const relatedById = new Map(relatedAlerts.map((relatedAlert) => [relatedAlert.id, relatedAlert]));
 
     const visibleLinks: CorrelationRow[] = [];
@@ -996,9 +1019,12 @@ alertCorrelationRoutes.post(
       .from(alertCorrelations)
       .where(or(eq(alertCorrelations.parentAlertId, alertId), eq(alertCorrelations.childAlertId, alertId)));
     const relatedIdsForMutation = links.map((link) => link.parentAlertId === alertId ? link.childAlertId : link.parentAlertId);
-    const relatedAlerts = relatedIdsForMutation.length > 0
+    const relatedAlertsRaw = relatedIdsForMutation.length > 0
       ? await db.select().from(alerts).where(and(eq(alerts.orgId, alert.orgId), inArray(alerts.id, relatedIdsForMutation)))
       : [];
+    // Site axis: a restricted caller must not acknowledge related alerts on
+    // out-of-site devices via the correlation fan-out.
+    const relatedAlerts = await filterAlertsBySiteScope(auth, relatedAlertsRaw);
     const result = await mutateAlerts([alert, ...relatedAlerts], 'acknowledge', auth.user.id);
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/tickets/siteScope.test.ts
+++ b/apps/api/src/routes/tickets/siteScope.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Direct unit tests for filterAlertsBySiteScope — the site-axis (sub-org) fail-safe
+// that GET /alerts, the bulk endpoint, and correlation grouping all rely on. The
+// security-critical branch is fail-CLOSED for a missing device: a row whose
+// deviceId no longer resolves to a devices row is DROPPED for a site-restricted
+// caller (it must not leak through as if it were org-wide). Uses the REAL
+// siteAccessCheck from middleware/auth so this never drifts from a stale inline
+// copy; the db device lookup is mocked the way the route tests mock it.
+
+const { state, tables, dbMock } = vi.hoisted(() => {
+  const tables = {
+    devices: { id: 'devices.id', siteId: 'devices.siteId', orgId: 'devices.orgId' },
+    tickets: { id: 'tickets.id', deviceId: 'tickets.deviceId' },
+  };
+
+  type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
+  const columnKey = (col: unknown) => String(col).split('.').pop()!;
+  const evalPredicate = (row: Record<string, unknown>, predicate: Predicate): boolean => {
+    if (!predicate) return true;
+    if (predicate.op === 'eq') return row[columnKey(predicate.col)] === predicate.val;
+    if (predicate.op === 'inArray') return (predicate.vals ?? []).includes(row[columnKey(predicate.col)]);
+    if (predicate.op === 'and') return (predicate.args ?? []).every((arg) => evalPredicate(row, arg));
+    if (predicate.op === 'or') return (predicate.args ?? []).some((arg) => evalPredicate(row, arg));
+    return true;
+  };
+
+  const state = { devices: [] as Array<Record<string, any>> };
+
+  class SelectQuery {
+    private predicate: Predicate;
+    constructor(private projection?: Record<string, unknown>) {}
+    where(predicate: Predicate) { this.predicate = predicate; return this; }
+    then(resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) {
+      return Promise.resolve(this.rows()).then(resolve, reject);
+    }
+    private rows() {
+      const filtered = state.devices.filter((row) => evalPredicate(row, this.predicate));
+      if (!this.projection) return filtered;
+      return filtered.map((row) => {
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(this.projection!)) out[key] = row[columnKey(this.projection![key])];
+        return out;
+      });
+    }
+  }
+
+  const dbMock = {
+    select: vi.fn((projection?: Record<string, unknown>) => ({
+      from: () => new SelectQuery(projection),
+    })),
+  };
+
+  return { state, tables, dbMock };
+});
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  or: (...args: unknown[]) => ({ op: 'or', args }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+}));
+
+vi.mock('../../db', () => ({ db: dbMock }));
+vi.mock('../../db/schema', () => ({ devices: tables.devices, tickets: tables.tickets }));
+
+// Pull the REAL siteAccessCheck so the predicate the helper applies can't drift.
+vi.mock('../../middleware/auth', async () => ({
+  siteAccessCheck: (await vi.importActual<typeof import('../../middleware/auth')>('../../middleware/auth')).siteAccessCheck,
+}));
+
+import { filterAlertsBySiteScope } from './siteScope';
+
+const ORG = '11111111-1111-4111-8111-111111111111';
+const SITE_A = '5a5a5a5a-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_B = '5b5b5b5b-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const DEVICE_A = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd';
+const DEVICE_B = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd';
+const MISSING_DEVICE = 'deadbeef-0000-4000-8000-000000000000';
+
+type AlertRow = { id: string; deviceId: string | null };
+
+describe('filterAlertsBySiteScope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.devices = [
+      { id: DEVICE_A, siteId: SITE_A, orgId: ORG },
+      { id: DEVICE_B, siteId: SITE_B, orgId: ORG },
+    ];
+  });
+
+  it('DROPS a row whose device no longer exists for a site-restricted caller (fail-closed)', async () => {
+    const rows: AlertRow[] = [{ id: 'alert-missing', deviceId: MISSING_DEVICE }];
+    const out = await filterAlertsBySiteScope({ allowedSiteIds: [SITE_A], orgId: ORG }, rows);
+    expect(out).toEqual([]);
+  });
+
+  it('KEEPS a deviceless (org-wide) alert for a site-restricted caller', async () => {
+    const rows: AlertRow[] = [{ id: 'alert-orgwide', deviceId: null }];
+    const out = await filterAlertsBySiteScope({ allowedSiteIds: [SITE_A], orgId: ORG }, rows);
+    expect(out.map((r) => r.id)).toEqual(['alert-orgwide']);
+  });
+
+  it('KEEPS in-site device alerts and DROPS out-of-site ones for a site-restricted caller', async () => {
+    const rows: AlertRow[] = [
+      { id: 'alert-a', deviceId: DEVICE_A },
+      { id: 'alert-b', deviceId: DEVICE_B },
+    ];
+    const out = await filterAlertsBySiteScope({ allowedSiteIds: [SITE_A], orgId: ORG }, rows);
+    expect(out.map((r) => r.id)).toEqual(['alert-a']);
+  });
+
+  it('passes every row through unchanged for an unrestricted caller (allowedSiteIds undefined)', async () => {
+    const rows: AlertRow[] = [
+      { id: 'alert-a', deviceId: DEVICE_A },
+      { id: 'alert-b', deviceId: DEVICE_B },
+      { id: 'alert-orgwide', deviceId: null },
+      { id: 'alert-missing', deviceId: MISSING_DEVICE },
+    ];
+    const out = await filterAlertsBySiteScope({ allowedSiteIds: undefined, orgId: ORG }, rows);
+    expect(out).toBe(rows);
+    // Unrestricted callers skip the device lookup entirely.
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('an empty allowlist keeps deviceless alerts but drops all device-bound ones', async () => {
+    const rows: AlertRow[] = [
+      { id: 'alert-a', deviceId: DEVICE_A },
+      { id: 'alert-orgwide', deviceId: null },
+    ];
+    const out = await filterAlertsBySiteScope({ allowedSiteIds: [], orgId: ORG }, rows);
+    expect(out.map((r) => r.id)).toEqual(['alert-orgwide']);
+  });
+
+  it('scopes the device lookup to auth.orgId (belt-and-suspenders) so a cross-org device never matches', async () => {
+    // Same device id, but it belongs to a different org than the caller — must not
+    // resolve to an in-site match even if its siteId is in the allowlist.
+    state.devices = [{ id: DEVICE_A, siteId: SITE_A, orgId: 'other-org' }];
+    const rows: AlertRow[] = [{ id: 'alert-a', deviceId: DEVICE_A }];
+    const out = await filterAlertsBySiteScope({ allowedSiteIds: [SITE_A], orgId: ORG }, rows);
+    expect(out).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/tickets/siteScope.ts
+++ b/apps/api/src/routes/tickets/siteScope.ts
@@ -14,7 +14,10 @@ import type { AuthContext } from '../../middleware/auth';
  * denied for restricted callers but passes for unrestricted ones — device
  * existence is enforced in the service layer.
  */
-export async function deviceInSiteScope(auth: AuthContext, deviceId: string): Promise<boolean> {
+export async function deviceInSiteScope(
+  auth: Pick<AuthContext, 'allowedSiteIds'>,
+  deviceId: string,
+): Promise<boolean> {
   if (!auth.allowedSiteIds) return true;
   const rows = await db
     .select({ siteId: devices.siteId })
@@ -22,6 +25,47 @@ export async function deviceInSiteScope(auth: AuthContext, deviceId: string): Pr
     .where(eq(devices.id, deviceId))
     .limit(1);
   return siteAccessCheck(auth.allowedSiteIds)(rows[0]?.siteId);
+}
+
+/**
+ * Site-axis filter for a batch of alert-like rows. Mirrors the alert list
+ * narrowing (`alerts.ts` GET /): a site-restricted caller sees deviceless
+ * (org-wide) alerts plus alerts whose device is in their allowed sites; alerts
+ * on out-of-site devices (or devices that no longer exist) are dropped.
+ * Unrestricted callers (partner/system scope, or org users with no site
+ * restriction) get the input back unchanged.
+ *
+ * Uses a single batched device→site lookup rather than an IN-subquery so the
+ * same JS predicate is reused by the in-memory correlation grouping and the
+ * bulk endpoint, and so it evaluates the site axis (which RLS does NOT enforce)
+ * uniformly across both call sites.
+ */
+export async function filterAlertsBySiteScope<T extends { deviceId: string | null }>(
+  auth: Pick<AuthContext, 'allowedSiteIds'>,
+  rows: T[],
+): Promise<T[]> {
+  const allowed = auth.allowedSiteIds;
+  if (!allowed) return rows;
+
+  const deviceIds = [...new Set(rows.map((row) => row.deviceId).filter((id): id is string => Boolean(id)))];
+  const deviceSites = new Map<string, string | null>();
+  if (deviceIds.length > 0) {
+    const deviceRows = await db
+      .select({ id: devices.id, siteId: devices.siteId })
+      .from(devices)
+      .where(inArray(devices.id, deviceIds));
+    for (const device of deviceRows) {
+      deviceSites.set(device.id, device.siteId ?? null);
+    }
+  }
+
+  const allowSite = siteAccessCheck(allowed);
+  return rows.filter((row) => {
+    // Deviceless (org-wide) alerts are not site-bound — keep them visible,
+    // matching the GET /alerts narrowing.
+    if (!row.deviceId) return true;
+    return allowSite(deviceSites.get(row.deviceId) ?? null);
+  });
 }
 
 /**

--- a/apps/api/src/routes/tickets/siteScope.ts
+++ b/apps/api/src/routes/tickets/siteScope.ts
@@ -1,4 +1,4 @@
-import { eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { tickets, devices } from '../../db/schema';
 import { siteAccessCheck } from '../../middleware/auth';
@@ -41,7 +41,7 @@ export async function deviceInSiteScope(
  * uniformly across both call sites.
  */
 export async function filterAlertsBySiteScope<T extends { deviceId: string | null }>(
-  auth: Pick<AuthContext, 'allowedSiteIds'>,
+  auth: Pick<AuthContext, 'allowedSiteIds'> & { orgId?: string | null },
   rows: T[],
 ): Promise<T[]> {
   const allowed = auth.allowedSiteIds;
@@ -50,10 +50,17 @@ export async function filterAlertsBySiteScope<T extends { deviceId: string | nul
   const deviceIds = [...new Set(rows.map((row) => row.deviceId).filter((id): id is string => Boolean(id)))];
   const deviceSites = new Map<string, string | null>();
   if (deviceIds.length > 0) {
+    // Belt-and-suspenders org scope on the device lookup (mirrors alerts.ts:186):
+    // RLS already confines breeze_app to accessible orgs, but pinning orgId here
+    // means a cross-org device id can never resolve to a same-site match. A site-
+    // restricted caller is always organization scope, so auth.orgId is present.
+    const deviceWhere = auth.orgId
+      ? and(inArray(devices.id, deviceIds), eq(devices.orgId, auth.orgId))
+      : inArray(devices.id, deviceIds);
     const deviceRows = await db
       .select({ id: devices.id, siteId: devices.siteId })
       .from(devices)
-      .where(inArray(devices.id, deviceIds));
+      .where(deviceWhere);
     for (const device of deviceRows) {
       deviceSites.set(device.id, device.siteId ?? null);
     }


### PR DESCRIPTION
## Summary

Site scope (sub-org device restriction) is an app-layer-only authz axis that RLS does **not** enforce (same class as #1051). The alert **list** endpoints narrow results by the caller's allowed sites, but the **correlation** endpoints and **`POST /alerts/bulk`** did not — so a site-restricted org user could read and mutate alert state for *other sites within the same org*.

This PR adds site-axis narrowing to:

- **`routes/alerts/correlations.ts`** — every handler that reads or mutates alert/correlation state:
  - `GET /alerts/correlations`, `GET /alerts/correlations/:groupId`, `GET /:alertId/correlations` (out-of-site alerts filtered out of lists/detail; an out-of-site primary alert returns 404)
  - `POST /alerts/correlations/:groupId/acknowledge` · `.../resolve` · `POST /:alertId/correlations/acknowledge` (out-of-site members are never mutated)
- **`routes/alerts/alerts.ts`** — `POST /alerts/bulk` drops out-of-site alert IDs before mutating.

Implementation reuses the existing site-scope helpers (`deviceInSiteScope`, `siteAccessCheck`, `allowedSiteIds`) plus one new shared helper, `filterAlertsBySiteScope`, which batches the device→site lookup and applies the same predicate the list GET uses. Out-of-site by-id reads/mutations return not-found rather than an explicit denial, matching the existing by-id paths (no oracle).

## Behavior change (release-notes)

Behavior-changing **for site-restricted org users only**: they can no longer see or act on alerts/correlations belonging to sites outside their allowed-site list. Unrestricted callers (partner/system scope, and org users with no site restriction) are unaffected. Deviceless (org-wide) alerts remain visible to site-restricted callers, matching the existing `GET /alerts` narrowing.

## Tests (TDD — written failing first, then fixed)

`apps/api/src/routes/alerts/correlations.test.ts` (T2):
- filters out a SITE_B alert from a persisted group detail for a SITE_A-restricted user
- does not acknowledge / resolve a SITE_B alert when a SITE_A-restricted user acks/resolves the group
- returns 404 on `GET /:alertId/correlations` for a SITE_B alert
- filters SITE_B related alerts out of `GET /:alertId/correlations`
- does not acknowledge a SITE_B related alert via `POST /:alertId/correlations/acknowledge`
- returns 404 on `POST /:alertId/correlations/acknowledge` for a SITE_B alert
- unrestricted user still sees/acks the whole group (no regression)

`apps/api/src/routes/alerts/alerts.authz.test.ts` (T3, `POST /alerts/bulk`):
- does not acknowledge a SITE_B alert for a SITE_A-restricted user
- still acknowledges org-wide (deviceless) alerts for a SITE_A-restricted user
- acknowledges across all sites for an unrestricted user (no regression)

`pnpm exec vitest run src/routes/alerts/ src/routes/tickets/` → **185 passed (11 files)**. Typecheck clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)