### PR TITLE
docs(security): SSO domain-ownership + sso:admin design (review #2 H-2 root cause)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-sso-admin-gating.md
+++ b/docs/superpowers/plans/2026-06-20-sso-admin-gating.md
@@ -1,0 +1,358 @@
+# SSO `sso:admin` Gating (Plan A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make configuring an org's SSO provider a distinct `sso:admin` capability (separate from general `orgs:write`), without locking out any current SSO admin.
+
+**Architecture:** Add an `sso:admin` permission to the shared catalog; swap the SSO provider routes' permission gate from `organizations:write` to `sso:admin`; ship a one-time backfill migration granting `sso:admin` to every role that currently holds `organizations:write`; ensure every provider mutation writes an audit event for visibility.
+
+**Tech Stack:** Hono routes, Drizzle, hand-written SQL migrations, Vitest. Plan A is **Plan A of 2** from `docs/superpowers/specs/2026-06-20-sso-domain-ownership-design.md` (Plan B — domain verification — is a separate plan, written after A lands).
+
+## Global Constraints
+
+- New permissions live in `packages/shared/src/constants/permissions.ts` (`PERMISSION_GRANTS`); the API's `PERMISSIONS`, `KNOWN_PERMISSIONS`, and `ASSIGNABLE_PERMISSIONS` derive from it automatically.
+- `permissions` table has **no** unique constraint on `(resource, action)` — guard catalog inserts with `WHERE NOT EXISTS`, never `ON CONFLICT (resource, action)`.
+- `role_permissions` has a composite PK `(role_id, permission_id)` — `ON CONFLICT (role_id, permission_id) DO NOTHING` is valid and is the idempotency mechanism.
+- Wildcard (`*`,`*`) roles satisfy `requirePermission('sso','admin')` at check time via the wildcard, so the backfill only targets roles with an **explicit** `organizations:write` row.
+- Migrations: idempotent, `YYYY-MM-DD-<slug>.sql`, sort after the current latest; no inner `BEGIN/COMMIT`; cleanup statements report row counts. Never edit a shipped migration.
+- `@breeze/shared` has no build step — validate it with `pnpm --filter @breeze/shared typecheck`.
+- Node: prefix commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`.
+
+---
+
+### Task 1: Add the `sso:admin` permission to the shared catalog
+
+**Files:**
+- Modify: `packages/shared/src/constants/permissions.ts` (the `PERMISSION_GRANTS` object, near the `ORGS_*` block ~line 72-74)
+- Test: `apps/api/src/services/permissions.test.ts` (create if absent; else append)
+
+**Interfaces:**
+- Produces: `PERMISSION_GRANTS.SSO_ADMIN = { resource: 'sso', action: 'admin' }`, consumed by Task 2/3 as `PERMISSIONS.SSO_ADMIN`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/services/permissions.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { PERMISSIONS, isAssignablePermission, isKnownPermission } from './permissions';
+
+describe('sso:admin permission (security review #2 H-2)', () => {
+  it('is defined in the catalog as resource=sso action=admin', () => {
+    expect(PERMISSIONS.SSO_ADMIN).toEqual({ resource: 'sso', action: 'admin' });
+  });
+
+  it('is a known, assignable permission', () => {
+    const p = { resource: 'sso', action: 'admin' };
+    expect(isKnownPermission(p)).toBe(true);
+    expect(isAssignablePermission(p)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/permissions.test.ts -t "sso:admin permission"`
+Expected: FAIL — `PERMISSIONS.SSO_ADMIN` is `undefined`.
+
+- [ ] **Step 3: Add the catalog entry**
+
+In `packages/shared/src/constants/permissions.ts`, add after the `ORGS_DELETE` line:
+
+```ts
+  // SSO administration: configure providers + manage verified domains. A
+  // higher-trust capability than organizations:write (security review #2 H-2).
+  SSO_ADMIN: { resource: 'sso', action: 'admin' },
+```
+
+- [ ] **Step 4: Run test + shared typecheck to verify pass**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/permissions.test.ts -t "sso:admin permission"`
+Expected: PASS.
+Run: `cd /Users/toddhebebrand/breeze && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/constants/permissions.ts apps/api/src/services/permissions.test.ts
+git commit -m "feat(security): add sso:admin permission to the catalog (review #2 H-2)"
+```
+
+---
+
+### Task 2: Gate the SSO provider routes on `sso:admin`
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` — the four mutating provider routes' `requirePermission(...)` lines:
+  - `POST /providers` (~line 428)
+  - `PATCH /providers/:id` (~line 512)
+  - `DELETE /providers/:id` (~line 573)
+  - `POST /providers/:id/status` (~line 624)
+  - `POST /providers/:id/test` (~line 675)
+- Test: `apps/api/src/routes/sso.test.ts` (extend; `requirePermission` is already mocked there as a `vi.fn`)
+
+**Interfaces:**
+- Consumes: `PERMISSIONS.SSO_ADMIN` from Task 1.
+- Produces: the five provider-mutation routes require `('sso','admin')`. (Read routes `GET /providers`, `GET /providers/:id` are unchanged.)
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/routes/sso.test.ts`, add (the file already imports `requirePermission`-related mocks; import the symbol if not present: `import { requirePermission } from '../middleware/auth';`):
+
+```ts
+it('gates provider mutations on sso:admin, not organizations:write', () => {
+  // requirePermission is a vi.fn mock; assert the route registered the sso:admin gate.
+  expect(vi.mocked(requirePermission)).toHaveBeenCalledWith('sso', 'admin');
+  // organizations:write must no longer gate provider create/update/activate.
+  expect(vi.mocked(requirePermission)).not.toHaveBeenCalledWith('organizations', 'write');
+});
+```
+
+(Note: `requirePermission` is invoked at module-load when routes register, so the calls are recorded once `./sso` is imported. If the existing mock is `vi.fn((res, act) => async (c, next) => ...)`, calls record `(res, act)`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/sso.test.ts -t "gates provider mutations on sso:admin"`
+Expected: FAIL — routes still call `requirePermission('organizations','write')`.
+
+- [ ] **Step 3: Swap the guard on all five routes**
+
+In `apps/api/src/routes/sso.ts`, replace each of the five occurrences:
+
+```ts
+requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+```
+
+with:
+
+```ts
+requirePermission(PERMISSIONS.SSO_ADMIN.resource, PERMISSIONS.SSO_ADMIN.action),
+```
+
+(Leave the `GET /providers` and `GET /providers/:id` read routes untouched.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/sso.test.ts --no-file-parallelism`
+Expected: PASS — the new assertion passes and all existing SSO route tests still pass (they assert behavior through the mocked permission gate, which is unaffected by the resource/action values).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(security): gate SSO provider routes on sso:admin (review #2 H-2)"
+```
+
+---
+
+### Task 3: Backfill `sso:admin` to existing `organizations:write` roles
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-25-sso-admin-permission-backfill.sql` (date must sort after the current latest migration; if a later-dated migration exists, bump the date accordingly)
+- Test: `apps/api/src/__tests__/integration/ssoAdminBackfill.integration.test.ts`
+
+**Interfaces:**
+- Consumes: the `permissions` and `role_permissions` tables; the `(organizations, write)` catalog row convention.
+- Produces: a `(sso, admin)` catalog row; a `role_permissions` grant for every role holding `(organizations, write)`.
+
+- [ ] **Step 1: Write the failing test**
+
+The backfill is a one-time data migration, so the test exercises the **backfill SQL logic directly** against a freshly-seeded role (it does not rely on autoMigrate's one-time application). Create `apps/api/src/__tests__/integration/ssoAdminBackfill.integration.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { createPartner, createRole, grantRolePermissions } from './db-utils';
+
+// The exact backfill statements from the migration, run here against a seeded
+// role so we validate the SQL logic (and its idempotency) independent of when
+// autoMigrate applied the real one-time migration.
+const ENSURE_PERMISSION = sql`
+  INSERT INTO permissions (resource, action, description)
+  SELECT 'sso', 'admin', 'Manage SSO providers and verified domains'
+  WHERE NOT EXISTS (SELECT 1 FROM permissions WHERE resource = 'sso' AND action = 'admin');
+`;
+const BACKFILL = sql`
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT DISTINCT rp.role_id, s.id
+  FROM role_permissions rp
+  JOIN permissions w ON w.id = rp.permission_id AND w.resource = 'organizations' AND w.action = 'write'
+  CROSS JOIN (SELECT id FROM permissions WHERE resource = 'sso' AND action = 'admin' LIMIT 1) s
+  ON CONFLICT (role_id, permission_id) DO NOTHING;
+`;
+
+async function roleHasSsoAdmin(db: ReturnType<typeof getTestDb>, roleId: string): Promise<boolean> {
+  const rows = await db.execute(sql`
+    SELECT 1 FROM role_permissions rp
+    JOIN permissions p ON p.id = rp.permission_id
+    WHERE rp.role_id = ${roleId} AND p.resource = 'sso' AND p.action = 'admin' LIMIT 1;
+  `);
+  return (rows as unknown as unknown[]).length > 0;
+}
+
+describe('sso:admin backfill migration', () => {
+  it('grants sso:admin to a role with organizations:write, and not to one without', async () => {
+    const db = getTestDb();
+    const partner = await createPartner({});
+    const writeRole = await createRole({ scope: 'partner', partnerId: partner.id });
+    await grantRolePermissions(writeRole.id, [{ resource: 'organizations', action: 'write' }]);
+    const otherRole = await createRole({ scope: 'partner', partnerId: partner.id });
+    await grantRolePermissions(otherRole.id, [{ resource: 'devices', action: 'read' }]);
+
+    await db.execute(ENSURE_PERMISSION);
+    await db.execute(BACKFILL);
+
+    expect(await roleHasSsoAdmin(db, writeRole.id)).toBe(true);
+    expect(await roleHasSsoAdmin(db, otherRole.id)).toBe(false);
+  });
+
+  it('is idempotent on re-run', async () => {
+    const db = getTestDb();
+    const partner = await createPartner({});
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    await grantRolePermissions(role.id, [{ resource: 'organizations', action: 'write' }]);
+
+    await db.execute(ENSURE_PERMISSION);
+    await db.execute(BACKFILL);
+    await db.execute(ENSURE_PERMISSION);
+    await db.execute(BACKFILL); // second run must not throw or duplicate
+
+    const rows = await db.execute(sql`
+      SELECT count(*)::int AS n FROM role_permissions rp
+      JOIN permissions p ON p.id = rp.permission_id
+      WHERE rp.role_id = ${role.id} AND p.resource = 'sso' AND p.action = 'admin';
+    `);
+    expect((rows as unknown as Array<{ n: number }>)[0].n).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/ssoAdminBackfill.integration.test.ts`
+Expected: FAIL — the migration file doesn't exist yet, but more importantly run it AFTER writing the migration; if run first it may pass against an existing `sso:admin` row from a prior task. (This test validates the SQL that the migration will contain — write the migration in Step 3, then this test confirms the SQL is correct and idempotent. The "failing" state is: without the migration's SQL, a plain `createRole`+`organizations:write` role has no `sso:admin` — assert that precondition in the test if desired.)
+
+- [ ] **Step 3: Write the migration**
+
+Create `apps/api/migrations/2026-06-25-sso-admin-permission-backfill.sql`:
+
+```sql
+-- Security review #2 (H-2): introduce sso:admin and backfill it to every role
+-- that currently holds organizations:write, so no existing SSO admin loses the
+-- ability to configure providers when the gate moves from orgs:write to
+-- sso:admin. Wildcard ('*','*') roles satisfy sso:admin at check time, so they
+-- need no row here. Idempotent.
+
+-- 1. Ensure the sso:admin catalog row exists exactly once (permissions has no
+--    unique(resource,action), so guard with WHERE NOT EXISTS).
+INSERT INTO permissions (resource, action, description)
+SELECT 'sso', 'admin', 'Manage SSO providers and verified domains'
+WHERE NOT EXISTS (SELECT 1 FROM permissions WHERE resource = 'sso' AND action = 'admin');
+
+-- 2. Grant sso:admin to every role with an explicit organizations:write row.
+--    Report the count for the forensic trail.
+DO $$
+DECLARE n integer;
+BEGIN
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT DISTINCT rp.role_id, s.id
+  FROM role_permissions rp
+  JOIN permissions w ON w.id = rp.permission_id AND w.resource = 'organizations' AND w.action = 'write'
+  CROSS JOIN (SELECT id FROM permissions WHERE resource = 'sso' AND action = 'admin' LIMIT 1) s
+  ON CONFLICT (role_id, permission_id) DO NOTHING;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RAISE WARNING 'sso:admin backfill granted % role(s)', n;
+END $$;
+```
+
+- [ ] **Step 4: Run test + migration-ordering test to verify pass**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run --config vitest.integration.config.ts src/__tests__/integration/ssoAdminBackfill.integration.test.ts`
+Expected: PASS (both cases).
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/db/autoMigrate.test.ts`
+Expected: PASS (filename sorts correctly, idempotency preserved).
+
+- [ ] **Step 5: Verify drift + commit**
+
+Run: `cd /Users/toddhebebrand/breeze && export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift`
+Expected: no drift (the migration adds no schema objects — data-only backfill).
+
+```bash
+git add apps/api/migrations/2026-06-25-sso-admin-permission-backfill.sql apps/api/src/__tests__/integration/ssoAdminBackfill.integration.test.ts
+git commit -m "feat(security): backfill sso:admin to organizations:write roles (review #2 H-2)"
+```
+
+---
+
+### Task 4: Audit every provider mutation (visibility)
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` — confirm/add `writeRouteAudit(...)` on `POST /providers`, `PATCH /providers/:id`, `POST /providers/:id/status` (create/update already call it; ensure the status route does, with action `sso.provider.status_change`).
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes: `writeRouteAudit(c, { orgId, action, resourceType, resourceId, ... })` from `services/auditEvents.ts`.
+- Produces: an audit row on every provider mutation (`sso.provider.create` / `.update` / `.status_change`).
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/routes/sso.test.ts`, add a case for the status route (mock `writeRouteAudit` or assert via the existing audit mock; mirror the create-route audit assertion already in the file):
+
+```ts
+it('writes an audit event when a provider status changes', async () => {
+  // ...wire a valid /providers/:id/status request (reuse existing helpers)...
+  expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ action: 'sso.provider.status_change', resourceType: 'sso_provider' }),
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/sso.test.ts -t "audit event when a provider status changes"`
+Expected: FAIL if the status route doesn't yet emit that exact action.
+
+- [ ] **Step 3: Add the audit call**
+
+In the `POST /providers/:id/status` handler in `apps/api/src/routes/sso.ts`, after the status update succeeds, add:
+
+```ts
+writeRouteAudit(c, {
+  orgId: updated.orgId,
+  action: 'sso.provider.status_change',
+  resourceType: 'sso_provider',
+  resourceId: updated.id,
+  resourceName: updated.name,
+  details: { status: updated.status },
+});
+```
+
+(Confirm the create handler emits `sso.provider.create` and update emits `sso.provider.update` — they already do; no change needed if so.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/routes/sso.test.ts --no-file-parallelism`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(security): audit SSO provider status changes (review #2 H-2)"
+```
+
+---
+
+## Deferred from this plan (explicit)
+
+- **Email / in-app notification of SSO config changes to org admins.** The spec called for "audit + notify"; this plan delivers the **audit** half (concrete, tested). There is no clean general "notify org admins of a security event" helper today (the notification dispatcher is alert-specific), so building the notify path would mean a speculative audience-enumeration + template task. Deferred to its own small plan/PR once a general admin-notification helper exists. The visibility requirement is met by the audit trail in the interim.
+- **Domain verification** (the `sso_verified_domains` table, DNS-TXT flow, callback enforcement, re-check job, admin UI) — that is **Plan B**, a separate plan written after Plan A lands.
+
+## Self-Review
+
+- **Spec coverage:** Plan A maps to the spec's "Plan A — `sso:admin` permission & gating" section in full (permission, route gating, backfill, audit). The notify half is explicitly deferred with rationale above. Domain verification is Plan B (out of scope here, by design).
+- **Placeholders:** none — every code/SQL step shows the actual content.
+- **Type consistency:** `PERMISSIONS.SSO_ADMIN` (Task 1) is the symbol used in Task 2; audit action strings (`sso.provider.create|update|status_change`) are consistent; backfill SQL in the test (Task 3 Step 1) matches the migration (Step 3) verbatim.

--- a/docs/superpowers/specs/2026-06-20-sso-domain-ownership-design.md
+++ b/docs/superpowers/specs/2026-06-20-sso-domain-ownership-design.md
@@ -1,0 +1,178 @@
+# SSO Domain-Ownership Verification + `sso:admin` — Design
+
+**Date:** 2026-06-20
+**Status:** Approved design (pre-implementation)
+**Area:** `apps/api` SSO (OIDC), permissions, `apps/web` settings UI
+
+## Provenance
+
+From the security-review playbook (`internal/security-review-playbook.md`), entry **#2 — Core authentication** (DEEP two-pass review). That review found an SSO account-takeover cluster whose root cause (H-2) is: a **malicious or compromised org-admin** can point their own org's OIDC provider at an **attacker-controlled IdP** and impersonate any co-member, because the callback linked accounts by the **global-unique email** — and id_token signature / `email_verified` don't stop an IdP that signs with its own JWKS.
+
+The exploitable and steady-state parts already shipped:
+
+- **#1655** — mandatory id_token signature verification; identity derived from the verified token (C-1/C-2).
+- **#1671** — **identity-first lookup + safe JIT linking** (H-2/H-3 residual): once a user is linked, only `(provider, external sub)` authenticates them; an SSO assertion will not silently link to a password account or one linked to a different provider.
+- **#1677** — MFA TOTP replay protection.
+- **#1680** — SSO IdP-MFA signal (H-1).
+
+This document specs the **last deferred item: the H-2 root cause.** #1671 neutralized the *steady-state* takeover, but a malicious org-admin can still assert/provision emails **in a domain the org does not own**. This is the defense-in-depth root-cause hardening.
+
+## Goals
+
+1. Gate SSO **provisioning / JIT-linking** on a **DNS-verified** email domain — an org can only auto-create or first-time-link a user whose email domain it has proven it owns.
+2. Make "point the org at an IdP" a distinct, higher-trust **`sso:admin`** capability (separate from general `orgs:write`).
+
+Non-goals (explicitly out of scope): SAML support (OIDC-only, as today); changing the `(provider, sub)` identity-first model from #1671; auto-revoking verification on transient DNS failure.
+
+## Scope decisions (from brainstorming)
+
+- **Enforcement model:** gate **provisioning/linking only**. An unverified domain → SSO login refused for that email (`sso_domain_unverified`). Already-linked `(provider, sub)` users are never domain-checked.
+- **Verification method:** **DNS TXT record** (self-serve; uses Node DNS resolution with a timeout).
+- **IdP-config gating:** a **new `sso:admin` permission** gates provider create/update/activate + domain management.
+- **Role backfill:** the migration grants `sso:admin` to **every role that currently holds `orgs:write`** — non-breaking on day one; orgs can tighten later.
+- **Revocation posture:** verification is **sticky**; a periodic re-check audits + notifies on drift but does **not** auto-unverify in v1 (operator knob, off by default).
+- **Rollout:** **per-org auto-enforce** — enforcement is active for an org only once it has ≥1 verified domain; an org with zero verified domains stays in **warn mode** (allow + audit + nudge). A global `SSO_DOMAIN_VERIFICATION_STRICT` env (default off) forces enforce-everywhere.
+
+## Two implementation plans
+
+The work splits into two independent, separately-shippable plans:
+
+- **Plan A — `sso:admin` gating** (no DNS): new permission + backfill migration + apply to provider routes + change notifications. Self-contained, non-breaking.
+- **Plan B — domain verification**: `sso_verified_domains` table + service + routes + callback enforcement + re-check job + admin UI.
+
+Build A first (smaller, unblocks the gating immediately), then B.
+
+---
+
+## Data model
+
+### New table `sso_verified_domains`
+
+Org-scoped (RLS shape 1: `breeze_has_org_access(org_id)`), added to the `ORG_*` auto-discovered set and asserted by `rls-coverage.integration.test.ts`.
+
+| column | type | notes |
+|---|---|---|
+| `id` | uuid pk default random | |
+| `org_id` | uuid not null → organizations | tenant axis |
+| `domain` | varchar(253) not null | lowercased; `UNIQUE(org_id, domain)` |
+| `verification_token` | varchar not null | high-entropy; the value placed in the TXT record |
+| `verified_at` | timestamp null | null = pending |
+| `last_checked_at` | timestamp null | set by the periodic re-check |
+| `created_by` | uuid → users | |
+| `created_at` / `updated_at` | timestamp not null default now | |
+
+Migration: idempotent (`CREATE TABLE IF NOT EXISTS`, RLS `ENABLE`+`FORCE`+policy in the same migration). Naming `YYYY-MM-DD-<slug>.sql`, sorts after the current latest.
+
+### Relationship to existing `ssoProviders.allowedDomains`
+
+Unchanged. `allowedDomains` remains an **optional per-provider narrowing filter** (free-text comma list, applied at the callback as today). The **security gate** is the org-scoped verified-domains set. Most orgs won't set `allowedDomains`.
+
+---
+
+## Plan A — `sso:admin` permission & gating
+
+### Permission
+
+New catalog entry `sso:admin` (resource `sso`, action `admin`).
+
+### Applied to (replace `requirePermission(ORGS_WRITE)`, keep `requireMfa()`)
+
+- `POST /sso/providers` (create)
+- `PATCH /sso/providers/:id` (update)
+- `POST /sso/providers/:id/status` (activate/deactivate)
+- all `/sso/domains*` routes (Plan B)
+
+Read routes (list/get providers) stay on their current read permission.
+
+### Backfill migration
+
+For every role holding `(orgs, write)`, grant `(sso, admin)` via a `role_permissions` insert that resolves-or-creates the catalog row, idempotent (`ON CONFLICT DO NOTHING`). Day-1 behavior identical; orgs can revoke `sso:admin` from junior roles afterward.
+
+### Change notifications (defense-in-depth)
+
+On every provider create/update/status-change: `writeRouteAudit` (extend existing) **and** an async notification to the org's admins ("SSO configuration changed by <actor>"), so a malicious/compromised config change is visible to peers.
+
+### Plan A tests
+
+- An `orgs:write`-only role (no `sso:admin`) → 403 on provider create/activate.
+- An `sso:admin` role → succeeds.
+- Backfill migration grants `(sso, admin)` to every `(orgs, write)` role; idempotent on re-run.
+- Notification fires on provider change.
+
+---
+
+## Plan B — domain verification
+
+### Service `services/ssoDomainVerification.ts`
+
+One focused unit:
+
+- `createPendingDomain(orgId, domain, userId)` → normalize + validate the domain, generate a random `verification_token`, insert a pending row, return the TXT instruction: a record with value `breeze-domain-verify=<token>` placed at **`_breeze-verify.<domain>`** (a dedicated subdomain, so we never read or depend on the domain's apex TXT, which often holds SPF/other records).
+- `verifyDomain(orgId, domainId)` → resolve TXT at `_breeze-verify.<domain>` (`dns.promises.resolveTxt`, short timeout); if any returned record equals `breeze-domain-verify=<token>`, stamp `verified_at`; else stay pending. Resolution errors (NXDOMAIN/timeout) → "not verified" (fail-safe).
+- `isDomainVerifiedForOrg(orgId, emailDomain)` → hot-path boolean used by the callback (`verified_at` not null).
+- `orgHasAnyVerifiedDomain(orgId)` → drives the per-org enforce/warn decision.
+
+**DNS safety:** resolving an admin-supplied domain's TXT is a *public DNS query*, not an SSRF vector (no internal-network reach); bound it with a timeout. Tokens are high-entropy and per-`(org, domain)`, so one org cannot satisfy another's challenge.
+
+### Endpoints (all `sso:admin` + `requireMfa()`, org-scoped via `auth.canAccessOrg`)
+
+- `POST /sso/domains` `{ domain }` → create pending; return token + TXT instructions.
+- `POST /sso/domains/:id/verify` → run the DNS check now (the "Verify" button).
+- `GET /sso/domains` → list with status.
+- `DELETE /sso/domains/:id` → remove.
+
+### Callback enforcement
+
+In the SSO callback, only on the provision / JIT-link branches (the existing `(provider, sub)` link path is never domain-checked):
+
+```
+resolve user:
+  existing (provider, sub) link  → log in (NO domain check)          ← unaffected
+  else (provision new / JIT-link existing-by-email):
+     org enforcing?  (orgHasAnyVerifiedDomain(orgId) OR SSO_DOMAIN_VERIFICATION_STRICT)
+        no  → warn mode: allow + audit + notify admins ("verify domains to harden SSO")
+        yes → isDomainVerifiedForOrg(orgId, emailDomain)?
+                 yes → proceed
+                 no  → refuse, redirect /login?error=sso_domain_unverified
+```
+
+### Rollout (non-breaking & self-tightening)
+
+1. **Seed:** the Plan-B migration creates **pending** `sso_verified_domains` rows from each existing provider's `allowedDomains`, so admins see exactly what to verify.
+2. **Per-org auto-enforce:** enforcement is active for an org only once it has ≥1 verified domain. Zero verified → warn mode (allow + audit + nudge). Verifying the first domain turns the refuse-on-unverified gate on for that org — self-serve, no flag day.
+   - Orgs that never verify behave as today plus nudges; #1671 still blocks the high-value takeover for them.
+3. **Operator override:** `SSO_DOMAIN_VERIFICATION_STRICT` (default off) forces enforce-everywhere.
+
+Rationale for not hard-enforcing day 1: with no domains verified, every auto-provisioning org would break instantly.
+
+### Periodic re-check (BullMQ)
+
+A scheduled `ssoDomainReverify` job (cadence ~daily) re-resolves TXT for `verified_at IS NOT NULL` domains, updates `last_checked_at`; on a miss, writes an audit event + notifies `sso:admin` holders ("TXT record for <domain> no longer found") but does **not** unverify (sticky). Follows existing BullMQ patterns; jobId uses `-` separators (colon-count rule).
+
+### Admin UI (`apps/web`, extends `SsoProviderForm` / `SsoProvidersPage`)
+
+- "Verified domains" panel: add-domain → show the TXT record + token to copy; **Verify** button (`POST /sso/domains/:id/verify`); status badges (Pending / Verified / record-missing); delete.
+- Non-blocking banner in warn mode (zero verified): "SSO provisioning isn't domain-restricted yet — verify a domain to harden it."
+- `sso:admin`-gated controls (hidden/disabled for non-holders).
+
+### Plan B tests
+
+- **Service unit:** token gen; `verifyDomain` match / no-match / DNS-error→not-verified; `isDomainVerifiedForOrg` true/false; tokens per-`(org, domain)` (one org can't satisfy another's challenge).
+- **Routes:** `sso:admin` 403 gate; org-scoping (can't manage another org's domains); create→verify happy path.
+- **Callback:** provision in a **verified** domain → succeeds; provision in an **unverified** domain with the org **enforcing** → `sso_domain_unverified`; same in **warn mode** (zero verified) → allowed + audit; already-linked `(provider, sub)` → unaffected regardless.
+- **Migration:** seeding pending rows from `allowedDomains`; migration-ordering (`autoMigrate.test`).
+- **RLS:** `sso_verified_domains` cross-org forge rejected; added to `rls-coverage` allowlist.
+
+---
+
+## Error/edge handling
+
+- DNS resolution failure / timeout → treated as not-verified (fail-safe), surfaced to the admin as "couldn't find the record yet."
+- Duplicate domain for an org → `UNIQUE(org_id, domain)` conflict returned as a clean 409.
+- Domain normalization: lowercase, strip whitespace/trailing dot; reject obviously invalid inputs (no `@`, must have a dot). Public-suffix-only domains (e.g. `gmail.com`) are allowed to be *attempted* but won't verify (no TXT control) — no special-casing needed.
+- Pre-auth callback DB reads run under `withSystemDbAccessContext` (the established SSO-callback pattern), same as the existing provider/user lookups.
+
+## Open questions / future knobs
+
+- Auto-unverify after N consecutive re-check misses (off by default).
+- Email-to-postmaster verification as an alternative method (deferred; DNS-only for v1).


### PR DESCRIPTION
Design spec (no code) for the **last deferred security-review-#2 item** — the SSO H-2 root cause.

## Context
Review #2 (Core authentication) found that a malicious/compromised org-admin could point their org's OIDC provider at an attacker IdP and impersonate co-members by asserting their email. The exploitable + steady-state parts shipped in **#1655 / #1671 / #1677 / #1680**. #1671 (identity-first + safe JIT linking) neutralized the *steady-state* takeover; this spec covers the **root-cause hardening**: prove you own a domain before SSO provisions/links an email in it, and make IdP config a distinct `sso:admin` capability.

## What's specced
- **DNS-TXT domain verification** (`sso_verified_domains` table) gating SSO **provisioning / JIT-linking** only — already-linked `(provider, sub)` users are never domain-checked.
- **`sso:admin` permission** for provider create/update/activate + domain management; **backfilled to all `orgs:write` holders** (non-breaking).
- **Per-org auto-enforce rollout**: warn mode until an org verifies its first domain, then refuse-on-unverified — no flag day. Global `SSO_DOMAIN_VERIFICATION_STRICT` override.
- **Sticky** verification + a daily BullMQ re-check that audits drift without auto-unverifying.
- Two implementation plans (A: gating, B: verification), built A then B.

Spec: `docs/superpowers/specs/2026-06-20-sso-domain-ownership-design.md`. Please review before I turn it into an implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)