### PR TITLE
fix(billing): audit Stripe full-refund payment voids

### DIFF
--- a/apps/api/src/services/stripeReconcile.test.ts
+++ b/apps/api/src/services/stripeReconcile.test.ts
@@ -46,14 +46,18 @@ vi.mock('../db', () => {
   };
 });
 
-const { recompute, emit, capture } = vi.hoisted(() => ({ recompute: vi.fn(), emit: vi.fn(), capture: vi.fn() }));
+const { recompute, emit, capture, audit } = vi.hoisted(() => ({ recompute: vi.fn(), emit: vi.fn(), capture: vi.fn(), audit: vi.fn() }));
 vi.mock('./invoiceService', () => ({ recomputeInvoiceStatus: recompute }));
 vi.mock('./invoiceEvents', () => ({ emitInvoiceEvent: emit }));
 vi.mock('./sentry', () => ({ captureException: capture }));
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: audit,
+  requestLikeFromSnapshot: () => ({ req: { header: () => undefined } }),
+}));
 
 import { recordStripePayment, reflectStripeRefund } from './stripeReconcile';
 
-beforeEach(() => { results.length = 0; recompute.mockReset(); emit.mockReset(); capture.mockReset(); setAmount.calls.length = 0; deleteWhereArgs.calls.length = 0; setMapping.calls.length = 0; insertValues.calls.length = 0; });
+beforeEach(() => { results.length = 0; recompute.mockReset(); emit.mockReset(); capture.mockReset(); audit.mockReset(); setAmount.calls.length = 0; deleteWhereArgs.calls.length = 0; setMapping.calls.length = 0; insertValues.calls.length = 0; });
 
 describe('recordStripePayment', () => {
   it('inserts a card payment, links the mapping, recomputes, emits payment.recorded', async () => {
@@ -205,9 +209,11 @@ describe('recordStripePayment', () => {
 
 describe('reflectStripeRefund', () => {
   it('full refund voids the linked payment (delete, NOT update) and recomputes', async () => {
-    // db call order: select mapping → delete payment → update mapping →
-    // (recompute, mocked) → invoicePartnerId: select invoice → (emit, mocked)
+    // db call order: select mapping → select payment (pre-delete audit snapshot) →
+    // delete payment → update mapping → (recompute, mocked) →
+    // invoicePartnerId: select invoice → (emit, mocked)
     queueResult([{ id: 'm1', invoiceId: 'inv1', orgId: 'org1', invoicePaymentId: 'pay1', stripeAccountId: 'acct_1' }]); // mapping
+    queueResult([{ id: 'pay1', invoiceId: 'inv1', orgId: 'org1', amount: '100.00', method: 'card', recordedBy: null }]); // payment snapshot
     queueResult([]); // delete payment
     queueResult([]); // update mapping → refunded
     queueResult([{ partnerId: 'p1' }]); // invoicePartnerId select
@@ -221,6 +227,48 @@ describe('reflectStripeRefund', () => {
     expect(setAmount.calls).not.toContain('10000.00');
     expect(recompute).toHaveBeenCalledWith('inv1');
     expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'payment.voided', invoiceId: 'inv1' }));
+  });
+
+  it('full refund writes a durable audit event capturing the destroyed payment pre-delete', async () => {
+    // The Stripe-webhook-initiated void deletes the financial record, so the audit
+    // entry must be written from a snapshot read BEFORE the delete (mirrors the
+    // manual void route's pre-destroy capture, R2). System-scope writer (no req ctx).
+    queueResult([{ id: 'm1', invoiceId: 'inv1', orgId: 'org1', invoicePaymentId: 'pay1', stripeAccountId: 'acct_1' }]); // mapping
+    queueResult([{ id: 'pay1', invoiceId: 'inv1', orgId: 'org1', amount: '100.00', method: 'card', recordedBy: 'usr1' }]); // payment snapshot
+    queueResult([]); // delete payment
+    queueResult([]); // update mapping → refunded
+    queueResult([{ partnerId: 'p1' }]); // invoicePartnerId select
+
+    await reflectStripeRefund({ stripePaymentIntentId: 'pi_1', amountRefundedCents: 10000, chargeAmountCents: 10000, currency: 'USD', stripeAccountId: 'acct_1' });
+
+    expect(audit).toHaveBeenCalledTimes(1);
+    const [, event] = audit.mock.calls[0] as [unknown, Record<string, any>];
+    expect(event).toMatchObject({
+      orgId: 'org1',
+      action: 'invoice.payment.voided',
+      resourceType: 'invoice_payment',
+      resourceId: 'pay1',
+      actorType: 'system',
+    });
+    // Financial details captured from the snapshot read before db.delete destroyed it.
+    expect(event.details).toMatchObject({
+      amount: '100.00',
+      method: 'card',
+      recordedBy: 'usr1',
+      invoiceId: 'inv1',
+      reason: 'stripe_refund',
+    });
+  });
+
+  it('partial refund does NOT write a void audit event (the row survives, only reduced)', async () => {
+    queueResult([{ id: 'm1', invoiceId: 'inv1', orgId: 'org1', invoicePaymentId: 'pay1', stripeAccountId: 'acct_1' }]); // mapping
+    queueResult([]); // update payment amount
+    queueResult([]); // update mapping → partially_refunded
+    queueResult([{ partnerId: 'p1' }]); // invoicePartnerId select
+
+    await reflectStripeRefund({ stripePaymentIntentId: 'pi_1', amountRefundedCents: 4000, chargeAmountCents: 10000, currency: 'USD', stripeAccountId: 'acct_1' });
+
+    expect(audit).not.toHaveBeenCalled();
   });
 
   it('partial refund reduces the payment amount (update, NOT delete) and recomputes', async () => {

--- a/apps/api/src/services/stripeReconcile.ts
+++ b/apps/api/src/services/stripeReconcile.ts
@@ -6,6 +6,7 @@ import { recomputeInvoiceStatus } from './invoiceService';
 import { emitInvoiceEvent } from './invoiceEvents';
 import { fromMinorUnits } from './stripeMoney';
 import { captureException } from './sentry';
+import { writeAuditEvent, requestLikeFromSnapshot } from './auditEvents';
 
 function toCents(v: string | number) { return Math.round(Number(v) * 100); }
 
@@ -136,10 +137,36 @@ export async function reflectStripeRefund(input: RefundInput): Promise<void> {
     const full = input.amountRefundedCents >= input.chargeAmountCents;
     if (full) {
       // Full refund → void the payment row (mirrors voidPayment mechanics).
+      // Snapshot the financial record BEFORE deleting so the destroyed payment
+      // (amount/method/recordedBy/invoiceId) survives in the durable audit chain —
+      // this is a webhook path with no Hono request context, so we use the
+      // system-scope audit writer (mirrors quoteExpiryReaper), not writeRouteAudit.
+      const [snapshot] = await db.select().from(invoicePayments).where(eq(invoicePayments.id, paymentId)).limit(1);
       await db.delete(invoicePayments).where(eq(invoicePayments.id, paymentId));
       await db.update(invoiceStripePayments)
         .set({ status: 'refunded', invoicePaymentId: null, lastEventAt: new Date(), updatedAt: new Date() })
         .where(eq(invoiceStripePayments.id, mapping.id));
+      // Best-effort, never throwing (consistent with the rest of this reconcile path).
+      try {
+        writeAuditEvent(requestLikeFromSnapshot({}), {
+          orgId: mapping.orgId,
+          action: 'invoice.payment.voided',
+          resourceType: 'invoice_payment',
+          resourceId: paymentId,
+          actorType: 'system',
+          actorId: null,
+          result: 'success',
+          details: {
+            amount: snapshot?.amount,
+            method: snapshot?.method,
+            recordedBy: snapshot?.recordedBy ?? null,
+            invoiceId: mapping.invoiceId,
+            reason: 'stripe_refund',
+          },
+        });
+      } catch (err) {
+        console.error('[stripeReconcile] failed to write void audit event', err);
+      }
     } else {
       // Partial refund → reduce the positive payment amount (stays > 0; respects the amount>0 CHECK).
       // Currency-aware: zero-decimal currencies (JPY, …) must NOT be divided by 100.


### PR DESCRIPTION
## Summary

Follow-up to R2 (#1701), which added audit logging to the manual invoice payment record/void routes. The Stripe-webhook reconcile path (`reflectStripeRefund`) was missed: on a full refund it deletes the `invoice_payments` row (mirroring `voidPayment` mechanics) but wrote no `audit_logs` entry, so a Stripe-initiated void left no durable audit trail of the destroyed financial record.

## Change

- In the full-refund branch of `reflectStripeRefund`, snapshot the payment row (amount/method/recordedBy/invoiceId) **before** `db.delete`, then write a system-scope audit event.
- This is a webhook/service path with no Hono request context, so it uses `writeAuditEvent` + `requestLikeFromSnapshot` (the same system-scope writer used by `quoteExpiryReaper`), not `writeRouteAudit`.
- Action `invoice.payment.voided`, resourceType `invoice_payment`, resourceId = the deleted payment id, orgId from the mapping, `reason: 'stripe_refund'` in details.
- Fire-and-forget / non-throwing, consistent with the surrounding reconcile code.

Additive — no behavior change to the refund/void mechanics. Partial refunds (row survives) do not write a void event.

## Tests

`apps/api/src/services/stripeReconcile.test.ts`:
- New test asserting the full-refund path writes the audit event with the correct action/resource and details captured pre-delete.
- New test asserting partial refunds write no void audit event.
- Existing full-refund test updated for the added pre-delete snapshot read.

15/15 green; typecheck clean. Non-vacuity confirmed (test fails without the prod audit write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)