### PR TITLE
fix(alerts,network): enforce site-axis on by-id and bulk endpoints

### DIFF
--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -24,7 +24,7 @@ import { listAlertsSchema, resolveAlertSchema, suppressAlertSchema, bulkAlertAct
 import { getPagination, ensureOrgAccess, getAlertWithOrgCheck } from './helpers';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
 import { createTicketFromAlert, TicketServiceError } from '../../services/ticketService';
-import { deviceInSiteScope, filterAlertsBySiteScope } from '../tickets/siteScope';
+import { filterAlertsBySiteScope } from '../tickets/siteScope';
 
 export const alertsRoutes = new Hono();
 
@@ -854,15 +854,13 @@ alertsRoutes.post(
 
     // Verify the alert is visible to the caller before calling the service
     // (defense-in-depth: service also re-checks via createTicket org access).
+    // getAlertWithOrgCheck now enforces BOTH axes: org (RLS-backed) and site
+    // (app-layer-only). A site-restricted caller therefore cannot create a
+    // ticket from an alert whose device is outside their allowed sites — the
+    // alert resolves null and surfaces as 404 (no oracle), same shape as the
+    // ticket-side gate. No separate deviceInSiteScope call is needed.
     const alert = await getAlertWithOrgCheck(id, auth);
     if (!alert) {
-      return c.json({ error: 'Alert not found' }, 404);
-    }
-
-    // Site-axis gate (R2): a site-restricted caller must not create tickets
-    // from alerts whose device is outside their allowed sites. Out-of-site
-    // alerts are invisible, not forbidden — same shape as the ticket-side gate.
-    if (alert.deviceId && !(await deviceInSiteScope(auth, alert.deviceId))) {
       return c.json({ error: 'Alert not found' }, 404);
     }
 

--- a/apps/api/src/routes/alerts/byid.sitescope.test.ts
+++ b/apps/api/src/routes/alerts/byid.sitescope.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Site-axis enforcement on the single-alert by-id paths (T9, #1051 class):
+// GET /:id, POST /:id/acknowledge, POST /:id/resolve, POST /:id/suppress.
+// Site scope is app-layer-only (RLS does NOT enforce it). The list endpoint
+// narrows by allowedSiteIds, but these by-id handlers historically did not, so
+// a site-restricted org user could read/mutate alerts on devices in other
+// sites of the same org. Out-of-site → 404 (no oracle); deviceless alerts stay
+// visible; unrestricted callers are unaffected.
+//
+// This file deliberately does NOT mock ./helpers — it exercises the real
+// getAlertWithOrgCheck (now site-aware) against an in-memory db.
+
+const { authRef, grantedRef, state, tables, dbMock } = vi.hoisted(() => {
+  const tables = {
+    alerts: { id: 'alerts.id', orgId: 'alerts.orgId', deviceId: 'alerts.deviceId', status: 'alerts.status', ruleId: 'alerts.ruleId', title: 'alerts.title' },
+    devices: { id: 'devices.id', siteId: 'devices.siteId', orgId: 'devices.orgId' },
+    alertRules: { id: 'alertRules.id' },
+    alertNotifications: { id: 'alertNotifications.id', alertId: 'alertNotifications.alertId', channelId: 'alertNotifications.channelId', status: 'alertNotifications.status', sentAt: 'alertNotifications.sentAt', errorMessage: 'alertNotifications.errorMessage', createdAt: 'alertNotifications.createdAt' },
+    notificationChannels: { id: 'notificationChannels.id', name: 'notificationChannels.name', type: 'notificationChannels.type' },
+  };
+
+  type Predicate = { op: string; col?: unknown; val?: unknown; vals?: unknown[]; args?: Predicate[] } | undefined;
+  const columnKey = (col: unknown) => String(col).split('.').pop()!;
+  const evalPredicate = (row: Record<string, unknown>, predicate: Predicate): boolean => {
+    if (!predicate) return true;
+    if (predicate.op === 'eq') return row[columnKey(predicate.col)] === predicate.val;
+    if (predicate.op === 'inArray') return (predicate.vals ?? []).includes(row[columnKey(predicate.col)]);
+    if (predicate.op === 'and') return (predicate.args ?? []).every((arg) => evalPredicate(row, arg));
+    if (predicate.op === 'or') return (predicate.args ?? []).some((arg) => evalPredicate(row, arg));
+    return true;
+  };
+
+  const state = {
+    alerts: [] as Array<Record<string, any>>,
+    devices: [] as Array<Record<string, any>>,
+  };
+
+  class SelectQuery {
+    private predicate: Predicate;
+    constructor(private table: unknown, private projection?: Record<string, unknown>) {}
+    where(predicate: Predicate) { this.predicate = predicate; return this; }
+    leftJoin() { return this; }
+    orderBy() { return this; }
+    limit(limit: number) { return Promise.resolve(this.rows().slice(0, limit)); }
+    then(resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) {
+      return Promise.resolve(this.rows()).then(resolve, reject);
+    }
+    private rows() {
+      let source: Array<Record<string, unknown>> = [];
+      if (this.table === tables.alerts) source = state.alerts;
+      else if (this.table === tables.devices) source = state.devices;
+      else source = [];
+      const filtered = source.filter((row) => evalPredicate(row, this.predicate));
+      if (!this.projection) return filtered;
+      return filtered.map((row) => {
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(this.projection!)) out[key] = row[columnKey(this.projection![key])];
+        return out;
+      });
+    }
+  }
+
+  const dbMock = {
+    select: vi.fn((projection?: Record<string, unknown>) => ({
+      from: (table: unknown) => new SelectQuery(table, projection),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (predicate: Predicate) => {
+          const source = table === tables.alerts ? state.alerts : [];
+          const written: Array<Record<string, unknown>> = [];
+          for (const row of source) {
+            if (!evalPredicate(row, predicate)) continue;
+            Object.assign(row, values);
+            written.push(row);
+          }
+          return {
+            returning: () => Promise.resolve(written),
+            then: (resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) =>
+              Promise.resolve(written.map(() => ({}))).then(resolve, reject),
+          };
+        },
+      }),
+    })),
+  };
+
+  return {
+    authRef: {
+      current: {
+        scope: 'organization' as string,
+        user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+        partnerId: null as string | null,
+        orgId: 'org-1' as string | null,
+        accessibleOrgIds: null as string[] | null,
+        allowedSiteIds: undefined as string[] | undefined,
+        canAccessOrg: (_id: string) => true as boolean,
+      },
+    },
+    grantedRef: { current: new Set<string>() },
+    state,
+    tables,
+    dbMock,
+  };
+});
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  gte: (col: unknown, val: unknown) => ({ op: 'gte', col, val }),
+  lte: (col: unknown, val: unknown) => ({ op: 'lte', col, val }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  or: (...args: unknown[]) => ({ op: 'or', args }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: 'inArray', col, vals }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  sql: Object.assign(() => ({ op: 'sql' }), { raw: () => ({ op: 'sql' }) }),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: (resource: string, action: string) => async (c: any, next: any) => {
+    if (!grantedRef.current.has(`${resource}:${action}`)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    c.set('permissions', { allowedSiteIds: authRef.current?.allowedSiteIds });
+    await next();
+  },
+  requireMfa: () => async (_c: any, next: any) => next(),
+  siteAccessCheck: (allowedSiteIds?: string[]) => (siteId: string | null | undefined) => {
+    if (!allowedSiteIds) return true;
+    if (!siteId) return false;
+    return allowedSiteIds.includes(siteId);
+  },
+}));
+
+vi.mock('../../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+vi.mock('../../db/schema', () => ({
+  alertCorrelationGroups: {}, alertCorrelationMembers: {},
+  alertRules: tables.alertRules, alertTemplates: {}, alerts: tables.alerts,
+  notificationChannels: tables.notificationChannels,
+  alertNotifications: tables.alertNotifications, devices: tables.devices, tickets: {}, ticketAlertLinks: {},
+  organizations: {}, partners: {}, escalationPolicies: {},
+}));
+vi.mock('../../services/alertCooldown', () => ({
+  setCooldown: vi.fn(), markConfigPolicyRuleCooldown: vi.fn(),
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: vi.fn(),
+  emitCorrelationFeedback: vi.fn(),
+}));
+vi.mock('../../services/ticketService', () => ({
+  createTicketFromAlert: vi.fn(),
+  TicketServiceError: class TicketServiceError extends Error { status = 400; },
+}));
+vi.mock('../../services/notificationSenders', () => ({
+  validateEmailConfig: vi.fn(() => ({ errors: [] })),
+  validateWebhookConfig: vi.fn(() => ({ errors: [] })),
+  validateSmsConfig: vi.fn(() => ({ errors: [] })),
+  validatePagerDutyConfig: vi.fn(() => ({ errors: [] })),
+  validatePushoverConfig: vi.fn(() => ({ errors: [] })),
+}));
+
+import { alertsRoutes } from './alerts';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', alertsRoutes);
+  return app;
+}
+
+const ORG = 'org-1';
+const SITE_A = '5a5a5a5a-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_B = '5b5b5b5b-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const DEVICE_A = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd';
+const DEVICE_B = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd';
+const ALERT_A = 'a1a1a1a1-1111-4111-8111-111111111111'; // SITE_A device
+const ALERT_B = 'a2a2a2a2-2222-4222-8222-222222222222'; // SITE_B device
+const ALERT_ORGWIDE = 'a3a3a3a3-3333-4333-8333-333333333333'; // deviceless
+const ALERTS_WRITE = 'alerts:write';
+const ALERTS_ACKNOWLEDGE = 'alerts:acknowledge';
+
+function resetState() {
+  state.devices = [
+    { id: DEVICE_A, siteId: SITE_A, orgId: ORG },
+    { id: DEVICE_B, siteId: SITE_B, orgId: ORG },
+  ];
+  state.alerts = [
+    { id: ALERT_A, orgId: ORG, deviceId: DEVICE_A, status: 'active', ruleId: null, title: 'A' },
+    { id: ALERT_B, orgId: ORG, deviceId: DEVICE_B, status: 'active', ruleId: null, title: 'B' },
+    { id: ALERT_ORGWIDE, orgId: ORG, deviceId: null, status: 'active', ruleId: null, title: 'org' },
+  ];
+}
+
+describe('alert by-id site-axis scope (T9, #1051)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    grantedRef.current = new Set<string>([ALERTS_WRITE, ALERTS_ACKNOWLEDGE]);
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Reed Only', email: 'reed@org.example' },
+      partnerId: null, orgId: ORG, accessibleOrgIds: null, allowedSiteIds: undefined, canAccessOrg: () => true,
+    } as typeof authRef.current;
+    resetState();
+  });
+
+  const restrictToSiteA = () => {
+    authRef.current = { ...authRef.current, allowedSiteIds: [SITE_A] } as typeof authRef.current;
+  };
+
+  // ---- GET /:id ----
+  describe('GET /alerts/:id', () => {
+    it('404 on an out-of-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_B}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('200 on an in-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_A}`);
+      expect(res.status).toBe(200);
+    });
+
+    it('200 on a deviceless (org-wide) alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_ORGWIDE}`);
+      expect(res.status).toBe(200);
+    });
+
+    it('200 on an out-of-site alert for an unrestricted user (no regression)', async () => {
+      const res = await makeApp().request(`/alerts/${ALERT_B}`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ---- POST /:id/acknowledge ----
+  describe('POST /alerts/:id/acknowledge', () => {
+    it('404 and no write on an out-of-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_B}/acknowledge`, { method: 'POST' });
+      expect(res.status).toBe(404);
+      expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('active');
+    });
+
+    it('acknowledges an in-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_A}/acknowledge`, { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_A)?.status).toBe('acknowledged');
+    });
+
+    it('acknowledges an out-of-site alert for an unrestricted user (no regression)', async () => {
+      const res = await makeApp().request(`/alerts/${ALERT_B}/acknowledge`, { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('acknowledged');
+    });
+  });
+
+  // ---- POST /:id/resolve ----
+  describe('POST /alerts/:id/resolve', () => {
+    it('404 and no write on an out-of-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_B}/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(404);
+      expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('active');
+    });
+
+    it('resolves an in-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_A}/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_A)?.status).toBe('resolved');
+    });
+  });
+
+  // ---- POST /:id/suppress ----
+  describe('POST /alerts/:id/suppress', () => {
+    it('404 and no write on an out-of-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_B}/suppress`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ until: '2030-01-01T00:00:00.000Z' }),
+      });
+      expect(res.status).toBe(404);
+      expect(state.alerts.find((a) => a.id === ALERT_B)?.status).toBe('active');
+    });
+
+    it('suppresses an in-site alert for a SITE_A-restricted user', async () => {
+      restrictToSiteA();
+      const res = await makeApp().request(`/alerts/${ALERT_A}/suppress`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ until: '2030-01-01T00:00:00.000Z' }),
+      });
+      expect(res.status).toBe(200);
+      expect(state.alerts.find((a) => a.id === ALERT_A)?.status).toBe('suppressed');
+    });
+  });
+});

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -5,11 +5,13 @@ import {
   alertRules,
   alertTemplates,
   alerts,
+  devices,
   notificationChannels,
   escalationPolicies,
   organizations,
   partners,
 } from '../../db/schema';
