### PR TITLE
feat(integrations): surface Huntress inbound webhook URL + secret in the GUI (#1737)

### DIFF
--- a/apps/web/src/components/integrations/HuntressIntegration.test.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.test.tsx
@@ -7,7 +7,8 @@ import { useOrgStore } from '../../stores/orgStore';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
-  registerOrgIdProvider: vi.fn()
+  registerOrgIdProvider: vi.fn(),
+  resolveApiOrigin: vi.fn(() => 'https://us.2breeze.app')
 }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
@@ -272,5 +273,63 @@ describe('HuntressIntegration', () => {
       huntressOrgId: 'huntress-org-1',
       orgId: breezeOrg.id
     });
+  });
+
+  it('surfaces a region-correct, copyable inbound webhook URL carrying the integrationId', async () => {
+    useOrgStore.setState({ currentOrgId: null });
+    mockPartnerLoad({ integration: existingIntegration });
+
+    render(<HuntressIntegration />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Inbound webhook (push from Huntress)')).toBeInTheDocument()
+    );
+    expect(
+      screen.getByText('https://us.2breeze.app/api/v1/huntress/webhook?integrationId=huntress-1')
+    ).toBeInTheDocument();
+    // Signing scheme is documented so the user can configure the Huntress side.
+    expect(screen.getByText(/Signing scheme to configure on Huntress/)).toBeInTheDocument();
+  });
+
+  it('warns that inbound webhooks are rejected until a webhook secret is configured', async () => {
+    useOrgStore.setState({ currentOrgId: null });
+    // existingIntegration.hasWebhookSecret is false.
+    mockPartnerLoad({ integration: existingIntegration });
+
+    render(<HuntressIntegration />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Inbound webhook (push from Huntress)')).toBeInTheDocument()
+    );
+    expect(screen.getByText(/inbound webhooks are rejected with 403/i)).toBeInTheDocument();
+  });
+
+  it('generates a webhook secret, fills the input, and shows a copy-once notice that is submitted on save', async () => {
+    const user = userEvent.setup();
+    useOrgStore.setState({ currentOrgId: null });
+    mockPartnerLoad({ integration: existingIntegration });
+
+    render(<HuntressIntegration />);
+    await waitFor(() => expect(screen.getByText('Partner connection')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /Generate/i }));
+
+    // Copy-once notice appears; the secret input is revealed (type=text) and populated.
+    expect(screen.getByText(/Copy this webhook secret now/i)).toBeInTheDocument();
+    const secretInput = screen.getByPlaceholderText('Enter or generate a webhook secret') as HTMLInputElement;
+    expect(secretInput.value).toMatch(/^[0-9a-f]{64}$/);
+    const generated = secretInput.value;
+
+    await user.click(screen.getByRole('button', { name: /Update/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchWithAuthMock.mock.calls.some(([url, init]) => url === '/huntress/integration' && init?.method === 'POST')
+      ).toBe(true);
+    });
+    const postCall = fetchWithAuthMock.mock.calls.find(
+      ([url, init]) => url === '/huntress/integration' && init?.method === 'POST'
+    );
+    expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({ webhookSecret: generated });
   });
 });

--- a/apps/web/src/components/integrations/HuntressIntegration.test.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.test.tsx
@@ -304,6 +304,25 @@ describe('HuntressIntegration', () => {
     expect(screen.getByText(/inbound webhooks are rejected with 403/i)).toBeInTheDocument();
   });
 
