### PR TITLE
fix(roles): block cross-scope role assignment via empty-permission short-circuit

### DIFF
--- a/apps/api/src/routes/roles.test.ts
+++ b/apps/api/src/routes/roles.test.ts
@@ -292,6 +292,224 @@ describe('role routes', () => {
       expect(res.status).toBe(403);
       expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
     });
+
+    it('blocks a non-admin caller from inheriting an EMPTY system parent role', async () => {
+      // Caller holds only users:write — NOT *:*. Without the fix the empty
+      // effective set of the system parent short-circuits validateAssignablePermissions
+      // to "allow", letting a low-privilege caller reach a system-scoped role.
+      vi.mocked(getUserPermissions).mockResolvedValueOnce({
+        permissions: [{ resource: 'users', action: 'write' }],
+        partnerId: 'partner-123',
+        orgId: null,
+        roleId: 'role-limited',
+        scope: 'partner'
+      } as any);
+
+      vi.mocked(db.select)
+        // validateParentRole — parent is a SYSTEM role in the same scope
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                {
+                  id: '11111111-1111-4111-8111-111111111111',
+                  scope: 'partner',
+                  isSystem: true,
+                  partnerId: null,
+                  orgId: null
+                }
+              ])
+            })
+          })
+        } as any)
+        // getEffectivePermissions — role row (parentRoleId null)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                { id: '11111111-1111-4111-8111-111111111111', name: 'Admin', parentRoleId: null }
+              ])
+            })
+          })
+        } as any)
+        // getEffectivePermissions — direct permissions: EMPTY system role
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+
+      const res = await app.request('/roles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Sneaky',
+          parentRoleId: '11111111-1111-4111-8111-111111111111',
+          permissions: []
+        })
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
+
+    it('still allows a full-admin caller to inherit an EMPTY system parent role', async () => {
+      // Default caller holds *:* — assigning a system role is legitimate.
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                {
+                  id: '11111111-1111-4111-8111-111111111111',
+                  scope: 'partner',
+                  isSystem: true,
+                  partnerId: null,
+                  orgId: null
+                }
+              ])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                { id: '11111111-1111-4111-8111-111111111111', name: 'Admin', parentRoleId: null }
+              ])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+
+      const roleInsertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'role-9',
+            name: 'Inherited',
+            description: null,
+            scope: 'partner',
+            isSystem: false,
+            parentRoleId: '11111111-1111-4111-8111-111111111111',
+            createdAt: new Date(),
+            updatedAt: new Date()
+          }
+        ])
+      });
+      const txInsert = vi
+        .fn()
+        .mockReturnValueOnce({ values: roleInsertValues })
+        .mockReturnValueOnce({ values: vi.fn().mockResolvedValue(undefined) });
+      vi.mocked(db.transaction).mockImplementation(async (fn) => fn({ insert: txInsert } as any));
+
+      const res = await app.request('/roles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Inherited',
+          parentRoleId: '11111111-1111-4111-8111-111111111111',
+          permissions: []
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('still allows a non-admin caller to create an EMPTY CUSTOM role (no regression)', async () => {
+      // Caller holds only users:write. An empty custom role grants nothing and
+      // must remain creatable — the system-role guard must NOT touch this path.
+      vi.mocked(getUserPermissions).mockResolvedValueOnce({
+        permissions: [{ resource: 'users', action: 'write' }],
+        partnerId: 'partner-123',
+        orgId: null,
+        roleId: 'role-limited',
+        scope: 'partner'
+      } as any);
+
+      const roleInsertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'role-empty',
+            name: 'Empty',
+            description: null,
+            scope: 'partner',
+            isSystem: false,
+            parentRoleId: null,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          }
+        ])
+      });
+      const txInsert = vi.fn().mockReturnValueOnce({ values: roleInsertValues });
+      vi.mocked(db.transaction).mockImplementation(async (fn) => fn({ insert: txInsert } as any));
+
+      const res = await app.request('/roles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Empty', permissions: [] })
+      });
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('POST /roles/:id/clone — system-role scope guard', () => {
+    it('blocks a non-admin caller from cloning an EMPTY system role', async () => {
+      vi.mocked(getUserPermissions).mockResolvedValueOnce({
+        permissions: [{ resource: 'users', action: 'write' }],
+        partnerId: 'partner-123',
+        orgId: null,
+        roleId: 'role-limited',
+        scope: 'partner'
+      } as any);
+
+      // The 403 path consumes exactly two selects: source-role lookup, then
+      // source-permissions (empty). The post-insert new-role-permissions select
+      // is never reached, so it must NOT be queued — a leaked once-mock would
+      // corrupt the next test in the file.
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                {
+                  id: '11111111-1111-4111-8111-111111111111',
+                  name: 'System Empty',
+                  description: null,
+                  scope: 'partner',
+                  isSystem: true,
+                  partnerId: null,
+                  orgId: null
+                }
+              ])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+
+      const res = await app.request('/roles/11111111-1111-4111-8111-111111111111/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Clone' })
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /roles/:id', () => {

--- a/apps/api/src/routes/roles.ts
+++ b/apps/api/src/routes/roles.ts
@@ -179,9 +179,21 @@ async function getCallerPermissions(
 
 function validateAssignablePermissions(
   requested: Array<{ resource: string; action: string }>,
-  callerPermissions: UserPermissions | null
+  callerPermissions: UserPermissions | null,
+  // True when `requested` is the effective permission set of a SYSTEM role
+  // (e.g. a clone source or a system parent role). Defaults false because the
+  // create/update paths build CUSTOM roles from caller-supplied permissions.
+  fromSystemRole = false
 ): string | null {
   if (requested.length === 0) {
+    // A legitimately-empty custom permission set grants nothing and is fine.
+    // But an empty SYSTEM role has no enumerable permissions to subset-check
+    // below, so the loop would never run and the empty set would silently
+    // short-circuit to "allow" — letting a low-privilege caller clone/inherit a
+    // system role they shouldn't reach. Require full (*:*) privilege first.
+    if (fromSystemRole && (!callerPermissions || !hasPermission(callerPermissions, '*', '*'))) {
+      return 'Cannot assign a system role without full administrative permissions';
+    }
     return null;
   }
 
@@ -283,7 +295,7 @@ async function wouldCreateCircularInheritance(roleId: string, newParentId: strin
 async function validateParentRole(
   parentRoleId: string,
   scopeContext: ScopeContext
-): Promise<{ valid: boolean; error?: string }> {
+): Promise<{ valid: boolean; error?: string; isSystem?: boolean }> {
   const [parentRole] = await db
     .select({
       id: roles.id,
@@ -315,7 +327,7 @@ async function validateParentRole(
     }
   }
 
-  return { valid: true };
+  return { valid: true, isSystem: parentRole.isSystem };
 }
 
 // Helper to get effective permissions (own + inherited from parent chain)
@@ -512,7 +524,8 @@ roleRoutes.post(
       }
       const parentPermissionError = validateAssignablePermissions(
         await getEffectivePermissions(body.parentRoleId),
-        callerPermissions
+        callerPermissions,
+        validation.isSystem
       );
       if (parentPermissionError) {
         return c.json({ error: parentPermissionError }, 403);
@@ -776,7 +789,8 @@ roleRoutes.patch(
       }
       const parentPermissionError = validateAssignablePermissions(
         await getEffectivePermissions(body.parentRoleId),
-        callerPermissions
+        callerPermissions,
+        validation.isSystem
       );
       if (parentPermissionError) {
         return c.json({ error: parentPermissionError }, 403);
@@ -1055,7 +1069,7 @@ roleRoutes.post(
       .from(rolePermissions)
       .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
       .where(eq(rolePermissions.roleId, roleId));
-    const permissionError = validateAssignablePermissions(sourcePerms, callerPermissions);
+    const permissionError = validateAssignablePermissions(sourcePerms, callerPermissions, sourceRole.isSystem);
     if (permissionError) {
       return c.json({ error: permissionError }, 403);
     }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -421,6 +421,153 @@ describe('user routes', () => {
       expect(clearPermissionCache).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
     });
 
+    it('blocks a non-admin caller from assigning an EMPTY system role', async () => {
+      // Caller holds only users:invite — NOT *:*. Without the fix, the empty
+      // effective permission set of the system role short-circuits
+      // validateAssignableRole to "allow", letting a low-privilege caller assign
+      // a system-scoped role (cross-scope escalation primitive).
+      vi.mocked(getUserPermissions).mockResolvedValueOnce({
+        permissions: [{ resource: 'users', action: 'invite' }],
+        partnerId: 'partner-123',
+        orgId: null,
+        roleId: 'role-limited',
+        scope: 'partner'
+      } as any);
+
+      vi.mocked(db.select)
+        // getScopedRole — a SYSTEM role in the caller's (partner) scope
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                {
+                  id: '22222222-2222-2222-2222-222222222222',
+                  scope: 'partner',
+                  name: 'Admin',
+                  description: null,
+                  isSystem: true,
+                  partnerId: null,
+                  orgId: null
+                }
+              ])
+            })
+          })
+        } as any)
+        // getEffectiveRolePermissions — role row (parentRoleId null)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ parentRoleId: null }])
+            })
+          })
+        } as any)
+        // getEffectiveRolePermissions — direct permissions: EMPTY system role
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+
+      const res = await app.request('/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'invitee@example.com',
+          name: 'Invitee',
+          roleId: '22222222-2222-2222-2222-222222222222',
+          orgAccess: 'all'
+        })
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
+
+    it('still allows a non-admin caller to assign an EMPTY CUSTOM role (no regression)', async () => {
+      // An empty same-scope CUSTOM role grants nothing and must stay assignable.
+      vi.mocked(getUserPermissions).mockResolvedValueOnce({
+        permissions: [{ resource: 'users', action: 'invite' }],
+        partnerId: 'partner-123',
+        orgId: null,
+        roleId: 'role-limited',
+        scope: 'partner'
+      } as any);
+
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                {
+                  id: '22222222-2222-2222-2222-222222222222',
+                  scope: 'partner',
+                  name: 'Empty Custom',
+                  description: null,
+                  isSystem: false,
+                  partnerId: 'partner-123',
+                  orgId: null
+                }
+              ])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ parentRoleId: null }])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+
+      const txSelect = vi
+        .fn()
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+          })
+        })
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+          })
+        });
+      const txInsert = vi
+        .fn()
+        .mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([
+              { id: '11111111-1111-1111-1111-111111111111', email: 'invitee@example.com', name: 'Invitee', status: 'invited' }
+            ])
+          })
+        })
+        .mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'link-1' }]) })
+        });
+      vi.mocked(db.transaction).mockImplementation(async (fn) => fn({ select: txSelect, insert: txInsert } as any));
+
+      const res = await app.request('/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'invitee@example.com',
+          name: 'Invitee',
+          roleId: '22222222-2222-2222-2222-222222222222',
+          orgAccess: 'all'
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
     it('should require orgIds when orgAccess is selected', async () => {
       const res = await app.request('/users/invite', {
         method: 'POST',

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -199,13 +199,25 @@ async function validateAssignableRole(
   role: { id: string; isSystem: boolean }
 ): Promise<string | null> {
   const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
-  if (rolePermissionsForAssignment.length === 0) {
-    return null;
-  }
 
   const callerPermissions = await getCallerPermissions(c, auth);
   if (!callerPermissions) {
     return 'No permissions found';
+  }
+
+  if (rolePermissionsForAssignment.length === 0) {
+    // A legitimately-empty CUSTOM role (no inherited or direct permissions)
+    // grants nothing and stays assignable by anyone allowed to invite/update.
+    // A SYSTEM role, however, is a platform-defined privilege bundle: an empty
+    // effective set has no enumerable permissions to subset-check below, so the
+    // per-permission caller check would never run. Without this guard the empty
+    // set silently short-circuits to "allow", letting a low-privilege caller
+    // assign a system-scoped role (cross-scope escalation primitive). Require
+    // the caller to hold full (*:*) privilege before assigning any system role.
+    if (role.isSystem && !hasPermission(callerPermissions, '*', '*')) {
+      return 'Cannot assign a system role without full administrative permissions';
+    }
+    return null;
   }
 
   for (const permission of rolePermissionsForAssignment) {


### PR DESCRIPTION
## Summary

`validateAssignableRole` (`apps/api/src/routes/users.ts`) and `validateAssignablePermissions` (`apps/api/src/routes/roles.ts`) short-circuited and **returned allow** the instant a role's effective permission set was empty — before any per-permission caller check ran.

Combined with the data model, this is a latent privilege-escalation primitive:

- Seeded **system roles carry `scope='partner'`/`'organization'`** (the `'system'` scope value is effectively unused), and `getScopedRole` returns any `isSystem` role in the caller's scope.
- So a low-privilege caller (e.g. holding only `users:invite`) could **assign, clone, or inherit a zero-permission SYSTEM role** because the empty effective set bypassed the subset check entirely.

Today's blast radius is limited (a zero-permission role grants nothing, and all currently-seeded system roles are non-empty), but the empty-set "allow" is an escalation foothold the moment any empty system role exists.

## What this does NOT do

The naive fix — "treat an empty permission set as deny" — would be **wrong**: a legitimately-empty same-scope **custom** role grants nothing and must stay assignable. This PR preserves that.

## Fix

Scope the empty-set short-circuit to **non-system** roles. An empty **system** role (assigned, cloned, or used as an inheritance parent) now requires the caller to hold full (`*:*`) privilege. Non-empty subset checks are unchanged.

- `users.ts` — resolve caller permissions before the empty-set branch; gate empty system roles on caller `*:*`. Covers both `POST /users/invite` and `POST /users/:id/role`.
- `roles.ts` — `validateAssignablePermissions` gains a `fromSystemRole` flag (defaults `false`, so custom create/update paths are untouched). `POST /roles/:id/clone` passes `sourceRole.isSystem`; the parent-inheritance paths pass `validateParentRole`'s newly-returned `isSystem`.

## Tests added

- `users.test.ts`: non-admin caller blocked from assigning an empty system role; non-admin caller still allowed to assign an empty same-scope custom role (no regression).
- `roles.test.ts`: non-admin caller blocked from inheriting an empty system **parent** role; blocked from cloning an empty system role; full-admin caller still allowed to inherit an empty system parent; non-admin still allowed to create an empty custom role.

Confirmed RED before the fix (3 "blocks" tests fail), GREEN after.

## Verification

- `vitest run src/routes/roles.test.ts src/routes/users.test.ts` → **126 passed** (2 files)
- `tsc --noEmit` on `apps/api` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)