### PR TITLE
fix(web): neutralize CSV formula injection in fleet log export

### DIFF
--- a/apps/web/src/components/logs/LogSearch.tsx
+++ b/apps/web/src/components/logs/LogSearch.tsx
@@ -3,6 +3,7 @@ import { Download, Save, Search } from 'lucide-react';
 
 import { fetchWithAuth } from '../../stores/auth';
 import { formatDateTime } from '@/lib/dateTimeFormat';
+import { toCsv } from '@/lib/csvExport';
 
 type EventLogRow = {
   log: {
@@ -47,11 +48,6 @@ const LEVELS: Array<{ value: EventLogRow['log']['level']; label: string }> = [
 function toDatetimeLocalInput(date: Date): string {
   const offsetMs = date.getTimezoneOffset() * 60_000;
   return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
-}
-
-function escapeCsv(value: string): string {
-  const escaped = value.replaceAll('"', '""');
-  return `"${escaped}"`;
 }
 
 export default function LogSearch() {
@@ -204,9 +200,9 @@ export default function LogSearch() {
       row.site?.name ?? '',
     ]);
 
-    const csv = [header, ...rows]
-      .map((line) => line.map((value) => escapeCsv(String(value))).join(','))
-      .join('\n');
+    // Neutralize spreadsheet-formula injection from agent-supplied fields
+    // (message/source/category/hostname) before quoting (F7).
+    const csv = toCsv(header, rows);
 
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
     const url = URL.createObjectURL(blob);

--- a/apps/web/src/components/reports/reportExport.ts
+++ b/apps/web/src/components/reports/reportExport.ts
@@ -1,28 +1,17 @@
 import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import { formatDateTime } from '@/lib/dateTimeFormat';
+import { escapeCsvCell, escapeTsvCell, neutralizeSpreadsheetFormula } from '@/lib/csvExport';
+
+// Re-export the shared CSV helpers so existing importers of these names from
+// './reportExport' keep working; the canonical definitions now live in
+// lib/csvExport (jsPDF-free so non-report exporters don't bundle a PDF library).
+export { escapeCsvCell, escapeTsvCell, neutralizeSpreadsheetFormula };
 
 /** Convert an unknown cell value to a display string. */
 function cellToString(value: unknown): string {
   if (value === null || value === undefined) return '';
   return String(value);
-}
-
-const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '\r', '\n']);
-
-export function neutralizeSpreadsheetFormula(value: string): string {
-  if (value.length === 0) return value;
-  return FORMULA_PREFIXES.has(value[0]!) ? `'${value}` : value;
-}
-
-export function escapeCsvCell(value: string): string {
-  const safe = neutralizeSpreadsheetFormula(value);
-  return `"${safe.replace(/"/g, '""')}"`;
-}
-
-export function escapeTsvCell(value: string): string {
-  const safe = neutralizeSpreadsheetFormula(value);
-  return /[\t\r\n"]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
 }
 
 /** Extract column headers and string[][] body from raw row objects. */

--- a/apps/web/src/lib/csvExport.test.ts
+++ b/apps/web/src/lib/csvExport.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { escapeCsvCell, escapeTsvCell, neutralizeSpreadsheetFormula, toCsv } from './csvExport';
+
+describe('csvExport spreadsheet-injection safety', () => {
+  it.each(['=cmd', '+cmd', '-cmd', '@cmd', '\tcmd', '\rcmd', '\ncmd'])(
+    'neutralizes spreadsheet formula prefix %j',
+    (value) => {
+      expect(neutralizeSpreadsheetFormula(value)).toBe(`'${value}`);
+      expect(escapeCsvCell(value)).toBe(`"'${value}"`);
+    },
+  );
+
+  it('leaves benign values unprefixed', () => {
+    expect(neutralizeSpreadsheetFormula('host-1')).toBe('host-1');
+    expect(neutralizeSpreadsheetFormula('')).toBe('');
+    expect(escapeCsvCell('host-1')).toBe('"host-1"');
+  });
+
+  it('escapes embedded quotes after neutralization', () => {
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvCell('=HYPERLINK("http://evil")')).toBe('"\'=HYPERLINK(""http://evil"")"');
+  });
+
+  it('quotes TSV cells only when they contain separators', () => {
+    expect(escapeTsvCell('\tcmd')).toBe('"\'\tcmd"');
+    expect(escapeTsvCell('host-1')).toBe('host-1');
+  });
+
+  describe('toCsv (fleet event-log export)', () => {
+    it('neutralizes agent-supplied fields that would be spreadsheet formulas', () => {
+      const header = ['Timestamp', 'Level', 'Source', 'Message'];
+      const rows = [
+        ['2026-06-20T00:00:00Z', 'critical', 'Security', '=cmd|"/c calc"!A1'],
+        ['2026-06-20T00:01:00Z', 'info', '+SUM(A1)', 'normal message'],
+      ];
+      const csv = toCsv(header, rows);
+      const lines = csv.split('\n');
+
+      // Header row is quoted but otherwise unchanged.
+      expect(lines[0]).toBe('"Timestamp","Level","Source","Message"');
+      // The malicious message is prefixed with a single quote and quotes doubled.
+      expect(lines[1]).toContain('"\'=cmd|""/c calc""!A1"');
+      // The malicious source field is neutralized too.
+      expect(lines[2]).toContain('"\'+SUM(A1)"');
+    });
+
+    it('coerces null/undefined/number cells without throwing', () => {
+      const csv = toCsv(['A', 'B', 'C'], [[null, undefined, 42]]);
+      expect(csv).toBe('"A","B","C"\n"","","42"');
+    });
+  });
+});

--- a/apps/web/src/lib/csvExport.ts
+++ b/apps/web/src/lib/csvExport.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared CSV/TSV cell helpers with spreadsheet-formula-injection neutralization.
+ *
+ * Kept free of heavy deps (no jsPDF) so any component that exports a CSV can
+ * import these without pulling a PDF bundle into its chunk. `reportExport.ts`
+ * re-exports these for back-compat.
+ */
+
+const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '\r', '\n']);
+
+/**
+ * Neutralize a value that a spreadsheet would otherwise interpret as a formula
+ * by prefixing a single quote when it starts with a dangerous character. This
+ * is the standard CSV-injection mitigation for fields that may carry
+ * attacker-influenced content (e.g. agent-supplied event-log text).
+ */
+export function neutralizeSpreadsheetFormula(value: string): string {
+  if (value.length === 0) return value;
+  return FORMULA_PREFIXES.has(value[0]!) ? `'${value}` : value;
+}
+
+/** Neutralize then RFC-4180-quote a CSV cell. */
+export function escapeCsvCell(value: string): string {
+  const safe = neutralizeSpreadsheetFormula(value);
+  return `"${safe.replace(/"/g, '""')}"`;
+}
+
+/** Neutralize then quote a TSV cell only when it contains tab/quote/newline. */
+export function escapeTsvCell(value: string): string {
+  const safe = neutralizeSpreadsheetFormula(value);
+  return /[\t\r\n"]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
+}
+
+/**
+ * Serialize a header row + body rows to a CSV string, neutralizing every cell.
+ * Cells are coerced to strings first.
+ */
+export function toCsv(header: string[], rows: Array<Array<string | number | null | undefined>>): string {
+  return [header, ...rows]
+    .map((line) => line.map((value) => escapeCsvCell(String(value ?? ''))).join(','))
+    .join('\n');
+}


### PR DESCRIPTION
## Summary

The fleet event-log CSV export (`LogSearch`) doubled embedded quotes but did **not** neutralize spreadsheet formulas. Agent-supplied fields — `message`, `source`, `category`, hostname — that start with `=`, `+`, `-`, `@`, tab, CR or LF would execute as formulas when an operator opens the exported CSV in Excel/Google Sheets (CSV formula/DDE injection).

## Fix

The codebase already had a correct neutralizer (`neutralizeSpreadsheetFormula` / `escapeCsvCell`) but it lived in `reportExport.ts`, which top-level imports `jsPDF` — so importing it into `LogSearch` would have pulled a PDF library into that chunk.

- Extract the helpers into a jsPDF-free `apps/web/src/lib/csvExport.ts` (single source of truth) and add a `toCsv(header, rows)` serializer.
- Route the log export through `toCsv`; delete the local quote-only `escapeCsv`.
- `reportExport.ts` now re-exports the helpers, so its existing importers and `reportExport.test.ts` are unaffected.

## Verification
- New `csvExport.test.ts`: every dangerous prefix (`=`,`+`,`-`,`@`,`\t`,`\r`,`\n`), quote escaping, the `toCsv` fleet-log path with a `=cmd|"/c calc"!A1` payload, and null/number coercion. `reportExport.test.ts` still green (20 tests across both).
- `eslint` clean; `astro check` → 0 errors.

## Rollout
No behavior change for legitimate data — only cells that *start* with a formula character get a leading `'` in the exported file. No API/agent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)