### PR TITLE
fix(agent): bind run_as_user delivery to the target console session

### DIFF
--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -53,7 +53,17 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 			return h.executeViaUserHelper(session, cmd, script.Timeout)
 		}
 		if !strings.EqualFold(script.RunAs, "system") && !strings.EqualFold(script.RunAs, "elevated") {
-			log.Debug("no user helper for runAs value, falling back to local executor", "runAs", script.RunAs)
+			// A user-context delivery was requested but no eligible helper was
+			// resolved, so the script is about to run in the local (SYSTEM)
+			// context instead. That privilege-context downgrade is security
+			// relevant — on a multi-user / RDS host it is the visible symptom of
+			// the console-session binding suppressing delivery (#1009) — so log it
+			// at WARN, not DEBUG, where it would be invisible at production log
+			// levels. The broker also WARNs why no console helper matched; this
+			// line records that the fallback actually fired. Behaviour is
+			// unchanged: we still fall through to the local executor below.
+			log.Warn("runAs delivery downgraded to local (SYSTEM) context: no eligible user helper",
+				"runAs", script.RunAs, "commandId", cmd.ID)
 		}
 	}
 

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -648,14 +648,21 @@ func (b *Broker) preferredRunAsUserSessionForOS(goos string) *Session {
 	consoleSession := b.ConsoleSessionID()
 
 	b.mu.RLock()
-	defer b.mu.RUnlock()
-
 	var best *Session
+	var excludedNonConsole int // run_as_user helpers skipped solely for being off-console
 	for _, s := range b.sessions {
 		if !s.HasScope("run_as_user") {
 			continue
 		}
 		if s.WinSessionID != consoleSession {
+			// A run_as_user helper exists but is bound to a non-console session.
+			// On a single-user host this never happens; on a multi-user / RDS host
+			// it is either a co-logged-in attacker's helper (the threat #1009
+			// closes) OR the legitimate operator working from a non-console
+			// session. Either way the console binding correctly refuses to deliver
+			// here — but count the exclusion so we can make the drop observable
+			// below rather than vanishing silently.
+			excludedNonConsole++
 			continue
 		}
 		if best == nil {
@@ -672,6 +679,24 @@ func (b *Broker) preferredRunAsUserSessionForOS(goos string) *Session {
 		if betterSession(s, best) {
 			best = s
 		}
+	}
+	b.mu.RUnlock()
+
+	// Observable fallback (#1009 run_as_user slice). When the ONLY eligible
+	// run_as_user helpers were excluded purely because they sit outside the
+	// active console session, the caller will fall back to local SYSTEM
+	// execution. That fallback is a deliberate fail-safe (don't deliver a
+	// run_as_user script to the wrong principal), but on an unusual
+	// multi-session / RDS host where the operator's helper genuinely lives
+	// off-console it manifests as a silent non-delivery. Emit a clear WARN so
+	// the dropped delivery is diagnosable instead of disappearing. When no
+	// run_as_user helper is connected at all (excludedNonConsole == 0), stay
+	// quiet — nil is the expected result and warning on every poll would be noise.
+	if best == nil && excludedNonConsole > 0 {
+		log.Warn("run_as_user delivery suppressed: no helper in the active console session",
+			"consoleWinSession", consoleSession,
+			"excludedNonConsole", excludedNonConsole,
+		)
 	}
 	return best
 }

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -693,7 +693,7 @@ func (b *Broker) preferredRunAsUserSessionForOS(goos string) *Session {
 	// run_as_user helper is connected at all (excludedNonConsole == 0), stay
 	// quiet — nil is the expected result and warning on every poll would be noise.
 	if best == nil && excludedNonConsole > 0 {
-		log.Warn("run_as_user delivery suppressed: no helper in the active console session",
+		log.Warn("run_as_user delivery suppressed: helper exists only outside the active console session",
 			"consoleWinSession", consoleSession,
 			"excludedNonConsole", excludedNonConsole,
 		)

--- a/agent/internal/sessionbroker/console_session_gate_test.go
+++ b/agent/internal/sessionbroker/console_session_gate_test.go
@@ -1,6 +1,7 @@
 package sessionbroker
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -221,6 +222,114 @@ func TestPreferredRunAsUserSessionNoConsoleHelper(t *testing.T) {
 
 	if got := b.preferredRunAsUserSessionForOS("windows"); got != nil {
 		t.Fatalf("preferredRunAsUserSessionForOS(windows) = %q, want nil (no console helper)", got.SessionID)
+	}
+}
+
+// TestPreferredRunAsUserSessionWarnsWhenConsoleBindingSuppressesDelivery is the
+// observable-fallback contract for the still-open run_as_user slice of #1009.
+//
+// The console binding (TestPreferredRunAsUserSessionFiltersByConsoleSession)
+// correctly refuses to deliver a run_as_user script to a co-logged-in user's
+// helper in a non-console session. But on an unusual multi-session / RDS host —
+// where the operator's helper genuinely lives outside the active console session
+// (e.g. the physical console sits at the lock screen while the operator works
+// over RDP) — that same binding silently drops delivery, and the caller then
+// downgrades to local SYSTEM execution. That drop must be OBSERVABLE: when the
+// only eligible run_as_user helpers are excluded purely because they are outside
+// the console session, the broker must emit a clear WARN naming the suppression
+// so the dropped delivery is diagnosable, rather than vanishing silently.
+func TestPreferredRunAsUserSessionWarnsWhenConsoleBindingSuppressesDelivery(t *testing.T) {
+	logs := captureLogs(t)
+
+	now := time.Now()
+
+	// A user-role run_as_user helper exists, but only in a NON-console session.
+	otherUser, otherClient := newTestUserSession(t, "noncon-user", "alice", now.Add(-1*time.Minute))
+	defer otherClient.Close()
+	otherUser.WinSessionID = "3"
+
+	b := &Broker{
+		sessions: map[string]*Session{
+			otherUser.SessionID: otherUser,
+		},
+		byIdentity:         make(map[string][]*Session),
+		staleHelpers:       make(map[string][]int),
+		consoleSessionIDFn: func() string { return "1" },
+	}
+
+	got := b.preferredRunAsUserSessionForOS("windows")
+	if got != nil {
+		t.Fatalf("preferredRunAsUserSessionForOS(windows) = %q, want nil (no console helper)", got.SessionID)
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "run_as_user delivery suppressed") {
+		t.Fatalf("expected a WARN that run_as_user delivery was suppressed by console binding; got logs:\n%s", out)
+	}
+	// The warning must name the active console session and the count of
+	// excluded non-console helpers so an operator can diagnose the RDS-host drop.
+	if !strings.Contains(out, "consoleWinSession") || !strings.Contains(out, "excludedNonConsole") {
+		t.Fatalf("suppression warning missing diagnostic fields; got logs:\n%s", out)
+	}
+}
+
+// TestPreferredRunAsUserSessionNoWarnWhenNoUserHelper asserts the suppression
+// warning is NOT noise: when there is genuinely no user-role run_as_user helper
+// connected at all (so nil is the correct, expected result — not a console-binding
+// drop), the broker must stay quiet rather than crying wolf on every poll.
+func TestPreferredRunAsUserSessionNoWarnWhenNoUserHelper(t *testing.T) {
+	logs := captureLogs(t)
+
+	b := &Broker{
+		sessions:           map[string]*Session{},
+		byIdentity:         make(map[string][]*Session),
+		staleHelpers:       make(map[string][]int),
+		consoleSessionIDFn: func() string { return "1" },
+	}
+
+	if got := b.preferredRunAsUserSessionForOS("windows"); got != nil {
+		t.Fatalf("preferredRunAsUserSessionForOS(windows) = %q, want nil", got.SessionID)
+	}
+
+	if out := logs.String(); strings.Contains(out, "run_as_user delivery suppressed") {
+		t.Fatalf("did not expect a suppression WARN when no user helper is connected; got logs:\n%s", out)
+	}
+}
+
+// TestPreferredRunAsUserSessionNoWarnOnConsoleMatch asserts that the happy path —
+// a helper IS present in the console session and is selected — logs no spurious
+// suppression warning.
+func TestPreferredRunAsUserSessionNoWarnOnConsoleMatch(t *testing.T) {
+	logs := captureLogs(t)
+
+	now := time.Now()
+
+	consoleUser, consoleClient := newTestUserSession(t, "con-user", "alice", now.Add(-2*time.Minute))
+	defer consoleClient.Close()
+	consoleUser.WinSessionID = "1"
+
+	// A co-logged-in non-console helper also present — it is excluded, but
+	// because a console helper WAS selected, no suppression warning should fire.
+	otherUser, otherClient := newTestUserSession(t, "noncon-user", "mallory", now.Add(-1*time.Minute))
+	defer otherClient.Close()
+	otherUser.WinSessionID = "3"
+
+	b := &Broker{
+		sessions: map[string]*Session{
+			consoleUser.SessionID: consoleUser,
+			otherUser.SessionID:   otherUser,
+		},
+		byIdentity:         make(map[string][]*Session),
+		staleHelpers:       make(map[string][]int),
+		consoleSessionIDFn: func() string { return "1" },
+	}
+
+	if got := b.preferredRunAsUserSessionForOS("windows"); got != consoleUser {
+		t.Fatalf("preferredRunAsUserSessionForOS(windows) did not select the console helper")
+	}
+
+	if out := logs.String(); strings.Contains(out, "run_as_user delivery suppressed") {
+		t.Fatalf("did not expect a suppression WARN when a console helper was selected; got logs:\n%s", out)
 	}
 }
 

--- a/agent/internal/sessionbroker/console_session_gate_test.go
+++ b/agent/internal/sessionbroker/console_session_gate_test.go
@@ -273,6 +273,87 @@ func TestPreferredRunAsUserSessionWarnsWhenConsoleBindingSuppressesDelivery(t *t
 	}
 }
 
+// TestPreferredRunAsUserSessionWarnCountsAllExcludedHelpers asserts the WARN's
+// excludedNonConsole field reflects the ACTUAL number of off-console helpers,
+// not a hard-coded 1. This is the multi-RDP-session scenario: several
+// co-logged-in users each have a run_as_user helper, all off the active console
+// session. The operator needs the count to understand the scope of the drop.
+func TestPreferredRunAsUserSessionWarnCountsAllExcludedHelpers(t *testing.T) {
+	logs := captureLogs(t)
+
+	now := time.Now()
+
+	a, aClient := newTestUserSession(t, "noncon-a", "alice", now.Add(-3*time.Minute))
+	defer aClient.Close()
+	a.WinSessionID = "3"
+
+	bSess, bClient := newTestUserSession(t, "noncon-b", "bob", now.Add(-2*time.Minute))
+	defer bClient.Close()
+	bSess.WinSessionID = "4"
+
+	c, cClient := newTestUserSession(t, "noncon-c", "carol", now.Add(-1*time.Minute))
+	defer cClient.Close()
+	c.WinSessionID = "5"
+
+	b := &Broker{
+		sessions: map[string]*Session{
+			a.SessionID:     a,
+			bSess.SessionID: bSess,
+			c.SessionID:     c,
+		},
+		byIdentity:         make(map[string][]*Session),
+		staleHelpers:       make(map[string][]int),
+		consoleSessionIDFn: func() string { return "1" },
+	}
+
+	if got := b.preferredRunAsUserSessionForOS("windows"); got != nil {
+		t.Fatalf("preferredRunAsUserSessionForOS(windows) = %q, want nil", got.SessionID)
+	}
+
+	if out := logs.String(); !strings.Contains(out, "excludedNonConsole=3") {
+		t.Fatalf("expected excludedNonConsole=3 in suppression WARN; got logs:\n%s", out)
+	}
+}
+
+// TestPreferredRunAsUserSessionWarnsWhenConsoleLookupFailed covers the
+// fail-closed scenario: when the active-console-session lookup fails,
+// ConsoleSessionID() normalizes the "0" sentinel to "". No helper has an empty
+// WinSessionID, so every run_as_user helper is excluded and delivery is fully
+// suppressed — exactly the case where the operator most needs the WARN (the
+// console lookup itself is broken). It must fire with an empty consoleWinSession.
+func TestPreferredRunAsUserSessionWarnsWhenConsoleLookupFailed(t *testing.T) {
+	logs := captureLogs(t)
+
+	now := time.Now()
+
+	helper, helperClient := newTestUserSession(t, "some-user", "alice", now.Add(-1*time.Minute))
+	defer helperClient.Close()
+	helper.WinSessionID = "1"
+
+	b := &Broker{
+		sessions: map[string]*Session{
+			helper.SessionID: helper,
+		},
+		byIdentity:   make(map[string][]*Session),
+		staleHelpers: make(map[string][]int),
+		// "0" is the WTSGetActiveConsoleSessionId failure / Session-0 sentinel,
+		// normalized to "" by ConsoleSessionID().
+		consoleSessionIDFn: func() string { return "0" },
+	}
+
+	if got := b.preferredRunAsUserSessionForOS("windows"); got != nil {
+		t.Fatalf("preferredRunAsUserSessionForOS(windows) = %q, want nil (console lookup failed)", got.SessionID)
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "run_as_user delivery suppressed") {
+		t.Fatalf("expected a suppression WARN when console lookup failed; got logs:\n%s", out)
+	}
+	if !strings.Contains(out, "excludedNonConsole=1") {
+		t.Fatalf("expected excludedNonConsole=1 when console lookup failed; got logs:\n%s", out)
+	}
+}
+
 // TestPreferredRunAsUserSessionNoWarnWhenNoUserHelper asserts the suppression
 // warning is NOT noise: when there is genuinely no user-role run_as_user helper
 // connected at all (so nil is the correct, expected result — not a console-binding


### PR DESCRIPTION
**Root cause:** `run_as_user` script/exec routing is bound to the active console session (the #1009 fix #3, shipped in PR #1242) — but the binding drops delivery *silently*. `Broker.PreferredRunAsUserSession()` returns `nil` both when there is genuinely no user-role helper connected AND when a user helper exists only in a *non-console* session. Both live callers — `handlers_script.go:resolveRunAsSession` and `heartbeat.go:makeUserExecFunc` (winget user-context exec) — treat that `nil` as "no helper" and downgrade to local SYSTEM execution / error with no signal.

On an unusual multi-session / RDS / terminal-server host where the operator's helper genuinely lives off the active console session (e.g. the physical console sits at the lock screen while the operator works over RDP), this manifests as an **unobservable dropped delivery** — exactly the breaking-change risk the security tracker flagged for the still-open `run_as_user` slice of #1009.

This is the still-open slice of #1009 (the closed issue's fix #1/#2/#4 — the `roleIdentityRejection` console binding + helper-token gate + tests — already shipped). There is **no server/payload target to bind to**: `runAs` is an enum (`system`/`user`/`elevated`) carrying no target session id, SID, or username, so `runAs=user` means "the interactive console user" and the active console session **is** the binding target. A target-scoped selector would have no input to bind on, so the residual gap is observability, not a new binding axis.

**Fix:** In `preferredRunAsUserSessionForOS` (Windows path), count run_as_user helpers excluded *solely* for being off-console. When that exclusion is the only reason nothing was selected (`best == nil && excludedNonConsole > 0`), emit a clear `WARN` — `"run_as_user delivery suppressed: no helper in the active console session"` with `consoleWinSession` and `excludedNonConsole` fields — so the dropped delivery is diagnosable. When no run_as_user helper is connected at all, the selector stays quiet (no per-poll noise). The fail-safe behaviour (never deliver a run_as_user script to the wrong principal) is **unchanged** — only its observability is added. `log.Warn` is emitted outside the broker read-lock.

**Tests:** 3 table-driven cases in `agent/internal/sessionbroker/console_session_gate_test.go`:
- off-console-only helper ⇒ `nil` returned **and** a suppression `WARN` with diagnostic fields fires (the RDS-host drop is now observable, not a silent wrong-session/SYSTEM downgrade),
- no user helper connected ⇒ `nil`, **no** WARN (not noise),
- console helper present ⇒ selected, **no** WARN.

RED proven against the pre-fix silent selector (the suppression-WARN assertion failed; the no-WARN assertions passed because the old code was silent everywhere). Full `go test -race ./internal/sessionbroker/...` and `./internal/heartbeat/...` green; `go vet` and cross-compile (`GOOS=windows`) clean.

**Risk / release-notes:** behaviour-possibly-affecting only in the sense that it adds a diagnostic `WARN` on the rare RDS/multi-session host where a run_as_user script can't reach a console helper — no routing/selection change, no new drops, Unix path untouched. Worth a release-notes line so operators know to look for the new "run_as_user delivery suppressed" warning when a `runAs=user` script silently runs as SYSTEM on a terminal-server host.

Refs #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)