### PR TITLE
fix(aitools): site-axis narrowing on no-deviceId list tools

### DIFF
--- a/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
+++ b/apps/api/src/services/aiTools.deviceAccessSiteScope.contract.test.ts
@@ -85,6 +85,9 @@ const SITE_GATED_NON_VERIFY_FILES = [
   'aiToolsDns.ts',
   'aiToolsHuntress.ts',
   'aiToolsSLABackup.ts',
+  'aiToolsAudit.ts',
+  'aiToolsCisBenchmark.ts',
+  'aiToolsPam.ts',
 ];
 
 const SITE_GATE_MARKERS = [

--- a/apps/api/src/services/aiToolsAudit.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAudit.siteScope.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerAuditTools } from './aiToolsAudit';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerAuditTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('query_change_log — site narrowing (no deviceId branch)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive change-log rows for a device in a forbidden site', async () => {
+    let changeScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      changeScanRan = true;
+      return chain([
+        { timestamp: null, changeType: 'software', changeAction: 'added', subject: 's', beforeValue: null, afterValue: null, details: null, hostname: 'forbidden-host', deviceId: 'd-siteB' },
+      ]);
+    });
+
+    const r = await handlerFor('query_change_log')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.changes).toEqual([]);
+    expect(parsed.total).toBe(0);
+    expect(parsed.showing).toBe(0);
+    expect(changeScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
+  });
+
+  it('unrestricted caller enumerates change log normally (no regression)', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols && typeof cols === 'object' && 'count' in (cols as object) && Object.keys(cols as object).length === 1) {
+        return chain([{ count: 1 }]);
+      }
+      return chain([
+        { timestamp: null, changeType: 'software', changeAction: 'added', subject: 's', beforeValue: null, afterValue: null, details: null, hostname: 'h1', deviceId: 'd1' },
+      ]);
+    });
+    const r = await handlerFor('query_change_log')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(1);
+    expect(parsed.total).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -8,9 +8,10 @@
 
 import { db } from '../db';
 import { devices, auditLogs, deviceChangeLog } from '../db/schema';
