### PR TITLE
fix(devices): show display names in the Device column

### DIFF
--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -90,7 +90,7 @@ describe('search routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([
-              { id: 'dev-1', title: 'Workstation 01', hostname: 'ws-01', status: 'online' }
+              { id: 'dev-1', title: 'Workstation 01', hostname: 'ws-01', status: 'online', lastUser: null }
             ])
           })
         })
@@ -122,6 +122,88 @@ describe('search routes', () => {
     expect(body.results.some((row: { type?: string }) => row.type === 'devices')).toBe(true);
     expect(body.results.some((row: { type?: string }) => row.type === 'scripts')).toBe(true);
     expect(body.results.some((row: { type?: string }) => row.type === 'alerts')).toBe(true);
+  });
+
+  it('includes hostname in device result descriptions when display name is the title', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: 'dev-1',
+                title: 'Alek 2019 MBP',
+                hostname: 'Aleksey-16-MacBook-Pro.decom-09cb5eb9',
+                status: 'online',
+                lastUser: 'admitriev'
+              }
+            ])
+          })
+        })
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as never);
+
+    const res = await app.request('/search?q=16');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results).toContainEqual({
+      id: 'dev-1',
+      type: 'devices',
+      title: 'Alek 2019 MBP',
+      description: 'Aleksey-16-MacBook-Pro.decom-09cb5eb9 · online · admitriev'
+    });
+  });
+
+  it('does not duplicate hostname in device result descriptions when hostname is the title', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              { id: 'dev-1', title: null, hostname: 'host-16', status: 'online', lastUser: null }
+            ])
+          })
+        })
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as never);
+
+    const res = await app.request('/search?q=16');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results).toContainEqual({
+      id: 'dev-1',
+      type: 'devices',
+      title: 'host-16',
+      description: 'online'
+    });
   });
 
   it('validates required query parameter', async () => {

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -19,6 +19,32 @@ const SETTINGS_ENTRIES = [
   { id: 'settings-users', type: 'settings', title: 'User management', description: 'Manage users and roles', href: '/settings/users' }
 ] as const;
 
+type DeviceSearchRow = {
+  id: string;
+  title: string | null;
+  hostname: string | null;
+  status: string | null;
+  lastUser: string | null;
+};
+
+function deviceSearchResult(row: DeviceSearchRow): Record<string, unknown> {
+  const displayName = row.title?.trim() || null;
+  const hostname = row.hostname?.trim() || null;
+  const title = displayName || hostname || 'Unknown device';
+  const descriptionParts = [
+    displayName && hostname && displayName !== hostname ? hostname : null,
+    row.status,
+    row.lastUser
+  ];
+
+  return {
+    id: row.id,
+    type: 'devices',
+    title,
+    description: descriptionParts.filter(Boolean).join(' · ') || undefined
+  };
+}
+
 export const searchRoutes = new Hono();
 
 searchRoutes.use('*', authMiddleware);
@@ -110,12 +136,7 @@ searchRoutes.get('/', zValidator('query', searchQuerySchema), async (c) => {
   ]);
 
   const results: Array<Record<string, unknown>> = [
-    ...deviceRows.map((row) => ({
-      id: row.id,
-      type: 'devices',
-      title: row.title || row.hostname,
-      description: [row.status, row.lastUser].filter(Boolean).join(' · ') || undefined
-    })),
+    ...deviceRows.map((row) => deviceSearchResult(row)),
     ...scriptRows.map((row) => ({
       id: row.id,
       type: 'scripts',

--- a/apps/web/src/components/devices/DeviceFilterToolbar.test.tsx
+++ b/apps/web/src/components/devices/DeviceFilterToolbar.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DeviceFilterToolbar } from './DeviceFilterToolbar';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ data: [] }),
+  })),
+}));
+
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: Object.assign(
+    (selector?: (state: { currentOrgId: string | null }) => unknown) => {
+      const state = { currentOrgId: null };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ currentOrgId: null }) },
+  ),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('./SavedViewsMenu', () => ({
+  SavedViewsMenu: () => null,
+}));
+
+describe('DeviceFilterToolbar — device search', () => {
+  it('labels the quick search as device search and writes into listFilters.search', () => {
+    const onListFiltersChange = vi.fn();
+
+    render(
+      <DeviceFilterToolbar
+        value={null}
+        onChange={vi.fn()}
+        listFilters={{ search: '' }}
+        onListFiltersChange={onListFiltersChange}
+      />
+    );
+
+    const input = screen.getByLabelText('Search devices');
+    expect(input).toHaveAttribute('placeholder', 'Search devices');
+
+    fireEvent.change(input, { target: { value: 'Reception' } });
+
+    expect(onListFiltersChange).toHaveBeenCalledWith({ search: 'Reception' });
+  });
+});

