### PR TITLE
fix(agents): require agent-role token for security + patch ingest

### DIFF
--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -129,6 +129,18 @@ describe('PUT /agents/:id/patches - third-party fields', () => {
     patchRows = [];
     patchUpsertSet = undefined;
     app = new Hono();
+    // Simulate agentAuthMiddleware setting the main-agent credential so the
+    // requireAgentRole guard on patchesRoutes lets these ingest tests through.
+    app.use('*', async (c, next) => {
+      c.set('agent', {
+        deviceId: DEVICE_ID,
+        agentId: AGENT_ID,
+        orgId: ORG_ID,
+        siteId: 'site-1',
+        role: 'agent',
+      } as never);
+      return next();
+    });
     app.route('/agents', patchesRoutes);
 
     vi.mocked(db.select).mockImplementation(() => ({
@@ -302,6 +314,18 @@ describe('PUT /agents/:id/patches - ENABLE_AI_PATCH_TESTING gating', () => {
       alreadyExisted: false,
     });
     app = new Hono();
+    // Simulate agentAuthMiddleware setting the main-agent credential so the
+    // requireAgentRole guard on patchesRoutes lets these ingest tests through.
+    app.use('*', async (c, next) => {
+      c.set('agent', {
+        deviceId: DEVICE_ID,
+        agentId: AGENT_ID,
+        orgId: ORG_ID,
+        siteId: 'site-1',
+        role: 'agent',
+      } as never);
+      return next();
+    });
     app.route('/agents', patchesRoutes);
 
     vi.mocked(db.select).mockImplementation(() => ({
@@ -380,5 +404,50 @@ describe('PUT /agents/:id/patches - ENABLE_AI_PATCH_TESTING gating', () => {
       catalogId: 'cat-1',
       version: '121.0',
     });
+  });
+});
+
+describe('PUT /agents/:id/patches - requireAgentRole gate (F3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a watchdog-role token with 403 and does not touch the DB', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('agent', {
+        deviceId: DEVICE_ID,
+        agentId: AGENT_ID,
+        orgId: ORG_ID,
+        siteId: 'site-1',
+        role: 'watchdog',
+      } as never);
+      return next();
+    });
+    app.route('/agents', patchesRoutes);
+
+    const res = await app.request(`/agents/${AGENT_ID}/patches`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patches: [] }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects when no agent credential is present (missing context)', async () => {
+    const app = new Hono();
+    app.route('/agents', patchesRoutes);
+
+    const res = await app.request(`/agents/${AGENT_ID}/patches`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patches: [] }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.select).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -8,6 +8,7 @@ import { writeAuditEvent } from '../../services/auditEvents';
 import { enrichFromCatalog } from '../../services/thirdPartyEnrichment';
 import { submitPatchesSchema } from './schemas';
 import { inferPatchOsType, parseDate, sanitizeDate } from './helpers';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 // Derive vendor from package id; ignore agent-supplied vendor for winget-style ids.
 function deriveVendor(packageId: string | null | undefined, fallback: string | null | undefined): string | null {
@@ -50,6 +51,9 @@ export async function pruneStaleTombstones(
 }
 
 export const patchesRoutes = new Hono();
+// Patch/compliance scan ingest is the main agent's job; reject watchdog-role
+// tokens so a weaker credential can't falsify operator-facing patch posture (F3).
+patchesRoutes.use('*', requireAgentRole);
 
 patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async (c) => {
   const agentId = c.req.param('id');

--- a/apps/api/src/routes/agents/security.test.ts
+++ b/apps/api/src/routes/agents/security.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { db } from '../../db';
+import { agentSecurityRoutes } from './security';
+
+const AGENT_ID = 'agent-001';
+const DEVICE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORG_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+vi.mock('drizzle-orm', () => ({
+  eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: { id: 'devices.id', agentId: 'devices.agentId', orgId: 'devices.orgId' },
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+vi.mock('./helpers', () => ({
+  upsertSecurityStatusForDevice: vi.fn(async () => undefined),
+}));
+
+function mountWithRole(role: 'agent' | 'watchdog' | undefined): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    // Simulate agentAuthMiddleware setting the credential context.
+    if (role) {
+      c.set('agent', {
+        deviceId: DEVICE_ID,
+        agentId: AGENT_ID,
+        orgId: ORG_ID,
+        siteId: 'site-1',
+        role,
+      } as never);
+    }
+    return next();
+  });
+  app.route('/agents', agentSecurityRoutes);
+  return app;
+}
+
+function mockDeviceLookup() {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([{ id: DEVICE_ID, orgId: ORG_ID }]),
+      }),
+    }),
+  } as never);
+  vi.mocked(db.update).mockReturnValue({
+    set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+  } as never);
+}
+
+describe('agent security routes — requireAgentRole gate (F3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('PUT /agents/:id/security/status', () => {
+    it('rejects a watchdog-role token with 403', async () => {
+      const app = mountWithRole('watchdog');
+      const res = await app.request(`/agents/${AGENT_ID}/security/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'defender', threatCount: 0 }),
+      });
+      expect(res.status).toBe(403);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('allows the main agent-role token', async () => {
+      mockDeviceLookup();
+      const app = mountWithRole('agent');
+      const res = await app.request(`/agents/${AGENT_ID}/security/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'defender', threatCount: 0 }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('PUT /agents/:id/management/posture', () => {
+    const validPosture = {
+      collectedAt: '2026-06-20T00:00:00.000Z',
+      scanDurationMs: 0,
+      categories: {},
+      identity: {
+        joinType: 'none',
+        azureAdJoined: false,
+        domainJoined: false,
+        workplaceJoined: false,
+        source: 'agent',
+      },
+    };
+
+    it('rejects a watchdog-role token with 403', async () => {
+      const app = mountWithRole('watchdog');
+      const res = await app.request(`/agents/${AGENT_ID}/management/posture`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPosture),
+      });
+      expect(res.status).toBe(403);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('allows the main agent-role token', async () => {
+      mockDeviceLookup();
+      const app = mountWithRole('agent');
+      const res = await app.request(`/agents/${AGENT_ID}/management/posture`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPosture),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/apps/api/src/routes/agents/security.ts
+++ b/apps/api/src/routes/agents/security.ts
@@ -6,8 +6,13 @@ import { devices } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { securityStatusIngestSchema, managementPostureIngestSchema } from './schemas';
 import { upsertSecurityStatusForDevice } from './helpers';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 export const agentSecurityRoutes = new Hono();
+// Security + management-posture ingest is the main agent's job; reject
+// watchdog-role tokens so a weaker credential can't falsify operator-facing
+// security/compliance posture for the device (F3).
+agentSecurityRoutes.use('*', requireAgentRole);
 
 agentSecurityRoutes.put('/:id/security/status', zValidator('json', securityStatusIngestSchema), async (c) => {
   const agentId = c.req.param('id');


### PR DESCRIPTION
## Summary

The agent security-status, management-posture, and patch-scan ingest routes authenticated the credential but never checked its **role**. The watchdog token — least-privileged, meant for monitoring + heartbeat — could therefore submit security and patch/compliance state for its own device, letting a weaker credential falsify operator-facing posture.

This extends the existing `requireAgentRole` guard (already applied to inventory / state / sessions / elevation ingest in #1021) to the security and patch ingest routes. Same least-privilege / defense-in-depth class — both tokens live in the device's root-only secrets, so this is not independently obtainable, but the ingest routes should still demand the main-agent role.

## Changes
- `agentSecurityRoutes.use('*', requireAgentRole)` — guards `PUT /:id/security/status` and `PUT /:id/management/posture`.
- `patchesRoutes.use('*', requireAgentRole)` — guards `PUT /:id/patches`.
- New `security.test.ts`: watchdog-403 + agent-role-allowed for both security routes.
- `patches.test.ts`: watchdog-403 + missing-context-403 regression tests; existing ingest tests now set the main-agent credential so they exercise the guard.

## Verification
- New regression tests fail with the guard removed (proven non-vacuous) and pass with it in place.
- `vitest run src/routes/agents/ routeScan.test.ts requireAgentRole.test.ts` → 329 passed.
- API type check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)