### PR TITLE
fix(agents): chunk device_connections bulk insert under Postgres param limit (#1696)

### DIFF
--- a/apps/api/src/routes/agents/connections.test.ts
+++ b/apps/api/src/routes/agents/connections.test.ts
@@ -354,7 +354,7 @@ describe('connections routes', () => {
         return fn(tx);
       });
 
-      // 12 columns/row × 10,000 rows = 120,000 bind params — far over the
+      // 11 columns/row × 10,000 rows = 110,000 bind params — far over the
       // 65534 limit if sent as one statement. The schema cap is 10,000.
       const COUNT = 10000;
       const connections = Array.from({ length: COUNT }, (_, i) => ({
@@ -375,13 +375,15 @@ describe('connections routes', () => {
 
       // Must have split into multiple batches (old code inserted in one shot).
       expect(insertedBatches.length).toBeGreaterThan(1);
-      // No batch may exceed the chunk size (5000 rows × 12 cols = 60k params).
+      // No batch may exceed the chunk size (5000 rows × 11 cols = 55k params).
       for (const batch of insertedBatches) {
         expect(batch.length).toBeLessThanOrEqual(5000);
       }
-      // No rows lost or duplicated across batches.
-      const total = insertedBatches.reduce((n, b) => n + b.length, 0);
-      expect(total).toBe(COUNT);
+      // Concatenated batches must equal the original rows IN ORDER — guards
+      // against a chunk() off-by-one that drops/duplicates a specific row while
+      // keeping the total count correct (localPort is the unique per-row marker).
+      const flatPorts = insertedBatches.flat().map((r: { localPort: number }) => r.localPort);
+      expect(flatPorts).toEqual(connections.map((c) => c.localPort));
     });
   });
 

--- a/apps/api/src/routes/agents/connections.test.ts
+++ b/apps/api/src/routes/agents/connections.test.ts
@@ -328,6 +328,61 @@ describe('connections routes', () => {
       const body = await res.json();
       expect(body.count).toBe(4);
     });
+
+    it('chunks large inserts to stay under the Postgres 65534-param limit (#1696)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: DEVICE_ID, agentId: AGENT_ID, orgId: 'org-1' }]),
+          }),
+        }),
+      } as any);
+
+      const insertedBatches: any[][] = [];
+      vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+        const tx = {
+          delete: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockImplementation((rows: any[]) => {
+              insertedBatches.push(rows);
+              return Promise.resolve(undefined);
+            }),
+          }),
+        };
+        return fn(tx);
+      });
+
+      // 12 columns/row × 10,000 rows = 120,000 bind params — far over the
+      // 65534 limit if sent as one statement. The schema cap is 10,000.
+      const COUNT = 10000;
+      const connections = Array.from({ length: COUNT }, (_, i) => ({
+        protocol: 'tcp',
+        localAddr: '0.0.0.0',
+        localPort: (i % 65535),
+      }));
+
+      const res = await app.request(`/agents/${AGENT_ID}/connections`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ connections }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.count).toBe(COUNT);
+
+      // Must have split into multiple batches (old code inserted in one shot).
+      expect(insertedBatches.length).toBeGreaterThan(1);
+      // No batch may exceed the chunk size (5000 rows × 12 cols = 60k params).
+      for (const batch of insertedBatches) {
+        expect(batch.length).toBeLessThanOrEqual(5000);
+      }
+      // No rows lost or duplicated across batches.
+      const total = insertedBatches.reduce((n, b) => n + b.length, 0);
+      expect(total).toBe(COUNT);
+    });
   });
 
   // ----------------------------------------------------------------

--- a/apps/api/src/routes/agents/connections.ts
+++ b/apps/api/src/routes/agents/connections.ts
@@ -17,12 +17,13 @@ const STATE_MAX = 20;
 const PROCESS_NAME_MAX = 255;
 const ADDR_MAX = 128; // local_addr / remote_addr are text; cap for sanity (e.g. IPv6 zone IDs)
 
-// device_connections binds 12 columns per row, and Postgres caps a single
-// statement at 65534 bound parameters. The submit schema allows up to 10,000
-// connections, which at 12 cols would need 120,000 params and fail the insert
-// with MAX_PARAMETERS_EXCEEDED — silently dropping the device's entire
+// device_connections binds 11 columns per row (the row object omits `id`, which
+// Postgres fills via its DEFAULT — it costs no bind param), and Postgres caps a
+// single statement at 65534 bound parameters. The submit schema allows up to
+// 10,000 connections, which at 11 cols would need 110,000 params and fail the
+// insert with MAX_PARAMETERS_EXCEEDED — silently dropping the device's entire
 // connection inventory (#1696). Chunk the insert well under the limit:
