### PR TITLE
fix(dns): fetch/mutate outside the DB transaction in the DNS sync worker (#1697)

### DIFF
--- a/apps/api/src/jobs/dnsSyncJob.dbcontext.test.ts
+++ b/apps/api/src/jobs/dnsSyncJob.dbcontext.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// #1697 — the DNS sync worker must NOT hold a pooled DB connection in an open
+// transaction across its external provider HTTP (event fetch + domain
+// mutations). Same depth-tracking model as the Huntress/Pax8 sync tests:
+// withSystemDbAccessContext increments depth, runOutsideDbContext zeroes it;
+// assert the provider calls run at depth 0 while DB reads/writes run at depth
+// > 0, for both the event-sync and policy-sync paths.
+// ---------------------------------------------------------------------------
+
+let contextDepth = 0;
+const fetchDepths: number[] = [];
+const dbCallDepths: number[] = [];
+let selectResults: unknown[][] = [];
+
+function chain(result: unknown) {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'from', 'where', 'limit', 'set', 'values', 'returning',
+    'onConflictDoNothing', 'onConflictDoUpdate', 'innerJoin', 'leftJoin',
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  return c;
+}
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(selectResults.shift() ?? []);
+    }),
+    insert: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain([]);
+    }),
+    update: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+    delete: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    contextDepth += 1;
+    try {
+      return await fn();
+    } finally {
+      contextDepth -= 1;
+    }
+  }),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => {
+    const saved = contextDepth;
+    contextDepth = 0;
+    try {
+      return fn();
+    } finally {
+      contextDepth = saved;
+    }
+  }),
+}));
+
+const createDnsProviderMock = vi.fn();
+vi.mock('../services/dnsProviders', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/dnsProviders')>();
+  return { ...actual, createDnsProvider: createDnsProviderMock };
+});
+
+vi.mock('../services/secretCrypto', () => ({
+  decryptForColumn: (_t: string, _c: string, value: unknown) => value ?? 'decrypted',
+}));
+
+vi.mock('../services/eventBus', () => ({
+  publishEvent: vi.fn().mockResolvedValue(undefined),
+  EVENT_TYPES: { DNS_THREAT_BLOCKED: 'dns.threat.blocked' },
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+
+const { processSyncIntegration, processPolicySync } = await import('./dnsSyncJob');
+
+describe('dnsSyncJob — DB context boundaries (#1697)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contextDepth = 0;
+    fetchDepths.length = 0;
+    dbCallDepths.length = 0;
+    selectResults = [];
+  });
+
+  it('processSyncIntegration: fetches events with no DB context held, persists inside one', async () => {
+    // Phase 1 integration read, then mapDevicesByIp's device read.
+    selectResults = [
+      [{ id: 'int-1', orgId: 'org-1', provider: 'pihole', apiKey: 'k', apiSecret: null, isActive: true, config: {}, lastSync: null }],
+      [],
+    ];
+    const syncEvents = vi.fn(async () => {
+      fetchDepths.push(contextDepth);
+      return [];
+    });
+    createDnsProviderMock.mockReturnValue({ syncEvents });
+
+    const result = await processSyncIntegration({ type: 'sync-integration', integrationId: 'int-1' });
+
+    expect(syncEvents).toHaveBeenCalledTimes(1);
+    expect(fetchDepths).toEqual([0]);            // fetch ran with no txn held
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);          // reads/writes ran inside a context
+    }
+    expect(result.integrationId).toBe('int-1');
+  });
+
+  it('processPolicySync: pushes domain mutations with no DB context held, writes status inside one', async () => {
+    selectResults = [
+      [{
+        policy: { id: 'pol-1', type: 'blocklist', domains: [{ domain: 'evil.example.com' }] },
+        integration: { id: 'int-1', orgId: 'org-1', provider: 'adguard_home', apiKey: 'k', apiSecret: 's', config: {} },
+      }],
+    ];
+    const addBlocklistDomain = vi.fn(async () => {
+      fetchDepths.push(contextDepth);
+    });
+    createDnsProviderMock.mockReturnValue({
+      addBlocklistDomain,
+      removeBlocklistDomain: vi.fn(async () => {}),
+    });
+
+    const result = await processPolicySync({ type: 'sync-policy', policyId: 'pol-1' });
+
+    expect(addBlocklistDomain).toHaveBeenCalledWith('evil.example.com');
+    expect(fetchDepths).toEqual([0]);            // provider mutation ran with no txn held
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);
+    }
+    expect(result.added).toBe(1);
+  });
+});

