### PR TITLE
feat(scripts): add a scope changer on the edit screen (#1734)

### DIFF
--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -1024,4 +1024,191 @@ describe('scripts routes', () => {
       expect(body.error).toMatch(/system scripts are read-only/i);
     });
   });
+
+  describe('Task 9: re-scope on edit (issue #1734)', () => {
+    function makePartnerAuth() {
+      return {
+        user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+        scope: 'partner' as const,
+        partnerId: PARTNER_ID,
+        orgId: null,
+        token: {
+          sub: 'user-123', email: 'test@example.com', roleId: 'role-123',
+          orgId: null, partnerId: PARTNER_ID, scope: 'partner', type: 'access', mfa: true,
+        },
+        accessibleOrgIds: [ORG_ID, ORG_ID_2],
+        canAccessOrg: (id: string) => [ORG_ID, ORG_ID_2].includes(id),
+      };
+    }
+
+    function makeOrgAuth() {
+      return {
+        user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+        scope: 'organization' as const,
+        partnerId: PARTNER_ID,
+        orgId: ORG_ID,
+        token: {
+          sub: 'user-123', email: 'test@example.com', roleId: 'role-123',
+          orgId: ORG_ID, partnerId: PARTNER_ID, scope: 'organization', type: 'access', mfa: true,
+        },
+        accessibleOrgIds: [ORG_ID],
+        canAccessOrg: (id: string) => id === ORG_ID,
+      };
+    }
+
+    async function withAuth(auth: any) {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', auth);
+        return next();
+      });
+    }
+
+    // The PUT handler's getScriptWithOrgCheck uses .from().where().limit();
+    // the reference-count checks use .from().where() (no .limit()). This mock
+    // serves the existing script for the first call and zero counts thereafter.
+    function mockScriptLookup(script: any, refCount = 0) {
+      vi.mocked(db.select).mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => ({
+            // count-query path (no .limit) resolves directly to a count row
+            then: (resolve: (v: any) => void) => resolve([{ count: refCount }]),
+            limit: vi.fn().mockResolvedValue([script]),
+          })),
+        }),
+      }) as any);
+    }
+
+    function captureUpdate(returnedRow: any) {
+      let setValues: any;
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          setValues = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([returnedRow]),
+            }),
+          };
+        }),
+      } as any);
+      return () => setValues;
+    }
+
+    it('partner user promotes an org script to All Orgs (org_id→null)', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+      const getSet = captureUpdate({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: null, partnerId: PARTNER_ID, version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'partner' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(getSet().orgId).toBeNull();
+      expect(getSet().partnerId).toBe(PARTNER_ID);
+    });
+
+    it('partner user moves a script org→org (when no references exist)', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 0);
+      const getSet = captureUpdate({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID_2, partnerId: PARTNER_ID, version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'org', orgId: ORG_ID_2 }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(getSet().orgId).toBe(ORG_ID_2);
+      expect(getSet().partnerId).toBe(PARTNER_ID);
+    });
+
+    it('blocks a narrowing re-scope (partner-wide→org) when policy references exist → 409', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Shared Script', orgId: null, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 2); // 2 referencing policies
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'org', orgId: ORG_ID }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toMatch(/referenced by automation or patch policies/i);
+    });
+
+    it('org-scope user cannot re-scope → 403', async () => {
+      await withAuth(makeOrgAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'partner' }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/only partner-scope users/i);
+    });
+
+    it('partner user cannot move a script to an org they cannot access → 403', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'org', orgId: 'a0000000-0000-4000-8000-000000000000' }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/access to this organization denied/i);
+    });
+
+    it('a plain metadata edit (no availability) never touches scope', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+      const getSet = captureUpdate({
+        id: SCRIPT_ID_1, name: 'Renamed', orgId: ORG_ID, partnerId: PARTNER_ID, version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(getSet().orgId).toBeUndefined();
+      expect(getSet().partnerId).toBeUndefined();
+    });
+  });
 });

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -54,6 +54,9 @@ vi.mock('../db/schema', () => ({
   deviceCommands: {},
   organizations: {},
   patchPolicies: {},
+  configPolicyComplianceRules: {},
+  configPolicyFeatureLinks: {},
+  configurationPolicies: {},
   alertRules: {},
   backupConfigs: {},
   securityPolicies: {},
@@ -1066,16 +1069,24 @@ describe('scripts routes', () => {
 
     // The PUT handler's getScriptWithOrgCheck uses .from().where().limit();
     // the reference-count checks use .from().where() (no .limit()). This mock
-    // serves the existing script for the first call and zero counts thereafter.
+    // serves the existing script for the lookup (.where().limit()) and a count
+    // for each reference-check query. Reference queries take two shapes:
+    // direct `.from().where()` (automation/patch policies) and the
+    // join-chained `.from().innerJoin().innerJoin().where()` (compliance
+    // rules). `refCount` is the per-query count (use 0 for "no references").
     function mockScriptLookup(script: any, refCount = 0) {
+      const countResult = {
+        // count-query path (no .limit) — a thenable resolving to a count row.
+        then: (resolve: (v: any) => void) => resolve([{ count: refCount }]),
+        limit: vi.fn().mockResolvedValue([script]),
+      };
+      const whereMock = vi.fn().mockReturnValue(countResult);
+      const joinable: any = {
+        where: whereMock,
+        innerJoin: vi.fn(() => joinable),
+      };
       vi.mocked(db.select).mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockImplementation(() => ({
-            // count-query path (no .limit) resolves directly to a count row
-            then: (resolve: (v: any) => void) => resolve([{ count: refCount }]),
-            limit: vi.fn().mockResolvedValue([script]),
-          })),
-        }),
+        from: vi.fn().mockReturnValue(joinable),
       }) as any);
     }
 
