### PR TITLE
feat(devices): add a sortable Device Reliability column (#1720)

### DIFF
--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -89,6 +89,7 @@ vi.mock('../db', () => ({
 vi.mock('../db/schema', () => ({
   devices: { id: 'id', orgId: 'orgId', siteId: 'siteId', status: 'status', hostname: 'hostname', displayName: 'displayName', osType: 'osType', lastSeenAt: 'lastSeenAt', createdAt: 'createdAt', updatedAt: 'updatedAt', tags: 'tags', agentVersion: 'agentVersion' },
   deviceHardware: { deviceId: 'deviceId' },
+  deviceReliability: { deviceId: 'deviceId', reliabilityScore: 'reliabilityScore', trendDirection: 'trendDirection' },
   deviceNetwork: { deviceId: 'deviceId' },
   deviceMetrics: { deviceId: 'deviceId', timestamp: 'timestamp' },
   deviceSoftware: { deviceId: 'deviceId' },
@@ -162,15 +163,21 @@ describe('device routes', () => {
             as: vi.fn(() => ({ deviceId: 'deviceId', latestTimestamp: 'latestTimestamp' }))
           }))
         })),
-        leftJoin: vi.fn(() => ({
-          where: vi.fn(() => Object.assign(Promise.resolve([]), {
-            orderBy: vi.fn(() => ({
-              limit: vi.fn(() => ({
-                offset: vi.fn(() => Promise.resolve([]))
+        // Two chained leftJoins (deviceHardware, then deviceReliability #1720):
+        // each leftJoin returns an object exposing both the next leftJoin and
+        // the terminal where(), so .leftJoin(...).leftJoin(...).where(...) works.
+        leftJoin: vi.fn(function leftJoinMock(): any {
+          return {
+            leftJoin: leftJoinMock,
+            where: vi.fn(() => Object.assign(Promise.resolve([]), {
+              orderBy: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  offset: vi.fn(() => Promise.resolve([]))
+                }))
               }))
             }))
-          }))
-        })),
+          };
+        }),
         innerJoin: vi.fn(() => ({
           where: vi.fn(() => Promise.resolve([]))
         }))
@@ -504,17 +511,22 @@ describe('device routes', () => {
             where: vi.fn().mockResolvedValue([{ count: 2 }])
           })
         } as any)
-        // 2nd: device list query
+        // 2nd: device list query — two chained leftJoins now (deviceHardware,
+        // then deviceReliability #1720), so the leftJoin mock returns itself
+        // before resolving to the terminal where().
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
-            leftJoin: vi.fn().mockReturnValue({
-              where: vi.fn().mockReturnValue({
-                orderBy: vi.fn().mockReturnValue({
-                  limit: vi.fn().mockReturnValue({
-                    offset: vi.fn().mockResolvedValue(deviceList)
+            leftJoin: vi.fn(function leftJoinMock(): any {
+              return {
+                leftJoin: leftJoinMock,
+                where: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockReturnValue({
+                      offset: vi.fn().mockResolvedValue(deviceList)
+                    })
                   })
                 })
-              })
+              };
             })
           })
         } as any);

--- a/apps/api/src/routes/devices/core.list-response-shape.test.ts
+++ b/apps/api/src/routes/devices/core.list-response-shape.test.ts
@@ -90,7 +90,12 @@ function rigDeviceListRows(rows: unknown[]) {
   const limit = vi.fn().mockReturnValue({ offset });
   const orderBy = vi.fn().mockReturnValue({ limit });
   const where = vi.fn().mockReturnValue({ orderBy });
-  const leftJoin = vi.fn().mockReturnValue({ where });
+  // Two chained leftJoins (deviceHardware, then deviceReliability #1720), so
+  // each leftJoin returns a thenable that also exposes the next leftJoin.
+  const chain: Record<string, unknown> = {};
+  const leftJoin = vi.fn().mockReturnValue(chain);
+  chain.leftJoin = leftJoin;
+  chain.where = where;
   const from = vi.fn().mockReturnValue({ leftJoin });
   vi.mocked(db.select).mockReturnValue({ from } as never);
   vi.mocked(db.execute).mockResolvedValue([] as never);
@@ -141,6 +146,8 @@ describe('GET /devices — response shape', () => {
         cpuCores: null,
         ramTotalMb: null,
         diskTotalGb: null,
+        reliabilityScore: 42,
+        reliabilityTrend: 'degrading',
       },
     ]);
 
