### PR TITLE
fix(security): SSO identity-first lookup + safe JIT linking (review #2 H-2/H-3)

### DIFF
--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -226,7 +226,9 @@ describe('sso routes', () => {
     // Default the verifier to "passes" with minimal claims so flows that don't
     // assert subject/email binding keep linking via userinfo as before; tests
     // that exercise binding/rejection override this.
-    vi.mocked(verifyIdTokenSignature).mockResolvedValue({ nonce: 'nonce' } as any);
+    // sub matches getUserInfo's sub so the verified-subject binding (security
+    // review #2) and the identity-first lookup resolve cleanly by default.
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
     setAuthContext();
     app = new Hono();
     app.route('/sso', ssoRoutes);
@@ -607,6 +609,14 @@ describe('sso routes', () => {
           })
         })
       } as any)
+      // security review #2: identity-first — (provider, sub) link → user by id.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ userId: USER_UUID }])
+          })
+        })
+      } as any)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -736,6 +746,14 @@ describe('sso routes', () => {
           })
         })
       } as any)
+      // security review #2: identity-first — (provider, sub) link → user by id.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ userId: USER_UUID }])
+          })
+        })
+      } as any)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -844,6 +862,15 @@ describe('sso routes', () => {
                 allowedDomains: null,
                 defaultRoleId: null
               }])
+            })
+          })
+        } as any)
+        // security review #2: identity-first — a returning user is resolved by
+        // the (provider, external sub) link, then loaded by id.
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ userId: USER_UUID }])
             })
           })
         } as any)
@@ -1011,6 +1038,91 @@ describe('sso routes', () => {
       expect(res.status).toBe(302);
       expect(res.headers.get('location') ?? '').toContain('error=sso_subject_mismatch');
       expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    // ── security review #2: identity-first lookup (1A) + safe JIT linking (1B)
+    const sel = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) })
+    } as any);
+    const selJoin = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) }) })
+    } as any);
+    const PROVIDER_ROW = [{
+      id: PROVIDER_UUID, orgId: ORG_UUID, type: 'oidc',
+      issuer: 'https://issuer.example.com', authorizationUrl: 'https://issuer.example.com/auth',
+      tokenUrl: 'https://issuer.example.com/token', userInfoUrl: 'https://issuer.example.com/userinfo',
+      jwksUrl: 'https://issuer.example.com/jwks', clientId: 'client-id', clientSecret: 'client-secret',
+      scopes: 'openid profile email', attributeMapping: { email: 'email', name: 'name' },
+      autoProvision: false, allowedDomains: null, defaultRoleId: null
+    }];
+    const primeCallback = () => {
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({ access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'test@example.com', name: 'Test User' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'test@example.com', name: 'Test User' } as any);
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-z', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/dashboard' }]) })
+      } as any);
+    };
+    const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
+
+    it('resolves the user by the (provider, sub) link regardless of the asserted email (1A)', async () => {
+      primeCallback();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel(PROVIDER_ROW))
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }])) // identity link by (provider, sub)
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'someone-else@corp.com', name: 'Linked' }])) // user by id — email DIFFERS from asserted
+        .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
+        .mockReturnValueOnce(sel([{ id: 'identity-1' }]));
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      // The session is the LINKED user — proving the email was not the lookup key.
+      expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ sub: USER_UUID }), expect.any(Object));
+    });
+
+    it('refuses to JIT-link an SSO assertion to an existing PASSWORD account (1B)', async () => {
+      primeCallback();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel(PROVIDER_ROW))
+        .mockReturnValueOnce(sel([])) // no (provider, sub) link yet
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'Pw', passwordHash: '$argon2id$hash' }]))
+        .mockReturnValueOnce(sel([])); // no other-provider link (still denied — has a password)
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_link_required');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('refuses to JIT-link when the account is linked to a DIFFERENT provider (1B)', async () => {
+      primeCallback();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel(PROVIDER_ROW))
+        .mockReturnValueOnce(sel([])) // no link for THIS provider
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'SsoOnly', passwordHash: null }]))
+        .mockReturnValueOnce(sel([{ id: 'other-provider-link' }])); // linked to another provider
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_link_required');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('auto-links an existing SSO-only account with no conflicting credential (1B safe path)', async () => {
+      primeCallback();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel(PROVIDER_ROW))
+        .mockReturnValueOnce(sel([])) // no link yet
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'SsoOnly', passwordHash: null }]))
+        .mockReturnValueOnce(sel([])) // no other-provider link → safe to link
+        .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
+        .mockReturnValueOnce(sel([])); // existingIdentity none → insert the new link
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(createTokenPair).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { eq, and, gt } from 'drizzle-orm';
+import { eq, and, gt, ne } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
 import { db, withSystemDbAccessContext } from '../db';
@@ -964,16 +964,64 @@ ssoRoutes.get('/callback', async (c) => {
       }
     }
 
