### PR TITLE
fix(web): resolve org name for quote detail Customer label (#1712)

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteDetail.customer.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.customer.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import { type QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { useOrgStore } from '../../../stores/orgStore';
+
+// Regression for #1712: the Customer row used to render `quote.orgId.slice(0,8)`
+// (the raw UUID prefix) whenever `billToName` was null — making the proposal
+// header look unfinished. The fix resolves the real organization name from the
+// client-side org list (the same source the org switcher uses), with the UUID
+// prefix kept only as a last resort.
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [{ resource: 'quotes', action: 'read' }] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const ORG_ID = 'aa0e43c8-1111-2222-3333-444455556666';
+
+function detailWith(billToName: string | null): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: 'Q-1', partnerId: 'p-1', orgId: ORG_ID, siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00',
+      billToName, introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null,
+      declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null,
+      viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    },
+    blocks: [],
+    lines: [],
+  };
+}
+
+const initialOrgState = useOrgStore.getState();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'quotes', action: 'read' }];
+  useOrgStore.setState({ organizations: [] });
+});
+
+afterEach(() => {
+  useOrgStore.setState(initialOrgState, true);
+});
+
+describe('QuoteDetail — Customer label', () => {
+  it('prefers the explicit billToName when present', async () => {
+    useOrgStore.setState({
+      organizations: [{ id: ORG_ID, partnerId: 'p-1', name: 'Default Organization', status: 'active', createdAt: '' }],
+    });
+    render(<QuoteDetail detail={detailWith('Acme Inc.')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-detail-customer')).toHaveTextContent('Acme Inc.');
+  });
+
+  it('resolves the org name from the store when billToName is null (not the UUID prefix)', async () => {
+    useOrgStore.setState({
+      organizations: [{ id: ORG_ID, partnerId: 'p-1', name: 'Default Organization', status: 'active', createdAt: '' }],
+    });
+    render(<QuoteDetail detail={detailWith(null)} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    const customer = screen.getByTestId('quote-detail-customer');
+    expect(customer).toHaveTextContent('Default Organization');
+    // The raw UUID prefix must NOT leak into the header.
+    expect(customer).not.toHaveTextContent(ORG_ID.slice(0, 8));
+  });
+
+  it('falls back to the UUID prefix only when no name resolves', async () => {
+    // Org not in the loaded list (e.g. All-orgs scope) and no billToName.
+    render(<QuoteDetail detail={detailWith(null)} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-detail-customer')).toHaveTextContent(ORG_ID.slice(0, 8));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.customer.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.customer.test.tsx
@@ -78,6 +78,18 @@ describe('QuoteDetail — Customer label', () => {
     expect(customer).not.toHaveTextContent(ORG_ID.slice(0, 8));
   });
 
+  it('treats a blank/whitespace billToName as absent and resolves the org name', async () => {
+    // The bill-to validator allows an empty string, so `??` alone would render a
+    // blank Customer cell — the #1712 symptom via a different input. A whitespace
+    // billToName must fall through to the resolved org name.
+    useOrgStore.setState({
+      organizations: [{ id: ORG_ID, partnerId: 'p-1', name: 'Default Organization', status: 'active', createdAt: '' }],
+    });
+    render(<QuoteDetail detail={detailWith('   ')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-detail-customer')).toHaveTextContent('Default Organization');
+  });
+
   it('falls back to the UUID prefix only when no name resolves', async () => {
     // Org not in the loaded list (e.g. All-orgs scope) and no billToName.
     render(<QuoteDetail detail={detailWith(null)} onChanged={vi.fn()} />);

--- a/apps/web/src/components/billing/quotes/QuoteDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.permissions.test.tsx
@@ -16,6 +16,7 @@ const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
 
 vi.mock('../../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
       selector({ user: { permissions: state.permissions } }),

--- a/apps/web/src/components/billing/quotes/QuoteDetail.totals.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.totals.test.tsx
@@ -14,6 +14,7 @@ const state = vi.hoisted(() => ({ permissions: [{ resource: 'quotes', action: 'r
 
 vi.mock('../../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
       selector({ user: { permissions: state.permissions } }),

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -3,6 +3,7 @@ import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
+import { useOrgStore } from '../../../stores/orgStore';
 import { quotePdfUrl, sendQuote } from '../../../lib/api/quotes';
 import {
   type QuoteDetail as QuoteDetailData,
@@ -28,6 +29,7 @@ interface Props {
 
 export default function QuoteDetail({ detail, onChanged }: Props) {
   const { can } = usePermissions();
+  const organizations = useOrgStore((s) => s.organizations);
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
 
@@ -96,7 +98,17 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
 
-  const orgName = quote.billToName ?? quote.orgId.slice(0, 8);
+  // Customer label: prefer the explicit bill-to name; otherwise resolve the real
+  // organization name from the client-side org list (same source the org switcher
+  // renders). Fall back to the UUID prefix only when neither is available (e.g.
+  // the quote's org isn't in the currently-loaded list, such as All-orgs scope).
+  const orgName = useMemo(
+    () =>
+      quote.billToName ??
+      organizations.find((o) => o.id === quote.orgId)?.name ??
+      quote.orgId.slice(0, 8),
+    [quote.billToName, quote.orgId, organizations],
+  );
 
   return (
     <div className="space-y-6" data-testid="quote-detail">
@@ -138,7 +150,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
               )}
             </div>
             <dl className="space-y-1 text-sm">
-              <div className="flex justify-between"><dt className="text-muted-foreground">Customer</dt><dd className="text-right">{orgName}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted-foreground">Customer</dt><dd className="text-right" data-testid="quote-detail-customer">{orgName}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Issued</dt><dd>{formatDate(quote.issueDate)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Created</dt><dd>{formatDate(quote.createdAt)}</dd></div>
             </dl>

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -102,13 +102,17 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
   // organization name from the client-side org list (same source the org switcher
   // renders). Fall back to the UUID prefix only when neither is available (e.g.
   // the quote's org isn't in the currently-loaded list, such as All-orgs scope).
-  const orgName = useMemo(
-    () =>
-      quote.billToName ??
-      organizations.find((o) => o.id === quote.orgId)?.name ??
-      quote.orgId.slice(0, 8),
-    [quote.billToName, quote.orgId, organizations],
-  );
+  // Use truthiness after trim, not `??`: the bill-to validator allows an empty
+  // string, and a blank/whitespace billToName would otherwise render an empty
+  // Customer cell — the same "unfinished header" symptom (#1712) via a different
+  // input.
+  const orgName = useMemo(() => {
+    const billTo = quote.billToName?.trim();
+    if (billTo) return billTo;
+    const resolved = organizations.find((o) => o.id === quote.orgId)?.name?.trim();
+    if (resolved) return resolved;
+    return quote.orgId.slice(0, 8);
+  }, [quote.billToName, quote.orgId, organizations]);
 
   return (
     <div className="space-y-6" data-testid="quote-detail">


### PR DESCRIPTION
## Summary

The admin **Quote Detail** page's **Customer** field rendered the first 8 characters of the organization's UUID (e.g. `aa0e43c8`) instead of the organization's name whenever `quote.billToName` was null — the common case for a quote created without an explicit bill-to name. Cosmetic/display-only, but it made the proposal header look unfinished.

## Fix

`apps/web/src/components/billing/quotes/QuoteDetail.tsx`

- Resolve the real organization name from the client-side org list in `useOrgStore` (the same source the org switcher renders), following the existing `organizations.find((o) => o.id === orgId)?.name` precedent (`CatalogItemEditorDrawer.tsx`).
- New `orgName` fallback chain: `billToName` → resolved org name → `orgId.slice(0, 8)` (last resort only, e.g. when the quote's org isn't in the currently-loaded list under All-orgs scope).
- Added a `quote-detail-customer` testid on the Customer `<dd>` for assertions.

Importing the org store into `QuoteDetail` transitively loads `orgStore.ts`, whose module-level `registerOrgIdProvider` call requires that export on the mocked `stores/auth`; added `registerOrgIdProvider: vi.fn()` to the two existing `QuoteDetail` test files so they keep loading.

## Tests

- New `QuoteDetail.customer.test.tsx` (3 cases): prefers `billToName`; resolves the org name from the store when `billToName` is null (and asserts the UUID prefix does **not** leak); falls back to the UUID prefix only when no name resolves.
- All `src/components/billing/quotes/` tests green (6 files, 15 tests); `tsc --noEmit` clean.

Scope confirmed unchanged from the issue: the `orgId.slice(0,8)` fallback existed only in `QuoteDetail.tsx` (`InvoiceDetail.tsx` does not share the pattern).

Closes #1712

🤖 Generated with [Claude Code](https://claude.com/claude-code)