### PR TITLE
feat(agent/remote): configurable WebRTC bitrate ceiling + raise 1440p/4K cap (#1410)

### DIFF
--- a/agent/internal/remote/desktop/bitrate_ceiling.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling.go
@@ -2,6 +2,7 @@ package desktop
 
 import (
 	"log/slog"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -61,7 +62,10 @@ func configuredMaxBitrate() int {
 			return
 		}
 		mbps, err := strconv.ParseFloat(raw, 64)
-		if err != nil || mbps <= 0 {
+		// ParseFloat accepts the literals "NaN"/"Inf" with err==nil; reject them
+		// here so they get the accurate "invalid" message rather than falling
+		// through to the out-of-range branch with garbage after int() conversion.
+		if err != nil || math.IsNaN(mbps) || math.IsInf(mbps, 0) || mbps <= 0 {
 			slog.Warn("Ignoring invalid "+maxBitrateEnvVar+" (expected a positive number of Mbps)",
 				"value", raw)
 			return

--- a/agent/internal/remote/desktop/bitrate_ceiling.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling.go
@@ -1,0 +1,101 @@
+package desktop
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Resolution-based default ceilings for the adaptive bitrate controller.
+//
+// The stream always adapts *downward* to network conditions (see adaptive.go);
+// these values are the upper bound it may ramp up to on a healthy link with a
+// hardware encoder. They are deliberately conservative so that an unconfigured
+// agent on a WAN link does not try to saturate a thin uplink, but they are high
+// enough that 1440p/4K screen content stays sharp on a LAN/fiber deployment.
+//
+// Operators on high-bandwidth networks can raise the ceiling (or lower it for
+// constrained WAN) with BREEZE_REMOTE_DESKTOP_MAX_MBPS — see resolveMaxBitrate.
+const (
+	// defaultMaxBitrateHD is the ceiling at or below 1080p.
+	defaultMaxBitrateHD = 10_000_000
+	// defaultMaxBitrateHiRes is the ceiling above 1080p (1440p / 4K). Raised
+	// from the historical 15 Mbps, which was the limiting factor for 4K
+	// sharpness well before the network was (see issue #1410).
+	defaultMaxBitrateHiRes = 25_000_000
+
+	// minConfiguredMaxBitrate / maxConfiguredMaxBitrate bound an operator's
+	// BREEZE_REMOTE_DESKTOP_MAX_MBPS override so a typo cannot starve the
+	// stream (too low) or hand a single session an absurd ceiling (too high).
+	minConfiguredMaxBitrate = 1_000_000   // 1 Mbps
+	maxConfiguredMaxBitrate = 200_000_000 // 200 Mbps
+
+	// maxBitrateEnvVar is the operator override for the adaptive ceiling,
+	// expressed in Mbps (whole or fractional, e.g. "50" or "1.5").
+	maxBitrateEnvVar = "BREEZE_REMOTE_DESKTOP_MAX_MBPS"
+)
+
+// hiResPixels is the pixel-count threshold above which the hi-res ceiling
+// applies (anything larger than 1920x1080).
+const hiResPixels = 1920 * 1080
+
+var (
+	envCeilingOnce sync.Once
+	// envCeiling is the operator-configured ceiling in bits/sec, or 0 when the
+	// env var is unset/invalid (resolved once, since env vars are immutable for
+	// the agent process lifetime).
+	envCeiling int
+)
+
+// configuredMaxBitrate returns the operator-configured ceiling in bits/sec, or
+// 0 when BREEZE_REMOTE_DESKTOP_MAX_MBPS is unset/blank/invalid. An out-of-range
+// or unparseable value is reported (warning) and ignored rather than silently
+// applied, so a misconfiguration is visible in the agent log instead of quietly
+// degrading or over-driving the stream.
+func configuredMaxBitrate() int {
+	envCeilingOnce.Do(func() {
+		raw := strings.TrimSpace(os.Getenv(maxBitrateEnvVar))
+		if raw == "" {
+			return
+		}
+		mbps, err := strconv.ParseFloat(raw, 64)
+		if err != nil || mbps <= 0 {
+			slog.Warn("Ignoring invalid "+maxBitrateEnvVar+" (expected a positive number of Mbps)",
+				"value", raw)
+			return
+		}
+		bps := int(mbps * 1_000_000)
+		if bps < minConfiguredMaxBitrate || bps > maxConfiguredMaxBitrate {
+			slog.Warn("Ignoring out-of-range "+maxBitrateEnvVar,
+				"value", raw,
+				"minMbps", minConfiguredMaxBitrate/1_000_000,
+				"maxMbps", maxConfiguredMaxBitrate/1_000_000)
+			return
+		}
+		envCeiling = bps
+		slog.Info("Remote-desktop adaptive bitrate ceiling overridden by operator",
+			"maxMbps", mbps)
+	})
+	return envCeiling
+}
+
+// resolveMaxBitrate returns the adaptive bitrate ceiling (bits/sec) for a stream
+// of the given dimensions. When the operator has set a valid
+// BREEZE_REMOTE_DESKTOP_MAX_MBPS it takes precedence at every resolution;
+// otherwise the resolution-based default applies.
+//
+// This is the single source of truth for the ceiling — session start
+// (session_webrtc.go), hardware-encoder swap (session_capture.go), and
+// hardware-encoder restore (session_encoder_restore.go) all call it so they can
+// never drift apart.
+func resolveMaxBitrate(w, h int) int {
+	if configured := configuredMaxBitrate(); configured > 0 {
+		return configured
+	}
+	if w*h > hiResPixels {
+		return defaultMaxBitrateHiRes
+	}
+	return defaultMaxBitrateHD
+}

--- a/agent/internal/remote/desktop/bitrate_ceiling_test.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling_test.go
@@ -1,0 +1,125 @@
+package desktop
+
+import (
+	"sync"
+	"testing"
+)
+
+// resetEnvCeilingForTest forces configuredMaxBitrate() to re-read the
+// environment on its next call. configuredMaxBitrate memoizes via sync.Once
+// (env vars are immutable for the real process lifetime), so a test that wants
+// to exercise a different env value must reset the latch and the cached value.
+func resetEnvCeilingForTest() {
+	envCeilingOnce = sync.Once{}
+	envCeiling = 0
+}
+
+func TestResolveMaxBitrate_ResolutionDefaults(t *testing.T) {
+	t.Setenv(maxBitrateEnvVar, "")
+	resetEnvCeilingForTest()
+
+	cases := []struct {
+		name string
+		w, h int
+		want int
+	}{
+		{"1080p uses HD ceiling", 1920, 1080, defaultMaxBitrateHD},
+		{"720p uses HD ceiling", 1280, 720, defaultMaxBitrateHD},
+		{"just above 1080p uses hi-res ceiling", 1920, 1081, defaultMaxBitrateHiRes},
+		{"1440p uses hi-res ceiling", 2560, 1440, defaultMaxBitrateHiRes},
+		{"4K uses hi-res ceiling", 3840, 2160, defaultMaxBitrateHiRes},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetEnvCeilingForTest()
+			if got := resolveMaxBitrate(tc.w, tc.h); got != tc.want {
+				t.Fatalf("resolveMaxBitrate(%d,%d) = %d, want %d", tc.w, tc.h, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveMaxBitrate_RaisedFromHistoricalCaps(t *testing.T) {
+	t.Setenv(maxBitrateEnvVar, "")
+	resetEnvCeilingForTest()
+
+	// Regression guard for issue #1410: the new defaults must exceed the
+	// historical 8 Mbps / 15 Mbps hardcodes so 1440p/4K is actually usable.
+	if got := resolveMaxBitrate(1920, 1080); got <= 8_000_000 {
+		t.Fatalf("HD ceiling %d should exceed the historical 8 Mbps cap", got)
+	}
+	if got := resolveMaxBitrate(3840, 2160); got <= 15_000_000 {
+		t.Fatalf("hi-res ceiling %d should exceed the historical 15 Mbps cap", got)
+	}
+}
+
+func TestResolveMaxBitrate_EnvOverride(t *testing.T) {
+	t.Setenv(maxBitrateEnvVar, "50")
+	resetEnvCeilingForTest()
+
+	// A valid override takes precedence at every resolution.
+	if got := resolveMaxBitrate(1920, 1080); got != 50_000_000 {
+		t.Fatalf("HD with override = %d, want 50000000", got)
+	}
+	if got := resolveMaxBitrate(3840, 2160); got != 50_000_000 {
+		t.Fatalf("4K with override = %d, want 50000000", got)
+	}
+}
+
+func TestResolveMaxBitrate_EnvOverrideFractional(t *testing.T) {
+	t.Setenv(maxBitrateEnvVar, "1.5")
+	resetEnvCeilingForTest()
+
+	if got := resolveMaxBitrate(1920, 1080); got != 1_500_000 {
+		t.Fatalf("fractional override = %d, want 1500000", got)
+	}
+}
+
+func TestResolveMaxBitrate_EnvOverrideCanLowerForWAN(t *testing.T) {
+	// The override must be able to *lower* the ceiling so a thin-uplink WAN
+	// deployment stays protected — not just raise it for LAN.
+	t.Setenv(maxBitrateEnvVar, "2")
+	resetEnvCeilingForTest()
+
+	if got := resolveMaxBitrate(3840, 2160); got != 2_000_000 {
+		t.Fatalf("4K with low override = %d, want 2000000 (below the default ceiling)", got)
+	}
+}
+
+func TestResolveMaxBitrate_InvalidEnvIgnored(t *testing.T) {
+	cases := []string{"abc", "-5", "0", "  "}
+	for _, raw := range cases {
+		t.Run("raw="+raw, func(t *testing.T) {
+			t.Setenv(maxBitrateEnvVar, raw)
+			resetEnvCeilingForTest()
+			// Falls back to the resolution default rather than applying garbage.
+			if got := resolveMaxBitrate(1920, 1080); got != defaultMaxBitrateHD {
+				t.Fatalf("invalid override %q applied: got %d, want default %d", raw, got, defaultMaxBitrateHD)
+			}
+		})
+	}
+}
+
+func TestResolveMaxBitrate_OutOfRangeEnvIgnored(t *testing.T) {
+	cases := []string{
+		"0.5", // below 1 Mbps floor
+		"500", // above 200 Mbps ceiling
+	}
+	for _, raw := range cases {
+		t.Run("raw="+raw, func(t *testing.T) {
+			t.Setenv(maxBitrateEnvVar, raw)
+			resetEnvCeilingForTest()
+			if got := resolveMaxBitrate(2560, 1440); got != defaultMaxBitrateHiRes {
+				t.Fatalf("out-of-range override %q applied: got %d, want default %d", raw, got, defaultMaxBitrateHiRes)
+			}
+		})
+	}
+}
+
+func TestConfiguredMaxBitrate_UnsetReturnsZero(t *testing.T) {
+	t.Setenv(maxBitrateEnvVar, "")
+	resetEnvCeilingForTest()
+	if got := configuredMaxBitrate(); got != 0 {
+		t.Fatalf("configuredMaxBitrate() with unset env = %d, want 0", got)
+	}
+}

--- a/agent/internal/remote/desktop/bitrate_ceiling_test.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling_test.go
@@ -86,6 +86,43 @@ func TestResolveMaxBitrate_EnvOverrideCanLowerForWAN(t *testing.T) {
 	}
 }
 
+func TestResolveMaxBitrate_EnvOverrideAcceptsExactBounds(t *testing.T) {
+	// Guards the inclusive [1, 200] Mbps window: a future `<`→`<=` (or
+	// `>`→`>=`) flip in the bounds check would silently start rejecting a
+	// legitimately-configured floor/ceiling and fall back to the default.
+	cases := []struct {
+		raw  string
+		want int
+	}{
+		{"1", minConfiguredMaxBitrate},   // exact lower bound, accepted
+		{"200", maxConfiguredMaxBitrate}, // exact upper bound, accepted
+	}
+	for _, tc := range cases {
+		t.Run("raw="+tc.raw, func(t *testing.T) {
+			t.Setenv(maxBitrateEnvVar, tc.raw)
+			resetEnvCeilingForTest()
+			if got := resolveMaxBitrate(3840, 2160); got != tc.want {
+				t.Fatalf("boundary override %q = %d, want %d (must be accepted, not clamped to default)", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveMaxBitrate_NaNAndInfIgnored(t *testing.T) {
+	// ParseFloat accepts these literals with err==nil; they must be rejected,
+	// not applied or crashed on.
+	cases := []string{"NaN", "Inf", "+Inf", "-Inf"}
+	for _, raw := range cases {
+		t.Run("raw="+raw, func(t *testing.T) {
+			t.Setenv(maxBitrateEnvVar, raw)
+			resetEnvCeilingForTest()
+			if got := resolveMaxBitrate(2560, 1440); got != defaultMaxBitrateHiRes {
+				t.Fatalf("non-finite override %q applied: got %d, want default %d", raw, got, defaultMaxBitrateHiRes)
+			}
+		})
+	}
+}
+
 func TestResolveMaxBitrate_InvalidEnvIgnored(t *testing.T) {
 	cases := []string{"abc", "-5", "0", "  "}
 	for _, raw := range cases {

--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -1185,11 +1185,7 @@ func (s *Session) restoreHardwareEncoder(tp TextureProvider) {
 	// Mirror the resolution-based ceiling used in StartSession.
 	if s.adaptive != nil {
 		s.adaptive.SetEncoder(newEnc)
-		hwMaxBitrate := 8_000_000
-		if w*h > 1920*1080 {
-			hwMaxBitrate = 15_000_000
-		}
-		s.adaptive.SetMaxBitrate(hwMaxBitrate)
+		s.adaptive.SetMaxBitrate(resolveMaxBitrate(w, h))
 	}
 
 	slog.Info("Restored hardware encoder after desktop transition",

--- a/agent/internal/remote/desktop/session_encoder_restore.go
+++ b/agent/internal/remote/desktop/session_encoder_restore.go
@@ -168,11 +168,7 @@ func (s *Session) maybeRestoreHardwareEncoder(now time.Time) {
 	// Mirror the resolution-based ceiling used in StartSession.
 	if s.adaptive != nil {
 		s.adaptive.SetEncoder(newEnc)
-		hwMaxBitrate := 8_000_000
-		if w*h > 1920*1080 {
-			hwMaxBitrate = 15_000_000
-		}
-		s.adaptive.SetMaxBitrate(hwMaxBitrate)
+		s.adaptive.SetMaxBitrate(resolveMaxBitrate(w, h))
 	}
 
 	s.hwRestore.onRestored()

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -356,13 +356,12 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 		session.fps = maxFrameRate
 	}
 
-	// Create adaptive bitrate controller — ceiling scales with resolution.
-	// Hardware encoders (AMF, NVENC) sustain high bitrate without stalling;
-	// CapForSoftwareEncoder() clamps to 4Mbps when the backend is software.
-	maxAdaptiveBitrate := 8_000_000
-	if w*h > 1920*1080 {
-		maxAdaptiveBitrate = 15_000_000
-	}
+	// Create adaptive bitrate controller — ceiling scales with resolution and
+	// honors the operator BREEZE_REMOTE_DESKTOP_MAX_MBPS override (see
+	// resolveMaxBitrate). Hardware encoders (AMF, NVENC) sustain high bitrate
+	// without stalling; CapForSoftwareEncoder() clamps to 4Mbps when the
+	// backend is software.
+	maxAdaptiveBitrate := resolveMaxBitrate(w, h)
 	adaptive, err := NewAdaptiveBitrate(AdaptiveConfig{
 		Encoder:        enc,
 		InitialBitrate: initBitrate,


### PR DESCRIPTION
## What

Makes the remote-desktop WebRTC adaptive **bitrate ceiling configurable** and **raises the default cap** for 1440p/4K.

Previously the ceiling was a fixed, resolution-based hardcode — **8 Mbps** at ≤1080p, **15 Mbps** above — duplicated across three sites (session start, hardware-encoder swap, hardware-encoder restore). The 15 Mbps cap was the limiting factor for 4K sharpness well before the network was, with no operator lever to raise it on LAN/fiber or lower it on a thin WAN uplink.

## Changes

- **`resolveMaxBitrate(w, h)`** — new single source of truth for the ceiling (`agent/internal/remote/desktop/bitrate_ceiling.go`), replacing the three drift-prone duplicated blocks at `session_webrtc.go:362`, `session_capture.go:1188`, `session_encoder_restore.go:171`.
- **Raised defaults** — ≤1080p `8 → 10 Mbps`, >1080p `15 → 25 Mbps`. Conservative enough for WAN out of the box, high enough to make 1440p/4K usable.
- **`BREEZE_REMOTE_DESKTOP_MAX_MBPS` operator override** (Mbps, whole or fractional). Takes precedence at every resolution — raise it for high-bandwidth networks or lower it to protect a constrained uplink. Bounded to 1–200 Mbps; out-of-range or unparseable values are **warned-and-ignored** (fall back to the default), never silently applied.

The stream still adapts **downward** to RTT/loss (`adaptive.go`) and is still clamped to 4 Mbps on software encoders (`CapForSoftwareEncoder`). This only changes the upper bound it may ramp to on a healthy link with a hardware encoder.

## Scope note

This delivers the **agent-side configurable-ceiling slice** of #1410 — the lowest-risk, no-migration, self-hosted-friendly surface the issue lists first. The two remaining asks from the issue — an **org / config-policy default** and a **per-session quality-preset UI** — are genuinely design-open (which surface owns it) and are left for a follow-up.

## Testing

- `bitrate_ceiling_test.go`: resolution defaults, raised-cap regression guard (#1410), valid + fractional override, lower-for-WAN, invalid + out-of-range rejection, unset→0.
- Full `internal/remote/desktop` package green with `-race`; `go vet` and `gofmt` clean; whole agent module builds.

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)