### PR TITLE
feat(onedrive-helper): provisioning + library-sync server foundation (Sub-project A, Phase 1)

### DIFF
--- a/apps/api/migrations/2026-06-19-a-onedrive-helper-feature-enum.sql
+++ b/apps/api/migrations/2026-06-19-a-onedrive-helper-feature-enum.sql
@@ -1,0 +1,4 @@
+-- Add the onedrive_helper feature type to the config_feature_type enum.
+-- ADD VALUE IF NOT EXISTS is transaction-safe in PG12+ as long as the value
+-- isn't *used* in the same transaction (it isn't here).
+ALTER TYPE config_feature_type ADD VALUE IF NOT EXISTS 'onedrive_helper';

--- a/apps/api/migrations/2026-06-19-b-onedrive-helper-settings.sql
+++ b/apps/api/migrations/2026-06-19-b-onedrive-helper-settings.sql
@@ -1,0 +1,44 @@
+-- Base OneDrive provisioning settings (one row per onedrive_helper feature link).
+-- Direct org_id RLS shape 1. Idempotent throughout.
+-- autoMigrate wraps this file in a transaction.
+
+CREATE TABLE IF NOT EXISTS config_policy_onedrive_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  feature_link_id UUID NOT NULL REFERENCES config_policy_feature_links(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  silent_account_config BOOLEAN NOT NULL DEFAULT true,
+  files_on_demand BOOLEAN NOT NULL DEFAULT true,
+  kfm_silent_opt_in BOOLEAN NOT NULL DEFAULT false,
+  kfm_folders JSONB NOT NULL DEFAULT '["Desktop","Documents","Pictures"]'::jsonb,
+  kfm_block_opt_out BOOLEAN NOT NULL DEFAULT false,
+  tenant_association_id VARCHAR(64),
+  restart_on_change BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT onedrive_settings_kfm_folders_array_check CHECK (jsonb_typeof(kfm_folders) = 'array')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS onedrive_settings_feature_link_uniq
+  ON config_policy_onedrive_settings (feature_link_id);
+CREATE INDEX IF NOT EXISTS onedrive_settings_org_idx
+  ON config_policy_onedrive_settings (org_id);
+
+ALTER TABLE config_policy_onedrive_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_onedrive_settings FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_onedrive_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_onedrive_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_onedrive_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_onedrive_settings;
+
+CREATE POLICY breeze_org_isolation_select ON config_policy_onedrive_settings
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON config_policy_onedrive_settings
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON config_policy_onedrive_settings
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON config_policy_onedrive_settings
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE config_policy_onedrive_settings TO breeze_app;

--- a/apps/api/migrations/2026-06-19-c-onedrive-helper-libraries.sql
+++ b/apps/api/migrations/2026-06-19-c-onedrive-helper-libraries.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS config_policy_onedrive_libraries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  settings_id UUID NOT NULL REFERENCES config_policy_onedrive_settings(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  library_id VARCHAR(1024) NOT NULL,
+  display_name VARCHAR(255) NOT NULL,
+  site_url VARCHAR(1024),
+  site_id VARCHAR(512),
+  web_id VARCHAR(128),
+  list_id VARCHAR(128),
+  targeting_mode VARCHAR(20) NOT NULL DEFAULT 'everyone',
+  group_id VARCHAR(128),
+  group_name VARCHAR(255),
+  hive_scope VARCHAR(8) NOT NULL DEFAULT 'hkcu',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT onedrive_libraries_targeting_mode_check CHECK (
+    targeting_mode IN ('everyone', 'graph_group', 'local_ad_group')
+  ),
+  CONSTRAINT onedrive_libraries_hive_scope_check CHECK (hive_scope IN ('hkcu', 'hklm')),
+  CONSTRAINT onedrive_libraries_group_required_check CHECK (
+    targeting_mode = 'everyone' OR group_id IS NOT NULL OR group_name IS NOT NULL
+  )
+);
+
+CREATE INDEX IF NOT EXISTS onedrive_libraries_settings_idx
+  ON config_policy_onedrive_libraries (settings_id);
+CREATE INDEX IF NOT EXISTS onedrive_libraries_org_idx
+  ON config_policy_onedrive_libraries (org_id);
+
+ALTER TABLE config_policy_onedrive_libraries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_onedrive_libraries FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_onedrive_libraries;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_onedrive_libraries;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_onedrive_libraries;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_onedrive_libraries;
+
+CREATE POLICY breeze_org_isolation_select ON config_policy_onedrive_libraries
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON config_policy_onedrive_libraries
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON config_policy_onedrive_libraries
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON config_policy_onedrive_libraries
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE config_policy_onedrive_libraries TO breeze_app;

--- a/apps/api/migrations/2026-06-19-d-onedrive-device-state.sql
+++ b/apps/api/migrations/2026-06-19-d-onedrive-device-state.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS onedrive_device_state (
+  device_id UUID PRIMARY KEY REFERENCES devices(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  signed_in BOOLEAN NOT NULL DEFAULT false,
+  onedrive_version VARCHAR(64),
+  files_on_demand_on BOOLEAN NOT NULL DEFAULT false,
+  kfm_folder_states JSONB NOT NULL DEFAULT '{}'::jsonb,
+  mounted_libraries JSONB NOT NULL DEFAULT '[]'::jsonb,
+  entitled_libraries JSONB NOT NULL DEFAULT '[]'::jsonb,
+  drift_entries JSONB NOT NULL DEFAULT '[]'::jsonb,
+  last_reported_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS onedrive_device_state_org_idx
+  ON onedrive_device_state (org_id);
+
+ALTER TABLE onedrive_device_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE onedrive_device_state FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON onedrive_device_state;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON onedrive_device_state;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON onedrive_device_state;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON onedrive_device_state;
+
+CREATE POLICY breeze_org_isolation_select ON onedrive_device_state
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON onedrive_device_state
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON onedrive_device_state
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON onedrive_device_state
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE onedrive_device_state TO breeze_app;

--- a/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
@@ -1,10 +1,13 @@
 /**
- * Integration test: buildOnedriveHelperConfigUpdate(deviceId)
+ * Integration test: buildOnedriveHelperConfigUpdate(deviceId) + heartbeat ingest
  *
  * Verifies that the resolver correctly joins config policy assignments →
  * active policies → feature links (onedrive_helper) → settings + libraries,
  * applying closest-level-wins hierarchy, and that it returns null when no
  * onedrive_helper policy is assigned to the device.
+ *
+ * Also verifies that the heartbeat route accepts an optional onedriveDeviceState
+ * payload and upserts it into the onedrive_device_state table (Task 9).
  *
  * All seeding runs under withSystemDbAccessContext so RLS does not hide
  * the freshly inserted rows. The function under test uses the bare `db`
@@ -15,7 +18,10 @@
  * partners/organizations CASCADE on beforeEach, wiping all policy rows.
  */
 import './setup';
+import { createHash } from 'node:crypto';
 import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import {
   configPolicyOnedriveSettings,
@@ -27,8 +33,10 @@ import {
   organizations,
   partners,
   sites,
+  onedriveDeviceState,
 } from '../../db/schema';
 import { buildOnedriveHelperConfigUpdate } from '../../routes/agents/helpers';
+import { agentRoutes } from '../../routes/agents';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -49,6 +57,9 @@ interface LibrarySeed {
 interface SeedResult {
   deviceId: string;
   settingsId: string | null;
+  agentId: string;
+  agentToken: string;
+  orgId: string;
 }
 
 /**
@@ -102,19 +113,23 @@ async function seedDeviceWithOnedrivePolicy(options: {
       .returning({ id: sites.id });
     if (!site) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert site');
 
-    // 4. Device
+    // 4. Device — include agentTokenHash so the heartbeat route can auth
+    const agentId = `od-delivery-test-${ts}-${rand}`;
+    const agentToken = `brz_od_test_${ts}_${rand}`;
+    const agentTokenHash = createHash('sha256').update(agentToken).digest('hex');
     const [device] = await db
       .insert(devices)
       .values({
         orgId: org.id,
         siteId: site.id,
-        agentId: `od-delivery-test-${ts}-${rand}`,
+        agentId,
         hostname: `od-host-${rand}`,
         osType: 'windows',
         osVersion: '11',
         architecture: 'x86_64',
         agentVersion: '0.0.0-test',
         status: 'online',
+        agentTokenHash,
         enrolledAt: new Date(),
       })
       .returning({ id: devices.id });
@@ -122,7 +137,7 @@ async function seedDeviceWithOnedrivePolicy(options: {
 
     if (options.base === null) {
       // No policy — test the null path
-      return { deviceId: device.id, settingsId: null };
+      return { deviceId: device.id, settingsId: null, agentId, agentToken, orgId: org.id };
     }
 
     // 5. Configuration policy (active)
@@ -179,8 +194,18 @@ async function seedDeviceWithOnedrivePolicy(options: {
       priority: 10,
     });
 
-    return { deviceId: device.id, settingsId: settings.id };
+    return { deviceId: device.id, settingsId: settings.id, agentId, agentToken, orgId: org.id };
   });
+}
+
+// ============================================================================
+// Heartbeat app for ingest tests
+// ============================================================================
+
+function buildHeartbeatApp(): Hono {
+  const app = new Hono();
+  app.route('/', agentRoutes);
+  return app;
 }
 
 // ============================================================================
@@ -253,5 +278,110 @@ describe('buildOnedriveHelperConfigUpdate', () => {
     expect(cfg!.base.filesOnDemand).toBe(true);
     expect(cfg!.base.kfmSilentOptIn).toBe(false);
     expect(cfg!.libraries).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Task 9: Heartbeat ingest — persisting onedriveDeviceState
+// ============================================================================
+
+describe('heartbeat ingest: onedriveDeviceState', () => {
+  runDb('persists reported onedrive device state via heartbeat (insert)', async () => {
+    const { deviceId, agentId, agentToken } = await seedDeviceWithOnedrivePolicy({
+      base: null,
+      libraries: [],
+    });
+
+    const app = buildHeartbeatApp();
+    const res = await app.request(`/${agentId}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${agentToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'ok',
+        agentVersion: '1.0.0-test',
+        onedriveDeviceState: {
+          signedIn: true,
+          filesOnDemandOn: true,
+          kfmFolderStates: { Documents: 'redirected' },
+          mountedLibraries: ['lib-all'],
+          entitledLibraries: ['lib-all'],
+          driftEntries: [],
+        },
+      }),
+    });
+
+    expect(res.status, `heartbeat returned ${res.status}: ${await res.text()}`).toBe(200);
+
+    const [row] = await withSystemDbAccessContext(() =>
+      db.select().from(onedriveDeviceState).where(eq(onedriveDeviceState.deviceId, deviceId))
+    );
+    expect(row, 'onedrive_device_state row should exist after heartbeat').toBeDefined();
+    expect(row!.signedIn).toBe(true);
+    expect(row!.filesOnDemandOn).toBe(true);
+    expect(row!.mountedLibraries).toEqual(['lib-all']);
+    expect(row!.kfmFolderStates).toEqual({ Documents: 'redirected' });
+  });
+
+  runDb('second heartbeat updates (not duplicates) the state row', async () => {
+    const { deviceId, agentId, agentToken } = await seedDeviceWithOnedrivePolicy({
+      base: null,
+      libraries: [],
+    });
+
+    const app = buildHeartbeatApp();
+
+    // First heartbeat — signedIn: true
+    await app.request(`/${agentId}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${agentToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'ok',
+        agentVersion: '1.0.0-test',
+        onedriveDeviceState: {
+          signedIn: true,
+          filesOnDemandOn: false,
+          kfmFolderStates: {},
+          mountedLibraries: ['lib-v1'],
+          entitledLibraries: ['lib-v1'],
+          driftEntries: [],
+        },
+      }),
+    });
+
+    // Second heartbeat — signedIn: false, different libraries
+    await app.request(`/${agentId}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${agentToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'ok',
+        agentVersion: '1.0.0-test',
+        onedriveDeviceState: {
+          signedIn: false,
+          filesOnDemandOn: true,
+          kfmFolderStates: { Desktop: 'redirected' },
+          mountedLibraries: ['lib-v2'],
+          entitledLibraries: ['lib-v2'],
+          driftEntries: [],
+        },
+      }),
+    });
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(onedriveDeviceState).where(eq(onedriveDeviceState.deviceId, deviceId))
+    );
+    // Must be exactly one row (upsert, not duplicate insert)
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.signedIn).toBe(false);
+    expect(rows[0]!.filesOnDemandOn).toBe(true);
+    expect(rows[0]!.mountedLibraries).toEqual(['lib-v2']);
   });
 });

--- a/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Integration test: buildOnedriveHelperConfigUpdate(deviceId)
+ *
+ * Verifies that the resolver correctly joins config policy assignments →
+ * active policies → feature links (onedrive_helper) → settings + libraries,
+ * applying closest-level-wins hierarchy, and that it returns null when no
+ * onedrive_helper policy is assigned to the device.
+ *
+ * All seeding runs under withSystemDbAccessContext so RLS does not hide
+ * the freshly inserted rows. The function under test uses the bare `db`
+ * pool (breeze_app, same as the monitoring resolver), so it must be called
+ * inside a withSystemDbAccessContext wrapper in these tests.
+ *
+ * Fixtures are re-seeded per test — setup.ts cleanupDatabase() TRUNCATEs
+ * partners/organizations CASCADE on beforeEach, wiping all policy rows.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  configPolicyOnedriveSettings,
+  configPolicyOnedriveLibraries,
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  devices,
+  organizations,
+  partners,
+  sites,
+} from '../../db/schema';
+import { buildOnedriveHelperConfigUpdate } from '../../routes/agents/helpers';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+// ============================================================================
+// Seed helpers
+// ============================================================================
+
+interface LibrarySeed {
+  libraryId: string;
+  displayName: string;
+  targetingMode?: string;
+  groupId?: string;
+  groupName?: string;
+  hiveScope?: string;
+  enabled?: boolean;
+}
+
+interface SeedResult {
+  deviceId: string;
+  settingsId: string | null;
+}
+
+/**
+ * Seeds a partner → org → site → device → (optionally) config policy chain.
+ * When `base` is null, no config policy is assigned (tests the null path).
+ */
+async function seedDeviceWithOnedrivePolicy(options: {
+  base: {
+    silentAccountConfig?: boolean;
+    filesOnDemand?: boolean;
+    kfmSilentOptIn?: boolean;
+    kfmBlockOptOut?: boolean;
+    restartOnChange?: boolean;
+  } | null;
+  libraries?: LibrarySeed[];
+}): Promise<SeedResult> {
+  return withSystemDbAccessContext(async () => {
+    const ts = Date.now();
+    const rand = Math.random().toString(36).slice(2, 7);
+
+    // 1. Partner
+    const [partner] = await db
+      .insert(partners)
+      .values({
+        name: `OD Test Partner ${ts}-${rand}`,
+        slug: `od-tp-${ts}-${rand}`,
+        type: 'msp',
+        plan: 'pro',
+        status: 'active',
+      })
+      .returning({ id: partners.id });
+    if (!partner) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert partner');
+
+    // 2. Organization
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        partnerId: partner.id,
+        name: `OD Test Org ${ts}-${rand}`,
+        slug: `od-org-${ts}-${rand}`,
+        type: 'customer',
+        status: 'active',
+      })
+      .returning({ id: organizations.id });
+    if (!org) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert organization');
+
+    // 3. Site
+    const [site] = await db
+      .insert(sites)
+      .values({ orgId: org.id, name: `OD Site ${ts}`, timezone: 'UTC' })
+      .returning({ id: sites.id });
+    if (!site) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert site');
+
+    // 4. Device
+    const [device] = await db
+      .insert(devices)
+      .values({
+        orgId: org.id,
+        siteId: site.id,
+        agentId: `od-delivery-test-${ts}-${rand}`,
+        hostname: `od-host-${rand}`,
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+        status: 'online',
+        enrolledAt: new Date(),
+      })
+      .returning({ id: devices.id });
+    if (!device) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert device');
+
+    if (options.base === null) {
+      // No policy — test the null path
+      return { deviceId: device.id, settingsId: null };
+    }
+
+    // 5. Configuration policy (active)
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: org.id, name: `OD Policy ${ts}`, status: 'active' })
+      .returning({ id: configurationPolicies.id });
+    if (!policy) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert policy');
+
+    // 6. Feature link
+    const [featureLink] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy.id, featureType: 'onedrive_helper' })
+      .returning({ id: configPolicyFeatureLinks.id });
+    if (!featureLink) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert feature link');
+
+    // 7. Onedrive settings row
+    const [settings] = await db
+      .insert(configPolicyOnedriveSettings)
+      .values({
+        featureLinkId: featureLink.id,
+        orgId: org.id,
+        silentAccountConfig: options.base.silentAccountConfig ?? true,
+        filesOnDemand: options.base.filesOnDemand ?? true,
+        kfmSilentOptIn: options.base.kfmSilentOptIn ?? false,
+        kfmBlockOptOut: options.base.kfmBlockOptOut ?? false,
+        restartOnChange: options.base.restartOnChange ?? true,
+      })
+      .returning({ id: configPolicyOnedriveSettings.id });
+    if (!settings) throw new Error('seedDeviceWithOnedrivePolicy: failed to insert settings');
+
+    // 8. Library rows
+    for (let i = 0; i < (options.libraries ?? []).length; i++) {
+      const lib = options.libraries![i]!;
+      await db.insert(configPolicyOnedriveLibraries).values({
+        settingsId: settings.id,
+        orgId: org.id,
+        libraryId: lib.libraryId,
+        displayName: lib.displayName,
+        targetingMode: lib.targetingMode ?? 'everyone',
+        groupId: lib.groupId ?? null,
+        groupName: lib.groupName ?? null,
+        hiveScope: lib.hiveScope ?? 'hkcu',
+        sortOrder: i,
+        enabled: lib.enabled ?? true,
+      });
+    }
+
+    // 9. Assignment at organization level
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId: policy.id,
+      level: 'organization',
+      targetId: org.id,
+      priority: 10,
+    });
+
+    return { deviceId: device.id, settingsId: settings.id };
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('buildOnedriveHelperConfigUpdate', () => {
+  runDb('returns base config + library rules for an assigned device', async () => {
+    const { deviceId } = await seedDeviceWithOnedrivePolicy({
+      base: { silentAccountConfig: true, filesOnDemand: true, kfmSilentOptIn: true },
+      libraries: [
+        { libraryId: 'lib-fin', displayName: 'Finance', targetingMode: 'graph_group', groupId: 'g-fin' },
+        { libraryId: 'lib-all', displayName: 'Company', targetingMode: 'everyone' },
+      ],
+    });
+
+    const cfg = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+    expect(cfg).not.toBeNull();
+    expect(cfg!.base.kfmSilentOptIn).toBe(true);
+    expect(cfg!.base.silentAccountConfig).toBe(true);
+    expect(cfg!.base.filesOnDemand).toBe(true);
+    expect(cfg!.libraries).toHaveLength(2);
+    const finLib = cfg!.libraries.find((l) => l.libraryId === 'lib-fin');
+    expect(finLib).toBeDefined();
+    expect(finLib!.targetingMode).toBe('graph_group');
+    expect(finLib!.groupId).toBe('g-fin');
+    const allLib = cfg!.libraries.find((l) => l.libraryId === 'lib-all');
+    expect(allLib).toBeDefined();
+    expect(allLib!.targetingMode).toBe('everyone');
+  });
+
+  runDb('returns null for a device with no onedrive_helper policy assigned', async () => {
+    const { deviceId } = await seedDeviceWithOnedrivePolicy({ base: null, libraries: [] });
+    const result = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+    expect(result).toBeNull();
+  });
+
+  runDb('returns null for an unknown device id', async () => {
+    const result = await withSystemDbAccessContext(() =>
+      buildOnedriveHelperConfigUpdate('00000000-0000-0000-0000-000000000000')
+    );
+    expect(result).toBeNull();
+  });
+
+  runDb('only returns enabled libraries', async () => {
+    const { deviceId } = await seedDeviceWithOnedrivePolicy({
+      base: { kfmSilentOptIn: false },
+      libraries: [
+        { libraryId: 'lib-on', displayName: 'Enabled', targetingMode: 'everyone', enabled: true },
+        { libraryId: 'lib-off', displayName: 'Disabled', targetingMode: 'everyone', enabled: false },
+      ],
+    });
+
+    const cfg = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+    expect(cfg).not.toBeNull();
+    expect(cfg!.libraries).toHaveLength(1);
+    expect(cfg!.libraries[0]!.libraryId).toBe('lib-on');
+  });
+
+  runDb('returns correct base defaults when minimal settings seeded', async () => {
+    const { deviceId } = await seedDeviceWithOnedrivePolicy({
+      base: {},
+      libraries: [],
+    });
+
+    const cfg = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+    expect(cfg).not.toBeNull();
+    // Schema defaults: silentAccountConfig=true, filesOnDemand=true, kfmSilentOptIn=false
+    expect(cfg!.base.silentAccountConfig).toBe(true);
+    expect(cfg!.base.filesOnDemand).toBe(true);
+    expect(cfg!.base.kfmSilentOptIn).toBe(false);
+    expect(cfg!.libraries).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
@@ -52,6 +52,8 @@ interface LibrarySeed {
   groupName?: string;
   hiveScope?: string;
   enabled?: boolean;
+  /** Explicit sort_order; defaults to the array index when omitted. */
+  sortOrder?: number;
 }
 
 interface SeedResult {
@@ -60,6 +62,7 @@ interface SeedResult {
   agentId: string;
   agentToken: string;
   orgId: string;
+  siteId: string;
 }
 
 /**
@@ -137,7 +140,7 @@ async function seedDeviceWithOnedrivePolicy(options: {
 
     if (options.base === null) {
       // No policy — test the null path
-      return { deviceId: device.id, settingsId: null, agentId, agentToken, orgId: org.id };
+      return { deviceId: device.id, settingsId: null, agentId, agentToken, orgId: org.id, siteId: site.id };
     }
 
     // 5. Configuration policy (active)
@@ -181,7 +184,7 @@ async function seedDeviceWithOnedrivePolicy(options: {
         groupId: lib.groupId ?? null,
         groupName: lib.groupName ?? null,
         hiveScope: lib.hiveScope ?? 'hkcu',
-        sortOrder: i,
+        sortOrder: lib.sortOrder ?? i,
         enabled: lib.enabled ?? true,
       });
     }
@@ -194,7 +197,63 @@ async function seedDeviceWithOnedrivePolicy(options: {
       priority: 10,
     });
 
-    return { deviceId: device.id, settingsId: settings.id, agentId, agentToken, orgId: org.id };
+    return { deviceId: device.id, settingsId: settings.id, agentId, agentToken, orgId: org.id, siteId: site.id };
+  });
+}
+
+/**
+ * Attaches an *additional* onedrive_helper policy (policy → feature link →
+ * settings + one marker library → assignment) to an existing org, at a given
+ * assignment level/target/priority. Used to set up competing assignments so
+ * the closest-level-wins resolution and same-level priority tiebreak can be
+ * exercised. The marker library id identifies which policy won.
+ */
+async function attachOnedrivePolicy(opts: {
+  orgId: string;
+  level: 'organization' | 'site' | 'device' | 'device_group' | 'partner';
+  targetId: string;
+  priority: number;
+  /** Distinguishing library id, so the delivered config reveals which policy won. */
+  marker: string;
+  kfmSilentOptIn?: boolean;
+}): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    const ts = Date.now();
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: opts.orgId, name: `OD Policy ${opts.level} ${ts}-${opts.marker}`, status: 'active' })
+      .returning({ id: configurationPolicies.id });
+    if (!policy) throw new Error('attachOnedrivePolicy: failed to insert policy');
+
+    const [featureLink] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy.id, featureType: 'onedrive_helper' })
+      .returning({ id: configPolicyFeatureLinks.id });
+    if (!featureLink) throw new Error('attachOnedrivePolicy: failed to insert feature link');
+
+    const [settings] = await db
+      .insert(configPolicyOnedriveSettings)
+      .values({ featureLinkId: featureLink.id, orgId: opts.orgId, kfmSilentOptIn: opts.kfmSilentOptIn ?? false })
+      .returning({ id: configPolicyOnedriveSettings.id });
+    if (!settings) throw new Error('attachOnedrivePolicy: failed to insert settings');
+
+    await db.insert(configPolicyOnedriveLibraries).values({
+      settingsId: settings.id,
+      orgId: opts.orgId,
+      libraryId: opts.marker,
+      displayName: opts.marker,
+      targetingMode: 'everyone',
+      hiveScope: 'hkcu',
+      sortOrder: 0,
+      enabled: true,
+    });
+
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId: policy.id,
+      level: opts.level,
+      targetId: opts.targetId,
+      priority: opts.priority,
+    });
   });
 }
 