-// 5000 rows × 12 cols = 60,000 params, a comfortable margin under 65534.
+// 5000 rows × 11 cols = 55,000 params, a comfortable margin under 65534.
 const CONNECTION_INSERT_CHUNK_SIZE = 5000;
 
 function chunk<T>(items: T[], size: number): T[][] {

--- a/apps/api/src/routes/agents/connections.ts
+++ b/apps/api/src/routes/agents/connections.ts
@@ -17,6 +17,22 @@ const STATE_MAX = 20;
 const PROCESS_NAME_MAX = 255;
 const ADDR_MAX = 128; // local_addr / remote_addr are text; cap for sanity (e.g. IPv6 zone IDs)
 
+// device_connections binds 12 columns per row, and Postgres caps a single
+// statement at 65534 bound parameters. The submit schema allows up to 10,000
+// connections, which at 12 cols would need 120,000 params and fail the insert
+// with MAX_PARAMETERS_EXCEEDED — silently dropping the device's entire
+// connection inventory (#1696). Chunk the insert well under the limit:
+// 5000 rows × 12 cols = 60,000 params, a comfortable margin under 65534.
+const CONNECTION_INSERT_CHUNK_SIZE = 5000;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+}
+
 function clampNullable(value: string | null | undefined, max: number): string | null {
   if (value === null || value === undefined || value === '') return null;
   return value.length > max ? value.slice(0, max) : value;
@@ -54,21 +70,24 @@ connectionsRoutes.put(
 
       if (data.connections.length > 0) {
         const now = new Date();
-        await tx.insert(deviceConnections).values(
-          data.connections.map((conn) => ({
-            deviceId: device.id,
-            orgId: device.orgId,
-            protocol: conn.protocol,
-            localAddr: clampRequired(conn.localAddr, ADDR_MAX),
-            localPort: conn.localPort,
-            remoteAddr: clampNullable(conn.remoteAddr, ADDR_MAX),
-            remotePort: conn.remotePort || null,
-            state: clampNullable(conn.state, STATE_MAX),
-            pid: conn.pid || null,
-            processName: clampNullable(conn.processName, PROCESS_NAME_MAX),
-            updatedAt: now
-          }))
-        );
+        const rows = data.connections.map((conn) => ({
+          deviceId: device.id,
+          orgId: device.orgId,
+          protocol: conn.protocol,
+          localAddr: clampRequired(conn.localAddr, ADDR_MAX),
+          localPort: conn.localPort,
+          remoteAddr: clampNullable(conn.remoteAddr, ADDR_MAX),
+          remotePort: conn.remotePort || null,
+          state: clampNullable(conn.state, STATE_MAX),
+          pid: conn.pid || null,
+          processName: clampNullable(conn.processName, PROCESS_NAME_MAX),
+          updatedAt: now
+        }));
+        // Chunk to stay under Postgres' 65534 bound-parameter limit (#1696).
+        // All batches share the transaction, so delete+replace stays atomic.
+        for (const batch of chunk(rows, CONNECTION_INSERT_CHUNK_SIZE)) {
+          await tx.insert(deviceConnections).values(batch);
+        }
       }
     });
   } catch (err) {


### PR DESCRIPTION
## What
Chunks the `device_connections` bulk insert in `PUT /agents/:id/connections` so a high-connection device can no longer blow Postgres' 65,534 bound-parameter limit.

Closes #1696.

## Why
**Root cause:** the handler did a single `tx.insert(deviceConnections).values(connections.map(...))`. Each row binds **12 columns** and the submit schema (`schemas.ts:530`) allows up to **10,000** connections → 120,000 params, ≫ 65,534. The limit trips at **> 5,461 rows**, the insert throws `MAX_PARAMETERS_EXCEEDED`, and the whole batch is dropped — **silent loss** of that device's connection inventory.

**Evidence:** EU `breeze-api` logs showed ~20 occurrences in a 3h window:
```
Error: MAX_PARAMETERS_EXCEEDED: Max number of parameters (65534) exceeded
  insert into "device_connections" (...12 cols...) values (default,$1..),(default,$12..),...
```

## Fix
- Map rows once, then insert in batches of **5,000** (60,000 params — comfortable margin under 65,534).
- All batches run **inside the existing transaction**, so the `delete`-then-replace semantics stay atomic.
- Local `chunk()` helper mirroring the style already used in `jobs/dnsSyncJob.ts`.

## Test
- New regression test: a 10,000-connection payload must split into **multiple** bounded batches (≤ 5,000 each) with no rows lost. The old single-insert code calls `values()` once, so this test fails pre-fix.
- Full `connections.test.ts`: **11/11 pass**. `tsc --noEmit` clean.

## Notes
The companion production issue #1697 (DB connections pinned in open transaction / US pool starvation) is filed separately with confirmed root causes and a fix plan — intentionally **not** bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