--- a/apps/api/src/jobs/dnsSyncJob.dbcontext.test.ts
+++ b/apps/api/src/jobs/dnsSyncJob.dbcontext.test.ts
@@ -13,15 +13,21 @@ let contextDepth = 0;
 const fetchDepths: number[] = [];
 const dbCallDepths: number[] = [];
 let selectResults: unknown[][] = [];
+// `.set(payload)` calls (update writes) with the context depth at call time.
+const updatePayloads: Array<{ depth: number; payload: Record<string, unknown> }> = [];
 
 function chain(result: unknown) {
   const c: Record<string, unknown> = {};
   for (const m of [
-    'from', 'where', 'limit', 'set', 'values', 'returning',
+    'from', 'where', 'limit', 'values', 'returning',
     'onConflictDoNothing', 'onConflictDoUpdate', 'innerJoin', 'leftJoin',
   ]) {
     c[m] = vi.fn(() => c);
   }
+  c.set = vi.fn((payload: Record<string, unknown>) => {
+    updatePayloads.push({ depth: contextDepth, payload });
+    return c;
+  });
   (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
     Promise.resolve(result).then(resolve, reject);
   return c;
@@ -92,6 +98,7 @@ describe('dnsSyncJob — DB context boundaries (#1697)', () => {
     fetchDepths.length = 0;
     dbCallDepths.length = 0;
     selectResults = [];
+    updatePayloads.length = 0;
   });
 
   it('processSyncIntegration: fetches events with no DB context held, persists inside one', async () => {
@@ -141,5 +148,39 @@ describe('dnsSyncJob — DB context boundaries (#1697)', () => {
       expect(depth).toBeGreaterThan(0);
     }
     expect(result.added).toBe(1);
+  });
+
+  it('processSyncIntegration: on fetch failure records error status on a fresh context and re-throws the ORIGINAL error', async () => {
+    selectResults = [
+      [{ id: 'int-1', orgId: 'org-1', provider: 'pihole', apiKey: 'k', apiSecret: null, isActive: true, config: {}, lastSync: null }],
+    ];
+    const boom = new Error('dns fetch exploded');
+    createDnsProviderMock.mockReturnValue({ syncEvents: vi.fn().mockRejectedValue(boom) });
+
+    await expect(
+      processSyncIntegration({ type: 'sync-integration', integrationId: 'int-1' }),
+    ).rejects.toBe(boom);
+
+    const errorWrite = updatePayloads.find((u) => u.payload.lastSyncStatus === 'error');
+    expect(errorWrite).toBeDefined();
+    expect(errorWrite!.depth).toBeGreaterThan(0);
+  });
+
+  it('processSyncIntegration: a failing error-status write does not mask the original sync error', async () => {
+    selectResults = [
+      [{ id: 'int-1', orgId: 'org-1', provider: 'pihole', apiKey: 'k', apiSecret: null, isActive: true, config: {}, lastSync: null }],
+    ];
+    const boom = new Error('dns fetch exploded');
+    createDnsProviderMock.mockReturnValue({ syncEvents: vi.fn().mockRejectedValue(boom) });
+    const dbm = await import('../db');
+    // Make the error-status bookkeeping write itself throw (e.g. pool exhausted).
+    (dbm.db.update as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('pool exhausted');
+    });
+
+    // The ORIGINAL provider error must still propagate, not the bookkeeping failure.
+    await expect(
+      processSyncIntegration({ type: 'sync-integration', integrationId: 'int-1' }),
+    ).rejects.toBe(boom);
   });
 });

--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -688,19 +688,26 @@ export async function processSyncIntegration(data: SyncIntegrationJobData): Prom
     // Pi-hole puts the API key in the URL query string (?auth=<key>) and an
     // upstream body could echo arbitrary public-host content (SSRF read
     // oracle) — neither may land in dnsFilterIntegrations.lastSyncError.
-    // Record on a FRESH transaction so it survives Phase 3's rollback.
-    await dbModule.runOutsideDbContext(() =>
-      runWithSystemDbAccess(() =>
-        db
-          .update(dnsFilterIntegrations)
-          .set({
-            lastSyncStatus: 'error',
-            lastSyncError: tenantVisibleSyncError(error),
-            updatedAt: new Date()
-          })
-          .where(eq(dnsFilterIntegrations.id, integration.id))
-      )
-    );
+    // Record on a FRESH transaction so it survives Phase 3's rollback. Guard the
+    // write itself so a failure to record the status can't mask the original
+    // sync error (which is re-thrown below regardless).
+    try {
+      await dbModule.runOutsideDbContext(() =>
+        runWithSystemDbAccess(() =>
+          db
+            .update(dnsFilterIntegrations)
+            .set({
+              lastSyncStatus: 'error',
+              lastSyncError: tenantVisibleSyncError(error),
+              updatedAt: new Date()
+            })
+            .where(eq(dnsFilterIntegrations.id, integration.id))
+        )
+      );
+    } catch (dbErr) {
+      console.error(`[DnsSyncJob] Failed to record sync error for integration ${integration.id}:`, dbErr);
+      captureException(dbErr instanceof Error ? dbErr : new Error(String(dbErr)));
+    }
     throw error;
   }
 }
