### PR TITLE
feat(agent/devices): detect virtual/VDI hypervisor as an orthogonal device attribute (#1387)

### DIFF
--- a/agent/cmd/breeze-agent/main.go
+++ b/agent/cmd/breeze-agent/main.go
@@ -975,15 +975,28 @@ func enrollDevice(enrollmentKey string) {
 		fmt.Printf("Device role: %s\n", deviceRole)
 	}
 
+	// Orthogonal virtualization attribute (issue #1387): is this a VM, and on
+	// what hypervisor. Derived from the hardware identity strings already
+	// collected above; a virtual box keeps its role-based policies.
+	virt := collectors.ClassifyVirtualization(hardwareInfo)
+	if virt.IsVirtual {
+		enrollLog.Info("detected virtualization", "platform", virt.Platform)
+		if !quietEnroll {
+			fmt.Printf("Virtualization: %s\n", virt.Platform)
+		}
+	}
+
 	enrollReq := &api.EnrollRequest{
-		EnrollmentKey:    enrollmentKey,
-		EnrollmentSecret: secret,
-		Hostname:         systemInfo.Hostname,
-		OSType:           systemInfo.OSType,
-		OSVersion:        systemInfo.OSVersion,
-		Architecture:     systemInfo.Architecture,
-		AgentVersion:     version,
-		DeviceRole:       deviceRole,
+		EnrollmentKey:          enrollmentKey,
+		EnrollmentSecret:       secret,
+		Hostname:               systemInfo.Hostname,
+		OSType:                 systemInfo.OSType,
+		OSVersion:              systemInfo.OSVersion,
+		Architecture:           systemInfo.Architecture,
+		AgentVersion:           version,
+		DeviceRole:             deviceRole,
+		IsVirtual:              virt.IsVirtual,
+		VirtualizationPlatform: virt.Platform,
 		HardwareInfo: &api.HardwareInfo{
 			CPUModel:                hardwareInfo.CPUModel,
 			CPUCores:                hardwareInfo.CPUCores,

--- a/agent/internal/collectors/classify.go
+++ b/agent/internal/collectors/classify.go
@@ -106,9 +106,12 @@ var virtualizationMarkers = []virtualizationMarker{
 	// Bochs (rare, used by some cloud/emulation stacks).
 	{platform: "bochs", needles: []string{"bochs"}},
 	// Hyper-V: Manufacturer "Microsoft Corporation" + Model "Virtual Machine".
-	// Microsoft is ALSO the manufacturer of physical Surface hardware, so this
-	// marker is the model string ("virtual machine"), never the manufacturer
-	// alone — handled specially below so a physical Surface is not flagged.
+	// Microsoft is ALSO the manufacturer of physical Surface hardware, so the
+	// needle is the MODEL substring "virtual machine", never the manufacturer
+	// string "microsoft". That narrow needle is the whole mechanism — there is
+	// no special-case branch — so a physical Surface (Manufacturer "Microsoft
+	// Corporation", Model "Surface Laptop 5") simply doesn't match. (Covered by
+	// the Surface test case in classify_test.go.)
 	{platform: "hyperv", needles: []string{"virtual machine"}},
 }
 

--- a/agent/internal/collectors/classify.go
+++ b/agent/internal/collectors/classify.go
@@ -55,3 +55,88 @@ func ClassifyDeviceRole(sysInfo *SystemInfo, hw *HardwareInfo) string {
 
 	return "workstation"
 }
+
+// VirtualizationInfo is the orthogonal "is this a VM, and on what hypervisor"
+// attribute derived from the same hardware identity strings (Manufacturer /
+// Model / BIOS) already collected for role classification. It is intentionally
+// separate from device role: a virtual box is still a workstation (or server)
+// and must keep matching its role-based policies — virtualization is a second
+// targeting axis, not a role. See issue #1387.
+type VirtualizationInfo struct {
+	// IsVirtual is true when the host is running on a hypervisor.
+	IsVirtual bool
+	// Platform is the detected hypervisor, lowercased and normalized to a
+	// small known set (vmware / hyperv / virtualbox / qemu / kvm / xen /
+	// parallels). Empty when IsVirtual is false, or when the host is virtual
+	// but the specific platform could not be identified.
+	Platform string
+}
+
+// virtualizationPlatform holds the normalized platform token plus the
+// case-insensitive substrings (matched against Manufacturer/Model/BIOS) that
+// identify it. Order matters: the first matching entry wins, so more specific
+// vendors are listed before generic ones.
+type virtualizationMarker struct {
+	platform string
+	needles  []string
+}
+
+// virtualizationMarkers are the SMBIOS identity strings real hypervisors stamp
+// into Win32_ComputerSystem (Manufacturer/Model), Linux DMI (sys_vendor /
+// product_name), and the BIOS vendor string. These values are well-documented
+// and stable across the major hypervisors.
+var virtualizationMarkers = []virtualizationMarker{
+	// VMware: Manufacturer "VMware, Inc.", Model "VMware Virtual Platform" /
+	// "VMware7,1", "VMware20,1".
+	{platform: "vmware", needles: []string{"vmware"}},
+	// VirtualBox: Manufacturer "innotek GmbH", Model "VirtualBox", BIOS
+	// vendor "innotek GmbH".
+	{platform: "virtualbox", needles: []string{"virtualbox", "innotek"}},
+	// Parallels (Mac VDI / Desktop): "Parallels Software International" /
+	// Model "Parallels Virtual Platform".
+	{platform: "parallels", needles: []string{"parallels"}},
+	// QEMU (incl. libvirt): Manufacturer "QEMU", Model "Standard PC (...)" with
+	// BIOS vendor "SeaBIOS"/"QEMU". Listed before kvm/xen since QEMU is the
+	// most specific identifier when present.
+	{platform: "qemu", needles: []string{"qemu"}},
+	// KVM: some guests report Manufacturer "KVM" or product "KVM".
+	{platform: "kvm", needles: []string{"kvm"}},
+	// Xen: Manufacturer "Xen", Model "HVM domU".
+	{platform: "xen", needles: []string{"xen", "hvm domu"}},
+	// Bochs (rare, used by some cloud/emulation stacks).
+	{platform: "bochs", needles: []string{"bochs"}},
+	// Hyper-V: Manufacturer "Microsoft Corporation" + Model "Virtual Machine".
+	// Microsoft is ALSO the manufacturer of physical Surface hardware, so this
+	// marker is the model string ("virtual machine"), never the manufacturer
+	// alone — handled specially below so a physical Surface is not flagged.
+	{platform: "hyperv", needles: []string{"virtual machine"}},
+}
+
+// ClassifyVirtualization derives the orthogonal virtual/VDI hardware attribute
+// from hardware identity strings. It is a pure function (no syscalls) so it is
+// fully unit-testable and produces identical results on every platform — the
+// underlying Manufacturer/Model/BIOS strings are already collected per-OS by
+// CollectHardware. Returns the zero value (not virtual, no platform) when hw is
+// nil or carries no recognizable markers.
+func ClassifyVirtualization(hw *HardwareInfo) VirtualizationInfo {
+	if hw == nil {
+		return VirtualizationInfo{}
+	}
+
+	manufacturer := strings.ToLower(hw.Manufacturer)
+	model := strings.ToLower(hw.Model)
+	bios := strings.ToLower(hw.BIOSVersion)
+	mbManufacturer := strings.ToLower(hw.MotherboardManufacturer)
+	// Single haystack so a marker can match in any identity field.
+	haystack := strings.Join([]string{manufacturer, model, bios, mbManufacturer}, " ")
+
+	for _, marker := range virtualizationMarkers {
+		for _, needle := range marker.needles {
+			if strings.Contains(haystack, needle) {
+				return VirtualizationInfo{IsVirtual: true, Platform: marker.platform}
+			}
+		}
+	}
+
+	return VirtualizationInfo{}
+}

--- a/agent/internal/collectors/classify_test.go
+++ b/agent/internal/collectors/classify_test.go
@@ -161,6 +161,15 @@ func TestClassifyVirtualization(t *testing.T) {
 			wantPlatform: "vmware",
 		},
 		{
+			// Marker precedence: a QEMU/KVM guest can carry BOTH "qemu" and
+			// "kvm" tokens; qemu is listed before kvm, so first-match-wins must
+			// resolve to qemu (the more specific identifier).
+			name:         "qemu wins over kvm when both tokens present (precedence)",
+			hw:           &HardwareInfo{Manufacturer: "QEMU", Model: "KVM"},
+			wantVirtual:  true,
+			wantPlatform: "qemu",
+		},
+		{
 			name:         "nil hardware is not virtual",
 			hw:           nil,
 			wantVirtual:  false,

--- a/agent/internal/collectors/classify_test.go
+++ b/agent/internal/collectors/classify_test.go
@@ -74,3 +74,115 @@ func TestClassifyDeviceRole(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyVirtualization(t *testing.T) {
+	tests := []struct {
+		name         string
+		hw           *HardwareInfo
+		wantVirtual  bool
+		wantPlatform string
+	}{
+		{
+			name:         "vmware manufacturer + model",
+			hw:           &HardwareInfo{Manufacturer: "VMware, Inc.", Model: "VMware Virtual Platform"},
+			wantVirtual:  true,
+			wantPlatform: "vmware",
+		},
+		{
+			name:         "vmware modern model string (VMware20,1)",
+			hw:           &HardwareInfo{Manufacturer: "VMware, Inc.", Model: "VMware20,1"},
+			wantVirtual:  true,
+			wantPlatform: "vmware",
+		},
+		{
+			name:         "hyper-v: microsoft manufacturer + Virtual Machine model",
+			hw:           &HardwareInfo{Manufacturer: "Microsoft Corporation", Model: "Virtual Machine"},
+			wantVirtual:  true,
+			wantPlatform: "hyperv",
+		},
+		{
+			name:         "virtualbox via innotek manufacturer",
+			hw:           &HardwareInfo{Manufacturer: "innotek GmbH", Model: "VirtualBox"},
+			wantVirtual:  true,
+			wantPlatform: "virtualbox",
+		},
+		{
+			name:         "qemu manufacturer",
+			hw:           &HardwareInfo{Manufacturer: "QEMU", Model: "Standard PC (Q35 + ICH9, 2009)"},
+			wantVirtual:  true,
+			wantPlatform: "qemu",
+		},
+		{
+			name:         "kvm product name",
+			hw:           &HardwareInfo{Manufacturer: "Red Hat", Model: "KVM"},
+			wantVirtual:  true,
+			wantPlatform: "kvm",
+		},
+		{
+			name:         "xen HVM domU model",
+			hw:           &HardwareInfo{Manufacturer: "Xen", Model: "HVM domU"},
+			wantVirtual:  true,
+			wantPlatform: "xen",
+		},
+		{
+			name:         "parallels virtual platform (mac VDI)",
+			hw:           &HardwareInfo{Manufacturer: "Parallels Software International Inc.", Model: "Parallels Virtual Platform"},
+			wantVirtual:  true,
+			wantPlatform: "parallels",
+		},
+		{
+			name:         "marker matched in BIOS vendor string when model is generic",
+			hw:           &HardwareInfo{Manufacturer: "", Model: "Standard PC", BIOSVersion: "SeaBIOS / VirtualBox"},
+			wantVirtual:  true,
+			wantPlatform: "virtualbox",
+		},
+		{
+			name:         "physical Microsoft Surface is NOT virtual (model is not Virtual Machine)",
+			hw:           &HardwareInfo{Manufacturer: "Microsoft Corporation", Model: "Surface Laptop 5"},
+			wantVirtual:  false,
+			wantPlatform: "",
+		},
+		{
+			name:         "physical Dell workstation is not virtual",
+			hw:           &HardwareInfo{Manufacturer: "Dell Inc.", Model: "OptiPlex 7090"},
+			wantVirtual:  false,
+			wantPlatform: "",
+		},
+		{
+			name:         "physical Apple Mac is not virtual",
+			hw:           &HardwareInfo{Manufacturer: "Apple", Model: "MacBookPro18,3"},
+			wantVirtual:  false,
+			wantPlatform: "",
+		},
+		{
+			name:         "case-insensitive match (lowercased vendor string)",
+			hw:           &HardwareInfo{Manufacturer: "vmware, inc.", Model: "vmware7,1"},
+			wantVirtual:  true,
+			wantPlatform: "vmware",
+		},
+		{
+			name:         "nil hardware is not virtual",
+			hw:           nil,
+			wantVirtual:  false,
+			wantPlatform: "",
+		},
+		{
+			name:         "empty hardware is not virtual",
+			hw:           &HardwareInfo{},
+			wantVirtual:  false,
+			wantPlatform: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyVirtualization(tc.hw)
+			if got.IsVirtual != tc.wantVirtual {
+				t.Errorf("ClassifyVirtualization().IsVirtual = %v, want %v", got.IsVirtual, tc.wantVirtual)
+			}
+			if got.Platform != tc.wantPlatform {
+				t.Errorf("ClassifyVirtualization().Platform = %q, want %q", got.Platform, tc.wantPlatform)
+			}
+		})
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -233,8 +233,22 @@ type Heartbeat struct {
 	// Cached virtualization classification (issue #1387) — the orthogonal
 	// "is this a VM and on what hypervisor" attribute. Computed in the same
 	// hardware-collection pass as cachedDeviceRole and guarded by h.mu.
+	//
+	// cachedVirtComputed gates the heartbeat send: virtualization is derivable
+	// ONLY from full hardware collection (CollectHardware), which runs in a
+	// background goroutine that can take ~75s on Windows and may fail. Until it
+	// succeeds, cachedIsVirtual is its zero value (false) — an affirmative
+	// "physical" claim we have NOT actually established. Sending that false
+	// would overwrite the correct is_virtual/platform that synchronous
+	// enrollment already persisted for a real VM (the server treats a present
+	// false as authoritative and clears the platform). So we send the
+	// virtualization fields only once cachedVirtComputed is true; before that
+	// the heartbeat omits them (nil) and the server leaves the stored value
+	// untouched — same "don't touch" semantics as an old agent that lacks the
+	// field entirely.
 	cachedIsVirtual    bool
 	cachedVirtPlatform string
+	cachedVirtComputed bool
 
 	// Cached system info (hostname, OS version) — refreshed every 10 min
 	cachedSysInfo      *collectors.SystemInfo
@@ -368,7 +382,7 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 			defer observability.Recoverer("heartbeat.hardwareCollect")
 			hwInfo, err := h.hardwareCol.CollectHardware()
 			if err != nil {
-				log.Warn("hardware collection failed in background; device role will use system-info-only classification", "error", err.Error())
+				log.Warn("hardware collection failed in background; device role will use system-info-only classification and virtualization detection (#1387) is unavailable — heartbeat will omit is_virtual so the enroll-time value is preserved", "error", err.Error())
 				return
 			}
 			virt := collectors.ClassifyVirtualization(hwInfo)
@@ -376,6 +390,7 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 			h.cachedDeviceRole = collectors.ClassifyDeviceRole(sysInfo, hwInfo)
 			h.cachedIsVirtual = virt.IsVirtual
 			h.cachedVirtPlatform = virt.Platform
+			h.cachedVirtComputed = true
 			h.mu.Unlock()
 		}(sysInfo)
 	} else {
@@ -2198,17 +2213,26 @@ func (h *Heartbeat) sendHeartbeat() {
 	deviceRole := h.cachedDeviceRole
 	isVirtual := h.cachedIsVirtual
 	virtPlatform := h.cachedVirtPlatform
+	virtComputed := h.cachedVirtComputed
 	h.mu.Unlock()
 
 	payload := HeartbeatPayload{
-		Status:                 status,
-		AgentVersion:           h.agentVersion,
-		HelperVersion:          h.helperMgr.InstalledVersion(),
-		HealthStatus:           h.healthMon.Summary(),
-		DeviceRole:             deviceRole,
-		IsVirtual:              &isVirtual,
-		VirtualizationPlatform: virtPlatform,
-		IsHeadless:             h.isHeadless,
+		Status:        status,
+		AgentVersion:  h.agentVersion,
+		HelperVersion: h.helperMgr.InstalledVersion(),
+		HealthStatus:  h.healthMon.Summary(),
+		DeviceRole:    deviceRole,
+		IsHeadless:    h.isHeadless,
+	}
+
+	// Only report virtualization once background hardware collection has
+	// actually classified it (#1387). Before then — or if hardware collection
+	// failed — leave IsVirtual nil so the field is omitted and the server keeps
+	// the value synchronous enrollment already established, rather than letting
+	// a not-yet-determined zero value flip a real VM to "physical".
+	if virtComputed {
+		payload.IsVirtual = &isVirtual
+		payload.VirtualizationPlatform = virtPlatform
 	}
 
 	// Include hostname/OS version so the server can detect changes

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -69,7 +69,13 @@ type HeartbeatPayload struct {
 	LastUser         string                    `json:"lastUser,omitempty"`
 	UptimeSeconds    int64                     `json:"uptime,omitempty"`
 	DeviceRole       string                    `json:"deviceRole,omitempty"`
-	HealthStatus     map[string]any            `json:"healthStatus,omitempty"`
+	// Orthogonal virtualization attribute (issue #1387). IsVirtual is a
+	// pointer so an old-agent omission (nil) is distinguishable from a
+	// genuine "physical" report (false) — the server only overwrites the
+	// stored value when the agent actually sends one.
+	IsVirtual              *bool          `json:"isVirtual,omitempty"`
+	VirtualizationPlatform string         `json:"virtualizationPlatform,omitempty"`
+	HealthStatus           map[string]any `json:"healthStatus,omitempty"`
 	DroppedLogs      int64                     `json:"droppedLogs,omitempty"`
 	HelperVersion    string                    `json:"helperVersion,omitempty"`
 	TCCPermissions   *ipc.TCCStatus            `json:"tccPermissions,omitempty"`
@@ -224,6 +230,12 @@ type Heartbeat struct {
 	// Cached device role classification (computed once at startup)
 	cachedDeviceRole string
 
+	// Cached virtualization classification (issue #1387) — the orthogonal
+	// "is this a VM and on what hypervisor" attribute. Computed in the same
+	// hardware-collection pass as cachedDeviceRole and guarded by h.mu.
+	cachedIsVirtual    bool
+	cachedVirtPlatform string
+
 	// Cached system info (hostname, OS version) — refreshed every 10 min
 	cachedSysInfo      *collectors.SystemInfo
 	lastSysInfoRefresh time.Time
@@ -359,8 +371,11 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 				log.Warn("hardware collection failed in background; device role will use system-info-only classification", "error", err.Error())
 				return
 			}
+			virt := collectors.ClassifyVirtualization(hwInfo)
 			h.mu.Lock()
 			h.cachedDeviceRole = collectors.ClassifyDeviceRole(sysInfo, hwInfo)
+			h.cachedIsVirtual = virt.IsVirtual
+			h.cachedVirtPlatform = virt.Platform
 			h.mu.Unlock()
 		}(sysInfo)
 	} else {
@@ -2181,15 +2196,19 @@ func (h *Heartbeat) sendHeartbeat() {
 	}
 	sysInfo := h.cachedSysInfo
 	deviceRole := h.cachedDeviceRole
+	isVirtual := h.cachedIsVirtual
+	virtPlatform := h.cachedVirtPlatform
 	h.mu.Unlock()
 
 	payload := HeartbeatPayload{
-		Status:        status,
-		AgentVersion:  h.agentVersion,
-		HelperVersion: h.helperMgr.InstalledVersion(),
-		HealthStatus:  h.healthMon.Summary(),
-		DeviceRole:    deviceRole,
-		IsHeadless:    h.isHeadless,
+		Status:                 status,
+		AgentVersion:           h.agentVersion,
+		HelperVersion:          h.helperMgr.InstalledVersion(),
+		HealthStatus:           h.healthMon.Summary(),
+		DeviceRole:             deviceRole,
+		IsVirtual:              &isVirtual,
+		VirtualizationPlatform: virtPlatform,
+		IsHeadless:             h.isHeadless,
 	}
 
 	// Include hostname/OS version so the server can detect changes

--- a/agent/pkg/api/client.go
+++ b/agent/pkg/api/client.go
@@ -40,7 +40,13 @@ type EnrollRequest struct {
 	Architecture     string        `json:"architecture"`
 	AgentVersion     string        `json:"agentVersion,omitempty"`
 	DeviceRole       string        `json:"deviceRole,omitempty"`
-	HardwareInfo     *HardwareInfo `json:"hardwareInfo,omitempty"`
+	// IsVirtual / VirtualizationPlatform are the orthogonal "is this a VM and
+	// on what hypervisor" attribute (issue #1387), derived by the agent from
+	// the same hardware identity strings that drive DeviceRole. They are a
+	// second policy-targeting axis, not a role.
+	IsVirtual              bool          `json:"isVirtual,omitempty"`
+	VirtualizationPlatform string        `json:"virtualizationPlatform,omitempty"`
+	HardwareInfo           *HardwareInfo `json:"hardwareInfo,omitempty"`
 }
 
 type HardwareInfo struct {

--- a/apps/api/migrations/2026-06-27-device-virtualization-attribute.sql
+++ b/apps/api/migrations/2026-06-27-device-virtualization-attribute.sql
@@ -1,0 +1,21 @@
+-- Issue #1387: orthogonal virtual/VDI device attribute for policy targeting.
+--
+-- Adds two columns to `devices`:
+--   is_virtual               — true when the host runs on a hypervisor
+--   virtualization_platform  — normalized hypervisor token (vmware / hyperv /
+--                              virtualbox / qemu / kvm / xen / bochs /
+--                              parallels), NULL when physical or undetermined.
+--
+-- These are a SECOND policy-targeting axis, NOT new device_role values: a
+-- virtual workstation is still a workstation and keeps matching role-based
+-- policies. The agent derives both from the SMBIOS hardware identity strings
+-- (Manufacturer / Model / BIOS) it already collects.
+--
+-- RLS: `devices` already has org_id RLS policies; added columns inherit the
+-- table's existing protection — no new policy required.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS so re-application is a no-op.
+
+ALTER TABLE devices
+  ADD COLUMN IF NOT EXISTS is_virtual boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS virtualization_platform varchar(30);

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -49,6 +49,15 @@ export const devices = pgTable('devices', {
   osType: osTypeEnum('os_type').notNull(),
   deviceRole: varchar('device_role', { length: 30 }).notNull().default('unknown'),
   deviceRoleSource: varchar('device_role_source', { length: 20 }).notNull().default('auto'),
+  // Orthogonal virtualization attribute (issue #1387): is this box running on a
+  // hypervisor, and which one. Set by the agent from SMBIOS hardware identity
+  // strings. Distinct from device_role — a virtual workstation is still a
+  // workstation and keeps matching role-based policies; virtualization is a
+  // second policy-targeting axis. virtualization_platform is one of
+  // VIRTUALIZATION_PLATFORMS (vmware/hyperv/virtualbox/qemu/kvm/xen/bochs/
+  // parallels), or null when physical or undetermined.
+  isVirtual: boolean('is_virtual').notNull().default(false),
+  virtualizationPlatform: varchar('virtualization_platform', { length: 30 }),
   osVersion: varchar('os_version', { length: 100 }).notNull(),
   osBuild: varchar('os_build', { length: 100 }),
   architecture: varchar('architecture', { length: 20 }).notNull(),

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -1445,4 +1445,74 @@ describe('POST /agents/enroll — virtualization attribute persistence (#1387)',
     expect(deviceValues.isVirtual).toBe(false);
     expect(deviceValues.virtualizationPlatform).toBeNull();
   });
+
+  it('carries the virtualization fields onto the fresh-id INSERT when re-enrolling over a decommissioned row (#914 path)', async () => {
+    // The decom-bypass-fresh-id branch is a SECOND device INSERT site (it
+    // renames the old row then inserts a new one). Assert it also persists the
+    // virtualization attribute so a VM reinstalling onto a decommissioned
+    // hostname keeps its is_virtual/platform.
+    mockKeyLookup({
+      id: 'key-decom-virt',
+      orgId: 'org-decom-virt',
+      siteId: 'site-decom-virt',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([
+            { id: 'key-decom-virt', orgId: 'org-decom-virt', siteId: 'site-decom-virt' },
+          ]),
+        })),
+      })),
+    } as any);
+    mockSelectRows([{ partnerId: 'partner-decom-virt' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    // Existing row is DECOMMISSIONED, no token on the request → decom-bypass-fresh-id.
+    mockSelectRows([{
+      id: 'device-decom-existing',
+      status: 'decommissioned',
+      agentTokenHash: 'old-decom-hash',
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+    }]);
+
+    const deviceInsertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([
+        { id: 'device-decom-fresh', orgId: 'org-decom-virt', siteId: 'site-decom-virt', hostname: 'host-1' },
+      ]),
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 0 }]) }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn(() => Object.assign(
+              Promise.resolve(undefined) as any,
+              { returning: vi.fn().mockResolvedValue([{ id: 'key-decom-virt' }]) },
+            )),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({ values: deviceInsertValues }),
+        delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      };
+      return fn(fakeTx);
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...baseEnrollBody, isVirtual: true, virtualizationPlatform: 'vmware' }),
+    });
+    expect(resp.status).toBe(201);
+    const deviceValues = (deviceInsertValues.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(deviceValues.isVirtual).toBe(true);
+    expect(deviceValues.virtualizationPlatform).toBe('vmware');
+  });
 });

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -1357,3 +1357,92 @@ describe('POST /agents/enroll — enrollment key not consumed on failed device i
     expect(db.transaction).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /agents/enroll — virtualization attribute persistence (#1387)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_ENROLLMENT_SECRET;
+    process.env.NODE_ENV = 'test';
+  });
+
+  // Stands up the full happy enrollment path and returns the spy that captures
+  // the device INSERT .values(...) payload so a test can assert the persisted
+  // virtualization columns.
+  function arrangeFreshEnroll() {
+    mockKeyLookup({
+      id: 'key-virt',
+      orgId: 'org-virt',
+      siteId: 'site-virt',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([
+            { id: 'key-virt', orgId: 'org-virt', siteId: 'site-virt' },
+          ]),
+        })),
+      })),
+    } as any);
+    mockSelectRows([{ partnerId: 'partner-virt' }]); // org lookup
+    mockSelectRows([{ maxDevices: null }]); // partner.maxDevices
+    mockSelectRows([]); // existing-device lookup → fresh
+
+    const deviceInsertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([
+        { id: 'device-virt', orgId: 'org-virt', siteId: 'site-virt', hostname: 'host-1' },
+      ]),
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }]),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({ values: deviceInsertValues }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'key-virt' }]),
+            }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      };
+      return fn(fakeTx);
+    });
+    return deviceInsertValues;
+  }
+
+  it('persists isVirtual + virtualizationPlatform from the enroll payload', async () => {
+    const deviceInsertValues = arrangeFreshEnroll();
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...baseEnrollBody, isVirtual: true, virtualizationPlatform: 'hyperv' }),
+    });
+    expect(resp.status).toBe(201);
+    // First insert call is the devices row.
+    const deviceValues = (deviceInsertValues.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(deviceValues.isVirtual).toBe(true);
+    expect(deviceValues.virtualizationPlatform).toBe('hyperv');
+  });
+
+  it('defaults to isVirtual=false / null platform when the agent omits the fields', async () => {
+    const deviceInsertValues = arrangeFreshEnroll();
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody), // no virtualization fields
+    });
+    expect(resp.status).toBe(201);
+    const deviceValues = (deviceInsertValues.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(deviceValues.isVirtual).toBe(false);
+    expect(deviceValues.virtualizationPlatform).toBeNull();
+  });
+});

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -620,6 +620,8 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
             previousHelperTokenExpiresAt: null,
             deviceRole: data.deviceRole || 'unknown',
             deviceRoleSource: 'auto',