+  it('does not surface the partner webhook URL or Generate button in organization scope', async () => {
+    // currentOrgId is set (org scope) by the default beforeEach. The webhook
+    // endpoint + secret are partner-level and must not leak into a customer-org
+    // context (guarded by isPartnerView).
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (url === '/huntress/integration') return makeResponse({ data: existingIntegration, mapped: true });
+      if (url === '/huntress/status') return makeResponse({ ...emptyStatus, mapped: true });
+      if (url === '/huntress/incidents?limit=5') return makeResponse({ data: [] });
+      return makeResponse({}, false, 404);
+    });
+
+    render(<HuntressIntegration />);
+
+    await waitFor(() => expect(screen.getByText('Sync status')).toBeInTheDocument());
+    expect(screen.queryByText('Inbound webhook (push from Huntress)')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Generate/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/huntress\/webhook\?integrationId=/)).not.toBeInTheDocument();
+  });
+
   it('generates a webhook secret, fills the input, and shows a copy-once notice that is submitted on save', async () => {
     const user = userEvent.setup();
     useOrgStore.setState({ currentOrgId: null });
@@ -331,5 +350,22 @@ describe('HuntressIntegration', () => {
       ([url, init]) => url === '/huntress/integration' && init?.method === 'POST'
     );
     expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({ webhookSecret: generated });
+  });
+
+  it('clears the copy-once notice when the user manually edits the generated secret', async () => {
+    const user = userEvent.setup();
+    useOrgStore.setState({ currentOrgId: null });
+    mockPartnerLoad({ integration: existingIntegration });
+
+    render(<HuntressIntegration />);
+    await waitFor(() => expect(screen.getByText('Partner connection')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /Generate/i }));
+    expect(screen.getByText(/Copy this webhook secret now/i)).toBeInTheDocument();
+
+    // Typing into the secret field means the user is supplying their own value;
+    // the "you just generated this, copy it now" banner no longer applies.
+    await user.type(screen.getByPlaceholderText('Enter or generate a webhook secret'), 'x');
+    expect(screen.queryByText(/Copy this webhook secret now/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/integrations/HuntressIntegration.tsx
+++ b/apps/web/src/components/integrations/HuntressIntegration.tsx
@@ -2,16 +2,19 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
+  Check,
   CheckCircle2,
+  Copy,
   Eye,
   EyeOff,
   Loader2,
   RefreshCw,
   Save,
   Shield,
-  Unplug
+  Unplug,
+  Webhook
 } from 'lucide-react';
-import { fetchWithAuth } from '../../stores/auth';
+import { fetchWithAuth, resolveApiOrigin } from '../../stores/auth';
 import { type Organization, useOrgStore } from '../../stores/orgStore';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 
@@ -147,6 +150,9 @@ export default function HuntressIntegration() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [showApiSecret, setShowApiSecret] = useState(false);
   const [showWebhookSecret, setShowWebhookSecret] = useState(false);
+  // Set when Breeze generates a webhook secret for the user: copy-once banner
+  // stays until the user saves (which clears webhookSecret) or dismisses it.
+  const [generatedSecretNotice, setGeneratedSecretNotice] = useState(false);
 
   const [saveState, setSaveState] = useState<SaveState>({ status: 'idle' });
   const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
@@ -163,6 +169,26 @@ export default function HuntressIntegration() {
     : null;
   const canSave = name.trim().length > 0 && (integration ? !hasCredentialInput || hasCompleteCredential : hasCompleteCredential);
   const unmappedCount = useMemo(() => huntressOrgs.filter((row) => !row.mappedOrgId).length, [huntressOrgs]);
+
+  // Region-correct inbound webhook endpoint to paste into Huntress. Built from
+  // the API origin (PUBLIC_API_URL, or the current page origin behind Caddy) and
+  // the per-integration id used by the receiver to resolve tenancy.
+  const webhookUrl = useMemo(() => {
+    if (!integration) return '';
+    const origin = resolveApiOrigin().replace(/\/$/, '');
+    if (!origin) return '';
+    return `${origin}/api/v1/huntress/webhook?integrationId=${encodeURIComponent(integration.id)}`;
+  }, [integration]);
+
+  const handleGenerateWebhookSecret = () => {
+    // 32 random bytes → 64 hex chars. Surfaced once for copy; saved encrypted.
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    const secret = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    setWebhookSecret(secret);
+    setShowWebhookSecret(true);
+    setGeneratedSecretNotice(true);
+  };
 
   const fetchIntegration = useCallback(async () => {
     const res = await fetchWithAuth('/huntress/integration');
@@ -264,6 +290,7 @@ export default function HuntressIntegration() {
       setApiKey('');
       setApiSecret('');
       setWebhookSecret('');
+      setGeneratedSecretNotice(false);
       await load();
     } catch (err) {
       setSaveState({ status: 'error', message: err instanceof Error ? err.message : 'Network error' });
@@ -419,15 +446,41 @@ export default function HuntressIntegration() {
               </p>
               {credentialPairError && <p className="mt-1 text-xs text-red-600">{credentialPairError}</p>}
             </div>
-            <SecretInput
-              label="Webhook Secret"
-              hint={integration?.hasWebhookSecret ? 'leave blank to keep existing' : 'optional'}
-              value={webhookSecret}
-              onChange={setWebhookSecret}
-              visible={showWebhookSecret}
-              onToggle={() => setShowWebhookSecret((value) => !value)}
-              placeholder={integration?.hasWebhookSecret ? '************' : 'Enter webhook secret'}
-            />
+            <div className="md:col-span-2">
+              <div className="flex items-end gap-2">
+                <div className="flex-1">
+                  <SecretInput
+                    label="Webhook Secret"
+                    hint={integration?.hasWebhookSecret ? 'leave blank to keep existing' : 'optional — used to verify inbound Huntress webhooks'}
+                    value={webhookSecret}
+                    onChange={(value) => {
+                      setWebhookSecret(value);
+                      if (generatedSecretNotice) setGeneratedSecretNotice(false);
+                    }}
+                    visible={showWebhookSecret}
+                    onToggle={() => setShowWebhookSecret((value) => !value)}
+                    placeholder={integration?.hasWebhookSecret ? '************' : 'Enter or generate a webhook secret'}
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={handleGenerateWebhookSecret}
+                  className="inline-flex h-10 shrink-0 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+                >
+                  <RefreshCw className="h-4 w-4" /> Generate
+                </button>
+              </div>
+              {generatedSecretNotice && (
+                <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+                  <p className="font-medium">Copy this webhook secret now, then click Update to save it.</p>
+                  <p className="mt-1">
+                    Paste the same value into Huntress&apos;s webhook configuration. After saving, Breeze stores it
+                    encrypted and never displays it again.
+                  </p>
+                  <CopyButton value={webhookSecret} label="Copy secret" className="mt-2" />
+                </div>
+              )}
+            </div>
           </div>
 
           <div className="mt-4 flex flex-wrap items-center gap-3">
@@ -457,6 +510,68 @@ export default function HuntressIntegration() {
             {syncState.message && (
               <span className={`text-sm ${syncState.status === 'error' ? 'text-red-600' : 'text-emerald-600'}`}>{syncState.message}</span>
             )}
+          </div>
+        </div>
+      )}
+
+      {isPartnerView && integration && (
+        <div className="rounded-xl border bg-card p-6 shadow-sm">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <Webhook className="h-4 w-4" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Inbound webhook (push from Huntress)</h2>
+              <p className="text-sm text-muted-foreground">
+                Paste this endpoint into Huntress so it can push events to Breeze in near-real-time, instead of
+                waiting for the next poll. Inbound webhooks require a webhook secret (above) for signature verification.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <label className="mb-1 block text-sm font-medium">Webhook URL</label>
+            {webhookUrl ? (
+              <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
+                <code className="flex-1 truncate font-mono text-xs" title={webhookUrl}>{webhookUrl}</code>
+                <CopyButton value={webhookUrl} label="Copy" className="shrink-0" />
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">Resolving webhook URL…</p>
+            )}
+            <p className="mt-1 text-xs text-muted-foreground">
+              The <code className="font-mono">integrationId</code> query parameter tells Breeze which partner the
+              events belong to. Keep it in the URL.
+            </p>
+          </div>
+
+          {!integration.hasWebhookSecret && (
+            <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                No webhook secret is set yet. Generate or enter a Webhook Secret above and click Update — inbound
+                webhooks are rejected with 403 until a secret is configured.
+              </span>
+            </div>
+          )}
+
+          <div className="mt-4 rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+            <p className="font-medium text-foreground">Signing scheme to configure on Huntress</p>
+            <ul className="mt-1 list-disc space-y-1 pl-4">
+              <li>
+                Header <code className="font-mono">x-huntress-signature</code>:{' '}
+                <code className="font-mono">sha256=HMAC-SHA256(&#123;timestamp&#125;.&#123;rawBody&#125;, secret)</code>
+              </li>
+              <li>
+                Header <code className="font-mono">x-huntress-timestamp</code>: Unix seconds, signed alongside the
+                body (requests older than 10 minutes are rejected).
+              </li>
+              <li>
+                Optional <code className="font-mono">x-huntress-account-id</code> /{' '}
+                <code className="font-mono">x-huntress-integration-id</code> headers are also accepted in place of
+                the query parameter.
+              </li>
+            </ul>
           </div>
         </div>
       )}
@@ -638,6 +753,32 @@ function SecretInput(props: {
         </button>
       </div>
     </div>
+  );
+}
+
+function CopyButton({ value, label = 'Copy', className }: { value: string; label?: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard blocked (insecure context / permissions); the value is still
+      // selectable in the adjacent field, so fail quietly rather than toast.
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      disabled={!value}
+      className={`inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 ${className ?? ''}`}
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? 'Copied' : label}
+    </button>
   );
 }
 

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -8,6 +8,7 @@ import {
   apiResetPassword,
   apiVerifyMFA,
   fetchWithAuth,
+  resolveApiOrigin,
   restoreAccessTokenFromCookie,
   useAuthStore,
   waitForPendingRefresh
@@ -548,5 +549,18 @@ describe('waitForPendingRefresh (#950)', () => {
 
     await expect(waitForPendingRefresh()).resolves.toBeUndefined();
     await inflight;
+  });
+});
+
+describe('resolveApiOrigin', () => {
+  // PUBLIC_API_URL is blank in the test/CI env (and in production behind Caddy),
+  // so this exercises exactly the production fallback path that makes the
+  // Huntress webhook URL region-correct (#1737): fall back to the page origin.
+  it('falls back to the current page origin when PUBLIC_API_URL is blank', () => {
+    const origin = resolveApiOrigin();
+    expect(origin).toBe(window.location.origin);
+    // Must be an absolute origin (scheme + host) with no path, so callers can
+    // safely append /api/v1/... without producing a scheme-less or doubled URL.
+    expect(origin).toMatch(/^https?:\/\/[^/]+$/);
   });
 });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -246,6 +246,21 @@ function buildApiUrl(path: string): string {
   return `${apiHost}/api/v1${cleanPath}`;
 }
 
+/**
+ * Resolve the absolute origin (scheme + host) that serves the API, for building
+ * user-facing copyable URLs (e.g. inbound webhook endpoints to paste into a
+ * third-party integration). Unlike `resolveApiHost`, this never returns an empty
+ * string: in production `PUBLIC_API_URL` is blank (relative paths behind Caddy),
+ * so it falls back to the current page origin, which is region-correct
+ * (us.2breeze.app / eu.2breeze.app). Returns '' only during SSR with no host.
+ */
+export function resolveApiOrigin(): string {
+  const apiHost = resolveApiHost();
+  if (apiHost) return apiHost;
+  if (typeof window !== 'undefined') return window.location.origin;
+  return '';
+}
+
 const REFRESH_LOCK_NAME = 'breeze-token-refresh';
 
 // One low-level /auth/refresh attempt. Returns the new tokens on success, or a


### PR DESCRIPTION
## Summary

Closes #1737.

The Huntress inbound-webhook receiver (`POST /api/v1/huntress/webhook`) already exists and verifies signatures, resolves tenancy by `integrationId`/`accountId`, and writes idempotently under system scope. The gap was purely in the GUI: the Huntress integration page let an admin **set** a webhook secret but never showed **the URL to paste into Huntress** or the per-integration `integrationId` needed in the query string. This PR surfaces that.

## What changed (web only — no backend/receiver changes)

- **Inbound webhook card** (partner scope, when an integration exists) in `HuntressIntegration.tsx`:
  - A read-only, **copyable webhook URL**, region-correct via the API origin + the integration `id`:
    `https://us.2breeze.app/api/v1/huntress/webhook?integrationId=<id>` (EU resolves to `eu.2breeze.app`).
  - **Signing-scheme docs** matching the receiver: `x-huntress-signature: sha256=HMAC-SHA256({timestamp}.{rawBody})`, `x-huntress-timestamp` (10-minute replay window), and the accepted `x-huntress-account-id` / `x-huntress-integration-id` header alternatives.
  - A **warning** when no webhook secret is configured (the receiver rejects inbound webhooks with 403 until one is set).
- **Generate webhook secret** affordance next to the existing Webhook Secret input: fills it with 32 random bytes (`crypto.getRandomValues`, 64 hex chars) and shows a **copy-once** notice. The value is saved through the **existing encrypted-at-rest POST path** — no new endpoint, and the secret is never logged.
- Exported `resolveApiOrigin()` from the auth store: returns an absolute origin (`PUBLIC_API_URL`, falling back to `window.location.origin` so it stays region-correct behind Caddy where `PUBLIC_API_URL` is blank).

The integration `id` was already present in the `GET /huntress/integration` response and the frontend `Integration` type, so no API change was required.

## Tenancy / security notes

- Webhook URL is only rendered in **partner scope** (where credentials/secrets are already managed); the integration is partner-level.
- The displayed URL contains only the integration `id` (already a client-known value), not the secret.
- The secret is generated client-side, shown once for copy, and persisted via the existing `encryptSecret` path — same storage as before. No secret is written to logs.

## Tests

`apps/web/src/components/integrations/HuntressIntegration.test.tsx` — added 3 cases (region-correct copyable URL with `integrationId`, the no-secret 403 warning, and generate → copy-once → submitted-on-save). Updated the `../../stores/auth` mock to include `resolveApiOrigin`.

- `vitest run HuntressIntegration.test.tsx` → 11 passed
- `vitest run IntegrationsPage.test.tsx` → 11 passed
- `vitest run stores/auth.test.ts` → 22 passed
- `tsc --noEmit` (apps/web) → clean

## Out of scope (tracked in the issue's open questions)

Confirming Huntress's real outbound-webhook spec/headers and the supplement-vs-replace relationship to the poll sync are left as follow-ups; this PR surfaces the affordance against the receiver's already-implemented scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)