### PR TITLE
fix(tunnels): audit viewer-transition tunnel handlers (R1c)

### DIFF
--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -1354,6 +1354,7 @@ describe('Audit logging — credential-minting tunnel endpoints', () => {
     app = new Hono();
     app.route('/tunnels', tunnelRoutes);
     app.route('/vnc-exchange', vncExchangeRoutes);
+    app.route('/vnc-viewer', vncViewerRoutes);
   });
 
   it('POST /:id/ws-ticket writes a tunnel.ws_ticket.mint audit row', async () => {
@@ -1420,5 +1421,93 @@ describe('Audit logging — credential-minting tunnel endpoints', () => {
       result: 'success',
     }));
     expect(audits[0].details).toEqual(expect.objectContaining({ deviceId: DEVICE_ID }));
+  });
+
+  it('POST /vnc-viewer/upgrade-to-webrtc writes a tunnel.upgrade_webrtc audit row attributed to the tunnel owner', async () => {
+    const NEW_SESSION_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+    vi.mocked(verifyViewerAccessToken).mockResolvedValueOnce({
+      sub: USER_ID,
+      email: 'test@example.com',
+      sessionId: SESSION_ID,
+      purpose: 'viewer',
+      jti: 'viewer-jti-up',
+    });
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinedSelectChain([{
+      tunnelUserId: USER_ID,
+      tunnelOrgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      tunnelType: 'vnc',
+      tunnelStatus: 'pending',
+      deviceStatus: 'online',
+      agentId: 'agent-abc',
+      userEmail: 'test@example.com',
+    }]) as any);
+    // db.update (terminate stragglers) then db.insert (new desktop session)
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    const insertMock = vi.fn().mockReturnValue(makeAuditAwareInsertChain([{ id: NEW_SESSION_ID }]));
+    vi.mocked(db.insert).mockImplementation(insertMock as any);
+    vi.mocked(createViewerAccessToken).mockResolvedValueOnce('viewer-token-up');
+
+    const res = await app.request('/vnc-viewer/upgrade-to-webrtc', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer viewer-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const audits = auditCalls(insertMock);
+    expect(audits).toHaveLength(1);
+    // Viewer-token auth — actor is the tunnel-bound owner, not a JWT subject.
+    expect(audits[0]).toEqual(expect.objectContaining({
+      action: 'tunnel.upgrade_webrtc',
+      resourceType: 'tunnel_session',
+      resourceId: NEW_SESSION_ID,
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      result: 'success',
+    }));
+    expect(audits[0].details).toEqual(expect.objectContaining({ deviceId: DEVICE_ID, type: 'desktop' }));
+  });
+
+  it('POST /vnc-viewer/downgrade-to-vnc writes a tunnel.open audit row for the newly created tunnel', async () => {
+    const NEW_TUNNEL_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+    vi.mocked(verifyViewerAccessToken).mockResolvedValueOnce({
+      sub: USER_ID,
+      email: 'test@example.com',
+      sessionId: SESSION_ID,
+      purpose: 'viewer',
+      jti: 'viewer-jti-down',
+    });
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinedSelectChain([{
+      userId: USER_ID,
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      deviceStatus: 'online',
+      agentId: 'agent-abc',
+      userEmail: 'test@example.com',
+    }]) as any);
+    const insertMock = vi.fn().mockReturnValue(makeAuditAwareInsertChain([{ id: NEW_TUNNEL_ID }]));
+    vi.mocked(db.insert).mockImplementation(insertMock as any);
+    vi.mocked(createViewerAccessToken).mockResolvedValueOnce('viewer-token-down');
+
+    const res = await app.request('/vnc-viewer/downgrade-to-vnc', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer viewer-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const audits = auditCalls(insertMock);
+    expect(audits).toHaveLength(1);
+    // New tunnel created under viewer-token auth — actor is the session-bound owner.
+    expect(audits[0]).toEqual(expect.objectContaining({
+      action: 'tunnel.open',
+      resourceType: 'tunnel_session',
+      resourceId: NEW_TUNNEL_ID,
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      result: 'success',
+    }));
+    expect(audits[0].details).toEqual(expect.objectContaining({ deviceId: DEVICE_ID, type: 'vnc', via: 'downgrade_vnc' }));
   });
 });

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -1146,6 +1146,19 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
     sessionId: session.id,
   });
 
+  // Viewer-token auth — no JWT actor. Attribute the upgrade to the tunnel-bound
+  // owner (the user who opened the originating VNC tunnel) so the credential
+  // mint is traceable. logTunnelAudit runs in its own system DB context.
+  await logTunnelAudit(
+    'tunnel.upgrade_webrtc',
+    'tunnel_session',
+    session.id,
+    bound.tunnelUserId,
+    bound.tunnelOrgId,
+    { deviceId: bound.deviceId, type: 'desktop', fromTunnelId: auth.sessionId },
+    getClientIp(c),
+  );
+
   return c.json({
     sessionId: session.id,
     accessToken,
@@ -1260,6 +1273,20 @@ vncViewerRoutes.post('/downgrade-to-vnc', async (c) => {
     email: bound.userEmail,
     sessionId: tunnel.id,
   });
+
+  // This path creates a brand-new tunnel session under viewer-token auth (no
+  // JWT actor), mirroring POST /tunnels — so emit the same tunnel.open audit,
+  // attributed to the session-bound owner. Without this the downgrade opens a
+  // tunnel with no audit trail at all.
+  await logTunnelAudit(
+    'tunnel.open',
+    'tunnel_session',
+    tunnel.id,
+    bound.userId,
+    bound.orgId,
+    { deviceId: bound.deviceId, type: 'vnc', via: 'downgrade_vnc', fromSessionId: auth.sessionId },
+    getClientIp(c),
+  );
 
   return c.json({
     tunnelId: tunnel.id,


### PR DESCRIPTION
## Summary

Closes an audit-log coverage gap (R1c, same class as R1 #1700 / R1b #1705). Two VNC viewer-transition handlers in `apps/api/src/routes/tunnels.ts` minted credentials / created tunnels with **no `audit_logs` entry**:

- `POST /vnc-viewer/upgrade-to-webrtc` — minted a viewer access token for a WebRTC upgrade (now emits `tunnel.upgrade_webrtc`).
- `POST /vnc-viewer/downgrade-to-vnc` — **created a brand-new tunnel session** and minted a ws-ticket with no `tunnel.open`-equivalent audit at all (now emits `tunnel.open`, mirroring the JWT-gated `POST /tunnels` path).

## Actor resolution

Both handlers run under **viewer-token auth** (no `auth.user.id`). The actor is resolved to the bound tunnel/session owner (`bound.tunnelUserId` / `bound.userId`), mirroring how the existing `POST /vnc-exchange/:code` handler attributes its redemption to the code-bound `record.userId`. The event is always recorded with a resolved owner, so it stays traceable without a JWT actor.

`logTunnelAudit` already runs in its own system DB context and escalates failures to `captureException` — it never throws into the primary op.

## Tests (TDD)

Added two unit tests to the `Audit logging — credential-minting tunnel endpoints` block, asserting each handler writes an audit row with the right action/resource/actor (audit layer mocked per the existing `tunnels.test.ts` pattern).

- RED proof: removing the two new `logTunnelAudit` calls fails exactly the 2 new tests (`toHaveLength(1)` → 0 audit rows).
- GREEN: `62 passed` in `src/routes/tunnels.test.ts`.
- `tsc --noEmit` on `apps/api`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)