+import { siteAccessCheck } from '../../middleware/auth';
 import {
   validateEmailConfig,
   validateWebhookConfig,
@@ -114,7 +116,26 @@ export async function getAlertRuleWithOrgCheck(ruleId: string, auth: { canAccess
   return rule;
 }
 
-export async function getAlertWithOrgCheck(alertId: string, auth: { canAccessOrg: (orgId: string) => boolean }) {
+/**
+ * Resolve an alert and enforce BOTH tenancy axes:
+ *  - org axis (RLS-backed): the caller must be able to access the alert's org.
+ *  - site axis (app-layer ONLY — RLS does NOT enforce it): a site-restricted
+ *    org user (`auth.allowedSiteIds` set) must not read/act on an alert whose
+ *    device lives in a site outside their allowlist.
+ *
+ * The site axis mirrors the alert-list narrowing (`alerts.ts` GET /) and the
+ * create-ticket gate (`deviceInSiteScope`): deviceless (org-wide) alerts stay
+ * visible; out-of-site alerts return null so the caller surfaces a 404 (no
+ * oracle distinguishing "absent" from "forbidden"). Unrestricted callers
+ * (partner/system scope, or org users with no site restriction — i.e.
+ * `allowedSiteIds` undefined) are unaffected. Centralizing the site check here
+ * covers every by-id path uniformly (GET /:id, acknowledge, resolve, suppress,
+ * create-ticket, tickets) rather than per-handler.
+ */
+export async function getAlertWithOrgCheck(
+  alertId: string,
+  auth: { canAccessOrg: (orgId: string) => boolean; allowedSiteIds?: string[] }
+) {
   const [alert] = await db
     .select()
     .from(alerts)
@@ -128,6 +149,19 @@ export async function getAlertWithOrgCheck(alertId: string, auth: { canAccessOrg
   const hasAccess = ensureOrgAccess(alert.orgId, auth);
   if (!hasAccess) {
     return null;
+  }
+
+  // Site-axis gate. Only restricted callers (allowedSiteIds set) are narrowed.
+  // Deviceless alerts are org-wide and not site-bound, so they pass.
+  if (auth.allowedSiteIds && alert.deviceId) {
+    const [device] = await db
+      .select({ siteId: devices.siteId })
+      .from(devices)
+      .where(eq(devices.id, alert.deviceId))
+      .limit(1);
+    if (!siteAccessCheck(auth.allowedSiteIds)(device?.siteId ?? null)) {
+      return null;
+    }
   }
 
   return alert;

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -663,6 +663,89 @@ describe('mobile routes', () => {
         },
       }));
     });
+
+    const SITE_A = 'aaaaaaaa-0000-0000-0000-00000000000a';
+    const SITE_B = 'bbbbbbbb-0000-0000-0000-00000000000b';
+
+    it('should 404 and not mutate when site-restricted caller targets an out-of-site alert', async () => {
+      authState.permissions = { allowedSiteIds: [SITE_A] };
+      vi.mocked(db.select)
+        // alert lookup
+        .mockReturnValueOnce(
+          mockSelectLimitChain([
+            { id: 'alert-1', status: 'active', orgId: 'org-123', ruleId: 'rule-1', deviceId: 'device-b' }
+          ]) as any
+        )
+        // device site lookup -> device lives in SITE_B (outside allowlist)
+        .mockReturnValueOnce(mockSelectLimitChain([{ siteId: SITE_B }]) as any);
+
+      const res = await app.request('/mobile/alerts/alert-1/acknowledge', {
+        method: 'POST'
+      });
+
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+      expect(emitAlertStateFeedbackMock).not.toHaveBeenCalled();
+    });
+
+    it('should allow a same-site restricted caller to acknowledge', async () => {
+      authState.permissions = { allowedSiteIds: [SITE_A] };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(
+          mockSelectLimitChain([
+            { id: 'alert-1', status: 'active', orgId: 'org-123', ruleId: 'rule-1', deviceId: 'device-a' }
+          ]) as any
+        )
+        // device site lookup -> device lives in SITE_A (in allowlist)
+        .mockReturnValueOnce(mockSelectLimitChain([{ siteId: SITE_A }]) as any);
+      vi.mocked(db.update).mockReturnValue(
+        mockUpdateReturning([{ id: 'alert-1', status: 'acknowledged' }]) as any
+      );
+
+      const res = await app.request('/mobile/alerts/alert-1/acknowledge', {
+        method: 'POST'
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('should leave deviceless alert visible to a site-restricted caller', async () => {
+      authState.permissions = { allowedSiteIds: [SITE_A] };
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: 'alert-1', status: 'active', orgId: 'org-123', ruleId: 'rule-1', deviceId: null }
+        ]) as any
+      );
+      vi.mocked(db.update).mockReturnValue(
+        mockUpdateReturning([{ id: 'alert-1', status: 'acknowledged' }]) as any
+      );
+
+      const res = await app.request('/mobile/alerts/alert-1/acknowledge', {
+        method: 'POST'
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('should not narrow an unrestricted caller (allowedSiteIds undefined)', async () => {
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: 'alert-1', status: 'active', orgId: 'org-123', ruleId: 'rule-1', deviceId: 'device-b' }
+        ]) as any
+      );
+      vi.mocked(db.update).mockReturnValue(
+        mockUpdateReturning([{ id: 'alert-1', status: 'acknowledged' }]) as any
+      );
+
+      const res = await app.request('/mobile/alerts/alert-1/acknowledge', {
+        method: 'POST'
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
   });
 
   describe('POST /mobile/alerts/:id/resolve', () => {
@@ -729,6 +812,97 @@ describe('mobile routes', () => {
           hasResolutionNote: true,
         },
       }));
+    });
+
+    const SITE_A = 'aaaaaaaa-0000-0000-0000-00000000000a';
+    const SITE_B = 'bbbbbbbb-0000-0000-0000-00000000000b';
+
+    it('should 404 and not mutate when site-restricted caller targets an out-of-site alert', async () => {
+      authState.permissions = { allowedSiteIds: [SITE_A] };
+      vi.mocked(db.select)
+        // alert lookup
+        .mockReturnValueOnce(
+          mockSelectLimitChain([
+            { id: 'alert-1', status: 'acknowledged', orgId: 'org-123', deviceId: 'device-b' }
+          ]) as any
+        )
+        // device site lookup -> device lives in SITE_B (outside allowlist)
+        .mockReturnValueOnce(mockSelectLimitChain([{ siteId: SITE_B }]) as any);
+
+      const res = await app.request('/mobile/alerts/alert-1/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 'done' })
+      });
+
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+      expect(emitAlertStateFeedbackMock).not.toHaveBeenCalled();
+    });
+
+    it('should allow a same-site restricted caller to resolve', async () => {
+      authState.permissions = { allowedSiteIds: [SITE_A] };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(
+          mockSelectLimitChain([
+            { id: 'alert-1', status: 'acknowledged', orgId: 'org-123', deviceId: 'device-a' }
+          ]) as any
+        )
+        // device site lookup -> device lives in SITE_A (in allowlist)
+        .mockReturnValueOnce(mockSelectLimitChain([{ siteId: SITE_A }]) as any);
+      vi.mocked(db.update).mockReturnValue(
+        mockUpdateReturning([{ id: 'alert-1', status: 'resolved', resolutionNote: 'done' }]) as any
+      );
+
+      const res = await app.request('/mobile/alerts/alert-1/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 'done' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('should leave deviceless alert visible to a site-restricted caller', async () => {
+      authState.permissions = { allowedSiteIds: [SITE_A] };
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: 'alert-1', status: 'acknowledged', orgId: 'org-123', deviceId: null }
+        ]) as any
+      );
+      vi.mocked(db.update).mockReturnValue(
+        mockUpdateReturning([{ id: 'alert-1', status: 'resolved', resolutionNote: 'done' }]) as any
+      );
+
+      const res = await app.request('/mobile/alerts/alert-1/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 'done' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('should not narrow an unrestricted caller (allowedSiteIds undefined)', async () => {
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: 'alert-1', status: 'acknowledged', orgId: 'org-123', deviceId: 'device-b' }
+        ]) as any
+      );
+      vi.mocked(db.update).mockReturnValue(
+        mockUpdateReturning([{ id: 'alert-1', status: 'resolved', resolutionNote: 'done' }]) as any
+      );
+
+      const res = await app.request('/mobile/alerts/alert-1/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 'done' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -147,9 +147,20 @@ async function getDeviceWithOrgCheck(
   return device;
 }
 
