### PR TITLE
fix(integrations): fetch outside the DB transaction in Huntress + Pax8 syncs (#1697)

### DIFF
--- a/apps/api/src/jobs/huntressSync.test.ts
+++ b/apps/api/src/jobs/huntressSync.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// #1697 — the Huntress sync must NOT hold a pooled DB connection in an open
+// transaction across its external HTTP fetch. We model the DB-context depth
+// with a counter that withSystemDbAccessContext increments and
+// runOutsideDbContext zeroes, then assert the HuntressClient calls were issued
+// at depth 0 while the DB reads/writes ran at depth > 0.
+// ---------------------------------------------------------------------------
+
+let contextDepth = 0;
+const fetchDepths: number[] = [];
+const dbCallDepths: number[] = [];
+
+// Chainable, awaitable stub for a drizzle query builder. Every builder method
+// returns the same chain; awaiting it resolves to `result`.
+function chain(result: unknown) {
+  const c: Record<string, unknown> = {};
+  for (const m of ['from', 'where', 'limit', 'set', 'values', 'onConflictDoUpdate']) {
+    c[m] = vi.fn(() => c);
+  }
+  (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  return c;
+}
+
+const INTEGRATION_ROW = {
+  id: 'integration-1',
+  partnerId: 'partner-1',
+  accountId: 'acct-1',
+  apiBaseUrl: 'https://api.huntress.example',
+  apiKeyEncrypted: 'enc',
+  isActive: true,
+  lastSyncAt: null,
+};
+
+vi.mock('../db', () => ({
+  db: {
+    // `.select()` with no projection = Phase 1 integration read; with a
+    // projection arg = loadMappedOrgIds. Distinguish so each returns the right
+    // shape. Both record the context depth at call time.
+    select: vi.fn((projection?: unknown) => {
+      dbCallDepths.push(contextDepth);
+      return chain(projection === undefined ? [INTEGRATION_ROW] : []);
+    }),
+    update: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+    insert: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    contextDepth += 1;
+    try {
+      return await fn();
+    } finally {
+      contextDepth -= 1;
+    }
+  }),
+  // Mirrors AsyncLocalStorage.exit: store disabled for the synchronous call (and
+  // the async work it kicks off). The fetch promises are created synchronously
+  // inside `fn`, so the client methods are invoked while depth is 0.
+  runOutsideDbContext: vi.fn((fn: () => unknown) => {
+    const saved = contextDepth;
+    contextDepth = 0;
+    try {
+      return fn();
+    } finally {
+      contextDepth = saved;
+    }
+  }),
+}));
+
+const listOrganizations = vi.fn(async () => {
+  fetchDepths.push(contextDepth);
+  return [];
+});
+const listAgents = vi.fn(async () => {
+  fetchDepths.push(contextDepth);
+  return [];
+});
+const listIncidents = vi.fn(async () => {
+  fetchDepths.push(contextDepth);
+  return [];
+});
+
+vi.mock('../services/huntressClient', () => ({
+  HuntressClient: class {
+    listOrganizations = listOrganizations;
+    listAgents = listAgents;
+    listIncidents = listIncidents;
+  },
+  parseHuntressWebhookPayload: vi.fn(),
+}));
+
+vi.mock('../services/secretCrypto', () => ({
+  decryptSecret: vi.fn(() => 'plaintext-api-key'),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+import { syncIntegrationById } from './huntressSync';
+
+describe('huntressSync — DB context boundaries (#1697)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contextDepth = 0;
+    fetchDepths.length = 0;
+    dbCallDepths.length = 0;
+  });
+
+  it('fetches from Huntress with no DB context held, but reads/writes inside one', async () => {
+    const result = await syncIntegrationById('integration-1', 'scheduled');
+
+    // All three external calls were issued.
+    expect(listOrganizations).toHaveBeenCalledTimes(1);
+    expect(listAgents).toHaveBeenCalledTimes(1);
+    expect(listIncidents).toHaveBeenCalledTimes(1);
+
+    // The core regression guard: every external HTTP call ran with NO open
+    // transaction held (depth 0). Pre-fix the whole job ran inside one context,
+    // so these would all be > 0.
+    expect(fetchDepths).toEqual([0, 0, 0]);
+
+    // Sanity: the DB reads/writes still ran inside a context (depth > 0), so RLS
+    // is satisfied and the contextless-write guard (#1375) stays quiet.
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);
+    }
+
+    expect(result.integrationId).toBe('integration-1');
+  });
+
+  it('keeps the fetch outside the transaction even when wrapped in an outer DB context (guards against re-adding the blanket worker wrap)', async () => {
+    const dbm = await import('../db');
+    await dbm.withSystemDbAccessContext(async () => {
+      await syncIntegrationById('integration-1', 'scheduled');
+    });
+
+    // Even with an outer context held (depth >= 1), runOutsideDbContext escaped
+    // it for the fetch. If a future change drops that escape, these become >= 1.
+    expect(fetchDepths).toEqual([0, 0, 0]);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);
+    }
+  });
+
+  it('skips an inactive integration without fetching', async () => {
+    const { db } = (await import('../db')) as unknown as { db: { select: ReturnType<typeof vi.fn> } };
+    db.select.mockReturnValueOnce(chain([{ ...INTEGRATION_ROW, isActive: false }]) as never);
+
+    const result = await syncIntegrationById('integration-1', 'scheduled');
+
+    expect(listOrganizations).not.toHaveBeenCalled();
+    expect(result.upsertedAgents).toBe(0);
+  });
+});

