### PR TITLE
feat(remote-desktop): configurable + raised WebRTC bitrate ceiling (#1410)

### DIFF
--- a/agent/internal/remote/desktop/bitrate_ceiling.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling.go
@@ -1,0 +1,127 @@
+package desktop
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Bitrate ceilings for the WebRTC remote-desktop stream.
+//
+// The adaptive controller (adaptive.go) always ramps the stream UP toward a
+// ceiling and DOWN under network pressure; these constants set how high it is
+// allowed to ramp. They are intentionally generous for screen content on
+// hardware encoders (AMF/NVENC/VideoToolbox sustain these without stalling) —
+// CapForSoftwareEncoder() separately clamps software backends to 4 Mbps.
+//
+// Defaults were raised for #1410: the previous 15 Mbps ceiling above 1080p was
+// the limiting factor for sharpness on 1440p/4K screen content well before the
+// network was. The numbers below track typical "good" H.264 screen-content
+// rates: ~8 Mbps @ 1080p, ~30 Mbps @ 1440p, ~50 Mbps @ 4K.
+const (
+	defaultBitrate1080p = 8_000_000  // ≤ 1920×1080
+	defaultBitrate1440p = 30_000_000 // ≤ 2560×1440
+	defaultBitrate4K    = 50_000_000 // > 1440p (4K and beyond)
+
+	// pixels1080p / pixels1440p are the inclusive upper pixel-count bounds for
+	// each tier. A resolution at or below the bound uses that tier's ceiling.
+	pixels1080p = 1920 * 1080
+	pixels1440p = 2560 * 1440
+
+	// envMaxBitrate lets an operator override the resolution-derived ceiling
+	// with a single absolute cap (in bits per second). This is the
+	// "configurable ceiling" half of #1410: defaults stay conservative enough
+	// for WAN, while LAN/fiber deployments can raise (or lower) the cap without
+	// a rebuild. When unset or invalid the resolution defaults apply.
+	envMaxBitrate = "BREEZE_REMOTE_MAX_BITRATE_BPS"
+
+	// absoluteBitrateFloor / absoluteBitrateCeiling bound any operator-supplied
+	// override so a typo can't drive the encoder to a degenerate value. 1 Mbps
+	// is the lowest sane screen-share rate; 200 Mbps comfortably covers 4K
+	// high-motion with headroom while preventing absurd values.
+	absoluteBitrateFloor   = 1_000_000   // 1 Mbps
+	absoluteBitrateCeiling = 200_000_000 // 200 Mbps
+)
+
+var (
+	bitrateOverrideOnce sync.Once
+	bitrateOverrideBps  int // 0 = no valid override configured
+)
+
+// loadBitrateOverride parses BREEZE_REMOTE_MAX_BITRATE_BPS once and caches the
+// result (the env value is fixed for the process lifetime).
+func loadBitrateOverride() int {
+	bitrateOverrideOnce.Do(func() {
+		bitrateOverrideBps = parseBitrateOverride(os.Getenv(envMaxBitrate))
+	})
+	return bitrateOverrideBps
+}
+
+// parseBitrateOverride validates a raw BREEZE_REMOTE_MAX_BITRATE_BPS value,
+// clamping it to the sane [floor, ceiling] band. Invalid, empty, or
+// out-of-range values return 0 (logged) so callers fall back to the
+// resolution-based defaults. Split out from loadBitrateOverride so it is
+// testable without the process-lifetime sync.Once cache.
+func parseBitrateOverride(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		slog.Warn("Ignoring invalid "+envMaxBitrate+" (not an integer)", "value", raw, "error", err.Error())
+		return 0
+	}
+	if v < absoluteBitrateFloor || v > absoluteBitrateCeiling {
+		slog.Warn("Ignoring out-of-range "+envMaxBitrate,
+			"value", v, "min", absoluteBitrateFloor, "max", absoluteBitrateCeiling)
+		return 0
+	}
+	slog.Info("Remote-desktop max bitrate overridden by env", "bps", v)
+	return v
+}
+
+// resolutionBitrateCeiling returns the adaptive-controller ceiling (in bps) for
+// a stream of the given pixel dimensions. An operator override
+// (BREEZE_REMOTE_MAX_BITRATE_BPS), when set, takes precedence over the
+// resolution-derived default at every resolution.
+//
+// This is the single source of truth for the ceiling — StartSession and both
+// hardware-encoder restore paths call it so they can never drift apart (they
+// previously each inlined the same 8/15 Mbps ladder).
+func resolutionBitrateCeiling(w, h int) int {
+	return ceilingForResolution(w, h, loadBitrateOverride())
+}
+
+// ceilingForResolution is the pure core of resolutionBitrateCeiling, split out
+// so it can be tested across the resolution ladder and the override branch
+// without touching the process env / sync.Once cache.
+func ceilingForResolution(w, h, override int) int {
+	if override > 0 {
+		return override
+	}
+	pixels := w * h
+	switch {
+	case pixels <= pixels1080p:
+		return defaultBitrate1080p
+	case pixels <= pixels1440p:
+		return defaultBitrate1440p
+	default:
+		return defaultBitrate4K
+	}
+}
+
+// viewerBitrateHardCap is the absolute ceiling the viewer's `set_bitrate`
+// control message may request. It honors the operator override when set so a
+// quality slider in the viewer can climb to whatever the operator allows;
+// otherwise it defaults to the 4K ceiling. Keeping this in sync with
+// resolutionBitrateCeiling means a viewer can request the full 4K rate (the
+// previous hard 20 Mbps cap silently truncated 4K requests — #1410).
+func viewerBitrateHardCap() int {
+	if override := loadBitrateOverride(); override > 0 {
+		return override
+	}
+	return defaultBitrate4K
+}