@@ -263,6 +322,48 @@ describe('buildOnedriveHelperConfigUpdate', () => {
     expect(cfg).not.toBeNull();
     expect(cfg!.libraries).toHaveLength(1);
     expect(cfg!.libraries[0]!.libraryId).toBe('lib-on');
+  });
+
+  runDb('closest-level-wins: a device-level assignment beats an organization-level one', async () => {
+    const { deviceId, orgId } = await seedDeviceWithOnedrivePolicy({ base: null, libraries: [] });
+    // Two competing policies for the same device: org-level vs device-level.
+    // Device is the closer level, so its config must win regardless of priority.
+    await attachOnedrivePolicy({ orgId, level: 'organization', targetId: orgId, priority: 1, marker: 'org-loses', kfmSilentOptIn: false });
+    await attachOnedrivePolicy({ orgId, level: 'device', targetId: deviceId, priority: 99, marker: 'device-wins', kfmSilentOptIn: true });
+
+    const cfg = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+    expect(cfg).not.toBeNull();
+    expect(cfg!.libraries.map((l) => l.libraryId)).toEqual(['device-wins']);
+    expect(cfg!.base.kfmSilentOptIn).toBe(true);
+  });
+
+  runDb('same-level tiebreak: the lower priority number wins', async () => {
+    const { deviceId, orgId } = await seedDeviceWithOnedrivePolicy({ base: null, libraries: [] });
+    // Two org-level assignments at the same level — the lower priority number wins.
+    await attachOnedrivePolicy({ orgId, level: 'organization', targetId: orgId, priority: 50, marker: 'high-number-loses', kfmSilentOptIn: false });
+    await attachOnedrivePolicy({ orgId, level: 'organization', targetId: orgId, priority: 1, marker: 'low-number-wins', kfmSilentOptIn: true });
+
+    const cfg = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+    expect(cfg).not.toBeNull();
+    expect(cfg!.libraries.map((l) => l.libraryId)).toEqual(['low-number-wins']);
+    expect(cfg!.base.kfmSilentOptIn).toBe(true);
+  });
+
+  runDb('delivers enabled libraries ordered by sortOrder, not insertion order', async () => {
+    // Insert order deliberately differs from sortOrder so a dropped ORDER BY
+    // would surface as a mismatch rather than passing by accident.
+    const { deviceId } = await seedDeviceWithOnedrivePolicy({
+      base: {},
+      libraries: [
+        { libraryId: 'lib-third', displayName: 'Third', sortOrder: 2 },
+        { libraryId: 'lib-first', displayName: 'First', sortOrder: 0 },
+        { libraryId: 'lib-second', displayName: 'Second', sortOrder: 1 },
+      ],
+    });
+
+    const cfg = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+    expect(cfg).not.toBeNull();
+    expect(cfg!.libraries.map((l) => l.libraryId)).toEqual(['lib-first', 'lib-second', 'lib-third']);
   });
 
   runDb('returns correct base defaults when minimal settings seeded', async () => {
@@ -383,5 +484,51 @@ describe('heartbeat ingest: onedriveDeviceState', () => {
     expect(rows[0]!.signedIn).toBe(false);
     expect(rows[0]!.filesOnDemandOn).toBe(true);
     expect(rows[0]!.mountedLibraries).toEqual(['lib-v2']);
+  });
+
+  runDb('heartbeat without an onedriveDeviceState field creates no state row', async () => {
+    const { deviceId, agentId, agentToken } = await seedDeviceWithOnedrivePolicy({
+      base: null,
+      libraries: [],
+    });
+
+    const app = buildHeartbeatApp();
+    const res = await app.request(`/${agentId}/heartbeat`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${agentToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'ok', agentVersion: '1.0.0-test' }),
+    });
+    expect(res.status, `heartbeat returned ${res.status}: ${await res.text()}`).toBe(200);
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(onedriveDeviceState).where(eq(onedriveDeviceState.deviceId, deviceId))
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  runDb('malformed onedriveDeviceState is dropped — heartbeat still 200, no row written', async () => {
+    const { deviceId, agentId, agentToken } = await seedDeviceWithOnedrivePolicy({
+      base: null,
+      libraries: [],
+    });
+
+    const app = buildHeartbeatApp();
+    const res = await app.request(`/${agentId}/heartbeat`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${agentToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        status: 'ok',
+        agentVersion: '1.0.0-test',
+        // signedIn must be a boolean — this fails the inner object schema, which
+        // is `.catch(undefined)`, so the field is dropped rather than 400-ing.
+        onedriveDeviceState: { signedIn: 'yes-please', filesOnDemandOn: true },
+      }),
+    });
+    expect(res.status, `heartbeat returned ${res.status}: ${await res.text()}`).toBe(200);
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(onedriveDeviceState).where(eq(onedriveDeviceState.deviceId, deviceId))
+    );
+    expect(rows).toHaveLength(0);
   });
 });

