### PR TITLE
fix(reliability): exclude pre-enrollment time from uptime window (#1738)

### DIFF
--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -133,6 +133,64 @@ describe('scoreUptime', () => {
   it('returns 50 at 95% uptime (midpoint of linear range)', () => expect(scoreUptime(95)).toBe(50));
 });
 
+describe('computeUptimePercent', () => {
+  const { computeUptimePercent } = reliabilityScoringInternals;
+  const now = new Date('2026-02-20T00:00:00.000Z');
+  const DAY = 24 * 60 * 60;
+
+  function makeLatest(uptimeSeconds: number, bootOffsetSeconds: number) {
+    return {
+      collectedAt: now,
+      uptimeSeconds,
+      // bootTime = now - bootOffsetSeconds
+      bootTime: new Date(now.getTime() - bootOffsetSeconds * 1000),
+    };
+  }
+
+  it('returns 100 with no history snapshot', () => {
+    expect(computeUptimePercent(null, 90, now)).toBe(100);
+    expect(computeUptimePercent(null, 90, now, new Date(now.getTime() - 2 * DAY * 1000))).toBe(100);
+  });
+
+  it('penalizes a young device against the full window when enrollment is ignored', () => {
+    // Device enrolled 2 days ago, up its whole life, but no enrollment clamp:
+    // 2 days of uptime against a 90-day denominator ≈ 2.2%.
+    const latest = makeLatest(2 * DAY, 2 * DAY);
+    expect(computeUptimePercent(latest, 90, now)).toBeCloseTo((2 / 90) * 100, 1);
+  });
+
+  it('clamps the window to enrollment so a 2-day-old all-up device scores 100%', () => {
+    // Enrolled 2 days ago, booted at enrollment, up the whole time → 100%.
+    const enrolledAt = new Date(now.getTime() - 2 * DAY * 1000);
+    const latest = makeLatest(2 * DAY, 2 * DAY);
+    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(100);
+    expect(computeUptimePercent(latest, 30, now, enrolledAt)).toBe(100);
+  });
+
+  it('counts a reboot within a young device lifetime as partial downtime', () => {
+    // Enrolled 4 days ago but only up 2 days (rebooted 2 days ago) →
+    // 2 days up over a 4-day clamped window = 50%.
+    const enrolledAt = new Date(now.getTime() - 4 * DAY * 1000);
+    const latest = makeLatest(2 * DAY, 2 * DAY);
+    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(50);
+  });
+
+  it('leaves an old device (older than the window) unchanged', () => {
+    // Enrolled 200 days ago — older than the 90-day window. Continuously up
+    // for the full window → 100% either way; enrollment clamp is a no-op.
+    const enrolledAt = new Date(now.getTime() - 200 * DAY * 1000);
+    const latest = makeLatest(120 * DAY, 120 * DAY);
+    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(computeUptimePercent(latest, 90, now));
+    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(100);
+  });
+
+  it('returns 100 when enrollment is at or after now (zero-length window)', () => {
+    const latest = makeLatest(0, 0);
+    expect(computeUptimePercent(latest, 90, now, now)).toBe(100);
+    expect(computeUptimePercent(latest, 90, now, new Date(now.getTime() + DAY * 1000))).toBe(100);
+  });
+});
+
 describe('scoreCrashes', () => {
   const { scoreCrashes } = reliabilityScoringInternals;
 

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -184,6 +184,15 @@ describe('computeUptimePercent', () => {
     expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(100);
   });
 
+  it('is a no-op when enrollment falls exactly on the window start (boundary)', () => {
+    // enrolledAt === now - windowDays: the clamp Math.max picks fixedStartSeconds,
+    // so the denominator stays the full window — identical to the no-enrollment call.
+    const enrolledAt = new Date(now.getTime() - 90 * DAY * 1000);
+    const latest = makeLatest(120 * DAY, 120 * DAY);
+    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(computeUptimePercent(latest, 90, now));
+    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(100);
+  });
+
   it('returns 100 when enrollment is at or after now (zero-length window)', () => {
     const latest = makeLatest(0, 0);
     expect(computeUptimePercent(latest, 90, now, now)).toBe(100);
@@ -289,6 +298,53 @@ describe('computeTopIssues', () => {
       criticalHardwareCount30d: 2,
     });
     expect(issues.length).toBeLessThanOrEqual(5);
+  });
+
+  // #1738: a newly-enrolled device that has been up its whole (short) life now
+  // computes uptime30d === 100 thanks to the enrollment clamp, so it must NOT
+  // be flagged with an `uptime` top-issue purely for time before it existed.
+  it('does not flag an uptime issue when uptime30d is 100 (young all-up device)', () => {
+    const issues = computeTopIssues({
+      dailyBuckets: [],
+      now,
+      uptime30d: 100,
+      crashCount30d: 0,
+      hangCount30d: 0,
+      serviceFailureCount30d: 0,
+      hardwareErrorCount30d: 0,
+      criticalHardwareCount30d: 0,
+    });
+    expect(issues.find((i) => i.type === 'uptime')).toBeUndefined();
+  });
+
+  it('flags an uptime issue (warning) when uptime30d is between 90 and 95', () => {
+    const issues = computeTopIssues({
+      dailyBuckets: [],
+      now,
+      uptime30d: 92,
+      crashCount30d: 0,
+      hangCount30d: 0,
+      serviceFailureCount30d: 0,
+      hardwareErrorCount30d: 0,
+      criticalHardwareCount30d: 0,
+    });
+    const uptime = issues.find((i) => i.type === 'uptime');
+    expect(uptime?.severity).toBe('warning');
+  });
+
+  it('flags an uptime issue (critical) when uptime30d is below 90', () => {
+    const issues = computeTopIssues({
+      dailyBuckets: [],
+      now,
+      uptime30d: 80,
+      crashCount30d: 0,
+      hangCount30d: 0,
+      serviceFailureCount30d: 0,
+      hardwareErrorCount30d: 0,
+      criticalHardwareCount30d: 0,
+    });
+    const uptime = issues.find((i) => i.type === 'uptime');
+    expect(uptime?.severity).toBe('critical');
   });
 });
 

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -205,13 +205,28 @@ function maxTimestamp(values: Array<string | undefined>): string | undefined {
   return raw;
 }
 
-function computeUptimePercent(latest: LatestHistorySnapshot | null, windowDays: number, now: Date): number {
+function computeUptimePercent(
+  latest: LatestHistorySnapshot | null,
+  windowDays: number,
+  now: Date,
+  enrolledAt?: Date | null
+): number {
   if (!latest) return 100;
-  const windowSeconds = windowDays * 24 * 60 * 60;
+  const fullWindowSeconds = windowDays * 24 * 60 * 60;
   const nowSeconds = Math.floor(now.getTime() / 1000);
-  const startSeconds = nowSeconds - windowSeconds;
+  // The measurement window starts at `now - windowDays`, but a device cannot be
+  // "up" before it was enrolled, so clamp the window start forward to the
+  // enrollment timestamp. This keeps pre-existence time out of the denominator
+  // (#1738) — a device enrolled 2 days ago is measured over ~2 days, not 90.
+  const fixedStartSeconds = nowSeconds - fullWindowSeconds;
+  const enrolledSeconds = enrolledAt ? Math.floor(enrolledAt.getTime() / 1000) : fixedStartSeconds;
+  const windowStartSeconds = Math.max(fixedStartSeconds, enrolledSeconds);
+  // Denominator is the length of the (possibly shortened) measurement window.
+  // Guard against a zero/negative window (enrolledAt at or after now).
+  const windowSeconds = Math.min(fullWindowSeconds, Math.max(0, nowSeconds - windowStartSeconds));
+  if (windowSeconds <= 0) return 100;
   const bootSeconds = Math.floor(latest.bootTime.getTime() / 1000);
-  const uptimeStart = Math.max(startSeconds, bootSeconds);
+  const uptimeStart = Math.max(windowStartSeconds, bootSeconds);
   const uptimeSecondsFromBoot = Math.max(0, nowSeconds - uptimeStart);
   const boundedUptimeSeconds = Math.min(windowSeconds, Math.min(uptimeSecondsFromBoot, Math.max(0, latest.uptimeSeconds)));
   return round2((boundedUptimeSeconds / windowSeconds) * 100);
@@ -806,6 +821,7 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
     .select({
       id: devices.id,
       orgId: devices.orgId,
+      enrolledAt: devices.enrolledAt,
     })
     .from(devices)
     .where(eq(devices.id, deviceId))
@@ -847,9 +863,10 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
   pruneDailyBuckets(dailyBucketMap, lookbackStart, now);
   const dailyBuckets = sortDailyBuckets(dailyBucketMap);
 
-  const uptime7d = computeUptimePercent(latest, 7, now);
-  const uptime30d = computeUptimePercent(latest, 30, now);
-  const uptime90d = computeUptimePercent(latest, 90, now);
+  const enrolledAt = device.enrolledAt ?? null;
+  const uptime7d = computeUptimePercent(latest, 7, now, enrolledAt);
+  const uptime30d = computeUptimePercent(latest, 30, now, enrolledAt);
+  const uptime90d = computeUptimePercent(latest, 90, now, enrolledAt);
 
   const crashCount7d = sumBucketsInWindow(dailyBuckets, 7, now, (bucket) => bucket.crashCount);
   const crashCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.crashCount);
@@ -1425,6 +1442,7 @@ export const reliabilityScoringInternals = {
   buildDailyTrendPoints,
   computeTrend,
   computeMtbfHours,
+  computeUptimePercent,
   scoreUptime,
   scoreCrashes,
   scoreHangs,

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -219,6 +219,10 @@ function computeUptimePercent(
   // enrollment timestamp. This keeps pre-existence time out of the denominator
   // (#1738) — a device enrolled 2 days ago is measured over ~2 days, not 90.
   const fixedStartSeconds = nowSeconds - fullWindowSeconds;
+  // `devices.enrolledAt` is NOT NULL (defaults to now()), so in practice it is
+  // always supplied. If it is ever missing we deliberately fall back to the
+  // fixed window start, i.e. the unclamped pre-#1738 behavior, rather than
+  // guess an enrollment time.
   const enrolledSeconds = enrolledAt ? Math.floor(enrolledAt.getTime() / 1000) : fixedStartSeconds;
   const windowStartSeconds = Math.max(fixedStartSeconds, enrolledSeconds);
   // Denominator is the length of the (possibly shortened) measurement window.


### PR DESCRIPTION
## Summary

The reliability uptime factor measured uptime over a **fixed** rolling window (90d for the score, 30d/7d for display) anchored only to `now`, ignoring when the device was actually enrolled. A device deployed 2 days ago was still scored against a full 90-day denominator, so the ~88 days *before it existed* counted as missing uptime — `scoreUptime` returned **0**, dragging 30 points (the uptime weight) off the overall reliability score for time before the agent existed.

**Root cause:** `computeUptimePercent` (`reliabilityScoring.ts`) divided bounded uptime by the full fixed `windowSeconds`. The only lower bound was last-boot-time on the *numerator*; the denominator never shrank and `enrolledAt` was never read.

**Fix:** `computeUptimePercent` now takes the device's `enrolledAt` and clamps the window start to `max(now - windowDays, enrolledAt)`, dividing by the length of that (possibly shortened) interval. A device enrolled 2 days ago is measured over ~2 days, not 90. Once a device is older than the window, the clamp is a no-op and behavior is unchanged. A zero/negative window (enrolledAt at/after now) returns 100.

`computeAndPersistDeviceReliability` now selects `devices.enrolledAt` and threads it into all three windowed uptime computations (`uptime7d/30d/90d`). The `uptime` top-issue (`uptime30d < 95`) is no longer flagged for a young all-up device, since `uptime30d` now reflects the clamped window.

## Acceptance criteria

- [x] Uptime denominator starts at `max(windowStart, enrolledAt)`, not the full fixed window.
- [x] A device enrolled 2 days ago is scored over ~2 days, not 90/30.
- [x] `computeAndPersistDeviceReliability` selects + threads the enrollment timestamp.
- [x] The `uptime` top-issue is not flagged for a young all-up device.
- [x] Tests cover the clamp (young all-up → 100%, mid-life reboot → partial, old device unchanged).

## Testing

- `vitest run src/services/reliabilityScoring.test.ts` — 44 passed (6 new `computeUptimePercent` cases).
- `tsc --noEmit` clean.

No schema/migration change; `devices.enrolledAt` already exists (NOT NULL, default `now()`).

Closes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)