### PR TITLE
fix(ai-tools): set subjectUserId on tech_jit_admin elevation requests

### DIFF
--- a/apps/api/src/services/aiToolsPam.test.ts
+++ b/apps/api/src/services/aiToolsPam.test.ts
@@ -239,6 +239,11 @@ describe('aiToolsPam handlers', () => {
       partnerId: PARTNER_ID,
       deviceId: DEVICE_ID,
       flowType: 'tech_jit_admin',
+      // tech_jit_admin requires subject_user_id IS NOT NULL (DB CHECK
+      // elevation_requests_flow_shape_chk); the AI path must populate the
+      // operator as the subject so the insert satisfies the constraint AND
+      // the maker/checker self-approval guard in routes/pam.ts applies.
+      subjectUserId: 'user-1',
       subjectUsername: 'localadmin',
       reason: 'Install driver',
       status: 'pending',

--- a/apps/api/src/services/aiToolsPam.ts
+++ b/apps/api/src/services/aiToolsPam.ts
@@ -216,7 +216,12 @@ export function registerPamTools(aiTools: Map<string, AiTool>): void {
           partnerId: device.partnerId ?? auth.partnerId ?? null,
           deviceId: device.id,
           flowType: 'tech_jit_admin',
-          subjectUserId: null,
+          // tech_jit_admin requires subject_user_id IS NOT NULL (DB CHECK
+          // elevation_requests_flow_shape_chk). The subject is the operator on
+          // whose behalf the elevation is requested, so use the authenticated
+          // user — this satisfies the constraint AND brings the request under
+          // the maker/checker self-approval guard in routes/pam.ts.
+          subjectUserId: auth.user.id,
           subjectUsername,
           reason,
           status: decision.status,


### PR DESCRIPTION
## Summary

The `request_elevation` AI tool (`apps/api/src/services/aiToolsPam.ts`) inserted an `elevation_requests` row with `flowType: 'tech_jit_admin'` but `subjectUserId: null`, storing the operator only in `metadata.requestedByUserId`.

The DB CHECK `elevation_requests_flow_shape_chk` (`apps/api/migrations/2026-06-10-b-helper-tool-action-elevations.sql:34`) requires `tech_jit_admin` rows to have `subject_user_id IS NOT NULL`. So this insert **always failed the CHECK** — a dead / CHECK-violating insert path.

## Fix

Set `subjectUserId: auth.user.id` (the authenticated operator on whose behalf the request is made), matching the canonical route flow in `apps/api/src/routes/remediationSuggestions.ts:737-738`, which uses the same `tech_jit_admin` + `subjectUserId: auth.user.id` shape.

This has two effects:
1. The insert now satisfies the CHECK constraint.
2. The AI elevation path now comes under the maker/checker self-approval guard in `routes/pam.ts:472` (`approve && row.subjectUserId && row.subjectUserId === auth.user.id` → rejected), which previously never fired on this path because `subjectUserId` was null.

## Tests

Extended the existing pending-request unit test in `aiToolsPam.test.ts` to assert the insert payload now sets `subjectUserId: 'user-1'` for `tech_jit_admin`. Confirmed it failed before the fix (was `null`) and passes after.

Note: the real CHECK only fires against Postgres; a mocked-db unit test asserting the payload field is the appropriate unit-level coverage here.

- `npx vitest run src/services/aiToolsPam.test.ts` → 27 passed (27)
- `npx tsc --noEmit` (apps/api) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)