--- a/agent/internal/remote/desktop/bitrate_ceiling.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling.go
@@ -16,17 +16,21 @@ import (
 // hardware encoders (AMF/NVENC/VideoToolbox sustain these without stalling) —
 // CapForSoftwareEncoder() separately clamps software backends to 4 Mbps.
 //
-// Defaults were raised for #1410: the previous 15 Mbps ceiling above 1080p was
-// the limiting factor for sharpness on 1440p/4K screen content well before the
-// network was. The numbers below track typical "good" H.264 screen-content
-// rates: ~8 Mbps @ 1080p, ~30 Mbps @ 1440p, ~50 Mbps @ 4K.
+// Defaults were raised for #1410: the previous flat 15 Mbps ceiling above 1080p
+// throttled 1440p/4K screen content. The numbers below track typical "good"
+// H.264 screen-content rates: ~8 Mbps @ 1080p, ~30 Mbps @ 1440p, ~50 Mbps @ 4K.
+//
+// Tiers are selected by TOTAL PIXEL COUNT (w*h), not by width/height, so the
+// "≤ …px" annotations below are area bounds — a non-16:9 resolution such as
+// 2048×1080 (DCI 2K, 2,211,840 px) lands in the 1440p tier, not the 1080p one.
 const (
-	defaultBitrate1080p = 8_000_000  // ≤ 1920×1080
-	defaultBitrate1440p = 30_000_000 // ≤ 2560×1440
-	defaultBitrate4K    = 50_000_000 // > 1440p (4K and beyond)
+	defaultBitrate1080p = 8_000_000  // ≤ 2,073,600 px (1920×1080)
+	defaultBitrate1440p = 30_000_000 // ≤ 3,686,400 px (2560×1440)
+	defaultBitrate4K    = 50_000_000 // larger (4K and beyond)
 
 	// pixels1080p / pixels1440p are the inclusive upper pixel-count bounds for
-	// each tier. A resolution at or below the bound uses that tier's ceiling.
+	// each tier. A resolution whose w*h is at or below the bound uses that
+	// tier's ceiling.
 	pixels1080p = 1920 * 1080
 	pixels1440p = 2560 * 1440
 
@@ -114,13 +118,20 @@ func ceilingForResolution(w, h, override int) int {
 }
 
 // viewerBitrateHardCap is the absolute ceiling the viewer's `set_bitrate`
-// control message may request. It honors the operator override when set so a
-// quality slider in the viewer can climb to whatever the operator allows;
-// otherwise it defaults to the 4K ceiling. Keeping this in sync with
-// resolutionBitrateCeiling means a viewer can request the full 4K rate (the
-// previous hard 20 Mbps cap silently truncated 4K requests — #1410).
+// control message may request. It defaults to the top tier (defaultBitrate4K)
+// so the viewer slider is never itself the limiting factor, and honors the
+// operator override identically to resolutionBitrateCeiling so a quality slider
+// can climb to whatever the operator allows. The previous hard 20 Mbps cap
+// silently truncated higher 4K requests (#1410).
 func viewerBitrateHardCap() int {
-	if override := loadBitrateOverride(); override > 0 {
+	return viewerHardCap(loadBitrateOverride())
+}
+
+// viewerHardCap is the pure core of viewerBitrateHardCap, split out so the
+// override branch is testable without the process env / sync.Once cache (mirrors
+// the ceilingForResolution split).
+func viewerHardCap(override int) int {
+	if override > 0 {
 		return override
 	}
 	return defaultBitrate4K

--- a/agent/internal/remote/desktop/bitrate_ceiling_test.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling_test.go
@@ -1,0 +1,80 @@
+package desktop
+
+import "testing"
+
+func TestCeilingForResolution(t *testing.T) {
+	tests := []struct {
+		name     string
+		w, h     int
+		override int
+		want     int
+	}{
+		{"720p uses 1080p tier", 1280, 720, 0, defaultBitrate1080p},
+		{"exactly 1080p", 1920, 1080, 0, defaultBitrate1080p},
+		{"just above 1080p uses 1440p tier", 1920, 1081, 0, defaultBitrate1440p},
+		{"exactly 1440p", 2560, 1440, 0, defaultBitrate1440p},
+		{"just above 1440p uses 4K tier", 2560, 1441, 0, defaultBitrate4K},
+		{"4K uses 4K tier", 3840, 2160, 0, defaultBitrate4K},
+		{"5K uses 4K tier", 5120, 2880, 0, defaultBitrate4K},
+		{"override beats 1080p default", 1920, 1080, 25_000_000, 25_000_000},
+		{"override beats 4K default", 3840, 2160, 12_000_000, 12_000_000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ceilingForResolution(tt.w, tt.h, tt.override); got != tt.want {
+				t.Errorf("ceilingForResolution(%d, %d, override=%d) = %d, want %d",
+					tt.w, tt.h, tt.override, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolutionLadderRaisedAboveLegacyCap(t *testing.T) {
+	// Regression guard for #1410: the previous ceiling above 1080p was a flat
+	// 15 Mbps, which throttled 1440p/4K screen content. Both higher tiers must
+	// now exceed that legacy cap.
+	const legacyCap = 15_000_000
+	if defaultBitrate1440p <= legacyCap {
+		t.Errorf("1440p ceiling %d must exceed legacy %d", defaultBitrate1440p, legacyCap)
+	}
+	if defaultBitrate4K <= legacyCap {
+		t.Errorf("4K ceiling %d must exceed legacy %d", defaultBitrate4K, legacyCap)
+	}
+}
+
+func TestParseBitrateOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{"empty", "", 0},
+		{"whitespace only", "   ", 0},
+		{"non-integer", "fast", 0},
+		{"float not accepted", "10.5", 0},
+		{"below floor ignored", "500000", 0},
+		{"above ceiling ignored", "999000000", 0},
+		{"valid mid-range", "30000000", 30_000_000},
+		{"valid at floor", "1000000", absoluteBitrateFloor},
+		{"valid at ceiling", "200000000", absoluteBitrateCeiling},
+		{"trimmed", "  40000000 ", 40_000_000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseBitrateOverride(tt.raw); got != tt.want {
+				t.Errorf("parseBitrateOverride(%q) = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestViewerHardCapAboveLegacy(t *testing.T) {
+	// The viewer set_bitrate control path was previously hard-capped at 20 Mbps,
+	// silently truncating higher 4K quality requests (#1410). The default cap
+	// (no override) must now allow the full 4K ceiling.
+	const legacyControlCap = 20_000_000
+	if defaultBitrate4K <= legacyControlCap {
+		t.Errorf("default viewer hard cap %d must exceed legacy control cap %d",
+			defaultBitrate4K, legacyControlCap)
+	}
+}

--- a/agent/internal/remote/desktop/bitrate_ceiling_test.go
+++ b/agent/internal/remote/desktop/bitrate_ceiling_test.go
@@ -68,6 +68,25 @@ func TestParseBitrateOverride(t *testing.T) {
 	}
 }
 
+func TestViewerHardCap(t *testing.T) {
+	tests := []struct {
+		name     string
+		override int
+		want     int
+	}{
+		{"no override defaults to 4K ceiling", 0, defaultBitrate4K},
+		{"override takes precedence", 35_000_000, 35_000_000},
+		{"override below default still wins", 10_000_000, 10_000_000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := viewerHardCap(tt.override); got != tt.want {
+				t.Errorf("viewerHardCap(%d) = %d, want %d", tt.override, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestViewerHardCapAboveLegacy(t *testing.T) {
 	// The viewer set_bitrate control path was previously hard-capped at 20 Mbps,
 	// silently truncating higher 4K quality requests (#1410). The default cap

--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -1185,11 +1185,7 @@ func (s *Session) restoreHardwareEncoder(tp TextureProvider) {
 	// Mirror the resolution-based ceiling used in StartSession.
 	if s.adaptive != nil {
 		s.adaptive.SetEncoder(newEnc)
-		hwMaxBitrate := 8_000_000
-		if w*h > 1920*1080 {
-			hwMaxBitrate = 15_000_000
-		}
-		s.adaptive.SetMaxBitrate(hwMaxBitrate)
+		s.adaptive.SetMaxBitrate(resolutionBitrateCeiling(w, h))
 	}
 
 	slog.Info("Restored hardware encoder after desktop transition",

--- a/agent/internal/remote/desktop/session_control.go
+++ b/agent/internal/remote/desktop/session_control.go
@@ -165,7 +165,11 @@ func (s *Session) handleControlMessage(data []byte) {
 		return
 	}
 
-	const maxBitrateCap = 20_000_000 // 20 Mbps hard cap
+	// Absolute ceiling a viewer-requested bitrate may reach. Tracks the 4K
+	// resolution ceiling (and the BREEZE_REMOTE_MAX_BITRATE_BPS override) so a
+	// viewer quality slider can climb to the full 4K rate — the previous hard
+	// 20 Mbps cap silently truncated higher 4K requests (#1410).
+	maxBitrateCap := viewerBitrateHardCap()
 	switch msg.Type {
 	case "set_bitrate":
 		if msg.Value > 0 && msg.Value <= maxBitrateCap {

--- a/agent/internal/remote/desktop/session_control.go
+++ b/agent/internal/remote/desktop/session_control.go
@@ -172,18 +172,30 @@ func (s *Session) handleControlMessage(data []byte) {
 	maxBitrateCap := viewerBitrateHardCap()
 	switch msg.Type {
 	case "set_bitrate":
-		if msg.Value > 0 && msg.Value <= maxBitrateCap {
+		if msg.Value > 0 {
+			// Clamp to the hard cap rather than silently dropping an
+			// above-cap request — silently ignoring higher requests is the
+			// exact truncation #1410 set out to fix. A request below the cap
+			// is honored as-is; one above it is honored at the cap.
+			bitrate := msg.Value
+			if bitrate > maxBitrateCap {
+				slog.Debug("Clamping requested bitrate to hard cap",
+					"session", s.id, "requested", msg.Value, "cap", maxBitrateCap)
+				bitrate = maxBitrateCap
+			}
 			// Update the adaptive controller's ceiling so it ramps up to
 			// the user-chosen max rather than bypassing adaptive entirely.
 			if s.adaptive != nil {
-				s.adaptive.SetMaxBitrate(msg.Value)
+				s.adaptive.SetMaxBitrate(bitrate)
 			} else {
 				if enc := s.encoder.Load(); enc != nil {
-					if err := enc.SetBitrate(msg.Value); err != nil {
-						slog.Warn("Failed to set bitrate", "session", s.id, "bitrate", msg.Value, "error", err.Error())
+					if err := enc.SetBitrate(bitrate); err != nil {
+						slog.Warn("Failed to set bitrate", "session", s.id, "bitrate", bitrate, "error", err.Error())
 					}
 				}
 			}
+		} else {
+			slog.Debug("Ignoring non-positive set_bitrate request", "session", s.id, "value", msg.Value)
 		}
 	case "set_fps":
 		if msg.Value > 0 && msg.Value <= maxFrameRate {

--- a/agent/internal/remote/desktop/session_encoder_restore.go
+++ b/agent/internal/remote/desktop/session_encoder_restore.go
@@ -168,11 +168,7 @@ func (s *Session) maybeRestoreHardwareEncoder(now time.Time) {
 	// Mirror the resolution-based ceiling used in StartSession.
 	if s.adaptive != nil {
 		s.adaptive.SetEncoder(newEnc)
-		hwMaxBitrate := 8_000_000
-		if w*h > 1920*1080 {
-			hwMaxBitrate = 15_000_000
-		}
-		s.adaptive.SetMaxBitrate(hwMaxBitrate)
+		s.adaptive.SetMaxBitrate(resolutionBitrateCeiling(w, h))
 	}
 
 	s.hwRestore.onRestored()

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -356,13 +356,11 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 		session.fps = maxFrameRate
 	}
 
-	// Create adaptive bitrate controller — ceiling scales with resolution.
-	// Hardware encoders (AMF, NVENC) sustain high bitrate without stalling;
-	// CapForSoftwareEncoder() clamps to 4Mbps when the backend is software.
-	maxAdaptiveBitrate := 8_000_000
-	if w*h > 1920*1080 {
-		maxAdaptiveBitrate = 15_000_000
-	}
+	// Create adaptive bitrate controller — ceiling scales with resolution and
+	// honors the BREEZE_REMOTE_MAX_BITRATE_BPS override. Hardware encoders
+	// (AMF, NVENC) sustain high bitrate without stalling; CapForSoftwareEncoder()
+	// clamps to 4Mbps when the backend is software.
+	maxAdaptiveBitrate := resolutionBitrateCeiling(w, h)
 	adaptive, err := NewAdaptiveBitrate(AdaptiveConfig{
 		Encoder:        enc,
 		InitialBitrate: initBitrate,


### PR DESCRIPTION
## What

Makes the WebRTC remote-desktop max bitrate configurable and raises the ceiling for 1440p/4K, resolving #1410.

The adaptive stream had a fixed resolution-based ceiling (8 Mbps ≤1080p, **15 Mbps above**) inlined in three separate places, plus a hard **20 Mbps** cap on the viewer's `set_bitrate` control path. The 15 Mbps cap was the limiting factor for sharpness on high-res screen content well before the network was, and there was no way to raise it without a rebuild.

## Changes

- **Single source of truth:** centralize the resolution→ceiling computation in `resolutionBitrateCeiling()` (`agent/internal/remote/desktop/bitrate_ceiling.go`). It was previously duplicated across `session_webrtc.go` (StartSession) and both hardware-encoder restore paths (`session_capture.go`, `session_encoder_restore.go`) — so the three could drift.
- **Raised tiered defaults** for H.264 screen content: 8 Mbps ≤1080p, **30 Mbps ≤1440p**, **50 Mbps for 4K+**.
- **`BREEZE_REMOTE_MAX_BITRATE_BPS` env override** (clamped to a sane 1–200 Mbps band) so LAN/fiber deployments can raise — or WAN deployments lower — the cap without a rebuild. Defaults stay conservative for WAN.
- **Viewer control cap** (`session_control.go` `set_bitrate`) now tracks the 4K ceiling (and the override) instead of a hard 20 Mbps, so a viewer quality slider can request the full 4K rate.

The adaptive controller still ramps **down** under network pressure (EWMA RTT/loss) and `CapForSoftwareEncoder()` still clamps software backends to 4 Mbps — this only raises the ceiling hardware encoders may reach on capable links.

## Scope note

This delivers the issue's two core asks (raise the ceiling + make it configurable) via an agent-side env knob. A richer per-session/org-policy quality-preset **UI/API surface** (the "slider in the dashboard" half) is a larger follow-up and intentionally out of scope here.

## Testing

`go vet`, `go build`, and `go test -race ./internal/remote/desktop/` all clean. New tests cover the ceiling ladder boundaries (720p/1080p/1440p/4K/5K + exact-boundary cases), env-override parse/clamp (empty, non-integer, below-floor, above-ceiling, trimmed, boundaries), and regression guards that both higher tiers and the viewer cap exceed the legacy 15/20 Mbps limits.

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)