### PR TITLE
fix(security): SSO IdP-MFA signal (security review #2 H-1)

### DIFF
--- a/apps/api/migrations/2026-06-24-sso-trusts-idp-mfa.sql
+++ b/apps/api/migrations/2026-06-24-sso-trusts-idp-mfa.sql
@@ -1,0 +1,11 @@
+-- Security review #2 (H-1): per-provider opt-in for trusting IdP-asserted MFA.
+-- When trusts_idp_mfa is true AND the verified OIDC id_token's `amr` attests
+-- multi-factor (RFC 8176 `mfa`), the SSO callback mints mfa:true so the org can
+-- satisfy Breeze's MFA-gated routes via their IdP. Off by default (fail-safe);
+-- providers that don't opt in always yield mfa:false. The claim never satisfies
+-- the L4 step-up, which independently re-verifies a Breeze-held factor.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS. No tenant axis (sso_providers is
+-- org-scoped and already RLS-covered).
+ALTER TABLE sso_providers
+  ADD COLUMN IF NOT EXISTS trusts_idp_mfa boolean NOT NULL DEFAULT false;

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -47,6 +47,10 @@ export const ssoProviders = pgTable('sso_providers', {
   defaultRoleId: uuid('default_role_id'),
   allowedDomains: varchar('allowed_domains', { length: 1000 }), // comma-separated
   enforceSSO: boolean('enforce_sso').notNull().default(false), // disable password login
+  // security review #2 (H-1): when true AND the verified id_token's `amr`
+  // attests multi-factor, SSO logins mint mfa:true (so the org can satisfy
+  // Breeze MFA-gated routes via their IdP). Off by default — fail-safe.
+  trustsIdpMfa: boolean('trusts_idp_mfa').notNull().default(false),
 
   // Metadata
   createdBy: uuid('created_by').references(() => users.id),

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -33,6 +33,8 @@ vi.mock('../services/sso', () => ({
   verifyIdTokenClaims: vi.fn(),
   verifyIdTokenSignature: vi.fn(),
   assertEmailVerified: vi.fn(),
+  // Real logic (not a stub) so the IdP-MFA tests exercise the amr check.
+  idpAssertedMfa: (claims: { amr?: unknown }) => Array.isArray(claims?.amr) && claims.amr.includes('mfa'),
   mapUserAttributes: vi.fn(),
   discoverOIDCConfig: vi.fn(),
   PROVIDER_PRESETS: {
@@ -1123,6 +1125,41 @@ describe('sso routes', () => {
       expect(res.status).toBe(302);
       expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
       expect(createTokenPair).toHaveBeenCalled();
+    });
+
+    // ── security review #2 (H-1): IdP-asserted MFA signal
+    // Wire a returning linked user (identity-first happy path) for a provider
+    // whose trustsIdpMfa is set as given, with the verified id_token amr set.
+    const wireLinkedLogin = (opts: { trustsIdpMfa: boolean; amr?: string[] }) => {
+      primeCallback();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce', amr: opts.amr } as any);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([{ ...PROVIDER_ROW[0], trustsIdpMfa: opts.trustsIdpMfa }]))
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }])) // identity link
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'Linked' }]))
+        .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
+        .mockReturnValueOnce(sel([{ id: 'identity-1' }]));
+    };
+
+    it('mints mfa:true when the provider trusts IdP MFA and amr attests it', async () => {
+      wireLinkedLogin({ trustsIdpMfa: true, amr: ['pwd', 'mfa'] });
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ mfa: true }), expect.any(Object));
+    });
+
+    it('mints mfa:false when the provider trusts IdP MFA but amr does NOT attest it', async () => {
+      wireLinkedLogin({ trustsIdpMfa: true, amr: ['pwd'] });
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ mfa: false }), expect.any(Object));
+    });
+
+    it('mints mfa:false when the provider does NOT trust IdP MFA even if amr attests it', async () => {
+      wireLinkedLogin({ trustsIdpMfa: false, amr: ['mfa'] });
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ mfa: false }), expect.any(Object));
     });
   });
 });

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -24,6 +24,7 @@ import {
   getUserInfo,
   verifyIdTokenSignature,
   assertEmailVerified,
+  idpAssertedMfa,
   mapUserAttributes,
   discoverOIDCConfig,
   PROVIDER_PRESETS,
@@ -138,7 +139,8 @@ const createProviderSchema = z.object({
   autoProvision: z.boolean().optional(),
   defaultRoleId: z.string().guid().optional(),
   allowedDomains: z.string().optional(),
-  enforceSSO: z.boolean().optional()
+  enforceSSO: z.boolean().optional(),
+  trustsIdpMfa: z.boolean().optional()
 });
 
 const updateProviderSchema = createProviderSchema.omit({ orgId: true }).partial();
@@ -385,6 +387,7 @@ ssoRoutes.get('/providers', authMiddleware, requireScope('organization', 'partne
       issuer: ssoProviders.issuer,
       autoProvision: ssoProviders.autoProvision,
       enforceSSO: ssoProviders.enforceSSO,
+      trustsIdpMfa: ssoProviders.trustsIdpMfa,
       createdAt: ssoProviders.createdAt
     })
     .from(ssoProviders)
@@ -479,6 +482,7 @@ ssoRoutes.post(
       defaultRoleId: body.defaultRoleId,
       allowedDomains: body.allowedDomains,
       enforceSSO: body.enforceSSO ?? false,
+      trustsIdpMfa: body.trustsIdpMfa ?? false,
       createdBy: auth.user.id,
       status: 'inactive'
     })
