### PR TITLE
fix(aitools): site-narrow device-referencing audit rows in query_audit_log (R3b residual)

### DIFF
--- a/apps/api/src/__tests__/integration/aiToolsAuditDetailsSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiToolsAuditDetailsSiteScope.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Integration test — query_audit_log site-narrowing of device-REFERENCING rows
+ * (R3b residual).
+ *
+ * PR #1706 (R3b) site-narrowed `audit_logs` rows whose `resourceType` is
+ * literally `'device'` (their `resourceId` is the device id). But a large class
+ * of audit rows have a NON-device `resourceType` while still REFERENCING a
+ * device id inside the `details` jsonb — overwhelmingly under the `details.deviceId`
+ * key (the dominant write convention: device commands, elevation/PAM, backup,
+ * network/authenticator changes, etc.). Those rows were returned org-axis only,
+ * so a site-restricted operator's chat could read audit entries about devices in
+ * sites they cannot access.
+ *
+ * This proves the residual fix end-to-end against real Postgres as the
+ * unprivileged `breeze_app` role (so org-axis RLS is genuinely enforced while
+ * the site axis is applied app-layer on top):
+ *
+ *   1. A site-restricted caller does NOT receive a non-device audit row whose
+ *      `details.deviceId` points at an out-of-scope device.
+ *   2. The same caller DOES receive a non-device audit row whose
+ *      `details.deviceId` points at an IN-scope device.
+ *   3. The same caller DOES receive a row with NO device reference at all
+ *      (e.g. an org-level / ticket row) — we do not over-exclude.
+ *   4. A row whose `details.deviceId` holds an id that is NOT a fleet device
+ *      (e.g. an authenticator credential id) is NOT excluded — the predicate
+ *      keys off the *forbidden org-device set*, not "any id not in the allowed
+ *      set", so non-fleet ids are never mistaken for out-of-scope devices.
+ *   5. An unrestricted (all-sites) caller sees every row — no-op.
+ *
+ * Mirrors R3/R3b: narrows both the returned rows (count is derived from rows in
+ * this tool, which has no separate count query).
+ */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { db, withDbAccessContext } from '../../db';
+import { auditLogs } from '../../db/schema';
+import { devices, sites } from '../../db/schema';
+import { createPartner, createOrganization, createSite } from './db-utils';
+import { getTestDb } from './setup';
+import { registerAuditTools } from '../../services/aiToolsAudit';
+import type { AuthContext } from '../../middleware/auth';
+import type { AiTool } from '../../services/aiTools';
+
+function auditHandler(): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerAuditTools(reg);
+  return reg.get('query_audit_log')!.handler;
+}
+
+// Build an org-scope AuthContext. `allowedSiteIds` (+ canAccessSite) makes the
+// caller site-restricted; omit them for an unrestricted caller.
+function makeAuth(orgId: string, allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: randomUUID(), email: 'op@example.com', name: 'Op', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId,
+    scope: 'organization',
+    accessibleOrgIds: [orgId],
+    // The handler filters audit_logs on the org axis via orgCondition; under
+    // breeze_app RLS the row is also gated by org access, so an org-scope
+    // condition is the realistic shape.
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (s: string | null | undefined) =>
+      !allowedSiteIds ? true : !!s && allowedSiteIds.includes(s),
+  } as unknown as AuthContext;
+}
+
+async function seedDevice(orgId: string, siteId: string) {
+  const [d] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-${randomUUID()}`,
+      hostname: `host-${randomUUID().slice(0, 8)}`,
+      osType: 'linux',
+      osVersion: '1.0',
+      architecture: 'amd64',
+      agentVersion: '1.0.0',
+      status: 'online',
+    })
+    .returning();
+  return d!;
+}
+
+// audit_logs is append-only (rows survive the per-test TRUNCATE), so scope every
+// query to a per-run marker `action` to avoid cross-run / cross-test bleed.
+async function seedAudit(
+  orgId: string,
+  action: string,
+  resourceType: string,
+  resourceId: string | null,
+  details: Record<string, unknown> | null,
+) {
+  await getTestDb()
+    .insert(auditLogs)
+    .values({
+      orgId,
+      actorType: 'user',
+      actorId: randomUUID(),
+      action,
+      resourceType,
+      resourceId,
+      details,
+      result: 'success',
+    });
+}
+
+describe('query_audit_log — details.deviceId site narrowing (R3b residual)', () => {
+  it('narrows non-device rows that reference an out-of-scope device via details.deviceId', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const siteAllowed = await createSite({ orgId: org.id });
+    const siteForbidden = await createSite({ orgId: org.id });
+
+    const inScopeDevice = await seedDevice(org.id, siteAllowed.id);
+    const outScopeDevice = await seedDevice(org.id, siteForbidden.id);
+
+    const marker = `r3b-residual-${randomUUID()}`;
+
+    // (a) non-device row referencing an OUT-of-scope device → must be hidden
+    await seedAudit(org.id, marker, 'remote_session', randomUUID(), {
+      deviceId: outScopeDevice.id,
+      reason: 'forbidden-ref',
+    });
+    // (b) non-device row referencing an IN-scope device → must be visible
+    await seedAudit(org.id, marker, 'remote_session', randomUUID(), {
+      deviceId: inScopeDevice.id,
+      reason: 'allowed-ref',
+    });
+    // (c) row with NO device reference → must be visible (no over-exclusion)
+    await seedAudit(org.id, marker, 'org_update', org.id, { field: 'name' });
+    // (d) details.deviceId that is NOT a fleet device (e.g. authenticator
+    //     credential id) → must be visible (keyed off forbidden device set)
+    await seedAudit(org.id, marker, 'auth_authenticator', randomUUID(), {
+      deviceId: randomUUID(),
+      reason: 'credential-revoke',
+    });
+    // (e) device-typed row for an out-of-scope device → must be hidden
+    //     (existing R3b device-typed narrowing stays intact)
+    await seedAudit(org.id, marker, 'device', outScopeDevice.id, null);
+
+    const handler = auditHandler();
+    const auth = makeAuth(org.id, [siteAllowed.id]);
+
+    const raw = await withDbAccessContext(
+      { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id] },
+      async () => handler({ action: marker, hoursBack: 168, limit: 100 }, auth),
+    );
+    const parsed = JSON.parse(raw);
+    const reasons = (parsed.entries ?? []).map((e: any) => e.details?.reason ?? e.resourceType);
+
+    expect(parsed.error).toBeUndefined();
+    expect(reasons).toContain('allowed-ref');
+    expect(reasons).toContain('org_update');
+    expect(reasons).toContain('credential-revoke');
+    expect(reasons).not.toContain('forbidden-ref');
+    // device-typed out-of-scope row excluded too
+    expect((parsed.entries ?? []).some((e: any) => e.resourceType === 'device')).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain(outScopeDevice.id);
+  });
+
+  it('unrestricted caller sees every row including out-of-scope device references (no-op)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const siteA = await createSite({ orgId: org.id });
+    const siteB = await createSite({ orgId: org.id });
+    const devA = await seedDevice(org.id, siteA.id);
+    const devB = await seedDevice(org.id, siteB.id);
+
+    const marker = `r3b-unrestricted-${randomUUID()}`;
+    await seedAudit(org.id, marker, 'remote_session', randomUUID(), { deviceId: devA.id, reason: 'a' });
+    await seedAudit(org.id, marker, 'remote_session', randomUUID(), { deviceId: devB.id, reason: 'b' });
+
+    const handler = auditHandler();
+    const auth = makeAuth(org.id, undefined); // unrestricted
+
+    const raw = await withDbAccessContext(
+      { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id] },
+      async () => handler({ action: marker, hoursBack: 168, limit: 100 }, auth),
+    );
+    const parsed = JSON.parse(raw);
+    const reasons = (parsed.entries ?? []).map((e: any) => e.details?.reason);
+
+    expect(parsed.error).toBeUndefined();
+    expect(reasons).toContain('a');
+    expect(reasons).toContain('b');
+    expect(parsed.showing).toBe(2);
+  });
+});

--- a/apps/api/src/__tests__/integration/aiToolsAuditDetailsSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiToolsAuditDetailsSiteScope.integration.test.ts
@@ -143,6 +143,18 @@ describe('query_audit_log — details.deviceId site narrowing (R3b residual)', (
     // (e) device-typed row for an out-of-scope device → must be hidden
     //     (existing R3b device-typed narrowing stays intact)
     await seedAudit(org.id, marker, 'device', outScopeDevice.id, null);
+    // (f) non-device row referencing an OUT-of-scope device via the secondary
+    //     `linkedDeviceId` key (discovery linking convention) → must be hidden
+    await seedAudit(org.id, marker, 'discovered_asset', randomUUID(), {
+      linkedDeviceId: outScopeDevice.id,
+      reason: 'forbidden-linked-ref',
+    });
+    // (g) non-device row referencing an IN-scope device via `linkedDeviceId`
+    //     → must be visible
+    await seedAudit(org.id, marker, 'discovered_asset', randomUUID(), {
+      linkedDeviceId: inScopeDevice.id,
+      reason: 'allowed-linked-ref',
+    });
 
     const handler = auditHandler();
     const auth = makeAuth(org.id, [siteAllowed.id]);
@@ -158,10 +170,50 @@ describe('query_audit_log — details.deviceId site narrowing (R3b residual)', (
     expect(reasons).toContain('allowed-ref');
     expect(reasons).toContain('org_update');
     expect(reasons).toContain('credential-revoke');
+    expect(reasons).toContain('allowed-linked-ref');
     expect(reasons).not.toContain('forbidden-ref');
+    expect(reasons).not.toContain('forbidden-linked-ref');
     // device-typed out-of-scope row excluded too
     expect((parsed.entries ?? []).some((e: any) => e.resourceType === 'device')).toBe(false);
+    // Exactly the 4 in-scope / no-ref rows survive (b, c, d, g) — no over- or
+    // under-inclusion. Marker-scoped so only this run's rows are counted.
+    expect(parsed.showing).toBe(4);
     expect(JSON.stringify(parsed)).not.toContain(outScopeDevice.id);
+  });
+
+  it('does NOT over-exclude device-referencing rows when the caller has no forbidden devices (empty forbidden set)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const onlySite = await createSite({ orgId: org.id });
+    // The single device is in the caller's only allowed site, so the forbidden
+    // set is empty and the details predicate must be SKIPPED entirely — the
+    // device-referencing row must still be returned.
+    const device = await seedDevice(org.id, onlySite.id);
+
+    const marker = `r3b-empty-forbidden-${randomUUID()}`;
+    await seedAudit(org.id, marker, 'remote_session', randomUUID(), {
+      deviceId: device.id,
+      reason: 'in-scope-ref',
+    });
+    await seedAudit(org.id, marker, 'remote_session', randomUUID(), {
+      linkedDeviceId: device.id,
+      reason: 'in-scope-linked-ref',
+    });
+
+    const handler = auditHandler();
+    const auth = makeAuth(org.id, [onlySite.id]); // restricted, but all devices in-scope
+
+    const raw = await withDbAccessContext(
+      { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id] },
+      async () => handler({ action: marker, hoursBack: 168, limit: 100 }, auth),
+    );
+    const parsed = JSON.parse(raw);
+    const reasons = (parsed.entries ?? []).map((e: any) => e.details?.reason);
+
+    expect(parsed.error).toBeUndefined();
+    expect(reasons).toContain('in-scope-ref');
+    expect(reasons).toContain('in-scope-linked-ref');
+    expect(parsed.showing).toBe(2);
   });
 
   it('unrestricted caller sees every row including out-of-scope device references (no-op)', async () => {

--- a/apps/api/src/services/aiToolsAudit.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAudit.siteScope.test.ts
@@ -170,4 +170,41 @@ describe('query_audit_log — device-typed row site narrowing', () => {
     expect(parsed.showing).toBe(1);
     expect(resolverRan).toBe(false);
   });
+
+  // R3b residual: a NON-device row may reference a device via `details.deviceId`.
+  // An explicit lookup by a `resourceId` that is a known out-of-scope fleet
+  // device is denied outright (regardless of resourceType), and the scan is
+  // never reached. Both resolver SELECTs (allowed + forbidden) share the
+  // `{id, siteId}` shape; `canAccessSite` derives the in/out-of-scope split.
+  it('explicit resourceId that is a known out-of-scope device is denied/empty (any resourceType)', async () => {
+    let scanRan = false;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (isDeviceResolverSelect(cols)) {
+        return {
+          from: () => ({
+            where: () =>
+              Promise.resolve([
+                { id: 'd-inscope', siteId: 'site-A' },
+                { id: 'd-forbidden', siteId: 'site-B' },
+              ]),
+          }),
+        };
+      }
+      scanRan = true;
+      return chain([
+        { id: 'a1', timestamp: null, actorType: 'user', actorEmail: 'x', action: 'a', resourceType: 'remote_session', resourceName: 'leak', result: 'ok', details: { deviceId: 'd-forbidden' } },
+      ]);
+    });
+
+    const r = await handlerFor('query_audit_log')(
+      { resourceId: 'd-forbidden' },
+      makeAuth(['site-A']),
+    );
+    const parsed = JSON.parse(r);
+    expect(parsed.entries).toEqual([]);
+    expect(parsed.showing).toBe(0);
+    expect(parsed.scopeNote).toBe(SITE_SCOPE_EMPTY_NOTE);
+    expect(scanRan).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('leak');
+  });
 });

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -8,10 +8,14 @@
 
 import { db } from '../db';
 import { devices, auditLogs, deviceChangeLog } from '../db/schema';
-import { eq, ne, or, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
+import { eq, ne, or, and, not, isNull, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
-import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
+import {
+  resolveSiteAllowedDeviceIds,
+  resolveSiteForbiddenDeviceIds,
+  SITE_SCOPE_EMPTY_NOTE,
+} from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -72,12 +76,30 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
       // Site axis (app-layer only; RLS does NOT enforce it). audit_logs is
       // org-keyed and heterogeneous — `resourceId` is a device id only when
       // `resourceType === 'device'`; other rows reference orgs/users/tickets/etc.
-      // The site axis is device-centric, so narrow ONLY device-typed rows to the
-      // caller's allowed device set, leaving other resource types governed by the
-      // existing org axis. No-op for unrestricted partner/system callers.
+      // The site axis is device-centric, so:
+      //   (1) narrow device-typed rows (resourceId IS the device id) to the
+      //       caller's allowed device set (R3b), and
+      //   (2) narrow NON-device rows that still REFERENCE a device id inside the
+      //       `details` jsonb — overwhelmingly under `details.deviceId` (the
+      //       dominant write convention: commands, elevation/PAM, backup,
+      //       network/authenticator changes; `details.linkedDeviceId` for
+      //       discovery linking). This excludes rows referencing an
+      //       OUT-of-scope fleet device (R3b residual).
+      // Both narrowings leave rows with no device reference governed by the org
+      // axis only, and are a no-op for unrestricted partner/system callers.
+      //
+      // Known residual (documented, not closed here): array-valued `details.deviceIds`
+      // (sparse) and free-text device hostnames in `resourceName` carry no reliable
+      // single device id to key off, so those references are left to the org axis.
       if (auth.allowedSiteIds && auth.canAccessSite) {
         const orgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
         const allowedDeviceIds = orgId ? await resolveSiteAllowedDeviceIds(orgId, auth) : [];
+        // The forbidden set = org devices outside the caller's sites. We key the
+        // details narrowing off this set (rather than "any id not in allowed")
+        // so an id under `details.deviceId` that is NOT a fleet device at all —
+        // e.g. an authenticator credential id — is never mistaken for an
+        // out-of-scope device and over-excluded.
+        const forbiddenDeviceIds = orgId ? await resolveSiteForbiddenDeviceIds(orgId, auth) : [];
         if (allowedDeviceIds !== null) {
           // An explicit device-row lookup outside the allowed set is denied outright.
           if (
@@ -87,7 +109,16 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
           ) {
             return JSON.stringify({ entries: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
           }
-          // Show non-device rows as before; device rows only for in-scope devices.
+          // An explicit lookup of a device id known to be out-of-scope is denied
+          // outright (mirrors the device-typed short-circuit above).
+          if (
+            input.resourceId &&
+            forbiddenDeviceIds &&
+            forbiddenDeviceIds.includes(input.resourceId as string)
+          ) {
+            return JSON.stringify({ entries: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
+          }
+          // (1) Device-typed rows: only for in-scope devices.
           // Empty allowed set ⇒ exclude all device rows.
           conditions.push(
             allowedDeviceIds.length > 0
@@ -97,6 +128,20 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
                 )!
               : ne(auditLogs.resourceType, 'device'),
           );
+          // (2) `details`-referenced rows: exclude any row whose
+          // `details.deviceId` / `details.linkedDeviceId` is a known out-of-scope
+          // fleet device. Rows where the key is absent (NULL ->> result) are
+          // untouched — only a positive match against the forbidden set excludes.
+          if (forbiddenDeviceIds && forbiddenDeviceIds.length > 0) {
+            const deviceIdRef = sql`${auditLogs.details}->>'deviceId'`;
+            const linkedDeviceIdRef = sql`${auditLogs.details}->>'linkedDeviceId'`;
+            conditions.push(
+              and(
+                or(isNull(deviceIdRef), not(inArray(deviceIdRef, forbiddenDeviceIds)))!,
+                or(isNull(linkedDeviceIdRef), not(inArray(linkedDeviceIdRef, forbiddenDeviceIds)))!,
+              )!,
+            );
+          }
         }
       }
 

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -13,7 +13,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import {
   resolveSiteAllowedDeviceIds,
-  resolveSiteForbiddenDeviceIds,
+  resolveSiteDevicePartition,
   SITE_SCOPE_EMPTY_NOTE,
 } from './aiToolsSiteScope';
 
@@ -93,14 +93,16 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
       // single device id to key off, so those references are left to the org axis.
       if (auth.allowedSiteIds && auth.canAccessSite) {
         const orgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
-        const allowedDeviceIds = orgId ? await resolveSiteAllowedDeviceIds(orgId, auth) : [];
-        // The forbidden set = org devices outside the caller's sites. We key the
-        // details narrowing off this set (rather than "any id not in allowed")
-        // so an id under `details.deviceId` that is NOT a fleet device at all —
-        // e.g. an authenticator credential id — is never mistaken for an
-        // out-of-scope device and over-excluded.
-        const forbiddenDeviceIds = orgId ? await resolveSiteForbiddenDeviceIds(orgId, auth) : [];
-        if (allowedDeviceIds !== null) {
+        // One device scan yields both partitions: `allowed` (in-scope, for the
+        // device-typed narrowing) and `forbidden` (out-of-site-scope org
+        // devices). We key the `details` narrowing off `forbidden` (rather than
+        // "any id not in allowed") so an id under `details.deviceId` that is NOT
+        // a fleet device at all — e.g. an authenticator credential id — is never
+        // mistaken for an out-of-scope device and over-excluded.
+        const partition = orgId ? await resolveSiteDevicePartition(orgId, auth) : { allowed: [], forbidden: [] };
+        if (partition !== null) {
+          const allowedDeviceIds = partition.allowed;
+          const forbiddenDeviceIds = partition.forbidden;
           // An explicit device-row lookup outside the allowed set is denied outright.
           if (
             input.resourceType === 'device' &&
@@ -111,11 +113,7 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
           }
           // An explicit lookup of a device id known to be out-of-scope is denied
           // outright (mirrors the device-typed short-circuit above).
-          if (
-            input.resourceId &&
-            forbiddenDeviceIds &&
-            forbiddenDeviceIds.includes(input.resourceId as string)
-          ) {
+          if (input.resourceId && forbiddenDeviceIds.includes(input.resourceId as string)) {
             return JSON.stringify({ entries: [], showing: 0, scopeNote: SITE_SCOPE_EMPTY_NOTE });
           }
           // (1) Device-typed rows: only for in-scope devices.
@@ -132,7 +130,7 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
           // `details.deviceId` / `details.linkedDeviceId` is a known out-of-scope
           // fleet device. Rows where the key is absent (NULL ->> result) are
           // untouched — only a positive match against the forbidden set excludes.
-          if (forbiddenDeviceIds && forbiddenDeviceIds.length > 0) {
+          if (forbiddenDeviceIds.length > 0) {
             const deviceIdRef = sql`${auditLogs.details}->>'deviceId'`;
             const linkedDeviceIdRef = sql`${auditLogs.details}->>'linkedDeviceId'`;
             conditions.push(

--- a/apps/api/src/services/aiToolsSiteScope.ts
+++ b/apps/api/src/services/aiToolsSiteScope.ts
@@ -55,6 +55,33 @@ export async function resolveSiteAllowedDeviceIds(
 }
 
 /**
+ * Resolve the org device IDs a site-restricted caller may NOT read — i.e. the
+ * `orgId` devices whose site is outside the caller's allowlist. Returns `null`
+ * when the caller is NOT site-restricted (no narrowing needed). A restricted
+ * caller all of whose org devices are in-scope gets an empty array.
+ *
+ * Unlike `resolveSiteAllowedDeviceIds` (the in-scope set), this is the explicit
+ * forbidden set, which lets a caller exclude rows that *reference* an
+ * out-of-scope fleet device by id without over-excluding rows whose device-id
+ * field happens to hold an id that is not a fleet device at all (e.g. an
+ * authenticator credential id stored under `details.deviceId`). Only ids that
+ * are real out-of-site-scope org devices land in this set.
+ */
+export async function resolveSiteForbiddenDeviceIds(
+  orgId: string,
+  auth: AuthContext,
+): Promise<string[] | null> {
+  if (!auth.allowedSiteIds || !auth.canAccessSite) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => !auth.canAccessSite!(d.siteId))
+    .map((d) => d.id);
+}
+
+/**
  * True when a site-restricted caller must be denied access to a device with the
  * given `siteId`. Fails closed: a null-site device is denied for a restricted
  * caller. Always false (allow) for an unrestricted caller. Use this for tools

--- a/apps/api/src/services/aiToolsSiteScope.ts
+++ b/apps/api/src/services/aiToolsSiteScope.ts
@@ -55,30 +55,33 @@ export async function resolveSiteAllowedDeviceIds(
 }
 
 /**
- * Resolve the org device IDs a site-restricted caller may NOT read — i.e. the
- * `orgId` devices whose site is outside the caller's allowlist. Returns `null`
- * when the caller is NOT site-restricted (no narrowing needed). A restricted
- * caller all of whose org devices are in-scope gets an empty array.
+ * Partition an org's devices into the caller's in-scope (`allowed`) and
+ * out-of-site-scope (`forbidden`) sets in a single query. Returns `null` when
+ * the caller is NOT site-restricted (no narrowing needed).
  *
- * Unlike `resolveSiteAllowedDeviceIds` (the in-scope set), this is the explicit
- * forbidden set, which lets a caller exclude rows that *reference* an
- * out-of-scope fleet device by id without over-excluding rows whose device-id
- * field happens to hold an id that is not a fleet device at all (e.g. an
- * authenticator credential id stored under `details.deviceId`). Only ids that
- * are real out-of-site-scope org devices land in this set.
+ * The `forbidden` set is the complement of `allowed` over the org's devices and
+ * lets a caller exclude rows that *reference* an out-of-scope fleet device by id
+ * (e.g. via `details.deviceId`) WITHOUT over-excluding rows whose device-id
+ * field holds an id that is not a fleet device at all (e.g. an authenticator
+ * credential id) — only real out-of-site-scope org devices land in `forbidden`.
+ * Prefer this over calling `resolveSiteAllowedDeviceIds` and a separate
+ * forbidden lookup when both partitions are needed (one device scan, not two).
  */
-export async function resolveSiteForbiddenDeviceIds(
+export async function resolveSiteDevicePartition(
   orgId: string,
   auth: AuthContext,
-): Promise<string[] | null> {
+): Promise<{ allowed: string[]; forbidden: string[] } | null> {
   if (!auth.allowedSiteIds || !auth.canAccessSite) return null;
   const orgDevices = await db
     .select({ id: devices.id, siteId: devices.siteId })
     .from(devices)
     .where(eq(devices.orgId, orgId));
-  return orgDevices
-    .filter((d) => !auth.canAccessSite!(d.siteId))
-    .map((d) => d.id);
+  const allowed: string[] = [];
+  const forbidden: string[] = [];
+  for (const d of orgDevices) {
+    (auth.canAccessSite!(d.siteId) ? allowed : forbidden).push(d.id);
+  }
+  return { allowed, forbidden };
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to **R3b (#1706)**, which site-narrowed `audit_logs` rows whose `resourceType === 'device'` (their `resourceId` is the device id). This closes the **R3b residual**: audit rows with a **non-device** `resourceType` that still **reference a device id inside the `details` jsonb**.

`audit_logs` is org-keyed and heterogeneous. A large class of rows carry a device reference under `details.deviceId` — the dominant write convention across device commands, elevation/PAM, backup, and network/authenticator changes (`details.linkedDeviceId` for discovery linking). Those rows were returned **org-axis only**, so a site-restricted operator's chat could read audit entries about devices in sites they cannot access.

## The fix (conservative scope)

`query_audit_log` now excludes any row whose `details.deviceId` / `details.linkedDeviceId` references an **out-of-scope fleet device**, keyed off the **forbidden org-device set** (org devices outside the caller's sites) — *not* "any id not in the allowed set". This matters: an id stored under `details.deviceId` that is **not a fleet device at all** (e.g. an authenticator credential id from `auth.authenticator.device.revoke`) is never mistaken for an out-of-scope device and over-excluded. Only a positive match against a real out-of-scope fleet device removes a row.

- Existing device-typed narrowing (R3b) stays intact.
- Rows with **no** device reference are untouched (no over-exclusion).
- Explicit `resourceId` that is a known out-of-scope device short-circuits to empty + `SITE_SCOPE_EMPTY_NOTE`, mirroring R3b.
- No-op for unrestricted partner/system callers.
- `query_audit_log` has no separate count query (count is derived from the returned rows), so narrowing the rows narrows the count.

New helper `resolveSiteForbiddenDeviceIds` in `aiToolsSiteScope.ts` mirrors `resolveSiteAllowedDeviceIds` and returns the out-of-site-scope org device ids.

## Documented remaining residual (intentionally left to the org axis)

- **Array-valued `details.deviceIds`** (sparse; e.g. `softwarePolicies` compliance checks) — would need `@>` containment with a real false-exclude risk; left as a known gap.
- **Free-text device hostnames in `resourceName`** — no reliable single device id to key off. Fail-safe choice: narrow only when a structured device id is present.

These are noted in a code comment and here so the residual is explicit.

## Tests

- New real-DB integration test `aiToolsAuditDetailsSiteScope.integration.test.ts` (runs as unprivileged `breeze_app`, RLS enforced — confirmed `NOBYPASSRLS`): a site-restricted caller does **not** receive a non-device row whose `details.deviceId` points at an out-of-scope device; **does** receive in-scope-device, no-device-ref, and non-fleet-id (authenticator credential) rows; the out-of-scope device-typed row is excluded too; an unrestricted caller sees everything. **RED proven before the fix** (`expected [...] to not include 'forbidden-ref'`), GREEN after.
- Added a unit-mock case to `aiToolsAudit.siteScope.test.ts` for the explicit out-of-scope-id short-circuit.
- `aiToolsAudit.ts` already in the `SITE_GATED_NON_VERIFY_FILES` allowlist (36-test contract green). API typecheck clean.

## Release notes

Behavior change: AI-chat/MCP users restricted to specific sites now see fewer `query_audit_log` results — audit entries referencing devices outside their site access are no longer returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)