### PR TITLE
feat(security): SSO domain verification (review #2 H-2, defense-in-depth) — backend

### DIFF
--- a/apps/api/migrations/2026-06-26-sso-verified-domains.sql
+++ b/apps/api/migrations/2026-06-26-sso-verified-domains.sql
@@ -28,8 +28,12 @@ END $$;
 DO $$
 DECLARE n integer;
 BEGIN
+  -- Built-in token (pgcrypto's gen_random_bytes is NOT installed — only pg_trgm
+  -- is; gen_random_uuid is PG core). Two dash-stripped UUIDs = 64 hex chars.
+  -- Seeded pending rows only; the app mints real tokens via crypto.randomBytes.
   INSERT INTO sso_verified_domains (org_id, domain, verification_token)
-  SELECT DISTINCT p.org_id, lower(trim(d.domain)), encode(gen_random_bytes(24), 'hex')
+  SELECT DISTINCT p.org_id, lower(trim(d.domain)),
+    replace(gen_random_uuid()::text, '-', '') || replace(gen_random_uuid()::text, '-', '')
   FROM sso_providers p
   CROSS JOIN LATERAL unnest(string_to_array(coalesce(p.allowed_domains, ''), ',')) AS d(domain)
   WHERE trim(d.domain) <> ''

--- a/apps/api/migrations/2026-06-26-sso-verified-domains.sql
+++ b/apps/api/migrations/2026-06-26-sso-verified-domains.sql
@@ -1,0 +1,39 @@
+-- Security review #2 (H-2, Plan B): org-scoped verified domains for SSO. An org
+-- proves DNS ownership before SSO may provision/JIT-link an email in it. RLS
+-- shape 1 (direct org_id). Idempotent.
+CREATE TABLE IF NOT EXISTS sso_verified_domains (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  domain varchar(253) NOT NULL,
+  verification_token varchar(128) NOT NULL,
+  verified_at timestamp,
+  last_checked_at timestamp,
+  created_by uuid REFERENCES users(id),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS sso_verified_domains_org_domain_idx
+  ON sso_verified_domains (org_id, domain);
+
+ALTER TABLE sso_verified_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sso_verified_domains FORCE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='sso_verified_domains' AND policyname='sso_verified_domains_org_isolation') THEN
+    CREATE POLICY sso_verified_domains_org_isolation ON sso_verified_domains
+      USING (public.breeze_has_org_access(org_id))
+      WITH CHECK (public.breeze_has_org_access(org_id));
+  END IF;
+END $$;
+
+DO $$
+DECLARE n integer;
+BEGIN
+  INSERT INTO sso_verified_domains (org_id, domain, verification_token)
+  SELECT DISTINCT p.org_id, lower(trim(d.domain)), encode(gen_random_bytes(24), 'hex')
+  FROM sso_providers p
+  CROSS JOIN LATERAL unnest(string_to_array(coalesce(p.allowed_domains, ''), ',')) AS d(domain)
+  WHERE trim(d.domain) <> ''
+  ON CONFLICT (org_id, domain) DO NOTHING;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'seeded % pending sso_verified_domains from allowed_domains', n; END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/ssoVerifiedDomainsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoVerifiedDomainsRls.integration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Cross-org RLS forge tests for sso_verified_domains (security review #2, H-2).
+ *
+ * Migration under test: 2026-06-26-sso-verified-domains.sql.
+ * RLS shape 1: direct org_id, USING + WITH CHECK on breeze_has_org_access(org_id).
+ *
+ * The rls-coverage contract test only proves the policies exist in pg_catalog; it
+ * does NOT prove a real cross-tenant insert is rejected at runtime. This file is
+ * the behavioral guard: it runs code-under-test as the unprivileged `breeze_app`
+ * role (rolbypassrls=f) so RLS is actually enforced, and asserts that a forged
+ * write for another org is denied (42501) and that another org's rows are invisible.
+ *
+ * Fixture topology (seeded fresh per test under system scope):
+ *   partnerA → orgA   (the caller's tenant)
+ *   partnerB → orgB   (the foreign tenant)
+ *   domainB           = a sso_verified_domains row under orgB (hidden-SELECT case)
+ *
+ * No memoization: setup.ts's beforeEach cleanupDatabase() TRUNCATEs
+ * partners/organizations CASCADE before every test, cascading through the FKs.
+ * A module-level fixture cache would hand later tests rows that no longer exist,
+ * making cross-tenant assertions vacuous (matching the pattern of quotes-rls and
+ * catalog-rls integration tests).
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import { ssoVerifiedDomains } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+interface Fixture {
+  partnerA: { id: string };
+  orgA: { id: string };
+  partnerB: { id: string };
+  orgB: { id: string };
+  /** A sso_verified_domains row owned by orgB (seeded under system scope). */
+  domainB: { id: string };
+  /** breeze_app context scoped to org A (mirrors authMiddleware org scope). */
+  orgAContext: DbAccessContext;
+}
+
+// Re-seeds fresh on every call. Intentionally NOT memoized: setup.ts's
+// beforeEach cleanupDatabase() TRUNCATEs partners/organizations CASCADE before
+// each test, so any cached rows would already be deleted by the time an
+// assertion runs — which would silently make every cross-tenant case vacuous.
+async function seedFixture(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+
+    // A verified domain row owned by orgB, written under system scope (bypasses
+    // RLS for the seed). The hidden-SELECT case proves an orgA caller cannot see it.
+    const [domainB] = await db
+      .insert(ssoVerifiedDomains)
+      .values({
+        orgId: orgB.id,
+        domain: 'orgb-example.com',
+        verificationToken: 'seed-token-for-orgb-domain',
+      })
+      .returning({ id: ssoVerifiedDomains.id });
+    if (!domainB) throw new Error('failed to seed orgB verified domain');
+
+    // Org-scoped breeze_app context for org A. sso_verified_domains is org-axis
+    // RLS, so the accessible-org axis must list orgA for the breeze_app
+    // insert/select to pass — this mirrors how request middleware populates an
+    // org-scoped ctx.
+    const orgAContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [partnerA.id],
+      userId: null,
+    };
+
+    return {
+      partnerA: { id: partnerA.id },
+      orgA: { id: orgA.id },
+      partnerB: { id: partnerB.id },
+      orgB: { id: orgB.id },
+      domainB: { id: domainB.id },
+      orgAContext,
+    };
+  });
+}
+
+describe('sso_verified_domains RLS isolation (breeze_app)', () => {
+  // (0) Non-vacuity guard: the pool that code-under-test runs on inside
+  // withDbAccessContext must be the unprivileged breeze_app role with
+  // rolbypassrls=f. If this is ever a BYPASSRLS connection, every assertion
+  // below would pass even with broken policies — so fail loudly here first.
+  runDb('code-under-test runs as a non-BYPASSRLS role (guards against vacuous RLS)', async () => {
+    const fx = await seedFixture();
+    const rows = await withDbAccessContext(fx.orgAContext, () =>
+      db.execute(sql`SELECT current_user AS who, rolbypassrls
+                     FROM pg_roles WHERE rolname = current_user`)
+    );
+    const row = (rows as unknown as Array<{ who: string; rolbypassrls: boolean }>)[0];
+    expect(row?.who).toBe('breeze_app');
+    expect(row?.rolbypassrls).toBe(false);
+  });
+
+  // (1) Cross-tenant INSERT denied. Under an orgA-scoped breeze_app context, a
+  // raw insert of a domain row for orgB is rejected by the INSERT WITH CHECK
+  // policy (42501). Drizzle wraps the driver error; the original Postgres error
+  // is carried on `cause`. We assert cause.code=42501 (not a FK 23503) to prove
+  // RLS WITH CHECK is the gate — orgB is a real seeded org, so its FK resolves.
+  runDb('blocks a forged cross-tenant sso_verified_domains INSERT for another org (42501)', async () => {
+    const fx = await seedFixture();
+    await expect(
+      withDbAccessContext(fx.orgAContext, () =>
+        db.insert(ssoVerifiedDomains).values({
+          orgId: fx.orgB.id, // foreign org — RLS WITH CHECK must reject
+          domain: 'forged-domain.example.com',
+          verificationToken: 'forged-token',
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  // (2) Cross-tenant SELECT hidden. orgB's domain row is invisible to an orgA
+  // caller. The system-scope probe first confirms the row really exists (so a
+  // 0-row read under orgA is meaningfully "RLS hid it", not "it was never
+  // created") — this guards against a vacuous hidden-row test.
+  runDb('hides another org domain row from SELECT (system probe confirms it exists)', async () => {
+    const fx = await seedFixture();
+
+    // Probe: under system scope (RLS-bypassing) the orgB domain row is present.
+    const existsUnderSystem = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: ssoVerifiedDomains.id })
+        .from(ssoVerifiedDomains)
+        .where(eq(ssoVerifiedDomains.id, fx.domainB.id))
+    );
+    expect(existsUnderSystem).toHaveLength(1);
+
+    // Under orgA breeze_app context the same id returns 0 rows — RLS hides it.
+    const visibleToA = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .select({ id: ssoVerifiedDomains.id })
+        .from(ssoVerifiedDomains)
+        .where(eq(ssoVerifiedDomains.id, fx.domainB.id))
+    );
+    expect(visibleToA).toHaveLength(0);
+  });
+
+  // (3) Same-tenant happy path. Under orgA context, inserting + selecting orgA's
+  // own domain row succeeds. This proves the policy is not simply deny-everything
+  // (which would make cases 1/2 pass for the wrong reason).
+  runDb('allows inserting + selecting a verified domain within the caller org', async () => {
+    const fx = await seedFixture();
+
+    const [inserted] = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .insert(ssoVerifiedDomains)
+        .values({
+          orgId: fx.orgA.id,
+          domain: 'orga-example.com',
+          verificationToken: 'valid-token-for-orga',
+        })
+        .returning({ id: ssoVerifiedDomains.id, orgId: ssoVerifiedDomains.orgId })
+    );
+    expect(inserted?.orgId).toBe(fx.orgA.id);
+
+    const fetched = await withDbAccessContext(fx.orgAContext, () =>
+      db
+        .select({ id: ssoVerifiedDomains.id })
+        .from(ssoVerifiedDomains)
+        .where(eq(ssoVerifiedDomains.id, inserted!.id))
+    );
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0]?.id).toBe(inserted!.id);
+  });
+});

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -407,6 +407,11 @@ const envSchema = z
     // self-hosted operator may deliberately run 2FA-off).
     ENABLE_2FA: z.string().optional(),
 
+    // SSO domain verification enforcement. When 'true', EVERY org is required to
+    // verify its domain before SSO login is allowed. When unset or 'false', enforcement
+    // is gradual: only orgs that already have a verified domain are gated.
+    SSO_DOMAIN_VERIFICATION_STRICT: z.string().optional(),
+
     // OAuth Dynamic Client Registration (DCR) hardening. Both default OFF.
     // See env.ts and provider.ts for the runtime read-paths; the
     // production-only validation in superRefine refuses boot when

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, uniqueIndex } from 'drizzle-orm/pg-core';
 import { organizations } from './orgs';
 import { users } from './users';
 
@@ -94,3 +94,20 @@ export const ssoSessions = pgTable('sso_sessions', {
   expiresAt: timestamp('expires_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull()
 });
+
+// SSO Verified Domains — org proves DNS ownership before JIT-provisioning is
+// allowed for addresses in the domain (security review #2, H-2, Plan B).
+// RLS shape 1: direct org_id, breeze_has_org_access(org_id).
+export const ssoVerifiedDomains = pgTable('sso_verified_domains', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  domain: varchar('domain', { length: 253 }).notNull(),
+  verificationToken: varchar('verification_token', { length: 128 }).notNull(),
+  verifiedAt: timestamp('verified_at'),
+  lastCheckedAt: timestamp('last_checked_at'),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  orgDomainUnique: uniqueIndex('sso_verified_domains_org_domain_idx').on(t.orgId, t.domain),
+}));

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -214,6 +214,7 @@ import { initializeDrExecutionWorker, shutdownDrExecutionWorker } from './jobs/d
 import { initializeRecoveryMediaWorker, shutdownRecoveryMediaWorker } from './jobs/recoveryMediaWorker';
 import { initializeRecoveryBootMediaWorker, shutdownRecoveryBootMediaWorker } from './jobs/recoveryBootMediaWorker';
 import { initializeWarrantyWorker, shutdownWarrantyWorker } from './services/warrantyWorker';