--- a/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Real-driver cross-tenant forge tests for config_policy_onedrive_settings (Task 3).
+ *
+ * Runs under vitest.integration.config.ts — code-under-test connects as the
+ * unprivileged `breeze_app` role (rolbypassrls=f), so RLS is actually
+ * enforced.  If `.env.test` is missing the symlink that pins this to the
+ * breeze_app role, the positive control in case (b) would still insert (no
+ * RLS block on own-org rows), but a BYPASSRLS admin connection would allow
+ * the cross-org insert in case (c) — which is why we include a non-vacuity
+ * guard (case 0) and a positive control (case b) in addition to the forge
+ * case (case c).
+ *
+ * Fixture topology (seeded fresh per test under system scope, which bypasses
+ * RLS — see "why no memoization" below):
+ *   partnerA → orgA → configPolicyA → featureLinkA
+ *   partnerB → orgB → configPolicyB → featureLinkB
+ *
+ * Why NO memoization: setup.ts runs cleanupDatabase() in a beforeEach that
+ * TRUNCATE ... CASCADEs partners/organizations before every test, which
+ * cascades through the configuration_policies and config_policy_feature_links
+ * FKs and wipes all fixture rows. A module-level fixture cache would hand
+ * later tests rows that no longer exist, making the RLS assertions vacuous
+ * (a forged insert can surface an incidental FK 23503 instead of 42501).
+ * Each it() re-seeds fresh — matching every sibling *-rls.integration.test.ts.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import {
+  configPolicyOnedriveSettings,
+  configurationPolicies,
+  configPolicyFeatureLinks,
+} from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+interface Fixture {
+  partnerA: { id: string };
+  orgA: { id: string };
+  partnerB: { id: string };
+  orgB: { id: string };
+  featureLinkA: { id: string };
+  featureLinkB: { id: string };
+  /** breeze_app context scoped to org A (mirrors authMiddleware org scope). */
+  orgAContext: DbAccessContext;
+}
+
+// Re-seeds fresh on every call. Intentionally NOT memoized: setup.ts's
+// beforeEach cleanupDatabase() TRUNCATEs partners/organizations CASCADE before
+// each test, so any cached rows would already be deleted by the time an
+// assertion runs — which would silently make every cross-tenant case vacuous.
+async function seedFixture(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+
+    // Seed a configuration policy + feature link for org A.
+    const [configPolicyA] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: orgA.id, name: 'OD Policy A' })
+      .returning({ id: configurationPolicies.id });
+    if (!configPolicyA) throw new Error('failed to seed config policy A');
+
+    const [featureLinkA] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: configPolicyA.id, featureType: 'onedrive_helper' })
+      .returning({ id: configPolicyFeatureLinks.id });
+    if (!featureLinkA) throw new Error('failed to seed feature link A');
+
+    // Seed a configuration policy + feature link for org B.
+    const [configPolicyB] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: orgB.id, name: 'OD Policy B' })
+      .returning({ id: configurationPolicies.id });
+    if (!configPolicyB) throw new Error('failed to seed config policy B');
+
+    const [featureLinkB] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: configPolicyB.id, featureType: 'onedrive_helper' })
+      .returning({ id: configPolicyFeatureLinks.id });
+    if (!featureLinkB) throw new Error('failed to seed feature link B');
+
+    // Org-scoped breeze_app context for org A.
+    const orgAContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [partnerA.id],
+      userId: null,
+    };
+
+    return {
+      partnerA: { id: partnerA.id },
+      orgA: { id: orgA.id },
+      partnerB: { id: partnerB.id },
+      orgB: { id: orgB.id },
+      featureLinkA: { id: featureLinkA.id },
+      featureLinkB: { id: featureLinkB.id },
+      orgAContext,
+    };
+  });
+}
+
+describe('config_policy_onedrive_settings RLS isolation (breeze_app)', () => {
+  // (0) Non-vacuity guard: code-under-test runs as the unprivileged breeze_app
+  // role with rolbypassrls=f. If this is ever a BYPASSRLS connection, every
+  // assertion below would pass even with broken policies.
+  runDb('code-under-test runs as a non-BYPASSRLS role (guards against vacuous RLS)', async () => {
+    const fx = await seedFixture();
+    const rows = await withDbAccessContext(fx.orgAContext, () =>
+      db.execute(sql`SELECT current_user AS who, rolbypassrls
+                     FROM pg_roles WHERE rolname = current_user`)
+    );
+    const row = (rows as unknown as Array<{ who: string; rolbypassrls: boolean }>)[0];
+    expect(row?.who).toBe('breeze_app');
+    expect(row?.rolbypassrls).toBe(false);
+  });
+
+  // (a) Positive control: under org A's context, an org-A settings row for
+  // org A's own feature link succeeds. This proves the policy is not
+  // deny-everything, which would make the forge case pass for the wrong reason.
+  runDb('positive control: org A context can insert its own onedrive settings row', async () => {
+    const fx = await seedFixture();
+
+    const [inserted] = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .insert(configPolicyOnedriveSettings)
+        .values({
+          featureLinkId: fx.featureLinkA.id,
+          orgId: fx.orgA.id,
+        })
+        .returning({ id: configPolicyOnedriveSettings.id, orgId: configPolicyOnedriveSettings.orgId })
+    );
+    expect(inserted?.orgId).toBe(fx.orgA.id);
+
+    // Confirm the row is readable back under the same context.
+    const fetched = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .select({ id: configPolicyOnedriveSettings.id })
+        .from(configPolicyOnedriveSettings)
+        .where(eq(configPolicyOnedriveSettings.id, inserted!.id))
+    );
+    expect(fetched).toHaveLength(1);
+  });
+
+  // (b) Cross-org SELECT hidden: a settings row seeded for org B is invisible
+  // to an org A caller. The system-scope probe first confirms the row really
+  // exists so the 0-row read under org A is meaningfully "RLS hid it" rather
+  // than "it was never seeded" — guarding against a vacuous hidden-row test.
+  runDb('hides org B settings from org A SELECT (system probe confirms it exists)', async () => {
+    const fx = await seedFixture();
+
+    // Seed org B's settings row under system scope (RLS-bypassing seed).
+    const seededId = await withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .insert(configPolicyOnedriveSettings)
+        .values({
+          featureLinkId: fx.featureLinkB.id,
+          orgId: fx.orgB.id,
+        })
+        .returning({ id: configPolicyOnedriveSettings.id });
+      return row!.id;
+    });
+
+    // Probe: under system scope the row really exists.
+    const existsUnderSystem = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: configPolicyOnedriveSettings.id })
+        .from(configPolicyOnedriveSettings)
+        .where(eq(configPolicyOnedriveSettings.id, seededId))
+    );
+    expect(existsUnderSystem).toHaveLength(1);
+
+    // Under org A breeze_app context the same id returns 0 rows — RLS hides it.
+    const visibleToA = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .select({ id: configPolicyOnedriveSettings.id })
+        .from(configPolicyOnedriveSettings)
+        .where(eq(configPolicyOnedriveSettings.id, seededId))
+    );
+    expect(visibleToA).toHaveLength(0);
+  });
+
+  // (c) Cross-org INSERT denied: under an org A context, inserting a settings
+  // row carrying org B's feature link + org_id is rejected by the INSERT WITH
+  // CHECK policy. Both featureLinkB and orgB are real seeded rows (FKs
+  // resolve), so the failure MUST be the RLS 42501, not a 23503 FK violation.
+  // Drizzle wraps the driver error: cause.code carries the Postgres SQLSTATE.
+  runDb('blocks a forged cross-org config_policy_onedrive_settings INSERT for another org (42501)', async () => {
+    const fx = await seedFixture();
+
+    await expect(
+      withDbAccessContext(fx.orgAContext, () =>
+        db.insert(configPolicyOnedriveSettings).values({
+          featureLinkId: fx.featureLinkB.id, // org B's real feature link (FK resolves)
+          orgId: fx.orgB.id, // foreign org — RLS WITH CHECK must reject
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+});

--- a/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
@@ -34,6 +34,7 @@ import {
 } from '../../db';
 import {
   configPolicyOnedriveSettings,
+  configPolicyOnedriveLibraries,
   configurationPolicies,
   configPolicyFeatureLinks,
 } from '../../db/schema';
@@ -203,6 +204,86 @@ describe('config_policy_onedrive_settings RLS isolation (breeze_app)', () => {
         db.insert(configPolicyOnedriveSettings).values({
           featureLinkId: fx.featureLinkB.id, // org B's real feature link (FK resolves)
           orgId: fx.orgB.id, // foreign org — RLS WITH CHECK must reject
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// config_policy_onedrive_libraries RLS isolation (Task 4)
+// ---------------------------------------------------------------------------
+// Fixture re-use: seedFixture() is defined above and seeds both orgs, both
+// feature links, and an org-A-scoped breeze_app context. Library tests need
+// a settings row for the FK reference (settings_id), so each test seeds one
+// under system scope before the RLS assertion.
+// ---------------------------------------------------------------------------
+describe('config_policy_onedrive_libraries RLS isolation (breeze_app)', () => {
+  // (a) Positive control: org A can insert a library row for its own settings.
+  runDb('positive control: org A context can insert its own library mapping', async () => {
+    const fx = await seedFixture();
+
+    // Seed org A's settings row under system scope (FK prerequisite).
+    const settingsId = await withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .insert(configPolicyOnedriveSettings)
+        .values({ featureLinkId: fx.featureLinkA.id, orgId: fx.orgA.id })
+        .returning({ id: configPolicyOnedriveSettings.id });
+      return row!.id;
+    });
+
+    // Under org A's breeze_app context, inserting a library row for org A succeeds.
+    const [inserted] = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .insert(configPolicyOnedriveLibraries)
+        .values({
+          settingsId,
+          orgId: fx.orgA.id,
+          libraryId: 'lib-a1',
+          displayName: 'Org A Documents',
+          targetingMode: 'everyone',
+        })
+        .returning({
+          id: configPolicyOnedriveLibraries.id,
+          orgId: configPolicyOnedriveLibraries.orgId,
+        })
+    );
+    expect(inserted?.orgId).toBe(fx.orgA.id);
+
+    // Confirm the row is readable back under the same context.
+    const fetched = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .select({ id: configPolicyOnedriveLibraries.id })
+        .from(configPolicyOnedriveLibraries)
+        .where(eq(configPolicyOnedriveLibraries.id, inserted!.id))
+    );
+    expect(fetched).toHaveLength(1);
+  });
+
+  // (b) Cross-org INSERT denied: org A context cannot insert a library row
+  // carrying org B's org_id. The settings_id used is from org B's seeded
+  // settings row so the FK resolves — the rejection MUST be RLS (42501),
+  // not a FK violation (23503).
+  runDb('blocks a forged cross-org config_policy_onedrive_libraries INSERT (42501)', async () => {
+    const fx = await seedFixture();
+
+    // Seed org B's settings row under system scope so the FK resolves.
+    const orgBSettingsId = await withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .insert(configPolicyOnedriveSettings)
+        .values({ featureLinkId: fx.featureLinkB.id, orgId: fx.orgB.id })
+        .returning({ id: configPolicyOnedriveSettings.id });
+      return row!.id;
+    });
+
+    await expect(
+      withDbAccessContext(fx.orgAContext, () =>
+        db.insert(configPolicyOnedriveLibraries).values({
+          settingsId: orgBSettingsId, // org B's real settings row (FK resolves)
+          orgId: fx.orgB.id,          // foreign org — RLS WITH CHECK must reject
+          libraryId: 'lib-x',
+          displayName: 'Finance',
+          targetingMode: 'everyone',
         })
       )
     ).rejects.toMatchObject({ cause: { code: '42501' } });

--- a/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
@@ -35,10 +35,12 @@ import {
 import {
   configPolicyOnedriveSettings,
   configPolicyOnedriveLibraries,
+  onedriveDeviceState,
   configurationPolicies,
   configPolicyFeatureLinks,
+  devices,
 } from '../../db/schema';
-import { createOrganization, createPartner } from './db-utils';
+import { createOrganization, createPartner, createSite } from './db-utils';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -284,6 +286,140 @@ describe('config_policy_onedrive_libraries RLS isolation (breeze_app)', () => {
           libraryId: 'lib-x',
           displayName: 'Finance',
           targetingMode: 'everyone',
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onedrive_device_state RLS isolation (Task 5)
+// ---------------------------------------------------------------------------
+// This table is device-keyed (PK = device_id) with a denormalized org_id
+// (Shape 5). Policies are the same breeze_has_org_access(org_id) form as
+// the prior tables, so one row per device and cross-tenant isolation is
+// enforced at the org boundary.
+//
+// Each test seeds its own device (+ site) under system scope to satisfy
+// the device_id FK. Fixtures are re-seeded per test (same rationale as
+// prior suites — beforeEach cleanupDatabase() TRUNCATE wipes everything).
+// ---------------------------------------------------------------------------
+
+let deviceAgentCounter = 0;
+
+/** Insert a device under system scope and return its id. */
+async function seedDevice(orgId: string, siteId: string): Promise<string> {
+  deviceAgentCounter++;
+  const [row] = await db
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `onedrive-state-test-${deviceAgentCounter}-${Date.now()}`,
+      hostname: `host-${deviceAgentCounter}`,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('seedDevice: insert returned no row');
+  return row.id;
+}
+
+describe('onedrive_device_state RLS isolation (breeze_app)', () => {
+  // (a) Positive control: under org A's context, upsert state for org A's
+  // own device succeeds and reads back correctly.
+  runDb('positive control: org A context can upsert state for its own device', async () => {
+    const fx = await seedFixture();
+
+    const { deviceId } = await withSystemDbAccessContext(async () => {
+      const siteA = await createSite({ orgId: fx.orgA.id });
+      const devId = await seedDevice(fx.orgA.id, siteA.id);
+      return { deviceId: devId };
+    });
+
+    const [inserted] = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .insert(onedriveDeviceState)
+        .values({
+          deviceId,
+          orgId: fx.orgA.id,
+          signedIn: true,
+        })
+        .returning({
+          deviceId: onedriveDeviceState.deviceId,
+          orgId: onedriveDeviceState.orgId,
+        })
+    );
+    expect(inserted?.orgId).toBe(fx.orgA.id);
+    expect(inserted?.deviceId).toBe(deviceId);
+
+    // Confirm the row is readable back under the same context.
+    const fetched = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .select({ deviceId: onedriveDeviceState.deviceId })
+        .from(onedriveDeviceState)
+        .where(eq(onedriveDeviceState.deviceId, deviceId))
+    );
+    expect(fetched).toHaveLength(1);
+  });
+
+  // (b) Cross-org SELECT hidden: a state row seeded for org B's device is
+  // invisible to an org A caller. System-scope probe first confirms the row
+  // really exists so the 0-row read under org A is meaningfully "RLS hid it".
+  runDb('hides org B device state from org A SELECT (system probe confirms it exists)', async () => {
+    const fx = await seedFixture();
+
+    const orgBDeviceId = await withSystemDbAccessContext(async () => {
+      const siteB = await createSite({ orgId: fx.orgB.id });
+      const devId = await seedDevice(fx.orgB.id, siteB.id);
+      await db
+        .insert(onedriveDeviceState)
+        .values({ deviceId: devId, orgId: fx.orgB.id, signedIn: false });
+      return devId;
+    });
+
+    // Probe: under system scope the row really exists.
+    const existsUnderSystem = await withSystemDbAccessContext(() =>
+      db
+        .select({ deviceId: onedriveDeviceState.deviceId })
+        .from(onedriveDeviceState)
+        .where(eq(onedriveDeviceState.deviceId, orgBDeviceId))
+    );
+    expect(existsUnderSystem).toHaveLength(1);
+
+    // Under org A breeze_app context the same device returns 0 rows — RLS hides it.
+    const visibleToA = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .select({ deviceId: onedriveDeviceState.deviceId })
+        .from(onedriveDeviceState)
+        .where(eq(onedriveDeviceState.deviceId, orgBDeviceId))
+    );
+    expect(visibleToA).toHaveLength(0);
+  });
+
+  // (c) Cross-org INSERT denied: under org A's context, inserting state
+  // carrying org B's device_id + org_id is rejected by the INSERT WITH CHECK
+  // policy. Both the device row and org row are real (FKs resolve), so the
+  // failure MUST be RLS (42501), not a FK violation (23503).
+  runDb('blocks a forged cross-org onedrive_device_state INSERT (42501)', async () => {
+    const fx = await seedFixture();
+
+    // Seed org B's device under system scope so the FK resolves.
+    const orgBDeviceId = await withSystemDbAccessContext(async () => {
+      const siteB = await createSite({ orgId: fx.orgB.id });
+      return seedDevice(fx.orgB.id, siteB.id);
+    });
+
+    await expect(
+      withDbAccessContext(fx.orgAContext, () =>
+        db.insert(onedriveDeviceState).values({
+          deviceId: orgBDeviceId, // org B's real device (FK resolves)
+          orgId: fx.orgB.id,     // foreign org — RLS WITH CHECK must reject
+          signedIn: false,
         })
       )
     ).rejects.toMatchObject({ cause: { code: '42501' } });

--- a/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
@@ -210,6 +210,59 @@ describe('config_policy_onedrive_settings RLS isolation (breeze_app)', () => {
       )
     ).rejects.toMatchObject({ cause: { code: '42501' } });
   });
+
+  // (d) Cross-org UPDATE WITH CHECK denied: org A owns a settings row and tries
+  // to reassign its org_id to org B → 42501 (covers the UPDATE WITH CHECK policy).
+  runDb('blocks org A re-homing its own settings row to org B (42501)', async () => {
+    const fx = await seedFixture();
+
+    const settingsId = await withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .insert(configPolicyOnedriveSettings)
+        .values({ featureLinkId: fx.featureLinkA.id, orgId: fx.orgA.id })
+        .returning({ id: configPolicyOnedriveSettings.id });
+      return row!.id;
+    });
+
+    await expect(
+      withDbAccessContext(fx.orgAContext, () =>
+        db
+          .update(configPolicyOnedriveSettings)
+          .set({ orgId: fx.orgB.id })
+          .where(eq(configPolicyOnedriveSettings.id, settingsId))
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  // (e) Cross-org DELETE hidden (USING): org A cannot delete org B's settings
+  // row — 0 rows affected, and a system probe confirms it survives.
+  runDb('org A DELETE of org B settings affects 0 rows and leaves it intact', async () => {
+    const fx = await seedFixture();
+
+    const orgBSettingsId = await withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .insert(configPolicyOnedriveSettings)
+        .values({ featureLinkId: fx.featureLinkB.id, orgId: fx.orgB.id })
+        .returning({ id: configPolicyOnedriveSettings.id });
+      return row!.id;
+    });
+
+    const deleted = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .delete(configPolicyOnedriveSettings)
+        .where(eq(configPolicyOnedriveSettings.id, orgBSettingsId))
+        .returning({ id: configPolicyOnedriveSettings.id })
+    );
+    expect(deleted).toHaveLength(0);
+
+    const survivors = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: configPolicyOnedriveSettings.id })
+        .from(configPolicyOnedriveSettings)
+        .where(eq(configPolicyOnedriveSettings.id, orgBSettingsId))
+    );
+    expect(survivors).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -289,6 +342,79 @@ describe('config_policy_onedrive_libraries RLS isolation (breeze_app)', () => {
         })
       )
     ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  // (c) Cross-org UPDATE WITH CHECK denied: org A owns a library row and tries
+  // to reassign its org_id to org B → 42501 (covers the UPDATE WITH CHECK policy).
+  runDb('blocks org A re-homing its own library row to org B (42501)', async () => {
+    const fx = await seedFixture();
+
+    const libraryId = await withSystemDbAccessContext(async () => {
+      const [settings] = await db
+        .insert(configPolicyOnedriveSettings)
+        .values({ featureLinkId: fx.featureLinkA.id, orgId: fx.orgA.id })
+        .returning({ id: configPolicyOnedriveSettings.id });
+      const [lib] = await db
+        .insert(configPolicyOnedriveLibraries)
+        .values({
+          settingsId: settings!.id,
+          orgId: fx.orgA.id,
+          libraryId: 'lib-a-own',
+          displayName: 'Own',
+          targetingMode: 'everyone',
+        })
+        .returning({ id: configPolicyOnedriveLibraries.id });
+      return lib!.id;
+    });
+
+    await expect(
+      withDbAccessContext(fx.orgAContext, () =>
+        db
+          .update(configPolicyOnedriveLibraries)
+          .set({ orgId: fx.orgB.id })
+          .where(eq(configPolicyOnedriveLibraries.id, libraryId))
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  // (d) Cross-org DELETE hidden (USING): org A cannot delete org B's library row
+  // — 0 rows affected, and a system probe confirms it survives.
+  runDb('org A DELETE of org B library affects 0 rows and leaves it intact', async () => {
+    const fx = await seedFixture();
+
+    const orgBLibraryId = await withSystemDbAccessContext(async () => {
+      const [settings] = await db
+        .insert(configPolicyOnedriveSettings)
+        .values({ featureLinkId: fx.featureLinkB.id, orgId: fx.orgB.id })
+        .returning({ id: configPolicyOnedriveSettings.id });
+      const [lib] = await db
+        .insert(configPolicyOnedriveLibraries)
+        .values({
+          settingsId: settings!.id,
+          orgId: fx.orgB.id,
+          libraryId: 'lib-b-own',
+          displayName: 'Org B',
+          targetingMode: 'everyone',
+        })
+        .returning({ id: configPolicyOnedriveLibraries.id });
+      return lib!.id;
+    });
+
+    const deleted = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .delete(configPolicyOnedriveLibraries)
+        .where(eq(configPolicyOnedriveLibraries.id, orgBLibraryId))
+        .returning({ id: configPolicyOnedriveLibraries.id })
+    );
+    expect(deleted).toHaveLength(0);
+
+    const survivors = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: configPolicyOnedriveLibraries.id })
+        .from(configPolicyOnedriveLibraries)
+        .where(eq(configPolicyOnedriveLibraries.id, orgBLibraryId))
+    );
+    expect(survivors).toHaveLength(1);
   });
 });
 
@@ -423,5 +549,89 @@ describe('onedrive_device_state RLS isolation (breeze_app)', () => {
         })
       )
     ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  // (d) Cross-org UPDATE hidden (USING): org A cannot update org B's existing
+  // state row. The row is invisible under org A's context, so the UPDATE matches
+  // 0 rows (no error) and a system-scope probe confirms it is untouched.
+  runDb('org A UPDATE of org B device state affects 0 rows and leaves it unchanged', async () => {
+    const fx = await seedFixture();
+
+    const orgBDeviceId = await withSystemDbAccessContext(async () => {
+      const siteB = await createSite({ orgId: fx.orgB.id });
+      const devId = await seedDevice(fx.orgB.id, siteB.id);
+      await db.insert(onedriveDeviceState).values({ deviceId: devId, orgId: fx.orgB.id, signedIn: true });
+      return devId;
+    });
+
+    const updated = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .update(onedriveDeviceState)
+        .set({ signedIn: false })
+        .where(eq(onedriveDeviceState.deviceId, orgBDeviceId))
+        .returning({ deviceId: onedriveDeviceState.deviceId })
+    );
+    expect(updated).toHaveLength(0);
+
+    // System-scope probe: org B's row is intact (still signedIn = true).
+    const [survivor] = await withSystemDbAccessContext(() =>
+      db
+        .select({ signedIn: onedriveDeviceState.signedIn })
+        .from(onedriveDeviceState)
+        .where(eq(onedriveDeviceState.deviceId, orgBDeviceId))
+    );
+    expect(survivor?.signedIn).toBe(true);
+  });
+
+  // (e) Cross-org UPDATE WITH CHECK denied: org A owns a state row and tries to
+  // reassign its org_id to org B. USING passes (its own row) but the new org_id
+  // violates the UPDATE WITH CHECK policy → 42501.
+  runDb('blocks org A re-homing its own device state to org B (42501)', async () => {
+    const fx = await seedFixture();
+
+    const orgADeviceId = await withSystemDbAccessContext(async () => {
+      const siteA = await createSite({ orgId: fx.orgA.id });
+      const devId = await seedDevice(fx.orgA.id, siteA.id);
+      await db.insert(onedriveDeviceState).values({ deviceId: devId, orgId: fx.orgA.id, signedIn: true });
+      return devId;
+    });
+
+    await expect(
+      withDbAccessContext(fx.orgAContext, () =>
+        db
+          .update(onedriveDeviceState)
+          .set({ orgId: fx.orgB.id }) // foreign org — UPDATE WITH CHECK must reject
+          .where(eq(onedriveDeviceState.deviceId, orgADeviceId))
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  // (f) Cross-org DELETE hidden (USING): org A cannot delete org B's state row.
+  // The DELETE matches 0 rows and a system-scope probe confirms it survives.
+  runDb('org A DELETE of org B device state affects 0 rows and leaves it intact', async () => {
+    const fx = await seedFixture();
+
+    const orgBDeviceId = await withSystemDbAccessContext(async () => {
+      const siteB = await createSite({ orgId: fx.orgB.id });
+      const devId = await seedDevice(fx.orgB.id, siteB.id);
+      await db.insert(onedriveDeviceState).values({ deviceId: devId, orgId: fx.orgB.id, signedIn: true });
+      return devId;
+    });
+
+    const deleted = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .delete(onedriveDeviceState)
+        .where(eq(onedriveDeviceState.deviceId, orgBDeviceId))
+        .returning({ deviceId: onedriveDeviceState.deviceId })
+    );
+    expect(deleted).toHaveLength(0);
+
+    const survivors = await withSystemDbAccessContext(() =>
+      db
+        .select({ deviceId: onedriveDeviceState.deviceId })
+        .from(onedriveDeviceState)
+        .where(eq(onedriveDeviceState.deviceId, orgBDeviceId))
+    );
+    expect(survivors).toHaveLength(1);
   });
 });

--- a/apps/api/src/db/schema/configurationPolicies.ts
+++ b/apps/api/src/db/schema/configurationPolicies.ts
@@ -42,6 +42,7 @@ export const configFeatureTypeEnum = pgEnum('config_feature_type', [
   'helper',
   'remote_access',
   'pam',
+  'onedrive_helper',
 ]);
 
 export const configAssignmentLevelEnum = pgEnum('config_assignment_level', [

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -93,3 +93,4 @@ export * from './clientAi';
 export * from './mlFeedback';
 export * from './remediationSuggestions';
 export * from './pax8';
+export * from './onedriveHelper';

--- a/apps/api/src/db/schema/onedriveHelper.ts
+++ b/apps/api/src/db/schema/onedriveHelper.ts
@@ -1,0 +1,31 @@
+import {
+  pgTable,
+  uuid,
+  boolean,
+  varchar,
+  jsonb,
+  timestamp,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { configPolicyFeatureLinks } from './configurationPolicies';
+
+export const configPolicyOnedriveSettings = pgTable('config_policy_onedrive_settings', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  featureLinkId: uuid('feature_link_id').notNull()
+    .references(() => configPolicyFeatureLinks.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  silentAccountConfig: boolean('silent_account_config').notNull().default(true),
+  filesOnDemand: boolean('files_on_demand').notNull().default(true),
+  kfmSilentOptIn: boolean('kfm_silent_opt_in').notNull().default(false),
+  kfmFolders: jsonb('kfm_folders').notNull().default(['Desktop', 'Documents', 'Pictures']),
+  kfmBlockOptOut: boolean('kfm_block_opt_out').notNull().default(false),
+  tenantAssociationId: varchar('tenant_association_id', { length: 64 }),
+  restartOnChange: boolean('restart_on_change').notNull().default(true),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  featureLinkUniq: uniqueIndex('onedrive_settings_feature_link_uniq').on(t.featureLinkId),
+  orgIdx: index('onedrive_settings_org_idx').on(t.orgId),
+}));

--- a/apps/api/src/db/schema/onedriveHelper.ts
+++ b/apps/api/src/db/schema/onedriveHelper.ts
@@ -11,6 +11,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { organizations } from './orgs';
 import { configPolicyFeatureLinks } from './configurationPolicies';
+import { devices } from './devices';
 
 export const configPolicyOnedriveSettings = pgTable('config_policy_onedrive_settings', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -52,4 +53,20 @@ export const configPolicyOnedriveLibraries = pgTable('config_policy_onedrive_lib
 }, (t) => ({
   settingsIdx: index('onedrive_libraries_settings_idx').on(t.settingsId),
   orgIdx: index('onedrive_libraries_org_idx').on(t.orgId),
+}));
+
+export const onedriveDeviceState = pgTable('onedrive_device_state', {
+  deviceId: uuid('device_id').primaryKey().references(() => devices.id),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  signedIn: boolean('signed_in').notNull().default(false),
+  oneDriveVersion: varchar('onedrive_version', { length: 64 }),
+  filesOnDemandOn: boolean('files_on_demand_on').notNull().default(false),
+  kfmFolderStates: jsonb('kfm_folder_states').notNull().default({}),
+  mountedLibraries: jsonb('mounted_libraries').notNull().default([]),
+  entitledLibraries: jsonb('entitled_libraries').notNull().default([]),
+  driftEntries: jsonb('drift_entries').notNull().default([]),
+  lastReportedAt: timestamp('last_reported_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  orgIdx: index('onedrive_device_state_org_idx').on(t.orgId),
 }));

--- a/apps/api/src/db/schema/onedriveHelper.ts
+++ b/apps/api/src/db/schema/onedriveHelper.ts
@@ -5,6 +5,7 @@ import {
   varchar,
   jsonb,
   timestamp,
+  integer,
   index,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
@@ -28,4 +29,27 @@ export const configPolicyOnedriveSettings = pgTable('config_policy_onedrive_sett
 }, (t) => ({
   featureLinkUniq: uniqueIndex('onedrive_settings_feature_link_uniq').on(t.featureLinkId),
   orgIdx: index('onedrive_settings_org_idx').on(t.orgId),
+}));
+
+export const configPolicyOnedriveLibraries = pgTable('config_policy_onedrive_libraries', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  settingsId: uuid('settings_id').notNull()
+    .references(() => configPolicyOnedriveSettings.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  libraryId: varchar('library_id', { length: 1024 }).notNull(),
+  displayName: varchar('display_name', { length: 255 }).notNull(),
+  siteUrl: varchar('site_url', { length: 1024 }),
+  siteId: varchar('site_id', { length: 512 }),
+  webId: varchar('web_id', { length: 128 }),
+  listId: varchar('list_id', { length: 128 }),
+  targetingMode: varchar('targeting_mode', { length: 20 }).notNull().default('everyone'),
+  groupId: varchar('group_id', { length: 128 }),
+  groupName: varchar('group_name', { length: 255 }),
+  hiveScope: varchar('hive_scope', { length: 8 }).notNull().default('hkcu'),
+  sortOrder: integer('sort_order').notNull().default(0),
+  enabled: boolean('enabled').notNull().default(true),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (t) => ({
+  settingsIdx: index('onedrive_libraries_settings_idx').on(t.settingsId),
+  orgIdx: index('onedrive_libraries_org_idx').on(t.orgId),
 }));

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -8,6 +8,7 @@ import {
   deviceMetrics,
   agentVersions,
   agentLogs,
+  onedriveDeviceState,
 } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { heartbeatSchema } from './schemas';
@@ -457,6 +458,40 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       }
     } catch (err) {
       console.error(`[agents] failed to queue threshold filesystem scan for ${device.id}:`, err);
+    }
+  }
+
+  if (data.onedriveDeviceState) {
+    const s = data.onedriveDeviceState;
+    try {
+      await db.insert(onedriveDeviceState).values({
+        deviceId: device.id,
+        orgId: device.orgId,
+        signedIn: s.signedIn,
+        oneDriveVersion: s.oneDriveVersion ?? null,
+        filesOnDemandOn: s.filesOnDemandOn,
+        kfmFolderStates: s.kfmFolderStates,
+        mountedLibraries: s.mountedLibraries,
+        entitledLibraries: s.entitledLibraries,
+        driftEntries: s.driftEntries,
+        lastReportedAt: new Date(),
+        updatedAt: new Date(),
+      }).onConflictDoUpdate({
+        target: onedriveDeviceState.deviceId,
+        set: {
+          signedIn: s.signedIn,
+          oneDriveVersion: s.oneDriveVersion ?? null,
+          filesOnDemandOn: s.filesOnDemandOn,
+          kfmFolderStates: s.kfmFolderStates,
+          mountedLibraries: s.mountedLibraries,
+          entitledLibraries: s.entitledLibraries,
+          driftEntries: s.driftEntries,
+          lastReportedAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+    } catch (err) {
+      console.error(`[agents] failed to upsert onedrive device state for ${agentId}:`, err);
     }
   }
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -21,7 +21,9 @@ import {
   buildMonitoringConfigUpdate,
   buildHelperConfigUpdate,
   buildPamConfigUpdate,
+  buildOnedriveHelperConfigUpdate,
   getOrgAgentUpdatePolicy,
+  type OnedriveConfigUpdate,
 } from './helpers';
 import { shouldSendAgentUpgrade } from './agentUpdatePolicy';
 import { processDeviceIPHistoryUpdate } from '../../services/deviceIpHistory';
@@ -632,14 +634,24 @@ if (latestHelper) {
     captureException(err);
   }
 
+  let onedriveSettings: OnedriveConfigUpdate | null = null;
+  try {
+    onedriveSettings = await buildOnedriveHelperConfigUpdate(device.id);
+  } catch (err) {
+    console.error(`[agents] failed to build onedrive_helper config update for ${agentId}:`, err);
+  }
+
   let mergedConfigUpdate: Record<string, unknown> | null = null;
-  if (configUpdate || eventLogSettings || monitoringSettings) {
+  if (configUpdate || eventLogSettings || monitoringSettings || onedriveSettings) {
     mergedConfigUpdate = { ...(configUpdate ?? {}) };
     if (eventLogSettings) {
       mergedConfigUpdate.event_log_settings = eventLogSettings;
     }
     if (monitoringSettings) {
       mergedConfigUpdate.monitoring_settings = monitoringSettings;
+    }
+    if (onedriveSettings) {
+      mergedConfigUpdate.onedrive_helper_settings = onedriveSettings;
     }
   }
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -492,6 +492,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       });
     } catch (err) {
       console.error(`[agents] failed to upsert onedrive device state for ${agentId}:`, err);
+      captureException(err);
     }
   }
 
@@ -674,6 +675,7 @@ if (latestHelper) {
     onedriveSettings = await buildOnedriveHelperConfigUpdate(device.id);
   } catch (err) {
     console.error(`[agents] failed to build onedrive_helper config update for ${agentId}:`, err);
+    captureException(err);
   }
 
   let mergedConfigUpdate: Record<string, unknown> | null = null;

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -27,6 +27,8 @@ import {
   configPolicyEventLogSettings,
   configPolicyMonitoringSettings,
   configPolicyMonitoringWatches,
+  configPolicyOnedriveSettings,
+  configPolicyOnedriveLibraries,
 } from '../../db/schema';
 import { getRedis } from '../../services/redis';
 import { publishEvent } from '../../services/eventBus';
@@ -2341,4 +2343,145 @@ export async function buildPamConfigUpdate(deviceId: string): Promise<PamSetting
   }
 
   return settings;
+}
+
+// ============================================
+// OneDrive Helper Config
+// ============================================
+
+export interface OnedriveConfigUpdate {
+  base: {
+    silentAccountConfig: boolean;
+    filesOnDemand: boolean;
+    kfmSilentOptIn: boolean;
+    kfmFolders: string[];
+    kfmBlockOptOut: boolean;
+    tenantAssociationId: string | null;
+    restartOnChange: boolean;
+  };
+  libraries: Array<{
+    libraryId: string;
+    displayName: string;
+    siteUrl: string | null;
+    targetingMode: string;
+    groupId: string | null;
+    groupName: string | null;
+    hiveScope: string;
+  }>;
+}
+
+async function resolveDeviceOnedriveSettings(deviceId: string): Promise<OnedriveConfigUpdate | null> {
+  // 1. Load device
+  const [device] = await db
+    .select({ orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.id, deviceId))
+    .limit(1);
+
+  if (!device) return null;
+
+  // 2. Load org (for partnerId)
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, device.orgId))
+    .limit(1);
+
+  // 3. Load device group memberships
+  const groupRows = await db
+    .select({ groupId: deviceGroupMemberships.groupId })
+    .from(deviceGroupMemberships)
+    .where(eq(deviceGroupMemberships.deviceId, deviceId));
+  const groupIds = groupRows.map((r) => r.groupId);
+
+  // 4. Build target match conditions (closest-level-wins hierarchy)
+  const targetConditions = [
+    and(eq(configPolicyAssignments.level, 'device'), eq(configPolicyAssignments.targetId, deviceId)),
+    and(eq(configPolicyAssignments.level, 'site'), eq(configPolicyAssignments.targetId, device.siteId)),
+    and(eq(configPolicyAssignments.level, 'organization'), eq(configPolicyAssignments.targetId, device.orgId)),
+  ];
+  if (groupIds.length > 0) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'device_group'), inArray(configPolicyAssignments.targetId, groupIds))!
+    );
+  }
+  if (org?.partnerId) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'partner'), eq(configPolicyAssignments.targetId, org.partnerId))!
+    );
+  }
+
+  // 5. Single query: assignments → active policies → onedrive_helper feature link → settings
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      settingsId: configPolicyOnedriveSettings.id,
+      silentAccountConfig: configPolicyOnedriveSettings.silentAccountConfig,
+      filesOnDemand: configPolicyOnedriveSettings.filesOnDemand,
+      kfmSilentOptIn: configPolicyOnedriveSettings.kfmSilentOptIn,
+      kfmFolders: configPolicyOnedriveSettings.kfmFolders,
+      kfmBlockOptOut: configPolicyOnedriveSettings.kfmBlockOptOut,
+      tenantAssociationId: configPolicyOnedriveSettings.tenantAssociationId,
+      restartOnChange: configPolicyOnedriveSettings.restartOnChange,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'onedrive_helper'),
+    ))
+    .innerJoin(configPolicyOnedriveSettings, eq(configPolicyOnedriveSettings.featureLinkId, configPolicyFeatureLinks.id))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      eq(configurationPolicies.orgId, device.orgId),
+      or(...targetConditions),
+    ));
+
+  if (rows.length === 0) return null;
+
+  // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
+  rows.sort((a, b) => {
+    const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
+    if (levelDiff !== 0) return levelDiff;
+    return a.assignmentPriority - b.assignmentPriority;
+  });
+
+  const winner = rows[0];
+  if (!winner) return null;
+
+  // 7. Load enabled libraries for the winning settings row, in sort order
+  const libs = await db
+    .select()
+    .from(configPolicyOnedriveLibraries)
+    .where(and(
+      eq(configPolicyOnedriveLibraries.settingsId, winner.settingsId),
+      eq(configPolicyOnedriveLibraries.enabled, true),
+    ))
+    .orderBy(configPolicyOnedriveLibraries.sortOrder);
+
+  return {
+    base: {
+      silentAccountConfig: winner.silentAccountConfig,
+      filesOnDemand: winner.filesOnDemand,
+      kfmSilentOptIn: winner.kfmSilentOptIn,
+      kfmFolders: (winner.kfmFolders as string[]) ?? [],
+      kfmBlockOptOut: winner.kfmBlockOptOut,
+      tenantAssociationId: winner.tenantAssociationId,
+      restartOnChange: winner.restartOnChange,
+    },
+    libraries: libs.map((l) => ({
+      libraryId: l.libraryId,
+      displayName: l.displayName,
+      siteUrl: l.siteUrl,
+      targetingMode: l.targetingMode,
+      groupId: l.groupId,
+      groupName: l.groupName,
+      hiveScope: l.hiveScope,
+    })),
+  };
+}
+
+export async function buildOnedriveHelperConfigUpdate(deviceId: string): Promise<OnedriveConfigUpdate | null> {
+  return resolveDeviceOnedriveSettings(deviceId);
 }

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -177,6 +177,15 @@ export const heartbeatSchema = z.object({
   mainAgentLastRestartAt: z.string().datetime({ offset: true }).optional().catch(undefined),
   flapDetected: z.boolean().optional().catch(undefined),
   osType: z.string().optional().catch(undefined),
+  onedriveDeviceState: z.object({
+    signedIn: z.boolean(),
+    oneDriveVersion: z.string().max(64).optional(),
+    filesOnDemandOn: z.boolean(),
+    kfmFolderStates: z.record(z.string(), z.string()).default({}),
+    mountedLibraries: z.array(z.string().max(1024)).default([]),
+    entitledLibraries: z.array(z.string().max(1024)).default([]),
+    driftEntries: z.array(z.record(z.string(), z.unknown())).default([]),
+  }).optional().catch(undefined),
 });
 
 // ============================================

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -110,6 +110,7 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
   'group_membership_log',
   'huntress_agents', 'huntress_incidents', 'hyperv_vms', 'local_vaults',
   'metric_anomaly_candidates', 'metric_anomalies', 'metric_rollups',