+            isVirtual: data.isVirtual ?? false,
+            virtualizationPlatform: data.virtualizationPlatform ?? null,
             status: 'online',
             lastSeenAt: new Date(),
             updatedAt: new Date(),
@@ -646,6 +648,8 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
             helperTokenIssuedAt: tokenIssuedAt,
             deviceRole: data.deviceRole || 'unknown',
             deviceRoleSource: 'auto',
+            isVirtual: data.isVirtual ?? false,
+            virtualizationPlatform: data.virtualizationPlatform ?? null,
             status: 'online',
             lastSeenAt: new Date(),
             tags: []

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1243,10 +1243,25 @@ describe('POST /agents/:id/heartbeat — virtualization attribute (#1387)', () =
 
   it('leaves stored virtualization untouched when an old agent omits the field', async () => {
     const setSpy = arrange({ isVirtual: true, virtualizationPlatform: 'vmware' });
-    await beat({}); // no isVirtual in payload
+    await beat({}); // no isVirtual in payload (also covers the agent's not-yet-classified startup window, where IsVirtual is nil)
     const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
     expect(updateArg.isVirtual).toBeUndefined();
     expect(updateArg.virtualizationPlatform).toBeUndefined();
+  });
+
+  it('persists virtualization independently of deviceRoleSource (admin-pinned role still updates the axis)', async () => {
+    // A VDI box with an operator-pinned role (deviceRoleSource='manual') must
+    // still have its orthogonal virtualization axis updated — the two are
+    // independent. Guards against a future refactor folding both under the
+    // deviceRole 'auto' gate.
+    const setSpy = arrange({ deviceRoleSource: 'manual', deviceRole: 'server' });
+    await beat({ deviceRole: 'workstation', isVirtual: true, virtualizationPlatform: 'vmware' });
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    // Role NOT updated (source is manual)...
+    expect(updateArg.deviceRole).toBeUndefined();
+    // ...but virtualization IS.
+    expect(updateArg.isVirtual).toBe(true);
+    expect(updateArg.virtualizationPlatform).toBe('vmware');
   });
 
   // NOTE: schema-level coercion (e.g. an unrecognized platform string being

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1171,3 +1171,86 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
     expect(body.watchdogUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite manual
   });
 });
