### PR TITLE
fix(security): TOTP replay protection (RFC 6238 §5.2) from security review #2

### DIFF
--- a/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // --- Mocks must be declared before importing the unit under test ---
 // vi.mock factories are hoisted above module-scope consts, so the shared mock
 // references are declared via vi.hoisted (which is also hoisted) and reused here.
-const { selectLimit, db, getRedis, rateLimiter, verifyMFAToken, decryptMfaTotpSecret } = vi.hoisted(() => {
+const { selectLimit, db, getRedis, rateLimiter, consumeMFAToken, decryptMfaTotpSecret } = vi.hoisted(() => {
   const selectLimit = vi.fn();
   const db = {
     // db.select(...).from(...).where(...).limit(...) chain returning the mocked user row.
@@ -20,7 +20,7 @@ const { selectLimit, db, getRedis, rateLimiter, verifyMFAToken, decryptMfaTotpSe
     db,
     getRedis: vi.fn(),
     rateLimiter: vi.fn(),
-    verifyMFAToken: vi.fn(),
+    consumeMFAToken: vi.fn(),
     decryptMfaTotpSecret: vi.fn(),
   };
 });
@@ -48,7 +48,7 @@ vi.mock('../../services', () => ({
 }));
 
 vi.mock('../../services/mfa', () => ({
-  verifyMFAToken,
+  consumeMFAToken,
 }));
 
 vi.mock('../../services/mfaSecretCrypto', () => ({
@@ -87,19 +87,19 @@ describe('requireFreshMfaStepUp', () => {
     rateLimiter.mockResolvedValue({ allowed: true, resetAt: new Date(Date.now() + 60_000) });
     mockUserRow({ mfaEnabled: true, mfaSecret: 'enc-secret', mfaMethod: 'totp' });
     decryptMfaTotpSecret.mockReturnValue('PLAINTEXT-SECRET');
-    verifyMFAToken.mockResolvedValue(true);
+    consumeMFAToken.mockResolvedValue(true);
   });
 
   it('returns null for a valid TOTP code', async () => {
     const c = makeContext();
     const result = await requireFreshMfaStepUp(c, USER_ID, '123456');
     expect(result).toBeNull();
-    expect(verifyMFAToken).toHaveBeenCalledWith('PLAINTEXT-SECRET', '123456');
+    expect(consumeMFAToken).toHaveBeenCalledWith('PLAINTEXT-SECRET', '123456', USER_ID);
     expect(c.json).not.toHaveBeenCalled();
   });
 
   it('returns 401 for an invalid TOTP code', async () => {
-    verifyMFAToken.mockResolvedValue(false);
+    consumeMFAToken.mockResolvedValue(false);
     const c = makeContext();
     const result = await requireFreshMfaStepUp(c, USER_ID, '000000');
     expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
@@ -111,7 +111,7 @@ describe('requireFreshMfaStepUp', () => {
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
     expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
-    expect(verifyMFAToken).not.toHaveBeenCalled();
+    expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
   it('returns 401 when the MFA method is sms', async () => {
@@ -119,7 +119,7 @@ describe('requireFreshMfaStepUp', () => {
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
     expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
-    expect(verifyMFAToken).not.toHaveBeenCalled();
+    expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
   it('returns 401 when the MFA method is passkey', async () => {
@@ -127,7 +127,7 @@ describe('requireFreshMfaStepUp', () => {
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
     expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
-    expect(verifyMFAToken).not.toHaveBeenCalled();
+    expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
   it('returns 401 when no MFA secret is stored', async () => {
@@ -135,7 +135,7 @@ describe('requireFreshMfaStepUp', () => {
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
     expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
-    expect(verifyMFAToken).not.toHaveBeenCalled();
+    expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
   it('returns 401 when the stored secret cannot be decrypted', async () => {
@@ -143,7 +143,7 @@ describe('requireFreshMfaStepUp', () => {
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
     expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
-    expect(verifyMFAToken).not.toHaveBeenCalled();
+    expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
   it('returns 401 when the user does not exist', async () => {
@@ -162,7 +162,7 @@ describe('requireFreshMfaStepUp', () => {
       429,
     );
     expect((result as any).__status).toBe(429);
-    expect(verifyMFAToken).not.toHaveBeenCalled();
+    expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
   it('returns 503 when redis is unavailable', async () => {

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -13,7 +13,7 @@ import {
 } from '../../services';
 import { createAuditLogAsync } from '../../services/auditService';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
-import { verifyMFAToken } from '../../services/mfa';
+import { consumeMFAToken } from '../../services/mfa';
 import type { RequestLike } from '../../services/auditEvents';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
 import {
@@ -156,7 +156,10 @@ export async function requireFreshMfaStepUp(
     return c.json({ error: 'Invalid credentials' }, 401);
   }
 
-  const valid = await verifyMFAToken(secret, code);
+  // consumeMFAToken (not verifyMFAToken): enforce single-use of the TOTP step
+  // so a sniffed live code cannot re-authorize multiple critical actions within
+  // its validity window. This L4 path had no other single-use binding. (sec review #2)
+  const valid = await consumeMFAToken(secret, code, userId);
   if (!valid) {
     return c.json({ error: 'Invalid credentials' }, 401);
   }

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -8,6 +8,7 @@ import {
   createTokenPair,
   generateMFASecret,
   verifyMFAToken,
+  consumeMFAToken,
   generateOTPAuthURL,
   generateQRCode,
   generateRecoveryCodes,
@@ -192,7 +193,9 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
         return c.json({ error: 'Invalid MFA configuration' }, 400);
       }
       migratedMfaSecret = decrypted.migratedSecret;
-      valid = await verifyMFAToken(decryptedMfaSecret, code);
+      // consumeMFAToken: single-use per (user, step) so a live code can't be
+      // replayed into a second login session. (security review #2)
+      valid = await consumeMFAToken(decryptedMfaSecret, code, user.id);
     }
 
     if (!valid) {
@@ -414,7 +417,8 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
     if (!decryptedMfaSecret) {
       return c.json({ error: 'Invalid MFA configuration' }, 400);
     }
-    const valid = await verifyMFAToken(decryptedMfaSecret, code);
+    // consumeMFAToken: a replayed live code must not disable MFA. (sec review #2)
+    const valid = await consumeMFAToken(decryptedMfaSecret, code, auth.user.id);
     if (!valid) {
       writeAuthAudit(c, {
         orgId: auth.orgId ?? undefined,

--- a/apps/api/src/services/mfa.test.ts
+++ b/apps/api/src/services/mfa.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import { generateMFASecret, generateOTPAuthURL, generateRecoveryCodes } from './mfa';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generate } from 'otplib';
+import { generateMFASecret, generateOTPAuthURL, generateRecoveryCodes, consumeMFAToken } from './mfa';
+
+// In-memory stand-in for the Redis single-use store. `eval` mirrors the Lua in
+// consumeMFAToken: accept (and record) only when the step is newer than the
+// last consumed step for that key.
+const redisState = vi.hoisted(() => ({ store: new Map<string, string>(), available: true }));
+vi.mock('./redis', () => ({
+  getRedis: () => redisState.available ? {
+    eval: async (_script: string, _numKeys: number, key: string, step: string) => {
+      const cur = redisState.store.get(key);
+      if (cur && Number(step) <= Number(cur)) return 0;
+      redisState.store.set(key, step);
+      return 1;
+    }
+  } : null,
+}));
 
 describe('mfa service', () => {
   describe('generateMFASecret', () => {
@@ -71,6 +87,46 @@ describe('mfa service', () => {
       // With random generation, there's a tiny chance of collision
       // but with 100 codes it should be extremely rare
       expect(uniqueCodes.size).toBe(codes.length);
+    });
+  });
+
+  // security review #2: TOTP replay protection (RFC 6238 §5.2)
+  describe('consumeMFAToken (single-use per user+step)', () => {
+    beforeEach(() => {
+      redisState.store.clear();
+      redisState.available = true;
+    });
+
+    it('accepts a valid code once, then rejects a replay of the same step', async () => {
+      const secret = generateMFASecret();
+      const code = await generate({ secret });
+
+      expect(await consumeMFAToken(secret, code, 'user-1')).toBe(true);
+      // Same live code, same time-step → replay → rejected.
+      expect(await consumeMFAToken(secret, code, 'user-1')).toBe(false);
+    });
+
+    it('rejects an invalid code', async () => {
+      const secret = generateMFASecret();
+      expect(await consumeMFAToken(secret, '000000', 'user-1')).toBe(false);
+    });
+
+    it('scopes single-use per user (the same code is consumable once per user)', async () => {
+      const secret = generateMFASecret();
+      const code = await generate({ secret });
+
+      expect(await consumeMFAToken(secret, code, 'user-A')).toBe(true);
+      expect(await consumeMFAToken(secret, code, 'user-B')).toBe(true);
+      // user-A already consumed this step.
+      expect(await consumeMFAToken(secret, code, 'user-A')).toBe(false);
+    });
+
+    it('fails closed when Redis is unavailable (cannot guarantee single-use)', async () => {
+      redisState.available = false;
+      const secret = generateMFASecret();
+      const code = await generate({ secret });
+
+      expect(await consumeMFAToken(secret, code, 'user-1')).toBe(false);
     });
   });
 });

--- a/apps/api/src/services/mfa.ts
+++ b/apps/api/src/services/mfa.ts
@@ -1,6 +1,7 @@
 import { generateSecret, generateURI, verify } from 'otplib';
 import QRCode from 'qrcode';
 import { randomInt } from 'crypto';
+import { getRedis } from './redis';
 
 export function generateMFASecret(): string {
   return generateSecret({ length: 20 });
@@ -15,6 +16,69 @@ export async function verifyMFAToken(secret: string, token: string): Promise<boo
     });
     return result.valid;
   } catch {
+    return false;
+  }
+}
+
+// A used time-step record must outlive the real-time window in which any code
+// for that step is still acceptable. With period=30s and ±1 step of tolerance,
+// a code is valid for roughly 90s; 120s is a comfortable upper bound.
+const MFA_USED_STEP_TTL_SECONDS = 120;
+
+// Atomic "accept only if this step is strictly newer than the last consumed
+// step" — single round-trip so concurrent verifies can't both win. Returns 1
+// when accepted (and records the step), 0 on replay of an already-used step.
+const MFA_USED_STEP_LUA = `
+local cur = redis.call('GET', KEYS[1])
+if cur and tonumber(ARGV[1]) <= tonumber(cur) then return 0 end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+return 1
+`;
+
+/**
+ * Verify a TOTP code AND enforce single-use per (user, time-step). RFC 6238
+ * §5.2 requires rejecting a previously-accepted OTP within its validity window;
+ * otherwise a sniffed live code can be replayed — most impactful on the L4
+ * step-up re-auth path (`requireFreshMfaStepUp`), which has no other single-use
+ * binding. Returns false for an invalid code OR a replay of an already-consumed
+ * step.
+ *
+ * Fails CLOSED on Redis unavailability: without recording the step we cannot
+ * guarantee single-use, so we reject — consistent with the token-revocation /
+ * login posture (which already requires Redis), so this adds no new outage
+ * surface. The per-user 5/5min limiter still bounds attempts.
+ */
+export async function consumeMFAToken(secret: string, token: string, userId: string): Promise<boolean> {
+  let result: Awaited<ReturnType<typeof verify>>;
+  try {
+    result = await verify({ secret, token, epochTolerance: 30 });
+  } catch {
+    return false;
+  }
+  // otplib's verify result carries the matched `timeStep` at runtime, but its
+  // TS types omit it — read it through a narrow cast.
+  const timeStep = (result as { timeStep?: unknown }).timeStep;
+  if (!result.valid || typeof timeStep !== 'number') {
+    return false;
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    console.error('[mfa] Redis unavailable — cannot enforce TOTP single-use; rejecting code');
+    return false;
+  }
+
+  try {
+    const accepted = await redis.eval(
+      MFA_USED_STEP_LUA,
+      1,
+      `mfa:usedstep:${userId}`,
+      String(timeStep),
+      String(MFA_USED_STEP_TTL_SECONDS)
+    );
+    return accepted === 1;
+  } catch (err) {
+    console.error('[mfa] TOTP single-use check failed — rejecting code:', err);
     return false;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1655 / #1671 (security review #2 deferred items). A valid TOTP code was accepted for its whole ~60–90s validity window with **no used-code tracking**, so a sniffed live code could be replayed. Most impactful on the **L4 critical-action step-up** (`requireFreshMfaStepUp`, used by approvals/PAM), which had **no single-use binding at all** — one observed code could re-authorize multiple sensitive operations within the window (up to the 5/5min limit).

## Change

Add `consumeMFAToken(secret, token, userId)`:
- Verifies the code, then atomically (a small Redis Lua script) enforces **single-use per `(user, time-step)`** using otplib 13.4.1's matched `result.timeStep`. A replay of an already-consumed step is rejected (RFC 6238 §5.2).
- **Fails closed** on Redis unavailability — consistent with the existing login / token-revocation posture (which already requires Redis), so no new outage surface. The per-user 5/5min limiter still bounds attempts.

Wired into the three paths that verify an **existing enrolled** factor:
- login MFA verify (`/mfa/verify`)
- the L4 step-up (`requireFreshMfaStepUp`)
- MFA disable (`/mfa/disable`)

The two **enrollment-confirmation** sites (`/mfa/setup` confirm, `/mfa/enable`) keep `verifyMFAToken` — replaying your own just-created setup code is harmless.

## Verification
- `tsc` clean; **118 affected auth/mfa tests pass**.
- 4 new `consumeMFAToken` unit tests (real otplib + mocked Redis): accept-once-then-reject-replay, invalid code, per-user scoping, fail-closed. `helpers.mfaStepUp.test` updated to the new consume path.

## Remaining deferred (review #2)
SSO **domain-ownership verification** + raising the bar to configure an IdP (the root-cause H-2 hardening; 1A+1B in #1671 already neutralize the steady-state takeover), and the SSO **IdP-MFA signal** (H-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)