### PR TITLE
feat(config-policies): partner-owned (partner-wide / all-orgs) policies (#1724)

### DIFF
--- a/apps/api/migrations/2026-06-27-config-policies-partner-ownership.sql
+++ b/apps/api/migrations/2026-06-27-config-policies-partner-ownership.sql
@@ -1,0 +1,319 @@
+-- Partner-owned configuration policies (#1724).
+--
+-- Until now a configuration_policies row was always owned by exactly one org
+-- (org_id NOT NULL). The "Partner" assignment level existed but a policy still
+-- had to belong to a single org, so a partner-wide policy could not span all of
+-- a partner's organizations.
+--
+-- This migration makes a policy ownable by EITHER an org (org_id set,
+-- partner_id NULL — the existing shape) OR a partner (partner_id set,
+-- org_id NULL — the new "partner-wide / all orgs" shape). Exactly one axis is
+-- set per row, enforced by a CHECK constraint.
+--
+-- RLS: configuration_policies now carries BOTH axes, so its policy is dual-axis
+-- (org OR partner), mirroring custom_field_definitions / client_ai_prompt_templates.
+-- A partner-owned row is visible/writable only to callers with
+-- breeze_has_partner_access(partner_id); an org-owned row only to
+-- breeze_has_org_access(org_id). System scope short-circuits both.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded ALTER/CHECK, DROP POLICY IF
+-- EXISTS then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT
+-- (autoMigrate wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, enforce exactly-one-axis
+-- ============================================
+
+ALTER TABLE configuration_policies
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+-- org_id was NOT NULL; partner-owned rows must allow NULL org_id.
+ALTER TABLE configuration_policies
+  ALTER COLUMN org_id DROP NOT NULL;
+
+-- Exactly one ownership axis must be set. (org_id IS NULL) <> (partner_id IS NULL)
+-- is true iff exactly one of the two is NULL — i.e. exactly one is set.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'configuration_policies_one_owner_chk'
+      AND conrelid = 'configuration_policies'::regclass
+  ) THEN
+    ALTER TABLE configuration_policies
+      ADD CONSTRAINT configuration_policies_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS config_policies_partner_id_idx
+  ON configuration_policies(partner_id);
+
+-- ============================================
+-- Step 2: RLS — dual-axis (org OR partner) + FORCE
+-- ============================================
+
+ALTER TABLE configuration_policies ENABLE ROW LEVEL SECURITY;
+-- FORCE was missing on the original baseline policy; add it so the table owner
+-- (breeze_app is not owner, but defense-in-depth for any privileged role) is
+-- also subject to RLS, matching the partner-axis precedent (time_entries).
+ALTER TABLE configuration_policies FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS configuration_policies_org_isolation ON configuration_policies;
+CREATE POLICY configuration_policies_org_isolation
+  ON configuration_policies
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- Step 3: child-table RLS — extend to reach a partner-owned parent
+-- ============================================
+-- The feature-link / assignment / per-feature child tables reach their tenant
+-- through configuration_policies and previously gated ONLY on
+-- breeze_has_org_access(cp.org_id). For a partner-owned parent (org_id NULL)
+-- that branch is NULL/false, so the children would become invisible and
+-- unwritable. Extend each to also accept breeze_has_partner_access(cp.partner_id).
+-- breeze_has_org_access(NULL) / breeze_has_partner_access(NULL) are false, so the
+-- org-owned case is unchanged.
+
+DROP POLICY IF EXISTS config_policy_feature_links_org_isolation ON config_policy_feature_links;
+CREATE POLICY config_policy_feature_links_org_isolation
+  ON config_policy_feature_links
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM configuration_policies cp
+      WHERE cp.id = config_policy_feature_links.config_policy_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+DROP POLICY IF EXISTS config_policy_assignments_org_isolation ON config_policy_assignments;
+CREATE POLICY config_policy_assignments_org_isolation
+  ON config_policy_assignments
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM configuration_policies cp
+      WHERE cp.id = config_policy_assignments.config_policy_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+-- Per-feature children that join feature_link -> policy. Same OR-extension.
+DROP POLICY IF EXISTS config_policy_alert_rules_org_isolation ON config_policy_alert_rules;
+CREATE POLICY config_policy_alert_rules_org_isolation
+  ON config_policy_alert_rules
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_alert_rules.feature_link_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+DROP POLICY IF EXISTS config_policy_automations_org_isolation ON config_policy_automations;
+CREATE POLICY config_policy_automations_org_isolation
+  ON config_policy_automations
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_automations.feature_link_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+DROP POLICY IF EXISTS config_policy_compliance_rules_org_isolation ON config_policy_compliance_rules;
+CREATE POLICY config_policy_compliance_rules_org_isolation
+  ON config_policy_compliance_rules
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_compliance_rules.feature_link_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+DROP POLICY IF EXISTS config_policy_patch_settings_org_isolation ON config_policy_patch_settings;
+CREATE POLICY config_policy_patch_settings_org_isolation
+  ON config_policy_patch_settings
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_patch_settings.feature_link_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+DROP POLICY IF EXISTS config_policy_maintenance_settings_org_isolation ON config_policy_maintenance_settings;
+CREATE POLICY config_policy_maintenance_settings_org_isolation
+  ON config_policy_maintenance_settings
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_maintenance_settings.feature_link_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+-- event_log settings: single USING-only policy (0029-event-log-policy-settings.sql).
+DROP POLICY IF EXISTS config_policy_event_log_settings_org_isolation ON config_policy_event_log_settings;
+CREATE POLICY config_policy_event_log_settings_org_isolation
+  ON config_policy_event_log_settings
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM config_policy_feature_links fl
+      JOIN configuration_policies cp ON cp.id = fl.config_policy_id
+      WHERE fl.id = config_policy_event_log_settings.feature_link_id
+        AND (public.breeze_has_org_access(cp.org_id)
+             OR public.breeze_has_partner_access(cp.partner_id))
+    )
+  );
+
+-- ── sensitive_data / monitoring children: per-command split policies ─────────
+-- These were redefined as breeze_org_isolation_{select,insert,update,delete}
+-- in 2026-06-23-sec-review-1-fk-child-rls-backstop.sql, using scalar-subquery
+-- chains (single-table FROM configuration_policies, #1016-safe). We re-create
+-- each with the extra partner_id branch. The chain terminates at
+-- configuration_policies; breeze_has_org_access(NULL) is false so org-owned is
+-- unchanged. config_policy_sensitive_data_settings:
+ALTER TABLE config_policy_sensitive_data_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_sensitive_data_settings FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_sensitive_data_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_sensitive_data_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_sensitive_data_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_sensitive_data_settings;
+CREATE POLICY breeze_org_isolation_select ON config_policy_sensitive_data_settings FOR SELECT USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_insert ON config_policy_sensitive_data_settings FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_update ON config_policy_sensitive_data_settings FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_delete ON config_policy_sensitive_data_settings FOR DELETE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_sensitive_data_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+
+-- config_policy_monitoring_settings:
+ALTER TABLE config_policy_monitoring_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_monitoring_settings FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_monitoring_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_monitoring_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_monitoring_settings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_monitoring_settings;
+CREATE POLICY breeze_org_isolation_select ON config_policy_monitoring_settings FOR SELECT USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_insert ON config_policy_monitoring_settings FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_update ON config_policy_monitoring_settings FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_delete ON config_policy_monitoring_settings FOR DELETE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = config_policy_monitoring_settings.feature_link_id)
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+
+-- config_policy_monitoring_watches: one extra hop (settings_id -> settings).
+ALTER TABLE config_policy_monitoring_watches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_policy_monitoring_watches FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON config_policy_monitoring_watches;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON config_policy_monitoring_watches;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON config_policy_monitoring_watches;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON config_policy_monitoring_watches;
+CREATE POLICY breeze_org_isolation_select ON config_policy_monitoring_watches FOR SELECT USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_insert ON config_policy_monitoring_watches FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_update ON config_policy_monitoring_watches FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);
+CREATE POLICY breeze_org_isolation_delete ON config_policy_monitoring_watches FOR DELETE USING (
+  EXISTS (SELECT 1 FROM configuration_policies cp
+    WHERE cp.id = (SELECT fl.config_policy_id FROM config_policy_feature_links fl
+                   WHERE fl.id = (SELECT ms.feature_link_id FROM config_policy_monitoring_settings ms
+                                  WHERE ms.id = config_policy_monitoring_watches.settings_id))
+    AND (public.breeze_has_org_access(cp.org_id) OR public.breeze_has_partner_access(cp.partner_id)))
+);

