### PR TITLE
fix(scripts): require script org to match target device org

### DIFF
--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1045,6 +1045,135 @@ describe('mobile routes', () => {
       const body = await res.json();
       expect(body.commandId).toBe('cmd-1');
     });
+
+    describe('run_script cross-org isolation', () => {
+      const DEVICE_ORG = 'org-b';
+      const SCRIPT_ORG = 'org-a';
+      const SCRIPT_ID = '11111111-1111-1111-1111-111111111111';
+
+      // A multi-org partner caller whose canAccessOrg passes for BOTH the
+      // script's org and the device's org. Without the same-org invariant both
+      // access checks pass and org A's script content lands on org B's device.
+      const useMultiOrgPartnerAuth = () => {
+        vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+          c.set('auth', {
+            user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+            scope: 'partner',
+            orgId: null,
+            partnerId: 'partner-123',
+            accessibleOrgIds: [SCRIPT_ORG, DEVICE_ORG],
+            canAccessOrg: (orgId: string) => orgId === SCRIPT_ORG || orgId === DEVICE_ORG,
+          });
+          return next();
+        });
+      };
+
+      it('rejects running an org A script on an org B device (no insert)', async () => {
+        useMultiOrgPartnerAuth();
+        vi.mocked(db.select)
+          .mockReturnValueOnce(
+            mockSelectLimitChain([
+              { id: 'device-1', orgId: DEVICE_ORG, status: 'online', osType: 'linux', siteId: null }
+            ]) as any
+          )
+          .mockReturnValueOnce(
+            mockSelectLimitChain([
+              {
+                id: SCRIPT_ID,
+                orgId: SCRIPT_ORG,
+                isSystem: false,
+                osTypes: ['linux'],
+                language: 'bash',
+                content: 'echo pwned',
+                timeoutSeconds: 60,
+                runAs: 'root'
+              }
+            ]) as any
+          );
+        vi.mocked(db.insert).mockReturnValue(mockInsertReturning([{ id: 'exec-1' }]) as any);
+
+        const res = await app.request('/mobile/devices/device-1/actions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'run_script', scriptId: SCRIPT_ID })
+        });
+
+        expect(res.status).toBe(403);
+        expect(db.insert).not.toHaveBeenCalled();
+      });
+
+      it('allows running a same-org script on its own org device', async () => {
+        useMultiOrgPartnerAuth();
+        vi.mocked(db.select)
+          .mockReturnValueOnce(
+            mockSelectLimitChain([
+              { id: 'device-1', orgId: DEVICE_ORG, status: 'online', osType: 'linux', siteId: null }
+            ]) as any
+          )
+          .mockReturnValueOnce(
+            mockSelectLimitChain([
+              {
+                id: SCRIPT_ID,
+                orgId: DEVICE_ORG,
+                isSystem: false,
+                osTypes: ['linux'],
+                language: 'bash',
+                content: 'echo ok',
+                timeoutSeconds: 60,
+                runAs: 'root'
+              }
+            ]) as any
+          );
+        vi.mocked(db.insert)
+          .mockReturnValueOnce(mockInsertReturning([{ id: 'exec-1' }]) as any)
+          .mockReturnValueOnce(mockInsertReturning([{ id: 'cmd-1' }]) as any);
+
+        const res = await app.request('/mobile/devices/device-1/actions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'run_script', scriptId: SCRIPT_ID })
+        });
+
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.executionId).toBe('exec-1');
+      });
+
+      it('allows running a system (org-less) script on any accessible device', async () => {
+        useMultiOrgPartnerAuth();
+        vi.mocked(db.select)
+          .mockReturnValueOnce(
+            mockSelectLimitChain([
+              { id: 'device-1', orgId: DEVICE_ORG, status: 'online', osType: 'linux', siteId: null }
+            ]) as any
+          )
+          .mockReturnValueOnce(
+            mockSelectLimitChain([
+              {
+                id: SCRIPT_ID,
+                orgId: null,
+                isSystem: true,
+                osTypes: ['linux'],
+                language: 'bash',
+                content: 'echo system',
+                timeoutSeconds: 60,
+                runAs: 'root'
+              }
+            ]) as any
+          );
+        vi.mocked(db.insert)
+          .mockReturnValueOnce(mockInsertReturning([{ id: 'exec-1' }]) as any)
+          .mockReturnValueOnce(mockInsertReturning([{ id: 'cmd-1' }]) as any);
+
+        const res = await app.request('/mobile/devices/device-1/actions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'run_script', scriptId: SCRIPT_ID })
+        });
+
+        expect(res.status).toBe(201);
+      });
+    });
   });
 
   describe('GET /mobile/summary', () => {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -975,6 +975,14 @@ mobileRoutes.post(
         }
       }
 
+      // Org-equality invariant (mirrors playbooks.ts): a system/org-less script
+      // is universally runnable, but a non-null script org must match the
+      // target device's org. Otherwise a multi-org caller could run one org's
+      // script content on another org's device with both access checks passing.
+      if (script.orgId && script.orgId !== device.orgId) {
+        return c.json({ error: 'Script and device must belong to the same organization' }, 403);
+      }
+
       if (!script.osTypes.includes(device.osType)) {
         return c.json({ error: 'Script is not compatible with device OS' }, 400);
       }

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Sibling to the scriptExecution.ts / mobile.ts cross-org-script fix (#1674):
+ * the AI `run_script` tool resolves a script by `orgCondition` and each device
+ * by org+site `verifyDeviceAccess`, but neither check ties the script's org to
+ * the device's org. For a multi-org caller, `orgCondition` is
+ * `inArray(orgId, accessibleOrgIds)`, so an org-A script resolves AND an org-B
+ * device passes verifyDeviceAccess — org A's script content would land on an
+ * org-B device. This asserts the per-device org-equality invariant: a non-null
+ * script org must match the device org, while a system (null-org) script stays
+ * universally runnable.
+ */
+
+const executeCommand = vi.fn().mockResolvedValue({ ok: true });
+
+vi.mock('./commandQueue', () => ({ executeCommand }));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerScriptTools } from './aiToolsScripts';
+import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const SCRIPT_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_B = '22222222-2222-2222-2222-222222222222';
+
+function runScriptTool(): AiTool {
+  const map = new Map<string, AiTool>();
+  registerScriptTools(map);
+  return map.get('run_script')!;
+}
+
+// A multi-org caller (org A and org B both accessible). orgCondition is a no-op
+// in the mock so the script select returns whatever the mock yields; the access
+// breadth is modeled by what the mocked queries return, matching production
+// where inArray(orgId, accessibleOrgIds) would resolve both.
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'u@example.com', name: 'U' },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_A,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_A, ORG_B],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    canAccessSite: () => true,
+  } as any;
+}
+
+/**
+ * The handler issues exactly two kinds of select():
+ *   1. script: db.select({ ...projection }).from(scripts).where(...).limit(1)
+ *   2. device (verifyDeviceAccess): db.select().from(devices).where(...).limit(1)
+ * Distinguish by whether a projection arg was passed.
+ */
+function mockDb(scriptRow: any, deviceRow: any) {
+  vi.mocked(db.select).mockImplementation(((projection?: unknown) => {
+    const rows = projection === undefined ? [deviceRow].filter(Boolean) : [scriptRow].filter(Boolean);
+    return {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+      }),
+    } as any;
+  }) as any);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('run_script enforces script-device org equality', () => {
+  it('does NOT execute an org-A script on an org-B device (cross-org rejected)', async () => {
+    mockDb(
+      { id: SCRIPT_ID, orgId: ORG_A, language: 'powershell', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' },
+      { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' },
+    );
+
+    const out = JSON.parse(
+      await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth()),
+    );
+
+    expect(executeCommand).not.toHaveBeenCalled();
+    expect(out.results[DEVICE_B].error).toMatch(/not found or access denied/i);
+  });
+
+  it('executes a same-org script on a same-org device', async () => {
+    mockDb(
+      { id: SCRIPT_ID, orgId: ORG_B, language: 'powershell', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' },
+      { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' },
+    );
+
+    await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenCalledWith(DEVICE_B, 'script', expect.objectContaining({ content: 'echo hi' }), expect.anything());
+  });
+
+  it('executes a system (null-org) script on any accessible device', async () => {
+    mockDb(
+      { id: SCRIPT_ID, orgId: null, language: 'powershell', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' },
+      { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' },
+    );
+
+    await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -150,6 +150,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       const [script] = await db
         .select({
           id: scripts.id,
+          orgId: scripts.orgId,
           language: scripts.language,
           content: scripts.content,
           timeoutSeconds: scripts.timeoutSeconds,
@@ -169,6 +170,18 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
           const access = await verifyDeviceAccess(deviceId, auth);
           if ('error' in access) {
             results[deviceId] = { error: access.error };
+            continue;
+          }
+
+          // Org-equality invariant (mirrors scriptExecution.ts / playbooks.ts):
+          // a system/org-less script (orgId === null) is universally runnable,
+          // but a non-null script org MUST match the target device's org. For a
+          // multi-org caller, orgCondition resolves an org-A script and
+          // verifyDeviceAccess admits an org-B device — both pass canAccessOrg —
+          // so without this an org-A script's content lands on an org-B device.
+          // Treat a mismatch like an inaccessible device.
+          if (script.orgId !== null && script.orgId !== access.device.orgId) {
+            results[deviceId] = { error: 'Device not found or access denied' };
             continue;
           }
 

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the db layer with chainable select/insert/update builders.
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+// Maintenance window check — keep devices executable by default.
+vi.mock('./featureConfigResolver', () => ({
+  checkDeviceMaintenanceWindow: vi.fn().mockResolvedValue({ active: false, suppressScripts: false }),
+}));
+
+// Command dispatch + agent WS — no real delivery in unit tests.
+vi.mock('./commandDispatch', () => ({
+  claimPendingCommandForDelivery: vi.fn().mockResolvedValue(null),
+  releaseClaimedCommandDelivery: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../routes/agentWs', () => ({
+  sendCommandToAgent: vi.fn().mockReturnValue(false),
+}));
+
+// Real permissions module is fine; canAccessSite is only consulted when
+// allowedSiteIds is set, which these tests don't exercise.
+
+import { db } from '../db';
+import { executeScriptOnDevices } from './scriptExecution';
+
+// db.select() is used twice per call: first the script (.limit chain), then the
+// devices (.where chain, no limit). Return a script-shaped chain first, then a
+// devices-shaped chain.
+const scriptSelectChain = (rows: unknown[]) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue(rows),
+    }),
+  }),
+});
+
+const devicesSelectChain = (rows: unknown[]) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn().mockResolvedValue(rows),
+  }),
+});
+
+const insertReturning = (rows: unknown[]) => ({
+  values: vi.fn().mockReturnValue({
+    returning: vi.fn().mockResolvedValue(rows),
+  }),
+});
+
+const updateChain = () => ({
+  set: vi.fn().mockReturnValue({
+    where: vi.fn().mockResolvedValue(undefined),
+  }),
+});
+
+const baseScript = (overrides: Record<string, unknown> = {}) => ({
+  id: 'script-1',
+  orgId: 'org-a',
+  isSystem: false,
+  osTypes: ['linux'],
+  language: 'bash',
+  content: 'echo hi',
+  timeoutSeconds: 60,
+  runAs: 'system',
+  deletedAt: null,
+  ...overrides,
+});
+
+const baseDevice = (overrides: Record<string, unknown> = {}) => ({
+  id: 'device-1',
+  orgId: 'org-b',
+  siteId: null,
+  osType: 'linux',
+  status: 'online',
+  agentId: null,
+  ...overrides,
+});
+
+// Multi-org partner caller: canAccessOrg passes for both org A and org B.
+const multiOrgAuth = {
+  user: { id: 'user-1' },
+  orgId: null as string | null,
+  canAccessOrg: (orgId: string) => orgId === 'org-a' || orgId === 'org-b',
+};
+
+describe('executeScriptOnDevices — cross-org isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.insert).mockReturnValue(insertReturning([{ id: 'inserted-1' }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+  });
+
+  it('excludes a device whose org differs from a non-null script org', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-a' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ orgId: 'org-b' })]) as any);
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-1'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+    }
+    // No execution/command rows for the cross-org device.
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('executes when the script and device share the same org', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ orgId: 'org-b' })]) as any);
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-1'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.executions).toHaveLength(1);
+      expect(result.executions[0]!.deviceId).toBe('device-1');
+    }
+  });
+
+  it('executes a system (org-less) script on any accessible device', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: null, isSystem: true })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ orgId: 'org-b' })]) as any);
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-1'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.executions).toHaveLength(1);
+    }
+  });
+
+  it('runs only same-org devices in a mixed batch (cross-org excluded)', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-a' })]) as any)
+      .mockReturnValueOnce(
+        devicesSelectChain([
+          baseDevice({ id: 'device-a', orgId: 'org-a' }),
+          baseDevice({ id: 'device-b', orgId: 'org-b' }),
+        ]) as any,
+      );
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const targetedIds = result.executions.map((e) => e.deviceId);
+      expect(targetedIds).toContain('device-a');
+      expect(targetedIds).not.toContain('device-b');
+    }
+  });
+});

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -104,6 +104,13 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
   const siteDeniedDeviceIds: string[] = [];
   for (const device of deviceRecords) {
     if (!ensureOrgAccess(device.orgId, input.auth)) continue;
+    // Org-equality invariant (mirrors playbooks.ts): a system/org-less script
+    // (orgId === null) is universally runnable, but a non-null script org must
+    // match the target device's org. Without this, a multi-org caller can run
+    // one org's script content on another org's devices even though both
+    // canAccessOrg checks pass. Treat a mismatch like an inaccessible device:
+    // exclude it from the executable set rather than failing the whole batch.
+    if (script.orgId !== null && script.orgId !== device.orgId) continue;
     if (!canAccessDeviceSite(device.siteId, input.permissions)) {
       siteDeniedDeviceIds.push(device.id);
       continue;


### PR DESCRIPTION
## What

Script execution checked caller access to the script's org and to the target device's org *independently*, but never asserted the two were the same org. A caller with access to multiple orgs could run one org's script **content** on another org's devices — both `canAccessOrg` checks pass, and the script body is copied into the device command.

## Fix

Adds the org-equality invariant already used by `playbooks.ts` (a system/org-less script — `orgId === null` — stays universally runnable; a non-null script org must equal the target device's org):

- `services/scriptExecution.ts` (`executeScriptOnDevices`): a device whose org differs from a non-null `script.orgId` is excluded from the executable set (same handling as an inaccessible device — a legitimate same-org batch is unaffected).
- `routes/mobile.ts` (`run_script` action): returns 403 when `script.orgId` is set and differs from the device's org.

## Behavior change (release notes)

A caller with access to multiple organizations can no longer run one organization's script on another organization's devices. System/built-in (org-less) scripts are unaffected.

## Tests

Added cross-org rejection + same-org / system-script no-regression coverage to `scriptExecution.test.ts` and `mobile.test.ts` (43 passed, 5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)