### PR TITLE
feat(ticketing): Phase 5 — email-to-ticket customer routing

### DIFF
--- a/apps/api/migrations/2026-06-20-a-customer-email-domains.sql
+++ b/apps/api/migrations/2026-06-20-a-customer-email-domains.sql
@@ -13,9 +13,13 @@ CREATE TABLE IF NOT EXISTS customer_email_domains (
   updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
--- Org must belong to the partner (DB-enforced; mirrors ticket_categories composite FK).
--- Relies on UNIQUE(id, partner_id) on organizations (already used by ticket_categories
--- and users). Add it if a fresh DB somehow lacks it (idempotent, by-columns check).
+-- Org must belong to the partner (DB-enforced, dual-axis pattern).
+-- Relies on a UNIQUE(id, partner_id) constraint on organizations — the same one the
+-- `users` composite FK uses (2026-04-11-users-rls.sql). (ticket_categories' composite
+-- FK references ticket_categories(id, partner_id), NOT organizations, so it is not a
+-- precedent here.) Add it if a fresh DB somehow lacks it. The by-columns existence
+-- check means the pre-existing constraint's name is irrelevant; the ADD only runs on
+-- the rare fresh-DB fallback path, under its own name.
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid

--- a/apps/api/migrations/2026-06-20-a-customer-email-domains.sql
+++ b/apps/api/migrations/2026-06-20-a-customer-email-domains.sql
@@ -1,0 +1,50 @@
+-- Phase 5 (native ticketing): sender-domain -> customer-org routing for email-to-ticket
+-- Spec: docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md
+
+CREATE TABLE IF NOT EXISTS customer_email_domains (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id UUID NOT NULL REFERENCES partners(id),
+  org_id UUID NOT NULL,
+  domain VARCHAR(255) NOT NULL,
+  auto_create_contact BOOLEAN NOT NULL DEFAULT TRUE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by UUID REFERENCES users(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Org must belong to the partner (DB-enforced; mirrors ticket_categories composite FK).
+-- Relies on UNIQUE(id, partner_id) on organizations (already used by ticket_categories
+-- and users). Add it if a fresh DB somehow lacks it (idempotent, by-columns check).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid
+    WHERE t.relname = 'organizations' AND c.contype IN ('p','u')
+      AND c.conkey = (SELECT array_agg(attnum ORDER BY attnum)
+                      FROM pg_attribute WHERE attrelid = t.oid AND attname IN ('id','partner_id'))
+  ) THEN
+    ALTER TABLE organizations ADD CONSTRAINT organizations_id_partner_id_key UNIQUE (id, partner_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE customer_email_domains
+    ADD CONSTRAINT customer_email_domains_org_partner_fk
+    FOREIGN KEY (org_id, partner_id) REFERENCES organizations(id, partner_id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS customer_email_domains_partner_domain_uq
+  ON customer_email_domains (partner_id, domain);
+CREATE INDEX IF NOT EXISTS customer_email_domains_lookup_idx
+  ON customer_email_domains (partner_id, is_active);
+
+-- RLS: partner-axis (Shape 3) + denormalized org_id. System scope (the inbound worker)
+-- sees all; partner scope sees only its own rows.
+ALTER TABLE customer_email_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE customer_email_domains FORCE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  CREATE POLICY customer_email_domains_partner_access ON customer_email_domains
+    FOR ALL TO breeze_app
+    USING (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id))
+    WITH CHECK (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/api/src/__tests__/integration/customerEmailDomainsConfig.integration.test.ts
+++ b/apps/api/src/__tests__/integration/customerEmailDomainsConfig.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration coverage for the Phase 5 customer-email-domain config service
+ * (listCustomerEmailDomains / create / update / delete), run against the real
+ * test DB through partner-scope request context (as the routes call them).
+ *
+ * Proves the IDOR boundary functionally: a partner cannot map a domain to — or
+ * re-point one at — an org outside its partner, and cannot mutate another
+ * partner's mapping (404, scoped out).
+ */
+import './setup';
+import { afterAll, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { withDbAccessContext, type DbAccessContext } from '../../db';
+import { customerEmailDomains } from '../../db/schema/emailInbound';
+import { organizations, partners, users } from '../../db/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+import {
+  listCustomerEmailDomains,
+  createCustomerEmailDomain,
+  updateCustomerEmailDomain,
+  deleteCustomerEmailDomain,
+} from '../../services/ticketConfigService';
+
+const seededPartnerIds: string[] = [];
+const seededOrgIds: string[] = [];
+const seededUserIds: string[] = [];
+const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+async function seedTwoPartners() {
+  const a = await createPartner();
+  const aOrg = await createOrganization({ partnerId: a.id });
+  const aUser = await createUser({ partnerId: a.id });
+  const b = await createPartner();
+  const bOrg = await createOrganization({ partnerId: b.id });
+  seededPartnerIds.push(a.id, b.id);
+  seededOrgIds.push(aOrg.id, bOrg.id);
+  seededUserIds.push(aUser.id);
+
+  const ctxA: DbAccessContext = {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [aOrg.id],
+    accessiblePartnerIds: [a.id],
+    userId: aUser.id,
+  };
+  return { a, aOrg, aUser, b, bOrg, ctxA };
+}
+
+afterAll(async () => {
+  if (seededPartnerIds.length === 0) return;
+  const adminDb = getTestDb() as any;
+  const partnerList = sql.join(seededPartnerIds.map((id) => sql`${id}`), sql`, `);
+  await adminDb.delete(customerEmailDomains).where(sql`${customerEmailDomains.partnerId} IN (${partnerList})`);
+  if (seededUserIds.length > 0) {
+    const userList = sql.join(seededUserIds.map((id) => sql`${id}`), sql`, `);
+    await adminDb.delete(users).where(sql`${users.id} IN (${userList})`);
+  }
+  const orgList = sql.join(seededOrgIds.map((id) => sql`${id}`), sql`, `);
+  await adminDb.delete(organizations).where(sql`${organizations.id} IN (${orgList})`);
+  await adminDb.delete(partners).where(sql`${partners.id} IN (${partnerList})`);
+});
+
+describe('customer email domain config service', () => {
+  it('creates a mapping and lists it joined with the org name', async () => {
+    const { a, aOrg, aUser, ctxA } = await seedTwoPartners();
+    const domain = `acme-${uniqueSuffix()}.test`;
+
+    const created = await withDbAccessContext(ctxA, () =>
+      createCustomerEmailDomain(a.id, { domain, orgId: aOrg.id, autoCreateContact: true }, { userId: aUser.id })
+    );
+    expect(created.domain).toBe(domain);
+
+    const list = await withDbAccessContext(ctxA, () => listCustomerEmailDomains(a.id));
+    const row = list.find((r) => r.domain === domain);
+    expect(row).toBeDefined();
+    expect(row!.orgId).toBe(aOrg.id);
+    expect(row!.orgName).toBe(aOrg.name);
+  });
+
+  it('rejects mapping an org outside the partner (ORG_NOT_ACCESSIBLE, 400)', async () => {
+    const { a, bOrg, aUser, ctxA } = await seedTwoPartners();
+    await expect(
+      withDbAccessContext(ctxA, () =>
+        createCustomerEmailDomain(a.id, { domain: `evil-${uniqueSuffix()}.test`, orgId: bOrg.id, autoCreateContact: true }, { userId: aUser.id })
+      )
+    ).rejects.toMatchObject({ status: 400, code: 'ORG_NOT_ACCESSIBLE' });
+  });
+
+  it('rejects a duplicate domain for the same partner (409)', async () => {
+    const { a, aOrg, aUser, ctxA } = await seedTwoPartners();
+    const domain = `dup-${uniqueSuffix()}.test`;
+    await withDbAccessContext(ctxA, () =>
+      createCustomerEmailDomain(a.id, { domain, orgId: aOrg.id, autoCreateContact: true }, { userId: aUser.id })
+    );
+    await expect(
+      withDbAccessContext(ctxA, () =>
+        createCustomerEmailDomain(a.id, { domain, orgId: aOrg.id, autoCreateContact: true }, { userId: aUser.id })
+      )
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('updates isActive and rejects re-pointing at another partner org (400)', async () => {
+    const { a, aOrg, bOrg, aUser, ctxA } = await seedTwoPartners();
+    const domain = `upd-${uniqueSuffix()}.test`;
+    const created = await withDbAccessContext(ctxA, () =>
+      createCustomerEmailDomain(a.id, { domain, orgId: aOrg.id, autoCreateContact: true }, { userId: aUser.id })
+    );
+
+    const updated = await withDbAccessContext(ctxA, () =>
+      updateCustomerEmailDomain(a.id, created.id, { isActive: false })
+    );
+    expect(updated.isActive).toBe(false);
+
+    await expect(
+      withDbAccessContext(ctxA, () => updateCustomerEmailDomain(a.id, created.id, { orgId: bOrg.id }))
+    ).rejects.toMatchObject({ status: 400, code: 'ORG_NOT_ACCESSIBLE' });
+  });
+
+  it('returns 404 deleting a non-existent / other-partner mapping', async () => {
+    const { a, ctxA } = await seedTwoPartners();
+    await expect(
+      withDbAccessContext(ctxA, () => deleteCustomerEmailDomain(a.id, '11111111-1111-4111-8111-111111111111'))
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/apps/api/src/__tests__/integration/customerEmailDomainsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/customerEmailDomainsRls.integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Functional forge proof for the Phase 5 sender-domain routing table
+ * (`customer_email_domains`).
+ *
+ * Migration under test: 2026-06-20-a-customer-email-domains.sql
+ *
+ * Shape 3 (partner-axis) + denormalized org_id. Two independent guards:
+ *   1. RLS policy (USING + WITH CHECK):
+ *        public.breeze_current_scope() = 'system'
+ *          OR public.breeze_has_partner_access(partner_id)
+ *   2. Composite FK (org_id, partner_id) -> organizations(id, partner_id):
+ *        the mapped org MUST belong to the row's partner.
+ *
+ * The rls-coverage contract test only proves *a* partner policy exists; it
+ * cannot prove the org_id can't be pointed at another partner's org (the
+ * dual-axis blindspot, #1594/custom_field_definitions). This suite is the
+ * functional proof, run through the real postgres.js driver as the
+ * unprivileged `breeze_app` role (rolbypassrls = false; see setup.ts), so the
+ * assertions are NOT vacuous.
+ *
+ * It proves, as the app role:
+ *   1. a legitimate partner-A row (partner A, org A) INSERTs successfully
+ *   2. cross-partner INSERT (partner A writing a partner-B row) is rejected by RLS
+ *   3. cross-org INSERT (partner A, but org belonging to partner B) is rejected
+ *      by the composite FK — the dual-axis proof
+ *   4. a partner-B row (seeded via system scope) is invisible to a partner-A SELECT
+ *
+ * postgres.js surfaces the policy/constraint error on `.cause` (drizzle wraps
+ * the top-level message), so rejections are matched against the cause message
+ * (same convention as emailInboundRls).
+ */
+import './setup';
+import { afterAll, describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { customerEmailDomains } from '../../db/schema/emailInbound';
+import { organizations, partners } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+import { getTestDb } from './setup';
+
+const seededPartnerIds: string[] = [];
+const seededOrgIds: string[] = [];
+
+/**
+ * Seeds two unrelated partners, each with an org, as the privileged test role
+ * (which bypasses RLS). Partner A is the "attacker"; partner B is the victim.
+ */
+async function seedTwoPartners() {
+  const a = await createPartner();
+  const aOrg = await createOrganization({ partnerId: a.id });
+  const b = await createPartner();
+  const bOrg = await createOrganization({ partnerId: b.id });
+
+  seededPartnerIds.push(a.id, b.id);
+  seededOrgIds.push(aOrg.id, bOrg.id);
+
+  const partnerAContext: DbAccessContext = {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [aOrg.id],
+    accessiblePartnerIds: [a.id],
+    userId: null,
+  };
+
+  return { a, aOrg, b, bOrg, partnerAContext };
+}
+
+const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+async function captureRlsCause(fn: () => Promise<unknown>): Promise<string | undefined> {
+  try {
+    await fn();
+    return undefined; // no throw = isolation hole
+  } catch (err) {
+    return (err as { cause?: { message?: string } } | undefined)?.cause?.message;
+  }
+}
+
+afterAll(async () => {
+  if (seededPartnerIds.length === 0) return;
+  const adminDb = getTestDb() as any;
+  const partnerList = sql.join(seededPartnerIds.map((id) => sql`${id}`), sql`, `);
+
+  // FK order: customer_email_domains (FK partner_id, org_id) → orgs → partners.
+  await adminDb
+    .delete(customerEmailDomains)
+    .where(sql`${customerEmailDomains.partnerId} IN (${partnerList})`);
+  if (seededOrgIds.length > 0) {
+    const orgList = sql.join(seededOrgIds.map((id) => sql`${id}`), sql`, `);
+    await adminDb.delete(organizations).where(sql`${organizations.id} IN (${orgList})`);
+  }
+  await adminDb.delete(partners).where(sql`${partners.id} IN (${partnerList})`);
+});
+
+describe('customer_email_domains RLS — partner + org forge (breeze_app role)', () => {
+  it('allows a legitimate partner-A row (partner A, org A)', async () => {
+    const { a, aOrg, partnerAContext } = await seedTwoPartners();
+
+    const domain = `legit-${uniqueSuffix()}.example.test`;
+    const [row] = await withDbAccessContext(partnerAContext, () =>
+      db
+        .insert(customerEmailDomains)
+        .values({ partnerId: a.id, orgId: aOrg.id, domain })
+        .returning({ id: customerEmailDomains.id })
+    );
+
+    expect(row?.id).toBeDefined();
+  });
+
+  it('rejects a cross-partner INSERT (partner A writing a partner-B row) via RLS', async () => {
+    const { b, bOrg, partnerAContext } = await seedTwoPartners();
+
+    const cause = await captureRlsCause(() =>
+      withDbAccessContext(partnerAContext, () =>
+        db.insert(customerEmailDomains).values({
+          partnerId: b.id, // forged: belongs to partner B
+          orgId: bOrg.id,
+          domain: `forge-${uniqueSuffix()}.example.test`,
+        })
+      )
+    );
+
+    expect(cause).toBeDefined();
+    expect(cause).toMatch(/row-level security/i);
+    expect(cause).toMatch(
+      /new row violates row-level security policy for table "customer_email_domains"/
+    );
+  });
+
+  it('rejects a cross-org INSERT (partner A, but org belonging to partner B) via the composite FK', async () => {
+    const { a, b, bOrg, partnerAContext } = await seedTwoPartners();
+    expect(b.id).toBeDefined();
+
+    const cause = await captureRlsCause(() =>
+      withDbAccessContext(partnerAContext, () =>
+        db.insert(customerEmailDomains).values({
+          partnerId: a.id, // passes the partner RLS predicate...
+          orgId: bOrg.id, // ...but this org is not in partner A
+          domain: `forge-org-${uniqueSuffix()}.example.test`,
+        })
+      )
+    );
+
+    expect(cause).toBeDefined();
+    expect(cause).toMatch(/violates foreign key constraint/i);
+    expect(cause).toMatch(/customer_email_domains_org_partner_fk/);
+  });
+
+  it('hides a partner-B row from a partner-A SELECT (seeded via system scope)', async () => {
+    const { b, bOrg, partnerAContext } = await seedTwoPartners();
+
+    const domain = `seed-b-${uniqueSuffix()}.example.test`;
+    const [seeded] = await withSystemDbAccessContext(() =>
+      db
+        .insert(customerEmailDomains)
+        .values({ partnerId: b.id, orgId: bOrg.id, domain })
+        .returning({ id: customerEmailDomains.id })
+    );
+    expect(seeded?.id).toBeDefined();
+
+    const rows = await withDbAccessContext(partnerAContext, () =>
+      db
+        .select({ id: customerEmailDomains.id })
+        .from(customerEmailDomains)
+        .where(eq(customerEmailDomains.domain, domain))
+    );
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
+++ b/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Integration coverage for the Phase 5 sender-domain resolver helpers
+ * (apps/api/src/services/inboundEmail/resolveOrg.ts), exercised against the
+ * real test DB. These run in system scope, exactly as the inbound worker calls
+ * them (processInboundEmail is wrapped in withSystemDbAccessContext).
+ */
+import './setup';
+import { afterAll, describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { customerEmailDomains } from '../../db/schema/emailInbound';
+import { organizations, partners } from '../../db/schema';
+import { portalUsers } from '../../db/schema/portal';
+import { createOrganization, createPartner } from './db-utils';
+import { getTestDb } from './setup';
+import {
+  resolveOrgBySenderDomain,
+  findOrCreateEmailContact,
+  loadPartnerInboundPolicy,
+} from '../../services/inboundEmail/resolveOrg';
+
+const seededPartnerIds: string[] = [];
+const seededOrgIds: string[] = [];
+const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+async function seedPartnerOrg() {
+  const p = await createPartner();
+  const org = await createOrganization({ partnerId: p.id });
+  seededPartnerIds.push(p.id);
+  seededOrgIds.push(org.id);
+  return { p, org };
+}
+
+afterAll(async () => {
+  if (seededPartnerIds.length === 0) return;
+  const adminDb = getTestDb() as any;
+  const partnerList = sql.join(seededPartnerIds.map((id) => sql`${id}`), sql`, `);
+  const orgList = sql.join(seededOrgIds.map((id) => sql`${id}`), sql`, `);
+  await adminDb.delete(customerEmailDomains).where(sql`${customerEmailDomains.partnerId} IN (${partnerList})`);
+  await adminDb.delete(portalUsers).where(sql`${portalUsers.orgId} IN (${orgList})`);
+  await adminDb.delete(organizations).where(sql`${organizations.id} IN (${orgList})`);
+  await adminDb.delete(partners).where(sql`${partners.id} IN (${partnerList})`);
+});
+
+describe('resolveOrgBySenderDomain', () => {
+  it('matches a mapped domain case-insensitively and returns autoCreateContact', async () => {
+    const { p, org } = await seedPartnerOrg();
+    const domain = `acme-${uniqueSuffix()}.test`;
+    await withSystemDbAccessContext(() =>
+      db.insert(customerEmailDomains).values({ partnerId: p.id, orgId: org.id, domain, autoCreateContact: true })
+    );
+
+    const r = await withSystemDbAccessContext(() => resolveOrgBySenderDomain(`Bob.Smith@${domain.toUpperCase()}`, p.id));
+    expect(r).toEqual({ orgId: org.id, autoCreateContact: true });
+  });
+
+  it('ignores inactive mappings', async () => {
+    const { p, org } = await seedPartnerOrg();
+    const domain = `inactive-${uniqueSuffix()}.test`;
+    await withSystemDbAccessContext(() =>
+      db.insert(customerEmailDomains).values({ partnerId: p.id, orgId: org.id, domain, isActive: false })
+    );
+
+    const r = await withSystemDbAccessContext(() => resolveOrgBySenderDomain(`x@${domain}`, p.id));
+    expect(r).toBeNull();
+  });
+
+  it('returns null for an unmapped domain', async () => {
+    const { p } = await seedPartnerOrg();
+    const r = await withSystemDbAccessContext(() => resolveOrgBySenderDomain(`x@nowhere-${uniqueSuffix()}.test`, p.id));
+    expect(r).toBeNull();
+  });
+
+  it('returns null for an address with no @', async () => {
+    const { p } = await seedPartnerOrg();
+    const r = await withSystemDbAccessContext(() => resolveOrgBySenderDomain('garbage', p.id));
+    expect(r).toBeNull();
+  });
+});
+
+describe('findOrCreateEmailContact', () => {
+  it('creates a password-less contact and is idempotent on the same (org,email)', async () => {
+    const { org } = await seedPartnerOrg();
+    const email = `Contact-${uniqueSuffix()}@acme.test`;
+
+    const id1 = await withSystemDbAccessContext(() => findOrCreateEmailContact(org.id, email, 'Acme Bob'));
+    const id2 = await withSystemDbAccessContext(() => findOrCreateEmailContact(org.id, email.toUpperCase(), 'Acme Bob'));
+    expect(id1).toBe(id2);
+
+    const adminDb = getTestDb() as any;
+    const [row] = await adminDb
+      .select({ passwordHash: portalUsers.passwordHash, email: portalUsers.email })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, id1));
+    expect(row.passwordHash).toBeNull();
+    expect(row.email).toBe(email.toLowerCase());
+  });
+});
+
+describe('loadPartnerInboundPolicy', () => {
+  it('reads triage flags from partners.settings JSONB, defaulting absent to off', async () => {
+    const { p } = await seedPartnerOrg();
+    const defaults = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
+    expect(defaults).toEqual({ triageUnknownSenders: false, defaultTriageOrgId: null });
+
+    const adminDb = getTestDb() as any;
+    await adminDb
+      .update(partners)
+      .set({ settings: { ticketing: { inbound: { triageUnknownSenders: true, defaultTriageOrgId: 'org-triage' } } } })
+      .where(eq(partners.id, p.id));
+
+    const set = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
+    expect(set).toEqual({ triageUnknownSenders: true, defaultTriageOrgId: 'org-triage' });
+  });
+});

--- a/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
+++ b/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
@@ -76,6 +76,25 @@ describe('resolveOrgBySenderDomain', () => {
     const r = await withSystemDbAccessContext(() => resolveOrgBySenderDomain('garbage', p.id));
     expect(r).toBeNull();
   });
+
+  it('scopes by partner_id — the same domain under partner B is invisible to partner A', async () => {
+    // Runs in SYSTEM scope (RLS bypassed for the worker), so the partner_id
+    // predicate in the query is the ONLY tenant boundary. Prove it: map the same
+    // domain under two partners and confirm A resolves to A's org, not B's.
+    const a = await seedPartnerOrg();
+    const b = await seedPartnerOrg();
+    const domain = `shared-${uniqueSuffix()}.test`;
+    await withSystemDbAccessContext(async () => {
+      await db.insert(customerEmailDomains).values({ partnerId: a.p.id, orgId: a.org.id, domain });
+      await db.insert(customerEmailDomains).values({ partnerId: b.p.id, orgId: b.org.id, domain });
+    });
+
+    const ra = await withSystemDbAccessContext(() => resolveOrgBySenderDomain(`x@${domain}`, a.p.id));
+    const rb = await withSystemDbAccessContext(() => resolveOrgBySenderDomain(`x@${domain}`, b.p.id));
+    expect(ra?.orgId).toBe(a.org.id);
+    expect(rb?.orgId).toBe(b.org.id);
+    expect(ra?.orgId).not.toBe(b.org.id);
+  });
 });
 
 describe('findOrCreateEmailContact', () => {

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -94,6 +94,11 @@ const ORG_AXIS_POLICY_EXCLUDED_TABLES: ReadonlySet<string> = new Set<string>([
   'pax8_company_mappings',
   'pax8_subscription_snapshots',
   'pax8_contract_line_links',
+  // customer_email_domains (Phase 5): partner-axis (Shape 3) carrying a
+  // denormalized org_id (the routing target). RLS axis is partner_id; the
+  // org_id is for routing + cascade only. Functional cross-partner/cross-org
+  // forge proof: customerEmailDomainsRls.integration.test.ts.
+  'customer_email_domains',
 ]);
 
 // Tables whose own `id` column is the tenant identifier (no `org_id`).
@@ -144,6 +149,11 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   // Functional cross-partner forge proof: emailInboundRls.integration.test.ts.
   ['ticket_email_inbound', 'partner_id'],
   ['partner_inbound_domains', 'partner_id'],
+  // customer_email_domains (Phase 5): sender-domain -> customer-org routing.
+  // Partner-axis + denormalized org_id (also in ORG_AXIS_POLICY_EXCLUDED_TABLES).
+  // Policy: breeze_current_scope()='system' OR breeze_has_partner_access(partner_id).
+  // Functional forge: customerEmailDomainsRls.integration.test.ts.
+  ['customer_email_domains', 'partner_id'],
   // Stripe payments (2026-06-15): one connected Stripe account per partner
   // (RLS shape 3, flat breeze_has_partner_access(partner_id)). The sibling
   // invoice_stripe_payments table carries a direct org_id column and is

--- a/apps/api/src/db/schema/emailInbound.ts
+++ b/apps/api/src/db/schema/emailInbound.ts
@@ -1,6 +1,7 @@
-import { pgTable, uuid, text, varchar, timestamp, jsonb, uniqueIndex, index } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, varchar, timestamp, jsonb, boolean, uniqueIndex, index } from 'drizzle-orm/pg-core';
 import { partners } from './orgs';
 import { tickets } from './portal';
+import { users } from './users';
 
 // Shape 3 (partner-axis). Audit trail + dead-letter/review queue for inbound mail.
 // partner_id is nullable: rows whose recipient resolves to no partner are logged
@@ -40,4 +41,23 @@ export const partnerInboundDomains = pgTable('partner_inbound_domains', {
 }, (t) => [
   uniqueIndex('partner_inbound_domains_domain_uq').on(t.domain),
   index('partner_inbound_domains_partner_idx').on(t.partnerId)
+]);
+
+// Phase 5: sender-domain -> customer-org routing for email-to-ticket.
+// Shape 3 (partner-axis) + denormalized org_id. The composite FK
+// (org_id, partner_id) -> organizations(id, partner_id) is enforced in SQL only
+// (Drizzle references() is single-column); see the 2026-06-20-a migration.
+export const customerEmailDomains = pgTable('customer_email_domains', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  orgId: uuid('org_id').notNull(),
+  domain: varchar('domain', { length: 255 }).notNull(),
+  autoCreateContact: boolean('auto_create_contact').notNull().default(true),
+  isActive: boolean('is_active').notNull().default(true),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (t) => [
+  uniqueIndex('customer_email_domains_partner_domain_uq').on(t.partnerId, t.domain),
+  index('customer_email_domains_lookup_idx').on(t.partnerId, t.isActive)
 ]);

--- a/apps/api/src/routes/ticketConfig.test.ts
+++ b/apps/api/src/routes/ticketConfig.test.ts
@@ -10,6 +10,10 @@ const { serviceMocks, authRef, permsRef } = vi.hoisted(() => ({
     listEmailInboundQueue: vi.fn(),
     convertEmailInbound: vi.fn(),
     dismissEmailInbound: vi.fn(),
+    listCustomerEmailDomains: vi.fn(),
+    createCustomerEmailDomain: vi.fn(),
+    updateCustomerEmailDomain: vi.fn(),
+    deleteCustomerEmailDomain: vi.fn(),
   },
   authRef: {
     current: {
@@ -274,5 +278,108 @@ describe('PATCH /ticket-config/email-inbound/:id/dismiss', () => {
     serviceMocks.dismissEmailInbound.mockRejectedValue(new TicketConfigServiceError('done', 409, 'INBOUND_ROW_ALREADY_RESOLVED'));
     const res = await ticketConfigRoutes.request(`/email-inbound/${INBOUND_ID}/dismiss`, { method: 'PATCH' });
     expect(res.status).toBe(409);
+  });
+});
+
+describe('inbound-domains routes (Phase 5)', () => {
+  const ORG_ID = 'aaaaaaaa-1111-4222-8333-444455556666';
+  const MAP_ID = 'bbbbbbbb-1111-4222-8333-444455556666';
+
+  it('GET 403 for a non-admin', async () => {
+    const res = await ticketConfigRoutes.request('/inbound-domains');
+    expect(res.status).toBe(403);
+  });
+
+  it('GET 200 lists mappings for an admin', async () => {
+    permsRef.current = ADMIN_PERMS;
+    serviceMocks.listCustomerEmailDomains.mockResolvedValue([
+      { id: MAP_ID, domain: 'acme.com', orgId: ORG_ID, orgName: 'ACME', autoCreateContact: true, isActive: true },
+    ]);
+    const res = await ticketConfigRoutes.request('/inbound-domains');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [{ id: MAP_ID, domain: 'acme.com', orgId: ORG_ID, orgName: 'ACME', autoCreateContact: true, isActive: true }] });
+    expect(serviceMocks.listCustomerEmailDomains).toHaveBeenCalledWith('p-1');
+  });
+
+  it('POST 403 for a non-admin', async () => {
+    const res = await ticketConfigRoutes.request('/inbound-domains', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain: 'acme.com', orgId: ORG_ID }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('POST 200 creates a mapping for an admin', async () => {
+    permsRef.current = ADMIN_PERMS;
+    serviceMocks.createCustomerEmailDomain.mockResolvedValue({ id: MAP_ID, domain: 'acme.com' });
+    const res = await ticketConfigRoutes.request('/inbound-domains', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain: 'ACME.com', orgId: ORG_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { id: MAP_ID, domain: 'acme.com' } });
+    // domain lowercased by the validator; actor.userId threaded from auth.
+    expect(serviceMocks.createCustomerEmailDomain).toHaveBeenCalledWith(
+      'p-1',
+      expect.objectContaining({ domain: 'acme.com', orgId: ORG_ID }),
+      { userId: 'u-1' },
+    );
+  });
+
+  it('POST 400 for a freemail domain (validator rejects before the service)', async () => {
+    permsRef.current = ADMIN_PERMS;
+    const res = await ticketConfigRoutes.request('/inbound-domains', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain: 'gmail.com', orgId: ORG_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect(serviceMocks.createCustomerEmailDomain).not.toHaveBeenCalled();
+  });
+
+  it('POST maps ORG_NOT_ACCESSIBLE to 400 (cross-partner org IDOR)', async () => {
+    permsRef.current = ADMIN_PERMS;
+    serviceMocks.createCustomerEmailDomain.mockRejectedValue(
+      new TicketConfigServiceError('That organization is not in your partner', 400, 'ORG_NOT_ACCESSIBLE'),
+    );
+    const res = await ticketConfigRoutes.request('/inbound-domains', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain: 'acme.com', orgId: ORG_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: 'ORG_NOT_ACCESSIBLE' });
+  });
+
+  it('PATCH maps a not-found mapping to 404', async () => {
+    permsRef.current = ADMIN_PERMS;
+    serviceMocks.updateCustomerEmailDomain.mockRejectedValue(
+      new TicketConfigServiceError('Domain mapping not found', 404, 'DOMAIN_MAPPING_NOT_FOUND'),
+    );
+    const res = await ticketConfigRoutes.request(`/inbound-domains/${MAP_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isActive: false }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE 200 for an admin', async () => {
+    permsRef.current = ADMIN_PERMS;
+    serviceMocks.deleteCustomerEmailDomain.mockResolvedValue(undefined);
+    const res = await ticketConfigRoutes.request(`/inbound-domains/${MAP_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(serviceMocks.deleteCustomerEmailDomain).toHaveBeenCalledWith('p-1', MAP_ID);
+  });
+
+  it('DELETE maps a not-found mapping to 404', async () => {
+    permsRef.current = ADMIN_PERMS;
+    serviceMocks.deleteCustomerEmailDomain.mockRejectedValue(
+      new TicketConfigServiceError('Domain mapping not found', 404, 'DOMAIN_MAPPING_NOT_FOUND'),
+    );
+    const res = await ticketConfigRoutes.request(`/inbound-domains/${MAP_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/api/src/routes/ticketConfig.ts
+++ b/apps/api/src/routes/ticketConfig.ts
@@ -7,12 +7,14 @@ import type { AuthContext } from '../middleware/auth';
 import { PERMISSIONS, hasPermission, type UserPermissions } from '../services/permissions';
 import {
   createTicketStatusSchema, updateTicketStatusSchema, reorderTicketStatusesSchema,
-  prioritySettingsSchema
+  prioritySettingsSchema,
+  createCustomerEmailDomainSchema, updateCustomerEmailDomainSchema
 } from '@breeze/shared';
 import {
   getTicketConfig, createTicketStatus, updateTicketStatus, reorderTicketStatuses,
   upsertPrioritySettings, TicketConfigServiceError,
   listEmailInboundQueue, convertEmailInbound, dismissEmailInbound,
+  listCustomerEmailDomains, createCustomerEmailDomain, updateCustomerEmailDomain, deleteCustomerEmailDomain,
 } from '../services/ticketConfigService';
 
 export const ticketConfigRoutes = new Hono();
@@ -112,6 +114,53 @@ ticketConfigRoutes.patch('/email-inbound/:id/dismiss', scopes, writePerm, adminM
     const { id } = c.req.valid('param');
     const row = await dismissEmailInbound(partnerId, id);
     return c.json({ data: row });
+  } catch (err) {
+    return handleServiceError(c, err);
+  }
+});
+
+// --- Phase 5: customer email-domain routing (sender domain -> customer org) ---
+
+// GET /inbound-domains — list this partner's sender-domain mappings (joined org name).
+ticketConfigRoutes.get('/inbound-domains', scopes, readPerm, adminMiddleware, async (c) => {
+  const partnerId = requirePartnerId(c);
+  if (partnerId instanceof Response) return partnerId;
+  const data = await listCustomerEmailDomains(partnerId);
+  return c.json({ data });
+});
+
+// POST /inbound-domains — map a customer sender domain to one of the partner's orgs.
+ticketConfigRoutes.post('/inbound-domains', scopes, writePerm, adminMiddleware, zValidator('json', createCustomerEmailDomainSchema), async (c) => {
+  const partnerId = requirePartnerId(c);
+  if (partnerId instanceof Response) return partnerId;
+  const auth = c.get('auth') as AuthContext;
+  try {
+    const row = await createCustomerEmailDomain(partnerId, c.req.valid('json'), { userId: auth.user.id });
+    return c.json({ data: row });
+  } catch (err) {
+    return handleServiceError(c, err);
+  }
+});
+
+// PATCH /inbound-domains/:id — update org/auto-create/active for a mapping.
+ticketConfigRoutes.patch('/inbound-domains/:id', scopes, writePerm, adminMiddleware, zValidator('param', idParam), zValidator('json', updateCustomerEmailDomainSchema), async (c) => {
+  const partnerId = requirePartnerId(c);
+  if (partnerId instanceof Response) return partnerId;
+  try {
+    const row = await updateCustomerEmailDomain(partnerId, c.req.valid('param').id, c.req.valid('json'));
+    return c.json({ data: row });
+  } catch (err) {
+    return handleServiceError(c, err);
+  }
+});
+
+// DELETE /inbound-domains/:id — remove a mapping.
+ticketConfigRoutes.delete('/inbound-domains/:id', scopes, writePerm, adminMiddleware, zValidator('param', idParam), async (c) => {
+  const partnerId = requirePartnerId(c);
+  if (partnerId instanceof Response) return partnerId;
+  try {
+    await deleteCustomerEmailDomain(partnerId, c.req.valid('param').id);
+    return c.json({ data: { ok: true } });
   } catch (err) {
     return handleServiceError(c, err);
   }

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -148,6 +148,19 @@ vi.mock('../../config/validate', () => ({ getConfig: () => ({ TICKETS_INBOUND_DO
 const { resolveMock } = vi.hoisted(() => ({ resolveMock: vi.fn() }));
 vi.mock('./resolvePartner', () => ({ resolvePartnerByRecipient: resolveMock }));
 
+// Phase 5: sender-domain routing helpers. Mocked so the dispatch-precedence
+// tests don't hit the DB — resolveOrg has its own integration suite.
+const { resolveOrgMock, findOrCreateContactMock, loadPolicyMock } = vi.hoisted(() => ({
+  resolveOrgMock: vi.fn(),
+  findOrCreateContactMock: vi.fn(),
+  loadPolicyMock: vi.fn()
+}));
+vi.mock('./resolveOrg', () => ({
+  resolveOrgBySenderDomain: resolveOrgMock,
+  findOrCreateEmailContact: findOrCreateContactMock,
+  loadPartnerInboundPolicy: loadPolicyMock
+}));
+
 const { createTicketMock, changeStatusMock } = vi.hoisted(() => ({
   createTicketMock: vi.fn(),
   changeStatusMock: vi.fn()
@@ -208,6 +221,13 @@ beforeEach(() => {
   maybeSendAutoresponseMock.mockReset();
   captureExceptionMock.mockReset();
   createTicketMock.mockResolvedValue({ id: 't-new', internalNumber: 'T-2026-0009' });
+  // Phase 5 default: no sender-domain mapping, triage off — so an unmatched
+  // unknown sender still quarantines (preserves the pre-Phase-5 behavior).
+  resolveOrgMock.mockReset();
+  resolveOrgMock.mockResolvedValue(null);
+  findOrCreateContactMock.mockReset();
+  loadPolicyMock.mockReset();
+  loadPolicyMock.mockResolvedValue({ triageUnknownSenders: false, defaultTriageOrgId: null });
 });
 
 describe('processInboundEmail', () => {
@@ -729,5 +749,86 @@ describe('processInboundEmail', () => {
     const log = inboundOf();
     expect(log[0]!.parseStatus).toBe('matched');
     expect(log[0]!.ticketId).toBe('t-1');
+  });
+});
+
+describe('processInboundEmail — Phase 5 sender-domain routing', () => {
+  beforeEach(() => {
+    // Verified sender, no dup, no thread/closed match, NOT a known portal user
+    // -> falls through to the new domain/triage/quarantine precedence.
+    state.selectRows['ticket_email_inbound'] = [];
+    state.selectRows['tickets'] = [];
+    state.selectRows['portal_users'] = [];
+    resolveMock.mockResolvedValue('p-1');
+    resolveOrgMock.mockReset();
+    findOrCreateContactMock.mockReset();
+    loadPolicyMock.mockReset();
+    // Safe defaults: no domain match, triage off.
+    resolveOrgMock.mockResolvedValue(null);
+    loadPolicyMock.mockResolvedValue({ triageUnknownSenders: false, defaultTriageOrgId: null });
+  });
+
+  it('routes a mapped domain (autoCreateContact true) -> creates ticket in the org + onboards a contact', async () => {
+    state.selectRows['organizations'] = [{ id: 'o-9' }];
+    resolveOrgMock.mockResolvedValue({ orgId: 'o-9', autoCreateContact: true });
+    findOrCreateContactMock.mockResolvedValue('pu-auto');
+    createTicketMock.mockResolvedValue({ id: 't-d', internalNumber: 'T-2026-0099' });
+
+    await processInboundEmail(email());
+
+    expect(findOrCreateContactMock).toHaveBeenCalledWith('o-9', 'jane@customer.com', 'Jane Doe');
+    expect(createTicketMock).toHaveBeenCalledTimes(1);
+    const input = createTicketMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(input.orgId).toBe('o-9');
+    expect(input.submittedBy).toBe('pu-auto');
+    expect(inboundOf()[0]!.parseStatus).toBe('created');
+  });
+
+  it('routes a mapped domain (autoCreateContact false) -> creates ticket, NO contact onboarding', async () => {
+    state.selectRows['organizations'] = [{ id: 'o-9' }];
+    resolveOrgMock.mockResolvedValue({ orgId: 'o-9', autoCreateContact: false });
+    createTicketMock.mockResolvedValue({ id: 't-d', internalNumber: 'T-2026-0099' });
+
+    await processInboundEmail(email());
+
+    expect(findOrCreateContactMock).not.toHaveBeenCalled();
+    const input = createTicketMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(input.orgId).toBe('o-9');
+    expect(input.submittedBy ?? null).toBeNull();
+    expect(inboundOf()[0]!.parseStatus).toBe('created');
+  });
+
+  it('falls back to the triage org when enabled and no domain matches (no contact onboarding)', async () => {
+    state.selectRows['organizations'] = [{ id: 'o-triage' }];
+    resolveOrgMock.mockResolvedValue(null);
+    loadPolicyMock.mockResolvedValue({ triageUnknownSenders: true, defaultTriageOrgId: 'o-triage' });
+    createTicketMock.mockResolvedValue({ id: 't-t', internalNumber: 'T-2026-0100' });
+
+    await processInboundEmail(email());
+
+    expect(findOrCreateContactMock).not.toHaveBeenCalled();
+    const input = createTicketMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(input.orgId).toBe('o-triage');
+    expect(inboundOf()[0]!.parseStatus).toBe('created');
+  });
+
+  it('quarantines when nothing matches and triage is disabled', async () => {
+    resolveOrgMock.mockResolvedValue(null);
+    loadPolicyMock.mockResolvedValue({ triageUnknownSenders: false, defaultTriageOrgId: null });
+
+    await processInboundEmail(email());
+
+    expect(createTicketMock).not.toHaveBeenCalled();
+    expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
+  });
+
+  it('does NOT reach domain routing for an unverified sender (existing DMARC gate wins)', async () => {
+    resolveOrgMock.mockResolvedValue({ orgId: 'o-9', autoCreateContact: true });
+
+    await processInboundEmail(email({ senderAuth: { spf: 'fail', dkim: 'fail', dmarc: 'fail', verified: false } }));
+
+    expect(resolveOrgMock).not.toHaveBeenCalled();
+    expect(createTicketMock).not.toHaveBeenCalled();
+    expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
   });
 });

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -831,4 +831,22 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
     expect(createTicketMock).not.toHaveBeenCalled();
     expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
   });
+
+  it('a known portal user WINS over a domain mapping (precedence #5 before #6)', async () => {
+    // Both signals match: the sender is a known portal user in org o-known AND
+    // their domain maps to a different org o-domain. The portal-user branch is
+    // most-specific and must win — the domain resolver must not even be consulted.
+    state.selectRows['portal_users'] = [{ id: 'pu-known', orgId: 'o-known' }];
+    state.selectRows['organizations'] = [{ id: 'o-known' }];
+    resolveOrgMock.mockResolvedValue({ orgId: 'o-domain', autoCreateContact: true });
+    createTicketMock.mockResolvedValue({ id: 't-k', internalNumber: 'T-2026-0101' });
+
+    await processInboundEmail(email());
+
+    expect(resolveOrgMock).not.toHaveBeenCalled();
+    expect(findOrCreateContactMock).not.toHaveBeenCalled();
+    const input = createTicketMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(input.orgId).toBe('o-known');
+    expect(input.submittedBy).toBe('pu-known');
+  });
 });

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -3,6 +3,7 @@ import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { ticketEmailInbound, tickets, ticketComments, portalUsers, organizations, partners } from '../../db/schema';
 import { createTicket } from '../ticketService';
 import { resolvePartnerByRecipient } from './resolvePartner';
+import { resolveOrgBySenderDomain, findOrCreateEmailContact, loadPartnerInboundPolicy } from './resolveOrg';
 import { maybeSendAutoresponse } from './autoresponder';
 import { emitTicketEvent } from '../ticketEvents';
 import { captureException } from '../sentry';
@@ -205,14 +206,42 @@ export async function processInboundEmail(n: NormalizedInboundEmail): Promise<vo
       return;
     }
 
-    // (5)/(6) Unmatched: known portal-user sender -> create; unknown -> quarantine.
+    // (5) Known portal-user sender -> their home org. Most specific; wins over
+    // domain rules (a user who belongs to a sub-org isn't overridden by a
+    // broader domain mapping).
     const sender = await findPortalUserInPartner(n.from, partnerId);
-    if (!sender) {
-      await logInbound(n, partnerId, 'quarantined', null);
+    if (sender) {
+      const t = await createFromEmail(n, partnerId, sender.orgId, null, null, sender.id);
+      await logInbound(n, partnerId, 'created', t.id);
       return;
     }
-    const t = await createFromEmail(n, partnerId, sender.orgId, null, null, sender.id);
-    await logInbound(n, partnerId, 'created', t.id);
+
+    // (6) Sender domain mapped to a customer org (Phase 5) -> ALWAYS create the
+    // ticket; optionally onboard a password-less contact so future replies
+    // thread + attribute. This sits behind the senderAuth.verified (DMARC) gate
+    // above, so a forged From: @customer.com can't file into the customer's org.
+    const domainMatch = await resolveOrgBySenderDomain(n.from, partnerId);
+    if (domainMatch) {
+      const submittedBy = domainMatch.autoCreateContact
+        ? await findOrCreateEmailContact(domainMatch.orgId, n.from, n.fromName ?? null)
+        : null;
+      const t = await createFromEmail(n, partnerId, domainMatch.orgId, null, null, submittedBy);
+      await logInbound(n, partnerId, 'created', t.id);
+      return;
+    }
+
+    // (7) Triage fallback for unknown senders, only if the partner opted in
+    // (settings.ticketing.inbound). No contact is onboarded — the customer is
+    // unknown. Default-off: absent settings keep the Phase 4 quarantine behavior.
+    const policy = await loadPartnerInboundPolicy(partnerId);
+    if (policy.triageUnknownSenders && policy.defaultTriageOrgId) {
+      const t = await createFromEmail(n, partnerId, policy.defaultTriageOrgId, null, null, null);
+      await logInbound(n, partnerId, 'created', t.id);
+      return;
+    }
+
+    // (8) Nothing matched -> quarantine for manual review.
+    await logInbound(n, partnerId, 'quarantined', null);
   } catch (err) {
     // (7) Any guard/error -> failed, logged under the RESOLVED partner (or null if
     // resolution failed). Never a cross-tenant write.

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -224,7 +224,7 @@ export async function processInboundEmail(n: NormalizedInboundEmail): Promise<vo
     if (domainMatch) {
       const submittedBy = domainMatch.autoCreateContact
         ? await findOrCreateEmailContact(domainMatch.orgId, n.from, n.fromName ?? null)
-        : null;
+        : undefined;
       const t = await createFromEmail(n, partnerId, domainMatch.orgId, null, null, submittedBy);
       await logInbound(n, partnerId, 'created', t.id);
       return;
@@ -235,7 +235,7 @@ export async function processInboundEmail(n: NormalizedInboundEmail): Promise<vo
     // unknown. Default-off: absent settings keep the Phase 4 quarantine behavior.
     const policy = await loadPartnerInboundPolicy(partnerId);
     if (policy.triageUnknownSenders && policy.defaultTriageOrgId) {
-      const t = await createFromEmail(n, partnerId, policy.defaultTriageOrgId, null, null, null);
+      const t = await createFromEmail(n, partnerId, policy.defaultTriageOrgId, null, null);
       await logInbound(n, partnerId, 'created', t.id);
       return;
     }

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -243,7 +243,7 @@ export async function processInboundEmail(n: NormalizedInboundEmail): Promise<vo
     // (8) Nothing matched -> quarantine for manual review.
     await logInbound(n, partnerId, 'quarantined', null);
   } catch (err) {
-    // (7) Any guard/error -> failed, logged under the RESOLVED partner (or null if
+    // (9) Any guard/error -> failed, logged under the RESOLVED partner (or null if
     // resolution failed). Never a cross-tenant write.
     //
     // The outer work transaction is now poisoned (25P02): we CANNOT log on it. Record

--- a/apps/api/src/services/inboundEmail/resolveOrg.ts
+++ b/apps/api/src/services/inboundEmail/resolveOrg.ts
@@ -57,7 +57,7 @@ export async function findOrCreateEmailContact(
     .insert(portalUsers)
     .values({ orgId, email: lower, name, passwordHash: null, authMethod: 'password', status: 'active' })
     .returning({ id: portalUsers.id });
-  return inserted[0].id;
+  return inserted[0]!.id;
 }
 
 /**

--- a/apps/api/src/services/inboundEmail/resolveOrg.ts
+++ b/apps/api/src/services/inboundEmail/resolveOrg.ts
@@ -14,6 +14,11 @@ function domainOf(address: string): string | null {
 /**
  * Resolve a sender's email domain to a mapped customer org (Phase 5).
  * Read-only; caller is in system context (the inbound worker).
+ *
+ * Matches the EXACT sender domain only — `bob@mail.acme.com` does NOT match an
+ * `acme.com` mapping (it falls through to triage/quarantine). This is deliberate:
+ * a suffix match would route arbitrary subdomains the MSP never vetted into the org.
+ * Do not "fix" this into an endsWith() match.
  */
 export async function resolveOrgBySenderDomain(
   fromAddress: string,
@@ -40,6 +45,14 @@ export async function resolveOrgBySenderDomain(
  * contact for attribution + future thread matching. A null passwordHash is
  * inherently non-login (mirrors the Entra path's password-less rows); this is
  * NOT an auth-capable account. Returns the portal user id.
+ *
+ * SELECT-then-INSERT is not atomic and `portal_users` has no (org_id, email)
+ * unique index (the login path already tolerates duplicates — see
+ * portal/auth.ts). The inbound worker processes one message per transaction, so
+ * the only way to double-insert is two distinct first-time emails from the SAME
+ * new sender arriving concurrently — rare, and the dup is benign (both rows point
+ * at the same org; attribution binds to one). A real fix is a partial unique index
+ * on portal_users, which is a broader, auth-table change tracked separately.
  */
 export async function findOrCreateEmailContact(
   orgId: string,

--- a/apps/api/src/services/inboundEmail/resolveOrg.ts
+++ b/apps/api/src/services/inboundEmail/resolveOrg.ts
@@ -1,0 +1,84 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { customerEmailDomains, partners } from '../../db/schema';
+import { portalUsers } from '../../db/schema/portal';
+
+/** Lowercased domain part of an email address, or null if malformed. */
+function domainOf(address: string): string | null {
+  const at = address.lastIndexOf('@');
+  if (at < 0) return null;
+  const domain = address.slice(at + 1).trim().toLowerCase();
+  return domain || null;
+}
+
+/**
+ * Resolve a sender's email domain to a mapped customer org (Phase 5).
+ * Read-only; caller is in system context (the inbound worker).
+ */
+export async function resolveOrgBySenderDomain(
+  fromAddress: string,
+  partnerId: string,
+): Promise<{ orgId: string; autoCreateContact: boolean } | null> {
+  const domain = domainOf(fromAddress);
+  if (!domain) return null;
+  const rows = await db
+    .select({ orgId: customerEmailDomains.orgId, autoCreateContact: customerEmailDomains.autoCreateContact })
+    .from(customerEmailDomains)
+    .where(
+      and(
+        eq(customerEmailDomains.partnerId, partnerId),
+        eq(customerEmailDomains.domain, domain),
+        eq(customerEmailDomains.isActive, true),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Find an existing portal user by (org, email) or create a password-less
+ * contact for attribution + future thread matching. A null passwordHash is
+ * inherently non-login (mirrors the Entra path's password-less rows); this is
+ * NOT an auth-capable account. Returns the portal user id.
+ */
+export async function findOrCreateEmailContact(
+  orgId: string,
+  email: string,
+  name: string | null,
+): Promise<string> {
+  const lower = email.toLowerCase();
+  const existing = await db
+    .select({ id: portalUsers.id })
+    .from(portalUsers)
+    .where(and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, lower)))
+    .limit(1);
+  if (existing[0]) return existing[0].id;
+  const inserted = await db
+    .insert(portalUsers)
+    .values({ orgId, email: lower, name, passwordHash: null, authMethod: 'password', status: 'active' })
+    .returning({ id: portalUsers.id });
+  return inserted[0].id;
+}
+
+/**
+ * Read the partner's inbound triage policy from partners.settings JSONB
+ * (settings.ticketing.inbound). Absent fields read as disabled.
+ */
+export async function loadPartnerInboundPolicy(
+  partnerId: string,
+): Promise<{ triageUnknownSenders: boolean; defaultTriageOrgId: string | null }> {
+  const rows = await db
+    .select({ settings: partners.settings })
+    .from(partners)
+    .where(eq(partners.id, partnerId))
+    .limit(1);
+  const settings = (rows[0]?.settings ?? {}) as Record<string, unknown>;
+  const inbound =
+    (((settings.ticketing as Record<string, unknown> | undefined)?.inbound) as
+      | { defaultTriageOrgId?: string | null; triageUnknownSenders?: boolean }
+      | undefined) ?? {};
+  return {
+    triageUnknownSenders: inbound.triageUnknownSenders === true,
+    defaultTriageOrgId: inbound.defaultTriageOrgId ?? null,
+  };
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -122,6 +122,9 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'contract_lines',
   'contracts',
   'custom_field_definitions',
+  // NB: sorts AFTER custom_field_definitions — localeCompare puts the '_' in
+  // 'custom_field' before the 'e' in 'customer' (the prefix-extension trap).
+  'customer_email_domains',
   'delegant_m365_connections',
   'deployment_invites',
   'deployments',

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -1,7 +1,7 @@
 // Owns ticketing configuration: custom statuses, priority SLA settings, and org-level overrides — per 2026-06-12 spec.
 
 import { eq, and, asc, desc, inArray, count } from 'drizzle-orm';
-import { ticketStatuses, ticketPrioritySettings, orgTicketSettings, partners, ticketEmailInbound, organizations } from '../db/schema';
+import { ticketStatuses, ticketPrioritySettings, orgTicketSettings, partners, ticketEmailInbound, organizations, customerEmailDomains } from '../db/schema';
 import { ticketStatusEnum } from '../db/schema/portal';
 import { getConfig } from '../config/validate';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
@@ -9,7 +9,8 @@ import { createTicket, type TicketActor } from './ticketService';
 import { isPgUniqueViolation } from '../utils/pgErrors';
 import type {
   CreateTicketStatusInput, UpdateTicketStatusInput, PrioritySettingsInput,
-  OrgTicketSettingsInput, TicketPriorityValue
+  OrgTicketSettingsInput, TicketPriorityValue,
+  CreateCustomerEmailDomainInput, UpdateCustomerEmailDomainInput
 } from '@breeze/shared';
 import type { TicketSlaPriority } from './ticketSla';
 
@@ -361,7 +362,7 @@ export async function getTicketConfig(partnerId: string) {
   const slug = partner?.slug ?? '';
   const settings = (partner?.settings as Record<string, unknown> | null) ?? {};
   const inboundCfg = (((settings.ticketing as Record<string, unknown> | undefined)?.inbound) as
-    { enabled?: boolean; address?: string; defaultTriageOrgId?: string | null; autoresponderEnabled?: boolean } | undefined) ?? {};
+    { enabled?: boolean; address?: string; defaultTriageOrgId?: string | null; autoresponderEnabled?: boolean; triageUnknownSenders?: boolean } | undefined) ?? {};
   const domain = getConfig().TICKETS_INBOUND_DOMAIN ?? '';
   const domainConfigured = domain.length > 0;
   const derived = domainConfigured && slug ? `${slug}@${domain}` : '';
@@ -373,6 +374,7 @@ export async function getTicketConfig(partnerId: string) {
     addressOverride,
     defaultTriageOrgId: inboundCfg.defaultTriageOrgId ?? null,
     autoresponderEnabled: inboundCfg.autoresponderEnabled ?? true,
+    triageUnknownSenders: inboundCfg.triageUnknownSenders ?? false,
     slug,
     domainConfigured,
   };
@@ -782,4 +784,93 @@ export async function dismissEmailInbound(partnerId: string, id: string): Promis
     .returning(returnQueueCols());
   if (!updated) throw new TicketConfigServiceError('Inbound email not found', 404, 'INBOUND_ROW_NOT_FOUND');
   return updated;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5: customer email-domain routing (sender domain -> customer org).
+// Partner-admin managed. Org-ownership is enforced both here (explicit
+// partner_id equality, mirroring convertEmailInbound) and at the DB layer via
+// the composite FK (org_id, partner_id) -> organizations(id, partner_id).
+// ---------------------------------------------------------------------------
+
+export async function listCustomerEmailDomains(partnerId: string) {
+  return db
+    .select({
+      id: customerEmailDomains.id,
+      domain: customerEmailDomains.domain,
+      orgId: customerEmailDomains.orgId,
+      orgName: organizations.name,
+      autoCreateContact: customerEmailDomains.autoCreateContact,
+      isActive: customerEmailDomains.isActive,
+      createdAt: customerEmailDomains.createdAt,
+    })
+    .from(customerEmailDomains)
+    .leftJoin(organizations, eq(customerEmailDomains.orgId, organizations.id))
+    .where(eq(customerEmailDomains.partnerId, partnerId))
+    .orderBy(asc(customerEmailDomains.domain));
+}
+
+export async function createCustomerEmailDomain(
+  partnerId: string,
+  input: CreateCustomerEmailDomainInput,
+  actor: { userId: string },
+) {
+  // Security boundary: the mapped org MUST belong to the caller's partner.
+  const [orgOk] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(and(eq(organizations.id, input.orgId), eq(organizations.partnerId, partnerId)))
+    .limit(1);
+  if (!orgOk) throw new TicketConfigServiceError('That organization is not in your partner', 400, 'ORG_NOT_ACCESSIBLE');
+
+  try {
+    const [row] = await db
+      .insert(customerEmailDomains)
+      .values({
+        partnerId,
+        orgId: input.orgId,
+        domain: input.domain,
+        autoCreateContact: input.autoCreateContact,
+        createdBy: actor.userId,
+      })
+      .returning();
+    return row;
+  } catch (err) {
+    if (isPgUniqueViolation(err)) {
+      throw new TicketConfigServiceError('That domain is already mapped', 409, 'DOMAIN_ALREADY_MAPPED');
+    }
+    throw err;
+  }
+}
+
+export async function updateCustomerEmailDomain(
+  partnerId: string,
+  id: string,
+  input: UpdateCustomerEmailDomainInput,
+) {
+  // Re-assert org ownership if the mapping is being re-pointed at another org.
+  if (input.orgId) {
+    const [orgOk] = await db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(and(eq(organizations.id, input.orgId), eq(organizations.partnerId, partnerId)))
+      .limit(1);
+    if (!orgOk) throw new TicketConfigServiceError('That organization is not in your partner', 400, 'ORG_NOT_ACCESSIBLE');
+  }
+
+  const [updated] = await db
+    .update(customerEmailDomains)
+    .set({ ...input, updatedAt: new Date() })
+    .where(and(eq(customerEmailDomains.id, id), eq(customerEmailDomains.partnerId, partnerId)))
+    .returning();
+  if (!updated) throw new TicketConfigServiceError('Domain mapping not found', 404, 'DOMAIN_MAPPING_NOT_FOUND');
+  return updated;
+}
+
+export async function deleteCustomerEmailDomain(partnerId: string, id: string) {
+  const [deleted] = await db
+    .delete(customerEmailDomains)
+    .where(and(eq(customerEmailDomains.id, id), eq(customerEmailDomains.partnerId, partnerId)))
+    .returning({ id: customerEmailDomains.id });
+  if (!deleted) throw new TicketConfigServiceError('Domain mapping not found', 404, 'DOMAIN_MAPPING_NOT_FOUND');
 }

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -280,7 +280,9 @@ export type TicketConfigServiceErrorCode =
   | 'INBOUND_ROW_NOT_FOUND'
   | 'INBOUND_ROW_ALREADY_RESOLVED'
   | 'INBOUND_ROW_NO_SENDER'
-  | 'ORG_NOT_ACCESSIBLE';
+  | 'ORG_NOT_ACCESSIBLE'
+  | 'DOMAIN_ALREADY_MAPPED'
+  | 'DOMAIN_MAPPING_NOT_FOUND';
 
 export class TicketConfigServiceError extends Error {
   constructor(message: string, public status: 400 | 404 | 409 = 400, public code?: TicketConfigServiceErrorCode) {
@@ -834,7 +836,7 @@ export async function createCustomerEmailDomain(
         createdBy: actor.userId,
       })
       .returning();
-    return row;
+    return row!;
   } catch (err) {
     if (isPgUniqueViolation(err)) {
       throw new TicketConfigServiceError('That domain is already mapped', 409, 'DOMAIN_ALREADY_MAPPED');

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -838,7 +838,9 @@ export async function createCustomerEmailDomain(
       .returning();
     return row!;
   } catch (err) {
-    if (isPgUniqueViolation(err)) {
+    // Pin the constraint name (matches the isUniqueNameViolation pattern above):
+    // a future second unique index must not be mislabeled as a domain collision.
+    if (isPgUniqueViolation(err, 'customer_email_domains_partner_domain_uq')) {
       throw new TicketConfigServiceError('That domain is already mapped', 409, 'DOMAIN_ALREADY_MAPPED');
     }
     throw err;

--- a/apps/web/src/components/settings/CustomerDomainsCard.test.tsx
+++ b/apps/web/src/components/settings/CustomerDomainsCard.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../lib/authScope', () => ({ loginPathWithNext: () => '/login' }));
+vi.mock('../../lib/runAction', () => ({
+  runAction: async (o: { request: () => Promise<Response> }) => {
+    const r = await o.request();
+    return r.json().catch(() => null);
+  },
+  handleActionError: vi.fn(),
+}));
+
+import { CustomerDomainsCard } from './CustomerDomainsCard';
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('CustomerDomainsCard', () => {
+  it('lists existing domain mappings', async () => {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url === '/ticket-config/inbound-domains') {
+        return Promise.resolve(
+          jsonRes({
+            data: [
+              {
+                id: '1',
+                domain: 'acme.com',
+                orgId: 'o-1',
+                orgName: 'ACME',
+                autoCreateContact: true,
+                isActive: true,
+              },
+            ],
+          }),
+        );
+      }
+      if (url === '/orgs/organizations?limit=100') {
+        return Promise.resolve(jsonRes({ data: [{ id: 'o-1', name: 'ACME' }] }));
+      }
+      return Promise.resolve(jsonRes({ data: [] }));
+    });
+
+    render(<CustomerDomainsCard />);
+
+    await waitFor(() => expect(screen.getByText('acme.com')).toBeInTheDocument());
+    expect(within(screen.getByTestId('customer-domain-row-1')).getByText('ACME')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/CustomerDomainsCard.tsx
+++ b/apps/web/src/components/settings/CustomerDomainsCard.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { handleActionError, runAction } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+
+interface DomainRow {
+  id: string;
+  domain: string;
+  orgId: string;
+  orgName: string;
+  autoCreateContact: boolean;
+  isActive: boolean;
+}
+
+interface OrgOption {
+  id: string;
+  name: string;
+}
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+const LOAD_ERROR = 'Customer domain mappings failed to load.';
+const SAVE_ERROR = 'Could not save customer domain mapping. Retry.';
+
+export function CustomerDomainsCard() {
+  const [rows, setRows] = useState<DomainRow[]>([]);
+  const [orgs, setOrgs] = useState<OrgOption[]>([]);
+  const [domain, setDomain] = useState('');
+  const [orgId, setOrgId] = useState('');
+  const [autoCreateContact, setAutoCreateContact] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const loadRows = useCallback(async () => {
+    const res = await fetchWithAuth('/ticket-config/inbound-domains');
+    if (!res.ok) {
+      setError(true);
+      return;
+    }
+    const body = (await res.json()) as { data?: DomainRow[] };
+    setRows(body.data ?? []);
+  }, []);
+
+  const loadOrgs = useCallback(async () => {
+    const res = await fetchWithAuth('/orgs/organizations?limit=100');
+    if (!res.ok) {
+      setError(true);
+      return;
+    }
+    const body = (await res.json()) as { data?: OrgOption[] };
+    const nextOrgs = body.data ?? [];
+    setOrgs(nextOrgs);
+    setOrgId((current) => current || nextOrgs[0]?.id || '');
+  }, []);
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      await Promise.all([loadRows(), loadOrgs()]);
+    } catch {
+      setError(true);
+    }
+    setLoading(false);
+  }, [loadRows, loadOrgs]);
+
+  useEffect(() => {
+    void loadAll();
+  }, [loadAll]);
+
+  const addDomain = useCallback(async () => {
+    const trimmedDomain = domain.trim();
+    if (!trimmedDomain || !orgId) return;
+    setSaving(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth('/ticket-config/inbound-domains', {
+            method: 'POST',
+            body: JSON.stringify({ domain: trimmedDomain, orgId, autoCreateContact }),
+          }),
+        errorFallback: SAVE_ERROR,
+        successMessage: 'Customer domain mapping added',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setDomain('');
+      setAutoCreateContact(true);
+      await loadRows();
+    } catch (err) {
+      handleActionError(err, SAVE_ERROR);
+    } finally {
+      setSaving(false);
+    }
+  }, [autoCreateContact, domain, loadRows, orgId]);
+
+  const updateRow = useCallback(
+    async (id: string, patch: Partial<Pick<DomainRow, 'autoCreateContact' | 'isActive'>>) => {
+      setSaving(true);
+      try {
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/ticket-config/inbound-domains/${id}`, {
+              method: 'PATCH',
+              body: JSON.stringify(patch),
+            }),
+          errorFallback: SAVE_ERROR,
+          successMessage: 'Customer domain mapping saved',
+          onUnauthorized: UNAUTHORIZED,
+        });
+        await loadRows();
+      } catch (err) {
+        handleActionError(err, SAVE_ERROR);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [loadRows],
+  );
+
+  const removeRow = useCallback(
+    async (id: string) => {
+      setSaving(true);
+      try {
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/ticket-config/inbound-domains/${id}`, {
+              method: 'DELETE',
+            }),
+          errorFallback: SAVE_ERROR,
+          successMessage: 'Customer domain mapping deleted',
+          onUnauthorized: UNAUTHORIZED,
+        });
+        await loadRows();
+      } catch (err) {
+        handleActionError(err, SAVE_ERROR);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [loadRows],
+  );
+
+  return (
+    <section className="rounded-lg border p-4" data-testid="customer-domains-card">
+      <h2 className="mb-1 text-sm font-semibold">Customer email domains</h2>
+      <p className="mb-3 text-xs text-muted-foreground">
+        Route verified customer email domains to the right organization.
+      </p>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground" data-testid="customer-domains-loading">
+          Loading.
+        </p>
+      ) : error ? (
+        <p className="text-sm text-muted-foreground" data-testid="customer-domains-error">
+          {LOAD_ERROR}{' '}
+          <button
+            type="button"
+            onClick={() => void loadAll()}
+            className="underline hover:text-foreground"
+            data-testid="customer-domains-retry"
+          >
+            Retry
+          </button>
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y text-sm">
+            <thead className="text-left text-xs text-muted-foreground">
+              <tr>
+                <th className="px-2 py-2 font-medium">Domain</th>
+                <th className="px-2 py-2 font-medium">Organization</th>
+                <th className="px-2 py-2 font-medium">Auto-create contact</th>
+                <th className="px-2 py-2 font-medium">Active</th>
+                <th className="px-2 py-2 font-medium">
+                  <span className="sr-only">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {rows.map((row) => (
+                <tr key={row.id} data-testid={`customer-domain-row-${row.id}`}>
+                  <td className="px-2 py-2 font-medium">{row.domain}</td>
+                  <td className="px-2 py-2">{row.orgName}</td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="checkbox"
+                      checked={row.autoCreateContact}
+                      disabled={saving}
+                      onChange={(e) => void updateRow(row.id, { autoCreateContact: e.target.checked })}
+                      data-testid={`customer-domain-auto-create-${row.id}`}
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="checkbox"
+                      checked={row.isActive}
+                      disabled={saving}
+                      onChange={(e) => void updateRow(row.id, { isActive: e.target.checked })}
+                      data-testid={`customer-domain-active-${row.id}`}
+                    />
+                  </td>
+                  <td className="px-2 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => void removeRow(row.id)}
+                      disabled={saving}
+                      className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+                      data-testid={`customer-domain-delete-${row.id}`}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td className="px-2 py-3 text-muted-foreground" colSpan={5}>
+                    No customer domain mappings yet.
+                  </td>
+                </tr>
+              )}
+              <tr data-testid="customer-domain-add-row">
+                <td className="px-2 py-2">
+                  <input
+                    type="text"
+                    value={domain}
+                    onChange={(e) => setDomain(e.target.value)}
+                    placeholder="customer.example.com"
+                    className="w-full rounded-md border bg-background px-2 py-1 text-sm"
+                    data-testid="customer-domain-input"
+                  />
+                </td>
+                <td className="px-2 py-2">
+                  <select
+                    value={orgId}
+                    onChange={(e) => setOrgId(e.target.value)}
+                    className="w-full rounded-md border bg-background px-2 py-1 text-sm"
+                    data-testid="customer-domain-org"
+                  >
+                    <option value="">Select organization...</option>
+                    {orgs.map((org) => (
+                      <option key={org.id} value={org.id}>
+                        {org.name}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+                <td className="px-2 py-2">
+                  <input
+                    type="checkbox"
+                    checked={autoCreateContact}
+                    onChange={(e) => setAutoCreateContact(e.target.checked)}
+                    data-testid="customer-domain-auto-create"
+                  />
+                </td>
+                <td className="px-2 py-2 text-muted-foreground">New</td>
+                <td className="px-2 py-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => void addDomain()}
+                    disabled={saving || !domain.trim() || !orgId}
+                    className="rounded-md bg-primary px-2.5 py-1 text-sm text-white disabled:opacity-50"
+                    data-testid="customer-domain-add"
+                  >
+                    Add domain
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/InboundEmailCard.tsx
+++ b/apps/web/src/components/settings/InboundEmailCard.tsx
@@ -5,6 +5,7 @@ import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 import { showToast } from '../shared/Toast';
 import { formatDateTime } from '@/lib/dateTimeFormat';
+import { CustomerDomainsCard } from './CustomerDomainsCard';
 
 interface InboundConfig {
   enabled: boolean;
@@ -12,6 +13,7 @@ interface InboundConfig {
   addressOverride: string | null;
   defaultTriageOrgId: string | null;
   autoresponderEnabled: boolean;
+  triageUnknownSenders: boolean;
   slug: string;
   domainConfigured: boolean;
 }
@@ -117,7 +119,11 @@ export default function InboundEmailCard() {
   }, [loadAll]);
 
   const saveConfig = useCallback(
-    async (patch: Partial<Pick<InboundConfig, 'enabled' | 'defaultTriageOrgId' | 'autoresponderEnabled'>>) => {
+    async (
+      patch: Partial<
+        Pick<InboundConfig, 'enabled' | 'defaultTriageOrgId' | 'autoresponderEnabled' | 'triageUnknownSenders'>
+      >,
+    ) => {
       if (!cfg) return;
       const next = { ...cfg, ...patch };
       // Send the COMPLETE ticketing.inbound object — PATCH /partners/me shallow-
@@ -128,6 +134,7 @@ export default function InboundEmailCard() {
         enabled: next.enabled,
         defaultTriageOrgId: next.defaultTriageOrgId,
         autoresponderEnabled: next.autoresponderEnabled,
+        triageUnknownSenders: next.triageUnknownSenders,
       };
       if (next.addressOverride) inbound.address = next.addressOverride;
       setSaving(true);
@@ -286,8 +293,7 @@ export default function InboundEmailCard() {
 
         <div className="mt-3">
           <label className="text-xs font-medium" htmlFor="inbound-triage-org">
-            Default triage organization{' '}
-            <span className="text-muted-foreground">(reserved for future use)</span>
+            Default triage organization
           </label>
           <select
             id="inbound-triage-org"
@@ -309,6 +315,17 @@ export default function InboundEmailCard() {
         <label className="mt-3 flex items-center gap-2 text-sm">
           <input
             type="checkbox"
+            checked={cfg.triageUnknownSenders ?? false}
+            disabled={saving || !cfg.defaultTriageOrgId}
+            onChange={(e) => void saveConfig({ triageUnknownSenders: e.target.checked })}
+            data-testid="inbound-triage-toggle"
+          />
+          Route unknown senders to the triage org instead of quarantining
+        </label>
+
+        <label className="mt-3 flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
             checked={cfg.autoresponderEnabled}
             disabled={saving}
             onChange={(e) => void saveConfig({ autoresponderEnabled: e.target.checked })}
@@ -317,6 +334,8 @@ export default function InboundEmailCard() {
           Send an autoresponse acknowledging new email tickets
         </label>
       </section>
+
+      <CustomerDomainsCard />
 
       <section className="rounded-lg border p-4" data-testid="inbound-review-queue">
         <h2 className="mb-1 text-sm font-semibold">Review queue</h2>

--- a/docs/superpowers/plans/2026-06-20-ticketing-phase5-email-customer-routing.md
+++ b/docs/superpowers/plans/2026-06-20-ticketing-phase5-email-customer-routing.md
@@ -1,0 +1,963 @@
+# Ticketing Phase 5 — Email-to-Ticket Customer Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the org-resolution layer of email-to-ticket so inbound mail auto-routes to the right customer org via a configurable sender-domain → org mapping, with a triage-org fallback and opt-in unknown-sender contact onboarding.
+
+**Architecture:** A new partner-axis `customer_email_domains` table maps a sender domain to a customer org. The inbound worker (`inboundEmailService.ts`) gains two new resolution steps after the existing portal-user lookup and before quarantine: (2) domain → org (always creates the ticket; optionally onboards a contact), (3) triage-org fallback (opt-in). Both new steps sit behind the existing `senderAuth.verified` (DMARC-pass) gate, so they inherit spoofing protection. Partner admins manage mappings and the triage toggle through new `ticket-config` endpoints and a settings card.
+
+**Tech Stack:** Hono + Drizzle (Postgres, RLS as `breeze_app`), Zod (v4) shared validators, Vitest (unit/integration/RLS), Astro + React Islands web, BullMQ worker for inbound email.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md`
+
+## Global Constraints
+
+- **Node pin:** prefix pnpm/vitest commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict). Fresh worktree needs `pnpm install` first.
+- **Zod v4:** use `z.string().guid()` for UUIDs (never `.uuid()` — strict-RFC rejects nil sentinel). Existing ticket-config routes already use `.guid()`.
+- **Migrations:** date-prefixed `2026-06-20-*.sql`; idempotent (`CREATE TABLE IF NOT EXISTS`, `pg_policies`/`DO $$ … EXCEPTION` guards); no inner `BEGIN/COMMIT`; no `gen_random_bytes` (pgcrypto absent — `gen_random_uuid()` is fine). Never edit a shipped migration.
+- **RLS:** every tenant-scoped table is `ENABLE` + `FORCE ROW LEVEL SECURITY` with policies in the same migration. API connects as unprivileged `breeze_app`.
+- **RLS forge tests** must run against a real DB as `breeze_app` with a non-BYPASSRLS role. Fresh worktrees need the gitignored `.env.test` symlink — confirm `rolbypassrls=false` for the test role or forge tests pass vacuously. Real-DB tests go in `apps/api/src/__tests__/integration/*.integration.test.ts`.
+- **Web mutations** go through `runAction` (`apps/web/src/lib/runAction.ts`).
+- **Table name:** `customer_email_domains`; Drizzle export `customerEmailDomains`.
+
+---
+
+### Task 1: Migration + Drizzle schema for `customer_email_domains`
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-20-a-customer-email-domains.sql`
+- Modify: `apps/api/src/db/schema/emailInbound.ts` (add table; it already imports `partners`, `tickets`, and pg helpers)
+
+**Interfaces:**
+- Produces: Drizzle table `customerEmailDomains` with columns `{ id, partnerId, orgId, domain, autoCreateContact, isActive, createdBy, createdAt, updatedAt }`, re-exported through `apps/api/src/db/schema/index.ts` (it already `export *`s `emailInbound`).
+
+- [ ] **Step 1: Write the migration file**
+
+Create `apps/api/migrations/2026-06-20-a-customer-email-domains.sql`:
+
+```sql
+-- Phase 5 (native ticketing): sender-domain -> customer-org routing for email-to-ticket
+-- Spec: docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md
+
+CREATE TABLE IF NOT EXISTS customer_email_domains (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id UUID NOT NULL REFERENCES partners(id),
+  org_id UUID NOT NULL,
+  domain VARCHAR(255) NOT NULL,
+  auto_create_contact BOOLEAN NOT NULL DEFAULT TRUE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by UUID REFERENCES users(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Org must belong to the partner (DB-enforced; mirrors ticket_categories composite FK).
+-- Relies on the UNIQUE(id, partner_id) constraint on organizations already used by
+-- ticket_categories and users. Add it if a fresh DB somehow lacks it (idempotent).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid
+    WHERE t.relname = 'organizations' AND c.contype IN ('p','u')
+      AND c.conkey = (SELECT array_agg(attnum ORDER BY attnum)
+                      FROM pg_attribute WHERE attrelid = t.oid AND attname IN ('id','partner_id'))
+  ) THEN
+    ALTER TABLE organizations ADD CONSTRAINT organizations_id_partner_id_key UNIQUE (id, partner_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE customer_email_domains
+    ADD CONSTRAINT customer_email_domains_org_partner_fk
+    FOREIGN KEY (org_id, partner_id) REFERENCES organizations(id, partner_id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS customer_email_domains_partner_domain_uq
+  ON customer_email_domains (partner_id, domain);
+CREATE INDEX IF NOT EXISTS customer_email_domains_lookup_idx
+  ON customer_email_domains (partner_id, is_active);
+
+-- RLS: partner-axis (Shape 3) + denormalized org_id. System scope (the inbound worker)
+-- sees all; partner scope sees only its own rows.
+ALTER TABLE customer_email_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE customer_email_domains FORCE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  CREATE POLICY customer_email_domains_partner_access ON customer_email_domains
+    FOR ALL TO breeze_app
+    USING (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id))
+    WITH CHECK (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+```
+
+- [ ] **Step 2: Add the Drizzle table to `emailInbound.ts`**
+
+Append to `apps/api/src/db/schema/emailInbound.ts` (it already imports `pgTable, uuid, varchar, text, jsonb, timestamp, boolean, index, uniqueIndex` and `partners`; add `organizations` and `users` imports if missing):
+
+```typescript
+export const customerEmailDomains = pgTable('customer_email_domains', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  orgId: uuid('org_id').notNull(),
+  domain: varchar('domain', { length: 255 }).notNull(),
+  autoCreateContact: boolean('auto_create_contact').notNull().default(true),
+  isActive: boolean('is_active').notNull().default(true),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (t) => [
+  uniqueIndex('customer_email_domains_partner_domain_uq').on(t.partnerId, t.domain),
+  index('customer_email_domains_lookup_idx').on(t.partnerId, t.isActive)
+]);
+```
+
+> Note: the composite FK `(org_id, partner_id)` is enforced in SQL only (Drizzle's `references()` is single-column); this mirrors `ticket_categories`. Do not add a single-column `org_id` FK in Drizzle — it would drift from the migration.
+
+- [ ] **Step 3: Apply migration against a clean DB and verify no drift**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+```
+Expected: reports no schema drift between `emailInbound.ts` and the migration.
+
+- [ ] **Step 4: Verify the table + RLS apply against empty Postgres (Check Migrations parity)**
+
+Run the migration against a throwaway `postgres:16` (or local `breeze-postgres`) and confirm it applies cleanly and re-applies as a no-op:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsx src/db/autoMigrate.ts 2>&1 | tail -20
+```
+Expected: migration `2026-06-20-a-customer-email-domains` applied; second run logs it as already applied (no checksum error).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-20-a-customer-email-domains.sql apps/api/src/db/schema/emailInbound.ts
+git commit -m "feat(ticketing): add customer_email_domains table + RLS (Phase 5)"
+```
+
+---
+
+### Task 2: RLS coverage allowlists + functional forge test
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (add to `PARTNER_TENANT_TABLES` and `ORG_AXIS_POLICY_EXCLUDED_TABLES`)
+- Create: `apps/api/src/__tests__/integration/customerEmailDomainsRls.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `customerEmailDomains` from Task 1.
+
+- [ ] **Step 1: Add the table to both allowlists**
+
+In `rls-coverage.integration.test.ts`, add to the `PARTNER_TENANT_TABLES` map (near the `ticket_email_inbound` entry):
+```typescript
+  ['customer_email_domains', 'partner_id'],
+```
+And add to `ORG_AXIS_POLICY_EXCLUDED_TABLES` (it carries `org_id` but is partner-axis — same reason as `time_entries`):
+```typescript
+  'customer_email_domains', // partner-axis (Shape 3) carrying denormalized org_id
+```
+
+- [ ] **Step 2: Write the functional forge test (cross-partner + cross-org)**
+
+Create `apps/api/src/__tests__/integration/customerEmailDomainsRls.integration.test.ts`. Re-seed fixtures inside each `it` (the `beforeEach` TRUNCATE wipes module-scope fixtures, which makes later cross-tenant cases vacuous). Pattern mirrors existing `*Rls.integration.test.ts` files:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { withDbAccessContext } from '../../db';
+import { seedPartnerWithOrg } from './helpers'; // use the existing seed helpers in this dir
+
+describe('customer_email_domains RLS', () => {
+  it('partner A cannot read partner B rows', async () => {
+    const a = await seedPartnerWithOrg();
+    const b = await seedPartnerWithOrg();
+    await withDbAccessContext({ scope: 'system' }, async (db) => {
+      await db.execute(/* sql */`INSERT INTO customer_email_domains (partner_id, org_id, domain)
+        VALUES (${b.partnerId}, ${b.orgId}, 'acme.com')`);
+    });
+    const rows = await withDbAccessContext(
+      { scope: 'partner', partnerId: a.partnerId },
+      (db) => db.execute(/* sql */`SELECT id FROM customer_email_domains`)
+    );
+    expect(rows.length).toBe(0);
+  });
+
+  it('forging a row for another partner org fails the WITH CHECK / composite FK', async () => {
+    const a = await seedPartnerWithOrg();
+    const b = await seedPartnerWithOrg();
+    await expect(
+      withDbAccessContext({ scope: 'partner', partnerId: a.partnerId }, (db) =>
+        db.execute(/* sql */`INSERT INTO customer_email_domains (partner_id, org_id, domain)
+          VALUES (${a.partnerId}, ${b.orgId}, 'evil.com')`)
+      )
+    ).rejects.toThrow(/row-level security|violates foreign key/i);
+  });
+});
+```
+
+> Adapt `seedPartnerWithOrg`/`withDbAccessContext` calls to the actual helper signatures in this integration dir (read a neighboring `*Rls.integration.test.ts` first). The two assertions that matter: a partner cannot SELECT another partner's rows, and a partner cannot INSERT a row pointing at another partner's org.
+
+- [ ] **Step 3: Run the forge test (real DB) and confirm it passes**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/__tests__/integration/customerEmailDomainsRls.integration.test.ts --config vitest.integration.config.ts
+```
+Expected: PASS (2 tests). If the cross-partner read returns rows, the policy is wrong — fix the migration before continuing.
+
+- [ ] **Step 4: Run the rls-coverage contract test**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/__tests__/integration/rls-coverage.integration.test.ts --config vitest.integration.config.ts
+```
+Expected: PASS — the new table is now accounted for in both allowlists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts apps/api/src/__tests__/integration/customerEmailDomainsRls.integration.test.ts
+git commit -m "test(ticketing): RLS forge + coverage for customer_email_domains"
+```
+
+---
+
+### Task 3: Org cascade-delete coverage
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts` (`ORG_CASCADE_DELETE_ORDER`)
+
+**Interfaces:**
+- Consumes: `customer_email_domains` table name (string) from Task 1.
+
+- [ ] **Step 1: Insert the table into `ORG_CASCADE_DELETE_ORDER` at the localeCompare slot**
+
+The list is `localeCompare`-sorted and the contract test is strict about position (prefix-extension siblings do NOT sort adjacent-by-eye — see issue history). Insert `'customer_email_domains'` near `'custom_field_definitions'`. Add the line, then let the contract test (Step 2) confirm the exact slot — if it fails with an ordering error, move the line up/down one position until green.
+
+```typescript
+  'customer_email_domains',
+  'custom_field_definitions',
+```
+
+- [ ] **Step 2: Run the tenantCascade list-contract + integration test**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/tenantCascade.test.ts
+```
+Expected: PASS. If it reports an alpha-order violation, adjust the insertion point per the error and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/services/tenantCascade.ts
+git commit -m "feat(ticketing): cascade-delete customer_email_domains on org erasure"
+```
+
+---
+
+### Task 4: Shared validators (domain schema + freemail blocklist)
+
+**Files:**
+- Modify: `packages/shared/src/validators/ticketConfig.ts`
+- Test: `packages/shared/src/validators/ticketConfig.test.ts`
+
+**Interfaces:**
+- Produces: `createCustomerEmailDomainSchema` (`{ domain: string; orgId: string; autoCreateContact?: boolean }`), `updateCustomerEmailDomainSchema` (`{ orgId?: string; autoCreateContact?: boolean; isActive?: boolean }`), `FREEMAIL_DOMAINS: ReadonlySet<string>`, types `CreateCustomerEmailDomainInput` / `UpdateCustomerEmailDomainInput`. Re-exported via `packages/shared/src/validators/index.ts` (already `export * from './ticketConfig'`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/shared/src/validators/ticketConfig.test.ts`:
+
+```typescript
+import {
+  createCustomerEmailDomainSchema,
+  updateCustomerEmailDomainSchema,
+} from './ticketConfig';
+
+describe('createCustomerEmailDomainSchema', () => {
+  const orgId = '11111111-1111-4111-8111-111111111111';
+
+  it('accepts a normal domain and lowercases it, defaulting autoCreateContact true', () => {
+    const r = createCustomerEmailDomainSchema.parse({ domain: 'ACME.com', orgId });
+    expect(r.domain).toBe('acme.com');
+    expect(r.autoCreateContact).toBe(true);
+  });
+
+  it('rejects free-provider domains', () => {
+    expect(() => createCustomerEmailDomainSchema.parse({ domain: 'gmail.com', orgId })).toThrow();
+  });
+
+  it('rejects malformed domains', () => {
+    expect(() => createCustomerEmailDomainSchema.parse({ domain: 'not a domain', orgId })).toThrow();
+  });
+
+  it('update requires at least one field', () => {
+    expect(() => updateCustomerEmailDomainSchema.parse({})).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared exec vitest run src/validators/ticketConfig.test.ts
+```
+Expected: FAIL ("createCustomerEmailDomainSchema is not exported" / undefined).
+
+- [ ] **Step 3: Implement the schemas**
+
+Append to `packages/shared/src/validators/ticketConfig.ts`:
+
+```typescript
+export const FREEMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  'gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'live.com',
+  'msn.com', 'yahoo.com', 'ymail.com', 'icloud.com', 'me.com', 'mac.com',
+  'aol.com', 'proton.me', 'protonmail.com', 'gmx.com', 'mail.com', 'zoho.com',
+]);
+
+const domainSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .regex(
+    /^(?=.{1,255}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/,
+    'Enter a valid domain like acme.com',
+  )
+  .refine((d) => !FREEMAIL_DOMAINS.has(d), 'Free email providers cannot be mapped to a single organization');
+
+export const createCustomerEmailDomainSchema = z.object({
+  domain: domainSchema,
+  orgId: z.string().guid(),
+  autoCreateContact: z.boolean().optional().default(true),
+});
+export type CreateCustomerEmailDomainInput = z.infer<typeof createCustomerEmailDomainSchema>;
+
+export const updateCustomerEmailDomainSchema = z
+  .object({
+    orgId: z.string().guid().optional(),
+    autoCreateContact: z.boolean().optional(),
+    isActive: z.boolean().optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, 'At least one field is required');
+export type UpdateCustomerEmailDomainInput = z.infer<typeof updateCustomerEmailDomainSchema>;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared exec vitest run src/validators/ticketConfig.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/ticketConfig.ts packages/shared/src/validators/ticketConfig.test.ts
+git commit -m "feat(ticketing): validators for customer email domain mapping"
+```
+
+---
+
+### Task 5: Resolver — `resolveOrgBySenderDomain` + contact onboarding helpers
+
+**Files:**
+- Create: `apps/api/src/services/inboundEmail/resolveOrg.ts`
+- Test: `apps/api/src/services/inboundEmail/resolveOrg.test.ts`
+
+**Interfaces:**
+- Consumes: `customerEmailDomains`, `portalUsers`, `partners` schema; the shared `db`.
+- Produces:
+  - `resolveOrgBySenderDomain(fromAddress: string, partnerId: string): Promise<{ orgId: string; autoCreateContact: boolean } | null>`
+  - `findOrCreateEmailContact(orgId: string, email: string, name: string | null): Promise<string>` (returns portalUser id)
+  - `loadPartnerInboundPolicy(partnerId: string): Promise<{ triageUnknownSenders: boolean; defaultTriageOrgId: string | null }>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/services/inboundEmail/resolveOrg.test.ts`. Mock `../../db` the same way the sibling `inboundEmailService.test.ts` does (read it first for the exact mock shape):
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// (mock ../../db to return a chainable select/insert — copy the pattern from inboundEmailService.test.ts)
+
+import { resolveOrgBySenderDomain } from './resolveOrg';
+
+describe('resolveOrgBySenderDomain', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the org + autoCreateContact for an active matching domain', async () => {
+    // arrange db.select(...).where(...).limit() -> [{ orgId: 'org-1', autoCreateContact: true }]
+    const r = await resolveOrgBySenderDomain('bob@Acme.com', 'partner-1');
+    expect(r).toEqual({ orgId: 'org-1', autoCreateContact: true });
+  });
+
+  it('returns null when no domain matches', async () => {
+    // arrange db ... -> []
+    const r = await resolveOrgBySenderDomain('bob@nowhere.com', 'partner-1');
+    expect(r).toBeNull();
+  });
+
+  it('returns null for an address with no @', async () => {
+    expect(await resolveOrgBySenderDomain('garbage', 'partner-1')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/inboundEmail/resolveOrg.test.ts
+```
+Expected: FAIL ("resolveOrg" module not found).
+
+- [ ] **Step 3: Implement the resolver module**
+
+Create `apps/api/src/services/inboundEmail/resolveOrg.ts`:
+
+```typescript
+import { and, eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { customerEmailDomains, partners } from '../../db/schema';
+import { portalUsers } from '../../db/schema/portal';
+
+function domainOf(address: string): string | null {
+  const at = address.lastIndexOf('@');
+  if (at < 0) return null;
+  const domain = address.slice(at + 1).trim().toLowerCase();
+  return domain || null;
+}
+
+export async function resolveOrgBySenderDomain(
+  fromAddress: string,
+  partnerId: string,
+): Promise<{ orgId: string; autoCreateContact: boolean } | null> {
+  const domain = domainOf(fromAddress);
+  if (!domain) return null;
+  const rows = await db
+    .select({ orgId: customerEmailDomains.orgId, autoCreateContact: customerEmailDomains.autoCreateContact })
+    .from(customerEmailDomains)
+    .where(
+      and(
+        eq(customerEmailDomains.partnerId, partnerId),
+        eq(customerEmailDomains.domain, domain),
+        eq(customerEmailDomains.isActive, true),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function findOrCreateEmailContact(
+  orgId: string,
+  email: string,
+  name: string | null,
+): Promise<string> {
+  const lower = email.toLowerCase();
+  const existing = await db
+    .select({ id: portalUsers.id })
+    .from(portalUsers)
+    .where(and(eq(portalUsers.orgId, orgId), eq(portalUsers.email, lower)))
+    .limit(1);
+  if (existing[0]) return existing[0].id;
+  const inserted = await db
+    .insert(portalUsers)
+    .values({ orgId, email: lower, name, passwordHash: null, authMethod: 'password', status: 'active' })
+    .returning({ id: portalUsers.id });
+  return inserted[0].id;
+}
+
+export async function loadPartnerInboundPolicy(
+  partnerId: string,
+): Promise<{ triageUnknownSenders: boolean; defaultTriageOrgId: string | null }> {
+  const rows = await db.select({ settings: partners.settings }).from(partners).where(eq(partners.id, partnerId)).limit(1);
+  const settings = (rows[0]?.settings ?? {}) as Record<string, unknown>;
+  const inbound =
+    (((settings.ticketing as Record<string, unknown> | undefined)?.inbound) as
+      | { defaultTriageOrgId?: string | null; triageUnknownSenders?: boolean }
+      | undefined) ?? {};
+  return {
+    triageUnknownSenders: inbound.triageUnknownSenders === true,
+    defaultTriageOrgId: inbound.defaultTriageOrgId ?? null,
+  };
+}
+```
+
+> Verify the `partners` export carries a `settings` JSONB column (ticketConfigService.ts reads `partners.settings` at the inbound config read). If `partners` is exported from a different schema file than the barrel, import it from there.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/inboundEmail/resolveOrg.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/inboundEmail/resolveOrg.ts apps/api/src/services/inboundEmail/resolveOrg.test.ts
+git commit -m "feat(ticketing): sender-domain org resolver + contact onboarding helpers"
+```
+
+---
+
+### Task 6: Wire new resolution steps into the inbound dispatch
+
+**Files:**
+- Modify: `apps/api/src/services/inboundEmail/inboundEmailService.ts` (the new-ticket branch, currently ~lines 208–215)
+- Test: `apps/api/src/services/inboundEmail/inboundEmailService.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveOrgBySenderDomain`, `findOrCreateEmailContact`, `loadPartnerInboundPolicy` (Task 5); existing `findPortalUserInPartner`, `createFromEmail`, `logInbound`.
+
+- [ ] **Step 1: Write failing tests for the three new branches**
+
+Add to `inboundEmailService.test.ts` (mirror the existing `processInboundEmail` tests; the existing `senderAuth.verified` gate must be satisfied — pass a normalized email with `senderAuth: { verified: true, ... }`):
+
+```typescript
+describe('processInboundEmail — domain routing (Phase 5)', () => {
+  it('routes a verified unknown sender whose domain is mapped, auto-creating a contact', async () => {
+    // findPortalUserInPartner -> null; resolveOrgBySenderDomain -> { orgId: 'org-9', autoCreateContact: true }
+    // expect findOrCreateEmailContact called with ('org-9', from, fromName)
+    // expect createFromEmail called with orgId 'org-9' and the new contact id as submittedBy
+    // expect logInbound(..., 'created', ticketId)
+  });
+
+  it('routes a mapped domain WITHOUT creating a contact when autoCreateContact is false', async () => {
+    // resolveOrgBySenderDomain -> { orgId: 'org-9', autoCreateContact: false }
+    // expect findOrCreateEmailContact NOT called; createFromEmail submittedBy === null
+  });
+
+  it('falls back to the triage org when enabled and no domain matches', async () => {
+    // resolveOrgBySenderDomain -> null; loadPartnerInboundPolicy -> { triageUnknownSenders: true, defaultTriageOrgId: 'org-triage' }
+    // expect createFromEmail orgId === 'org-triage', submittedBy === null
+  });
+
+  it('quarantines when nothing matches and triage is disabled', async () => {
+    // resolveOrgBySenderDomain -> null; loadPartnerInboundPolicy -> { triageUnknownSenders: false, defaultTriageOrgId: null }
+    // expect logInbound(..., 'quarantined', null)
+  });
+});
+```
+
+Mock `./resolveOrg` exports with `vi.mock('./resolveOrg', ...)`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/inboundEmail/inboundEmailService.test.ts
+```
+Expected: FAIL (new branches not implemented).
+
+- [ ] **Step 3: Implement the new branches**
+
+Add the import near the top of `inboundEmailService.ts`:
+```typescript
+import { resolveOrgBySenderDomain, findOrCreateEmailContact, loadPartnerInboundPolicy } from './resolveOrg';
+```
+
+Replace the current new-ticket block (the `findPortalUserInPartner` → quarantine code, ~lines 208–215) with:
+
+```typescript
+// (5) Known portal-user sender -> their home org (most specific; wins over domain rules).
+const sender = await findPortalUserInPartner(n.from, partnerId);
+if (sender) {
+  const t = await createFromEmail(n, partnerId, sender.orgId, null, null, sender.id);
+  await logInbound(n, partnerId, 'created', t.id);
+  return;
+}
+
+// (6) Sender domain mapped to a customer org -> always create; optionally onboard a contact.
+const domainMatch = await resolveOrgBySenderDomain(n.from, partnerId);
+if (domainMatch) {
+  const submittedBy = domainMatch.autoCreateContact
+    ? await findOrCreateEmailContact(domainMatch.orgId, n.from, n.fromName ?? null)
+    : null;
+  const t = await createFromEmail(n, partnerId, domainMatch.orgId, null, null, submittedBy);
+  await logInbound(n, partnerId, 'created', t.id);
+  return;
+}
+
+// (7) Triage fallback for unknown senders, if the partner opted in.
+const policy = await loadPartnerInboundPolicy(partnerId);
+if (policy.triageUnknownSenders && policy.defaultTriageOrgId) {
+  const t = await createFromEmail(n, partnerId, policy.defaultTriageOrgId, null, null, null);
+  await logInbound(n, partnerId, 'created', t.id);
+  return;
+}
+
+// (8) Nothing matched -> quarantine.
+await logInbound(n, partnerId, 'quarantined', null);
+return;
+```
+
+> Match `createFromEmail`'s exact positional signature from the existing call site (`createFromEmail(n, partnerId, orgId, null, null, submittedBy)`); do not invent new parameters. This block sits AFTER the existing `senderAuth.verified` gate (~line 172), so all three new paths are spoofing-protected without new code.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/inboundEmail/inboundEmailService.test.ts
+```
+Expected: PASS (all branches).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/inboundEmail/inboundEmailService.ts apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+git commit -m "feat(ticketing): route inbound email by sender domain + triage fallback"
+```
+
+---
+
+### Task 7: Config service — domain CRUD + triage toggle read/write
+
+**Files:**
+- Modify: `apps/api/src/services/ticketConfigService.ts`
+- Test: `apps/api/src/services/ticketConfigService.test.ts`
+
+**Interfaces:**
+- Consumes: `customerEmailDomains` schema; `createCustomerEmailDomainSchema`/`updateCustomerEmailDomainSchema` types.
+- Produces:
+  - `listCustomerEmailDomains(partnerId: string): Promise<Array<{ id; domain; orgId; orgName; autoCreateContact; isActive; createdAt }>>`
+  - `createCustomerEmailDomain(partnerId, input: CreateCustomerEmailDomainInput, actor: { userId: string }): Promise<{ id; ... }>`
+  - `updateCustomerEmailDomain(partnerId, id, input: UpdateCustomerEmailDomainInput): Promise<{ id; ... }>`
+  - `deleteCustomerEmailDomain(partnerId, id): Promise<void>`
+  - The existing inbound config read now also returns `triageUnknownSenders: boolean`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ticketConfigService.test.ts` (mirror existing service tests; mock `../db`):
+
+```typescript
+describe('customer email domains', () => {
+  it('createCustomerEmailDomain rejects an org that is not in the partner (composite FK / 403 path)', async () => {
+    // db.insert(...).returning() rejects with a FK violation -> service throws TicketConfigServiceError
+  });
+  it('listCustomerEmailDomains returns rows joined with org names for the partner', async () => {
+    // db.select(...).leftJoin(organizations) -> [{ id, domain, orgId, orgName, autoCreateContact, isActive }]
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/ticketConfigService.test.ts
+```
+Expected: FAIL (functions undefined).
+
+- [ ] **Step 3: Implement the CRUD functions + triage read**
+
+Add to `ticketConfigService.ts` (reuse the file's existing `TicketConfigServiceError`, `db`/`withDbAccessContext`, and `organizations` import; add `customerEmailDomains` to the schema import):
+
+```typescript
+export async function listCustomerEmailDomains(partnerId: string) {
+  return db
+    .select({
+      id: customerEmailDomains.id,
+      domain: customerEmailDomains.domain,
+      orgId: customerEmailDomains.orgId,
+      orgName: organizations.name,
+      autoCreateContact: customerEmailDomains.autoCreateContact,
+      isActive: customerEmailDomains.isActive,
+      createdAt: customerEmailDomains.createdAt,
+    })
+    .from(customerEmailDomains)
+    .leftJoin(organizations, eq(customerEmailDomains.orgId, organizations.id))
+    .where(eq(customerEmailDomains.partnerId, partnerId))
+    .orderBy(customerEmailDomains.domain);
+}
+
+export async function createCustomerEmailDomain(
+  partnerId: string,
+  input: CreateCustomerEmailDomainInput,
+  actor: { userId: string },
+) {
+  try {
+    const rows = await db
+      .insert(customerEmailDomains)
+      .values({
+        partnerId,
+        orgId: input.orgId,
+        domain: input.domain,
+        autoCreateContact: input.autoCreateContact,
+        createdBy: actor.userId,
+      })
+      .returning();
+    return rows[0];
+  } catch (err) {
+    if (isUniqueViolation(err)) throw new TicketConfigServiceError('That domain is already mapped', 409);
+    if (isForeignKeyViolation(err)) throw new TicketConfigServiceError('That organization is not in your partner', 403);
+    throw err;
+  }
+}
+
+export async function updateCustomerEmailDomain(
+  partnerId: string,
+  id: string,
+  input: UpdateCustomerEmailDomainInput,
+) {
+  const rows = await db
+    .update(customerEmailDomains)
+    .set({ ...input, updatedAt: new Date() })
+    .where(and(eq(customerEmailDomains.id, id), eq(customerEmailDomains.partnerId, partnerId)))
+    .returning();
+  if (!rows[0]) throw new TicketConfigServiceError('Domain mapping not found', 404);
+  return rows[0];
+}
+
+export async function deleteCustomerEmailDomain(partnerId: string, id: string) {
+  const rows = await db
+    .delete(customerEmailDomains)
+    .where(and(eq(customerEmailDomains.id, id), eq(customerEmailDomains.partnerId, partnerId)))
+    .returning({ id: customerEmailDomains.id });
+  if (!rows[0]) throw new TicketConfigServiceError('Domain mapping not found', 404);
+}
+```
+
+In the existing inbound config read (the block around line 363–374 that builds `inboundCfg` → the returned object), add the triage flag to both the typed shape and the returned object:
+```typescript
+// widen the inboundCfg cast:
+//   { enabled?; address?; defaultTriageOrgId?; autoresponderEnabled?; triageUnknownSenders?: boolean }
+// and add to the returned inbound object:
+triageUnknownSenders: inboundCfg.triageUnknownSenders === true,
+```
+
+> Reuse the file's existing `isUniqueViolation`/`isForeignKeyViolation` helpers if present; if not, detect Postgres error codes `23505` (unique) and `23503` (FK) on `err.code`. The 403-on-FK is defense-in-depth behind the explicit partner-ownership check added in the route (Task 8).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/ticketConfigService.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketConfigService.ts apps/api/src/services/ticketConfigService.test.ts
+git commit -m "feat(ticketing): config service CRUD for customer email domains + triage flag"
+```
+
+---
+
+### Task 8: Config routes — `/ticket-config/inbound-domains`
+
+**Files:**
+- Modify: `apps/api/src/routes/ticketConfig.ts`
+- Test: `apps/api/src/routes/ticketConfig.test.ts`
+
+**Interfaces:**
+- Consumes: service functions from Task 7; `createCustomerEmailDomainSchema`/`updateCustomerEmailDomainSchema`; existing `scopes`, `writePerm`/`readPerm`, `adminMiddleware`, `requirePartnerId`, `handleServiceError`, `idParam`.
+
+- [ ] **Step 1: Write failing route tests (incl. cross-partner 403/404)**
+
+Add to `ticketConfig.test.ts` (mirror existing email-inbound route tests):
+
+```typescript
+describe('inbound-domains routes', () => {
+  it('GET lists domains for the partner', async () => { /* 200 + data array */ });
+  it('POST creates a mapping', async () => { /* 201/200 + data.id */ });
+  it('POST mapping an org outside the partner returns 403', async () => {
+    // service throws TicketConfigServiceError(403) -> handleServiceError -> 403
+  });
+  it('PATCH a mapping owned by another partner returns 404', async () => {
+    // service update with mismatched partnerId -> not found -> 404
+  });
+  it('non-admin is rejected 403', async () => { /* adminMiddleware */ });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/routes/ticketConfig.test.ts
+```
+Expected: FAIL (routes 404).
+
+- [ ] **Step 3: Implement the routes**
+
+Add to `ticketConfig.ts` (import the four service fns and the two schemas; mirror the `/email-inbound/:id/convert` handler idiom exactly):
+
+```typescript
+ticketConfigRoutes.get('/inbound-domains', scopes, readPerm, adminMiddleware, async (c) => {
+  const partnerId = requirePartnerId(c);
+  if (partnerId instanceof Response) return partnerId;
+  const data = await listCustomerEmailDomains(partnerId);
+  return c.json({ data });
+});
+
+ticketConfigRoutes.post('/inbound-domains', scopes, writePerm, adminMiddleware,
+  zValidator('json', createCustomerEmailDomainSchema), async (c) => {
+    const partnerId = requirePartnerId(c);
+    if (partnerId instanceof Response) return partnerId;
+    const auth = c.get('auth') as AuthContext;
+    try {
+      const row = await createCustomerEmailDomain(partnerId, c.req.valid('json'), { userId: auth.user.id });
+      return c.json({ data: row });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  });
+
+ticketConfigRoutes.patch('/inbound-domains/:id', scopes, writePerm, adminMiddleware,
+  zValidator('param', idParam), zValidator('json', updateCustomerEmailDomainSchema), async (c) => {
+    const partnerId = requirePartnerId(c);
+    if (partnerId instanceof Response) return partnerId;
+    try {
+      const row = await updateCustomerEmailDomain(partnerId, c.req.valid('param').id, c.req.valid('json'));
+      return c.json({ data: row });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  });
+
+ticketConfigRoutes.delete('/inbound-domains/:id', scopes, writePerm, adminMiddleware,
+  zValidator('param', idParam), async (c) => {
+    const partnerId = requirePartnerId(c);
+    if (partnerId instanceof Response) return partnerId;
+    try {
+      await deleteCustomerEmailDomain(partnerId, c.req.valid('param').id);
+      return c.json({ data: { ok: true } });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  });
+```
+
+- [ ] **Step 4: Run to verify pass + typecheck**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/routes/ticketConfig.test.ts
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsc --noEmit
+```
+Expected: tests PASS; no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/ticketConfig.ts apps/api/src/routes/ticketConfig.test.ts
+git commit -m "feat(ticketing): inbound-domains config endpoints"
+```
+
+---
+
+### Task 9: Web UI — customer domains card + triage toggle un-stub
+
+**Files:**
+- Create: `apps/web/src/components/settings/CustomerDomainsCard.tsx`
+- Modify: `apps/web/src/components/settings/InboundEmailCard.tsx` (un-stub triage picker + add toggle + render the new card)
+- Test: `apps/web/src/components/settings/CustomerDomainsCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `/ticket-config/inbound-domains` (GET/POST/PATCH/DELETE), `/orgs/organizations?limit=100`, `/ticket-config` (now returns `inbound.triageUnknownSenders`), `runAction`, `fetchWithAuth`.
+
+- [ ] **Step 1: Write failing component test**
+
+Create `CustomerDomainsCard.test.tsx` (mirror existing settings component tests; mock `fetchWithAuth`/`runAction`):
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { CustomerDomainsCard } from './CustomerDomainsCard';
+
+it('lists existing domain mappings', async () => {
+  // mock GET /ticket-config/inbound-domains -> [{ id:'1', domain:'acme.com', orgName:'ACME', autoCreateContact:true, isActive:true }]
+  render(<CustomerDomainsCard />);
+  await waitFor(() => expect(screen.getByText('acme.com')).toBeInTheDocument());
+  expect(screen.getByText('ACME')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/settings/CustomerDomainsCard.test.tsx
+```
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `CustomerDomainsCard.tsx`**
+
+Create the component following `InboundEmailCard.tsx` conventions (`fetchWithAuth` for reads, `runAction` for mutations, `data-testid` attributes, org dropdown loaded from `/orgs/organizations?limit=100`). It renders: a table of `{domain → orgName, auto-create-contact toggle, active toggle, delete}`, and an "Add domain" row with a domain input + org `<select>` + a per-row auto-create-contact checkbox, POSTing to `/ticket-config/inbound-domains` via `runAction` and reloading the list. Surface validation errors (freemail/malformed → 400) through `runAction`'s error path.
+
+```tsx
+// Skeleton — full handlers mirror InboundEmailCard's loadConfig/saveConfig pattern.
+export function CustomerDomainsCard() {
+  const [rows, setRows] = useState<DomainRow[]>([]);
+  const [orgs, setOrgs] = useState<OrgOption[]>([]);
+  // loadRows(): fetchWithAuth('/ticket-config/inbound-domains') -> setRows(body.data)
+  // loadOrgs(): fetchWithAuth('/orgs/organizations?limit=100') -> setOrgs(body.data)
+  // addDomain(domain, orgId, autoCreateContact): runAction(POST ...) then loadRows()
+  // updateRow(id, patch): runAction(PATCH ...) then loadRows()
+  // removeRow(id): runAction(DELETE ...) then loadRows()
+  return (/* table + add-row form with data-testid="customer-domains-card" */);
+}
+```
+
+- [ ] **Step 4: Un-stub the triage picker and add the toggle in `InboundEmailCard.tsx`**
+
+- Remove the `(reserved for future use)` span (line ~290) from the "Default triage organization" label.
+- Add a "Route unknown senders to triage org" checkbox bound to `cfg.triageUnknownSenders`, saved via the existing `saveConfig` by extending its `Pick<...>` to include `triageUnknownSenders` and adding it to the `inbound` payload object (lines ~119–139).
+- Add `triageUnknownSenders: boolean` to the `InboundConfig` type.
+- Render `<CustomerDomainsCard />` below the inbound settings.
+
+```tsx
+// In saveConfig's inbound payload (after autoresponderEnabled):
+triageUnknownSenders: next.triageUnknownSenders,
+// New control near the triage-org picker:
+<label className="mt-2 flex items-center gap-2 text-sm">
+  <input
+    type="checkbox"
+    checked={cfg.triageUnknownSenders ?? false}
+    disabled={saving || !cfg.defaultTriageOrgId}
+    onChange={(e) => void saveConfig({ triageUnknownSenders: e.target.checked })}
+    data-testid="inbound-triage-toggle"
+  />
+  Route unverified-but-unknown senders to the triage org instead of quarantining
+</label>
+```
+
+- [ ] **Step 5: Run component tests + web typecheck**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/settings/CustomerDomainsCard.test.tsx src/components/settings/InboundEmailCard.test.tsx
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web exec astro check
+```
+Expected: tests PASS; `astro check` clean (plain tsc skips `.astro`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/settings/CustomerDomainsCard.tsx apps/web/src/components/settings/CustomerDomainsCard.test.tsx apps/web/src/components/settings/InboundEmailCard.tsx
+git commit -m "feat(ticketing): customer email domain settings UI + triage fallback toggle"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Customer domain → org mapping → Tasks 1, 4, 5, 7, 8, 9 ✓
+- Org-resolution precedence (portal user → domain → triage → quarantine) → Task 6 ✓
+- Spoofing gate (reuse existing `senderAuth.verified`) → Task 6 sits behind it; no new code, noted ✓
+- `customer_email_domains` schema, composite FK, unique, RLS partner-axis + org_id → Task 1 ✓
+- rls-coverage both allowlists + forge test → Task 2 ✓
+- Cascade order → Task 3 ✓
+- Freemail guard → Task 4 ✓
+- Auto-create contact (password-less, toggleable) → Tasks 5, 6 ✓
+- Triage-org fallback in `partners.settings` JSONB + UI un-stub → Tasks 5, 7, 9 ✓
+- Partner-admin CRUD API + IDOR 403 → Tasks 7, 8 ✓
+- Web card + runAction → Task 9 ✓
+
+**Placeholder scan:** UI handler bodies in Task 9 Step 3 are described as skeletons that explicitly mirror `InboundEmailCard`'s concrete `loadConfig`/`saveConfig`/`runAction` patterns (shown verbatim in the research) rather than left as "TODO"; every backend task carries complete code. Acceptable for a React card whose every primitive is established in the same directory.
+
+**Type consistency:** `resolveOrgBySenderDomain` returns `{ orgId, autoCreateContact }` (Task 5) and is consumed with those exact fields (Task 6). `loadPartnerInboundPolicy` returns `{ triageUnknownSenders, defaultTriageOrgId }` (Task 5) consumed identically (Task 6). `triageUnknownSenders` flows JSONB → service read (Task 7) → config GET → UI (Task 9) under one name. Service fn names match between Tasks 7 and 8.

--- a/docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md
+++ b/docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md
@@ -1,0 +1,123 @@
+# Ticketing Phase 5 — Email-to-Ticket Customer Routing
+
+**Status:** Design approved, ready for implementation plan
+**Date:** 2026-06-20
+**Depends on:** Phase 4 email-to-ticket (`2026-06-13-ticketing-phase4-email-to-ticket-design.md`)
+
+## Problem
+
+Phase 4 shipped inbound email-to-ticket, but the **org-resolution layer is incomplete**. An inbound email resolves to a **partner** (via the MSP's branded inbound domain or `{slug}@TICKETS_INBOUND_DOMAIN`), but the **customer organization** is resolved *only* by matching the sender's address to an existing `portal_users` row. Consequences:
+
+- Email from `bob@acme.com`, where Bob is not yet a portal user, **quarantines** — even though `acme.com` is obviously the ACME customer. An admin must manually pick the org in the review queue and convert.
+- The settings UI has a **"Default triage organization" picker literally labeled "(reserved for future use)"** — wired to nothing.
+- There is **no way to map a customer's sender domain → a customer org**.
+
+This phase completes the org-resolution layer: customer-domain routing, a triage-org fallback, and configurable onboarding of unknown senders.
+
+## Scope
+
+In scope:
+1. **Customer domain → org mapping** — an MSP maps a customer sender domain (`acme.com`) to one of their customer orgs, so inbound mail from anyone at that domain auto-routes to the right customer.
+2. **Triage-org fallback** — wire the existing `defaultTriageOrgId` picker so unmapped/unknown senders can route to a configured catch-all org instead of always quarantining.
+3. **Onboarding unknown senders** — when a domain match routes a ticket, optionally auto-create a contact (`portal_users` row) for the sender so future replies thread and attribute correctly.
+
+Out of scope (unchanged from Phase 4 deferrals):
+- Branded inbound-domain DNS-verification wizard ("Model B", the `partner_inbound_domains.verificationStatus`/`dnsRecords` flow).
+- Per-org *inbound* addresses (recipient-side). This phase is about the **sender** domain.
+- Changes to thread-matching/reopen logic.
+
+## Key decisions (locked during brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Where does the sender-domain mapping live? | **New table** `customer_email_domains`, not a column on `partner_inbound_domains`. Recipient-domain (MSP inbound address) and sender-domain (customer identity) are semantically distinct with different uniqueness rules. |
+| Does a domain match auto-create the ticket? | **Always.** That is the point of mapping the domain. |
+| What is toggleable? | **Only contact/portal-user creation** — it has login/notification side effects. Per-domain-row `autoCreateContact` flag (default on). |
+| Triage-org fallback default | **Off.** Opt-in via a `triageUnknownSenders` boolean + the `defaultTriageOrgId` picker. When off, behavior is unchanged (quarantine). |
+| Spoofing guard | Auto-routing on a domain/triage match requires the **Mailgun SPF/DKIM result to pass**; on auth failure the email quarantines even if the domain matches. |
+
+## Org-resolution precedence (new-ticket path)
+
+In `inboundEmailService.ts`, for an inbound email that is **not** a reply to a live thread, resolve the org in this order. First match wins:
+
+1. **Known sender** — sender address matches a `portal_users` row in the resolved partner → that user's home org. *(Existing. Most specific — wins over domain mapping so a user who belongs to a sub-org isn't overridden by a broader domain rule.)*
+2. **Sender domain** — sender's email domain matches an active `customer_email_domains` row for the partner → that org. *(NEW.)* Always create the ticket. If that row's `autoCreateContact` is on, create a contact and set it as the submitter.
+3. **Triage fallback** — partner has `triageUnknownSenders` enabled **and** `defaultTriageOrgId` set → that catch-all org. *(NEW wiring.)* Create the ticket; **no** contact auto-create (the customer is unknown).
+4. **Quarantine** — none matched. *(Existing.)*
+
+**Spoofing gate:** Steps 2 and 3 (the new auto-route paths) only proceed when the inbound payload's SPF/DKIM verification passes. On auth failure, fall through to quarantine even if a domain matched. Step 1 is unchanged from Phase 4 (it already trusts the From address); steps 2–3 widen that trust to a whole domain, so the gate is required to prevent `From:`-header forgery from filing tickets into a customer's org.
+
+## Data model — `customer_email_domains` (new table)
+
+Org-routing table for inbound sender domains. Partner-managed (the MSP configures all its customers' domains in one settings surface).
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid pk | |
+| `partner_id` | uuid not null → partners | RLS axis |
+| `org_id` | uuid not null | Target customer org (denormalized for routing + cascade) |
+| `domain` | text not null | Lowercased hostname, e.g. `acme.com` |
+| `auto_create_contact` | boolean not null default true | Toggle for sender contact creation |
+| `is_active` | boolean not null default true | Soft enable/disable |
+| `created_by` | uuid → users | |
+| `created_at` / `updated_at` | timestamptz | |
+
+Constraints & indexes:
+- **Composite FK** `(org_id, partner_id) → organizations(id, partner_id)` — DB-enforces the mapped org belongs to the partner (eliminates the cross-tenant-mapping IDOR at the database layer; mirrors the `ticket_categories` composite-FK pattern).
+- **Unique** `(partner_id, domain)` — one org per domain within a partner.
+- Index on `(partner_id, is_active)` for the resolver's lookup.
+
+### Tenancy / RLS
+
+- **Shape:** Partner-axis (`breeze_has_partner_access(partner_id)`) **plus** denormalized `org_id`.
+- Because it is partner-axis but carries `org_id`, per the established trap it must be added to **both** `PARTNER_TENANT_TABLES` **and** `ORG_AXIS_POLICY_EXCLUDED_TABLES` in `rls-coverage.integration.test.ts`, or the org-axis coverage check fails. (Precedent: `time_entries`, `huntress_*`.)
+- Add to org **and** partner cascade-delete order lists (`tenantCascade.ts`), inserted at the correct `localeCompare` slot, with a matching `core.ts`/integration cascade contract entry. RLS-coverage passing ≠ cascade coverage.
+- RLS forge test (functional `breeze_app` insert) proving cross-partner **and** cross-org isolation — the contract test alone does not catch a missing second axis.
+- Migration is idempotent (`CREATE TABLE IF NOT EXISTS`, `pg_policies` existence checks), date-prefixed, no inner `BEGIN/COMMIT`, no `gen_random_bytes`.
+
+### Freemail guard
+
+Reject mapping free-provider domains (`gmail.com`, `outlook.com`, `hotmail.com`, `yahoo.com`, `icloud.com`, `aol.com`, `proton.me`, …) at the API with a clear error. Mapping a free-provider domain would route every consumer sender to a single org. Maintain the blocklist in `packages/shared`.
+
+## Resolver + auto-provisioning
+
+- New `resolveOrgBySenderDomain(fromAddress, partnerId): { orgId, autoCreateContact } | null` in `apps/api/src/services/inboundEmail/` (system-context; used by the worker). Keyed on the **sender** (From) domain — kept separate from `resolvePartnerByRecipient`, which keys on the **recipient**.
+- `inboundEmailService.ts` new-ticket path calls it after the existing portal-user lookup fails and before quarantine, applying the precedence and SPF/DKIM gate above.
+- **Auto-created contact** = a `portal_users` row with `org_id`, email, display name (from the `From` header), `source = 'email_auto'`, and **no password / non-login status**. It exists for attribution and future threading only and must **not** be an auth-capable account — explicitly not a portal-login bypass. The ticket's `submittedBy` points at it; the next email from the same sender then matches precedence step 1.
+
+## API (partner/admin-scoped, under `ticket-config`)
+
+- `GET /ticket-config/inbound-domains` — list mappings for the partner, joined with org names.
+- `POST /ticket-config/inbound-domains` — create `{ domain, orgId, autoCreateContact }`.
+- `PATCH /ticket-config/inbound-domains/:id` — update `{ orgId?, autoCreateContact?, isActive? }`.
+- `DELETE /ticket-config/inbound-domains/:id` — remove.
+- Wire `defaultTriageOrgId` + new `triageUnknownSenders` boolean into the existing config `GET`/`PATCH`.
+
+Authz:
+- Partner-admin scope (`requirePermission`); org-scope users have no access (partner config surface).
+- Server-side, `orgId` must belong to the caller's partner — cross-tenant attempt → **403** (explicit IDOR test, in addition to the DB composite FK).
+- Validate/normalize `domain` (lowercase, hostname shape, freemail rejection) in the shared Zod schema.
+
+## Web UI
+
+`apps/web/src/components/settings/` (extend `InboundEmailCard.tsx` or add `CustomerDomainsCard.tsx`):
+- **"Customer email domains"** table — domain → org rows; add/edit/delete; per-row **auto-create-contact** toggle.
+- Un-stub the **"Default triage organization"** picker (remove "reserved for future use"); add a **"Route unknown senders to triage org"** toggle bound to `triageUnknownSenders`.
+- Mutations go through `runAction` (success/failure always surfaced).
+- The review queue is unchanged but now quarantines fewer emails.
+
+## Testing
+
+- **RLS forge** (`*.integration.test.ts`, `breeze_app`): cross-partner and cross-org isolation on `customer_email_domains`; re-seed fixtures per `it` (no memoized fixture).
+- **rls-coverage** allowlist updates: `PARTNER_TENANT_TABLES` + `ORG_AXIS_POLICY_EXCLUDED_TABLES`.
+- **tenantCascade** contract: org + partner cascade order entries at correct `localeCompare` slot.
+- **Resolver unit tests:** precedence order; freemail rejection; SPF/DKIM-fail → quarantine even on domain match; `autoCreateContact` on vs off.
+- **Inbound integration:** mapped-domain email auto-creates a ticket in the correct org; auto-created contact then matches as a known sender on the next email; triage fallback routes when enabled and quarantines when not.
+- **Config route tests:** CRUD + cross-tenant **403** (partner A cannot map a domain to partner B's org); `runAction` failure surfacing in the web layer.
+- **Validator tests:** domain normalization + freemail blocklist.
+
+## Migration & rollout notes
+
+- Single additive migration creating `customer_email_domains` + RLS policies (idempotent, date-prefixed `2026-06-20-*`). `triageUnknownSenders` added to the existing partner ticket-settings table via `ADD COLUMN IF NOT EXISTS` (default false → unchanged behavior on deploy).
+- No backfill. Behavior is opt-in: with no domain mappings and triage disabled, routing is identical to Phase 4.
+- Confirm during planning where `defaultTriageOrgId` is currently persisted and that the SPF/DKIM result is available on the inbound payload at the resolution point.

--- a/docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md
+++ b/docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md
@@ -33,8 +33,8 @@ Out of scope (unchanged from Phase 4 deferrals):
 | Where does the sender-domain mapping live? | **New table** `customer_email_domains`, not a column on `partner_inbound_domains`. Recipient-domain (MSP inbound address) and sender-domain (customer identity) are semantically distinct with different uniqueness rules. |
 | Does a domain match auto-create the ticket? | **Always.** That is the point of mapping the domain. |
 | What is toggleable? | **Only contact/portal-user creation** — it has login/notification side effects. Per-domain-row `autoCreateContact` flag (default on). |
-| Triage-org fallback default | **Off.** Opt-in via a `triageUnknownSenders` boolean + the `defaultTriageOrgId` picker. When off, behavior is unchanged (quarantine). |
-| Spoofing guard | Auto-routing on a domain/triage match requires the **Mailgun SPF/DKIM result to pass**; on auth failure the email quarantines even if the domain matches. |
+| Triage-org fallback default | **Off.** Opt-in via a `triageUnknownSenders` boolean + the `defaultTriageOrgId` picker. Both live in `partners.settings` JSONB (`settings.ticketing.inbound`) — no column/migration. When off, behavior is unchanged (quarantine). |
+| Spoofing guard | **Reuse the existing gate.** `inboundEmailService.ts` already quarantines unmatched emails unless `senderAuth.verified` (Mailgun **DMARC-pass**, the only From-domain-aligned signal). The new domain/triage routing sits behind that gate and inherits it — no new gate is built. |
 
 ## Org-resolution precedence (new-ticket path)
 
@@ -45,7 +45,7 @@ In `inboundEmailService.ts`, for an inbound email that is **not** a reply to a l
 3. **Triage fallback** — partner has `triageUnknownSenders` enabled **and** `defaultTriageOrgId` set → that catch-all org. *(NEW wiring.)* Create the ticket; **no** contact auto-create (the customer is unknown).
 4. **Quarantine** — none matched. *(Existing.)*
 
-**Spoofing gate:** Steps 2 and 3 (the new auto-route paths) only proceed when the inbound payload's SPF/DKIM verification passes. On auth failure, fall through to quarantine even if a domain matched. Step 1 is unchanged from Phase 4 (it already trusts the From address); steps 2–3 widen that trust to a whole domain, so the gate is required to prevent `From:`-header forgery from filing tickets into a customer's org.
+**Spoofing gate (already present):** `inboundEmailService.ts` already requires `senderAuth.verified` (Mailgun DMARC-pass) before an unmatched email reaches sender resolution — unverified senders quarantine with `'unverified sender (SPF/DKIM/DMARC)'`. The new steps 2–3 are inserted *after* that existing gate, so they inherit it: a forged `From: @acme.com` that fails DMARC never reaches domain routing. DMARC-pass is specifically the From-domain-aligned signal (a standalone SPF/DKIM pass is deliberately not treated as verified), which is exactly the trust we need to route on the From domain. No new gate is added.
 
 ## Data model — `customer_email_domains` (new table)
 
@@ -83,7 +83,7 @@ Reject mapping free-provider domains (`gmail.com`, `outlook.com`, `hotmail.com`,
 
 - New `resolveOrgBySenderDomain(fromAddress, partnerId): { orgId, autoCreateContact } | null` in `apps/api/src/services/inboundEmail/` (system-context; used by the worker). Keyed on the **sender** (From) domain — kept separate from `resolvePartnerByRecipient`, which keys on the **recipient**.
 - `inboundEmailService.ts` new-ticket path calls it after the existing portal-user lookup fails and before quarantine, applying the precedence and SPF/DKIM gate above.
-- **Auto-created contact** = a `portal_users` row with `org_id`, email, display name (from the `From` header), `source = 'email_auto'`, and **no password / non-login status**. It exists for attribution and future threading only and must **not** be an auth-capable account — explicitly not a portal-login bypass. The ticket's `submittedBy` points at it; the next email from the same sender then matches precedence step 1.
+- **Auto-created contact** = a `portal_users` row with `org_id`, email, display name (from the `From` header), and `passwordHash: null`. A null hash is inherently non-login (the Entra path already creates password-less rows, so this is an existing shape, not a new one) — explicitly not a portal-login bypass. `authMethod` stays `'password'`, `status` `'active'` so the contact can receive notifications/autoresponses. The ticket's `submittedBy` points at it; the next email from the same sender then matches precedence step 1. (No `source` column exists on `portal_users` and none is added — the table is auth-sensitive and left unchanged.)
 
 ## API (partner/admin-scoped, under `ticket-config`)
 
@@ -118,6 +118,7 @@ Authz:
 
 ## Migration & rollout notes
 
-- Single additive migration creating `customer_email_domains` + RLS policies (idempotent, date-prefixed `2026-06-20-*`). `triageUnknownSenders` added to the existing partner ticket-settings table via `ADD COLUMN IF NOT EXISTS` (default false → unchanged behavior on deploy).
+- Single additive migration creating `customer_email_domains` + RLS policies (idempotent, date-prefixed `2026-06-20-*`). The composite FK `(org_id, partner_id) → organizations(id, partner_id)` reuses the unique constraint already present on `organizations(id, partner_id)` (used by `ticket_categories` and `users`); confirm it exists during Task 1.
+- `triageUnknownSenders` is **not** a column — it lives in `partners.settings` JSONB at `settings.ticketing.inbound.triageUnknownSenders`, alongside the existing `defaultTriageOrgId`. No migration; default-absent reads as `false`.
 - No backfill. Behavior is opt-in: with no domain mappings and triage disabled, routing is identical to Phase 4.
-- Confirm during planning where `defaultTriageOrgId` is currently persisted and that the SPF/DKIM result is available on the inbound payload at the resolution point.
+- Resolution findings (verified during planning): `defaultTriageOrgId` is persisted in `partners.settings` JSONB; the DMARC-pass auth signal is on `NormalizedInboundEmail.senderAuth.verified` and already gates the unmatched-email path at `inboundEmailService.ts:172`.

--- a/packages/shared/src/validators/ticketConfig.test.ts
+++ b/packages/shared/src/validators/ticketConfig.test.ts
@@ -163,3 +163,44 @@ describe('orgTicketSettingsSchema', () => {
     expect(orgTicketSettingsSchema.safeParse({ slaOverrides: { normal: { resolutionMinutes: 480 } } }).success).toBe(true);
   });
 });
+
+import { createCustomerEmailDomainSchema, updateCustomerEmailDomainSchema } from './ticketConfig';
+
+describe('createCustomerEmailDomainSchema', () => {
+  const orgId = '11111111-1111-4111-8111-111111111111';
+
+  it('accepts a normal domain, lowercases it, and defaults autoCreateContact true', () => {
+    const r = createCustomerEmailDomainSchema.parse({ domain: 'ACME.com', orgId });
+    expect(r.domain).toBe('acme.com');
+    expect(r.autoCreateContact).toBe(true);
+  });
+
+  it('honors an explicit autoCreateContact false', () => {
+    const r = createCustomerEmailDomainSchema.parse({ domain: 'acme.com', orgId, autoCreateContact: false });
+    expect(r.autoCreateContact).toBe(false);
+  });
+
+  it('rejects free-provider domains', () => {
+    expect(createCustomerEmailDomainSchema.safeParse({ domain: 'gmail.com', orgId }).success).toBe(false);
+    expect(createCustomerEmailDomainSchema.safeParse({ domain: 'Outlook.com', orgId }).success).toBe(false);
+  });
+
+  it('rejects malformed domains', () => {
+    expect(createCustomerEmailDomainSchema.safeParse({ domain: 'not a domain', orgId }).success).toBe(false);
+    expect(createCustomerEmailDomainSchema.safeParse({ domain: 'acme', orgId }).success).toBe(false);
+  });
+
+  it('rejects a non-uuid orgId', () => {
+    expect(createCustomerEmailDomainSchema.safeParse({ domain: 'acme.com', orgId: 'nope' }).success).toBe(false);
+  });
+});
+
+describe('updateCustomerEmailDomainSchema', () => {
+  it('requires at least one field', () => {
+    expect(updateCustomerEmailDomainSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('accepts a partial update', () => {
+    expect(updateCustomerEmailDomainSchema.safeParse({ isActive: false }).success).toBe(true);
+  });
+});

--- a/packages/shared/src/validators/ticketConfig.ts
+++ b/packages/shared/src/validators/ticketConfig.ts
@@ -64,3 +64,38 @@ export const orgTicketSettingsSchema = z.object({
   defaultBillable: z.boolean().nullable().optional()
 }).refine((v) => Object.keys(v).length > 0, { message: 'At least one field is required' });
 export type OrgTicketSettingsInput = z.infer<typeof orgTicketSettingsSchema>;
+
+// Phase 5: sender-domain -> customer-org mapping. Free email providers are
+// rejected — mapping e.g. gmail.com would route every consumer sender to a
+// single org.
+export const FREEMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  'gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'live.com',
+  'msn.com', 'yahoo.com', 'ymail.com', 'icloud.com', 'me.com', 'mac.com',
+  'aol.com', 'proton.me', 'protonmail.com', 'gmx.com', 'mail.com', 'zoho.com'
+]);
+
+const customerDomainSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .regex(
+    /^(?=.{1,255}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/,
+    'Enter a valid domain like acme.com'
+  )
+  .refine((d) => !FREEMAIL_DOMAINS.has(d), 'Free email providers cannot be mapped to a single organization');
+
+export const createCustomerEmailDomainSchema = z.object({
+  domain: customerDomainSchema,
+  orgId: z.string().guid(),
+  autoCreateContact: z.boolean().optional().default(true)
+});
+export type CreateCustomerEmailDomainInput = z.infer<typeof createCustomerEmailDomainSchema>;
+
+export const updateCustomerEmailDomainSchema = z
+  .object({
+    orgId: z.string().guid().optional(),
+    autoCreateContact: z.boolean().optional(),
+    isActive: z.boolean().optional()
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: 'At least one field is required' });
+export type UpdateCustomerEmailDomainInput = z.infer<typeof updateCustomerEmailDomainSchema>;


### PR DESCRIPTION
## Summary

Completes the **org-resolution layer** of email-to-ticket (Phase 4 shipped ingest, but inbound mail only resolved a customer org when the sender was already a registered portal user — everyone else quarantined). This phase lets an MSP map a customer's sender domain to a customer org, adds an opt-in triage-org fallback, and onboards unknown senders.

**New inbound org-resolution precedence** (`inboundEmailService.ts`, behind the existing `senderAuth.verified` DMARC gate):
1. Known portal user → their home org *(existing, most specific)*
2. **Sender domain mapped to a customer org → that org** *(new; always creates the ticket; optionally onboards a password-less contact)*
3. **Triage-org fallback** → opt-in catch-all org *(new; wires the previously-stubbed picker)*
4. Quarantine *(existing)*

## Design decisions
- **New `customer_email_domains` table** (not a column on `partner_inbound_domains`) — sender-domain (customer identity) and recipient-domain (MSP inbound address) are distinct concepts.
- **Partner-axis RLS + denormalized `org_id`**, with a composite FK `(org_id, partner_id) → organizations(id, partner_id)` closing the cross-org IDOR at the DB layer (the `#1594` dual-axis blindspot). Added to **both** `PARTNER_TENANT_TABLES` and `ORG_AXIS_POLICY_EXCLUDED_TABLES`, plus the cascade order.
- **Spoofing**: the new routing inherits the existing DMARC-pass gate — no new gate. A forged `From:` that fails DMARC never reaches domain routing.
- **Auto-created contact** = `passwordHash: null` portal user (non-login; same shape as the Entra path). No `portal_users` schema change.
- **Triage settings** live in `partners.settings` JSONB — no migration.
- **Freemail blocklist** rejects mapping `gmail.com`/`outlook.com`/etc.

## Implementation
9 TDD tasks (spec `docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md`, plan `docs/superpowers/plans/2026-06-20-ticketing-phase5-email-customer-routing.md`):
migration + schema, RLS forge + coverage, cascade, shared validators, resolver + contact onboarding, dispatch wiring, config-service CRUD, config routes, and the settings UI (`CustomerDomainsCard` + triage toggle un-stub).

## Tests
- **RLS forge** (real `breeze_app` role, non-vacuous): cross-partner reject, **cross-org composite-FK reject**, cross-partner SELECT invisibility, legit insert.
- **Resolver**: case-insensitive match, `isActive` filter, idempotent contact, partner-scoping (same domain under two partners), JSONB triage policy.
- **Dispatch**: all four precedence branches, **known-user-wins-over-domain**, and DMARC-gate-skips-domain-routing (negative assertion).
- **Config/routes**: CRUD + IDOR 400/404, freemail 400, duplicate 409.
- Full suites green: **API 9367 passed** (the 2 failures are the known-flaky `mcpServer.effectiveTier.test.ts`, green in isolation — unrelated to this PR), **shared 839/839**, **web 1848/1848**. apps/api typechecks clean.

## Review
Five-agent review (code-quality, silent-failure, coverage, type-design, comments): **no Critical issues**; security-critical paths independently verified. Findings addressed in `refactor(ticketing): address Phase 5 review findings` (pinned unique-constraint name, two added precedence/partner-scope tests, comment corrections).

**Deferred (non-blocking, documented):** a `portal_users (org_id, email)` unique index (pre-existing dup tolerance; needs a dedicated auth-table migration) and write-time validation of `defaultTriageOrgId` (debuggability only — security holds via the runtime org-in-partner guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)