### PR TITLE
fix(tickets): enforce partner org access on reads

### DIFF
--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -376,6 +376,23 @@ describe('GET /tickets', () => {
     const res = await makeApp().request('/tickets?deviceId=not-a-uuid');
     expect(res.status).toBe(400);
   });
+
+  it('constrains the unfiltered partner list to the user accessible org ids (org_access=selected)', async () => {
+    // org_access='selected' partner with a concrete accessible-org set hitting
+    // GET /tickets without an explicit ?orgId=. The base partner branch must
+    // narrow to inArray(orgId, accessibleOrgIds) — parity with detail/stats —
+    // not rely on RLS alone.
+    authRef.current = { ...DEFAULT_AUTH, accessibleOrgIds: ['org-selected-a', 'org-selected-b'] };
+    dbSelectMock.mockResolvedValue([]);
+
+    const res = await makeApp().request('/tickets');
+
+    expect(res.status).toBe(200);
+    expect(lastWhereArgs.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(lastWhereArgs[0]!.conditions);
+    expect(serialized).toContain('org-selected-a');
+    expect(serialized).toContain('org-selected-b');
+  });
 });
 
 describe('POST /tickets', () => {

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -31,7 +31,7 @@ const { serviceMocks, ticketTriageMocks, dbSelectMock, dbGroupByMock, authRef, l
         user: { id: 'u-1', name: 'Tess Tech', email: 'tess@msp.example', isPlatformAdmin: false },
         partnerId: 'p-1' as string | null,
         orgId: null as string | null,
-        accessibleOrgIds: null as string[] | null,
+        accessibleOrgIds: ['org-1', '3f2f1d8e-1111-4222-8333-444455556666'] as string[] | null,
         orgCondition: () => undefined,
         canAccessOrg: (_id: string) => true as boolean
       }
@@ -201,7 +201,7 @@ const DEFAULT_AUTH = {
   user: { id: 'u-1', name: 'Tess Tech', email: 'tess@msp.example', isPlatformAdmin: false },
   partnerId: 'p-1' as string | null,
   orgId: null as string | null,
-  accessibleOrgIds: null as string[] | null,
+  accessibleOrgIds: ['org-1', ORG_ID] as string[] | null,
   orgCondition: () => undefined,
   canAccessOrg: (_id: string) => true as boolean
 };
@@ -323,6 +323,15 @@ describe('GET /tickets', () => {
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body).toHaveProperty('error', 'Partner context required');
+  });
+
+  it('rejects an explicit orgId outside the partner user org allowlist', async () => {
+    authRef.current = { ...DEFAULT_AUTH, canAccessOrg: () => false };
+
+    const res = await makeApp().request(`/tickets?orgId=${ORG_ID}`);
+
+    expect(res.status).toBe(403);
+    expect(dbSelectMock).not.toHaveBeenCalled();
   });
 
   it('scoped org query includes a WHERE arg (org scope adds condition)', async () => {
@@ -458,6 +467,17 @@ describe('GET /tickets/stats', () => {
 
 describe('GET /tickets/:id — scoped pre-check', () => {
   beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('constrains partner ticket lookup to the user accessible org ids', async () => {
+    authRef.current = { ...DEFAULT_AUTH, accessibleOrgIds: ['org-visible'] };
+    dbSelectMock.mockResolvedValue([]);
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`);
+
+    expect(res.status).toBe(404);
+    expect(lastWhereArgs.length).toBeGreaterThan(0);
+    expect(JSON.stringify(lastWhereArgs[0]!.conditions)).toContain('org-visible');
+  });
 
   it('returns 404 when getScopedTicketOr404 finds no row even if service would succeed', async () => {
     // The scoped SELECT returns nothing (out-of-scope or missing ticket)

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -267,14 +267,17 @@ ticketsRoutes.get(
     const q = c.req.valid('query');
     const offset = (q.page - 1) * q.limit;
 
-    const conditions: SQL[] = [];
-    if (auth.scope === 'organization') {
-      if (!auth.orgId) return c.json({ error: 'Organization context required' }, 403);
-      conditions.push(eq(tickets.orgId, auth.orgId));
-    } else if (auth.scope === 'partner') {
-      if (!auth.partnerId) return c.json({ error: 'Partner context required' }, 403);
-      conditions.push(eq(tickets.partnerId, auth.partnerId));
+    // Base tenant scope via the shared helper so the list path applies the same
+    // partner org-access narrowing (inArray(orgId, accessibleOrgIds), fail-closed
+    // on an empty list) as the stats and detail paths — defense-in-depth parity.
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
     }
+    const scopeResult = buildScopeConditions(auth);
+    if (scopeResult === SCOPE_MISSING) {
+      return c.json({ error: 'Partner context required' }, 403);
+    }
+    const conditions: SQL[] = scopeResult;
     if (q.orgId) {
       if (auth.scope !== 'system' && !auth.canAccessOrg(q.orgId)) {
         return c.json({ error: 'Organization not found or access denied' }, 403);

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -117,6 +117,9 @@ export async function getScopedTicketOr404(
   } else if (auth.scope === 'partner') {
     if (!auth.partnerId) return null;
     conditions.push(eq(tickets.partnerId, auth.partnerId));
+    const orgIds = auth.accessibleOrgIds ?? [];
+    if (orgIds.length === 0) return null;
+    conditions.push(inArray(tickets.orgId, orgIds));
   }
   // system scope: no extra condition
 
@@ -160,6 +163,8 @@ function buildScopeConditions(auth: AuthContext): SQL[] | typeof SCOPE_MISSING {
   } else if (auth.scope === 'partner') {
     if (!auth.partnerId) return SCOPE_MISSING;
     conditions.push(eq(tickets.partnerId, auth.partnerId));
+    const orgIds = auth.accessibleOrgIds ?? [];
+    conditions.push(orgIds.length > 0 ? inArray(tickets.orgId, orgIds) : sql`false`);
   }
   return conditions;
 }
@@ -270,7 +275,12 @@ ticketsRoutes.get(
       if (!auth.partnerId) return c.json({ error: 'Partner context required' }, 403);
       conditions.push(eq(tickets.partnerId, auth.partnerId));
     }
-    if (q.orgId) conditions.push(eq(tickets.orgId, q.orgId));
+    if (q.orgId) {
+      if (auth.scope !== 'system' && !auth.canAccessOrg(q.orgId)) {
+        return c.json({ error: 'Organization not found or access denied' }, 403);
+      }
+      conditions.push(eq(tickets.orgId, q.orgId));
+    }
     if (q.deviceId) {
       // Site gate on the explicit device filter (alerts pattern): a restricted
       // caller asking for a device outside their sites gets a hard 403, not an


### PR DESCRIPTION
## Summary
- constrain partner ticket detail/stat queries to the caller accessibleOrgIds
- reject explicit ticket list orgId filters when the partner user cannot access that org
- add route regressions for selected-org partner access

## Tests
- pnpm --dir apps/api exec vitest run src/routes/tickets/tickets.test.ts
- pnpm --dir apps/api exec tsc --noEmit --pretty false

Draft while security-review playbook follow-up continues.