--- a/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
@@ -1,0 +1,254 @@
+/**
+ * configuration_policies RLS — dual-axis (org OR partner) enforcement (#1724).
+ *
+ * Migration under test: 2026-06-27-config-policies-partner-ownership.sql.
+ *
+ * A configuration policy is owned by EITHER an org (org_id set, partner_id NULL —
+ * the original Shape-1 form) OR a partner (partner_id set, org_id NULL —
+ * "partner-wide / all orgs"). The dual-axis policy is:
+ *   system OR (org_id IS NOT NULL AND breeze_has_org_access(org_id))
+ *          OR (partner_id IS NOT NULL AND breeze_has_partner_access(partner_id))
+ *
+ * Same blindspot as client_ai_prompt_templates / custom_field_definitions: the
+ * rls-coverage contract test does NOT prove the partner branch (it accepts an
+ * org-only policy), so this functional test through the REAL postgres.js driver
+ * (breeze_app role) is the required guard that a partner cannot forge a
+ * partner_id for another partner.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { configurationPolicies } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const created: string[] = [];
+
+afterEach(async () => {
+  if (created.length === 0) return;
+  await withDbAccessContext(
+    { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null },
+    async () => {
+      for (const id of created) {
+        await db.delete(configurationPolicies).where(eq(configurationPolicies.id, id));
+      }
+    },
+  );
+  created.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+async function seedPartnerPolicy(partnerId: string, track = true): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(configurationPolicies)
+      .values({ orgId: null, partnerId, name: 'Seed partner-wide policy' })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  if (track) created.push(id);
+  return id;
+}
+
+describe('configuration_policies RLS — dual-axis (2026-06-27 migration)', () => {
+  it('partner scope can INSERT a partner-wide policy (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(configurationPolicies)
+        .values({ orgId: null, partnerId: partner.id, name: 'All-orgs baseline' })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) created.push(rows[0].id);
+  });
+
+  it('partner scope can SELECT back its own partner-wide policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visible = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .select({ id: configurationPolicies.id })
+        .from(configurationPolicies)
+        .where(eq(configurationPolicies.partnerId, partner.id)),
+    );
+
+    expect(visible.map((r) => r.id)).toContain(id);
+  });
+
+  it('a different partner can neither see nor forge a policy attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerPolicy(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .select({ id: configurationPolicies.id })
+        .from(configurationPolicies)
+        .where(eq(configurationPolicies.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // WITH CHECK denies the cross-partner forge. Drizzle wraps the driver error,
+    // so the RLS signal is Postgres code 42501 on the cause.
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(configurationPolicies)
+          .values({ orgId: null, partnerId: partnerA.id, name: 'Forged partner-wide' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('org scope can INSERT and SELECT an org-scoped policy (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(configurationPolicies)
+        .values({ orgId: org.id, partnerId: null, name: 'Org policy' })
+        .returning(),
+    );
+    if (inserted[0]) created.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: configurationPolicies.id })
+        .from(configurationPolicies)
+        .where(eq(configurationPolicies.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('an org-scope caller cannot see a partner-wide policy owned by its partner', async () => {
+    // Org scope is intentionally narrower than partner scope: partner-wide
+    // policies belong to the partner axis, which org-scope tokens don't hold.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: configurationPolicies.id })
+        .from(configurationPolicies)
+        .where(eq(configurationPolicies.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('the one-owner CHECK rejects a row that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    // Both axes set → CHECK violation (23514).
+    await expect(
+      withDbAccessContext(
+        { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null },
+        () =>
+          db
+            .insert(configurationPolicies)
+            .values({ orgId: org.id, partnerId: partner.id, name: 'Both axes' })
+            .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    // Neither axis set → CHECK violation (23514).
+    await expect(
+      withDbAccessContext(
+        { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null },
+        () =>
+          db
+            .insert(configurationPolicies)
+            .values({ orgId: null, partnerId: null, name: 'No axis' })
+            .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id, false);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(configurationPolicies)
+        .set({ name: 'Renamed' })
+        .where(eq(configurationPolicies.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.name).toBe('Renamed');
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .delete(configurationPolicies)
+        .where(eq(configurationPolicies.id, id))
+        .returning(),
+    );
+    expect(deleted).toHaveLength(1);
+  });
+
+  it('a different partner UPDATE/DELETE silently match zero rows', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerPolicy(partnerA.id);
+
+    const updatedByB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .update(configurationPolicies)
+        .set({ name: 'Hijacked' })
+        .where(eq(configurationPolicies.id, id))
+        .returning(),
+    );
+    expect(updatedByB).toEqual([]);
+
+    const deletedByB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .delete(configurationPolicies)
+        .where(eq(configurationPolicies.id, id))
+        .returning(),
+    );
+    expect(deletedByB).toEqual([]);
+  });
+
+  it('stays fail-closed without a DB access context (scope "none")', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const rows = await db
+      .select({ id: configurationPolicies.id })
+      .from(configurationPolicies)
+      .where(eq(configurationPolicies.id, id));
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/integration/configurationPolicyPartnerResolution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configurationPolicyPartnerResolution.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Partner-wide configuration policy RESOLUTION (#1724).
+ *
+ * The RLS forge test (configurationPoliciesPartnerRls) proves VISIBILITY. This
+ * test proves the core acceptance criterion: a partner-OWNED policy (org_id
+ * NULL, partner_id set) actually resolves as the effective config for devices
+ * across MULTIPLE organizations of the same partner — plus filter gating
+ * (role/os) and closest-wins override precedence.
+ *
+ * Resolution runs under a system-scope AuthContext so the device-access gate is
+ * a no-op and we exercise the policy-ownership + assignment-matching logic
+ * directly (the same query the agent-facing path runs).
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  devices,
+} from '../../db/schema';
+import { resolveEffectiveConfig } from '../../services/configurationPolicy';
+import type { AuthContext } from '../../middleware/auth';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+const createdPolicies: string[] = [];
+
+afterEach(async () => {
+  if (createdPolicies.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdPolicies) {
+      await db.delete(configurationPolicies).where(eq(configurationPolicies.id, id));
+    }
+  });
+  createdPolicies.length = 0;
+});
+
+// System-scope AuthContext: orgCondition returns undefined so the resolver's
+// device-access filter is a no-op (we're testing ownership/assignment matching).
+function systemAuth(): AuthContext {
+  return {
+    user: { id: randomUUID(), email: 'sys@example.com', name: 'Sys', isPlatformAdmin: false },
+    token: {} as never,
+    partnerId: null,
+    orgId: null,
+    scope: 'system',
+    accessibleOrgIds: null,
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as unknown as AuthContext;
+}
+
+async function seedDevice(orgId: string, siteId: string, osType: 'windows' | 'macos' | 'linux', deviceRole: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [d] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType,
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        deviceRole,
+      })
+      .returning();
+    return d!;
+  });
+}
+
+async function seedPartnerPolicyWithFeature(partnerId: string): Promise<{ policyId: string; featureLinkId: string }> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: null, partnerId, name: 'Partner-wide security', status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy!.id, featureType: 'security', inlineSettings: { tag: 'partner-wide' } })
+      .returning();
+    return { policyId: policy!.id, featureLinkId: link!.id };
+  });
+}
+
+async function assign(
+  policyId: string,
+  level: 'partner' | 'organization' | 'device',
+  targetId: string,
+  opts: { roleFilter?: string[]; osFilter?: string[] } = {},
+) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId: policyId,
+      level,
+      targetId,
+      priority: 0,
+      roleFilter: opts.roleFilter ?? null,
+      osFilter: opts.osFilter ?? null,
+    });
+  });
+}
+
+describe('partner-wide configuration policy resolution (#1724)', () => {
+  it('resolves a partner-owned policy for devices in DIFFERENT orgs of the same partner', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const siteA = await createSite({ orgId: orgA!.id });
+    const siteB = await createSite({ orgId: orgB!.id });
+    const deviceA = await seedDevice(orgA!.id, siteA!.id, 'windows', 'server');
+    const deviceB = await seedDevice(orgB!.id, siteB!.id, 'linux', 'workstation');
+
+    const { policyId } = await seedPartnerPolicyWithFeature(partner.id);
+    await assign(policyId, 'partner', partner.id);
+
+    const resolvedA = await withSystemDbAccessContext(() => resolveEffectiveConfig(deviceA.id, systemAuth()));
+    const resolvedB = await withSystemDbAccessContext(() => resolveEffectiveConfig(deviceB.id, systemAuth()));
+
+    // Both devices, in two distinct orgs, resolve the SAME partner-owned policy.
+    expect(resolvedA?.features.security?.sourcePolicyId).toBe(policyId);
+    expect(resolvedB?.features.security?.sourcePolicyId).toBe(policyId);
+    expect(resolvedA?.features.security?.sourceLevel).toBe('partner');
+  });
+
+  it('applies the role/os filter as a gate during resolution', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org!.id });
+    const serverDevice = await seedDevice(org!.id, site!.id, 'windows', 'server');
+    const workstationDevice = await seedDevice(org!.id, site!.id, 'windows', 'workstation');
+
+    const { policyId } = await seedPartnerPolicyWithFeature(partner.id);
+    // Partner-wide, but only for server-role devices.
+    await assign(policyId, 'partner', partner.id, { roleFilter: ['server'] });
+
+    const onServer = await withSystemDbAccessContext(() => resolveEffectiveConfig(serverDevice.id, systemAuth()));
+    const onWorkstation = await withSystemDbAccessContext(() => resolveEffectiveConfig(workstationDevice.id, systemAuth()));
+
+    expect(onServer?.features.security?.sourcePolicyId).toBe(policyId);
+    // The workstation is gated out by the role filter — no security feature.
+    expect(onWorkstation?.features.security).toBeUndefined();
+  });
+
+  it('lets an org-level assignment override a partner-wide one (closest wins)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org!.id });
+    const device = await seedDevice(org!.id, site!.id, 'windows', 'server');
+
+    // Partner-wide policy assigned partner-wide.
+    const partnerWide = await seedPartnerPolicyWithFeature(partner.id);
+    await assign(partnerWide.policyId, 'partner', partner.id);
+
+    // Org-owned policy with the same feature, assigned at org level.
+    const orgPolicyId = await withDbAccessContext(SYSTEM_CTX, async () => {
+      const [p] = await db
+        .insert(configurationPolicies)
+        .values({ orgId: org!.id, partnerId: null, name: 'Org override', status: 'active' })
+        .returning();
+      createdPolicies.push(p!.id);
+      await db
+        .insert(configPolicyFeatureLinks)
+        .values({ configPolicyId: p!.id, featureType: 'security', inlineSettings: { tag: 'org-override' } });
+      return p!.id;
+    });
+    await assign(orgPolicyId, 'organization', org!.id);
+
+    const resolved = await withSystemDbAccessContext(() => resolveEffectiveConfig(device.id, systemAuth()));
+
+    // Org level (priority 2) beats partner level (priority 1): the org policy wins.
+    expect(resolved?.features.security?.sourcePolicyId).toBe(orgPolicyId);
+    expect(resolved?.features.security?.sourceLevel).toBe('organization');
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -200,6 +200,17 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // partner-axis (breeze_has_partner_access) branch — the dual-axis blindspot.
   // A functional breeze_app insert test lives in client-ai-templates-rls.integration.test.ts.
   'client_ai_prompt_templates',
+  // configuration_policies (#1724): a policy is org-scoped (org_id set,
+  // partner_id NULL — the original shape) OR partner-wide (partner_id set,
+  // org_id NULL — "all orgs"). Converted from org-only to dual-axis in
+  // 2026-06-27-config-policies-partner-ownership. Same blindspot as
+  // client_ai_prompt_templates: the org_id column means org-tenant
+  // auto-discovery already asserts the breeze_has_org_access branch, so this
+  // entry is what asserts the breeze_has_partner_access (partner-wide) branch.
+  // A CHECK constraint (configuration_policies_one_owner_chk) enforces exactly
+  // one axis per row. Functional cross-partner forge proof:
+  // configurationPoliciesPartnerRls.integration.test.ts.
+  'configuration_policies',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/db/schema/configurationPolicies.ts
+++ b/apps/api/src/db/schema/configurationPolicies.ts
@@ -12,7 +12,7 @@ import {
   index,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 import { alertSeverityEnum } from './alerts';
 import { automationOnFailureEnum, policyEnforcementEnum } from './automations';
@@ -60,9 +60,14 @@ export const backupModeEnum = pgEnum('backup_mode_enum', [
   'system_image',
 ]);
 
+// A policy is owned by EITHER an org (orgId set, partnerId NULL — the original
+// org-scoped shape) OR a partner (partnerId set, orgId NULL — "partner-wide /
+// all orgs"). Exactly one axis is set per row; the CHECK constraint
+// `configuration_policies_one_owner_chk` (migration 2026-06-27) enforces it.
 export const configurationPolicies = pgTable('configuration_policies', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
   status: configPolicyStatusEnum('status').notNull().default('active'),
@@ -71,6 +76,7 @@ export const configurationPolicies = pgTable('configuration_policies', {
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => ({
   orgIdIdx: index('config_policies_org_id_idx').on(table.orgId),
+  partnerIdIdx: index('config_policies_partner_id_idx').on(table.partnerId),
   statusIdx: index('config_policies_status_idx').on(table.status),
 }));
 

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -148,8 +148,11 @@ async function processCheckSchedules(): Promise<{ enqueued: number }> {
 
   let enqueued = 0;
 
-  // 2. For each org, resolve all backup-assigned devices via config policy hierarchy
+  // 2. For each org, resolve all backup-assigned devices via config policy hierarchy.
+  // Backup features are org-owned only (#1724 rejects backup on partner-wide
+  // policies), so org_id is always present here; skip defensively if NULL.
   for (const { orgId } of orgRows) {
+    if (!orgId) continue;
     try {
       const entries = await resolveAllBackupAssignedDevices(orgId);
 

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -357,6 +357,10 @@ async function scanAndCreateJobs(): Promise<{
 
   for (const row of patchPoliciesWithSchedules) {
     try {
+      // Partner-owned policies (org_id NULL, #1724) don't target org-scoped
+      // devices, so there's nothing to schedule patches for here.
+      if (row.policyOrgId === null) continue;
+
       const policyLocal = await loadPolicyLocalPatchConfig(row.configPolicyId);
       if (!policyLocal) continue;
 

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -357,8 +357,10 @@ async function scanAndCreateJobs(): Promise<{
 
   for (const row of patchPoliciesWithSchedules) {
     try {
-      // Partner-owned policies (org_id NULL, #1724) don't target org-scoped
-      // devices, so there's nothing to schedule patches for here.
+      // Partner-owned policies (org_id NULL, #1724) cannot carry a patch
+      // feature link — the feature-link route rejects 'patch' on partner-wide
+      // policies (ORG_SCOPED_ONLY_FEATURES), so this query never returns one.
+      // The guard is a defensive backstop; it never skips real work.
       if (row.policyOrgId === null) continue;
 
       const policyLocal = await loadPolicyLocalPatchConfig(row.configPolicyId);

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -505,7 +505,9 @@ automationRoutes.get(
         .from(configurationPolicies)
         .where(eq(configurationPolicies.id, run.configPolicyId))
         .limit(1);
-      if (!policy || !ensureOrgAccess(policy.orgId, auth)) {
+      // Partner-owned policies (org_id NULL, #1724) have no owning org to
+      // tenant-check against on this org-scoped path; treat as not found.
+      if (!policy || policy.orgId === null || !ensureOrgAccess(policy.orgId, auth)) {
         return c.json({ error: 'Automation run not found' }, 404);
       }
 

--- a/apps/api/src/routes/configurationPolicies/assignments.test.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.test.ts
@@ -45,6 +45,7 @@ import { assignmentRoutes } from './assignments';
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const POLICY_ID = '22222222-2222-2222-2222-222222222222';
 const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const PARTNER_ID = '66666666-6666-6666-6666-666666666666';
 
 function makeAuth(overrides: Record<string, unknown> = {}): any {
   return {
@@ -74,7 +75,7 @@ describe('configurationPolicies assignment routes', () => {
   });
 
   it('assigns a policy when the target belongs to the policy organization', async () => {
-    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, name: 'Policy 1' });
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' });
     validateAssignmentTargetMock.mockResolvedValue({ valid: true });
     assignPolicyMock.mockResolvedValue({
       id: '44444444-4444-4444-4444-444444444444',
@@ -90,7 +91,11 @@ describe('configurationPolicies assignment routes', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(validateAssignmentTargetMock).toHaveBeenCalledWith(ORG_ID, 'device', DEVICE_ID);
+    expect(validateAssignmentTargetMock).toHaveBeenCalledWith(
+      { orgId: ORG_ID, partnerId: null },
+      'device',
+      DEVICE_ID
+    );
     expect(assignPolicyMock).toHaveBeenCalledWith(
       POLICY_ID,
       'device',
@@ -103,7 +108,7 @@ describe('configurationPolicies assignment routes', () => {
   });
 
   it('denies cross-org assignment targets before inserting the assignment', async () => {
-    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, name: 'Policy 1' });
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' });
     validateAssignmentTargetMock.mockResolvedValue({
       valid: false,
       error: 'Device target not found in the policy organization',
@@ -120,5 +125,39 @@ describe('configurationPolicies assignment routes', () => {
       error: 'Device target not found in the policy organization',
     });
     expect(assignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('derives the partner target server-side for a partner-wide assignment (#1724)', async () => {
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    assignPolicyMock.mockResolvedValue({
+      id: '55555555-5555-5555-5555-555555555555',
+      configPolicyId: POLICY_ID,
+      level: 'partner',
+      targetId: PARTNER_ID,
+    });
+
+    // No targetId in the body — the server must fill it from the policy's partner.
+    const res = await app.request(`/${POLICY_ID}/assignments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ level: 'partner' }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(validateAssignmentTargetMock).toHaveBeenCalledWith(
+      { orgId: null, partnerId: PARTNER_ID },
+      'partner',
+      PARTNER_ID
+    );
+    expect(assignPolicyMock).toHaveBeenCalledWith(
+      POLICY_ID,
+      'partner',
+      PARTNER_ID,
+      0,
+      'user-1',
+      undefined,
+      undefined
+    );
   });
 });

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -58,7 +58,30 @@ assignmentRoutes.post(
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
 
-    const targetValidation = await validateAssignmentTarget(policy.orgId, data.level, data.targetId);
+    // For a Partner-Wide assignment the target is the partner itself, derived
+    // server-side (#1724) — never trust a client-supplied partner id. For a
+    // partner-OWNED policy that is its own partner_id; for an org-owned policy
+    // assigned partner-wide it is the owning org's partner (resolved in the
+    // validator). The client may omit targetId for the partner level.
+    let targetId = data.targetId;
+    if (data.level === 'partner') {
+      if (policy.partnerId) {
+        targetId = policy.partnerId;
+      } else if (auth.partnerId) {
+        targetId = auth.partnerId;
+      } else {
+        return c.json({ error: 'Partner-wide assignments require partner scope' }, 403);
+      }
+    }
+    if (!targetId) {
+      return c.json({ error: 'targetId is required for this assignment level' }, 400);
+    }
+
+    const targetValidation = await validateAssignmentTarget(
+      { orgId: policy.orgId, partnerId: policy.partnerId },
+      data.level,
+      targetId
+    );
     if (!targetValidation.valid) {
       return c.json({ error: targetValidation.error ?? 'Assignment target is not valid for this policy organization' }, 403);
     }
@@ -67,7 +90,7 @@ assignmentRoutes.post(
       const assignment = await assignPolicy(
         id,
         data.level,
-        data.targetId,
+        targetId,
         data.priority ?? 0,
         auth.user.id,
         data.roleFilter,
@@ -83,7 +106,7 @@ assignmentRoutes.post(
         resourceType: 'configuration_policy',
         resourceId: id,
         resourceName: policy.name,
-        details: { level: data.level, targetId: data.targetId, priority: data.priority },
+        details: { level: data.level, targetId, priority: data.priority },
       });
 
       return c.json(assignment, 201);
@@ -142,6 +165,9 @@ assignmentRoutes.get(
     // Filter results to only include policies the caller can access
     const filtered = result.filter((r) => {
       if (auth.scope === 'system') return true;
+      // Partner-owned policies (org_id NULL, #1724) aren't org-scoped, so an
+      // org-axis access check can't apply — exclude them from these scopes.
+      if (r.policyOrgId === null) return false;
       if (auth.scope === 'organization') return auth.orgId === r.policyOrgId;
       return auth.canAccessOrg(r.policyOrgId);
     });

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -218,6 +218,50 @@ describe('configurationPolicies CRUD routes', () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it('creates a partner-wide policy with server-derived partner for partner scope (#1724)', async () => {
+      const PARTNER_ID = '99999999-9999-9999-9999-999999999999';
+      const policy = { id: POLICY_ID, name: 'Partner-wide', orgId: null, partnerId: PARTNER_ID, status: 'active' };
+      createConfigPolicyMock.mockResolvedValue(policy);
+
+      const appPartner = new Hono();
+      appPartner.use('*', async (c, next) => {
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID }));
+        await next();
+      });
+      appPartner.route('/', crudRoutes);
+
+      const res = await appPartner.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // A client-supplied orgId must be IGNORED for ownerScope:'partner'.
+        body: JSON.stringify({ name: 'Partner-wide', ownerScope: 'partner', orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(201);
+      // The partner is derived from auth.partnerId, not from the request body.
+      expect(createConfigPolicyMock).toHaveBeenCalledWith(
+        { partnerId: PARTNER_ID },
+        expect.objectContaining({ name: 'Partner-wide' }),
+        'user-1'
+      );
+    });
+
+    it('rejects ownerScope:partner for an org-scope caller (no partner) (#1724)', async () => {
+      const appOrg = new Hono();
+      appOrg.use('*', async (c, next) => {
+        c.set('auth', makeAuth({ scope: 'organization', orgId: ORG_ID, partnerId: null }));
+        await next();
+      });
+      appOrg.route('/', crudRoutes);
+
+      const res = await appOrg.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Nope', ownerScope: 'partner' }),
+      });
+      expect(res.status).toBe(403);
+      expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    });
   });
 
   // ============================================

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -55,6 +55,26 @@ crudRoutes.post(
     const auth = c.get('auth') as AuthContext;
     const data = c.req.valid('json');
 
+    // Partner-wide / all-orgs policy (#1724). The partner is ALWAYS derived from
+    // the caller's own token — never from a client-supplied value — so a caller
+    // cannot create a policy owned by another partner. Org-scope callers have no
+    // partner of their own and cannot own partner-wide policies.
+    if (data.ownerScope === 'partner') {
+      if (!auth.partnerId) {
+        return c.json({ error: 'Partner-wide policies require partner scope' }, 403);
+      }
+      const policy = await createConfigPolicy({ partnerId: auth.partnerId }, data, auth.user.id);
+      writeRouteAudit(c, {
+        orgId: null,
+        action: 'config_policy.create',
+        resourceType: 'configuration_policy',
+        resourceId: policy.id,
+        resourceName: policy.name,
+        details: { ownerScope: 'partner', partnerId: auth.partnerId },
+      });
+      return c.json(policy, 201);
+    }
+
     let orgId = data.orgId;
     if (auth.scope === 'organization') {
       if (!auth.orgId) return c.json({ error: 'Organization context required' }, 403);
@@ -73,7 +93,7 @@ crudRoutes.post(
       return c.json({ error: 'orgId is required' }, 400);
     }
 
-    const policy = await createConfigPolicy(orgId as string, data, auth.user.id);
+    const policy = await createConfigPolicy({ orgId: orgId as string }, data, auth.user.id);
 
     writeRouteAudit(c, {
       orgId: policy.orgId,

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -265,4 +265,55 @@ describe('featureLinks routes', () => {
       expect(addFeatureLinkMock).not.toHaveBeenCalled();
     });
   });
+
+  // ============================================================
+  // POST /:id/features — org-scoped features rejected on partner-wide (#1724)
+  // ============================================================
+  describe('POST /:id/features — org-scoped features rejected on partner-wide policy', () => {
+    const PARTNER_POLICY = {
+      id: POLICY_ID,
+      orgId: null,
+      partnerId: '99999999-9999-9999-9999-999999999999',
+      name: 'Partner-wide',
+      featureLinks: [],
+    };
+
+    beforeEach(() => {
+      getConfigPolicyMock.mockResolvedValue(PARTNER_POLICY);
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'backup' });
+    });
+
+    // onedrive_helper is also in ORG_SCOPED_ONLY_FEATURES but isn't accepted by
+    // addFeatureLinkSchema's enum, so it can't reach the route at all — only
+    // backup and patch are exercisable here.
+    it.each(['backup', 'patch'])(
+      'rejects the %s feature on a partner-owned policy → 400 (no insert)',
+      async (featureType) => {
+        const res = await app.request(`/${POLICY_ID}/features`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          // Valid body (passes the schema refine) so we exercise the
+          // partner-wide guard, not the generic validator.
+          body: JSON.stringify({ featureType, inlineSettings: { enabled: true } }),
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(String(body.error)).toContain('partner-wide');
+        expect(addFeatureLinkMock).not.toHaveBeenCalled();
+      }
+    );
+
+    it('still allows an org-derived feature (security) on a partner-owned policy', async () => {
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'security' });
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ featureType: 'security', inlineSettings: { enabled: true } }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -27,6 +27,15 @@ export const featureLinkRoutes = new Hono();
 const requireConfigPolicyRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
 const requireConfigPolicyWrite = requirePermission(PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action);
 
+// Feature types whose per-feature config is fundamentally org-scoped and cannot
+// be authored on a partner-wide policy (#1724): backup/onedrive_helper settings
+// carry a concrete org_id FK, and patch scheduling is org-batch only (the
+// scheduler iterates orgs, not partners). Rejecting these at the feature-link
+// write layer keeps the read side (effective-config resolution) and the write
+// side consistent — a partner-wide policy never advertises coverage the
+// scheduler won't deliver. See the PR scope note.
+const ORG_SCOPED_ONLY_FEATURES = new Set(['backup', 'onedrive_helper', 'patch']);
+
 // GET /:id/features — list feature links for a policy
 featureLinkRoutes.get(
   '/:id/features',
@@ -59,6 +68,15 @@ featureLinkRoutes.post(
 
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
+
+    // Partner-wide policies (org_id NULL, #1724) can't carry org-scoped feature
+    // settings. Reject at write time so the scheduler/read-side stay consistent.
+    if (policy.orgId === null && ORG_SCOPED_ONLY_FEATURES.has(data.featureType)) {
+      return c.json(
+        { error: `The "${data.featureType}" feature is not supported on partner-wide policies; it must be configured on an organization-scoped policy.` },
+        400
+      );
+    }
 
     if (data.featureType === 'patch' && !hasSatisfiedMfa(auth)) {
       return c.json({ error: 'MFA required' }, 403);

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -66,6 +66,11 @@ featureLinkRoutes.post(
 
     // Validate the referenced feature policy exists (only when a policy ID is provided)
     if (data.featurePolicyId) {
+      // Referenced feature policies are org-scoped; a partner-owned config
+      // policy (org_id NULL, #1724) cannot link one.
+      if (policy.orgId === null) {
+        return c.json({ error: 'Cannot link an org-scoped feature policy to a partner-owned policy' }, 400);
+      }
       const validation = await validateFeaturePolicyExists(
         data.featureType,
         data.featurePolicyId,
@@ -173,6 +178,11 @@ featureLinkRoutes.patch(
     }
 
     if (data.featurePolicyId !== undefined && data.featurePolicyId !== null) {
+      // Referenced feature policies are org-scoped; a partner-owned config
+      // policy (org_id NULL, #1724) cannot link one.
+      if (policy.orgId === null) {
+        return c.json({ error: 'Cannot link an org-scoped feature policy to a partner-owned policy' }, 400);
+      }
       const validation = await validateFeaturePolicyExists(
         existingLink.featureType as any,
         data.featurePolicyId,

--- a/apps/api/src/routes/policyManagement/compliance.ts
+++ b/apps/api/src/routes/policyManagement/compliance.ts
@@ -653,7 +653,9 @@ complianceRoutes.get(
       .where(eq(configurationPolicies.id, id))
       .limit(1);
 
-    if (!configPolicy || !ensureOrgAccess(configPolicy.orgId, auth)) {
+    // Partner-owned policies (org_id NULL, #1724) have no owning org to
+    // tenant-check against on this org-scoped compliance path; treat as not found.
+    if (!configPolicy || configPolicy.orgId === null || !ensureOrgAccess(configPolicy.orgId, auth)) {
       return c.json({ error: 'Policy not found' }, 404);
     }
 

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -77,7 +77,7 @@ describe('configuration policy AI tools', () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: POLICY_ID, orgId: ORG_ID, name: 'Policy 1' }]),
+          limit: vi.fn().mockResolvedValue([{ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' }]),
         }),
       }),
     } as any);
@@ -98,7 +98,13 @@ describe('configuration policy AI tools', () => {
     expect(JSON.parse(output)).toEqual({
       error: 'Device target not found in the policy organization',
     });
-    expect(validateAssignmentTargetMock).toHaveBeenCalledWith(ORG_ID, 'device', DEVICE_ID);
+    // validateAssignmentTarget now takes the policy owner ({ orgId, partnerId })
+    // so it can gate partner-wide policies (#1724), not a bare orgId string.
+    expect(validateAssignmentTargetMock).toHaveBeenCalledWith(
+      { orgId: ORG_ID, partnerId: null },
+      'device',
+      DEVICE_ID
+    );
     expect(assignPolicyMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -210,7 +210,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
       if (!policy) return JSON.stringify({ error: 'Configuration policy not found or access denied' });
 
       const targetValidation = await validateAssignmentTarget(
-        policy.orgId,
+        { orgId: policy.orgId, partnerId: policy.partnerId },
         input.level as any,
         input.targetId as string
       );
@@ -363,7 +363,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
           });
         }
 
-        const policy = await createConfigPolicy(orgId, {
+        const policy = await createConfigPolicy({ orgId }, {
           name: input.name as string,
           description: input.description as string | undefined,
           status: (input.status as 'active' | 'inactive' | 'archived') ?? 'active',

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -300,6 +300,16 @@ export async function loadPolicyLocalPatchConfig(
       })
     : storedInline;
 
+  // Patch feature links are rejected on partner-wide policies (org_id NULL) at the
+  // featureLinks route (#1724), so reaching this load path with a patch link and no
+  // org is a misconfiguration that escaped the write-side gate. Warn rather than
+  // silently resolving so it surfaces instead of masking. (Defense-in-depth: the
+  // ring still resolves from partnerId below since patch_policies is partner-axis.)
+  if (row.featurePolicyId && !row.orgId) {
+    console.warn(
+      `[configPolicyPatching] patch feature link ${row.featurePolicyId} on partner-wide config policy ${row.configPolicyId} (no org) — should have been blocked at write time`
+    );
+  }
   // Partner-wide config policies (#1724) carry partnerId directly and orgId === null;
   // org-scoped policies derive the partner from their org. Prefer the explicit
   // partnerId so partner-wide policies still resolve their (partner-axis) patch ring.

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -316,8 +316,8 @@ export async function loadPolicyLocalPatchConfig(
   const partnerId = row.partnerId ?? (row.orgId ? await resolvePartnerIdForOrg(row.orgId) : null);
   if (!partnerId) {
     console.warn(
-      `[configPolicyPatching] config policy has no resolvable partner — cannot resolve patch ring`,
-      { orgId: row.orgId, partnerId: row.partnerId, configPolicyId: row.configPolicyId }
+      `[configPolicyPatching] orphaned org has no partner — cannot resolve patch ring`,
+      { orgId: row.orgId, configPolicyId: row.configPolicyId }
     );
     return null;
   }
@@ -407,8 +407,8 @@ async function buildPatchInventory(conditions: SQL[]): Promise<PatchInventoryRow
     const rowPartnerId = row.partnerId ?? (row.orgId ? await resolvePartnerIdForOrg(row.orgId) : null);
     if (!rowPartnerId) {
       console.warn(
-        `[configPolicyPatching] config policy has no resolvable partner — classifying as missing_target`,
-        { orgId: row.orgId, partnerId: row.partnerId, configPolicyId: row.configPolicyId }
+        `[configPolicyPatching] orphaned org has no partner — classifying as missing_target`,
+        { orgId: row.orgId, configPolicyId: row.configPolicyId }
       );
     }
     const classification = rowPartnerId

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -25,7 +25,8 @@ export type PatchEffectiveStatus = 'ok' | 'needs_repair' | 'invalid_reference';
 export interface PatchInventoryRow {
   configPolicyId: string;
   configPolicyName: string;
-  orgId: string;
+  // null for partner-wide policies (#1724).
+  orgId: string | null;
   featureLinkId: string;
   referencedTargetId: string | null;
   classification: PatchReferenceClassification;
@@ -46,7 +47,8 @@ export interface PatchRingResolution {
 export interface PolicyLocalPatchConfig {
   configPolicyId: string;
   configPolicyName: string;
-  orgId: string;
+  // null for partner-wide policies (#1724).
+  orgId: string | null;
   featureLinkId: string;
   featurePolicyId: string | null;
   settings: PatchInlineSettings;
@@ -165,10 +167,15 @@ function normalizeStoredInlineSettingsWithSalvage(
 }
 
 export async function resolvePatchPolicyReference(
-  partnerId: string,
+  // patch_policies is partner-axis (scoped by partner_id, no org_id). Partner-wide
+  // config policies (#1724) carry orgId === null; callers resolve a partnerId from
+  // the org (or, for a partner-wide policy, derive it directly) before calling here,
+  // so a null partnerId short-circuits to the empty/'null' classification just as a
+  // missing featurePolicyId does.
+  partnerId: string | null,
   featurePolicyId: string | null
 ): Promise<PatchRingResolution> {
-  if (!featurePolicyId) {
+  if (!featurePolicyId || !partnerId) {
     return {
       classification: 'null',
       valid: true,
@@ -247,6 +254,7 @@ export async function loadPolicyLocalPatchConfig(
       configPolicyId: configurationPolicies.id,
       configPolicyName: configurationPolicies.name,
       orgId: configurationPolicies.orgId,
+      partnerId: configurationPolicies.partnerId,
       featureLinkId: configPolicyFeatureLinks.id,
       featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
       storedInlineSettings: configPolicyFeatureLinks.inlineSettings,
@@ -292,11 +300,14 @@ export async function loadPolicyLocalPatchConfig(
       })
     : storedInline;
 
-  const partnerId = await resolvePartnerIdForOrg(row.orgId);
+  // Partner-wide config policies (#1724) carry partnerId directly and orgId === null;
+  // org-scoped policies derive the partner from their org. Prefer the explicit
+  // partnerId so partner-wide policies still resolve their (partner-axis) patch ring.
+  const partnerId = row.partnerId ?? (row.orgId ? await resolvePartnerIdForOrg(row.orgId) : null);
   if (!partnerId) {
     console.warn(
-      `[configPolicyPatching] orphaned org has no partner — cannot resolve patch ring`,
-      { orgId: row.orgId, configPolicyId: row.configPolicyId }
+      `[configPolicyPatching] config policy has no resolvable partner — cannot resolve patch ring`,
+      { orgId: row.orgId, partnerId: row.partnerId, configPolicyId: row.configPolicyId }
     );
     return null;
   }
@@ -366,6 +377,7 @@ async function buildPatchInventory(conditions: SQL[]): Promise<PatchInventoryRow
       configPolicyId: configurationPolicies.id,
       configPolicyName: configurationPolicies.name,
       orgId: configurationPolicies.orgId,
+      partnerId: configurationPolicies.partnerId,
       featureLinkId: configPolicyFeatureLinks.id,
       referencedTargetId: configPolicyFeatureLinks.featurePolicyId,
       storedInlineSettings: configPolicyFeatureLinks.inlineSettings,
@@ -380,11 +392,13 @@ async function buildPatchInventory(conditions: SQL[]): Promise<PatchInventoryRow
 
   // TODO: batch-fetch patch policy references to avoid N+1 queries
   for (const row of rows) {
-    const rowPartnerId = await resolvePartnerIdForOrg(row.orgId);
+    // Prefer the policy's own partnerId (set for partner-wide policies, #1724);
+    // fall back to deriving it from the org for org-scoped policies.
+    const rowPartnerId = row.partnerId ?? (row.orgId ? await resolvePartnerIdForOrg(row.orgId) : null);
     if (!rowPartnerId) {
       console.warn(
-        `[configPolicyPatching] orphaned org has no partner — classifying as missing_target`,
-        { orgId: row.orgId, configPolicyId: row.configPolicyId }
+        `[configPolicyPatching] config policy has no resolvable partner — classifying as missing_target`,
+        { orgId: row.orgId, partnerId: row.partnerId, configPolicyId: row.configPolicyId }
       );
     }
     const classification = rowPartnerId

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -107,15 +107,41 @@ export interface EffectiveConfiguration {
 // CRUD
 // ============================================
 
+/**
+ * Access condition for a configuration_policies row, honoring both ownership
+ * axes (#1724). A caller may reach a row that is owned by an org they can
+ * access (the original shape) OR owned by their own partner (partner-wide /
+ * all-orgs policies, org_id NULL). System scope returns undefined (no filter).
+ *
+ * RLS already enforces this at the DB layer; this app-layer condition keeps
+ * partner-owned policies visible to org/partner-scoped reads that filter by
+ * `auth.orgCondition` (which would otherwise exclude org_id IS NULL rows).
+ */
+function policyAccessCondition(auth: AuthContext): SQL | undefined {
+  const orgCond = auth.orgCondition(configurationPolicies.orgId);
+  // System scope: no filter on either axis.
+  if (!orgCond) return undefined;
+  // Org-owned rows the caller can reach, OR partner-owned rows for the caller's
+  // own partner. partner-scope callers have a partnerId; org-scope callers do
+  // not own partner-wide policies, so the partner branch is a no-op for them.
+  if (auth.partnerId) {
+    return and(
+      sql`(${orgCond} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${auth.partnerId}))`
+    );
+  }
+  return orgCond;
+}
+
 export async function createConfigPolicy(
-  orgId: string,
+  owner: { orgId: string; partnerId?: null } | { orgId?: null; partnerId: string },
   data: { name: string; description?: string; status?: 'active' | 'inactive' | 'archived' },
   userId: string
 ) {
   const [policy] = await db
     .insert(configurationPolicies)
     .values({
-      orgId,
+      orgId: owner.orgId ?? null,
+      partnerId: owner.partnerId ?? null,
       name: data.name,
       description: data.description ?? null,
       status: data.status ?? 'active',
@@ -128,8 +154,8 @@ export async function createConfigPolicy(
 
 export async function getConfigPolicy(id: string, auth: AuthContext) {
   const conditions: SQL[] = [eq(configurationPolicies.id, id)];
-  const orgCond = auth.orgCondition(configurationPolicies.orgId);
-  if (orgCond) conditions.push(orgCond);
+  const accessCond = policyAccessCondition(auth);
+  if (accessCond) conditions.push(accessCond);
 
   const [policy] = await db
     .select()
@@ -150,8 +176,8 @@ export async function listConfigPolicies(
   pagination: { page: number; limit: number }
 ) {
   const conditions: SQL[] = [];
-  const orgCond = auth.orgCondition(configurationPolicies.orgId);
-  if (orgCond) conditions.push(orgCond);
+  const accessCond = policyAccessCondition(auth);
+  if (accessCond) conditions.push(accessCond);
 
   if (filters.orgId) {
     conditions.push(eq(configurationPolicies.orgId, filters.orgId));
@@ -192,8 +218,8 @@ export async function updateConfigPolicy(
   auth: AuthContext
 ) {
   const conditions: SQL[] = [eq(configurationPolicies.id, id)];
-  const orgCond = auth.orgCondition(configurationPolicies.orgId);
-  if (orgCond) conditions.push(orgCond);
+  const accessCond = policyAccessCondition(auth);
+  if (accessCond) conditions.push(accessCond);
 
   const [existing] = await db.select().from(configurationPolicies).where(and(...conditions)).limit(1);
   if (!existing) return null;
@@ -215,8 +241,8 @@ export async function updateConfigPolicy(
 
 export async function deleteConfigPolicy(id: string, auth: AuthContext) {
   const conditions: SQL[] = [eq(configurationPolicies.id, id)];
-  const orgCond = auth.orgCondition(configurationPolicies.orgId);
-  if (orgCond) conditions.push(orgCond);
+  const accessCond = policyAccessCondition(auth);
+  if (accessCond) conditions.push(accessCond);
 
   const [deleted] = await db
     .delete(configurationPolicies)
@@ -470,6 +496,13 @@ async function decomposeInlineSettings(
         .where(eq(configPolicyFeatureLinks.id, linkId))
         .limit(1);
       if (!policyRow) throw new Error(`Cannot resolve orgId for feature link ${linkId}`);
+      // Backup settings carry a concrete org_id FK (per-org backup target). A
+      // partner-wide policy (org_id NULL) has no single owning org, so backup is
+      // not supported on partner-owned policies (#1724 — deferred; would need a
+      // per-device org-resolved backup design). Reject rather than write NULL.
+      if (!policyRow.orgId) {
+        throw new Error('Backup settings are not supported on partner-wide configuration policies');
+      }
       await tx.insert(configPolicyBackupSettings).values({
         featureLinkId: linkId,
         orgId: policyRow.orgId,
@@ -1021,10 +1054,30 @@ export async function assignPolicy(
 }
 
 export async function validateAssignmentTarget(
-  policyOrgId: string,
+  policyOwner: { orgId: string | null; partnerId: string | null },
   level: ConfigAssignmentLevel,
   targetId: string
 ): Promise<{ valid: boolean; error?: string }> {
+  const policyOrgId = policyOwner.orgId;
+
+  // Partner-owned policies (#1724) span all of the partner's orgs and may only
+  // carry a partner-level assignment targeting their own partner. Org/site/
+  // group/device assignments are nonsensical for a policy with no owning org.
+  if (policyOwner.partnerId) {
+    if (level !== 'partner') {
+      return { valid: false, error: 'Partner-wide policies can only be assigned at the Partner level' };
+    }
+    if (targetId !== policyOwner.partnerId) {
+      return { valid: false, error: 'A partner-wide policy can only target its own partner' };
+    }
+    return { valid: true };
+  }
+
+  // Org-owned policies: org_id is guaranteed non-null by the ownership CHECK.
+  if (!policyOrgId) {
+    return { valid: false, error: 'Policy has no owning organization' };
+  }
+
   switch (level) {
     case 'organization': {
       if (targetId !== policyOrgId) {
@@ -1218,10 +1271,20 @@ async function resolveEffectiveConfigWithExecutor(
     .innerJoin(configurationPolicies, and(
       eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
       eq(configurationPolicies.status, 'active'),
-      eq(configurationPolicies.orgId, device.orgId)
+      // Org-owned policies for this device's org, OR partner-owned policies
+      // (org_id NULL) for this device's partner (#1724).
+      org?.partnerId
+        ? sql`(${configurationPolicies.orgId} = ${device.orgId} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${org.partnerId}))`
+        : eq(configurationPolicies.orgId, device.orgId)
     ))
     .innerJoin(configPolicyFeatureLinks, eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id))
-    .where(sql`(${sql.join(targetConditions, sql` OR `)})`)
+    .where(and(
+      sql`(${sql.join(targetConditions, sql` OR `)})`,
+      // Apply the optional role/os device-type filter (#1724). A NULL filter
+      // matches all; a set filter gates the assignment to matching devices.
+      sql`(${configPolicyAssignments.roleFilter} IS NULL OR ${sql.param(device.deviceRole)} = ANY(${configPolicyAssignments.roleFilter}))`,
+      sql`(${configPolicyAssignments.osFilter} IS NULL OR ${sql.param(device.osType)} = ANY(${configPolicyAssignments.osFilter}))`
+    ))
     .orderBy(configPolicyAssignments.level, configPolicyAssignments.priority, configPolicyAssignments.createdAt);
 
   // 6. Sort by level priority (device=5 first), then priority ASC, then createdAt ASC

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -133,6 +133,26 @@ function buildRoleOsFilterConditions(hierarchy: DeviceHierarchy): SQL[] {
   ];
 }
 
+/**
+ * Build the policy-ownership condition for a device's hierarchy.
+ *
+ * A configuration_policies row resolves for this device when it is owned by
+ * the device's own org (the original org-scoped shape) OR owned by the
+ * device's partner (org_id NULL, partner_id set — the "partner-wide / all orgs"
+ * shape, #1724). breeze_has_org_access / breeze_has_partner_access at the RLS
+ * layer still gate visibility; this is the additional "does this policy apply
+ * to this device" join predicate.
+ *
+ * Use this in place of a bare org-equality join on every per-device resolver
+ * so partner-owned policies span all of the partner's orgs.
+ */
+function policyOwnershipCondition(hierarchy: DeviceHierarchy): SQL {
+  if (hierarchy.partnerId) {
+    return sql`(${configurationPolicies.orgId} = ${hierarchy.orgId} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${hierarchy.partnerId}))`;
+  }
+  return sql`${configurationPolicies.orgId} = ${hierarchy.orgId}`;
+}
+
 function buildTargetConditions(hierarchy: DeviceHierarchy): SQL[] {
   const conditions: SQL[] = [];
 
@@ -232,7 +252,7 @@ export async function resolveAlertRulesForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(
@@ -293,7 +313,7 @@ export async function resolveAutomationsForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(
@@ -451,7 +471,7 @@ export async function resolvePatchConfigDetailsForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(
@@ -526,7 +546,7 @@ export async function resolveBackupConfigForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(
@@ -587,7 +607,7 @@ export async function resolveMaintenanceConfigForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(
@@ -641,7 +661,7 @@ export async function resolveComplianceRulesForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(
@@ -700,7 +720,7 @@ export async function resolveSoftwarePolicyForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(
@@ -1157,7 +1177,7 @@ export async function resolveBackupProtectionForDevice(
       and(
         eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
         eq(configurationPolicies.status, 'active'),
-        eq(configurationPolicies.orgId, hierarchy.orgId)
+        policyOwnershipCondition(hierarchy)
       )
     )
     .innerJoin(

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
+
+import AssignmentsTab from './AssignmentsTab';
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const POLICY_ID = '11111111-1111-1111-1111-111111111111';
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  // Default: assignments list is empty; any target list returns empty.
+  fetchWithAuth.mockResolvedValue(jsonResponse({ data: [] }));
+});
+
+describe('AssignmentsTab — Partner-Wide (All Orgs)', () => {
+  it('never calls /orgs/partners when the Partner-Wide level is selected (#1724)', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} />);
+
+    // Initial load fetches the assignments list + the default (organization)
+    // target options. Wait for that to settle.
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+
+    // Switch the Level select to Partner-Wide.
+    const levelSelect = screen.getByDisplayValue('Organization');
+    fireEvent.change(levelSelect, { target: { value: 'partner' } });
+
+    await waitFor(() =>
+      expect(screen.getByText('All organizations in your partner')).toBeInTheDocument()
+    );
+
+    // The old system-scoped partner-list call must NEVER be made.
+    const urls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/orgs/partners'))).toBe(false);
+  });
+
+  it('POSTs a partner assignment with no targetId (server-derived) (#1724)', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByDisplayValue('Organization'), { target: { value: 'partner' } });
+    await waitFor(() =>
+      expect(screen.getByText('All organizations in your partner')).toBeInTheDocument()
+    );
+
+    // The create POST returns a created assignment; the follow-up list refetch
+    // returns empty.
+    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ id: 'a1', level: 'partner' }, 201));
+
+    fireEvent.click(screen.getByRole('button', { name: /Assign/i }));
+
+    await waitFor(() => {
+      const post = fetchWithAuth.mock.calls.find(
+        (c) => String(c[0]).endsWith(`/configuration-policies/${POLICY_ID}/assignments`) &&
+          (c[1] as RequestInit | undefined)?.method === 'POST'
+      );
+      expect(post).toBeTruthy();
+      const body = JSON.parse(String((post![1] as RequestInit).body));
+      expect(body.level).toBe('partner');
+      expect(body).not.toHaveProperty('targetId');
+    });
+  });
+});

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
@@ -18,7 +18,7 @@ type Assignment = {
 type TargetOption = { id: string; name: string; extra?: string };
 
 const assignmentLevels = [
-  { value: 'partner', label: 'Partner' },
+  { value: 'partner', label: 'Partner-Wide (All Orgs)' },
   { value: 'organization', label: 'Organization' },
   { value: 'site', label: 'Site' },
   { value: 'device_group', label: 'Device Group' },
@@ -86,6 +86,15 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
 
   // Fetch target options when level changes
   const fetchTargetOptions = useCallback(async (level: string) => {
+    // Partner-Wide (All Orgs) needs no target picker: the partner is derived
+    // server-side from the caller's own partner_id (#1724). Listing partners
+    // (the old `/orgs/partners` call) requires system scope and 403s for a
+    // normal MSP user, so we must NOT call it here.
+    if (level === 'partner') {
+      setTargetOptions([]);
+      setLoadingTargets(false);
+      return;
+    }
     setLoadingTargets(true);
     setTargetOptions([]);
     const endpointMap: Record<string, string> = {
@@ -93,7 +102,6 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
       site: `/orgs/sites?orgId=${orgId}&limit=200`,
       device_group: `/device-groups?orgId=${orgId}&limit=200`,
       device: '/devices?limit=200',
-      partner: '/orgs/partners?limit=200',
     };
     try {
       const url = endpointMap[level];
@@ -141,17 +149,20 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // Resolve target names for existing assignments (skip already-attempted IDs)
+  // Resolve target names for existing assignments (skip already-attempted IDs).
+  // Partner rows are rendered as "All Organizations" without a lookup — the
+  // old `/partners/:id` path is system-scoped and 403s for MSP users (#1724).
   useEffect(() => {
     const missing = assignments.filter(
-      (a) => !targetNameCache[a.targetId] && !attemptedIdsRef.current.has(a.targetId)
+      (a) => a.level !== 'partner' &&
+        !targetNameCache[a.targetId] && !attemptedIdsRef.current.has(a.targetId)
     );
     if (missing.length === 0) return;
     missing.forEach((a) => attemptedIdsRef.current.add(a.targetId));
 
     const levelEndpoint: Record<string, string> = {
       organization: '/organizations', site: '/sites', device: '/devices',
-      device_group: '/devices/groups', partner: '/partners',
+      device_group: '/devices/groups',
     };
     const resolveAll = async () => {
       const resolved: Record<string, string> = {};
@@ -188,8 +199,11 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
     setTargetSearch('');
   };
 
+  const isPartnerLevel = newLevel === 'partner';
+
   const handleAddAssignment = async () => {
-    if (!policyId || !newTargetId.trim()) return;
+    // Partner-Wide needs no target; the server derives it (#1724).
+    if (!policyId || (!isPartnerLevel && !newTargetId.trim())) return;
     setAddingAssignment(true);
     setError(undefined);
     try {
@@ -197,7 +211,9 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
         method: 'POST',
         body: JSON.stringify({
           level: newLevel,
-          targetId: newTargetId.trim(),
+          // Omit targetId entirely for Partner-Wide — the server uses the
+          // caller's / policy's own partner_id and ignores any client value.
+          ...(isPartnerLevel ? {} : { targetId: newTargetId.trim() }),
           priority: Number(newPriority) || 0,
           ...(newRoleFilter.length > 0 ? { roleFilter: newRoleFilter } : {}),
           ...(newOsFilter.length > 0 ? { osFilter: newOsFilter } : {}),
@@ -267,6 +283,11 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
           </div>
           <div ref={dropdownRef} className="relative">
             <label className="text-sm font-medium">Target</label>
+            {isPartnerLevel ? (
+              <div className="mt-2 flex h-10 w-full items-center rounded-md border bg-muted/40 px-3 text-sm text-muted-foreground">
+                All organizations in your partner
+              </div>
+            ) : (
             <button
               type="button"
               onClick={() => setTargetDropdownOpen(!targetDropdownOpen)}
@@ -277,7 +298,8 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
               </span>
               <ChevronDown className="h-4 w-4 text-muted-foreground" />
             </button>
-            {targetDropdownOpen && (
+            )}
+            {!isPartnerLevel && targetDropdownOpen && (
               <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-lg">
                 <div className="flex items-center border-b px-3 py-2">
                   <Search className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -410,7 +432,7 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
           <button
             type="button"
             onClick={handleAddAssignment}
-            disabled={addingAssignment || !newTargetId.trim()}
+            disabled={addingAssignment || (!isPartnerLevel && !newTargetId.trim())}
             className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />
@@ -452,7 +474,9 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
                     </td>
                     <td className="px-4 py-3">
                       <div>
-                        {targetNameCache[assignment.targetId] ? (
+                        {assignment.level === 'partner' ? (
+                          <span className="font-medium">All Organizations</span>
+                        ) : targetNameCache[assignment.targetId] ? (
                           <>
                             <span className="font-medium">{targetNameCache[assignment.targetId]}</span>
                             <span className="ml-2 font-mono text-[10px] text-muted-foreground">

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -442,6 +442,11 @@ export const createConfigPolicySchema = z.object({
   description: z.string().optional(),
   status: z.enum(['active', 'inactive', 'archived']).optional(),
   orgId: z.string().guid().optional(),
+  // Ownership axis (#1724). 'organization' (default) = the classic org-scoped
+  // policy. 'partner' = partner-wide / all-orgs; the server derives the partner
+  // from the caller's own partner_id — a client-supplied partner id is NEVER
+  // trusted. orgId is ignored when ownerScope is 'partner'.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
 });
 
 export const updateConfigPolicySchema = z.object({
@@ -636,7 +641,10 @@ export const updateFeatureLinkSchema = z.object({
 
 export const assignPolicySchema = z.object({
   level: z.enum(['partner', 'organization', 'site', 'device_group', 'device']),
-  targetId: z.string().guid(),
+  // Optional: for the 'partner' level the server derives the target from the
+  // caller's / policy's own partner_id (#1724) and ignores any client value.
+  // Required (enforced server-side) for all other levels.
+  targetId: z.string().guid().optional(),
   priority: z.number().int().min(0).max(1000).optional(),
   roleFilter: z.array(z.enum(DEVICE_ROLES)).optional(),
   osFilter: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),


### PR DESCRIPTION
## Summary

Fixes the **Configuration Policies "Partner" scope error** and implements the maintainer-approved **partner-owned policy** model (issue #1724, option 2).

Previously the "Partner" assignment scope tried to list partners via the system-scoped `/orgs/partners` endpoint (403 for normal MSP users) and a policy could only be owned by one org, so a partner-wide policy couldn't span all of a partner's organizations.

## Ownership model

`configuration_policies.org_id` is now **NULLABLE** and a **`partner_id`** column is added. A policy is owned by EITHER an org (`org_id` set — the original shape) OR a partner (`partner_id` set, `org_id` NULL — "partner-wide / all orgs"). A CHECK constraint `configuration_policies_one_owner_chk` enforces exactly one axis per row.

## Tenant isolation (RLS)

- **`configuration_policies` is now dual-axis** (org OR partner): `system OR breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id)`, plus `FORCE ROW LEVEL SECURITY` (was missing on the baseline). The child feature-link / assignment / per-feature-settings tables that reach their tenant through the policy are extended to also accept `breeze_has_partner_access(cp.partner_id)`.
- **Contract test:** `configuration_policies` added to **`DUAL_AXIS_TENANT_TABLES`** — the technically-correct bucket for an `org_id`-carrying table whose policy *also* has a partner branch (verbatim `client_ai_prompt_templates` precedent), **not** the pure partner-axis `time_entries` pattern named in the original triage (that pattern is for tables with no org-axis policy). `breeze_app` forced-RLS coverage + FORCE are both asserted.
- **Functional cross-partner forge proof:** `configurationPoliciesPartnerRls.integration.test.ts` (9 cases) — a different partner **cannot see or forge** a policy attributed to partner A (insert rejected with **42501** "new row violates row-level security policy"); the one-owner CHECK rejects both-axes and neither-axis rows (23514); org scope cannot see partner-wide rows; fail-closed without a DB context.

## Resolution

Every per-device feature resolver in `featureConfigResolver.ts` (×8) and the preview resolver in `configurationPolicy.ts` now match a partner-owned policy for any device whose org belongs to that partner (in addition to the device's own org). The optional **`role_filter`/`os_filter`** is now applied during preview resolution too (the runtime resolver already applied it via `buildRoleOsFilterConditions`).

## UI / API

- `AssignmentsTab.tsx` no longer calls `/orgs/partners`; the option is relabeled **"Partner-Wide (All Orgs)"**; no target picker is shown for that level; the partner target is **derived server-side** from the caller's / policy's own `partner_id` (a client-supplied partner id is never trusted) and `targetId` is optional for the partner level.
- `createConfigPolicy` gains an `ownerScope: 'partner'` path (server-derived partner).
- The existing-assignment name resolver renders partner rows as **"All Organizations"** instead of hitting the system-scoped `/partners/:id` route.

## Scope note (deferred)

`backup`, `onedrive_helper`, and `patch` features are **org-scoped** (backup/onedrive settings carry a concrete `org_id` FK; patch scheduling is org-batch only), so they are **not supported on partner-owned policies** — the feature-link route rejects them with a clear **400** so the read side (resolution) and write side (scheduler) stay consistent. Per-device-org execution for those features on partner-wide policies (and the config-policy automation-run notification-channel org context) is intentionally deferred to a follow-up. The org-owned path for all features is unchanged.

## Verification

- `configurationPoliciesPartnerRls.integration.test.ts` — **9 passed** (real Postgres, unprivileged `breeze_app`; cross-partner forge → 42501).
- `rls-coverage.integration.test.ts` — **45 passed** (dual-axis + FORCE coverage).
- `tenantCascade` + `tenantCascadePartner` integration — **8 passed** (`partner_id` auto-discovered by partner cascade; nullable `org_id` safe in org cascade).
- `autoMigrate.test.ts` — **43 passed** (migration ordering).
- Affected unit suites — config-policy routes/services **132 passed** (incl. new partner-wide assignment test); web `AssignmentsTab.test.tsx` **2 passed** (no `/orgs/partners`; partner POST omits `targetId`).
- `tsc --noEmit` clean for `apps/api`, `apps/web`, `packages/shared`.

Closes #1724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