+  'onedrive_device_state',
   'peripheral_events', 'playbook_executions', 'provision_credential_handles',
   'recovery_readiness', 'recovery_tokens', 'remediation_suggestions', 'remote_sessions', 'restore_jobs',
   's1_actions', 's1_agents', 's1_threats',

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -216,6 +216,8 @@ export const DEVICE_CASCADE_DELETE_TABLES = [
   // Provisioning one-time credential handles (FK device_id → devices.id ON DELETE CASCADE;
   // listed for the explicit-cascade coverage contract — leaf table, no children)
   'provision_credential_handles',
+  // OneDrive helper — persisted device state (PK = device_id; leaf table, no children)
+  'onedrive_device_state',
 ] as const;
 
 export const coreRoutes = new Hono();

--- a/apps/api/src/services/configurationPolicy.onedrive.test.ts
+++ b/apps/api/src/services/configurationPolicy.onedrive.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../db', () => ({ db: {}, withDbAccessContext: vi.fn(), withSystemDbAccessContext: vi.fn() }));
+
+import { validateFeaturePolicyExists } from './configurationPolicy';
+
+describe('onedrive_helper feature type', () => {
+  it('rejects a featurePolicyId (inline-only feature)', async () => {
+    const res = await validateFeaturePolicyExists('onedrive_helper', 'some-id', 'org-1');
+    expect(res.valid).toBe(false);
+    expect(res.error).toMatch(/does not support featurePolicyId/);
+  });
+
+  it('accepts inline-only (no featurePolicyId)', async () => {
+    const res = await validateFeaturePolicyExists('onedrive_helper', null, 'org-1');
+    expect(res.valid).toBe(true);
+  });
+});

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -53,7 +53,7 @@ export const pamInlineSettingsSchema = z
 // Types
 // ============================================
 
-type ConfigFeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam';
+type ConfigFeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam' | 'onedrive_helper';
 export type ConfigAssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device';
 
 const LEVEL_PRIORITY: Record<ConfigAssignmentLevel, number> = {
@@ -1344,8 +1344,8 @@ export async function validateFeaturePolicyExists(
     return { valid: true };
   }
 
-  if (featureType === 'monitoring' || featureType === 'event_log') {
-    // Monitoring and event_log have no policy table — requires inlineSettings
+  if (featureType === 'monitoring' || featureType === 'event_log' || featureType === 'onedrive_helper') {
+    // Monitoring, event_log, and onedrive_helper have no policy table — requires inlineSettings
     if (featurePolicyId) {
       return { valid: false, error: `${featureType} feature type does not support featurePolicyId; use inlineSettings instead` };
     }

--- a/apps/api/src/services/m365DirectGraph.ts
+++ b/apps/api/src/services/m365DirectGraph.ts
@@ -58,7 +58,7 @@ function generateTempPassword(): string {
   return `Mz9!${raw.slice(0, 18)}`;
 }
 
-async function getToken(orgId: string): Promise<{ token: string } | DirectInvokeResult> {
+export async function getToken(orgId: string): Promise<{ token: string } | DirectInvokeResult> {
   const [row] = await db
     .select()
     .from(m365Connections)
@@ -89,7 +89,7 @@ async function getToken(orgId: string): Promise<{ token: string } | DirectInvoke
   }
 }
 
-async function graphFetch(
+export async function graphFetch(
   token: string,
   method: 'GET' | 'PATCH' | 'POST' | 'DELETE',
   path: string,

--- a/apps/api/src/services/onedriveGraph.test.ts
+++ b/apps/api/src/services/onedriveGraph.test.ts
@@ -5,7 +5,10 @@ vi.mock('./m365DirectGraph', () => ({
   graphFetch: vi.fn(),
 }));
 
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
 import { getToken, graphFetch } from './m365DirectGraph';
+import { captureException } from './sentry';
 import { listSharePointLibraries, resolveUserGroupMembership } from './onedriveGraph';
 
 describe('listSharePointLibraries', () => {
@@ -36,6 +39,59 @@ describe('listSharePointLibraries', () => {
     (getToken as any).mockResolvedValueOnce({ kind: 'error', code: 'no_connection', message: 'x' });
     const res = await listSharePointLibraries('org-1');
     expect(res.kind).toBe('error');
+  });
+
+  it('skips an unreadable site (5xx/throttle) but still returns readable sites and records the skip', async () => {
+    (graphFetch as any)
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'siteA', displayName: 'A', webUrl: 'https://c/a' },
+        { id: 'siteB', displayName: 'B', webUrl: 'https://c/b' },
+      ] } }) // /sites
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'drA', name: 'Docs', list: { id: 'lA' } },
+      ] } }) // siteA /drives
+      .mockResolvedValueOnce({ kind: 'error', code: 'graph_unavailable', message: 'boom' }); // siteB /drives
+
+    const res = await listSharePointLibraries('org-1');
+    expect(res.kind).toBe('ok');
+    expect((res as any).data.libraries).toHaveLength(1);
+    expect((res as any).data.libraries[0].driveId).toBe('drA');
+    expect((res as any).data.skippedSites).toEqual([{ siteId: 'siteB', code: 'graph_unavailable' }]);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a forbidden (403) site quietly — not recorded, not alerted', async () => {
+    (graphFetch as any)
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'siteA', displayName: 'A', webUrl: 'https://c/a' },
+        { id: 'siteB', displayName: 'B', webUrl: 'https://c/b' },
+      ] } }) // /sites
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'drA', name: 'Docs', list: { id: 'lA' } },
+      ] } }) // siteA /drives
+      .mockResolvedValueOnce({ kind: 'error', code: 'forbidden', message: 'no access' }); // siteB /drives
+
+    const res = await listSharePointLibraries('org-1');
+    expect(res.kind).toBe('ok');
+    expect((res as any).data.libraries).toHaveLength(1);
+    expect((res as any).data.skippedSites).toEqual([]);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('drops a malformed drive row with no string id rather than emitting an empty driveId', async () => {
+    (graphFetch as any)
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'siteA', displayName: 'A', webUrl: 'https://c/a' },
+      ] } }) // /sites
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'drA', name: 'Docs', list: { id: 'lA' } },
+        { name: 'Broken', list: { id: 'lB' } }, // no id — must be dropped
+      ] } }); // siteA /drives
+
+    const res = await listSharePointLibraries('org-1');
+    expect(res.kind).toBe('ok');
+    expect((res as any).data.libraries).toHaveLength(1);
+    expect((res as any).data.libraries[0].driveId).toBe('drA');
   });
 });
 

--- a/apps/api/src/services/onedriveGraph.test.ts
+++ b/apps/api/src/services/onedriveGraph.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./m365DirectGraph', () => ({
+  getToken: vi.fn(async () => ({ token: 'tok' })),
+  graphFetch: vi.fn(),
+}));
+
+import { getToken, graphFetch } from './m365DirectGraph';
+import { listSharePointLibraries } from './onedriveGraph';
+
+describe('listSharePointLibraries', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns flattened site+library list', async () => {
+    (graphFetch as any)
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'host,scid,webid', displayName: 'Marketing', webUrl: 'https://c.sharepoint.com/sites/mktg' },
+      ] } }) // /sites?search=*
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'drive-1', name: 'Documents', list: { id: 'list-1' } },
+      ] } }); // /sites/{id}/drives
+
+    const res = await listSharePointLibraries('org-1');
+    expect(res.kind).toBe('ok');
+    expect((res as any).data.libraries[0]).toMatchObject({
+      siteName: 'Marketing', driveId: 'drive-1', listId: 'list-1', libraryName: 'Documents',
+    });
+  });
+
+  it('propagates a token error', async () => {
+    (getToken as any).mockResolvedValueOnce({ kind: 'error', code: 'no_connection', message: 'x' });
+    const res = await listSharePointLibraries('org-1');
+    expect(res.kind).toBe('error');
+  });
+});

