### PR TITLE
fix(agent): report pressure-aware RAM usage on macOS

### DIFF
--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.11'
 
 jobs:
   build-arm64:

--- a/agent/internal/collectors/memory_metrics.go
+++ b/agent/internal/collectors/memory_metrics.go
@@ -1,0 +1,15 @@
+package collectors
+
+import "github.com/shirou/gopsutil/v3/mem"
+
+const bytesPerMiB = 1024 * 1024
+
+func collectGopsutilMemoryMetrics(metrics *SystemMetrics) error {
+	vmem, err := mem.VirtualMemory()
+	if err != nil {
+		return err
+	}
+	metrics.RAMPercent = vmem.UsedPercent
+	metrics.RAMUsedMB = vmem.Used / bytesPerMiB
+	return nil
+}

--- a/agent/internal/collectors/memory_metrics_darwin.go
+++ b/agent/internal/collectors/memory_metrics_darwin.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package collectors
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const memoryPressureCommandTimeout = 2 * time.Second
+const memoryPressureCommandPath = "/usr/bin/memory_pressure"
+
+var darwinMemoryPressureFallbackOnce sync.Once
+
+func collectMemoryMetrics(metrics *SystemMetrics) {
+	if err := collectDarwinPressureAwareMemoryMetrics(metrics); err == nil {
+		return
+	} else {
+		darwinMemoryPressureFallbackOnce.Do(func() {
+			slog.Warn("macOS pressure-aware memory collection failed, falling back to gopsutil", "error", err.Error())
+		})
+	}
+	_ = collectGopsutilMemoryMetrics(metrics)
+}
+
+func collectDarwinPressureAwareMemoryMetrics(metrics *SystemMetrics) error {
+	out, err := runCollectorOutput(memoryPressureCommandTimeout, memoryPressureCommandPath, "-Q")
+	if err != nil {
+		return fmt.Errorf("memory_pressure failed: %w", err)
+	}
+	totalBytes, freePercent, err := parseMemoryPressureOutput(string(out))
+	if err != nil {
+		return err
+	}
+	applyPressureAwareMemoryMetrics(metrics, totalBytes, freePercent)
+	return nil
+}

--- a/agent/internal/collectors/memory_metrics_other.go
+++ b/agent/internal/collectors/memory_metrics_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package collectors
+
+func collectMemoryMetrics(metrics *SystemMetrics) {
+	_ = collectGopsutilMemoryMetrics(metrics)
+}

--- a/agent/internal/collectors/memory_pressure.go
+++ b/agent/internal/collectors/memory_pressure.go
@@ -1,0 +1,48 @@
+package collectors
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var (
+	memoryPressureTotalRe = regexp.MustCompile(`(?m)^The system has\s+(\d+)\s+\(`)
+	memoryPressureFreeRe  = regexp.MustCompile(`(?m)^System-wide memory free percentage:\s+([0-9]+(?:\.[0-9]+)?)%`)
+)
+
+func parseMemoryPressureOutput(output string) (totalBytes uint64, freePercent float64, err error) {
+	totalMatch := memoryPressureTotalRe.FindStringSubmatch(output)
+	if len(totalMatch) != 2 {
+		return 0, 0, fmt.Errorf("missing total memory")
+	}
+	totalBytes, err = strconv.ParseUint(totalMatch[1], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse total memory: %w", err)
+	}
+	if totalBytes == 0 {
+		return 0, 0, fmt.Errorf("total memory is zero")
+	}
+
+	freeMatch := memoryPressureFreeRe.FindStringSubmatch(output)
+	if len(freeMatch) != 2 {
+		return 0, 0, fmt.Errorf("missing free percentage")
+	}
+	freePercent, err = strconv.ParseFloat(freeMatch[1], 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse free percentage: %w", err)
+	}
+	if freePercent < 0 || freePercent > 100 {
+		return 0, 0, fmt.Errorf("free percentage %.2f out of range", freePercent)
+	}
+
+	return totalBytes, freePercent, nil
+}
+
+func applyPressureAwareMemoryMetrics(metrics *SystemMetrics, totalBytes uint64, freePercent float64) {
+	usedPercent := 100 - freePercent
+	metrics.RAMPercent = usedPercent
+	// RAMUsedMB is the pressure-used equivalent for consistency with RAMPercent,
+	// not literal resident/allocated memory.
+	metrics.RAMUsedMB = uint64((float64(totalBytes) * usedPercent / 100) / bytesPerMiB)
+}