+// Resolve an alert and enforce BOTH tenancy axes (mirrors the web helper in
+// routes/alerts/helpers.ts):
+//  - org axis (RLS-backed) via ensureOrgAccess.
+//  - site axis (app-layer ONLY — RLS does NOT enforce it): a site-restricted
+//    org user (`perms.allowedSiteIds` set) must not read/act on an alert whose
+//    device lives in a site outside their allowlist. Deviceless (org-wide)
+//    alerts stay visible; out-of-site alerts return null so the handler surfaces
+//    a 404 (no oracle distinguishing "absent" from "forbidden"). Unrestricted
+//    callers (partner/system scope, or org users with no site restriction —
+//    `allowedSiteIds` undefined) are unaffected.
 async function getAlertWithOrgCheck(
   alertId: string,
-  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>,
+  perms?: UserPermissions
 ) {
   const [alert] = await db
     .select()
@@ -164,6 +175,19 @@ async function getAlertWithOrgCheck(
   const hasAccess = await ensureOrgAccess(alert.orgId, auth);
   if (!hasAccess) {
     return null;
+  }
+
+  // Site-axis gate. Only restricted callers (allowedSiteIds set) are narrowed.
+  // Deviceless alerts are org-wide and not site-bound, so they pass.
+  if (perms?.allowedSiteIds && alert.deviceId) {
+    const [device] = await db
+      .select({ siteId: devices.siteId })
+      .from(devices)
+      .where(eq(devices.id, alert.deviceId))
+      .limit(1);
+    if (typeof device?.siteId !== 'string' || !canAccessSite(perms, device.siteId)) {
+      return null;
+    }
   }
 
   return alert;
@@ -661,8 +685,9 @@ mobileRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const alertId = c.req.param('id')!;
+    const perms = c.get('permissions') as UserPermissions | undefined;
 
-    const alert = await getAlertWithOrgCheck(alertId, auth);
+    const alert = await getAlertWithOrgCheck(alertId, auth, perms);
     if (!alert) {
       return c.json({ error: 'Alert not found' }, 404);
     }
@@ -734,8 +759,9 @@ mobileRoutes.post(
     const auth = c.get('auth');
     const alertId = c.req.param('id')!;
     const data = c.req.valid('json');
+    const perms = c.get('permissions') as UserPermissions | undefined;
 
-    const alert = await getAlertWithOrgCheck(alertId, auth);
+    const alert = await getAlertWithOrgCheck(alertId, auth, perms);
     if (!alert) {
       return c.json({ error: 'Alert not found' }, 404);
     }

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -106,6 +106,24 @@ async function getBaselineWithAccess(
   return baseline ?? null;
 }
 
+/**
+ * Site-axis (sub-org) gate for a single baseline. Site scope is app-layer-only
+ * (RLS does NOT enforce it) and the by-id handlers (unlike GET /, POST /)
+ * historically skipped it, so a site-restricted org user could read/update/
+ * scan/delete baselines outside their allowed sites. Mirrors the GET /
+ * narrowing (`inArray(networkBaselines.siteId, allowedSiteIds)`): a restricted
+ * caller is denied for a baseline in a site outside the allowlist. No-op for
+ * unrestricted callers (`perms` undefined / `allowedSiteIds` unset). Returns
+ * true when access is permitted.
+ */
+function baselineInSiteScope(
+  perms: UserPermissions | undefined,
+  baseline: typeof networkBaselines.$inferSelect
+): boolean {
+  if (!perms?.allowedSiteIds) return true;
+  return canAccessSite(perms, baseline.siteId);
+}
+
 networkBaselineRoutes.use('*', authMiddleware);
 
 networkBaselineRoutes.get(
@@ -321,10 +339,11 @@ networkBaselineRoutes.get(
   requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const baselineId = c.req.param('id')!;
 
     const baseline = await getBaselineWithAccess(baselineId, auth);
-    if (!baseline) {
+    if (!baseline || !baselineInSiteScope(perms, baseline)) {
       return c.json({ error: 'Baseline not found' }, 404);
     }
 
@@ -339,11 +358,12 @@ networkBaselineRoutes.patch(
   zValidator('json', updateBaselineSchema),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const baselineId = c.req.param('id')!;
     const body = c.req.valid('json');
 
     const baseline = await getBaselineWithAccess(baselineId, auth);
-    if (!baseline) {
+    if (!baseline || !baselineInSiteScope(perms, baseline)) {
       return c.json({ error: 'Baseline not found' }, 404);
     }
 
@@ -395,10 +415,11 @@ networkBaselineRoutes.post(
   requirePermission('devices', 'write'),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const baselineId = c.req.param('id')!;
 
     const baseline = await getBaselineWithAccess(baselineId, auth);
-    if (!baseline) {
+    if (!baseline || !baselineInSiteScope(perms, baseline)) {
       return c.json({ error: 'Baseline not found' }, 404);
     }
 
@@ -438,11 +459,12 @@ networkBaselineRoutes.get(
   zValidator('query', baselineChangesQuerySchema),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const baselineId = c.req.param('id')!;
     const query = c.req.valid('query');
 
     const baseline = await getBaselineWithAccess(baselineId, auth);
-    if (!baseline) {
+    if (!baseline || !baselineInSiteScope(perms, baseline)) {
       return c.json({ error: 'Baseline not found' }, 404);
     }
 
@@ -491,11 +513,12 @@ networkBaselineRoutes.delete(
   zValidator('query', deleteBaselineQuerySchema),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const baselineId = c.req.param('id')!;
     const query = c.req.valid('query');
 
     const baseline = await getBaselineWithAccess(baselineId, auth);
-    if (!baseline) {
+    if (!baseline || !baselineInSiteScope(perms, baseline)) {
       return c.json({ error: 'Baseline not found' }, 404);
     }
 

--- a/apps/api/src/routes/networkBaselines_byid_sitescope.test.ts
+++ b/apps/api/src/routes/networkBaselines_byid_sitescope.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Site-axis enforcement on networkBaseline by-id paths (T9, #1051):
+// GET /:id, PATCH /:id, POST /:id/scan, GET /:id/changes, DELETE /:id.
+// Site scope is app-layer-only (RLS does NOT enforce it). GET / / POST /
+// narrow by allowedSiteIds, but the by-id handlers historically did not, so a
+// site-restricted org user could read/update/scan/delete baselines in other
+// sites of the same org. Out-of-site → 404 (no oracle).
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const BASELINE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+vi.mock('../services', () => ({}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/redis', () => ({ isRedisAvailable: vi.fn(() => true) }));
+vi.mock('../jobs/networkBaselineWorker', () => ({
+  enqueueBaselineScan: vi.fn().mockResolvedValue('job-123'),
+}));
+vi.mock('../services/networkBaseline', () => ({
+  normalizeBaselineScanSchedule: vi.fn((s) => s ?? { enabled: false, intervalHours: 24 }),
+  normalizeBaselineAlertSettings: vi.fn((s) => s ?? { newDevice: true, disappeared: true, changed: true, rogueDevice: true }),
+}));
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  networkBaselines: {
+    id: 'id', orgId: 'org_id', siteId: 'site_id', subnet: 'subnet', knownDevices: 'known_devices',
+    scanSchedule: 'scan_schedule', alertSettings: 'alert_settings', lastScanAt: 'last_scan_at',
+    lastScanJobId: 'last_scan_job_id', createdAt: 'created_at', updatedAt: 'updated_at',
+  },
+  networkChangeEvents: {
+    id: 'id', orgId: 'org_id', siteId: 'site_id', baselineId: 'baseline_id', eventType: 'event_type',
+    acknowledged: 'acknowledged', detectedAt: 'detected_at', createdAt: 'created_at', acknowledgedAt: 'acknowledged_at',
+  },
+  sites: { id: 'id', orgId: 'org_id' },
+  discoveryProfiles: { id: 'id', orgId: 'org_id', siteId: 'site_id', subnets: 'subnets' },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization', orgId: ORG_ID, partnerId: null,
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+      orgCondition: () => null,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    const restrict = c.req.header('x-restrict-site');
+    c.set('permissions', restrict ? {
+      permissions: [{ resource: 'devices', action: 'write' }],
+      partnerId: null, orgId: ORG_ID, roleId: 'role-1', scope: 'organization',
+      allowedSiteIds: restrict === '__empty__' ? [] : [restrict],
+    } : undefined);
+    return next();
+  }),
+}));
+
+import { db } from '../db';
+import { networkBaselineRoutes } from './networkBaselines';
+
+function makeBaseline(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BASELINE_ID, orgId: ORG_ID, siteId: SITE_A, subnet: '192.168.1.0/24',
+    knownDevices: [], scanSchedule: { enabled: false, intervalHours: 24 },
+    alertSettings: { newDevice: true, disappeared: true, changed: true, rogueDevice: true },
+    lastScanAt: null, lastScanJobId: null,
+    createdAt: new Date('2026-01-01'), updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+function selectOne(rows: any[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as any;
+}
+
+describe('networkBaseline by-id site-axis scope (T9, #1051)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.update).mockReset();
+    vi.mocked(db.delete).mockReset();
+    vi.mocked(db.transaction).mockReset();
+    app = new Hono();
+    app.route('/baselines', networkBaselineRoutes);
+  });
+
+  describe('GET /baselines/:id', () => {
+    it('404 on an out-of-site baseline for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_B })]));
+      const res = await app.request(`/baselines/${BASELINE_ID}`, { headers: { 'x-restrict-site': SITE_A } });
+      expect(res.status).toBe(404);
+    });
+
+    it('200 on an in-site baseline for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_A })]));
+      const res = await app.request(`/baselines/${BASELINE_ID}`, { headers: { 'x-restrict-site': SITE_A } });
+      expect(res.status).toBe(200);
+    });
+
+    it('200 on an out-of-site baseline for an unrestricted caller (no regression)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_B })]));
+      const res = await app.request(`/baselines/${BASELINE_ID}`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('PATCH /baselines/:id', () => {
+    it('404 and no write on an out-of-site baseline for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_B })]));
+      const res = await app.request(`/baselines/${BASELINE_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', 'x-restrict-site': SITE_A },
+        body: JSON.stringify({ alertSettings: { newDevice: false } }),
+      });
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('updates an in-site baseline for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_A })]));
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([makeBaseline({ siteId: SITE_A })]),
+          }),
+        }),
+      } as any);
+      const res = await app.request(`/baselines/${BASELINE_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', 'x-restrict-site': SITE_A },
+        body: JSON.stringify({ alertSettings: { newDevice: false } }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('POST /baselines/:id/scan', () => {
+    it('404 on an out-of-site baseline for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_B })]));
+      const res = await app.request(`/baselines/${BASELINE_ID}/scan`, {
+        method: 'POST',
+        headers: { 'x-restrict-site': SITE_A },
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /baselines/:id/changes', () => {
+    it('404 on an out-of-site baseline for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_B })]));
+      const res = await app.request(`/baselines/${BASELINE_ID}/changes`, { headers: { 'x-restrict-site': SITE_A } });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /baselines/:id', () => {
+    it('404 and no delete on an out-of-site baseline for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectOne([makeBaseline({ siteId: SITE_B })]));
+      const res = await app.request(`/baselines/${BASELINE_ID}`, {
+        method: 'DELETE',
+        headers: { 'x-restrict-site': SITE_A },
+      });
+      expect(res.status).toBe(404);
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/networkChanges.ts
+++ b/apps/api/src/routes/networkChanges.ts
@@ -66,6 +66,25 @@ async function getChangeEventWithAccess(
   return event ?? null;
 }
 
+/**
+ * Site-axis (sub-org) gate for a single change event. Site scope is an
+ * app-layer-only authz axis — RLS does NOT enforce it — and the by-id handlers
+ * (unlike GET /) historically skipped it, so a site-restricted org user could
+ * read/acknowledge/link events outside their allowed sites. Mirrors the GET /
+ * narrowing (`inArray(networkChangeEvents.siteId, allowedSiteIds)`): a
+ * restricted caller is denied for an event in a site outside the allowlist (or
+ * with no siteId). No-op for unrestricted callers (`perms` undefined or
+ * `allowedSiteIds` unset — partner/system scope, or org users with no
+ * restriction). Returns true when access is permitted.
+ */
+function changeEventInSiteScope(
+  perms: UserPermissions | undefined,
+  event: { siteId: string }
+): boolean {
+  if (!perms?.allowedSiteIds) return true;
+  return canAccessSite(perms, event.siteId);
+}
+
 networkChangeRoutes.use('*', authMiddleware);
 
 networkChangeRoutes.get(
@@ -199,10 +218,11 @@ networkChangeRoutes.get(
   requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const eventId = c.req.param('id')!;
 
     const event = await getChangeEventWithAccess(eventId, auth);
-    if (!event) {
+    if (!event || !changeEventInSiteScope(perms, event)) {
       return c.json({ error: 'Network change event not found' }, 404);
     }
 
@@ -226,11 +246,12 @@ networkChangeRoutes.post(
   zValidator('json', acknowledgeChangeSchema),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const eventId = c.req.param('id')!;
     const body = c.req.valid('json');
 
     const event = await getChangeEventWithAccess(eventId, auth);
-    if (!event) {
+    if (!event || !changeEventInSiteScope(perms, event)) {
       return c.json({ error: 'Network change event not found' }, 404);
     }
 
@@ -276,11 +297,12 @@ networkChangeRoutes.post(
   zValidator('json', linkDeviceSchema),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const eventId = c.req.param('id')!;
     const body = c.req.valid('json');
 
     const event = await getChangeEventWithAccess(eventId, auth);
-    if (!event) {
+    if (!event || !changeEventInSiteScope(perms, event)) {
       return c.json({ error: 'Network change event not found' }, 404);
     }
 
@@ -345,6 +367,7 @@ networkChangeRoutes.post(
   zValidator('json', bulkAcknowledgeSchema),
   async (c) => {
     const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
     const body = c.req.valid('json');
 
     const conditions: SQL[] = [inArray(networkChangeEvents.id, body.eventIds)];
@@ -354,9 +377,13 @@ networkChangeRoutes.post(
     }
 
     const accessibleEvents = await db
-      .select({ id: networkChangeEvents.id, orgId: networkChangeEvents.orgId })
+      .select({ id: networkChangeEvents.id, orgId: networkChangeEvents.orgId, siteId: networkChangeEvents.siteId })
       .from(networkChangeEvents)
-      .where(and(...conditions));
+      .where(and(...conditions))
+      // Site-axis filter (RLS does not enforce site scope): drop events whose
+      // site is outside a restricted caller's allowlist before mutating. No-op
+      // for unrestricted callers (perms undefined / allowedSiteIds unset).
+      .then((events) => events.filter((event) => changeEventInSiteScope(perms, event)));
 
     if (accessibleEvents.length === 0) {
       return c.json({ error: 'No accessible network change events found' }, 404);

--- a/apps/api/src/routes/networkChanges_byid_sitescope.test.ts
+++ b/apps/api/src/routes/networkChanges_byid_sitescope.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Site-axis enforcement on networkChange by-id and bulk paths (T9, #1051):
+// GET /:id, POST /:id/acknowledge, POST /:id/link-device, POST /bulk-acknowledge.
+// Site scope is app-layer-only (RLS does NOT enforce it). GET / narrows by
+// allowedSiteIds, but the by-id/bulk handlers historically did not, so a
+// site-restricted org user could read/act on events in other sites of the same
+// org. Out-of-site → 404 (single) / dropped from the mutated set (bulk).
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const EVENT_A = 'c1c1c1c1-cccc-4ccc-8ccc-cccccccccccc'; // SITE_A
+const EVENT_B = 'c2c2c2c2-cccc-4ccc-8ccc-cccccccccccc'; // SITE_B
+const DEVICE_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+vi.mock('../services', () => ({}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), update: vi.fn() },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  networkChangeEvents: {
+    id: 'id', orgId: 'org_id', siteId: 'site_id', baselineId: 'baseline_id',
+    profileId: 'profile_id', eventType: 'event_type', ipAddress: 'ip_address',
+    macAddress: 'mac_address', hostname: 'hostname', acknowledged: 'acknowledged',
+    acknowledgedBy: 'acknowledged_by', acknowledgedAt: 'acknowledged_at', notes: 'notes',
+    alertId: 'alert_id', linkedDeviceId: 'linked_device_id', detectedAt: 'detected_at',
+    createdAt: 'created_at',
+  },
+  networkBaselines: { id: 'id', subnet: 'subnet' },
+  sites: { id: 'id', orgId: 'org_id' },
+  devices: { id: 'id', orgId: 'org_id' },
+  alerts: { id: 'id', deviceId: 'device_id' },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization', orgId: ORG_ID, partnerId: null,
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+      orgCondition: () => null,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    // Mirror prod: requirePermission populates `permissions`.
+    const restrict = c.req.header('x-restrict-site');
+    c.set('permissions', restrict ? {
+      permissions: [{ resource: 'devices', action: 'read' }],
+      partnerId: null, orgId: ORG_ID, roleId: 'role-1', scope: 'organization',
+      allowedSiteIds: restrict === '__empty__' ? [] : [restrict],
+    } : undefined);
+    return next();
+  }),
+}));
+
+import { db } from '../db';
+import { networkChangeRoutes } from './networkChanges';
+
+function makeEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: EVENT_A, orgId: ORG_ID, siteId: SITE_A, baselineId: null, profileId: null,
+    eventType: 'new_device', ipAddress: '192.168.1.50', macAddress: 'aa:bb:cc:dd:ee:ff',
+    hostname: 'new-host', vendor: null, deviceData: null, previousData: null,
+    acknowledged: false, acknowledgedBy: null, acknowledgedAt: null, notes: null,
+    alertId: null, linkedDeviceId: null,
+    detectedAt: new Date('2026-03-01T12:00:00Z'), createdAt: new Date('2026-03-01T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+// db.select chain that resolves the same payload regardless of terminator
+function selectResolving(rows: any[]) {
+  const chain: any = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit: vi.fn().mockResolvedValue(rows),
+    then: (resolve: (v: any) => void, reject?: (r: any) => void) => Promise.resolve(rows).then(resolve, reject),
+  };
+  return chain;
+}
+
+describe('networkChange by-id/bulk site-axis scope (T9, #1051)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.update).mockReset();
+    app = new Hono();
+    app.route('/changes', networkChangeRoutes);
+  });
+
+  // ---- GET /:id ----
+  describe('GET /changes/:id', () => {
+    it('404 on an out-of-site event for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectResolving([makeEvent({ id: EVENT_B, siteId: SITE_B })]) as any);
+      const res = await app.request(`/changes/${EVENT_B}`, { headers: { 'x-restrict-site': SITE_A } });
+      expect(res.status).toBe(404);
+    });
+
+    it('200 on an in-site event for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectResolving([makeEvent({ id: EVENT_A, siteId: SITE_A })]) as any)
+        .mockReturnValueOnce(selectResolving([]) as any); // baseline lookup
+      const res = await app.request(`/changes/${EVENT_A}`, { headers: { 'x-restrict-site': SITE_A } });
+      expect(res.status).toBe(200);
+    });
+
+    it('200 on an out-of-site event for an unrestricted caller (no regression)', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectResolving([makeEvent({ id: EVENT_B, siteId: SITE_B })]) as any)
+        .mockReturnValueOnce(selectResolving([]) as any);
+      const res = await app.request(`/changes/${EVENT_B}`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ---- POST /:id/acknowledge ----
+  describe('POST /changes/:id/acknowledge', () => {
+    it('404 and no write on an out-of-site event for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectResolving([makeEvent({ id: EVENT_B, siteId: SITE_B })]) as any);
+      const res = await app.request(`/changes/${EVENT_B}/acknowledge`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-restrict-site': SITE_A },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('acknowledges an in-site event for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectResolving([makeEvent({ id: EVENT_A, siteId: SITE_A })]) as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([makeEvent({ id: EVENT_A, siteId: SITE_A, acknowledged: true })]),
+          }),
+        }),
+      } as any);
+      const res = await app.request(`/changes/${EVENT_A}/acknowledge`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-restrict-site': SITE_A },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---- POST /:id/link-device ----
+  describe('POST /changes/:id/link-device', () => {
+    it('404 and no write on an out-of-site event for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectResolving([makeEvent({ id: EVENT_B, siteId: SITE_B })]) as any);
+      const res = await app.request(`/changes/${EVENT_B}/link-device`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-restrict-site': SITE_A },
+        body: JSON.stringify({ deviceId: DEVICE_ID }),
+      });
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- POST /bulk-acknowledge ----
+  describe('POST /changes/bulk-acknowledge', () => {
+    it('drops out-of-site events from the mutated set for a SITE_A-restricted caller', async () => {
+      // accessibleEvents lookup returns both; site filter must keep only EVENT_A
+      vi.mocked(db.select).mockReturnValueOnce(selectResolving([
+        { id: EVENT_A, orgId: ORG_ID, siteId: SITE_A },
+        { id: EVENT_B, orgId: ORG_ID, siteId: SITE_B },
+      ]) as any);
+
+      const whereSpy = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: EVENT_A, orgId: ORG_ID }]),
+      });
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({ where: whereSpy }),
+      } as any);
+
+      const res = await app.request('/changes/bulk-acknowledge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-restrict-site': SITE_A },
+        body: JSON.stringify({ eventIds: [EVENT_A, EVENT_B] }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.acknowledgedCount).toBe(1);
+      expect(body.requestedCount).toBe(2);
+      expect(body.inaccessibleCount).toBe(1);
+    });
+
+    it('404 (no write) when every event is out-of-site for a SITE_A-restricted caller', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectResolving([
+        { id: EVENT_B, orgId: ORG_ID, siteId: SITE_B },
+      ]) as any);
+
+      const res = await app.request('/changes/bulk-acknowledge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-restrict-site': SITE_A },
+        body: JSON.stringify({ eventIds: [EVENT_B] }),
+      });
+
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('acknowledges all events for an unrestricted caller (no regression)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(selectResolving([
+        { id: EVENT_A, orgId: ORG_ID, siteId: SITE_A },
+        { id: EVENT_B, orgId: ORG_ID, siteId: SITE_B },
+      ]) as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([
+              { id: EVENT_A, orgId: ORG_ID }, { id: EVENT_B, orgId: ORG_ID },
+            ]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/changes/bulk-acknowledge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventIds: [EVENT_A, EVENT_B] }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.acknowledgedCount).toBe(2);
+      expect(body.inaccessibleCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Site scope is an **app-layer-only** authz axis — **RLS does not enforce it**. List endpoints narrow by `permissions.allowedSiteIds`, but the single-record by-id and bulk handlers for alerts and network records did not. A site-restricted org user could therefore **read or mutate other sites' alerts and network records within their own org** by hitting the by-id/bulk routes directly (T9, #1051 site-axis class).

## Changes

**Alerts** (`routes/alerts/helpers.ts`, `routes/alerts/alerts.ts`)
- `getAlertWithOrgCheck` is now site-aware: for an alert carrying a `deviceId`, a site-restricted caller whose device is outside their allowlist gets `null` → handlers surface **404** (no oracle). Centralizes the gate across all four by-id paths — `GET /:id`, `POST /:id/acknowledge`, `POST /:id/resolve`, `POST /:id/suppress` — plus `create-ticket` and `tickets`, replacing the per-handler `deviceInSiteScope` call on create-ticket. Deviceless (org-wide) alerts stay visible.

**Network change events** (`routes/networkChanges.ts`)
- `GET /:id`, `POST /:id/acknowledge`, `POST /:id/link-device` now apply `canAccessSite(perms, siteId)` (→ 404 out-of-site).
- `POST /bulk-acknowledge` drops out-of-site ids from the mutated set (reflected in `inaccessibleCount`).

**Network baselines** (`routes/networkBaselines.ts`)
- `GET /:id`, `PATCH /:id`, `POST /:id/scan`, `GET /:id/changes`, `DELETE /:id` now apply the same site check (→ 404 out-of-site).

Unrestricted callers (partner/system scope, or org users with no site restriction — `allowedSiteIds` undefined) are **unaffected**.

## Behavior change (release-notes line)

Site-restricted users can no longer read or act on other sites' alerts and network change/baseline records by hitting the record-id or bulk endpoints directly. These now return 404 (single) or silently drop out-of-site ids (bulk), matching the existing list-endpoint narrowing.

## Tests added

- `routes/alerts/byid.sitescope.test.ts` — GET/acknowledge/resolve/suppress: out-of-site denied (404, no write), in-site allowed, deviceless-alert-stays-visible, unrestricted-unaffected.
- `routes/networkChanges_byid_sitescope.test.ts` — GET/acknowledge/link-device by-id + bulk-acknowledge: out-of-site denied/dropped, in-site allowed, unrestricted-unaffected.
- `routes/networkBaselines_byid_sitescope.test.ts` — GET/PATCH/scan/changes/DELETE by-id: out-of-site denied (404, no write), in-site allowed, unrestricted-unaffected.

All written test-first (confirmed failing pre-fix). Full touched test dirs green (193 tests); `tsc --noEmit` on `apps/api` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)