### PR TITLE
fix(devices): make device Activity pane an index-backed last-N feed (#1726)

### DIFF
--- a/apps/api/migrations/2026-06-21-a-audit-logs-device-feed-indexes.sql
+++ b/apps/api/migrations/2026-06-21-a-audit-logs-device-feed-indexes.sql
@@ -1,0 +1,34 @@
+-- @no-transaction
+-- Device-detail Activity pane (issue #1726): make the per-device audit feed an
+-- index-backed "last N" read instead of a full-history sort.
+--
+-- The feed query (apps/api/src/routes/devices/events.ts) filters on an OR across
+-- two columns and orders by timestamp DESC LIMIT N:
+--
+--   WHERE resource_id = $device
+--      OR details->>'deviceId' = $device
+--   ORDER BY timestamp DESC LIMIT N
+--
+-- The shipped scale indexes (2026-05-17-c) only get us partway:
+--   * audit_logs_resource_type_id_timestamp_idx is (resource_type, resource_id,
+--     timestamp DESC) — the query does NOT filter resource_type, so the leading
+--     column is not a usable prefix for a resource_id-only seek.
+--   * audit_logs_details_device_id_idx is on ((details->>'deviceId')) only — no
+--     timestamp column, so matching rows must be sorted before LIMIT applies.
+--
+-- Neither branch returns rows already ordered by timestamp, so the planner
+-- BitmapOrs both branches and sorts the device's whole history on every load.
+-- These two composites let each branch read N pre-sorted rows directly:
+--
+--   * (resource_id, timestamp DESC)            -> resource_id branch
+--   * ((details->>'deviceId'), timestamp DESC) -> JSONB branch
+--
+-- CREATE INDEX CONCURRENTLY (autoMigrate's @no-transaction lane) avoids taking a
+-- SHARE lock on audit_logs at deploy time — critical because every API route
+-- writes here. IF NOT EXISTS keeps re-application a no-op.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_resource_id_timestamp_idx
+  ON audit_logs (resource_id, timestamp DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_details_device_id_timestamp_idx
+  ON audit_logs ((details->>'deviceId'), timestamp DESC);

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
+// Tracks how many times the count(*) query (db.select({ count })...where()) is
+// issued, so tests can prove the unbounded count is skipped unless withTotal is
+// set. The count select is distinguishable from the row select by its shape:
+// the count projection has a `count` key; the row projection does not.
+const countQueryCalls = vi.fn();
+
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
-    select: vi.fn(() => ({
+    select: vi.fn((projection?: Record<string, unknown>) => ({
       from: vi.fn(() => ({
         leftJoin: vi.fn(() => ({
           where: vi.fn(() => ({
@@ -17,7 +23,10 @@ vi.mock('../../db', () => ({
             }))
           }))
         })),
-        where: vi.fn(() => Promise.resolve([{ count: 0 }])),
+        where: vi.fn(() => {
+          if (projection && 'count' in projection) countQueryCalls();
+          return Promise.resolve([{ count: 0 }]);
+        }),
       }))
     })),
   }
@@ -69,7 +78,24 @@ vi.mock('./helpers', () => ({
   SITE_ACCESS_DENIED: Symbol('SITE_ACCESS_DENIED'),
 }));
 
-import { eventsRoutes } from './events';
+import { eventsRoutes, likePrefixPattern } from './events';
+
+describe('likePrefixPattern (action-prefix LIKE escaping)', () => {
+  it('appends a trailing wildcard for a clean dotted prefix', () => {
+    expect(likePrefixPattern('device.command')).toBe('device.command%');
+  });
+
+  it('escapes LIKE metacharacters so they match literally', () => {
+    // `_` and `%` would otherwise act as wildcards.
+    expect(likePrefixPattern('device_x')).toBe('device\\_x%');
+    expect(likePrefixPattern('a%b')).toBe('a\\%b%');
+    expect(likePrefixPattern('back\\slash')).toBe('back\\\\slash%');
+  });
+
+  it('escapes all metacharacters in a single value', () => {
+    expect(likePrefixPattern('a_b%c\\d')).toBe('a\\_b\\%c\\\\d%');
+  });
+});
 
 describe('GET /devices/:id/events validation', () => {
   let app: Hono;
@@ -128,6 +154,18 @@ describe('GET /devices/:id/events validation', () => {
     expect(res.status).toBe(200);
   });
 
+  it('treats an empty / whitespace-only actions value as no filter (200, no empty OR)', async () => {
+    // The transform splits, trims, and drops empties; the handler guards on a
+    // non-empty array, so these must not build an empty or(...) (which throws).
+    for (const value of ['', ',,,', '%20%20']) {
+      const res = await app.request(
+        `/devices/11111111-1111-1111-1111-111111111111/events?actions=${value}&limit=10`,
+        { method: 'GET', headers: { Authorization: 'Bearer token' } }
+      );
+      expect(res.status).toBe(200);
+    }
+  });
+
   it('rejects an actions value over 500 chars with 400', async () => {
     const long = 'a.'.repeat(300); // 600 chars
     const res = await app.request(
@@ -137,7 +175,7 @@ describe('GET /devices/:id/events validation', () => {
     expect(res.status).toBe(400);
   });
 
-  it('omits the total count by default (withTotal not set)', async () => {
+  it('omits the total count by default and does NOT run the count(*) query', async () => {
     const res = await app.request('/devices/11111111-1111-1111-1111-111111111111/events?limit=10', {
       method: 'GET',
       headers: { Authorization: 'Bearer token' },
@@ -145,9 +183,11 @@ describe('GET /devices/:id/events validation', () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as { pagination: { total: number | null } };
     expect(json.pagination.total).toBeNull();
+    // The whole point of #1726: the unbounded count(*) must not run by default.
+    expect(countQueryCalls).not.toHaveBeenCalled();
   });
 
-  it('includes a numeric total when withTotal=true', async () => {
+  it('includes a numeric total and runs the count(*) query when withTotal=true', async () => {
     const res = await app.request(
       '/devices/11111111-1111-1111-1111-111111111111/events?limit=10&withTotal=true',
       { method: 'GET', headers: { Authorization: 'Bearer token' } }
@@ -155,6 +195,7 @@ describe('GET /devices/:id/events validation', () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as { pagination: { total: number | null } };
     expect(json.pagination.total).toBe(0);
+    expect(countQueryCalls).toHaveBeenCalledTimes(1);
   });
 
   it('rejects an invalid withTotal value with 400', async () => {

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -119,4 +119,49 @@ describe('GET /devices/:id/events validation', () => {
     );
     expect(res.status).toBe(200);
   });
+
+  it('accepts an actions prefix filter', async () => {
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?actions=device.command,script.,device.patch&limit=10',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an actions value over 500 chars with 400', async () => {
+    const long = 'a.'.repeat(300); // 600 chars
+    const res = await app.request(
+      `/devices/11111111-1111-1111-1111-111111111111/events?actions=${long}`,
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('omits the total count by default (withTotal not set)', async () => {
+    const res = await app.request('/devices/11111111-1111-1111-1111-111111111111/events?limit=10', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { pagination: { total: number | null } };
+    expect(json.pagination.total).toBeNull();
+  });
+
+  it('includes a numeric total when withTotal=true', async () => {
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?limit=10&withTotal=true',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { pagination: { total: number | null } };
+    expect(json.pagination.total).toBe(0);
+  });
+
+  it('rejects an invalid withTotal value with 400', async () => {
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?withTotal=maybe',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -37,6 +37,14 @@ const eventsParamSchema = z.object({
   id: z.string().guid(),
 });
 
+// Build a case-sensitive LIKE prefix pattern from a user-supplied action prefix.
+// The three LIKE metacharacters (% _ \) are escaped so a value like `device_x`
+// matches the literal underscore instead of acting as a single-char wildcard;
+// the trailing `%` makes it a prefix match. Postgres' default LIKE escape is `\`.
+export function likePrefixPattern(prefix: string): string {
+  return prefix.replace(/[%_\\]/g, '\\$&') + '%';
+}
+
 const eventsQuerySchema = z.object({
   search: z.string().max(200).optional(),
   category: eventCategoryEnum.optional(),
@@ -125,11 +133,11 @@ eventsRoutes.get(
 
     if (actions && actions.length > 0) {
       // Match any of the supplied action prefixes (server-side equivalent of the
-      // overview pane's "deliberate action" filter). `like` with an escaped
+      // overview pane's "deliberate action" filter). `LIKE` with an escaped
       // prefix keeps it index-friendly and avoids ILIKE's case-fold cost — audit
       // action keys are already lowercase dotted identifiers.
       conditions.push(
-        or(...actions.map((prefix) => sql`${auditLogs.action} LIKE ${prefix.replace(/[%_\\]/g, '\\$&') + '%'}`))!
+        or(...actions.map((prefix) => sql`${auditLogs.action} LIKE ${likePrefixPattern(prefix)}`))!
       );
     }
 

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -48,6 +48,31 @@ const eventsQuerySchema = z.object({
   to: z.coerce.date().optional(),
   page: z.coerce.number().int().min(1).max(10000).default(1),
   limit: z.coerce.number().int().min(1).max(200).default(50),
+  // Server-side "deliberate action" filter for the device-overview Activity
+  // pane (issue #1726). Comma-separated list of action prefixes; a row matches
+  // if its action starts with any of them. Lets the overview feed request only
+  // the rows it renders instead of over-fetching and filtering client-side.
+  actions: z
+    .string()
+    .max(500)
+    .optional()
+    .transform((v) =>
+      v
+        ? v
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined
+    ),
+  // Whether to run the parallel unbounded count(*) over the same predicate.
+  // Defaults to false so the common "last N" feed read does not pay for a full
+  // history count on every load (issue #1726). When false, pagination.total is
+  // null. Set true only when a total is actually rendered.
+  withTotal: z
+    .enum(['true', 'false'])
+    .optional()
+    .default('false')
+    .transform((v) => v === 'true'),
 });
 
 // GET /devices/:id/events - Get activity feed for a device from audit logs
@@ -60,7 +85,8 @@ eventsRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const { id: deviceId } = c.req.valid('param');
-    const { search, category, result, initiatedBy, from, to, page, limit } = c.req.valid('query');
+    const { search, category, result, initiatedBy, from, to, page, limit, actions, withTotal } =
+      c.req.valid('query');
     const offset = (page - 1) * limit;
 
     const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
@@ -97,6 +123,16 @@ eventsRoutes.get(
       conditions.push(ilike(auditLogs.action, `${category}.%`));
     }
 
+    if (actions && actions.length > 0) {
+      // Match any of the supplied action prefixes (server-side equivalent of the
+      // overview pane's "deliberate action" filter). `like` with an escaped
+      // prefix keeps it index-friendly and avoids ILIKE's case-fold cost — audit
+      // action keys are already lowercase dotted identifiers.
+      conditions.push(
+        or(...actions.map((prefix) => sql`${auditLogs.action} LIKE ${prefix.replace(/[%_\\]/g, '\\$&') + '%'}`))!
+      );
+    }
+
     if (result) {
       conditions.push(eq(auditLogs.result, result));
     }
@@ -114,13 +150,19 @@ eventsRoutes.get(
 
     const whereClause = and(...conditions);
 
-    // Count + fetch in parallel
+    // The total count is an unbounded count(*) over the device's whole audit
+    // history; only run it when the caller actually renders a total. The feed
+    // read itself is a bounded ORDER BY timestamp DESC LIMIT N (issue #1726).
+    const countPromise = withTotal
+      ? db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(auditLogs)
+          .where(whereClause)
+          .then((r) => r[0]?.count ?? 0)
+      : Promise.resolve(null);
+
     const [countResult, rows] = await Promise.all([
-      db
-        .select({ count: sql<number>`count(*)::int` })
-        .from(auditLogs)
-        .where(whereClause)
-        .then((r) => r[0]?.count ?? 0),
+      countPromise,
       db
         .select({
           id: auditLogs.id,
@@ -147,7 +189,7 @@ eventsRoutes.get(
         .offset(offset),
     ]);
 
-    const total = Number(countResult);
+    const total = countResult === null ? null : Number(countResult);
 
     const data = rows.map((row) => ({
       id: row.id,

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
@@ -99,20 +99,33 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(false);
+  // A failed "Load more" is surfaced separately from the whole-pane `error` so a
+  // failed append never blanks the rows already on screen.
+  const [loadMoreError, setLoadMoreError] = useState(false);
   // Whether the last page came back full, i.e. there may be more to load.
   const [hasMore, setHasMore] = useState(false);
+  // Highest page already appended to `events`. The next "Load more" fetches
+  // loadedPage + 1 and only advances on success, so a failed page can be retried
+  // without skipping rows.
+  const [loadedPage, setLoadedPage] = useState(0);
+
+  // Single in-flight controller for the component. Aborting it on a device
+  // switch (or unmount) cancels BOTH the initial load and any in-flight "Load
+  // more", so a slow request can't append the previous device's rows.
+  const abortRef = useRef<AbortController | null>(null);
 
   // Fetch one page of deliberate-action events. page 1 (re)loads from scratch;
   // higher pages append. Filtering runs server-side and the count(*) is skipped
   // (withTotal omitted), so each page is a bounded index-backed read.
   const loadPage = useCallback(
-    async (page: number, signal?: AbortSignal) => {
+    async (page: number, signal: AbortSignal) => {
       const isFirst = page === 1;
       if (isFirst) {
         setLoading(true);
         setError(false);
       } else {
         setLoadingMore(true);
+        setLoadMoreError(false);
       }
       try {
         const eventsUrl = `/devices/${deviceId}/events?limit=${PAGE_SIZE}&page=${page}&actions=${encodeURIComponent(
@@ -120,16 +133,19 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
         )}`;
         // The active-alert count is only needed on the initial load.
         const [eventsRes, alertsRes] = await Promise.all([
-          fetchWithAuth(eventsUrl),
-          isFirst ? fetchWithAuth(`/devices/${deviceId}/alerts?status=active`) : Promise.resolve(null),
+          fetchWithAuth(eventsUrl, { signal }),
+          isFirst
+            ? fetchWithAuth(`/devices/${deviceId}/alerts?status=active`, { signal })
+            : Promise.resolve(null),
         ]);
-        if (signal?.aborted) return;
+        if (signal.aborted) return;
         if (!eventsRes.ok) throw new Error('events');
 
         const eventsJson = await eventsRes.json();
         const pageEvents: ActivityEvent[] = Array.isArray(eventsJson?.data) ? eventsJson.data : [];
         setEvents((prev) => (isFirst ? pageEvents : [...prev, ...pageEvents]));
         setHasMore(pageEvents.length === PAGE_SIZE);
+        setLoadedPage(page);
 
         if (isFirst && alertsRes && alertsRes.ok) {
           const alertsJson = await alertsRes.json();
@@ -137,9 +153,13 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
           setActiveAlerts(Array.isArray(payload) ? payload.length : 0);
         }
       } catch {
-        if (!signal?.aborted && isFirst) setError(true);
+        if (signal.aborted) return;
+        // Surface the failure: whole-pane error on the first page, inline
+        // "Load more" error otherwise — never swallowed.
+        if (isFirst) setError(true);
+        else setLoadMoreError(true);
       } finally {
-        if (!signal?.aborted) {
+        if (!signal.aborted) {
           if (isFirst) setLoading(false);
           else setLoadingMore(false);
         }
@@ -148,24 +168,31 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
     [deviceId]
   );
 
-  // Page number for the next "Load more" fetch. Reset to 1 whenever the device
-  // changes so the effect below reloads cleanly.
-  const [page, setPage] = useState(1);
-  useEffect(() => {
-    setPage(1);
-  }, [deviceId]);
-
+  // Reload from page 1 whenever the device changes; abort any in-flight request
+  // (initial or load-more) on switch/unmount.
   useEffect(() => {
     const controller = new AbortController();
+    abortRef.current = controller;
+    setLoadedPage(0);
     void loadPage(1, controller.signal);
     return () => controller.abort();
   }, [loadPage]);
 
+  // Retry the whole pane from page 1 on a fresh controller (the mount effect's
+  // controller is aborted once its cleanup runs).
+  const reload = useCallback(() => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoadedPage(0);
+    void loadPage(1, controller.signal);
+  }, [loadPage]);
+
   const loadMore = useCallback(() => {
-    const next = page + 1;
-    setPage(next);
-    void loadPage(next);
-  }, [page, loadPage]);
+    const signal = abortRef.current?.signal;
+    if (!signal || signal.aborted) return;
+    void loadPage(loadedPage + 1, signal);
+  }, [loadedPage, loadPage]);
 
   const visible = events;
 
@@ -208,7 +235,7 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
             Couldn&apos;t load activity.{' '}
             <button
               type="button"
-              onClick={() => void loadPage(1)}
+              onClick={reload}
               className="font-medium text-primary hover:underline"
             >
               Retry
@@ -256,14 +283,19 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
         )}
 
         {!loading && !error && hasMore && (
-          <button
-            type="button"
-            onClick={loadMore}
-            disabled={loadingMore}
-            className="mt-3 text-sm font-medium text-primary hover:underline disabled:opacity-60"
-          >
-            {loadingMore ? 'Loading…' : 'Load more'}
-          </button>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={loadMore}
+              disabled={loadingMore}
+              className="text-sm font-medium text-primary hover:underline disabled:opacity-60"
+            >
+              {loadingMore ? 'Loading…' : loadMoreError ? 'Try again' : 'Load more'}
+            </button>
+            {loadMoreError && !loadingMore && (
+              <span className="text-xs text-destructive">Couldn&apos;t load more.</span>
+            )}
+          </div>
         )}
       </div>
 

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
@@ -29,8 +29,6 @@ type ActivityEvent = {
 type DeviceActivityFeedProps = {
   deviceId: string;
   timezone?: string;
-  /** How many activity rows to show on the overview. */
-  limit?: number;
 };
 
 // "Deliberate actions taken on this endpoint." An event is shown only if its
@@ -54,6 +52,15 @@ function ruleFor(action?: string) {
   if (!action) return undefined;
   return ACTION_RULES.find((r) => action.startsWith(r.prefix));
 }
+
+// The same prefix set, sent to the API so the "deliberate action" filter runs
+// server-side (index-backed) instead of over-fetching raw rows and discarding
+// most of them client-side (issue #1726).
+const ACTION_PREFIXES = ACTION_RULES.map((r) => r.prefix).join(',');
+
+// How many filtered rows to request per page. Small fixed window for a fast,
+// predictable first paint; "Load more" pulls the next page on demand.
+const PAGE_SIZE = 10;
 
 // initiatedBy values worth surfacing — a person doing something is implicit via
 // the actor name, but "this happened automatically" is the interesting signal.
@@ -86,48 +93,81 @@ function absoluteTime(value?: string, timezone?: string): string | undefined {
   return formatDateTime(d, timezone ? { timeZone: timezone } : undefined);
 }
 
-export default function DeviceActivityFeed({ deviceId, timezone, limit = 8 }: DeviceActivityFeedProps) {
+export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivityFeedProps) {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [activeAlerts, setActiveAlerts] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(false);
+  // Whether the last page came back full, i.e. there may be more to load.
+  const [hasMore, setHasMore] = useState(false);
 
-  const load = useCallback(async (signal?: AbortSignal) => {
-    setLoading(true);
-    setError(false);
-    try {
-      // Over-fetch raw events, then keep only the endpoint actions. Alerts are
-      // a separate source — we only need the active count for the pinned strip.
-      const [eventsRes, alertsRes] = await Promise.all([
-        fetchWithAuth(`/devices/${deviceId}/events?limit=40`),
-        fetchWithAuth(`/devices/${deviceId}/alerts?status=active`),
-      ]);
-      if (signal?.aborted) return;
-      if (!eventsRes.ok) throw new Error('events');
-
-      const eventsJson = await eventsRes.json();
-      const rawEvents: ActivityEvent[] = Array.isArray(eventsJson?.data) ? eventsJson.data : [];
-      setEvents(rawEvents.filter((e) => ruleFor(e.action)));
-
-      if (alertsRes.ok) {
-        const alertsJson = await alertsRes.json();
-        const payload = alertsJson?.data ?? alertsJson;
-        setActiveAlerts(Array.isArray(payload) ? payload.length : 0);
+  // Fetch one page of deliberate-action events. page 1 (re)loads from scratch;
+  // higher pages append. Filtering runs server-side and the count(*) is skipped
+  // (withTotal omitted), so each page is a bounded index-backed read.
+  const loadPage = useCallback(
+    async (page: number, signal?: AbortSignal) => {
+      const isFirst = page === 1;
+      if (isFirst) {
+        setLoading(true);
+        setError(false);
+      } else {
+        setLoadingMore(true);
       }
-    } catch {
-      if (!signal?.aborted) setError(true);
-    } finally {
-      if (!signal?.aborted) setLoading(false);
-    }
+      try {
+        const eventsUrl = `/devices/${deviceId}/events?limit=${PAGE_SIZE}&page=${page}&actions=${encodeURIComponent(
+          ACTION_PREFIXES
+        )}`;
+        // The active-alert count is only needed on the initial load.
+        const [eventsRes, alertsRes] = await Promise.all([
+          fetchWithAuth(eventsUrl),
+          isFirst ? fetchWithAuth(`/devices/${deviceId}/alerts?status=active`) : Promise.resolve(null),
+        ]);
+        if (signal?.aborted) return;
+        if (!eventsRes.ok) throw new Error('events');
+
+        const eventsJson = await eventsRes.json();
+        const pageEvents: ActivityEvent[] = Array.isArray(eventsJson?.data) ? eventsJson.data : [];
+        setEvents((prev) => (isFirst ? pageEvents : [...prev, ...pageEvents]));
+        setHasMore(pageEvents.length === PAGE_SIZE);
+
+        if (isFirst && alertsRes && alertsRes.ok) {
+          const alertsJson = await alertsRes.json();
+          const payload = alertsJson?.data ?? alertsJson;
+          setActiveAlerts(Array.isArray(payload) ? payload.length : 0);
+        }
+      } catch {
+        if (!signal?.aborted && isFirst) setError(true);
+      } finally {
+        if (!signal?.aborted) {
+          if (isFirst) setLoading(false);
+          else setLoadingMore(false);
+        }
+      }
+    },
+    [deviceId]
+  );
+
+  // Page number for the next "Load more" fetch. Reset to 1 whenever the device
+  // changes so the effect below reloads cleanly.
+  const [page, setPage] = useState(1);
+  useEffect(() => {
+    setPage(1);
   }, [deviceId]);
 
   useEffect(() => {
     const controller = new AbortController();
-    void load(controller.signal);
+    void loadPage(1, controller.signal);
     return () => controller.abort();
-  }, [load]);
+  }, [loadPage]);
 
-  const visible = useMemo(() => events.slice(0, limit), [events, limit]);
+  const loadMore = useCallback(() => {
+    const next = page + 1;
+    setPage(next);
+    void loadPage(next);
+  }, [page, loadPage]);
+
+  const visible = events;
 
   return (
     <div className="rounded-lg border bg-card p-6 shadow-sm">
@@ -166,7 +206,11 @@ export default function DeviceActivityFeed({ deviceId, timezone, limit = 8 }: De
         ) : error ? (
           <p className="text-sm text-muted-foreground">
             Couldn&apos;t load activity.{' '}
-            <button type="button" onClick={() => void load()} className="font-medium text-primary hover:underline">
+            <button
+              type="button"
+              onClick={() => void loadPage(1)}
+              className="font-medium text-primary hover:underline"
+            >
               Retry
             </button>
           </p>
@@ -209,6 +253,17 @@ export default function DeviceActivityFeed({ deviceId, timezone, limit = 8 }: De
               );
             })}
           </ul>
+        )}
+
+        {!loading && !error && hasMore && (
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loadingMore}
+            className="mt-3 text-sm font-medium text-primary hover:underline disabled:opacity-60"
+          >
+            {loadingMore ? 'Loading…' : 'Load more'}
+          </button>
         )}
       </div>
 

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -113,6 +113,11 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
   // switch (or unmount) cancels BOTH the initial load and any in-flight "Load
   // more", so a slow request can't append the previous device's rows.
   const abortRef = useRef<AbortController | null>(null);
+  // Synchronous in-flight guard for "Load more". `disabled={loadingMore}` is
+  // driven by async React state, so a fast double-click can slip two clicks
+  // through before the re-render — both would fetch the same page and append
+  // duplicate rows. This ref flips synchronously at click time to serialize.
+  const loadMoreInFlight = useRef(false);
 
   // Fetch one page of deliberate-action events. page 1 (re)loads from scratch;
   // higher pages append. Filtering runs server-side and the count(*) is skipped
@@ -152,6 +157,10 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
           const payload = alertsJson?.data ?? alertsJson;
           setActiveAlerts(Array.isArray(payload) ? payload.length : 0);
         }
+        // Deliberate: if the events fetch succeeded but the alerts fetch failed,
+        // we don't fail the whole pane — the feed is the primary content and the
+        // pinned alert banner is a secondary signal. activeAlerts stays at its
+        // prior value (0 on first load) and the banner simply doesn't render.
       } catch {
         if (signal.aborted) return;
         // Surface the failure: whole-pane error on the first page, inline
@@ -190,8 +199,11 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
 
   const loadMore = useCallback(() => {
     const signal = abortRef.current?.signal;
-    if (!signal || signal.aborted) return;
-    void loadPage(loadedPage + 1, signal);
+    if (!signal || signal.aborted || loadMoreInFlight.current) return;
+    loadMoreInFlight.current = true;
+    void loadPage(loadedPage + 1, signal).finally(() => {
+      loadMoreInFlight.current = false;
+    });
   }, [loadedPage, loadPage]);
 
   const visible = events;

--- a/apps/web/src/components/devices/DeviceEventLogViewer.tsx
+++ b/apps/web/src/components/devices/DeviceEventLogViewer.tsx
@@ -180,6 +180,9 @@ export default function DeviceEventLogViewer({ deviceId, timezone }: DeviceEvent
       const params = new URLSearchParams();
       params.set('page', String(page));
       params.set('limit', '50');
+      // This view renders a total count and page-number pagination, so it needs
+      // the count(*). The lightweight overview feed omits it (issue #1726).
+      params.set('withTotal', 'true');
       if (debouncedSearch) params.set('search', debouncedSearch);
       if (categoryFilter) params.set('category', categoryFilter);
       if (initiatedByFilter) params.set('initiatedBy', initiatedByFilter);


### PR DESCRIPTION
## Summary

The device-detail **Activity pane** (`DeviceActivityFeed`) was slow because the backing `GET /devices/:id/events` query couldn't read device-filtered rows already ordered by `timestamp`, so Postgres collected a device's whole audit history, sorted it, then applied `LIMIT` — plus ran an unbounded `count(*)` over the same predicate on every load. The component compounded it by over-fetching 40 rows to display ~8.

## Changes

**Index-backed reads** — `apps/api/migrations/2026-06-21-a-audit-logs-device-feed-indexes.sql` adds two composite indexes so each branch of the device `OR`-predicate returns N pre-sorted rows instead of sorting full history:
- `audit_logs (resource_id, timestamp DESC)` — `resource_id` branch
- `audit_logs ((details->>'deviceId'), timestamp DESC)` — JSONB branch

`CREATE INDEX CONCURRENTLY` via the `@no-transaction` lane (no SHARE lock on the hot `audit_logs` table at deploy), `IF NOT EXISTS` for idempotency — mirrors the shipped `2026-05-17-c` pattern.

**Cheaper endpoint** — `apps/api/src/routes/devices/events.ts`:
- New `actions` query param (comma-separated action prefixes) applies the "deliberate action" filter **server-side** via `LIKE prefix%`, so the overview feed requests only the rows it renders.
- New `withTotal` flag (default `false`) **skips the unbounded `count(*)`** unless a total is actually rendered; `pagination.total` is `null` when not counted.

**Lighter component** — `apps/web/src/components/devices/DeviceActivityFeed.tsx`:
- Requests the deliberate-action prefixes server-side with a small fixed page size (10), dropping the 40→8 client over-fetch.
- Adds a **"Load more"** affordance (page-append, no count needed).

`DeviceEventLogViewer` (the full Activities tab) keeps its page-number total by passing `withTotal=true`.

## Acceptance criteria

- [x] Activity pane bounded by a small fixed `LIMIT N` with a "load more" affordance.
- [x] Each branch of the device predicate index-backed for `ORDER BY timestamp DESC LIMIT N`.
- [x] Unbounded per-load `count(*)` avoided by default (only run when a total is rendered).
- [x] Deliberate-action filtering pushed server-side so the 40→8 over-fetch goes away.

## Tests

- `apps/api/src/routes/devices/events.test.ts`: +5 cases (actions filter, actions length cap, default omits total → null, `withTotal=true` numeric total, invalid `withTotal` → 400). 10 passed.
- `autoMigrate.test.ts` ordering regression: 43 passed.
- `tsc --noEmit` clean for `apps/api` and `apps/web`.

Closes #1726

🤖 Generated with [Claude Code](https://claude.com/claude-code)