### PR TITLE
fix(devices): fail closed when permissions context is absent in site check

### DIFF
--- a/apps/api/src/routes/devices/actuateElevation.test.ts
+++ b/apps/api/src/routes/devices/actuateElevation.test.ts
@@ -9,7 +9,19 @@ const {
 } = vi.hoisted(() => ({
   authMiddlewareMock: vi.fn(),
   requireScopeMock: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermissionMock: vi.fn(() => async (_c: any, next: any) => next()),
+  // Production `requirePermission` ALWAYS populates `permissions`; the
+  // canAccessDeviceSite helper fails closed when it is absent (T10), so the
+  // mock must mirror that with an unrestricted context.
+  requirePermissionMock: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
+    c.set('permissions', {
+      permissions: [{ resource, action }],
+      partnerId: null,
+      orgId: ORG_ID,
+      roleId: 'role-1',
+      scope: 'organization',
+    });
+    return next();
+  }),
   requireMfaMock: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
@@ -31,7 +43,8 @@ vi.mock('../../middleware/auth', () => ({
   requireMfa: requireMfaMock,
 }));
 
-vi.mock('./helpers', () => ({
+vi.mock('./helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./helpers')>()),
   getDeviceWithOrgCheck: vi.fn(),
 }));
 

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -17,8 +17,8 @@ import {
 } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { canAccessSite, type UserPermissions } from '../../services/permissions';
-import { getDeviceWithOrgCheck } from './helpers';
+import { type UserPermissions } from '../../services/permissions';
+import { getDeviceWithOrgCheck, canAccessDeviceSite } from './helpers';
 
 export const actuateElevationRoutes = new Hono();
 
@@ -74,14 +74,6 @@ const actuateElevationSchema = z.object({
   password: z.string().min(1).max(1024).optional(),
   timeoutMs: z.number().int().min(1000).max(60000).optional(),
 });