-    // Find or create user.
-    // Pre-auth lookup — wrap in system scope so the `users` RLS policy
-    // doesn't deny the read before the real request scope is applied.
-    let [user] = await withSystemDbAccessContext(async () =>
-      db
-        .select()
-        .from(users)
-        .where(eq(users.email, attrs.email.toLowerCase()))
-        .limit(1)
-    );
+    // ── Identity resolution (security review #2: identity-first + safe JIT link)
+    // The authoritative key is the (provider, external subject) pair recorded in
+    // user_sso_identities — NOT the global-unique email. Once a user is linked to
+    // a provider, only that provider asserting that exact `sub` can authenticate
+    // as them; a different (or re-pointed, attacker-controlled) IdP cannot
+    // impersonate them by asserting their email. Pre-auth lookups run under
+    // system scope (RLS would otherwise deny before the request scope is set).
+    const externalSub = idClaims.sub;
+    if (typeof externalSub !== 'string' || externalSub.length === 0) {
+      clearStateCookie();
+      return c.redirect('/login?error=sso_no_subject');
+    }
+
+    let user = await withSystemDbAccessContext(async () => {
+      const [link] = await db
+        .select({ userId: userSsoIdentities.userId })
+        .from(userSsoIdentities)
+        .where(and(
+          eq(userSsoIdentities.providerId, provider.id),
+          eq(userSsoIdentities.externalId, externalSub)
+        ))
+        .limit(1);
+      if (!link) return null;
+      const [linkedUser] = await db.select().from(users).where(eq(users.id, link.userId)).limit(1);
+      return linkedUser ?? null;
+    });
+
+    if (!user) {
+      // No link yet for this provider+sub. Try to match an existing user by the
+      // verified email — but JIT-linking an SSO assertion to a pre-existing
+      // account is the account-takeover surface (a malicious/misconfigured IdP
+      // can assert a victim's email). Only auto-link when it is SAFE: the
+      // account has no password AND no link to a DIFFERENT provider. Otherwise
+      // the user must opt into SSO linking from an authenticated session.
+      const [byEmail] = await withSystemDbAccessContext(async () =>
+        db.select().from(users).where(eq(users.email, attrs.email.toLowerCase())).limit(1)
+      );
+
+      if (byEmail) {
+        const hasPassword = byEmail.passwordHash != null;
+        const [otherProviderLink] = await withSystemDbAccessContext(async () =>
+          db
+            .select({ id: userSsoIdentities.id })
+            .from(userSsoIdentities)
+            .where(and(
+              eq(userSsoIdentities.userId, byEmail.id),
+              ne(userSsoIdentities.providerId, provider.id)
+            ))
+            .limit(1)
+        );
+        if (hasPassword || otherProviderLink) {
+          clearStateCookie();
+          return c.redirect('/login?error=sso_link_required');
+        }
+        // Safe: an SSO-only account with no conflicting credential.
+        user = byEmail;
+      }
+    }
 
     if (!user) {
       if (!provider.autoProvision) {
@@ -1095,7 +1143,7 @@ ssoRoutes.get('/callback', async (c) => {
         await db.insert(userSsoIdentities).values({
           userId: user.id,
           providerId: provider.id,
-          externalId: userInfo.sub,
+          externalId: externalSub,
           email: attrs.email,
           profile: userInfo,
           accessToken: encryptSecret(tokens.access_token),


### PR DESCRIPTION
## Summary

Follow-up to #1655. Closes the **residual SSO account-takeover surface** from security review #2 (the deferred H-2/H-3 cluster): a malicious or compromised org-admin (`orgs:write`+MFA) could point their org's OIDC provider at an attacker-controlled IdP and **impersonate any co-member of their org** (including higher-priv users), because the callback linked accounts by the **global-unique email** — and signature/`email_verified` (shipped in #1655) don't stop a malicious IdP that signs with its own JWKS.

## Changes

**1A — identity-first lookup.** The authoritative key is now the `(provider, external sub)` pair in the existing `user_sso_identities` table, **not** the email. Once a user is linked to a provider, only that provider asserting that exact `sub` can authenticate as them; a different (or re-pointed, attacker-controlled) IdP cannot impersonate them by asserting their email. The recorded link's `externalId` is the **signature-verified** id_token `sub` (from #1655).

**1B — safe JIT linking.** When no link exists yet and an existing user matches by the verified email, only auto-link when **safe** — the account has **no password** AND **no link to a different provider**. Otherwise the callback refuses (`sso_link_required`); that user must opt into SSO linking from an authenticated session. This blocks silent impersonation of password-based accounts (the high-value admins) while preserving SSO-only and new-user provisioning.

| Scenario | Before | After |
|---|---|---|
| Returning linked user `(provider, sub)` | matched by email | **matched by link (authoritative)** |
| Existing **password** user, IdP asserts their email | silently logged in (takeover) | **`sso_link_required`** (denied) |
| Existing user linked to a **different** provider | silently logged in | **`sso_link_required`** (denied) |
| Existing **SSO-only** user, same provider | logged in | logged in (safe auto-link) |
| Brand-new user (autoProvision) | provisioned | provisioned (unchanged) |

## Deferred (still tracked — need a dedicated design)

- **Domain-ownership verification** (`sso_verified_domains` + DNS-TXT flow) and **raising the bar to configure an IdP** (a `sso:admin` permission / notify-all-admins-on-change). These root out the org-admin IdP trust *at the source*; 1A+1B already neutralize the steady-state takeover.
- SSO IdP-MFA signal (H-1); MFA TOTP used-step replay cache.

## Verification
- `tsc` clean; **53 SSO tests pass**.
- 4 new `sso.test` cases: link authoritative over a differing email; deny JIT-link for a password account and for an account linked elsewhere; allow the safe SSO-only path. Existing callback tests updated to the identity-first flow. No SSO callback integration test exists (only `rls-coverage` references the table, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)