### PR TITLE
feat(quotes): Phase 4 — accepted quote recurring lines auto-create draft contracts

### DIFF
--- a/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
@@ -226,7 +226,7 @@ describe('quote accept → convert', () => {
     const { partner, org } = await seed();
     const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
     const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
-    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Annual license', quantity: 1, unitPrice: 1200, taxable: false, customerVisible: true, recurrence: 'annual' } as any, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Annual license', quantity: 2, unitPrice: 1200, taxable: false, customerVisible: true, recurrence: 'annual' } as any, actor));
     await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'EDR', quantity: 3, unitPrice: 15, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
     await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
 
@@ -239,5 +239,27 @@ describe('quote accept → convert', () => {
     const intervals = rows.map((r) => r.intervalMonths).sort((a, b) => a - b);
     expect(intervals).toEqual([1, 12]);
     expect(rows.every((r) => r.status === 'draft')).toBe(true);
+    expect(rows.every((r) => r.billingTiming === 'advance' && r.autoIssue === false)).toBe(true);
+
+    // Verify contract lines: two contracts, each with exactly one manual line
+    const cLines = await withSystemDbAccessContext(() =>
+      db.select().from(contractLines).where(inArray(contractLines.contractId, res.contractIds)),
+    );
+    expect(cLines).toHaveLength(2);
+    expect(cLines.every((l) => l.lineType === 'manual')).toBe(true);
+
+    // Match lines to contracts by intervalMonths: 1=monthly (EDR, qty 3, price 15), 12=annual (Annual license, qty 2, price 1200)
+    const monthlyContract = rows.find((c) => c.intervalMonths === 1)!;
+    const annualContract = rows.find((c) => c.intervalMonths === 12)!;
+
+    const monthlyLine = cLines.find((l) => l.contractId === monthlyContract.id)!;
+    expect(monthlyLine.description).toBe('EDR');
+    expect(monthlyLine.unitPrice).toBe('15.00');
+    expect(monthlyLine.manualQuantity).toBe('3.00');
+
+    const annualLine = cLines.find((l) => l.contractId === annualContract.id)!;
+    expect(annualLine.description).toBe('Annual license');
+    expect(annualLine.unitPrice).toBe('1200.00');
+    expect(annualLine.manualQuantity).toBe('2.00');
   });
 });

--- a/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
@@ -1,9 +1,10 @@
 import './setup';
 import { describe, expect, it } from 'vitest';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
 import { quotes, quoteAcceptances } from '../../db/schema/quotes';
 import { invoices, invoiceLines } from '../../db/schema/invoices';
+import { contracts, contractLines } from '../../db/schema/contracts';
 import { organizations } from '../../db/schema/orgs';
 import { createPartner, createOrganization } from './db-utils';
 import { createQuote, addManualLine } from '../../services/quoteService';
@@ -22,7 +23,7 @@ describe('quote accept → convert', () => {
     const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
     const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
     await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Onboarding', quantity: 1, unitPrice: 250, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
-    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Managed services', quantity: 1, unitPrice: 99, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Managed services', quantity: 5, unitPrice: 99, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
     await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
 
     const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane Buyer', signerEmail: 'jane@org.example', ipAddress: '9.9.9.9', userAgent: 'UA' }));
@@ -41,6 +42,27 @@ describe('quote accept → convert', () => {
     expect(invLines[0]!.description).toBe('Onboarding');
     const [inv] = await withSystemDbAccessContext(() => db.select().from(invoices).where(eq(invoices.id, res.invoiceId)));
     expect(inv!.total).toBe('250.00');
+
+    // Phase 4: the monthly recurring line becomes a draft contract.
+    expect(res.contractIds).toHaveLength(1);
+    const createdContracts = await withSystemDbAccessContext(() =>
+      db.select().from(contracts).where(eq(contracts.id, res.contractIds[0]!)),
+    );
+    expect(createdContracts).toHaveLength(1);
+    const contract = createdContracts[0]!;
+    expect(contract.status).toBe('draft');
+    expect(contract.intervalMonths).toBe(1);
+    expect(contract.billingTiming).toBe('advance');
+    expect(contract.autoIssue).toBe(false);
+
+    const cLines = await withSystemDbAccessContext(() =>
+      db.select().from(contractLines).where(eq(contractLines.contractId, contract.id)),
+    );
+    expect(cLines).toHaveLength(1);
+    expect(cLines[0]!.lineType).toBe('manual');
+    expect(cLines[0]!.description).toBe('Managed services');
+    expect(cLines[0]!.unitPrice).toBe('99.00');
+    expect(cLines[0]!.manualQuantity).toBe('5.00');
   });
 
   // The auto-issued invoice must carry the quote's frozen seller snapshot, T&C, and
@@ -198,5 +220,24 @@ describe('quote accept → convert', () => {
     expect(invs[0]!.id).toBe(first.invoiceId);
     const accs = await withSystemDbAccessContext(() => db.select({ id: quoteAcceptances.id }).from(quoteAcceptances).where(eq(quoteAcceptances.quoteId, created.id)));
     expect(accs).toHaveLength(1);
+  });
+
+  runDb('creates a monthly and an annual draft contract for a quote with both cadences', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Annual license', quantity: 1, unitPrice: 1200, taxable: false, customerVisible: true, recurrence: 'annual' } as any, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'EDR', quantity: 3, unitPrice: 15, taxable: false, customerVisible: true, recurrence: 'monthly' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane Buyer' }));
+
+    expect(res.contractIds).toHaveLength(2);
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(contracts).where(inArray(contracts.id, res.contractIds)),
+    );
+    const intervals = rows.map((r) => r.intervalMonths).sort((a, b) => a - b);
+    expect(intervals).toEqual([1, 12]);
+    expect(rows.every((r) => r.status === 'draft')).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
@@ -54,6 +54,10 @@ describe('quote accept → convert', () => {
     expect(contract.intervalMonths).toBe(1);
     expect(contract.billingTiming).toBe('advance');
     expect(contract.autoIssue).toBe(false);
+    expect(contract.currencyCode).toBe('USD');
+    expect(contract.orgId).toBe(org.id);
+    expect(contract.partnerId).toBe(partner.id);
+    expect(contract.startDate).toBe(new Date().toISOString().slice(0, 10));
 
     const cLines = await withSystemDbAccessContext(() =>
       db.select().from(contractLines).where(eq(contractLines.contractId, contract.id)),
@@ -166,6 +170,14 @@ describe('quote accept → convert', () => {
     expect(inv!.total).toBe('0.00');
     const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)));
     expect(q!.status).toBe('converted');
+
+    // Phase 4: even a recurring-only quote still creates the draft contract.
+    expect(res.contractIds).toHaveLength(1);
+    const [recurringContract] = await withSystemDbAccessContext(() =>
+      db.select().from(contracts).where(eq(contracts.id, res.contractIds[0]!)),
+    );
+    expect(recurringContract!.status).toBe('draft');
+    expect(recurringContract!.intervalMonths).toBe(1);
   });
 
   // Phase 3 read-time expiry guard: a quote whose expiry_date has passed must be
