### PR TITLE
fix(patches): reconcile orphaned scheduled patch_jobs never enqueued to executor (#1733)

### DIFF
--- a/apps/api/src/__tests__/integration/patchJobReconcileWindow.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchJobReconcileWindow.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * `selectStaleScheduledJobIds` window semantics, against a real DB (#1733).
+ *
+ * The orphan-recovery sweep keys its [maxAge, minAge) window off
+ * COALESCE(scheduledAt, createdAt) — the job's intended run time, NOT createdAt.
+ * That distinction is the whole safety design:
+ *   - the 2-minute grace window (minAge) keeps the sweep from racing a fresh
+ *     enqueue (re-enqueuing a job whose Redis job is still mid-creation), and
+ *   - the 45-day bound (maxAge) keeps it from firing a long-stale window, and
+ *   - keying on scheduledAt (not createdAt) keeps a future-scheduled POST-route
+ *     job (created now, due in the future) from being treated as "stale" 2
+ *     minutes after creation — which would otherwise fire it up to 45 days
+ *     early.
+ *
+ * A Drizzle mock returns whatever rows we fabricate and never runs the WHERE,
+ * so this must be exercised against a real DB to actually verify the predicate.
+ * The function reads cross-tenant patch_jobs through the breeze_app pool, so it
+ * runs under withSystemDbAccessContext exactly as the scheduler invokes it.
+ *
+ * Prerequisites (from apps/api):
+ *   pnpm test:docker:up
+ * Run (from apps/api):
+ *   pnpm test:integration -- src/__tests__/integration/patchJobReconcileWindow.integration.test.ts
+ */
+import './setup';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTestDb } from './setup';
+import { setupTestEnvironment } from './db-utils';
+import { patchJobs } from '../../db/schema';
+import { withSystemDbAccessContext } from '../../db';
+import { selectStaleScheduledJobIds } from '../../jobs/patchJobExecutor';
+
+const NOW = new Date('2026-06-21T12:00:00.000Z');
+const MIN_AGE_MS = 2 * 60 * 1000; // RECONCILE_MIN_AGE_MS
+const MAX_AGE_MS = 45 * 24 * 60 * 60 * 1000; // RECONCILE_MAX_AGE_MS
+
+let jobSeq = 0;
+async function seedJob(
+  orgId: string,
+  status: 'scheduled' | 'running' | 'completed',
+  scheduledAt: Date | null,
+  createdAt: Date
+): Promise<string> {
+  jobSeq++;
+  const tdb = getTestDb();
+  const [row] = await tdb
+    .insert(patchJobs)
+    .values({
+      orgId,
+      name: `reconcile-window-${jobSeq}`,
+      status,
+      scheduledAt,
+      createdAt,
+      devicesTotal: 1,
+      devicesPending: 1,
+    })
+    .returning({ id: patchJobs.id });
+  if (!row) throw new Error('seedJob: no row returned');
+  return row.id;
+}
+
+describe('selectStaleScheduledJobIds window (#1733)', () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    orgId = env.organization.id;
+  });
+
+  it('selects only scheduled rows whose run time is in [maxAge, minAge)', async () => {
+    // Inside the grace window (run time 1 min ago) — excluded (likely mid-enqueue).
+    const tooFresh = await seedJob(orgId, 'scheduled', new Date(NOW.getTime() - 60 * 1000), NOW);
+    // Comfortably stale (run time 10 min ago) — included.
+    const stale = await seedJob(
+      orgId,
+      'scheduled',
+      new Date(NOW.getTime() - 10 * 60 * 1000),
+      new Date(NOW.getTime() - 10 * 60 * 1000)
+    );
+    // Older than the max-age bound (run time 46 days ago) — excluded.
+    const tooOld = await seedJob(
+      orgId,
+      'scheduled',
+      new Date(NOW.getTime() - MAX_AGE_MS - 24 * 60 * 60 * 1000),
+      new Date(NOW.getTime() - MAX_AGE_MS - 24 * 60 * 60 * 1000)
+    );
+    // Stale run time but NOT scheduled status — excluded.
+    const running = await seedJob(
+      orgId,
+      'running',
+      new Date(NOW.getTime() - 10 * 60 * 1000),
+      new Date(NOW.getTime() - 10 * 60 * 1000)
+    );
+
+    const result = await withSystemDbAccessContext(() => selectStaleScheduledJobIds(NOW));
+    const ids = result.map((r) => r.id);
+
+    expect(ids).toContain(stale);
+    expect(ids).not.toContain(tooFresh);
+    expect(ids).not.toContain(tooOld);
+    expect(ids).not.toContain(running);
+  });
+
+  it('keys the window off scheduledAt, not createdAt — a future-scheduled fresh job is excluded', async () => {
+    // POST-route shape: created now, scheduled 1h in the future. createdAt is
+    // well past the 2-min grace, but the run time has NOT arrived, so the sweep
+    // must NOT pick it up (otherwise it would fire ~1h early).
+    const futureScheduled = await seedJob(
+      orgId,
+      'scheduled',
+      new Date(NOW.getTime() + 60 * 60 * 1000),
+      new Date(NOW.getTime() - 10 * 60 * 1000)
+    );
+
+    const result = await withSystemDbAccessContext(() => selectStaleScheduledJobIds(NOW));
+    const ids = result.map((r) => r.id);
+
+    expect(ids).not.toContain(futureScheduled);
+  });
+
+  it('falls back to createdAt when scheduledAt is null (legacy rows stay recoverable)', async () => {
+    // No scheduledAt; createdAt is 10 min ago → COALESCE makes it stale-eligible.
+    const nullScheduled = await seedJob(
+      orgId,
+      'scheduled',
+      null,
+      new Date(NOW.getTime() - 10 * 60 * 1000)
+    );
+
+    const result = await withSystemDbAccessContext(() => selectStaleScheduledJobIds(NOW));
+    const match = result.find((r) => r.id === nullScheduled);
+
+    expect(match).toBeDefined();
+    expect(match?.scheduledAt).toBeNull();
+  });
+
+  it('returns scheduledAt alongside id so the caller can preserve the delay', async () => {
+    const sched = new Date(NOW.getTime() - 5 * 60 * 1000);
+    const id = await seedJob(orgId, 'scheduled', sched, sched);
+
+    const result = await withSystemDbAccessContext(() => selectStaleScheduledJobIds(NOW));
+    const match = result.find((r) => r.id === id);
+
+    expect(match?.scheduledAt?.getTime()).toBe(sched.getTime());
+    // sanity: minAge boundary constant referenced so the intent is documented
+    expect(MIN_AGE_MS).toBe(120000);
+  });
+});