+
+// ---------------------------------------------------------------------
+// #1387 — orthogonal virtualization attribute persistence
+// ---------------------------------------------------------------------
+
+describe('POST /agents/:id/heartbeat — virtualization attribute (#1387)', () => {
+  function arrange(deviceOverrides: Record<string, unknown> = {}) {
+    vi.clearAllMocks();
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host-1',
+          osType: 'windows',
+          osVersion: 'Microsoft Windows 11 Pro',
+          osBuild: null,
+          architecture: 'amd64',
+          agentVersion: '0.65.10',
+          deviceRole: 'workstation',
+          deviceRoleSource: 'auto',
+          isVirtual: false,
+          virtualizationPlatform: null,
+          agentTokenHash: 'hash',
+          tokenIssuedAt: new Date(),
+          ...deviceOverrides,
+        },
+      ]),
+    );
+    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    updateMock.mockReturnValue({ set: setSpy });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    selectMock.mockReturnValue(selectChainResolving([]));
+    return setSpy;
+  }
+
+  async function beat(body: Record<string, unknown>) {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...minimalHeartbeatBody, ...body }),
+    });
+  }
+
+  it('persists isVirtual=true + platform when the agent reports a hypervisor', async () => {
+    const setSpy = arrange();
+    const resp = await beat({ isVirtual: true, virtualizationPlatform: 'vmware' });
+    expect(resp.status).toBe(200);
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.isVirtual).toBe(true);
+    expect(updateArg.virtualizationPlatform).toBe('vmware');
+  });
+
+  it('clears the platform to NULL when the agent reports isVirtual=false', async () => {
+    const setSpy = arrange({ isVirtual: true, virtualizationPlatform: 'hyperv' });
+    await beat({ isVirtual: false });
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.isVirtual).toBe(false);
+    expect(updateArg.virtualizationPlatform).toBeNull();
+  });
+
+  it('clears the platform to NULL when isVirtual=true but no platform is identified', async () => {
+    const setSpy = arrange();
+    await beat({ isVirtual: true });
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.isVirtual).toBe(true);
+    expect(updateArg.virtualizationPlatform).toBeNull();
+  });
+
+  it('leaves stored virtualization untouched when an old agent omits the field', async () => {
+    const setSpy = arrange({ isVirtual: true, virtualizationPlatform: 'vmware' });
+    await beat({}); // no isVirtual in payload
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.isVirtual).toBeUndefined();
+    expect(updateArg.virtualizationPlatform).toBeUndefined();
+  });
+
+  // NOTE: schema-level coercion (e.g. an unrecognized platform string being
+  // dropped to undefined by .catch) is asserted against the real schema in
+  // schemas.test.ts — this route test mocks zValidator out, so the handler
+  // here only ever sees already-validated `data`.
+});

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -343,6 +343,18 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     deviceUpdates.deviceRole = data.deviceRole;
   }
 
