### PR TITLE
feat(web): add user time format setting

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -615,6 +615,7 @@ describe('user routes', () => {
       ['theme', 'sepia', /Invalid theme value/i],
       ['density', 'tiny', /Invalid density value/i],
       ['font', 'comic-sans', /Invalid font value/i],
+      ['timeFormat', 'military-ish', /Invalid timeFormat value/i],
     ])('rejects invalid %s appearance preference', async (key, value, message) => {
       const res = await app.request('/users/me', {
         method: 'PATCH',
@@ -630,11 +631,13 @@ describe('user routes', () => {
       const existingPreferences = {
         theme: 'dark',
         density: 'compact',
+        timeFormat: '12h',
         customKey: 'preserve-me'
       };
       const mergedPreferences = {
         ...existingPreferences,
-        font: 'system'
+        font: 'system',
+        timeFormat: '24h'
       };
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -668,7 +671,7 @@ describe('user routes', () => {
       const res = await app.request('/users/me', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-        body: JSON.stringify({ preferences: { font: 'system' } })
+        body: JSON.stringify({ preferences: { font: 'system', timeFormat: '24h' } })
       });
 
       expect(res.status).toBe(200);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -560,7 +560,8 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
           ['comfortable', 'compact', 'dense'],
           'comfortable, compact, or dense'
         )
-        ?? validatePreferenceEnum(prefs, 'font', ['breeze', 'system'], 'breeze or system');
+        ?? validatePreferenceEnum(prefs, 'font', ['breeze', 'system'], 'breeze or system')
+        ?? validatePreferenceEnum(prefs, 'timeFormat', ['12h', '24h'], '12h or 24h');
       if (validationError) {
         return c.json({ error: validationError }, 400);
       }

--- a/apps/web/src/components/account/relativeTime.ts
+++ b/apps/web/src/components/account/relativeTime.ts
@@ -1,6 +1,8 @@
 // Minimal relative-time helper for lifecycle pages. Picks the largest unit
 // that fits and rounds; falls back to a locale date for anything older than
 // ~1 month.
+import { formatDateTime } from '@/lib/dateTimeFormat';
+
 export function formatRelative(input: string | null | undefined): string {
   if (!input) return 'Never';
   const date = new Date(input);
@@ -24,7 +26,7 @@ export function formatAbsolute(input: string | null | undefined): string {
   if (!input) return '—';
   const date = new Date(input);
   if (Number.isNaN(date.getTime())) return '—';
-  return date.toLocaleString(undefined, {
+  return formatDateTime(date, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/components/ai-risk/AiRiskDashboard.tsx
+++ b/apps/web/src/components/ai-risk/AiRiskDashboard.tsx
@@ -6,6 +6,7 @@ import { ToolExecutionAnalytics } from './ToolExecutionAnalytics';
 import { ApprovalHistoryFeed } from './ApprovalHistoryFeed';
 import { RateLimitStatus } from './RateLimitStatus';
 import { RejectionDenialLog } from './RejectionDenialLog';
+import { formatTime } from '@/lib/dateTimeFormat';
 
 type TimeRange = '24h' | '7d' | '30d';
 
@@ -177,7 +178,7 @@ export default function AiRiskDashboard() {
 
           {needsData && lastUpdated && (
             <span className="text-xs text-muted-foreground">
-              Updated {lastUpdated.toLocaleTimeString()}
+              Updated {formatTime(lastUpdated)}
             </span>
           )}
         </div>

--- a/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
+++ b/apps/web/src/components/alerts/CorrelatedAlertGroups.tsx
@@ -23,6 +23,7 @@ import { showToast } from '../shared/Toast';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 import CreateTicketFromAlertDialog from './CreateTicketFromAlertDialog';
 import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 
 type AlertItem = {
   id: string;
@@ -114,12 +115,12 @@ function formatDateTime(value: string | undefined) {
   if (!value) return 'Unknown';
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return 'Unknown';
-  return new Intl.DateTimeFormat(undefined, {
+  return formatUserDateTime(parsed, {
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit'
-  }).format(parsed);
+  });
 }
 
 function evidenceLabel(source: string) {

--- a/apps/web/src/components/alerts/alertConfig.ts
+++ b/apps/web/src/components/alerts/alertConfig.ts
@@ -1,4 +1,5 @@
 import { AlertTriangle } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type AlertStatus = 'active' | 'acknowledged' | 'resolved' | 'suppressed';
@@ -90,5 +91,5 @@ export function formatRelativeTime(dateString: string): string {
 export function formatDateTime(dateString: string): string {
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) return dateString;
-  return date.toLocaleString();
+  return formatUserDateTime(date);
 }

--- a/apps/web/src/components/analytics/AnalyticsPage.tsx
+++ b/apps/web/src/components/analytics/AnalyticsPage.tsx
@@ -7,6 +7,7 @@ import CapacityForecast, { type ForecastPoint, type Thresholds } from './Capacit
 import SLAComplianceCard from './SLAComplianceCard';
 import ExecutiveSummary, { type ExecutiveSummaryProps } from './ExecutiveSummary';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatTime } from '@/lib/dateTimeFormat';
 
 const dashboardOptions = [
   { value: 'operations', label: 'Operations Overview' },
@@ -749,7 +750,7 @@ export default function AnalyticsPage({ timezone }: AnalyticsPageProps) {
           </button>
           {lastUpdated && (
             <span className="text-xs text-muted-foreground">
-              Updated {lastUpdated.toLocaleTimeString([], { timeZone: timezone })}
+              Updated {formatTime(lastUpdated, { timeZone: timezone })}
             </span>
           )}
         </div>

--- a/apps/web/src/components/audit/AuditLogDetail.tsx
+++ b/apps/web/src/components/audit/AuditLogDetail.tsx
@@ -1,4 +1,5 @@
 import { Clock, Globe, Shield, User, X } from 'lucide-react';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type AuditLogEntry = {
   id: string;
@@ -63,7 +64,7 @@ export default function AuditLogDetail({ entry, isOpen, onClose, timezone }: Aud
               <div className="mt-3 space-y-2 text-sm text-muted-foreground">
                 <p>
                   <span className="font-medium text-foreground">Timestamp:</span>{' '}
-                  {new Date(entry.timestamp).toLocaleString([], { timeZone: timezone })}
+                  {formatDateTime(entry.timestamp, { timeZone: timezone })}
                 </p>
                 <p>
                   <span className="font-medium text-foreground">Action:</span> {entry.action}

--- a/apps/web/src/components/audit/AuditLogViewer.tsx
+++ b/apps/web/src/components/audit/AuditLogViewer.tsx
@@ -18,6 +18,7 @@ import AuditLogDetail, { type AuditLogEntry } from './AuditLogDetail';
 import AuditFilters from './AuditFilters';
 import { navigateTo } from '@/lib/navigation';
 import { formatAuditAction, formatAuditDetails } from '@/lib/auditFormat';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type SortKey = 'timestamp' | 'user' | 'action' | 'resource' | 'details' | 'ipAddress';
 
@@ -432,7 +433,7 @@ export default function AuditLogViewer({ timezone }: AuditLogViewerProps) {
                           </button>
                           <div>
                             <p className="font-medium text-foreground">
-                              {new Date(entry.timestamp).toLocaleString([], { timeZone: timezone })}
+                              {formatDateTime(entry.timestamp, { timeZone: timezone })}
                             </p>
                             <p className="text-xs text-muted-foreground">{entry.resourceType}</p>
                           </div>

--- a/apps/web/src/components/audit/UserActivityReport.tsx
+++ b/apps/web/src/components/audit/UserActivityReport.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { formatAuditAction } from '@/lib/auditFormat';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type ActivityEntry = {
   id: string;
@@ -20,7 +21,7 @@ type UserOption = {
   name: string;
 };
 
-const formatTimestamp = (value: string, timezone?: string) => new Date(value).toLocaleString([], { timeZone: timezone });
+const formatTimestamp = (value: string, timezone?: string) => formatDateTime(value, { timeZone: timezone });
 
 interface UserActivityReportProps {
   timezone?: string;

--- a/apps/web/src/components/auditBaselines/BaselineApplyTab.tsx
+++ b/apps/web/src/components/auditBaselines/BaselineApplyTab.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { extractApiError } from '@/lib/apiError';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import type { Baseline } from './BaselineFormModal';
@@ -525,13 +526,13 @@ export default function BaselineApplyTab({ baseline, mode }: Props) {
                   </td>
                   <td className="px-4 py-3 text-right">{deviceCount}</td>
                   <td className="px-4 py-3 text-muted-foreground">
-                    {new Date(approval.createdAt).toLocaleString()}
+                    {formatDateTime(approval.createdAt)}
                   </td>
                   <td className="px-4 py-3 text-muted-foreground">
                     {isExpired && approval.status === 'pending' ? (
                       <span className="text-red-600">Expired</span>
                     ) : (
-                      new Date(approval.expiresAt).toLocaleString()
+                      formatDateTime(approval.expiresAt)
                     )}
                   </td>
                   <td className="px-4 py-3">

--- a/apps/web/src/components/auditBaselines/BaselineOverviewTab.tsx
+++ b/apps/web/src/components/auditBaselines/BaselineOverviewTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Pencil } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import BaselineFormModal, { type Baseline } from './BaselineFormModal';
 
 type Props = {
@@ -66,11 +67,11 @@ export default function BaselineOverviewTab({ baseline, onUpdated }: Props) {
         </div>
         <div className="rounded-lg border bg-card p-4 shadow-sm">
           <p className="text-xs text-muted-foreground">Created</p>
-          <p className="mt-1 text-sm">{new Date(baseline.createdAt).toLocaleString()}</p>
+          <p className="mt-1 text-sm">{formatDateTime(baseline.createdAt)}</p>
         </div>
         <div className="rounded-lg border bg-card p-4 shadow-sm">
           <p className="text-xs text-muted-foreground">Last Updated</p>
-          <p className="mt-1 text-sm">{new Date(baseline.updatedAt).toLocaleString()}</p>
+          <p className="mt-1 text-sm">{formatDateTime(baseline.updatedAt)}</p>
         </div>
       </div>
 

--- a/apps/web/src/components/automations/AutomationRunHistory.tsx
+++ b/apps/web/src/components/automations/AutomationRunHistory.tsx
@@ -13,6 +13,7 @@ import {
   Timer
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type DeviceRunResult = {
   deviceId: string;
@@ -94,7 +95,7 @@ const triggerLabels: Record<string, string> = {
 function formatDate(dateString: string, timezone: string): string {
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) return dateString;
-  return date.toLocaleString([], { timeZone: timezone });
+  return formatDateTime(date, { timeZone: timezone });
 }
 
 function formatDuration(ms: number): string {

--- a/apps/web/src/components/backup/BackupJobList.tsx
+++ b/apps/web/src/components/backup/BackupJobList.tsx
@@ -11,6 +11,7 @@ import {
   XCircle
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type JobStatus = 'completed' | 'running' | 'failed' | 'queued' | 'cancelled';
@@ -127,10 +128,8 @@ function formatDuration(startedAt?: string | null, completedAt?: string | null):
 }
 
 function formatTime(iso?: string | null): string {
-  if (!iso) return '--';
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return '--';
-  return date.toLocaleString([], {
+  return formatDateTime(iso, {
+    fallback: '--',
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/apps/web/src/components/backup/BackupVerificationOverview.tsx
+++ b/apps/web/src/components/backup/BackupVerificationOverview.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, CheckCircle2, Clock, Loader2, ShieldCheck } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { friendlyFetchError } from '../../lib/utils';
 
@@ -65,10 +66,7 @@ function formatMinutes(minutes?: number | null): string {
 }
 
 function formatTime(iso?: string | null): string {
-  if (!iso) return '--';
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return '--';
-  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  return formatUserDateTime(iso, { fallback: '--', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 }
 
 export default function BackupVerificationOverview() {

--- a/apps/web/src/components/backup/BackupVerificationTab.tsx
+++ b/apps/web/src/components/backup/BackupVerificationTab.tsx
@@ -10,6 +10,7 @@ import {
   ShieldCheck,
   XCircle,
 } from 'lucide-react';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { friendlyFetchError } from '../../lib/utils';
 
@@ -349,7 +350,7 @@ export default function BackupVerificationTab({
                         )}
                       </td>
                       <td className="py-2 pr-4 text-muted-foreground">
-                        {new Date(v.startedAt).toLocaleString()}
+                        {formatDateTime(v.startedAt)}
                       </td>
                       <td className="py-2 pr-4">
                         {formatDuration(v.restoreTimeSeconds ?? duration)}

--- a/apps/web/src/components/backup/DeviceBackupTab.tsx
+++ b/apps/web/src/components/backup/DeviceBackupTab.tsx
@@ -10,6 +10,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { friendlyFetchError } from '../../lib/utils';
 import BackupVerificationTab from './BackupVerificationTab';
@@ -93,10 +94,8 @@ function formatBytes(bytes: number | null | undefined): string {
 }
 
 function formatTime(iso: string | null | undefined): string {
-  if (!iso) return '-';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '-';
-  return d.toLocaleString(undefined, {
+  return formatDateTime(iso, {
+    fallback: '-',
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/apps/web/src/components/backup/RestoreWizard.tsx
+++ b/apps/web/src/components/backup/RestoreWizard.tsx
@@ -15,6 +15,7 @@ import {
   XCircle
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import AlphaBadge from '../shared/AlphaBadge';
 
@@ -111,10 +112,7 @@ function formatBytes(bytes?: number | null): string {
 }
 
 function formatTimestamp(value?: string | null): string {
-  if (!value) return '--';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '--';
-  return date.toLocaleString();
+  return formatDateTime(value, { fallback: '--' });
 }
 
 function renderJson(value: unknown): string {

--- a/apps/web/src/components/backup/SnapshotBrowser.tsx
+++ b/apps/web/src/components/backup/SnapshotBrowser.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCw,
 } from 'lucide-react';
 import { cn, marginLeftPxClass } from '@/lib/utils';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type TreeNode = {
@@ -99,10 +100,8 @@ function formatBytes(bytes: number | null | undefined): string {
 }
 
 function formatDateTime(value: string | null | undefined): string {
-  if (!value) return '-';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '-';
-  return date.toLocaleString(undefined, {
+  return formatUserDateTime(value, {
+    fallback: '-',
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/apps/web/src/components/backup/backupDashboardHelpers.ts
+++ b/apps/web/src/components/backup/backupDashboardHelpers.ts
@@ -221,10 +221,7 @@ export function formatBytes(bytes: number): string {
 }
 
 export function formatTime(iso?: string | null): string {
-  if (!iso) return '--';
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return '--';
-  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  return formatDateTime(iso, { fallback: '--', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 }
 
 export function formatDuration(startedAt?: string | null, completedAt?: string | null): string {
@@ -273,3 +270,4 @@ export function buildLinePath(values: number[], maxValue: number): string {
     })
     .join(' ');
 }
+import { formatDateTime } from '@/lib/dateTimeFormat';

--- a/apps/web/src/components/c2c/C2CDashboard.tsx
+++ b/apps/web/src/components/c2c/C2CDashboard.tsx
@@ -14,6 +14,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import C2CConnectionWizard from './C2CConnectionWizard';
 import C2CRestoreDialog from './C2CRestoreDialog';
@@ -108,8 +109,7 @@ function formatBytes(bytes: number | null): string {
 }
 
 function formatDate(d: string | null): string {
-  if (!d) return '-';
-  return new Date(d).toLocaleString();
+  return formatDateTime(d, { fallback: '-' });
 }
 
 export default function C2CDashboard() {

--- a/apps/web/src/components/c2c/C2CRestoreDialog.tsx
+++ b/apps/web/src/components/c2c/C2CRestoreDialog.tsx
@@ -10,6 +10,7 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 
@@ -52,8 +53,7 @@ function formatBytes(bytes: number | null): string {
 }
 
 function formatDate(value: string | null): string {
-  if (!value) return '-';
-  return new Date(value).toLocaleString();
+  return formatDateTime(value, { fallback: '-' });
 }
 
 function formatProvider(provider: string): string {

--- a/apps/web/src/components/clientAi/SessionsTab.tsx
+++ b/apps/web/src/components/clientAi/SessionsTab.tsx
@@ -5,6 +5,7 @@ import { Dialog } from '../shared/Dialog';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { runAction, handleActionError } from '@/lib/runAction';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 /**
  * AI for Office — client-session audit viewer (spec §9.3). excel_client
@@ -88,7 +89,7 @@ interface SessionDetail {
 }
 
 const formatCost = (cents: number) => `$${(cents / 100).toFixed(2)}`;
-const formatTime = (iso: string) => new Date(iso).toLocaleString();
+const formatTime = (iso: string) => formatDateTime(iso);
 
 /** Workbook-context chips (spec §9.3): tool name + range/sheet from toolInput. */
 function workbookChips(m: TranscriptMessage): string[] {

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
@@ -18,6 +18,7 @@ import { useFeatureLink } from './useFeatureLink';
 import FeatureTabShell from './FeatureTabShell';
 import { fetchWithAuth } from '../../../stores/auth';
 import { extractApiError } from '@/lib/apiError';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -373,7 +374,7 @@ function capabilitySummary(config?: BackupConfig | null): string {
     return 'Run Test to verify that the selected bucket has object lock enabled.';
   }
   if (capability.supported) {
-    return `Object lock verified on ${new Date(capability.checkedAt).toLocaleString()}.`;
+    return `Object lock verified on ${formatDateTime(capability.checkedAt)}.`;
   }
   return capability.error ?? 'Object lock is not available for this config.';
 }

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -4,6 +4,7 @@ import { Dialog } from '../shared/Dialog';
 import { showToast } from '../shared/Toast';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fallbackInstallerFilename, filenameFromContentDisposition } from '@/lib/downloadFilename';
 import { buildInstallCommands } from '@/lib/installCommands';
 import { navigateTo } from '@/lib/navigation';
@@ -62,7 +63,7 @@ function formatTokenExpiry(iso: string): string {
   if (diffMinutes < 60) return `in about ${diffMinutes} minute${diffMinutes === 1 ? '' : 's'}`;
   const diffHours = Math.round(diffMinutes / 60);
   if (diffHours < 48) return `in about ${diffHours} hour${diffHours === 1 ? '' : 's'}`;
-  return `on ${new Date(expiresMs).toLocaleString()}`;
+  return `on ${formatDateTime(expiresMs)}`;
 }
 
 interface AddDeviceModalProps {

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -13,6 +13,7 @@ import {
   RotateCcw,
   type LucideIcon,
 } from 'lucide-react';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type ActivityEvent = {
@@ -82,7 +83,7 @@ function absoluteTime(value?: string, timezone?: string): string | undefined {
   if (!value) return undefined;
   const d = new Date(value);
   if (Number.isNaN(d.getTime())) return undefined;
-  return d.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return formatDateTime(d, timezone ? { timeZone: timezone } : undefined);
 }
 
 export default function DeviceActivityFeed({ deviceId, timezone, limit = 8 }: DeviceActivityFeedProps) {

--- a/apps/web/src/components/devices/DeviceAlertHistory.tsx
+++ b/apps/web/src/components/devices/DeviceAlertHistory.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, Calendar } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type AlertItem = {
@@ -34,7 +35,7 @@ const severityStyles: Record<string, string> = {
 function formatDateTime(value?: string, timezone?: string) {
   if (!value) return 'Not reported';
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return Number.isNaN(date.getTime()) ? value : formatUserDateTime(date, timezone ? { timeZone: timezone } : undefined);
 }
 
 export default function DeviceAlertHistory({

--- a/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
+++ b/apps/web/src/components/devices/DeviceAnomaliesPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Activity, AlertTriangle, CheckCircle, ExternalLink, RefreshCw, TrendingUp, XCircle } from 'lucide-react';
 
 import { runAction, handleActionError } from '../../lib/runAction';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { showToast } from '../shared/Toast';
 import RemediationSuggestionsPanel from '../remediation/RemediationSuggestionsPanel';
@@ -118,7 +119,7 @@ function formatMetricValue(metricName: string, value: number): string {
 function formatDate(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], {
+  return formatDateTime(date, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/apps/web/src/components/devices/DeviceBootPerformanceTab.tsx
+++ b/apps/web/src/components/devices/DeviceBootPerformanceTab.tsx
@@ -21,6 +21,7 @@ import {
   Legend,
   ResponsiveContainer
 } from 'recharts';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatBytes, friendlyFetchError } from '../../lib/utils';
 
@@ -78,7 +79,7 @@ function formatTimestampShort(value: string): string {
 function formatTimestampFull(value: string, timezone?: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return formatDateTime(date, timezone ? { timeZone: timezone } : undefined);
 }
 
 function getImpactBadgeClass(score: number | null): string {

--- a/apps/web/src/components/devices/DeviceCompare.tsx
+++ b/apps/web/src/components/devices/DeviceCompare.tsx
@@ -19,6 +19,7 @@ import {
   ResponsiveContainer,
   Legend
 } from 'recharts';
+import { formatDateTime as formatUserDateTime, formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 import type { Device, DeviceStatus, OSType } from './DeviceList';
 
 type SoftwareItem = {
@@ -136,20 +137,20 @@ function formatTimestamp(timestamp: string, range: TimeRange, timezone?: string)
   const tzOptions = timezone ? { timeZone: timezone } : undefined;
   switch (range) {
     case '1h':
-      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', ...tzOptions });
+      return formatUserTime(date, { hour: '2-digit', minute: '2-digit', ...tzOptions });
     case '6h':
-      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', ...tzOptions });
+      return formatUserTime(date, { hour: '2-digit', minute: '2-digit', ...tzOptions });
     case '24h':
-      return date.toLocaleDateString([], { weekday: 'short', hour: '2-digit', ...tzOptions });
+      return formatUserDateTime(date, { weekday: 'short', hour: '2-digit', ...tzOptions });
     default:
-      return date.toLocaleTimeString([], tzOptions);
+      return formatUserTime(date, tzOptions);
   }
 }
 
 function formatDateTime(value: string, timezone?: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return formatUserDateTime(date, timezone ? { timeZone: timezone } : undefined);
 }
 
 function createSeededRandom(seed: number) {

--- a/apps/web/src/components/devices/DeviceEventLogViewer.tsx
+++ b/apps/web/src/components/devices/DeviceEventLogViewer.tsx
@@ -22,6 +22,7 @@ import {
   Activity,
   Bot,
 } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type ActivityEntry = {
@@ -101,7 +102,7 @@ function formatDateTime(value?: string | null, timezone?: string) {
   if (!value) return null;
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], {
+  return formatUserDateTime(date, {
     ...(timezone ? { timeZone: timezone } : {}),
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/components/devices/DeviceFilesystemTab.tsx
+++ b/apps/web/src/components/devices/DeviceFilesystemTab.tsx
@@ -8,6 +8,7 @@ import {
   Clock,
   FolderOpen
 } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import type { OSType } from './DeviceList';
 
@@ -168,7 +169,7 @@ function formatDateTime(value: string | undefined): string {
   if (!value) return '-';
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString([], {
+  return formatUserDateTime(parsed, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/components/devices/DeviceInfoTab.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.tsx
@@ -5,6 +5,7 @@ import MacOSPermissionsCard from './MacOSPermissionsCard';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatUptime } from '../../lib/utils';
 import { runAction, ActionError } from '../../lib/runAction';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import {
   DEVICE_ROLES,
   getDeviceRoleLabel,
@@ -80,9 +81,7 @@ function formatDisk(valueGb: number | null | undefined): string {
 
 function formatDate(dateString: string | null | undefined): string {
   if (!dateString) return '—';
-  const date = new Date(dateString);
-  if (Number.isNaN(date.getTime())) return dateString;
-  return date.toLocaleString([], {
+  return formatDateTime(dateString, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/components/devices/DeviceIpHistoryTab.tsx
+++ b/apps/web/src/components/devices/DeviceIpHistoryTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, Clock3, Network, RefreshCw, Search, X } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type IPAssignmentType = 'dhcp' | 'static' | 'vpn' | 'link-local' | 'unknown';
@@ -39,7 +40,7 @@ function formatDateTime(value?: string | null): string {
   if (!value) return '—';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], {
+  return formatUserDateTime(date, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/components/devices/DeviceLogsTab.tsx
+++ b/apps/web/src/components/devices/DeviceLogsTab.tsx
@@ -9,6 +9,7 @@ import {
   ShieldAlert,
   XCircle,
 } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type LogLevel = 'info' | 'warning' | 'error' | 'critical';
@@ -68,7 +69,7 @@ const categoryConfig: Record<LogCategory, { label: string; color: string }> = {
 function formatDateTime(value: string, timezone?: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return formatUserDateTime(date, timezone ? { timeZone: timezone } : undefined);
 }
 
 const osSourcePresets: Record<OSType, { label: string; value: string }[]> = {

--- a/apps/web/src/components/devices/DeviceManagementTab.tsx
+++ b/apps/web/src/components/devices/DeviceManagementTab.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 
 import { friendlyFetchError } from '../../lib/utils';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -118,7 +119,7 @@ const STATUS_BADGE: Record<DetectionStatus, string> = {
 function formatDateTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], {
+  return formatUserDateTime(date, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/components/devices/DeviceMetricsChart.tsx
+++ b/apps/web/src/components/devices/DeviceMetricsChart.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
   Legend
 } from 'recharts';
+import { formatDate, formatDateTime, formatTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 
@@ -27,20 +28,18 @@ type MetricDataPoint = {
 };
 
 function formatTimestamp(timestamp: string, range: TimeRange): string {
-  const date = new Date(timestamp);
-
   switch (range) {
     case '1h':
     case '6h':
-      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      return formatTime(timestamp, { hour: '2-digit', minute: '2-digit' });
     case '24h':
-      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      return formatTime(timestamp, { hour: '2-digit', minute: '2-digit' });
     case '7d':
-      return date.toLocaleDateString([], { weekday: 'short', hour: '2-digit' });
+      return formatDateTime(timestamp, { weekday: 'short', hour: '2-digit' });
     case '30d':
-      return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+      return formatDate(timestamp, { month: 'short', day: 'numeric' });
     default:
-      return date.toLocaleTimeString();
+      return formatTime(timestamp);
   }
 }
 
@@ -163,7 +162,7 @@ export default function DeviceMetricsChart({ compact = false, deviceId }: Device
               />
               <Tooltip
                 wrapperClassName="chart-tooltip"
-                labelFormatter={(value) => new Date(value).toLocaleString()}
+                labelFormatter={(value) => formatDateTime(String(value))}
               />
               <Line
                 type="monotone"
@@ -268,7 +267,7 @@ export default function DeviceMetricsChart({ compact = false, deviceId }: Device
             />
             <Tooltip
               wrapperClassName="chart-tooltip"
-              labelFormatter={(value) => new Date(value).toLocaleString()}
+              labelFormatter={(value) => formatDateTime(String(value))}
               formatter={(value: number, name: string) => [`${value}%`, name]}
             />
             <Legend />

--- a/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
+++ b/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveContainer,
   Legend
 } from 'recharts';
+import { formatDate, formatDateTime, formatTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import ProcessDrilldownPanel from './ProcessDrilldownPanel';
 
@@ -66,12 +67,12 @@ function formatTimestamp(value: string, range: TimeRange) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   if (range === '24h') {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return formatTime(date, { hour: '2-digit', minute: '2-digit' });
   }
   if (range === '7d') {
-    return date.toLocaleDateString([], { weekday: 'short', hour: '2-digit' });
+    return formatDateTime(date, { weekday: 'short', hour: '2-digit' });
   }
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  return formatDate(date, { month: 'short', day: 'numeric' });
 }
 
 export default function DevicePerformanceGraphs({ deviceId, compact = false }: DevicePerformanceGraphsProps) {
@@ -240,7 +241,7 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
             />
             <Tooltip
               wrapperClassName="chart-tooltip"
-              labelFormatter={(value) => new Date(value).toLocaleString()}
+              labelFormatter={(value) => formatDateTime(String(value))}
               formatter={(value: number, name: string) => [`${value}%`, name]}
             />
             {!compact && <Legend />}
@@ -304,7 +305,7 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
                 />
                 <Tooltip
                   wrapperClassName="chart-tooltip"
-                  labelFormatter={(value) => new Date(value).toLocaleString()}
+                  labelFormatter={(value) => formatDateTime(String(value))}
                   formatter={(value: number, name: string) => [formatBandwidth(value), name]}
                 />
                 {!compact && <Legend />}
@@ -385,7 +386,7 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
                 />
                 <Tooltip
                   wrapperClassName="chart-tooltip"
-                  labelFormatter={(value) => new Date(value).toLocaleString()}
+                  labelFormatter={(value) => formatDateTime(String(value))}
                   formatter={(value: number, name: string) => [formatBytesPerSec(value), name]}
                 />
                 {!compact && <Legend />}

--- a/apps/web/src/components/devices/DevicePeripheralsTab.tsx
+++ b/apps/web/src/components/devices/DevicePeripheralsTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Usb, ShieldAlert, Activity, Shield } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type PeripheralEvent = {
@@ -45,7 +46,7 @@ const actionBadge: Record<string, string> = {
 function formatDateTime(value?: string, timezone?: string) {
   if (!value) return '—';
   const d = new Date(value);
-  return Number.isNaN(d.getTime()) ? value : d.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return Number.isNaN(d.getTime()) ? value : formatUserDateTime(d, timezone ? { timeZone: timezone } : undefined);
 }
 
 export default function DevicePeripheralsTab({ deviceId, timezone }: DevicePeripheralsTabProps) {

--- a/apps/web/src/components/devices/DevicePlaybookHistory.tsx
+++ b/apps/web/src/components/devices/DevicePlaybookHistory.tsx
@@ -12,6 +12,7 @@ import {
   Undo2,
   Ban,
 } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type PlaybookStepResult = {
@@ -86,7 +87,7 @@ function formatDateTime(value?: string, timezone?: string) {
   const date = new Date(value);
   return Number.isNaN(date.getTime())
     ? value
-    : date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+    : formatUserDateTime(date, timezone ? { timeZone: timezone } : undefined);
 }
 
 function formatDurationMs(ms?: number) {

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, CheckCircle, RefreshCw, ShieldCheck, Wrench, XCircle } from 'lucide-react';
 
 import { runAction, handleActionError } from '../../lib/runAction';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 
@@ -66,7 +67,7 @@ function scoreBarClass(score: number): string {
 function formatDate(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  return formatDateTime(date, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 }
 
 function formatEvidenceKey(value: string): string {

--- a/apps/web/src/components/devices/DeviceScriptHistory.tsx
+++ b/apps/web/src/components/devices/DeviceScriptHistory.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Terminal, RefreshCw, Eye, X, ChevronDown, ChevronUp, Copy, Check, CheckCircle, XCircle, Loader2, AlertTriangle, Clock, AlertOctagon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 type ScriptExecution = {
@@ -48,7 +49,7 @@ const statusConfig: Record<string, { label: string; color: string; bgColor: stri
 function formatDateTime(value?: string, timezone?: string) {
   if (!value) return 'Not reported';
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return Number.isNaN(date.getTime()) ? value : formatUserDateTime(date, timezone ? { timeZone: timezone } : undefined);
 }
 
 function formatDuration(ms?: number, seconds?: number) {

--- a/apps/web/src/components/devices/DeviceSecurityTab.tsx
+++ b/apps/web/src/components/devices/DeviceSecurityTab.tsx
@@ -12,6 +12,7 @@ import {
 
 import { ENABLE_ENDPOINT_AV_FEATURES } from '../../lib/featureFlags';
 import { friendlyFetchError } from '../../lib/utils';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import DeviceSecurityStatus from '../security/DeviceSecurityStatus';
 
@@ -66,7 +67,7 @@ function formatDateTime(value: string | null, timezone?: string): string {
   if (!value) return '-';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '-';
-  return date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return formatUserDateTime(date, timezone ? { timeZone: timezone } : undefined);
 }
 
 function compactPath(value: string): string {

--- a/apps/web/src/components/devices/DeviceUserIdleStat.tsx
+++ b/apps/web/src/components/devices/DeviceUserIdleStat.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Timer } from 'lucide-react';
+import { formatTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 
 export type ActiveSession = {
@@ -49,7 +50,7 @@ function tooltip(sessions: ActiveSession[]): string | undefined {
   if (updatedAt) {
     const d = new Date(updatedAt);
     if (!isNaN(d.getTime())) {
-      lines.push(`As of ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`);
+      lines.push(`As of ${formatTime(d, { hour: '2-digit', minute: '2-digit' })}`);
     }
   }
   return lines.join('\n');

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { Dialog } from '../shared/Dialog';
 
@@ -92,7 +93,7 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
           {live
             ? 'Live (now)'
             : sampleTime
-              ? `Nearest sample: ${new Date(sampleTime).toLocaleString()}`
+              ? `Nearest sample: ${formatDateTime(sampleTime)}`
               : 'No sample near this time'}
         </p>
 

--- a/apps/web/src/components/discovery/AssetDetailModal.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.tsx
@@ -5,6 +5,7 @@ import { typeConfig, approvalStatusConfig } from './DiscoveredAssetList';
 import AssetMonitoringSection from './AssetMonitoringSection';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { buildRemoteProxyPageUrl } from '@/lib/remoteTunnelUrls';
 
 export type AssetDetail = DiscoveredAsset & {
@@ -238,7 +239,7 @@ export default function AssetDetailModal({
             <p className="mt-1 text-sm text-muted-foreground">
               {asset.ip}{asset.mac !== '—' && <> • {asset.mac}</>}
               {asset.manufacturer !== '—' && <> • {asset.manufacturer}</>}
-              {asset.lastSeen && <> • Last seen {new Date(asset.lastSeen).toLocaleString()}</>}
+              {asset.lastSeen && <> • Last seen {formatDateTime(asset.lastSeen)}</>}
             </p>
           </div>
           <button

--- a/apps/web/src/components/discovery/AssetMonitoringSection.tsx
+++ b/apps/web/src/components/discovery/AssetMonitoringSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import EnableMonitoringForm from './EnableMonitoringForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type MonitoringStatus = {
   enabled: boolean;
@@ -187,7 +188,7 @@ export default function AssetMonitoringSection({ assetId, ipAddress, open }: Ass
               <p className="text-xs font-medium">SNMP Device Monitor</p>
               <p className="mt-1 text-xs text-muted-foreground">
                 {snmpDevice.snmpVersion} &middot; every {snmpDevice.pollingInterval}s
-                {snmpDevice.lastPolled ? ` • last polled ${new Date(snmpDevice.lastPolled).toLocaleString()}` : ''}
+                {snmpDevice.lastPolled ? ` • last polled ${formatDateTime(snmpDevice.lastPolled)}` : ''}
               </p>
             </div>
           )}

--- a/apps/web/src/components/discovery/DiscoveredAssetList.tsx
+++ b/apps/web/src/components/discovery/DiscoveredAssetList.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Filter, Info, Signal, CheckCircle2, XCircle } from 'lucide-react';
 import AssetDetailModal, { type AssetDetail } from './AssetDetailModal';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type DiscoveredAssetApprovalStatus = 'pending' | 'approved' | 'dismissed';
 export type DiscoveredAssetType =
@@ -116,7 +117,7 @@ function formatLastSeen(value?: string, timezone?: string) {
   if (!value) return '—';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { timeZone: timezone });
+  return formatDateTime(date, { timeZone: timezone });
 }
 
 function formatPing(ms?: number | null) {

--- a/apps/web/src/components/discovery/DiscoveryJobList.tsx
+++ b/apps/web/src/components/discovery/DiscoveryJobList.tsx
@@ -3,6 +3,7 @@ import { CheckCircle, Clock, AlertTriangle, PlayCircle, X, ArrowRight, CalendarC
 import { fetchWithAuth } from '../../stores/auth';
 import { widthPercentClass } from '@/lib/utils';
 import { extractApiError } from '@/lib/apiError';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type DiscoveryJobStatus = 'scheduled' | 'running' | 'completed' | 'failed' | 'cancelled' | 'pending';
 
@@ -65,7 +66,7 @@ function formatTimestamp(value?: string, timezone?: string) {
   if (!value) return '—';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { timeZone: timezone });
+  return formatDateTime(date, { timeZone: timezone });
 }
 
 function formatDuration(startedAt?: string | null, completedAt?: string | null): string | null {

--- a/apps/web/src/components/discovery/networkTypes.ts
+++ b/apps/web/src/components/discovery/networkTypes.ts
@@ -4,6 +4,7 @@ import {
   type NetworkBaselineScanSchedule,
   type NetworkBaselineAlertSettings
 } from '@breeze/shared';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 
 export { NETWORK_EVENT_TYPES };
 export type { NetworkEventType, NetworkBaselineScanSchedule, NetworkBaselineAlertSettings };
@@ -192,6 +193,5 @@ export function formatDateTime(value: string | null | undefined, timezone?: stri
   if (!value) return '—';
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+  return formatUserDateTime(parsed, timezone ? { timeZone: timezone } : undefined);
 }
-

--- a/apps/web/src/components/dnsSecurity/DnsSecurityEventsTab.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityEventsTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { ScrollText, RefreshCw } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Action = 'allowed' | 'blocked' | 'redirected';
 
@@ -139,7 +140,7 @@ export default function DnsSecurityEventsTab() {
               {events.map((e) => (
                 <tr key={e.id} className="border-b last:border-b-0 hover:bg-muted/20">
                   <td className="px-3 py-1.5 whitespace-nowrap text-xs text-muted-foreground">
-                    {new Date(e.timestamp).toLocaleString()}
+                    {formatDateTime(e.timestamp)}
                   </td>
                   <td className="px-3 py-1.5">
                     {e.deviceHostname ?? e.sourceHostname ?? e.sourceIp ?? <span className="text-muted-foreground italic">unknown</span>}

--- a/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.tsx
@@ -4,6 +4,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import AddDnsIntegrationModal from './AddDnsIntegrationModal';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Provider =
   | 'umbrella'
@@ -168,7 +169,7 @@ export default function DnsSecurityIntegrationsTab() {
                   <td className="px-4 py-2">
                     {it.lastSync ? (
                       <span className={it.lastSyncStatus === 'error' ? 'text-destructive' : ''}>
-                        {new Date(it.lastSync).toLocaleString()}
+                        {formatDateTime(it.lastSync)}
                         {it.lastSyncStatus === 'error' && ' — failed'}
                       </span>
                     ) : (

--- a/apps/web/src/components/dr/DRDashboard.tsx
+++ b/apps/web/src/components/dr/DRDashboard.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import DRExecutionView from './DRExecutionView';
@@ -43,8 +44,7 @@ type DRExecution = {
 };
 
 function formatDate(value: string | null): string {
-  if (!value) return '-';
-  return new Date(value).toLocaleString();
+  return formatDateTime(value, { fallback: '-' });
 }
 
 function formatDuration(startedAt: string | null, completedAt: string | null): string {

--- a/apps/web/src/components/dr/DRExecutionView.tsx
+++ b/apps/web/src/components/dr/DRExecutionView.tsx
@@ -9,6 +9,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { Dialog } from '../shared/Dialog';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { fetchWithAuth } from '../../stores/auth';
@@ -52,8 +53,7 @@ type GroupFailure = {
 };
 
 function formatDate(value: string | null): string {
-  if (!value) return '-';
-  return new Date(value).toLocaleString();
+  return formatDateTime(value, { fallback: '-' });
 }
 
 function formatDuration(startedAt: string | null, completedAt: string | null): string {

--- a/apps/web/src/components/incidents/IncidentDetailPage.tsx
+++ b/apps/web/src/components/incidents/IncidentDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type IncidentSeverity = 'p1' | 'p2' | 'p3' | 'p4';
 type IncidentStatus = 'detected' | 'analyzing' | 'contained' | 'recovering' | 'closed';
@@ -199,7 +200,7 @@ export default function IncidentDetailPage({ incidentId }: IncidentDetailProps) 
             <div key={d.label} className="rounded-lg border bg-card p-3">
               <p className="text-xs font-medium text-muted-foreground">{d.label}</p>
               <p className="text-sm font-medium text-foreground mt-0.5">
-                {new Date(d.value!).toLocaleString()}
+                {formatDateTime(d.value)}
               </p>
             </div>
           ))}
@@ -261,7 +262,7 @@ function TimelineView({ entries }: { entries: TimelineEntry[] }) {
               <p className="text-sm text-foreground">{entry.summary}</p>
               <div className="flex items-center gap-2 mt-1">
                 <span className="text-xs text-muted-foreground">
-                  {new Date(entry.at).toLocaleString()}
+                  {formatDateTime(entry.at)}
                 </span>
                 {entry.actor && (
                   <>
@@ -318,7 +319,7 @@ function ActionsView({ entries }: { entries: ActionEntry[] }) {
                 {action.executedBy ?? '-'}
               </td>
               <td className="px-4 py-3 text-muted-foreground">
-                {new Date(action.executedAt).toLocaleString()}
+                {formatDateTime(action.executedAt)}
               </td>
             </tr>
           ))}
@@ -361,7 +362,7 @@ function EvidenceView({ entries }: { entries: EvidenceEntry[] }) {
                 {ev.collectedBy ?? '-'}
               </td>
               <td className="px-4 py-3 text-muted-foreground">
-                {new Date(ev.collectedAt).toLocaleString()}
+                {formatDateTime(ev.collectedAt)}
               </td>
               <td className="px-4 py-3 text-muted-foreground font-mono text-xs">
                 {ev.hash ? ev.hash.substring(0, 12) + '...' : '-'}

--- a/apps/web/src/components/incidents/IncidentsPage.tsx
+++ b/apps/web/src/components/incidents/IncidentsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type IncidentSeverity = 'p1' | 'p2' | 'p3' | 'p4';
 type IncidentStatus = 'detected' | 'analyzing' | 'contained' | 'recovering' | 'closed';
@@ -202,7 +203,7 @@ export default function IncidentsPage() {
                       {incident.classification ?? '-'}
                     </td>
                     <td className="px-4 py-3 text-muted-foreground">
-                      {new Date(incident.detectedAt).toLocaleString()}
+                      {formatDateTime(incident.detectedAt)}
                     </td>
                   </tr>
                 ))}

--- a/apps/web/src/components/integrations/GoogleWorkspaceIntegration.tsx
+++ b/apps/web/src/components/integrations/GoogleWorkspaceIntegration.tsx
@@ -10,6 +10,7 @@ import {
   Users
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Connection = {
   connected: boolean;
@@ -351,7 +352,7 @@ export default function GoogleWorkspaceIntegration() {
             <div className="flex justify-between text-muted-foreground">
               <span>Last verified</span>
               <span className="text-foreground">
-                {connection?.lastVerifiedAt ? new Date(connection.lastVerifiedAt).toLocaleString() : 'Never'}
+                {connection?.lastVerifiedAt ? formatDateTime(connection.lastVerifiedAt) : 'Never'}
               </span>
             </div>
           </div>

--- a/apps/web/src/components/integrations/HuntressIntegration.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { type Organization, useOrgStore } from '../../stores/orgStore';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Integration = {
   id: string;
@@ -470,7 +471,7 @@ export default function HuntressIntegration() {
             <div className="mt-4 space-y-2 text-sm">
               <div className="flex justify-between text-muted-foreground">
                 <span>Last sync</span>
-                <span className="text-foreground">{integration.lastSyncAt ? new Date(integration.lastSyncAt).toLocaleString() : 'Never'}</span>
+                <span className="text-foreground">{integration.lastSyncAt ? formatDateTime(integration.lastSyncAt) : 'Never'}</span>
               </div>
               {integration.lastSyncError && (
                 <div className="rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700">{integration.lastSyncError}</div>
@@ -591,7 +592,7 @@ export default function HuntressIntegration() {
                 <div>
                   <div className="font-medium">{incident.title}</div>
                   <div className="text-xs text-muted-foreground">
-                    {incident.reportedAt ? new Date(incident.reportedAt).toLocaleString() : 'Unknown time'} - {incident.status}
+                    {incident.reportedAt ? formatDateTime(incident.reportedAt) : 'Unknown time'} - {incident.status}
                   </div>
                 </div>
                 <SeverityBadge severity={incident.severity} />

--- a/apps/web/src/components/integrations/M365Integration.tsx
+++ b/apps/web/src/components/integrations/M365Integration.tsx
@@ -10,6 +10,7 @@ import {
   Building2
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Connection = {
   connected: boolean;
@@ -342,7 +343,7 @@ export default function M365Integration() {
             <div className="flex justify-between text-muted-foreground">
               <span>Last verified</span>
               <span className="text-foreground">
-                {connection?.lastVerifiedAt ? new Date(connection.lastVerifiedAt).toLocaleString() : 'Never'}
+                {connection?.lastVerifiedAt ? formatDateTime(connection.lastVerifiedAt) : 'Never'}
               </span>
             </div>
           </div>

--- a/apps/web/src/components/integrations/Pax8Integration.tsx
+++ b/apps/web/src/components/integrations/Pax8Integration.tsx
@@ -15,6 +15,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext, getJwtClaims } from '../../lib/authScope';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 // ── Types mirrored from apps/api/src/routes/pax8.ts ────────────────────────
 interface Pax8Integration {
@@ -487,7 +488,7 @@ export default function Pax8Integration() {
             <div className="flex justify-between text-muted-foreground">
               <span>Last sync</span>
               <span className="text-foreground">
-                {integration?.lastSyncAt ? new Date(integration.lastSyncAt).toLocaleString() : 'Never'}
+                {integration?.lastSyncAt ? formatDateTime(integration.lastSyncAt) : 'Never'}
               </span>
             </div>
             <div className="flex justify-between text-muted-foreground">

--- a/apps/web/src/components/integrations/SecurityIntegration.tsx
+++ b/apps/web/src/components/integrations/SecurityIntegration.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Integration = {
   id: string;
@@ -406,7 +407,7 @@ export default function SecurityIntegration() {
                 <span>Last sync</span>
                 <span className="text-foreground">
                   {integration.lastSyncAt
-                    ? new Date(integration.lastSyncAt).toLocaleString()
+                    ? formatDateTime(integration.lastSyncAt)
                     : 'Never'}
                 </span>
               </div>

--- a/apps/web/src/components/integrations/WebhookTestPanel.tsx
+++ b/apps/web/src/components/integrations/WebhookTestPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Send } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { extractApiError } from '@/lib/apiError';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type TestHistoryItem = {
   id: string;
@@ -91,7 +92,7 @@ export default function WebhookTestPanel({ webhookId, timezone }: WebhookTestPan
           id: delivery.id,
           event: delivery.event || 'unknown',
           status: delivery.statusCode || 0,
-          timestamp: delivery.createdAt ? new Date(delivery.createdAt).toLocaleString([], { timeZone: timezone }) : 'Unknown'
+          timestamp: delivery.createdAt ? formatDateTime(delivery.createdAt, { timeZone: timezone }) : 'Unknown'
         }))
       );
     } catch (err) {

--- a/apps/web/src/components/logs/LogSearch.tsx
+++ b/apps/web/src/components/logs/LogSearch.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Download, Save, Search } from 'lucide-react';
 
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type EventLogRow = {
   log: {
@@ -353,7 +354,7 @@ export default function LogSearch() {
               {results.map((row) => (
                 <tr key={row.log.id} className="border-t align-top">
                   <td className="whitespace-nowrap px-3 py-2 text-xs text-muted-foreground">
-                    {new Date(row.log.timestamp).toLocaleString()}
+                    {formatDateTime(row.log.timestamp)}
                   </td>
                   <td className="px-3 py-2">
                     <span className="rounded px-2 py-0.5 text-xs font-medium capitalize bg-muted">

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Download, ScrollText } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import {
   type ElevationFlowType,
   type ElevationRequest,
@@ -319,7 +320,7 @@ export default function PamAuditTab({ liveTick }: { liveTick: number }) {
                 return (
                 <tr key={r.id} className="border-b last:border-0" data-testid={`pam-audit-row-${r.id}`}>
                   <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
-                    {new Date(r.requestedAt).toLocaleString()}
+                    {formatDateTime(r.requestedAt)}
                   </td>
                   <td className="px-3 py-2">{r.deviceHostname ?? r.deviceId}</td>
                   <td className="px-3 py-2">{r.subjectUsername}</td>

--- a/apps/web/src/components/pam/PamRequestsTab.tsx
+++ b/apps/web/src/components/pam/PamRequestsTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Inbox } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import PamRespondModal from './PamRespondModal';
 import PamRevokeModal from './PamRevokeModal';
 import PamRuleModal from './PamRuleModal';
@@ -183,7 +184,7 @@ export default function PamRequestsTab({ liveTick }: { liveTick: number }) {
                 return (
                   <tr key={r.id} className="border-b align-top last:border-0" data-testid={`pam-request-row-${r.id}`}>
                     <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
-                      {new Date(r.requestedAt).toLocaleString()}
+                      {formatDateTime(r.requestedAt)}
                     </td>
                     <td className="px-3 py-2">{r.deviceHostname ?? r.deviceId}</td>
                     <td className="px-3 py-2">{r.subjectUsername}</td>

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -3,6 +3,7 @@ import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import {
   type ElevationStatus,
   type PamRule,
@@ -699,7 +700,7 @@ export default function PamRuleModal({
               <ul className="space-y-1">
                 {preview.sample.slice(0, 5).map((s) => (
                   <li key={s.id} className="truncate text-xs text-muted-foreground">
-                    {new Date(s.requestedAt).toLocaleString()} · {s.subjectUsername} ·{' '}
+                    {formatDateTime(s.requestedAt)} · {s.subjectUsername} ·{' '}
                     {s.targetExecutablePath ?? s.toolName ?? '—'}
                   </li>
                 ))}

--- a/apps/web/src/components/peripherals/PeripheralActivityLog.tsx
+++ b/apps/web/src/components/peripherals/PeripheralActivityLog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 
 type PeripheralEvent = {
   id: string;
@@ -31,7 +32,7 @@ type PeripheralActivityLogProps = {
 function formatDateTime(value?: string) {
   if (!value) return '—';
   const d = new Date(value);
-  return Number.isNaN(d.getTime()) ? value : d.toLocaleString();
+  return Number.isNaN(d.getTime()) ? value : formatUserDateTime(d);
 }
 
 export default function PeripheralActivityLog({ deviceId, limit: propLimit }: PeripheralActivityLogProps) {

--- a/apps/web/src/components/portal/AssetHistory.tsx
+++ b/apps/web/src/components/portal/AssetHistory.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type AssetHistoryEntry = {
   id: string;
@@ -31,7 +32,7 @@ export default function AssetHistory({ entries, timezone }: AssetHistoryProps) {
             <div>
               <div className="text-sm font-medium text-foreground">{entry.user}</div>
               <div className="text-xs text-muted-foreground">
-                {new Date(entry.date).toLocaleString([], { timeZone: timezone })}
+                {formatDateTime(entry.date, { timeZone: timezone })}
               </div>
             </div>
             <div className="flex items-center gap-3 text-xs">

--- a/apps/web/src/components/remote/EventViewer.tsx
+++ b/apps/web/src/components/remote/EventViewer.tsx
@@ -20,6 +20,7 @@ import {
   ExternalLink
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 
 // Platform type
 export type Platform = 'windows' | 'macos' | 'linux';
@@ -155,7 +156,7 @@ function formatDateTime(dateString?: string): string {
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) return dateString;
   
-  return date.toLocaleString(undefined, {
+  return formatUserDateTime(date, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/apps/web/src/components/remote/RemoteDeviceLauncherPage.tsx
+++ b/apps/web/src/components/remote/RemoteDeviceLauncherPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, Loader2, Monitor, RefreshCcw, Search } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type LauncherMode = 'terminal' | 'files';
 
@@ -78,9 +79,7 @@ function formatOs(osType?: string): string {
 
 function formatLastSeen(value?: string): string {
   if (!value) return '-';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '-';
-  return date.toLocaleString();
+  return formatDateTime(value, { fallback: '-' });
 }
 
 export default function RemoteDeviceLauncherPage({ mode }: RemoteDeviceLauncherPageProps) {

--- a/apps/web/src/components/remote/ScheduledTasks.tsx
+++ b/apps/web/src/components/remote/ScheduledTasks.tsx
@@ -24,6 +24,7 @@ import {
   Filter
 } from 'lucide-react';
 import { cn, paddingLeftPxClass } from '@/lib/utils';
+import { formatDateTime as formatUserDateTime, formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 
 // Types
 export type TaskStatus = 'ready' | 'running' | 'disabled' | 'queued' | 'unknown';
@@ -187,7 +188,7 @@ function formatDateTime(dateString?: string): string {
   const isToday = date.toDateString() === now.toDateString();
 
   if (isToday) {
-    return 'Today ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return 'Today ' + formatUserTime(date, { hour: '2-digit', minute: '2-digit' });
   }
 
   const tomorrow = new Date(now);
@@ -195,10 +196,10 @@ function formatDateTime(dateString?: string): string {
   const isTomorrow = date.toDateString() === tomorrow.toDateString();
 
   if (isTomorrow) {
-    return 'Tomorrow ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return 'Tomorrow ' + formatUserTime(date, { hour: '2-digit', minute: '2-digit' });
   }
 
-  return date.toLocaleDateString([], {
+  return formatUserDateTime(date, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/apps/web/src/components/remote/SessionHistory.tsx
+++ b/apps/web/src/components/remote/SessionHistory.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '@/stores/auth';
+import { formatDateTime as formatUserDateTime, formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 
 const DATE_LOCALE = 'en-US';
 const DATE_TIME_ZONE = 'UTC';
@@ -115,7 +116,8 @@ function formatDateTime(dateString?: string): string {
   const isToday = isSameUtcDate(date, now);
 
   if (isToday) {
-    return `Today ${date.toLocaleTimeString(DATE_LOCALE, {
+    return `Today ${formatUserTime(date, {
+      locale: DATE_LOCALE,
       hour: '2-digit',
       minute: '2-digit',
       timeZone: DATE_TIME_ZONE
@@ -127,14 +129,16 @@ function formatDateTime(dateString?: string): string {
   const isYesterday = isSameUtcDate(date, yesterday);
 
   if (isYesterday) {
-    return `Yesterday ${date.toLocaleTimeString(DATE_LOCALE, {
+    return `Yesterday ${formatUserTime(date, {
+      locale: DATE_LOCALE,
       hour: '2-digit',
       minute: '2-digit',
       timeZone: DATE_TIME_ZONE
     })}`;
   }
 
-  return date.toLocaleString(DATE_LOCALE, {
+  return formatUserDateTime(date, {
+    locale: DATE_LOCALE,
     month: 'short',
     day: 'numeric',
     year: date.getUTCFullYear() !== now.getUTCFullYear() ? 'numeric' : undefined,

--- a/apps/web/src/components/remote/SessionHistoryPage.tsx
+++ b/apps/web/src/components/remote/SessionHistoryPage.tsx
@@ -4,6 +4,7 @@ import SessionHistory, { normalizeRemoteSession, type RemoteSession, type Remote
 import { fetchWithAuth } from '@/stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { getSafeHttpHref } from '@/lib/safeHref';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 
 type SessionHistoryPageProps = {
   limit?: number;
@@ -83,7 +84,7 @@ export default function SessionHistoryPage({ limit }: SessionHistoryPageProps) {
 
   const formatDateTime = (dateString?: string) => {
     if (!dateString) return '-';
-    return new Date(dateString).toLocaleString();
+    return formatUserDateTime(dateString);
   };
 
   const formatDuration = (seconds?: number) => {

--- a/apps/web/src/components/reports/DashboardWidgets.tsx
+++ b/apps/web/src/components/reports/DashboardWidgets.tsx
@@ -17,6 +17,7 @@ import {
 import { cn, widthPercentClass } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import AccessDenied from '../shared/AccessDenied';
+import { formatTime } from '@/lib/dateTimeFormat';
 
 type DeviceStatusData = {
   total: number;
@@ -527,7 +528,7 @@ export default function DashboardWidgets({
 
       {/* Last Updated */}
       <div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
-        <span>Last updated: {lastUpdated.toLocaleTimeString([], { timeZone: effectiveTimezone })}</span>
+        <span>Last updated: {formatTime(lastUpdated, { timeZone: effectiveTimezone })}</span>
         <button
           type="button"
           onClick={fetchData}

--- a/apps/web/src/components/reports/ReportPreview.tsx
+++ b/apps/web/src/components/reports/ReportPreview.tsx
@@ -10,6 +10,7 @@ import {
   FileText
 } from 'lucide-react';
 import { cn, widthPercentClass } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import type { ReportType } from './ReportsList';
 
 type PreviewMode = 'table' | 'chart';
@@ -103,9 +104,9 @@ export default function ReportPreview({
   const formatCellValue = (value: unknown): string => {
     if (value === null || value === undefined) return '-';
     if (typeof value === 'boolean') return value ? 'Yes' : 'No';
-    if (value instanceof Date) return value.toLocaleString([], { timeZone: effectiveTimezone });
+    if (value instanceof Date) return formatDateTime(value, { timeZone: effectiveTimezone });
     if (typeof value === 'string' && value.match(/^\d{4}-\d{2}-\d{2}/)) {
-      return new Date(value).toLocaleString([], { timeZone: effectiveTimezone });
+      return formatDateTime(value, { timeZone: effectiveTimezone });
     }
     if (Array.isArray(value)) return value.join(', ');
     if (typeof value === 'object') return JSON.stringify(value);
@@ -175,7 +176,7 @@ export default function ReportPreview({
         <div>
           <h3 className="text-lg font-semibold">{reportTypeLabels[data.type]}</h3>
           <p className="text-sm text-muted-foreground">
-            Generated {new Date(data.generatedAt).toLocaleString([], { timeZone: effectiveTimezone })}
+            Generated {formatDateTime(data.generatedAt, { timeZone: effectiveTimezone })}
             {data.data.rowCount !== undefined && ` - ${data.data.rowCount} records`}
           </p>
         </div>

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { exportReport, getBrowserTimezone } from './reportExport';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type ReportType =
   | 'device_inventory'
@@ -227,7 +228,7 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
 
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return 'Never';
-    return new Date(dateStr).toLocaleString([], { timeZone: effectiveTimezone });
+    return formatDateTime(dateStr, { timeZone: effectiveTimezone });
   };
 
   if (loading) {

--- a/apps/web/src/components/reports/ScheduledReports.tsx
+++ b/apps/web/src/components/reports/ScheduledReports.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getSafeHttpHref } from '@/lib/safeHref';
+import { formatDateTime as formatUserDateTime, formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 import type { Report } from './ReportsList';
 
 const getBrowserTimezone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -95,7 +96,7 @@ function formatDateTime(dateString?: string | null, timezone?: string): string {
   if (!dateString) return '-';
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) return dateString;
-  return date.toLocaleString([], { timeZone: timezone });
+  return formatUserDateTime(date, { timeZone: timezone });
 }
 
 function formatTime(time: string, timezone?: string): string {
@@ -106,7 +107,7 @@ function formatTime(time: string, timezone?: string): string {
   if (Number.isNaN(hour) || Number.isNaN(minute)) return time;
   const date = new Date();
   date.setHours(hour, minute, 0, 0);
-  return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', timeZone: timezone });
+  return formatUserTime(date, { hour: 'numeric', minute: '2-digit', timeZone: timezone });
 }
 
 function isValidEmail(email: string): boolean {

--- a/apps/web/src/components/reports/reportExport.ts
+++ b/apps/web/src/components/reports/reportExport.ts
@@ -1,5 +1,6 @@
 import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 /** Convert an unknown cell value to a display string. */
 function cellToString(value: unknown): string {
@@ -98,7 +99,7 @@ export function exportReport(
 
   // PDF
   const title = reportType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-  const generatedAt = new Date().toLocaleString([], { timeZone: timezone });
+  const generatedAt = formatDateTime(new Date(), { timeZone: timezone });
 
   const doc = new jsPDF({ orientation: 'landscape' });
   doc.setFontSize(18);

--- a/apps/web/src/components/scripts/ExecutionDetails.tsx
+++ b/apps/web/src/components/scripts/ExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { X, ChevronDown, ChevronUp, Copy, Check, Clock, CheckCircle, XCircle, Loader2, AlertTriangle, Terminal, AlertOctagon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import type { ScriptExecution, ExecutionStatus } from './ExecutionHistory';
 
 type ExecutionDetailsProps = {
@@ -32,7 +33,7 @@ function formatDateTime(dateString: string, timezone?: string): string {
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) return dateString;
   const tz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-  return date.toLocaleString([], {
+  return formatUserDateTime(date, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/apps/web/src/components/scripts/ExecutionHistory.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, Eye, Clock, CheckCircle, XCircle, Loader2, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime as formatUserDateTime, formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 export type ExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'timeout';
 
 export type ScriptExecution = {
@@ -53,7 +54,7 @@ function formatDateTime(dateString: string, timezone?: string): string {
   const isToday = date.toDateString() === now.toDateString();
 
   if (isToday) {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: tz });
+    return formatUserTime(date, { hour: '2-digit', minute: '2-digit', timeZone: tz });
   }
 
   const yesterday = new Date(now);
@@ -61,10 +62,10 @@ function formatDateTime(dateString: string, timezone?: string): string {
   const isYesterday = date.toDateString() === yesterday.toDateString();
 
   if (isYesterday) {
-    return `Yesterday ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: tz })}`;
+    return `Yesterday ${formatUserTime(date, { hour: '2-digit', minute: '2-digit', timeZone: tz })}`;
   }
 
-  return date.toLocaleString([], {
+  return formatUserDateTime(date, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/apps/web/src/components/security/DeviceSecurityStatus.tsx
+++ b/apps/web/src/components/security/DeviceSecurityStatus.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { CheckCircle2, Loader2, Shield, ShieldAlert, XCircle, Zap } from 'lucide-react';
 
 import { fetchWithAuth } from '@/stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { friendlyFetchError } from '@/lib/utils';
 
 type DeviceSecurity = {
@@ -90,8 +91,7 @@ export default function DeviceSecurityStatus({ deviceId, showAvActions = false }
 
   const formatDate = (value: string | null): string => {
     if (!value) return '-';
-    const parsed = new Date(value);
-    return Number.isNaN(parsed.getTime()) ? '-' : parsed.toLocaleString();
+    return formatDateTime(value, { fallback: '-' });
   };
 
   if (loading) {

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -12,6 +12,7 @@ import {
   TrendingUp,
   User
 } from 'lucide-react';
+import { formatTime } from '@/lib/dateTimeFormat';
 import {
   CartesianGrid,
   Line,
@@ -587,7 +588,7 @@ export default function SecurityDashboard({ timezone }: SecurityDashboardProps) 
           </button>
           {lastUpdated && (
             <span className="text-xs text-muted-foreground">
-              Updated {lastUpdated.toLocaleTimeString([], { timeZone: timezone })}
+              Updated {formatTime(lastUpdated, { timeZone: timezone })}
             </span>
           )}
         </div>

--- a/apps/web/src/components/security/SecurityScanManager.tsx
+++ b/apps/web/src/components/security/SecurityScanManager.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Activity, CheckCircle2, HardDrive, Loader2, Play, Timer } from 'lucide-react';
 
 import { fetchWithAuth } from '@/stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 import { friendlyFetchError } from '@/lib/utils';
 import ProgressBar, { ProgressItemList, type ProgressItem } from '../shared/ProgressBar';
 
@@ -205,8 +206,7 @@ export default function SecurityScanManager() {
 
   const formatTimestamp = (value: string | null): string => {
     if (!value) return '-';
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
+    return formatDateTime(value, { fallback: '-' });
   };
 
   return (

--- a/apps/web/src/components/security/ThreatDetail.tsx
+++ b/apps/web/src/components/security/ThreatDetail.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from 'react';
 import { AlertTriangle, CheckCircle2, Clock, Loader2, Shield, ShieldCheck, ShieldOff, Trash2 } from 'lucide-react';
 
 import { fetchWithAuth } from '@/stores/auth';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { friendlyFetchError } from '@/lib/utils';
 
 type ThreatSeverity = 'low' | 'medium' | 'high' | 'critical';
@@ -146,7 +147,7 @@ export default function ThreatDetail({ threatId, timezone }: ThreatDetailProps) 
   const formatDateTime = (value: string): string => {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return value;
-    return date.toLocaleString([], { timeZone: timezone });
+    return formatUserDateTime(date, { timeZone: timezone });
   };
 
   if (loading) {

--- a/apps/web/src/components/security/ThreatList.tsx
+++ b/apps/web/src/components/security/ThreatList.tsx
@@ -3,6 +3,7 @@ import { Filter, Loader2, Search, ShieldAlert, ShieldCheck } from 'lucide-react'
 
 import { cn, friendlyFetchError } from '@/lib/utils';
 import { fetchWithAuth } from '@/stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type ThreatSeverity = 'low' | 'medium' | 'high' | 'critical';
 type ThreatStatus = 'active' | 'quarantined' | 'removed';
@@ -35,7 +36,7 @@ const statusBadge: Record<ThreatStatus, string> = {
 function formatDetectedAt(value: string, timezone?: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { timeZone: timezone });
+  return formatDateTime(date, { timeZone: timezone });
 }
 
 interface ThreatListProps {

--- a/apps/web/src/components/security/UserRiskPage.tsx
+++ b/apps/web/src/components/security/UserRiskPage.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, ShieldAlert, UserCheck
 import { runAction, handleActionError } from '../../lib/runAction';
 import { fetchWithAuth } from '../../stores/auth';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type UserRiskScore = {
   orgId: string;
@@ -92,7 +93,7 @@ const formatPercent = (value: number | null): string => (
 const formatDate = (value: string): string => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  return formatDateTime(date, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 };
 
 const formatFactor = (value: string): string => (

--- a/apps/web/src/components/sensitiveData/ScansTab.tsx
+++ b/apps/web/src/components/sensitiveData/ScansTab.tsx
@@ -3,6 +3,7 @@ import { Plus, RefreshCw } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { SCAN_STATUS_COLORS } from './constants';
 import CreateScanModal from './CreateScanModal';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Scan = {
   id: string;
@@ -122,7 +123,7 @@ export default function ScansTab() {
                 </td>
                 <td className="px-4 py-3 text-xs">{scan.findings?.total ?? '-'}</td>
                 <td className="px-4 py-3 text-xs text-muted-foreground">
-                  {scan.startedAt ? new Date(scan.startedAt).toLocaleString() : scan.createdAt ? new Date(scan.createdAt).toLocaleString() : '-'}
+                  {scan.startedAt ? formatDateTime(scan.startedAt) : scan.createdAt ? formatDateTime(scan.createdAt) : '-'}
                 </td>
                 <td className="px-4 py-3 text-xs text-muted-foreground">
                   {formatDuration(scan.startedAt, scan.completedAt)}

--- a/apps/web/src/components/settings/AiUsagePage.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Bot, DollarSign, Flag, MessageSquare, Zap, Save, Loader2, Lock } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 interface UsageData {
   daily: { inputTokens: number; outputTokens: number; totalCostCents: number; messageCount: number };
@@ -406,7 +407,7 @@ export default function AiUsagePage() {
                     ) : null}
                   </td>
                   <td className="px-4 py-2.5 text-muted-foreground text-xs">
-                    {new Date(s.createdAt).toLocaleString()}
+                    {formatDateTime(s.createdAt)}
                   </td>
                 </tr>
               ))}

--- a/apps/web/src/components/settings/ConnectedAppsList.tsx
+++ b/apps/web/src/components/settings/ConnectedAppsList.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 interface ConnectedApp {
   client_id: string;
@@ -16,8 +17,7 @@ type Status =
 
 function formatDate(value: string | null | undefined): string {
   if (!value) return 'Never';
-  const d = new Date(value);
-  return Number.isNaN(d.valueOf()) ? '—' : d.toLocaleString();
+  return formatDateTime(value, { fallback: '—' });
 }
 
 export default function ConnectedAppsList() {

--- a/apps/web/src/components/settings/InboundEmailCard.tsx
+++ b/apps/web/src/components/settings/InboundEmailCard.tsx
@@ -4,6 +4,7 @@ import { runAction, handleActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 import { showToast } from '../shared/Toast';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 interface InboundConfig {
   enabled: boolean;
@@ -340,7 +341,7 @@ export default function InboundEmailCard() {
                     <div className="text-muted-foreground">{r.subject ?? '(no subject)'}</div>
                     <div className="mt-0.5 text-xs text-muted-foreground">
                       <span className="rounded border px-1 py-0.5">{r.parseStatus}</span>{' '}
-                      {new Date(r.createdAt).toLocaleString()}
+                      {formatDateTime(r.createdAt)}
                       {r.parseStatus === 'failed' && r.error && (
                         <span className="ml-2 text-red-600">{r.error}</span>
                       )}

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -29,6 +29,7 @@ import { useOrgStore } from '../../stores/orgStore';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
+import { formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 
 const tabs = [
   {
@@ -185,10 +186,10 @@ type OrgDetails = {
 };
 
 // Fixed reference time for SSR hydration consistency
-const REFERENCE_TIME = '12:00 PM';
+const REFERENCE_TIME = '12:00';
 
 const formatTime = (date: Date) =>
-  date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  formatUserTime(date, { locale: 'en-US', hour: 'numeric', minute: '2-digit' });
 
 type OrgSettingsPageProps = {
   orgId?: string;

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ProfilePage from './ProfilePage';
 import { fetchWithAuth } from '../../stores/auth';
-import { writeDensity, writeFontPreference, writeThemePreference } from '@/lib/appearance';
+import { writeDensity, writeFontPreference, writeThemePreference, writeTimeFormatPreference } from '@/lib/appearance';
 
 vi.mock('../../stores/auth', () => ({
   createPasskeyCredential: vi.fn(),
@@ -225,7 +225,8 @@ describe('ProfilePage theming settings', () => {
           preferences: {
             theme: 'dark',
             density: 'compact',
-            font: 'system'
+            font: 'system',
+            timeFormat: '12h'
           }
         });
       }
@@ -265,7 +266,8 @@ describe('ProfilePage theming settings', () => {
           preferences: {
             theme: 'light',
             density: 'comfortable',
-            font: 'breeze'
+            font: 'breeze',
+            timeFormat: '12h'
           }
         }}
       />
@@ -277,12 +279,14 @@ describe('ProfilePage theming settings', () => {
       writeThemePreference('dark');
       writeDensity('dense');
       writeFontPreference('system');
+      writeTimeFormatPreference('24h');
     });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Dark/i })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('button', { name: /Dense/i })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByText('OS interface font').closest('button')).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByText('24-hour').closest('button')).toHaveAttribute('aria-pressed', 'true');
     });
   });
 
@@ -297,7 +301,8 @@ describe('ProfilePage theming settings', () => {
           preferences: {
             theme: 'dark',
             density: 'compact',
-            font: 'breeze'
+            font: 'breeze',
+            timeFormat: '12h'
           }
         }}
       />
@@ -319,11 +324,65 @@ describe('ProfilePage theming settings', () => {
       preferences: {
         theme: 'dark',
         density: 'compact',
-        font: 'system'
+        font: 'system',
+        timeFormat: '12h'
       }
     });
     expect(localStorage.getItem('breeze.font')).toBe('system');
     expect(document.documentElement).toHaveAttribute('data-font', 'system');
+  });
+
+  it('saves the selected time format with existing appearance preferences', async () => {
+    fetchWithAuthMock.mockImplementation(async (url, init) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      if (String(url) === '/users/me') {
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        return makeJsonResponse({ preferences: body.preferences });
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: false,
+          preferences: {
+            theme: 'dark',
+            density: 'compact',
+            font: 'breeze',
+            timeFormat: '12h'
+          }
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByText('24-hour').closest('button')!);
+
+    await screen.findByText('Theming preferences saved.');
+
+    const preferenceCall = fetchWithAuthMock.mock.calls.find(
+      ([url]) => String(url) === '/users/me'
+    );
+    expect(preferenceCall).toBeDefined();
+    const [, init] = preferenceCall!;
+    expect(init?.method).toBe('PATCH');
+    expect(JSON.parse(String(init?.body))).toEqual({
+      preferences: {
+        theme: 'dark',
+        density: 'compact',
+        font: 'breeze',
+        timeFormat: '24h'
+      }
+    });
+    expect(localStorage.getItem('breeze.timeFormat')).toBe('24h');
+    await waitFor(() => {
+      expect(screen.getByText('24-hour').closest('button')).toHaveAttribute('aria-pressed', 'true');
+    });
   });
 });
 

--- a/apps/web/src/components/settings/SiteDetailPage.tsx
+++ b/apps/web/src/components/settings/SiteDetailPage.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from '@/lib/utils';
 import Breadcrumbs from '../layout/Breadcrumbs';
 import { fetchWithAuth } from '../../stores/auth';
+import { formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 
 // --- Types ---
 
@@ -96,10 +97,10 @@ const statusBadge: Record<string, { label: string; className: string }> = {
 };
 
 // Fixed reference time for SSR hydration consistency
-const REFERENCE_TIME = '12:00 PM';
+const REFERENCE_TIME = '12:00';
 
 const formatTime = (date: Date) =>
-  date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  formatUserTime(date, { locale: 'en-US', hour: 'numeric', minute: '2-digit' });
 
 // --- Component ---
 

--- a/apps/web/src/components/settings/ThemingSettings.tsx
+++ b/apps/web/src/components/settings/ThemingSettings.tsx
@@ -1,19 +1,23 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AlignJustify, Check, Monitor, Moon, Rows3, Rows4, Sun, Type } from 'lucide-react';
+import { AlignJustify, Check, Clock, Monitor, Moon, Rows3, Rows4, Sun, Type } from 'lucide-react';
 import type { UserPreferences } from '../../stores/auth';
 import {
   applyAppearancePreferences,
   normalizeDensity,
   normalizeFont,
   normalizeTheme,
+  normalizeTimeFormat,
   readDensity,
   readFontPreference,
+  readResolvedTimeFormatPreference,
   readThemePreference,
   subscribeDensity,
   subscribeFont,
+  subscribeTimeFormat,
   subscribeTheme,
   type Density,
   type FontPreference,
+  type TimeFormatPreference,
   type ThemePreference,
 } from '@/lib/appearance';
 import { saveUserPreferences } from '@/lib/userPreferences';
@@ -35,11 +39,17 @@ const fontOptions = [
   { value: 'system' as const, label: 'System', description: 'OS interface font', Icon: Monitor },
 ];
 
+const timeFormatOptions = [
+  { value: '12h' as const, label: '12-hour', description: '3:45 PM' },
+  { value: '24h' as const, label: '24-hour', description: '15:45' },
+];
+
 function resolveAppearance(preferences?: UserPreferences | null): Required<UserPreferences> {
   return {
     theme: normalizeTheme(preferences?.theme) ?? readThemePreference(),
     density: normalizeDensity(preferences?.density) ?? readDensity(),
     font: normalizeFont(preferences?.font) ?? readFontPreference(),
+    timeFormat: normalizeTimeFormat(preferences?.timeFormat) ?? readResolvedTimeFormatPreference(),
   };
 }
 
@@ -52,6 +62,7 @@ export default function ThemingSettings({ preferences, onSaved }: ThemingSetting
   const [themePreference, setThemePreference] = useState<ThemePreference>('system');
   const [densityPreference, setDensityPreference] = useState<Density>('comfortable');
   const [fontPreference, setFontPreference] = useState<FontPreference>('breeze');
+  const [timeFormatPreference, setTimeFormatPreference] = useState<TimeFormatPreference>(readResolvedTimeFormatPreference);
   const [appearanceError, setAppearanceError] = useState<string | undefined>();
   const [appearanceSuccess, setAppearanceSuccess] = useState<string | undefined>();
   const [isSavingAppearance, setIsSavingAppearance] = useState(false);
@@ -61,6 +72,7 @@ export default function ThemingSettings({ preferences, onSaved }: ThemingSetting
     setThemePreference(next.theme);
     setDensityPreference(next.density);
     setFontPreference(next.font);
+    setTimeFormatPreference(next.timeFormat);
   }, []);
 
   useEffect(() => {
@@ -71,26 +83,30 @@ export default function ThemingSettings({ preferences, onSaved }: ThemingSetting
     const unsubscribeTheme = subscribeTheme(setThemePreference);
     const unsubscribeDensity = subscribeDensity(setDensityPreference);
     const unsubscribeFont = subscribeFont(setFontPreference);
+    const unsubscribeTimeFormat = subscribeTimeFormat(setTimeFormatPreference);
 
     return () => {
       unsubscribeTheme();
       unsubscribeDensity();
       unsubscribeFont();
+      unsubscribeTimeFormat();
     };
   }, []);
 
   const handleAppearanceChange = async (
-    patch: Partial<Pick<Required<UserPreferences>, 'theme' | 'density' | 'font'>>
+    patch: Partial<Pick<Required<UserPreferences>, 'theme' | 'density' | 'font' | 'timeFormat'>>
   ) => {
     const next: Required<UserPreferences> = {
       theme: patch.theme ?? themePreference,
       density: patch.density ?? densityPreference,
       font: patch.font ?? fontPreference,
+      timeFormat: patch.timeFormat ?? timeFormatPreference,
     };
 
     setThemePreference(next.theme);
     setDensityPreference(next.density);
     setFontPreference(next.font);
+    setTimeFormatPreference(next.timeFormat);
     setAppearanceError(undefined);
     setAppearanceSuccess(undefined);
     applyAppearancePreferences(next);
@@ -102,6 +118,7 @@ export default function ThemingSettings({ preferences, onSaved }: ThemingSetting
       setThemePreference(resolved.theme);
       setDensityPreference(resolved.density);
       setFontPreference(resolved.font);
+      setTimeFormatPreference(resolved.timeFormat);
       onSaved?.(saved);
       setAppearanceSuccess('Theming preferences saved.');
     } catch (error) {
@@ -183,6 +200,31 @@ export default function ThemingSettings({ preferences, onSaved }: ThemingSetting
                   <span className="block text-xs text-muted-foreground">{description}</span>
                 </span>
                 {fontPreference === value && <Check className="h-4 w-4 shrink-0" />}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">Time format</legend>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {timeFormatOptions.map(({ value, label, description }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => void handleAppearanceChange({ timeFormat: value })}
+                aria-pressed={timeFormatPreference === value}
+                disabled={isSavingAppearance}
+                className={`flex min-h-14 items-center gap-3 rounded-md border px-3 py-2 text-left text-sm transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 ${
+                  timeFormatPreference === value ? 'border-primary bg-primary/10 text-primary' : 'bg-background'
+                }`}
+              >
+                <Clock className="h-4 w-4 shrink-0" />
+                <span className="min-w-0 flex-1">
+                  <span className="block font-medium">{label}</span>
+                  <span className="block text-xs text-muted-foreground">{description}</span>
+                </span>
+                {timeFormatPreference === value && <Check className="h-4 w-4 shrink-0" />}
               </button>
             ))}
           </div>

--- a/apps/web/src/components/software/ComplianceDashboard.tsx
+++ b/apps/web/src/components/software/ComplianceDashboard.tsx
@@ -11,6 +11,7 @@ import {
 import { fetchWithAuth } from '../../stores/auth';
 import { showToast } from '../shared/Toast';
 import PolicyForm, { type PolicyFormValues } from './PolicyForm';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Policy = {
   id: string;
@@ -482,7 +483,7 @@ export default function ComplianceDashboard({ prefill }: ComplianceDashboardProp
                 Remediation: {row.compliance.remediationStatus ?? 'none'}
               </div>
               <div className="text-xs text-muted-foreground">
-                Checked: {new Date(row.compliance.lastChecked).toLocaleString()}
+                Checked: {formatDateTime(row.compliance.lastChecked)}
               </div>
             </div>
           ))}

--- a/apps/web/src/components/tickets/TicketFeed.tsx
+++ b/apps/web/src/components/tickets/TicketFeed.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { statusConfig, type TicketComment, type TicketStatus } from './ticketConfig';
+import { formatDateTime, formatTime } from '@/lib/dateTimeFormat';
 
 const SYSTEM_TYPES = new Set(['status_change', 'assignment', 'system', 'time_entry']);
 
@@ -54,7 +55,7 @@ function SystemRun({ items }: { items: TicketComment[] }) {
       {items.map((c) => (
         <div key={c.id} className="flex items-baseline gap-2 px-1 text-xs text-muted-foreground">
           <span>{systemLine(c)}</span>
-          <span title={new Date(c.createdAt).toLocaleString()}>{new Date(c.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+          <span title={formatDateTime(c.createdAt)}>{formatTime(c.createdAt, { hour: '2-digit', minute: '2-digit' })}</span>
         </div>
       ))}
     </div>
@@ -85,8 +86,8 @@ export default function TicketFeed({ comments }: { comments: TicketComment[] }) 
             <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
               <span className="font-medium text-foreground">{b.item.authorName ?? (b.item.portalUserId ? 'Requester' : 'Technician')}</span>
               {!b.item.isPublic && <span className="font-medium text-warning">Internal</span>}
-              <span className="ml-auto" title={new Date(b.item.createdAt).toLocaleString()}>
-                {new Date(b.item.createdAt).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+              <span className="ml-auto" title={formatDateTime(b.item.createdAt)}>
+                {formatDateTime(b.item.createdAt, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
               </span>
             </div>
             <p className="whitespace-pre-wrap text-sm">{b.item.content}</p>

--- a/apps/web/src/components/tickets/TicketQueueList.tsx
+++ b/apps/web/src/components/tickets/TicketQueueList.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import SlaChip from './SlaChip';
 import { statusConfig, priorityConfig, type TicketSummary } from './ticketConfig';
 import { priorityLabel, statusLabel, type TicketConfig } from '../../lib/ticketConfigApi';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 interface Props {
   tickets: TicketSummary[];
@@ -121,7 +122,7 @@ function TicketQueueList({ tickets, selectedId, onSelect, loading, config = null
               <span className="truncate">{t.orgName ?? ''}</span>
               <span className="ml-auto shrink-0 flex items-center gap-2">
                 <SlaChip ticket={t} />
-                <span title={new Date(t.updatedAt).toLocaleString()}>{timeAgo(t.updatedAt)}</span>
+                <span title={formatDateTime(t.updatedAt)}>{timeAgo(t.updatedAt)}</span>
               </span>
             </div>
           </button>

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -14,6 +14,7 @@ import TicketPartsCard from './TicketPartsCard';
 import { statusConfig, priorityConfig, slaState, type TicketDetail, type TicketStatus, type TicketPriority } from './ticketConfig';
 import { fetchTicketConfig, statusLabel, priorityLabel, activeStatusesByCore, type TicketConfig } from '../../lib/ticketConfigApi';
 import { onTimerChanged, onBillingChanged } from '../../lib/timerActions';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 interface Props {
   ticketId: string;
@@ -664,8 +665,8 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
               <dl className="space-y-3">
                 <div><dt className="text-xs text-muted-foreground">Requester</dt><dd>{ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}</dd></div>
                 <div><dt className="text-xs text-muted-foreground">Source</dt><dd className="capitalize">{ticket.source}</dd></div>
-                <div><dt className="text-xs text-muted-foreground">Created</dt><dd>{new Date(ticket.createdAt).toLocaleString()}</dd></div>
-                {ticket.dueDate && <div><dt className="text-xs text-muted-foreground">Due</dt><dd>{new Date(ticket.dueDate).toLocaleString()}</dd></div>}
+                <div><dt className="text-xs text-muted-foreground">Created</dt><dd>{formatDateTime(ticket.createdAt)}</dd></div>
+                {ticket.dueDate && <div><dt className="text-xs text-muted-foreground">Due</dt><dd>{formatDateTime(ticket.dueDate)}</dd></div>}
                 {ticket.pendingReason && <div><dt className="text-xs text-muted-foreground">Waiting on</dt><dd>{ticket.pendingReason}</dd></div>}
                 {ticket.resolutionNote && (ticket.status === 'resolved' || ticket.status === 'closed') && (
                   <div><dt className="text-xs text-muted-foreground">Resolution</dt><dd>{ticket.resolutionNote}</dd></div>

--- a/apps/web/src/components/webhooks/WebhookDeliveryHistory.tsx
+++ b/apps/web/src/components/webhooks/WebhookDeliveryHistory.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { CheckCircle, XCircle, Clock, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type WebhookDeliveryStatus = 'success' | 'failed' | 'pending';
 
@@ -40,7 +41,7 @@ const statusIcons: Record<WebhookDeliveryStatus, typeof CheckCircle> = {
 function formatTimestamp(value: string, timezone?: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { timeZone: timezone });
+  return formatDateTime(date, { timeZone: timezone });
 }
 
 export default function WebhookDeliveryHistory({

--- a/apps/web/src/components/webhooks/WebhookList.tsx
+++ b/apps/web/src/components/webhooks/WebhookList.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type MouseEvent } from 'react';
 import { Pencil, Trash2, Play, ToggleLeft, ToggleRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/dateTimeFormat';
 
 export type WebhookStatus = 'active' | 'disabled';
 
@@ -65,7 +66,7 @@ const formatTimestamp = (value?: string | null, timezone?: string) => {
   if (!value) return 'N/A';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { timeZone: timezone });
+  return formatDateTime(date, { timeZone: timezone });
 };
 
 export default function WebhookList({

--- a/apps/web/src/lib/appearance.ts
+++ b/apps/web/src/lib/appearance.ts
@@ -1,3 +1,5 @@
+import type { TimeFormat } from '@breeze/shared';
+
 export const THEME_OPTIONS = ['light', 'dark', 'system'] as const;
 export type ThemePreference = (typeof THEME_OPTIONS)[number];
 
@@ -7,10 +9,14 @@ export type Density = (typeof DENSITY_OPTIONS)[number];
 export const FONT_OPTIONS = ['breeze', 'system'] as const;
 export type FontPreference = (typeof FONT_OPTIONS)[number];
 
+export const TIME_FORMAT_OPTIONS = ['12h', '24h'] as const satisfies readonly TimeFormat[];
+export type TimeFormatPreference = TimeFormat;
+
 export type AppearancePreferences = {
   theme?: ThemePreference;
   density?: Density;
   font?: FontPreference;
+  timeFormat?: TimeFormatPreference;
 };
 
 export const DEFAULT_THEME: ThemePreference = 'system';
@@ -20,6 +26,7 @@ export const DEFAULT_FONT: FontPreference = 'breeze';
 export const THEME_STORAGE_KEY = 'theme';
 export const DENSITY_STORAGE_KEY = 'breeze.density';
 export const FONT_STORAGE_KEY = 'breeze.font';
+export const TIME_FORMAT_STORAGE_KEY = 'breeze.timeFormat';
 
 export function isValidTheme(value: unknown): value is ThemePreference {
   return typeof value === 'string' && (THEME_OPTIONS as readonly string[]).includes(value);
@@ -33,6 +40,10 @@ export function isValidFont(value: unknown): value is FontPreference {
   return typeof value === 'string' && (FONT_OPTIONS as readonly string[]).includes(value);
 }
 
+export function isValidTimeFormat(value: unknown): value is TimeFormatPreference {
+  return typeof value === 'string' && (TIME_FORMAT_OPTIONS as readonly string[]).includes(value);
+}
+
 export function normalizeTheme(value: unknown): ThemePreference | undefined {
   return isValidTheme(value) ? value : undefined;
 }
@@ -43,6 +54,10 @@ export function normalizeDensity(value: unknown): Density | undefined {
 
 export function normalizeFont(value: unknown): FontPreference | undefined {
   return isValidFont(value) ? value : undefined;
+}
+
+export function normalizeTimeFormat(value: unknown): TimeFormatPreference | undefined {
+  return isValidTimeFormat(value) ? value : undefined;
 }
 
 function readStorageValue(key: string): string | null {
@@ -77,6 +92,27 @@ export function readDensity(): Density {
 
 export function readFontPreference(): FontPreference {
   return normalizeFont(readStorageValue(FONT_STORAGE_KEY)) ?? DEFAULT_FONT;
+}
+
+export function readTimeFormatPreference(): TimeFormatPreference | undefined {
+  return normalizeTimeFormat(readStorageValue(TIME_FORMAT_STORAGE_KEY));
+}
+
+export function detectBrowserTimeFormat(): TimeFormatPreference {
+  if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
+    return '12h';
+  }
+
+  try {
+    const hourCycle = new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions().hourCycle;
+    return hourCycle === 'h23' || hourCycle === 'h24' ? '24h' : '12h';
+  } catch {
+    return '12h';
+  }
+}
+
+export function readResolvedTimeFormatPreference(): TimeFormatPreference {
+  return readTimeFormatPreference() ?? detectBrowserTimeFormat();
 }
 
 export function applyThemePreference(value: ThemePreference): void {
@@ -119,6 +155,12 @@ export function writeFontPreference(value: FontPreference): void {
   notifyFont(value);
 }
 
+export function writeTimeFormatPreference(value: TimeFormatPreference): void {
+  if (!isValidTimeFormat(value)) return;
+  writeStorageValue(TIME_FORMAT_STORAGE_KEY, value);
+  notifyTimeFormat(value);
+}
+
 export function applyAppearancePreferences(preferences: AppearancePreferences): void {
   if (preferences.theme) {
     writeThemePreference(preferences.theme);
@@ -129,11 +171,15 @@ export function applyAppearancePreferences(preferences: AppearancePreferences): 
   if (preferences.font) {
     writeFontPreference(preferences.font);
   }
+  if (preferences.timeFormat) {
+    writeTimeFormatPreference(preferences.timeFormat);
+  }
 }
 
 const themeSubscribers = new Set<(value: ThemePreference) => void>();
 const densitySubscribers = new Set<(value: Density) => void>();
 const fontSubscribers = new Set<(value: FontPreference) => void>();
+const timeFormatSubscribers = new Set<(value: TimeFormatPreference) => void>();
 
 function notifyTheme(value: ThemePreference): void {
   for (const fn of themeSubscribers) {
@@ -165,6 +211,16 @@ function notifyFont(value: FontPreference): void {
   }
 }
 
+function notifyTimeFormat(value: TimeFormatPreference): void {
+  for (const fn of timeFormatSubscribers) {
+    try {
+      fn(value);
+    } catch {
+      // Subscriber errors must not break setter.
+    }
+  }
+}
+
 export function subscribeTheme(fn: (value: ThemePreference) => void): () => void {
   themeSubscribers.add(fn);
   return () => {
@@ -183,6 +239,13 @@ export function subscribeFont(fn: (value: FontPreference) => void): () => void {
   fontSubscribers.add(fn);
   return () => {
     fontSubscribers.delete(fn);
+  };
+}
+
+export function subscribeTimeFormat(fn: (value: TimeFormatPreference) => void): () => void {
+  timeFormatSubscribers.add(fn);
+  return () => {
+    timeFormatSubscribers.delete(fn);
   };
 }
 

--- a/apps/web/src/lib/dateTimeFormat.test.ts
+++ b/apps/web/src/lib/dateTimeFormat.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { formatDateTime, formatTime, withUserTimeFormatOptions } from './dateTimeFormat';
+
+let authState: { user: { preferences?: { timeFormat?: '12h' | '24h' } } | null } = { user: null };
+
+vi.mock('../stores/auth', () => ({
+  useAuthStore: {
+    getState: () => authState,
+  },
+}));
+
+const baseUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'User One',
+  mfaEnabled: false,
+};
+
+function makeMemoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.has(key) ? (data.get(key) as string) : null;
+    },
+    key(index: number) {
+      return Array.from(data.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    setItem(key: string, value: string) {
+      data.set(key, String(value));
+    },
+  };
+}
+
+describe('dateTimeFormat', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: makeMemoryStorage(),
+      writable: true,
+      configurable: true,
+    });
+    authState = { user: null };
+    window.localStorage.clear();
+  });
+
+  it('formats 24-hour time without AM/PM and with 00 for midnight', () => {
+    const rendered = formatTime('2026-01-01T00:05:00.000Z', {
+      locale: 'en-US',
+      timeZone: 'UTC',
+      hour: '2-digit',
+      minute: '2-digit',
+      timeFormat: '24h',
+    });
+
+    expect(rendered).toBe('00:05');
+    expect(rendered).not.toMatch(/AM|PM/i);
+  });
+
+  it('formats 12-hour time with a day period', () => {
+    expect(formatTime('2026-01-01T15:45:00.000Z', {
+      locale: 'en-US',
+      timeZone: 'UTC',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeFormat: '12h',
+    })).toBe('3:45 PM');
+  });
+
+  it('uses the authenticated user preference when no explicit timeFormat is provided', () => {
+    authState = {
+      user: { ...baseUser, preferences: { timeFormat: '24h' } },
+    };
+
+    expect(formatDateTime('2026-01-01T15:45:00.000Z', {
+      locale: 'en-US',
+      timeZone: 'UTC',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })).toBe('Jan 1, 15:45');
+  });
+
+  it('does not apply hour-cycle options to date-only formatting', () => {
+    expect(formatDateTime('2026-01-01T15:45:00.000Z', {
+      locale: 'en-US',
+      timeZone: 'UTC',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeFormat: '24h',
+    })).toBe('Jan 1, 2026');
+  });
+
+  it('preserves caller fallback for missing or invalid dates', () => {
+    expect(formatDateTime(null, { fallback: '--' })).toBe('--');
+    expect(formatDateTime('not-a-date', { fallback: 'Unknown' })).toBe('Unknown');
+  });
+
+  it('overrides caller hour12 settings only when formatting includes time', () => {
+    expect(withUserTimeFormatOptions({ hour: '2-digit', hour12: true }, '24h', 'dateTime'))
+      .toEqual({ hour: '2-digit', hourCycle: 'h23' });
+    expect(withUserTimeFormatOptions({ year: 'numeric', hour12: true }, '24h', 'dateTime'))
+      .toEqual({ year: 'numeric', hour12: true });
+  });
+});

--- a/apps/web/src/lib/dateTimeFormat.test.ts
+++ b/apps/web/src/lib/dateTimeFormat.test.ts
@@ -1,20 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { writeTimeFormatPreference } from './appearance';
 import { formatDateTime, formatTime, withUserTimeFormatOptions } from './dateTimeFormat';
-
-let authState: { user: { preferences?: { timeFormat?: '12h' | '24h' } } | null } = { user: null };
-
-vi.mock('../stores/auth', () => ({
-  useAuthStore: {
-    getState: () => authState,
-  },
-}));
-
-const baseUser = {
-  id: 'user-1',
-  email: 'user@example.com',
-  name: 'User One',
-  mfaEnabled: false,
-};
 
 function makeMemoryStorage(): Storage {
   const data = new Map<string, string>();
@@ -47,7 +33,6 @@ describe('dateTimeFormat', () => {
       writable: true,
       configurable: true,
     });
-    authState = { user: null };
     window.localStorage.clear();
   });
 
@@ -74,10 +59,8 @@ describe('dateTimeFormat', () => {
     })).toBe('3:45 PM');
   });
 
-  it('uses the authenticated user preference when no explicit timeFormat is provided', () => {
-    authState = {
-      user: { ...baseUser, preferences: { timeFormat: '24h' } },
-    };
+  it('uses the saved appearance preference when no explicit timeFormat is provided', () => {
+    writeTimeFormatPreference('24h');
 
     expect(formatDateTime('2026-01-01T15:45:00.000Z', {
       locale: 'en-US',

--- a/apps/web/src/lib/dateTimeFormat.ts
+++ b/apps/web/src/lib/dateTimeFormat.ts
@@ -1,6 +1,5 @@
 import type { TimeFormat } from '@breeze/shared';
 import { normalizeTimeFormat, readTimeFormatPreference } from './appearance';
-import { useAuthStore } from '../stores/auth';
 
 type DateInput = string | number | Date | null | undefined;
 type FormatMode = 'date' | 'time' | 'dateTime';
@@ -40,11 +39,7 @@ function fallbackFor(value: DateInput, fallback?: string): string {
 }
 
 export function getEffectiveTimeFormat(explicit?: TimeFormat | null): TimeFormat | undefined {
-  return (
-    normalizeTimeFormat(explicit)
-    ?? normalizeTimeFormat(useAuthStore.getState().user?.preferences?.timeFormat)
-    ?? readTimeFormatPreference()
-  );
+  return normalizeTimeFormat(explicit) ?? readTimeFormatPreference();
 }
 
 function formatIncludesTime(options: Intl.DateTimeFormatOptions, mode: FormatMode): boolean {

--- a/apps/web/src/lib/dateTimeFormat.ts
+++ b/apps/web/src/lib/dateTimeFormat.ts
@@ -1,0 +1,99 @@
+import type { TimeFormat } from '@breeze/shared';
+import { normalizeTimeFormat, readTimeFormatPreference } from './appearance';
+import { useAuthStore } from '../stores/auth';
+
+type DateInput = string | number | Date | null | undefined;
+type FormatMode = 'date' | 'time' | 'dateTime';
+
+export type UserDateTimeFormatOptions = Intl.DateTimeFormatOptions & {
+  fallback?: string;
+  locale?: Intl.LocalesArgument;
+  timeFormat?: TimeFormat | null;
+};
+
+const TIME_OPTION_KEYS: Array<keyof Intl.DateTimeFormatOptions> = [
+  'hour',
+  'minute',
+  'second',
+  'fractionalSecondDigits',
+  'timeStyle',
+];
+
+const DATE_OPTION_KEYS: Array<keyof Intl.DateTimeFormatOptions> = [
+  'weekday',
+  'era',
+  'year',
+  'month',
+  'day',
+  'dateStyle',
+];
+
+function parseDate(value: DateInput): Date | null {
+  if (value === null || value === undefined || value === '') return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function fallbackFor(value: DateInput, fallback?: string): string {
+  if (fallback !== undefined) return fallback;
+  return typeof value === 'string' ? value : '';
+}
+
+export function getEffectiveTimeFormat(explicit?: TimeFormat | null): TimeFormat | undefined {
+  return (
+    normalizeTimeFormat(explicit)
+    ?? normalizeTimeFormat(useAuthStore.getState().user?.preferences?.timeFormat)
+    ?? readTimeFormatPreference()
+  );
+}
+
+function formatIncludesTime(options: Intl.DateTimeFormatOptions, mode: FormatMode): boolean {
+  if (mode === 'time') return true;
+  if (mode === 'date') return false;
+  if (TIME_OPTION_KEYS.some((key) => options[key] !== undefined)) return true;
+  if (DATE_OPTION_KEYS.some((key) => options[key] !== undefined)) return false;
+  return true;
+}
+
+export function withUserTimeFormatOptions(
+  options: Intl.DateTimeFormatOptions,
+  timeFormat: TimeFormat | undefined,
+  mode: FormatMode
+): Intl.DateTimeFormatOptions {
+  if (!timeFormat || !formatIncludesTime(options, mode)) return options;
+  const next: Intl.DateTimeFormatOptions = { ...options };
+  delete next.hour12;
+  delete next.hourCycle;
+  next.hourCycle = timeFormat === '24h' ? 'h23' : 'h12';
+  return next;
+}
+
+function splitFormatOptions({ fallback, locale, timeFormat, ...intlOptions }: UserDateTimeFormatOptions) {
+  return {
+    fallback,
+    locale,
+    timeFormat: getEffectiveTimeFormat(timeFormat),
+    intlOptions,
+  };
+}
+
+export function formatDateTime(value: DateInput, options: UserDateTimeFormatOptions = {}): string {
+  const date = parseDate(value);
+  const { fallback, locale, timeFormat, intlOptions } = splitFormatOptions(options);
+  if (!date) return fallbackFor(value, fallback);
+  return date.toLocaleString(locale, withUserTimeFormatOptions(intlOptions, timeFormat, 'dateTime'));
+}
+
+export function formatTime(value: DateInput, options: UserDateTimeFormatOptions = {}): string {
+  const date = parseDate(value);
+  const { fallback, locale, timeFormat, intlOptions } = splitFormatOptions(options);
+  if (!date) return fallbackFor(value, fallback);
+  return date.toLocaleTimeString(locale, withUserTimeFormatOptions(intlOptions, timeFormat, 'time'));
+}
+
+export function formatDate(value: DateInput, options: UserDateTimeFormatOptions = {}): string {
+  const date = parseDate(value);
+  const { fallback, locale, intlOptions } = splitFormatOptions(options);
+  if (!date) return fallbackFor(value, fallback);
+  return date.toLocaleDateString(locale, intlOptions);
+}

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -13,6 +13,7 @@ import {
   applyAppearancePreferences,
   type Density,
   type FontPreference,
+  type TimeFormatPreference,
   type ThemePreference,
 } from '@/lib/appearance';
 
@@ -20,6 +21,7 @@ export interface UserPreferences {
   theme?: ThemePreference;
   density?: Density;
   font?: FontPreference;
+  timeFormat?: TimeFormatPreference;
 }
 
 /** A single permission grant ({ resource, action }), mirroring the API. */


### PR DESCRIPTION
## Summary

- Adds a user-level 12-hour / 24-hour time format preference in Profile → Theming.
- Persists and validates `timeFormat` through `/users/me` preferences.
- Applies the selected time format across web timestamp/date-time rendering helpers and relevant UI call sites.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Testing

- [x] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [x] Manual testing (describe below)

Focused checks run:

- `pnpm --dir apps/web exec vitest run src/lib/dateTimeFormat.test.ts src/components/settings/ProfilePage.test.tsx`
- `pnpm --dir apps/api exec vitest run src/routes/users.test.ts`
- Built and pushed API/web-only test images from the throwaway branch for production validation.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included