### PR TITLE
fix(invoices): audit log manual payment record/void

### DIFF
--- a/apps/api/src/routes/invoices/invoices.test.ts
+++ b/apps/api/src/routes/invoices/invoices.test.ts
@@ -28,6 +28,12 @@ vi.mock('../../services/invoicePdf', () => ({
   getInvoicePdf: vi.fn()
 }));
 
+// Payment routes write to the durable audit chain; stub it so route tests don't
+// hit the real audit persistence path.
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn()
+}));
+
 // InvoiceServiceError lives in invoiceTypes; routes import the class from there.
 vi.mock('../../services/invoiceTypes', () => ({
   InvoiceServiceError: class InvoiceServiceError extends Error {
@@ -262,7 +268,10 @@ describe('invoice payment routes', () => {
   });
 
   it('POST /:id/payments records a payment', async () => {
-    (svc.recordPayment as any).mockResolvedValue({ id: 'pay1', amount: '40.00' });
+    (svc.recordPayment as any).mockResolvedValue({
+      invoice: { id: INV_ID, amount: '40.00' },
+      audit: { orgId: ORG_ID, paymentId: 'pay1', invoiceId: INV_ID, amount: '40.00', method: 'card', reference: null, recordedBy: 'u1' }
+    });
     const res = await app().request(`/${INV_ID}/payments`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/apps/api/src/routes/invoices/payments.test.ts
+++ b/apps/api/src/routes/invoices/payments.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the service layer — the route is thin; we assert it writes a durable audit
+// entry for each money-path mutation with the right action/resource/details.
+vi.mock('../../services/invoiceService', () => ({
+  recordPayment: vi.fn(),
+  listPayments: vi.fn(),
+  voidPayment: vi.fn()
+}));
+
+// The audit writer is the durable chain; assert the route calls it (separate from
+// the intentionally-unconsumed emitInvoiceEvent bus).
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn()
+}));
+
+vi.mock('../../services/invoiceTypes', () => ({
+  InvoiceServiceError: class InvoiceServiceError extends Error {
+    constructor(msg: string, public status = 400, public code?: string) { super(msg); }
+  }
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null });
+    await next();
+  },
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next()
+}));
+
+import { Hono } from 'hono';
+import { invoicePaymentRoutes } from './payments';
+import * as svc from '../../services/invoiceService';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { InvoiceServiceError } from '../../services/invoiceTypes';
+
+const INV_ID = '11111111-1111-1111-1111-111111111111';
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const PAY_ID = '33333333-3333-3333-3333-333333333333';
+
+// payments.ts assumes the auth middleware already ran; mount under a wrapper that
+// injects the auth context (mirrors how invoiceRoutes applies it internally).
+function app() {
+  const a = new Hono();
+  a.use('*', async (c, next) => {
+    c.set('auth' as never, { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null } as never);
+    await next();
+  });
+  a.route('/', invoicePaymentRoutes);
+  return a;
+}
+
+describe('invoice payment audit logging', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('POST /:id/payments writes invoice.payment.recorded to the audit chain', async () => {
+    (svc.recordPayment as any).mockResolvedValue({
+      invoice: { id: INV_ID, status: 'partial' },
+      audit: {
+        orgId: ORG_ID, paymentId: PAY_ID, invoiceId: INV_ID,
+        amount: '40.00', method: 'card', reference: 'REF-1', recordedBy: 'u1'
+      }
+    });
+    const res = await app().request(`/${INV_ID}/payments`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ amount: 40, method: 'card', reference: 'REF-1', receivedAt: '2026-06-14' })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Response shape is still the invoice — additive change, no behavior break.
+    expect(body.data.id).toBe(INV_ID);
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), {
+      orgId: ORG_ID,
+      action: 'invoice.payment.recorded',
+      resourceType: 'invoice_payment',
+      resourceId: PAY_ID,
+      details: { amount: '40.00', method: 'card', reference: 'REF-1', invoiceId: INV_ID }
+    });
+  });
+
+  it('DELETE /:id/payments/:pid writes invoice.payment.voided with the pre-delete financial details', async () => {
+    (svc.voidPayment as any).mockResolvedValue({
+      invoice: { id: INV_ID, status: 'sent' },
+      audit: {
+        orgId: ORG_ID, paymentId: PAY_ID, invoiceId: INV_ID,
+        amount: '40.00', method: 'card', reference: 'REF-1', recordedBy: 'u9'
+      }
+    });
+    const res = await app().request(`/${INV_ID}/payments/${PAY_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.id).toBe(INV_ID);
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), {
+      orgId: ORG_ID,
+      action: 'invoice.payment.voided',
+      resourceType: 'invoice_payment',
+      resourceId: PAY_ID,
+      // The destroyed row's amount/method/recordedBy must survive in the chain.
+      details: { amount: '40.00', method: 'card', reference: 'REF-1', invoiceId: INV_ID, recordedBy: 'u9' }
+    });
+  });
+
+  it('does not write an audit entry when the service throws', async () => {
+    (svc.recordPayment as any).mockRejectedValue(new InvoiceServiceError('Payment exceeds balance', 409, 'OVERPAYMENT'));
+    const res = await app().request(`/${INV_ID}/payments`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ amount: 40, method: 'card', receivedAt: '2026-06-14' })
+    });
+    expect(res.status).toBe(409);
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/invoices/payments.ts
+++ b/apps/api/src/routes/invoices/payments.ts
@@ -5,6 +5,7 @@ import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { recordPaymentSchema } from '@breeze/shared';
 import { recordPayment, listPayments, voidPayment } from '../../services/invoiceService';
+import { writeRouteAudit } from '../../services/auditEvents';
 import { invoiceActorFrom, handleServiceError } from './invoices';
 
 export const invoicePaymentRoutes = new Hono();
@@ -19,10 +20,30 @@ invoicePaymentRoutes.get('/:id/payments', scopes, readPerm, zValidator('param', 
   catch (err) { return handleServiceError(c, err); }
 });
 invoicePaymentRoutes.post('/:id/payments', scopes, sendPerm, zValidator('param', idParam), zValidator('json', recordPaymentSchema), async (c) => {
-  try { return c.json({ data: await recordPayment(c.req.valid('param').id, c.req.valid('json'), invoiceActorFrom(c)) }); }
-  catch (err) { return handleServiceError(c, err); }
+  try {
+    const { invoice, audit } = await recordPayment(c.req.valid('param').id, c.req.valid('json'), invoiceActorFrom(c));
+    writeRouteAudit(c, {
+      orgId: audit.orgId,
+      action: 'invoice.payment.recorded',
+      resourceType: 'invoice_payment',
+      resourceId: audit.paymentId,
+      details: { amount: audit.amount, method: audit.method, reference: audit.reference, invoiceId: audit.invoiceId }
+    });
+    return c.json({ data: invoice });
+  } catch (err) { return handleServiceError(c, err); }
 });
 invoicePaymentRoutes.delete('/:id/payments/:pid', scopes, sendPerm, zValidator('param', payParam), async (c) => {
-  try { return c.json({ data: await voidPayment(c.req.valid('param').pid, invoiceActorFrom(c)) }); }
-  catch (err) { return handleServiceError(c, err); }
+  try {
+    const { invoice, audit } = await voidPayment(c.req.valid('param').pid, invoiceActorFrom(c));
+    // The financial details were captured before the row was destroyed, so the
+    // voided payment (incl. who recorded it) survives in the durable chain.
+    writeRouteAudit(c, {
+      orgId: audit.orgId,
+      action: 'invoice.payment.voided',
+      resourceType: 'invoice_payment',
+      resourceId: audit.paymentId,
+      details: { amount: audit.amount, method: audit.method, reference: audit.reference, invoiceId: audit.invoiceId, recordedBy: audit.recordedBy }
+    });
+    return c.json({ data: invoice });
+  } catch (err) { return handleServiceError(c, err); }
 });

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -548,18 +548,44 @@ export async function recordPayment(invoiceId: string, input: RecordPaymentInput
   await emitInvoiceEvent({ type: 'payment.recorded', invoiceId, orgId: inv.orgId, partnerId: inv.partnerId, paymentId: payment!.id, actorUserId: actor.userId });
   const updated = await getOwnedInvoiceOr404(invoiceId);
   if (updated.status === 'paid') await emitInvoiceEvent({ type: 'invoice.paid', invoiceId, orgId: inv.orgId, partnerId: inv.partnerId, actorUserId: actor.userId });
-  return updated;
+  // Surface the persisted payment alongside the refreshed invoice so the route
+  // can write a durable audit_logs entry for this money-path mutation. The
+  // emitInvoiceEvent bus above is intentionally unconsumed and is NOT the
+  // durable chain.
+  return {
+    invoice: updated,
+    audit: {
+      orgId: inv.orgId,
+      paymentId: payment!.id,
+      invoiceId,
+      amount: payment!.amount,
+      method: payment!.method,
+      reference: payment!.reference,
+      recordedBy: payment!.recordedBy,
+    },
+  };
 }
 
 export async function voidPayment(paymentId: string, actor: InvoiceActor) {
   const [pay] = await db.select().from(invoicePayments).where(eq(invoicePayments.id, paymentId)).limit(1);
   if (!pay) throw new InvoiceServiceError('Payment not found', 404, 'PAYMENT_NOT_FOUND');
   requireOrgAccess(actor, pay.orgId);
+  // Capture the destroyed row's financial details BEFORE the delete so the voided
+  // payment survives in the durable audit chain even after the row is gone.
+  const audit = {
+    orgId: pay.orgId,
+    paymentId,
+    invoiceId: pay.invoiceId,
+    amount: pay.amount,
+    method: pay.method,
+    reference: pay.reference,
+    recordedBy: pay.recordedBy,
+  };
   await db.delete(invoicePayments).where(eq(invoicePayments.id, paymentId));
   await recomputeInvoiceStatus(pay.invoiceId);
   const inv = await getOwnedInvoiceOr404(pay.invoiceId);
   await emitInvoiceEvent({ type: 'payment.voided', invoiceId: pay.invoiceId, orgId: pay.orgId, partnerId: inv.partnerId, paymentId, actorUserId: actor.userId });
-  return inv;
+  return { invoice: inv, audit };
 }
 
 export async function listPayments(invoiceId: string, actor: InvoiceActor) {


### PR DESCRIPTION
## What

Manual invoice payment **record** and **void** now write a durable entry to the `audit_logs` chain via `writeRouteAudit`, matching the sibling money/connection routes (`stripeConnect`, `psa`).

- `POST /invoices/:id/payments` → action `invoice.payment.recorded`
- `DELETE /invoices/:id/payments/:pid` → action `invoice.payment.voided`
- `resourceType: invoice_payment`, `resourceId` = payment id, `orgId` from the invoice
- `details`: `amount`, `method`, `reference`, `invoiceId` (plus `recordedBy` on void)

## Why

These routes mutate the money path but previously only published to the intentionally-unconsumed BullMQ invoice-event bus — nothing landed in the durable audit chain. A voided payment's financial details are now captured **before** the row is deleted, so the destroyed record (amount/method/recordedBy) survives in the audit trail.

The service returns the refreshed invoice alongside the captured audit payload; the HTTP response body is unchanged (still the invoice). Additive only — no user-facing behavior change.

## Tests

- New `apps/api/src/routes/invoices/payments.test.ts` asserts both routes call `writeRouteAudit` with the correct action/resource/details, and that void details are captured pre-delete. Confirmed RED before the route change.
- Updated `invoices.test.ts` for the new service return shape; service unit tests and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)