### PR TITLE
fix(devices): distinct empty states + drillable area charts for process drilldown (#1722)

### DIFF
--- a/apps/api/src/routes/devices/processSamples.test.ts
+++ b/apps/api/src/routes/devices/processSamples.test.ts
@@ -2,13 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
 const DEFAULT_NEAREST = [{ timestamp: new Date('2026-06-13T12:00:00Z'), agentTimestamp: null, topProcesses: [{ name: 'chrome', pid: 1, cpu: 9, ramMb: 100 }] }];
-const calls: any = { nearest: null, markers: null, nearestRows: DEFAULT_NEAREST };
+// `anyRows` backs the existence probe the route runs when the nearest lookup
+// misses, to distinguish "device has no samples at all" from "none before this
+// time" (issue #1722). Default: device HAS a sample somewhere.
+const calls: any = { nearest: null, markers: null, anyProbe: null, nearestRows: DEFAULT_NEAREST, anyRows: [{ timestamp: new Date('2026-06-13T11:00:00Z') }] };
 vi.mock('../../db', () => {
-  const chain = (kind: string) => ({
+  // Nearest snapshot: full row select → .from().where().orderBy().limit()
+  const nearestChain = () => ({
     from: () => ({
       where: () => ({
         orderBy: () => ({
-          limit: () => { calls.nearest = kind; return Promise.resolve(calls.nearestRows); },
+          limit: () => { calls.nearest = 'nearest'; return Promise.resolve(calls.nearestRows); },
         }),
       }),
     }),
@@ -16,11 +20,20 @@ vi.mock('../../db', () => {
   return {
     db: {
       select: (cols: any) => {
-        // markers query selects only { timestamp }
+        // Both the markers query and the existence probe select only { timestamp }.
+        // They diverge by terminal: markers ends in .orderBy() (no limit), the
+        // existence probe ends in .where().limit() (no orderBy).
         if (cols && Object.keys(cols).length === 1 && 'timestamp' in cols) {
-          return { from: () => ({ where: () => ({ orderBy: () => { calls.markers = true; return Promise.resolve([{ timestamp: new Date('2026-06-13T11:57:00Z') }]); } }) }) };
+          return {
+            from: () => ({
+              where: () => ({
+                orderBy: () => { calls.markers = true; return Promise.resolve([{ timestamp: new Date('2026-06-13T11:57:00Z') }]); },
+                limit: () => { calls.anyProbe = true; return Promise.resolve(calls.anyRows); },
+              }),
+            }),
+          };
         }
-        return chain('nearest');
+        return nearestChain();
       }
     },
     withDbAccessContext: (_ctx: any, fn: any) => fn()
@@ -56,14 +69,21 @@ function app() {
 }
 
 describe('GET /:id/process-samples', () => {
-  beforeEach(() => { calls.nearest = null; calls.markers = null; calls.nearestRows = DEFAULT_NEAREST; });
+  beforeEach(() => {
+    calls.nearest = null; calls.markers = null; calls.anyProbe = null;
+    calls.nearestRows = DEFAULT_NEAREST;
+    calls.anyRows = [{ timestamp: new Date('2026-06-13T11:00:00Z') }];
+  });
 
-  it('returns the nearest snapshot for ?at', async () => {
+  it('returns the nearest snapshot for ?at (hasAnySample true, no probe)', async () => {
     const res = await app().request('/dev-1/process-samples?at=2026-06-13T12:00:30.000Z');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.sample.topProcesses[0].name).toBe('chrome');
+    expect(body.hasAnySample).toBe(true);
     expect(calls.nearest).toBe('nearest');
+    // A sample was found, so the existence probe must NOT run.
+    expect(calls.anyProbe).toBeNull();
   });
 
   it('returns timestamp markers for ?from&to', async () => {
@@ -74,13 +94,28 @@ describe('GET /:id/process-samples', () => {
     expect(calls.markers).toBe(true);
   });
 
-  it('returns { sample: null } when no snapshot exists at-or-before the time', async () => {
+  it('returns { sample: null, hasAnySample: true } when samples exist but none at-or-before the time', async () => {
     calls.nearestRows = [];
+    // device has other samples — existence probe finds one
+    calls.anyRows = [{ timestamp: new Date('2026-06-13T11:00:00Z') }];
     const res = await app().request('/dev-1/process-samples?at=2026-06-13T12:00:30.000Z');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.sample).toBeNull();
+    expect(body.hasAnySample).toBe(true);
     expect(calls.nearest).toBe('nearest');
+    expect(calls.anyProbe).toBe(true);
+  });
+
+  it('returns { sample: null, hasAnySample: false } when the device has no samples at all', async () => {
+    calls.nearestRows = [];
+    calls.anyRows = []; // existence probe finds nothing
+    const res = await app().request('/dev-1/process-samples?at=2026-06-13T12:00:30.000Z');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sample).toBeNull();
+    expect(body.hasAnySample).toBe(false);
+    expect(calls.anyProbe).toBe(true);
   });
 
   it('rejects a request with neither ?at nor ?from&to (400)', async () => {

--- a/apps/api/src/routes/devices/processSamples.ts
+++ b/apps/api/src/routes/devices/processSamples.ts
@@ -53,13 +53,26 @@ processSamplesRoutes.get(
       .orderBy(desc(deviceProcessSamples.timestamp))
       .limit(1);
 
-    if (!sample) return c.json({ sample: null });
+    if (!sample) {
+      // Distinguish "this device has never recorded a process sample" from
+      // "samples exist, but none at-or-before the clicked time" so the UI can
+      // show a meaningful empty state instead of a single ambiguous blank
+      // message (issue #1722). A hit here is cheap: the same
+      // (device_id, timestamp DESC) index backs this existence probe.
+      const [anySample] = await db
+        .select({ timestamp: deviceProcessSamples.timestamp })
+        .from(deviceProcessSamples)
+        .where(eq(deviceProcessSamples.deviceId, deviceId))
+        .limit(1);
+      return c.json({ sample: null, hasAnySample: Boolean(anySample) });
+    }
     return c.json({
       sample: {
         timestamp: sample.timestamp.toISOString(),
         agentTimestamp: sample.agentTimestamp ? sample.agentTimestamp.toISOString() : null,
         topProcesses: sample.topProcesses
-      }
+      },
+      hasAnySample: true
     });
   }
 );

--- a/apps/web/src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx
+++ b/apps/web/src/components/devices/DevicePerformanceGraphs.drilldown.test.tsx
@@ -9,7 +9,7 @@ class ResizeObserverStub {
 }
 (globalThis as any).ResizeObserver = (globalThis as any).ResizeObserver ?? ResizeObserverStub;
 
-import DevicePerformanceGraphs from './DevicePerformanceGraphs';
+import DevicePerformanceGraphs, { resolveDrilldownAt } from './DevicePerformanceGraphs';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
@@ -26,5 +26,24 @@ describe('DevicePerformanceGraphs drill-down lazy-load', () => {
     const calledUrls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
     expect(calledUrls.some((u) => u.includes('/process-samples'))).toBe(false);
     expect(calledUrls.every((u) => u.includes('/metrics'))).toBe(true);
+  });
+});
+
+// resolveDrilldownAt is the shared click→timestamp resolver every chart (line +
+// both area charts) routes through, so this guards the #1722 wiring against a
+// regression that would silently make the charts un-drillable again.
+describe('resolveDrilldownAt', () => {
+  it('returns the activeLabel timestamp when a data point is clicked', () => {
+    expect(resolveDrilldownAt({ activeLabel: '2026-06-13T12:00:00.000Z' })).toBe('2026-06-13T12:00:00.000Z');
+  });
+
+  it('coerces a numeric activeLabel to a string', () => {
+    expect(resolveDrilldownAt({ activeLabel: 1718280000000 })).toBe('1718280000000');
+  });
+
+  it('returns null when the click lands off a data point (null state / missing activeLabel)', () => {
+    expect(resolveDrilldownAt(null)).toBeNull();
+    expect(resolveDrilldownAt({})).toBeNull();
+    expect(resolveDrilldownAt({ activeLabel: undefined })).toBeNull();
   });
 });

--- a/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
+++ b/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
@@ -51,6 +51,17 @@ type DevicePerformanceGraphsProps = {
   compact?: boolean;
 };
 
+// Resolve the drilldown timestamp from a recharts click state. Exported (and
+// unit-tested) because it is the load-bearing bit of the #1722 fix: every chart
+// (line + the two area charts) routes its onClick through here, so a regression
+// that stops extracting `activeLabel` would silently make the charts un-drillable.
+// Returns the ISO timestamp string to drill into, or null when the click landed
+// off a data point (recharts passes a null state / undefined activeLabel).
+export function resolveDrilldownAt(state: { activeLabel?: string | number } | null): string | null {
+  if (state && state.activeLabel != null) return String(state.activeLabel);
+  return null;
+}
+
 const rangeLabels: Record<TimeRange, string> = {
   '24h': '24h',
   '7d': '7d',
@@ -135,7 +146,8 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
   // line chart and the Network Bandwidth / Disk Activity area charts behave
   // consistently (issue #1722 — previously only the line chart was clickable).
   const handleChartClick = useCallback((state: { activeLabel?: string | number } | null) => {
-    if (state && state.activeLabel != null) setDrilldownAt(String(state.activeLabel));
+    const at = resolveDrilldownAt(state);
+    if (at != null) setDrilldownAt(at);
   }, []);
 
   const latest = useMemo(() => data[data.length - 1], [data]);

--- a/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
+++ b/apps/web/src/components/devices/DevicePerformanceGraphs.tsx
@@ -130,6 +130,14 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
     fetchMetrics();
   }, [fetchMetrics]);
 
+  // Process drilldown is time-keyed, not metric-specific: clicking any chart
+  // opens the "top processes at that timestamp" panel. Shared so the CPU/RAM/Disk
+  // line chart and the Network Bandwidth / Disk Activity area charts behave
+  // consistently (issue #1722 — previously only the line chart was clickable).
+  const handleChartClick = useCallback((state: { activeLabel?: string | number } | null) => {
+    if (state && state.activeLabel != null) setDrilldownAt(String(state.activeLabel));
+  }, []);
+
   const latest = useMemo(() => data[data.length - 1], [data]);
   const hasBandwidth = useMemo(() => data.some(d => d.bandwidthInBps > 0 || d.bandwidthOutBps > 0), [data]);
   const hasDiskActivity = useMemo(
@@ -218,12 +226,7 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
 
       <div className={compact ? 'mt-4 h-56' : 'mt-6 h-80'}>
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart
-            data={data}
-            onClick={(state: { activeLabel?: string | number } | null) => {
-              if (state && state.activeLabel != null) setDrilldownAt(String(state.activeLabel));
-            }}
-          >
+          <LineChart data={data} onClick={handleChartClick}>
             <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
             <XAxis
               dataKey="timestamp"
@@ -277,7 +280,7 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
           </div>
           <div className={compact ? 'mt-2 h-40' : 'mt-3 h-64'}>
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={data}>
+              <AreaChart data={data} onClick={handleChartClick}>
                 <defs>
                   <linearGradient id="bandwidthInGrad" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor="#06b6d4" stopOpacity={0.3} />
@@ -358,7 +361,7 @@ export default function DevicePerformanceGraphs({ deviceId, compact = false }: D
           </div>
           <div className={compact ? 'mt-2 h-40' : 'mt-3 h-64'}>
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={data}>
+              <AreaChart data={data} onClick={handleChartClick}>
                 <defs>
                   <linearGradient id="diskReadGrad" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor="#16a34a" stopOpacity={0.3} />

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.test.tsx
@@ -53,4 +53,24 @@ describe('ProcessDrilldownPanel', () => {
     // and the live row actually renders from `data` (regression guard for the array-under-data shape)
     await waitFor(() => expect(screen.getByTestId('process-drilldown-row-0')).toHaveTextContent('live'));
   });
+
+  it('shows the "no samples recorded yet" empty state when hasAnySample is false (#1722)', async () => {
+    fetchWithAuth.mockReturnValue(jsonResponse({ sample: null, hasAnySample: false }));
+    render(<ProcessDrilldownPanel deviceId="dev-1" at="2026-06-13T12:32:00.000Z" onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('process-drilldown-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('process-drilldown-empty')).toHaveTextContent(/No process samples have been recorded for this device yet/i);
+    expect(screen.getByTestId('process-drilldown-sample-time')).toHaveTextContent(/No process samples recorded for this device yet/i);
+    // no data rows
+    expect(screen.queryByTestId('process-drilldown-row-0')).toBeNull();
+  });
+
+  it('shows the "none at/before this time" empty state when hasAnySample is true (#1722)', async () => {
+    fetchWithAuth.mockReturnValue(jsonResponse({ sample: null, hasAnySample: true }));
+    render(<ProcessDrilldownPanel deviceId="dev-1" at="2026-06-13T12:32:00.000Z" onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('process-drilldown-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('process-drilldown-empty')).toHaveTextContent(/No process sample was recorded at or before this point/i);
+    expect(screen.getByTestId('process-drilldown-sample-time')).toHaveTextContent(/No process sample recorded at or before this time/i);
+  });
 });

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
@@ -12,9 +12,17 @@ type Props = {
   onClose: () => void;
 };
 
+// Why a sample-less drilldown is empty:
+// - 'none-recorded': the device has never recorded any process sample
+//   (e.g. the sampler hasn't run / isn't shipping yet) — issue #1722.
+// - 'none-near-time': samples exist, but none at-or-before the clicked time
+//   (the click predates the first sample).
+type EmptyKind = null | 'none-recorded' | 'none-near-time';
+
 export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) {
   const [rows, setRows] = useState<Row[]>([]);
   const [sampleTime, setSampleTime] = useState<string | null>(null);
+  const [emptyKind, setEmptyKind] = useState<EmptyKind>(null);
   const [sortKey, setSortKey] = useState<SortKey>('cpu');
   const [live, setLive] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -49,14 +57,23 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
             ramMb: Number(p.memoryMb ?? p.ramMb ?? 0),
           })));
           setSampleTime(null);
+          setEmptyKind(null);
         } else {
           const res = await fetchWithAuth(`/devices/${deviceId}/process-samples?at=${encodeURIComponent(at)}`);
           if (!res.ok) throw new Error('Failed to fetch process sample');
           const json = await res.json();
           if (cancelled) return;
-          if (!json.sample) { setRows([]); setSampleTime(null); return; }
+          if (!json.sample) {
+            setRows([]);
+            setSampleTime(null);
+            // The API tells us whether the device has ANY recorded sample so we
+            // can disambiguate the empty state (issue #1722).
+            setEmptyKind(json.hasAnySample ? 'none-near-time' : 'none-recorded');
+            return;
+          }
           setRows((json.sample.topProcesses ?? []) as Row[]);
           setSampleTime(json.sample.timestamp);
+          setEmptyKind(null);
         }
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load processes');
@@ -94,7 +111,11 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
             ? 'Live (now)'
             : sampleTime
               ? `Nearest sample: ${formatDateTime(sampleTime)}`
-              : 'No sample near this time'}
+              : emptyKind === 'none-recorded'
+                ? 'No process samples recorded for this device yet'
+                : emptyKind === 'none-near-time'
+                  ? 'No process sample recorded at or before this time'
+                  : 'No sample near this time'}
         </p>
 
         <div className="mt-3 flex gap-2 text-sm">
@@ -112,6 +133,17 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
             </tr>
           </thead>
           <tbody>
+            {!loading && sorted.length === 0 && !error && (
+              <tr data-testid="process-drilldown-empty">
+                <td colSpan={4} className="py-4 text-center text-muted-foreground">
+                  {live
+                    ? 'No processes returned for this device.'
+                    : emptyKind === 'none-recorded'
+                      ? 'No process samples have been recorded for this device yet. The agent collects them periodically — check back once it has reported.'
+                      : 'No process sample was recorded at or before this point. Try clicking a more recent point on the graph.'}
+                </td>
+              </tr>
+            )}
             {sorted.map((r, i) => (
               <tr key={r.pid} data-testid={`process-drilldown-row-${i}`}>
                 <td>{r.name}</td>

--- a/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
+++ b/apps/web/src/components/devices/ProcessDrilldownPanel.tsx
@@ -36,6 +36,7 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
     (async () => {
       setLoading(true);
       setError(undefined);
+      setEmptyKind(null);
       try {
         if (live) {
           // On-demand process listing lives under /system-tools; the agent
@@ -107,15 +108,20 @@ export default function ProcessDrilldownPanel({ deviceId, at, onClose }: Props) 
         </div>
 
         <p className="mt-1 text-xs text-muted-foreground" data-testid="process-drilldown-sample-time">
-          {live
-            ? 'Live (now)'
-            : sampleTime
-              ? `Nearest sample: ${formatDateTime(sampleTime)}`
-              : emptyKind === 'none-recorded'
-                ? 'No process samples recorded for this device yet'
-                : emptyKind === 'none-near-time'
-                  ? 'No process sample recorded at or before this time'
-                  : 'No sample near this time'}
+          {/* Suppressed on error so the red error banner below isn't contradicted
+              by a stale "no sample" subtitle (the catch sets neither sampleTime
+              nor emptyKind). */}
+          {error
+            ? ''
+            : live
+              ? 'Live (now)'
+              : sampleTime
+                ? `Nearest sample: ${formatDateTime(sampleTime)}`
+                : emptyKind === 'none-recorded'
+                  ? 'No process samples recorded for this device yet'
+                  : emptyKind === 'none-near-time'
+                    ? 'No process sample recorded at or before this time'
+                    : 'No sample near this time'}
         </p>
 
         <div className="mt-3 flex gap-2 text-sm">


### PR DESCRIPTION
## Summary

Fixes #1722. Clicking a performance-graph point opened the process drilldown but showed an ambiguous blank table whenever no sample was returned, and only the CPU/RAM/Disk line chart was clickable.

The most-likely root cause flagged in the issue (candidate #1 — the device simply has no `device_process_samples` rows yet, because the deployed agent's sampler isn't shipping) is a data/ops condition, not a code bug: the read path and response shapes are correct. This PR addresses the code-side acceptance criteria so that condition is communicated clearly and the other charts behave consistently.

## Changes

**API — `apps/api/src/routes/devices/processSamples.ts`**
- `GET /:id/process-samples?at=` now returns `hasAnySample` next to `{ sample: null }`. When the nearest-at-or-before lookup misses, a cheap existence probe (same `(device_id, timestamp DESC)` index) distinguishes "device has never recorded a sample" from "samples exist, but none before the clicked time". `hasAnySample: true` is returned whenever a sample is found (no extra query).

**Web — `ProcessDrilldownPanel.tsx`**
- Tracks an `emptyKind` and renders **distinct** empty-state messaging (header line + an explicit empty table row) instead of a single silent blank table:
  - none recorded → "No process samples have been recorded for this device yet…"
  - none at/before the clicked time → "No process sample was recorded at or before this point…"

**Web — `DevicePerformanceGraphs.tsx`** (AC #4)
- Extracts a shared `handleChartClick` and wires it to the **Network Bandwidth** and **Disk Activity** area charts as well as the line chart. Process samples are time-keyed (not metric-specific), so clicking any chart opens the drilldown consistently.

## Acceptance criteria

- [x] Distinct, non-silent empty state distinguishing "no samples for this device yet" vs. "none near this time".
- [x] Network Bandwidth / Disk Activity charts are now drillable (consistent behavior).
- [x] When a sample exists at/before the click, the top processes render (unchanged path).
- [ ] Whether `device_process_samples` actually has rows / the deployed agent ships samples — an ops/deploy verification, out of scope for a code change. The new empty state makes the "no data yet" case legible in-product.

## Tests
- `apps/api` `processSamples.test.ts`: 6 passed (added `hasAnySample` true/false cases + probe-not-run assertion). `tsc --noEmit` clean.
- `apps/web` `ProcessDrilldownPanel.test.tsx`: added both empty-state cases; suite green (5 passed incl. drilldown lazy-load). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)