-import { eq, and, desc, sql, gte, lte, SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -134,6 +135,20 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
         const access = await verifyDeviceAccess(input.deviceId as string, auth);
         if ('error' in access) return JSON.stringify({ error: access.error });
         conditions.push(eq(deviceChangeLog.deviceId, input.deviceId as string));
+      } else if (auth.allowedSiteIds && auth.canAccessSite) {
+        // Site axis (app-layer only; RLS does NOT enforce it). deviceChangeLog is
+        // device-keyed; when no deviceId is supplied, a site-restricted caller may
+        // only see changes for devices in their allowed sites. Narrow both the rows
+        // and count queries (they share `whereClause`). No-op for unrestricted callers.
+        const orgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        if (!orgId) {
+          return JSON.stringify({ changes: [], total: 0, showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
+        }
+        const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({ changes: [], total: 0, showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
+        }
+        conditions.push(inArray(deviceChangeLog.deviceId, allowed));
       }
 
       if (input.startTime) {

--- a/apps/api/src/services/aiToolsCisBenchmark.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsCisBenchmark.siteScope.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+vi.mock('../jobs/cisJobs', () => ({ scheduleCisRemediationWithResult: vi.fn() }));
+vi.mock('./cisHardening', () => ({ extractFailedCheckIds: vi.fn(() => new Set()) }));
+
+import { db } from '../db';
+import { registerCisBenchmarkTools } from './aiToolsCisBenchmark';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerCisBenchmarkTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset', 'as']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('get_cis_compliance — site narrowing (no deviceId branch)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive CIS rows for a device in a forbidden site', async () => {
+    let cisScanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      cisScanRan = true;
+      return chain([
+        { orgId: 'org-1', deviceId: 'd-siteB', baselineName: 'CIS', deviceHostname: 'forbidden-host', checkedAt: new Date(), score: 50, totalChecks: 10, passedChecks: 5, failedChecks: 5, summary: {} },
+      ]);
+    });
+
+    const r = await handlerFor('get_cis_compliance')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.count).toBe(0);
+    expect(parsed.results).toEqual([]);
+    expect(cisScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden-host');
+  });
+
+  it('unrestricted caller enumerates CIS compliance normally (no regression)', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call += 1;
+      if (call === 1) {
+        // ranked subquery -> .as()
+        return chain(null);
+      }
+      if (call === 2) {
+        // summary aggregation
+        return chain([{ total: 1, averageScore: 50, failingDevices: 1 }]);
+      }
+      // rows
+      return chain([
+        { orgId: 'org-1', baselineId: 'b1', baselineName: 'CIS', baselineBenchmarkVersion: '1', baselineLevel: 1, baselineIsActive: true, baselineOsType: 'windows', deviceId: 'd1', deviceHostname: 'h1', deviceStatus: 'online', deviceOsType: 'windows', checkedAt: new Date(), score: 50, totalChecks: 10, passedChecks: 5, failedChecks: 5, summary: {} },
+      ]);
+    });
+
+    const r = await handlerFor('get_cis_compliance')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.count).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsCisBenchmark.ts
+++ b/apps/api/src/services/aiToolsCisBenchmark.ts
@@ -19,6 +19,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { scheduleCisRemediationWithResult } from '../jobs/cisJobs';
 import { extractFailedCheckIds } from './cisHardening';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -87,6 +88,31 @@ registerTool({
     }
     if (typeof input.osType === 'string') {
       conditions.push(eq(cisBaselines.osType, input.osType as 'windows' | 'macos' | 'linux'));
+    }
+
+    // Site axis (app-layer only; RLS does NOT enforce it). cisBaselineResults are
+    // device-keyed; a site-restricted caller may only see results for devices in
+    // their allowed sites. Narrow to that set (no-op for unrestricted callers).
+    if (auth.allowedSiteIds && auth.canAccessSite) {
+      const queryOrgId =
+        (typeof input.orgId === 'string' ? input.orgId : null) ??
+        auth.orgId ??
+        auth.accessibleOrgIds?.[0] ??
+        null;
+      const emptyResult = JSON.stringify({
+        count: 0,
+        totalMatched: 0,
+        summary: { averageScore: 100, devicesAudited: 0, failingDevices: 0, compliantDevices: 0 },
+        results: [],
+        scopeNote: SITE_SCOPE_EMPTY_NOTE,
+      });
+      if (!queryOrgId) return emptyResult;
+      const allowed = await resolveSiteAllowedDeviceIds(queryOrgId, auth);
+      if (!allowed || allowed.length === 0) return emptyResult;
+      if (typeof input.deviceId === 'string' && !allowed.includes(input.deviceId)) {
+        return emptyResult;
+      }
+      conditions.push(inArray(cisBaselineResults.deviceId, allowed));
     }
 
     const rankedResults = db

--- a/apps/api/src/services/aiToolsPam.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsPam.siteScope.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('./pamRuleEngine', () => ({ evaluatePamRules: vi.fn() }));
+
+import { db } from '../db';
+import { registerPamTools } from './aiToolsPam';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerPamTools(reg);
+  return reg.get(name)!.handler;
+}
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s: string | null | undefined) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as unknown as AuthContext;
+}
+function isDeviceResolverSelect(cols: unknown): boolean {
+  return (
+    !!cols && typeof cols === 'object' &&
+    'id' in (cols as object) && 'siteId' in (cols as object) &&
+    Object.keys(cols as object).length === 2
+  );
+}
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('get_elevation_history — site narrowing (no deviceId branch)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('site-restricted caller does NOT receive elevation rows for a device in a forbidden site', async () => {
+    let historyScanRan = false;
+    const forbiddenRow = {
+      id: 'er-1', deviceId: 'd-siteB', flowType: 'os', status: 'approved',
+      subjectUsername: 'admin', reason: 'r', requestedAt: null, approvedAt: null,
+      expiresAt: null, revokedAt: null, denialReason: null, revokedReason: null, metadata: null,
+    };
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      historyScanRan = true;
+      return chain([forbiddenRow]);
+    });
+
+    const r = await handlerFor('get_elevation_history')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(Array.isArray(parsed)).toBe(false);
+    expect(parsed.results).toEqual([]);
+    expect(historyScanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('d-siteB');
+  });
+
+  it('unrestricted caller enumerates elevation history normally (no regression)', async () => {
+    mockDb.select.mockImplementation(() => chain([
+      {
+        id: 'er-1', deviceId: 'd1', flowType: 'os', status: 'approved',
+        subjectUsername: 'admin', reason: 'r', requestedAt: null, approvedAt: null,
+        expiresAt: null, revokedAt: null, denialReason: null, revokedReason: null, metadata: null,
+      },
+    ]));
+    const r = await handlerFor('get_elevation_history')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(1);
+  });
+});

