### PR TITLE
fix(quotes): scope catalog-line lookup to the quote's partner

### DIFF
--- a/apps/api/src/__tests__/integration/quoteService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteService.integration.test.ts
@@ -499,4 +499,65 @@ describe('quoteService (breeze_app, real DB)', () => {
     expect(fetched.quote.monthlyRecurringTotal).toBe('60.00'); // 2 * 30
     expect(fetched.quote.annualRecurringTotal).toBe('0.00');
   });
+
+  // --- Cross-partner catalog disclosure (T7) ------------------------------
+  // catalog_items is partner-axis RLS. For a partner-scope caller RLS contains
+  // a foreign item, but under SYSTEM scope the partner predicate short-circuits,
+  // so a system-scope request could snapshot ANOTHER partner's catalog item into
+  // a quote line (name/unitPrice/taxable/billingType disclosure + binding a
+  // foreign catalog_item_id FK). addCatalogLine must therefore resolve the item
+  // scoped to the quote's OWN partner — a foreign item must be not-found even
+  // when RLS would otherwise let the read through.
+  runDb('addCatalogLine rejects a catalog item owned by a different partner (system scope, no snapshot)', async () => {
+    const fx = await seedFixture();
+    // A second partner with its own catalog item (the "victim").
+    const partnerB = await withSystemDbAccessContext(() => createPartner());
+    const foreignItem = await seedCatalogItem(partnerB.id, {
+      name: "Partner B's secret SKU",
+      unitPrice: '999.99',
+      billingType: 'recurring',
+      billingFrequency: 'annual',
+      commitmentTermMonths: 36,
+      taxable: false,
+    });
+    // partner-A's draft quote.
+    const quote = await withDbAccessContext(fx.ctxA, () =>
+      createQuote({ orgId: fx.orgA.id, currencyCode: 'USD' }, fx.actorA)
+    );
+
+    // Run under SYSTEM scope (the attack vector): the catalog partner predicate
+    // short-circuits, so without an explicit partner filter the foreign item
+    // would resolve and be snapshotted. With the fix it must be not-found.
+    await expect(
+      withSystemDbAccessContext(() =>
+        addCatalogLine(quote.id, foreignItem.id, 1, undefined, fx.actorA)
+      )
+    ).rejects.toMatchObject({ code: 'CATALOG_ITEM_NOT_FOUND', status: 404 });
+
+    // No line was snapshotted, so no foreign data leaked onto the quote.
+    const lines = await withSystemDbAccessContext(() =>
+      db.select().from(quoteLines).where(eq(quoteLines.quoteId, quote.id))
+    );
+    expect(lines).toHaveLength(0);
+  });
+
+  runDb('addCatalogLine still works for a same-partner item under system scope', async () => {
+    const fx = await seedFixture();
+    const item = await seedCatalogItem(fx.partnerA.id, {
+      name: 'Own SKU',
+      unitPrice: '10.00',
+      billingType: 'one_time',
+      taxable: true,
+    });
+    const quote = await withDbAccessContext(fx.ctxA, () =>
+      createQuote({ orgId: fx.orgA.id, currencyCode: 'USD' }, fx.actorA)
+    );
+    const line = await withSystemDbAccessContext(() =>
+      addCatalogLine(quote.id, item.id, 3, undefined, fx.actorA)
+    );
+    expect(line.catalogItemId).toBe(item.id);
+    expect(line.unitPrice).toBe('10.00');
+    expect(line.description).toBe('Own SKU');
+    expect(line.lineTotal).toBe('30.00'); // 3 * 10.00
+  });
 });

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -240,7 +240,17 @@ export async function addCatalogLine(
   actor: QuoteActor
 ) {
   const q = await loadDraft(quoteId, actor);
-  const [item] = await db.select().from(catalogItems).where(eq(catalogItems.id, catalogItemId)).limit(1);
+  // Scope the catalog lookup to the quote's OWN partner. catalog_items is
+  // partner-axis RLS, which contains a foreign item for a partner-scope caller —
+  // but under SYSTEM scope the partner predicate short-circuits, so without this
+  // explicit filter a system-scope request could snapshot another partner's
+  // catalog item (name/price/taxable/billingType) into the quote line and bind a
+  // foreign catalog_item_id FK. Mirrors invoiceService → catalogService's
+  // getOwnedItemOr404(id, partnerId): a foreign item resolves to not-found
+  // regardless of read scope.
+  const [item] = await db.select().from(catalogItems)
+    .where(and(eq(catalogItems.id, catalogItemId), eq(catalogItems.partnerId, q.partnerId)))
+    .limit(1);
   if (!item) throw new QuoteServiceError('Catalog item not found', 404, 'CATALOG_ITEM_NOT_FOUND');
   // Phase 1 recurrence is monthly|annual only; quarterly is not offered (dropped
   // from the catalog Zod enum). The DB enum retains 'quarterly' for a future phase.


### PR DESCRIPTION
## Summary

`quoteService.addCatalogLine` (reached via `POST /quotes/:id/lines/catalog`) read `catalog_items` by id with **no `partnerId` filter**:

```ts
db.select().from(catalogItems).where(eq(catalogItems.id, catalogItemId))
```

`catalog_items` is partner-axis RLS. For a partner-scope caller RLS contains a foreign item, but under **SYSTEM scope** the partner predicate short-circuits — so a system-scope request could snapshot **another partner's** catalog item (name, unitPrice, taxable, billingType, etc.) onto the quote line and bind a foreign `catalog_item_id` FK. That is a cross-partner disclosure, and this was the lone exception to the lookup pattern used everywhere else.

## Fix

Scope the lookup to the quote's own partner — `and(eq(catalogItems.id, catalogItemId), eq(catalogItems.partnerId, q.partnerId))` — so a foreign item resolves to not-found (`CATALOG_ITEM_NOT_FOUND`, 404) regardless of read scope. This mirrors `invoiceService` → `catalogService.getOwnedItemOr404(id, partnerId)`. Legitimate same-partner items are unaffected.

## Tests (TDD)

Added two real-DB integration tests in `quoteService.integration.test.ts`:

- `addCatalogLine rejects a catalog item owned by a different partner (system scope, no snapshot)` — confirmed FAIL before the fix (Partner B's `999.99` SKU was snapshotted onto Partner A's quote), PASS after.
- `addCatalogLine still works for a same-partner item under system scope` — regression guard.

Full file: 13/13 pass. Route test `quotes.test.ts`: 13/13 pass. `tsc --noEmit` on `apps/api`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)