-
-function canAccessDeviceSite(
-  device: { siteId?: string | null },
-  userPerms: UserPermissions | undefined,
-): boolean {
-  if (!userPerms?.allowedSiteIds) return true;
-  return typeof device.siteId === 'string' && canAccessSite(userPerms, device.siteId);
-}
 
 actuateElevationRoutes.post(
   '/:id/actuate-elevation',

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -42,22 +42,27 @@ vi.mock('../../middleware/auth', () => ({
     if (resource === 'devices' && action === 'read' && c.req.header('x-deny-read') === 'true') {
       return c.json({ error: 'Permission denied' }, 403);
     }
-    if (c.req.header('x-site-restricted') === 'true') {
-      c.set('permissions', {
-        permissions: [{ resource, action }],
-        partnerId: null,
-        orgId: 'org-123',
-        roleId: 'role-123',
-        scope: 'organization',
-        allowedSiteIds: ['site-allowed']
-      });
-    }
+    // Production `requirePermission` ALWAYS populates `permissions`; the
+    // canAccessDeviceSite helper fails closed when it is absent (T10), so the
+    // mock must mirror that — set an unrestricted context by default, and add
+    // a site restriction only when the test asks for one.
+    c.set('permissions', {
+      permissions: [{ resource, action }],
+      partnerId: null,
+      orgId: 'org-123',
+      roleId: 'role-123',
+      scope: 'organization',
+      ...(c.req.header('x-site-restricted') === 'true'
+        ? { allowedSiteIds: ['site-allowed'] }
+        : {}),
+    });
     return next();
   }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
-vi.mock('./helpers', () => ({
+vi.mock('./helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./helpers')>()),
   getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
   getDeviceWithOrgCheck: vi.fn()
 }));

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -6,8 +6,8 @@ import { randomUUID } from 'node:crypto';
 import { db } from '../../db';
 import { deviceCommands, devices } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
-import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
-import { getPagination, getDeviceWithOrgCheck } from './helpers';
+import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { getPagination, getDeviceWithOrgCheck, canAccessDeviceSite } from './helpers';
 import { createCommandSchema, bulkCommandSchema, maintenanceModeSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { commandAuditDetails, sanitizeCommandForHistory } from '../../services/commandAudit';
@@ -19,11 +19,6 @@ export const commandsRoutes = new Hono();
 commandsRoutes.use('*', authMiddleware);
 
 const COMMAND_SET_AUTO_UPDATE = 'set_auto_update';
-
-function canAccessDeviceSite(device: { siteId?: string | null }, userPerms: UserPermissions | undefined): boolean {
-  if (!userPerms?.allowedSiteIds) return true;
-  return typeof device.siteId === 'string' && canAccessSite(userPerms, device.siteId);
-}
 
 // POST /devices/bulk/commands - Queue a command for multiple devices
 commandsRoutes.post(

--- a/apps/api/src/routes/devices/helpers.test.ts
+++ b/apps/api/src/routes/devices/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { stripSensitiveDeviceFields } from './helpers';
+import { stripSensitiveDeviceFields, canAccessDeviceSite } from './helpers';
+import type { UserPermissions } from '../../services/permissions';
 
 // SR-008 (systemic twin): GET /devices/:id spreads the full device row to the
 // client. Credential verifiers + mTLS material must never reach any client,
@@ -49,5 +50,50 @@ describe('stripSensitiveDeviceFields (SR-008)', () => {
     const input = { ...safe, ...sensitive };
     stripSensitiveDeviceFields(input);
     expect(input.agentTokenHash).toBe('a'.repeat(64));
+  });
+});
+
+// T10 (defense-in-depth): the per-device site check must FAIL CLOSED when the
+// permissions context is entirely absent. A missing permissions object means
+// requirePermission did not run (a dropped/reordered gate) — in that state we
+// must deny, not silently grant cross-site access. This mirrors the fail-loud
+// behavior of getDeviceWithOrgAndSiteCheck.
+describe('canAccessDeviceSite (T10 fail-closed)', () => {
+  const restricted = {
+    permissions: [],
+    partnerId: null,
+    orgId: 'org-1',
+    roleId: 'role-1',
+    scope: 'organization',
+    allowedSiteIds: ['site-a', 'site-b'],
+  } satisfies UserPermissions;
+  const unrestricted = {
+    permissions: [],
+    partnerId: null,
+    orgId: 'org-1',
+    roleId: 'role-1',
+    scope: 'organization',
+  } satisfies UserPermissions;
+
+  it('DENIES when permissions context is absent (undefined) — fail closed', () => {
+    expect(canAccessDeviceSite({ siteId: 'site-a' }, undefined)).toBe(false);
+  });
+
+  it('allows when permissions are present but unrestricted (allowedSiteIds undefined)', () => {
+    expect(canAccessDeviceSite({ siteId: 'site-a' }, unrestricted)).toBe(true);
+    expect(canAccessDeviceSite({ siteId: null }, unrestricted)).toBe(true);
+  });
+
+  it('allows a restricted user when the device is in an allowed site', () => {
+    expect(canAccessDeviceSite({ siteId: 'site-b' }, restricted)).toBe(true);
+  });
+
+  it('denies a restricted user when the device is out of the allowed sites', () => {
+    expect(canAccessDeviceSite({ siteId: 'site-z' }, restricted)).toBe(false);
+  });
+
+  it('denies a restricted user when the device has no site', () => {
+    expect(canAccessDeviceSite({ siteId: null }, restricted)).toBe(false);
+    expect(canAccessDeviceSite({}, restricted)).toBe(false);
   });
 });

--- a/apps/api/src/routes/devices/helpers.ts
+++ b/apps/api/src/routes/devices/helpers.ts
@@ -35,6 +35,34 @@ export function stripSensitiveDeviceFields<T extends Record<string, unknown>>(
   return clone;
 }
 
+/**
+ * Per-device site-scope check shared by the high-power, MFA-gated device
+ * routes (commands, scripts, actuate-elevation, software actions).
+ *
+ * Fails CLOSED on an absent permissions context (T10, defense-in-depth):
+ *   - `userPerms === undefined` → DENY. A missing permissions object means
+ *     `requirePermission` middleware did not run (a dropped/reordered gate).
+ *     We must not silently grant cross-site access in that state. This mirrors
+ *     the fail-loud behavior of {@link getDeviceWithOrgAndSiteCheck}; here we
+ *     return `false` (the caller already maps that to a 403) rather than throw,
+ *     so the boolean contract these routes rely on is preserved.
+ *   - permissions present but `allowedSiteIds` undefined → ALLOW (the user has
+ *     no site restriction; the org check has already passed upstream).
+ *   - permissions present with a site restriction → ALLOW only when the
+ *     device's site is in the allowlist.
+ */
+export function canAccessDeviceSite(
+  device: { siteId?: string | null },
+  userPerms: UserPermissions | undefined
+): boolean {
+  // Fail closed: an absent permissions context means requirePermission did
+  // not run. Deny rather than fall through to "no site restriction → allow".
+  if (!userPerms) return false;
+  // Permissions present but no site restriction → org check already passed.
+  if (!userPerms.allowedSiteIds) return true;
+  return typeof device.siteId === 'string' && canAccessSite(userPerms, device.siteId);
+}
+
 export async function ensureOrgAccess(
   orgId: string,
   auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>

--- a/apps/api/src/routes/devices/scripts.test.ts
+++ b/apps/api/src/routes/devices/scripts.test.ts
@@ -47,21 +47,26 @@ vi.mock('../../middleware/auth', () => ({
     if (resource === 'scripts' && action === 'read' && c.req.header('x-deny-scripts-read') === 'true') {
       return c.json({ error: 'Permission denied' }, 403);
     }
-    if (c.req.header('x-site-restricted') === 'true') {
-      c.set('permissions', {
-        permissions: [{ resource, action }],
-        partnerId: null,
-        orgId: 'org-123',
-        roleId: 'role-123',
-        scope: 'organization',
-        allowedSiteIds: ['site-allowed']
-      });
-    }
+    // Production `requirePermission` ALWAYS populates `permissions`; the
+    // canAccessDeviceSite helper fails closed when it is absent (T10), so the
+    // mock must mirror that — set an unrestricted context by default, and add
+    // a site restriction only when the test asks for one.
+    c.set('permissions', {
+      permissions: [{ resource, action }],
+      partnerId: null,
+      orgId: 'org-123',
+      roleId: 'role-123',
+      scope: 'organization',
+      ...(c.req.header('x-site-restricted') === 'true'
+        ? { allowedSiteIds: ['site-allowed'] }
+        : {}),
+    });
     return next();
   })
 }));
 
-vi.mock('./helpers', () => ({
+vi.mock('./helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./helpers')>()),
   getDeviceWithOrgCheck: vi.fn()
 }));
 