@@ -1169,6 +1173,14 @@ ssoRoutes.get('/callback', async (c) => {
     const ip = getClientIP(c);
     const userAgent = c.req.header('user-agent') || 'unknown';
 
+    // IdP-asserted MFA (security review #2 H-1): when the org opts in via
+    // `trustsIdpMfa` AND the verified id_token's `amr` attests multi-factor,
+    // propagate mfa:true so the org can satisfy Breeze's MFA-gated routes via
+    // their IdP. Fail-safe: any provider that hasn't opted in, or an assertion
+    // without the `mfa` amr, yields mfa:false. This claim never satisfies the
+    // L4 step-up (requireFreshMfaStepUp re-verifies a Breeze-held TOTP).
+    const ssoMfa = provider.trustsIdpMfa === true && idpAssertedMfa(idClaims);
+
     const tokenPayload = {
       sub: user.id,
       email: user.email,
@@ -1176,9 +1188,7 @@ ssoRoutes.get('/callback', async (c) => {
       orgId: provider.orgId,
       partnerId: null,
       scope: 'organization' as const,
-      // SSO does not currently propagate an MFA signal into the Breeze JWT.
-      // Treat as non-MFA unless explicitly modeled from IdP claims.
-      mfa: false
+      mfa: ssoMfa
     };
 
     // Mint a fresh refresh-token family for the SSO-completed session so

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -4,12 +4,28 @@ import {
   verifyIdTokenClaims,
   verifyIdTokenSignature,
   assertEmailVerified,
+  idpAssertedMfa,
   discoverOIDCConfig,
   type OIDCConfig,
   PROVIDER_PRESETS,
   SAML_PROVIDER_PRESETS,
   ALL_SSO_PRESETS
 } from './sso';
+
+describe('idpAssertedMfa (security review #2 H-1)', () => {
+  it('is true only when amr contains the RFC 8176 "mfa" reference', () => {
+    expect(idpAssertedMfa({ amr: ['mfa'] })).toBe(true);
+    expect(idpAssertedMfa({ amr: ['pwd', 'otp', 'mfa'] })).toBe(true);
+  });
+
+  it('is false for single-factor or missing amr', () => {
+    expect(idpAssertedMfa({ amr: ['pwd'] })).toBe(false);
+    expect(idpAssertedMfa({ amr: [] })).toBe(false);
+    expect(idpAssertedMfa({})).toBe(false);
+    // A non-array amr (malformed) must not be trusted.
+    expect(idpAssertedMfa({ amr: 'mfa' as unknown as string[] })).toBe(false);
+  });
+});
 
 vi.mock('dns/promises', () => ({
   lookup: vi.fn()

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -208,7 +208,22 @@ export interface IDTokenClaims {
   email?: string;
   email_verified?: boolean | string;
   name?: string;
+  // OIDC authentication context (RFC 8176 / OIDC Core §2). `amr` lists the
+  // authentication methods the IdP used; `mfa` means multi-factor was performed.
+  amr?: string[];
+  acr?: string;
   [key: string]: unknown;
+}
+
+/**
+ * True when the IdP's id_token attests that multi-factor authentication was
+ * performed — `amr` contains the RFC 8176 `mfa` method reference. This is only
+ * trusted when the provider opts in via `trustsIdpMfa`; an org that does not
+ * opt in always gets `mfa:false` (fail-safe). Never used to satisfy the L4
+ * step-up, which independently re-verifies a Breeze-held factor.
+ */
+export function idpAssertedMfa(claims: Pick<IDTokenClaims, 'amr'>): boolean {
+  return Array.isArray(claims.amr) && claims.amr.includes('mfa');
 }
 
 export function decodeIdToken(idToken: string): IDTokenClaims {


### PR DESCRIPTION
## Summary

Follow-up to #1655 / #1671 / #1677 (security review #2 deferred items). SSO logins hardcoded `mfa:false` and never read the IdP's authentication-context claims, so an org that **enforces MFA at its IdP got no Breeze MFA credit**, and base SSO sessions carried no MFA signal at all.

## Change

Per-provider opt-in **`trusts_idp_mfa`** (boolean, default `false`). When the provider opts in **and** the **signature-verified** id_token's `amr` attests multi-factor (RFC 8176 `mfa`), the callback mints `mfa:true`; otherwise `mfa:false`.

- **Fail-safe by default:** a provider that hasn't opted in, or an assertion without the `mfa` amr, always yields `mfa:false`.
- The claim can satisfy `requireMfa()`-gated routes but **never** the L4 step-up — `requireFreshMfaStepUp` independently re-verifies a Breeze-held TOTP (mirrors the CF-Access `CF_ACCESS_TRUSTS_MFA` trust model, and stacks with #1677's TOTP replay protection).

Touches: idempotent migration (`ADD COLUMN IF NOT EXISTS`), `idpAssertedMfa()` helper + `amr`/`acr` on `IDTokenClaims`, provider create/update schema + routes (persist the flag; admin list surfaces it).

## Verification
- `tsc` clean; **54 SSO tests + migration-ordering test pass**.
- New tests: `idpAssertedMfa` unit cases; 3 callback cases — `trust+amr → mfa:true`, `trust without amr → mfa:false`, `no-trust even with amr → mfa:false`.

## Remaining deferred (review #2)
SSO **domain-ownership verification** + raising the bar to configure an IdP (the root-cause H-2 hardening; #1671's identity-first + safe JIT linking already neutralize the steady-state takeover). This is the last open item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)