### PR TITLE
feat(pam): rule matching cluster — command-line, negation, default-unmatched verdict

### DIFF
--- a/apps/api/migrations/2026-06-27-pam-matching-cluster.sql
+++ b/apps/api/migrations/2026-06-27-pam-matching-cluster.sql
@@ -1,0 +1,62 @@
+-- PAM rule-matching cluster: command-line criterion, rule negation, and a
+-- per-org default verdict for unmatched elevations.
+--   * pam_rules.match_command_line — case-insensitive substring of the launched
+--     process command line (uac_intercept payload carries command_line).
+--   * pam_rules.match_negate — jsonb array of criterion keys the engine inverts.
+--   * pam_org_config — one row per org; default verdict when nothing matches.
+-- File version matching is intentionally NOT included: the agent does not yet
+-- capture the binary's file version, so a column would be a dead criterion.
+-- Tenancy: pam_org_config is Shape 1 (direct org_id), RLS mirrors pam_rules.
+-- Idempotent: re-applying is a no-op.
+
+-- New rule criteria (additive, nullable — no backfill, no shape change).
+ALTER TABLE pam_rules ADD COLUMN IF NOT EXISTS match_command_line text;
+ALTER TABLE pam_rules ADD COLUMN IF NOT EXISTS match_negate jsonb;
+
+-- Per-org default verdict for unmatched elevations.
+DO $$ BEGIN
+  CREATE TYPE pam_unmatched_verdict AS ENUM (
+    'require_approval',
+    'auto_deny'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS pam_org_config (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Tenancy (Shape 1)
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+  default_unmatched_verdict pam_unmatched_verdict NOT NULL DEFAULT 'require_approval',
+
+  updated_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One config row per org.
+CREATE UNIQUE INDEX IF NOT EXISTS pam_org_config_org_id_unique
+  ON pam_org_config (org_id);
+
+-- ============================================================
+-- RLS — pam_org_config (Shape 1, mirrors pam_rules #1163)
+-- ============================================================
+ALTER TABLE pam_org_config ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pam_org_config FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON pam_org_config;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON pam_org_config;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON pam_org_config;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON pam_org_config;
+
+CREATE POLICY breeze_org_isolation_select ON pam_org_config
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON pam_org_config
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON pam_org_config
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON pam_org_config
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/src/db/schema/pam.ts
+++ b/apps/api/src/db/schema/pam.ts
@@ -20,6 +20,7 @@ import {
   smallint,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
@@ -46,6 +47,30 @@ export interface PamRuleTimeWindow {
   timezone?: string;
 }
 
+/**
+ * Criterion keys eligible for negation via pam_rules.match_negate. Each maps
+ * to a single match* column; the engine inverts that criterion's result.
+ * time_window is deliberately excluded (it narrows, it doesn't identify).
+ */
+export const PAM_RULE_NEGATE_KEYS = [
+  'signer',
+  'hash',
+  'pathGlob',
+  'parentImage',
+  'commandLine',
+  'user',
+  'adGroup',
+  'toolName',
+  'riskTier',
+] as const;
+export type PamRuleNegateKey = (typeof PAM_RULE_NEGATE_KEYS)[number];
+
+/** Default verdict applied when no software policy or PAM rule matches. */
+export const pamUnmatchedVerdictEnum = pgEnum('pam_unmatched_verdict', [
+  'require_approval',
+  'auto_deny',
+]);
+
 export const pamRules = pgTable(
   'pam_rules',
   {
@@ -68,6 +93,11 @@ export const pamRules = pgTable(
     matchHash: varchar('match_hash', { length: 64 }),
     matchPathGlob: text('match_path_glob'),
     matchParentImage: text('match_parent_image'),
+    // Case-insensitive substring of the launched process command line. Lets a
+    // rule scope auto-elevation to a specific invocation of an otherwise broad
+    // binary — e.g. only `rundll32 ... printui.dll,PrintUIEntry`, not all of
+    // rundll32. The uac_intercept payload carries `command_line`.
+    matchCommandLine: text('match_command_line'),
     matchUser: varchar('match_user', { length: 255 }),
     matchAdGroup: varchar('match_ad_group', { length: 255 }),
     // Tool-action criteria (Phase 1 Helper governance). A rule is either
@@ -75,6 +105,12 @@ export const pamRules = pgTable(
     // (tool name / risk tier) — the API layer rejects mixing the two.
     matchToolName: varchar('match_tool_name', { length: 100 }),
     matchRiskTier: smallint('match_risk_tier'),
+    // Criterion keys whose match the engine INVERTS ("does NOT match"), e.g.
+    // ["pathGlob"] turns a path-glob criterion into an exclusion. Negation
+    // requires the candidate field to be present (absent data never satisfies
+    // a negated criterion — it can't accidentally over-grant). See
+    // pamRuleEngine.ruleMatches.
+    matchNegate: jsonb('match_negate').$type<PamRuleNegateKey[] | null>(),
     timeWindow: jsonb('time_window').$type<PamRuleTimeWindow | null>(),
 
     verdict: pamRuleVerdictEnum('verdict').notNull(),
@@ -102,3 +138,38 @@ export const pamRules = pgTable(
 
 export type PamRule = typeof pamRules.$inferSelect;
 export type NewPamRule = typeof pamRules.$inferInsert;
+
+/**
+ * Per-org PAM configuration (#PAM matching cluster).
+ *
+ * Today: the default verdict for an elevation that matches no software policy
+ * and no PAM rule. The historical behavior is `require_approval` (the request
+ * waits for a human); an org can opt into `auto_deny` (block-by-default).
+ *
+ * Tenancy: Shape 1 (direct org_id) — RLS policies in the migration use
+ * breeze_has_org_access(org_id), mirroring pam_rules. One row per org
+ * (unique org_id); absence of a row means the `require_approval` default.
+ */
+export const pamOrgConfig = pgTable(
+  'pam_org_config',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    defaultUnmatchedVerdict: pamUnmatchedVerdictEnum('default_unmatched_verdict')
+      .notNull()
+      .default('require_approval'),
+    updatedByUserId: uuid('updated_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    orgIdUnique: uniqueIndex('pam_org_config_org_id_unique').on(table.orgId),
+  }),
+);
+
+export type PamOrgConfig = typeof pamOrgConfig.$inferSelect;
+export type NewPamOrgConfig = typeof pamOrgConfig.$inferInsert;

--- a/apps/api/src/routes/agents/elevationRequests.test.ts
+++ b/apps/api/src/routes/agents/elevationRequests.test.ts
@@ -34,6 +34,11 @@ vi.mock('../../db/schema', () => ({
     enabled: 'enabled',
     priority: 'priority',
   },
+  pamOrgConfig: {
+    id: 'id',
+    orgId: 'orgId',
+    defaultUnmatchedVerdict: 'defaultUnmatchedVerdict',
+  },
 }));
 
 const pamMocks = vi.hoisted(() => ({
@@ -121,6 +126,34 @@ function mockSelects(
         })),
       }) as any,
   );
+}
+
+/**
+ * Rig db.select for the unmatched-default path, which fires three selects in
+ * order: (1) device lookup [.limit() -> deviceRows], (2) pam_rules load
+ * [.where() awaited -> [] (no rule matches)], (3) pam_org_config lookup
+ * [.where().limit() -> configRows]. Distinguishes the device and config selects
+ * (same chain shape) by call order.
+ */
+function mockSelectsWithConfig(
+  deviceRows: Array<{ id: string; orgId: string; siteId: string | null }>,
+  configRows: Array<{ verdict: string }>,
+) {
+  let call = 0;
+  vi.mocked(db.select).mockImplementation(() => {
+    call += 1;
+    const isConfig = call >= 3;
+    return {
+      from: vi.fn(() => ({
+        where: vi.fn(() => {
+          // pam_rules load awaits .from().where() directly → resolve [] (no match)
+          const thenable: any = Promise.resolve([]);
+          thenable.limit = vi.fn().mockResolvedValue(isConfig ? configRows : deviceRows);
+          return thenable;
+        }),
+      })),
+    } as any;
+  });
 }
 
 function happyPathInsert(returningRows: Array<{ id: string; status: string }>) {
@@ -439,6 +472,45 @@ describe('ingest decisioning (#1163)', () => {
     expect(await res.json()).toEqual({ id: null, status: 'ignored' });
     expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
     expect(vi.mocked(writeAuditEvent)).toHaveBeenCalledOnce();
+  });
+
+  it('no policy + no rule + org default auto_deny -> denied (source default)', async () => {
+    mockSelectsWithConfig(
+      [{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }],
+      [{ verdict: 'auto_deny' }],
+    );
+    const { values } = happyPathInsert([{ id: 'req-def', status: 'denied' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'denied',
+        denialReason: 'Blocked by org default (no matching policy or rule)',
+        softwarePolicyMatchId: null,
+      }),
+    );
+    expect(pamMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.denied',
+      'org-1',
+      expect.objectContaining({ elevationRequestId: 'req-def' }),
+      'pam-ingest',
+    );
+  });
+
+  it('no policy + no rule + no config row -> stays pending (historical default)', async () => {
+    mockSelectsWithConfig([{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }], []);
+    const { values } = happyPathInsert([{ id: 'req-pend', status: 'pending' }]);
+
+    const res = await post(buildApp());
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending' }));
+    expect(pamMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.requested',
+      'org-1',
+      expect.anything(),
+      'pam-ingest',
+    );
   });
 
   it('bridge failure fails SAFE to pending (never auto-approves on error)', async () => {

--- a/apps/api/src/routes/agents/elevationRequests.ts
+++ b/apps/api/src/routes/agents/elevationRequests.ts
@@ -4,7 +4,7 @@ import { and, eq, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from '../../db';
-import { devices, elevationAudit, elevationRequests, pamRules } from '../../db/schema';
+import { devices, elevationAudit, elevationRequests, pamOrgConfig, pamRules } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { getRedis } from '../../services/redis';
 import { rateLimiter } from '../../services/rate-limit';
@@ -66,7 +66,7 @@ type IngestDecision =
       rule?: PamRuleMatch;
       durationMinutes: number;
     }
-  | { kind: 'denied'; source: 'policy' | 'rule'; policyId?: string; rule?: PamRuleMatch }
+  | { kind: 'denied'; source: 'policy' | 'rule' | 'default'; policyId?: string; rule?: PamRuleMatch }
   | { kind: 'ignored'; rule: PamRuleMatch };
 
 /** Event emission must never fail ingest — the row is already committed. */
@@ -206,9 +206,23 @@ elevationRequestsRoutes.post(
           targetExecutableSigner: payload.target_executable_signer,
           subjectUsername: payload.subject_username,
           parentImage: payload.parent_image,
+          commandLine: payload.command_line,
           at: observedAt,
         });
-        if (ruleMatch) {
+        if (!ruleMatch) {
+          // No software policy and no PAM rule matched — apply the org's
+          // default verdict for unmatched elevations. The historical default
+          // (and the default when no config row exists) is require_approval,
+          // i.e. leave the request pending; an org can opt into auto_deny.
+          const [cfg] = await db
+            .select({ verdict: pamOrgConfig.defaultUnmatchedVerdict })
+            .from(pamOrgConfig)
+            .where(eq(pamOrgConfig.orgId, device.orgId))
+            .limit(1);
+          if (cfg?.verdict === 'auto_deny') {
+            decision = { kind: 'denied', source: 'default' };
+          }
+        } else {
           switch (ruleMatch.verdict) {
             case 'auto_approve':
               decision = {
@@ -297,7 +311,9 @@ elevationRequestsRoutes.post(
             decision.kind === 'denied'
               ? decision.source === 'policy'
                 ? 'Blocked by software policy'
-                : `Blocked by PAM rule "${decision.rule?.ruleName ?? ''}"`
+                : decision.source === 'default'
+                  ? 'Blocked by org default (no matching policy or rule)'
+                  : `Blocked by PAM rule "${decision.rule?.ruleName ?? ''}"`
               : null,
           softwarePolicyMatchId:
             decision.kind !== 'pending' && decision.source === 'policy'
@@ -348,10 +364,12 @@ elevationRequestsRoutes.post(
             details:
               decision.source === 'policy'
                 ? { software_policy_id: decision.policyId }
-                : {
-                    pam_rule_id: decision.rule?.ruleId,
-                    pam_rule_name: decision.rule?.ruleName,
-                  },
+                : decision.source === 'default'
+                  ? { default_unmatched_verdict: 'auto_deny' }
+                  : {
+                      pam_rule_id: decision.rule?.ruleId,
+                      pam_rule_name: decision.rule?.ruleName,
+                    },
             occurredAt: now,
           });
         }

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -1703,7 +1703,7 @@ describe('PAM org config — default unmatched verdict', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.config.defaultUnmatchedVerdict).toBe('auto_deny');
-    const valuesArg = values.mock.calls[0]![0] as {
+    const valuesArg = (values as any).mock.calls[0][0] as {
       orgId: string;
       defaultUnmatchedVerdict: string;
       updatedByUserId: string;

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -67,6 +67,22 @@ vi.mock('../db/schema', () => ({
     priority: 'priority',
     createdAt: 'createdAt',
   },
+  pamOrgConfig: {
+    id: 'id',
+    orgId: 'orgId',
+    defaultUnmatchedVerdict: 'defaultUnmatchedVerdict',
+  },
+  PAM_RULE_NEGATE_KEYS: [
+    'signer',
+    'hash',
+    'pathGlob',
+    'parentImage',
+    'commandLine',
+    'user',
+    'adGroup',
+    'toolName',
+    'riskTier',
+  ],
   aiToolExecutions: { id: 'id', status: 'status' },
   softwarePolicies: { id: 'id', name: 'name' },
   authenticatorDevices: {
@@ -1061,6 +1077,48 @@ describe('POST /pam/rules', () => {
     expect(valuesArg.matchRiskTier).toBe(2);
   });
 
+  it('passes matchCommandLine and matchNegate through to the insert', async () => {
+    const returning = vi.fn().mockResolvedValue([
+      { id: 'rule-cl', name: 'printui only', verdict: 'auto_approve', priority: 100 },
+    ]);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn(() => ({ returning })),
+    } as any);
+
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'printui only',
+        verdict: 'auto_approve',
+        matchPathGlob: 'C:\\Windows\\System32\\rundll32.exe',
+        matchCommandLine: 'printui.dll,PrintUIEntry',
+        matchNegate: ['pathGlob'],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { matchCommandLine: string; matchNegate: string[] };
+    expect(valuesArg.matchCommandLine).toBe('printui.dll,PrintUIEntry');
+    expect(valuesArg.matchNegate).toEqual(['pathGlob']);
+  });
+
+  it('rejects a matchNegate key outside PAM_RULE_NEGATE_KEYS (400)', async () => {
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'bad negate',
+        verdict: 'auto_approve',
+        matchSigner: 'Acme Corp',
+        matchNegate: ['nonsense'],
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
   it('rejects a rule mixing executable and tool-action criteria (400)', async () => {
     const res = await app().request('/pam/rules', {
       method: 'POST',
@@ -1579,5 +1637,89 @@ describe('POST /pam/rules/preview', () => {
     // 06:00Z = 06:00 UTC → outside 00:00–05:00
     expect(body.totalMatched).toBe(0);
     expect(body.totalScanned).toBe(1);
+  });
+});
+
+describe('PAM org config — default unmatched verdict', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+  });
+
+  // clearAllMocks doesn't drain queued onces; reset the db method mocks so a
+  // queued-but-unconsumed select can't leak across cases.
+  afterEach(() => {
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.insert).mockReset();
+  });
+
+  it('GET /config returns require_approval default when no row exists', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+      })),
+    } as any);
+
+    const res = await app().request('/pam/config');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.config.orgId).toBe(ORG_ID);
+    expect(body.config.defaultUnmatchedVerdict).toBe('require_approval');
+  });
+
+  it('GET /config returns the stored verdict when a row exists', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([{ defaultUnmatchedVerdict: 'auto_deny' }]),
+        })),
+      })),
+    } as any);
+
+    const res = await app().request('/pam/config');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.config.defaultUnmatchedVerdict).toBe('auto_deny');
+  });
+
+  it('PUT /config upserts the verdict and returns the saved row', async () => {
+    const returning = vi
+      .fn()
+      .mockResolvedValue([{ id: 'cfg-1', orgId: ORG_ID, defaultUnmatchedVerdict: 'auto_deny' }]);
+    const onConflictDoUpdate = vi.fn(() => ({ returning }));
+    const values = vi.fn(() => ({ onConflictDoUpdate }));
+    vi.mocked(db.insert).mockReturnValue({ values } as any);
+
+    const res = await app().request('/pam/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ defaultUnmatchedVerdict: 'auto_deny' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.config.defaultUnmatchedVerdict).toBe('auto_deny');
+    const valuesArg = values.mock.calls[0]![0] as {
+      orgId: string;
+      defaultUnmatchedVerdict: string;
+      updatedByUserId: string;
+    };
+    expect(valuesArg.orgId).toBe(ORG_ID);
+    expect(valuesArg.defaultUnmatchedVerdict).toBe('auto_deny');
+    expect(valuesArg.updatedByUserId).toBe(USER_ID);
+  });
+
+  it('PUT /config rejects a verdict outside the enum (400)', async () => {
+    const res = await app().request('/pam/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ defaultUnmatchedVerdict: 'auto_approve' }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -241,6 +241,10 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
         pamRuleId,
         pamRuleName,
         decisionSource,
+        // Surfaced from metadata so "Create rule from this request" can seed a
+        // command-line / parent-image criterion (uac_intercept captures both).
+        commandLine: typeof meta.command_line === 'string' ? meta.command_line : null,
+        parentImage: typeof meta.parent_image === 'string' ? meta.parent_image : null,
       };
     }),
     pagination: { page, limit, total: countRows[0]?.total ?? 0 },

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -30,6 +30,8 @@ import {
   devices,
   elevationAudit,
   elevationRequests,
+  PAM_RULE_NEGATE_KEYS,
+  pamOrgConfig,
   pamRules,
   sites,
   softwarePolicies,
@@ -771,6 +773,7 @@ const ruleCriteriaFields = [
   'matchHash',
   'matchPathGlob',
   'matchParentImage',
+  'matchCommandLine',
   'matchUser',
   'matchAdGroup',
 ] as const;
@@ -794,10 +797,12 @@ const ruleCriteriaValidators = {
     .optional(),
   matchPathGlob: z.string().min(1).max(4096).nullable().optional(),
   matchParentImage: z.string().min(1).max(4096).nullable().optional(),
+  matchCommandLine: z.string().min(1).max(4096).nullable().optional(),
   matchUser: z.string().min(1).max(255).nullable().optional(),
   matchAdGroup: z.string().min(1).max(255).nullable().optional(),
   matchToolName: z.string().min(1).max(100).nullable().optional(),
   matchRiskTier: z.number().int().min(0).max(4).nullable().optional(),
+  matchNegate: z.array(z.enum(PAM_RULE_NEGATE_KEYS)).max(PAM_RULE_NEGATE_KEYS.length).nullable().optional(),
   timeWindow: timeWindowSchema.nullable().optional(),
 };
 
@@ -823,6 +828,7 @@ type RuleCriteriaShape = {
   matchHash?: string | null;
   matchPathGlob?: string | null;
   matchParentImage?: string | null;
+  matchCommandLine?: string | null;
   matchUser?: string | null;
   matchAdGroup?: string | null;
   matchToolName?: string | null;
@@ -844,6 +850,7 @@ const executableCriteriaFields = [
   'matchHash',
   'matchPathGlob',
   'matchParentImage',
+  'matchCommandLine',
 ] as const;
 
 function hasToolActionCriteria(rule: RuleCriteriaShape): boolean {
@@ -928,10 +935,12 @@ pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', creat
       matchHash: payload.matchHash ? payload.matchHash.toLowerCase() : null,
       matchPathGlob: payload.matchPathGlob ?? null,
       matchParentImage: payload.matchParentImage ?? null,
+      matchCommandLine: payload.matchCommandLine ?? null,
       matchUser: payload.matchUser ?? null,
       matchAdGroup: payload.matchAdGroup ?? null,
       matchToolName: payload.matchToolName ?? null,
       matchRiskTier: payload.matchRiskTier ?? null,
+      matchNegate: payload.matchNegate ?? null,
       timeWindow: payload.timeWindow ?? null,
       verdict: payload.verdict,
       approvalDurationMinutes: payload.approvalDurationMinutes ?? null,
@@ -1027,10 +1036,12 @@ pamRoutes.post(
       matchHash: body.matchHash ? body.matchHash.toLowerCase() : null,
       matchPathGlob: body.matchPathGlob ?? null,
       matchParentImage: body.matchParentImage ?? null,
+      matchCommandLine: body.matchCommandLine ?? null,
       matchUser: body.matchUser ?? null,
       matchAdGroup: body.matchAdGroup ?? null,
       matchToolName: body.matchToolName ?? null,
       matchRiskTier: body.matchRiskTier ?? null,
+      matchNegate: body.matchNegate ?? null,
       timeWindow: body.timeWindow ?? null,
     };
 
@@ -1054,6 +1065,7 @@ pamRoutes.post(
         targetExecutableSigner: r.targetExecutableSigner ?? undefined,
         subjectUsername: r.subjectUsername,
         parentImage: typeof meta.parent_image === 'string' ? meta.parent_image : undefined,
+        commandLine: typeof meta.command_line === 'string' ? meta.command_line : undefined,
         toolName: r.toolName ?? undefined,
         riskTier: r.riskTier ?? undefined,
         at: r.requestedAt,
@@ -1126,10 +1138,14 @@ pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', 
       ...(payload.matchParentImage !== undefined
         ? { matchParentImage: payload.matchParentImage }
         : {}),
+      ...(payload.matchCommandLine !== undefined
+        ? { matchCommandLine: payload.matchCommandLine }
+        : {}),
       ...(payload.matchUser !== undefined ? { matchUser: payload.matchUser } : {}),
       ...(payload.matchAdGroup !== undefined ? { matchAdGroup: payload.matchAdGroup } : {}),
       ...(payload.matchToolName !== undefined ? { matchToolName: payload.matchToolName } : {}),
       ...(payload.matchRiskTier !== undefined ? { matchRiskTier: payload.matchRiskTier } : {}),
+      ...(payload.matchNegate !== undefined ? { matchNegate: payload.matchNegate } : {}),
       ...(payload.timeWindow !== undefined ? { timeWindow: payload.timeWindow } : {}),
       ...(payload.verdict !== undefined ? { verdict: payload.verdict } : {}),
       ...(payload.approvalDurationMinutes !== undefined
@@ -1179,3 +1195,80 @@ pamRoutes.delete('/rules/:id', requirePamWrite, requireMfa(), async (c) => {
 
   return c.json({ success: true });
 });
+
+// ============================================================
+// Org config — default verdict for unmatched elevations
+// ============================================================
+// When an elevation matches no software policy and no PAM rule, the org's
+// configured default applies. Absent a row, the default is require_approval
+// (the historical behavior — the request waits for a human).
+const updateConfigSchema = z.object({
+  orgId: z.string().guid().optional(),
+  defaultUnmatchedVerdict: z.enum(['require_approval', 'auto_deny']),
+});
+
+pamRoutes.get('/config', requirePamRead, async (c) => {
+  const auth = c.get('auth');
+  const resolvedOrg = resolveOrgIdForWrite(auth, c.req.query('orgId') ?? undefined);
+  if (!resolvedOrg.orgId) {
+    return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
+  }
+  const [cfg] = await db
+    .select()
+    .from(pamOrgConfig)
+    .where(eq(pamOrgConfig.orgId, resolvedOrg.orgId))
+    .limit(1);
+  return c.json({
+    success: true,
+    config: {
+      orgId: resolvedOrg.orgId,
+      defaultUnmatchedVerdict: cfg?.defaultUnmatchedVerdict ?? 'require_approval',
+    },
+  });
+});
+
+pamRoutes.put(
+  '/config',
+  requirePamWrite,
+  requireMfa(),
+  zValidator('json', updateConfigSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const payload = c.req.valid('json');
+    const resolvedOrg = resolveOrgIdForWrite(
+      auth,
+      payload.orgId ?? c.req.query('orgId') ?? undefined,
+    );
+    if (!resolvedOrg.orgId) {
+      return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
+    }
+    const [saved] = await db
+      .insert(pamOrgConfig)
+      .values({
+        orgId: resolvedOrg.orgId,
+        defaultUnmatchedVerdict: payload.defaultUnmatchedVerdict,
+        updatedByUserId: auth.user.id,
+      })
+      .onConflictDoUpdate({
+        target: pamOrgConfig.orgId,
+        set: {
+          defaultUnmatchedVerdict: payload.defaultUnmatchedVerdict,
+          updatedByUserId: auth.user.id,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+
+    writeAuditEvent(c, {
+      orgId: resolvedOrg.orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      action: 'pam.config.update',
+      resourceType: 'pam_org_config',
+      resourceId: saved?.id ?? resolvedOrg.orgId,
+      details: { defaultUnmatchedVerdict: payload.defaultUnmatchedVerdict },
+    });
+
+    return c.json({ success: true, config: saved });
+  },
+);

--- a/apps/api/src/services/pamRuleEngine.test.ts
+++ b/apps/api/src/services/pamRuleEngine.test.ts
@@ -25,10 +25,12 @@ function rule(overrides: Partial<PamRule>): PamRule {
     matchHash: null,
     matchPathGlob: null,
     matchParentImage: null,
+    matchCommandLine: null,
     matchUser: null,
     matchAdGroup: null,
     matchToolName: null,
     matchRiskTier: null,
+    matchNegate: null,
     timeWindow: null,
     verdict: 'require_approval',
     approvalDurationMinutes: null,
@@ -313,5 +315,105 @@ describe('tool-action rules (Phase 1 helper governance)', () => {
     const deny = rule({ matchToolName: 'manage_services', verdict: 'auto_deny', priority: 10 });
     const approve = rule({ matchToolName: 'manage_services', verdict: 'auto_approve', priority: 20 });
     expect(evaluatePamToolActionRules([approve, deny], toolCandidate)?.verdict).toBe('auto_deny');
+  });
+});
+
+describe('command-line matching', () => {
+  const printerCandidate: PamRuleCandidate = {
+    targetExecutablePath: 'C:\\Windows\\System32\\rundll32.exe',
+    targetExecutableSigner: 'Microsoft Windows',
+    subjectUsername: 'CORP\\alice',
+    commandLine: 'rundll32.exe printui.dll,PrintUIEntry /il',
+  };
+
+  it('matches a case-insensitive substring of the command line', () => {
+    const r = rule({ matchCommandLine: 'printui.dll,PrintUIEntry', verdict: 'auto_approve' });
+    expect(evaluatePamRules([r], printerCandidate)?.verdict).toBe('auto_approve');
+  });
+
+  it('does not match when the substring is absent', () => {
+    const r = rule({ matchCommandLine: 'KeyboardLayout', verdict: 'auto_approve' });
+    expect(evaluatePamRules([r], printerCandidate)).toBeNull();
+  });
+
+  it('fails closed when the candidate carries no command line', () => {
+    const r = rule({ matchCommandLine: 'printui', verdict: 'auto_approve' });
+    expect(evaluatePamRules([r], candidate)).toBeNull();
+  });
+
+  it('ANDs with a path glob (both must hold)', () => {
+    const r = rule({
+      matchPathGlob: 'C:\\Windows\\System32\\rundll32.exe',
+      matchCommandLine: 'printui.dll,PrintUIEntry',
+      verdict: 'auto_approve',
+    });
+    expect(evaluatePamRules([r], printerCandidate)).not.toBeNull();
+    // Same rule, command line that doesn't contain the substring → no match.
+    expect(
+      evaluatePamRules([r], { ...printerCandidate, commandLine: 'rundll32.exe shell32.dll,Control_RunDLL' }),
+    ).toBeNull();
+  });
+});
+
+describe('rule negation (match_negate)', () => {
+  it('inverts a path-glob criterion: matches when the path does NOT match', () => {
+    const r = rule({
+      matchPathGlob: 'C:\\Program Files\\Vendor\\**',
+      matchNegate: ['pathGlob'],
+      verdict: 'auto_deny',
+    });
+    // candidate's path IS under Vendor → negated criterion fails → no match.
+    expect(evaluatePamRules([r], candidate)).toBeNull();
+    // a path outside Vendor → negated criterion holds → match.
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutablePath: 'C:\\Temp\\evil.exe' })?.verdict,
+    ).toBe('auto_deny');
+  });
+
+  it('inverts a signer criterion combined (ANDed) with a positive path criterion', () => {
+    const r = rule({
+      matchPathGlob: 'C:\\Program Files\\Vendor\\**',
+      matchSigner: 'Evil Corp',
+      matchNegate: ['signer'],
+      verdict: 'auto_approve',
+    });
+    // path matches AND signer is NOT "Evil Corp" → match.
+    expect(evaluatePamRules([r], candidate)?.verdict).toBe('auto_approve');
+    // signer IS "Evil Corp" → negated signer fails → no match.
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Evil Corp' }),
+    ).toBeNull();
+  });
+
+  it('negation fails closed when the candidate field is absent (never over-grants)', () => {
+    const r = rule({
+      matchSigner: 'Evil Corp',
+      matchNegate: ['signer'],
+      verdict: 'auto_approve',
+    });
+    // unsigned binary (no signer) → absent data never satisfies a criterion,
+    // even a negated one → no match.
+    const unsigned: PamRuleCandidate = {
+      targetExecutablePath: 'C:\\Temp\\unsigned.exe',
+      subjectUsername: 'CORP\\alice',
+    };
+    expect(evaluatePamRules([r], unsigned)).toBeNull();
+  });
+
+  it('inverts a command-line criterion', () => {
+    const r = rule({
+      matchPathGlob: '**',
+      matchCommandLine: '--uninstall',
+      matchNegate: ['commandLine'],
+      verdict: 'auto_approve',
+    });
+    const installing: PamRuleCandidate = {
+      targetExecutablePath: 'C:\\App\\setup.exe',
+      subjectUsername: 'CORP\\alice',
+      commandLine: 'setup.exe --install',
+    };
+    const uninstalling: PamRuleCandidate = { ...installing, commandLine: 'setup.exe --uninstall' };
+    expect(evaluatePamRules([r], installing)?.verdict).toBe('auto_approve');
+    expect(evaluatePamRules([r], uninstalling)).toBeNull();
   });
 });

--- a/apps/api/src/services/pamRuleEngine.ts
+++ b/apps/api/src/services/pamRuleEngine.ts
@@ -30,7 +30,7 @@
  *   evaluated via evaluatePamToolActionRules, which only considers rules
  *   carrying a tool-action criterion.
  */
-import type { PamRule, PamRuleTimeWindow } from '../db/schema/pam';
+import type { PamRule, PamRuleNegateKey, PamRuleTimeWindow } from '../db/schema/pam';
 import { matchPathGlob } from './pamBridge';
 
 export interface PamRuleCandidate {
@@ -40,6 +40,8 @@ export interface PamRuleCandidate {
   targetExecutableSigner?: string;
   subjectUsername: string;
   parentImage?: string;
+  /** Launched process command line, when the agent captured it. */
+  commandLine?: string;
   /** AD/local group names of the subject, when known. */
   subjectAdGroups?: string[];
   /** ai_tool_action candidates: bare tool name (no mcp__ prefix). */
@@ -69,6 +71,7 @@ function hasAnyCriteria(rule: PamRule): boolean {
       rule.matchHash ||
       rule.matchPathGlob ||
       rule.matchParentImage ||
+      rule.matchCommandLine ||
       rule.matchUser ||
       rule.matchAdGroup ||
       rule.matchToolName ||
@@ -135,38 +138,65 @@ export function isWithinTimeWindow(window: PamRuleTimeWindow, at: Date): boolean
 function ruleMatches(rule: PamRule, candidate: PamRuleCandidate): boolean {
   if (!hasAnyCriteria(rule)) return false;
 
+  const negate = new Set<PamRuleNegateKey>(rule.matchNegate ?? []);
+  // A criterion is satisfied when its candidate data is PRESENT and the
+  // comparison holds (or, for a negated criterion, fails to hold). Absent
+  // candidate data NEVER satisfies a criterion — negation can't accidentally
+  // turn missing data into a tenant-wide grant.
+  const satisfied = (key: PamRuleNegateKey, present: boolean, positive: boolean): boolean => {
+    if (!present) return false;
+    return negate.has(key) ? !positive : positive;
+  };
+
   if (rule.matchHash) {
-    if (!candidate.targetExecutableHash) return false;
-    if (!eqCi(rule.matchHash, candidate.targetExecutableHash)) return false;
+    const present = candidate.targetExecutableHash != null;
+    const positive = present && eqCi(rule.matchHash, candidate.targetExecutableHash!);
+    if (!satisfied('hash', present, positive)) return false;
   }
   if (rule.matchSigner) {
-    if (!candidate.targetExecutableSigner) return false;
-    if (!eqCi(rule.matchSigner, candidate.targetExecutableSigner)) return false;
+    const present = candidate.targetExecutableSigner != null;
+    const positive = present && eqCi(rule.matchSigner, candidate.targetExecutableSigner!);
+    if (!satisfied('signer', present, positive)) return false;
   }
   if (rule.matchPathGlob) {
-    if (!candidate.targetExecutablePath) return false;
-    if (!matchPathGlob(rule.matchPathGlob, candidate.targetExecutablePath)) return false;
+    const present = candidate.targetExecutablePath != null;
+    const positive = present && matchPathGlob(rule.matchPathGlob, candidate.targetExecutablePath!);
+    if (!satisfied('pathGlob', present, positive)) return false;
   }
   if (rule.matchParentImage) {
-    if (!candidate.parentImage) return false;
-    if (!matchPathGlob(rule.matchParentImage, candidate.parentImage)) return false;
+    const present = candidate.parentImage != null;
+    const positive = present && matchPathGlob(rule.matchParentImage, candidate.parentImage!);
+    if (!satisfied('parentImage', present, positive)) return false;
+  }
+  if (rule.matchCommandLine) {
+    const present = candidate.commandLine != null;
+    const positive =
+      present && candidate.commandLine!.toLowerCase().includes(rule.matchCommandLine.toLowerCase());
+    if (!satisfied('commandLine', present, positive)) return false;
   }
   if (rule.matchUser) {
-    if (!eqCi(rule.matchUser, candidate.subjectUsername)) return false;
+    // subjectUsername is always present on a candidate.
+    const positive = eqCi(rule.matchUser, candidate.subjectUsername);
+    if (!satisfied('user', true, positive)) return false;
   }
   if (rule.matchAdGroup) {
-    const groups = candidate.subjectAdGroups ?? [];
-    if (!groups.some((g) => eqCi(g, rule.matchAdGroup!))) return false;
+    const present = candidate.subjectAdGroups !== undefined;
+    const positive =
+      present && candidate.subjectAdGroups!.some((g) => eqCi(g, rule.matchAdGroup!));
+    if (!satisfied('adGroup', present, positive)) return false;
   }
   if (rule.matchToolName) {
-    if (!candidate.toolName) return false;
-    if (!eqCi(rule.matchToolName, candidate.toolName)) return false;
+    const present = candidate.toolName != null;
+    const positive = present && eqCi(rule.matchToolName, candidate.toolName!);
+    if (!satisfied('toolName', present, positive)) return false;
   }
   if (rule.matchRiskTier != null) {
-    if (candidate.riskTier == null) return false;
-    if (rule.matchRiskTier !== candidate.riskTier) return false;
+    const present = candidate.riskTier != null;
+    const positive = present && rule.matchRiskTier === candidate.riskTier;
+    if (!satisfied('riskTier', present, positive)) return false;
   }
   if (rule.timeWindow) {
+    // A time window NARROWS; it is never negated.
     if (!isWithinTimeWindow(rule.timeWindow, candidate.at ?? new Date())) return false;
   }
   return true;

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -207,6 +207,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'onedrive_device_state',
   'org_ticket_settings',
   'organization_users',
+  'pam_org_config',
   'pam_rules',
   'patch_approvals',
   'patch_compliance_reports',

--- a/apps/web/src/components/pam/PamRuleModal.test.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PamRuleModal from './PamRuleModal';
 import { fetchWithAuth } from '../../stores/auth';
-import type { PamRuleDraft } from './types';
+import type { PamRuleDraft, PamRuleNegateKey } from './types';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -66,6 +66,90 @@ describe('PamRuleModal', () => {
     expect((screen.getByTestId('pam-rule-signer') as HTMLInputElement).value).toBe('Acme Corp');
     // Executable shape selected by the seed.
     expect(screen.getByTestId('pam-rule-shape-executable')).toHaveClass('border-primary');
+  });
+
+  it('sends matchCommandLine and a matchNegate array for negated criteria', async () => {
+    const user = userEvent.setup();
+    installFetchRoutes();
+    let postBody: Record<string, unknown> | null = null;
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+      if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+      if (url === '/pam/rules' && method === 'POST') {
+        postBody = JSON.parse(init!.body as string);
+        return makeJsonResponse({ success: true, rule: {} }, true, 201);
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('pam-rule-match-command-line')).toBeInTheDocument());
+
+    await user.type(screen.getByTestId('pam-rule-name'), 'Only printui rundll32');
+    await user.type(screen.getByTestId('pam-rule-path'), 'C:\\Windows\\System32\\rundll32.exe');
+    await user.type(screen.getByTestId('pam-rule-match-command-line'), 'printui.dll,PrintUIEntry');
+    // Negate the path glob: "rundll32 unless ..." — the path stays, but the
+    // command-line criterion is the positive match.
+    await user.click(screen.getByTestId('pam-rule-negate-pathGlob'));
+    await user.click(screen.getByTestId('pam-rule-submit'));
+
+    await waitFor(() => expect(postBody).not.toBeNull());
+    expect(postBody!.matchCommandLine).toBe('printui.dll,PrintUIEntry');
+    expect(postBody!.matchNegate).toEqual(['pathGlob']);
+  });
+
+  it('omits a dangling negate key whose criterion is empty', async () => {
+    const user = userEvent.setup();
+    installFetchRoutes();
+    let postBody: Record<string, unknown> | null = null;
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+      if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+      if (url === '/pam/rules' && method === 'POST') {
+        postBody = JSON.parse(init!.body as string);
+        return makeJsonResponse({ success: true, rule: {} }, true, 201);
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('pam-rule-signer')).toBeInTheDocument());
+
+    await user.type(screen.getByTestId('pam-rule-name'), 'Signer only');
+    await user.type(screen.getByTestId('pam-rule-signer'), 'Acme Corp');
+    // Toggle parentImage negation but leave the parent-image field empty.
+    await user.click(screen.getByTestId('pam-rule-negate-parentImage'));
+    await user.click(screen.getByTestId('pam-rule-submit'));
+
+    await waitFor(() => expect(postBody).not.toBeNull());
+    // No populated negatable criterion → matchNegate is null, not ['parentImage'].
+    expect(postBody!.matchNegate).toBeNull();
+  });
+
+  it('seeds the negate toggles and command line from an edited rule', async () => {
+    installFetchRoutes();
+    const rule = {
+      id: 'rule-x',
+      orgId: 'org-1',
+      name: 'rundll32 not printui',
+      enabled: true,
+      priority: 100,
+      matchPathGlob: 'C:\\Windows\\System32\\rundll32.exe',
+      matchCommandLine: 'printui.dll',
+      matchNegate: ['commandLine'] as PamRuleNegateKey[],
+      verdict: 'require_approval' as const,
+      createdAt: '2026-06-10T00:00:00.000Z',
+      updatedAt: '2026-06-10T00:00:00.000Z',
+    };
+    render(<PamRuleModal rule={rule} onClose={() => {}} onSaved={() => {}} />);
+
+    await waitFor(() =>
+      expect((screen.getByTestId('pam-rule-match-command-line') as HTMLInputElement).value).toBe('printui.dll'),
+    );
+    expect((screen.getByTestId('pam-rule-negate-commandLine') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('pam-rule-negate-pathGlob') as HTMLInputElement).checked).toBe(false);
   });
 
   it('seeds tool-shape fields from a draft', async () => {

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -116,8 +116,12 @@ export default function PamRuleModal({
   const [matchSigner, setMatchSigner] = useState(rule?.matchSigner ?? seedExec?.matchSigner ?? '');
   const [matchHash, setMatchHash] = useState(rule?.matchHash ?? seedExec?.matchHash ?? '');
   const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? seedExec?.matchPathGlob ?? '');
-  const [matchParentImage, setMatchParentImage] = useState(rule?.matchParentImage ?? '');
-  const [matchCommandLine, setMatchCommandLine] = useState(rule?.matchCommandLine ?? '');
+  const [matchParentImage, setMatchParentImage] = useState(
+    rule?.matchParentImage ?? seedExec?.matchParentImage ?? '',
+  );
+  const [matchCommandLine, setMatchCommandLine] = useState(
+    rule?.matchCommandLine ?? seedExec?.matchCommandLine ?? '',
+  );
   const [matchUser, setMatchUser] = useState(rule?.matchUser ?? seedExec?.matchUser ?? '');
   const [matchAdGroup, setMatchAdGroup] = useState(rule?.matchAdGroup ?? '');
   const [matchToolName, setMatchToolName] = useState(rule?.matchToolName ?? seedTool?.matchToolName ?? '');

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -8,6 +8,7 @@ import {
   type ElevationStatus,
   type PamRule,
   type PamRuleDraft,
+  type PamRuleNegateKey,
   type PamVerdict,
   STATUS_LABELS,
   VERDICT_LABELS,
@@ -116,6 +117,7 @@ export default function PamRuleModal({
   const [matchHash, setMatchHash] = useState(rule?.matchHash ?? seedExec?.matchHash ?? '');
   const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? seedExec?.matchPathGlob ?? '');
   const [matchParentImage, setMatchParentImage] = useState(rule?.matchParentImage ?? '');
+  const [matchCommandLine, setMatchCommandLine] = useState(rule?.matchCommandLine ?? '');
   const [matchUser, setMatchUser] = useState(rule?.matchUser ?? seedExec?.matchUser ?? '');
   const [matchAdGroup, setMatchAdGroup] = useState(rule?.matchAdGroup ?? '');
   const [matchToolName, setMatchToolName] = useState(rule?.matchToolName ?? seedTool?.matchToolName ?? '');
@@ -125,6 +127,12 @@ export default function PamRuleModal({
       : seedTool?.matchRiskTier !== null && seedTool?.matchRiskTier !== undefined
         ? String(seedTool.matchRiskTier)
         : '',
+  );
+  // Criterion keys the engine inverts ("does not match"). Same keys as the API's
+  // PAM_RULE_NEGATE_KEYS; only the keys whose criterion is actually populated
+  // are sent (see buildCriteria).
+  const [negate, setNegate] = useState<Set<PamRuleNegateKey>>(
+    () => new Set(rule?.matchNegate ?? []),
   );
   const [windowStart, setWindowStart] = useState(rule?.timeWindow?.start ?? '');
   const [windowEnd, setWindowEnd] = useState(rule?.timeWindow?.end ?? '');
@@ -229,10 +237,12 @@ export default function PamRuleModal({
     matchHash,
     matchPathGlob,
     matchParentImage,
+    matchCommandLine,
     matchUser,
     matchAdGroup,
     matchToolName,
     matchRiskTier,
+    negate,
     windowStart,
     windowEnd,
     windowDays,
@@ -244,6 +254,15 @@ export default function PamRuleModal({
     setWindowDays((prev) =>
       prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day].sort((a, b) => a - b),
     );
+  };
+
+  const toggleNegate = (key: PamRuleNegateKey) => {
+    setNegate((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
   };
 
   /**
@@ -262,6 +281,7 @@ export default function PamRuleModal({
       matchHash: matchHash.trim() || null,
       matchPathGlob: matchPathGlob.trim() || null,
       matchParentImage: matchParentImage.trim() || null,
+      matchCommandLine: matchCommandLine.trim() || null,
     };
     const tool = {
       matchToolName: matchToolName.trim() || null,
@@ -272,7 +292,7 @@ export default function PamRuleModal({
       matchAdGroup: matchAdGroup.trim() || null,
     };
 
-    const activeCriteria =
+    const activeCriteria: Record<string, unknown> =
       shape === 'executable'
         ? { ...executable, matchToolName: null, matchRiskTier: null, ...common }
         : {
@@ -280,6 +300,7 @@ export default function PamRuleModal({
             matchHash: null,
             matchPathGlob: null,
             matchParentImage: null,
+            matchCommandLine: null,
             ...tool,
             ...common,
           };
@@ -291,6 +312,26 @@ export default function PamRuleModal({
       setError('At least one match criterion is required.');
       return null;
     }
+
+    // Send negation only for criteria that are actually populated in this
+    // shape — a dangling negate key (its match* field cleared) would be a no-op
+    // and confuse the rule summary. Maps each negate key to its match* column.
+    const negateFieldByKey: Record<PamRuleNegateKey, string> = {
+      signer: 'matchSigner',
+      hash: 'matchHash',
+      pathGlob: 'matchPathGlob',
+      parentImage: 'matchParentImage',
+      commandLine: 'matchCommandLine',
+      user: 'matchUser',
+      adGroup: 'matchAdGroup',
+      toolName: 'matchToolName',
+      riskTier: 'matchRiskTier',
+    };
+    const matchNegate = [...negate].filter((key) => {
+      const v = activeCriteria[negateFieldByKey[key]];
+      return v !== null && v !== '' && v !== undefined;
+    });
+    activeCriteria.matchNegate = matchNegate.length > 0 ? matchNegate : null;
     if (Boolean(windowStart) !== Boolean(windowEnd)) {
       setError('Time window start and end must both be set (or both left empty).');
       return null;
@@ -573,14 +614,15 @@ export default function PamRuleModal({
 
         {shape === 'executable' ? (
           <div className="grid gap-4 sm:grid-cols-2">
-            <Field label="Signer" value={matchSigner} onChange={setMatchSigner} placeholder="e.g. Microsoft Corporation" testId="pam-rule-signer" />
-            <Field label="SHA-256 hash" value={matchHash} onChange={setMatchHash} placeholder="64 hex chars" testId="pam-rule-hash" />
-            <Field label="Path glob" value={matchPathGlob} onChange={setMatchPathGlob} placeholder="C:\\Program Files\\**" testId="pam-rule-path" />
-            <Field label="Parent image" value={matchParentImage} onChange={setMatchParentImage} placeholder="explorer.exe" testId="pam-rule-parent" />
+            <Field label="Signer" value={matchSigner} onChange={setMatchSigner} placeholder="e.g. Microsoft Corporation" testId="pam-rule-signer" negateKey="signer" negated={negate.has('signer')} onToggleNegate={toggleNegate} />
+            <Field label="SHA-256 hash" value={matchHash} onChange={setMatchHash} placeholder="64 hex chars" testId="pam-rule-hash" negateKey="hash" negated={negate.has('hash')} onToggleNegate={toggleNegate} />
+            <Field label="Path glob" value={matchPathGlob} onChange={setMatchPathGlob} placeholder="C:\\Program Files\\**" testId="pam-rule-path" negateKey="pathGlob" negated={negate.has('pathGlob')} onToggleNegate={toggleNegate} />
+            <Field label="Parent image" value={matchParentImage} onChange={setMatchParentImage} placeholder="explorer.exe" testId="pam-rule-parent" negateKey="parentImage" negated={negate.has('parentImage')} onToggleNegate={toggleNegate} />
+            <Field label="Command line" value={matchCommandLine} onChange={setMatchCommandLine} placeholder="printui.dll,PrintUIEntry" testId="pam-rule-match-command-line" negateKey="commandLine" negated={negate.has('commandLine')} onToggleNegate={toggleNegate} />
           </div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">
-            <Field label="Tool name" value={matchToolName} onChange={setMatchToolName} placeholder="run_script" testId="pam-rule-toolname" />
+            <Field label="Tool name" value={matchToolName} onChange={setMatchToolName} placeholder="run_script" testId="pam-rule-toolname" negateKey="toolName" negated={negate.has('toolName')} onToggleNegate={toggleNegate} />
             <Field
               label="Risk tier (0-4)"
               value={matchRiskTier}
@@ -588,13 +630,16 @@ export default function PamRuleModal({
               placeholder="2"
               type="number"
               testId="pam-rule-risktier"
+              negateKey="riskTier"
+              negated={negate.has('riskTier')}
+              onToggleNegate={toggleNegate}
             />
           </div>
         )}
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <Field label="User (optional)" value={matchUser} onChange={setMatchUser} placeholder="DOMAIN\\user" testId="pam-rule-user" />
-          <Field label="AD group (optional)" value={matchAdGroup} onChange={setMatchAdGroup} placeholder="Helpdesk Tier 1" testId="pam-rule-adgroup" />
+          <Field label="User (optional)" value={matchUser} onChange={setMatchUser} placeholder="DOMAIN\\user" testId="pam-rule-user" negateKey="user" negated={negate.has('user')} onToggleNegate={toggleNegate} />
+          <Field label="AD group (optional)" value={matchAdGroup} onChange={setMatchAdGroup} placeholder="Helpdesk Tier 1" testId="pam-rule-adgroup" negateKey="adGroup" negated={negate.has('adGroup')} onToggleNegate={toggleNegate} />
         </div>
 
         <div className="grid gap-4 sm:grid-cols-3">
@@ -740,6 +785,9 @@ function Field({
   placeholder,
   testId,
   type = 'text',
+  negateKey,
+  negated,
+  onToggleNegate,
 }: {
   label: string;
   value: string;
@@ -747,6 +795,11 @@ function Field({
   placeholder?: string;
   testId: string;
   type?: string;
+  // When provided, a small "does not match" toggle renders under the input,
+  // marking this criterion for engine-side negation (PAM_RULE_NEGATE_KEYS).
+  negateKey?: PamRuleNegateKey;
+  negated?: boolean;
+  onToggleNegate?: (key: PamRuleNegateKey) => void;
 }) {
   const id = useId();
   return (
@@ -763,6 +816,17 @@ function Field({
         data-testid={testId}
         className="w-full rounded-md border bg-background px-3 py-2 text-sm"
       />
+      {negateKey && onToggleNegate && (
+        <label className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={negated ?? false}
+            onChange={() => onToggleNegate(negateKey)}
+            data-testid={`pam-rule-negate-${negateKey}`}
+          />
+          Negate (does not match)
+        </label>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/pam/PamRulesTab.test.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.test.tsx
@@ -49,15 +49,23 @@ function installFetchRoutes({
   rules = [] as PamRule[],
   sites = [] as Array<{ id: string; name: string }>,
   orgs = [{ id: 'org-1', name: 'Acme' }],
+  defaultUnmatchedVerdict = 'require_approval' as 'require_approval' | 'auto_deny',
 }: {
   rules?: PamRule[];
   sites?: Array<{ id: string; name: string }>;
   orgs?: Array<{ id: string; name: string }>;
+  defaultUnmatchedVerdict?: 'require_approval' | 'auto_deny';
 } = {}) {
   fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
     const method = init?.method ?? 'GET';
     if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: orgs });
     if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: sites });
+    if (url === '/pam/config' && method === 'GET') {
+      return makeJsonResponse({ success: true, config: { orgId: 'org-1', defaultUnmatchedVerdict } });
+    }
+    if (url === '/pam/config' && method === 'PUT') {
+      return makeJsonResponse({ success: true, config: {} });
+    }
     if (url === '/pam/rules' && method === 'POST') {
       return makeJsonResponse({ success: true, rule: rules[0] ?? signedRule }, true, 201);
     }
@@ -103,6 +111,39 @@ describe('PamRulesTab', () => {
     expect(
       screen.getByText(/Software policies are evaluated first/i),
     ).toBeInTheDocument();
+  });
+
+  describe('default unmatched verdict', () => {
+    it('loads the current default verdict from GET /pam/config', async () => {
+      installFetchRoutes({ rules: [], defaultUnmatchedVerdict: 'auto_deny' });
+      render(<PamRulesTab />);
+      await waitFor(() => {
+        expect((screen.getByTestId('pam-default-unmatched-verdict') as HTMLSelectElement).value).toBe(
+          'auto_deny',
+        );
+      });
+    });
+
+    it('PUTs the new default verdict on change', async () => {
+      installFetchRoutes({ rules: [] });
+      render(<PamRulesTab />);
+      await waitFor(() => {
+        expect((screen.getByTestId('pam-default-unmatched-verdict') as HTMLSelectElement).value).toBe(
+          'require_approval',
+        );
+      });
+
+      fireEvent.change(screen.getByTestId('pam-default-unmatched-verdict'), {
+        target: { value: 'auto_deny' },
+      });
+
+      await waitFor(() => {
+        expect(findMutationCall('/pam/config', 'PUT')).toBeDefined();
+      });
+      expect(bodyOf(findMutationCall('/pam/config', 'PUT'))).toEqual({
+        defaultUnmatchedVerdict: 'auto_deny',
+      });
+    });
   });
 
   it('re-fetches rules when the liveTick prop changes', async () => {

--- a/apps/web/src/components/pam/PamRulesTab.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.tsx
@@ -6,7 +6,7 @@ import { navigateTo } from '@/lib/navigation';
 import { showToast } from '../shared/Toast';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import PamRuleModal from './PamRuleModal';
-import { type PamRule, VERDICT_LABELS } from './types';
+import { type PamRule, type PamUnmatchedVerdict, VERDICT_LABELS } from './types';
 
 function ruleCriteriaSummary(rule: PamRule): string {
   const parts: string[] = [];
@@ -14,6 +14,7 @@ function ruleCriteriaSummary(rule: PamRule): string {
   if (rule.matchHash) parts.push(`hash=${rule.matchHash.slice(0, 12)}…`);
   if (rule.matchPathGlob) parts.push(`path=${rule.matchPathGlob}`);
   if (rule.matchParentImage) parts.push(`parent=${rule.matchParentImage}`);
+  if (rule.matchCommandLine) parts.push(`cmdline=${rule.matchCommandLine}`);
   if (rule.matchUser) parts.push(`user=${rule.matchUser}`);
   if (rule.matchAdGroup) parts.push(`group=${rule.matchAdGroup}`);
   if (rule.matchToolName) parts.push(`tool=${rule.matchToolName}`);
@@ -34,6 +35,9 @@ export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number }) {
   // siteId → name, resolved once for the Scope column (GET /pam/rules returns
   // only siteId; no per-row lookups).
   const [siteNames, setSiteNames] = useState<Record<string, string>>({});
+  // Org default verdict for an elevation matching no policy and no rule.
+  const [defaultVerdict, setDefaultVerdict] = useState<PamUnmatchedVerdict>('require_approval');
+  const [savingDefault, setSavingDefault] = useState(false);
 
   useEffect(() => {
     fetchWithAuth('/orgs/sites?limit=100')
@@ -45,6 +49,45 @@ export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number }) {
       })
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    fetchWithAuth('/pam/config')
+      .then(async (res) => {
+        if (!res.ok) return;
+        const body = await res.json();
+        if (body?.config?.defaultUnmatchedVerdict) {
+          setDefaultVerdict(body.config.defaultUnmatchedVerdict as PamUnmatchedVerdict);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const changeDefaultVerdict = async (next: PamUnmatchedVerdict) => {
+    if (savingDefault) return;
+    const prev = defaultVerdict;
+    setDefaultVerdict(next);
+    setSavingDefault(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth('/pam/config', {
+            method: 'PUT',
+            body: JSON.stringify({ defaultUnmatchedVerdict: next }),
+          }),
+        errorFallback: 'Failed to update default verdict',
+        successMessage: `Default verdict set to ${VERDICT_LABELS[next]}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+    } catch (err) {
+      setDefaultVerdict(prev); // roll back the optimistic change on failure
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) {
+        showToast({ type: 'error', message: 'Failed to update default verdict' });
+      }
+    } finally {
+      setSavingDefault(false);
+    }
+  };
 
   const fetchRules = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -136,6 +179,26 @@ export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number }) {
           <Plus className="h-4 w-4" />
           Add rule
         </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 rounded-md border bg-card px-3 py-2">
+        <label htmlFor="pam-default-unmatched-verdict" className="text-sm font-medium">
+          Default verdict
+        </label>
+        <select
+          id="pam-default-unmatched-verdict"
+          value={defaultVerdict}
+          onChange={(e) => void changeDefaultVerdict(e.target.value as PamUnmatchedVerdict)}
+          disabled={savingDefault}
+          data-testid="pam-default-unmatched-verdict"
+          className="rounded-md border bg-background px-2 py-1 text-sm disabled:opacity-50"
+        >
+          <option value="require_approval">Require approval</option>
+          <option value="auto_deny">Auto-deny</option>
+        </select>
+        <span className="text-xs text-muted-foreground">
+          Verdict when an elevation matches no policy or rule.
+        </span>
       </div>
 
       {error && (

--- a/apps/web/src/components/pam/types.test.ts
+++ b/apps/web/src/components/pam/types.test.ts
@@ -87,4 +87,27 @@ describe('requestToRuleDraft precedence', () => {
     expect(d.orgId).toBe('org-7');
     expect(d.siteId).toBe('site-3');
   });
+
+  it('seeds observed command line + parent image alongside the primary criterion', () => {
+    const d = requestToRuleDraft({
+      ...base,
+      targetExecutablePath: 'C:\\Windows\\System32\\rundll32.exe',
+      targetExecutableSigner: 'Microsoft Windows',
+      commandLine: 'rundll32.exe printui.dll,PrintUIEntry /il',
+      parentImage: 'C:\\Windows\\explorer.exe',
+    });
+    expect(d.shape).toBe('executable');
+    if (d.shape !== 'executable') throw new Error('unreachable');
+    expect(d.matchSigner).toBe('Microsoft Windows');
+    expect(d.matchCommandLine).toBe('rundll32.exe printui.dll,PrintUIEntry /il');
+    expect(d.matchParentImage).toBe('C:\\Windows\\explorer.exe');
+  });
+
+  it('omits command line / parent image when the request did not capture them', () => {
+    const d = requestToRuleDraft({ ...base, targetExecutableSigner: 'Acme Corp' });
+    expect(d.shape).toBe('executable');
+    if (d.shape !== 'executable') throw new Error('unreachable');
+    expect(d.matchCommandLine).toBeNull();
+    expect(d.matchParentImage).toBeNull();
+  });
 });

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -40,6 +40,10 @@ export interface ElevationRequest {
   toolName?: string | null;
   riskTier?: number | null;
   executionId?: string | null;
+  // Surfaced from metadata by the API (uac_intercept capture) so a rule can be
+  // seeded with a command-line / parent-image criterion.
+  commandLine?: string | null;
+  parentImage?: string | null;
   // Joined by the API
   deviceHostname?: string | null;
   siteName?: string | null;
@@ -129,6 +133,8 @@ export type PamRuleDraft =
       matchSigner?: string | null;
       matchHash?: string | null;
       matchPathGlob?: string | null;
+      matchParentImage?: string | null;
+      matchCommandLine?: string | null;
       matchUser?: string | null;
     }
   | {
@@ -165,13 +171,25 @@ export function requestToRuleDraft(r: ElevationRequest): PamRuleDraft {
     return { shape: 'executable', orgId: r.orgId, siteId: r.siteId ?? null, matchUser: r.subjectUsername };
   }
   const name = r.targetExecutablePath ? `Rule for ${baseName(r.targetExecutablePath)}` : undefined;
+  // Pre-fill the observed command line / parent image as additional (editable)
+  // narrowing alongside the primary criterion — this is what makes a one-click
+  // "auto-elevate only this exact invocation" rule (e.g. the printer recipe)
+  // possible. The admin can clear them in the modal if the rule should be broader.
+  const base = {
+    shape: 'executable' as const,
+    name,
+    orgId: r.orgId,
+    siteId: r.siteId ?? null,
+    matchParentImage: r.parentImage ?? null,
+    matchCommandLine: r.commandLine ?? null,
+  };
   if (r.targetExecutableSigner) {
-    return { shape: 'executable', name, orgId: r.orgId, siteId: r.siteId ?? null, matchSigner: r.targetExecutableSigner };
+    return { ...base, matchSigner: r.targetExecutableSigner };
   }
   if (r.targetExecutableHash) {
-    return { shape: 'executable', name, orgId: r.orgId, siteId: r.siteId ?? null, matchHash: r.targetExecutableHash };
+    return { ...base, matchHash: r.targetExecutableHash };
   }
-  return { shape: 'executable', name, orgId: r.orgId, siteId: r.siteId ?? null, matchPathGlob: r.targetExecutablePath ?? null };
+  return { ...base, matchPathGlob: r.targetExecutablePath ?? null };
 }
 
 export const STATUS_LABELS: Record<ElevationStatus, string> = {

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -68,6 +68,27 @@ export interface PamTimeWindow {
   timezone?: string;
 }
 
+/**
+ * Criterion keys eligible for negation via pam_rules.matchNegate. Mirrors the
+ * API's PAM_RULE_NEGATE_KEYS (db/schema/pam.ts) — each inverts one match*
+ * criterion ("does NOT match").
+ */
+export const PAM_RULE_NEGATE_KEYS = [
+  'signer',
+  'hash',
+  'pathGlob',
+  'parentImage',
+  'commandLine',
+  'user',
+  'adGroup',
+  'toolName',
+  'riskTier',
+] as const;
+export type PamRuleNegateKey = (typeof PAM_RULE_NEGATE_KEYS)[number];
+
+/** Per-org default verdict for an elevation that matches no policy and no rule. */
+export type PamUnmatchedVerdict = 'require_approval' | 'auto_deny';
+
 export interface PamRule {
   id: string;
   orgId: string;
@@ -80,10 +101,12 @@ export interface PamRule {
   matchHash?: string | null;
   matchPathGlob?: string | null;
   matchParentImage?: string | null;
+  matchCommandLine?: string | null;
   matchUser?: string | null;
   matchAdGroup?: string | null;
   matchToolName?: string | null;
   matchRiskTier?: number | null;
+  matchNegate?: PamRuleNegateKey[] | null;
   timeWindow?: PamTimeWindow | null;
   verdict: PamVerdict;
   approvalDurationMinutes?: number | null;


### PR DESCRIPTION
## What

Three additive PAM rule-engine enhancements that make auto-elevation recipes for everyday tasks (QuickBooks updater, printer settings) practical, from the competitive-research gap analysis:

1. **Command-line matching** (`pam_rules.match_command_line`) — a case-insensitive substring of the launched process command line. Lets a rule scope auto-elevation to a *specific invocation* of an otherwise broad binary, e.g. auto-elevate only `rundll32 ... printui.dll,PrintUIEntry` rather than all of `rundll32.exe`. The `command_line` is already captured in the `uac_intercept` payload (stored in `elevation_requests.metadata`), so this is fully functional — no agent change.

2. **Rule negation** (`pam_rules.match_negate`, a jsonb set of criterion keys) — the engine inverts the listed criteria ("does NOT match"), enabling carve-outs like *signer = Intuit AND path does NOT match `\Temp\`*. **Safety:** a negated criterion **fails closed when the candidate field is absent** — missing data can never satisfy a negated criterion, so it can't turn into a tenant-wide grant.

3. **Default verdict for unmatched elevations** (`pam_org_config`) — per-org config for what happens when an elevation matches no software policy and no PAM rule. Default is `require_approval` (today's behavior — the request waits for a human); an org can opt into `auto_deny` (block-by-default). Consulted by the `uac_intercept` ingest path.

## Deliberately NOT included: file-version matching

The fourth candidate (file-version min/max bounds) is **omitted on purpose**: the agent does not capture the binary's file/product version today, so a `match_file_version` column would be a criterion that can never match — a dead field. It needs an agent-side capture change first and is best done as its own change.

## Design notes

- `match_command_line` is treated as an executable-shape criterion (it describes the launched executable's invocation), so it can't be mixed with tool-action criteria and a command-line-only rule is valid like a path-only rule.
- Negation keys: `signer, hash, pathGlob, parentImage, commandLine, user, adGroup, toolName, riskTier` (time window narrows, it is never negated). The create/edit form only sends a negate key when its criterion is actually populated.
- `pam_org_config` is Shape 1 (direct `org_id`); RLS mirrors `pam_rules` (`breeze_has_org_access(org_id)`), policies created in the same migration. One row per org (unique `org_id`); absence = the `require_approval` default.

## Verification (local, green)

- **API** full suite: 9389 passed / 44 skipped, 0 fail. **Web** full suite: 1864 passed, 0 fail.
- `tsc --noEmit` clean (api + web); eslint clean on changed files.
- New engine unit tests (command-line substring incl. fail-closed-on-absent; negation incl. the absent-data-never-over-grants case; command-line negation).
- Migration applies cleanly (233 in sequence) and is idempotent; `db:check-drift` → no drift (298 files match the ledger).
- **Real-Postgres RLS proof** on `pam_org_config` as the unprivileged `breeze_app` role: insert for an accessible org **succeeds**, insert for a non-accessible org is **denied** (`new row violates row-level security policy`).
- No dependency changes (no `package.json`/lockfile delta), so the supply-chain scans are unaffected.

## Migration

`2026-06-27-pam-matching-cluster.sql` — adds the two nullable rule columns (no backfill, no shape change), the `pam_unmatched_verdict` enum, and the `pam_org_config` table with RLS. Idempotent.