--- a/agent/internal/collectors/memory_pressure_test.go
+++ b/agent/internal/collectors/memory_pressure_test.go
@@ -1,0 +1,88 @@
+package collectors
+
+import "testing"
+
+func TestParseMemoryPressureOutputAppleSiliconCapture(t *testing.T) {
+	const output = `The system has 51539607552 (3145728 pages with a page size of 16384).
+System-wide memory free percentage: 73%`
+
+	total, free, err := parseMemoryPressureOutput(output)
+	if err != nil {
+		t.Fatalf("parseMemoryPressureOutput error: %v", err)
+	}
+	if total != 51539607552 {
+		t.Fatalf("total = %d, want 51539607552", total)
+	}
+	if free != 73 {
+		t.Fatalf("free = %.2f, want 73", free)
+	}
+
+	metrics := &SystemMetrics{}
+	applyPressureAwareMemoryMetrics(metrics, total, free)
+	if metrics.RAMPercent != 27 {
+		t.Fatalf("RAMPercent = %.2f, want 27", metrics.RAMPercent)
+	}
+	if metrics.RAMUsedMB != 13271 {
+		t.Fatalf("RAMUsedMB = %d, want 13271", metrics.RAMUsedMB)
+	}
+}
+
+func TestParseMemoryPressureOutputIntelCapture(t *testing.T) {
+	const output = `The system has 68719476736 (16777216 pages with a page size of 4096).
+System-wide memory free percentage: 92%`
+
+	total, free, err := parseMemoryPressureOutput(output)
+	if err != nil {
+		t.Fatalf("parseMemoryPressureOutput error: %v", err)
+	}
+
+	metrics := &SystemMetrics{}
+	applyPressureAwareMemoryMetrics(metrics, total, free)
+	if metrics.RAMPercent != 8 {
+		t.Fatalf("RAMPercent = %.2f, want 8", metrics.RAMPercent)
+	}
+	if metrics.RAMUsedMB != 5242 {
+		t.Fatalf("RAMUsedMB = %d, want 5242", metrics.RAMUsedMB)
+	}
+}
+
+func TestParseMemoryPressureOutputDecimalFreePercent(t *testing.T) {
+	const output = `The system has 68719476736 (16777216 pages with a page size of 4096).
+System-wide memory free percentage: 91.5%`
+
+	total, free, err := parseMemoryPressureOutput(output)
+	if err != nil {
+		t.Fatalf("parseMemoryPressureOutput error: %v", err)
+	}
+
+	metrics := &SystemMetrics{}
+	applyPressureAwareMemoryMetrics(metrics, total, free)
+	if metrics.RAMPercent != 8.5 {
+		t.Fatalf("RAMPercent = %.2f, want 8.5", metrics.RAMPercent)
+	}
+	if metrics.RAMUsedMB != 5570 {
+		t.Fatalf("RAMUsedMB = %d, want 5570", metrics.RAMUsedMB)
+	}
+}
+
+func TestParseMemoryPressureOutputRejectsMalformedOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{name: "missing total", output: `System-wide memory free percentage: 92%`},
+		{name: "missing percentage", output: `The system has 68719476736 (16777216 pages with a page size of 4096).`},
+		{name: "zero total", output: `The system has 0 (0 pages with a page size of 4096).
+System-wide memory free percentage: 92%`},
+		{name: "percentage above 100", output: `The system has 68719476736 (16777216 pages with a page size of 4096).
+System-wide memory free percentage: 120%`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := parseMemoryPressureOutput(tt.output); err == nil {
+				t.Fatal("expected parse error")
+			}
+		})
+	}
+}

--- a/agent/internal/collectors/metrics.go
+++ b/agent/internal/collectors/metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
-	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/shirou/gopsutil/v3/net"
 	"github.com/shirou/gopsutil/v3/process"
 )
@@ -120,12 +119,7 @@ func (c *MetricsCollector) Collect() (*SystemMetrics, error) {
 		metrics.CPUPercent = pct
 	}
 
-	// Memory
-	vmem, err := mem.VirtualMemory()
-	if err == nil {
-		metrics.RAMPercent = vmem.UsedPercent
-		metrics.RAMUsedMB = vmem.Used / 1024 / 1024
-	}
+	collectMemoryMetrics(metrics)
 
 	// Disk (root partition)
 	diskUsage, err := disk.Usage("/")


### PR DESCRIPTION
## Summary

- Uses macOS `memory_pressure -Q` for agent RAM percent so Breeze reports pressure-aware memory usage instead of cache-inclusive gopsutil usage.
- Keeps non-macOS memory collection unchanged and falls back to gopsutil on macOS if pressure-aware collection fails.
- Aligns the dev agent build workflow Go version with `agent/go.mod`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] CI / build / tooling
- [ ] Other:

## Testing

- [ ] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [x] Manual testing (describe below)

Manual testing:
- Built and installed test macOS agents on Apple Silicon and Intel Macs.
- Verified Apple Silicon RAM graph dropped from cache-inclusive ~64% to pressure-aware ~28-31%, matching `memory_pressure -Q`.
- Captured Intel baseline showing the existing metric was also cache-inclusive relative to `memory_pressure -Q`.

Checks run:
- `cd agent && go test ./internal/collectors`
- `cd agent && go test -race ./internal/collectors`
- `cd agent && go test ./cmd/breeze-agent ./internal/heartbeat ./pkg/api`
- `cd agent && go test -race ./...`
- `cd agent && go vet ./...`
- `pnpm lint`
- `pnpm build`

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included