### PR TITLE
harden agent backup/vault WS result integrity

### DIFF
--- a/apps/api/src/__tests__/integration/backupVaultResultIntegrity.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupVaultResultIntegrity.integration.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Backup + Vault WS result integrity (security-hardening F5 / F6).
+ *
+ * Threat model: a compromised-but-legitimately-enrolled agent (valid token + WS
+ * for its own device) tries to forge or replay "backup completed" / "vault
+ * synced" state for its own device. Org-axis RLS and agent-auth all hold; this is
+ * a same-device integrity gap. These tests drive the real WS orphaned-result
+ * handler against a real DB + Redis and assert the server-side consume-once gates.
+ *
+ * Why integration, not unit: F5 derives legitimacy from a real persisted backup
+ * snapshot row and mutates `local_vaults`; F6 consume-once lives in Redis and the
+ * accept path enqueues a BullMQ job. A Drizzle/Redis mock wouldn't exercise the
+ * snapshot correlation, the RLS-context writes, or the atomic Redis consume.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/backupVaultResultIntegrity.integration.test.ts
+ */
+import './setup';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { withDbAccessContext } from '../../db';
+import { createPartner, createOrganization, createSite } from './db-utils';
+import {
+  devices,
+  backupConfigs,
+  backupJobs,
+  backupSnapshots,
+  localVaults,
+} from '../../db/schema';
+import { processOrphanedCommandResult } from '../../routes/agentWs';
+import { recordDispatchedExpectation } from '../../services/agentWorkExpectation';
+import { getBackupQueue } from '../../jobs/backupEnqueue';
+
+type OrphanResult = Parameters<typeof processOrphanedCommandResult>[2];
+
+/**
+ * Drive the orphaned-result handler the same way the live WS message loop does:
+ * inside the agent's org-scoped DB context (runWithAgentDbAccess in agentWs.ts).
+ * Calling it bare would leave RLS with no context and silently return 0 rows —
+ * which is itself the failure mode we hardened other paths against.
+ */
+async function runHandler(orgId: string, agentId: string, deviceId: string, result: OrphanResult) {
+  return withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId,
+      accessibleOrgIds: [orgId],
+      accessiblePartnerIds: [],
+      currentPartnerId: null,
+    },
+    () => processOrphanedCommandResult(agentId, deviceId, result),
+  );
+}
+
+let agentCounter = 0;
+
+interface Seeded {
+  orgId: string;
+  deviceId: string;
+  agentId: string;
+  configId: string;
+}
+
+async function seedDeviceWithBackup(): Promise<Seeded> {
+  const db = getTestDb();
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  agentCounter++;
+  const agentId = `agent-bvi-${agentCounter}-${Date.now()}`;
+
+  const [device] = await db
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId,
+      hostname: `bvi-host-${agentCounter}`,
+      displayName: `bvi-host-${agentCounter}`,
+      osType: 'windows',
+      osVersion: '11',
+      osBuild: '22000',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+
+  const [config] = await db
+    .insert(backupConfigs)
+    .values({
+      orgId: org.id,
+      name: 'bvi-config',
+      type: 'file',
+      provider: 'local',
+      providerConfig: {},
+    })
+    .returning({ id: backupConfigs.id });
+
+  return { orgId: org.id, deviceId: device!.id, agentId, configId: config!.id };
+}
+
+async function insertBackupJob(s: Seeded, status: 'pending' | 'running' | 'completed' | 'failed') {
+  const db = getTestDb();
+  const [job] = await db
+    .insert(backupJobs)
+    .values({
+      orgId: s.orgId,
+      configId: s.configId,
+      deviceId: s.deviceId,
+      status,
+      type: 'manual',
+      startedAt: new Date(),
+    })
+    .returning({ id: backupJobs.id });
+  return job!.id;
+}
+
+async function insertCompletedSnapshot(s: Seeded, snapshotId: string, timestamp: Date, jobId: string) {
+  const db = getTestDb();
+  await db.insert(backupSnapshots).values({
+    orgId: s.orgId,
+    jobId,
+    deviceId: s.deviceId,
+    snapshotId,
+    timestamp,
+    size: 1024,
+  });
+}
+
+async function insertVault(s: Seeded, vaultPath = '/vault/bvi') {
+  const db = getTestDb();
+  const [vault] = await db
+    .insert(localVaults)
+    .values({
+      orgId: s.orgId,
+      deviceId: s.deviceId,
+      vaultPath,
+      isActive: true,
+    })
+    .returning({ id: localVaults.id });
+  return vault!.id;
+}
+
+async function getVault(vaultId: string) {
+  const db = getTestDb();
+  const [v] = await db
+    .select()
+    .from(localVaults)
+    .where(eq(localVaults.id, vaultId))
+    .limit(1);
+  if (!v) throw new Error(`getVault: vault ${vaultId} not found`);
+  return v;
+}
+
+/** Count enqueued process-results jobs for a given backup job id. */
+async function resultJobExists(jobId: string): Promise<boolean> {
+  const queue = getBackupQueue();
+  const job = await queue.getJob(`backup-result-${jobId}`);
+  return Boolean(job);
+}
+
+function vaultSyncResult(snapshotId: string, vaultId: string) {
+  return {
+    type: 'command_result' as const,
+    commandId: `vault-auto-sync-${snapshotId}`,
+    status: 'completed' as const,
+    stdout: JSON.stringify({
+      auto: true,
+      snapshotId,
+      vaultId,
+      totalBytes: 1024,
+      fileCount: 3,
+      manifestVerified: true,
+    }),
+  };
+}
+
+function backupResult(jobId: string) {
+  return {
+    type: 'command_result' as const,
+    commandId: jobId,
+    status: 'completed' as const,
+    result: {
+      snapshotId: 'snap-real-1',
+      filesBackedUp: 3,
+      bytesBackedUp: 1024,
+    },
+  };
+}
+
+beforeEach(async () => {
+  // Each test seeds fresh; cleanupDatabase already truncated + flushed Redis.
+  await getBackupQueue().obliterate({ force: true }).catch(() => {});
+});
+
+describe('F5 — vault auto-sync orphan result integrity', () => {
+  it('drops a forged vault-auto-sync result with no matching completed snapshot (vault unchanged)', async () => {
+    const s = await seedDeviceWithBackup();
+    const vaultId = await insertVault(s);
+    const before = await getVault(vaultId);
+    expect(before.lastSyncStatus).toBeNull();
+
+    // Forged: snapshot id the server has never seen.
+    await runHandler(s.orgId, s.agentId, s.deviceId, vaultSyncResult('snap-forged-xyz', vaultId));
+
+    const after = await getVault(vaultId);
+    expect(after.lastSyncStatus).toBeNull();
+    expect(after.lastSyncSnapshotId).toBeNull();
+  });
+
+  it('applies a vault-auto-sync result that matches a fresh completed snapshot exactly once', async () => {
+    const s = await seedDeviceWithBackup();
+    const vaultId = await insertVault(s);
+    const jobId = await insertBackupJob(s, 'completed');
+    const snapshotId = 'snap-fresh-1';
+    await insertCompletedSnapshot(s, snapshotId, new Date(), jobId);
+
+    await runHandler(s.orgId, s.agentId, s.deviceId, vaultSyncResult(snapshotId, vaultId));
+
+    const applied = await getVault(vaultId);
+    expect(applied.lastSyncStatus).toBe('completed');
+    expect(applied.lastSyncSnapshotId).toBe(snapshotId);
+
+    // Replay of the SAME snapshot is a no-op (consume-once): mutate the vault row
+    // out-of-band, replay, and assert the replay did not re-apply.
+    const db = getTestDb();
+    await db
+      .update(localVaults)
+      .set({ lastSyncStatus: 'sentinel', lastSyncSnapshotId: 'sentinel' })
+      .where(eq(localVaults.id, vaultId));
+
+    await runHandler(s.orgId, s.agentId, s.deviceId, vaultSyncResult(snapshotId, vaultId));
+
+    const afterReplay = await getVault(vaultId);
+    expect(afterReplay.lastSyncStatus).toBe('sentinel');
+    expect(afterReplay.lastSyncSnapshotId).toBe('sentinel');
+  });
+
+  it('drops a vault-auto-sync result whose matching snapshot is outside the freshness window', async () => {
+    const s = await seedDeviceWithBackup();
+    const vaultId = await insertVault(s);
+    const jobId = await insertBackupJob(s, 'completed');
+    const snapshotId = 'snap-stale-1';
+    // 48h old — outside the 24h freshness window.
+    await insertCompletedSnapshot(s, snapshotId, new Date(Date.now() - 48 * 60 * 60 * 1000), jobId);
+
+    await runHandler(s.orgId, s.agentId, s.deviceId, vaultSyncResult(snapshotId, vaultId));
+
+    const after = await getVault(vaultId);
+    expect(after.lastSyncStatus).toBeNull();
+  });
+});
+
+describe('F6 — backup completion forgery integrity', () => {
+  it('accepts a backup result for a dispatched job exactly once; replay is rejected', async () => {
+    const s = await seedDeviceWithBackup();
+    const jobId = await insertBackupJob(s, 'running');
+    await recordDispatchedExpectation('backup', s.deviceId, jobId);
+
+    await runHandler(s.orgId, s.agentId, s.deviceId, backupResult(jobId));
+    expect(await resultJobExists(jobId)).toBe(true);
+
+    // Replay: the dispatch expectation was consumed, so the second result is
+    // dropped. Remove the enqueued job first so its presence can't mask a drop.
+    await getBackupQueue().getJob(`backup-result-${jobId}`).then((j) => j?.remove());
+    await runHandler(s.orgId, s.agentId, s.deviceId, backupResult(jobId));
+    expect(await resultJobExists(jobId)).toBe(false);
+  });
+
+  it('rejects a backup result for a job UUID that was never dispatched', async () => {
+    const s = await seedDeviceWithBackup();
+    // Job row exists + agent owns the device, but no dispatch expectation recorded.
+    const jobId = await insertBackupJob(s, 'running');
+
+    await runHandler(s.orgId, s.agentId, s.deviceId, backupResult(jobId));
+
+    expect(await resultJobExists(jobId)).toBe(false);
+  });
+
+  it('rejects a re-driven result for an already-terminal (consumed) job', async () => {
+    const s = await seedDeviceWithBackup();
+    const jobId = await insertBackupJob(s, 'completed');
+    await recordDispatchedExpectation('backup', s.deviceId, jobId);
+
+    // First result consumes the expectation.
+    await runHandler(s.orgId, s.agentId, s.deviceId, backupResult(jobId));
+    await getBackupQueue().getJob(`backup-result-${jobId}`).then((j) => j?.remove());
+
+    // Re-drive after terminal: expectation already consumed → dropped.
+    await runHandler(s.orgId, s.agentId, s.deviceId, backupResult(jobId));
+    expect(await resultJobExists(jobId)).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/integration/backupVaultResultIntegrity.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupVaultResultIntegrity.integration.test.ts
@@ -182,6 +182,23 @@ function vaultSyncResult(snapshotId: string, vaultId: string) {
   };
 }
 
+/** A vault-sync result that carries NO vaultId/vaultPath, so the target vault
+ *  can only be derived via the (now-disabled) single-active-vault fallback. */
+function vaultSyncResultNoVaultHint(snapshotId: string) {
+  return {
+    type: 'command_result' as const,
+    commandId: `vault-auto-sync-${snapshotId}`,
+    status: 'completed' as const,
+    stdout: JSON.stringify({
+      auto: true,
+      snapshotId,
+      totalBytes: 1024,
+      fileCount: 3,
+      manifestVerified: true,
+    }),
+  };
+}
+
 function backupResult(jobId: string) {
   return {
     type: 'command_result' as const,
@@ -256,6 +273,50 @@ describe('F5 — vault auto-sync orphan result integrity', () => {
     const after = await getVault(vaultId);
     expect(after.lastSyncStatus).toBeNull();
   });
+
+  it('drops an unhinted vault-auto-sync result instead of guessing the single active vault', async () => {
+    const s = await seedDeviceWithBackup();
+    // Exactly ONE active vault: the old single-active-vault fallback would have
+    // happily picked it. The orphan path disables that fallback, so a result
+    // carrying no vaultId/vaultPath must be dropped, not applied to this vault.
+    const vaultId = await insertVault(s);
+    const jobId = await insertBackupJob(s, 'completed');
+    const snapshotId = 'snap-unhinted-1';
+    await insertCompletedSnapshot(s, snapshotId, new Date(), jobId);
+
+    await runHandler(s.orgId, s.agentId, s.deviceId, vaultSyncResultNoVaultHint(snapshotId));
+
+    expect((await getVault(vaultId)).lastSyncStatus).toBeNull();
+  });
+
+  it('drops a vault-auto-sync result with an empty snapshot id', async () => {
+    const s = await seedDeviceWithBackup();
+    const vaultId = await insertVault(s);
+
+    await runHandler(s.orgId, s.agentId, s.deviceId, {
+      type: 'command_result' as const,
+      commandId: 'vault-auto-sync-',
+      status: 'completed' as const,
+      stdout: JSON.stringify({ auto: true, vaultId, totalBytes: 1 }),
+    });
+
+    expect((await getVault(vaultId)).lastSyncStatus).toBeNull();
+  });
+
+  it('drops a vault-auto-sync result for a snapshot that belongs to a different device', async () => {
+    // device A is the authenticated agent; device B (another org) has the real snapshot.
+    const a = await seedDeviceWithBackup();
+    const b = await seedDeviceWithBackup();
+    const vaultA = await insertVault(a);
+    const jobB = await insertBackupJob(b, 'completed');
+    const snapshotId = 'snap-other-device';
+    await insertCompletedSnapshot(b, snapshotId, new Date(), jobB);
+
+    // Agent A forges a vault-sync referencing device B's snapshot id.
+    await runHandler(a.orgId, a.agentId, a.deviceId, vaultSyncResult(snapshotId, vaultA));
+
+    expect((await getVault(vaultA)).lastSyncStatus).toBeNull();
+  });
 });
 
 describe('F6 — backup completion forgery integrity', () => {
@@ -296,5 +357,19 @@ describe('F6 — backup completion forgery integrity', () => {
     // Re-drive after terminal: expectation already consumed → dropped.
     await runHandler(s.orgId, s.agentId, s.deviceId, backupResult(jobId));
     expect(await resultJobExists(jobId)).toBe(false);
+  });
+
+  it('rejects a backup result for a job that belongs to another device', async () => {
+    // device B owns a dispatched job; agent A (different org) tries to report it.
+    const a = await seedDeviceWithBackup();
+    const b = await seedDeviceWithBackup();
+    const jobB = await insertBackupJob(b, 'running');
+    await recordDispatchedExpectation('backup', b.deviceId, jobB);
+
+    // Under agent A's own org context the job row isn't even visible (RLS) and
+    // the agent-ownership guard rejects it; the result must be dropped.
+    await runHandler(a.orgId, a.agentId, a.deviceId, backupResult(jobB));
+
+    expect(await resultJobExists(jobB)).toBe(false);
   });
 });

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -40,6 +40,7 @@ import { getDueOccurrenceKey } from '../routes/backup/helpers';
 import { applyBackupCommandResultToJob } from '../services/backupResultPersistence';
 import { markBackupJobFailedIfInFlight } from '../services/backupResultPersistence';
 import { createScheduledBackupJobIfAbsent } from '../services/backupJobCreation';
+import { recordDispatchedExpectation } from '../services/agentWorkExpectation';
 import { attachWorkerObservability } from './workerObservability';
 import { assertQueueJobName, parseQueueJobData } from '../services/bullmqValidation';
 import {
@@ -515,6 +516,11 @@ async function processDispatchBackup(
     const sent = sendCommandToAgent(agentId, command);
     if (sent) {
       sentCount++;
+      // Record a server-side dispatch expectation so the WS result handler can
+      // verify this completion corresponds to work we actually dispatched and
+      // hasn't already been consumed (F6). Best-effort: a Redis outage here
+      // makes the result fail-closed on arrival (dropped), not trusted.
+      await recordDispatchedExpectation('backup', data.deviceId, commandJobId);
     } else {
       console.warn(`[BackupWorker] Failed to send ${target.commandType} command for job ${commandJobId}`);
       failedTargets.push(target.commandType);

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -513,14 +513,19 @@ async function processDispatchBackup(
       },
     };
 
+    // Record the server-side dispatch expectation BEFORE sending so the WS
+    // result handler can verify this completion corresponds to work we actually
+    // dispatched and hasn't already been consumed (F6). Recording first closes
+    // the (otherwise negligible) window where a result could arrive before the
+    // expectation lands. If the send then fails, the orphaned expectation is
+    // harmless — it expires via TTL and can't be consumed without a matching
+    // job + owning device. Best-effort: a Redis outage makes the result
+    // fail-closed on arrival (dropped), not trusted.
+    await recordDispatchedExpectation('backup', data.deviceId, commandJobId);
+
     const sent = sendCommandToAgent(agentId, command);
     if (sent) {
       sentCount++;
-      // Record a server-side dispatch expectation so the WS result handler can
-      // verify this completion corresponds to work we actually dispatched and
-      // hasn't already been consumed (F6). Best-effort: a Redis outage here
-      // makes the result fail-closed on arrival (dropped), not trusted.
-      await recordDispatchedExpectation('backup', data.deviceId, commandJobId);
     } else {
       console.warn(`[BackupWorker] Failed to send ${target.commandType} command for job ${commandJobId}`);
       failedTargets.push(target.commandType);

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -22,7 +22,7 @@ import {
   findRecentCompletedSnapshotForDevice,
   resolveVaultForResult,
 } from '../services/vaultSyncPersistence';
-import { claimConsumeOnce, consumeDispatchedExpectation } from '../services/agentWorkExpectation';
+import { claimConsumeOnce, consumeDispatchedExpectation, recordDispatchedExpectation } from '../services/agentWorkExpectation';
 import { backupCommandResultSchema } from './backup/resultSchemas';
 import { claimPendingCommandsForDevice } from '../services/commandDispatch';
 import { matchRoleScopedAgentTokenHash, suspendAgentToken, type AgentCredentialRole } from '../middleware/agentAuth';
@@ -1275,6 +1275,11 @@ export async function processOrphanedCommandResult(
     } catch (err) {
       console.error(`[AgentWs] Failed to process backup results for ${agentId}:`, err);
       captureException(err);
+      // We already consumed the dispatch expectation but persistence failed
+      // (e.g. transient BullMQ/DB error). Re-record it so a legitimate agent
+      // retry of this same result can be accepted instead of being permanently
+      // dropped as "already-consumed". Best-effort; safe to no-op on Redis down.
+      await recordDispatchedExpectation('backup', backupJob.deviceId, backupJob.id);
     }
     return;
   }

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -17,7 +17,12 @@ import { isIP } from 'node:net';
 import { processDeviceIPHistoryUpdate } from '../services/deviceIpHistory';
 import { processBackupVerificationResult } from './backup/verificationService';
 import { applyBackupCommandResultToJob } from '../services/backupResultPersistence';
-import { applyVaultSyncCommandResult } from '../services/vaultSyncPersistence';
+import {
+  applyVaultSyncCommandResult,
+  findRecentCompletedSnapshotForDevice,
+  resolveVaultForResult,
+} from '../services/vaultSyncPersistence';
+import { claimConsumeOnce, consumeDispatchedExpectation } from '../services/agentWorkExpectation';
 import { backupCommandResultSchema } from './backup/resultSchemas';
 import { claimPendingCommandsForDevice } from '../services/commandDispatch';
 import { matchRoleScopedAgentTokenHash, suspendAgentToken, type AgentCredentialRole } from '../middleware/agentAuth';
@@ -488,6 +493,13 @@ const agentPingStates = new Map<string, AgentPingState>();
 const AGENT_PING_INTERVAL_MS = 30_000;
 const AGENT_PONG_TIMEOUT_MS = 10_000;
 const ORPHANED_RESULT_EXPECTATION_TTL_MS = 30 * 60 * 1000;
+
+// F5: a `vault-auto-sync-<snapshotID>` result is only honored if a real,
+// recently-COMPLETED backup snapshot exists for the authenticated device with
+// that snapshot id. Auto-sync runs right after a backup, but the agent may be
+// slow or reconnect, so the window is generous; dropping a legitimate late
+// result only degrades vault state to "not-synced" (fail-safe).
+const VAULT_AUTO_SYNC_SNAPSHOT_FRESHNESS_MS = 24 * 60 * 60 * 1000; // 24h
 const MONITOR_COMMAND_TYPES = new Set(['network_ping', 'network_tcp_check', 'network_http_check', 'network_dns_check']);
 
 type OrphanedResultExpectation =
@@ -846,7 +858,7 @@ async function updateDeviceStatus(agentId: string, status: 'online' | 'offline')
  * (without a deviceCommands DB record). This covers discovery scans
  * and SNMP polls which use their own job tracking tables.
  */
-async function processOrphanedCommandResult(
+export async function processOrphanedCommandResult(
   agentId: string,
   authenticatedDeviceId: string,
   result: z.infer<typeof commandResultSchema>
@@ -946,14 +958,65 @@ async function processOrphanedCommandResult(
 
   if (result.commandId.startsWith('vault-auto-sync-')) {
     try {
+      // Integrity gate (F5): the `vault-auto-sync-<snapshotID>` command id is
+      // agent-generated — there is no server dispatch to bind to. Derive
+      // legitimacy from a server-known event instead: a real, recently-completed
+      // backup snapshot for THIS device carrying that snapshot id. Without a
+      // matching snapshot, a compromised agent could forge sync-completed/failed
+      // state on the device's vault, so we log + drop (mutate nothing).
+      const snapshotId = result.commandId.slice('vault-auto-sync-'.length);
+      if (!snapshotId) {
+        console.warn(`[AgentWs] Dropping vault auto-sync result from agent ${agentId}: empty snapshot id. reason=empty-snapshot-id`);
+        return;
+      }
+
+      const snapshot = await findRecentCompletedSnapshotForDevice(
+        authenticatedDeviceId,
+        snapshotId,
+        VAULT_AUTO_SYNC_SNAPSHOT_FRESHNESS_MS,
+      );
+      if (!snapshot) {
+        console.warn(
+          `[AgentWs] Dropping vault auto-sync result for snapshot ${snapshotId} from agent ${agentId} ` +
+          `(device ${authenticatedDeviceId}): no recent completed backup snapshot matches. reason=no-matching-snapshot`
+        );
+        return;
+      }
+
       const { normalizedResult, stdout, validationError } = normalizeCriticalResultIfNeeded('vault_sync', result);
+
+      // Resolve the target vault unambiguously (no single-active-vault fallback)
+      // so we can key consume-once on (deviceId, snapshotId, vaultId) and refuse
+      // to guess which vault a forged result is "for".
+      const vault = await resolveVaultForResult(authenticatedDeviceId, stdout);
+      if (!vault) {
+        console.warn(
+          `[AgentWs] Dropping vault auto-sync result for snapshot ${snapshotId} from agent ${agentId} ` +
+          `(device ${authenticatedDeviceId}): vault could not be unambiguously derived. reason=ambiguous-vault`
+        );
+        return;
+      }
+
+      // Consume-once on the derived tuple: the same snapshot can't drive repeated
+      // or overwriting vault-state updates. Fail-closed (Redis down ⇒ dropped).
+      const claim = await claimConsumeOnce('vault_sync', authenticatedDeviceId, `${snapshotId}:${vault.id}`);
+      if (!claim.ok) {
+        console.warn(
+          `[AgentWs] Dropping vault auto-sync result for snapshot ${snapshotId} (vault ${vault.id}) from agent ${agentId}: ` +
+          `already consumed or Redis unavailable. reason=consume-once-rejected`
+        );
+        return;
+      }
+
       if (validationError) {
         console.warn(`[AgentWs] ${validationError} for orphaned auto-sync ${result.commandId}`);
-        // Update vault state to reflect the validation failure so it's visible to operators
+        // Snapshot-correlated + consumed: a malformed payload from an otherwise
+        // legitimate sync is surfaced to operators as a failure on the resolved vault.
         await applyVaultSyncCommandResult({
           deviceId: authenticatedDeviceId,
           resultStatus: 'failed',
           error: validationError,
+          allowSingleVaultFallback: false,
         });
         return;
       }
@@ -963,6 +1026,7 @@ async function processOrphanedCommandResult(
         stdout,
         stderr: normalizedResult.stderr,
         error: normalizedResult.error,
+        allowSingleVaultFallback: false,
       });
     } catch (err) {
       console.error(`[AgentWs] Failed to process vault auto-sync result for ${agentId}:`, err);
@@ -1149,6 +1213,19 @@ async function processOrphanedCommandResult(
   if (backupJob) {
     if (!backupJob.agentId || backupJob.agentId !== agentId) {
       console.warn(`[AgentWs] Rejecting backup result for job ${backupJob.id} from unexpected agent ${agentId}`);
+      return;
+    }
+    // Integrity gate (F6): accept a backup completion only if it corresponds to a
+    // dispatch we recorded and hasn't already been consumed. This blocks a
+    // compromised agent that preemptively reports `completed` with fabricated
+    // metadata, replays a result, or re-drives an already-terminal/never-dispatched
+    // job UUID. Fail-closed: Redis unavailable ⇒ dropped (not trusted).
+    const backupExpectation = await consumeDispatchedExpectation('backup', backupJob.deviceId, backupJob.id);
+    if (!backupExpectation.ok) {
+      console.warn(
+        `[AgentWs] Dropping backup result for job ${backupJob.id} from agent ${agentId}: ` +
+        `no outstanding dispatch expectation (forged, replayed, or already-consumed). reason=expectation-not-consumed`
+      );
       return;
     }
     console.log(`[AgentWs] Processing backup result for job ${backupJob.id} from agent ${agentId}`);

--- a/apps/api/src/services/agentWorkExpectation.test.ts
+++ b/apps/api/src/services/agentWorkExpectation.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisState: {
+  store: Map<string, string>;
+  client: {
+    set: ReturnType<typeof vi.fn>;
+    eval: ReturnType<typeof vi.fn>;
+  } | null;
+} = { store: new Map(), client: null };
+
+vi.mock('./redis', () => ({
+  getRedis: vi.fn(() => redisState.client),
+}));
+
+import {
+  claimConsumeOnce,
+  consumeDispatchedExpectation,
+  recordDispatchedExpectation,
+} from './agentWorkExpectation';
+
+function buildRedisClient() {
+  redisState.store = new Map();
+  return {
+    // ioredis-style: set(key, val, 'EX', ttl[, 'NX']) → 'OK' | null
+    set: vi.fn(async (key: string, val: string, ..._args: unknown[]) => {
+      const nx = _args.includes('NX');
+      if (nx && redisState.store.has(key)) {
+        return null;
+      }
+      redisState.store.set(key, val);
+      return 'OK';
+    }),
+    // ioredis-style: eval(lua, numKeys, key, ...) — we only use a GET+DEL atomic check.
+    eval: vi.fn(async (_lua: string, _numKeys: number, key: string) => {
+      if (redisState.store.has(key)) {
+        redisState.store.delete(key);
+        return 1;
+      }
+      return 0;
+    }),
+  };
+}
+
+beforeEach(() => {
+  redisState.client = buildRedisClient();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('claimConsumeOnce (F5 derived-expectation consume-once)', () => {
+  it('first claim succeeds, replay of same tuple fails', async () => {
+    const first = await claimConsumeOnce('vault_sync', 'device-1', 'snap-1:vault-1');
+    expect(first.ok).toBe(true);
+
+    const replay = await claimConsumeOnce('vault_sync', 'device-1', 'snap-1:vault-1');
+    expect(replay.ok).toBe(false);
+  });
+
+  it('different tuples are independent', async () => {
+    expect((await claimConsumeOnce('vault_sync', 'device-1', 'snap-1:vault-1')).ok).toBe(true);
+    expect((await claimConsumeOnce('vault_sync', 'device-1', 'snap-2:vault-1')).ok).toBe(true);
+    expect((await claimConsumeOnce('vault_sync', 'device-2', 'snap-1:vault-1')).ok).toBe(true);
+  });
+
+  it('fails closed when Redis is unavailable', async () => {
+    redisState.client = null;
+    const result = await claimConsumeOnce('vault_sync', 'device-1', 'snap-1:vault-1');
+    expect(result.ok).toBe(false);
+  });
+
+  it('fails closed when Redis throws', async () => {
+    redisState.client!.set.mockRejectedValueOnce(new Error('connection reset'));
+    const result = await claimConsumeOnce('vault_sync', 'device-1', 'snap-1:vault-1');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('record/consume dispatched expectation (F6 dispatch-bound)', () => {
+  it('a recorded expectation can be consumed exactly once', async () => {
+    await recordDispatchedExpectation('backup', 'device-1', 'job-1');
+
+    const first = await consumeDispatchedExpectation('backup', 'device-1', 'job-1');
+    expect(first.ok).toBe(true);
+
+    const replay = await consumeDispatchedExpectation('backup', 'device-1', 'job-1');
+    expect(replay.ok).toBe(false);
+  });
+
+  it('rejects a never-dispatched expectation', async () => {
+    const result = await consumeDispatchedExpectation('backup', 'device-1', 'never-dispatched');
+    expect(result.ok).toBe(false);
+  });
+
+  it('scopes the expectation to the device that was dispatched', async () => {
+    await recordDispatchedExpectation('backup', 'device-1', 'job-1');
+    // A different device cannot consume device-1's expectation.
+    const wrongDevice = await consumeDispatchedExpectation('backup', 'device-2', 'job-1');
+    expect(wrongDevice.ok).toBe(false);
+    // The legitimate device still can.
+    const rightDevice = await consumeDispatchedExpectation('backup', 'device-1', 'job-1');
+    expect(rightDevice.ok).toBe(true);
+  });
+
+  it('consume fails closed when Redis is unavailable', async () => {
+    redisState.client = null;
+    const result = await consumeDispatchedExpectation('backup', 'device-1', 'job-1');
+    expect(result.ok).toBe(false);
+  });
+
+  it('consume fails closed when Redis throws', async () => {
+    await recordDispatchedExpectation('backup', 'device-1', 'job-1');
+    redisState.client!.eval.mockRejectedValueOnce(new Error('connection reset'));
+    const result = await consumeDispatchedExpectation('backup', 'device-1', 'job-1');
+    expect(result.ok).toBe(false);
+  });
+
+  it('record is best-effort and does not throw when Redis is unavailable', async () => {
+    redisState.client = null;
+    await expect(recordDispatchedExpectation('backup', 'device-1', 'job-1')).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/services/agentWorkExpectation.ts
+++ b/apps/api/src/services/agentWorkExpectation.ts
@@ -69,15 +69,19 @@ export async function recordDispatchedExpectation(
   deviceId: string,
   key: string,
 ): Promise<void> {
-  const redis = getRedis();
-  if (!redis) {
-    console.warn(
-      `[AgentWorkExpectation] Redis unavailable while recording ${kind} expectation ` +
-      `(device=${deviceId}, key=${key}); the corresponding result will be dropped on arrival`,
-    );
-    return;
-  }
+  // Whole body wrapped: getRedis() can construct the client lazily and must not
+  // be able to throw out of this best-effort recorder (it runs inside the backup
+  // dispatch loop). A failure to record just means the result fails-closed on
+  // arrival, which is the safe direction.
   try {
+    const redis = getRedis();
+    if (!redis) {
+      console.warn(
+        `[AgentWorkExpectation] Redis unavailable while recording ${kind} expectation ` +
+        `(device=${deviceId}, key=${key}); the corresponding result will be dropped on arrival`,
+      );
+      return;
+    }
     await redis.set(
       dispatchedKey(kind, deviceId, key),
       '1',
@@ -103,15 +107,15 @@ export async function consumeDispatchedExpectation(
   deviceId: string,
   key: string,
 ): Promise<{ ok: boolean }> {
-  const redis = getRedis();
-  if (!redis) {
-    console.warn(
-      `[AgentWorkExpectation] Redis unavailable consuming ${kind} expectation ` +
-      `(device=${deviceId}, key=${key}); dropping result (fail-closed)`,
-    );
-    return { ok: false };
-  }
   try {
+    const redis = getRedis();
+    if (!redis) {
+      console.warn(
+        `[AgentWorkExpectation] Redis unavailable consuming ${kind} expectation ` +
+        `(device=${deviceId}, key=${key}); dropping result (fail-closed)`,
+      );
+      return { ok: false };
+    }
     const consumed = await redis.eval(
       CONSUME_IF_PRESENT_LUA,
       1,
@@ -139,15 +143,15 @@ export async function claimConsumeOnce(
   deviceId: string,
   key: string,
 ): Promise<{ ok: boolean }> {
-  const redis = getRedis();
-  if (!redis) {
-    console.warn(
-      `[AgentWorkExpectation] Redis unavailable claiming ${kind} consume-once ` +
-      `(device=${deviceId}, key=${key}); dropping result (fail-closed)`,
-    );
-    return { ok: false };
-  }
   try {
+    const redis = getRedis();
+    if (!redis) {
+      console.warn(
+        `[AgentWorkExpectation] Redis unavailable claiming ${kind} consume-once ` +
+        `(device=${deviceId}, key=${key}); dropping result (fail-closed)`,
+      );
+      return { ok: false };
+    }
     const result = await redis.set(
       consumeOnceKey(kind, deviceId, key),
       '1',

--- a/apps/api/src/services/agentWorkExpectation.ts
+++ b/apps/api/src/services/agentWorkExpectation.ts
@@ -1,0 +1,167 @@
+import { getRedis } from './redis';
+
+/**
+ * Consume-once expectations for agent WS result integrity.
+ *
+ * Both the backup-completion (F6) and vault-auto-sync (F5) result paths accept a
+ * completion from an authenticated agent based on identifiers the agent already
+ * knows. A compromised-but-legitimately-enrolled agent can therefore forge or
+ * replay a "completed" result for its own device. These helpers add a server-side
+ * record of "this specific unit of work is outstanding and not-yet-consumed" so a
+ * forged/replayed result can be dropped.
+ *
+ * Two shapes, both **fail-closed** — if Redis is unavailable or errors, the
+ * consume returns `{ ok: false }` and the caller drops the result (degrades to
+ * "not-completed", which is the safe direction: we under-report protection
+ * rather than trust the agent):
+ *
+ *  - {@link recordDispatchedExpectation} / {@link consumeDispatchedExpectation}:
+ *    server-dispatched work (F6 backup jobs). The dispatcher records the
+ *    expectation when it sends the command; the result path consumes it exactly
+ *    once. Replay, never-dispatched job UUIDs, and a result for the wrong device
+ *    all fail to consume.
+ *
+ *  - {@link claimConsumeOnce}: derived expectation (F5 vault auto-sync). There is
+ *    no server dispatch to bind to, so legitimacy is established separately (a
+ *    real recently-completed backup snapshot for the device). This helper only
+ *    enforces consume-once on that derived tuple so the same snapshot can't drive
+ *    repeated/overwriting vault-state updates.
+ */
+
+export type AgentWorkExpectationKind = 'backup' | 'vault_sync';
+
+// Generous TTLs: a legitimate result can arrive long after dispatch (slow backup,
+// agent reconnect). Tune toward over-accepting late legitimate results rather than
+// dropping them — see the rollout notes in the design doc.
+const DISPATCHED_EXPECTATION_TTL_SECONDS = 24 * 60 * 60; // 24h
+const CONSUME_ONCE_TTL_SECONDS = 24 * 60 * 60; // 24h
+
+function dispatchedKey(kind: AgentWorkExpectationKind, deviceId: string, key: string): string {
+  return `agent-work-expect:${kind}:${deviceId}:${key}`;
+}
+
+function consumeOnceKey(kind: AgentWorkExpectationKind, deviceId: string, key: string): string {
+  return `agent-work-consumed:${kind}:${deviceId}:${key}`;
+}
+
+/**
+ * Atomic GET-exists + DEL via a Redis Lua script (ioredis `eval`). This is a
+ * Redis server-side script — NOT JavaScript `eval`; it executes the literal Lua
+ * below against Redis with no client-controlled code. Returns 1 if the key
+ * existed (and was deleted), 0 otherwise, so a concurrent double-report can only
+ * succeed once.
+ */
+const CONSUME_IF_PRESENT_LUA = `
+if redis.call('EXISTS', KEYS[1]) == 1 then
+  redis.call('DEL', KEYS[1])
+  return 1
+end
+return 0
+`;
+
+/**
+ * Record that a unit of server-dispatched work is outstanding for a device.
+ * Best-effort: a Redis outage here means {@link consumeDispatchedExpectation}
+ * will later fail-closed and drop the result, which is the safe direction.
+ */
+export async function recordDispatchedExpectation(
+  kind: AgentWorkExpectationKind,
+  deviceId: string,
+  key: string,
+): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    console.warn(
+      `[AgentWorkExpectation] Redis unavailable while recording ${kind} expectation ` +
+      `(device=${deviceId}, key=${key}); the corresponding result will be dropped on arrival`,
+    );
+    return;
+  }
+  try {
+    await redis.set(
+      dispatchedKey(kind, deviceId, key),
+      '1',
+      'EX',
+      DISPATCHED_EXPECTATION_TTL_SECONDS,
+    );
+  } catch (err) {
+    console.error(
+      `[AgentWorkExpectation] Failed to record ${kind} expectation (device=${deviceId}, key=${key}):`,
+      err,
+    );
+  }
+}
+
+/**
+ * Consume a previously-recorded dispatched expectation exactly once.
+ * Returns `{ ok: true }` only if the expectation currently exists for this
+ * (kind, device, key); the consume deletes it so replay and re-drive of an
+ * already-consumed/terminal job both fail. Fail-closed on Redis errors.
+ */
+export async function consumeDispatchedExpectation(
+  kind: AgentWorkExpectationKind,
+  deviceId: string,
+  key: string,
+): Promise<{ ok: boolean }> {
+  const redis = getRedis();
+  if (!redis) {
+    console.warn(
+      `[AgentWorkExpectation] Redis unavailable consuming ${kind} expectation ` +
+      `(device=${deviceId}, key=${key}); dropping result (fail-closed)`,
+    );
+    return { ok: false };
+  }
+  try {
+    const consumed = await redis.eval(
+      CONSUME_IF_PRESENT_LUA,
+      1,
+      dispatchedKey(kind, deviceId, key),
+    );
+    return { ok: consumed === 1 };
+  } catch (err) {
+    console.error(
+      `[AgentWorkExpectation] Failed to consume ${kind} expectation (device=${deviceId}, key=${key}); ` +
+      `dropping result (fail-closed):`,
+      err,
+    );
+    return { ok: false };
+  }
+}
+
+/**
+ * Claim a derived (non-dispatched) unit of work consume-once. Returns
+ * `{ ok: true }` only on the first claim for this (kind, device, key); replays
+ * return `{ ok: false }`. Fail-closed on Redis unavailable/error. Uses
+ * `SET ... NX` so the claim is atomic.
+ */
+export async function claimConsumeOnce(
+  kind: AgentWorkExpectationKind,
+  deviceId: string,
+  key: string,
+): Promise<{ ok: boolean }> {
+  const redis = getRedis();
+  if (!redis) {
+    console.warn(
+      `[AgentWorkExpectation] Redis unavailable claiming ${kind} consume-once ` +
+      `(device=${deviceId}, key=${key}); dropping result (fail-closed)`,
+    );
+    return { ok: false };
+  }
+  try {
+    const result = await redis.set(
+      consumeOnceKey(kind, deviceId, key),
+      '1',
+      'EX',
+      CONSUME_ONCE_TTL_SECONDS,
+      'NX',
+    );
+    return { ok: result === 'OK' };
+  } catch (err) {
+    console.error(
+      `[AgentWorkExpectation] Failed to claim ${kind} consume-once (device=${deviceId}, key=${key}); ` +
+      `dropping result (fail-closed):`,
+      err,
+    );
+    return { ok: false };
+  }
+}

--- a/apps/api/src/services/vaultSyncPersistence.ts
+++ b/apps/api/src/services/vaultSyncPersistence.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, gte } from 'drizzle-orm';
 
 import { db } from '../db';
 import { backupSnapshots, localVaults, vaultSnapshotInventory } from '../db/schema';
@@ -15,6 +15,14 @@ export interface ApplyVaultSyncCommandResultInput {
   stdout?: string;
   stderr?: string;
   error?: string;
+  /**
+   * When false, a result whose vault can't be unambiguously derived (explicit
+   * vaultId/vaultPath) is dropped rather than guessed via the single-active-vault
+   * fallback. Used by the orphaned auto-sync path (F5) where the result is not
+   * bound to a server-dispatched command. Defaults to true for the
+   * server-dispatched path, which preserves prior behavior.
+   */
+  allowSingleVaultFallback?: boolean;
 }
 
 function parseStructuredStdout(stdout?: string): Record<string, unknown> {
@@ -38,7 +46,12 @@ function parsePayload(command?: VaultSyncCommandLike | null): { vaultId?: string
   };
 }
 
-async function resolveVaultRecord(deviceId: string, structured: Record<string, unknown>, payload: { vaultId?: string }): Promise<{ id: string; orgId: string } | null> {
+async function resolveVaultRecord(
+  deviceId: string,
+  structured: Record<string, unknown>,
+  payload: { vaultId?: string },
+  allowSingleVaultFallback: boolean,
+): Promise<{ id: string; orgId: string } | null> {
   if (payload.vaultId || structured.vaultId) {
     const [vault] = await db
       .select({ id: localVaults.id, orgId: localVaults.orgId })
@@ -68,6 +81,10 @@ async function resolveVaultRecord(deviceId: string, structured: Record<string, u
     if (vault) return vault;
   }
 
+  if (!allowSingleVaultFallback) {
+    return null;
+  }
+
   const vaults = await db
     .select({ id: localVaults.id, orgId: localVaults.orgId })
     .from(localVaults)
@@ -77,11 +94,69 @@ async function resolveVaultRecord(deviceId: string, structured: Record<string, u
   return vaults.length === 1 ? vaults[0]! : null;
 }
 
+/**
+ * Look up a recently-completed backup snapshot for this device by the provider
+ * snapshot id the agent embedded in the `vault-auto-sync-<snapshotID>` command id.
+ *
+ * The agent derives the auto-sync snapshot id from the backup_run result's
+ * `snapshot.id`, which the server persists as `backup_snapshots.snapshot_id`
+ * (see backupResultPersistence). So a *legitimate* auto-sync always has a matching
+ * snapshot row; a forged orphan result for a snapshot that was never produced has
+ * none. Returns the snapshot (and its org) when found within the freshness window,
+ * else null.
+ */
+export async function findRecentCompletedSnapshotForDevice(
+  deviceId: string,
+  snapshotId: string,
+  freshnessWindowMs: number,
+): Promise<{ id: string; orgId: string; size: number | null } | null> {
+  const cutoff = new Date(Date.now() - freshnessWindowMs);
+  const [snapshot] = await db
+    .select({
+      id: backupSnapshots.id,
+      orgId: backupSnapshots.orgId,
+      size: backupSnapshots.size,
+    })
+    .from(backupSnapshots)
+    .where(
+      and(
+        eq(backupSnapshots.snapshotId, snapshotId),
+        eq(backupSnapshots.deviceId, deviceId),
+        gte(backupSnapshots.timestamp, cutoff)
+      )
+    )
+    .orderBy(desc(backupSnapshots.timestamp))
+    .limit(1);
+  return snapshot ?? null;
+}
+
+/**
+ * Resolve the vault a vault-sync result targets, without mutating anything.
+ * Used by the orphaned auto-sync path (F5) so the caller can derive a stable
+ * consume-once key `(deviceId, snapshotId, vaultId)` before applying. Returns
+ * null when the vault can't be unambiguously derived (the single-active-vault
+ * fallback is disabled here on purpose).
+ */
+export async function resolveVaultForResult(
+  deviceId: string,
+  stdout?: string,
+  command?: VaultSyncCommandLike | null,
+): Promise<{ id: string; orgId: string } | null> {
+  const structured = parseStructuredStdout(stdout);
+  const payload = parsePayload(command);
+  return resolveVaultRecord(deviceId, structured, payload, false);
+}
+
 export async function applyVaultSyncCommandResult(input: ApplyVaultSyncCommandResultInput): Promise<void> {
   const structured = parseStructuredStdout(input.stdout);
   const payload = parsePayload(input.command);
   const snapshotId = typeof structured.snapshotId === 'string' ? structured.snapshotId : payload.snapshotId ?? null;
-  const vault = await resolveVaultRecord(input.deviceId, structured, payload);
+  const vault = await resolveVaultRecord(
+    input.deviceId,
+    structured,
+    payload,
+    input.allowSingleVaultFallback ?? true,
+  );
 
   if (!vault) {
     console.warn(


### PR DESCRIPTION
Tightens the agent WebSocket result path so a completion is only accepted when it corresponds to a specific server-known unit of work that is currently outstanding and not-yet-consumed. Two related findings from the internal security-hardening tracker (F5, F6), sharing one consume-once primitive.

**Background:** both result paths accepted a completion based on identifiers the agent already knows or chooses, with no server-side record that the work was expected. In the compromised-but-enrolled-agent threat model this lets an agent forge or replay "backup completed" / "vault synced" state for its own device. Org-axis RLS and agent-auth are unaffected — this is same-device integrity, operator-facing posture/forensics.

**Shared primitive (`services/agentWorkExpectation.ts`):** a small Redis-backed, TTL'd, fail-closed helper.
- `recordDispatchedExpectation` / `consumeDispatchedExpectation` — server-dispatched work (F6).
- `claimConsumeOnce` — derived expectation (F5), after the snapshot correlation is established.
- Redis unavailable or erroring => `{ ok: false }` => the result is dropped. Dropping a legitimate late result only degrades to "not-completed", which is the safe direction.

**F6 — backup completion:** the dispatcher now records a `(deviceId, jobId)` expectation when it sends the command; the result handler consumes it exactly once. Replays, never-dispatched job UUIDs, and re-driven terminal jobs are dropped.

**F5 — vault auto-sync:** the `vault-auto-sync-<snapshotID>` id is agent-generated (no dispatch), so legitimacy is derived from a real recently-completed backup snapshot for the device with that id, within a generous freshness window. The target vault is resolved unambiguously (single-active-vault fallback disabled for this path), then consumed once on `(deviceId, snapshotId, vaultId)`. No vault state is mutated on a dropped result.

Every dropped result logs a reason/count so false drops are visible (mirrors the migration cleanup-count discipline).

**Scope:** server-only — no agent-side change, no schema migration. Fail-safe by design (under-reports protection, never over-reports it).

**Tests:** new unit coverage for the helper (consume-once + fail-closed) and real-DB integration coverage for F5/F6 (forged / replayed / stale / never-dispatched). Each gate proven non-vacuous (fails without the fix).

Same-device integrity, compromised-agent precondition — not outsider/tenant-reachable; normal release cadence (consistent with prior F3/F8 classification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)