+  // Orthogonal virtualization attribute (issue #1387). Old agents omit
+  // isVirtual entirely (undefined) — leave the stored value untouched in that
+  // case. A present value (true/false) is authoritative; the platform is
+  // cleared when the agent reports virtual=false or sends no platform, so a
+  // box that stops reporting a hypervisor doesn't keep a stale platform.
+  if (data.isVirtual !== undefined) {
+    deviceUpdates.isVirtual = data.isVirtual;
+    deviceUpdates.virtualizationPlatform = data.isVirtual
+      ? (data.virtualizationPlatform ?? null)
+      : null;
+  }
+
   // Update hostname/OS version when agent reports changes
   if (data.hostname && data.hostname !== device.hostname) {
     deviceUpdates.hostname = data.hostname;

--- a/apps/api/src/routes/agents/schemas.test.ts
+++ b/apps/api/src/routes/agents/schemas.test.ts
@@ -4,6 +4,8 @@ import {
   CHANGE_INGEST_MAX_ITEMS,
   __resolveChangeIngestMaxItemsForTests,
   agentWarrantyInfoSchema,
+  enrollSchema,
+  heartbeatSchema,
 } from './schemas';
 
 // Build a minimal valid change item the schema accepts.
@@ -111,5 +113,70 @@ describe('agentWarrantyInfoSchema — coverageKind acceptance', () => {
   it("still rejects an unknown non-empty coverageKind (e.g. 'lease')", () => {
     const parsed = agentWarrantyInfoSchema.safeParse({ ...base, coverageKind: 'lease' });
     expect(parsed.success).toBe(false);
+  });
+});
+
+// Issue #1387 — orthogonal virtualization attribute validation.
+describe('virtualization attribute — enrollSchema (strict)', () => {
+  const base = {
+    enrollmentKey: 'k',
+    hostname: 'host-1',
+    osType: 'windows' as const,
+    osVersion: 'Windows 11 Pro',
+    architecture: 'amd64',
+    agentVersion: '0.65.0',
+  };
+
+  it('accepts isVirtual + a known virtualizationPlatform', () => {
+    const parsed = enrollSchema.safeParse({ ...base, isVirtual: true, virtualizationPlatform: 'vmware' });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.isVirtual).toBe(true);
+      expect(parsed.data.virtualizationPlatform).toBe('vmware');
+    }
+  });
+
+  it('treats the virtualization fields as optional (absent → undefined)', () => {
+    const parsed = enrollSchema.safeParse(base);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.isVirtual).toBeUndefined();
+      expect(parsed.data.virtualizationPlatform).toBeUndefined();
+    }
+  });
+
+  it('REJECTS an unrecognized platform (strict enroll path)', () => {
+    const parsed = enrollSchema.safeParse({ ...base, isVirtual: true, virtualizationPlatform: 'totally-made-up' });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('virtualization attribute — heartbeatSchema (tolerant)', () => {
+  const base = { status: 'ok' as const, agentVersion: '0.65.0' };
+
+  it('accepts isVirtual + a known virtualizationPlatform', () => {
+    const parsed = heartbeatSchema.safeParse({ ...base, isVirtual: true, virtualizationPlatform: 'hyperv' });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.isVirtual).toBe(true);
+      expect(parsed.data.virtualizationPlatform).toBe('hyperv');
+    }
+  });
+
+  it('DROPS an unrecognized platform to undefined (does not reject the heartbeat)', () => {
+    const parsed = heartbeatSchema.safeParse({ ...base, isVirtual: true, virtualizationPlatform: 'totally-made-up' });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.isVirtual).toBe(true);
+      expect(parsed.data.virtualizationPlatform).toBeUndefined();
+    }
+  });
+
+  it('drops a non-boolean isVirtual to undefined rather than rejecting', () => {
+    const parsed = heartbeatSchema.safeParse({ ...base, isVirtual: 'yes' as unknown as boolean });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.isVirtual).toBeUndefined();
+    }
   });
 });

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -10,6 +10,14 @@ const DEVICE_ROLES = [
   'firewall', 'access_point', 'phone', 'iot', 'camera', 'nas', 'unknown'
 ] as const;
 