--- a/apps/api/src/services/onedriveGraph.test.ts
+++ b/apps/api/src/services/onedriveGraph.test.ts
@@ -25,6 +25,11 @@ describe('listSharePointLibraries', () => {
     expect((res as any).data.libraries[0]).toMatchObject({
       siteName: 'Marketing', driveId: 'drive-1', listId: 'list-1', libraryName: 'Documents',
     });
+
+    // Composite site IDs contain literal commas (hostname,scGuid,webGuid); Graph does not accept %2C
+    const drivesPath = (graphFetch as any).mock.calls[1][2] as string;
+    expect(drivesPath).toContain('/sites/host,scid,webid/drives');
+    expect(drivesPath).not.toContain('%2C');
   });
 
   it('propagates a token error', async () => {

--- a/apps/api/src/services/onedriveGraph.test.ts
+++ b/apps/api/src/services/onedriveGraph.test.ts
@@ -6,7 +6,7 @@ vi.mock('./m365DirectGraph', () => ({
 }));
 
 import { getToken, graphFetch } from './m365DirectGraph';
-import { listSharePointLibraries } from './onedriveGraph';
+import { listSharePointLibraries, resolveUserGroupMembership } from './onedriveGraph';
 
 describe('listSharePointLibraries', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -36,5 +36,27 @@ describe('listSharePointLibraries', () => {
     (getToken as any).mockResolvedValueOnce({ kind: 'error', code: 'no_connection', message: 'x' });
     const res = await listSharePointLibraries('org-1');
     expect(res.kind).toBe('error');
+  });
+});
+
+describe('resolveUserGroupMembership', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns transitive group ids for the user', async () => {
+    (graphFetch as any).mockResolvedValueOnce({ kind: 'ok', data: { value: [
+      { id: 'g-1' }, { id: 'g-2' },
+    ] } });
+    const res = await resolveUserGroupMembership('org-1', "user@contoso.com");
+    expect((res as any).data.groupIds).toEqual(['g-1', 'g-2']);
+    // verify the OData id was single-quote-escaped into the path
+    const calledPath = (graphFetch as any).mock.calls[0][2] as string;
+    expect(calledPath).toContain('/users/');
+    expect(calledPath).toContain('transitiveMemberOf');
+  });
+
+  it('rejects an empty upn before calling Graph', async () => {
+    const res = await resolveUserGroupMembership('org-1', '');
+    expect(res.kind).toBe('error');
+    expect((graphFetch as any)).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/onedriveGraph.test.ts
+++ b/apps/api/src/services/onedriveGraph.test.ts
@@ -48,7 +48,7 @@ describe('resolveUserGroupMembership', () => {
     ] } });
     const res = await resolveUserGroupMembership('org-1', "user@contoso.com");
     expect((res as any).data.groupIds).toEqual(['g-1', 'g-2']);
-    // verify the OData id was single-quote-escaped into the path
+    // verify the upn was encodeURIComponent-encoded into the path segment
     const calledPath = (graphFetch as any).mock.calls[0][2] as string;
     expect(calledPath).toContain('/users/');
     expect(calledPath).toContain('transitiveMemberOf');

--- a/apps/api/src/services/onedriveGraph.ts
+++ b/apps/api/src/services/onedriveGraph.ts
@@ -40,3 +40,22 @@ export async function listSharePointLibraries(orgId: string): Promise<DirectInvo
 
   return { kind: 'ok', data: { libraries } };
 }
+
+export async function resolveUserGroupMembership(orgId: string, upn: string): Promise<DirectInvokeResult> {
+  if (!upn || typeof upn !== 'string') {
+    return { kind: 'error', code: 'bad_request', message: 'upn is required.' };
+  }
+  const tok = await getToken(orgId);
+  if ('kind' in tok) return tok;
+
+  // transitiveMemberOf so nested group membership counts; only group objects, ids only.
+  const res = await graphFetch(
+    tok.token, 'GET',
+    `/users/${encodeURIComponent(upn)}/transitiveMemberOf/microsoft.graph.group?$select=id&$top=200`,
+  );
+  if (res.kind === 'error') return res;
+
+  const rows = Array.isArray((res.data as any)?.value) ? (res.data as any).value : [];
+  const groupIds = rows.map((g: any) => g.id).filter((id: unknown): id is string => typeof id === 'string');
+  return { kind: 'ok', data: { groupIds } };
+}

--- a/apps/api/src/services/onedriveGraph.ts
+++ b/apps/api/src/services/onedriveGraph.ts
@@ -1,4 +1,5 @@
 import { getToken, graphFetch, type DirectInvokeResult } from './m365DirectGraph';
+import { captureException } from './sentry';
 
 /** Encode a Graph composite site ID (hostname,scGuid,webGuid) for use in a path segment.
  * encodeURIComponent encodes commas to %2C, but Graph requires literal commas in this position. */
@@ -17,28 +18,52 @@ export async function listSharePointLibraries(orgId: string): Promise<DirectInvo
 
   const siteRows = Array.isArray((sites.data as any)?.value) ? (sites.data as any).value : [];
   const libraries: Array<Record<string, string>> = [];
+  // Sites we could not enumerate drives for due to an *unexpected* error
+  // (throttling, 5xx, …). Returned so the caller can surface "N sites could
+  // not be read" rather than presenting a silently-truncated picker as if it
+  // were the complete set. A 403 (app simply lacks access to the site) is an
+  // expected, stable condition and is skipped quietly, not recorded.
+  const skippedSites: Array<{ siteId: string; code: string }> = [];
 
   for (const site of siteRows) {
+    const siteId = typeof site?.id === 'string' ? site.id : null;
+    if (!siteId) continue; // malformed site row with no usable id — nothing to fetch
+
     const drives = await graphFetch(
       token,
       'GET',
-      `/sites/${encodeSiteId(site.id)}/drives?$select=id,name,list`,
+      `/sites/${encodeSiteId(siteId)}/drives?$select=id,name,list`,
     );
-    if (drives.kind === 'error') continue; // skip a site we can't read; don't fail the whole list
+    if (drives.kind === 'error') {
+      if (drives.code !== 'forbidden') {
+        // An unexpected failure that would otherwise silently drop this site's
+        // libraries — record it and alert so it's traceable later.
+        skippedSites.push({ siteId, code: drives.code });
+        captureException(
+          new Error(
+            `listSharePointLibraries: could not read drives for site ${siteId} (${drives.code}: ${drives.message})`,
+          ),
+        );
+      }
+      continue;
+    }
+
     const driveRows = Array.isArray((drives.data as any)?.value) ? (drives.data as any).value : [];
     for (const d of driveRows) {
+      const driveId = typeof d?.id === 'string' ? d.id : null;
+      if (!driveId) continue; // malformed drive row — skip rather than ship a NULL/garbage library_id downstream
       libraries.push({
-        siteId: site.id,
-        siteName: site.displayName ?? '',
-        siteUrl: site.webUrl ?? '',
-        driveId: d.id,
-        listId: d.list?.id ?? '',
-        libraryName: d.name ?? '',
+        siteId,
+        siteName: typeof site.displayName === 'string' ? site.displayName : '',
+        siteUrl: typeof site.webUrl === 'string' ? site.webUrl : '',
+        driveId,
+        listId: typeof d.list?.id === 'string' ? d.list.id : '',
+        libraryName: typeof d.name === 'string' ? d.name : '',
       });
     }
   }
 