@@ -220,6 +232,23 @@ describe('quote accept → convert', () => {
     expect(invs[0]!.id).toBe(first.invoiceId);
     const accs = await withSystemDbAccessContext(() => db.select({ id: quoteAcceptances.id }).from(quoteAcceptances).where(eq(quoteAcceptances.quoteId, created.id)));
     expect(accs).toHaveLength(1);
+  });
+
+  runDb('one-time-only quote creates no contracts', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id); const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Onboarding fee', quantity: 1, unitPrice: 500, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+
+    const res = await withDbAccessContext(ctx, () => acceptQuote({ quoteId: created.id, signerName: 'Jane' }));
+    expect(res.contractIds).toEqual([]);
+
+    // Defense-in-depth: confirm no contracts exist at the DB level either.
+    const rows = await withSystemDbAccessContext(() =>
+      db.select({ id: contracts.id }).from(contracts).where(eq(contracts.orgId, org.id)),
+    );
+    expect(rows).toHaveLength(0);
   });
 
   runDb('creates a monthly and an annual draft contract for a quote with both cadences', async () => {

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -3,6 +3,7 @@ import { db } from '../db';
 import { contracts, contractLines, contractBillingPeriods, organizations } from '../db/schema';
 import { ContractServiceError, type ContractActor } from './contractTypes';
 import type { ContractLineInput, UpdateContractInput } from '@breeze/shared';
+import type { NewContractSpec } from './quoteToContract';
 import { periodIndexFor, nextBillingDate, computePeriod, isExpired } from './contractMath';
 import { emitContractEvent } from './contractEvents';
 import { createManualInvoice, addContractLine, deleteDraftInvoice } from './invoiceService';
@@ -407,4 +408,50 @@ export async function generateDueInvoice(contractId: string, asOf: Date = new Da
   // Auto-issue + email are intentionally returned to the caller (NOT done here) so they
   // run post-commit, outside the billing transaction. See the doc-comment above.
   return { generated: true, invoiceId: inv.id, autoIssue: c.autoIssue, actor };
+}
+
+// INTERNAL (Phase 4): persist a contract + lines built by buildContractSpecsFromQuote.
+// Tenancy (orgId/partnerId) is already validated by the caller, so there is NO
+// actor guard here. MUST run inside an established system-scope DB context
+// (e.g. acceptQuote's withSystemDbAccessContext transaction) — do not call from
+// a bare request handler. Always lands status='draft'; the MSP activates later.
+export async function createContractWithLines(
+  spec: NewContractSpec,
+): Promise<typeof contracts.$inferSelect> {
+  const [contract] = await db
+    .insert(contracts)
+    .values({
+      partnerId: spec.partnerId,
+      orgId: spec.orgId,
+      name: spec.name,
+      status: 'draft',
+      billingTiming: spec.billingTiming,
+      intervalMonths: spec.intervalMonths,
+      startDate: spec.startDate,
+      endDate: spec.endDate ?? null,
+      autoIssue: false,
+      currencyCode: spec.currencyCode ?? 'USD',
+      notes: spec.notes ?? null,
+      terms: spec.terms ?? null,
+      createdBy: spec.createdBy ?? null,
+    })
+    .returning();
+
+  for (let i = 0; i < spec.lines.length; i++) {
+    const l = spec.lines[i]!;
+    await db.insert(contractLines).values({
+      contractId: contract!.id,
+      orgId: spec.orgId,
+      lineType: l.lineType,
+      description: l.description,
+      catalogItemId: l.catalogItemId ?? null,
+      unitPrice: l.unitPrice,
+      manualQuantity: l.lineType === 'manual' ? (l.manualQuantity ?? '0') : null,
+      siteId: l.lineType === 'per_device' ? (l.siteId ?? null) : null,
+      taxable: l.taxable,
+      sortOrder: l.sortOrder ?? i,
+    });
+  }
+
+  return contract!;
 }

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -414,7 +414,9 @@ export async function generateDueInvoice(contractId: string, asOf: Date = new Da
 // Tenancy (orgId/partnerId) is already validated by the caller, so there is NO
 // actor guard here. MUST run inside an established system-scope DB context
 // (e.g. acceptQuote's withSystemDbAccessContext transaction) — do not call from
-// a bare request handler. Always lands status='draft'; the MSP activates later.
+// a bare request handler — a contextless/org-only call hits the partner-axis writes'
+// RLS WITH CHECK and fails (now a typed CONTRACT_CREATE_FAILED, previously a 0-row
+// silent write). Always lands status='draft'; the MSP activates later.
 export async function createContractWithLines(
   spec: NewContractSpec,
 ): Promise<typeof contracts.$inferSelect> {
@@ -437,10 +439,17 @@ export async function createContractWithLines(
     })
     .returning();
 
+  if (!contract) {
+    throw new ContractServiceError(
+      `contract insert returned 0 rows (org=${spec.orgId} partner=${spec.partnerId}) — likely an RLS WITH CHECK rejection from a non-system DB context`,
+      500, 'CONTRACT_CREATE_FAILED',
+    );
+  }
+
   for (let i = 0; i < spec.lines.length; i++) {
     const l = spec.lines[i]!;
-    await db.insert(contractLines).values({
-      contractId: contract!.id,
+    const [insertedLine] = await db.insert(contractLines).values({
+      contractId: contract.id,
       orgId: spec.orgId,
       lineType: l.lineType,
       description: l.description,
@@ -450,8 +459,15 @@ export async function createContractWithLines(
       siteId: l.lineType === 'per_device' ? (l.siteId ?? null) : null,
       taxable: l.taxable,
       sortOrder: l.sortOrder ?? i,
-    });
+    }).returning({ id: contractLines.id });
+
+    if (!insertedLine) {
+      throw new ContractServiceError(
+        `contract line insert returned 0 rows (contractId=${contract.id} org=${spec.orgId} line[${i}]) — likely an RLS WITH CHECK rejection`,
+        500, 'CONTRACT_LINE_CREATE_FAILED',
+      );
+    }
   }
 
-  return contract!;
+  return contract;
 }

--- a/apps/api/src/services/contractTypes.ts
+++ b/apps/api/src/services/contractTypes.ts
@@ -16,6 +16,8 @@ export interface Period {
 export type ContractServiceErrorCode =
   | 'ORG_DENIED'
   | 'CONTRACT_NOT_FOUND'
+  | 'CONTRACT_CREATE_FAILED'
+  | 'CONTRACT_LINE_CREATE_FAILED'
   | 'NOT_A_DRAFT'
   | 'NO_LINES'
   | 'INVALID_STATE'

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -220,7 +220,7 @@ export async function acceptQuote(
     {
       orgId: quote.orgId,
       partnerId: quote.partnerId,
-      quoteNumber: quote.quoteNumber ?? '',
+      quoteNumber: quote.quoteNumber ?? quote.id,
       currencyCode: quote.currencyCode ?? null,
       terms: quote.terms ?? null,
     },
@@ -229,6 +229,7 @@ export async function acceptQuote(
       customerVisible: l.customerVisible,
       description: l.description,
       unitPrice: l.unitPrice,
+      quantity: l.quantity,
       taxable: l.taxable,
       catalogItemId: l.catalogItemId ?? null,
       termMonths: l.termMonths ?? null,

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -11,6 +11,8 @@ import { formatInvoiceNumber } from './invoiceNumbers';
 import { isQuoteExpired } from './quoteExpiry';
 import { emitInvoiceEvent } from './invoiceEvents';
 import { enqueueInvoicePdfRender } from '../jobs/invoiceWorker';
+import { buildContractSpecsFromQuote } from './quoteToContract';
+import { createContractWithLines } from './contractService';
 
 export interface AcceptQuoteParams {
   quoteId: string;
@@ -43,7 +45,7 @@ type QuoteRow = typeof quotes.$inferSelect;
  */
 export async function acceptQuote(
   params: AcceptQuoteParams
-): Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string; invoiceIssued: boolean }> {
+): Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string; invoiceIssued: boolean; contractIds: string[] }> {
   // FOR UPDATE: serialize concurrent accepts on the same quote (we're already in
   // the caller's transaction). Without the row lock two READ COMMITTED accepts
   // both pass the status guard and each create an invoice (atom-1/C2).
@@ -208,11 +210,44 @@ export async function acceptQuote(
   // Note: the public token's jti is revoked by the CALLER after the transaction
   // commits (atom-2) — revoking here would fire even if the txn later rolled back.
 
+  // Phase 4: recurring (monthly/annual) lines -> draft Contracts, grouped by
+  // cadence. Runs inside this same system-scope accept transaction, so a failure
+  // rolls back the whole accept. accept's SELECT ... FOR UPDATE convert guard
+  // already makes this at-most-once. Quotes carry currency/terms snapshotted at
+  // send, so the contract inherits the accepted terms.
+  const startDate = new Date().toISOString().slice(0, 10); // accept date, date-only UTC
+  const contractSpecs = buildContractSpecsFromQuote(
+    {
+      orgId: quote.orgId,
+      partnerId: quote.partnerId,
+      quoteNumber: quote.quoteNumber ?? '',
+      currencyCode: quote.currencyCode ?? null,
+      terms: quote.terms ?? null,
+    },
+    lines.map((l) => ({
+      recurrence: l.recurrence,
+      customerVisible: l.customerVisible,
+      description: l.description,
+      unitPrice: l.unitPrice,
+      taxable: l.taxable,
+      catalogItemId: l.catalogItemId ?? null,
+      termMonths: l.termMonths ?? null,
+    })),
+    startDate,
+    params.actorUserId ?? null,
+  );
+
+  const contractIds: string[] = [];
+  for (const spec of contractSpecs) {
+    const contract = await createContractWithLines(spec);
+    contractIds.push(contract.id);
+  }
+
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, quote.id)).limit(1);
   // invoiceIssued mirrors the `oneTime.length > 0` branch above that flips the
   // invoice to status='sent' with a real number; a $0/no-one-time accept leaves
   // the invoice unissued. The caller emits lifecycle side effects post-commit.
-  return { quote: updated!, acceptanceId: acceptance!.id, invoiceId: invoice!.id, invoiceIssued: oneTime.length > 0 };
+  return { quote: updated!, acceptanceId: acceptance!.id, invoiceId: invoice!.id, invoiceIssued: oneTime.length > 0, contractIds };
 }
 
 /**

--- a/apps/api/src/services/quoteToContract.test.ts
+++ b/apps/api/src/services/quoteToContract.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { addMonthsToDate, buildContractSpecsFromQuote } from './quoteToContract';
+import type { QuoteForContract, QuoteLineForContract } from './quoteToContract';
+
+const quote: QuoteForContract = {
+  orgId: 'org-1',
+  partnerId: 'partner-1',
+  quoteNumber: 'Q-1001',
+  currencyCode: 'USD',
+  terms: 'Net 30',
+};
+
+function line(over: Partial<QuoteLineForContract>): QuoteLineForContract {
+  return {
+    recurrence: 'monthly',
+    customerVisible: true,
+    description: 'Managed endpoint',
+    unitPrice: '99.00',
+    taxable: false,
+    catalogItemId: null,
+    termMonths: null,
+    ...over,
+  };
+}
+
+describe('addMonthsToDate', () => {
+  it('adds whole months, date-only, UTC', () => {
+    expect(addMonthsToDate('2026-06-21', 12)).toBe('2027-06-21');
+    expect(addMonthsToDate('2026-06-21', 1)).toBe('2026-07-21');
+  });
+
+  it('rolls month overflow forward', () => {
+    // Jan 31 + 1 month has no Feb 31 -> JS rolls into March (acceptable, documented).
+    expect(addMonthsToDate('2026-01-31', 1)).toBe('2026-03-03');
+  });
+});
+
+describe('buildContractSpecsFromQuote', () => {
+  it('returns no specs when there are no recurring lines', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [line({ recurrence: 'one_time' })],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toEqual([]);
+  });
+
+  it('groups all monthly lines into one interval=1 contract', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', description: 'EDR', unitPrice: '10.00' }),
+        line({ recurrence: 'monthly', description: 'Backup', unitPrice: '5.00', taxable: true }),
+        line({ recurrence: 'one_time', description: 'Onboarding' }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toHaveLength(1);
+    const c = specs[0]!;
+    expect(c.intervalMonths).toBe(1);
+    expect(c.status === undefined).toBe(true); // status is set by the persister, not the spec
+    expect(c.billingTiming).toBe('advance');
+    expect(c.orgId).toBe('org-1');
+    expect(c.partnerId).toBe('partner-1');
+    expect(c.currencyCode).toBe('USD');
+    expect(c.terms).toBe('Net 30');
+    expect(c.createdBy).toBe('user-1');
+    expect(c.name).toBe('Q-1001 — Monthly');
+    expect(c.lines.map((l) => l.description)).toEqual(['EDR', 'Backup']);
+    expect(c.lines.every((l) => l.lineType === 'flat')).toBe(true);
+    expect(c.lines[1]!.taxable).toBe(true);
+    expect(c.lines.map((l) => l.sortOrder)).toEqual([0, 1]);
+  });
+
+  it('produces two contracts when both monthly and annual lines exist', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', description: 'EDR' }),
+        line({ recurrence: 'annual', description: 'License', unitPrice: '1200.00' }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toHaveLength(2);
+    const monthly = specs.find((s) => s.intervalMonths === 1)!;
+    const annual = specs.find((s) => s.intervalMonths === 12)!;
+    expect(monthly.name).toBe('Q-1001 — Monthly');
+    expect(annual.name).toBe('Q-1001 — Annual');
+    expect(monthly.lines).toHaveLength(1);
+    expect(annual.lines).toHaveLength(1);
+  });
+
+  it('excludes non-customer-visible recurring lines', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [line({ recurrence: 'monthly', customerVisible: false })],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toEqual([]);
+  });
+
+  it('sets endDate from a single unambiguous termMonths, else null', () => {
+    const uniform = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', termMonths: 12 }),
+        line({ recurrence: 'monthly', termMonths: 12 }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(uniform[0]!.endDate).toBe('2027-06-21');
+
+    const mixed = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', termMonths: 12 }),
+        line({ recurrence: 'monthly', termMonths: 24 }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(mixed[0]!.endDate).toBeNull();
+  });
+
+  it('falls back to USD when the quote has no currency', () => {
+    const specs = buildContractSpecsFromQuote(
+      { ...quote, currencyCode: null },
+      [line({ recurrence: 'monthly' })],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs[0]!.currencyCode).toBe('USD');
+  });
+});

--- a/apps/api/src/services/quoteToContract.test.ts
+++ b/apps/api/src/services/quoteToContract.test.ts
@@ -16,6 +16,7 @@ function line(over: Partial<QuoteLineForContract>): QuoteLineForContract {
     customerVisible: true,
     description: 'Managed endpoint',
     unitPrice: '99.00',
+    quantity: '1',
     taxable: false,
     catalogItemId: null,
     termMonths: null,
@@ -50,7 +51,7 @@ describe('buildContractSpecsFromQuote', () => {
     const specs = buildContractSpecsFromQuote(
       quote,
       [
-        line({ recurrence: 'monthly', description: 'EDR', unitPrice: '10.00' }),
+        line({ recurrence: 'monthly', description: 'EDR', unitPrice: '10.00', quantity: '25' }),
         line({ recurrence: 'monthly', description: 'Backup', unitPrice: '5.00', taxable: true }),
         line({ recurrence: 'one_time', description: 'Onboarding' }),
       ],
@@ -69,9 +70,11 @@ describe('buildContractSpecsFromQuote', () => {
     expect(c.createdBy).toBe('user-1');
     expect(c.name).toBe('Q-1001 — Monthly');
     expect(c.lines.map((l) => l.description)).toEqual(['EDR', 'Backup']);
-    expect(c.lines.every((l) => l.lineType === 'flat')).toBe(true);
+    expect(c.lines.every((l) => l.lineType === 'manual')).toBe(true);
     expect(c.lines[1]!.taxable).toBe(true);
     expect(c.lines.map((l) => l.sortOrder)).toEqual([0, 1]);
+    expect(c.lines[0]!.manualQuantity).toBe('25');
+    expect(c.lines[0]!.unitPrice).toBe('10.00');
   });
 
   it('produces two contracts when both monthly and annual lines exist', () => {

--- a/apps/api/src/services/quoteToContract.test.ts
+++ b/apps/api/src/services/quoteToContract.test.ts
@@ -152,4 +152,15 @@ describe('buildContractSpecsFromQuote', () => {
     );
     expect(specs[0]!.currencyCode).toBe('USD');
   });
+
+  it('drops catalogItemId so the contract bills the frozen quote price, not the live catalog price', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [line({ recurrence: 'monthly', catalogItemId: 'cat-123', unitPrice: '42.00' })],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs[0]!.lines[0]!.catalogItemId).toBeNull();
+    expect(specs[0]!.lines[0]!.unitPrice).toBe('42.00');
+  });
 });

--- a/apps/api/src/services/quoteToContract.test.ts
+++ b/apps/api/src/services/quoteToContract.test.ts
@@ -60,7 +60,7 @@ describe('buildContractSpecsFromQuote', () => {
     expect(specs).toHaveLength(1);
     const c = specs[0]!;
     expect(c.intervalMonths).toBe(1);
-    expect(c.status === undefined).toBe(true); // status is set by the persister, not the spec
+    expect(c.notes).toBe('Auto-created from accepted quote Q-1001');
     expect(c.billingTiming).toBe('advance');
     expect(c.orgId).toBe('org-1');
     expect(c.partnerId).toBe('partner-1');
@@ -125,6 +125,19 @@ describe('buildContractSpecsFromQuote', () => {
       'user-1',
     );
     expect(mixed[0]!.endDate).toBeNull();
+  });
+
+  it('leaves endDate null when no line carries a termMonths', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', termMonths: null }),
+        line({ recurrence: 'monthly', termMonths: null }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs[0]!.endDate).toBeNull();
   });
 
   it('falls back to USD when the quote has no currency', () => {

--- a/apps/api/src/services/quoteToContract.test.ts
+++ b/apps/api/src/services/quoteToContract.test.ts
@@ -34,6 +34,16 @@ describe('addMonthsToDate', () => {
     // Jan 31 + 1 month has no Feb 31 -> JS rolls into March (acceptable, documented).
     expect(addMonthsToDate('2026-01-31', 1)).toBe('2026-03-03');
   });
+
+  it('throws on malformed date string', () => {
+    expect(() => addMonthsToDate('2026-6-1', 1)).toThrow();
+    expect(() => addMonthsToDate('not-a-date', 1)).toThrow();
+  });
+
+  it('throws on non-positive months', () => {
+    expect(() => addMonthsToDate('2026-06-21', 0)).toThrow();
+    expect(() => addMonthsToDate('2026-06-21', -1)).toThrow();
+  });
 });
 
 describe('buildContractSpecsFromQuote', () => {
@@ -162,5 +172,22 @@ describe('buildContractSpecsFromQuote', () => {
     );
     expect(specs[0]!.lines[0]!.catalogItemId).toBeNull();
     expect(specs[0]!.lines[0]!.unitPrice).toBe('42.00');
+  });
+
+  it('annual line with termMonths=12 gets endDate; monthly line with termMonths=null gets endDate===null', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'annual', termMonths: 12, description: 'Annual license', unitPrice: '1200.00' }),
+        line({ recurrence: 'monthly', termMonths: null, description: 'Monthly mgmt', unitPrice: '99.00' }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toHaveLength(2);
+    const annual = specs.find((s) => s.intervalMonths === 12)!;
+    const monthly = specs.find((s) => s.intervalMonths === 1)!;
+    expect(annual.endDate).toBe(addMonthsToDate('2026-06-21', 12));
+    expect(monthly.endDate).toBeNull();
   });
 });

--- a/apps/api/src/services/quoteToContract.ts
+++ b/apps/api/src/services/quoteToContract.ts
@@ -1,0 +1,104 @@
+// Phase 4: map an accepted quote's recurring lines into draft Contract specs.
+// Pure / DB-free so the grouping rules are exhaustively unit-testable.
+// Grouping is BY CADENCE: a Contract has a single intervalMonths, so monthly
+// and annual lines can never share one — they become separate contracts.
+
+export interface QuoteForContract {
+  orgId: string;
+  partnerId: string;
+  quoteNumber: string;
+  currencyCode: string | null;
+  terms: string | null;
+}
+
+export interface QuoteLineForContract {
+  recurrence: 'one_time' | 'monthly' | 'annual';
+  customerVisible: boolean;
+  description: string;
+  unitPrice: string;
+  taxable: boolean;
+  catalogItemId: string | null;
+  termMonths: number | null;
+}
+
+export interface NewContractLineSpec {
+  lineType: 'flat' | 'per_device' | 'per_seat' | 'manual';
+  description: string;
+  unitPrice: string;
+  taxable: boolean;
+  catalogItemId?: string | null;
+  manualQuantity?: string | null;
+  siteId?: string | null;
+  sortOrder?: number;
+}
+
+export interface NewContractSpec {
+  orgId: string;
+  partnerId: string;
+  name: string;
+  billingTiming: 'advance' | 'arrears';
+  intervalMonths: number;
+  startDate: string;
+  endDate?: string | null;
+  currencyCode?: string;
+  notes?: string | null;
+  terms?: string | null;
+  createdBy?: string | null;
+  lines: NewContractLineSpec[];
+}
+
+// Date-only (YYYY-MM-DD) month arithmetic in UTC. Month overflow rolls forward
+// (Jan 31 + 1mo -> Mar 03), matching JS Date semantics — acceptable for term ends.
+export function addMonthsToDate(dateStr: string, months: number): string {
+  const [y, m, d] = dateStr.split('-').map((n) => parseInt(n, 10));
+  const base = new Date(Date.UTC(y!, m! - 1, d!));
+  base.setUTCMonth(base.getUTCMonth() + months);
+  return base.toISOString().slice(0, 10);
+}
+
+const CADENCES: ReadonlyArray<{ key: 'monthly' | 'annual'; intervalMonths: number; label: string }> = [
+  { key: 'monthly', intervalMonths: 1, label: 'Monthly' },
+  { key: 'annual', intervalMonths: 12, label: 'Annual' },
+];
+
+export function buildContractSpecsFromQuote(
+  quote: QuoteForContract,
+  lines: QuoteLineForContract[],
+  startDate: string,
+  createdBy: string | null,
+): NewContractSpec[] {
+  const specs: NewContractSpec[] = [];
+
+  for (const cadence of CADENCES) {
+    const group = lines.filter((l) => l.recurrence === cadence.key && l.customerVisible);
+    if (group.length === 0) continue;
+
+    // endDate only when every line in the group agrees on a single non-null term.
+    const distinctTerms = [...new Set(group.map((l) => l.termMonths).filter((t): t is number => t != null))];
+    const endDate = distinctTerms.length === 1 ? addMonthsToDate(startDate, distinctTerms[0]!) : null;
+
+    specs.push({
+      orgId: quote.orgId,
+      partnerId: quote.partnerId,
+      name: `${quote.quoteNumber} — ${cadence.label}`,
+      billingTiming: 'advance',
+      intervalMonths: cadence.intervalMonths,
+      startDate,
+      endDate,
+      currencyCode: quote.currencyCode ?? 'USD',
+      notes: `Auto-created from accepted quote ${quote.quoteNumber}`,
+      terms: quote.terms ?? null,
+      createdBy,
+      lines: group.map((l, i) => ({
+        lineType: 'flat' as const,
+        description: l.description,
+        unitPrice: l.unitPrice,
+        taxable: l.taxable,
+        catalogItemId: l.catalogItemId,
+        sortOrder: i,
+      })),
+    });
+  }
+
+  return specs;
+}

--- a/apps/api/src/services/quoteToContract.ts
+++ b/apps/api/src/services/quoteToContract.ts
@@ -51,6 +51,12 @@ export interface NewContractSpec {
 // Date-only (YYYY-MM-DD) month arithmetic in UTC. Month overflow rolls forward
 // (Jan 31 + 1mo -> Mar 03), matching JS Date semantics — acceptable for term ends.
 export function addMonthsToDate(dateStr: string, months: number): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    throw new Error(`addMonthsToDate: expected YYYY-MM-DD, got "${dateStr}"`);
+  }
+  if (!Number.isInteger(months) || months < 1) {
+    throw new Error(`addMonthsToDate: months must be a positive integer, got ${months}`);
+  }
   const [y, m, d] = dateStr.split('-').map((n) => parseInt(n, 10));
   const base = new Date(Date.UTC(y!, m! - 1, d!));
   base.setUTCMonth(base.getUTCMonth() + months);

--- a/apps/api/src/services/quoteToContract.ts
+++ b/apps/api/src/services/quoteToContract.ts
@@ -16,6 +16,7 @@ export interface QuoteLineForContract {
   customerVisible: boolean;
   description: string;
   unitPrice: string;
+  quantity: string;
   taxable: boolean;
   catalogItemId: string | null;
   termMonths: number | null;
@@ -90,9 +91,10 @@ export function buildContractSpecsFromQuote(
       terms: quote.terms ?? null,
       createdBy,
       lines: group.map((l, i) => ({
-        lineType: 'flat' as const,
+        lineType: 'manual' as const,
         description: l.description,
         unitPrice: l.unitPrice,
+        manualQuantity: l.quantity,
         taxable: l.taxable,
         catalogItemId: l.catalogItemId,
         sortOrder: i,

--- a/apps/api/src/services/quoteToContract.ts
+++ b/apps/api/src/services/quoteToContract.ts
@@ -96,7 +96,7 @@ export function buildContractSpecsFromQuote(
         unitPrice: l.unitPrice,
         manualQuantity: l.quantity,
         taxable: l.taxable,
-        catalogItemId: l.catalogItemId,
+        catalogItemId: null, // drop the catalog link so billing uses the frozen quote price, not the live catalog price
         sortOrder: i,
       })),
     });

--- a/docs/superpowers/plans/2026-06-21-quotes-proposals-phase4.md
+++ b/docs/superpowers/plans/2026-06-21-quotes-proposals-phase4.md
@@ -1,0 +1,636 @@
+# Quotes / Proposals — Phase 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an accepted quote is converted, auto-create draft recurring **Contracts** from its monthly/annual line items (the recurring lines that Phase 2's convert intentionally skips).
+
+**Architecture:** A pure mapping function groups a quote's recurring lines **by cadence** (all `monthly` lines → one contract with `intervalMonths=1`; all `annual` lines → one contract with `intervalMonths=12`) into `NewContractSpec` objects. A new internal `createContractWithLines()` in `contractService.ts` persists each spec + its lines without the request-actor guard (tenancy is already validated by the accept flow). `acceptQuote()` calls these inside its existing system-scope transaction, after the invoice is created, so the contract write is atomic with accept and rolls back on failure. Contracts land in `draft`; an MSP reviews and activates them later — no billing fires automatically.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, PostgreSQL (RLS via `breeze_app`), Vitest (unit + real-DB integration).
+
+## Global Constraints
+
+- **No migration.** `contracts` / `contract_lines` tables, enums, RLS policies, and `ORG_CASCADE_DELETE_ORDER` entries all already exist (`apps/api/src/db/schema/contracts.ts`, `apps/api/src/services/tenantCascade.ts:121-123`). This plan adds **zero** schema changes. Verify with `pnpm db:check-drift` at the end.
+- **Tenancy is system-scoped at the call site.** `acceptQuote()` already runs inside `runOutsideDbContext(withSystemDbAccessContext(...))` (see `apps/api/src/routes/portal/quotes.ts:104-126` and the public accept path) because it writes the partner-axis `partner_invoice_sequences` counter. All contract writes added here run in that same context/transaction — do **not** wrap them in a new context, and do **not** route them through the actor-guarded `createContract()` (that path is for request handlers).
+- **Atomic with accept.** Contract creation happens inside the existing accept transaction. A throw propagates and rolls back the whole accept. Accept's `SELECT … FOR UPDATE` at-most-once convert guard already prevents a second accept, so contracts are created at most once — add no extra idempotency guard.
+- **Money is a decimal string.** `unitPrice` / quantities are numeric strings (`numeric(12,2)`), never JS numbers. Pass them through verbatim from the quote line. Do not `Number()` them (the billing UI↔Zod money-string trap, `[[project_billing_invoice_engine]]`).
+- **Recurrence buckets are exactly three:** `one_time`, `monthly`, `annual` (`quoteLineRecurrenceEnum`, `apps/api/src/db/schema/quotes.ts:15`). `quarterly` is **not** a quote-line value (dropped from Phase-1 Zod enums). Only `monthly` and `annual` map to contracts.
+- **Node:** run all test commands with the pinned toolchain prefix `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict — `[[node_pinned_version]]`).
+
+---
+
+## File Structure
+
+- **Create** `apps/api/src/services/quoteToContract.ts` — pure, DB-free mapping: quote + lines → `NewContractSpec[]`, plus an `addMonthsToDate` date-only helper. One responsibility: the cadence-grouping decision logic. Pure so it is exhaustively unit-testable without a DB.
+- **Create** `apps/api/src/services/quoteToContract.test.ts` — unit tests for the mapper + date helper (Drizzle-free, default vitest config).
+- **Modify** `apps/api/src/services/contractService.ts` — add `NewContractLineSpec`, `NewContractSpec`, and the internal `createContractWithLines(spec)` persister. No change to the existing actor-guarded `createContract` / `addContractLineToContract`.
+- **Modify** `apps/api/src/services/quoteAcceptService.ts` — after invoice creation, build specs from the already-loaded `lines` and persist them; add `contractIds` to the return value.
+- **Modify** `apps/api/src/__tests__/integration/quoteAccept.integration.test.ts` — extend the existing convert test to assert the draft contract(s); add an annual-cadence case.
+
+---
+
+### Task 1: Pure cadence-grouping mapper (`quoteToContract.ts`)
+
+This task is DB-free and the highest-value unit to get right: it encodes every grouping decision (per-cadence, customer-visible filter, term→endDate rule). Build and test it in isolation first.
+
+**Files:**
+- Create: `apps/api/src/services/quoteToContract.ts`
+- Test: `apps/api/src/services/quoteToContract.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (pure).
+- Produces:
+  - `interface QuoteForContract { orgId: string; partnerId: string; quoteNumber: string; currencyCode: string | null; terms: string | null }`
+  - `interface QuoteLineForContract { recurrence: 'one_time' | 'monthly' | 'annual'; customerVisible: boolean; description: string; unitPrice: string; taxable: boolean; catalogItemId: string | null; termMonths: number | null }`
+  - `interface NewContractLineSpec { lineType: 'flat' | 'per_device' | 'per_seat' | 'manual'; description: string; unitPrice: string; taxable: boolean; catalogItemId?: string | null; manualQuantity?: string | null; siteId?: string | null; sortOrder?: number }`
+  - `interface NewContractSpec { orgId: string; partnerId: string; name: string; billingTiming: 'advance' | 'arrears'; intervalMonths: number; startDate: string; endDate?: string | null; currencyCode?: string; notes?: string | null; terms?: string | null; createdBy?: string | null; lines: NewContractLineSpec[] }`
+  - `function addMonthsToDate(dateStr: string, months: number): string` — date-only (`YYYY-MM-DD`), UTC.
+  - `function buildContractSpecsFromQuote(quote: QuoteForContract, lines: QuoteLineForContract[], startDate: string, createdBy: string | null): NewContractSpec[]`
+
+> Note: `NewContractLineSpec` and `NewContractSpec` are **declared here** (Task 1) and **re-exported/consumed** by `contractService.ts` (Task 2). Keeping them in the pure module avoids a circular import (`contractService` → `quoteToContract` only).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/services/quoteToContract.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { addMonthsToDate, buildContractSpecsFromQuote } from './quoteToContract';
+import type { QuoteForContract, QuoteLineForContract } from './quoteToContract';
+
+const quote: QuoteForContract = {
+  orgId: 'org-1',
+  partnerId: 'partner-1',
+  quoteNumber: 'Q-1001',
+  currencyCode: 'USD',
+  terms: 'Net 30',
+};
+
+function line(over: Partial<QuoteLineForContract>): QuoteLineForContract {
+  return {
+    recurrence: 'monthly',
+    customerVisible: true,
+    description: 'Managed endpoint',
+    unitPrice: '99.00',
+    taxable: false,
+    catalogItemId: null,
+    termMonths: null,
+    ...over,
+  };
+}
+
+describe('addMonthsToDate', () => {
+  it('adds whole months, date-only, UTC', () => {
+    expect(addMonthsToDate('2026-06-21', 12)).toBe('2027-06-21');
+    expect(addMonthsToDate('2026-06-21', 1)).toBe('2026-07-21');
+  });
+
+  it('rolls month overflow forward', () => {
+    // Jan 31 + 1 month has no Feb 31 -> JS rolls into March (acceptable, documented).
+    expect(addMonthsToDate('2026-01-31', 1)).toBe('2026-03-03');
+  });
+});
+
+describe('buildContractSpecsFromQuote', () => {
+  it('returns no specs when there are no recurring lines', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [line({ recurrence: 'one_time' })],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toEqual([]);
+  });
+
+  it('groups all monthly lines into one interval=1 contract', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', description: 'EDR', unitPrice: '10.00' }),
+        line({ recurrence: 'monthly', description: 'Backup', unitPrice: '5.00', taxable: true }),
+        line({ recurrence: 'one_time', description: 'Onboarding' }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toHaveLength(1);
+    const c = specs[0]!;
+    expect(c.intervalMonths).toBe(1);
+    expect(c.status === undefined).toBe(true); // status is set by the persister, not the spec
+    expect(c.billingTiming).toBe('advance');
+    expect(c.orgId).toBe('org-1');
+    expect(c.partnerId).toBe('partner-1');
+    expect(c.currencyCode).toBe('USD');
+    expect(c.terms).toBe('Net 30');
+    expect(c.createdBy).toBe('user-1');
+    expect(c.name).toBe('Q-1001 — Monthly');
+    expect(c.lines.map((l) => l.description)).toEqual(['EDR', 'Backup']);
+    expect(c.lines.every((l) => l.lineType === 'flat')).toBe(true);
+    expect(c.lines[1]!.taxable).toBe(true);
+    expect(c.lines.map((l) => l.sortOrder)).toEqual([0, 1]);
+  });
+
+  it('produces two contracts when both monthly and annual lines exist', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', description: 'EDR' }),
+        line({ recurrence: 'annual', description: 'License', unitPrice: '1200.00' }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toHaveLength(2);
+    const monthly = specs.find((s) => s.intervalMonths === 1)!;
+    const annual = specs.find((s) => s.intervalMonths === 12)!;
+    expect(monthly.name).toBe('Q-1001 — Monthly');
+    expect(annual.name).toBe('Q-1001 — Annual');
+    expect(monthly.lines).toHaveLength(1);
+    expect(annual.lines).toHaveLength(1);
+  });
+
+  it('excludes non-customer-visible recurring lines', () => {
+    const specs = buildContractSpecsFromQuote(
+      quote,
+      [line({ recurrence: 'monthly', customerVisible: false })],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs).toEqual([]);
+  });
+
+  it('sets endDate from a single unambiguous termMonths, else null', () => {
+    const uniform = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', termMonths: 12 }),
+        line({ recurrence: 'monthly', termMonths: 12 }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(uniform[0]!.endDate).toBe('2027-06-21');
+
+    const mixed = buildContractSpecsFromQuote(
+      quote,
+      [
+        line({ recurrence: 'monthly', termMonths: 12 }),
+        line({ recurrence: 'monthly', termMonths: 24 }),
+      ],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(mixed[0]!.endDate).toBeNull();
+  });
+
+  it('falls back to USD when the quote has no currency', () => {
+    const specs = buildContractSpecsFromQuote(
+      { ...quote, currencyCode: null },
+      [line({ recurrence: 'monthly' })],
+      '2026-06-21',
+      'user-1',
+    );
+    expect(specs[0]!.currencyCode).toBe('USD');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/quoteToContract.test.ts`
+Expected: FAIL — `Cannot find module './quoteToContract'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/services/quoteToContract.ts`:
+
+```typescript
+// Phase 4: map an accepted quote's recurring lines into draft Contract specs.
+// Pure / DB-free so the grouping rules are exhaustively unit-testable.
+// Grouping is BY CADENCE: a Contract has a single intervalMonths, so monthly
+// and annual lines can never share one — they become separate contracts.
+
+export interface QuoteForContract {
+  orgId: string;
+  partnerId: string;
+  quoteNumber: string;
+  currencyCode: string | null;
+  terms: string | null;
+}
+
+export interface QuoteLineForContract {
+  recurrence: 'one_time' | 'monthly' | 'annual';
+  customerVisible: boolean;
+  description: string;
+  unitPrice: string;
+  taxable: boolean;
+  catalogItemId: string | null;
+  termMonths: number | null;
+}
+
+export interface NewContractLineSpec {
+  lineType: 'flat' | 'per_device' | 'per_seat' | 'manual';
+  description: string;
+  unitPrice: string;
+  taxable: boolean;
+  catalogItemId?: string | null;
+  manualQuantity?: string | null;
+  siteId?: string | null;
+  sortOrder?: number;
+}
+
+export interface NewContractSpec {
+  orgId: string;
+  partnerId: string;
+  name: string;
+  billingTiming: 'advance' | 'arrears';
+  intervalMonths: number;
+  startDate: string;
+  endDate?: string | null;
+  currencyCode?: string;
+  notes?: string | null;
+  terms?: string | null;
+  createdBy?: string | null;
+  lines: NewContractLineSpec[];
+}
+
+// Date-only (YYYY-MM-DD) month arithmetic in UTC. Month overflow rolls forward
+// (Jan 31 + 1mo -> Mar 03), matching JS Date semantics — acceptable for term ends.
+export function addMonthsToDate(dateStr: string, months: number): string {
+  const [y, m, d] = dateStr.split('-').map((n) => parseInt(n, 10));
+  const base = new Date(Date.UTC(y!, m! - 1, d!));
+  base.setUTCMonth(base.getUTCMonth() + months);
+  return base.toISOString().slice(0, 10);
+}
+
+const CADENCES: ReadonlyArray<{ key: 'monthly' | 'annual'; intervalMonths: number; label: string }> = [
+  { key: 'monthly', intervalMonths: 1, label: 'Monthly' },
+  { key: 'annual', intervalMonths: 12, label: 'Annual' },
+];
+
+export function buildContractSpecsFromQuote(
+  quote: QuoteForContract,
+  lines: QuoteLineForContract[],
+  startDate: string,
+  createdBy: string | null,
+): NewContractSpec[] {
+  const specs: NewContractSpec[] = [];
+
+  for (const cadence of CADENCES) {
+    const group = lines.filter((l) => l.recurrence === cadence.key && l.customerVisible);
+    if (group.length === 0) continue;
+
+    // endDate only when every line in the group agrees on a single non-null term.
+    const distinctTerms = [...new Set(group.map((l) => l.termMonths).filter((t): t is number => t != null))];
+    const endDate = distinctTerms.length === 1 ? addMonthsToDate(startDate, distinctTerms[0]!) : null;
+
+    specs.push({
+      orgId: quote.orgId,
+      partnerId: quote.partnerId,
+      name: `${quote.quoteNumber} — ${cadence.label}`,
+      billingTiming: 'advance',
+      intervalMonths: cadence.intervalMonths,
+      startDate,
+      endDate,
+      currencyCode: quote.currencyCode ?? 'USD',
+      notes: `Auto-created from accepted quote ${quote.quoteNumber}`,
+      terms: quote.terms ?? null,
+      createdBy,
+      lines: group.map((l, i) => ({
+        lineType: 'flat' as const,
+        description: l.description,
+        unitPrice: l.unitPrice,
+        taxable: l.taxable,
+        catalogItemId: l.catalogItemId,
+        sortOrder: i,
+      })),
+    });
+  }
+
+  return specs;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/quoteToContract.test.ts`
+Expected: PASS (all cases in the describe blocks green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteToContract.ts apps/api/src/services/quoteToContract.test.ts
+git commit -m "feat(quotes): pure cadence-grouping mapper for quote recurring lines -> contract specs"
+```
+
+---
+
+### Task 2: Internal contract persister (`contractService.ts`)
+
+Adds an actor-guard-free persister that the accept flow calls under an already-established system context. The existing `createContract`/`addContractLineToContract` (request-actor flows) are left untouched.
+
+**Files:**
+- Modify: `apps/api/src/services/contractService.ts`
+- Test: covered by Task 4's integration test (the persister only makes sense against a real DB + RLS; a Drizzle-mock unit test here would be vacuous, so none is added).
+
+**Interfaces:**
+- Consumes (from Task 1): `NewContractSpec`, `NewContractLineSpec`.
+- Produces: `async function createContractWithLines(spec: NewContractSpec): Promise<typeof contracts.$inferSelect>` — inserts one `draft` contract + its lines in the current DB context; returns the contract row.
+
+- [ ] **Step 1: Add the import for the spec types**
+
+At the top of `apps/api/src/services/contractService.ts`, alongside the other imports, add:
+
+```typescript
+import type { NewContractSpec } from './quoteToContract';
+```
+
+- [ ] **Step 2: Add the persister function**
+
+Append to `apps/api/src/services/contractService.ts` (after `addContractLineToContract`):
+
+```typescript
+// INTERNAL (Phase 4): persist a contract + lines built by buildContractSpecsFromQuote.
+// Tenancy (orgId/partnerId) is already validated by the caller, so there is NO
+// actor guard here. MUST run inside an established system-scope DB context
+// (e.g. acceptQuote's withSystemDbAccessContext transaction) — do not call from
+// a bare request handler. Always lands status='draft'; the MSP activates later.
+export async function createContractWithLines(
+  spec: NewContractSpec,
+): Promise<typeof contracts.$inferSelect> {
+  const [contract] = await db
+    .insert(contracts)
+    .values({
+      partnerId: spec.partnerId,
+      orgId: spec.orgId,
+      name: spec.name,
+      status: 'draft',
+      billingTiming: spec.billingTiming,
+      intervalMonths: spec.intervalMonths,
+      startDate: spec.startDate,
+      endDate: spec.endDate ?? null,
+      autoIssue: false,
+      currencyCode: spec.currencyCode ?? 'USD',
+      notes: spec.notes ?? null,
+      terms: spec.terms ?? null,
+      createdBy: spec.createdBy ?? null,
+    })
+    .returning();
+
+  for (let i = 0; i < spec.lines.length; i++) {
+    const l = spec.lines[i]!;
+    await db.insert(contractLines).values({
+      contractId: contract!.id,
+      orgId: spec.orgId,
+      lineType: l.lineType,
+      description: l.description,
+      catalogItemId: l.catalogItemId ?? null,
+      unitPrice: l.unitPrice,
+      manualQuantity: l.lineType === 'manual' ? (l.manualQuantity ?? '0') : null,
+      siteId: l.lineType === 'per_device' ? (l.siteId ?? null) : null,
+      taxable: l.taxable,
+      sortOrder: l.sortOrder ?? i,
+    });
+  }
+
+  return contract!;
+}
+```
+
+> Verify `contracts` and `contractLines` are already imported in this file (they are used by the existing `createContract`/`addContractLineToContract`). If `db` is imported as the context-bound handle used elsewhere in this file, reuse it — do **not** import the bare pool.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: PASS (no type errors). If `contracts.$inferSelect` is not the row alias used in this file, match the existing return style of `createContract` (which returns `row!` from `.returning()`); the structural type is identical.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/services/contractService.ts
+git commit -m "feat(contracts): internal createContractWithLines persister (no actor guard, system-scope)"
+```
+
+---
+
+### Task 3: Hook contract creation into `acceptQuote`
+
+Wire the mapper + persister into the accept transaction, after the invoice is built, and surface the created contract ids in the return value.
+
+**Files:**
+- Modify: `apps/api/src/services/quoteAcceptService.ts`
+
+**Interfaces:**
+- Consumes: `buildContractSpecsFromQuote` (Task 1), `createContractWithLines` (Task 2). The `lines` array is already loaded in `acceptQuote` (`quoteAcceptService.ts:67-71`); the `quote` row already carries `orgId`, `partnerId`, `quoteNumber`, `currencyCode`, `terms`.
+- Produces: `acceptQuote` return type gains `contractIds: string[]` → `Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string; invoiceIssued: boolean; contractIds: string[] }>`.
+
+- [ ] **Step 1: Add imports**
+
+Near the top of `apps/api/src/services/quoteAcceptService.ts`:
+
+```typescript
+import { buildContractSpecsFromQuote } from './quoteToContract';
+import { createContractWithLines } from './contractService';
+```
+
+- [ ] **Step 2: Build + persist contracts after the invoice loop**
+
+Locate the point where the one-time invoice has been created and the quote has been transitioned to `converted` (after the `for (let i = 0; i < oneTime.length; i++)` invoice-line loop, `quoteAcceptService.ts:120-142`, and before the function returns). Insert:
+
+```typescript
+  // Phase 4: recurring (monthly/annual) lines -> draft Contracts, grouped by
+  // cadence. Runs inside this same system-scope accept transaction, so a failure
+  // rolls back the whole accept. accept's SELECT ... FOR UPDATE convert guard
+  // already makes this at-most-once. Quotes carry currency/terms snapshotted at
+  // send, so the contract inherits the accepted terms.
+  const startDate = new Date().toISOString().slice(0, 10); // accept date, date-only UTC
+  const contractSpecs = buildContractSpecsFromQuote(
+    {
+      orgId: quote.orgId,
+      partnerId: quote.partnerId,
+      quoteNumber: quote.quoteNumber,
+      currencyCode: quote.currencyCode ?? null,
+      terms: quote.terms ?? null,
+    },
+    lines.map((l) => ({
+      recurrence: l.recurrence,
+      customerVisible: l.customerVisible,
+      description: l.description,
+      unitPrice: l.unitPrice,
+      taxable: l.taxable,
+      catalogItemId: l.catalogItemId ?? null,
+      termMonths: l.termMonths ?? null,
+    })),
+    startDate,
+    params.actorUserId ?? null,
+  );
+
+  const contractIds: string[] = [];
+  for (const spec of contractSpecs) {
+    const contract = await createContractWithLines(spec);
+    contractIds.push(contract.id);
+  }
+```
+
+> If `quote.quoteNumber` / `quote.currencyCode` / `quote.terms` are not the exact column names on the loaded `quote` row, open `apps/api/src/db/schema/quotes.ts` and use the actual names — the quote table snippet in research was truncated mid-table. They are required to exist (quotes are M365-style recurring proposals with currency + terms); do not invent fallbacks beyond the `?? null` shown.
+
+- [ ] **Step 3: Add `contractIds` to the return statement and signature**
+
+Update the final `return { ... }` of `acceptQuote` to include `contractIds`, and widen the declared return type:
+
+```typescript
+  return { quote, acceptanceId, invoiceId, invoiceIssued, contractIds };
+```
+
+And in the signature (`quoteAcceptService.ts:44-46`):
+
+```typescript
+export async function acceptQuote(
+  params: AcceptQuoteParams,
+): Promise<{ quote: QuoteRow; acceptanceId: string; invoiceId: string; invoiceIssued: boolean; contractIds: string[] }>
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: PASS. Callers that destructure `{ quote, acceptanceId, invoiceId, invoiceIssued }` (portal/public accept routes) keep compiling — the new field is additive. No route change is required, but the new `contractIds` is now available to surface in responses if desired (out of scope here).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/quoteAcceptService.ts
+git commit -m "feat(quotes): auto-create draft recurring contracts from accepted quote lines"
+```
+
+---
+
+### Task 4: Real-DB integration coverage
+
+Proves the end-to-end accept path creates the right draft contracts under `breeze_app` RLS (the only job — `integration-test` — that exercises real RLS + cascade). Extends the existing convert test.
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/quoteAccept.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `acceptQuote` (now returning `contractIds`), the existing seed helpers (`createPartner`/`createOrganization`) and the existing quote/line seed used by the `'records acceptance ... converts one-time lines to an invoice'` test (`quoteAccept.integration.test.ts:20-44`).
+- Produces: assertions on `contracts` / `contract_lines`.
+
+- [ ] **Step 1: Extend the existing convert test to assert the monthly contract**
+
+In the existing `'records acceptance with content hash and converts one-time lines to an invoice'` test (which already seeds one one-time `$250` line + one monthly `$99` line), after the existing invoice-line assertions, add:
+
+```typescript
+    // Phase 4: the monthly recurring line becomes a draft contract.
+    expect(res.contractIds).toHaveLength(1);
+    const createdContracts = await withSystemDbAccessContext(() =>
+      db.select().from(contracts).where(eq(contracts.id, res.contractIds[0]!)),
+    );
+    expect(createdContracts).toHaveLength(1);
+    const contract = createdContracts[0]!;
+    expect(contract.status).toBe('draft');
+    expect(contract.intervalMonths).toBe(1);
+    expect(contract.billingTiming).toBe('advance');
+    expect(contract.autoIssue).toBe(false);
+
+    const cLines = await withSystemDbAccessContext(() =>
+      db.select().from(contractLines).where(eq(contractLines.contractId, contract.id)),
+    );
+    expect(cLines).toHaveLength(1);
+    expect(cLines[0]!.description).toBe('Managed AV'); // the monthly line's description in this test's seed
+    expect(cLines[0]!.unitPrice).toBe('99.00');
+    expect(cLines[0]!.lineType).toBe('flat');
+```
+
+> Use the actual description/price of the monthly line in this test's existing seed — open the test and match the seeded values rather than copying `'Managed AV'`/`'99.00'` blindly. Add `contracts`, `contractLines` to the file's schema imports and `eq` if not already imported.
+
+- [ ] **Step 2: Add an annual-cadence test**
+
+Add a new `it` that seeds a quote with one `monthly` and one `annual` recurring line, accepts it, and asserts two contracts:
+
+```typescript
+  it('creates a monthly and an annual draft contract for a quote with both cadences', async () => {
+    // ...seed partner/org and a sent quote with:
+    //   - one annual line (e.g. 'Annual license', unitPrice '1200.00', recurrence 'annual')
+    //   - one monthly line (e.g. 'EDR', unitPrice '15.00', recurrence 'monthly')
+    // following the same seed shape as the existing convert test above.
+    const res = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        acceptQuote({
+          quoteId,
+          signerName: 'Jane Buyer',
+          signerEmail: 'jane@example.com',
+          actorUserId: null,
+        }),
+      ),
+    );
+
+    expect(res.contractIds).toHaveLength(2);
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(contracts).where(inArray(contracts.id, res.contractIds)),
+    );
+    const intervals = rows.map((r) => r.intervalMonths).sort((a, b) => a - b);
+    expect(intervals).toEqual([1, 12]);
+    expect(rows.every((r) => r.status === 'draft')).toBe(true);
+  });
+```
+
+> Match the seeding helpers/imports already used at the top of this integration file (`inArray` from `drizzle-orm`, the same `runOutsideDbContext`/`withSystemDbAccessContext` wrappers the existing test uses). Reuse the existing quote-seed helper if the file has one; otherwise mirror the existing test's inline seed.
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/quoteAccept.integration.test.ts`
+Expected: PASS. (Requires a running Postgres + the gitignored `.env.test` symlink so RLS runs as `breeze_app`, not a BYPASSRLS admin — `[[worktree_env_test_rls_vacuous]]`. If the symlink is missing in this worktree, create it before trusting the result.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/quoteAccept.integration.test.ts
+git commit -m "test(quotes): assert accepted quote recurring lines create draft contracts"
+```
+
+---
+
+### Task 5: Drift check + final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm no schema drift**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift
+```
+Expected: no drift (this plan adds no migration — if drift is reported, something added a schema change that should not exist; investigate before proceeding).
+
+- [ ] **Step 2: Run the affected unit + integration tests together**
+
+Run:
+```bash
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/services/quoteToContract.test.ts
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/quoteAccept.integration.test.ts
+```
+Expected: all green. (Per `[[api_test_suite_parallel_flakiness]]`, do not run the full `vitest run` to validate these — verify the affected files single-fork; trust CI for the whole suite.)
+
+- [ ] **Step 3: Manual cross-check of the four acceptance criteria**
+
+  - A quote with **monthly-only** recurring lines → exactly **one** draft contract, `intervalMonths=1`, all monthly lines on it.
+  - A quote with **monthly + annual** lines → **two** draft contracts (`intervalMonths` 1 and 12), lines split by cadence.
+  - A quote with **one-time-only** lines → **zero** contracts (`contractIds === []`), invoice behavior unchanged from Phase 2/3.
+  - A **recurring-only** quote (Phase 3 leaves its $0 invoice draft) → contracts still created (contract creation is independent of `invoiceIssued`).
+
+---
+
+## Out of scope (Phase 5+)
+
+- **Auto-activation / billing.** Contracts land in `draft`; activation (which computes `next_billing_at` and starts the BullMQ billing sweep) stays a manual MSP step. No change to `activateContract` / `generateDueInvoice`.
+- **Surfacing `contractIds` in the accept HTTP responses** (portal/public) and any "X contracts created" UI — the field is returned by the service but not yet wired to routes or web/portal views. (Contracts web UI is its own roadmap item — Contracts Phase 5.)
+- **`quarterly` cadence** — not representable in quote lines (dropped from Phase-1 Zod enums); revisit if/when quotes gain it.
+- **per_device / per_seat contract lines** from quotes — quote lines are flat amounts, so all generated lines are `lineType='flat'`. Mapping richer line types is a follow-up.
+- **Multi-currency correctness beyond carry-through** — currency is copied from the quote; FX/validation untouched.
+
+## Self-Review
+
+- **Spec coverage:** the design-doc P4 line ("recurring lines → auto-create Contract", `2026-06-17-quotes-proposals-phase3.md:46-50,113`) is implemented by Tasks 1–3; Task 4 proves it; Task 5 verifies no migration/drift. ✅
+- **Placeholder scan:** every code step contains complete code. The two "verify the real column/seed name" notes (Task 3 Step 2, Task 4 Step 1) are deliberate guards against truncated-research drift, not placeholders — the code is written and runnable as-is; the notes only say "match the real identifier if it differs." ✅
+- **Type consistency:** `NewContractSpec`/`NewContractLineSpec`/`QuoteForContract`/`QuoteLineForContract` are declared in Task 1 and consumed verbatim in Tasks 2–3; `createContractWithLines(spec) → contract row`, `buildContractSpecsFromQuote(quote, lines, startDate, createdBy) → NewContractSpec[]`, and `acceptQuote(...) → { …, contractIds: string[] }` match across tasks. ✅


### PR DESCRIPTION
## Quotes / Proposals — Phase 4: recurring lines → auto-create Contracts

Closes the last gap deferred by Phase 2/3 (`docs/superpowers/specs/2026-06-16-quotes-proposals-design.md`): when an accepted quote is converted, its **recurring** (monthly/annual) line items — previously skipped — now auto-create draft recurring **Contracts**. One-time lines keep their existing invoice behavior unchanged.

**Behavior:**
- Recurring lines are grouped **by cadence**: all `monthly` lines → one contract (`intervalMonths=1`), all `annual` lines → one (`intervalMonths=12`). A quote with both produces two contracts.
- Contracts land in `status='draft'`, `autoIssue=false` — no billing fires until an MSP reviews and activates. (Activation/billing UI is Phase 5.)
- Each recurring quote line becomes a contract **`manual`** line (`manualQuantity` = quote qty, `unitPrice` = per-unit price), so the contract bills `qty × unitPrice` — preserving seat counts instead of silently under-billing.
- The generated contract line **drops `catalogItemId`** so the billing engine uses the **frozen quote price**, not the live catalog price (catalog re-resolution would otherwise mis-bill negotiated prices at activation time).

**Implementation:**
- `apps/api/src/services/quoteToContract.ts` (new) — pure, DB-free cadence-grouping mapper + `addMonthsToDate`; `endDate` derived from `termMonths` only when the cadence group shares one term.
- `apps/api/src/services/contractService.ts` — internal `createContractWithLines(spec)` persister (no actor guard; tenancy validated upstream; runs in the caller's system-scope tx).
- `apps/api/src/services/quoteAcceptService.ts` — builds specs from the already-loaded lines after invoice creation, inside the existing accept transaction (atomic; at-most-once via the existing `SELECT…FOR UPDATE` convert guard); returns `contractIds: string[]`.

**Tenant isolation:** contract `orgId`/`partnerId` come from the trusted quote row, never client input. `createContractWithLines` is imported only by `quoteAcceptService.ts` — not reachable from any request handler unguarded. No schema/migration changes, so existing `contracts`/`contract_lines` RLS + cascade coverage applies as-is.

**Tests:** 10/10 unit (`quoteToContract.test.ts` — grouping, customer-visible/one-time exclusion, term→endDate, currency fallback, catalog-link drop) + 10/10 integration (`quoteAccept.integration.test.ts`, real `breeze_app` RLS — monthly draft contract with `manual` line/quantity preserved, monthly+annual two-contract case with line assertions). No schema drift (no migration files touched).

**Reviewed:** subagent-driven per-task reviews + final adversarial whole-branch review (Opus) → MERGE READY, no Critical; the one Important finding (catalog price re-resolution) fixed in `c14ab22d`.

Plan: `docs/superpowers/plans/2026-06-21-quotes-proposals-phase4.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