+import { initializeSsoDomainRecheckWorker, shutdownSsoDomainRecheckWorker } from './services/ssoDomainRecheckWorker';
 import { backfillC2cConnectionSecrets } from './services/c2cSecrets';
 import {
   initializeIncidentCorrelationWorker,
@@ -1127,6 +1128,7 @@ async function initializeWorkers(): Promise<void> {
     ['recoveryMediaWorker', initializeRecoveryMediaWorker],
     ['recoveryBootMediaWorker', initializeRecoveryBootMediaWorker],
     ['warrantyWorker', initializeWarrantyWorker],
+    ['ssoDomainRecheckWorker', initializeSsoDomainRecheckWorker],
     ['incidentCorrelationWorker', initializeIncidentCorrelationWorker],
     ['incidentTimelineEnricher', initializeIncidentTimelineEnricher],
     ['incidentSlaMonitor', initializeIncidentSlaMonitor],
@@ -1251,6 +1253,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownSensitiveDataWorkers,
     shutdownPeripheralJobs,
     shutdownWarrantyWorker,
+    shutdownSsoDomainRecheckWorker,
     shutdownBrowserSecurityJobs,
     shutdownIncidentSlaMonitor,
     shutdownIncidentTimelineEnricher,

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -108,6 +108,15 @@ vi.mock('../db/schema', () => ({
     jwksUrl: 'jwksUrl'
   },
   ssoSessions: {},
+  ssoVerifiedDomains: {
+    id: 'id',
+    orgId: 'orgId',
+    domain: 'domain',
+    verificationToken: 'verificationToken',
+    verifiedAt: 'verifiedAt',
+    lastCheckedAt: 'lastCheckedAt',
+    createdAt: 'createdAt',
+  },
   userSsoIdentities: {
     id: 'id',
     userId: 'userId',
@@ -127,6 +136,13 @@ vi.mock('../db/schema', () => ({
     name: 'name',
     scope: 'scope'
   }
+}));
+
+vi.mock('../services/ssoDomainVerification', () => ({
+  createPendingDomain: vi.fn(),
+  verifyDomain: vi.fn(),
+  recordNameFor: vi.fn((domain: string) => `_breeze-verify.${domain}`),
+  recordValueFor: vi.fn((token: string) => `breeze-domain-verify=${token}`),
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -175,6 +191,7 @@ import {
   mapUserAttributes,
   verifyIdTokenSignature,
 } from '../services/sso';
+import { createPendingDomain, verifyDomain } from '../services/ssoDomainVerification';
 
 const PROVIDER_UUID = '00000000-0000-4000-8000-000000000001';
 const ORG_UUID = '00000000-0000-4000-8000-000000000010';
@@ -1171,6 +1188,205 @@ describe('sso routes', () => {
       const res = await doCallback();
       expect(res.status).toBe(302);
       expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ mfa: false }), expect.any(Object));
+    });
+  });
+
+  describe('SSO Domain Verification Routes', () => {
+    const DOMAIN_UUID = '00000000-0000-4000-8000-000000000050';
+    const DOMAIN_TOKEN = 'abc123def456';
+
+    it('POST /domains returns 201 with recordName and recordValue for an authorized sso:admin caller', async () => {
+      vi.mocked(createPendingDomain).mockResolvedValue({
+        id: DOMAIN_UUID,
+        orgId: ORG_UUID,
+        domain: 'example.com',
+        verificationToken: DOMAIN_TOKEN,
+        recordName: `_breeze-verify.example.com`,
+        recordValue: `breeze-domain-verify=${DOMAIN_TOKEN}`,
+        verifiedAt: null,
+      });
+
+      const res = await app.request('/sso/domains', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ domain: 'example.com' }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.id).toBe(DOMAIN_UUID);
+      expect(body.data.domain).toBe('example.com');
+      expect(body.data.recordName).toBe('_breeze-verify.example.com');
+      expect(body.data.recordValue).toBe(`breeze-domain-verify=${DOMAIN_TOKEN}`);
+      expect(body.data.verified).toBe(false);
+      expect(createPendingDomain).toHaveBeenCalledWith({
+        orgId: ORG_UUID,
+        domain: 'example.com',
+        createdBy: USER_UUID,
+      });
+    });
+
+    it('POST /domains returns 403 for a caller without sso:admin permission', async () => {
+      permissionGate.deny = true;
+
+      const res = await app.request('/sso/domains', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ domain: 'example.com' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(createPendingDomain).not.toHaveBeenCalled();
+    });
+
+    it('POST /domains returns 400 when the service throws (invalid domain)', async () => {
+      vi.mocked(createPendingDomain).mockRejectedValue(new Error('Invalid domain: not-a-real-domain'));
+
+      const res = await app.request('/sso/domains', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ domain: 'not-a-real-domain' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid domain');
+    });
+
+    it('POST /domains/:id/verify returns {data:{verified:true}} when the domain exists and DNS check passes', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: DOMAIN_UUID,
+              orgId: ORG_UUID,
+              domain: 'example.com',
+            }]),
+          }),
+        }),
+      } as any);
+
+      vi.mocked(verifyDomain).mockResolvedValue({ verified: true });
+
+      const res = await app.request(`/sso/domains/${DOMAIN_UUID}/verify`, {
+        method: 'POST',
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.verified).toBe(true);
+      expect(verifyDomain).toHaveBeenCalledWith({ orgId: ORG_UUID, domain: 'example.com' });
+    });
+
+    it('POST /domains/:id/verify returns 404 when the domain row does not exist', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/sso/domains/${DOMAIN_UUID}/verify`, {
+        method: 'POST',
+      });
+
+      expect(res.status).toBe(404);
+      expect(verifyDomain).not.toHaveBeenCalled();
+    });
+
+    it('POST /domains/:id/verify returns 403 when canAccessOrg is false', async () => {
+      setAuthContext({ canAccessOrg: () => false });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: DOMAIN_UUID,
+              orgId: ORG_UUID_OTHER,
+              domain: 'example.com',
+            }]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/sso/domains/${DOMAIN_UUID}/verify`, {
+        method: 'POST',
+      });
+
+      expect(res.status).toBe(403);
+      expect(verifyDomain).not.toHaveBeenCalled();
+    });
+
+    it('DELETE /domains/:id returns {data:{deleted:true}} on success', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: DOMAIN_UUID,
+              orgId: ORG_UUID,
+              domain: 'example.com',
+            }]),
+          }),
+        }),
+      } as any);
+
+      vi.mocked(db.delete).mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: DOMAIN_UUID }]),
+        }),
+      } as any);
+
+      const res = await app.request(`/sso/domains/${DOMAIN_UUID}`, {
+        method: 'DELETE',
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.deleted).toBe(true);
+    });
+
+    it('DELETE /domains/:id returns 404 when the domain row does not exist', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/sso/domains/${DOMAIN_UUID}`, {
+        method: 'DELETE',
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('GET /domains lists domains with recordName and recordValue for the org', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            id: DOMAIN_UUID,
+            domain: 'example.com',
+            verificationToken: DOMAIN_TOKEN,
+            verifiedAt: null,
+            lastCheckedAt: null,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          }]),
+        }),
+      } as any);
+
+      const res = await app.request('/sso/domains', {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].domain).toBe('example.com');
+      expect(body.data[0].verified).toBe(false);
+      expect(body.data[0].recordName).toBeDefined();
+      expect(body.data[0].recordValue).toBeDefined();
     });
   });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -143,6 +143,7 @@ vi.mock('../services/ssoDomainVerification', () => ({
   verifyDomain: vi.fn(),
   recordNameFor: vi.fn((domain: string) => `_breeze-verify.${domain}`),
   recordValueFor: vi.fn((token: string) => `breeze-domain-verify=${token}`),
+  isSsoProvisioningBlocked: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -191,7 +192,7 @@ import {
   mapUserAttributes,
   verifyIdTokenSignature,
 } from '../services/sso';
-import { createPendingDomain, verifyDomain } from '../services/ssoDomainVerification';
+import { createPendingDomain, verifyDomain, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
 
 const PROVIDER_UUID = '00000000-0000-4000-8000-000000000001';
 const ORG_UUID = '00000000-0000-4000-8000-000000000010';
@@ -1188,6 +1189,52 @@ describe('sso routes', () => {
       const res = await doCallback();
       expect(res.status).toBe(302);
       expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ mfa: false }), expect.any(Object));
+    });
+
+    // ── security review #2 (H-2): SSO domain-verification gate wiring
+    // These tests verify that the gate (isSsoProvisioningBlocked) is correctly
+    // wired into the callback handler. The decision logic is unit-tested
+    // exhaustively in ssoDomainVerification.test.ts; here we only test the
+    // wiring: that a blocked domain redirects correctly and doesn't provision,
+    // and that an already-linked identity bypasses the gate entirely.
+    it('redirects to sso_domain_unverified when isSsoProvisioningBlocked returns true for an unmatched identity', async () => {
+      primeCallback();
+      vi.mocked(isSsoProvisioningBlocked).mockResolvedValue(true);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel(PROVIDER_ROW))
+        .mockReturnValueOnce(sel([])) // no (provider, sub) link → user is null → gate is evaluated
+        .mockReturnValueOnce(sel([])); // user-by-id lookup for the identity-first block (the second withSystemDbAccessContext call for users)
+
+      const res = await doCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_domain_unverified');
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('does NOT invoke the gate (and succeeds) when the identity is already linked by provider+sub', async () => {
+      // Already-linked users resolve in the identity-first lookup, so user is non-null
+      // before the gate. The gate is inside `if (!user)` and must not fire.
+      vi.mocked(isSsoProvisioningBlocked).mockResolvedValue(true); // would block if called
+      primeCallback();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel(PROVIDER_ROW))
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }])) // identity link found → user resolved
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'Linked' }]))
+        .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
+        .mockReturnValueOnce(sel([{ id: 'identity-1' }]));
+
+      const res = await doCallback();
+
+      expect(res.status).toBe(302);
+      // Succeeds — gate was not reached
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(createTokenPair).toHaveBeenCalled();
+      // isSsoProvisioningBlocked is still called in the mock infrastructure
+      // but the gate block is inside `if (!user)` which is false here — so
+      // the callback must NOT have redirected to sso_domain_unverified.
+      expect(res.headers.get('location') ?? '').not.toContain('sso_domain_unverified');
     });
   });
 

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -1318,6 +1318,29 @@ describe('sso routes', () => {
       expect(verifyDomain).not.toHaveBeenCalled();
     });
 
+    it('DELETE /domains/:id returns 403 when canAccessOrg is false', async () => {
+      setAuthContext({ canAccessOrg: () => false });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: DOMAIN_UUID,
+              orgId: ORG_UUID_OTHER,
+              domain: 'example.com',
+            }]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/sso/domains/${DOMAIN_UUID}`, {
+        method: 'DELETE',
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
     it('DELETE /domains/:id returns {data:{deleted:true}} on success', async () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -15,7 +15,7 @@ import {
   organizationUsers,
   roles
 } from '../db/schema';
-import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor } from '../services/ssoDomainVerification';
+import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import {
   generateState,
@@ -1150,6 +1150,28 @@ ssoRoutes.get('/callback', async (c) => {
       const [linkedUser] = await db.select().from(users).where(eq(users.id, link.userId)).limit(1);
       return linkedUser ?? null;
     });
+
+    // ── SSO domain-verification gate (security review #2, H-2 / Plan B) ──────
+    // Before JIT-linking-by-email or provisioning a NEW account, require the
+    // asserted email's domain to be one the org proved it owns (DNS TXT). Blocks
+    // a malicious/compromised org-admin from pointing the org at an attacker IdP
+    // and claiming emails in a domain the org doesn't control. Already-linked
+    // identities (resolved above by provider+sub) are intentionally exempt, so
+    // turning enforcement on never locks out existing SSO users. System scope:
+    // the public callback is unauthenticated.
+    if (!user) {
+      const assertedEmailDomain = attrs.email.split('@')[1]?.toLowerCase() ?? null;
+      const domainBlocked = await withSystemDbAccessContext(() =>
+        isSsoProvisioningBlocked(provider.orgId, assertedEmailDomain)
+      );
+      if (domainBlocked) {
+        console.warn(
+          `[sso/callback] domain verification blocked link/provision: org=${provider.orgId} provider=${provider.id} emailDomain=${assertedEmailDomain ?? 'none'}`
+        );
+        clearStateCookie();
+        return c.redirect('/login?error=sso_domain_unverified');
+      }
+    }
 
     if (!user) {
       // No link yet for this provider+sub. Try to match an existing user by the

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -8,12 +8,14 @@ import { db, withSystemDbAccessContext } from '../db';
 import {
   ssoProviders,
   ssoSessions,
+  ssoVerifiedDomains,
   userSsoIdentities,
   users,
   organizations,
   organizationUsers,
   roles
 } from '../db/schema';
+import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor } from '../services/ssoDomainVerification';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import {
   generateState,
@@ -737,6 +739,160 @@ ssoRoutes.post(
       error: error.message || 'Configuration test failed'
     }, 400);
   }
+  }
+);
+
+// ====  SSO Domain Verification Routes (Admin)  ====
+
+const createDomainSchema = z.object({
+  domain: z.string().min(1).max(253),
+  orgId: z.string().guid().optional(),
+});
+const domainIdParamSchema = z.object({ id: z.string().guid() });
+
+// List domains (verified + pending) for an org
+ssoRoutes.get('/domains', authMiddleware, requireScope('organization', 'partner', 'system'), async (c) => {
+  const auth = c.get('auth') as AuthContext;
+  const orgResult = resolveOrgIdForProviderRoute(auth, c.req.query('orgId'));
+  if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+
+  const rows = await db
+    .select({
+      id: ssoVerifiedDomains.id,
+      domain: ssoVerifiedDomains.domain,
+      verificationToken: ssoVerifiedDomains.verificationToken,
+      verifiedAt: ssoVerifiedDomains.verifiedAt,
+      lastCheckedAt: ssoVerifiedDomains.lastCheckedAt,
+      createdAt: ssoVerifiedDomains.createdAt,
+    })
+    .from(ssoVerifiedDomains)
+    .where(eq(ssoVerifiedDomains.orgId, orgResult.orgId));
+
+  return c.json({
+    data: rows.map(r => ({
+      id: r.id,
+      domain: r.domain,
+      verified: !!r.verifiedAt,
+      verifiedAt: r.verifiedAt,
+      lastCheckedAt: r.lastCheckedAt,
+      createdAt: r.createdAt,
+      recordName: recordNameFor(r.domain),
+      recordValue: recordValueFor(r.verificationToken),
+    })),
+  });
+});
+
+// Create a pending domain — returns the DNS TXT instructions
+ssoRoutes.post(
+  '/domains',
+  authMiddleware,
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.SSO_ADMIN.resource, PERMISSIONS.SSO_ADMIN.action),
+  requireMfa(),
+  zValidator('json', createDomainSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const body = c.req.valid('json');
+    const orgResult = resolveOrgIdForProviderRoute(auth, body.orgId);
+    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+
+    let pending;
+    try {
+      pending = await createPendingDomain({ orgId: orgResult.orgId, domain: body.domain, createdBy: auth.user.id });
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : 'Invalid domain' }, 400);
+    }
+
+    writeRouteAudit(c, {
+      orgId: orgResult.orgId,
+      action: 'sso.domain.create',
+      resourceType: 'sso_verified_domain',
+      resourceId: pending.id,
+      resourceName: pending.domain,
+      details: { domain: pending.domain },
+    });
+
+    return c.json({
+      data: {
+        id: pending.id,
+        domain: pending.domain,
+        verified: !!pending.verifiedAt,
+        recordName: pending.recordName,
+        recordValue: pending.recordValue,
+      },
+    }, 201);
+  }
+);
+
+// Trigger a DNS TXT verification check for a domain
+ssoRoutes.post(
+  '/domains/:id/verify',
+  authMiddleware,
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.SSO_ADMIN.resource, PERMISSIONS.SSO_ADMIN.action),
+  requireMfa(),
+  zValidator('param', domainIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { id } = c.req.valid('param');
+
+    const [row] = await db
+      .select({ id: ssoVerifiedDomains.id, orgId: ssoVerifiedDomains.orgId, domain: ssoVerifiedDomains.domain })
+      .from(ssoVerifiedDomains)
+      .where(eq(ssoVerifiedDomains.id, id))
+      .limit(1);
+    if (!row) return c.json({ error: 'Domain not found' }, 404);
+    if (!auth.canAccessOrg(row.orgId)) return c.json({ error: 'Access denied' }, 403);
+
+    const result = await verifyDomain({ orgId: row.orgId, domain: row.domain });
+
+    writeRouteAudit(c, {
+      orgId: row.orgId,
+      action: 'sso.domain.verify',
+      resourceType: 'sso_verified_domain',
+      resourceId: row.id,
+      resourceName: row.domain,
+      details: { verified: result.verified, reason: result.reason },
+    });
+
+    return c.json({ data: { verified: result.verified, reason: result.reason } });
+  }
+);
+
+// Delete a domain
+ssoRoutes.delete(
+  '/domains/:id',
+  authMiddleware,
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.SSO_ADMIN.resource, PERMISSIONS.SSO_ADMIN.action),
+  requireMfa(),
+  zValidator('param', domainIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { id } = c.req.valid('param');
+
+    const [row] = await db
+      .select({ id: ssoVerifiedDomains.id, orgId: ssoVerifiedDomains.orgId, domain: ssoVerifiedDomains.domain })
+      .from(ssoVerifiedDomains)
+      .where(eq(ssoVerifiedDomains.id, id))
+      .limit(1);
+    if (!row) return c.json({ error: 'Domain not found' }, 404);
+    if (!auth.canAccessOrg(row.orgId)) return c.json({ error: 'Access denied' }, 403);
+
+    const [deleted] = await db
+      .delete(ssoVerifiedDomains)
+      .where(and(eq(ssoVerifiedDomains.id, id), eq(ssoVerifiedDomains.orgId, row.orgId)))
+      .returning({ id: ssoVerifiedDomains.id });
+
+    writeRouteAudit(c, {
+      orgId: row.orgId,
+      action: 'sso.domain.delete',
+      resourceType: 'sso_verified_domain',
+      resourceId: row.id,
+      resourceName: row.domain,
+    });
+
+    return c.json({ data: { deleted: !!deleted } });
   }
 );
 

