### PR TITLE
feat(pam): bridge uac_intercept elevations to the mobile approval surface (#1254)

### DIFF
--- a/apps/api/migrations/2026-06-27-pam-approval-elevation-link.sql
+++ b/apps/api/migrations/2026-06-27-pam-approval-elevation-link.sql
@@ -1,0 +1,36 @@
+-- PAM mobile approval bridge (#1254): link a fanned-out mobile approval_request
+-- back to the elevation_request it was created for. When a uac_intercept
+-- elevation lands 'pending', the agent-ingest route fans out one
+-- approval_requests row per eligible technician approver (each carrying this
+-- elevation_request_id); whichever approver decides first on mobile mirrors the
+-- decision back to the elevation (first-wins CAS) and the sibling approval rows
+-- are expired.
+--
+-- No RLS change: approval_requests stays Shape 6 (user_id-scoped). The new
+-- column is just a back-reference; the row is still owned by its user_id and
+-- the existing user-scoped policy continues to govern visibility.
+-- ON DELETE SET NULL so a purged elevation leaves the approval row readable for
+-- audit (mirrors the execution_id link's posture).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS; the FK is
+-- added only when absent via a pg_constraint existence check.
+
+ALTER TABLE approval_requests
+  ADD COLUMN IF NOT EXISTS elevation_request_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'approval_requests_elevation_request_id_fkey'
+  ) THEN
+    ALTER TABLE approval_requests
+      ADD CONSTRAINT approval_requests_elevation_request_id_fkey
+      FOREIGN KEY (elevation_request_id)
+      REFERENCES elevation_requests(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS approval_requests_elevation_request_id_idx
+  ON approval_requests(elevation_request_id);

--- a/apps/api/src/__tests__/integration/pam-mobile-bridge-sibling-expiry.integration.test.ts
+++ b/apps/api/src/__tests__/integration/pam-mobile-bridge-sibling-expiry.integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration test for #1254 (Todd's RLS review fix): the PAM mobile-bridge
+ * sibling-expiry MUST run in system scope.
+ *
+ * `approval_requests` is Shape-6 (user-id-scoped):
+ *   USING (user_id = breeze_current_user_id() OR breeze_current_scope() = 'system')
+ *
+ * One pending `uac_intercept` elevation fans out to N mobile approval_requests
+ * rows, one per approver — each row owned by a DIFFERENT user_id. When approver
+ * A decides, the route expires the SIBLING rows (approver B's etc.) so the
+ * request vanishes from the other approvers' phones. Those sibling rows belong
+ * to OTHER user_ids, so under `breeze_app` FORCE RLS they are INVISIBLE inside
+ * approver A's request context — a bare context-scoped UPDATE matches ZERO rows.
+ * The fix moves the sibling-expiry to system scope (post-commit, best-effort).
+ *
+ * These assertions run against a REAL Postgres as the unprivileged `breeze_app`
+ * role (the same pool the route uses), so RLS is genuinely enforced:
+ *
+ *   (1) cross-approver expiry — the OLD user-context UPDATE expires 0 sibling
+ *       rows (RLS-blind), while the NEW system-scoped UPDATE expires the
+ *       sibling (1 row). This is the exact behavior the production fix encodes.
+ *   (2) the cross-tenant elevation mirror-back is a clean no-op — an approver
+ *       deciding cannot flip an elevation in another org (RLS-contained).
+ */
+import './setup';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { and, eq, ne } from 'drizzle-orm';
+import { db, withDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { approvalRequests } from '../../db/schema/approvals';
+import { elevationRequests } from '../../db/schema/elevations';
+import {
+  partners,
+  organizations,
+  sites,
+  devices,
+  users,
+} from '../../db/schema';
+import { getTestDb } from './setup';
+
+// Request-scoped context for a given approver user (org scope, no org access —
+// approval_requests is keyed purely on user_id, so the org axis is irrelevant
+// to its policy). Mirrors approval-system-scope.integration.test.ts.
+function userContext(userId: string) {
+  return {
+    scope: 'organization' as const,
+    orgId: null,
+    accessibleOrgIds: [],
+    accessiblePartnerIds: [],
+    userId,
+  };
+}
+
+let orgId: string;
+let siteId: string;
+let deviceId: string;
+let approverAId: string;
+let approverBId: string;
+let elevationId: string;
+let approvalAId: string;
+let approvalBId: string;
+
+beforeEach(async () => {
+  // Seed as the superuser test connection (bypasses RLS). setup.ts TRUNCATEs
+  // the core tenant tables CASCADE on beforeEach, so these rows are cleared
+  // transitively each test.
+  const tdb = getTestDb();
+
+  const [p] = await tdb
+    .insert(partners)
+    .values({ name: 'PR1254 Mobile Bridge', slug: `pr1254-${Date.now()}`, type: 'msp', plan: 'pro', status: 'active' })
+    .returning({ id: partners.id });
+  const partnerId = p!.id;
+
+  const [org] = await tdb
+    .insert(organizations)
+    .values({ partnerId, name: 'PR1254 Org', slug: `pr1254-org-${Date.now()}`, type: 'customer', status: 'active' })
+    .returning({ id: organizations.id });
+  orgId = org!.id;
+
+  const [site] = await tdb
+    .insert(sites)
+    .values({ orgId, name: 'PR1254 Site', timezone: 'UTC' })
+    .returning({ id: sites.id });
+  siteId = site!.id;
+
+  const [device] = await tdb
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-pr1254-${Date.now()}`,
+      hostname: `ws-pr1254-${Date.now()}`,
+      osType: 'windows',
+      osVersion: '10.0',
+      architecture: 'amd64',
+      agentVersion: '1.0.0',
+      status: 'online',
+    })
+    .returning({ id: devices.id });
+  deviceId = device!.id;
+
+  const [a, b] = await tdb
+    .insert(users)
+    .values([
+      { partnerId, email: `approverA-${Date.now()}@pr1254.test`, name: 'Approver A', status: 'active' },
+      { partnerId, email: `approverB-${Date.now()}@pr1254.test`, name: 'Approver B', status: 'active' },
+    ])
+    .returning({ id: users.id });
+  approverAId = a!.id;
+  approverBId = b!.id;
+
+  // A pending uac_intercept elevation (target_executable_path NOT NULL is
+  // required by elevation_requests_flow_shape_chk for uac_intercept).
+  const [elev] = await tdb
+    .insert(elevationRequests)
+    .values({
+      orgId,
+      siteId,
+      partnerId,
+      deviceId,
+      flowType: 'uac_intercept',
+      subjectUsername: 'PR1254\\enduser',
+      reason: 'install setup.exe',
+      targetExecutablePath: 'C:\\Temp\\setup.exe',
+      status: 'pending',
+    })
+    .returning({ id: elevationRequests.id });
+  elevationId = elev!.id;
+
+  // Two pending mobile approval_requests for the SAME elevation, owned by two
+  // DIFFERENT approvers (the fan-out).
+  const [appA, appB] = await tdb
+    .insert(approvalRequests)
+    .values([
+      {
+        userId: approverAId,
+        requestingClientLabel: 'Breeze Mobile',
+        actionLabel: 'Elevate setup.exe',
+        actionToolName: 'uac_intercept',
+        riskTier: 'medium',
+        riskSummary: 'admin requested',
+        status: 'pending',
+        expiresAt: new Date(Date.now() + 5 * 60_000),
+        elevationRequestId: elevationId,
+      },
+      {
+        userId: approverBId,
+        requestingClientLabel: 'Breeze Mobile',
+        actionLabel: 'Elevate setup.exe',
+        actionToolName: 'uac_intercept',
+        riskTier: 'medium',
+        riskSummary: 'admin requested',
+        status: 'pending',
+        expiresAt: new Date(Date.now() + 5 * 60_000),
+        elevationRequestId: elevationId,
+      },
+    ])
+    .returning({ id: approvalRequests.id, userId: approvalRequests.userId });
+  approvalAId = appA!.id;
+  approvalBId = appB!.id;
+});
+
+describe('#1254 cross-approver sibling-expiry must run in system scope', () => {
+  it('the OLD user-context UPDATE matches ZERO sibling rows (RLS-blind)', async () => {
+    // Reproduce the bug: run the sibling-expiry inside approver A's request
+    // context (as the original code did). Under breeze_app RLS, approver B's
+    // row is invisible to A, so the UPDATE silently matches nothing.
+    await withDbAccessContext(userContext(approverAId), async () => {
+      await db
+        .update(approvalRequests)
+        .set({ status: 'expired' })
+        .where(
+          and(
+            eq(approvalRequests.elevationRequestId, elevationId),
+            ne(approvalRequests.id, approvalAId),
+            eq(approvalRequests.status, 'pending'),
+          ),
+        );
+    });
+
+    // Read both rows back as the superuser (bypasses RLS) to see ground truth.
+    const tdb = getTestDb();
+    const [siblingB] = await tdb
+      .select({ status: approvalRequests.status })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, approvalBId));
+    // The bug: approver B's sibling was NOT expired — it would still be on B's
+    // phone. This is what Todd flagged.
+    expect(siblingB!.status).toBe('pending');
+  });
+
+  it('the NEW system-scoped UPDATE expires the sibling (1 row)', async () => {
+    // The production fix: wrap the sibling-expiry in
+    // runOutsideDbContext(() => withSystemDbAccessContext(...)) so it runs in
+    // system scope, where the Shape-6 OR-branch (breeze_current_scope() =
+    // 'system') makes every approver's row visible. Run it from WITHIN approver
+    // A's ambient request context to prove runOutsideDbContext escapes it.
+    await withDbAccessContext(userContext(approverAId), async () => {
+      await runOutsideDbContext(() =>
+        withSystemDbAccessContext(async () => {
+          await db
+            .update(approvalRequests)
+            .set({ status: 'expired' })
+            .where(
+              and(
+                eq(approvalRequests.elevationRequestId, elevationId),
+                ne(approvalRequests.id, approvalAId),
+                eq(approvalRequests.status, 'pending'),
+              ),
+            );
+        }),
+      );
+    });
+
+    const tdb = getTestDb();
+    const [siblingB] = await tdb
+      .select({ status: approvalRequests.status })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, approvalBId));
+    // The fix: approver B's sibling is now expired — it vanishes from B's phone.
+    expect(siblingB!.status).toBe('expired');
+
+    // The decider's own row (approver A) is untouched by the sibling-expiry
+    // (the `ne(id, approvalAId)` guard) — it carries A's actual decision.
+    const [self] = await tdb
+      .select({ status: approvalRequests.status })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, approvalAId));
+    expect(self!.status).toBe('pending');
+  });
+});
+
+describe('#1254 cross-tenant elevation mirror-back is RLS-contained (clean no-op)', () => {
+  it('an approver cannot flip an elevation in another org — the CAS matches 0 rows', async () => {
+    // Seed a SECOND tenant with its own pending uac_intercept elevation.
+    const tdb = getTestDb();
+    const [p2] = await tdb
+      .insert(partners)
+      .values({ name: 'PR1254 Other MSP', slug: `pr1254-other-${Date.now()}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [org2] = await tdb
+      .insert(organizations)
+      .values({ partnerId: p2!.id, name: 'PR1254 Other Org', slug: `pr1254-other-org-${Date.now()}`, type: 'customer', status: 'active' })
+      .returning({ id: organizations.id });
+    const [site2] = await tdb
+      .insert(sites)
+      .values({ orgId: org2!.id, name: 'PR1254 Other Site', timezone: 'UTC' })
+      .returning({ id: sites.id });
+    const [device2] = await tdb
+      .insert(devices)
+      .values({
+        orgId: org2!.id,
+        siteId: site2!.id,
+        agentId: `agent-pr1254-other-${Date.now()}`,
+        hostname: `ws-pr1254-other-${Date.now()}`,
+        osType: 'windows',
+        osVersion: '10.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+      })
+      .returning({ id: devices.id });
+    const [otherElev] = await tdb
+      .insert(elevationRequests)
+      .values({
+        orgId: org2!.id,
+        siteId: site2!.id,
+        partnerId: p2!.id,
+        deviceId: device2!.id,
+        flowType: 'uac_intercept',
+        subjectUsername: 'OTHER\\enduser',
+        reason: 'install other.exe',
+        targetExecutablePath: 'C:\\Temp\\other.exe',
+        status: 'pending',
+      })
+      .returning({ id: elevationRequests.id });
+
+    // Approver A (org1) tries to mirror an approve onto org2's elevation, using
+    // the exact CAS shape the mirror block uses (status='pending' guard). A has
+    // no access to org2, so elevation_requests' org-axis RLS hides the row and
+    // the CAS returns 0 rows — a clean no-op, no cross-tenant write.
+    const flipped = await withDbAccessContext(userContext(approverAId), async () =>
+      db
+        .update(elevationRequests)
+        .set({ status: 'approved', approvedByUserId: approverAId, approvedAt: new Date() })
+        .where(and(eq(elevationRequests.id, otherElev!.id), eq(elevationRequests.status, 'pending')))
+        .returning({ id: elevationRequests.id }),
+    );
+    expect(flipped).toHaveLength(0);
+
+    // Ground truth (superuser read): the other tenant's elevation is untouched.
+    const [after] = await tdb
+      .select({ status: elevationRequests.status })
+      .from(elevationRequests)
+      .where(eq(elevationRequests.id, otherElev!.id));
+    expect(after!.status).toBe('pending');
+  });
+});

--- a/apps/api/src/db/schema/approvals.ts
+++ b/apps/api/src/db/schema/approvals.ts
@@ -54,6 +54,18 @@ export const approvalRequests = pgTable(
     executionId: uuid('execution_id'),
 
     /**
+     * #1254 PAM mobile bridge: links this fanned-out mobile approval back to
+     * the `elevation_requests` row it was created for (a pending
+     * uac_intercept). One elevation fans out to N approver rows that all carry
+     * the same elevation_request_id; the first approver to decide mirrors the
+     * decision onto the elevation (first-wins CAS) and the siblings are
+     * expired. Nullable — non-PAM approvals (AI agent, helper, dev seed) never
+     * set it. ON DELETE SET NULL so a purged elevation leaves the approval row
+     * readable for audit (mirrors execution_id).
+     */
+    elevationRequestId: uuid('elevation_request_id'),
+
+    /**
      * Server-issued: TRUE when the requesting OAuth client is the user's
      * own mobile app AND the request targets that same user (i.e. the phone
      * is approving its own action). Replaces the mobile client's
@@ -84,6 +96,16 @@ export const approvalRequests = pgTable(
       foreignColumns: [aiToolExecutions.id],
       name: 'approval_requests_execution_id_fkey',
     }).onDelete('set null'),
+    elevationRequestIdIdx: index('approval_requests_elevation_request_id_idx').on(
+      t.elevationRequestId,
+    ),
+    // FK to elevation_requests(id) ON DELETE SET NULL is declared in the
+    // migration only (2026-06-27-pam-approval-elevation-link.sql). Modeling it
+    // in Drizzle would force an `import { elevationRequests } from
+    // './elevations'`, but elevations.ts already imports approvalRequests
+    // (parentApprovalId) — the cycle makes TS infer both tables as `any`
+    // (TS7022). Same precedent as authenticatorDeviceId (DB FK, no Drizzle
+    // reference). db:check-drift tolerates the column+index match.
   })
 );
 

--- a/apps/api/src/routes/agents/elevationRequests.test.ts
+++ b/apps/api/src/routes/agents/elevationRequests.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../db/schema', () => ({
     orgId: 'orgId',
     siteId: 'siteId',
     agentId: 'agentId',
+    hostname: 'hostname',
   },
   elevationRequests: {
     id: 'id',
@@ -26,6 +27,12 @@ vi.mock('../../db/schema', () => ({
     id: 'id',
     orgId: 'orgId',
     elevationRequestId: 'elevationRequestId',
+  },
+  approvalRequests: {
+    id: 'id',
+    userId: 'userId',
+    elevationRequestId: 'elevationRequestId',
+    status: 'status',
   },
   pamRules: {
     id: 'id',
@@ -39,6 +46,21 @@ vi.mock('../../db/schema', () => ({
     orgId: 'orgId',
     defaultUnmatchedVerdict: 'defaultUnmatchedVerdict',
   },
+}));
+
+const bridgeMocks = vi.hoisted(() => ({
+  resolveElevationApprovers: vi.fn(),
+  getUserPushTokens: vi.fn(),
+  sendExpoPush: vi.fn(),
+  buildApprovalPush: vi.fn(() => ({ title: 'Approval requested', body: 'x' })),
+}));
+vi.mock('../../services/pamApprovers', () => ({
+  resolveElevationApprovers: bridgeMocks.resolveElevationApprovers,
+}));
+vi.mock('../../services/expoPush', () => ({
+  getUserPushTokens: bridgeMocks.getUserPushTokens,
+  sendExpoPush: bridgeMocks.sendExpoPush,
+  buildApprovalPush: bridgeMocks.buildApprovalPush,
 }));
 
 const pamMocks = vi.hoisted(() => ({
@@ -175,6 +197,10 @@ describe('agent elevation-requests ingestion route', () => {
     // Default: no software policy binds, no PAM rules -> 'pending'.
     pamMocks.evaluatePamBridge.mockResolvedValue({ match: null, auditMatches: [] });
     pamMocks.publishEvent.mockResolvedValue('evt-1');
+    // Default: no eligible approvers -> mobile bridge is a no-op.
+    bridgeMocks.resolveElevationApprovers.mockResolvedValue([]);
+    bridgeMocks.getUserPushTokens.mockResolvedValue([]);
+    bridgeMocks.sendExpoPush.mockResolvedValue([]);
   });
 
   it('inserts an elevation request and returns id + status', async () => {
@@ -343,6 +369,9 @@ describe('ingest decisioning (#1163)', () => {
     mockSelects([{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }]);
     pamMocks.evaluatePamBridge.mockResolvedValue({ match: null, auditMatches: [] });
     pamMocks.publishEvent.mockResolvedValue('evt-1');
+    bridgeMocks.resolveElevationApprovers.mockResolvedValue([]);
+    bridgeMocks.getUserPushTokens.mockResolvedValue([]);
+    bridgeMocks.sendExpoPush.mockResolvedValue([]);
   });
 
   async function post(app: Hono) {
@@ -528,5 +557,138 @@ describe('ingest decisioning (#1163)', () => {
       expect.anything(),
       'pam-ingest',
     );
+  });
+});
+
+import { elevationVerdictToRiskTier } from './elevationRequests';
+
+describe('elevationVerdictToRiskTier', () => {
+  it('maps a blocklist verdict to critical', () => {
+    expect(
+      elevationVerdictToRiskTier({ match: 'blocklist', auditMatches: [] }, true),
+    ).toBe('critical');
+  });
+
+  it('maps an allowlist verdict to low', () => {
+    expect(
+      elevationVerdictToRiskTier({ match: 'allowlist', auditMatches: [] }, false),
+    ).toBe('low');
+  });
+
+  it('no verdict + signed -> medium', () => {
+    expect(elevationVerdictToRiskTier(null, true)).toBe('medium');
+    expect(elevationVerdictToRiskTier({ match: null, auditMatches: [] }, true)).toBe('medium');
+  });
+
+  it('no verdict + unsigned -> high', () => {
+    expect(elevationVerdictToRiskTier(null, false)).toBe('high');
+  });
+});
+
+describe('#1254 mobile approval bridge (fan-out)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rateLimiter.mockResolvedValue({
+      allowed: true,
+      remaining: 599,
+      resetAt: new Date(Date.now() + 60_000),
+    });
+    mockSelects([{ id: 'device-1', orgId: 'org-1', siteId: 'site-1', hostname: 'WS-01' } as any]);
+    pamMocks.evaluatePamBridge.mockResolvedValue({ match: null, auditMatches: [] });
+    pamMocks.publishEvent.mockResolvedValue('evt-1');
+    bridgeMocks.getUserPushTokens.mockResolvedValue(['ExponentPushToken[abc]']);
+    bridgeMocks.sendExpoPush.mockResolvedValue([{ status: 'ok', id: 'tk' }]);
+  });
+
+  async function post(app: Hono) {
+    return app.request('/agents/agent-123/elevation-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(goodPayload),
+    });
+  }
+
+  // Capture approval_requests inserts (the bridge) distinctly from the
+  // elevation/audit inserts that share the same db.insert mock.
+  function approvalValueCalls(values: ReturnType<typeof vi.fn>) {
+    return values.mock.calls.filter(
+      (args) => (args[0] as { actionToolName?: string }).actionToolName === 'uac_intercept',
+    );
+  }
+
+  it('pending uac_intercept fans out one approval per approver + pushes', async () => {
+    bridgeMocks.resolveElevationApprovers.mockResolvedValue(['user-a', 'user-b']);
+    const { values } = happyPathInsert([{ id: 'req-uuid', status: 'pending' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+
+    expect(bridgeMocks.resolveElevationApprovers).toHaveBeenCalledWith('org-1');
+    const approvalCalls = approvalValueCalls(values);
+    expect(approvalCalls).toHaveLength(2);
+    expect(approvalCalls[0]![0]).toEqual(
+      expect.objectContaining({
+        userId: 'user-a',
+        elevationRequestId: 'req-uuid',
+        requestingClientLabel: 'Breeze Agent',
+        requestingMachineLabel: 'WS-01',
+        actionToolName: 'uac_intercept',
+        status: 'pending',
+      }),
+    );
+    expect(approvalCalls[1]![0]).toEqual(
+      expect.objectContaining({ userId: 'user-b', elevationRequestId: 'req-uuid' }),
+    );
+    // Push attempted for each approver.
+    expect(bridgeMocks.getUserPushTokens).toHaveBeenCalledTimes(2);
+    expect(bridgeMocks.sendExpoPush).toHaveBeenCalledTimes(2);
+  });
+
+  it('auto_approved elevation does NOT trigger the bridge', async () => {
+    pamMocks.evaluatePamBridge.mockResolvedValue({
+      match: 'allowlist',
+      policyId: 'pol-2',
+      auditMatches: [],
+    });
+    bridgeMocks.resolveElevationApprovers.mockResolvedValue(['user-a']);
+    happyPathInsert([{ id: 'req-auto', status: 'auto_approved' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(bridgeMocks.resolveElevationApprovers).not.toHaveBeenCalled();
+  });
+
+  it('denied elevation does NOT trigger the bridge', async () => {
+    pamMocks.evaluatePamBridge.mockResolvedValue({
+      match: 'blocklist',
+      policyId: 'pol-1',
+      auditMatches: [],
+    });
+    bridgeMocks.resolveElevationApprovers.mockResolvedValue(['user-a']);
+    happyPathInsert([{ id: 'req-deny', status: 'denied' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(bridgeMocks.resolveElevationApprovers).not.toHaveBeenCalled();
+  });
+
+  it('approver resolution throwing still returns 201 (best-effort)', async () => {
+    bridgeMocks.resolveElevationApprovers.mockRejectedValue(new Error('db down'));
+    happyPathInsert([{ id: 'req-uuid', status: 'pending' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ id: 'req-uuid', status: 'pending' });
+  });
+
+  it('a failing push does not abort the remaining approvers', async () => {
+    bridgeMocks.resolveElevationApprovers.mockResolvedValue(['user-a', 'user-b']);
+    bridgeMocks.sendExpoPush.mockRejectedValueOnce(new Error('expo 500'));
+    const { values } = happyPathInsert([{ id: 'req-uuid', status: 'pending' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    // Both approval rows still inserted despite the first push throwing.
+    expect(approvalValueCalls(values)).toHaveLength(2);
   });
 });

--- a/apps/api/src/routes/agents/elevationRequests.ts
+++ b/apps/api/src/routes/agents/elevationRequests.ts
@@ -3,8 +3,15 @@ import { zValidator } from '@hono/zod-validator';
 import { and, eq, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
 
-import { db } from '../../db';
-import { devices, elevationAudit, elevationRequests, pamOrgConfig, pamRules } from '../../db/schema';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import {
+  approvalRequests,
+  devices,
+  elevationAudit,
+  elevationRequests,
+  pamOrgConfig,
+  pamRules,
+} from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { getRedis } from '../../services/redis';
 import { rateLimiter } from '../../services/rate-limit';
@@ -13,6 +20,9 @@ import { requireAgentRole } from '../../middleware/requireAgentRole';
 import { evaluatePamBridge, type PamBridgeVerdict } from '../../services/pamBridge';
 import { evaluatePamRules, type PamRuleMatch } from '../../services/pamRuleEngine';
 import { publishEvent, type EventType } from '../../services/eventBus';
+import { resolveElevationApprovers } from '../../services/pamApprovers';
+import { buildApprovalPush, getUserPushTokens, sendExpoPush } from '../../services/expoPush';
+import type { RiskTier } from '@breeze/shared';
 
 // PAM Track 3: agent-side endpoint that records UAC consent.exe observations
 // as `elevation_requests` rows with flow_type='uac_intercept'. Auth is the
@@ -43,6 +53,41 @@ const ELEVATION_REQUEST_RATE_WINDOW_SECONDS = 60;
 // pam_rule nor (future) org config specifies a duration. Conservative: the
 // uac_intercept flow only needs the window in which consent.exe is satisfied.
 const PAM_DEFAULT_AUTO_APPROVAL_DURATION_MINUTES = 15;
+
+// #1254: how long a fanned-out mobile approval_request stays actionable. The
+// technician has this long to tap approve/deny before it self-expires; the
+// underlying elevation has its own (null-until-approved) expiry.
+const PAM_MOBILE_APPROVAL_TTL_MINUTES = 15;
+
+/**
+ * Map a software-policy bridge verdict + signer presence to the mobile
+ * approval risk tier shown on the technician's phone. Pure — unit-tested.
+ *
+ * At the pending insert site `verdict` is effectively null (an allowlist /
+ * blocklist match would already have auto-decided the elevation, so the row
+ * never reaches the mobile bridge). The signer signal still matters: an
+ * UNSIGNED binary asking for admin is riskier than a signed one, so it tiers
+ * up. A blocklist verdict (defensive — shouldn't reach here) is 'critical'; an
+ * allowlist verdict is 'low'.
+ */
+export function elevationVerdictToRiskTier(
+  verdict: PamBridgeVerdict | null,
+  hasSigner: boolean,
+): RiskTier {
+  if (verdict?.match === 'blocklist') return 'critical';
+  if (verdict?.match === 'allowlist') return 'low';
+  return hasSigner ? 'medium' : 'high';
+}
+
+/**
+ * Last path segment of a Windows or POSIX path. `node:path` basename only
+ * splits on the host separator, but the agent always reports Windows-style
+ * backslash paths, so split on both.
+ */
+function pathBasename(p: string): string {
+  const parts = p.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? '';
+}
 
 export const elevationRequestSchema = z.object({
   subject_username: z.string().min(1).max(255),
@@ -79,6 +124,126 @@ async function safePublish(
     await publishEvent(type, orgId, payload, 'pam-ingest');
   } catch (err) {
     console.error(`[ElevationRequests] event publish failed (${type}):`, err);
+  }
+}
+
+/**
+ * #1254 — mobile approval bridge. For a freshly-inserted PENDING uac_intercept
+ * elevation, fan out one mobile approval_request per eligible technician
+ * approver and push each to their phone. Whichever approver decides first on
+ * mobile mirrors that decision back onto the elevation (see decideHandler in
+ * routes/approvals.ts) and expires the siblings.
+ *
+ * BEST-EFFORT: the elevation row is already committed and the agent's 201 must
+ * not depend on this. The whole body is wrapped in try/catch by the caller, and
+ * each per-approver push is additionally swallowed so one bad token can't drop
+ * the rest. No actuate command is enqueued (parity with pam.ts respond — that's
+ * deferred to #1150).
+ */
+async function fanOutMobileApprovals(args: {
+  elevationRequestId: string;
+  device: { id: string; orgId: string; hostname: string };
+  payload: ElevationRequestPayload;
+  reason: string;
+  bridgeVerdict: PamBridgeVerdict | null;
+  expiresAt: Date;
+}): Promise<void> {
+  const { elevationRequestId, device, payload, reason, bridgeVerdict, expiresAt } = args;
+
+  const hasSigner = !!payload.target_executable_signer;
+  const riskTier = elevationVerdictToRiskTier(bridgeVerdict, hasSigner);
+  const exeName = pathBasename(payload.target_executable_path);
+  const actionLabel = exeName ? `Elevate ${exeName}` : 'Run as administrator';
+  const riskSummary = `${payload.subject_username} requested admin to run ${
+    payload.target_executable_path
+  }${hasSigner ? ` (signed by ${payload.target_executable_signer})` : ' (unsigned)'}.`;
+
+  const actionArguments: Record<string, unknown> = {
+    targetExecutablePath: payload.target_executable_path,
+    targetExecutableSigner: payload.target_executable_signer ?? null,
+    targetExecutableHash: payload.target_executable_hash ?? null,
+    parentImage: payload.parent_image ?? null,
+    commandLine: payload.command_line ?? null,
+    reason,
+    subjectUsername: payload.subject_username,
+    deviceHostname: device.hostname,
+  };
+
+  // approval_requests is Shape-6 RLS (USING/WITH CHECK user_id = current_user
+  // OR scope='system'). This ingest path runs in the agent's ORG-scoped DB
+  // context, under which the INSERT is DENIED. withSystemDbAccessContext is a
+  // no-op when a context is already open (db/index.ts), so we must FIRST escape
+  // the request context with runOutsideDbContext, THEN open a system context —
+  // exactly as routes/agents/commands.ts does. All DB reads/writes (resolve
+  // approvers, the per-approver approval_requests insert, push-token lookup) run
+  // inside this one system context; we then perform the Expo network calls
+  // AFTER it closes so we never hold the DB transaction open across the network
+  // round-trip (the held-context tripwire in db/index.ts).
+  const pushTargets = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const approverIds = await resolveElevationApprovers(device.orgId);
+      if (approverIds.length === 0) return [];
+
+      const targets: Array<{ approvalId: string; actionLabel: string; tokens: string[] }> = [];
+      for (const userId of approverIds) {
+        let approvalId: string;
+        try {
+          const [row] = await db
+            .insert(approvalRequests)
+            .values({
+              userId,
+              elevationRequestId,
+              requestingClientLabel: 'Breeze Agent',
+              requestingMachineLabel: device.hostname ?? null,
+              actionLabel,
+              actionToolName: 'uac_intercept',
+              actionArguments,
+              riskTier,
+              riskSummary,
+              status: 'pending',
+              isRecursive: false,
+              expiresAt,
+            })
+            .returning({ id: approvalRequests.id });
+          if (!row) continue;
+          approvalId = row.id;
+        } catch (err) {
+          console.error(
+            `[ElevationRequests] mobile approval insert failed for user=${userId} elevation=${elevationRequestId}:`,
+            err,
+          );
+          continue;
+        }
+
+        const tokens = await getUserPushTokens(userId);
+        targets.push({ approvalId, actionLabel, tokens });
+      }
+      return targets;
+    }),
+  );
+
+  // Expo network calls run OUTSIDE the system DB context (no open transaction
+  // held across the HTTP round-trip). Push is best-effort per approver — a dead
+  // token or Expo outage must not block the remaining approvers or the 201.
+  for (const { approvalId, actionLabel: label, tokens } of pushTargets) {
+    if (tokens.length === 0) continue;
+    try {
+      await sendExpoPush(
+        tokens.map((to) => ({
+          to,
+          ...buildApprovalPush({
+            approvalId,
+            actionLabel: label,
+            requestingClientLabel: 'Breeze Agent',
+          }),
+        })),
+      );
+    } catch (err) {
+      console.error(
+        `[ElevationRequests] mobile push failed for approval=${approvalId}:`,
+        err,
+      );
+    }
   }
 }
 
@@ -137,6 +302,7 @@ elevationRequestsRoutes.post(
         id: devices.id,
         orgId: devices.orgId,
         siteId: devices.siteId,
+        hostname: devices.hostname,
       })
       .from(devices)
       .where(eq(devices.agentId, agentId))
@@ -430,6 +596,29 @@ elevationRequestsRoutes.post(
           ? { pamRuleId: decision.rule.ruleId }
           : {}),
       });
+
+      // #1254: bridge a manually-pending uac_intercept to the mobile approval
+      // surface (fan-out to eligible technicians). Best-effort — the elevation
+      // row + audit are already committed and the agent must get its 201 even
+      // if the entire bridge fails. auto_approved / denied rows skip this (no
+      // human decision is needed).
+      if (decision.kind === 'pending') {
+        try {
+          await fanOutMobileApprovals({
+            elevationRequestId: row.id,
+            device: { id: device.id, orgId: device.orgId, hostname: device.hostname },
+            payload,
+            reason,
+            bridgeVerdict,
+            expiresAt: new Date(now.getTime() + PAM_MOBILE_APPROVAL_TTL_MINUTES * 60_000),
+          });
+        } catch (bridgeErr) {
+          console.error(
+            `[ElevationRequests] mobile bridge failed for request=${row.id}:`,
+            bridgeErr,
+          );
+        }
+      }
 
       return c.json({ id: row.id, status: row.status }, 201);
     } catch (err) {

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -7,6 +7,7 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    transaction: vi.fn(),
   },
 }));
 
