### PR TITLE
fix(ml): bound raw device_metrics rollup join to the window (prod DB peg)

### DIFF
--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -84,6 +84,22 @@ describe('metric rollups service', () => {
     expect(rawStatementSql).toContain('DO UPDATE SET');
   });
 
+  it('bounds the raw device_metrics join to the rollup window (incident 2026-06-21: prevents full per-device history scan)', async () => {
+    await rollupDeviceMetricsRange({
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
+
+    // The raw device statement is the first execute() call. Its LEFT JOIN must
+    // carry an explicit [from,to) bound in addition to the per-bucket bound;
+    // without it the generate_series-derived bucket_start predicate is
+    // non-sargable and Postgres bitmap-scans each device's entire history.
+    const rawDeviceSql = JSON.stringify(executeMock.mock.calls[0]);
+    expect(rawDeviceSql).toContain('LEFT JOIN device_metrics');
+    expect(rawDeviceSql).toContain('join window bound');
+  });
+
   it('lets derived rollups include gap buckets without averaging empty values', async () => {
     await rollupDeviceMetricsRange({
       orgId: '11111111-1111-1111-1111-111111111111',

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -214,6 +214,12 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
     LEFT JOIN device_metrics dm
       ON dm.org_id = bg.org_id
       AND dm.device_id = bg.device_id
+      -- join window bound: constrain the scan to [from,to). bucket_start comes
+      -- from generate_series, so the per-bucket predicates below are NOT sargable
+      -- and Postgres would bitmap-scan each device's ENTIRE metric history per
+      -- bucket. These two constant bounds let it index-range only the window.
+      AND dm.timestamp >= ${fromIso}::timestamp
+      AND dm.timestamp < ${toIso}::timestamp
       AND dm.timestamp >= bg.bucket_start
       AND dm.timestamp < bg.bucket_start + (interval '1 second' * ${RAW_BUCKET_SECONDS})
       AND ${valueSql} IS NOT NULL


### PR DESCRIPTION
## Incident

The US DigitalOcean managed Postgres was pegged at **100% CPU within ~1 hour of the v0.82.0 deploy** (2026-06-21). Root cause traced live via `pg_stat_activity` + `EXPLAIN` on prod.

## Root cause

`rollupRawDeviceMetric` (`apps/api/src/services/metricRollups.ts`) joined the **raw `device_metrics` table directly**, bounded only by per-bucket predicates:

```sql
LEFT JOIN device_metrics dm
  ON dm.org_id = bg.org_id AND dm.device_id = bg.device_id
  AND dm.timestamp >= bg.bucket_start
  AND dm.timestamp <  bg.bucket_start + interval '5 min'
```

`bucket_start` comes from `generate_series`, so these predicates are **non-sargable**. Postgres therefore bitmap-scanned **each (org, device)'s entire metric history** per bucket — ×10 device metrics × every 5 min × per org × worker concurrency 2. With only ~10 active devices on a 25-connection managed instance, that was enough to saturate CPU.

The sibling `rollupRawProcessSampleMetric` and `rollupRawSnmpMetrics` already join **windowed CTEs** (`sample_values` / `snmp_values`), so only the device path regressed — it never adopted the file's own pattern.

## Fix

Add the explicit `[from, to)` window bound to the `LEFT JOIN` so the scan is index-range-limited:

```sql
  AND dm.timestamp >= ${fromIso}::timestamp
  AND dm.timestamp <  ${toIso}::timestamp
```

**EXPLAIN on prod, same org/window:**

| | Plan | Est. cost |
|---|---|---|
| Before | Bitmap Heap Scan over full per-device history (`BitmapAnd` ~13k+50k rows) | ~50,720..53,537 |
| After | `Index Scan using device_metrics_org_id_timestamp_idx`, ~1 row/lookup | ~64..67 |

~800× cheaper. **Behavior unchanged** — the window bound is a strict superset of the per-bucket bound, so aggregates are identical.

## Production mitigation already applied

US droplet has a runtime kill switch in place (`ML_DISABLED_FLAGS=ml.metric_rollups.enabled`) gating the job before any heavy query (no deploy needed). **Remove that flag after this deploys.** EU runs identical code (also v0.82.0) — see PR discussion.

## Tests

- New regression test asserts the raw device statement carries the window bound. Verified **RED** without the fix, **GREEN** with it.
- Full `metricRollups.test.ts` (8 tests) pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)