--- a/apps/api/src/services/ssoDomainRecheckWorker.ts
+++ b/apps/api/src/services/ssoDomainRecheckWorker.ts
@@ -1,0 +1,83 @@
+import { Queue, Worker, Job } from 'bullmq';
+import * as dbModule from '../db';
+import { getBullMQConnection } from './redis';
+import { recheckAllDomains } from './ssoDomainVerification';
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+const SSO_DOMAIN_RECHECK_QUEUE = 'sso-domain-recheck';
+
+let recheckQueue: Queue | null = null;
+let recheckWorker: Worker | null = null;
+
+interface RecheckAllJob { type: 'recheck-all'; }
+
+export function getSsoDomainRecheckQueue(): Queue {
+  if (!recheckQueue) {
+    recheckQueue = new Queue(SSO_DOMAIN_RECHECK_QUEUE, { connection: getBullMQConnection() });
+  }
+  return recheckQueue;
+}
+
+function createSsoDomainRecheckWorker(): Worker<RecheckAllJob> {
+  return new Worker<RecheckAllJob>(
+    SSO_DOMAIN_RECHECK_QUEUE,
+    async (job: Job<RecheckAllJob>) => {
+      return runWithSystemDbAccess(async () => {
+        if (job.data.type === 'recheck-all') {
+          const result = await recheckAllDomains();
+          console.log(`[SsoDomainRecheck] Rechecked ${result.checked} domains, ${result.verified} verified`);
+          return result;
+        }
+        throw new Error(`Unknown sso-domain-recheck job type: ${(job.data as { type: string }).type}`);
+      });
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+      lockDuration: 300_000,
+      stalledInterval: 60_000,
+      maxStalledCount: 2,
+    }
+  );
+}
+
+async function scheduleSsoDomainRecheckJobs(): Promise<void> {
+  const queue = getSsoDomainRecheckQueue();
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    await queue.removeRepeatableByKey(job.key);
+  }
+  await queue.add(
+    'recheck-all',
+    { type: 'recheck-all' },
+    {
+      repeat: { every: 24 * 60 * 60 * 1000 }, // daily
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 50 },
+    }
+  );
+  console.log('[SsoDomainRecheck] Scheduled daily SSO domain re-check job');
+}
+
+export async function initializeSsoDomainRecheckWorker(): Promise<void> {
+  try {
+    recheckWorker = createSsoDomainRecheckWorker();
+    recheckWorker.on('error', (error) => console.error('[SsoDomainRecheck] Worker error:', error));
+    recheckWorker.on('failed', (job, error) => console.error(`[SsoDomainRecheck] Job ${job?.id} failed:`, error));
+    await scheduleSsoDomainRecheckJobs();
+    console.log('[SsoDomainRecheck] Worker initialized');
+  } catch (error) {
+    console.error('[SsoDomainRecheck] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownSsoDomainRecheckWorker(): Promise<void> {
+  if (recheckWorker) { await recheckWorker.close(); recheckWorker = null; }
+  if (recheckQueue) { await recheckQueue.close(); recheckQueue = null; }
+  console.log('[SsoDomainRecheck] Worker shut down');
+}

--- a/apps/api/src/services/ssoDomainVerification.test.ts
+++ b/apps/api/src/services/ssoDomainVerification.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── db mock (mirrors apiKeys.test.ts / clientAiUsage.test.ts pattern) ───────
 // We hoist the individual mock functions so that vi.mock factory can close
@@ -50,6 +50,7 @@ import {
   verifyDomain,
   isDomainVerifiedForOrg,
   orgHasAnyVerifiedDomain,
+  isSsoDomainVerificationStrict,
   TXT_RECORD_HOST_PREFIX,
   TXT_RECORD_VALUE_PREFIX,
 } from './ssoDomainVerification';
@@ -352,5 +353,52 @@ describe('orgHasAnyVerifiedDomain', () => {
   it('returns false when no verified domains exist', async () => {
     setupSelect([]);
     await expect(orgHasAnyVerifiedDomain('org-1')).resolves.toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isSsoDomainVerificationStrict
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isSsoDomainVerificationStrict', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    // Save the current value of the env var so we can restore it after each test
+    originalEnv = process.env.SSO_DOMAIN_VERIFICATION_STRICT;
+  });
+
+  afterEach(() => {
+    // Restore the original value (or clear it if it wasn't set)
+    if (originalEnv === undefined) {
+      delete process.env.SSO_DOMAIN_VERIFICATION_STRICT;
+    } else {
+      process.env.SSO_DOMAIN_VERIFICATION_STRICT = originalEnv;
+    }
+  });
+
+  it('returns false when env var is unset', () => {
+    delete process.env.SSO_DOMAIN_VERIFICATION_STRICT;
+    expect(isSsoDomainVerificationStrict()).toBe(false);
+  });
+
+  it('returns true when env var is "true"', () => {
+    process.env.SSO_DOMAIN_VERIFICATION_STRICT = 'true';
+    expect(isSsoDomainVerificationStrict()).toBe(true);
+  });
+
+  it('returns true when env var is "TRUE" (case-insensitive)', () => {
+    process.env.SSO_DOMAIN_VERIFICATION_STRICT = 'TRUE';
+    expect(isSsoDomainVerificationStrict()).toBe(true);
+  });
+
+  it('returns false when env var is "false"', () => {
+    process.env.SSO_DOMAIN_VERIFICATION_STRICT = 'false';
+    expect(isSsoDomainVerificationStrict()).toBe(false);
+  });
+
+  it('returns false when env var is "1" (literal "true" only)', () => {
+    process.env.SSO_DOMAIN_VERIFICATION_STRICT = '1';
+    expect(isSsoDomainVerificationStrict()).toBe(false);
   });
 });

--- a/apps/api/src/services/ssoDomainVerification.test.ts
+++ b/apps/api/src/services/ssoDomainVerification.test.ts
@@ -52,6 +52,7 @@ import {
   orgHasAnyVerifiedDomain,
   isSsoDomainVerificationStrict,
   isSsoProvisioningBlocked,
+  recheckAllDomains,
   TXT_RECORD_HOST_PREFIX,
   TXT_RECORD_VALUE_PREFIX,
 } from './ssoDomainVerification';
@@ -510,5 +511,111 @@ describe('isSsoProvisioningBlocked', () => {
 
     expect(result).toBe(true);
     expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// recheckAllDomains
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('recheckAllDomains', () => {
+  /**
+   * Build a chainable db.select mock: select().from() resolves to rows.
+   * Used for the top-level list query inside recheckAllDomains.
+   */
+  function setupListSelect(rows: unknown[]) {
+    const from = vi.fn().mockResolvedValue(rows);
+    dbSelectMock.mockReturnValueOnce({ from });
+    return { from };
+  }
+
+  /**
+   * Build a chainable db.select mock for verifyDomain's internal row fetch:
+   * select().from().where().limit() resolves to rows.
+   */
+  function setupRowSelect(rows: unknown[]) {
+    const limit = vi.fn().mockResolvedValue(rows);
+    const where = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where });
+    dbSelectMock.mockReturnValueOnce({ from });
+    return { from, where, limit };
+  }
+
+  it('returns {checked:0, verified:0} when no domains exist', async () => {
+    // The list select returns an empty array — verifyDomain is never called.
+    setupListSelect([]);
+
+    const result = await recheckAllDomains();
+
+    expect(result).toEqual({ checked: 0, verified: 0 });
+    // Only the list select was called; no per-domain selects or updates.
+    expect(dbSelectMock).toHaveBeenCalledTimes(1);
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns {checked:2, verified:1} when 2 domains exist and DNS matches only 1', async () => {
+    const TOKEN_A = 'tokenAAAAAAAAAAAAAAAAAAAA';
+    const TOKEN_B = 'tokenBBBBBBBBBBBBBBBBBBBB';
+
+    // 1) List select → two domain rows
+    setupListSelect([
+      { orgId: 'org-1', domain: 'acme.com' },
+      { orgId: 'org-2', domain: 'widgets.com' },
+    ]);
+
+    // 2) verifyDomain for acme.com: row select → full row with TOKEN_A
+    setupRowSelect([{
+      id: 'row-a',
+      orgId: 'org-1',
+      domain: 'acme.com',
+      verificationToken: TOKEN_A,
+      verifiedAt: null,
+    }]);
+    // update for acme.com (DNS matches → verified)
+    setupUpdate();
+
+    // 3) verifyDomain for widgets.com: row select → full row with TOKEN_B
+    setupRowSelect([{
+      id: 'row-b',
+      orgId: 'org-2',
+      domain: 'widgets.com',
+      verificationToken: TOKEN_B,
+      verifiedAt: null,
+    }]);
+    // update for widgets.com (DNS mismatches → lastCheckedAt only)
+    setupUpdate();
+
+    // DNS: acme.com matches, widgets.com does not
+    resolveTxtMock
+      .mockResolvedValueOnce([[`breeze-domain-verify=${TOKEN_A}`]] as any)
+      .mockResolvedValueOnce([[`breeze-domain-verify=WRONG`]] as any);
+
+    const result = await recheckAllDomains();
+
+    expect(result).toEqual({ checked: 2, verified: 1 });
+    // 1 list select + 2 per-domain selects
+    expect(dbSelectMock).toHaveBeenCalledTimes(3);
+    // 2 per-domain updates
+    expect(dbUpdateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns {checked:1, verified:1} for a single domain where DNS matches', async () => {
+    const TOKEN = 'singletoken123456789abcde';
+
+    setupListSelect([{ orgId: 'org-1', domain: 'example.com' }]);
+    setupRowSelect([{
+      id: 'row-1',
+      orgId: 'org-1',
+      domain: 'example.com',
+      verificationToken: TOKEN,
+      verifiedAt: null,
+    }]);
+    setupUpdate();
+
+    resolveTxtMock.mockResolvedValueOnce([[`breeze-domain-verify=${TOKEN}`]] as any);
+
+    const result = await recheckAllDomains();
+
+    expect(result).toEqual({ checked: 1, verified: 1 });
   });
 });

--- a/apps/api/src/services/ssoDomainVerification.test.ts
+++ b/apps/api/src/services/ssoDomainVerification.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── db mock (mirrors apiKeys.test.ts / clientAiUsage.test.ts pattern) ───────
+// We hoist the individual mock functions so that vi.mock factory can close
+// over them without the "accessed before initialization" Vitest limitation.
+const { dbInsertMock, dbSelectMock, dbUpdateMock } = vi.hoisted(() => ({
+  dbInsertMock: vi.fn(),
+  dbSelectMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    insert: dbInsertMock,
+    select: dbSelectMock,
+    update: dbUpdateMock,
+  },
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ _eq: args })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  isNotNull: vi.fn((...args: unknown[]) => ({ _isNotNull: args })),
+}));
+
+// ── schema mock ───────────────────────────────────────────────────────────────
+vi.mock('../db/schema/sso', () => ({
+  ssoVerifiedDomains: {
+    id: 'ssoVerifiedDomains.id',
+    orgId: 'ssoVerifiedDomains.orgId',
+    domain: 'ssoVerifiedDomains.domain',
+    verificationToken: 'ssoVerifiedDomains.verificationToken',
+    verifiedAt: 'ssoVerifiedDomains.verifiedAt',
+    lastCheckedAt: 'ssoVerifiedDomains.lastCheckedAt',
+  },
+}));
+
+// ── dns mock ──────────────────────────────────────────────────────────────────
+vi.mock('dns/promises', () => ({
+  resolveTxt: vi.fn(),
+}));
+
+// Lazy import AFTER mocks are registered.
+import {
+  normalizeDomain,
+  recordNameFor,
+  recordValueFor,
+  createPendingDomain,
+  verifyDomain,
+  isDomainVerifiedForOrg,
+  orgHasAnyVerifiedDomain,
+  TXT_RECORD_HOST_PREFIX,
+  TXT_RECORD_VALUE_PREFIX,
+} from './ssoDomainVerification';
+import { resolveTxt } from 'dns/promises';
+
+const resolveTxtMock = vi.mocked(resolveTxt);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Wire up db.insert → .values → .onConflictDoUpdate → .returning */
+function setupInsert(rows: unknown[]) {
+  const returning = vi.fn().mockResolvedValue(rows);
+  const onConflict = vi.fn().mockReturnValue({ returning });
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate: onConflict });
+  dbInsertMock.mockReturnValue({ values });
+  return { values, onConflict, returning };
+}
+
+/** Wire up db.select → .from → .where → .limit */
+function setupSelect(rows: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  dbSelectMock.mockReturnValue({ from });
+  return { from, where, limit };
+}
+
+/** Wire up db.update → .set → .where */
+function setupUpdate() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  dbUpdateMock.mockReturnValue({ set });
+  return { set, where };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// normalizeDomain
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('normalizeDomain', () => {
+  it.each([
+    ['  HTTPS://WWW.Acme.COM/path?q=1  ', 'www.acme.com'],
+    ['*.acme.com', 'acme.com'],
+    ['acme.com.', 'acme.com'],
+    ['acme.com:8080', 'acme.com'],
+    ['http://sub.example.co.uk', 'sub.example.co.uk'],
+    ['EXAMPLE.COM', 'example.com'],
+  ])('normalizes %s → %s', (input, expected) => {
+    expect(normalizeDomain(input)).toBe(expected);
+  });
+
+  it.each([
+    [''],
+    ['notadomain'],
+    ['http://'],
+    ['   '],
+    ['.'],
+    ['localhost'],
+  ])('throws on invalid input: %s', (input) => {
+    expect(() => normalizeDomain(input)).toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// recordNameFor / recordValueFor
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('recordNameFor', () => {
+  it('prefixes the domain with _breeze-verify.', () => {
+    expect(recordNameFor('acme.com')).toBe(`${TXT_RECORD_HOST_PREFIX}.acme.com`);
+    expect(recordNameFor('sub.acme.com')).toBe(`${TXT_RECORD_HOST_PREFIX}.sub.acme.com`);
+  });
+});
+
+describe('recordValueFor', () => {
+  it('formats breeze-domain-verify=<token>', () => {
+    expect(recordValueFor('abc123')).toBe(`${TXT_RECORD_VALUE_PREFIX}=abc123`);
+  });
+
+  it('uses the exact token value verbatim', () => {
+    const token = 'f4e3d2c1b0a9887766554433221100ff';
+    expect(recordValueFor(token)).toBe(`breeze-domain-verify=${token}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createPendingDomain
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createPendingDomain', () => {
+  it('returns a PendingDomain with recordName and recordValue', async () => {
+    const token = 'aabbccddeeff001122334455';
+    setupInsert([{
+      id: 'row-1',
+      orgId: 'org-1',
+      domain: 'acme.com',
+      verificationToken: token,
+      verifiedAt: null,
+    }]);
+
+    const result = await createPendingDomain({ orgId: 'org-1', domain: 'ACME.COM' });
+
+    expect(result.id).toBe('row-1');
+    expect(result.domain).toBe('acme.com');
+    expect(result.verificationToken).toBe(token);
+    expect(result.recordName).toBe(`_breeze-verify.acme.com`);
+    expect(result.recordValue).toBe(`breeze-domain-verify=${token}`);
+    expect(result.verifiedAt).toBeNull();
+  });
+
+  it('normalizes the domain before inserting', async () => {
+    const token = 'deadbeefdeadbeefdeadbeef';
+    const { values } = setupInsert([{
+      id: 'row-2', orgId: 'org-1', domain: 'sub.acme.com',
+      verificationToken: token, verifiedAt: null,
+    }]);
+
+    await createPendingDomain({ orgId: 'org-1', domain: '  HTTPS://Sub.Acme.COM/path  ' });
+
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ domain: 'sub.acme.com' }));
+  });
+
+  it('passes createdBy through to the insert values', async () => {
+    const { values } = setupInsert([{
+      id: 'r3', orgId: 'org-2', domain: 'test.com',
+      verificationToken: 'tok', verifiedAt: null,
+    }]);
+
+    await createPendingDomain({ orgId: 'org-2', domain: 'test.com', createdBy: 'user-99' });
+
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ createdBy: 'user-99' }));
+  });
+
+  it('defaults createdBy to null when not provided', async () => {
+    const { values } = setupInsert([{
+      id: 'r4', orgId: 'org-2', domain: 'test.com',
+      verificationToken: 'tok', verifiedAt: null,
+    }]);
+
+    await createPendingDomain({ orgId: 'org-2', domain: 'test.com' });
+
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ createdBy: null }));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// verifyDomain
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('verifyDomain', () => {
+  const TOKEN = 'mytoken1234567890abcdef';
+  const EXPECTED_VALUE = `breeze-domain-verify=${TOKEN}`;
+
+  const baseRow = {
+    id: 'domain-row-1',
+    orgId: 'org-1',
+    domain: 'acme.com',
+    verificationToken: TOKEN,
+    verifiedAt: null,
+  };
+
+  it('(a) returns {verified:true} when DNS returns matching chunked TXT record', async () => {
+    setupSelect([baseRow]);
+    const { set, where } = setupUpdate();
+
+    // Multi-chunk join test: chunks join to the expected value
+    resolveTxtMock.mockResolvedValue([['breeze-domain-', `verify=${TOKEN}`]] as any);
+
+    const result = await verifyDomain({ orgId: 'org-1', domain: 'acme.com' });
+
+    expect(result).toEqual({ verified: true });
+    // verifiedAt should be set in the update
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      verifiedAt: expect.any(Date),
+      lastCheckedAt: expect.any(Date),
+    }));
+    expect(where).toHaveBeenCalled();
+  });
+
+  it('(b) returns {verified:false} when DNS returns non-matching records, verifiedAt NOT set', async () => {
+    setupSelect([baseRow]);
+    const { set } = setupUpdate();
+
+    resolveTxtMock.mockResolvedValue([['breeze-domain-verify=WRONG_TOKEN']] as any);
+
+    const result = await verifyDomain({ orgId: 'org-1', domain: 'acme.com' });
+
+    expect(result).toEqual({ verified: false, reason: 'txt_not_found' });
+    // verifiedAt should NOT be set in the update
+    const updateArgs = set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateArgs).not.toHaveProperty('verifiedAt');
+    expect(updateArgs).toHaveProperty('lastCheckedAt');
+  });
+
+  it('(c) returns {verified:false} when resolveTxt throws ENOTFOUND, no throw propagated', async () => {
+    setupSelect([baseRow]);
+    setupUpdate();
+
+    const err = Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+    resolveTxtMock.mockRejectedValue(err);
+
+    await expect(verifyDomain({ orgId: 'org-1', domain: 'acme.com' })).resolves.toEqual({
+      verified: false,
+      reason: 'txt_not_found',
+    });
+  });
+
+  it('(d) already-verified row keeps verifiedAt sticky even when DNS now fails', async () => {
+    const alreadyVerifiedAt = new Date('2026-01-01T00:00:00Z');
+    setupSelect([{ ...baseRow, verifiedAt: alreadyVerifiedAt }]);
+    const { set } = setupUpdate();
+
+    // DNS now fails
+    resolveTxtMock.mockRejectedValue(new Error('ENODATA'));
+
+    const result = await verifyDomain({ orgId: 'org-1', domain: 'acme.com' });
+
+    // Still treated as not-found on this check, but row retains its verifiedAt
+    expect(result).toEqual({ verified: false, reason: 'txt_not_found' });
+    // The update should only bump lastCheckedAt, not overwrite verifiedAt
+    const updateArgs = set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateArgs).not.toHaveProperty('verifiedAt');
+    expect(updateArgs).toHaveProperty('lastCheckedAt');
+  });
+
+  it('(d) already-verified row that DNS still matches preserves original verifiedAt', async () => {
+    const originalVerifiedAt = new Date('2026-01-01T00:00:00Z');
+    setupSelect([{ ...baseRow, verifiedAt: originalVerifiedAt }]);
+    const { set } = setupUpdate();
+
+    resolveTxtMock.mockResolvedValue([[EXPECTED_VALUE]] as any);
+
+    const result = await verifyDomain({ orgId: 'org-1', domain: 'acme.com' });
+
+    expect(result).toEqual({ verified: true });
+    // verifiedAt in the update must be the ORIGINAL date (sticky), not a new Date()
+    const updateArgs = set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateArgs.verifiedAt).toBe(originalVerifiedAt);
+  });
+
+  it('(e) returns {verified:false, reason:"not_found"} when no row exists', async () => {
+    setupSelect([]); // empty result
+
+    resolveTxtMock.mockResolvedValue([[EXPECTED_VALUE]] as any);
+
+    const result = await verifyDomain({ orgId: 'org-1', domain: 'acme.com' });
+
+    expect(result).toEqual({ verified: false, reason: 'not_found' });
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isDomainVerifiedForOrg
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isDomainVerifiedForOrg', () => {
+  it('returns true when a verified row matches', async () => {
+    setupSelect([{ verifiedAt: new Date() }]);
+    await expect(isDomainVerifiedForOrg('org-1', 'acme.com')).resolves.toBe(true);
+  });
+
+  it('returns false when no matching verified row', async () => {
+    setupSelect([]);
+    await expect(isDomainVerifiedForOrg('org-1', 'acme.com')).resolves.toBe(false);
+  });
+
+  it('returns false (no throw) on invalid domain input', async () => {
+    await expect(isDomainVerifiedForOrg('org-1', 'notadomain')).resolves.toBe(false);
+    await expect(isDomainVerifiedForOrg('org-1', '')).resolves.toBe(false);
+    // db should NOT have been called for invalid domains
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('normalizes domain before querying', async () => {
+    setupSelect([{ verifiedAt: new Date() }]);
+    const result = await isDomainVerifiedForOrg('org-1', 'HTTPS://ACME.COM/');
+    expect(result).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// orgHasAnyVerifiedDomain
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('orgHasAnyVerifiedDomain', () => {
+  it('returns true when at least one verified domain exists', async () => {
+    setupSelect([{ id: 'row-1' }]);
+    await expect(orgHasAnyVerifiedDomain('org-1')).resolves.toBe(true);
+  });
+
+  it('returns false when no verified domains exist', async () => {
+    setupSelect([]);
+    await expect(orgHasAnyVerifiedDomain('org-1')).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/services/ssoDomainVerification.test.ts
+++ b/apps/api/src/services/ssoDomainVerification.test.ts
@@ -51,6 +51,7 @@ import {
   isDomainVerifiedForOrg,
   orgHasAnyVerifiedDomain,
   isSsoDomainVerificationStrict,
+  isSsoProvisioningBlocked,
   TXT_RECORD_HOST_PREFIX,
   TXT_RECORD_VALUE_PREFIX,
 } from './ssoDomainVerification';
@@ -400,5 +401,114 @@ describe('isSsoDomainVerificationStrict', () => {
   it('returns false when env var is "1" (literal "true" only)', () => {
     process.env.SSO_DOMAIN_VERIFICATION_STRICT = '1';
     expect(isSsoDomainVerificationStrict()).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isSsoProvisioningBlocked
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isSsoProvisioningBlocked', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.SSO_DOMAIN_VERIFICATION_STRICT;
+    delete process.env.SSO_DOMAIN_VERIFICATION_STRICT;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SSO_DOMAIN_VERIFICATION_STRICT;
+    } else {
+      process.env.SSO_DOMAIN_VERIFICATION_STRICT = originalEnv;
+    }
+  });
+
+  it('returns false (not blocked) when not strict and org has NO verified domains', async () => {
+    // orgHasAnyVerifiedDomain → empty (org has no verified domains)
+    setupSelect([]); // first db.select call → orgHasAnyVerifiedDomain returns false
+
+    const result = await isSsoProvisioningBlocked('org-1', 'acme.com');
+
+    expect(result).toBe(false);
+    // Short-circuits before calling isDomainVerifiedForOrg — only one select call made
+    expect(dbSelectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false (not blocked) when not strict, org HAS a verified domain, and asserted domain IS verified', async () => {
+    // orgHasAnyVerifiedDomain → returns a row (org has verified domains)
+    // isDomainVerifiedForOrg → returns a row (domain is verified)
+    // Two sequential db.select calls — use mockReturnValueOnce to chain them.
+    const makeSelectChain = (rows: unknown[]) => {
+      const limit = vi.fn().mockResolvedValue(rows);
+      const where = vi.fn().mockReturnValue({ limit });
+      const from = vi.fn().mockReturnValue({ where });
+      return { from };
+    };
+    dbSelectMock
+      .mockReturnValueOnce(makeSelectChain([{ id: 'row-1' }]))
+      .mockReturnValueOnce(makeSelectChain([{ verifiedAt: new Date() }]));
+
+    const result = await isSsoProvisioningBlocked('org-1', 'acme.com');
+
+    expect(result).toBe(false);
+    expect(dbSelectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns true (blocked) when not strict, org HAS a verified domain, but asserted domain NOT verified', async () => {
+    // orgHasAnyVerifiedDomain → returns a row (org has verified domains → enforcing)
+    // isDomainVerifiedForOrg → empty (domain not verified)
+    // Two sequential db.select calls — use mockReturnValueOnce to chain them.
+    const makeSelectChain = (rows: unknown[]) => {
+      const limit = vi.fn().mockResolvedValue(rows);
+      const where = vi.fn().mockReturnValue({ limit });
+      const from = vi.fn().mockReturnValue({ where });
+      return { from };
+    };
+    dbSelectMock
+      .mockReturnValueOnce(makeSelectChain([{ id: 'row-1' }]))
+      .mockReturnValueOnce(makeSelectChain([]));
+
+    const result = await isSsoProvisioningBlocked('org-1', 'attacker.com');
+
+    expect(result).toBe(true);
+    expect(dbSelectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns true (blocked) when strict, org has no verified domains, and asserted domain not verified', async () => {
+    process.env.SSO_DOMAIN_VERIFICATION_STRICT = 'true';
+    // orgHasAnyVerifiedDomain is STILL called (even if strict, the short-circuit is on
+    // the enforcing flag which is already true from strict; but isDomainVerifiedForOrg
+    // is what gates). With strict=true, enforcing=true immediately.
+    // The call sequence: isSsoDomainVerificationStrict() → true → skip orgHasAnyVerifiedDomain
+    // via short-circuit OR (JS || short-circuits left); isDomainVerifiedForOrg → empty
+    setupSelect([]); // isDomainVerifiedForOrg → not verified
+
+    const result = await isSsoProvisioningBlocked('org-1', 'example.com');
+
+    expect(result).toBe(true);
+    // orgHasAnyVerifiedDomain is NOT called when strict=true (short-circuit)
+    expect(dbSelectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false (not blocked) when strict and asserted domain IS verified', async () => {
+    process.env.SSO_DOMAIN_VERIFICATION_STRICT = 'true';
+    // isDomainVerifiedForOrg → verified
+    setupSelect([{ verifiedAt: new Date() }]);
+
+    const result = await isSsoProvisioningBlocked('org-1', 'acme.com');
+
+    expect(result).toBe(false);
+    expect(dbSelectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true (blocked) when enforcing and emailDomain is null', async () => {
+    process.env.SSO_DOMAIN_VERIFICATION_STRICT = 'true';
+    // No db call needed — emailDomain null skips isDomainVerifiedForOrg entirely
+
+    const result = await isSsoProvisioningBlocked('org-1', null);
+
+    expect(result).toBe(true);
+    expect(dbSelectMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/ssoDomainVerification.ts
+++ b/apps/api/src/services/ssoDomainVerification.ts
@@ -114,3 +114,14 @@ export async function orgHasAnyVerifiedDomain(orgId: string): Promise<boolean> {
     .limit(1);
   return !!row;
 }
+
+/**
+ * When true, the SSO callback enforces domain verification for EVERY org
+ * (refuses to provision/JIT-link an email whose domain isn't verified).
+ * When false (default), enforcement is per-org: only orgs that already have at
+ * least one verified domain are gated (gradual rollout). Read at call time so
+ * it can be toggled without a redeploy in dev.
+ */
+export function isSsoDomainVerificationStrict(): boolean {
+  return (process.env.SSO_DOMAIN_VERIFICATION_STRICT ?? '').toLowerCase() === 'true';
+}

--- a/apps/api/src/services/ssoDomainVerification.ts
+++ b/apps/api/src/services/ssoDomainVerification.ts
@@ -125,3 +125,19 @@ export async function orgHasAnyVerifiedDomain(orgId: string): Promise<boolean> {
 export function isSsoDomainVerificationStrict(): boolean {
   return (process.env.SSO_DOMAIN_VERIFICATION_STRICT ?? '').toLowerCase() === 'true';
 }
+
+/**
+ * Should the SSO callback REFUSE to JIT-link/provision for this org + asserted
+ * email domain? (security review #2 H-2 / Plan B.) Enforcement is global when
+ * SSO_DOMAIN_VERIFICATION_STRICT is set, otherwise per-org: an org becomes gated
+ * once it has ≥1 verified domain (gradual rollout). When enforcing, the asserted
+ * email's domain must be a verified domain for the org. Uses ambient db context —
+ * callers without a request context (the SSO callback) must wrap in
+ * withSystemDbAccessContext.
+ */
+export async function isSsoProvisioningBlocked(orgId: string, emailDomain: string | null): Promise<boolean> {
+  const enforcing = isSsoDomainVerificationStrict() || (await orgHasAnyVerifiedDomain(orgId));
+  if (!enforcing) return false;
+  const verified = emailDomain ? await isDomainVerifiedForOrg(orgId, emailDomain) : false;
+  return !verified;
+}

--- a/apps/api/src/services/ssoDomainVerification.ts
+++ b/apps/api/src/services/ssoDomainVerification.ts
@@ -141,3 +141,21 @@ export async function isSsoProvisioningBlocked(orgId: string, emailDomain: strin
   const verified = emailDomain ? await isDomainVerifiedForOrg(orgId, emailDomain) : false;
   return !verified;
 }
+
+/**
+ * Re-run DNS TXT verification for EVERY SSO domain. Sticky: never un-verifies
+ * (delegates to verifyDomain, which only sets verifiedAt and never clears it);
+ * flips pending→verified once DNS propagates and refreshes lastCheckedAt.
+ * Ambient db context — the re-check worker wraps this in withSystemDbAccessContext.
+ */
+export async function recheckAllDomains(): Promise<{ checked: number; verified: number }> {
+  const rows = await db
+    .select({ orgId: ssoVerifiedDomains.orgId, domain: ssoVerifiedDomains.domain })
+    .from(ssoVerifiedDomains);
+  let verified = 0;
+  for (const row of rows) {
+    const result = await verifyDomain({ orgId: row.orgId, domain: row.domain });
+    if (result.verified) verified++;
+  }
+  return { checked: rows.length, verified };
+}

--- a/apps/api/src/services/ssoDomainVerification.ts
+++ b/apps/api/src/services/ssoDomainVerification.ts
@@ -1,0 +1,116 @@
+import { randomBytes } from 'crypto';
+import { resolveTxt } from 'dns/promises';
+import { and, eq, isNotNull } from 'drizzle-orm';
+import { db } from '../db';
+import { ssoVerifiedDomains } from '../db/schema/sso';
+
+// DB-CONTEXT CONTRACT: these functions use the ambient DB context. Callers MUST
+// establish it. Request routes run inside withDbAccessContext (org scope).
+// The SSO callback and the daily re-check job have no org context and MUST wrap
+// these calls in withSystemDbAccessContext (a contextless read under breeze_app
+// silently returns 0 rows). Do not switch context inside this service.
+
+export const TXT_RECORD_HOST_PREFIX = '_breeze-verify';
+export const TXT_RECORD_VALUE_PREFIX = 'breeze-domain-verify';
+
+export interface PendingDomain {
+  id: string;
+  orgId: string;
+  domain: string;
+  verificationToken: string;
+  recordName: string;
+  recordValue: string;
+  verifiedAt: Date | null;
+}
+
+/** Normalize user-entered domain to a bare lowercased hostname (no scheme/path/port/wildcard). Throws on invalid. */
+export function normalizeDomain(input: string): string {
+  if (!input) throw new Error('Domain is required');
+  let d = input.trim().toLowerCase();
+  d = d.replace(/^https?:\/\//, '');
+  // Strip path, query string, and port — each split may theoretically yield undefined in TS strict mode
+  d = ((d.split('/')[0] ?? '').split('?')[0] ?? '').split(':')[0] ?? '';
+  d = d.replace(/^\*\./, '').replace(/^\.+/, '').replace(/\.+$/, '');
+  if (!d || !/^[a-z0-9.-]+\.[a-z]{2,}$/.test(d)) {
+    throw new Error(`Invalid domain: ${input}`);
+  }
+  return d;
+}
+
+export function recordNameFor(domain: string): string {
+  return `${TXT_RECORD_HOST_PREFIX}.${domain}`;
+}
+export function recordValueFor(token: string): string {
+  return `${TXT_RECORD_VALUE_PREFIX}=${token}`;
+}
+
+/** Create (or return existing) a pending domain row + its DNS instructions. Idempotent on (orgId, domain). */
+export async function createPendingDomain(opts: { orgId: string; domain: string; createdBy?: string | null }): Promise<PendingDomain> {
+  const domain = normalizeDomain(opts.domain);
+  const verificationToken = randomBytes(24).toString('hex');
+  const rows = await db
+    .insert(ssoVerifiedDomains)
+    .values({ orgId: opts.orgId, domain, verificationToken, createdBy: opts.createdBy ?? null })
+    .onConflictDoUpdate({
+      target: [ssoVerifiedDomains.orgId, ssoVerifiedDomains.domain],
+      set: { updatedAt: new Date() },
+    })
+    .returning();
+  const row = rows[0];
+  if (!row) throw new Error(`Failed to insert or retrieve domain row for ${domain}`);
+  return {
+    id: row.id, orgId: row.orgId, domain: row.domain,
+    verificationToken: row.verificationToken,
+    recordName: recordNameFor(row.domain),
+    recordValue: recordValueFor(row.verificationToken),
+    verifiedAt: row.verifiedAt,
+  };
+}
+
+/** Perform a DNS TXT check for a single org/domain. Sets verifiedAt on success; sticky (never clears it). Always bumps lastCheckedAt. */
+export async function verifyDomain(opts: { orgId: string; domain: string }): Promise<{ verified: boolean; reason?: string }> {
+  const domain = normalizeDomain(opts.domain);
+  const [row] = await db.select().from(ssoVerifiedDomains)
+    .where(and(eq(ssoVerifiedDomains.orgId, opts.orgId), eq(ssoVerifiedDomains.domain, domain)))
+    .limit(1);
+  if (!row) return { verified: false, reason: 'not_found' };
+  const expected = recordValueFor(row.verificationToken);
+  let found = false;
+  try {
+    const records = await resolveTxt(recordNameFor(domain)); // string[][]: one inner array of chunks per TXT record
+    found = records.some(chunks => chunks.join('').trim() === expected);
+  } catch {
+    found = false; // ENOTFOUND / ENODATA / SERVFAIL → simply not verified yet
+  }
+  const now = new Date();
+  if (found) {
+    await db.update(ssoVerifiedDomains)
+      .set({ verifiedAt: row.verifiedAt ?? now, lastCheckedAt: now, updatedAt: now })
+      .where(eq(ssoVerifiedDomains.id, row.id));
+    return { verified: true };
+  }
+  await db.update(ssoVerifiedDomains)
+    .set({ lastCheckedAt: now, updatedAt: now })
+    .where(eq(ssoVerifiedDomains.id, row.id));
+  return { verified: false, reason: 'txt_not_found' };
+}
+
+/** Is this exact email-domain verified for the org? Returns false on invalid input (never throws). */
+export async function isDomainVerifiedForOrg(orgId: string, rawDomain: string): Promise<boolean> {
+  let domain: string;
+  try { domain = normalizeDomain(rawDomain); } catch { return false; }
+  const [row] = await db.select({ verifiedAt: ssoVerifiedDomains.verifiedAt })
+    .from(ssoVerifiedDomains)
+    .where(and(eq(ssoVerifiedDomains.orgId, orgId), eq(ssoVerifiedDomains.domain, domain), isNotNull(ssoVerifiedDomains.verifiedAt)))
+    .limit(1);
+  return !!row;
+}
+
+/** Does the org have at least one verified domain? (Gate signal for the SSO callback.) */
+export async function orgHasAnyVerifiedDomain(orgId: string): Promise<boolean> {
+  const [row] = await db.select({ id: ssoVerifiedDomains.id })
+    .from(ssoVerifiedDomains)
+    .where(and(eq(ssoVerifiedDomains.orgId, orgId), isNotNull(ssoVerifiedDomains.verifiedAt)))
+    .limit(1);
+  return !!row;
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -273,6 +273,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'software_policy_audit',
   'sql_instances',
   'sso_providers',
+  'sso_verified_domains',
   'storage_encryption_keys',
   'ticket_alert_links',
   'ticket_parts',

--- a/docs/superpowers/plans/2026-06-20-sso-domain-verification-backend.md
+++ b/docs/superpowers/plans/2026-06-20-sso-domain-verification-backend.md
@@ -1,0 +1,366 @@
+# SSO Domain Verification — Backend (Plan B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate SSO provisioning / JIT-linking on a DNS-verified email domain, so an org can only auto-create or first-time-link a user whose email domain it has proven (via DNS TXT) it owns — closing the H-2 root cause from security review #2.
+
+**Architecture:** A new org-scoped `sso_verified_domains` table; a verification service that issues a per-domain token and confirms it via a DNS TXT lookup; `sso:admin`-gated CRUD routes; a callback gate that refuses provisioning/linking for an unverified domain once the org has verified at least one domain (warn-mode otherwise); a daily re-check job that audits drift without un-verifying.
+
+**Tech Stack:** Hono, Drizzle, hand-written SQL migrations, Node `dns/promises`, BullMQ, Vitest. This is **Plan B (backend)** of `docs/superpowers/specs/2026-06-20-sso-domain-ownership-design.md`. The **admin UI is a separate follow-up plan** (out of scope here). Plan A (`sso:admin` permission + gating) is already merged.
+
+## Global Constraints
+
+- `sso_verified_domains` is RLS shape 1 (direct `org_id`): policy `USING (breeze_has_org_access(org_id)) WITH CHECK (breeze_has_org_access(org_id))`, ENABLE+FORCE in the creating migration. It is auto-discovered by `rls-coverage.integration.test.ts` (org_id column) — no allowlist entry needed, but a functional cross-org forge test is required.
+- Migrations: idempotent (`CREATE TABLE IF NOT EXISTS`, `pg_policies` existence checks), `YYYY-MM-DD-<slug>.sql` sorting after the latest (`2026-06-25-sso-admin-permission-backfill.sql` from Plan A), no inner `BEGIN/COMMIT`, cleanup statements report row counts. Never edit a shipped migration.
+- Pre-auth callback DB reads/writes run under `withSystemDbAccessContext` (the established SSO-callback pattern).
+- New SSO domain routes are gated `requirePermission(PERMISSIONS.SSO_ADMIN.resource, PERMISSIONS.SSO_ADMIN.action)` + `requireMfa()` + `requireScope('organization','partner','system')`, org-scoped via `auth.canAccessOrg`.
+- DNS: use `dns/promises` `resolveTxt` with a short timeout; resolution errors (NXDOMAIN/timeout) → not verified (fail-safe). The TXT lives at `_breeze-verify.<domain>` with value `breeze-domain-verify=<token>`.
+- Enforcement is per-org: refuse only once the org has ≥1 verified domain, OR when `SSO_DOMAIN_VERIFICATION_STRICT` is on. Already-linked `(provider, sub)` logins are NEVER domain-checked.
+- Node: prefix node commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`.
+- Integration/real-DB tests live in `src/__tests__/integration/*.integration.test.ts` (validated by CI's Integration Tests job; may not run locally without the breeze_app harness — don't get stuck running them).
+- **Worktree discipline (a prior subagent committed to the wrong branch):** every implementer must `cd /Users/toddhebebrand/breeze/.claude/worktrees/sso-domain-verification-impl` first and verify `git rev-parse --show-toplevel` == that path and `git branch --show-current` == `worktree-sso-domain-verification-impl` before running anything; commit only on that branch; no `git pull/rebase/checkout/switch`.
+
+---
+
+### Task 1: `sso_verified_domains` schema + migration + RLS + seed
+
+**Files:**
+- Modify: `apps/api/src/db/schema/sso.ts` (add the `ssoVerifiedDomains` table near `ssoProviders`)
+- Create: `apps/api/migrations/2026-06-26-sso-verified-domains.sql`
+- Create: `apps/api/src/__tests__/integration/ssoVerifiedDomainsRls.integration.test.ts`
+
+**Interfaces:**
+- Produces: Drizzle `ssoVerifiedDomains` with columns `{ id, orgId, domain, verificationToken, verifiedAt, lastCheckedAt, createdBy, createdAt, updatedAt }`, consumed by Tasks 2/5/6.
+
+- [ ] **Step 1: Add the Drizzle table** in `apps/api/src/db/schema/sso.ts` (after `ssoProviders`):
+
+```ts
+export const ssoVerifiedDomains = pgTable('sso_verified_domains', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  domain: varchar('domain', { length: 253 }).notNull(),
+  verificationToken: varchar('verification_token', { length: 128 }).notNull(),
+  verifiedAt: timestamp('verified_at'),
+  lastCheckedAt: timestamp('last_checked_at'),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  orgDomainUnique: uniqueIndex('sso_verified_domains_org_domain_idx').on(t.orgId, t.domain),
+}));
+```
+(Ensure `uniqueIndex` is imported from `drizzle-orm/pg-core` in this file.)
+
+- [ ] **Step 2: Write the migration** `apps/api/migrations/2026-06-26-sso-verified-domains.sql`:
+
+```sql
+-- Security review #2 (H-2, Plan B): org-scoped verified domains for SSO. An org
+-- proves DNS ownership of a domain before SSO may provision/JIT-link an email in
+-- it. RLS shape 1 (direct org_id). Idempotent.
+CREATE TABLE IF NOT EXISTS sso_verified_domains (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  domain varchar(253) NOT NULL,
+  verification_token varchar(128) NOT NULL,
+  verified_at timestamp,
+  last_checked_at timestamp,
+  created_by uuid REFERENCES users(id),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS sso_verified_domains_org_domain_idx
+  ON sso_verified_domains (org_id, domain);
+
+ALTER TABLE sso_verified_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sso_verified_domains FORCE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='sso_verified_domains' AND policyname='sso_verified_domains_org_isolation') THEN
+    CREATE POLICY sso_verified_domains_org_isolation ON sso_verified_domains
+      USING (public.breeze_has_org_access(org_id))
+      WITH CHECK (public.breeze_has_org_access(org_id));
+  END IF;
+END $$;
+
+-- Seed PENDING rows from existing providers' allowedDomains so admins see what
+-- to verify. token = encode(gen_random_bytes(24),'hex'). Report the count.
+DO $$
+DECLARE n integer;
+BEGIN
+  INSERT INTO sso_verified_domains (org_id, domain, verification_token)
+  SELECT DISTINCT p.org_id, lower(trim(d.domain)), encode(gen_random_bytes(24), 'hex')
+  FROM sso_providers p
+  CROSS JOIN LATERAL unnest(string_to_array(coalesce(p.allowed_domains, ''), ',')) AS d(domain)
+  WHERE trim(d.domain) <> ''
+  ON CONFLICT (org_id, domain) DO NOTHING;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'seeded % pending sso_verified_domains from allowed_domains', n; END IF;
+END $$;
+```
+
+- [ ] **Step 3: Write the forge test** `apps/api/src/__tests__/integration/ssoVerifiedDomainsRls.integration.test.ts` — a cross-org INSERT as the breeze_app role must be rejected. Mirror an existing org-scoped forge test (find one under `src/__tests__/integration/` that does a cross-org insert and copy its harness; seed two orgs, set the request context to org A, attempt to insert a `sso_verified_domains` row for org B, expect an RLS rejection). Assert a verified-domain SELECT scoped to org A does not see org B's rows.
+
+- [ ] **Step 4: Run drift + ordering + tsc**
+
+Run: `cd /Users/toddhebebrand/breeze && export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift`
+Expected: no drift (schema matches the migration).
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/db/autoMigrate.test.ts` → PASS.
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx tsc --noEmit` → 0 errors.
+(The RLS forge test runs in CI's Integration Tests job; note if it can't run locally.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/db/schema/sso.ts apps/api/migrations/2026-06-26-sso-verified-domains.sql apps/api/src/__tests__/integration/ssoVerifiedDomainsRls.integration.test.ts
+git commit -m "feat(security): sso_verified_domains table + RLS + seed (review #2 H-2 Plan B)"
+```
+
+---
+
+### Task 2: Domain-verification service
+
+**Files:**
+- Create: `apps/api/src/services/ssoDomainVerification.ts`
+- Test: `apps/api/src/services/ssoDomainVerification.test.ts`
+
+**Interfaces:**
+- Consumes: `ssoVerifiedDomains` (Task 1), `db`, `withSystemDbAccessContext`.
+- Produces:
+  - `normalizeDomain(input: string): string | null` — lowercase, trim, strip trailing dot; null if invalid (no dot, contains `@`, empty).
+  - `createPendingDomain(orgId: string, domain: string, userId: string | null): Promise<{ id: string; domain: string; token: string; recordName: string }>` — inserts a pending row (token = 24 random bytes hex), returns the TXT instruction (`recordName = _breeze-verify.<domain>`, value `breeze-domain-verify=<token>`).
+  - `verifyDomain(orgId: string, domainId: string): Promise<{ verified: boolean }>` — resolves TXT at `_breeze-verify.<domain>`; if any record equals `breeze-domain-verify=<token>`, stamp `verifiedAt` + `lastCheckedAt`; else leave pending (still stamp `lastCheckedAt`).
+  - `isDomainVerifiedForOrg(orgId: string, emailDomain: string): Promise<boolean>` — true iff a row for `(orgId, emailDomain)` has `verifiedAt` not null.
+  - `orgHasAnyVerifiedDomain(orgId: string): Promise<boolean>` — true iff the org has ≥1 verified row.
+
+- [ ] **Step 1: Write the failing tests** `apps/api/src/services/ssoDomainVerification.test.ts` — mock `dns/promises` `resolveTxt` and the db. Cover:
+  - `normalizeDomain`: `'Corp.com '`→`'corp.com'`; `'a@b'`→null; `'nodot'`→null; `''`→null.
+  - `verifyDomain`: resolveTxt returns `[['breeze-domain-verify=TOKEN']]` → verified true (and `verifiedAt` set); returns `[['other']]` → verified false; resolveTxt throws (NXDOMAIN) → verified false (fail-safe).
+  - `isDomainVerifiedForOrg` / `orgHasAnyVerifiedDomain`: true when a verified row exists, false otherwise.
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('dns/promises', () => ({ resolveTxt: vi.fn() }));
+// ...mock '../db' (db.select/insert/update chains) + './redis' if needed...
+import { resolveTxt } from 'dns/promises';
+import { normalizeDomain /*, verifyDomain, ... */ } from './ssoDomainVerification';
+
+describe('normalizeDomain', () => {
+  it('lowercases and trims', () => { expect(normalizeDomain(' Corp.com ')).toBe('corp.com'); });
+  it('rejects invalid', () => { expect(normalizeDomain('a@b')).toBeNull(); expect(normalizeDomain('nodot')).toBeNull(); expect(normalizeDomain('')).toBeNull(); });
+});
+// + verifyDomain match / no-match / dns-error cases using vi.mocked(resolveTxt)
+```
+(Define the db mock so `verifyDomain` reads the pending row's token and updates it; assert the update is called with `verifiedAt` set on match and not on no-match. Adjust to the real chain shapes.)
+
+- [ ] **Step 2: Run, expect FAIL** — `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH npx vitest run src/services/ssoDomainVerification.test.ts` → FAIL (module/functions missing).
+
+- [ ] **Step 3: Implement `apps/api/src/services/ssoDomainVerification.ts`:**
+
+```ts
+import { randomBytes } from 'crypto';
+import { resolveTxt } from 'dns/promises';
+import { and, eq, isNotNull } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import { ssoVerifiedDomains } from '../db/schema';
+
+const TXT_PREFIX = 'breeze-domain-verify=';
+const RESOLVE_TIMEOUT_MS = 5000;
+
+export function normalizeDomain(input: string): string | null {
+  const d = input.trim().toLowerCase().replace(/\.$/, '');
+  if (!d || d.includes('@') || !d.includes('.') || /\s/.test(d)) return null;
+  return d;
+}
+
+export async function createPendingDomain(orgId: string, domain: string, userId: string | null) {
+  const normalized = normalizeDomain(domain);
+  if (!normalized) throw new Error('invalid domain');
+  const token = randomBytes(24).toString('hex');
+  const [row] = await withSystemDbAccessContext(async () =>
+    db.insert(ssoVerifiedDomains).values({ orgId, domain: normalized, verificationToken: token, createdBy: userId }).returning()
+  );
+  return { id: row.id, domain: normalized, token, recordName: `_breeze-verify.${normalized}` };
+}
+
+async function resolveTxtSafe(name: string): Promise<string[]> {
+  try {
+    const records = (await Promise.race([
+      resolveTxt(name),
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error('dns timeout')), RESOLVE_TIMEOUT_MS)),
+    ])) as string[][];
+    return records.map((chunks) => chunks.join(''));
+  } catch {
+    return [];
+  }
+}
+
+export async function verifyDomain(orgId: string, domainId: string): Promise<{ verified: boolean }> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(ssoVerifiedDomains)
+      .where(and(eq(ssoVerifiedDomains.id, domainId), eq(ssoVerifiedDomains.orgId, orgId))).limit(1);
+    if (!row) return { verified: false };
+    const txts = await resolveTxtSafe(`_breeze-verify.${row.domain}`);
+    const verified = txts.includes(`${TXT_PREFIX}${row.verificationToken}`);
+    await db.update(ssoVerifiedDomains)
+      .set({ verifiedAt: verified ? new Date() : row.verifiedAt, lastCheckedAt: new Date(), updatedAt: new Date() })
+      .where(eq(ssoVerifiedDomains.id, row.id));
+    return { verified };
+  });
+}
+
+export async function isDomainVerifiedForOrg(orgId: string, emailDomain: string): Promise<boolean> {
+  const normalized = normalizeDomain(emailDomain);
+  if (!normalized) return false;
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select({ id: ssoVerifiedDomains.id }).from(ssoVerifiedDomains)
+      .where(and(eq(ssoVerifiedDomains.orgId, orgId), eq(ssoVerifiedDomains.domain, normalized), isNotNull(ssoVerifiedDomains.verifiedAt)))
+      .limit(1);
+    return !!row;
+  });
+}
+
+export async function orgHasAnyVerifiedDomain(orgId: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select({ id: ssoVerifiedDomains.id }).from(ssoVerifiedDomains)
+      .where(and(eq(ssoVerifiedDomains.orgId, orgId), isNotNull(ssoVerifiedDomains.verifiedAt))).limit(1);
+    return !!row;
+  });
+}
+```
+
+- [ ] **Step 4: Run, expect PASS + tsc** — `npx vitest run src/services/ssoDomainVerification.test.ts` → PASS; `npx tsc --noEmit` → 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ssoDomainVerification.ts apps/api/src/services/ssoDomainVerification.test.ts
+git commit -m "feat(security): SSO domain-verification service (review #2 H-2 Plan B)"
+```
+
+---
+
+### Task 3: `sso:admin`-gated domain CRUD routes
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` (add 4 routes; reuse the `resolveOrgIdForProviderRoute`/`canAccessOrg` org-scoping helpers already in the file)
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes: the Task 2 service.
+- Produces: `POST /sso/domains` `{ orgId?, domain }` → `{ id, domain, recordName, token }`; `POST /sso/domains/:id/verify` → `{ verified }`; `GET /sso/domains?orgId=` → list; `DELETE /sso/domains/:id` → `{ ok: true }`. All `requireScope` + `requirePermission(SSO_ADMIN)` + `requireMfa()`, org-scoped.
+
+- [ ] **Step 1: Write failing tests** in `apps/api/src/routes/sso.test.ts`: (a) the new domain routes are registered with the `sso:admin` guard (extend the existing `recordedPermissionGuards` assertion to confirm domain routes are covered — they share the gate); (b) `POST /sso/domains` returns the TXT instruction for a valid domain; (c) a domain in another org cannot be verified/deleted (org-scoping → 403/404). Mock the Task 2 service functions.
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement the 4 routes** in `apps/api/src/routes/sso.ts` (place near the provider routes; import the service + a `domainBodySchema = z.object({ orgId: z.string().guid().optional(), domain: z.string().min(1).max(253) })` and a param schema). Each handler resolves the org (reuse `resolveOrgIdForProviderRoute` or the same `canAccessOrg` pattern the provider routes use), then calls the service. `verify`/`DELETE` first load the row scoped to the resolved org (404 if not in the caller's org). Use `withSystemDbAccessContext` for the DELETE/list DB ops consistent with the file's pre-auth/system-scope handling where applicable (these routes ARE authed, so request-scope `db` is fine for list/delete — match how the provider routes query).
+
+- [ ] **Step 4: Run, expect PASS + tsc + whole sso.test file.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(security): sso:admin-gated domain CRUD routes (review #2 H-2 Plan B)"
+```
+
+---
+
+### Task 4: `SSO_DOMAIN_VERIFICATION_STRICT` env flag
+
+**Files:**
+- Modify: `apps/api/src/config/validate.ts` (add to the env schema near the other optional flags)
+- Create or modify: a small reader (follow the `isHosted()` pattern) — add `export function isSsoDomainVerificationStrict(): boolean` somewhere sensible (e.g. a new `apps/api/src/services/ssoConfig.ts`, or alongside the existing config readers).
+- Test: a unit test for the reader (true/false/unset/garbage).
+
+**Interfaces:**
+- Produces: `isSsoDomainVerificationStrict(): boolean` (default false; true only for affirmative `1|true|yes|on`).
+
+- [ ] **Step 1: Write the failing test** for `isSsoDomainVerificationStrict` — `'true'`/`'1'`→true; unset/`'false'`/garbage→false (toggle `process.env.SSO_DOMAIN_VERIFICATION_STRICT`).
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** the reader + add `SSO_DOMAIN_VERIFICATION_STRICT: z.string().optional()` to the validate.ts env schema.
+- [ ] **Step 4: Run, expect PASS + tsc.**
+- [ ] **Step 5: Commit** `git commit -m "feat(security): SSO_DOMAIN_VERIFICATION_STRICT flag (review #2 H-2 Plan B)"`
+
+---
+
+### Task 5: Callback enforcement (the gate)
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` — the callback's `if (!user)` block (≈ line 1004, after the identity-first lookup, before the byEmail-JIT and autoProvision branches)
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes: `isDomainVerifiedForOrg`, `orgHasAnyVerifiedDomain` (Task 2), `isSsoDomainVerificationStrict` (Task 4), `writeRouteAudit`.
+
+- [ ] **Step 1: Write failing tests** (extend the existing callback test helpers `primeCallback`/`wireLinkedLogin`/`sel`): 
+  - provision/link in a **verified** domain (org enforcing) → succeeds (302 ssoCode, createTokenPair called).
+  - provision/link in an **unverified** domain with the org **enforcing** (orgHasAnyVerifiedDomain → true) → redirect `error=sso_domain_unverified`, createTokenPair NOT called.
+  - same in **warn mode** (orgHasAnyVerifiedDomain → false, strict off) → allowed (302 ssoCode) + audit event written.
+  - **already-linked** `(provider, sub)` login in an unverified domain → unaffected (succeeds, gate not consulted).
+  (Mock `isDomainVerifiedForOrg`/`orgHasAnyVerifiedDomain`/`isSsoDomainVerificationStrict` per case.)
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement the gate.** In `apps/api/src/routes/sso.ts`, at the very top of the `if (!user) {` block (the branch entered only when no `(provider, sub)` link resolved), before the byEmail lookup:
+
+```ts
+    if (!user) {
+      // security review #2 (H-2 Plan B): domain-ownership gate on the
+      // provision / JIT-link path. Already-linked (provider, sub) users skip
+      // this entirely (we're inside `if (!user)`). Enforce once the org has
+      // verified a domain (or globally via SSO_DOMAIN_VERIFICATION_STRICT);
+      // otherwise warn (allow + audit) so existing auto-provisioning orgs
+      // aren't broken before they verify.
+      const emailDomain = attrs.email.split('@')[1]?.toLowerCase() ?? '';
+      const enforcing = isSsoDomainVerificationStrict() || await orgHasAnyVerifiedDomain(provider.orgId);
+      const domainVerified = await isDomainVerifiedForOrg(provider.orgId, emailDomain);
+      if (!domainVerified) {
+        if (enforcing) {
+          clearStateCookie();
+          return c.redirect('/login?error=sso_domain_unverified');
+        }
+        // warn mode: allow, but record it so admins are nudged to verify.
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.provision.unverified_domain',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          details: { emailDomain, mode: 'warn' },
+        });
+      }
+      // ...existing byEmail-JIT-link + autoProvision logic follows unchanged...
+```
+(Insert before the existing `const [byEmail] = ...` line; keep the rest of the block intact.)
+
+- [ ] **Step 4: Run, expect PASS + tsc + whole sso.test file (54+ tests).**
+
+- [ ] **Step 5: Commit** `git commit -m "feat(security): gate SSO provisioning/linking on verified domain (review #2 H-2 Plan B)"`
+
+---
+
+### Task 6: Daily re-check job
+
+**Files:**
+- Create: `apps/api/src/services/ssoDomainReverifyJob.ts` (or add to an existing worker module — follow `apps/api/src/services/warrantyWorker.ts`'s repeatable-job registration)
+- Modify: wherever workers/schedulers are initialized (the same place `warrantyWorker` is registered)
+- Test: `apps/api/src/services/ssoDomainReverifyJob.test.ts`
+
+**Interfaces:**
+- Consumes: `ssoVerifiedDomains`, `verifyDomain`-style TXT resolution, `writeAudit`/notification.
+- Produces: a recurring job (cadence ~daily, jobId with `-` separators per the colon rule) that, for each `verifiedAt IS NOT NULL` domain, re-resolves the TXT, updates `last_checked_at`, and on a miss writes an audit event (action `sso.domain.txt_missing`) WITHOUT clearing `verifiedAt` (sticky).
+
+- [ ] **Step 1: Write the failing test** — given a verified domain whose TXT now resolves empty, the re-check writes the drift audit and does NOT null `verifiedAt`; given a still-present TXT, it just updates `last_checked_at`. Mock dns + db + audit.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** the job processor + registration (mirror `warrantyWorker.ts`). Sticky: never set `verifiedAt = null`.
+- [ ] **Step 4: Run, expect PASS + tsc.**
+- [ ] **Step 5: Commit** `git commit -m "feat(security): daily SSO domain re-check job (review #2 H-2 Plan B)"`
+
+---
+
+## Out of scope (this plan)
+- **Admin UI** (verified-domains panel + warn banner in `apps/web`) — separate follow-up plan/PR (per the chosen scope).
+
+## Self-Review
+- **Spec coverage:** Tasks 1-6 cover the spec's Plan B backend: table+RLS+seed (T1), service (T2), routes (T3), env flag (T4), callback enforcement with warn/enforce rollout (T5), re-check job (T6). Admin UI deferred by decision.
+- **Placeholders:** code shown for the load-bearing pieces (schema, migration, service, gate). T3/T6 describe routes/job concretely with exact signatures + templates to mirror (`warrantyWorker`, existing provider routes); no "TODO/handle edge cases".
+- **Type consistency:** service function names/signatures in T2 match their uses in T3 (CRUD) and T5 (`isDomainVerifiedForOrg`, `orgHasAnyVerifiedDomain`) and T4 (`isSsoDomainVerificationStrict`). `ssoVerifiedDomains` columns (T1) match the service queries (T2).


### PR DESCRIPTION
**Provenance:** Plan B of the SSO H-2 design (spec #1689). Backend only — admin UI is a tracked follow-up.

**What & why:** A malicious or compromised **org-admin** could point their org's SSO at an attacker IdP and provision/JIT-link emails in a domain the org doesn't own (security review #2, H-2). The *exploitable* and steady-state takeover were already closed by #1655 (mandatory id_token signature), #1671 (identity-first lookup + safe JIT-linking), and #1691 (`sso:admin` gate). This adds the industry-standard remaining layer: **DNS-TXT proof of domain ownership** before SSO will JIT-link-by-email or provision a *new* account. Defense-in-depth, not an open exploit fix.

**Behavior:**
- Enforcement is **global** via `SSO_DOMAIN_VERIFICATION_STRICT=true`, or **per-org**: an org becomes gated once it has ≥1 verified domain (gradual rollout). Ships dark (flag off, no org gated until it verifies a domain).
- **Already-linked identities** (matched by `(provider, sub)`) are exempt — turning enforcement on never locks out existing SSO users.
- Verification is **sticky** — a transient DNS failure never un-verifies a working org.

**Changes (6 tasks, TDD):**
- **Schema/RLS:** `sso_verified_domains` table (shape 1, direct `org_id`; ENABLE+FORCE RLS) + idempotent migration `2026-06-26-sso-verified-domains.sql` seeding pending rows from `sso_providers.allowed_domains`; cross-org forge test; added to `ORG_CASCADE_DELETE_ORDER` (`tenantCascade.ts`).
- **Service** `services/ssoDomainVerification.ts`: `normalizeDomain`, `createPendingDomain`, `verifyDomain` (DNS TXT at `_breeze-verify.<domain>` == `breeze-domain-verify=<token>`), `isDomainVerifiedForOrg`, `orgHasAnyVerifiedDomain`, `isSsoProvisioningBlocked`, `recheckAllDomains`.
- **Routes** (`routes/sso.ts`): `GET/POST /sso/domains`, `POST /sso/domains/:id/verify`, `DELETE /sso/domains/:id` — every mutation gated `requirePermission(sso:admin)` + `requireMfa()`; `:id` routes do `canAccessOrg` before acting.
- **Env flag** `SSO_DOMAIN_VERIFICATION_STRICT` (`config/validate.ts`, optional, never blocks boot).
- **Callback gate** (`routes/sso.ts`): refuses link/provision in an unverified domain when enforcing, after the identity-first lookup and before both email-based paths, under system DB context.
- **Daily re-check worker** `services/ssoDomainRecheckWorker.ts` (sticky), wired into `index.ts`.

**Tests:** 102 unit tests green locally (45 service + 42 routes + 15 cascade) + tsc clean. Cross-org RLS forge test and tenantCascade list-contract run in the **Integration Tests** CI job (real DB).

**Review:** Each task passed an individual spec+quality review (incl. an adversarial control-flow review of the callback gate). Whole-branch final review: **READY**, no must-fix defects.

**Follow-ups (not blockers):** admin UI; a per-org cap on pending domains (DNS-sweep abuse hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)