+// Orthogonal virtualization attribute (issue #1387). Kept in sync with the
+// agent's classify.go virtualizationMarkers and shared VIRTUALIZATION_PLATFORMS.
+// A value outside this set is dropped (heartbeat) / rejected (enroll) rather
+// than persisted, so an unrecognized platform never lands in the column.
+const VIRTUALIZATION_PLATFORMS = [
+  'vmware', 'hyperv', 'virtualbox', 'qemu', 'kvm', 'xen', 'bochs', 'parallels'
+] as const;
+
 const desktopAccessReasonSchema = z.enum([
   'missing_permission',
   'missing_entitlement',
@@ -28,6 +36,8 @@ export const enrollSchema = z.object({
   architecture: z.string().min(1),
   agentVersion: z.string().min(1),
   deviceRole: z.enum(DEVICE_ROLES).optional(),
+  isVirtual: z.boolean().optional(),
+  virtualizationPlatform: z.enum(VIRTUALIZATION_PLATFORMS).optional(),
   hardwareInfo: z.object({
     cpuModel: z.string().optional(),
     cpuCores: z.number().int().optional(),
@@ -149,6 +159,8 @@ export const heartbeatSchema = z.object({
   lastUser: z.string().max(255).optional().catch(undefined),
   uptime: z.number().int().min(0).optional().catch(undefined),
   deviceRole: z.enum(DEVICE_ROLES).optional().catch(undefined),
+  isVirtual: z.boolean().optional().catch(undefined),
+  virtualizationPlatform: z.enum(VIRTUALIZATION_PLATFORMS).optional().catch(undefined),
   hostname: z.string().min(1).max(255).optional().catch(undefined),
   osVersion: z.string().min(1).max(255).optional().catch(undefined),
   osBuild: z.string().max(255).optional().catch(undefined),

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -33,6 +33,16 @@ export const DEVICE_ROLES = [
 ] as const;
 export type DeviceRole = typeof DEVICE_ROLES[number];
 
+// Orthogonal virtualization attribute (issue #1387). A virtual/VDI box is still
+// a workstation (or server) — virtualization is a SECOND targeting axis, not a
+// device role. The agent derives the platform from SMBIOS hardware identity
+// strings (Manufacturer/Model/BIOS); these tokens are kept in sync with the
+// agent's classify.go virtualizationMarkers list.
+export const VIRTUALIZATION_PLATFORMS = [
+  'vmware', 'hyperv', 'virtualbox', 'qemu', 'kvm', 'xen', 'bochs', 'parallels'
+] as const;
+export type VirtualizationPlatform = typeof VIRTUALIZATION_PLATFORMS[number];
+
 // ============================================
 // Common Validators
 // ============================================


### PR DESCRIPTION
## What

Adds an **orthogonal** virtualization attribute to devices so config policies can target virtual/VDI hosts differently from physical workstations — the prerequisite for the motivating use case in #1387 (e.g. don't auto-enable BitLocker on non-persistent VMs).

Per the issue's chosen design: **`is_virtual` + `virtualization_platform` are a second targeting axis, NOT new `device_role` values.** A virtual box stays `device_role='workstation'` and keeps matching every existing workstation policy.

## Changes

**Agent (Go)**
- `ClassifyVirtualization(hw)` in `classify.go` — pure function deriving `is_virtual` + platform from the SMBIOS `Manufacturer`/`Model`/`BIOS` strings already collected for role classification. Platforms: `vmware`/`hyperv`/`virtualbox`/`qemu`/`kvm`/`xen`/`bochs`/`parallels`. Table-driven tests, including the **physical Microsoft Surface vs. Hyper-V** edge case (Microsoft is both a physical and a VM manufacturer — the marker keys off the `Virtual Machine` model string, never the manufacturer alone).
- Cached alongside `cachedDeviceRole` in the same background hardware-collection pass; sent on **enroll** and **heartbeat**. The heartbeat field is a `*bool` so an old agent's omission (`nil`) is distinguishable from a genuine physical (`false`) report.

**API / DB**
- New `devices` columns `is_virtual` (bool, default false) + `virtualization_platform` (varchar(30), nullable). Idempotent `ADD COLUMN IF NOT EXISTS` migration. **No new RLS policy** — added columns inherit the table's existing `org_id` policies.
- `enrollSchema` accepts the fields strictly (rejects an unknown platform); `heartbeatSchema` is tolerant (`.catch(undefined)` drops a bad value rather than 400-ing the beat). Persisted on enroll (insert + update) and heartbeat; platform is cleared to `NULL` when the agent reports `is_virtual=false`.
- Shared `VIRTUALIZATION_PLATFORMS` constant mirrors the agent's marker list.

## Scope deferred (follow-ups on #1387)

This PR lands the **detection + persisted-attribute foundation** only. Intentionally deferred so each can be reviewed on its own:
- Server-side **VDI** client detection (software-inventory name match → a `vdi_platform` marker). No perpetually-NULL column was added for it here.
- The **policy targeting axis** (`configPolicyAssignments` filter + `featureConfigResolver`).
- The **UI** Virtual/VDI badge + policy-assignment filter (depends on #1386 UX).

## Tests / verification

- Go: `go test -race ./internal/collectors/... ./internal/heartbeat/... ./pkg/api/...` — green.
- API: `vitest run schemas.test.ts heartbeat.test.ts enrollment.test.ts` — 83 passed (strict enroll-reject + tolerant heartbeat-drop + insert/update/heartbeat persistence + old-agent-omission).
- `tsc --noEmit` clean (api + shared); `autoMigrate.test.ts` ordering green.
- Drift: migration applied to a **fresh** DB (233+ migrations, mine last) → `db:check-drift` reports **no drift**; columns verified `boolean NOT NULL DEFAULT false` / `varchar(30) NULL`.

Closes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)