### PR TITLE
fix(agents): tenant-status gate on mTLS renew-cert

### DIFF
--- a/apps/api/src/routes/agents/mtls.test.ts
+++ b/apps/api/src/routes/agents/mtls.test.ts
@@ -52,6 +52,13 @@ vi.mock('../../middleware/agentAuth', () => ({
   matchAgentTokenHash: vi.fn(() => ({ mode: 'primary' })),
 }));
 
+const { tenantActiveMock } = vi.hoisted(() => ({
+  tenantActiveMock: vi.fn(async () => true),
+}));
+vi.mock('../../services/tenantStatus', () => ({
+  isAgentTenantActive: tenantActiveMock,
+}));
+
 vi.mock('../../services/auditEvents', () => ({
   writeAuditEvent: vi.fn(),
 }));
@@ -263,6 +270,73 @@ describe('POST /renew-cert — E4 per-device cooldown', () => {
       headers: { Authorization: 'Bearer brz_wrong' },
     });
     expect(resp.status).toBe(401);
+  });
+});
+
+describe('POST /renew-cert — tenant-status gate (F4)', () => {
+  const activeDeviceRow = {
+    id: DEVICE_ID,
+    orgId: ORG_ID,
+    agentId: AGENT_ID,
+    hostname: 'host-1',
+    status: 'online',
+    agentTokenHash: TOKEN_HASH,
+    previousTokenHash: null,
+    previousTokenExpiresAt: null,
+    agentTokenSuspendedAt: null,
+    // Valid (non-expired) cert so the handler does not divert into quarantine.
+    mtlsCertExpiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    mtlsCertCfId: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisState.clear();
+    issueCertMock.mockReset();
+    revokeCertMock.mockReset();
+    tenantActiveMock.mockResolvedValue(true);
+    mockDbUpdateOk();
+  });
+
+  it('rejects with opaque 401 and does NOT issue a cert when the tenant is inactive', async () => {
+    // The org/partner is suspended but the device token itself is not
+    // individually suspended — without the tenant gate the agent would still
+    // get fresh Cloudflare cert + private key material.
+    tenantActiveMock.mockResolvedValue(false);
+    mockDeviceLookup(activeDeviceRow);
+
+    const res = await buildApp().request('/agents/renew-cert', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    // Same opaque message as a stale/suspended token — suspension is not leaked.
+    expect(body.error).toBe('Invalid agent credentials');
+    expect(issueCertMock).not.toHaveBeenCalled();
+    expect(revokeCertMock).not.toHaveBeenCalled();
+  });
+
+  it('issues normally when the tenant is active', async () => {
+    issueCertMock.mockResolvedValue({
+      id: 'cf-cert-1',
+      certificate: 'CERT',
+      privateKey: 'KEY',
+      expiresOn: new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString(),
+      issuedOn: new Date().toISOString(),
+      serialNumber: 'sn-1',
+    });
+    mockDeviceLookup(activeDeviceRow);
+
+    const res = await buildApp().request('/agents/renew-cert', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(issueCertMock).toHaveBeenCalled();
+    expect(tenantActiveMock).toHaveBeenCalledWith(ORG_ID);
   });
 });
 

--- a/apps/api/src/routes/agents/mtls.ts
+++ b/apps/api/src/routes/agents/mtls.ts
@@ -6,6 +6,7 @@ import { createHash } from 'crypto';
 import { lookup as dnsLookup } from 'dns/promises';
 import { isIP } from 'net';
 import { db, withSystemDbAccessContext } from '../../db';
+import { isAgentTenantActive } from '../../services/tenantStatus';
 import { devices, organizations } from '../../db/schema';
 import { authMiddleware, requireMfa, requirePermission } from '../../middleware/auth';
 import { matchAgentTokenHash } from '../../middleware/agentAuth';
@@ -215,6 +216,29 @@ mtlsRoutes.post('/renew-cert', async (c) => {
       // failed-closed if redis is fully unavailable; if zcard fails we proceed.
       console.warn('[agents] mTLS success-window check failed:', String(err));
     }
+  }
+
+  // Tenant-status gate (F4): this route authenticates the device token by hand
+  // and never passes through agentAuthMiddleware, so it missed the org/partner
+  // lifecycle check the rest of the agent surface enforces. A device whose
+  // tenant is suspended/churned/soft-deleted — but whose token was not
+  // individually suspended — could otherwise keep minting fresh Cloudflare mTLS
+  // cert + private-key material. Mirror the agentAuth gate: run it after the
+  // per-device rate limiters (so an inactive tenant can't drive uncached
+  // lookups) and before any Cloudflare issuance, and return the same opaque 401
+  // as a stale token so suspension is not distinguishable from a bad credential.
+  if (!(await isAgentTenantActive(device.orgId))) {
+    writeAuditEvent(c, {
+      orgId: device.orgId,
+      actorType: 'agent',
+      actorId: device.agentId,
+      action: 'agent.mtls.renew.denied',
+      resourceType: 'device',
+      resourceId: device.id,
+      result: 'denied',
+      details: { reason: 'tenant_inactive' },
+    });
+    return c.json({ error: 'Invalid agent credentials' }, 401);
   }
 
   const cfService = CloudflareMtlsService.fromEnv();


### PR DESCRIPTION
## Summary

`POST /agents/renew-cert` authenticates the device token by hand rather than going through `agentAuthMiddleware`, so it never ran the org/partner tenant-lifecycle check the rest of the agent surface enforces. The handler checks device-level state (token suspension, decommission, quarantine) but **not** whether the device's tenant (org/partner) is still active.

Result: a device whose tenant is suspended/churned/soft-deleted — but whose token was not *individually* suspended — could keep minting fresh Cloudflare mTLS cert + private-key material via renewal.

## Fix

Add an `isAgentTenantActive(device.orgId)` gate, mirroring the one in `agentAuthMiddleware`:
- Runs **after** the per-device rate limiters (an inactive tenant can't drive uncached lookups; negatives aren't cached by design) and **before** any Cloudflare issuance.
- Returns the same opaque `401 Invalid agent credentials` as a stale/suspended token, so suspension stays indistinguishable from a bad credential.
- Records an `agent.mtls.renew.denied` audit event (`reason: tenant_inactive`).

## Verification
- New regression test: inactive tenant → 401, and neither `issueCertificate` nor `revokeCertificate` is called; plus an active-tenant happy path asserting the gate is consulted with the device's org id.
- Proven non-vacuous (tests fail with the gate bypassed).
- `vitest run src/routes/agents/` → 297 passed. API type check clean.

## Rollout
Behavior change for any agent on a suspended/inactive tenant: its cert renewal now fails closed (401) instead of succeeding. That is the intended containment — a suspended tenant's fleet should not keep renewing certs. No agent-side change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)