--- a/apps/api/src/routes/devices/scripts.ts
+++ b/apps/api/src/routes/devices/scripts.ts
@@ -3,17 +3,12 @@ import { eq, desc } from 'drizzle-orm';
 import { db } from '../../db';
 import { scriptExecutions, scripts } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
-import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
-import { getDeviceWithOrgCheck } from './helpers';
+import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { getDeviceWithOrgCheck, canAccessDeviceSite } from './helpers';
 
 export const scriptsRoutes = new Hono();
 
 scriptsRoutes.use('*', authMiddleware);
-
-function canAccessDeviceSite(device: { siteId?: string | null }, userPerms: UserPermissions | undefined): boolean {
-  if (!userPerms?.allowedSiteIds) return true;
-  return typeof device.siteId === 'string' && canAccessSite(userPerms, device.siteId);
-}
 
 // GET /devices/:id/scripts - Get script execution history for a device
 scriptsRoutes.get(

--- a/apps/api/src/routes/devices/softwareActions.test.ts
+++ b/apps/api/src/routes/devices/softwareActions.test.ts
@@ -35,16 +35,20 @@ vi.mock('../../middleware/auth', () => ({
       if (c.req.header('x-deny-devices-execute') === 'true' && resource === 'devices' && action === 'execute') {
         return c.json({ error: 'Permission denied' }, 403);
       }
-      if (c.req.header('x-site-restricted') === 'true') {
-        c.set('permissions', {
-          permissions: [{ resource, action }],
-          partnerId: null,
-          orgId: 'org-123',
-          roleId: 'role-123',
-          scope: 'organization',
-          allowedSiteIds: ['site-allowed'],
-        });
-      }
+      // Production `requirePermission` ALWAYS populates `permissions`; the
+      // canAccessDeviceSite helper fails closed when it is absent (T10), so the
+      // mock must mirror that — set an unrestricted context by default, and add
+      // a site restriction only when the test asks for one.
+      c.set('permissions', {
+        permissions: [{ resource, action }],
+        partnerId: null,
+        orgId: 'org-123',
+        roleId: 'role-123',
+        scope: 'organization',
+        ...(c.req.header('x-site-restricted') === 'true'
+          ? { allowedSiteIds: ['site-allowed'] }
+          : {}),
+      });
       return next();
     }
   ),
@@ -56,7 +60,8 @@ vi.mock('../../middleware/auth', () => ({
   }),
 }));
 