@@ -784,20 +791,27 @@ export async function processPolicySync(data: SyncPolicyJobData): Promise<{
   } catch (error) {
     // Full detail (including the upstream response body, redacted) goes to the
     // SERVER-SIDE log only; the tenant-visible column gets a body-free message.
-    // Record on a FRESH transaction so it survives any Phase 3 rollback.
+    // Record on a FRESH transaction so it survives any Phase 3 rollback. Guard
+    // the write itself so a failure to record the status can't mask the original
+    // sync error (which is re-thrown below regardless).
     logSyncFailureServerSide({ policyId: row.policy.id, orgId: row.integration.orgId }, error);
-    await dbModule.runOutsideDbContext(() =>
-      runWithSystemDbAccess(() =>
-        db
-          .update(dnsPolicies)
-          .set({
-            syncStatus: 'error',
-            syncError: tenantVisibleSyncError(error),
-            updatedAt: new Date()
-          })
-          .where(eq(dnsPolicies.id, row.policy.id))
-      )
-    );
+    try {
+      await dbModule.runOutsideDbContext(() =>
+        runWithSystemDbAccess(() =>
+          db
+            .update(dnsPolicies)
+            .set({
+              syncStatus: 'error',
+              syncError: tenantVisibleSyncError(error),
+              updatedAt: new Date()
+            })
+            .where(eq(dnsPolicies.id, row.policy.id))
+        )
+      );
+    } catch (dbErr) {
+      console.error(`[DnsSyncJob] Failed to record sync error for policy ${row.policy.id}:`, dbErr);
+      captureException(dbErr instanceof Error ? dbErr : new Error(String(dbErr)));
+    }
     throw error;
   }
 }