--- a/apps/web/src/components/devices/DeviceFilterToolbar.tsx
+++ b/apps/web/src/components/devices/DeviceFilterToolbar.tsx
@@ -1,7 +1,7 @@
 // DeviceFilterToolbar — the single, unified filter surface for the Devices
 // page, in the chip-centric model. EVERY structured filter is an editable chip
 // living in one server-resolved FilterConditionGroup; the only standing inline
-// control is the hostname Search box.
+// control is the device Search box.
 //
 // Layout (one control row):
 //   🔍 Search · quick-preset chips · More ▾ (add any chip type) · Advanced ▾
@@ -34,7 +34,7 @@ export interface DeviceFilterToolbarProps {
   // The server-resolved group (quick chips + More-added chips + Advanced drawer).
   value: FilterConditionGroup | null;
   onChange: (next: FilterConditionGroup | null) => void;
-  // Instant client-side filter (hostname search only), owned by DevicesPage and
+  // Instant client-side filter (device search only), owned by DevicesPage and
   // shared with DeviceList.
   listFilters: ListFilters;
   onListFiltersChange: (next: ListFilters) => void;
@@ -289,18 +289,18 @@ export function DeviceFilterToolbar({
 
   return (
     <div data-testid="device-filter-toolbar" className="flex flex-col gap-2">
-      {/* Unified filter bar — one surface holding the live hostname search, the
+      {/* Unified filter bar — one surface holding the live device search, the
           quick-preset chips, and the "+ Add filter" picker. The bar itself owns
           the border + focus ring; everything inside is borderless/chip-light so
           the controls read as one cohesive tool, not three stacked widgets. */}
       <div className="flex items-center gap-2 rounded-lg border bg-background px-2 py-1.5 transition focus-within:ring-2 focus-within:ring-ring">
-        {/* Hostname search — borderless, blends into the bar (the one live filter). */}
+        {/* Device search — borderless, blends into the bar (the one live filter). */}
         <div className="flex w-40 shrink-0 items-center gap-2 sm:w-56">
           <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
           <input
             type="text"
-            placeholder="Search hostname…"
-            aria-label="Search by hostname"
+            placeholder="Search devices"
+            aria-label="Search devices"
             value={listFilters.search}
             onChange={e => patch({ search: e.target.value })}
             className="w-full appearance-none border-0 bg-transparent p-0 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-0"

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -67,6 +67,60 @@ describe('DeviceList — OS version display', () => {
   });
 });
 
+describe('DeviceList — Device column display names', () => {
+  beforeEach(() => {
+    window.localStorage?.clear();
+  });
+
+  it('shows display name as the primary device label and hostname as secondary text', () => {
+    render(<DeviceList devices={[{ ...baseDevice, displayName: 'Reception Laptop' }]} />);
+
+    expect(screen.getByText('Device')).toBeInTheDocument();
+    expect(screen.getByText('Reception Laptop')).toBeInTheDocument();
+    expect(screen.getByText('host-a')).toBeInTheDocument();
+  });
+
+  it('falls back to hostname when display name is not set', () => {
+    render(<DeviceList devices={[baseDevice]} />);
+
+    expect(screen.getByText('host-a')).toBeInTheDocument();
+  });
+
+  it('matches the quick search against display name as well as hostname', () => {
+    const displayNamedDevice: Device = {
+      ...baseDevice,
+      id: '12121212-1212-1212-1212-121212121212',
+      hostname: 'host-alpha',
+      displayName: 'Reception Laptop',
+    };
+    const hostnameOnlyDevice: Device = {
+      ...baseDevice,
+      id: '34343434-3434-3434-3434-343434343434',
+      hostname: 'host-beta',
+    };
+
+    const { rerender } = render(
+      <DeviceList
+        devices={[displayNamedDevice, hostnameOnlyDevice]}
+        listFilters={{ search: 'reception' }}
+      />
+    );
+
+    expect(screen.getByText('Reception Laptop')).toBeInTheDocument();
+    expect(screen.queryByText('host-beta')).toBeNull();
+
+    rerender(
+      <DeviceList
+        devices={[displayNamedDevice, hostnameOnlyDevice]}
+        listFilters={{ search: 'host-beta' }}
+      />
+    );
+
+    expect(screen.getByText('host-beta')).toBeInTheDocument();
+    expect(screen.queryByText('Reception Laptop')).toBeNull();
+  });
+});
+
 describe('DeviceList — agent-silent (watchdog OK) badge (#800 web-UI gap)', () => {
   it('renders the amber badge when mainAgentSilentSince is set AND watchdog is reporting', () => {
     const device: Device = {
@@ -264,7 +318,7 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     expect(rowOrder(container)).toEqual(['host-zeta', 'host-mid', 'host-acme']);
   });
 
-  it('sorts hostnames with numeric collation (host-2 before host-10)', () => {
+  it('sorts devices with numeric collation (host-2 before host-10)', () => {
     const devices: Device[] = [
       { ...baseDevice, id: 'b1b1b1b1-0000-0000-0000-000000000001', hostname: 'host-10' },
       { ...baseDevice, id: 'b1b1b1b1-0000-0000-0000-000000000002', hostname: 'host-2' },
@@ -272,7 +326,7 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
 
     const { container } = render(<DeviceList devices={devices} />);
 
-    clickHeader('Sort by hostname');
+    clickHeader('Sort by device');
     expect(rowOrder(container)).toEqual(['host-2', 'host-10']);
   });
 
@@ -364,7 +418,7 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     ];
     render(<DeviceList devices={devices} />);
 
-    const hostHeader = screen.getByTitle('Sort by hostname');
+    const hostHeader = screen.getByTitle('Sort by device');
     const osHeader = screen.getByTitle('Sort by operating system');
     // Unsorted: every header advertises aria-sort="none".
     expect(hostHeader.getAttribute('aria-sort')).toBe('none');

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -137,7 +137,7 @@ type DeviceListProps = {
   onSelect?: (device: Device) => void;
   onAction?: (action: string, device: Device) => void;
   onBulkAction?: (action: string, devices: Device[]) => void;
-  // Controlled inline filter state — now just the hostname search box, owned by
+  // Controlled inline filter state — now just the device search box, owned by
   // DevicesPage and shared with DeviceFilterToolbar. Every other structured
   // filter lives in the server-resolved group (serverFilterIds). Defaults keep
   // DeviceList usable on its own (tests render it standalone).
@@ -311,7 +311,7 @@ export default function DeviceList({
   // Use provided timezone or browser default
   const effectiveTimezone = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  // The only inline (instant, client-side) filter is the hostname search box,
+  // The only inline (instant, client-side) filter is device search,
   // owned by DevicesPage and shared with DeviceFilterToolbar. Every other
   // structured filter (status/os/role/org/site/group/…) now lives in the
   // server-resolved group and arrives pre-resolved as `serverFilterIds`. When
@@ -430,7 +430,7 @@ export default function DeviceList({
     }
   }, [autoSelectGroupId, groups, onAutoSelectConsumed]);
 
-  // Reset to page 1 whenever the active filters change (the hostname search, the
+  // Reset to page 1 whenever the active filters change (device search, the
   // class facet, and the server-resolved id set are the only things that narrow
   // the list now). This replaces the per-control setCurrentPage(1) calls that
   // lived on each filter input before the toolbar was extracted.
@@ -647,12 +647,23 @@ export default function DeviceList({
     (device.deviceClass ?? 'agent') === 'network' ? dash : node;
   const columnDefs: Record<ColumnId, { header: () => React.ReactNode; cell: (device: Device) => React.ReactNode }> = {
     hostname: {
-      header: () => sortHeader('hostname', 'Hostname', 'Sort by hostname'),
-      cell: (device) => (
-        <td key="hostname" className="max-w-[200px] px-3 py-3 text-sm font-medium">
-          <span className="block truncate" title={device.displayName || device.hostname}>{device.displayName || device.hostname}</span>
-        </td>
-      ),
+      header: () => sortHeader('hostname', 'Device', 'Sort by device'),
+      cell: (device) => {
+        const hasDisplayName = !!device.displayName && device.displayName !== device.hostname;
+        const primaryName = device.displayName || device.hostname;
+        return (
+          <td key="hostname" className="max-w-[220px] px-3 py-3 text-sm">
+            <div className="min-w-0">
+              <span className="block truncate font-medium" title={primaryName}>{primaryName}</span>
+              {hasDisplayName && (
+                <span className="block truncate text-xs text-muted-foreground" title={device.hostname}>
+                  {device.hostname}
+                </span>
+              )}
+            </div>
+          </td>
+        );
+      },
     },
     class: {
       header: () => sortHeader('class', 'Class', 'Sort by class'),

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -123,13 +123,15 @@ vi.mock('./DeviceCard', () => ({
 // action over the FULL device array it was given (mirroring the real
 // DeviceList, which hands the unfiltered selection to onBulkAction). Tests use
 // the per-action buttons to drive DevicesPage.handleBulkAction directly.
-type StubDevice = { id: string; deviceClass?: string; hostname?: string; watchdogVersion?: string | null };
+type StubDevice = { id: string; deviceClass?: string; hostname?: string; displayName?: string; watchdogVersion?: string | null };
 vi.mock('./DeviceList', () => ({
   default: ({ devices, serverFilterIds, onBulkAction }: { devices: StubDevice[]; serverFilterIds?: Set<string> | null; onBulkAction?: (action: string, devices: StubDevice[]) => void }) => (
     <div
       data-testid="device-list"
       data-device-count={devices.length}
       data-filter-ids={serverFilterIds ? [...serverFilterIds].sort().join(',') : ''}
+      data-hostnames={devices.map(d => d.hostname ?? '').join(',')}
+      data-display-names={devices.map(d => d.displayName ?? '').join(',')}
       data-watchdog-versions={devices.map(d => d.watchdogVersion ?? '').join(',')}
     >
       {['maintenance-on', 'maintenance-off', 'decommission', 'reboot', 'run-script'].map(action => (
@@ -194,6 +196,18 @@ beforeEach(() => {
 });
 
 describe('DevicesPage — advanced filter applies to BOTH views', () => {
+  it('passes displayName through to DeviceList without replacing hostname', async () => {
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [{ ...rawDevice(DEV_1, 'host-alpha'), displayName: 'Reception Laptop' }],
+    } as never);
+
+    render(<DevicesPage />);
+
+    const list = await screen.findByTestId('device-list');
+    expect(list.getAttribute('data-hostnames')).toContain('host-alpha');
+    expect(list.getAttribute('data-display-names')).toContain('Reception Laptop');
+  });
+
   it('grid view renders only the devices matching the advanced filter (not the raw list)', async () => {
     render(<DevicesPage />);
 

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -262,7 +262,8 @@ export default function DevicesPage() {
 
         return {
           id: d.id as string,
-          hostname: (d.hostname ?? d.displayName ?? 'Unknown') as string,
+          hostname: (d.hostname ?? 'Unknown') as string,
+          displayName: typeof d.displayName === 'string' ? d.displayName : undefined,
           os: (d.osType ?? d.os ?? 'windows') as OSType,
           osVersion: (d.osVersion ?? '') as string,
           status: (d.status ?? 'offline') as DeviceStatus,
@@ -315,7 +316,8 @@ export default function DevicesPage() {
         id: d.id as string,
         deviceClass: (d.deviceClass as DeviceClass) ?? 'network',
         assetType: (d.assetType as DeviceRole | undefined) ?? 'unknown',
-        hostname: (d.hostname ?? d.displayName ?? 'Unknown') as string,
+        hostname: (d.hostname ?? 'Unknown') as string,
+        displayName: typeof d.displayName === 'string' ? d.displayName : undefined,
         // No OS for a network device; the OS column renders "—" for network rows.
         os: '' as OSType,
         osVersion: '',

--- a/apps/web/src/components/devices/SavedViewsMenu.tsx
+++ b/apps/web/src/components/devices/SavedViewsMenu.tsx
@@ -5,7 +5,7 @@
 //
 // Persistence reuses the existing saved-filters backend (GET/POST/DELETE
 // /filters); the conditions column stores the FilterConditionGroup verbatim. The
-// hostname quick-search is deliberately NOT part of a view — it's a transient
+// device quick-search is deliberately NOT part of a view — it's a transient
 // lookup, not a reusable saved query.
 //
 // "Default view" has no backend column, so it's a per-browser preference in

--- a/apps/web/src/components/devices/columnVisibility.ts
+++ b/apps/web/src/components/devices/columnVisibility.ts
@@ -40,7 +40,7 @@ export const COLUMN_IDS = [
 export type ColumnId = (typeof COLUMN_IDS)[number];
 
 export const COLUMN_LABELS: Record<ColumnId, string> = {
-  hostname: 'Hostname',
+  hostname: 'Device',
   class: 'Class',
   type: 'Type',
   organization: 'Organization',

--- a/apps/web/src/components/devices/deviceListFilters.ts
+++ b/apps/web/src/components/devices/deviceListFilters.ts
@@ -5,7 +5,8 @@
 // In the chip-centric model every structured filter (status/os/role/org/site/
 // group/CPU/etc.) lives in the single server-resolved FilterConditionGroup and
 // renders as an editable chip. The ONLY inline/instant client filter left is
-// the hostname search box, so this object now carries just `search`.
+// device search (display name or hostname), so this object now carries just
+// `search`.
 
 export interface ListFilters {
   search: string;


### PR DESCRIPTION
## Summary

- Rename the devices table `Hostname` column to `Device` while preserving the existing column id/preferences.
- Show `displayName` as the primary device label, fall back to hostname when unset, and show hostname as secondary text when it differs.
- Preserve raw hostname data from the API and add coverage for display-name passthrough/rendering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other: <!-- describe -->

## Testing

- [x] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [ ] Manual testing (describe below)

Verified with:
- `npx -p node@22.20.0 -c 'pnpm test'`
- `npx -p node@22.20.0 -c 'pnpm build'`
- `pnpm lint`
- `pnpm --filter=@breeze/web exec vitest run src/components/devices/DeviceList.test.tsx src/components/devices/DevicesPage.test.tsx`
- `pnpm --filter @breeze/web run csp:guard`

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included