--- a/apps/api/src/services/aiToolsPam.ts
+++ b/apps/api/src/services/aiToolsPam.ts
@@ -12,6 +12,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent, type EventType } from './eventBus';
 import { evaluatePamRules, type PamRuleMatch } from './pamRuleEngine';
+import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 // Input schemas for these tools live in the canonical `toolInputSchemas`
 // registry in ./aiToolSchemas (validated centrally by executeTool).
@@ -429,6 +430,24 @@ export function registerPamTools(aiTools: Map<string, AiTool>): void {
       if (typeof input.deviceId === 'string') conditions.push(eq(elevationRequests.deviceId, input.deviceId));
       if (typeof input.status === 'string') conditions.push(eq(elevationRequests.status, input.status as any));
       if (typeof input.flowType === 'string') conditions.push(eq(elevationRequests.flowType, input.flowType as any));
+
+      // Site axis (app-layer only; RLS does NOT enforce it). elevationRequests are
+      // device-keyed; a site-restricted caller may only see requests for devices in
+      // their allowed sites. Narrow to that set (no-op for unrestricted callers).
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const orgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        if (!orgId) {
+          return JSON.stringify({ results: [], scopeNote: SITE_SCOPE_EMPTY_NOTE });
+        }
+        const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({ results: [], scopeNote: SITE_SCOPE_EMPTY_NOTE });
+        }
+        if (typeof input.deviceId === 'string' && !allowed.includes(input.deviceId)) {
+          return JSON.stringify({ results: [], scopeNote: SITE_SCOPE_EMPTY_NOTE });
+        }
+        conditions.push(inArray(elevationRequests.deviceId, allowed));
+      }
 
       const limit = clampNumber(input.limit, 25, 100);
       const rows = await db


### PR DESCRIPTION
## What

Three list-style AI tools narrowed only on the org axis when their optional `deviceId` argument was omitted, skipping the site axis:

- `get_elevation_history` (`aiToolsPam.ts`) — `elevationRequests`
- `query_change_log` (`aiToolsAudit.ts`) — `deviceChangeLog` (both rows and count queries)
- `get_cis_compliance` (`aiToolsCisBenchmark.ts`) — `cisBaselineResults`

Each no-`deviceId` branch now resolves the caller's in-scope device set via `resolveSiteAllowedDeviceIds` (`aiToolsSiteScope.ts`) and constrains the query to it, short-circuiting to an empty result with `SITE_SCOPE_EMPTY_NOTE` when the in-scope set is empty. A supplied `deviceId` outside the allowed set is also rejected.

## Why

The site axis is an app-layer authorization axis — Postgres RLS does not enforce it. These three list tools were the remaining branches that filtered org-only, so a site-restricted chat/MCP caller could read device-keyed rows for devices in sites they lack access to. This mirrors the existing pattern already used by sibling tools (e.g. `aiToolsBackup.ts`, `aiToolsCompliance.ts`).

## Behavior change

Site-restricted AI callers (with `allowedSiteIds` set) now see only in-scope devices' rows — intended. Unrestricted partner/system callers are unaffected (the helper returns `null` and is a no-op for them).

## Tests

- New per-tool site-scope unit tests asserting a site-restricted caller with no `deviceId` sees zero out-of-scope rows, plus a no-regression case for unrestricted callers. Confirmed RED before the fix, GREEN after.
- Registered the three files in the `aiTools.deviceAccessSiteScope.contract.test.ts` allowlist.
- API typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)