### PR TITLE
fix(aitools): site-narrow device-typed rows in query_audit_log (R3b)

### DIFF
--- a/apps/api/src/services/aiToolsAudit.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAudit.siteScope.test.ts
@@ -9,6 +9,7 @@ vi.mock('../db', () => ({
 
 import { db } from '../db';
 import { registerAuditTools } from './aiToolsAudit';
+import { SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 
@@ -81,5 +82,92 @@ describe('query_change_log — site narrowing (no deviceId branch)', () => {
     expect(parsed.error).toBeUndefined();
     expect(parsed.showing).toBe(1);
     expect(parsed.total).toBe(1);
+  });
+});
+
+describe('query_audit_log — device-typed row site narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // The site-narrowing SQL predicate is opaque to the mock, so these tests
+  // assert the handler resolves the allowed device set (the resolver SELECT)
+  // before scanning — proving the narrowing path runs for restricted callers.
+  it('site-restricted caller resolves the allowed device set and applies a scan predicate', async () => {
+    let resolverRan = false;
+    let scanWhere: unknown;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        resolverRan = true;
+        return {
+          from: () => ({
+            where: () =>
+              Promise.resolve([
+                { id: 'd-inscope', siteId: 'site-A' },
+                { id: 'd-forbidden', siteId: 'site-B' },
+              ]),
+          }),
+        };
+      }
+      const p: any = Promise.resolve([
+        { id: 'a1', timestamp: null, actorType: 'user', actorEmail: 'x', action: 'agent.command.script', resourceType: 'device', resourceName: 'in-scope', result: 'ok', details: null },
+      ]);
+      for (const m of ['from', 'innerJoin', 'leftJoin', 'orderBy', 'limit', 'groupBy', 'offset']) p[m] = () => p;
+      p.where = (w: unknown) => {
+        scanWhere = w;
+        return p;
+      };
+      return p;
+    });
+
+    const r = await handlerFor('query_audit_log')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(resolverRan).toBe(true);
+    expect(scanWhere).toBeDefined();
+  });
+
+  it('site-restricted caller with explicit out-of-scope device returns denied/empty', async () => {
+    let scanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return {
+          from: () => ({
+            where: () => Promise.resolve([{ id: 'd-inscope', siteId: 'site-A' }]),
+          }),
+        };
+      }
+      scanRan = true;
+      return chain([
+        { id: 'a1', timestamp: null, actorType: 'user', actorEmail: 'x', action: 'a', resourceType: 'device', resourceName: 'forbidden', result: 'ok', details: null },
+      ]);
+    });
+
+    const r = await handlerFor('query_audit_log')(
+      { resourceType: 'device', resourceId: 'd-forbidden' },
+      makeAuth(['site-A']),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.entries).toEqual([]);
+    expect(parsed.showing).toBe(0);
+    expect(parsed.scopeNote).toBe(SITE_SCOPE_EMPTY_NOTE);
+    expect(scanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('forbidden');
+  });
+
+  it('unrestricted caller queries audit log normally (no regression)', async () => {
+    let resolverRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        resolverRan = true;
+        return { from: () => ({ where: () => Promise.resolve([]) }) };
+      }
+      return chain([
+        { id: 'a1', timestamp: null, actorType: 'user', actorEmail: 'x', action: 'a', resourceType: 'device', resourceName: 'r', result: 'ok', details: null },
+      ]);
+    });
+    const r = await handlerFor('query_audit_log')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.showing).toBe(1);
+    expect(resolverRan).toBe(false);
   });
 });

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -8,7 +8,7 @@
 
 import { db } from '../db';
 import { devices, auditLogs, deviceChangeLog } from '../db/schema';
-import { eq, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
+import { eq, ne, or, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
@@ -68,6 +68,37 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
       if (input.resourceType) conditions.push(eq(auditLogs.resourceType, input.resourceType as string));
       if (input.resourceId) conditions.push(eq(auditLogs.resourceId, input.resourceId as string));
       if (input.actorType) conditions.push(eq(auditLogs.actorType, input.actorType as typeof auditLogs.actorType.enumValues[number]));
+
+      // Site axis (app-layer only; RLS does NOT enforce it). audit_logs is
+      // org-keyed and heterogeneous — `resourceId` is a device id only when
+      // `resourceType === 'device'`; other rows reference orgs/users/tickets/etc.
+      // The site axis is device-centric, so narrow ONLY device-typed rows to the
+      // caller's allowed device set, leaving other resource types governed by the
+      // existing org axis. No-op for unrestricted partner/system callers.
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const orgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        const allowedDeviceIds = orgId ? await resolveSiteAllowedDeviceIds(orgId, auth) : [];
+        if (allowedDeviceIds !== null) {
+          // An explicit device-row lookup outside the allowed set is denied outright.
+          if (
+            input.resourceType === 'device' &&
+            input.resourceId &&
+            !allowedDeviceIds.includes(input.resourceId as string)
+          ) {
+            return JSON.stringify({ entries: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
+          }
+          // Show non-device rows as before; device rows only for in-scope devices.
+          // Empty allowed set ⇒ exclude all device rows.
+          conditions.push(
+            allowedDeviceIds.length > 0
+              ? or(
+                  ne(auditLogs.resourceType, 'device'),
+                  inArray(auditLogs.resourceId, allowedDeviceIds),
+                )!
+              : ne(auditLogs.resourceType, 'device'),
+          );
+        }
+      }
 
       const hoursBack = Math.min(Math.max(1, Number(input.hoursBack) || 24), 168);
       const since = new Date(Date.now() - hoursBack * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary

Follow-up to R3 (PR #1702). R3 site-narrowed the device-keyed aiTools list tools, but `query_audit_log` in `aiToolsAudit.ts` was not narrowed — it reads org-keyed `audit_logs` filtered only by the org axis. A site-restricted operator could therefore read audit entries referencing devices in sites they cannot access.

`audit_logs` is heterogeneous: `resourceId` is a device id only when `resourceType === 'device'`. The site axis is device-centric, so this change narrows only device-typed rows to the caller's allowed device set (via `resolveSiteAllowedDeviceIds`), leaving other resource types governed by their existing org axis. Explicit out-of-scope device lookups return an empty/denied result with the standard site-scope note. No-op for unrestricted partner/system callers.

## Tests

Added `query_audit_log` cases to `aiToolsAudit.siteScope.test.ts` asserting:
- a site-restricted caller resolves the allowed device set before scanning and applies a narrowing predicate,
- an explicit out-of-scope device lookup is denied/empty,
- unrestricted callers are unaffected (no resolver, no narrowing).

`aiToolsAudit.ts` is already in the `SITE_GATED_NON_VERIFY_FILES` allowlist. Typecheck and contract test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)