--- a/apps/api/src/jobs/huntressSync.test.ts
+++ b/apps/api/src/jobs/huntressSync.test.ts
@@ -11,14 +11,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let contextDepth = 0;
 const fetchDepths: number[] = [];
 const dbCallDepths: number[] = [];
+// `.set(payload)` calls (update writes) with the context depth at call time, so
+// tests can assert e.g. the error-status write happened inside a context.
+const updatePayloads: Array<{ depth: number; payload: Record<string, unknown> }> = [];
 
 // Chainable, awaitable stub for a drizzle query builder. Every builder method
 // returns the same chain; awaiting it resolves to `result`.
 function chain(result: unknown) {
   const c: Record<string, unknown> = {};
-  for (const m of ['from', 'where', 'limit', 'set', 'values', 'onConflictDoUpdate']) {
+  for (const m of ['from', 'where', 'limit', 'values', 'onConflictDoUpdate']) {
     c[m] = vi.fn(() => c);
   }
+  c.set = vi.fn((payload: Record<string, unknown>) => {
+    updatePayloads.push({ depth: contextDepth, payload });
+    return c;
+  });
   (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
     Promise.resolve(result).then(resolve, reject);
   return c;
@@ -112,6 +119,7 @@ describe('huntressSync — DB context boundaries (#1697)', () => {
     contextDepth = 0;
     fetchDepths.length = 0;
     dbCallDepths.length = 0;
+    updatePayloads.length = 0;
   });
 
   it('fetches from Huntress with no DB context held, but reads/writes inside one', async () => {
@@ -149,6 +157,37 @@ describe('huntressSync — DB context boundaries (#1697)', () => {
     for (const depth of dbCallDepths) {
       expect(depth).toBeGreaterThan(0);
     }
+  });
+
+  it('on fetch failure, records the error status on a fresh context and re-throws the ORIGINAL error', async () => {
+    const boom = new Error('huntress fetch exploded');
+    listAgents.mockRejectedValueOnce(boom);
+
+    // The original sync error must propagate — never be masked by the
+    // error-status bookkeeping write.
+    await expect(syncIntegrationById('integration-1', 'scheduled')).rejects.toBe(boom);
+
+    // The failure-status write happened, carried 'error', and ran inside a
+    // context (depth > 0) — i.e. on a real (fresh) transaction, not contextless.
+    const errorWrite = updatePayloads.find((u) => u.payload.lastSyncStatus === 'error');
+    expect(errorWrite).toBeDefined();
+    expect(errorWrite!.depth).toBeGreaterThan(0);
+  });
+
+  it('on the webhook path, persists without any external fetch', async () => {
+    const result = await syncIntegrationById('integration-1', 'webhook', { agents: [], incidents: [] });
+
+    expect(listOrganizations).not.toHaveBeenCalled();
+    expect(listAgents).not.toHaveBeenCalled();
+    expect(listIncidents).not.toHaveBeenCalled();
+    expect(fetchDepths).toEqual([]);
+
+    // The persist still ran inside a context.
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);
+    }
+    expect(result.integrationId).toBe('integration-1');
   });
 
   it('skips an inactive integration without fetching', async () => {

--- a/apps/api/src/jobs/huntressSync.ts
+++ b/apps/api/src/jobs/huntressSync.ts
@@ -710,16 +710,24 @@ async function upsertIncidents(params: {
   return { created, updated };
 }
 
-async function syncIntegrationById(
+// Exported for unit testing the DB-context boundaries (#1697). The production
+// entry points are the BullMQ worker (scheduled) and ingestHuntressWebhookPayload.
+export async function syncIntegrationById(
   integrationId: string,
   source: 'manual' | 'scheduled' | 'webhook' = 'scheduled',
   webhookPayload?: { agents: HuntressAgentRecord[]; incidents: HuntressIncidentRecord[]; }
 ): Promise<HuntressSyncResult> {
-  const [integration] = await db
-    .select()
-    .from(huntressIntegrations)
-    .where(eq(huntressIntegrations.id, integrationId))
-    .limit(1);
+  // Phase 1 — load the integration row in its own short DB context, kept
+  // separate from the write phase so the external Huntress fetch below holds
+  // NO open transaction (#1697). Pinning a pooled connection across the ~20s
+  // HTTP window starved the US connection pool (Sentry BREEZE-9).
+  const [integration] = await runWithSystemDbAccess(() =>
+    db
+      .select()
+      .from(huntressIntegrations)
+      .where(eq(huntressIntegrations.id, integrationId))
+      .limit(1)
+  );
 
   if (!integration) {
     console.warn(`[HuntressSync] Integration ${integrationId} not found, skipping sync`);
@@ -768,89 +776,100 @@ async function syncIntegrationById(
         ? new Date(integration.lastSyncAt.getTime() - 60_000)
         : new Date(Date.now() - DEFAULT_LOOKBACK_MS);
 
-      [organizations, agents, incidents] = await Promise.all([
-        client.listOrganizations(),
-        client.listAgents(since),
-        client.listIncidents(since),
-      ]);
-    }
-
-    const discoveredOrganizations = mergeDiscoveredOrganizations({ organizations, agents, incidents });
-    await upsertDiscoveredOrganizations({
-      integrationId: integration.id,
-      partnerId: integration.partnerId,
-      organizations: discoveredOrganizations,
-    });
-
-    const mappedOrgIds = await loadMappedOrgIds(integration.id);
-    const groupedAgents = groupByMappedOrg(agents, mappedOrgIds);
-    const groupedIncidents = groupByMappedOrg(incidents, mappedOrgIds);
-    const allMappedOrgIds = Array.from(new Set([
-      ...groupedAgents.byOrgId.keys(),
-      ...groupedIncidents.byOrgId.keys(),
-    ]));
-
-    let upsertedAgents = 0;
-    let createdIncidents = 0;
-    let updatedIncidents = 0;
-
-    for (const orgId of allMappedOrgIds) {
-      const orgAgents = groupedAgents.byOrgId.get(orgId) ?? [];
-      const orgIncidents = groupedIncidents.byOrgId.get(orgId) ?? [];
-      const devicesByHostname = await mapDevicesByHostname(
-        orgId,
-        collectCandidateHostnames(orgAgents, orgIncidents)
+      // Phase 2 — fetch from Huntress with NO DB context held.
+      // runOutsideDbContext guarantees this even when an outer context exists
+      // (e.g. the webhook caller wraps this function), so the external HTTP
+      // never sits inside an open transaction (#1105/#1697).
+      [organizations, agents, incidents] = await dbModule.runOutsideDbContext(() =>
+        Promise.all([
+          client.listOrganizations(),
+          client.listAgents(since),
+          client.listIncidents(since),
+        ])
       );
-
-      const [agentResult, incidentResult] = await Promise.all([
-        upsertAgents({
-          orgId,
-          integrationId: integration.id,
-          agents: orgAgents,
-          devicesByHostname,
-        }),
-        upsertIncidents({
-          orgId,
-          integrationId: integration.id,
-          incidents: orgIncidents,
-          devicesByHostname,
-        }),
-      ]);
-      upsertedAgents += agentResult.upserted;
-      createdIncidents += incidentResult.created;
-      updatedIncidents += incidentResult.updated;
     }
 
-    await db
-      .update(huntressIntegrations)
-      .set({
-        lastSyncAt: new Date(),
-        lastSyncStatus: 'success',
-        lastSyncError: null,
-        updatedAt: new Date(),
-      })
-      .where(eq(huntressIntegrations.id, integration.id));
+    // Phase 3 — persist everything in ONE DB context so the upserts and the
+    // success-status update commit atomically together.
+    return await runWithSystemDbAccess(async () => {
+      const discoveredOrganizations = mergeDiscoveredOrganizations({ organizations, agents, incidents });
+      await upsertDiscoveredOrganizations({
+        integrationId: integration.id,
+        partnerId: integration.partnerId,
+        organizations: discoveredOrganizations,
+      });
 
-    return {
-      integrationId: integration.id,
-      fetchedAgents: agents.length,
-      fetchedIncidents: incidents.length,
-      upsertedAgents,
-      createdIncidents,
-      updatedIncidents,
-      discoveredOrganizations: discoveredOrganizations.length,
-      skippedUnmappedAgents: groupedAgents.skipped,
-      skippedUnmappedIncidents: groupedIncidents.skipped,
-    };
+      const mappedOrgIds = await loadMappedOrgIds(integration.id);
+      const groupedAgents = groupByMappedOrg(agents, mappedOrgIds);
+      const groupedIncidents = groupByMappedOrg(incidents, mappedOrgIds);
+      const allMappedOrgIds = Array.from(new Set([
+        ...groupedAgents.byOrgId.keys(),
+        ...groupedIncidents.byOrgId.keys(),
+      ]));
+
+      let upsertedAgents = 0;
+      let createdIncidents = 0;
+      let updatedIncidents = 0;
+
+      for (const orgId of allMappedOrgIds) {
+        const orgAgents = groupedAgents.byOrgId.get(orgId) ?? [];
+        const orgIncidents = groupedIncidents.byOrgId.get(orgId) ?? [];
+        const devicesByHostname = await mapDevicesByHostname(
+          orgId,
+          collectCandidateHostnames(orgAgents, orgIncidents)
+        );
+
+        const [agentResult, incidentResult] = await Promise.all([
+          upsertAgents({
+            orgId,
+            integrationId: integration.id,
+            agents: orgAgents,
+            devicesByHostname,
+          }),
+          upsertIncidents({
+            orgId,
+            integrationId: integration.id,
+            incidents: orgIncidents,
+            devicesByHostname,
+          }),
+        ]);
+        upsertedAgents += agentResult.upserted;
+        createdIncidents += incidentResult.created;
+        updatedIncidents += incidentResult.updated;
+      }
+
+      await db
+        .update(huntressIntegrations)
+        .set({
+          lastSyncAt: new Date(),
+          lastSyncStatus: 'success',
+          lastSyncError: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(huntressIntegrations.id, integration.id));
+
+      return {
+        integrationId: integration.id,
+        fetchedAgents: agents.length,
+        fetchedIncidents: incidents.length,
+        upsertedAgents,
+        createdIncidents,
+        updatedIncidents,
+        discoveredOrganizations: discoveredOrganizations.length,
+        skippedUnmappedAgents: groupedAgents.skipped,
+        skippedUnmappedIncidents: groupedIncidents.skipped,
+      };
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     try {
-      // The whole sync job runs inside one withSystemDbAccessContext transaction.
-      // Re-throwing below rolls that transaction back, so recording the failure on
-      // the job's own connection would be undone and the row would keep its stale
-      // status. Escape the current context (runOutsideDbContext) and open a fresh
-      // transaction (runWithSystemDbAccess) so the 'error' status commits and
-      // survives the rollback.
+      // Record the failure on a FRESH transaction. Phase 3's write transaction
+      // (or, on the webhook path, the caller's outer context) is rolling back as
+      // we unwind, so recording the failure on that same connection would be
+      // undone and the row would keep its stale status. Escape the current
+      // context (runOutsideDbContext) and open a new transaction
+      // (runWithSystemDbAccess) so the 'error' status commits and survives the
+      // rollback.
       await dbModule.runOutsideDbContext(() =>
         runWithSystemDbAccess(() =>
           db
@@ -873,13 +892,19 @@ async function syncIntegrationById(
 
 async function processSyncAll(): Promise<{ queued: number }> {
   const queue = getHuntressSyncQueue();
-  const integrations = await db
-    .select({
-      id: huntressIntegrations.id,
-      lastSyncAt: huntressIntegrations.lastSyncAt,
-    })
-    .from(huntressIntegrations)
-    .where(eq(huntressIntegrations.isActive, true));
+  // Read inside a short DB context — huntress_integrations is partner-scoped, so
+  // a contextless read under breeze_app RLS silently returns 0 rows (#1375).
+  // The enqueue below then runs with no transaction held (Redis-in-context is
+  // itself the #1105 anti-pattern).
+  const integrations = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        id: huntressIntegrations.id,
+        lastSyncAt: huntressIntegrations.lastSyncAt,
+      })
+      .from(huntressIntegrations)
+      .where(eq(huntressIntegrations.isActive, true))
+  );
 
   const now = Date.now();
   const due = integrations.filter((integration) => {
@@ -980,16 +1005,17 @@ function createHuntressSyncWorker(): Worker<HuntressSyncJobData> {
   return new Worker<HuntressSyncJobData>(
     HUNTRESS_SYNC_QUEUE,
     async (job: Job<HuntressSyncJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        switch (job.data.type) {
-          case 'sync-all':
-            return processSyncAll();
-          case 'sync-integration':
-            return processSyncIntegration(job.data);
-          default:
-            throw new Error(`Unknown Huntress sync job type: ${(job.data as { type: string }).type}`);
-        }
-      });
+      // No blanket withSystemDbAccessContext wrap here — each path manages its
+      // own short DB contexts so the external Huntress fetch in syncIntegrationById
+      // runs with no pooled connection held in an open transaction (#1105/#1697).
+      switch (job.data.type) {
+        case 'sync-all':
+          return processSyncAll();
+        case 'sync-integration':
+          return processSyncIntegration(job.data);
+        default:
+          throw new Error(`Unknown Huntress sync job type: ${(job.data as { type: string }).type}`);
+      }
     },
     {
       connection: getBullMQConnection(),

--- a/apps/api/src/jobs/pax8SyncWorker.ts
+++ b/apps/api/src/jobs/pax8SyncWorker.ts
@@ -67,9 +67,9 @@ export async function enqueuePax8Sync(integrationId: string): Promise<string> {
 }
 
 export async function processPax8SyncIntegration(integrationId: string) {
-  return runOutsideDbContext(() =>
-    withSystemDbAccessContext(() => syncPax8Integration(integrationId))
-  );
+  // syncPax8Integration self-manages its DB contexts so its Pax8 API fetch runs
+  // outside any held transaction (#1697); no blanket wrap here.
+  return syncPax8Integration(integrationId);
 }
 
 export async function processPax8SyncAll(): Promise<{ queued: number; failed: number }> {

--- a/apps/api/src/services/pax8SyncService.dbcontext.test.ts
+++ b/apps/api/src/services/pax8SyncService.dbcontext.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// #1697 — the Pax8 sync must NOT hold a pooled DB connection in an open
+// transaction across its external HTTP fetch. Same depth-tracking model as the
+// Huntress sync test: withSystemDbAccessContext increments depth,
+// runOutsideDbContext zeroes it; assert the Pax8 client calls run at depth 0
+// while DB reads/writes run at depth > 0. (Kept in a separate file from
+// pax8SyncService.test.ts because it needs a chainable, context-aware db mock.)
+// ---------------------------------------------------------------------------
+
+let contextDepth = 0;
+const fetchDepths: number[] = [];
+const dbCallDepths: number[] = [];
+
+function chain(result: unknown) {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'from', 'where', 'limit', 'set', 'values', 'returning',
+    'onConflictDoUpdate', 'onConflictDoNothing', 'innerJoin', 'leftJoin',
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  return c;
+}
+
+const INTEGRATION_ROW = {
+  id: 'pax8-int-1',
+  partnerId: 'partner-1',
+  isActive: true,
+  clientIdEncrypted: 'enc-id',
+  clientSecretEncrypted: 'enc-secret',
+  accessTokenEncrypted: 'enc-token',
+  accessTokenExpiresAt: null,
+  apiBaseUrl: 'https://api.pax8.example',
+  tokenUrl: 'https://auth.pax8.example/token',
+};
+
+vi.mock('../db', () => ({
+  db: {
+    // `.select()` (no projection) = the integration read in
+    // createPax8ClientForIntegration; `.select({...})` = the mapped-company /
+    // contract-line reads, which return empty for this empty-sync test.
+    select: vi.fn((projection?: unknown) => {
+      dbCallDepths.push(contextDepth);
+      return chain(projection === undefined ? [INTEGRATION_ROW] : []);
+    }),
+    update: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+    insert: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain([]);
+    }),
+    delete: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    contextDepth += 1;
+    try {
+      return await fn();
+    } finally {
+      contextDepth -= 1;
+    }
+  }),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => {
+    const saved = contextDepth;
+    contextDepth = 0;
+    try {
+      return fn();
+    } finally {
+      contextDepth = saved;
+    }
+  }),
+}));
+
+const listCompanies = vi.fn(async () => {
+  fetchDepths.push(contextDepth);
+  return [];
+});
+const listSubscriptions = vi.fn(async () => {
+  fetchDepths.push(contextDepth);
+  return [];
+});
+
+vi.mock('./pax8Client', () => ({
+  DEFAULT_PAX8_API_BASE_URL: 'https://api.pax8.example',
+  DEFAULT_PAX8_TOKEN_URL: 'https://auth.pax8.example/token',
+  Pax8Client: class {
+    listCompanies = listCompanies;
+    listSubscriptions = listSubscriptions;
+    cachedAccessToken = { token: null as string | null, expiresAt: null };
+  },
+}));
+
+vi.mock('./secretCrypto', () => ({
+  decryptForColumn: vi.fn(() => 'plaintext-secret'),
+  encryptSecret: vi.fn(() => 'ciphertext'),
+}));
+
+import { syncPax8Integration } from './pax8SyncService';
+
+describe('pax8SyncService — DB context boundaries (#1697)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contextDepth = 0;
+    fetchDepths.length = 0;
+    dbCallDepths.length = 0;
+  });
+
+  it('fetches from Pax8 with no DB context held, but reads/writes inside one', async () => {
+    const result = await syncPax8Integration('pax8-int-1');
+
+    expect(listCompanies).toHaveBeenCalledTimes(1);
+    expect(listSubscriptions).toHaveBeenCalledTimes(1);
+
+    // Core regression guard: the external calls ran with NO open transaction.
+    expect(fetchDepths).toEqual([0, 0]);
+
+    // Reads/writes (running status, integration read, contract-line apply,
+    // success status) all ran inside a context.
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);
+    }
+
+    expect(result.integrationId).toBe('pax8-int-1');
+  });
+});

--- a/apps/api/src/services/pax8SyncService.dbcontext.test.ts
+++ b/apps/api/src/services/pax8SyncService.dbcontext.test.ts
@@ -12,15 +12,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let contextDepth = 0;
 const fetchDepths: number[] = [];
 const dbCallDepths: number[] = [];
+// `.set(payload)` calls (update writes) with the context depth at call time.
+const updatePayloads: Array<{ depth: number; payload: Record<string, unknown> }> = [];
 
 function chain(result: unknown) {
   const c: Record<string, unknown> = {};
   for (const m of [
-    'from', 'where', 'limit', 'set', 'values', 'returning',
+    'from', 'where', 'limit', 'values', 'returning',
     'onConflictDoUpdate', 'onConflictDoNothing', 'innerJoin', 'leftJoin',
   ]) {
     c[m] = vi.fn(() => c);
   }
+  c.set = vi.fn((payload: Record<string, unknown>) => {
+    updatePayloads.push({ depth: contextDepth, payload });
+    return c;
+  });
   (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
     Promise.resolve(result).then(resolve, reject);
   return c;
@@ -111,6 +117,7 @@ describe('pax8SyncService — DB context boundaries (#1697)', () => {
     contextDepth = 0;
     fetchDepths.length = 0;
     dbCallDepths.length = 0;
+    updatePayloads.length = 0;
   });
 
   it('fetches from Pax8 with no DB context held, but reads/writes inside one', async () => {
@@ -130,5 +137,34 @@ describe('pax8SyncService — DB context boundaries (#1697)', () => {
     }
 
     expect(result.integrationId).toBe('pax8-int-1');
+  });
+
+  it('on fetch failure, records the failed status on a fresh context and re-throws the ORIGINAL error', async () => {
+    const boom = new Error('pax8 fetch exploded');
+    listCompanies.mockRejectedValueOnce(boom);
+
+    await expect(syncPax8Integration('pax8-int-1')).rejects.toBe(boom);
+
+    const failedWrite = updatePayloads.find((u) => u.payload.lastSyncStatus === 'failed');
+    expect(failedWrite).toBeDefined();
+    expect(failedWrite!.depth).toBeGreaterThan(0);
+  });
+
+  it('a failing error-status write does not mask the original sync error', async () => {
+    const boom = new Error('pax8 fetch exploded');
+    listCompanies.mockRejectedValueOnce(boom);
+    const dbm = await import('../db');
+    // Phase 0 'running' write succeeds; make the error-status 'failed' write throw.
+    (dbm.db.update as unknown as ReturnType<typeof vi.fn>)
+      .mockImplementationOnce(() => {
+        dbCallDepths.push(contextDepth);
+        return chain(undefined);
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('pool exhausted');
+      });
+
+    // The ORIGINAL sync error must still propagate, not the bookkeeping failure.
+    await expect(syncPax8Integration('pax8-int-1')).rejects.toBe(boom);
   });
 });

--- a/apps/api/src/services/pax8SyncService.ts
+++ b/apps/api/src/services/pax8SyncService.ts
@@ -1,5 +1,5 @@
 import { and, eq, sql } from 'drizzle-orm';
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
   contractLines,
   organizations,
@@ -273,53 +273,76 @@ export interface Pax8SyncResult {
 }
 
 export async function syncPax8Integration(integrationId: string): Promise<Pax8SyncResult> {
+  // Self-manages DB contexts so the Pax8 API fetch (Phase 2) holds no open
+  // transaction — pinning a pooled connection across the ~20s HTTP window
+  // starved the connection pool (#1697). Phases: mark-running → read+build
+  // client → fetch (outside any context) → persist atomically.
   const startedAt = new Date();
-  await db.update(pax8Integrations).set({
-    lastSyncStatus: 'running',
-    lastSyncError: null,
-    updatedAt: startedAt,
-  }).where(eq(pax8Integrations.id, integrationId));
+  await withSystemDbAccessContext(() =>
+    db.update(pax8Integrations).set({
+      lastSyncStatus: 'running',
+      lastSyncError: null,
+      updatedAt: startedAt,
+    }).where(eq(pax8Integrations.id, integrationId))
+  );
 
   try {
-    const { integration, client } = await createPax8ClientForIntegration(integrationId);
-    const [companies, subscriptions] = await Promise.all([
-      client.listCompanies(),
-      client.listSubscriptions(),
-    ]);
-    await persistTokenCache(integrationId, client);
-    const companyCount = await upsertCompanies(integration.id, integration.partnerId, companies);
-    const mappedCompanies = await loadMappedCompanies(integration.id);
-    const subscriptionCount = await upsertSubscriptions({
-      integrationId: integration.id,
-      partnerId: integration.partnerId,
-      subscriptions,
-      mappedCompanies,
+    // Phase 1 — load the integration row and build the client (DB read only).
+    const { integration, client } = await withSystemDbAccessContext(() =>
+      createPax8ClientForIntegration(integrationId)
+    );
+
+    // Phase 2 — fetch from Pax8 with NO DB context held. The OAuth token
+    // refresh also runs here, outside any transaction (#1105/#1697).
+    const [companies, subscriptions] = await runOutsideDbContext(() =>
+      Promise.all([
+        client.listCompanies(),
+        client.listSubscriptions(),
+      ])
+    );
+
+    // Phase 3 — persist token cache + upserts + success status atomically.
+    return await withSystemDbAccessContext(async () => {
+      await persistTokenCache(integration.id, client);
+      const companyCount = await upsertCompanies(integration.id, integration.partnerId, companies);
+      const mappedCompanies = await loadMappedCompanies(integration.id);
+      const subscriptionCount = await upsertSubscriptions({
+        integrationId: integration.id,
+        partnerId: integration.partnerId,
+        subscriptions,
+        mappedCompanies,
+      });
+      const productCount = await upsertProductMappings(integration.id, integration.partnerId, subscriptions);
+      const applied = await applyEnabledPax8ContractLineLinks(integration.id);
+
+      await db.update(pax8Integrations).set({
+        lastSyncAt: new Date(),
+        lastSyncStatus: 'success',
+        lastSyncError: null,
+        updatedAt: new Date(),
+      }).where(eq(pax8Integrations.id, integration.id));
+
+      return {
+        integrationId: integration.id,
+        companies: companyCount,
+        subscriptions: subscriptionCount,
+        products: productCount,
+        appliedContractLines: applied.applied,
+        skippedContractLines: applied.skipped,
+      };
     });
-    const productCount = await upsertProductMappings(integration.id, integration.partnerId, subscriptions);
-    const applied = await applyEnabledPax8ContractLineLinks(integration.id);
-
-    await db.update(pax8Integrations).set({
-      lastSyncAt: new Date(),
-      lastSyncStatus: 'success',
-      lastSyncError: null,
-      updatedAt: new Date(),
-    }).where(eq(pax8Integrations.id, integration.id));
-
-    return {
-      integrationId: integration.id,
-      companies: companyCount,
-      subscriptions: subscriptionCount,
-      products: productCount,
-      appliedContractLines: applied.applied,
-      skippedContractLines: applied.skipped,
-    };
   } catch (err) {
-    await db.update(pax8Integrations).set({
-      lastSyncAt: new Date(),
-      lastSyncStatus: 'failed',
-      lastSyncError: errorMessage(err).slice(0, 2000),
-      updatedAt: new Date(),
-    }).where(eq(pax8Integrations.id, integrationId));
+    // Record failure on a FRESH transaction so it survives Phase 3's rollback.
+    await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        db.update(pax8Integrations).set({
+          lastSyncAt: new Date(),
+          lastSyncStatus: 'failed',
+          lastSyncError: errorMessage(err).slice(0, 2000),
+          updatedAt: new Date(),
+        }).where(eq(pax8Integrations.id, integrationId))
+      )
+    );
     throw err;
   }
 }

--- a/apps/api/src/services/pax8SyncService.ts
+++ b/apps/api/src/services/pax8SyncService.ts
@@ -9,6 +9,7 @@ import {
   pax8ProductMappings,
   pax8SubscriptionSnapshots,
 } from '../db/schema';
+import { captureException } from './sentry';
 import { decryptForColumn, encryptSecret } from './secretCrypto';
 import { DEFAULT_PAX8_API_BASE_URL, DEFAULT_PAX8_TOKEN_URL, Pax8Client, type Pax8CompanyRecord, type Pax8SubscriptionRecord } from './pax8Client';
 
@@ -333,16 +334,23 @@ export async function syncPax8Integration(integrationId: string): Promise<Pax8Sy
     });
   } catch (err) {
     // Record failure on a FRESH transaction so it survives Phase 3's rollback.
-    await runOutsideDbContext(() =>
-      withSystemDbAccessContext(() =>
-        db.update(pax8Integrations).set({
-          lastSyncAt: new Date(),
-          lastSyncStatus: 'failed',
-          lastSyncError: errorMessage(err).slice(0, 2000),
-          updatedAt: new Date(),
-        }).where(eq(pax8Integrations.id, integrationId))
-      )
-    );
+    // Guard the bookkeeping write itself: if it throws (e.g. pool exhaustion),
+    // log + capture it but re-throw the ORIGINAL sync error, never the DB error.
+    try {
+      await runOutsideDbContext(() =>
+        withSystemDbAccessContext(() =>
+          db.update(pax8Integrations).set({
+            lastSyncAt: new Date(),
+            lastSyncStatus: 'failed',
+            lastSyncError: errorMessage(err).slice(0, 2000),
+            updatedAt: new Date(),
+          }).where(eq(pax8Integrations.id, integrationId))
+        )
+      );
+    } catch (dbErr) {
+      console.error(`[Pax8Sync] Failed to record sync error for integration ${integrationId}:`, dbErr);
+      captureException(dbErr instanceof Error ? dbErr : new Error(String(dbErr)));
+    }
     throw err;
   }
 }


### PR DESCRIPTION
## What
Stops the integration sync workers from holding a pooled DB connection in an open transaction across their ~20s external HTTP fetches — the root cause of the `#1105` connection-hold flood and the US pool-starvation errors.

Part of #1697 (Huntress + Pax8; DNS scoped as follow-up below).

## Why
`withSystemDbAccessContext` opens **one** `baseDb.transaction` and pins that connection for the entire callback (`db/index.ts:114-185`). Both sync workers wrapped the **whole job — including the external API calls** — in that single context:

- **Huntress** (`jobs/huntressSync.ts`): the worker wrapped everything; `client.listOrganizations()/listAgents()/listIncidents()` (each a 20s-timeout client) ran inside it. The file even commented *"The whole sync job runs inside one withSystemDbAccessContext transaction."*
- **Pax8** (`jobs/pax8SyncWorker.ts` → `services/pax8SyncService.ts`): `processPax8SyncIntegration` wrapped `syncPax8Integration`, so `client.listCompanies()/listSubscriptions()` + the OAuth token refresh ran inside the transaction.

Each 20s HTTP window pinned a connection idle-in-transaction. Under the US managed-PG **25-connection ceiling**, these holds starved the pool → Sentry **BREEZE-9** (scope=system ~20s, 8.6k events) and **BREEZE-2** (`remaining connection slots are reserved for SUPERUSER`).

> Note: `runOutsideDbContext` only changes what *new* `db` calls resolve to — it does **not** release an already-open outer transaction. So the fix had to remove the blanket worker wrap, not just wrap the fetch.

## Fix (same shape for both)
Restructure each sync into three phases:
1. **Read** the integration row in its own short context.
2. **Fetch** from the vendor via `runOutsideDbContext` — **no transaction held**.
3. **Write** all upserts + the success status in **one** context (atomicity preserved).

Plus: removed the blanket worker wraps (each path self-scopes); wrapped Huntress `processSyncAll`'s read so it isn't a contextless RLS read (#1375), which also moves the Redis enqueue out of a held transaction; failure-status writes still escape to a fresh transaction so they survive the rollback. Webhook path (no HTTP) behavior unchanged.

## Tests
- `jobs/huntressSync.test.ts` (new, 3 cases) — asserts the fetch runs at DB-context depth 0 while reads/writes run inside a context, **including when called within a simulated outer context** (guards against re-adding the blanket wrap).
- `services/pax8SyncService.dbcontext.test.ts` (new) — same invariant for Pax8.
- Existing `pax8SyncService.test.ts` (5) and `huntress.test.ts` (10) still pass. Full `tsc --noEmit` clean.

## Audit / scope
Per #1697 I audited the sibling integration syncs that share the 20s-timeout client:
- **PSA** (ConnectWise/Autotask): **N/A** — no background sync worker; all client calls are request-scoped.
- **DNS** (`jobs/dnsSyncJob.ts`): **AFFECTED**, but deliberately **not** in this PR. Its worker wraps **three** job paths (`sync-all`, `sync-integration`, `sync-policy`) in one context, and `processPolicySync` does its own HTTP — a **sequential domain-mutation loop** (`addBlocklistDomain`/`removeBlocklistDomain`) inside the held transaction. Fixing it correctly means restructuring all three paths (a distinct, riskier change with its own write semantics), so it gets a dedicated follow-up PR + tests. Tracked on #1697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