--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -410,14 +410,19 @@ async function processSyncAll(): Promise<{ queued: number }> {
   const queue = getDnsSyncQueue();
   const now = Date.now();
 
-  const integrations = await db
-    .select({
-      id: dnsFilterIntegrations.id,
-      lastSync: dnsFilterIntegrations.lastSync,
-      config: dnsFilterIntegrations.config
-    })
-    .from(dnsFilterIntegrations)
-    .where(eq(dnsFilterIntegrations.isActive, true));
+  // Read inside a short DB context — dns_filter_integrations is tenant-scoped,
+  // so a contextless read under breeze_app RLS silently returns 0 rows (#1375).
+  // The enqueue below then runs with no transaction held (#1105/#1697).
+  const integrations = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        id: dnsFilterIntegrations.id,
+        lastSync: dnsFilterIntegrations.lastSync,
+        config: dnsFilterIntegrations.config
+      })
+      .from(dnsFilterIntegrations)
+      .where(eq(dnsFilterIntegrations.isActive, true))
+  );
 
   const dueIntegrations = integrations.filter((integration) => {
     const config = parseIntegrationConfig(integration.config);
@@ -444,6 +449,177 @@ async function processSyncAll(): Promise<{ queued: number }> {
   return { queued: dueIntegrations.length };
 }
 
+// Phase 3 of a DNS event sync: turn the fetched provider events into security
+// event rows + aggregation deltas, prune per retention, and mark the
+// integration synced — all inside a single DB context. Extracted so the
+// provider fetch in processSyncIntegration runs OUTSIDE any held transaction
+// (#1697); the caller wraps this in runWithSystemDbAccess. Returns the number
+// of newly-inserted security events.
+async function persistDnsEventSync(params: {
+  orgId: string;
+  integrationId: string;
+  config: DnsIntegrationConfig;
+  events: DnsEvent[];
+  until: Date;
+}): Promise<number> {
+  const { orgId, integrationId, config, events, until } = params;
+
+  const categoriesFilter = new Set(
+    (config.categories ?? [])
+      .map((item) => normalizeThreatCategory(item))
+      .filter((item): item is DnsThreatCategory => item !== null)
+  );
+  const devicesByIp = await mapDevicesByIp(orgId);
+
+  const values = events.flatMap((event) => {
+    const domain = normalizeDomain(event.domain);
+    if (!domain) return [];
+
+    const action = normalizeAction(event.action);
+    const category = normalizeThreatCategory(event.category);
+
+    if (categoriesFilter.size > 0) {
+      if (!category || !categoriesFilter.has(category)) {
+        return [];
+      }
+    }
+
+    const sourceIp = normalizeSourceIp(event.sourceIp);
+    const deviceId = sourceIp ? (devicesByIp.get(sourceIp) ?? null) : null;
+
+    return [{
+      orgId,
+      integrationId,
+      deviceId,
+      timestamp: event.timestamp,
+      domain,
+      queryType: normalizeQueryType(event.queryType),
+      action,
+      category,
+      threatType: normalizeThreatType(event.threatType),
+      sourceIp,
+      sourceHostname: normalizeSourceHost(event.sourceHostname),
+      providerEventId: normalizeSourceHost(event.providerEventId) ?? createFallbackProviderEventId(integrationId, event),
+      metadata: event.metadata ?? null
+    }];
+  });
+
+  let insertedCount = 0;
+  const aggregationMap = new Map<string, EventAggregationDelta>();
+
+  for (const batch of chunk(values, 500)) {
+    const inserted = await db
+      .insert(dnsSecurityEvents)
+      .values(batch)
+      .onConflictDoNothing({
+        target: [dnsSecurityEvents.integrationId, dnsSecurityEvents.providerEventId]
+      })
+      .returning({
+        orgId: dnsSecurityEvents.orgId,
+        integrationId: dnsSecurityEvents.integrationId,
+        deviceId: dnsSecurityEvents.deviceId,
+        timestamp: dnsSecurityEvents.timestamp,
+        domain: dnsSecurityEvents.domain,
+        category: dnsSecurityEvents.category,
+        action: dnsSecurityEvents.action
+      });
+
+    insertedCount += inserted.length;
+
+    for (const row of inserted) {
+      const day = toDateKey(row.timestamp);
+      const category = row.category as DnsThreatCategory | null;
+      const key = [
+        row.orgId,
+        day,
+        row.integrationId ?? '',
+        row.deviceId ?? '',
+        row.domain ?? '',
+        category ?? ''
+      ].join('|');
+
+      const current = aggregationMap.get(key) ?? {
+        orgId: row.orgId,
+        date: day,
+        integrationId: row.integrationId,
+        deviceId: row.deviceId,
+        domain: row.domain,
+        category,
+        totalQueries: 0,
+        blockedQueries: 0,
+        allowedQueries: 0
+      };
+
+      current.totalQueries += 1;
+      if (row.action === 'blocked') current.blockedQueries += 1;
+      if (row.action === 'allowed') current.allowedQueries += 1;
+      aggregationMap.set(key, current);
+
+      // #829 — emit dns.threat.blocked so the existing event-bus
+      // subscribers (webhookDelivery, automationWorker, alert rules) can
+      // consume the signal. Only fire for actually-blocked threat events
+      // (action=blocked AND category present) so an "allowed" DNS query
+      // doesn't pollute the bus. Best-effort: failure to publish here
+      // must not abort sync — the event-bus internals already swallow
+      // local-handler errors with structured logging (#820), but we
+      // still wrap the call to suppress a hypothetical xadd reject.
+      if (row.action === 'blocked' && category) {
+        publishEvent(
+          EVENT_TYPES.DNS_THREAT_BLOCKED,
+          row.orgId,
+          {
+            deviceId: row.deviceId,
+            domain: row.domain,
+            category,
+            integrationId: row.integrationId,
+            timestamp: row.timestamp.toISOString(),
+          },
+          'dns-sync-job',
+          { priority: 'high' }
+        ).catch((err) => {
+          console.error(
+            '[DnsSyncJob] dns.threat.blocked publish failed',
+            JSON.stringify({
+              orgId: row.orgId,
+              domain: row.domain,
+              category,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        });
+      }
+    }
+  }
+
+  await persistAggregationDeltas(Array.from(aggregationMap.values()));
+
+  const retentionDays = Number(config.retentionDays);
+  if (Number.isFinite(retentionDays) && retentionDays > 0) {
+    const cutoff = new Date(Date.now() - Math.round(retentionDays) * 24 * 60 * 60 * 1000);
+    await db
+      .delete(dnsSecurityEvents)
+      .where(
+        and(
+          eq(dnsSecurityEvents.integrationId, integrationId),
+          lte(dnsSecurityEvents.timestamp, cutoff)
+        )
+      );
+  }
+
+  await db
+    .update(dnsFilterIntegrations)
+    .set({
+      lastSync: until,
+      lastSyncStatus: 'success',
+      lastSyncError: null,
+      totalEventsProcessed: sql`${dnsFilterIntegrations.totalEventsProcessed} + ${insertedCount}`,
+      updatedAt: new Date()
+    })
+    .where(eq(dnsFilterIntegrations.id, integrationId));
+
+  return insertedCount;
+}
+
 // Exported for focused catch-block coverage (#1035 item 2): a unit test mocks
 // the provider to throw a DnsProviderHttpError carrying a distinctive upstream
 // body marker and asserts the SSRF read-oracle invariant — the tenant-visible
@@ -454,11 +630,15 @@ export async function processSyncIntegration(data: SyncIntegrationJobData): Prom
   fetched: number;
   inserted: number;
 }> {
-  const [integration] = await db
-    .select()
-    .from(dnsFilterIntegrations)
-    .where(eq(dnsFilterIntegrations.id, data.integrationId))
-    .limit(1);
+  // Phase 1 — read the integration row in its own short DB context, so the
+  // provider fetch (Phase 2) holds no open transaction (#1697).
+  const [integration] = await runWithSystemDbAccess(() =>
+    db
+      .select()
+      .from(dnsFilterIntegrations)
+      .where(eq(dnsFilterIntegrations.id, data.integrationId))
+      .limit(1)
+  );
 
   if (!integration || !integration.isActive) {
     return { integrationId: data.integrationId, fetched: 0, inserted: 0 };
@@ -479,164 +659,26 @@ export async function processSyncIntegration(data: SyncIntegrationJobData): Prom
       : new Date(Date.now() - 24 * 60 * 60 * 1000);
     const until = new Date();
 
-    const events = await provider.syncEvents(since, until);
-    const categoriesFilter = new Set(
-      (config.categories ?? [])
-        .map((item) => normalizeThreatCategory(item))
-        .filter((item): item is DnsThreatCategory => item !== null)
-    );
-    const devicesByIp = await mapDevicesByIp(integration.orgId);
+    // Phase 2 — fetch from the DNS provider with NO DB context held
+    // (#1105/#1697). The ~20s-timeout HTTP must not pin a pooled connection.
+    const events = await dbModule.runOutsideDbContext(() => provider.syncEvents(since, until));
 
-    const values = events.flatMap((event) => {
-      const domain = normalizeDomain(event.domain);
-      if (!domain) return [];
-
-      const action = normalizeAction(event.action);
-      const category = normalizeThreatCategory(event.category);
-
-      if (categoriesFilter.size > 0) {
-        if (!category || !categoriesFilter.has(category)) {
-          return [];
-        }
-      }
-
-      const sourceIp = normalizeSourceIp(event.sourceIp);
-      const deviceId = sourceIp ? (devicesByIp.get(sourceIp) ?? null) : null;
-
-      return [{
+    // Phase 3 — process + persist all events in ONE context (security events,
+    // aggregations, retention prune and success status commit together).
+    const inserted = await runWithSystemDbAccess(() =>
+      persistDnsEventSync({
         orgId: integration.orgId,
         integrationId: integration.id,
-        deviceId,
-        timestamp: event.timestamp,
-        domain,
-        queryType: normalizeQueryType(event.queryType),
-        action,
-        category,
-        threatType: normalizeThreatType(event.threatType),
-        sourceIp,
-        sourceHostname: normalizeSourceHost(event.sourceHostname),
-        providerEventId: normalizeSourceHost(event.providerEventId) ?? createFallbackProviderEventId(integration.id, event),
-        metadata: event.metadata ?? null
-      }];
-    });
-
-    let insertedCount = 0;
-    const aggregationMap = new Map<string, EventAggregationDelta>();
-
-    for (const batch of chunk(values, 500)) {
-      const inserted = await db
-        .insert(dnsSecurityEvents)
-        .values(batch)
-        .onConflictDoNothing({
-          target: [dnsSecurityEvents.integrationId, dnsSecurityEvents.providerEventId]
-        })
-        .returning({
-          orgId: dnsSecurityEvents.orgId,
-          integrationId: dnsSecurityEvents.integrationId,
-          deviceId: dnsSecurityEvents.deviceId,
-          timestamp: dnsSecurityEvents.timestamp,
-          domain: dnsSecurityEvents.domain,
-          category: dnsSecurityEvents.category,
-          action: dnsSecurityEvents.action
-        });
-
-      insertedCount += inserted.length;
-
-      for (const row of inserted) {
-        const day = toDateKey(row.timestamp);
-        const category = row.category as DnsThreatCategory | null;
-        const key = [
-          row.orgId,
-          day,
-          row.integrationId ?? '',
-          row.deviceId ?? '',
-          row.domain ?? '',
-          category ?? ''
-        ].join('|');
-
-        const current = aggregationMap.get(key) ?? {
-          orgId: row.orgId,
-          date: day,
-          integrationId: row.integrationId,
-          deviceId: row.deviceId,
-          domain: row.domain,
-          category,
-          totalQueries: 0,
-          blockedQueries: 0,
-          allowedQueries: 0
-        };
-
-        current.totalQueries += 1;
-        if (row.action === 'blocked') current.blockedQueries += 1;
-        if (row.action === 'allowed') current.allowedQueries += 1;
-        aggregationMap.set(key, current);
-
-        // #829 — emit dns.threat.blocked so the existing event-bus
-        // subscribers (webhookDelivery, automationWorker, alert rules) can
-        // consume the signal. Only fire for actually-blocked threat events
-        // (action=blocked AND category present) so an "allowed" DNS query
-        // doesn't pollute the bus. Best-effort: failure to publish here
-        // must not abort sync — the event-bus internals already swallow
-        // local-handler errors with structured logging (#820), but we
-        // still wrap the call to suppress a hypothetical xadd reject.
-        if (row.action === 'blocked' && category) {
-          publishEvent(
-            EVENT_TYPES.DNS_THREAT_BLOCKED,
-            row.orgId,
-            {
-              deviceId: row.deviceId,
-              domain: row.domain,
-              category,
-              integrationId: row.integrationId,
-              timestamp: row.timestamp.toISOString(),
-            },
-            'dns-sync-job',
-            { priority: 'high' }
-          ).catch((err) => {
-            console.error(
-              '[DnsSyncJob] dns.threat.blocked publish failed',
-              JSON.stringify({
-                orgId: row.orgId,
-                domain: row.domain,
-                category,
-                error: err instanceof Error ? err.message : String(err),
-              }),
-            );
-          });
-        }
-      }
-    }
-
-    await persistAggregationDeltas(Array.from(aggregationMap.values()));
-
-    const retentionDays = Number(config.retentionDays);
-    if (Number.isFinite(retentionDays) && retentionDays > 0) {
-      const cutoff = new Date(Date.now() - Math.round(retentionDays) * 24 * 60 * 60 * 1000);
-      await db
-        .delete(dnsSecurityEvents)
-        .where(
-          and(
-            eq(dnsSecurityEvents.integrationId, integration.id),
-            lte(dnsSecurityEvents.timestamp, cutoff)
-          )
-        );
-    }
-
-    await db
-      .update(dnsFilterIntegrations)
-      .set({
-        lastSync: until,
-        lastSyncStatus: 'success',
-        lastSyncError: null,
-        totalEventsProcessed: sql`${dnsFilterIntegrations.totalEventsProcessed} + ${insertedCount}`,
-        updatedAt: new Date()
+        config,
+        events,
+        until,
       })
-      .where(eq(dnsFilterIntegrations.id, integration.id));
+    );
 
     return {
       integrationId: integration.id,
       fetched: events.length,
-      inserted: insertedCount
+      inserted
     };
   } catch (error) {
     // Full detail (including the upstream response body, redacted) goes to the
@@ -646,14 +688,19 @@ export async function processSyncIntegration(data: SyncIntegrationJobData): Prom
     // Pi-hole puts the API key in the URL query string (?auth=<key>) and an
     // upstream body could echo arbitrary public-host content (SSRF read
     // oracle) — neither may land in dnsFilterIntegrations.lastSyncError.
-    await db
-      .update(dnsFilterIntegrations)
-      .set({
-        lastSyncStatus: 'error',
-        lastSyncError: tenantVisibleSyncError(error),
-        updatedAt: new Date()
-      })
-      .where(eq(dnsFilterIntegrations.id, integration.id));
+    // Record on a FRESH transaction so it survives Phase 3's rollback.
+    await dbModule.runOutsideDbContext(() =>
+      runWithSystemDbAccess(() =>
+        db
+          .update(dnsFilterIntegrations)
+          .set({
+            lastSyncStatus: 'error',
+            lastSyncError: tenantVisibleSyncError(error),
+            updatedAt: new Date()
+          })
+          .where(eq(dnsFilterIntegrations.id, integration.id))
+      )
+    );
     throw error;
   }
 }
@@ -666,15 +713,19 @@ export async function processPolicySync(data: SyncPolicyJobData): Promise<{
   added: number;
   removed: number;
 }> {
-  const [row] = await db
-    .select({
-      policy: dnsPolicies,
-      integration: dnsFilterIntegrations
-    })
-    .from(dnsPolicies)
-    .innerJoin(dnsFilterIntegrations, eq(dnsPolicies.integrationId, dnsFilterIntegrations.id))
-    .where(eq(dnsPolicies.id, data.policyId))
-    .limit(1);
+  // Phase 1 — read the policy + its integration in a short DB context, so the
+  // provider mutations (Phase 2) hold no open transaction (#1697).
+  const [row] = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        policy: dnsPolicies,
+        integration: dnsFilterIntegrations
+      })
+      .from(dnsPolicies)
+      .innerJoin(dnsFilterIntegrations, eq(dnsPolicies.integrationId, dnsFilterIntegrations.id))
+      .where(eq(dnsPolicies.id, data.policyId))
+      .limit(1)
+  );
 
   if (!row) {
     return { policyId: data.policyId, added: 0, removed: 0 };
@@ -697,25 +748,33 @@ export async function processPolicySync(data: SyncPolicyJobData): Promise<{
       ? normalizeDomainList(data.operations.remove)
       : [];
 
-    // Mutations MUST run sequentially — see runSequentialDomainMutations for
-    // why concurrency here causes silent rule clobbering (issue #827).
-    if (row.policy.type === 'blocklist') {
-      await runSequentialDomainMutations(addDomains, (domain) => provider.addBlocklistDomain(domain));
-      await runSequentialDomainMutations(removeDomains, (domain) => provider.removeBlocklistDomain(domain));
-    } else {
-      await runSequentialDomainMutations(addDomains, (domain) => provider.addAllowlistDomain(domain));
-      await runSequentialDomainMutations(removeDomains, (domain) => provider.removeAllowlistDomain(domain));
-    }
+    // Phase 2 — push domain mutations to the provider with NO DB context held
+    // (#1105/#1697): this is a sequential loop of ~20s-timeout HTTP calls and
+    // must not pin a pooled connection across the whole run. Mutations MUST run
+    // sequentially — see runSequentialDomainMutations for why concurrency here
+    // causes silent rule clobbering (issue #827).
+    await dbModule.runOutsideDbContext(async () => {
+      if (row.policy.type === 'blocklist') {
+        await runSequentialDomainMutations(addDomains, (domain) => provider.addBlocklistDomain(domain));
+        await runSequentialDomainMutations(removeDomains, (domain) => provider.removeBlocklistDomain(domain));
+      } else {
+        await runSequentialDomainMutations(addDomains, (domain) => provider.addAllowlistDomain(domain));
+        await runSequentialDomainMutations(removeDomains, (domain) => provider.removeAllowlistDomain(domain));
+      }
+    });
 
-    await db
-      .update(dnsPolicies)
-      .set({
-        syncStatus: 'synced',
-        lastSynced: new Date(),
-        syncError: null,
-        updatedAt: new Date()
-      })
-      .where(eq(dnsPolicies.id, row.policy.id));
+    // Phase 3 — mark the policy synced in a short context.
+    await runWithSystemDbAccess(() =>
+      db
+        .update(dnsPolicies)
+        .set({
+          syncStatus: 'synced',
+          lastSynced: new Date(),
+          syncError: null,
+          updatedAt: new Date()
+        })
+        .where(eq(dnsPolicies.id, row.policy.id))
+    );
 
     return {
       policyId: row.policy.id,
@@ -725,15 +784,20 @@ export async function processPolicySync(data: SyncPolicyJobData): Promise<{
   } catch (error) {
     // Full detail (including the upstream response body, redacted) goes to the
     // SERVER-SIDE log only; the tenant-visible column gets a body-free message.
+    // Record on a FRESH transaction so it survives any Phase 3 rollback.
     logSyncFailureServerSide({ policyId: row.policy.id, orgId: row.integration.orgId }, error);
-    await db
-      .update(dnsPolicies)
-      .set({
-        syncStatus: 'error',
-        syncError: tenantVisibleSyncError(error),
-        updatedAt: new Date()
-      })
-      .where(eq(dnsPolicies.id, row.policy.id));
+    await dbModule.runOutsideDbContext(() =>
+      runWithSystemDbAccess(() =>
+        db
+          .update(dnsPolicies)
+          .set({
+            syncStatus: 'error',
+            syncError: tenantVisibleSyncError(error),
+            updatedAt: new Date()
+          })
+          .where(eq(dnsPolicies.id, row.policy.id))
+      )
+    );
     throw error;
   }
 }
@@ -742,18 +806,20 @@ function createDnsSyncWorker(): Worker<DnsSyncJobData> {
   return new Worker<DnsSyncJobData>(
     DNS_SYNC_QUEUE,
     async (job: Job<DnsSyncJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        switch (job.data.type) {
-          case 'sync-all':
-            return processSyncAll();
-          case 'sync-integration':
-            return processSyncIntegration(job.data);
-          case 'sync-policy':
-            return processPolicySync(job.data);
-          default:
-            throw new Error(`Unknown DNS sync job type: ${(job.data as { type: string }).type}`);
-        }
-      });
+      // No blanket withSystemDbAccessContext wrap — each path self-scopes its DB
+      // contexts so the external DNS provider HTTP (event fetch / domain
+      // mutations) runs with no pooled connection held in an open transaction
+      // (#1105/#1697).
+      switch (job.data.type) {
+        case 'sync-all':
+          return processSyncAll();
+        case 'sync-integration':
+          return processSyncIntegration(job.data);
+        case 'sync-policy':
+          return processPolicySync(job.data);
+        default:
+          throw new Error(`Unknown DNS sync job type: ${(job.data as { type: string }).type}`);
+      }
     },
     {
       connection: getBullMQConnection(),

--- a/apps/api/src/jobs/dnsSyncJob_syncError.test.ts
+++ b/apps/api/src/jobs/dnsSyncJob_syncError.test.ts
@@ -42,7 +42,9 @@ const mockDb = {
 
 vi.mock('../db', () => ({
   db: mockDb,
-  withSystemDbAccessContext: undefined,
+  // Passthroughs — the processors now self-scope their DB contexts (#1697); the
+  // chainable db mock above is exercised directly, contexts are transparent.
+  withSystemDbAccessContext: <T>(fn: () => T): T => fn(),
   runOutsideDbContext: <T>(fn: () => T): T => fn(),
 }));
 


### PR DESCRIPTION
## What
Completes #1697: stops the **DNS** sync worker from holding a pooled DB connection in an open transaction across its external provider HTTP. Follow-up to #1703 (Huntress + Pax8).

Closes #1697.

## Why
`dnsSyncJob.ts`'s worker wrapped **all three** job paths in one `runWithSystemDbAccess` transaction, and two of them do external HTTP inside it:
- `processSyncIntegration` → `provider.syncEvents()` (20s-timeout client, `dnsProviders/http.ts`).
- `processPolicySync` → a **sequential `addBlocklistDomain`/`removeBlocklistDomain` mutation loop** — potentially many serial HTTP calls, all inside the held transaction.

Each pinned a connection idle-in-transaction across the HTTP window — the same root cause as #1703, contributing to the `#1105` flood and US pool starvation. (Reminder from #1703: `runOutsideDbContext` can't release an already-open outer transaction, so the blanket worker wrap had to go.)

## Fix
- **Remove the blanket worker wrap**; each path self-scopes its DB contexts.
- **`processSyncIntegration`**: read (short context) → `provider.syncEvents()` via `runOutsideDbContext` (no txn held) → persist via a new **`persistDnsEventSync`** helper in one context (security events + aggregations + retention prune + success status stay atomic). Phase 3 was extracted into the helper to keep the diff readable rather than re-indenting a ~170-line block.
- **`processPolicySync`**: read (short context) → sequential domain mutations via `runOutsideDbContext` → status write in a short context.
- **`processSyncAll`**: wrap the integration read (`dns_filter_integrations` is tenant-scoped — a contextless read silently returns 0 rows under RLS, #1375), which also moves the Redis enqueue out of a held transaction.
- Failure-status writes now record on a **fresh** transaction so they survive a Phase 3 rollback.

## Preserved invariants
The **SSRF read-oracle** protection (#1035) is intact — the catch paths still write only the body-free status line (`HTTP 502 Bad Gateway`) to the tenant-visible `lastSyncError`/`syncError` column, never the upstream body. Verified by the unchanged assertions in `dnsSyncJob_syncError.test.ts`.

## Tests
- `jobs/dnsSyncJob.dbcontext.test.ts` (new) — asserts the provider HTTP runs at DB-context depth 0 while reads/writes run inside a context, for **both** the event-sync and policy-sync paths.
- `dnsSyncJob_syncError.test.ts` mock updated (processors self-scope contexts now); its SSRF assertions unchanged and passing.
- All DNS tests (14) pass; full `tsc --noEmit` clean.

## Net effect (with #1703)
PSA has no background sync (N/A), so Huntress + Pax8 (#1703) + DNS (this PR) covers every background integration sync that was fetching inside a held transaction. The `#1105` scope=system connection-hold flood should drop to near-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