--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -796,29 +796,40 @@ describe('orphaned scheduled-job reconcile (#1733)', () => {
     shared.addMock.mockResolvedValue({ id: 'queue-job-1' });
   });
 
-  it('selectStaleScheduledJobIds returns ids of scheduled rows past the grace window', async () => {
+  it('selectStaleScheduledJobIds returns id + scheduledAt of stale scheduled rows', async () => {
+    const sched = new Date('2026-06-21T08:00:00Z');
     vi.mocked(db.select).mockImplementationOnce(
-      () => createWhereSelectChain([{ id: 'job-a' }, { id: 'job-b' }]) as any,
+      () => createWhereSelectChain([
+        { id: 'job-a', scheduledAt: sched },
+        { id: 'job-b', scheduledAt: null },
+      ]) as any,
     );
 
-    const ids = await selectStaleScheduledJobIds(new Date('2026-06-21T09:00:00Z'));
+    const jobs = await selectStaleScheduledJobIds(new Date('2026-06-21T09:00:00Z'));
 
-    expect(ids).toEqual(['job-a', 'job-b']);
+    expect(jobs).toEqual([
+      { id: 'job-a', scheduledAt: sched },
+      { id: 'job-b', scheduledAt: null },
+    ]);
     expect(db.select).toHaveBeenCalledTimes(1);
   });
 
-  it('filterOrphanedJobIds keeps only ids with no active queue job', async () => {
+  it('filterOrphanedJobIds keeps only jobs with no active queue job (carrying scheduledAt)', async () => {
     // job-a has an active (waiting) queue job → already enqueued, drop it.
-    // job-b has no queue job → orphaned, keep it.
+    // job-b has no queue job → orphaned, keep it (with its scheduledAt).
     shared.getJobMock.mockImplementation(async (id: string) =>
       id === 'patch-job-job-a'
         ? { id, getState: vi.fn().mockResolvedValue('waiting'), remove: vi.fn() }
         : null,
     );
 
-    const orphaned = await filterOrphanedJobIds(['job-a', 'job-b']);
+    const sched = new Date('2026-06-21T08:00:00Z');
+    const orphaned = await filterOrphanedJobIds([
+      { id: 'job-a', scheduledAt: null },
+      { id: 'job-b', scheduledAt: sched },
+    ]);
 
-    expect(orphaned).toEqual(['job-b']);
+    expect(orphaned).toEqual([{ id: 'job-b', scheduledAt: sched }]);
   });
 
   it('filterOrphanedJobIds treats a completed queue job as not active (orphan recoverable)', async () => {
@@ -831,9 +842,9 @@ describe('orphaned scheduled-job reconcile (#1733)', () => {
       remove: removeMock,
     });
 
-    const orphaned = await filterOrphanedJobIds(['job-c']);
+    const orphaned = await filterOrphanedJobIds([{ id: 'job-c', scheduledAt: null }]);
 
-    expect(orphaned).toEqual(['job-c']);
+    expect(orphaned).toEqual([{ id: 'job-c', scheduledAt: null }]);
     expect(removeMock).toHaveBeenCalled();
   });
 

--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -44,6 +44,8 @@ vi.mock('../db/schema', () => ({
     targets: 'patchJobs.targets',
     devicesFailed: 'patchJobs.devicesFailed',
     devicesPending: 'patchJobs.devicesPending',
+    scheduledAt: 'patchJobs.scheduledAt',
+    createdAt: 'patchJobs.createdAt',
   },
   patchJobResults: {},
   patches: {
@@ -93,6 +95,8 @@ import {
   createPatchJobDeviceWorker,
   createPatchJobWorker,
   enqueuePatchJob,
+  selectStaleScheduledJobIds,
+  filterOrphanedJobIds,
 } from './patchJobExecutor';
 import { resolveApprovedPatchesForDevice } from '../services/patchApprovalEvaluator';
 import { queueCommandForExecution } from '../services/commandQueue';
@@ -110,6 +114,15 @@ function createUpdateChain(returnedRows: any[] = []) {
   chain.set = vi.fn(() => chain);
   chain.where = vi.fn(() => chain);
   chain.returning = vi.fn(() => Promise.resolve(returnedRows));
+  return chain;
+}
+
+// Select chain whose terminal .where() resolves to the rows (no .limit()) —
+// matches selectStaleScheduledJobIds' query shape.
+function createWhereSelectChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
   return chain;
 }
 
@@ -773,5 +786,60 @@ describe('patch job executor queueing', () => {
     );
     expect(captureException).toHaveBeenCalledWith(expect.any(Error));
     warnSpy.mockRestore();
+  });
+});
+
+describe('orphaned scheduled-job reconcile (#1733)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shared.getJobMock.mockResolvedValue(null);
+    shared.addMock.mockResolvedValue({ id: 'queue-job-1' });
+  });
+
+  it('selectStaleScheduledJobIds returns ids of scheduled rows past the grace window', async () => {
+    vi.mocked(db.select).mockImplementationOnce(
+      () => createWhereSelectChain([{ id: 'job-a' }, { id: 'job-b' }]) as any,
+    );
+
+    const ids = await selectStaleScheduledJobIds(new Date('2026-06-21T09:00:00Z'));
+
+    expect(ids).toEqual(['job-a', 'job-b']);
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('filterOrphanedJobIds keeps only ids with no active queue job', async () => {
+    // job-a has an active (waiting) queue job → already enqueued, drop it.
+    // job-b has no queue job → orphaned, keep it.
+    shared.getJobMock.mockImplementation(async (id: string) =>
+      id === 'patch-job-job-a'
+        ? { id, getState: vi.fn().mockResolvedValue('waiting'), remove: vi.fn() }
+        : null,
+    );
+
+    const orphaned = await filterOrphanedJobIds(['job-a', 'job-b']);
+
+    expect(orphaned).toEqual(['job-b']);
+  });
+
+  it('filterOrphanedJobIds treats a completed queue job as not active (orphan recoverable)', async () => {
+    // A stable jobId left over as completed must NOT block recovery — the row is
+    // still status='scheduled', so the run never actually executed.
+    const removeMock = vi.fn().mockResolvedValue(undefined);
+    shared.getJobMock.mockResolvedValue({
+      id: 'patch-job-job-c',
+      getState: vi.fn().mockResolvedValue('completed'),
+      remove: removeMock,
+    });
+
+    const orphaned = await filterOrphanedJobIds(['job-c']);
+
+    expect(orphaned).toEqual(['job-c']);
+    expect(removeMock).toHaveBeenCalled();
+  });
+
+  it('filterOrphanedJobIds short-circuits on an empty list', async () => {
+    const orphaned = await filterOrphanedJobIds([]);
+    expect(orphaned).toEqual([]);
+    expect(shared.getJobMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -18,7 +18,7 @@ import {
   devices,
   deviceCommands,
 } from '../db/schema';
-import { eq, and, sql, inArray, lt } from 'drizzle-orm';
+import { eq, and, sql, inArray } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import {
@@ -172,21 +172,28 @@ export async function enqueuePatchJob(patchJobId: string, delayMs?: number): Pro
 // Orphan reconcile sweep (#1733)
 // ============================================
 
-// Grace period after a job's scheduledAt before the reconcile sweep will
-// re-enqueue it. The scheduler enqueues the Redis job immediately after the DB
-// commit, so a row that is only seconds old is almost certainly mid-enqueue (or
-// its execute-patch-job worker is about to claim it). Waiting a couple of
-// minutes avoids racing the happy path and only acts on jobs that genuinely
-// missed their enqueue (process restart / Redis-connection churn in the
-// create->enqueue gap — the #1733 failure window).
+// Grace period after a job's intended run time (scheduledAt) before the
+// reconcile sweep will re-enqueue it. The scheduler enqueues the Redis job
+// immediately after the DB commit, so a row whose run time only just passed is
+// almost certainly mid-enqueue (or its execute-patch-job worker is about to
+// claim it). Waiting a couple of minutes avoids racing the happy path and only
+// acts on jobs that genuinely missed their enqueue (process restart /
+// Redis-connection churn in the create->enqueue gap — the #1733 failure
+// window).
 const RECONCILE_MIN_AGE_MS = 2 * 60 * 1000;
 
-// Upper bound on how far back the sweep looks. Matches the scheduler's
-// occurrence-idempotency lookback (45 days): a `scheduled` row older than this
-// is well past any window we would still want to run, and re-enqueuing it would
-// fire a long-stale patch run. Such rows are stuck for a different reason and
-// should be surfaced/cleaned up rather than silently executed.
+// Upper bound on how far back the sweep looks (relative to scheduledAt). Matches
+// the scheduler's occurrence-idempotency lookback (45 days): a `scheduled` row
+// whose run time is older than this is well past any window we would still want
+// to run, and re-enqueuing it would fire a long-stale patch run. Such rows are
+// stuck for a different reason and should be surfaced/cleaned up rather than
+// silently executed.
 const RECONCILE_MAX_AGE_MS = 45 * 24 * 60 * 60 * 1000;
+
+export interface StaleScheduledJob {
+  id: string;
+  scheduledAt: Date | null;
+}
 
 /**
  * Recover `patch_jobs` rows that committed with `status='scheduled'` but whose
@@ -198,11 +205,21 @@ const RECONCILE_MAX_AGE_MS = 45 * 24 * 60 * 60 * 1000;
  * enqueue leaves the row with no queue job, and the occurrence-idempotency
  * guard then prevents the next scan from ever re-creating it.
  *
- * This sweep finds `scheduled` rows past a short grace period that have no
- * active execute-patch-job queue entry and re-enqueues them. `enqueuePatchJob`
- * is idempotent on the stable jobId, and `processExecutePatchJob` re-checks
+ * This sweep finds `scheduled` rows whose intended run time has passed (plus a
+ * grace window) that have no active execute-patch-job queue entry and
+ * re-enqueues them, preserving any remaining delay. `enqueuePatchJob` is
+ * idempotent on the stable jobId, and `processExecutePatchJob` re-checks
  * `status='scheduled'` under a conditional UPDATE, so re-enqueuing a job that is
  * actually fine (or already running) is a safe no-op.
+ *
+ * The window is keyed off `scheduledAt`, NOT `createdAt`: the POST creation
+ * route (`configurationPolicies/patchJobs.ts`) lets an operator schedule a job
+ * for a future `scheduledAt` and enqueues it with a matching BullMQ delay. If we
+ * gated on `createdAt`, a future-scheduled row whose delayed enqueue was lost
+ * would become "stale" 2 minutes after creation and the sweep would re-enqueue
+ * it with no delay — firing the patch run up to 45 days early. `scheduledAt` is
+ * nullable; scheduler rows always set it to the run time, and we COALESCE to
+ * `createdAt` for any legacy/null row so it stays recoverable.
  *
  * Split into two phases so the caller can keep the DB read inside its system DB
  * access context and the Redis round-trips outside it (#1105):
@@ -211,41 +228,48 @@ const RECONCILE_MAX_AGE_MS = 45 * 24 * 60 * 60 * 1000;
  *   2. filterOrphanedJobIds — Redis-only; drops ids that already have an active
  *      queue job. Runs outside the DB context, alongside the enqueue.
  */
-export async function selectStaleScheduledJobIds(now: Date = new Date()): Promise<string[]> {
+export async function selectStaleScheduledJobIds(now: Date = new Date()): Promise<StaleScheduledJob[]> {
   const minAge = new Date(now.getTime() - RECONCILE_MIN_AGE_MS);
   const maxAge = new Date(now.getTime() - RECONCILE_MAX_AGE_MS);
 
+  // Effective run time = scheduledAt when set, else createdAt (non-null). The
+  // [maxAge, minAge) window over that value only re-enqueues rows whose run time
+  // has actually passed (so we never fire early) but not so long ago that firing
+  // them would run a long-stale patch window. Dates are bound as ISO strings —
+  // postgres.js can't serialize a raw Date param inside a sql template (it must
+  // be a string/Buffer); the repo's other windowed sweeps do the same (see
+  // staleCommandReaper.ts).
+  const effectiveRunTime = sql`COALESCE(${patchJobs.scheduledAt}, ${patchJobs.createdAt})`;
+
   const candidates = await db
-    .select({ id: patchJobs.id })
+    .select({ id: patchJobs.id, scheduledAt: patchJobs.scheduledAt })
     .from(patchJobs)
     .where(
       and(
         eq(patchJobs.status, 'scheduled'),
-        // createdAt is non-null; the [maxAge, minAge) window only re-enqueues
-        // rows old enough to have missed their enqueue but not so old that
-        // firing them would run a long-stale patch window.
-        lt(patchJobs.createdAt, minAge),
-        sql`${patchJobs.createdAt} >= ${maxAge}`
+        sql`${effectiveRunTime} < ${minAge.toISOString()}`,
+        sql`${effectiveRunTime} >= ${maxAge.toISOString()}`
       )
     );
 
-  return candidates.map((row) => row.id);
+  return candidates.map((row) => ({ id: row.id, scheduledAt: row.scheduledAt }));
 }
 
 /**
- * Of the given `scheduled` job ids, return those with no active execute-patch-job
+ * Of the given `scheduled` jobs, return those with no active execute-patch-job
  * queue entry — i.e. the rows whose enqueue was lost (#1733). Pure Redis reads;
- * run this outside the DB access context.
+ * run this outside the DB access context. Carries `scheduledAt` through so the
+ * caller can re-enqueue with the correct remaining delay.
  */
-export async function filterOrphanedJobIds(jobIds: string[]): Promise<string[]> {
-  if (jobIds.length === 0) return [];
+export async function filterOrphanedJobIds(jobs: StaleScheduledJob[]): Promise<StaleScheduledJob[]> {
+  if (jobs.length === 0) return [];
   const queue = getPatchJobQueue();
-  const orphaned: string[] = [];
-  for (const jobId of jobIds) {
-    const stableJobId = getPatchJobExecutionId(jobId);
+  const orphaned: StaleScheduledJob[] = [];
+  for (const job of jobs) {
+    const stableJobId = getPatchJobExecutionId(job.id);
     const existing = await resolveActiveQueueJob(queue, [stableJobId]);
     if (!existing) {
-      orphaned.push(jobId);
+      orphaned.push(job);
     }
   }
   return orphaned;

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -18,7 +18,7 @@ import {
   devices,
   deviceCommands,
 } from '../db/schema';
-import { eq, and, sql, inArray } from 'drizzle-orm';
+import { eq, and, sql, inArray, lt } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import {
@@ -166,6 +166,89 @@ export async function enqueuePatchJob(patchJobId: string, delayMs?: number): Pro
       ? { ...PATCH_JOB_RETENTION, delay: delayMs, jobId: stableJobId }
       : { ...PATCH_JOB_RETENTION, jobId: stableJobId }
   );
+}
+
+// ============================================
+// Orphan reconcile sweep (#1733)
+// ============================================
+
+// Grace period after a job's scheduledAt before the reconcile sweep will
+// re-enqueue it. The scheduler enqueues the Redis job immediately after the DB
+// commit, so a row that is only seconds old is almost certainly mid-enqueue (or
+// its execute-patch-job worker is about to claim it). Waiting a couple of
+// minutes avoids racing the happy path and only acts on jobs that genuinely
+// missed their enqueue (process restart / Redis-connection churn in the
+// create->enqueue gap — the #1733 failure window).
+const RECONCILE_MIN_AGE_MS = 2 * 60 * 1000;
+
+// Upper bound on how far back the sweep looks. Matches the scheduler's
+// occurrence-idempotency lookback (45 days): a `scheduled` row older than this
+// is well past any window we would still want to run, and re-enqueuing it would
+// fire a long-stale patch run. Such rows are stuck for a different reason and
+// should be surfaced/cleaned up rather than silently executed.
+const RECONCILE_MAX_AGE_MS = 45 * 24 * 60 * 60 * 1000;
+
+/**
+ * Recover `patch_jobs` rows that committed with `status='scheduled'` but whose
+ * Redis enqueue was lost (issue #1733). The scheduler inserts the row inside
+ * its DB transaction and enqueues to BullMQ *after* the transaction commits and
+ * outside the DB access context (deliberately, to avoid holding a pooled
+ * connection idle-in-transaction across Redis round-trips — #1105). That gap is
+ * not atomic: a process restart or Redis-connection failure between commit and
+ * enqueue leaves the row with no queue job, and the occurrence-idempotency
+ * guard then prevents the next scan from ever re-creating it.
+ *
+ * This sweep finds `scheduled` rows past a short grace period that have no
+ * active execute-patch-job queue entry and re-enqueues them. `enqueuePatchJob`
+ * is idempotent on the stable jobId, and `processExecutePatchJob` re-checks
+ * `status='scheduled'` under a conditional UPDATE, so re-enqueuing a job that is
+ * actually fine (or already running) is a safe no-op.
+ *
+ * Split into two phases so the caller can keep the DB read inside its system DB
+ * access context and the Redis round-trips outside it (#1105):
+ *   1. selectStaleScheduledJobIds — DB-only; the scheduled rows past the grace
+ *      window. Runs inside the DB context.
+ *   2. filterOrphanedJobIds — Redis-only; drops ids that already have an active
+ *      queue job. Runs outside the DB context, alongside the enqueue.
+ */
+export async function selectStaleScheduledJobIds(now: Date = new Date()): Promise<string[]> {
+  const minAge = new Date(now.getTime() - RECONCILE_MIN_AGE_MS);
+  const maxAge = new Date(now.getTime() - RECONCILE_MAX_AGE_MS);
+
+  const candidates = await db
+    .select({ id: patchJobs.id })
+    .from(patchJobs)
+    .where(
+      and(
+        eq(patchJobs.status, 'scheduled'),
+        // createdAt is non-null; the [maxAge, minAge) window only re-enqueues
+        // rows old enough to have missed their enqueue but not so old that
+        // firing them would run a long-stale patch window.
+        lt(patchJobs.createdAt, minAge),
+        sql`${patchJobs.createdAt} >= ${maxAge}`
+      )
+    );
+
+  return candidates.map((row) => row.id);
+}
+
+/**
+ * Of the given `scheduled` job ids, return those with no active execute-patch-job
+ * queue entry — i.e. the rows whose enqueue was lost (#1733). Pure Redis reads;
+ * run this outside the DB access context.
+ */
+export async function filterOrphanedJobIds(jobIds: string[]): Promise<string[]> {
+  if (jobIds.length === 0) return [];
+  const queue = getPatchJobQueue();
+  const orphaned: string[] = [];
+  for (const jobId of jobIds) {
+    const stableJobId = getPatchJobExecutionId(jobId);
+    const existing = await resolveActiveQueueJob(queue, [stableJobId]);
+    if (!existing) {
+      orphaned.push(jobId);
+    }
+  }
+  return orphaned;
 }
 
 // ============================================

--- a/apps/api/src/jobs/patchSchedulerWorker.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.test.ts
@@ -46,7 +46,11 @@ vi.mock('../db/schema', () => ({
 // the worker doesn't spin up Redis/BullMQ or the full resolver graph.
 vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
 vi.mock('../services/featureConfigResolver', () => ({ checkDeviceMaintenanceWindow: vi.fn() }));
-vi.mock('./patchJobExecutor', () => ({ enqueuePatchJob: vi.fn() }));
+vi.mock('./patchJobExecutor', () => ({
+  enqueuePatchJob: vi.fn(),
+  selectStaleScheduledJobIds: vi.fn(),
+  filterOrphanedJobIds: vi.fn(),
+}));
 vi.mock('../services/patchJobSnapshot', () => ({ buildPatchesSnapshot: vi.fn() }));
 vi.mock('../services/configPolicyPatching', () => ({
   backfillMissingPatchSettings: vi.fn(),
@@ -57,8 +61,9 @@ vi.mock('../services/configPolicyPatching', () => ({
 vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
 
 import { __testOnly } from './patchSchedulerWorker';
+import { enqueuePatchJob, filterOrphanedJobIds } from './patchJobExecutor';
 
-const { loadDeviceSchedulingContexts } = __testOnly;
+const { loadDeviceSchedulingContexts, enqueueScanResults } = __testOnly;
 
 describe('loadDeviceSchedulingContexts (#1318 partner tz)', () => {
   beforeEach(() => {
@@ -163,5 +168,70 @@ describe('loadDeviceSchedulingContexts (#1318 partner tz)', () => {
     ];
     const [ctx] = await loadDeviceSchedulingContexts(['dev-1']);
     expect(ctx?.timezone).toBe('UTC');
+  });
+});
+
+describe('enqueueScanResults orphan reconcile (#1733)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues created jobs then re-enqueues only the orphaned scheduled jobs', async () => {
+    // staleScheduledJobIds includes the just-created job-1 (already enqueued)
+    // plus job-orphan (lost its enqueue). filterOrphanedJobIds is what
+    // distinguishes them — here it reports only job-orphan as needing recovery.
+    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce(['job-orphan']);
+
+    const result = await enqueueScanResults({
+      enqueueJobIds: ['job-1'],
+      staleScheduledJobIds: ['job-1', 'job-orphan'],
+    });
+
+    expect(filterOrphanedJobIds).toHaveBeenCalledWith(['job-1', 'job-orphan']);
+    // job-1 (fresh) + job-orphan (recovered)
+    expect(enqueuePatchJob).toHaveBeenCalledWith('job-1');
+    expect(enqueuePatchJob).toHaveBeenCalledWith('job-orphan');
+    expect(enqueuePatchJob).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ enqueued: 1, recovered: 1 });
+  });
+
+  it('does not throw or skip recovery when a fresh enqueue fails (still sweeps orphans)', async () => {
+    vi.mocked(enqueuePatchJob)
+      .mockRejectedValueOnce(new Error('redis down'))
+      .mockResolvedValue(undefined);
+    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce(['job-orphan']);
+
+    const result = await enqueueScanResults({
+      enqueueJobIds: ['job-fresh'],
+      staleScheduledJobIds: ['job-orphan'],
+    });
+
+    // fresh enqueue threw → enqueued stays 0, but the orphan sweep still ran
+    expect(result).toEqual({ enqueued: 0, recovered: 1 });
+    expect(enqueuePatchJob).toHaveBeenCalledWith('job-orphan');
+  });
+
+  it('recovers nothing when no scheduled rows are orphaned', async () => {
+    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce([]);
+
+    const result = await enqueueScanResults({
+      enqueueJobIds: ['job-1'],
+      staleScheduledJobIds: ['job-1'],
+    });
+
+    expect(result).toEqual({ enqueued: 1, recovered: 0 });
+    expect(enqueuePatchJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a reconcile-sweep failure without losing the fresh enqueues', async () => {
+    vi.mocked(filterOrphanedJobIds).mockRejectedValueOnce(new Error('queue read failed'));
+
+    const result = await enqueueScanResults({
+      enqueueJobIds: ['job-1'],
+      staleScheduledJobIds: ['job-1'],
+    });
+
+    expect(result).toEqual({ enqueued: 1, recovered: 0 });
+    expect(enqueuePatchJob).toHaveBeenCalledWith('job-1');
   });
 });

--- a/apps/api/src/jobs/patchSchedulerWorker.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.test.ts
@@ -51,6 +51,7 @@ vi.mock('./patchJobExecutor', () => ({
   selectStaleScheduledJobIds: vi.fn(),
   filterOrphanedJobIds: vi.fn(),
 }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
 vi.mock('../services/patchJobSnapshot', () => ({ buildPatchesSnapshot: vi.fn() }));
 vi.mock('../services/configPolicyPatching', () => ({
   backfillMissingPatchSettings: vi.fn(),
@@ -62,6 +63,7 @@ vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
 
 import { __testOnly } from './patchSchedulerWorker';
 import { enqueuePatchJob, filterOrphanedJobIds } from './patchJobExecutor';
+import { captureException } from '../services/sentry';
 
 const { loadDeviceSchedulingContexts, enqueueScanResults } = __testOnly;
 
@@ -176,39 +178,78 @@ describe('enqueueScanResults orphan reconcile (#1733)', () => {
     vi.clearAllMocks();
   });
 
+  const now = new Date('2026-06-21T09:00:00Z');
+
   it('enqueues created jobs then re-enqueues only the orphaned scheduled jobs', async () => {
-    // staleScheduledJobIds includes the just-created job-1 (already enqueued)
-    // plus job-orphan (lost its enqueue). filterOrphanedJobIds is what
+    // staleScheduledJobs includes the just-created job-1 (already enqueued) plus
+    // job-orphan (lost its enqueue, past run time). filterOrphanedJobIds is what
     // distinguishes them — here it reports only job-orphan as needing recovery.
-    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce(['job-orphan']);
+    const orphan = { id: 'job-orphan', scheduledAt: new Date('2026-06-21T08:00:00Z') };
+    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce([orphan]);
 
     const result = await enqueueScanResults({
       enqueueJobIds: ['job-1'],
-      staleScheduledJobIds: ['job-1', 'job-orphan'],
-    });
+      staleScheduledJobs: [{ id: 'job-1', scheduledAt: now }, orphan],
+    }, now);
 
-    expect(filterOrphanedJobIds).toHaveBeenCalledWith(['job-1', 'job-orphan']);
-    // job-1 (fresh) + job-orphan (recovered)
+    expect(filterOrphanedJobIds).toHaveBeenCalledWith([{ id: 'job-1', scheduledAt: now }, orphan]);
     expect(enqueuePatchJob).toHaveBeenCalledWith('job-1');
-    expect(enqueuePatchJob).toHaveBeenCalledWith('job-orphan');
+    // run time already passed → no delay (undefined)
+    expect(enqueuePatchJob).toHaveBeenCalledWith('job-orphan', undefined);
     expect(enqueuePatchJob).toHaveBeenCalledTimes(2);
     expect(result).toEqual({ enqueued: 1, recovered: 1 });
+    // recovered > 0 → surfaced to Sentry so the #1733 race rate is observable
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('#1733 race active') }),
+    );
+  });
+
+  it('preserves the remaining delay when recovering a future-scheduled orphan (regression: no early fire)', async () => {
+    // A POST-route job scheduled 1h in the future whose delayed enqueue was lost.
+    // Recovering it must NOT fire immediately — it must re-enqueue with the
+    // remaining delay so it runs at its intended window.
+    const futureOrphan = { id: 'job-future', scheduledAt: new Date('2026-06-21T10:00:00Z') };
+    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce([futureOrphan]);
+
+    const result = await enqueueScanResults({
+      enqueueJobIds: [],
+      staleScheduledJobs: [futureOrphan],
+    }, now);
+
+    // 10:00 - 09:00 = 3,600,000ms remaining delay
+    expect(enqueuePatchJob).toHaveBeenCalledWith('job-future', 60 * 60 * 1000);
+    expect(result).toEqual({ enqueued: 0, recovered: 1 });
   });
 
   it('does not throw or skip recovery when a fresh enqueue fails (still sweeps orphans)', async () => {
+    const orphan = { id: 'job-orphan', scheduledAt: null };
     vi.mocked(enqueuePatchJob)
       .mockRejectedValueOnce(new Error('redis down'))
       .mockResolvedValue(undefined);
-    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce(['job-orphan']);
+    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce([orphan]);
 
     const result = await enqueueScanResults({
       enqueueJobIds: ['job-fresh'],
-      staleScheduledJobIds: ['job-orphan'],
-    });
+      staleScheduledJobs: [orphan],
+    }, now);
 
     // fresh enqueue threw → enqueued stays 0, but the orphan sweep still ran
     expect(result).toEqual({ enqueued: 0, recovered: 1 });
-    expect(enqueuePatchJob).toHaveBeenCalledWith('job-orphan');
+    expect(enqueuePatchJob).toHaveBeenCalledWith('job-orphan', undefined);
+  });
+
+  it('surfaces a failed orphan re-enqueue to Sentry (a lost run staying lost is page-worthy)', async () => {
+    const orphan = { id: 'job-orphan', scheduledAt: null };
+    vi.mocked(filterOrphanedJobIds).mockResolvedValueOnce([orphan]);
+    vi.mocked(enqueuePatchJob).mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await enqueueScanResults({
+      enqueueJobIds: [],
+      staleScheduledJobs: [orphan],
+    }, now);
+
+    expect(result).toEqual({ enqueued: 0, recovered: 0 });
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('recovers nothing when no scheduled rows are orphaned', async () => {
@@ -216,22 +257,24 @@ describe('enqueueScanResults orphan reconcile (#1733)', () => {
 
     const result = await enqueueScanResults({
       enqueueJobIds: ['job-1'],
-      staleScheduledJobIds: ['job-1'],
-    });
+      staleScheduledJobs: [{ id: 'job-1', scheduledAt: now }],
+    }, now);
 
     expect(result).toEqual({ enqueued: 1, recovered: 0 });
     expect(enqueuePatchJob).toHaveBeenCalledTimes(1);
+    expect(captureException).not.toHaveBeenCalled();
   });
 
-  it('swallows a reconcile-sweep failure without losing the fresh enqueues', async () => {
+  it('swallows a reconcile-sweep failure without losing the fresh enqueues (but surfaces it)', async () => {
     vi.mocked(filterOrphanedJobIds).mockRejectedValueOnce(new Error('queue read failed'));
 
     const result = await enqueueScanResults({
       enqueueJobIds: ['job-1'],
-      staleScheduledJobIds: ['job-1'],
-    });
+      staleScheduledJobs: [{ id: 'job-1', scheduledAt: now }],
+    }, now);
 
     expect(result).toEqual({ enqueued: 1, recovered: 0 });
     expect(enqueuePatchJob).toHaveBeenCalledWith('job-1');
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -23,7 +23,13 @@ import { resolveEffectiveTimezone, canonicalizeTimezone } from '@breeze/shared';
 import { getBullMQConnection } from '../services/redis';
 import { attachWorkerObservability } from './workerObservability';
 import { checkDeviceMaintenanceWindow } from '../services/featureConfigResolver';
-import { enqueuePatchJob, selectStaleScheduledJobIds, filterOrphanedJobIds } from './patchJobExecutor';
+import {
+  enqueuePatchJob,
+  selectStaleScheduledJobIds,
+  filterOrphanedJobIds,
+  type StaleScheduledJob,
+} from './patchJobExecutor';
+import { captureException } from '../services/sentry';
 import { buildPatchesSnapshot } from '../services/patchJobSnapshot';
 import {
   backfillMissingPatchSettings,
@@ -321,7 +327,7 @@ async function scanAndCreateJobs(): Promise<{
   created: number;
   scanned: number;
   enqueueJobIds: string[];
-  staleScheduledJobIds: string[];
+  staleScheduledJobs: StaleScheduledJob[];
 }> {
   const now = new Date();
   let created = 0;
@@ -461,25 +467,26 @@ async function scanAndCreateJobs(): Promise<{
     }
   }
 
-  // Orphan-recovery read (#1733): collect `scheduled` patch_jobs rows that are
-  // past the grace window so the worker can re-enqueue any whose Redis job was
-  // lost in the create->enqueue gap. This is a DB-only read; the queue-state
-  // check + re-enqueue happen outside this DB access context (see the worker).
-  let staleScheduledJobIds: string[] = [];
+  // Orphan-recovery read (#1733): collect `scheduled` patch_jobs rows whose
+  // intended run time has passed (plus grace) so the worker can re-enqueue any
+  // whose Redis job was lost in the create->enqueue gap. This is a DB-only read;
+  // the queue-state check + re-enqueue happen outside this DB access context
+  // (see the worker). A failure here silently disables the backstop, so surface
+  // it to Sentry, not just the console (#1379 worker-observability convention).
+  let staleScheduledJobs: StaleScheduledJob[] = [];
   try {
-    staleScheduledJobIds = await selectStaleScheduledJobIds(now);
+    staleScheduledJobs = await selectStaleScheduledJobIds(now);
   } catch (err) {
-    console.error(
-      '[PatchScheduler] Failed to read stale scheduled jobs for reconcile:',
-      err instanceof Error ? err.message : err
-    );
+    const message = '[PatchScheduler] Failed to read stale scheduled jobs for reconcile';
+    console.error(`${message}:`, err instanceof Error ? err.message : err);
+    captureException(err instanceof Error ? err : new Error(message));
   }
 
   return {
     created,
     scanned: patchPoliciesWithSchedules.length,
     enqueueJobIds,
-    staleScheduledJobIds,
+    staleScheduledJobs,
   };
 }
 
@@ -492,16 +499,25 @@ async function scanAndCreateJobs(): Promise<{
 //      process restart or Redis-connection drop between the DB commit and
 //      enqueuePatchJob leaves the patch_jobs row status='scheduled' with no
 //      queue job, and the occurrence-idempotency guard stops the next scan from
-//      ever re-creating it. We re-enqueue any `scheduled` row (past the grace
-//      window) that has no active queue job. Just-created ids are also in this
-//      list, but they were enqueued moments ago so the filter sees their active
-//      job and skips them; the grace window keeps this from racing a fresh
-//      enqueue. enqueuePatchJob is idempotent on the stable jobId, so a
-//      redundant re-enqueue is a no-op.
-async function enqueueScanResults(result: {
-  enqueueJobIds: string[];
-  staleScheduledJobIds: string[];
-}): Promise<{ enqueued: number; recovered: number }> {
+//      ever re-creating it. We re-enqueue any `scheduled` row whose run time has
+//      passed (past the grace window) that has no active queue job, preserving
+//      the remaining delay so a future-scheduled job recovered early still waits
+//      for its window. Just-created ids are also in this list, but they were
+//      enqueued moments ago so the filter normally sees their active job and
+//      skips them; in the rare case a just-created job already completed, the
+//      status re-check in processExecutePatchJob makes the redundant enqueue a
+//      no-op. enqueuePatchJob is idempotent on the stable jobId.
+//
+// Observability (#1379): failing to recover an orphan, or a non-zero recovery
+// count (the #1733 race is actively firing in prod), is surfaced to Sentry —
+// console-only logging is not observable in this stack.
+async function enqueueScanResults(
+  result: {
+    enqueueJobIds: string[];
+    staleScheduledJobs: StaleScheduledJob[];
+  },
+  now: Date = new Date()
+): Promise<{ enqueued: number; recovered: number }> {
   let enqueued = 0;
   for (const jobId of result.enqueueJobIds) {
     try {
@@ -517,23 +533,37 @@ async function enqueueScanResults(result: {
 
   let recovered = 0;
   try {
-    const orphanedJobIds = await filterOrphanedJobIds(result.staleScheduledJobIds);
-    for (const jobId of orphanedJobIds) {
+    const orphaned = await filterOrphanedJobIds(result.staleScheduledJobs);
+    for (const job of orphaned) {
       try {
-        await enqueuePatchJob(jobId);
+        // Preserve any remaining delay: a future-scheduled orphan (POST route)
+        // recovered before its window must still wait, not fire immediately.
+        const delayMs = job.scheduledAt
+          ? Math.max(0, job.scheduledAt.getTime() - now.getTime())
+          : 0;
+        await enqueuePatchJob(job.id, delayMs || undefined);
         recovered += 1;
-        console.warn(`[PatchScheduler] Re-enqueued orphaned scheduled patch job ${jobId} (#1733 recovery)`);
+        console.warn(`[PatchScheduler] Re-enqueued orphaned scheduled patch job ${job.id} (#1733 recovery)`);
       } catch (err) {
-        console.error(
-          `[PatchScheduler] Failed to re-enqueue orphaned patch job ${jobId}:`,
-          err instanceof Error ? err.message : err
-        );
+        const message = `[PatchScheduler] Failed to re-enqueue orphaned patch job ${job.id} (#1733 recovery)`;
+        console.error(`${message}:`, err instanceof Error ? err.message : err);
+        // A recovery enqueue that fails means a silently-lost run stays lost —
+        // page-worthy, surface it.
+        captureException(err instanceof Error ? err : new Error(message));
       }
     }
   } catch (err) {
-    console.error(
-      '[PatchScheduler] Orphan-reconcile sweep failed:',
-      err instanceof Error ? err.message : err
+    const message = '[PatchScheduler] Orphan-reconcile sweep failed';
+    console.error(`${message}:`, err instanceof Error ? err.message : err);
+    captureException(err instanceof Error ? err : new Error(message));
+  }
+
+  if (recovered > 0) {
+    // A non-zero recovery means the #1733 create->enqueue race fired in prod and
+    // we backstopped it. Surface as a warning-level Sentry signal so the rate is
+    // observable (vs. only living in container logs).
+    captureException(
+      new Error(`[PatchScheduler] Recovered ${recovered} orphaned scheduled patch job(s) — #1733 race active`)
     );
   }
 
@@ -553,15 +583,15 @@ function createSchedulerWorker(): Worker {
               _configPolicyTableWarningLogged = true;
               console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
             }
-            return { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobIds: [] };
+            return { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobs: [] };
           }
           throw error;
         }
       });
 
-      await enqueueScanResults(result);
+      const { recovered } = await enqueueScanResults(result);
 
-      return { created: result.created, scanned: result.scanned };
+      return { created: result.created, scanned: result.scanned, recovered };
     },
     {
       connection: getBullMQConnection(),

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -23,7 +23,7 @@ import { resolveEffectiveTimezone, canonicalizeTimezone } from '@breeze/shared';
 import { getBullMQConnection } from '../services/redis';
 import { attachWorkerObservability } from './workerObservability';
 import { checkDeviceMaintenanceWindow } from '../services/featureConfigResolver';
-import { enqueuePatchJob } from './patchJobExecutor';
+import { enqueuePatchJob, selectStaleScheduledJobIds, filterOrphanedJobIds } from './patchJobExecutor';
 import { buildPatchesSnapshot } from '../services/patchJobSnapshot';
 import {
   backfillMissingPatchSettings,
@@ -317,7 +317,12 @@ async function hasExistingOccurrenceJob(
   });
 }
 
-async function scanAndCreateJobs(): Promise<{ created: number; scanned: number; enqueueJobIds: string[] }> {
+async function scanAndCreateJobs(): Promise<{
+  created: number;
+  scanned: number;
+  enqueueJobIds: string[];
+  staleScheduledJobIds: string[];
+}> {
   const now = new Date();
   let created = 0;
   // Job ids to enqueue to Redis AFTER the system DB access-context transaction
@@ -456,7 +461,83 @@ async function scanAndCreateJobs(): Promise<{ created: number; scanned: number; 
     }
   }
 
-  return { created, scanned: patchPoliciesWithSchedules.length, enqueueJobIds };
+  // Orphan-recovery read (#1733): collect `scheduled` patch_jobs rows that are
+  // past the grace window so the worker can re-enqueue any whose Redis job was
+  // lost in the create->enqueue gap. This is a DB-only read; the queue-state
+  // check + re-enqueue happen outside this DB access context (see the worker).
+  let staleScheduledJobIds: string[] = [];
+  try {
+    staleScheduledJobIds = await selectStaleScheduledJobIds(now);
+  } catch (err) {
+    console.error(
+      '[PatchScheduler] Failed to read stale scheduled jobs for reconcile:',
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  return {
+    created,
+    scanned: patchPoliciesWithSchedules.length,
+    enqueueJobIds,
+    staleScheduledJobIds,
+  };
+}
+
+// Post-scan Redis work, run OUTSIDE the system DB access context (#1105): all
+// DB writes committed when scanAndCreateJobs returned, so doing the BullMQ
+// round-trips here keeps the pooled connection from sitting idle-in-transaction.
+// Two phases:
+//   1. Enqueue the just-created jobs.
+//   2. Orphan-recovery sweep (#1733). The create->enqueue gap is not atomic: a
+//      process restart or Redis-connection drop between the DB commit and
+//      enqueuePatchJob leaves the patch_jobs row status='scheduled' with no
+//      queue job, and the occurrence-idempotency guard stops the next scan from
+//      ever re-creating it. We re-enqueue any `scheduled` row (past the grace
+//      window) that has no active queue job. Just-created ids are also in this
+//      list, but they were enqueued moments ago so the filter sees their active
+//      job and skips them; the grace window keeps this from racing a fresh
+//      enqueue. enqueuePatchJob is idempotent on the stable jobId, so a
+//      redundant re-enqueue is a no-op.
+async function enqueueScanResults(result: {
+  enqueueJobIds: string[];
+  staleScheduledJobIds: string[];
+}): Promise<{ enqueued: number; recovered: number }> {
+  let enqueued = 0;
+  for (const jobId of result.enqueueJobIds) {
+    try {
+      await enqueuePatchJob(jobId);
+      enqueued += 1;
+    } catch (err) {
+      console.error(
+        `[PatchScheduler] Failed to enqueue patch job ${jobId}:`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+
+  let recovered = 0;
+  try {
+    const orphanedJobIds = await filterOrphanedJobIds(result.staleScheduledJobIds);
+    for (const jobId of orphanedJobIds) {
+      try {
+        await enqueuePatchJob(jobId);
+        recovered += 1;
+        console.warn(`[PatchScheduler] Re-enqueued orphaned scheduled patch job ${jobId} (#1733 recovery)`);
+      } catch (err) {
+        console.error(
+          `[PatchScheduler] Failed to re-enqueue orphaned patch job ${jobId}:`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+  } catch (err) {
+    console.error(
+      '[PatchScheduler] Orphan-reconcile sweep failed:',
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  return { enqueued, recovered };
 }
 
 function createSchedulerWorker(): Worker {
@@ -472,29 +553,13 @@ function createSchedulerWorker(): Worker {
               _configPolicyTableWarningLogged = true;
               console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
             }
-            return { created: 0, scanned: 0, enqueueJobIds: [] };
+            return { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobIds: [] };
           }
           throw error;
         }
       });
 
-      // Enqueue OUTSIDE the system DB access-context transaction (#1105). All
-      // DB writes (incl. the patch_jobs inserts) committed when the context
-      // above returned; doing the Redis enqueue here keeps the pooled
-      // connection from sitting idle-in-transaction across BullMQ round-trips.
-      // A job that fails to enqueue is logged (its row already exists) and is
-      // skipped by the occurrence-idempotency guard on the next scan — same
-      // outcome as the prior in-transaction failure path.
-      for (const jobId of result.enqueueJobIds) {
-        try {
-          await enqueuePatchJob(jobId);
-        } catch (err) {
-          console.error(
-            `[PatchScheduler] Failed to enqueue patch job ${jobId}:`,
-            err instanceof Error ? err.message : err
-          );
-        }
-      }
+      await enqueueScanResults(result);
 
       return { created: result.created, scanned: result.scanned };
     },
@@ -572,4 +637,5 @@ export async function shutdownPatchSchedulerWorker(): Promise<void> {
 // (#1318). Internal helper, not part of the worker's public surface.
 export const __testOnly = {
   loadDeviceSchedulingContexts,
+  enqueueScanResults,
 };


### PR DESCRIPTION
## Summary

Closes #1733.

A weekly-Sunday-02:00 scheduled patch run for org **Toothzone** (US) created a `patch_jobs` row that stuck permanently in `status='scheduled'` and never reached the executor — silently, with zero results and no surfaced failure. Timezone handling was confirmed correct; this is a **create-then-enqueue atomicity gap**, not a tz bug.

**Root cause:** The scheduler inserts the `patch_jobs` row inside its DB transaction (`patchSchedulerWorker.ts`), then enqueues the executor job to BullMQ **after** the transaction commits and **outside** the DB access context — deliberately, to avoid holding a pooled connection idle-in-transaction across Redis round-trips (#1105). That gap is not atomic: a process restart / Redis-connection drop between commit and `enqueuePatchJob` (exactly the 08:00 UTC connection-churn window in the report) leaves the row with no queue job. The 45-day occurrence-idempotency guard then prevents the next 60s scan from ever re-creating it, so the run is stuck forever and the failure is completely silent.

## Fix

An **orphan-recovery sweep** added to the scheduler's existing 60s scan — no new queue, no migration, and the #1105 DB-context boundary is preserved:

- **`selectStaleScheduledJobIds`** (DB-only, runs **inside** the system DB access context): returns `status='scheduled'` rows past a 2-minute grace window and within the 45-day lookback. The grace window avoids racing a fresh enqueue; the upper bound stops ancient stuck rows from being resurrected and fired long-stale.
- **`filterOrphanedJobIds`** (Redis-only, runs **outside** the DB context): drops ids that already have an active `execute-patch-job` queue entry (a completed/failed leftover is treated as not-active, so recovery isn't blocked).
- The worker re-enqueues the remainder via the idempotent `enqueuePatchJob` and logs `Re-enqueued orphaned scheduled patch job <id> (#1733 recovery)` per recovery — making the previously-silent drop **observable** in logs. `processExecutePatchJob` re-checks `status='scheduled'` under a conditional `UPDATE`, so re-enqueuing a healthy/running job is a safe no-op.

The post-scan enqueue + reconcile logic is extracted to `enqueueScanResults` (exported via `__testOnly`) for direct unit coverage.

## Acceptance criteria

- [x] A scheduled window that produces a `patch_jobs` row reliably reaches the executor — recovered by a periodic reconcile sweep that re-enqueues `status='scheduled'` rows with no active queue job.
- [x] A run that fails to enqueue is **observable** (recovery warning logged) rather than silently left in `scheduled`.
- [x] Timezone path untouched; the existing `loadDeviceSchedulingContexts` (#1318) tz regression tests still pass.
- [x] Regression tests cover (a) an enqueue failure not silently dropping the run and (b) an orphaned `scheduled` job being recovered without the occurrence-idempotency guard blocking it.

## Tests

`apps/api/src/jobs/patchJobExecutor.test.ts` + `patchSchedulerWorker.test.ts` — **31 passed** single-fork (`vitest run --no-file-parallelism`). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)