-vi.mock('./helpers', () => ({
+vi.mock('./helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./helpers')>()),
   getDeviceWithOrgCheck: vi.fn(),
 }));
 

--- a/apps/api/src/routes/devices/softwareActions.ts
+++ b/apps/api/src/routes/devices/softwareActions.ts
@@ -2,8 +2,8 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
-import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
-import { getDeviceWithOrgCheck } from './helpers';
+import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { getDeviceWithOrgCheck, canAccessDeviceSite } from './helpers';
 import { CommandTypes, queueCommandForExecution } from '../../services/commandQueue';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { commandAuditDetails } from '../../services/commandAudit';
@@ -11,14 +11,6 @@ import { commandAuditDetails } from '../../services/commandAudit';
 export const softwareActionsRoutes = new Hono();
 
 softwareActionsRoutes.use('*', authMiddleware);
-
-function canAccessDeviceSite(
-  device: { siteId?: string | null },
-  userPerms: UserPermissions | undefined
-): boolean {
-  if (!userPerms?.allowedSiteIds) return true;
-  return typeof device.siteId === 'string' && canAccessSite(userPerms, device.siteId);
-}
 
 // Same name/version constraints as the agent's validateSoftwareName /
 // validateSoftwareVersion. Keeping these synchronized prevents a request


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the per-device **site-scope** check shared by four MFA-gated, high-power device routes: command exec, script history, privilege elevation, and software install/uninstall.

Each route carried an identical inline helper:

```ts
function canAccessDeviceSite(device, perms) {
  if (!perms?.allowedSiteIds) return true;   // <- fails OPEN when perms is undefined
  return typeof device.siteId === 'string' && canAccessSite(perms, device.siteId);
}
```

The `!perms?.allowedSiteIds` short-circuit conflates two states:
- **permissions present, no site restriction** — correct to allow
- **permissions entirely absent** — must NOT allow (it means `requirePermission` never populated the context)

In the absent case the helper falls **open** and grants cross-site access.

## Reachability

**Not reachable today.** `requirePermission` always runs ahead of these handlers and populates the permissions context, so `perms` is never `undefined` in practice. This is a latent fail-open footgun: a future dropped or reordered gate would silently grant access instead of denying. The combined `getDeviceWithOrgAndSiteCheck` chokepoint in the same file already fails loud (throws 500) in this situation — this change brings the four inline copies in line.

## Change

- Dedupes the four identical inline helpers into one shared `canAccessDeviceSite` in `apps/api/src/routes/devices/helpers.ts`.
- Fails **closed**: an `undefined` permissions argument now denies (`return false` → the callers already map that to 403). A present permissions object with `allowedSiteIds` undefined still allows (unrestricted — unchanged behavior).

## Tests

- New unit coverage for the helper in `helpers.test.ts`: undefined permissions → deny; present + unrestricted → allow; restricted in-site → allow; restricted out-of-site / no-site → deny.
- The four route suites mocked `requirePermission` to set the permissions context **only** when site-restricted; updated them to always populate it (matching production) so the fail-closed helper has a context to read.
- `apps/api`: 75 route+helper tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)