@@ -160,6 +167,9 @@ describe('GET /devices — response shape', () => {
     expect(row).toHaveProperty('watchdogVersion', 'v0.67.1');
     // #1273 regression — pendingReboot must survive the mapper for the list badge.
     expect(row).toHaveProperty('pendingReboot', true);
+    // #1720 — reliability score + trend surfaced for the list column.
+    expect(row).toHaveProperty('reliabilityScore', 42);
+    expect(row).toHaveProperty('reliabilityTrend', 'degrading');
   });
 
   it('returns null watchdogStatus / mainAgentSilentSince for healthy rows (still present in shape)', async () => {
@@ -197,6 +207,8 @@ describe('GET /devices — response shape', () => {
         cpuCores: null,
         ramTotalMb: null,
         diskTotalGb: null,
+        reliabilityScore: null,
+        reliabilityTrend: null,
       },
     ]);
 
@@ -208,6 +220,13 @@ describe('GET /devices — response shape', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     const row = body.data[0];
+
+    // #1720 — reliability keys present even with no computed score (null),
+    // so the UI distinguishes "no score yet" (dash) from "field absent".
+    expect(Object.prototype.hasOwnProperty.call(row, 'reliabilityScore')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(row, 'reliabilityTrend')).toBe(true);
+    expect(row.reliabilityScore).toBeNull();
+    expect(row.reliabilityTrend).toBeNull();
 
     // Keys must exist on the shape even when null — UI distinguishes
     // "field absent" (older API) from "field present, value null"

--- a/apps/api/src/routes/devices/core.permissions.test.ts
+++ b/apps/api/src/routes/devices/core.permissions.test.ts
@@ -208,7 +208,11 @@ function rigDeviceListRows(rows: unknown[]) {
   const limit = vi.fn().mockReturnValue({ offset });
   const orderBy = vi.fn().mockReturnValue({ limit });
   const where = vi.fn().mockReturnValue({ orderBy });
-  const leftJoin = vi.fn().mockReturnValue({ where });
+  // Two chained leftJoins (deviceHardware, then deviceReliability #1720), so
+  // each leftJoin returns a node exposing both the next leftJoin and where().
+  const chain: Record<string, unknown> = { where };
+  const leftJoin = vi.fn().mockReturnValue(chain);
+  chain.leftJoin = leftJoin;
   const from = vi.fn().mockReturnValue({ leftJoin });
   vi.mocked(db.select).mockReturnValue({ from } as never);
   vi.mocked(db.execute).mockResolvedValue([] as never);

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -6,6 +6,7 @@ import { createHash, randomBytes } from 'crypto';
 import {
   devices,
   deviceHardware,
+  deviceReliability,
   deviceNetwork,
   deviceMetrics,
   deviceGroupMemberships,
@@ -539,10 +540,16 @@ coreRoutes.get(
         cpuModel: deviceHardware.cpuModel,
         cpuCores: deviceHardware.cpuCores,
         ramTotalMb: deviceHardware.ramTotalMb,
-        diskTotalGb: deviceHardware.diskTotalGb
+        diskTotalGb: deviceHardware.diskTotalGb,
+        // Reliability headline score (#1720) — surfaced as a sortable list
+        // column. device_reliability is org-scoped (RLS shape #1), so the
+        // leftJoin stays tenant-safe; null when no score computed yet.
+        reliabilityScore: deviceReliability.reliabilityScore,
+        reliabilityTrend: deviceReliability.trendDirection
       })
       .from(devices)
       .leftJoin(deviceHardware, eq(devices.id, deviceHardware.deviceId))
+      .leftJoin(deviceReliability, eq(devices.id, deviceReliability.deviceId))
       .where(whereCondition)
       .orderBy(...orderBy)
       .limit(fetchLimit)
@@ -653,6 +660,10 @@ coreRoutes.get(
           ramTotalMb: d.ramTotalMb,
           diskTotalGb: d.diskTotalGb
         },
+        // Reliability column (#1720): null when the device has no computed
+        // score yet (no device_reliability row) — the list renders a dash.
+        reliabilityScore: d.reliabilityScore ?? null,
+        reliabilityTrend: d.reliabilityTrend ?? null,
         metrics: latestMetrics
           ? {
             cpuPercent: latestMetrics.cpuPercent,

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -467,6 +467,53 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     clickHeader('Sort by pending reboot');
     expect(rowOrder(container)).toEqual(['host-needs-reboot', 'host-clean', 'host-old-agent']);
   });
+
+  it('renders the reliability score as an opt-in badge column; devices with no score show a dash (#1720)', () => {
+    seedColumns('reliability');
+    const devices: Device[] = [
+      { ...baseDevice, id: 'c3c3c3c3-0000-0000-0000-000000000001', hostname: 'host-scored', reliabilityScore: 73 },
+      { ...baseDevice, id: 'c3c3c3c3-0000-0000-0000-000000000002', hostname: 'host-unscored', reliabilityScore: null },
+    ];
+
+    render(<DeviceList devices={devices} />);
+
+    const scored = screen.getByTestId('device-c3c3c3c3-0000-0000-0000-000000000001-reliability');
+    expect(scored.textContent).toContain('73');
+    const unscored = screen.getByTestId('device-c3c3c3c3-0000-0000-0000-000000000002-reliability');
+    // Em-dash dash cell for the missing score.
+    expect(unscored.textContent).toContain('—');
+    expect(unscored.textContent).not.toContain('0');
+  });
+
+  it('sorts reliability numerically with unscored devices last in both directions (#1720)', () => {
+    seedColumns('reliability');
+    const devices: Device[] = [
+      { ...baseDevice, id: 'c4c4c4c4-0000-0000-0000-000000000001', hostname: 'host-high', reliabilityScore: 95 },
+      { ...baseDevice, id: 'c4c4c4c4-0000-0000-0000-000000000002', hostname: 'host-low', reliabilityScore: 40 },
+      { ...baseDevice, id: 'c4c4c4c4-0000-0000-0000-000000000003', hostname: 'host-unscored', reliabilityScore: null },
+    ];
+
+    const { container } = render(<DeviceList devices={devices} />);
+
+    clickHeader('Sort by reliability score');
+    expect(rowOrder(container)).toEqual(['host-low', 'host-high', 'host-unscored']);
+
+    clickHeader('Sort by reliability score');
+    expect(rowOrder(container)).toEqual(['host-high', 'host-low', 'host-unscored']);
+  });
+
+  it('shows the trend glyph alongside the score when a trend is present (#1720)', () => {
+    seedColumns('reliability');
+    const devices: Device[] = [
+      { ...baseDevice, id: 'c5c5c5c5-0000-0000-0000-000000000001', hostname: 'host-degrading', reliabilityScore: 60, reliabilityTrend: 'degrading' },
+    ];
+
+    render(<DeviceList devices={devices} />);
+
+    const cell = screen.getByTestId('device-c5c5c5c5-0000-0000-0000-000000000001-reliability');
+    expect(cell.textContent).toContain('60');
+    expect(screen.getByLabelText('Degrading')).toBeInTheDocument();
+  });
 });
 
 describe('DeviceList — pending reboot badge', () => {

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -480,9 +480,55 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     const scored = screen.getByTestId('device-c3c3c3c3-0000-0000-0000-000000000001-reliability');
     expect(scored.textContent).toContain('73');
     const unscored = screen.getByTestId('device-c3c3c3c3-0000-0000-0000-000000000002-reliability');
-    // Em-dash dash cell for the missing score.
-    expect(unscored.textContent).toContain('—');
-    expect(unscored.textContent).not.toContain('0');
+    // Em-dash dash cell for the missing score — asserted exactly so a future
+    // `score ?? 0` regression (which would render a bare "0") fails here.
+    expect(unscored.textContent).toBe('—');
+  });
+
+  it('does not render a trend glyph for a scored device with no trend (#1720)', () => {
+    seedColumns('reliability');
+    const device: Device = {
+      ...baseDevice,
+      id: 'c6c6c6c6-0000-0000-0000-000000000001',
+      hostname: 'host-notrend',
+      reliabilityScore: 80,
+      // reliabilityTrend intentionally absent.
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    const cell = screen.getByTestId('device-c6c6c6c6-0000-0000-0000-000000000001-reliability');
+    expect(cell.textContent).toBe('80');
+    expect(screen.queryByLabelText('Improving')).toBeNull();
+    expect(screen.queryByLabelText('Stable')).toBeNull();
+    expect(screen.queryByLabelText('Degrading')).toBeNull();
+  });
+
+  // Pins the band-color ladder to DeviceReliabilityPanel.tsx scoreClass
+  // (≤50 destructive / ≤70 warning / ≤85 info / else success). The boundary
+  // values (50/51, 70/71, 85/86) are the ones a threshold typo would flip.
+  it.each([
+    [50, 'text-destructive'],
+    [51, 'text-warning'],
+    [70, 'text-warning'],
+    [71, 'text-info'],
+    [85, 'text-info'],
+    [86, 'text-success'],
+  ])('renders the %i reliability score in the %s band', (score, expectedClass) => {
+    seedColumns('reliability');
+    const device: Device = {
+      ...baseDevice,
+      id: 'c7c7c7c7-0000-0000-0000-000000000001',
+      hostname: 'host-band',
+      reliabilityScore: score,
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    const badge = screen
+      .getByTestId('device-c7c7c7c7-0000-0000-0000-000000000001-reliability')
+      .querySelector('span');
+    expect(badge?.className).toContain(expectedClass);
   });
 
   it('sorts reliability numerically with unscored devices last in both directions (#1720)', () => {
@@ -502,17 +548,26 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
     expect(rowOrder(container)).toEqual(['host-high', 'host-low', 'host-unscored']);
   });
 
-  it('shows the trend glyph alongside the score when a trend is present (#1720)', () => {
+  it.each([
+    ['improving', 'Improving', '↑'],
+    ['stable', 'Stable', '→'],
+    ['degrading', 'Degrading', '↓'],
+  ] as const)('shows the %s trend glyph alongside the score (#1720)', (trend, label, glyph) => {
     seedColumns('reliability');
-    const devices: Device[] = [
-      { ...baseDevice, id: 'c5c5c5c5-0000-0000-0000-000000000001', hostname: 'host-degrading', reliabilityScore: 60, reliabilityTrend: 'degrading' },
-    ];
+    const device: Device = {
+      ...baseDevice,
+      id: 'c5c5c5c5-0000-0000-0000-000000000001',
+      hostname: 'host-trend',
+      reliabilityScore: 60,
+      reliabilityTrend: trend,
+    };
 
-    render(<DeviceList devices={devices} />);
+    render(<DeviceList devices={[device]} />);
 
     const cell = screen.getByTestId('device-c5c5c5c5-0000-0000-0000-000000000001-reliability');
     expect(cell.textContent).toContain('60');
-    expect(screen.getByLabelText('Degrading')).toBeInTheDocument();
+    expect(cell.textContent).toContain(glyph);
+    expect(screen.getByLabelText(label)).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -106,6 +106,15 @@ export type Device = {
     ramTotalMb?: number;
     diskTotalGb?: number;
   };
+  /**
+   * Headline device reliability score (0-100) from the existing
+   * device_reliability subsystem (#1720). Null/undefined when no score has
+   * been computed yet (newly enrolled, or before the reliability worker runs)
+   * — the Reliability column renders a dash and sorts those rows last.
+   */
+  reliabilityScore?: number | null;
+  /** Reliability trend from the same subsystem; drives the small arrow indicator. */
+  reliabilityTrend?: 'improving' | 'stable' | 'degrading' | null;
 };
 
 // Columns that only make sense for the network arm (#1322); hidden unless
@@ -262,6 +271,9 @@ const sortValue: Record<ColumnId, (d: Device) => string | number | null> = {
   uptime: d => (d.status === 'online' && d.uptimeSeconds != null ? d.uptimeSeconds : null),
   enrolled: d => (d.enrolledAt ? new Date(d.enrolledAt).getTime() || null : null),
   desktopAccess: d => d.desktopAccess?.mode || null,
+  // No computed score yet (newly enrolled / pre-worker, or a network device)
+  // sorts as a blank-last null to match the dash the cell renders (#1284).
+  reliability: d => (typeof d.reliabilityScore === 'number' ? d.reliabilityScore : null),
 };
 
 export default function DeviceList({
@@ -603,6 +615,22 @@ export default function DeviceList({
     return version ? version : 'N/A';
   };
 
+  // Reliability score band → badge classes. Thresholds mirror
+  // DeviceReliabilityPanel.tsx (scoreClass): ≤50 critical, ≤70 warning,
+  // ≤85 info, else healthy — keep the two in sync so the list badge and the
+  // drill-down panel tell the same story (#1720).
+  const reliabilityBandClass = (score: number): string => {
+    if (score <= 50) return 'bg-destructive/15 text-destructive border-destructive/30';
+    if (score <= 70) return 'bg-warning/15 text-warning border-warning/30';
+    if (score <= 85) return 'bg-info/15 text-info border-info/30';
+    return 'bg-success/15 text-success border-success/30';
+  };
+  const reliabilityTrendGlyph: Record<NonNullable<Device['reliabilityTrend']>, { glyph: string; label: string }> = {
+    improving: { glyph: '↑', label: 'Improving' },
+    stable: { glyph: '→', label: 'Stable' },
+    degrading: { glyph: '↓', label: 'Degrading' },
+  };
+
   // columnDefs is the single source of truth for each toggleable column's
   // header and per-row cell. The thead and tbody iterate `renderedColumns`
   // and pick from this table, so adding a new column means adding one
@@ -925,6 +953,38 @@ export default function DeviceList({
           <td key="desktopAccess" className="px-3 py-3 text-sm text-muted-foreground">
             <span className="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium" title={`mode=${da.mode}; loginUi=${da.loginUiReachable}; virtualDisplay=${da.virtualDisplayReady}`}>
               {da.mode}
+            </span>
+          </td>
+        );
+      },
+    },
+    reliability: {
+      header: () => sortHeader('reliability', 'Reliability', 'Sort by reliability score', true),
+      cell: (device) => {
+        const score = device.reliabilityScore;
+        if (typeof score !== 'number') {
+          // No score computed yet (newly enrolled, pre-worker) or a network
+          // device — render a dash; sortValue maps these to null so they sort
+          // last in both directions (#1284 dash convention).
+          return (
+            <td key="reliability" className="px-3 py-3 text-right text-sm tabular-nums" data-testid={`device-${device.id}-reliability`}>
+              {dash}
+            </td>
+          );
+        }
+        const trend = device.reliabilityTrend ? reliabilityTrendGlyph[device.reliabilityTrend] : null;
+        return (
+          <td key="reliability" className="px-3 py-3 text-right text-sm" data-testid={`device-${device.id}-reliability`}>
+            <span
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium tabular-nums ${reliabilityBandClass(score)}`}
+              title={trend ? `Reliability ${score}/100 · ${trend.label}` : `Reliability ${score}/100`}
+            >
+              {score}
+              {trend && (
+                <span aria-label={trend.label} className="opacity-80">
+                  {trend.glyph}
+                </span>
+              )}
             </span>
           </td>
         );

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -273,9 +273,16 @@ export default function DevicesPage() {
           } : undefined,
           // Reliability column (#1720): score is null until the reliability
           // worker has computed one for the device; the column renders a dash
-          // and sorts those rows last.
+          // and sorts those rows last. Trend is validated against the known
+          // enum rather than blind-cast, so an unexpected API value falls back
+          // to null (no glyph) instead of leaking through the type.
           reliabilityScore: typeof d.reliabilityScore === 'number' ? d.reliabilityScore : null,
-          reliabilityTrend: (d.reliabilityTrend ?? null) as Device['reliabilityTrend'],
+          reliabilityTrend:
+            d.reliabilityTrend === 'improving' ||
+            d.reliabilityTrend === 'stable' ||
+            d.reliabilityTrend === 'degrading'
+              ? d.reliabilityTrend
+              : null,
         };
       });
 

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -271,6 +271,11 @@ export default function DevicesPage() {
             ramTotalMb: typeof hardware.ramTotalMb === 'number' ? hardware.ramTotalMb : undefined,
             diskTotalGb: typeof hardware.diskTotalGb === 'number' ? hardware.diskTotalGb : undefined,
           } : undefined,
+          // Reliability column (#1720): score is null until the reliability
+          // worker has computed one for the device; the column renders a dash
+          // and sorts those rows last.
+          reliabilityScore: typeof d.reliabilityScore === 'number' ? d.reliabilityScore : null,
+          reliabilityTrend: (d.reliabilityTrend ?? null) as Device['reliabilityTrend'],
         };
       });
 

--- a/apps/web/src/components/devices/columnVisibility.ts
+++ b/apps/web/src/components/devices/columnVisibility.ts
@@ -34,6 +34,7 @@ export const COLUMN_IDS = [
   'uptime',
   'enrolled',
   'desktopAccess',
+  'reliability',
 ] as const;
 
 export type ColumnId = (typeof COLUMN_IDS)[number];
@@ -66,6 +67,7 @@ export const COLUMN_LABELS: Record<ColumnId, string> = {
   uptime: 'Uptime',
   enrolled: 'Enrolled',
   desktopAccess: 'Desktop Access',
+  reliability: 'Reliability',
 };
 
 export const DEFAULT_VISIBLE_COLUMNS: ReadonlyArray<ColumnId> = [


### PR DESCRIPTION
## Summary

Adds a **Reliability** column to the Devices list/table view, surfacing each device's existing `device_reliability.reliability_score` (0-100) directly in the fleet table so MSP techs can see and sort by reliability without drilling into a device.

This is a **display-only** change — it reuses the score the existing reliability subsystem already computes. No new metric, no change to scoring. (Coordinated with in-flight #1746/#1738, which touches `reliabilityScoring.ts`; this PR does not touch that file.)

## Changes

**API — `apps/api/src/routes/devices/core.ts`**
- `leftJoin device_reliability` on the `GET /devices` list query; map `reliabilityScore` + `reliabilityTrend` (trend_direction) into each response row. `device_reliability` is org-scoped (RLS shape #1, direct `org_id`), so the join is tenant-safe. Score is `null` when no row exists yet.

**Web — `apps/web/src/components/devices/`**
- `columnVisibility.ts`: register `'reliability'` in `COLUMN_IDS` + `COLUMN_LABELS`. **Off-by-default** in the column picker — newly enrolled devices have no computed score yet, so default-on would show a column of dashes (same rationale as the `'type'` column).
- `DeviceList.tsx`: `Device.reliabilityScore`/`reliabilityTrend` fields, a `sortValue` accessor (unscored → `null` → dash + sort-last, per the #1284 convention), and a `columnDefs` entry rendering a colored band badge (thresholds mirror `DeviceReliabilityPanel`: ≤50 critical, ≤70 warning, ≤85 info, else healthy) with a trend arrow.
- `DevicesPage.tsx`: map the new API fields into the `Device` shape.

## Acceptance criteria

- [x] A **Reliability** column appears in the Devices view, controllable via the column show/hide picker.
- [x] Displays the `reliability_score` as a colored band badge (+ trend arrow when present).
- [x] Sortable via the table's existing mechanism; unscored devices sort last and render a dash.
- [x] The devices list API returns the score per device, sourced from the existing `device_reliability` table (no new computation).
- [x] Tenant isolation preserved (org-scoped RLS on the new join).

## Tests

- API `core.list-response-shape.test.ts`: asserts `reliabilityScore`+`reliabilityTrend` survive the response mapper, and are present-as-`null` for unscored rows.
- Web `DeviceList.test.tsx`: render (score badge + dash for unscored), numeric sort with unscored-last in both directions, and the trend glyph.
- `tsc --noEmit` clean for both apps.

Closes #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)