### PR TITLE
fix(agents): require agent-role token for 5 more posture-ingest routes (F8)

### DIFF
--- a/apps/api/src/routes/agents/bootPerformance.test.ts
+++ b/apps/api/src/routes/agents/bootPerformance.test.ts
@@ -43,6 +43,12 @@ describe('agent boot performance route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     app = new Hono();
+    // Simulate agentAuthMiddleware setting the main-agent credential so the
+    // requireAgentRole guard on bootPerformanceRoutes lets ingest tests through.
+    app.use('*', async (c, next) => {
+      c.set('agent', { deviceId: 'dev-1', agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', role: 'agent' } as never);
+      return next();
+    });
     app.route('/agents', bootPerformanceRoutes);
   });
 
@@ -90,3 +96,18 @@ describe('agent boot performance route', () => {
   });
 });
 
+
+describe('boot-performance ingest — requireAgentRole gate (F8)', () => {
+  it('rejects a watchdog-role token with 403', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('agent', { deviceId: 'dev-1', agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', role: 'watchdog' } as never);
+      return next();
+    });
+    app.route('/agents', bootPerformanceRoutes);
+    const res = await app.request('/agents/dev-1/boot-performance', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/agents/bootPerformance.ts
+++ b/apps/api/src/routes/agents/bootPerformance.ts
@@ -4,8 +4,12 @@ import { db } from '../../db';
 import { devices, deviceBootMetrics } from '../../db/schema';
 import { normalizeStartupItems } from '../../services/startupItems';
 import { sanitizeTimestamp } from './helpers';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 export const bootPerformanceRoutes = new Hono();
+// Boot-performance ingest is the main agent's job; reject watchdog-role tokens
+// so a weaker credential can't falsify operator-facing boot posture (F8).
+bootPerformanceRoutes.use('*', requireAgentRole);
 
 const MAX_BOOT_RECORDS_PER_DEVICE = 30;
 

--- a/apps/api/src/routes/agents/eventlogs.test.ts
+++ b/apps/api/src/routes/agents/eventlogs.test.ts
@@ -113,6 +113,12 @@ describe('agent event log routes', () => {
     vi.setSystemTime(new Date('2026-05-02T12:00:00.000Z'));
 
     app = new Hono();
+    // Simulate agentAuthMiddleware setting the main-agent credential so the
+    // requireAgentRole guard on eventLogsRoutes lets ingest tests through.
+    app.use('*', async (c, next) => {
+      c.set('agent', { deviceId: 'dev-1', agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', role: 'agent' } as never);
+      return next();
+    });
     app.route('/agents', eventLogsRoutes);
 
     mocks.getDeviceEventLogSettings.mockResolvedValue({
@@ -168,5 +174,20 @@ describe('agent event log routes', () => {
         ],
       })
     );
+  });
+});
+
+describe('eventlogs ingest — requireAgentRole gate (F8)', () => {
+  it('rejects a watchdog-role token with 403', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('agent', { deviceId: 'dev-1', agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', role: 'watchdog' } as never);
+      return next();
+    });
+    app.route('/agents', eventLogsRoutes);
+    const res = await app.request('/agents/dev-1/eventlogs', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/api/src/routes/agents/eventlogs.ts
+++ b/apps/api/src/routes/agents/eventlogs.ts
@@ -10,6 +10,7 @@ import { submitEventLogsSchema } from './schemas';
 import { getDeviceEventLogSettings, EVENT_LOG_DEFAULTS, sanitizeTimestamp, type EventLogSettings } from './helpers';
 import { enqueueLogForwarding } from '../../jobs/logForwardingWorker';
 import { getOrgForwardingConfig } from '../../services/logForwarding';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 const LEVEL_ORDER: Record<string, number> = {
   info: 0,
@@ -58,6 +59,9 @@ function mergeEventDetails(
 }
 
 export const eventLogsRoutes = new Hono();
+// Event-log ingest is the main agent's job; reject watchdog-role tokens so a
+// weaker credential can't falsify operator-facing event-log posture (F8).
+eventLogsRoutes.use('*', requireAgentRole);
 
 eventLogsRoutes.put('/:id/eventlogs', zValidator('json', submitEventLogsSchema), async (c) => {
   const agentId = c.req.param('id');

--- a/apps/api/src/routes/agents/peripherals.test.ts
+++ b/apps/api/src/routes/agents/peripherals.test.ts
@@ -86,7 +86,7 @@ describe('agent peripheral ingest', () => {
     vi.clearAllMocks();
     app = new Hono();
     app.use('*', async (c: any, next: any) => {
-      c.set('agent', { orgId: 'org-1', agentId: 'agent-1' });
+      c.set('agent', { orgId: 'org-1', agentId: 'agent-1', role: 'agent' });
       await next();
     });
     app.route('/agents', peripheralRoutes);
@@ -190,7 +190,7 @@ describe('agent peripheral ingest', () => {
     // Agent has orgId 'org-A' but device belongs to 'org-B'
     const orgMismatchApp = new Hono();
     orgMismatchApp.use('*', async (c: any, next: any) => {
-      c.set('agent', { orgId: 'org-A', agentId: 'agent-1' });
+      c.set('agent', { orgId: 'org-A', agentId: 'agent-1', role: 'agent' });
       await next();
     });
     orgMismatchApp.route('/agents', peripheralRoutes);
@@ -295,5 +295,20 @@ describe('agent peripheral ingest', () => {
         blockedPublishFailures: 0,
       },
     });
+  });
+});
+
+describe('peripheral-event ingest — requireAgentRole gate (F8)', () => {
+  it('rejects a watchdog-role token with 403', async () => {
+    const app = new Hono();
+    app.use('*', async (c: any, next: any) => {
+      c.set('agent', { deviceId: 'dev-1', agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', role: 'watchdog' });
+      await next();
+    });
+    app.route('/agents', peripheralRoutes);
+    const res = await app.request('/agents/dev-1/peripherals/events', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/api/src/routes/agents/peripherals.ts
+++ b/apps/api/src/routes/agents/peripherals.ts
@@ -11,6 +11,7 @@ import {
 } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { publishEvent } from '../../services/eventBus';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 const submitPeripheralEventsSchema = z.object({
   events: z.array(z.object({
@@ -27,6 +28,9 @@ const submitPeripheralEventsSchema = z.object({
 });
 
 export const peripheralRoutes = new Hono();
+// Peripheral-event ingest is the main agent's job; reject watchdog-role tokens
+// so a weaker credential can't falsify operator-facing peripheral/USB posture (F8).
+peripheralRoutes.use('*', requireAgentRole);
 
 peripheralRoutes.put('/:id/peripherals/events', zValidator('json', submitPeripheralEventsSchema), async (c) => {
   const agentId = c.req.param('id');

--- a/apps/api/src/routes/agents/processSample.test.ts
+++ b/apps/api/src/routes/agents/processSample.test.ts
@@ -69,3 +69,18 @@ describe('POST /:id/process-sample', () => {
     expect(res.status).toBe(403);
   });
 });
+
+describe('process-sample ingest — requireAgentRole gate (F8)', () => {
+  it('rejects a watchdog-role token with 403', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('agent', { deviceId: 'dev-1', agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', role: 'watchdog' } as never);
+      return next();
+    });
+    app.route('/', processSampleRoutes);
+    const res = await app.request('/dev-1/process-sample', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/agents/processSample.ts
+++ b/apps/api/src/routes/agents/processSample.ts
@@ -4,9 +4,13 @@ import { bodyLimit } from 'hono/body-limit';
 import { db } from '../../db';
 import { deviceProcessSamples } from '../../db/schema';
 import { type AgentAuthContext } from '../../middleware/agentAuth';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 import { processSampleSchema } from './schemas';
 
 export const processSampleRoutes = new Hono();
+// Process-sample ingest is the main agent's job; reject watchdog-role tokens so
+// a weaker credential can't falsify operator-facing process posture (F8).
+processSampleRoutes.use('*', requireAgentRole);
 
 processSampleRoutes.post(
   '/:id/process-sample',

--- a/apps/api/src/routes/agents/reliability.test.ts
+++ b/apps/api/src/routes/agents/reliability.test.ts
@@ -178,3 +178,18 @@ describe('agent reliability ingestion route', () => {
     expect(body).toEqual({ success: true, status: 'received' });
   });
 });
+
+describe('reliability ingest — requireAgentRole gate (F8)', () => {
+  it('rejects a watchdog-role token with 403', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('agent', { deviceId: 'dev-1', agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', role: 'watchdog' } as never);
+      return next();
+    });
+    app.route('/agents', reliabilityRoutes);
+    const res = await app.request('/agents/dev-1/reliability', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/agents/reliability.ts
+++ b/apps/api/src/routes/agents/reliability.ts
@@ -10,8 +10,12 @@ import { writeAuditEvent } from '../../services/auditEvents';
 import { computeAndPersistDeviceReliability } from '../../services/reliabilityScoring';
 import { captureException } from '../../services/sentry';
 import { sanitizeTimestamp } from './helpers';
+import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 export const reliabilityRoutes = new Hono();
+// Reliability-metric ingest is the main agent's job; reject watchdog-role
+// tokens so a weaker credential can't falsify operator-facing device posture (F8).
+reliabilityRoutes.use('*', requireAgentRole);
 
 reliabilityRoutes.post('/:id/reliability', zValidator('json', reliabilityMetricsSchema), async (c) => {
   const agentId = c.req.param('id');


### PR DESCRIPTION
## Summary

Follow-up to #1687 (F3), found during that PR's completeness review. The same watchdog-role least-privilege gap applies to **five more main-agent-only posture-ingest routes** that authenticated the credential but never checked its role:

- `POST /:id/reliability` — device reliability metrics
- `PUT /:id/eventlogs` — system event logs
- `POST /:id/process-sample` — running-process snapshots
- `PUT /:id/peripherals/events` — peripheral (USB) block/attach events
- `POST /:id/boot-performance` — boot metrics

A watchdog token — meant for monitoring + heartbeat — could submit any of these and falsify operator-facing device posture.

## Fix

Apply the existing `requireAgentRole` guard (the #1021 / #1687 pattern) to all five route groups. Add a watchdog-403 regression test to each, and set the main-agent credential in the existing ingest tests so they exercise the guard.

**Deliberately NOT gating `logs.ts` (`POST /:id/logs`):** the watchdog legitimately ships failover journal entries there (`agent/internal/watchdog/failover.go` `ShipLogs`, sets `X-Breeze-Role: watchdog`). Verified the watchdog failover client otherwise only hits heartbeat, command fetch/result, and logs — none of the five routes here — so gating these five is safe while `logs.ts` must stay open.

## Verification
- Watchdog-403 tests proven non-vacuous: all five fail with the guard removed, pass with it.
- `vitest run src/routes/agents/ routeScan.test.ts` → 334 passed. API type check clean.

## Rollout
Low risk — the watchdog never legitimately submitted these (the main agent owns them, like inventory/state/sessions in #1021). No real workflow affected; no agent-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)