@@ -1151,7 +1162,7 @@ describe('scripts routes', () => {
 
       expect(res.status).toBe(409);
       const body = await res.json();
-      expect(body.error).toMatch(/referenced by automation or patch policies/i);
+      expect(body.error).toMatch(/referenced by automation, patch, or configuration policies/i);
     });
 
     it('org-scope user cannot re-scope → 403', async () => {
@@ -1209,6 +1220,114 @@ describe('scripts routes', () => {
       expect(res.status).toBe(200);
       expect(getSet().orgId).toBeUndefined();
       expect(getSet().partnerId).toBeUndefined();
+    });
+
+    it('partner user cannot re-scope a script owned by a different partner → 403 (cross-partner forge guard)', async () => {
+      await withAuth(makePartnerAuth());
+      // Script belongs to a DIFFERENT partner (and would be unreachable via RLS
+      // in prod, but this asserts the route-level ownership guard explicitly).
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Other Partner Script', orgId: null,
+        partnerId: 'b0000000-0000-4000-8000-000000000000',
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'org', orgId: ORG_ID }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/not owned by your partner/i);
+    });
+
+    it('partner user choosing availability=org without an orgId → 400', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Partner-wide Script', orgId: null, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'org' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/orgId is required/i);
+    });
+
+    it('blocks an org→org narrowing re-scope when policy references exist → 409', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 1); // 1 referencing policy
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'org', orgId: ORG_ID_2 }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toMatch(/referenced by automation, patch, or configuration policies/i);
+    });
+
+    it('records the old→new scope in the script.update audit on a re-scope', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+      captureUpdate({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: null, partnerId: PARTNER_ID, version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'partner' }),
+      });
+
+      expect(res.status).toBe(200);
+      const auditCall = vi.mocked(writeRouteAudit).mock.calls.at(-1)?.[1] as any;
+      expect(auditCall?.details?.scopeChange).toEqual({
+        from: { orgId: ORG_ID, partnerId: PARTNER_ID },
+        to: { orgId: null, partnerId: PARTNER_ID },
+      });
+    });
+
+    it('a 0-row UPDATE (RLS reject / concurrent delete) → 404, no fabricated audit', async () => {
+      await withAuth(makePartnerAuth());
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      });
+      // UPDATE matches no rows (e.g. the RLS USING clause rejects between read
+      // and write) → returning() is empty.
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'partner' }),
+      });
+
+      expect(res.status).toBe(404);
+      // No audit row written for a write that didn't happen.
+      expect(vi.mocked(writeRouteAudit)).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -11,7 +11,10 @@ import {
   devices,
   deviceCommands,
   automationPolicies,
-  patchPolicies
+  patchPolicies,
+  configPolicyComplianceRules,
+  configPolicyFeatureLinks,
+  configurationPolicies
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
@@ -600,6 +603,15 @@ scriptRoutes.put(
         // (issue #1734 open question — block, don't silently detach/cascade).
         const widening = target.orgId === null; // → partner-wide covers all orgs
         if (!widening) {
+          // These counts run on the caller's request RLS context. The caller is
+          // always partner-scope here (resolveRescopeTarget enforces it), and
+          // all three reference tables resolve to a direct `org_id` (RLS shape
+          // 1) reachable via the partner short-circuit in breeze_has_org_access
+          // — so the partner sees references across ALL their orgs and the count
+          // can't silently under-report for the partner's own rows. A future
+          // RLS change on these tables would weaken this guard; keep them
+          // partner-visible. These cover every non-self-healing `scripts.id` FK
+          // (remediation_suggestions is onDelete:set null, so it self-heals).
           const [autoRef] = await db
             .select({ count: sql<number>`count(*)` })
             .from(automationPolicies)
@@ -613,13 +625,30 @@ scriptRoutes.put(
                 eq(patchPolicies.postInstallScript, scriptId)
               )
             );
+          // config_policy_compliance_rules has no direct org_id — join through
+          // its feature link to the parent configuration_policies (org_id) so
+          // the count is RLS-scoped to the partner's orgs.
+          const [complianceRef] = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(configPolicyComplianceRules)
+            .innerJoin(
+              configPolicyFeatureLinks,
+              eq(configPolicyComplianceRules.featureLinkId, configPolicyFeatureLinks.id)
+            )
+            .innerJoin(
+              configurationPolicies,
+              eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id)
+            )
+            .where(eq(configPolicyComplianceRules.remediationScriptId, scriptId));
           const referenceCount =
-            Number(autoRef?.count ?? 0) + Number(patchRef?.count ?? 0);
+            Number(autoRef?.count ?? 0) +
+            Number(patchRef?.count ?? 0) +
+            Number(complianceRef?.count ?? 0);
           if (referenceCount > 0) {
             return c.json(
               {
                 error:
-                  'Cannot narrow this script\'s scope while it is referenced by automation or patch policies. Detach those references first, or promote it to All Orgs instead.',
+                  'Cannot narrow this script\'s scope while it is referenced by automation, patch, or configuration policies. Detach those references first, or promote it to All Orgs instead.',
                 referencingPolicies: referenceCount
               },
               409
@@ -654,22 +683,31 @@ scriptRoutes.put(
       .where(eq(scripts.id, scriptId))
       .returning();
 
+    // The row was read+authorized above, but RLS (USING) or a concurrent
+    // soft-delete can still leave the UPDATE matching 0 rows. Without this
+    // guard the handler would write a fabricated `script.update` audit (a
+    // scopeChange to null/null that never happened) and return HTTP 200 with a
+    // null body, which the web layer toasts as success — a silent failure.
+    if (!updated) {
+      return c.json({ error: 'Script not found or no longer writable' }, 404);
+    }
+
     writeRouteAudit(c, {
       orgId: resolveScriptAuditOrgId(auth, script.orgId),
       action: 'script.update',
       resourceType: 'script',
-      resourceId: updated?.id,
-      resourceName: updated?.name,
+      resourceId: updated.id,
+      resourceName: updated.name,
       details: {
         changedFields: Object.keys(data),
-        newVersion: updated?.version,
+        newVersion: updated.version,
         // Forensic trail for scope changes (issue #1734): record the old and
         // new scope so a re-scope is auditable.
         ...(data.availability !== undefined
           ? {
               scopeChange: {
                 from: { orgId: script.orgId, partnerId: script.partnerId },
-                to: { orgId: updated?.orgId ?? null, partnerId: updated?.partnerId ?? null }
+                to: { orgId: updated.orgId ?? null, partnerId: updated.partnerId ?? null }
               }
             }
           : {})

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -9,7 +9,9 @@ import {
   scripts,
   scriptExecutions,
   devices,
-  deviceCommands
+  deviceCommands,
+  automationPolicies,
+  patchPolicies
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
@@ -64,6 +66,69 @@ function resolveScriptAuditOrgId(
   return scriptOrgId ?? deviceOrgId ?? auth.orgId ?? null;
 }
 
+type RescopeAuth = {
+  scope: string;
+  partnerId: string | null;
+  accessibleOrgIds: string[] | null;
+  canAccessOrg: (orgId: string) => boolean;
+};
+
+type RescopeTarget = { orgId: string | null; partnerId: string | null };
+type RescopeError = { error: string; status: 400 | 403 };
+
+function isRescopeError(r: RescopeTarget | RescopeError): r is RescopeError {
+  return 'error' in r;
+}
+
+/**
+ * Resolve the requested target scope for a script re-scope on edit (issue
+ * #1734). Returns the `{ orgId, partnerId }` to persist, or a typed error.
+ *
+ * Tenancy rules (mirror the create path at the POST handler):
+ * - Only partner-scope callers may re-scope. Org-scope callers can't move a
+ *   script across orgs or promote it partner-wide — they may only edit their
+ *   own org's scripts in place, so re-scope fields are rejected (403).
+ * - `availability: 'partner'` → partner-wide ("All Orgs"): org_id NULL,
+ *   partner_id = caller's partner. Never `is_system` (that stays seed-only).
+ * - `availability: 'org'` → a single org the caller can access; denied
+ *   otherwise. partner_id stays denormalized for RLS.
+ * The RLS UPDATE WITH CHECK (`breeze_has_org_access(org_id) OR
+ * breeze_has_partner_access(partner_id)`) is the backstop — a forged target
+ * the caller can't reach fails there with no row written.
+ */
+function resolveRescopeTarget(
+  auth: RescopeAuth,
+  availability: 'org' | 'partner',
+  requestedOrgId: string | null | undefined,
+  currentScope: { orgId: string | null; partnerId: string | null }
+): RescopeTarget | RescopeError {
+  if (auth.scope !== 'partner') {
+    return { error: 'Only partner-scope users can change a script\'s scope', status: 403 };
+  }
+  const partnerId = auth.partnerId;
+  if (!partnerId) {
+    return { error: 'Partner context required', status: 403 };
+  }
+  // The script must already belong to this partner — never re-scope a row
+  // from another partner or a system row through this path.
+  if (currentScope.partnerId !== partnerId) {
+    return { error: 'This script is not owned by your partner and cannot be re-scoped', status: 403 };
+  }
+
+  if (availability === 'partner') {
+    return { orgId: null, partnerId };
+  }
+
+  // availability === 'org': a single specific org the caller can access.
+  if (!requestedOrgId) {
+    return { error: 'orgId is required to scope a script to a specific organization', status: 400 };
+  }
+  if (!auth.canAccessOrg(requestedOrgId)) {
+    return { error: 'Access to this organization denied', status: 403 };
+  }
+  return { orgId: requestedOrgId, partnerId };
+}
+
 function getAllowedSiteIds(c: { get: (key: string) => unknown }): string[] | undefined {
   return (c.get('permissions') as UserPermissions | undefined)?.allowedSiteIds;
 }
@@ -116,7 +181,14 @@ const updateScriptSchema = z.object({
   parameters: z.any().optional(),
   timeoutSeconds: z.number().int().min(1).max(86400).optional(),
   runAs: z.enum(['system', 'user', 'elevated']).optional(),
-  exitCodeSeverityMapping: exitCodeSeverityMappingSchema.nullable().optional()
+  exitCodeSeverityMapping: exitCodeSeverityMappingSchema.nullable().optional(),
+  // Re-scope on edit (issue #1734). Mirrors the create-time "Available to"
+  // control: 'org' = a single specific org, 'partner' = partner-wide ("All
+  // Orgs"). When `availability` is present the PUT handler re-scopes the row.
+  // `isSystem` is intentionally NOT accepted here — promotion to a global
+  // system row stays system-scope-seed-only (the Discussion #633 write hole).
+  availability: z.enum(['org', 'partner']).optional(),
+  orgId: z.string().guid().nullable().optional()
 });
 
 const executeScriptSchema = z.object({
@@ -503,6 +575,63 @@ scriptRoutes.put(
     // Build updates object
     const updates: Record<string, unknown> = { updatedAt: new Date() };
 
+    // Re-scope on edit (issue #1734). Only applied when `availability` is sent;
+    // a plain content/metadata edit never touches org/partner. System scripts
+    // never get re-scoped here (the system read-only guard above already 403s
+    // non-system callers, and `availability` is the only path that writes
+    // org/partner — `isSystem` is not accepted by the schema, so the #633 hole
+    // stays closed).
+    if (data.availability !== undefined) {
+      const target = resolveRescopeTarget(
+        auth,
+        data.availability,
+        data.orgId,
+        { orgId: script.orgId, partnerId: script.partnerId }
+      );
+      if (isRescopeError(target)) {
+        return c.json({ error: target.error }, target.status);
+      }
+
+      const scopeChanged = target.orgId !== script.orgId;
+      if (scopeChanged) {
+        // Narrowing = the script stops covering an org it covered before
+        // (partner-wide → one org, or org A → org B). Block while live policy
+        // references exist so we never leave a dangling cross-org reference
+        // (issue #1734 open question — block, don't silently detach/cascade).
+        const widening = target.orgId === null; // → partner-wide covers all orgs
+        if (!widening) {
+          const [autoRef] = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(automationPolicies)
+            .where(eq(automationPolicies.remediationScriptId, scriptId));
+          const [patchRef] = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(patchPolicies)
+            .where(
+              or(
+                eq(patchPolicies.preInstallScript, scriptId),
+                eq(patchPolicies.postInstallScript, scriptId)
+              )
+            );
+          const referenceCount =
+            Number(autoRef?.count ?? 0) + Number(patchRef?.count ?? 0);
+          if (referenceCount > 0) {
+            return c.json(
+              {
+                error:
+                  'Cannot narrow this script\'s scope while it is referenced by automation or patch policies. Detach those references first, or promote it to All Orgs instead.',
+                referencingPolicies: referenceCount
+              },
+              409
+            );
+          }
+        }
+      }
+
+      updates.orgId = target.orgId;
+      updates.partnerId = target.partnerId;
+    }
+
     if (data.name !== undefined) updates.name = data.name;
     if (data.description !== undefined) updates.description = data.description;
     if (data.category !== undefined) updates.category = data.category;
@@ -533,7 +662,17 @@ scriptRoutes.put(
       resourceName: updated?.name,
       details: {
         changedFields: Object.keys(data),
-        newVersion: updated?.version
+        newVersion: updated?.version,
+        // Forensic trail for scope changes (issue #1734): record the old and
+        // new scope so a re-scope is auditable.
+        ...(data.availability !== undefined
+          ? {
+              scopeChange: {
+                from: { orgId: script.orgId, partnerId: script.partnerId },
+                to: { orgId: updated?.orgId ?? null, partnerId: updated?.partnerId ?? null }
+              }
+            }
+          : {})
       }
     });
 

--- a/apps/web/src/components/scripts/ScriptEditPage.tsx
+++ b/apps/web/src/components/scripts/ScriptEditPage.tsx
@@ -7,6 +7,7 @@ import { useOrgStore } from '../../stores/orgStore';
 import { ScopeBadge } from '../shared/ScopeBadge';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
+import { getJwtClaims } from '@/lib/authScope';
 import Breadcrumbs from '../layout/Breadcrumbs';
 
 type ScriptEditPageProps = {
@@ -28,6 +29,7 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
 
   const isNew = !scriptId;
   const { organizations } = useOrgStore();
+  const { scope: jwtScope } = getJwtClaims();
 
   const fetchScript = useCallback(async () => {
     if (!scriptId) return;
@@ -45,6 +47,7 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
       }
       const data = await response.json();
       const scriptData = data.script ?? data;
+      const scopeOrgId: string | null = scriptData.orgId ?? null;
       setScript({
         name: scriptData.name,
         description: scriptData.description || '',
@@ -56,9 +59,14 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
         timeoutSeconds: scriptData.timeoutSeconds || 300,
         runAs: scriptData.runAs || 'system',
         exitCodeSeverityMapping: mappingToRows(scriptData.exitCodeSeverityMapping),
+        // Seed the "Available to" re-scope picker from the current scope
+        // (issue #1734): org_id NULL = partner-wide ("All Orgs"), else a
+        // specific org. The picker only renders for partner-scope users.
+        availability: scopeOrgId ? 'org' : 'partner',
+        orgId: scopeOrgId ?? undefined,
       });
       setScriptScope({
-        orgId: scriptData.orgId ?? null,
+        orgId: scopeOrgId,
         partnerId: scriptData.partnerId ?? null,
         isSystem: scriptData.isSystem ?? false,
       });
@@ -81,18 +89,35 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
       const url = isNew ? '/scripts' : `/scripts/${scriptId}`;
       const method = isNew ? 'POST' : 'PUT';
 
-      let payload: typeof values & { availability?: 'org' | 'partner'; orgId?: string | null };
+      type ScriptPayload = Omit<ScriptSubmitValues, 'availability' | 'orgId'> & {
+        availability?: 'org' | 'partner';
+        orgId?: string | null;
+      };
+      const { availability: _availability, orgId: _orgId, ...baseValues } = values;
+      let payload: ScriptPayload = baseValues;
       if (isNew) {
         if (values.availability === 'org') {
           // Org-specific script: use the selected orgId from the form or fall back to the current org
           const orgId = values.orgId || useOrgStore.getState().currentOrgId || undefined;
-          payload = { ...values, availability: 'org', orgId };
+          payload = { ...baseValues, availability: 'org', orgId };
         } else {
           // Partner-wide (default) or single-org user: let the backend resolve
-          payload = { ...values, availability: 'partner' };
+          payload = { ...baseValues, availability: 'partner' };
         }
       } else {
-        payload = values;
+        // Edit: forward the re-scope fields only for partner-scope users whose
+        // scope actually differs from the script's current scope (issue #1734).
+        // Org-scope users can't re-scope (the picker is hidden and the backend
+        // 403s them), so strip the seeded `availability`/`orgId` for them.
+        const canRescope =
+          jwtScope === 'partner' && !scriptScope?.isSystem && _availability !== undefined;
+        if (canRescope) {
+          const targetOrgId = _availability === 'org' ? (_orgId || undefined) : null;
+          const scopeUnchanged = (scriptScope?.orgId ?? null) === (targetOrgId ?? null);
+          if (!scopeUnchanged) {
+            payload = { ...baseValues, availability: _availability, orgId: targetOrgId };
+          }
+        }
       }
 
       const response = await fetchWithAuth(url, {
@@ -207,6 +232,7 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
         submitLabel={isNew ? 'Create Script' : 'Save Changes'}
         loading={submitting}
         isNew={isNew}
+        isSystemScript={scriptScope?.isSystem ?? false}
       />
     </div>
   );

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -233,8 +233,15 @@ describe('ScriptForm availability picker — partner-scope gate', () => {
     expect(queryByText('Available to')).toBeNull();
   });
 
-  it('hides the picker when editing an existing script (not isNew)', async () => {
-    const { queryByText } = render(<ScriptForm />);
+  // Re-scope on edit (issue #1734): the picker now also renders when EDITING,
+  // so a partner-scope user can move a script org→org or promote it to All Orgs.
+  it('shows the "Available to" picker when editing an existing script (partner scope, >1 org)', async () => {
+    const { findByText } = render(<ScriptForm />);
+    expect(await findByText('Available to')).toBeTruthy();
+  });
+
+  it('hides the re-scope picker when editing a system script', async () => {
+    const { queryByText } = render(<ScriptForm isSystemScript />);
     await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
     expect(queryByText('Available to')).toBeNull();
   });

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -42,6 +42,9 @@ type ScriptFormProps = {
   submitLabel?: string;
   loading?: boolean;
   isNew?: boolean;
+  // System scripts can't be re-scoped through this form (they're read-only for
+  // non-system users and stay system-scope-seed-only). Hides the picker on edit.
+  isSystemScript?: boolean;
 };
 
 export default function ScriptForm({
@@ -51,6 +54,7 @@ export default function ScriptForm({
   submitLabel = 'Save script',
   loading,
   isNew = false,
+  isSystemScript = false,
 }: ScriptFormProps) {
   const [editorMounted, setEditorMounted] = useState(false);
   const editorInstanceRef = useRef<Parameters<NonNullable<EditorProps['onMount']>>[0] | null>(null);
@@ -272,13 +276,15 @@ export default function ScriptForm({
   // `GET /orgs/partners` endpoint and so is always empty for a real partner-scope
   // user (the picker would never render for its own audience). `organizations` IS
   // populated for partner users, so it still drives the >1-org check.
-  // The "Available to" picker shows only for partner-scope users creating a NEW
-  // script with >1 accessible org (single-org partner users don't need to pick;
-  // org-scope users always write to their own org — the backend forces it).
+  // The "Available to" picker shows for partner-scope users with >1 accessible
+  // org — on create (choose initial scope) AND on edit (re-scope a script:
+  // move org→org or promote to All Orgs, issue #1734). Single-org partner users
+  // don't need to pick; org-scope users always write to their own org and can't
+  // re-scope (the backend 403s a non-partner re-scope and forces org on create).
   const { organizations } = useOrgStore();
   const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
   const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
-  const showAvailabilityPicker = isNew && isPartnerScope && organizations.length > 1;
+  const showAvailabilityPicker = isPartnerScope && organizations.length > 1 && !isSystemScript;
 
   const monacoLanguage = useMemo(() => {
     return languageOptions.find(l => l.value === watchLanguage)?.monacoLang || 'plaintext';
@@ -328,16 +334,25 @@ export default function ScriptForm({
       })}
       className="space-y-8 rounded-lg border bg-card p-6 shadow-sm"
     >
-      {/* Availability picker — shown only for partner-scope users creating a new script with >1 org */}
+      {/* Availability picker — partner-scope users with >1 org. On create it
+          sets the initial scope; on edit it re-scopes the script (move org→org
+          or promote to All Orgs, issue #1734). The checked radio is driven by
+          react-hook-form's `availability` default (seeded from the current
+          scope on edit), so no hardcoded defaultChecked. */}
       {showAvailabilityPicker && (
         <fieldset className="space-y-2 rounded-md border p-4">
           <legend className="px-1 text-sm font-medium">Available to</legend>
+          {!isNew && (
+            <p className="text-xs text-muted-foreground">
+              Change which organizations can see and run this script. &ldquo;All my
+              organizations&rdquo; makes it partner-wide.
+            </p>
+          )}
           <label className="flex items-center gap-2 text-sm">
             <input
               type="radio"
               value="partner"
               {...register('availability')}
-              defaultChecked
             />
             All my organizations
           </label>


### PR DESCRIPTION
Closes #1734

## Summary

Adds a **scope changer to the script edit screen** so a partner-scope user can re-scope a script after creation: move it from one org to another, or promote a single-org script to **All Orgs** (partner-wide), and back. Previously scope was create-only and read-only on edit.

## What changed

**API — `PUT /scripts/:id`** (`apps/api/src/routes/scripts.ts`)
- `updateScriptSchema` now accepts `availability` (`'org'`|`'partner'`) + `orgId`.
- New `resolveRescopeTarget` helper mirrors the create path's tenancy gating: **only partner scope** may re-scope, the script must already belong to the caller's partner, and a target org must pass `canAccessOrg`. The RLS UPDATE `WITH CHECK` is the backstop.
- **`isSystem` is intentionally NOT accepted** on this path — promotion to a global system row stays system-scope-seed-only, keeping the Discussion #633 write-policy hole closed.
- **Dangling references** (issue open question → resolved as *block*): narrowing a script away from an org (partner-wide→org, or org A→org B) returns **409** while it's referenced by `automation_policies` or `patch_policies`. Widening to All Orgs never orphans references; run history (snapshotted `org_id`) is untouched.
- Scope changes are recorded in the `script.update` audit (`scopeChange: { from, to }`).

**Web** (`ScriptForm.tsx`, `ScriptEditPage.tsx`)
- The "Available to" picker now renders on edit too (partner scope, >1 org, non-system), seeded from the script's current scope.
- `ScriptEditPage` forwards `availability`/`orgId` in the PUT **only** for partner-scope users whose scope actually changed; org-scope users get the picker hidden and the seeded fields stripped (defense in depth alongside the backend 403).

## Tenancy notes

- Promotion is **partner-wide only** (`org_id NULL`, `partner_id` set) — never `is_system`.
- A single-org/org-scope user cannot forge a partner-wide or system row: the schema rejects `isSystem`, the route 403s non-partner re-scope, and RLS `WITH CHECK` rejects any target the caller can't reach.

## Tests

- 6 new API route cases: promote org→All Orgs, org→org move, 409-on-references, org-scope 403, inaccessible-org 403, no-`availability` no-op.
- Updated `ScriptForm` picker tests for the edit / system-script gating.
- `apps/api` scripts suite: 29 passed (+6 new). `apps/web` ScriptForm: 13 passed. `tsc --noEmit` + `astro check` clean on both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)