-  return { kind: 'ok', data: { libraries } };
+  return { kind: 'ok', data: { libraries, skippedSites } };
 }
 
 export async function resolveUserGroupMembership(orgId: string, upn: string): Promise<DirectInvokeResult> {

--- a/apps/api/src/services/onedriveGraph.ts
+++ b/apps/api/src/services/onedriveGraph.ts
@@ -1,0 +1,36 @@
+import { getToken, graphFetch, type DirectInvokeResult } from './m365DirectGraph';
+
+export async function listSharePointLibraries(orgId: string): Promise<DirectInvokeResult> {
+  const tok = await getToken(orgId);
+  if ('kind' in tok) return tok; // error result
+
+  const token = tok.token;
+
+  const sites = await graphFetch(token, 'GET', `/sites?search=*&$top=100&$select=id,displayName,webUrl`);
+  if (sites.kind === 'error') return sites;
+
+  const siteRows = Array.isArray((sites.data as any)?.value) ? (sites.data as any).value : [];
+  const libraries: Array<Record<string, string>> = [];
+
+  for (const site of siteRows) {
+    const drives = await graphFetch(
+      token,
+      'GET',
+      `/sites/${encodeURIComponent(site.id)}/drives?$select=id,name,list`,
+    );
+    if (drives.kind === 'error') continue; // skip a site we can't read; don't fail the whole list
+    const driveRows = Array.isArray((drives.data as any)?.value) ? (drives.data as any).value : [];
+    for (const d of driveRows) {
+      libraries.push({
+        siteId: site.id,
+        siteName: site.displayName ?? '',
+        siteUrl: site.webUrl ?? '',
+        driveId: d.id,
+        listId: d.list?.id ?? '',
+        libraryName: d.name ?? '',
+      });
+    }
+  }
+
+  return { kind: 'ok', data: { libraries } };
+}

--- a/apps/api/src/services/onedriveGraph.ts
+++ b/apps/api/src/services/onedriveGraph.ts
@@ -1,5 +1,11 @@
 import { getToken, graphFetch, type DirectInvokeResult } from './m365DirectGraph';
 
+/** Encode a Graph composite site ID (hostname,scGuid,webGuid) for use in a path segment.
+ * encodeURIComponent encodes commas to %2C, but Graph requires literal commas in this position. */
+function encodeSiteId(id: string): string {
+  return encodeURIComponent(id).replace(/%2C/g, ',');
+}
+
 export async function listSharePointLibraries(orgId: string): Promise<DirectInvokeResult> {
   const tok = await getToken(orgId);
   if ('kind' in tok) return tok; // error result
@@ -16,7 +22,7 @@ export async function listSharePointLibraries(orgId: string): Promise<DirectInvo
     const drives = await graphFetch(
       token,
       'GET',
-      `/sites/${encodeURIComponent(site.id)}/drives?$select=id,name,list`,
+      `/sites/${encodeSiteId(site.id)}/drives?$select=id,name,list`,
     );
     if (drives.kind === 'error') continue; // skip a site we can't read; don't fail the whole list
     const driveRows = Array.isArray((drives.data as any)?.value) ? (drives.data as any).value : [];

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -115,6 +115,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'client_ai_tenant_mappings',
   'client_ai_usage',
   'config_policy_backup_settings',
+  'config_policy_onedrive_libraries',
   'config_policy_onedrive_settings',
   'configuration_policies',
   'contract_billing_periods',

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -201,6 +201,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'oauth_client_blocks',
   'oauth_grants',
   'oauth_refresh_tokens',
+  'onedrive_device_state',
   'org_ticket_settings',
   'organization_users',
   'pam_rules',

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -115,6 +115,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'client_ai_tenant_mappings',
   'client_ai_usage',
   'config_policy_backup_settings',
+  'config_policy_onedrive_settings',
   'configuration_policies',
   'contract_billing_periods',
   'contract_lines',

--- a/docs/superpowers/plans/2026-06-19-onedrive-helper-server-foundation.md
+++ b/docs/superpowers/plans/2026-06-19-onedrive-helper-server-foundation.md
@@ -1,0 +1,1127 @@
+# OneDrive Helper — Phase 0 (Spike) + Phase 1 (Server Foundation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the server-side foundation for the OneDrive Helper — the `onedrive_helper` config-policy feature, its settings/library/device-state tables (with RLS), the Graph functions for listing libraries and resolving group membership, and the heartbeat config delivery + device-state ingest — and first de-risk the `TenantAutoMount` library-ID format with a spike.
+
+**Architecture:** A new `onedrive_helper` feature type plugs into the existing configuration-policy system (`config_policy_feature_links` → normalized per-feature tables, exactly like `monitoring`). Effective config is resolved per device with the existing "closest-level-wins" hierarchy merge and delivered in the heartbeat `configUpdate`. The agent reports OneDrive state back in the heartbeat payload, persisted to a device-scoped table. Graph calls reuse the per-org M365 connection (`getToken` → `graphFetch`).
+
+**Tech Stack:** Hono + Drizzle (API, TypeScript), PostgreSQL with forced RLS, hand-written SQL migrations, Vitest (unit + integration), Microsoft Graph v1.0.
+
+## Global Constraints
+
+- **Node:** prefix node/pnpm/vitest commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict).
+- **Scope:** Server-only. NO agent Go code and NO web UI in this plan — the agent applier and UI are separate plans gated on the Task 1 spike. Per-user Graph-group *filtering* delivery is gated on agent UPN reporting (see Task 8 note).
+- **Migrations:** `apps/api/migrations/YYYY-MM-DD-<slug>.sql`, same-day ordering via `-a-/-b-` infix. Idempotent (`IF NOT EXISTS`, `pg_policies` existence checks, `DO $$`). NO inner `BEGIN;`/`COMMIT;` (autoMigrate wraps each file in a transaction). Never edit a shipped migration. `ALTER TYPE ... ADD VALUE IF NOT EXISTS`.
+- **RLS (mandatory, same migration as the table):** every new tenant table gets `ENABLE` + `FORCE ROW LEVEL SECURITY` + per-command policies using `public.breeze_has_org_access(org_id)`, plus `GRANT SELECT,INSERT,UPDATE,DELETE ... TO breeze_app`. All three new tables carry a direct/denormalized `org_id` → Shape 1, auto-discovered by the RLS-coverage test (no allowlist entry needed). Add each to `ORG_CASCADE_DELETE_ORDER` alphabetically. Verify a forged cross-tenant insert fails as `breeze_app` before claiming done.
+- **Real-DB tests** go in `apps/api/src/__tests__/integration/*.integration.test.ts` (BLOCKING integration-test job, `breeze_app` conn, autoMigrate + TRUNCATE-per-test). Pure-logic/Graph tests go alongside source as `*.test.ts` with mocked `fetch`/`db`.
+- **Graph:** reuse `getToken(orgId)` → `graphFetch(token, method, path)` from `m365DirectGraph.ts`; never build a second token path. Secrets decrypt via `decryptForColumn('m365_connections','client_secret', cipher)`.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/migrations/2026-06-19-a-onedrive-helper-feature-enum.sql` — add enum value
+- `apps/api/migrations/2026-06-19-b-onedrive-helper-settings.sql` — settings table + RLS
+- `apps/api/migrations/2026-06-19-c-onedrive-helper-libraries.sql` — libraries table + RLS
+- `apps/api/migrations/2026-06-19-d-onedrive-device-state.sql` — device-state table + RLS
+- `apps/api/src/db/schema/onedriveHelper.ts` — Drizzle defs for the three tables
+- `apps/api/src/services/onedriveGraph.ts` — `listSharePointLibraries`, `resolveUserGroupMembership`
+- `apps/api/src/services/onedriveGraph.test.ts` — unit tests (mocked fetch)
+- `apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts` — RLS forge tests
+- `apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts` — delivery + ingest
+- `docs/superpowers/spikes/2026-06-19-tenant-automount-library-id.md` — spike findings
+
+**Modify:**
+- `apps/api/src/db/schema/configurationPolicies.ts` — add `'onedrive_helper'` to `configFeatureTypeEnum`
+- `apps/api/src/db/schema/index.ts` (or wherever schema is re-exported) — export `onedriveHelper`
+- `apps/api/src/services/configurationPolicy.ts` — add `'onedrive_helper'` to `ConfigFeatureType`; allow it in `validateFeaturePolicyExists` as inline-only
+- `apps/api/src/routes/agents/helpers.ts` — add `buildOnedriveHelperConfigUpdate(deviceId)` + `resolveDeviceOnedriveSettings`
+- `apps/api/src/routes/agents/heartbeat.ts` — merge onedrive config into the response; persist reported `onedriveDeviceState`
+- `apps/api/src/services/tenantCascade.ts` — add three table names to `ORG_CASCADE_DELETE_ORDER`
+
+---
+
+## Task 1: De-risking spike — `TenantAutoMount` library-ID format
+
+**This is a research task with a written decision gate, not a TDD task.** Everything downstream (the Graph library picker, the agent applier) depends on its outcome, so it runs first and its result is committed as a doc.
+
+**Files:**
+- Create: `docs/superpowers/spikes/2026-06-19-tenant-automount-library-id.md`
+
+- [ ] **Step 1: Establish ground truth from a real tenant**
+
+On a test Windows box signed into a OneDrive business account, manually "Sync" a SharePoint document library, then read the resulting AutoMount value:
+
+```powershell
+Get-ItemProperty 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\TenantAutoMount' 2>$null
+# also inspect the mounted-scope cache OneDrive actually wrote:
+Get-ChildItem 'HKCU:\SOFTWARE\Microsoft\OneDrive\Accounts\Business1\Tenants' -Recurse 2>$null
+```
+
+Record the **exact** value-name and value-data format (the composite `tenantId&siteId&webId&listId&webUrl&webTitle&listTitle`-style string) verbatim in the spike doc.
+
+- [ ] **Step 2: Pull the same library's IDs from Graph**
+
+For the same library, capture from Graph: site id (`GET /sites/{hostname}:/sites/{path}`), the drive/list (`GET /sites/{site-id}/drives`, `GET /sites/{site-id}/lists`), and note which Graph fields (`site.id` is itself a `hostname,siteCollectionId,webId` triple; `list.id`) map to the registry composite's `siteId`/`webId`/`listId` segments.
+
+- [ ] **Step 3: Validate construction round-trip**
+
+Construct an AutoMount value purely from Graph-derived IDs, write it to `TenantAutoMount` on a *clean* test user, restart OneDrive (`& "$env:LOCALAPPDATA\Microsoft\OneDrive\OneDrive.exe"`), and confirm the library actually mounts.
+
+- [ ] **Step 4: Record the decision**
+
+In the spike doc, write one of:
+- **CLEAN** — Graph IDs construct a working AutoMount value; document the exact mapping formula. The Graph library picker (Phase 1 Task 6) is viable as designed.
+- **NOT CLEAN** — document what's missing; the fallback is assisted "Copy library ID" capture (operator pastes the sync-client-produced ID), and Task 6's picker degrades to a verification helper. Note any extra Graph scope needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/spikes/2026-06-19-tenant-automount-library-id.md
+git commit -m "spike(onedrive-helper): validate TenantAutoMount library-id format vs Graph IDs"
+```
+
+> Tasks 6 and 8 below assume **CLEAN**. If the spike returns NOT CLEAN, keep the table columns (`siteId`/`webId`/`listId` plus a raw `libraryId`) — they still hold the captured composite — and the only change is how `libraryId` is *sourced* (operator paste vs Graph construction). The plan's data model is robust to either outcome.
+
+---
+
+## Task 2: Register the `onedrive_helper` feature type
+
+**Files:**
+- Modify: `apps/api/src/db/schema/configurationPolicies.ts:28-45` (`configFeatureTypeEnum`)
+- Modify: `apps/api/src/services/configurationPolicy.ts:56` (`ConfigFeatureType`) and `validateFeaturePolicyExists`
+- Create: `apps/api/migrations/2026-06-19-a-onedrive-helper-feature-enum.sql`
+- Test: `apps/api/src/services/configurationPolicy.onedrive.test.ts`
+
+**Interfaces:**
+- Produces: the literal `'onedrive_helper'` is a valid `ConfigFeatureType` and `config_feature_type` enum value; linking it requires `inlineSettings` (no `featurePolicyId`), validated like `monitoring`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/services/configurationPolicy.onedrive.test.ts
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../db', () => ({ db: {}, withDbAccessContext: vi.fn(), withSystemDbAccessContext: vi.fn() }));
+
+import { validateFeaturePolicyExists } from './configurationPolicy';
+
+describe('onedrive_helper feature type', () => {
+  it('rejects a featurePolicyId (inline-only feature)', async () => {
+    const res = await validateFeaturePolicyExists('onedrive_helper', 'some-id', 'org-1');
+    expect(res.valid).toBe(false);
+    expect(res.error).toMatch(/does not support featurePolicyId/);
+  });
+
+  it('accepts inline-only (no featurePolicyId)', async () => {
+    const res = await validateFeaturePolicyExists('onedrive_helper', null, 'org-1');
+    expect(res.valid).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/configurationPolicy.onedrive.test.ts`
+Expected: FAIL — `'onedrive_helper'` not assignable to `ConfigFeatureType` / validation falls through to "Unknown feature type".
+
+- [ ] **Step 3: Add the enum value (schema + service type)**
+
+In `configurationPolicies.ts`, add `'onedrive_helper'` to `configFeatureTypeEnum` (append after `'pam'`):
+
+```typescript
+export const configFeatureTypeEnum = pgEnum('config_feature_type', [
+  'patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance',
+  'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data',
+  'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam',
+  'onedrive_helper',
+]);
+```
+
+In `configurationPolicy.ts:56`, append `| 'onedrive_helper'` to the `ConfigFeatureType` union.
+
+- [ ] **Step 4: Treat it as inline-only in `validateFeaturePolicyExists`**
+
+Extend the existing `monitoring`/`event_log` inline-only branch to include the new type:
+
+```typescript
+if (featureType === 'monitoring' || featureType === 'event_log' || featureType === 'onedrive_helper') {
+  if (featurePolicyId) {
+    return { valid: false, error: `${featureType} feature type does not support featurePolicyId; use inlineSettings instead` };
+  }
+  return { valid: true };
+}
+```
+
+- [ ] **Step 5: Write the enum migration**
+
+```sql
+-- apps/api/migrations/2026-06-19-a-onedrive-helper-feature-enum.sql
+-- Add the onedrive_helper feature type to the config_feature_type enum.
+-- ADD VALUE IF NOT EXISTS is transaction-safe in PG12+ as long as the value
+-- isn't *used* in the same transaction (it isn't here).
+ALTER TYPE config_feature_type ADD VALUE IF NOT EXISTS 'onedrive_helper';
+```
+
+- [ ] **Step 6: Run the test + drift check**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/configurationPolicy.onedrive.test.ts`
+Expected: PASS.
+Run: `export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift`
+Expected: no drift.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/db/schema/configurationPolicies.ts apps/api/src/services/configurationPolicy.ts apps/api/src/services/configurationPolicy.onedrive.test.ts apps/api/migrations/2026-06-19-a-onedrive-helper-feature-enum.sql
+git commit -m "feat(onedrive-helper): register onedrive_helper config-policy feature type"
+```
+
+---
+
+## Task 3: `config_policy_onedrive_settings` table (base config)
+
+One row per `onedrive_helper` feature link, denormalized `org_id`, holding base-provisioning toggles.
+
+**Files:**
+- Create: `apps/api/src/db/schema/onedriveHelper.ts`
+- Modify: schema barrel export
+- Create: `apps/api/migrations/2026-06-19-b-onedrive-helper-settings.sql`
+- Modify: `apps/api/src/services/tenantCascade.ts` (`ORG_CASCADE_DELETE_ORDER`)
+- Test: `apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts`
+
+**Interfaces:**
+- Produces: Drizzle export `configPolicyOnedriveSettings` with columns `id, featureLinkId, orgId, silentAccountConfig, filesOnDemand, kfmSilentOptIn, kfmFolders (jsonb string[]), kfmBlockOptOut, tenantAssociationId, restartOnChange, createdAt, updatedAt`.
+
+- [ ] **Step 1: Write the failing RLS test (settings portion)**
+
+```typescript
+// apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getAppPool, seedTwoOrgsWithPolicy } from './helpers/rlsHarness'; // existing harness
+
+describe('onedrive_helper RLS — settings', () => {
+  beforeEach(async () => { await seedTwoOrgsWithPolicy(); });
+
+  it('breeze_app cannot insert settings for another org', async () => {
+    const pool = getAppPool('orgA'); // RLS context = orgA
+    await expect(pool.query(
+      `INSERT INTO config_policy_onedrive_settings (feature_link_id, org_id, silent_account_config)
+       VALUES ($1, $2, true)`,
+      [/* orgB feature link */ '00000000-0000-0000-0000-0000000000b1', '00000000-0000-0000-0000-0000000000b0'],
+    )).rejects.toThrow(/row-level security/);
+  });
+});
+```
+
+> Use the repo's existing integration RLS harness (the same one `rls-coverage` / other `*-rls.integration.test.ts` files use to set the `breeze_app` org context). If a reusable `seedTwoOrgsWithPolicy` helper doesn't exist, inline the seed (insert two orgs, a partner, a configuration policy + feature link per org) in `beforeEach`.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `export DATABASE_URL=... && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/onedrive-helper-rls.integration.test.ts`
+Expected: FAIL — relation `config_policy_onedrive_settings` does not exist.
+
+- [ ] **Step 3: Add the Drizzle schema**
+
+```typescript
+// apps/api/src/db/schema/onedriveHelper.ts
+import { pgTable, uuid, boolean, varchar, jsonb, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { organizations } from './organizations';
+import { configPolicyFeatureLinks } from './configurationPolicies';
+
+export const configPolicyOnedriveSettings = pgTable('config_policy_onedrive_settings', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  featureLinkId: uuid('feature_link_id').notNull()
+    .references(() => configPolicyFeatureLinks.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  silentAccountConfig: boolean('silent_account_config').notNull().default(true),
+  filesOnDemand: boolean('files_on_demand').notNull().default(true),
+  kfmSilentOptIn: boolean('kfm_silent_opt_in').notNull().default(false),
+  kfmFolders: jsonb('kfm_folders').notNull().default(['Desktop', 'Documents', 'Pictures']),
+  kfmBlockOptOut: boolean('kfm_block_opt_out').notNull().default(false),
+  tenantAssociationId: varchar('tenant_association_id', { length: 64 }),
+  restartOnChange: boolean('restart_on_change').notNull().default(true),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  featureLinkUniq: uniqueIndex('onedrive_settings_feature_link_uniq').on(t.featureLinkId),
+  orgIdx: index('onedrive_settings_org_idx').on(t.orgId),
+}));
+```
+
+Export it from the schema barrel.
+
+- [ ] **Step 4: Write the migration with RLS (template = `metric_anomalies`)**
+
+```sql
+-- apps/api/migrations/2026-06-19-b-onedrive-helper-settings.sql
+CREATE TABLE IF NOT EXISTS config_policy_onedrive_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  feature_link_id UUID NOT NULL REFERENCES config_policy_feature_links(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  silent_account_config BOOLEAN NOT NULL DEFAULT true,
+  files_on_demand BOOLEAN NOT NULL DEFAULT true,
+  kfm_silent_opt_in BOOLEAN NOT NULL DEFAULT false,
+  kfm_folders JSONB NOT NULL DEFAULT '["Desktop","Documents","Pictures"]'::jsonb,
+  kfm_block_opt_out BOOLEAN NOT NULL DEFAULT false,
+  tenant_association_id VARCHAR(64),
+  restart_on_change BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT onedrive_settings_kfm_folders_array_check CHECK (jsonb_typeof(kfm_folders) = 'array')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS onedrive_settings_feature_link_uniq
+  ON config_policy_onedrive_settings (feature_link_id);
+CREATE INDEX IF NOT EXISTS onedrive_settings_org_idx
+  ON config_policy_onedrive_settings (org_id);
+
+ALTER TABLE config_policy_onedrive_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_onedrive_settings FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_onedrive_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_onedrive_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_onedrive_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_onedrive_settings;
+
+CREATE POLICY breeze_org_isolation_select ON config_policy_onedrive_settings
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON config_policy_onedrive_settings
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON config_policy_onedrive_settings
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON config_policy_onedrive_settings
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE config_policy_onedrive_settings TO breeze_app;
+```
+
+- [ ] **Step 5: Add to the cascade list**
+
+In `tenantCascade.ts`, insert `'config_policy_onedrive_settings'` into `ORG_CASCADE_DELETE_ORDER` in `localeCompare` order (after `config_policy_monitoring_*` entries, before `config_policy_*` that sort later — verify exact neighbors by eye against the file, the list is alphabetical).
+
+- [ ] **Step 6: Run the test + drift check**
+
+Run: `export DATABASE_URL=... && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/onedrive-helper-rls.integration.test.ts`
+Expected: PASS (cross-org insert rejected).
+Run: `pnpm db:check-drift` → no drift.
+
+- [ ] **Step 7: Manually verify the forge as `breeze_app`**
+
+```bash
+docker exec -it breeze-postgres psql -U breeze_app -d breeze -c \
+  "INSERT INTO config_policy_onedrive_settings (feature_link_id, org_id) VALUES (gen_random_uuid(), gen_random_uuid());"
+```
+Expected: `ERROR: new row violates row-level security policy`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/db/schema/onedriveHelper.ts apps/api/src/db/schema/index.ts apps/api/migrations/2026-06-19-b-onedrive-helper-settings.sql apps/api/src/services/tenantCascade.ts apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
+git commit -m "feat(onedrive-helper): config_policy_onedrive_settings table + RLS"
+```
+
+---
+
+## Task 4: `config_policy_onedrive_libraries` table (per-library mappings)
+
+N rows per settings row; each is one SharePoint library + its targeting rule.
+
+**Files:**
+- Modify: `apps/api/src/db/schema/onedriveHelper.ts`
+- Create: `apps/api/migrations/2026-06-19-c-onedrive-helper-libraries.sql`
+- Modify: `apps/api/src/services/tenantCascade.ts`
+- Test: extend `onedrive-helper-rls.integration.test.ts`
+
+**Interfaces:**
+- Produces: `configPolicyOnedriveLibraries` with `id, settingsId, orgId, libraryId, displayName, siteUrl, siteId, webId, listId, targetingMode ('everyone'|'graph_group'|'local_ad_group'), groupId, groupName, hiveScope ('hkcu'|'hklm'), sortOrder, enabled, createdAt`.
+
+- [ ] **Step 1: Write the failing test (libraries portion)**
+
+Add to the RLS integration file:
+
+```typescript
+it('breeze_app cannot insert a library mapping for another org', async () => {
+  const pool = getAppPool('orgA');
+  await expect(pool.query(
+    `INSERT INTO config_policy_onedrive_libraries
+       (settings_id, org_id, library_id, display_name, targeting_mode)
+     VALUES ($1, $2, 'lib-x', 'Finance', 'everyone')`,
+    ['00000000-0000-0000-0000-0000000000b2', '00000000-0000-0000-0000-0000000000b0'],
+  )).rejects.toThrow(/row-level security/);
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: same integration command as Task 3 Step 6.
+Expected: FAIL — relation `config_policy_onedrive_libraries` does not exist.
+
+- [ ] **Step 3: Add the Drizzle schema**
+
+```typescript
+// append to apps/api/src/db/schema/onedriveHelper.ts
+import { integer } from 'drizzle-orm/pg-core';
+
+export const configPolicyOnedriveLibraries = pgTable('config_policy_onedrive_libraries', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  settingsId: uuid('settings_id').notNull()
+    .references(() => configPolicyOnedriveSettings.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  libraryId: varchar('library_id', { length: 1024 }).notNull(),
+  displayName: varchar('display_name', { length: 255 }).notNull(),
+  siteUrl: varchar('site_url', { length: 1024 }),
+  siteId: varchar('site_id', { length: 512 }),
+  webId: varchar('web_id', { length: 128 }),
+  listId: varchar('list_id', { length: 128 }),
+  targetingMode: varchar('targeting_mode', { length: 20 }).notNull().default('everyone'),
+  groupId: varchar('group_id', { length: 128 }),
+  groupName: varchar('group_name', { length: 255 }),
+  hiveScope: varchar('hive_scope', { length: 8 }).notNull().default('hkcu'),
+  sortOrder: integer('sort_order').notNull().default(0),
+  enabled: boolean('enabled').notNull().default(true),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (t) => ({
+  settingsIdx: index('onedrive_libraries_settings_idx').on(t.settingsId),
+  orgIdx: index('onedrive_libraries_org_idx').on(t.orgId),
+}));
+```
+
+- [ ] **Step 4: Write the migration with RLS**
+
+```sql
+-- apps/api/migrations/2026-06-19-c-onedrive-helper-libraries.sql
+CREATE TABLE IF NOT EXISTS config_policy_onedrive_libraries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  settings_id UUID NOT NULL REFERENCES config_policy_onedrive_settings(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  library_id VARCHAR(1024) NOT NULL,
+  display_name VARCHAR(255) NOT NULL,
+  site_url VARCHAR(1024),
+  site_id VARCHAR(512),
+  web_id VARCHAR(128),
+  list_id VARCHAR(128),
+  targeting_mode VARCHAR(20) NOT NULL DEFAULT 'everyone',
+  group_id VARCHAR(128),
+  group_name VARCHAR(255),
+  hive_scope VARCHAR(8) NOT NULL DEFAULT 'hkcu',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT onedrive_libraries_targeting_mode_check CHECK (
+    targeting_mode IN ('everyone', 'graph_group', 'local_ad_group')
+  ),
+  CONSTRAINT onedrive_libraries_hive_scope_check CHECK (hive_scope IN ('hkcu', 'hklm')),
+  CONSTRAINT onedrive_libraries_group_required_check CHECK (
+    targeting_mode = 'everyone' OR group_id IS NOT NULL OR group_name IS NOT NULL
+  )
+);
+
+CREATE INDEX IF NOT EXISTS onedrive_libraries_settings_idx
+  ON config_policy_onedrive_libraries (settings_id);
+CREATE INDEX IF NOT EXISTS onedrive_libraries_org_idx
+  ON config_policy_onedrive_libraries (org_id);
+
+ALTER TABLE config_policy_onedrive_libraries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_onedrive_libraries FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_onedrive_libraries;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_onedrive_libraries;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_onedrive_libraries;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_onedrive_libraries;
+
+CREATE POLICY breeze_org_isolation_select ON config_policy_onedrive_libraries
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON config_policy_onedrive_libraries
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON config_policy_onedrive_libraries
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON config_policy_onedrive_libraries
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE config_policy_onedrive_libraries TO breeze_app;
+```
+
+- [ ] **Step 5: Add to the cascade list**
+
+Insert `'config_policy_onedrive_libraries'` into `ORG_CASCADE_DELETE_ORDER` alphabetically (it sorts immediately before `config_policy_onedrive_settings` — `i` < `s`).
+
+- [ ] **Step 6: Run test + drift + forge**
+
+Run the integration test (PASS), `pnpm db:check-drift` (no drift), and the `breeze_app` forge insert (expect RLS rejection) as in Task 3.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(onedrive-helper): config_policy_onedrive_libraries table + RLS"
+```
+
+---
+
+## Task 5: `onedrive_device_state` table (agent-reported state)
+
+Device-scoped, denormalized `org_id`. One row per device.
+
+**Files:**
+- Modify: `apps/api/src/db/schema/onedriveHelper.ts`
+- Create: `apps/api/migrations/2026-06-19-d-onedrive-device-state.sql`
+- Modify: `apps/api/src/services/tenantCascade.ts`
+- Test: extend `onedrive-helper-rls.integration.test.ts`
+
+**Interfaces:**
+- Produces: `onedriveDeviceState` with `deviceId (PK), orgId, signedIn, oneDriveVersion, filesOnDemandOn, kfmFolderStates (jsonb), mountedLibraries (jsonb string[]), entitledLibraries (jsonb string[]), driftEntries (jsonb), lastReportedAt, updatedAt`.
+
+- [ ] **Step 1: Write the failing test (device-state portion)**
+
+```typescript
+it('breeze_app cannot read another org device state', async () => {
+  const pool = getAppPool('orgA');
+  const res = await pool.query(
+    `SELECT device_id FROM onedrive_device_state WHERE org_id = $1`,
+    ['00000000-0000-0000-0000-0000000000b0'], // orgB
+  );
+  expect(res.rows).toHaveLength(0); // RLS filters, no error on SELECT
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run the integration command. Expected: FAIL — relation `onedrive_device_state` does not exist.
+
+- [ ] **Step 3: Add the Drizzle schema (denormalized org_id, device-keyed)**
+
+```typescript
+// append to apps/api/src/db/schema/onedriveHelper.ts
+import { doublePrecision } from 'drizzle-orm/pg-core';
+import { devices } from './devices';
+
+export const onedriveDeviceState = pgTable('onedrive_device_state', {
+  deviceId: uuid('device_id').primaryKey().references(() => devices.id),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  signedIn: boolean('signed_in').notNull().default(false),
+  oneDriveVersion: varchar('onedrive_version', { length: 64 }),
+  filesOnDemandOn: boolean('files_on_demand_on').notNull().default(false),
+  kfmFolderStates: jsonb('kfm_folder_states').notNull().default({}),
+  mountedLibraries: jsonb('mounted_libraries').notNull().default([]),
+  entitledLibraries: jsonb('entitled_libraries').notNull().default([]),
+  driftEntries: jsonb('drift_entries').notNull().default([]),
+  lastReportedAt: timestamp('last_reported_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  orgIdx: index('onedrive_device_state_org_idx').on(t.orgId),
+}));
+```
+
+(`doublePrecision` import is unused here — drop it; left as a reminder that the schema file has multiple tables.)
+
+- [ ] **Step 4: Write the migration with RLS (Shape 5 — denormalized org_id, same policy form)**
+
+```sql
+-- apps/api/migrations/2026-06-19-d-onedrive-device-state.sql
+CREATE TABLE IF NOT EXISTS onedrive_device_state (
+  device_id UUID PRIMARY KEY REFERENCES devices(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  signed_in BOOLEAN NOT NULL DEFAULT false,
+  onedrive_version VARCHAR(64),
+  files_on_demand_on BOOLEAN NOT NULL DEFAULT false,
+  kfm_folder_states JSONB NOT NULL DEFAULT '{}'::jsonb,
+  mounted_libraries JSONB NOT NULL DEFAULT '[]'::jsonb,
+  entitled_libraries JSONB NOT NULL DEFAULT '[]'::jsonb,
+  drift_entries JSONB NOT NULL DEFAULT '[]'::jsonb,
+  last_reported_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS onedrive_device_state_org_idx
+  ON onedrive_device_state (org_id);
+
+ALTER TABLE onedrive_device_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE onedrive_device_state FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON onedrive_device_state;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON onedrive_device_state;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON onedrive_device_state;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON onedrive_device_state;
+
+CREATE POLICY breeze_org_isolation_select ON onedrive_device_state
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON onedrive_device_state
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON onedrive_device_state
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON onedrive_device_state
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE onedrive_device_state TO breeze_app;
+```
+
+- [ ] **Step 5: Add to cascade list + device-delete list**
+
+Insert `'onedrive_device_state'` into `ORG_CASCADE_DELETE_ORDER` alphabetically. Because it's device-scoped with a denormalized `org_id` kept in sync by the existing `breeze_cascade_device_org_id` trigger, no manual device-child clear-order entry is needed (the topological sort handles FK order via `device_id → devices`).
+
+- [ ] **Step 6: Run test + drift + forge (insert)**
+
+Integration test PASS; `pnpm db:check-drift` no drift; forge insert as `breeze_app` rejected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(onedrive-helper): onedrive_device_state table + RLS"
+```
+
+---
+
+## Task 6: Graph — `listSharePointLibraries(orgId)`
+
+Powers the library picker. Mirrors the `getToken` → `graphFetch` pattern.
+
+**Files:**
+- Create: `apps/api/src/services/onedriveGraph.ts`
+- Test: `apps/api/src/services/onedriveGraph.test.ts`
+
+**Interfaces:**
+- Consumes: `getToken(orgId)` and `graphFetch(token, method, path)` — re-export them from `m365DirectGraph.ts` (export them there if currently module-private) or replicate the tiny `getToken` body. Prefer exporting from `m365DirectGraph.ts`.
+- Produces: `listSharePointLibraries(orgId: string): Promise<DirectInvokeResult>` where success `data` is `{ libraries: Array<{ siteId: string; siteName: string; siteUrl: string; driveId: string; listId: string; libraryName: string }> }`.
+
+- [ ] **Step 1: Export the shared helpers from `m365DirectGraph.ts`**
+
+Change `async function getToken` → `export async function getToken` and `async function graphFetch` → `export async function graphFetch` (and export `DirectInvokeResult` if not already). No behavior change.
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// apps/api/src/services/onedriveGraph.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./m365DirectGraph', () => ({
+  getToken: vi.fn(async () => ({ token: 'tok' })),
+  graphFetch: vi.fn(),
+}));
+
+import { getToken, graphFetch } from './m365DirectGraph';
+import { listSharePointLibraries } from './onedriveGraph';
+
+describe('listSharePointLibraries', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns flattened site+library list', async () => {
+    (graphFetch as any)
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'host,scid,webid', displayName: 'Marketing', webUrl: 'https://c.sharepoint.com/sites/mktg' },
+      ] } }) // /sites?search=*
+      .mockResolvedValueOnce({ kind: 'ok', data: { value: [
+        { id: 'drive-1', name: 'Documents', list: { id: 'list-1' } },
+      ] } }); // /sites/{id}/drives
+
+    const res = await listSharePointLibraries('org-1');
+    expect(res.kind).toBe('ok');
+    expect((res as any).data.libraries[0]).toMatchObject({
+      siteName: 'Marketing', driveId: 'drive-1', listId: 'list-1', libraryName: 'Documents',
+    });
+  });
+
+  it('propagates a token error', async () => {
+    (getToken as any).mockResolvedValueOnce({ kind: 'error', code: 'no_connection', message: 'x' });
+    const res = await listSharePointLibraries('org-1');
+    expect(res.kind).toBe('error');
+  });
+});
+```
+
+- [ ] **Step 3: Run it to confirm it fails**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/onedriveGraph.test.ts`
+Expected: FAIL — `listSharePointLibraries` not exported.
+
+- [ ] **Step 4: Implement**
+
+```typescript
+// apps/api/src/services/onedriveGraph.ts
+import { getToken, graphFetch, type DirectInvokeResult } from './m365DirectGraph';
+
+export async function listSharePointLibraries(orgId: string): Promise<DirectInvokeResult> {
+  const tok = await getToken(orgId);
+  if ('kind' in tok) return tok; // error result
+  const token = tok.token;
+
+  const sites = await graphFetch(token, 'GET', `/sites?search=*&$top=100&$select=id,displayName,webUrl`);
+  if (sites.kind === 'error') return sites;
+
+  const siteRows = Array.isArray((sites.data as any)?.value) ? (sites.data as any).value : [];
+  const libraries: Array<Record<string, string>> = [];
+
+  for (const site of siteRows) {
+    const drives = await graphFetch(
+      token, 'GET',
+      `/sites/${encodeURIComponent(site.id)}/drives?$select=id,name,list`,
+    );
+    if (drives.kind === 'error') continue; // skip a site we can't read; don't fail the whole list
+    const driveRows = Array.isArray((drives.data as any)?.value) ? (drives.data as any).value : [];
+    for (const d of driveRows) {
+      libraries.push({
+        siteId: site.id,
+        siteName: site.displayName ?? '',
+        siteUrl: site.webUrl ?? '',
+        driveId: d.id,
+        listId: d.list?.id ?? '',
+        libraryName: d.name ?? '',
+      });
+    }
+  }
+
+  return { kind: 'ok', data: { libraries } };
+}
+```
+
+- [ ] **Step 5: Run it to confirm it passes**
+
+Run the Step-3 command. Expected: PASS (both cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/onedriveGraph.ts apps/api/src/services/onedriveGraph.test.ts apps/api/src/services/m365DirectGraph.ts
+git commit -m "feat(onedrive-helper): Graph listSharePointLibraries for the library picker"
+```
+
+---
+
+## Task 7: Graph — `resolveUserGroupMembership(orgId, upn)`
+
+Resolves a user's group ids for `graph_group` targeting.
+
+**Files:**
+- Modify: `apps/api/src/services/onedriveGraph.ts`
+- Test: extend `apps/api/src/services/onedriveGraph.test.ts`
+
+**Interfaces:**
+- Produces: `resolveUserGroupMembership(orgId: string, upn: string): Promise<DirectInvokeResult>` where success `data` is `{ groupIds: string[] }` (transitive membership, ids only).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to onedriveGraph.test.ts
+import { resolveUserGroupMembership } from './onedriveGraph';
+
+describe('resolveUserGroupMembership', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns transitive group ids for the user', async () => {
+    (graphFetch as any).mockResolvedValueOnce({ kind: 'ok', data: { value: [
+      { id: 'g-1' }, { id: 'g-2' },
+    ] } });
+    const res = await resolveUserGroupMembership('org-1', "user@contoso.com");
+    expect((res as any).data.groupIds).toEqual(['g-1', 'g-2']);
+    // verify the OData id was single-quote-escaped into the path
+    const calledPath = (graphFetch as any).mock.calls[0][2] as string;
+    expect(calledPath).toContain('/users/');
+    expect(calledPath).toContain('transitiveMemberOf');
+  });
+
+  it('rejects an empty upn before calling Graph', async () => {
+    const res = await resolveUserGroupMembership('org-1', '');
+    expect(res.kind).toBe('error');
+    expect((graphFetch as any)).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/onedriveGraph.test.ts`
+Expected: FAIL — `resolveUserGroupMembership` not exported.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// append to apps/api/src/services/onedriveGraph.ts
+export async function resolveUserGroupMembership(orgId: string, upn: string): Promise<DirectInvokeResult> {
+  if (!upn || typeof upn !== 'string') {
+    return { kind: 'error', code: 'bad_request', message: 'upn is required.' };
+  }
+  const tok = await getToken(orgId);
+  if ('kind' in tok) return tok;
+
+  // transitiveMemberOf so nested group membership counts; only group objects, ids only.
+  const res = await graphFetch(
+    tok.token, 'GET',
+    `/users/${encodeURIComponent(upn)}/transitiveMemberOf/microsoft.graph.group?$select=id&$top=200`,
+  );
+  if (res.kind === 'error') return res;
+
+  const rows = Array.isArray((res.data as any)?.value) ? (res.data as any).value : [];
+  const groupIds = rows.map((g: any) => g.id).filter((id: unknown): id is string => typeof id === 'string');
+  return { kind: 'ok', data: { groupIds } };
+}
+```
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+Run the Step-2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/onedriveGraph.ts apps/api/src/services/onedriveGraph.test.ts
+git commit -m "feat(onedrive-helper): Graph resolveUserGroupMembership for graph_group targeting"
+```
+
+---
+
+## Task 8: Heartbeat delivery — `buildOnedriveHelperConfigUpdate(deviceId)`
+
+Resolves the effective `onedrive_helper` settings + libraries for a device (closest-level-wins, mirroring `resolveDeviceMonitoringSettings`) and delivers base config + the library rules in the heartbeat `configUpdate`.
+
+> **Phase boundary:** this delivers base config + the full library list **with each library's targeting rule** (`mode` + `groupId`/`groupName`). It does NOT yet filter `graph_group` libraries per logged-in user — that requires the device to report logged-in UPNs (an agent change in the next plan). At that point the server calls `resolveUserGroupMembership` (Task 7) per reported UPN and tags allow/deny. For now `graph_group`/`local_ad_group` libraries are delivered as rules for the agent to (eventually) evaluate; `everyone` libraries are immediately actionable. This is the honest seam between the server-foundation and agent plans.
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/helpers.ts` (add resolver + builder)
+- Modify: `apps/api/src/routes/agents/heartbeat.ts` (merge into response)
+- Test: `apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `configPolicyOnedriveSettings`, `configPolicyOnedriveLibraries`, the existing `LEVEL_PRIORITY`, `configPolicyAssignments`, `configurationPolicies`, `configPolicyFeatureLinks`.
+- Produces: `buildOnedriveHelperConfigUpdate(deviceId: string): Promise<OnedriveConfigUpdate | null>` returning `{ base: {...}, libraries: Array<{ libraryId, displayName, siteUrl, targetingMode, groupId, groupName, hiveScope }> } | null`. Merged into the heartbeat response under key `onedrive_helper_settings`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```typescript
+// apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { seedDeviceWithOnedrivePolicy } from './helpers/onedriveSeed'; // create inline if absent
+import { buildOnedriveHelperConfigUpdate } from '../../routes/agents/helpers';
+
+describe('buildOnedriveHelperConfigUpdate', () => {
+  let deviceId: string;
+  beforeEach(async () => { ({ deviceId } = await seedDeviceWithOnedrivePolicy({
+    base: { silentAccountConfig: true, filesOnDemand: true, kfmSilentOptIn: true },
+    libraries: [
+      { libraryId: 'lib-fin', displayName: 'Finance', targetingMode: 'graph_group', groupId: 'g-fin' },
+      { libraryId: 'lib-all', displayName: 'Company', targetingMode: 'everyone' },
+    ],
+  })); });
+
+  it('returns base config + library rules for an assigned device', async () => {
+    const cfg = await buildOnedriveHelperConfigUpdate(deviceId);
+    expect(cfg).not.toBeNull();
+    expect(cfg!.base.kfmSilentOptIn).toBe(true);
+    expect(cfg!.libraries).toHaveLength(2);
+    expect(cfg!.libraries.find(l => l.libraryId === 'lib-fin')!.targetingMode).toBe('graph_group');
+  });
+
+  it('returns null for a device with no onedrive_helper policy', async () => {
+    const { deviceId: bare } = await seedDeviceWithOnedrivePolicy({ base: null, libraries: [] });
+    expect(await buildOnedriveHelperConfigUpdate(bare)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `export DATABASE_URL=... && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts`
+Expected: FAIL — `buildOnedriveHelperConfigUpdate` not exported.
+
+- [ ] **Step 3: Implement the resolver + builder** (mirror `resolveDeviceMonitoringSettings`)
+
+```typescript
+// apps/api/src/routes/agents/helpers.ts
+import { configPolicyOnedriveSettings, configPolicyOnedriveLibraries } from '../../db/schema/onedriveHelper';
+
+export interface OnedriveConfigUpdate {
+  base: {
+    silentAccountConfig: boolean;
+    filesOnDemand: boolean;
+    kfmSilentOptIn: boolean;
+    kfmFolders: string[];
+    kfmBlockOptOut: boolean;
+    tenantAssociationId: string | null;
+    restartOnChange: boolean;
+  };
+  libraries: Array<{
+    libraryId: string;
+    displayName: string;
+    siteUrl: string | null;
+    targetingMode: string;
+    groupId: string | null;
+    groupName: string | null;
+    hiveScope: string;
+  }>;
+}
+
+async function resolveDeviceOnedriveSettings(deviceId: string): Promise<OnedriveConfigUpdate | null> {
+  const [device] = await db
+    .select({ orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices).where(eq(devices.id, deviceId)).limit(1);
+  if (!device) return null;
+
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations).where(eq(organizations.id, device.orgId)).limit(1);
+
+  const groupRows = await db
+    .select({ groupId: deviceGroupMemberships.groupId })
+    .from(deviceGroupMemberships).where(eq(deviceGroupMemberships.deviceId, deviceId));
+  const groupIds = groupRows.map((r) => r.groupId);
+
+  const targetConditions = [
+    and(eq(configPolicyAssignments.level, 'device'), eq(configPolicyAssignments.targetId, deviceId)),
+    and(eq(configPolicyAssignments.level, 'site'), eq(configPolicyAssignments.targetId, device.siteId)),
+    and(eq(configPolicyAssignments.level, 'organization'), eq(configPolicyAssignments.targetId, device.orgId)),
+  ];
+  if (groupIds.length > 0) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'device_group'), inArray(configPolicyAssignments.targetId, groupIds))!,
+    );
+  }
+  if (org?.partnerId) {
+    targetConditions.push(
+      and(eq(configPolicyAssignments.level, 'partner'), eq(configPolicyAssignments.targetId, org.partnerId))!,
+    );
+  }
+
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      settingsId: configPolicyOnedriveSettings.id,
+      silentAccountConfig: configPolicyOnedriveSettings.silentAccountConfig,
+      filesOnDemand: configPolicyOnedriveSettings.filesOnDemand,
+      kfmSilentOptIn: configPolicyOnedriveSettings.kfmSilentOptIn,
+      kfmFolders: configPolicyOnedriveSettings.kfmFolders,
+      kfmBlockOptOut: configPolicyOnedriveSettings.kfmBlockOptOut,
+      tenantAssociationId: configPolicyOnedriveSettings.tenantAssociationId,
+      restartOnChange: configPolicyOnedriveSettings.restartOnChange,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'onedrive_helper'),
+    ))
+    .innerJoin(configPolicyOnedriveSettings, eq(configPolicyOnedriveSettings.featureLinkId, configPolicyFeatureLinks.id))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      eq(configurationPolicies.orgId, device.orgId),
+      or(...targetConditions),
+    ));
+
+  if (rows.length === 0) return null;
+
+  rows.sort((a, b) => {
+    const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
+    if (levelDiff !== 0) return levelDiff;
+    return a.assignmentPriority - b.assignmentPriority;
+  });
+  const winner = rows[0];
+  if (!winner) return null;
+
+  const libs = await db
+    .select()
+    .from(configPolicyOnedriveLibraries)
+    .where(and(
+      eq(configPolicyOnedriveLibraries.settingsId, winner.settingsId),
+      eq(configPolicyOnedriveLibraries.enabled, true),
+    ))
+    .orderBy(configPolicyOnedriveLibraries.sortOrder);
+
+  return {
+    base: {
+      silentAccountConfig: winner.silentAccountConfig,
+      filesOnDemand: winner.filesOnDemand,
+      kfmSilentOptIn: winner.kfmSilentOptIn,
+      kfmFolders: (winner.kfmFolders as string[]) ?? [],
+      kfmBlockOptOut: winner.kfmBlockOptOut,
+      tenantAssociationId: winner.tenantAssociationId,
+      restartOnChange: winner.restartOnChange,
+    },
+    libraries: libs.map((l) => ({
+      libraryId: l.libraryId,
+      displayName: l.displayName,
+      siteUrl: l.siteUrl,
+      targetingMode: l.targetingMode,
+      groupId: l.groupId,
+      groupName: l.groupName,
+      hiveScope: l.hiveScope,
+    })),
+  };
+}
+
+export async function buildOnedriveHelperConfigUpdate(deviceId: string): Promise<OnedriveConfigUpdate | null> {
+  return resolveDeviceOnedriveSettings(deviceId);
+}
+```
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+Run the Step-2 command. Expected: PASS (both cases).
+
+- [ ] **Step 5: Merge into the heartbeat response**
+
+In `heartbeat.ts`, beside the existing `buildMonitoringConfigUpdate`/`buildPamConfigUpdate` calls, add:
+
+```typescript
+let onedriveSettings: OnedriveConfigUpdate | null = null;
+try {
+  onedriveSettings = await buildOnedriveHelperConfigUpdate(device.id);
+} catch (err) {
+  console.error(`[agents] failed to build onedrive_helper config update for ${agentId}:`, err);
+}
+```
+
+and in the `mergedConfigUpdate` assembly:
+
+```typescript
+if (configUpdate || eventLogSettings || monitoringSettings || onedriveSettings) {
+  mergedConfigUpdate = { ...(configUpdate ?? {}) };
+  if (eventLogSettings) mergedConfigUpdate.event_log_settings = eventLogSettings;
+  if (monitoringSettings) mergedConfigUpdate.monitoring_settings = monitoringSettings;
+  if (onedriveSettings) mergedConfigUpdate.onedrive_helper_settings = onedriveSettings;
+}
+```
+
+- [ ] **Step 6: Run the full delivery test again + typecheck**
+
+Run: the Step-2 integration command (PASS) and
+`PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/agents/helpers.ts apps/api/src/routes/agents/heartbeat.ts apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
+git commit -m "feat(onedrive-helper): resolve + deliver effective config in heartbeat"
+```
+
+---
+
+## Task 9: Heartbeat ingest — persist reported `onedriveDeviceState`
+
+Accept an optional `onedriveDeviceState` field in the heartbeat payload and upsert it.
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/heartbeat.ts` (zod schema + upsert)
+- Test: extend `onedrive-helper-config-delivery.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `onedriveDeviceState` schema table.
+- Produces: heartbeat accepts `onedriveDeviceState?: { signedIn, oneDriveVersion?, filesOnDemandOn, kfmFolderStates, mountedLibraries, entitledLibraries, driftEntries }` and upserts one row keyed by `device_id`, writing the device's `org_id`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to onedrive-helper-config-delivery.integration.test.ts
+import { onedriveDeviceState } from '../../db/schema/onedriveHelper';
+import { postHeartbeat } from './helpers/heartbeatClient'; // existing helper that posts an authed heartbeat
+import { withSystemDbAccessContext, db } from '../../db';
+import { eq } from 'drizzle-orm';
+
+it('persists reported onedrive device state', async () => {
+  const { deviceId, agentToken } = await seedDeviceWithOnedrivePolicy({ base: null, libraries: [] });
+  await postHeartbeat(deviceId, agentToken, {
+    status: 'online', agentVersion: '1.0.0',
+    onedriveDeviceState: {
+      signedIn: true, filesOnDemandOn: true,
+      kfmFolderStates: { Documents: 'redirected' },
+      mountedLibraries: ['lib-all'], entitledLibraries: ['lib-all'], driftEntries: [],
+    },
+  });
+  const [row] = await withSystemDbAccessContext(() =>
+    db.select().from(onedriveDeviceState).where(eq(onedriveDeviceState.deviceId, deviceId)));
+  expect(row.signedIn).toBe(true);
+  expect(row.mountedLibraries).toEqual(['lib-all']);
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run the integration command for this file. Expected: FAIL — state row not written (field ignored).
+
+- [ ] **Step 3: Extend the heartbeat zod schema**
+
+Add to `heartbeatSchema` (optional, non-breaking):
+
+```typescript
+onedriveDeviceState: z.object({
+  signedIn: z.boolean(),
+  oneDriveVersion: z.string().max(64).optional(),
+  filesOnDemandOn: z.boolean(),
+  kfmFolderStates: z.record(z.string(), z.string()).default({}),
+  mountedLibraries: z.array(z.string().max(1024)).default([]),
+  entitledLibraries: z.array(z.string().max(1024)).default([]),
+  driftEntries: z.array(z.record(z.string(), z.unknown())).default([]),
+}).optional(),
+```
+
+- [ ] **Step 4: Upsert in the handler**
+
+After the device is loaded/validated, before building the response:
+
+```typescript
+if (data.onedriveDeviceState) {
+  const s = data.onedriveDeviceState;
+  await db.insert(onedriveDeviceState).values({
+    deviceId: device.id,
+    orgId: device.orgId,
+    signedIn: s.signedIn,
+    oneDriveVersion: s.oneDriveVersion ?? null,
+    filesOnDemandOn: s.filesOnDemandOn,
+    kfmFolderStates: s.kfmFolderStates,
+    mountedLibraries: s.mountedLibraries,
+    entitledLibraries: s.entitledLibraries,
+    driftEntries: s.driftEntries,
+    lastReportedAt: new Date(),
+    updatedAt: new Date(),
+  }).onConflictDoUpdate({
+    target: onedriveDeviceState.deviceId,
+    set: {
+      signedIn: s.signedIn,
+      oneDriveVersion: s.oneDriveVersion ?? null,
+      filesOnDemandOn: s.filesOnDemandOn,
+      kfmFolderStates: s.kfmFolderStates,
+      mountedLibraries: s.mountedLibraries,
+      entitledLibraries: s.entitledLibraries,
+      driftEntries: s.driftEntries,
+      lastReportedAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+}
+```
+
+> The heartbeat runs in the agent's request DB context (the device's own org), so this insert satisfies `breeze_has_org_access(org_id)` with `org_id = device.orgId`. No `withSystemDbAccessContext` needed here.
+
+- [ ] **Step 5: Run it to confirm it passes**
+
+Run the integration command. Expected: PASS.
+
+- [ ] **Step 6: Run the whole onedrive integration + the RLS-coverage contract test**
+
+Run: `export DATABASE_URL=... && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts src/__tests__/integration/onedrive-helper-rls.integration.test.ts`
+Expected: all PASS.
+Run the RLS-coverage contract test (auto-discovers the three new org_id tables):
+`... exec vitest run --config vitest.config.rls-coverage.ts` (per the repo's rls-coverage runner)
+Expected: PASS — no uncovered tenant tables.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/agents/heartbeat.ts apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
+git commit -m "feat(onedrive-helper): ingest + persist reported OneDrive device state"
+```
+
+---
+
+## Self-Review (completed during authoring)
+
+**Spec coverage:** Base-config ownership → Task 3 (`config_policy_onedrive_settings` incl. KFM fields). Source-flexible per-library targeting → Task 4 (`targetingMode` enum + group columns). Graph picker → Task 6. Graph-group resolution → Task 7. Server-side resolution split + delivery → Task 8 (with explicit phase seam for per-user filtering). State reporting (for the reporting view) → Task 5 + Task 9. RLS/cascade discipline → Tasks 3–5. The library-ID format risk → Task 1 spike, gating Task 6/8. *Deferred by design (not gaps):* agent applier, web UI, per-user graph filtering hookup, unmount, sync-health/alerting — all Sub-project B or the agent/UI plans.
+
+**Placeholder scan:** No "TBD"/"add error handling"/"similar to" — each step carries real SQL/TS/test code. The one intentional note is Task 1 (a genuine research spike, correctly not TDD) and the Task 8 phase-seam note (a real architectural boundary, not a deferred detail).
+
+**Type consistency:** `OnedriveConfigUpdate` defined in Task 8 and consumed in the heartbeat merge; `configPolicyOnedriveSettings`/`configPolicyOnedriveLibraries`/`onedriveDeviceState` Drizzle names consistent across Tasks 3–5, 8, 9; `getToken`/`graphFetch`/`DirectInvokeResult` reused from `m365DirectGraph.ts` consistently in Tasks 6–7. Heartbeat config key `onedrive_helper_settings` used once (delivery). Targeting-mode literals (`everyone`/`graph_group`/`local_ad_group`) match between the CHECK constraint (Task 4) and the test (Task 8).

--- a/docs/superpowers/specs/2026-06-19-onedrive-helper-library-sync-design.md
+++ b/docs/superpowers/specs/2026-06-19-onedrive-helper-library-sync-design.md
@@ -1,0 +1,211 @@
+# OneDrive Helper — Provisioning + Library Sync (Sub-project A) — Design Spec
+
+**Date:** 2026-06-19
+**Status:** Approved (brainstorm) — pending implementation plan
+**Author:** Todd Hebebrand + Claude
+
+## Summary
+
+A new **OneDrive Helper** capability in Breeze RMM that does reliably what
+Intune does badly: silently mount the right SharePoint document libraries to
+each Windows user based on their group membership, manage the foundational
+OneDrive configuration those mounts depend on, and give the MSP the visibility
+into mount/backup state that Intune never surfaces.
+
+It ships as a new **configuration-policy feature** (`onedrive_helper`) so it
+inherits the existing partner → org → site → device_group → device assignment
+and priority-merge model. Windows-only behavior; a no-op build on macOS/Linux.
+
+The overall product is **two sub-projects**, built in order:
+
+| | **Sub-project A — Provisioning + Library Sync** (this spec) | **Sub-project B — Sync Health** (later spec) |
+|---|---|---|
+| Job | Mount the right libraries per user + own base OneDrive config + report state | Detect / fix / alert on sync problems, nudge end users |
+| Depends on | M365 Graph, agent registry/hive writes, config policy | Agent state collection, alert engine, script/remediation, Breeze Helper |
+
+**This spec covers Sub-project A only.** Sub-project B is summarized under
+[Deferred to Sub-project B](#deferred-to-sub-project-b).
+
+## Scope decisions (from brainstorm)
+
+- **Group source is flexible, per library:** each library mapping is targeted by
+  one of `everyone` (ungated) · `graph_group` (Entra/M365 group via Graph) ·
+  `local_ad_group` (on-prem/hybrid, resolved on the device). The manual-list
+  mode (paste a library, apply to everyone) is the `everyone` case — i.e. the
+  Intune `AutoMountTeamSites` equivalent, but delivered and self-healed
+  reliably.
+- **Membership resolution is split by where the data lives:** `graph_group`
+  gates are resolved **server-side** (Graph credentials stay in the API);
+  `local_ad_group` gates are resolved **agent-side** from the local token;
+  `everyone` always applies.
+- **Own base config too:** the helper manages `SilentAccountConfig`,
+  `FilesOnDemandEnabled`, tenant association, and **Known Folder Move**
+  (`KFMSilentOptIn` + folder set; optional `KFMBlockOptOut`). Rationale: a
+  `TenantAutoMount` key does nothing unless OneDrive is already silently
+  signed in with Files On-Demand — in the messy tenants where the MSP looks
+  bad today, *that* is usually what's broken, not the library list.
+- **Additive-only mounting in v1:** when a user leaves a group, the helper
+  stops enforcing that library; it does **not** silently unmount (AutoMount is
+  one-way and there is no clean silent unmount). Entitlement drift
+  ("mounted but no longer entitled") is surfaced in reporting. An explicit,
+  gated unmount action is deferred to Sub-project B.
+- **Reporting is first-class in v1:** per-device and org-level rollup of
+  signed-in / FOD / KFM-redirection / mounted-vs-entitled / drift. This
+  visibility is roughly half the value over Intune.
+- **KFM is a health check, scoped two ways:** v1 (A) **enforces** KFM in base
+  config and **reports** known-folder redirection state. Alerting on KFM
+  backup *failures* rides with Sub-project B.
+
+## Existing platform building blocks this relies on
+
+| Concern | Reuse from |
+|---|---|
+| Per-org M365 tenant connection, OAuth client-credentials, admin consent | `apps/api/src/services/c2cM365.ts`, `apps/api/src/routes/c2c/m365Auth.ts`, `apps/api/src/db/schema/m365.ts` |
+| Direct Graph calls (client-credentials token → Graph endpoints) | `apps/api/src/services/m365DirectGraph.ts` |
+| Policy definition, feature links, hierarchical assignment + priority merge | `apps/api/src/db/schema/configurationPolicies.ts`, `apps/api/src/services/configurationPolicy.ts`, `apps/api/src/routes/configurationPolicies/crud.ts` |
+| Config delivery to agent (`ConfigUpdate` in heartbeat) | `agent/internal/heartbeat/heartbeat.go` |
+| Windows registry read/write | `golang.org/x/sys/windows/registry` (see `agent/internal/collectors/software_windows.go`) |
+| Logged-in user / SID / session resolution | `agent/internal/sessionbroker/session.go`, `agent/internal/collectors/sessions.go` |
+| PowerShell / user-context execution | `agent/internal/procoutput/shell_windows.go`, `agent/internal/executor/executor.go` |
+| Alerts (state reported by agent, raised server-side) | `apps/api/src/services/alertService.ts`, `apps/api/src/db/schema/alerts.ts` |
+
+## Architecture
+
+### 1 · Server data model
+
+New tables (org-scoped). **RLS is mandatory** and must ship in the same
+migration that creates each table, with the allowlist + cascade-list updates in
+the same PR (see [Tenancy / RLS](#tenancy--rls)).
+
+- **`onedrive_helper_settings`** (policy-linked, one row per `onedrive_helper`
+  feature link): base-config toggles — `silentAccountConfig`,
+  `filesOnDemandEnabled`, `tenantAssociationId`, `kfmSilentOptIn`,
+  `kfmFolders` (Desktop/Documents/Pictures subset), `kfmBlockOptOut`,
+  OneDrive restart behavior on key change.
+- **`sharepoint_library_mappings`** (policy-linked, N per policy): the composite
+  `libraryId` (the `AutoMountTeamSites` value), `displayName`, `siteUrl`, Graph
+  refs (`siteId` / `webId` / `listId`), `targetingMode`
+  (`everyone | graph_group | local_ad_group`), `groupId` / `groupName`,
+  `hiveScope` (`hkcu | hklm`).
+- **`onedrive_device_state`** (agent-reported, **device-scoped → denormalized
+  `org_id`**, hot write path): `signedIn`, `oneDriveVersion`,
+  `filesOnDemandOn`, `kfmFolderStates`, `mountedLibraries[]`,
+  `entitledLibraries[]`, `driftEntries[]`, `lastReportedAt`.
+
+### 2 · Server Graph integration (extend `m365DirectGraph.ts`)
+
+- `listSharePointLibraries(orgId)` → tenant sites + document libraries, powering
+  the **library picker** in the UI (the Intune-killer: browse instead of pasting
+  a cryptic ID).
+- `resolveUserGroupMembership(orgId, upn)` → `/users/{upn}/memberOf` group ids,
+  for `graph_group` targeting.
+- *(optional, recommended)* `userCanAccessLibrary(orgId, upn, libraryRef)` —
+  pre-mount access check so we don't manufacture sync errors by mounting a
+  library the user has no SharePoint permission to.
+
+### 3 · Config delivery / heartbeat
+
+- The effective `onedrive_helper` config is computed per device and delivered in
+  the heartbeat `ConfigUpdate`. For the device's reported logged-in user(s), the
+  API **pre-resolves `graph_group` gates** (tagging each library allow/deny per
+  SID/UPN); `local_ad_group` rules pass through for the agent to evaluate;
+  `everyone` always applies.
+- The agent reports `onedrive_device_state` back on each heartbeat.
+
+### 4 · Agent applier — new package `agent/internal/onedrivehelper` (Windows build tag)
+
+- Resolve active sessions via `sessionbroker` → SID + UPN. UPN source: read from
+  OneDrive's own account registry (`HKCU\Software\Microsoft\OneDrive\Accounts\*`
+  `UserEmail`), fallback to `whoami /upn` in user context.
+- Write **base config** to `HKLM\SOFTWARE\Policies\Microsoft\OneDrive`.
+- For each active user session: compute the effective library list (server-tagged
+  Graph allows + locally-evaluated AD groups + `everyone`) and write
+  `TenantAutoMount` keys into `HKU\<SID>\SOFTWARE\Policies\Microsoft\OneDrive\TenantAutoMount`.
+- **Verify *real* mount state** (read OneDrive's `Accounts\Business1` tenants /
+  scope cache), not just key presence. This handles the documented trap that
+  OneDrive will **not** re-mount a library the user previously stopped syncing:
+  rather than rewriting the key forever, record it as **drift**.
+- Idempotent self-heal each cycle; gently signal/restart OneDrive when keys
+  change.
+- macOS/Linux: no-op behind build tags.
+
+### 5 · Web UI
+
+- **Policy editor:** base-config toggles (silent sign-in, FOD, KFM folders);
+  library list with the **Graph picker** when a tenant is connected, or manual
+  paste when it isn't; per-library targeting (everyone / Graph group / AD group
+  name).
+- **Per-device OneDrive panel:** signed-in, FOD, KFM folder redirection,
+  mounted-vs-entitled libraries, drift flags.
+- **Org rollup:** who's entitled to what, mount success, drift, and a
+  "KFM not protected" list.
+
+### 6 · De-risking spike — do this FIRST in the implementation plan
+
+Validate that Graph `siteId` / `webId` / `listId` can construct a
+`TenantAutoMount` library ID that OneDrive **actually mounts**. The AutoMount
+value is a composite (`tenantId&siteId&webId&listId&webUrl&…`), not a plain URL,
+and it is not yet proven that Graph's IDs map cleanly to that exact format.
+
+- **If clean:** the Graph library picker is viable as designed.
+- **If not:** fall back to assisted "Copy library ID" capture (operator pastes
+  the ID OneDrive's sync client produces), and the picker becomes a
+  nice-to-have.
+
+This spike gates the picker UX, so it runs before the rest of the build is
+committed.
+
+## Tenancy / RLS
+
+Per `CLAUDE.md` + the RLS-coverage contract test:
+
+- `onedrive_helper_settings`, `sharepoint_library_mappings` — org-scoped
+  (Shape 1, direct `org_id`) or policy-scoped resolving to org; RLS policies in
+  the creating migration.
+- `onedrive_device_state` — device-id scoped hot write path → **denormalize
+  `org_id`** (Shape 5, Phase 1–4), with `breeze_has_org_access(org_id)` policy.
+- Update the relevant allowlists in
+  `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` and the
+  cascade-delete lists (`core.ts` device-delete + `tenantCascade.ts`
+  `ORG_CASCADE_DELETE_ORDER`, alpha-ordered via `localeCompare`) in the same PR.
+- Verify a forged cross-tenant insert fails as `breeze_app` before merging.
+
+## Carried risks (track through implementation)
+
+1. **Library-ID format** — top technical risk; gated by the §6 spike.
+2. **User-declined-library won't re-mount** — handled by real-mount-state
+   detection + drift flagging, not infinite key rewriting.
+3. **SID → UPN mapping** — multi-session / RDS hosts need per-SID handling.
+4. **Entra group ≠ SharePoint permission** — optional Graph access pre-check to
+   avoid generating sync errors.
+5. **Coexistence with existing Intune AutoMount** — both fight over the same
+   keys mid-migration; provide a clean "Breeze owns this now, retire your Intune
+   profile" story (and ideally detect existing Intune-managed AutoMount keys in
+   the report).
+
+## Deferred to Sub-project B
+
+- Sync-error detection taxonomy (no official OneDrive status API — reverse-
+  engineered from logs / Cloud Files sync-root state / named pipe).
+- Tiered remediation: auto-run **safe** fixes (resume paused, restart hung
+  OneDrive.exe); **gate** disruptive fixes (`/reset`, re-link) behind MSP
+  approval or a scheduled window; **alert-only** for unfixable (quota, file
+  conflicts, expired auth).
+- MSP alerts + **end-user nudge via the Breeze Helper** (per-user toast:
+  "OneDrive needs your attention"), to close the "broken for months because
+  nobody told the user" gap.
+- **KFM backup-*failure* alerting** (A reports KFM state; B alerts on it).
+- Explicit, gated **unmount / deprovisioning** action.
+- Data-safety pre-flight before destructive actions (reading 2 from brainstorm —
+  noted but not selected).
+
+## Success criteria (Sub-project A)
+
+- A library mapping targeted at a Graph group mounts for an entitled user and
+  not for a non-entitled user, silently, without per-device touch.
+- Base config (silent sign-in + FOD + KFM) is enforced and converges on a device
+  that started non-compliant.
+- The org rollup correctly shows entitled-vs-mounted state and flags drift for a
+  user removed from a group.
+- All new tenant tables pass the RLS-coverage contract test and a forged
+  cross-tenant insert fails as `breeze_app`.


### PR DESCRIPTION
## What this is

The **server foundation** for a new **OneDrive Helper** capability — reliably doing what Intune does badly: silently mounting the right SharePoint libraries per user, owning the base OneDrive config those mounts depend on, and giving the MSP the mount/health visibility Intune never surfaces. Delivered as a new configuration-policy feature (`onedrive_helper`), so it inherits the partner → org → site → device-group → device assignment model.

This PR is **Phase 1 (server only)** of Sub-project A. The Windows agent applier, the web UI/library picker, per-user `graph_group` filtering, and Sub-project B (sync-health/remediation/alerting) are deferred to follow-up PRs by design.

**Design docs included:** `docs/superpowers/specs/2026-06-19-onedrive-helper-library-sync-design.md` and `docs/superpowers/plans/2026-06-19-onedrive-helper-server-foundation.md`.

## What's in it

- **Feature type:** `onedrive_helper` added to `config_feature_type` enum + `ConfigFeatureType` union; inline-only (validated like `monitoring`).
- **Three forced-RLS tables** (each with idempotent migration, four `breeze_has_org_access(org_id)` policies, GRANT to `breeze_app`, and both cascade contracts):
  - `config_policy_onedrive_settings` — base provisioning (SilentAccountConfig, FilesOnDemand, KFM).
  - `config_policy_onedrive_libraries` — per-library targeting (`everyone` / `graph_group` / `local_ad_group`) with CHECK constraints.
  - `onedrive_device_state` — agent-reported state, device-scoped with denormalized `org_id`.
- **Graph (`apps/api/src/services/onedriveGraph.ts`):** `listSharePointLibraries` (powers the picker) and `resolveUserGroupMembership` (group targeting), reusing the existing per-org M365 `getToken`/`graphFetch` plumbing — secrets stay server-side.
- **Heartbeat:** `buildOnedriveHelperConfigUpdate` resolves effective config (closest-level-wins, mirroring `resolveDeviceMonitoringSettings`) and delivers it under `onedrive_helper_settings`; ingest upserts agent-reported `onedriveDeviceState` (org_id sourced from the device, not the agent).

## Tenant isolation

All three tables force RLS. Forge tests are deliberately non-vacuous — they include a BYPASSRLS guard, positive controls, system-scope existence probes before asserting 0-row reads, and INSERT forges asserting SQLSTATE `42501` (distinguished from `23503`). Agent-reported `org_id` cannot be forged (it flows from the RLS-validated device row inside the org request context — no silent-0-row write).

## Tests

**28 tests, all green at HEAD:** 16 integration (RLS forge + config delivery + state ingest, real `breeze_app` DB) + 12 unit (Graph, config-policy validation, device-cascade contract). rls-coverage contract: 45/45.

## Review

Every task was spec+quality reviewed; a final whole-branch review caught one issue the per-task reviews missed — `onedrive_device_state` was missing from `DEVICE_CASCADE_DELETE_TABLES` (a red `test-api` build via the device hard-delete coverage contract) — fixed in the final commit and independently re-verified (6/6).

## Deferred (tracked, not gaps)

Task 1 spike (validate the `TenantAutoMount` composite library-id can be built from Graph IDs — needs a real OneDrive box) · Windows agent applier · web UI/picker · per-user `graph_group` filtering (needs agent-reported UPNs) · Sub-project B · tightening `onedriveDeviceState` zod bounds once the agent payload is finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)