@@ -21,7 +22,16 @@ vi.mock('../services/expoPush', () => ({
 }));
 
 vi.mock('../db/schema/approvals', () => ({
-  approvalRequests: {},
+  approvalRequests: {
+    id: 'id',
+    elevationRequestId: 'elevation_request_id',
+    status: 'status',
+  },
+}));
+
+vi.mock('../db/schema/elevations', () => ({
+  elevationRequests: { id: 'id', orgId: 'org_id', status: 'status' },
+  elevationAudit: { id: 'id', orgId: 'org_id', elevationRequestId: 'elevation_request_id' },
 }));
 
 vi.mock('../db/schema/authenticatorDevices', () => ({
@@ -215,6 +225,7 @@ beforeEach(() => {
   vi.mocked(db.update).mockReset();
   vi.mocked(db.insert).mockReset();
   vi.mocked(db.delete).mockReset();
+  vi.mocked(db.transaction).mockReset();
   // Re-establish the default no-proof (L1 session_tap) assurance after
   // clearAllMocks wipes the implementation, so the unchanged approve tests
   // keep recording session_tap and per-case overrides start from a clean slate.
@@ -956,6 +967,129 @@ describe('POST /approvals/:id/deny', () => {
     expect(aiSet).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'rejected', approvedBy: TEST_USER.id }),
     );
+  });
+});
+
+describe('#1254 PAM mobile bridge: mirror decision back to elevation', () => {
+  // Builds a tx stub for db.transaction(fn). `elevationUpdateRows` is what the
+  // elevation CAS returns ([] = lost the race). Captures the elevation .set arg,
+  // the elevationAudit .values arg, and the sibling-expiry .set arg.
+  function mockElevationTx(elevationUpdateRows: unknown[]) {
+    const elevationSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(elevationUpdateRows) }),
+    });
+    const siblingExpireSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const auditValues = vi.fn().mockResolvedValue(undefined);
+    let updateCall = 0;
+    const tx = {
+      update: vi.fn(() => {
+        updateCall += 1;
+        // 1st update in the tx = elevation CAS; 2nd = sibling expiry.
+        return { set: updateCall === 1 ? elevationSet : siblingExpireSet } as any;
+      }),
+      insert: vi.fn(() => ({ values: auditValues } as any)),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+    return { elevationSet, siblingExpireSet, auditValues };
+  }
+
+  // The decideHandler pre-fetch select + the approval_requests CAS update. The
+  // updated row carries elevationRequestId so the mirror block runs.
+  function mockDecideWithElevation(opts: { status: 'pending'; riskTier: string; elevationRequestId: string | null }) {
+    const updatedRow = {
+      id: 'appr-1',
+      userId: TEST_USER.id,
+      requestingClientLabel: 'Breeze Agent',
+      requestingMachineLabel: 'WS-01',
+      actionLabel: 'Elevate setup.exe',
+      actionToolName: 'uac_intercept',
+      actionArguments: {},
+      riskTier: opts.riskTier,
+      riskSummary: 'admin requested',
+      status: 'approved',
+      expiresAt: new Date(Date.now() + 60_000),
+      decidedAt: new Date(),
+      decisionReason: null,
+      executionId: null,
+      elevationRequestId: opts.elevationRequestId,
+      isRecursive: false,
+      createdAt: new Date(),
+    };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ ...updatedRow, status: 'pending' }]),
+      }),
+    } as any);
+    const returning = vi.fn().mockResolvedValue([updatedRow]);
+    const set = vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning }) });
+    vi.mocked(db.update).mockReturnValue({ set } as any);
+    return updatedRow;
+  }
+
+  it('approve mirrors elevation to approved + expires siblings', async () => {
+    mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
+    const tx = mockElevationTx([{ id: 'elev-1', orgId: 'org-9' }]);
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(db.transaction).toHaveBeenCalledOnce();
+    expect(tx.elevationSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved', approvedByUserId: TEST_USER.id }),
+    );
+    // #1254: the approve grant is bounded (parity with pam.ts's 15-min default),
+    // not left open-ended.
+    const elevationSetArg = tx.elevationSet.mock.calls[0]![0] as { expiresAt: Date };
+    expect(elevationSetArg.expiresAt).toBeInstanceOf(Date);
+    expect(elevationSetArg.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(tx.auditValues).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'approved', actor: 'technician', orgId: 'org-9' }),
+    );
+    expect(tx.siblingExpireSet).toHaveBeenCalledWith({ status: 'expired' });
+  });
+
+  it('deny mirrors elevation to denied', async () => {
+    mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
+    const tx = mockElevationTx([{ id: 'elev-1', orgId: 'org-9' }]);
+
+    const res = await buildApp().request('/approvals/appr-1/deny', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'not allowed' }),
+    });
+    expect(res.status).toBe(200);
+    expect(tx.elevationSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'denied', deniedByUserId: TEST_USER.id, denialReason: 'not allowed' }),
+    );
+    expect(tx.auditValues).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'denied', actor: 'technician' }),
+    );
+  });
+
+  it('elevation already non-pending (CAS 0 rows) -> decide still 200, no audit/sibling write', async () => {
+    mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
+    const tx = mockElevationTx([]); // lost the race
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(tx.elevationSet).toHaveBeenCalled();
+    expect(tx.auditValues).not.toHaveBeenCalled();
+    expect(tx.siblingExpireSet).not.toHaveBeenCalled();
+  });
+
+  it('approval without elevationRequestId never opens the mirror transaction', async () => {
+    mockDecideWithElevation({ status: 'pending', riskTier: 'low', elevationRequestId: null });
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('mirror failure is non-fatal: decide still returns 200', async () => {
+    mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
+    vi.mocked(db.transaction).mockRejectedValue(new Error('tx blew up'));
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
   });
 });
 

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -9,6 +9,12 @@ vi.mock('../db', () => ({
     delete: vi.fn(),
     transaction: vi.fn(),
   },
+  // Pass-throughs: the post-commit sibling-expiry wraps its db.update in
+  // runOutsideDbContext(() => withSystemDbAccessContext(...)). Unwrapping both
+  // lets the mocked db.update run inline so tests can assert on it (same shape
+  // as the other route tests that mock these helpers).
+  runOutsideDbContext: (fn: any) => fn(),
+  withSystemDbAccessContext: (fn: any) => fn(),
 }));
 
 vi.mock('../services/expoPush', () => ({
@@ -972,29 +978,31 @@ describe('POST /approvals/:id/deny', () => {
 
 describe('#1254 PAM mobile bridge: mirror decision back to elevation', () => {
   // Builds a tx stub for db.transaction(fn). `elevationUpdateRows` is what the
-  // elevation CAS returns ([] = lost the race). Captures the elevation .set arg,
-  // the elevationAudit .values arg, and the sibling-expiry .set arg.
+  // elevation CAS returns ([] = lost the race). The tx now does ONLY the
+  // elevation CAS (.update) + the audit insert (.values) — the sibling-expiry
+  // moved OUT of the tx to a post-commit system-scoped db.update (see
+  // mockSiblingExpireUpdate). Captures the elevation .set arg and the
+  // elevationAudit .values arg.
   function mockElevationTx(elevationUpdateRows: unknown[]) {
     const elevationSet = vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(elevationUpdateRows) }),
     });
-    const siblingExpireSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
     const auditValues = vi.fn().mockResolvedValue(undefined);
-    let updateCall = 0;
     const tx = {
-      update: vi.fn(() => {
-        updateCall += 1;
-        // 1st update in the tx = elevation CAS; 2nd = sibling expiry.
-        return { set: updateCall === 1 ? elevationSet : siblingExpireSet } as any;
-      }),
+      update: vi.fn(() => ({ set: elevationSet } as any)),
       insert: vi.fn(() => ({ values: auditValues } as any)),
     };
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
-    return { elevationSet, siblingExpireSet, auditValues };
+    return { elevationSet, auditValues };
   }
 
   // The decideHandler pre-fetch select + the approval_requests CAS update. The
   // updated row carries elevationRequestId so the mirror block runs.
+  //
+  // On the win path the route now calls db.update TWICE: first the
+  // approval_requests CAS (inside decideHandler), then the post-commit
+  // system-scoped sibling-expiry. Wire both via mockReturnValueOnce so the
+  // sibling set arg is captured separately; return that captured set.
   function mockDecideWithElevation(opts: { status: 'pending'; riskTier: string; elevationRequestId: string | null }) {
     const updatedRow = {
       id: 'appr-1',
@@ -1020,14 +1028,19 @@ describe('#1254 PAM mobile bridge: mirror decision back to elevation', () => {
         where: vi.fn().mockResolvedValue([{ ...updatedRow, status: 'pending' }]),
       }),
     } as any);
-    const returning = vi.fn().mockResolvedValue([updatedRow]);
-    const set = vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning }) });
-    vi.mocked(db.update).mockReturnValue({ set } as any);
-    return updatedRow;
+    // 1) approval_requests CAS update
+    const casReturning = vi.fn().mockResolvedValue([updatedRow]);
+    const casSet = vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: casReturning }) });
+    // 2) post-commit sibling-expiry (system scope) — a terminal .set().where()
+    const siblingExpireSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    vi.mocked(db.update)
+      .mockReturnValueOnce({ set: casSet } as any)
+      .mockReturnValueOnce({ set: siblingExpireSet } as any);
+    return { updatedRow, casSet, siblingExpireSet };
   }
 
   it('approve mirrors elevation to approved + expires siblings', async () => {
-    mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
+    const { siblingExpireSet } = mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
     const tx = mockElevationTx([{ id: 'elev-1', orgId: 'org-9' }]);
 
     const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
@@ -1044,7 +1057,11 @@ describe('#1254 PAM mobile bridge: mirror decision back to elevation', () => {
     expect(tx.auditValues).toHaveBeenCalledWith(
       expect.objectContaining({ eventType: 'approved', actor: 'technician', orgId: 'org-9' }),
     );
-    expect(tx.siblingExpireSet).toHaveBeenCalledWith({ status: 'expired' });
+    // The sibling-expiry now runs POST-COMMIT in system scope (a second
+    // db.update), not as a second tx.update — proving the RLS-fix structure:
+    // the Shape-6 sibling rows belong to OTHER approvers, invisible to this
+    // user's request context, so the write must be system-scoped.
+    expect(siblingExpireSet).toHaveBeenCalledWith({ status: 'expired' });
   });
 
   it('deny mirrors elevation to denied', async () => {
@@ -1066,14 +1083,16 @@ describe('#1254 PAM mobile bridge: mirror decision back to elevation', () => {
   });
 
   it('elevation already non-pending (CAS 0 rows) -> decide still 200, no audit/sibling write', async () => {
-    mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
+    const { siblingExpireSet } = mockDecideWithElevation({ status: 'pending', riskTier: 'medium', elevationRequestId: 'elev-1' });
     const tx = mockElevationTx([]); // lost the race
 
     const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
     expect(res.status).toBe(200);
     expect(tx.elevationSet).toHaveBeenCalled();
     expect(tx.auditValues).not.toHaveBeenCalled();
-    expect(tx.siblingExpireSet).not.toHaveBeenCalled();
+    // wonElevation stays false on a lost race, so the post-commit sibling-expiry
+    // db.update is never invoked.
+    expect(siblingExpireSet).not.toHaveBeenCalled();
   });
 
   it('approval without elevationRequestId never opens the mirror transaction', async () => {

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -1,11 +1,12 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, gt, desc, inArray, isNull } from 'drizzle-orm';
+import { and, eq, gt, desc, inArray, isNull, ne } from 'drizzle-orm';
 
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
 import { approvalRequests } from '../db/schema/approvals';
+import { elevationRequests, elevationAudit } from '../db/schema/elevations';
 import { aiToolExecutions, aiSessions } from '../db/schema/ai';
 import { delegantM365Connections } from '../db/schema/delegant';
 import { auditLogs } from '../db/schema/audit';
@@ -27,6 +28,12 @@ import {
 // defaulted by assertionProofSchema) OR the mobile_hw_key proof. z.union tries
 // the strict mobile literal first, then falls back to the webauthn shape.
 const approveProofSchema = z.union([mobileHwKeyProofSchema, assertionProofSchema]);
+
+// #1254: how long a mobile-approved elevation grant stays valid. Matches the
+// web respond path's DEFAULT_APPROVAL_DURATION_MINUTES in pam.ts (15) so an
+// approve here is bounded identically — an unbounded grant would leave the
+// elevation valid indefinitely.
+const PAM_ELEVATION_GRANT_MINUTES = 15;
 
 export const approvalRoutes = new Hono();
 
@@ -486,6 +493,91 @@ async function decideHandler(
       // Non-fatal: the approval_request row is the source of truth for the
       // mobile UI. The SDK poll will time out at the 5-min ceiling if the
       // mirror fails — better than failing the user-facing decide call.
+    }
+  }
+
+  // #1254: PAM mobile bridge. If this approval was fanned out from a pending
+  // uac_intercept elevation, mirror the decision back onto the elevation and
+  // expire the sibling approval rows. First-wins: the CAS only fires while the
+  // elevation is still 'pending', so a second approver (or the web respond
+  // path) that already decided it is a clean no-op. No actuate command is
+  // enqueued on approve — parity with pam.ts respond, deferred to #1150.
+  // Best-effort (same posture as the executionId mirror): the approval_requests
+  // row is the source of truth for the mobile UI, so a mirror failure must not
+  // fail the user's decide call.
+  if (updated?.elevationRequestId) {
+    const elevationId = updated.elevationRequestId;
+    try {
+      await db.transaction(async (tx) => {
+        const now = new Date();
+        const elevationUpdate = await tx
+          .update(elevationRequests)
+          .set(
+            status === 'approved'
+              ? {
+                  status: 'approved',
+                  approvedByUserId: userId,
+                  approvedAt: now,
+                  expiresAt: new Date(now.getTime() + PAM_ELEVATION_GRANT_MINUTES * 60_000),
+                  updatedAt: now,
+                  decidedAssuranceLevel: assurance.decidedAssuranceLevel,
+                  decidedVia: assurance.decidedVia,
+                  authenticatorDeviceId: assurance.authenticatorDeviceId,
+                }
+              : {
+                  status: 'denied',
+                  deniedByUserId: userId,
+                  denialReason: reason ?? null,
+                  updatedAt: now,
+                  decidedAssuranceLevel: assurance.decidedAssuranceLevel,
+                  decidedVia: assurance.decidedVia,
+                  authenticatorDeviceId: assurance.authenticatorDeviceId,
+                },
+          )
+          .where(
+            and(
+              eq(elevationRequests.id, elevationId),
+              eq(elevationRequests.status, 'pending'),
+            ),
+          )
+          .returning({ id: elevationRequests.id, orgId: elevationRequests.orgId });
+
+        // Lost the race (already decided/expired by a sibling or the web path):
+        // leave everything as-is. Our approval_requests row is still decided.
+        if (elevationUpdate.length === 0) return;
+        const elevation = elevationUpdate[0]!;
+
+        await tx.insert(elevationAudit).values({
+          orgId: elevation.orgId,
+          elevationRequestId: elevationId,
+          eventType: status === 'approved' ? 'approved' : 'denied',
+          actor: 'technician',
+          actorUserId: userId,
+          details: {
+            source: 'mobile_approval',
+            approval_request_id: updated.id,
+            ...(status === 'denied' && reason ? { reason } : {}),
+          },
+          occurredAt: now,
+        });
+
+        // Expire the sibling approval rows so they vanish from other approvers'
+        // queues — first-wins fan-in.
+        await tx
+          .update(approvalRequests)
+          .set({ status: 'expired' })
+          .where(
+            and(
+              eq(approvalRequests.elevationRequestId, elevationId),
+              ne(approvalRequests.id, updated.id),
+              eq(approvalRequests.status, 'pending'),
+            ),
+          );
+      });
+    } catch (err) {
+      console.error('[approvals] Failed to mirror decision to elevation_requests:', err);
+      // Non-fatal: the approval_request row is the source of truth for the
+      // mobile decision; the elevation mirror can be reconciled out of band.
     }
   }
 

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 import { and, eq, gt, desc, inArray, isNull, ne } from 'drizzle-orm';
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { authMiddleware } from '../middleware/auth';
 import { approvalRequests } from '../db/schema/approvals';
 import { elevationRequests, elevationAudit } from '../db/schema/elevations';
@@ -507,6 +507,7 @@ async function decideHandler(
   // fail the user's decide call.
   if (updated?.elevationRequestId) {
     const elevationId = updated.elevationRequestId;
+    let wonElevation = false;
     try {
       await db.transaction(async (tx) => {
         const now = new Date();
@@ -545,6 +546,7 @@ async function decideHandler(
         // Lost the race (already decided/expired by a sibling or the web path):
         // leave everything as-is. Our approval_requests row is still decided.
         if (elevationUpdate.length === 0) return;
+        wonElevation = true;
         const elevation = elevationUpdate[0]!;
 
         await tx.insert(elevationAudit).values({
@@ -560,24 +562,38 @@ async function decideHandler(
           },
           occurredAt: now,
         });
-
-        // Expire the sibling approval rows so they vanish from other approvers'
-        // queues — first-wins fan-in.
-        await tx
-          .update(approvalRequests)
-          .set({ status: 'expired' })
-          .where(
-            and(
-              eq(approvalRequests.elevationRequestId, elevationId),
-              ne(approvalRequests.id, updated.id),
-              eq(approvalRequests.status, 'pending'),
-            ),
-          );
       });
     } catch (err) {
       console.error('[approvals] Failed to mirror decision to elevation_requests:', err);
       // Non-fatal: the approval_request row is the source of truth for the
       // mobile decision; the elevation mirror can be reconciled out of band.
+    }
+
+    // Expire the sibling approval rows so they vanish from other approvers'
+    // queues — first-wins fan-in. MUST run in system scope: approval_requests is
+    // Shape-6 (user-id-scoped), so the sibling rows belong to OTHER approvers and
+    // are invisible to this approver's request context — a bare context-scoped
+    // UPDATE would silently match zero rows. Best-effort, post-commit, and only
+    // when this decide won the elevation CAS (the winner owns the fan-in cleanup).
+    if (wonElevation) {
+      try {
+        await runOutsideDbContext(() =>
+          withSystemDbAccessContext(async () => {
+            await db
+              .update(approvalRequests)
+              .set({ status: 'expired' })
+              .where(
+                and(
+                  eq(approvalRequests.elevationRequestId, elevationId),
+                  ne(approvalRequests.id, updated.id),
+                  eq(approvalRequests.status, 'pending'),
+                ),
+              );
+          }),
+        );
+      } catch (err) {
+        console.error('[approvals] Failed to expire sibling approvals:', err);
+      }
     }
   }
 

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -1251,6 +1251,14 @@ describe('ai_tool_action elevation requests (Phase 1)', () => {
 
   it('uac_intercept respond never touches the execution mirror', async () => {
     const { updateSetCalls } = rigTransaction({ row: activeRow, casWins: true });
+    // #1254: the mobile-approval expiry moved OUT of the respond tx to a
+    // post-commit system-scoped db.update — approval_requests is Shape-6
+    // (user-id-scoped), so the fanned-out approver rows belong to OTHER users
+    // and are invisible to this web caller's request context; a bare in-tx
+    // update would silently match zero rows. Wire that post-commit db.update
+    // and capture its .set arg.
+    const expireSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    vi.mocked(db.update).mockReturnValue({ set: expireSet } as any);
 
     const res = await app().request(`/pam/elevation-requests/${REQ_ID}/respond`, {
       method: 'POST',
@@ -1259,12 +1267,13 @@ describe('ai_tool_action elevation requests (Phase 1)', () => {
     });
 
     expect(res.status).toBe(200);
-    // Two updates for uac_intercept: the elevation-status CAS, then the #1254
-    // mobile-approval expiry (clears any fanned-out approval_requests rows so
-    // a web decision also removes the request from approvers' phones). Neither
-    // is an execution mirror — that only happens for ai_tool_action.
-    expect(updateSetCalls.length).toBe(2);
-    expect((updateSetCalls[1] as { status?: string }).status).toBe('expired');
+    // In the tx, only the elevation-status CAS runs — no execution mirror (that
+    // only happens for ai_tool_action) and no in-tx approval expiry anymore.
+    expect(updateSetCalls.length).toBe(1);
+    // The #1254 mobile-approval expiry now runs post-commit via the system-scoped
+    // db.update (clears any fanned-out approval_requests rows so a web decision
+    // also removes the request from approvers' phones).
+    expect(expireSet).toHaveBeenCalledWith({ status: 'expired' });
   });
 });
 

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -61,6 +61,7 @@ vi.mock('../db/schema', () => ({
     denialReason: 'denialReason',
   },
   elevationAudit: { id: 'id' },
+  approvalRequests: { id: 'id', elevationRequestId: 'elevationRequestId', status: 'status' },
   pamRules: {
     id: 'id',
     orgId: 'orgId',
@@ -1258,7 +1259,12 @@ describe('ai_tool_action elevation requests (Phase 1)', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(updateSetCalls.length).toBe(1);
+    // Two updates for uac_intercept: the elevation-status CAS, then the #1254
+    // mobile-approval expiry (clears any fanned-out approval_requests rows so
+    // a web decision also removes the request from approvers' phones). Neither
+    // is an execution mirror — that only happens for ai_tool_action.
+    expect(updateSetCalls.length).toBe(2);
+    expect((updateSetCalls[1] as { status?: string }).status).toBe('expired');
   });
 });
 

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -26,6 +26,7 @@ import { z } from 'zod';
 
 import { db } from '../db';
 import {
+  approvalRequests,
   authenticatorDevices,
   devices,
   elevationAudit,
@@ -552,6 +553,26 @@ pamRoutes.post(
           },
           occurredAt: now,
         });
+
+        // #1254: a uac_intercept elevation may also have been fanned out to the
+        // mobile approval surface. A web decision here is authoritative, so
+        // expire any still-pending mobile approval_requests rows linked to this
+        // elevation — they vanish from approvers' phones. Symmetric to the mobile
+        // decideHandler's sibling-expiry; keeps the two approval surfaces
+        // consistent so an elevation can be decided from EITHER, exactly once.
+        // Only uac_intercept fans out (tech_jit_admin / ai_tool_action never do),
+        // so the update is scoped to that flow to avoid a pointless statement.
+        if (row.flowType === 'uac_intercept') {
+          await tx
+            .update(approvalRequests)
+            .set({ status: 'expired' })
+            .where(
+              and(
+                eq(approvalRequests.elevationRequestId, row.id),
+                eq(approvalRequests.status, 'pending'),
+              ),
+            );
+        }
 
         // ai_tool_action rows: mirror the decision onto the linked
         // ai_tool_executions row the SDK gate is polling — in the SAME

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -24,7 +24,7 @@ import { SQL, and, desc, eq, gt, gte, inArray, isNull, lte, or, sql } from 'driz
 import { alias } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
   approvalRequests,
   authenticatorDevices,
@@ -554,26 +554,6 @@ pamRoutes.post(
           occurredAt: now,
         });
 
-        // #1254: a uac_intercept elevation may also have been fanned out to the
-        // mobile approval surface. A web decision here is authoritative, so
-        // expire any still-pending mobile approval_requests rows linked to this
-        // elevation — they vanish from approvers' phones. Symmetric to the mobile
-        // decideHandler's sibling-expiry; keeps the two approval surfaces
-        // consistent so an elevation can be decided from EITHER, exactly once.
-        // Only uac_intercept fans out (tech_jit_admin / ai_tool_action never do),
-        // so the update is scoped to that flow to avoid a pointless statement.
-        if (row.flowType === 'uac_intercept') {
-          await tx
-            .update(approvalRequests)
-            .set({ status: 'expired' })
-            .where(
-              and(
-                eq(approvalRequests.elevationRequestId, row.id),
-                eq(approvalRequests.status, 'pending'),
-              ),
-            );
-        }
-
         // ai_tool_action rows: mirror the decision onto the linked
         // ai_tool_executions row the SDK gate is polling — in the SAME
         // transaction (Phase 1, security finding A). If the execution is no
@@ -651,6 +631,34 @@ pamRoutes.post(
       resourceId: result.row.id,
       details: { reason: body.reason, duration_minutes: approve ? durationMinutes : undefined },
     });
+
+    // #1254: a uac_intercept elevation may also have been fanned out to the
+    // mobile approval surface. This web decision is authoritative, so expire any
+    // still-pending mobile approval_requests rows linked to this elevation —
+    // they vanish from approvers' phones. MUST run in system scope:
+    // approval_requests is Shape-6 (user-id-scoped), so those rows belong to the
+    // fanned-out approvers and are invisible to THIS user's request context — a
+    // bare context-scoped UPDATE would silently match zero rows. Best-effort,
+    // post-commit; only uac_intercept fans out.
+    if (result.row.flowType === 'uac_intercept') {
+      try {
+        await runOutsideDbContext(() =>
+          withSystemDbAccessContext(async () => {
+            await db
+              .update(approvalRequests)
+              .set({ status: 'expired' })
+              .where(
+                and(
+                  eq(approvalRequests.elevationRequestId, result.row.id),
+                  eq(approvalRequests.status, 'pending'),
+                ),
+              );
+          }),
+        );
+      } catch (err) {
+        console.error('[pam] Failed to expire sibling mobile approvals:', err);
+      }
+    }
 
     await safePublish(
       approve ? 'elevation.approved' : 'elevation.denied',

--- a/apps/api/src/services/pamApprovers.test.ts
+++ b/apps/api/src/services/pamApprovers.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  organizations: { id: 'id', partnerId: 'partner_id' },
+  organizationUsers: { userId: 'user_id', orgId: 'org_id', roleId: 'role_id' },
+  partnerUsers: { userId: 'user_id', partnerId: 'partner_id', roleId: 'role_id', orgAccess: 'org_access', orgIds: 'org_ids' },
+  rolePermissions: { roleId: 'role_id', permissionId: 'permission_id' },
+  permissions: { id: 'id', resource: 'resource', action: 'action' },
+  mobileDevices: { userId: 'user_id', status: 'status', notificationsEnabled: 'notifications_enabled' },
+}));
+
+import { db } from '../db';
+import { resolveElevationApprovers } from './pamApprovers';
+
+/**
+ * The resolver issues these selects in order:
+ *   1. granting roles:  select().from(rolePermissions).innerJoin(permissions).where()
+ *   2. org partner:     select().from(organizations).where().limit()
+ *   3. org members:     select().from(organizationUsers).where()
+ *   4. partner members: select().from(partnerUsers).where()
+ *   5. mobile devices:  select().from(mobileDevices).where()
+ * (4 is skipped when the org has no partner; 5 is skipped when no candidates.)
+ */
+function queueSelects(opts: {
+  grantingRoles: Array<{ roleId: string }>;
+  org: Array<{ partnerId: string | null }>;
+  orgMembers: Array<{ userId: string }>;
+  partnerMembers: Array<{ userId: string; orgAccess: string; orgIds: string[] | null }>;
+  mobile: Array<{ userId: string }>;
+}) {
+  // 1. innerJoin chain
+  const joinWhere = vi.fn().mockResolvedValue(opts.grantingRoles);
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: joinWhere }),
+    }),
+  } as any);
+
+  // 2. org partner (where().limit())
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(opts.org) }),
+    }),
+  } as any);
+
+  // 3. org members (where())
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(opts.orgMembers),
+    }),
+  } as any);
+
+  // 4. partner members (where())
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(opts.partnerMembers),
+    }),
+  } as any);
+
+  // 5. mobile devices (where())
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(opts.mobile),
+    }),
+  } as any);
+}
+
+describe('resolveElevationApprovers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('returns distinct userIds with an active mobile device (org + partner members)', async () => {
+    queueSelects({
+      grantingRoles: [{ roleId: 'role-exec' }, { roleId: 'role-exec' }],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-org' }],
+      partnerMembers: [
+        { userId: 'u-all', orgAccess: 'all', orgIds: null },
+        { userId: 'u-sel-yes', orgAccess: 'selected', orgIds: ['org-1', 'org-9'] },
+        { userId: 'u-sel-no', orgAccess: 'selected', orgIds: ['org-other'] },
+        { userId: 'u-none', orgAccess: 'none', orgIds: null },
+      ],
+      // u-sel-yes has no mobile device → filtered out by the device query.
+      mobile: [{ userId: 'u-org' }, { userId: 'u-all' }, { userId: 'u-org' }],
+    });
+
+    const result = await resolveElevationApprovers('org-1');
+    expect([...result].sort()).toEqual(['u-all', 'u-org']);
+  });
+
+  it('includes a role whose only grant is a wildcard (resource=* or action=*)', async () => {
+    // The granting-roles query matches the concrete devices:execute pair AND
+    // the wildcard rows (resource='*' / action='*'), mirroring hasPermission().
+    // A superadmin role (whose grant is the wildcard row) must therefore be
+    // resolved as an eligible approver.
+    queueSelects({
+      grantingRoles: [{ roleId: 'role-superadmin' }],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-admin' }],
+      partnerMembers: [],
+      mobile: [{ userId: 'u-admin' }],
+    });
+
+    const result = await resolveElevationApprovers('org-1');
+    expect(result).toEqual(['u-admin']);
+  });
+
+  it('returns [] when no role grants devices:execute', async () => {
+    queueSelects({
+      grantingRoles: [],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [],
+      partnerMembers: [],
+      mobile: [],
+    });
+
+    const result = await resolveElevationApprovers('org-1');
+    expect(result).toEqual([]);
+    // Short-circuits before any membership lookup.
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns [] when eligible members have no active mobile device', async () => {
+    queueSelects({
+      grantingRoles: [{ roleId: 'role-exec' }],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-org' }],
+      partnerMembers: [],
+      mobile: [],
+    });
+
+    const result = await resolveElevationApprovers('org-1');
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/services/pamApprovers.ts
+++ b/apps/api/src/services/pamApprovers.ts
@@ -1,0 +1,119 @@
+/**
+ * PAM mobile bridge (#1254) — eligible-approver resolution.
+ *
+ * Given an org, returns the distinct set of user ids who may approve a
+ * uac_intercept elevation on their phone: a user is eligible iff
+ *   1. their role in (or covering) the org grants DEVICES_EXECUTE, AND
+ *   2. they have at least one active mobile device with notifications enabled
+ *      (mobile_devices.status = 'active' AND notifications_enabled = true).
+ *
+ * Org membership mirrors how permissions.ts resolves access:
+ *   - organization_users rows for the org itself (direct membership), AND
+ *   - partner_users of the org's owning partner whose org_access covers the org
+ *     (org_access='all', or org_access='selected' with the org id in org_ids).
+ *
+ * Runs under a system DB access context — the agent ingest route has no Breeze
+ * user, so without an elevated context the unprivileged breeze_app role would
+ * RLS-filter these membership/role reads to zero rows.
+ */
+
+import { eq, and, inArray } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import {
+  organizations,
+  organizationUsers,
+  partnerUsers,
+  rolePermissions,
+  permissions,
+  mobileDevices,
+} from '../db/schema';
+import { PERMISSIONS } from './permissions';
+
+/**
+ * Resolve the distinct user ids eligible to approve an elevation for `orgId`.
+ * Empty array when none qualify. Pure-read; opens its own system DB context.
+ */
+export async function resolveElevationApprovers(orgId: string): Promise<string[]> {
+  return withSystemDbAccessContext(async () => {
+    // Role ids that grant devices:execute. One join from role_permissions →
+    // permissions; we match the resource/action pair AND the wildcard grants
+    // (resource='*' / action='*') so this resolver mirrors hasPermission()
+    // (permissions.ts), which treats resource==='*' / action==='*' as covering
+    // any concrete pair. Without this a role granting devices:* or *:*
+    // (superadmin) passes the web PAM-approve gate but would get no mobile push.
+    const grantingRoles = await db
+      .select({ roleId: rolePermissions.roleId })
+      .from(rolePermissions)
+      .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
+      .where(
+        and(
+          inArray(permissions.resource, [PERMISSIONS.DEVICES_EXECUTE.resource, '*']),
+          inArray(permissions.action, [PERMISSIONS.DEVICES_EXECUTE.action, '*']),
+        ),
+      );
+
+    const grantingRoleIds = [...new Set(grantingRoles.map((r) => r.roleId))];
+    if (grantingRoleIds.length === 0) return [];
+
+    // The org's owning partner — needed to resolve partner-scope membership.
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    const candidateUserIds = new Set<string>();
+
+    // 1. Direct org members holding a devices:execute role.
+    const orgMembers = await db
+      .select({ userId: organizationUsers.userId })
+      .from(organizationUsers)
+      .where(
+        and(
+          eq(organizationUsers.orgId, orgId),
+          inArray(organizationUsers.roleId, grantingRoleIds),
+        ),
+      );
+    for (const m of orgMembers) candidateUserIds.add(m.userId);
+
+    // 2. Partner members of the org's partner whose org_access covers this org.
+    if (org?.partnerId) {
+      const partnerMembers = await db
+        .select({
+          userId: partnerUsers.userId,
+          orgAccess: partnerUsers.orgAccess,
+          orgIds: partnerUsers.orgIds,
+        })
+        .from(partnerUsers)
+        .where(
+          and(
+            eq(partnerUsers.partnerId, org.partnerId),
+            inArray(partnerUsers.roleId, grantingRoleIds),
+          ),
+        );
+      for (const m of partnerMembers) {
+        if (m.orgAccess === 'all') {
+          candidateUserIds.add(m.userId);
+        } else if (m.orgAccess === 'selected' && m.orgIds?.includes(orgId)) {
+          candidateUserIds.add(m.userId);
+        }
+      }
+    }
+
+    if (candidateUserIds.size === 0) return [];
+
+    // Narrow to users with an active, notifications-enabled mobile device.
+    const withDevices = await db
+      .select({ userId: mobileDevices.userId })
+      .from(mobileDevices)
+      .where(
+        and(
+          inArray(mobileDevices.userId, [...candidateUserIds]),
+          eq(mobileDevices.status, 'active'),
+          eq(mobileDevices.notificationsEnabled, true),
+        ),
+      );
+
+    return [...new Set(withDevices.map((d) => d.userId))];
+  });
+}


### PR DESCRIPTION
Closes #1254.

Bridges a pending `uac_intercept` elevation to the mobile approval surface end-to-end: the mobile app already *renders* these (#1252), but nothing on the backend turned a pending elevation into a mobile `approval_requests` row, pushed it, or mirrored the decision back. This wires that up.

## Behavior
When a `uac_intercept` elevation lands **pending** (no policy/rule auto-decision), the agent-ingest route fans out **one `approval_requests` row per eligible technician approver** and pushes each to their phone (best-effort). Whichever approver decides first on mobile mirrors the decision back onto the elevation (first-wins CAS) and the sibling approval rows are expired so they leave everyone else's queue.

**Approver routing (fan-out):** eligible = org users whose role grants `devices:execute` **and** who have an active, notifications-enabled mobile device. Membership mirrors `permissions.ts` (direct `organization_users` + `partner_users` whose `org_access` covers the org). Wildcard grants (`devices:*`, `*:*`) are expanded to match `hasPermission()` semantics, so admins whose only grant is a wildcard role still receive the push.

**No actuate command on approve** — this is intentional parity with `pam.ts` `respond`, which defers actuation to #1150/Track 6 ("approving here does not enqueue an agent command"). Mobile approve only transitions the elevation `status` to `approved`/`denied`, with a bounded grant window (`expiresAt = now + 15m`, matching the web `DEFAULT_APPROVAL_DURATION_MINUTES`).

## Changes
- **Migration `2026-06-27-pam-approval-elevation-link.sql`** — adds `approval_requests.elevation_request_id` (nullable FK → `elevation_requests(id) ON DELETE SET NULL`) + index. No RLS change: `approval_requests` stays Shape 6 (user-id scoped); the column is a back-reference only. Idempotent (`ADD COLUMN IF NOT EXISTS` + `pg_constraint` existence check + `CREATE INDEX IF NOT EXISTS`). Sorts last (after the `2026-06-26` files).
- **`db/schema/approvals.ts`** — models the new column + index.
- **`services/pamApprovers.ts`** (new) — `resolveElevationApprovers(orgId)`; runs under a system DB context (the agent route has no Breeze user).
- **`routes/agents/elevationRequests.ts`** — `elevationVerdictToRiskTier` (pure), and the best-effort fan-out after the pending insert. The fan-out's writes run inside `runOutsideDbContext(() => withSystemDbAccessContext(...))` (the `routes/agents/commands.ts` precedent) because `approval_requests` Shape-6 RLS requires `breeze_current_scope() = 'system'` to insert for arbitrary approver users; the Expo push happens **outside** that context so no DB transaction is held across the network round-trip. A bridge failure never 500s the agent (it still 201s).
- **`routes/approvals.ts`** — in `decideHandler`, after the existing `executionId` mirror, a best-effort elevation mirror-back: first-wins CAS (`WHERE status='pending'`) → on win, write the `elevation_audit` row (`actor:'technician'`, `source:'mobile_approval'`) and expire the sibling approval rows. A lost race is a clean no-op (the elevation was already decided by another approver or the web path). Assurance level/factor from the mobile decision are carried onto the elevation.

## Security / tenancy notes
- SoD: `uac_intercept` inserts `subjectUserId = null`, so the maker/checker guard (`subjectUserId === approver`) structurally never matches — the approver pool is technicians, not the end-user subject.
- Assurance is enforced by the existing `assertApprovalAssurance` in `decideHandler` on the row's `riskTier`.

## Test / gate
Local gate green on node 22.20.0 (`apps/api`): `tsc --noEmit` exit 0; `vitest run` on the touched files = **64 passed** (`pamApprovers.test.ts`, `elevationRequests.test.ts`, `approvals.test.ts`); adjacent `pam.test.ts` + `autoMigrate.test.ts` (migration ordering) = **96 passed**, no regressions. New coverage: risk-tier mapping, approver resolution incl. wildcard roles, fan-out (N rows + push, none for auto-decided, best-effort on resolver failure), and the mirror-back (approve→approved+siblings expired+bounded expiry, deny→denied, lost-race no-op, no-elevation-link no-op). CI runs the full Trivy / govulncheck / npm-audit suite (no new dependencies in this change).

🤖 Built with Claude Code under review; no auto-merge.
