### PR TITLE
feat(devices): unified chip-centric filter bar with saved views

### DIFF
--- a/apps/api/src/services/filterEngine.test.ts
+++ b/apps/api/src/services/filterEngine.test.ts
@@ -195,6 +195,27 @@ describe('filterEngine related-table fields via correlated subqueries (no joins)
     expect(sql).not.toMatch(/exists/i);
     expect(sql).toMatch(/ilike/i);
   });
+
+  // Regression: a scalar enum `in` (e.g. Status is any of online/offline, which
+  // the unified chip bar emits when two status presets are selected) must build
+  // an explicit IN list. The old `= ANY($1)` bound the JS array as a row tuple
+  // `($1, $2)` and Postgres 500'd with "op ANY/ALL (array) requires array".
+  it('scalar in → explicit IN list, never = ANY(array)', () => {
+    const sql = render({ field: 'status', operator: 'in', value: ['online', 'offline'] });
+    expect(sql).toMatch(/ in \(/i);
+    expect(sql).not.toMatch(/any\s*\(/i);
+  });
+  it('scalar notIn → explicit NOT IN list', () => {
+    const sql = render({ field: 'status', operator: 'notIn', value: ['online', 'offline'] });
+    expect(sql).toMatch(/not in \(/i);
+    expect(sql).not.toMatch(/all\s*\(/i);
+  });
+  it('scalar in [] → FALSE (matches nothing)', () => {
+    expect(render({ field: 'status', operator: 'in', value: [] })).toMatch(/false/i);
+  });
+  it('scalar notIn [] → TRUE (matches everything)', () => {
+    expect(render({ field: 'status', operator: 'notIn', value: [] })).toMatch(/true/i);
+  });
 });
 
 describe('filterEngine device-row catalog completion', () => {

--- a/apps/api/src/services/filterEngine.ts
+++ b/apps/api/src/services/filterEngine.ts
@@ -358,12 +358,23 @@ function applyOperator(columnRef: SQL<unknown>, operator: FilterOperator, value:
       return sql`${columnRef} ~ ${value}`;
     case 'in':
       if (Array.isArray(value)) {
-        return sql`${columnRef} = ANY(${value})`;
+        // Empty IN matches nothing. Build an explicit IN list (each value bound
+        // separately) rather than `= ANY($1)`: postgres.js interpolates a JS
+        // array as a row tuple `($1, $2)`, which Postgres rejects with "op
+        // ANY/ALL (array) requires array on right side". Mirrors the software
+        // `in` path above.
+        if (value.length === 0) return sql`FALSE`;
+        const items = (value as unknown[]).map((v) => sql`${v}`);
+        return sql`${columnRef} IN (${sql.join(items, sql`, `)})`;
       }
       throw new Error('Value must be array for "in" operator');
     case 'notIn':
       if (Array.isArray(value)) {
-        return sql`${columnRef} != ALL(${value})`;
+        // Empty NOT IN matches everything; otherwise an explicit NOT IN list
+        // for the same reason as `in` above.
+        if (value.length === 0) return sql`TRUE`;
+        const items = (value as unknown[]).map((v) => sql`${v}`);
+        return sql`${columnRef} NOT IN (${sql.join(items, sql`, `)})`;
       }
       throw new Error('Value must be array for "notIn" operator');
     case 'hasAny':

--- a/apps/web/src/components/devices/DeviceFilterToolbar.tsx
+++ b/apps/web/src/components/devices/DeviceFilterToolbar.tsx
@@ -1,0 +1,452 @@
+// DeviceFilterToolbar — the single, unified filter surface for the Devices
+// page, in the chip-centric model. EVERY structured filter is an editable chip
+// living in one server-resolved FilterConditionGroup; the only standing inline
+// control is the hostname Search box.
+//
+// Layout (one control row):
+//   🔍 Search · quick-preset chips · More ▾ (add any chip type) · Advanced ▾
+// Then an active editable-chip row (shown when the group has chips), each chip
+// click-to-edit (operator/value popover) and ✕-to-remove, with a Clear that
+// resets the group to null AND clears search.
+//
+// State routing:
+//  - search → listFilters.search (instant client filter, owned by DevicesPage,
+//    consumed by DeviceList).
+//  - everything else → the FilterConditionGroup (`value`/`onChange`), resolved
+//    server-side upstream via useAdvancedFilterIds. Status/OS/Role/Org/Site/
+//    Group are NO LONGER inline client state — they are group conditions/chips.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Search, Check, Plus, SlidersHorizontal } from 'lucide-react';
+import type { FilterCondition, FilterConditionGroup } from '@breeze/shared';
+import { type NamedRef } from './FilterValueEditor';
+import { FilterSentenceBuilder } from './FilterSentenceBuilder';
+import { FilterAddDropdown } from './FilterAddDropdown';
+import { Chip, defaultConditionForField } from './FilterChipBar';
+import { QUICK_ADD_CHIPS } from './QuickAddChips';
+import { SavedViewsMenu } from './SavedViewsMenu';
+import type { ListFilters } from './deviceListFilters';
+
+type Org = { id: string; name: string };
+type Site = { id: string; name: string };
+type Group = { id: string; name: string; type: 'static' | 'dynamic'; deviceCount: number };
+
+export interface DeviceFilterToolbarProps {
+  // The server-resolved group (quick chips + More-added chips + Advanced drawer).
+  value: FilterConditionGroup | null;
+  onChange: (next: FilterConditionGroup | null) => void;
+  // Instant client-side filter (hostname search only), owned by DevicesPage and
+  // shared with DeviceList.
+  listFilters: ListFilters;
+  onListFiltersChange: (next: ListFilters) => void;
+  orgs?: Org[];
+  sites?: Site[];
+  groups?: Group[];
+  softwareOptions?: string[];
+  onSoftwareSearch?: (q: string) => void;
+  // Opens the create-group flow (CreateGroupModal in DevicesPage); surfaced as a
+  // "+ New group…" shortcut in the Add-filter picker.
+  onCreateGroup?: () => void;
+}
+
+const EMPTY_GROUP: FilterConditionGroup = { operator: 'AND', conditions: [] };
+
+function chipMatches(c: FilterCondition, target: FilterCondition): boolean {
+  return c.field === target.field
+    && c.operator === target.operator
+    && JSON.stringify(c.value) === JSON.stringify(target.value);
+}
+
+function groupHasCondition(group: FilterConditionGroup | null, target: FilterCondition): boolean {
+  if (!group) return false;
+  for (const c of group.conditions) {
+    if ('conditions' in c) continue;
+    if (chipMatches(c, target)) return true;
+  }
+  return false;
+}
+
+function sameValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// The values currently selected for `field` via `equals`/`in` conditions. Two
+// `equals` on the same field would AND to empty (a device can't be both online
+// AND offline), so we model multi-select as ONE condition — OR within a field,
+// AND across fields. This reads them back out for toggling/active state.
+function fieldEqualsValues(group: FilterConditionGroup | null, field: string): unknown[] {
+  const vals: unknown[] = [];
+  for (const c of group?.conditions ?? []) {
+    if ('conditions' in c) continue;
+    if (c.field !== field) continue;
+    if (c.operator === 'equals') vals.push(c.value);
+    else if (c.operator === 'in' && Array.isArray(c.value)) vals.push(...c.value);
+  }
+  return vals;
+}
+
+// Replace every equals/in condition on `field` with one normalized condition for
+// `values` (none → drop the field; 1 → `equals`; >1 → `in`). The merged chip
+// takes the slot of the first replaced condition so chip order stays stable;
+// other fields and non-equals/in conditions on this field are left untouched.
+function setFieldEqualsValues(
+  group: FilterConditionGroup | null,
+  field: string,
+  values: unknown[],
+): FilterConditionGroup | null {
+  const base = group ?? EMPTY_GROUP;
+  const merged: FilterCondition | null =
+    values.length === 0
+      ? null
+      : values.length === 1
+        ? ({ field, operator: 'equals', value: values[0] } as FilterCondition)
+        : ({ field, operator: 'in', value: values } as FilterCondition);
+  let placed = false;
+  const next: FilterConditionGroup['conditions'] = [];
+  for (const c of base.conditions) {
+    const isTargetEnum =
+      !('conditions' in c) && c.field === field && (c.operator === 'equals' || c.operator === 'in');
+    if (isTargetEnum) {
+      if (merged && !placed) {
+        next.push(merged);
+        placed = true;
+      }
+      continue;
+    }
+    next.push(c);
+  }
+  if (merged && !placed) next.push(merged);
+  return next.length === 0 ? null : { operator: 'AND', conditions: next };
+}
+
+// Top-level chip conditions, with their absolute index in group.conditions so
+// edit/remove can target the right element even when nested groups (which only
+// the Advanced drawer can create) are interleaved.
+function topLevelConditions(
+  group: FilterConditionGroup | null,
+): Array<{ condition: FilterCondition; index: number }> {
+  if (!group) return [];
+  const out: Array<{ condition: FilterCondition; index: number }> = [];
+  group.conditions.forEach((c, index) => {
+    if (!('conditions' in c)) out.push({ condition: c, index });
+  });
+  return out;
+}
+
+// A value that actually constrains the query — blank text / empty array are
+// "incomplete" (a half-built Advanced-drawer row) and must NOT trigger merging,
+// or the drawer can't hold two in-progress rows on the same default field.
+function isConcrete(v: unknown): boolean {
+  if (v === '' || v === null || v === undefined) return false;
+  if (Array.isArray(v)) return v.length > 0;
+  return true;
+}
+
+// Collapse same-field `equals`/`in` conditions at the top level of an AND group
+// into ONE `in` condition (OR within a field). This is the single chokepoint
+// that makes a self-contradictory status filter (status=online AND
+// status=offline → always empty) structurally impossible, no matter which entry
+// point produced it: presets, the More picker, the chip editor, or the Advanced
+// drawer. Only fires for a field that has TWO OR MORE concrete equals/in values
+// — so a power user can still add blank/in-progress rows in the Advanced drawer,
+// and range filters (gt/lt, different operators) are never touched. OR / nested
+// groups (operator !== 'AND') are left untouched so a deliberately-built
+// advanced sentence keeps its meaning.
+function normalizeGroup(group: FilterConditionGroup | null): FilterConditionGroup | null {
+  if (!group || group.operator !== 'AND') return group;
+  const concreteCount = new Map<string, number>();
+  for (const c of group.conditions) {
+    if ('conditions' in c) continue;
+    if ((c.operator === 'equals' || c.operator === 'in') && isConcrete(c.value)) {
+      concreteCount.set(c.field, (concreteCount.get(c.field) ?? 0) + 1);
+    }
+  }
+  let acc: FilterConditionGroup | null = group;
+  for (const [field, count] of concreteCount) {
+    if (count < 2) continue; // single value (plus any blank rows) → leave as-is
+    const vals: unknown[] = [];
+    for (const v of fieldEqualsValues(acc, field)) {
+      if (isConcrete(v) && !vals.some(x => sameValue(x, v))) vals.push(v);
+    }
+    acc = setFieldEqualsValues(acc, field, vals);
+  }
+  return acc;
+}
+
+export function DeviceFilterToolbar({
+  value,
+  onChange: rawOnChange,
+  listFilters,
+  onListFiltersChange,
+  orgs = [],
+  sites = [],
+  groups: _groups = [],
+  softwareOptions,
+  onSoftwareSearch,
+  onCreateGroup,
+}: DeviceFilterToolbarProps) {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // Scroll-edge state for the chip row: with the scrollbar hidden, a right/left
+  // gradient is the only cue that more chips exist off-screen. Recomputed on
+  // scroll + resize.
+  const chipsRef = useRef<HTMLDivElement>(null);
+  const [edges, setEdges] = useState({ left: false, right: false });
+  const updateEdges = useCallback(() => {
+    const el = chipsRef.current;
+    if (!el) return;
+    const left = el.scrollLeft > 1;
+    const right = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+    setEdges(prev => (prev.left === left && prev.right === right ? prev : { left, right }));
+  }, []);
+  useEffect(() => {
+    updateEdges();
+    const el = chipsRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', updateEdges, { passive: true });
+    let ro: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(updateEdges);
+      ro.observe(el);
+    }
+    window.addEventListener('resize', updateEdges);
+    return () => {
+      el.removeEventListener('scroll', updateEdges);
+      ro?.disconnect();
+      window.removeEventListener('resize', updateEdges);
+    };
+  }, [updateEdges]);
+
+  // Every group mutation flows through here so the merge invariant holds for all
+  // entry points (preset toggle already produces merged output; chip edit and
+  // the Advanced drawer would not without this).
+  const onChange = (next: FilterConditionGroup | null) => rawOnChange(normalizeGroup(next));
+
+  const patch = (next: Partial<ListFilters>) => onListFiltersChange({ ...listFilters, ...next });
+
+  // --- GROUP helpers (all structured filters live here) ---
+  const addCondition = (cond: FilterCondition) => {
+    // An `equals` value is single-select per field: a device has exactly one
+    // status / OS / role, so picking a value REPLACES any existing value for
+    // that field (mirrors the old single-select dropdowns). This also makes a
+    // contradictory status=online AND status=offline impossible by construction.
+    if (cond.operator === 'equals') {
+      onChange(setFieldEqualsValues(value, cond.field, [cond.value]));
+      return;
+    }
+    const base = value ?? EMPTY_GROUP;
+    onChange({ operator: 'AND', conditions: [...base.conditions, cond] });
+  };
+  const removeConditionAt = (index: number) => {
+    if (!value) return;
+    const next = value.conditions.filter((_, i) => i !== index);
+    onChange(next.length === 0 ? null : { operator: 'AND', conditions: next });
+  };
+  const updateConditionAt = (index: number, cond: FilterCondition) => {
+    if (!value) return;
+    const next = value.conditions.map((c, i) => (i === index ? cond : c));
+    onChange({ operator: 'AND', conditions: next });
+  };
+  const toggleCondition = (cond: FilterCondition) => {
+    if (groupHasCondition(value, cond)) {
+      const idx = value!.conditions.findIndex(c => !('conditions' in c) && chipMatches(c, cond));
+      if (idx !== -1) removeConditionAt(idx);
+    } else {
+      addCondition(cond);
+    }
+  };
+
+  // A preset is active when its value is currently selected for the field
+  // (stored as `equals`, or part of an `in` built in the Advanced drawer).
+  // Non-equals presets (greaterThan / isEmpty / boolean) match exactly.
+  const presetActive = (cond: FilterCondition): boolean =>
+    cond.operator === 'equals'
+      ? fieldEqualsValues(value, cond.field).some(v => sameValue(v, cond.value))
+      : groupHasCondition(value, cond);
+
+  // `equals` presets are single-select within their field: clicking Offline
+  // while Online is active SWITCHES to Offline (online/offline are mutually
+  // exclusive, like the old status dropdown). Clicking the already-active value
+  // clears it. Other operators (greaterThan / isEmpty / boolean) toggle on/off.
+  const togglePreset = (cond: FilterCondition) => {
+    if (cond.operator !== 'equals') {
+      toggleCondition(cond);
+      return;
+    }
+    const current = fieldEqualsValues(value, cond.field);
+    const isSoleActive = current.length === 1 && sameValue(current[0], cond.value);
+    onChange(setFieldEqualsValues(value, cond.field, isSoleActive ? [] : [cond.value]));
+  };
+
+  const activeConditions = topLevelConditions(value);
+  const hasSearch = listFilters.search.trim().length > 0;
+  const hasChips = activeConditions.length > 0;
+  const hasAnyActive = hasChips || hasSearch;
+
+  const clearAll = () => {
+    onListFiltersChange({ ...listFilters, search: '' });
+    onChange(null);
+  };
+
+  return (
+    <div data-testid="device-filter-toolbar" className="flex flex-col gap-2">
+      {/* Unified filter bar — one surface holding the live hostname search, the
+          quick-preset chips, and the "+ Add filter" picker. The bar itself owns
+          the border + focus ring; everything inside is borderless/chip-light so
+          the controls read as one cohesive tool, not three stacked widgets. */}
+      <div className="flex items-center gap-2 rounded-lg border bg-background px-2 py-1.5 transition focus-within:ring-2 focus-within:ring-ring">
+        {/* Hostname search — borderless, blends into the bar (the one live filter). */}
+        <div className="flex w-40 shrink-0 items-center gap-2 sm:w-56">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search hostname…"
+            aria-label="Search by hostname"
+            value={listFilters.search}
+            onChange={e => patch({ search: e.target.value })}
+            className="w-full appearance-none border-0 bg-transparent p-0 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-0"
+          />
+        </div>
+
+        {/* Divider between the live search and the chip controls. */}
+        <div className="h-5 w-px shrink-0 bg-border" aria-hidden="true" />
+
+        {/* Quick-preset chips — scroll horizontally if they outgrow the row.
+            The scrollbar is hidden, so left/right gradient fades are the cue
+            that more chips exist off-screen. */}
+        <div className="relative flex min-w-0 flex-1 items-center">
+          <div
+            ref={chipsRef}
+            data-testid="quick-add-chips"
+            className="no-scrollbar flex w-full items-center gap-1.5 overflow-x-auto"
+            role="group"
+            aria-label="Quick filters"
+          >
+            {QUICK_ADD_CHIPS.map(chip => {
+              const active = presetActive(chip.condition);
+              return (
+                <button
+                  type="button"
+                  key={chip.id}
+                  data-testid={`quick-add-${chip.id}`}
+                  aria-pressed={active}
+                  onClick={() => togglePreset(chip.condition)}
+                  className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs transition-colors ${
+                    active ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90' : 'hover:bg-muted'
+                  }`}
+                >
+                  {active && <Check className="h-3 w-3" />}
+                  {chip.label}
+                </button>
+              );
+            })}
+          </div>
+          {edges.left && (
+            <div className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-background to-transparent" aria-hidden="true" />
+          )}
+          {edges.right && (
+            <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-background to-transparent" aria-hidden="true" />
+          )}
+        </div>
+
+        {/* + Add filter — the field-type picker, chip-styled so it reads as part
+            of the chip row. Kept OUTSIDE the scroll group so its dropdown isn't
+            clipped, and so it stays pinned/reachable as presets scroll. */}
+        <FilterAddDropdown
+          align="right"
+          onCreateGroup={onCreateGroup}
+          onSelect={(field) => addCondition(defaultConditionForField(field))}
+          renderTrigger={({ open, toggle }) => (
+            <button
+              type="button"
+              data-testid="filter-more-button"
+              aria-haspopup="true"
+              aria-expanded={open}
+              onClick={toggle}
+              className={`inline-flex shrink-0 items-center gap-1 rounded-full border border-dashed px-2.5 py-0.5 text-xs transition-colors hover:border-solid hover:bg-muted hover:text-foreground ${
+                open ? 'border-solid bg-muted text-foreground' : 'text-muted-foreground'
+              }`}
+            >
+              <Plus className="h-3 w-3" />
+              Add filter
+            </button>
+          )}
+        />
+
+        {/* Views — save/recall named filter templates (its own ghost menu so
+            recall stays separate from building chips). */}
+        <SavedViewsMenu value={value} onApply={onChange} />
+
+        {/* Advanced — de-emphasized ghost toggle; opens the boolean sentence
+            builder for power users. */}
+        <button
+          type="button"
+          data-testid="filter-advanced-toggle"
+          aria-expanded={advancedOpen}
+          onClick={() => setAdvancedOpen(o => !o)}
+          className={`inline-flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+            advancedOpen ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+          }`}
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          Advanced
+        </button>
+      </div>
+
+      {/* Active editable-chip row — only when the group has chips. */}
+      {hasChips && (
+        <div data-testid="active-filter-chips" className="flex flex-wrap items-center gap-2">
+          {activeConditions.map(({ condition, index }) => (
+            <Chip
+              key={index}
+              condition={condition}
+              onChange={next => updateConditionAt(index, next)}
+              onRemove={() => removeConditionAt(index)}
+              orgs={orgs as NamedRef[]}
+              sites={sites as NamedRef[]}
+              softwareOptions={softwareOptions}
+              onSoftwareSearch={onSoftwareSearch}
+            />
+          ))}
+          {hasAnyActive && (
+            <button
+              type="button"
+              data-testid="filter-clear-all"
+              onClick={clearAll}
+              className="ml-auto text-xs font-medium text-muted-foreground hover:text-foreground"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Clear control when only a search filter is active (no chips). */}
+      {!hasChips && hasSearch && (
+        <div className="flex items-center">
+          <button
+            type="button"
+            data-testid="filter-clear-all"
+            onClick={clearAll}
+            className="ml-auto text-xs font-medium text-muted-foreground hover:text-foreground"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
+      {/* Advanced drawer */}
+      {advancedOpen && (
+        <div className="rounded-md border bg-card p-2">
+          <FilterSentenceBuilder
+            value={value ?? EMPTY_GROUP}
+            onChange={(g) => onChange(g.conditions.length === 0 ? null : g)}
+            orgs={orgs as NamedRef[]}
+            sites={sites as NamedRef[]}
+            softwareOptions={softwareOptions}
+            onSoftwareSearch={onSoftwareSearch}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { Search, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Network, Cpu } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Network, Cpu } from 'lucide-react';
 import type { DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { widthPercentClass, formatUptime } from '@/lib/utils';
 import { formatLastSeen } from '@/lib/formatTime';
-import { DEVICE_ROLES, getDeviceRoleLabel, getDeviceRoleIcon, type DeviceRole } from '@/lib/deviceRoles';
+import { getDeviceRoleLabel, getDeviceRoleIcon, type DeviceRole } from '@/lib/deviceRoles';
 import {
   PAGE_SIZE_OPTIONS,
   readPageSizePreference,
@@ -28,6 +28,7 @@ import {
 } from '@/lib/density';
 import { OSIcon } from './osIcons';
 import { formatDeviceOsVersion } from './osDisplay';
+import { type ListFilters, DEFAULT_LIST_FILTERS } from './deviceListFilters';
 
 export type DeviceStatus = 'online' | 'offline' | 'maintenance' | 'decommissioned' | 'quarantined' | 'updating' | 'pending';
 export type OSType = 'windows' | 'macos' | 'linux';
@@ -117,6 +118,8 @@ type DeviceListProps = {
   orgs?: { id: string; name: string }[];
   sites?: { id: string; name: string }[];
   groups?: { id: string; name: string; type: 'static' | 'dynamic'; deviceCount: number }[];
+  // Still accepted by callers, but the device-group filter now lives in the
+  // chip bar (server-resolved), so DeviceList no longer filters by membership.
   groupMembershipMap?: Map<string, Set<string>>;
   onCreateGroup?: () => void;
   autoSelectGroupId?: string | null;
@@ -125,6 +128,14 @@ type DeviceListProps = {
   onSelect?: (device: Device) => void;
   onAction?: (action: string, device: Device) => void;
   onBulkAction?: (action: string, devices: Device[]) => void;
+  // Controlled inline filter state — now just the hostname search box, owned by
+  // DevicesPage and shared with DeviceFilterToolbar. Every other structured
+  // filter lives in the server-resolved group (serverFilterIds). Defaults keep
+  // DeviceList usable on its own (tests render it standalone).
+  // `onListFiltersChange` is accepted for API symmetry; DeviceList itself no
+  // longer mutates the search filter (the toolbar owns the input).
+  listFilters?: ListFilters;
+  onListFiltersChange?: (next: ListFilters) => void;
   // Initial page size if the user has no stored preference for this browser.
   // Once the component mounts, the live page size comes from localStorage
   // (see pageSizePreference.ts); subsequent changes to this prop are ignored.
@@ -134,6 +145,11 @@ type DeviceListProps = {
   // grid views filter against the same complete, uncapped id set.
   serverFilterIds?: Set<string> | null;
   serverFilterLoading?: boolean;
+  // When false (default), decommissioned devices are hidden — matching the old
+  // default view (status='all' implicitly excluded them). DevicesPage sets this
+  // true only when the active filter group explicitly targets the
+  // 'decommissioned' status, so filtering FOR decommissioned still shows them.
+  includeDecommissioned?: boolean;
   // Unified-list network arm (#1322). Off by default behind a build-time flag
   // (PUBLIC_ENABLE_NETWORK_DEVICES_IN_LIST); when false the Class/Type columns
   // and the All/Agent/Network facet are hidden entirely so the list is the
@@ -266,11 +282,7 @@ const sortValue: Record<ColumnId, (d: Device) => string | number | null> = {
 
 export default function DeviceList({
   devices,
-  orgs = [],
-  sites = [],
   groups = [],
-  groupMembershipMap = new Map(),
-  onCreateGroup,
   autoSelectGroupId,
   onAutoSelectConsumed,
   timezone,
@@ -278,24 +290,25 @@ export default function DeviceList({
   onAction,
   onBulkAction,
   pageSize = 10,
+  includeDecommissioned = false,
   serverFilterIds = null,
   serverFilterLoading = false,
-  networkDevicesEnabled = false
+  networkDevicesEnabled = false,
+  listFilters,
 }: DeviceListProps) {
   // Use provided timezone or browser default
   const effectiveTimezone = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  const [query, setQuery] = useState('');
-  // Unified-list class facet (#1322): All / Agent-managed / Network.
+  // The only inline (instant, client-side) filter is the hostname search box,
+  // owned by DevicesPage and shared with DeviceFilterToolbar. Every other
+  // structured filter (status/os/role/org/site/group/…) now lives in the
+  // server-resolved group and arrives pre-resolved as `serverFilterIds`. When
+  // rendered standalone (tests), fall back to the default so search is a no-op.
+  const filters = listFilters ?? DEFAULT_LIST_FILTERS;
+  const { search: query } = filters;
+  // Unified-list class facet (#1322): All / Agent-managed / Network. Kept
+  // local to DeviceList (it lives next to the count, not in the toolbar).
   const [classFilter, setClassFilter] = useState<'all' | 'agent' | 'network'>('all');
-  const [statusFilter, setStatusFilter] = useState<string>('all');
-  const [osFilter, setOsFilter] = useState<string>('all');
-  const [roleFilter, setRoleFilter] = useState<string>('all');
-  const [orgFilter, setOrgFilter] = useState<string>('all');
-  const [siteFilter, setSiteFilter] = useState<string>('all');
-  const [groupFilter, setGroupFilter] = useState<string[]>([]);
-  const [groupDropdownOpen, setGroupDropdownOpen] = useState(false);
-  const groupDropdownRef = useRef<HTMLDivElement>(null);
   const [currentPage, setCurrentPage] = useState(1);
   // Live, user-controllable page size. Initialized from localStorage; the
   // pageSize prop is just the fallback when no preference is stored.
@@ -329,7 +342,6 @@ export default function DeviceList({
   const [rowMenuAnchor, setRowMenuAnchor] = useState<{ top: number; bottom: number; right: number } | null>(null);
   const rowMenuRef = useRef<HTMLDivElement>(null);
   const rowMenuButtonRef = useRef<HTMLButtonElement | null>(null);
-  const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [sortField, setSortField] = useState<SortField>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
 
@@ -353,18 +365,6 @@ export default function DeviceList({
       window.removeEventListener('resize', handleScroll);
     };
   }, [rowMenuOpenId]);
-
-  // Close group dropdown on outside click
-  useEffect(() => {
-    if (!groupDropdownOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (groupDropdownRef.current && !groupDropdownRef.current.contains(e.target as Node)) {
-        setGroupDropdownOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [groupDropdownOpen]);
 
   // Close columns visibility menu on outside click
   useEffect(() => {
@@ -409,21 +409,36 @@ export default function DeviceList({
     });
   };
 
-  // Auto-select a newly created group
+  // Notify the parent that a freshly-created group has been handled. The group
+  // filter itself now lives in the chip bar (server-resolved), so there is no
+  // local group selection to toggle here — just consume the one-shot signal.
   useEffect(() => {
     if (autoSelectGroupId && groups.some(g => g.id === autoSelectGroupId)) {
-      setGroupFilter(prev =>
-        prev.includes(autoSelectGroupId) ? prev : [...prev, autoSelectGroupId]
-      );
       onAutoSelectConsumed?.();
     }
   }, [autoSelectGroupId, groups, onAutoSelectConsumed]);
+
+  // Reset to page 1 whenever the active filters change (the hostname search, the
+  // class facet, and the server-resolved id set are the only things that narrow
+  // the list now). This replaces the per-control setCurrentPage(1) calls that
+  // lived on each filter input before the toolbar was extracted.
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [query, classFilter, serverFilterIds]);
 
   const filteredDevices = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
 
     return devices.filter(device => {
-      // Apply server-side advanced filter
+      // Hide decommissioned by default — preserves the old list's hygiene
+      // (status='all' implicitly excluded them). Filtering FOR decommissioned
+      // via a status chip flips includeDecommissioned true upstream.
+      if (!includeDecommissioned && device.status === 'decommissioned') {
+        return false;
+      }
+
+      // Apply server-side advanced filter (status/os/role/org/site/group/… all
+      // resolve through this id set now — they are no longer client-side).
       if (serverFilterIds !== null && !serverFilterIds.has(device.id)) {
         return false;
       }
@@ -435,24 +450,10 @@ export default function DeviceList({
         ? true
         : device.hostname.toLowerCase().includes(normalizedQuery) ||
           (device.displayName?.toLowerCase().includes(normalizedQuery) ?? false);
-      const matchesStatus = statusFilter === 'all'
-        ? device.status !== 'decommissioned'
-        : device.status === statusFilter;
-      // OS is an agent-only attribute; an active OS facet narrows agent rows
-      // but never filters out network devices (they have no OS).
-      const matchesOs = osFilter === 'all'
-        ? true
-        : deviceClass === 'network' ? true : device.os === osFilter;
-      const matchesRole = roleFilter === 'all' ? true : device.deviceRole === roleFilter;
-      const matchesOrg = orgFilter === 'all' ? true : device.orgId === orgFilter;
-      const matchesSite = siteFilter === 'all' ? true : device.siteId === siteFilter;
-      const matchesGroup = groupFilter.length === 0
-        ? true
-        : groupFilter.some(gId => groupMembershipMap.get(gId)?.has(device.id));
 
-      return matchesClass && matchesQuery && matchesStatus && matchesOs && matchesRole && matchesOrg && matchesSite && matchesGroup;
+      return matchesClass && matchesQuery;
     });
-  }, [devices, query, classFilter, statusFilter, osFilter, roleFilter, orgFilter, siteFilter, groupFilter, groupMembershipMap, serverFilterIds]);
+  }, [devices, query, classFilter, serverFilterIds, includeDecommissioned]);
 
   const handleSort = (field: ColumnId) => {
     if (sortField === field) {
@@ -488,8 +489,6 @@ export default function DeviceList({
       return dir * cmp;
     });
   }, [filteredDevices, sortField, sortDirection]);
-
-  const moreFiltersCount = [roleFilter, orgFilter, siteFilter].filter(f => f !== 'all').length + (groupFilter.length > 0 ? 1 : 0);
 
   const totalPages = Math.ceil(sortedDevices.length / effectivePageSize);
 
@@ -570,15 +569,21 @@ export default function DeviceList({
     </th>
   );
 
-  // metricBar renders the colored CPU/RAM percent bar with em-dash
-  // fallback for non-online devices. Extracted so the cpu and ram column
-  // cells stay small.
+  // metricBar renders the CPU/RAM percent bar with em-dash fallback for
+  // non-online devices. Extracted so the cpu and ram column cells stay small.
+  //
+  // Color intent: green/red are reserved for *device status* (the Up/Down
+  // pills), so a calm brand fill carries normal utilization here — a 45%-RAM
+  // bar shouldn't read as "healthy green" and visually rhyme with an Up pill.
+  // We still escalate amber → red at genuine pressure (≥75% / ≥90%) because a
+  // pegged box is exactly what a tech must catch at a glance; the bar width
+  // and the trailing number carry the exact value at every level.
   const metricBar = (percent: number, online: boolean) =>
     online ? (
       <div className="flex items-center gap-2">
         <div className="h-2 w-16 overflow-hidden rounded-full bg-muted">
           <div
-            className={`h-full rounded-full ${percent > 80 ? 'bg-destructive' : percent > 60 ? 'bg-warning' : 'bg-success'} ${widthPercentClass(percent)}`}
+            className={`h-full rounded-full ${percent >= 90 ? 'bg-destructive' : percent >= 75 ? 'bg-warning' : 'bg-primary/70'} ${widthPercentClass(percent)}`}
           />
         </div>
         <span className="w-10 text-right tabular-nums">{percent}%</span>
@@ -937,7 +942,7 @@ export default function DeviceList({
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-muted-foreground">
-            {filteredDevices.length} of {statusFilter === 'all' ? devices.filter(d => d.status !== 'decommissioned').length : devices.length} devices
+            {filteredDevices.length} of {includeDecommissioned ? devices.length : devices.filter(d => d.status !== 'decommissioned').length} devices
             {serverFilterIds !== null && (
               <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
                 <Filter className="h-3 w-3" />
@@ -946,6 +951,9 @@ export default function DeviceList({
               </span>
             )}
           </p>
+          {/* Search / Status / OS / quick chips / More / Advanced now live in
+              DeviceFilterToolbar (rendered by DevicesPage). DeviceList keeps
+              only the class facet and the Columns menu next to the count. */}
           <div className="flex flex-wrap items-center gap-2">
             {hasNetworkDevices && (
               <div
@@ -963,10 +971,7 @@ export default function DeviceList({
                     type="button"
                     data-testid={`device-class-filter-${value}`}
                     aria-pressed={classFilter === value}
-                    onClick={() => {
-                      setClassFilter(value);
-                      setCurrentPage(1);
-                    }}
+                    onClick={() => setClassFilter(value)}
                     className={`h-full rounded px-3 font-medium transition ${
                       classFilter === value
                         ? 'bg-primary text-primary-foreground'
@@ -978,61 +983,6 @@ export default function DeviceList({
                 ))}
               </div>
             )}
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <input
-                type="search"
-                placeholder="Search by hostname"
-                value={query}
-                onChange={event => {
-                  setQuery(event.target.value);
-                  setCurrentPage(1);
-                }}
-                className="h-10 w-full rounded-md border bg-background pl-9 pr-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-56"
-              />
-            </div>
-            <select
-              value={statusFilter}
-              aria-label="Filter by status"
-              onChange={event => {
-                setStatusFilter(event.target.value);
-                setCurrentPage(1);
-              }}
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-32"
-            >
-              <option value="all">All Status</option>
-              <option value="online">Online</option>
-              <option value="offline">Offline</option>
-              <option value="maintenance">Maintenance</option>
-              <option value="decommissioned">Decommissioned</option>
-            </select>
-            <select
-              value={osFilter}
-              aria-label="Filter by operating system"
-              onChange={event => {
-                setOsFilter(event.target.value);
-                setCurrentPage(1);
-              }}
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-32"
-            >
-              <option value="all">All OS</option>
-              <option value="windows">Windows</option>
-              <option value="macos">macOS</option>
-              <option value="linux">Linux</option>
-            </select>
-            <button
-              type="button"
-              onClick={() => setShowMoreFilters(!showMoreFilters)}
-              className="h-10 whitespace-nowrap rounded-md border px-3 text-sm font-medium hover:bg-muted flex items-center gap-1.5"
-            >
-              <Filter className="h-3.5 w-3.5" />
-              More
-              {moreFiltersCount > 0 && (
-                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
-                  {moreFiltersCount}
-                </span>
-              )}
-            </button>
             {/* Interface density is now an account-wide control in the
                 top-bar theme/display menu (Header.tsx). The table still
                 reflects the saved preference via densityTableClasses +
@@ -1109,142 +1059,6 @@ export default function DeviceList({
                       <span>{COLUMN_LABELS[id]}</span>
                     </label>
                   ))}
-                </div>
-              )}
-            </div>
-            {(query || statusFilter !== 'all' || osFilter !== 'all' || roleFilter !== 'all' || orgFilter !== 'all' || siteFilter !== 'all' || groupFilter.length > 0) && (
-              <button
-                type="button"
-                onClick={() => {
-                  setQuery('');
-                  setStatusFilter('all');
-                  setOsFilter('all');
-                  setRoleFilter('all');
-                  setOrgFilter('all');
-                  setSiteFilter('all');
-                  setGroupFilter([]);
-                  setCurrentPage(1);
-                }}
-                className="h-10 whitespace-nowrap rounded-md px-3 text-sm font-medium text-muted-foreground hover:text-foreground"
-              >
-                Clear filters
-              </button>
-            )}
-          </div>
-        </div>
-        <div className={`grid transition-[grid-template-rows] duration-200 ease-out ${showMoreFilters ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
-          <div className="overflow-hidden">
-            <div className="flex flex-wrap items-center gap-2 pt-1">
-              <select
-                value={roleFilter}
-                aria-label="Filter by device role"
-                onChange={event => {
-                  setRoleFilter(event.target.value);
-                  setCurrentPage(1);
-                }}
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-36"
-              >
-                <option value="all">All Roles</option>
-                {DEVICE_ROLES.map(role => (
-                  <option key={role} value={role}>
-                    {getDeviceRoleLabel(role)}
-                  </option>
-                ))}
-              </select>
-              {orgs.length > 0 && (
-                <select
-                  value={orgFilter}
-                  aria-label="Filter by organization"
-                  onChange={event => {
-                    setOrgFilter(event.target.value);
-                    setCurrentPage(1);
-                  }}
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-40"
-                >
-                  <option value="all">All Orgs</option>
-                  {orgs.map(org => (
-                    <option key={org.id} value={org.id}>
-                      {org.name}
-                    </option>
-                  ))}
-                </select>
-              )}
-              {sites.length > 0 && (
-                <select
-                  value={siteFilter}
-                  aria-label="Filter by site"
-                  onChange={event => {
-                    setSiteFilter(event.target.value);
-                    setCurrentPage(1);
-                  }}
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-40"
-                >
-                  <option value="all">All Sites</option>
-                  {sites.map(site => (
-                    <option key={site.id} value={site.id}>
-                      {site.name}
-                    </option>
-                  ))}
-                </select>
-              )}
-              {groups.length > 0 && (
-                <div className="relative" ref={groupDropdownRef}>
-                  <button
-                    type="button"
-                    onClick={() => setGroupDropdownOpen(!groupDropdownOpen)}
-                    className="h-10 whitespace-nowrap rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted flex items-center gap-1.5"
-                  >
-                    Groups
-                    {groupFilter.length > 0 && (
-                      <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
-                        {groupFilter.length}
-                      </span>
-                    )}
-                    <ChevronDown className="h-3.5 w-3.5" />
-                  </button>
-                  {groupDropdownOpen && (
-                    <div className="absolute left-0 top-full z-20 mt-1 w-64 rounded-md border bg-card shadow-lg">
-                      <div className="max-h-48 overflow-y-auto p-2">
-                        {groups.map(group => (
-                          <label key={group.id} className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted">
-                            <input
-                              type="checkbox"
-                              checked={groupFilter.includes(group.id)}
-                              onChange={() => {
-                                setGroupFilter(prev =>
-                                  prev.includes(group.id)
-                                    ? prev.filter(id => id !== group.id)
-                                    : [...prev, group.id]
-                                );
-                                setCurrentPage(1);
-                              }}
-                              className="h-4 w-4 rounded border-border"
-                            />
-                            <span className="text-sm truncate">{group.name}</span>
-                            <span className="ml-auto text-[10px] text-muted-foreground">{group.type}</span>
-                          </label>
-                        ))}
-                      </div>
-                      <div className="border-t px-2 py-2 flex items-center gap-2">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setGroupDropdownOpen(false);
-                            onCreateGroup?.();
-                          }}
-                          className="text-xs font-medium text-primary hover:underline"
-                        >
-                          + New Group
-                        </button>
-                        <a
-                          href="/devices/groups"
-                          className="text-xs text-muted-foreground hover:text-foreground ml-auto"
-                        >
-                          Manage Groups
-                        </a>
-                      </div>
-                    </div>
-                  )}
                 </div>
               )}
             </div>

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -109,8 +109,7 @@ vi.mock('./DeviceSettingsModal', () => ({ default: () => null }));
 vi.mock('./AddDeviceModal', () => ({ default: () => null }));
 vi.mock('./CreateGroupModal', () => ({ default: () => null }));
 vi.mock('../filters/DeviceFilterBar', () => ({ DeviceFilterBar: () => null }));
-vi.mock('./FilterChipBar', () => ({ FilterChipBar: () => null }));
-vi.mock('./QuickAddChips', () => ({ QuickAddChips: () => null }));
+vi.mock('./DeviceFilterToolbar', () => ({ DeviceFilterToolbar: () => null }));
 vi.mock('../shared/ProgressBar', () => ({ default: () => null }));
 
 // DeviceCard stub renders the hostname so the grid contents are assertable.

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -12,13 +12,12 @@ import DeviceSettingsModal from './DeviceSettingsModal';
 import AddDeviceModal from './AddDeviceModal';
 import CreateGroupModal from './CreateGroupModal';
 import { DeviceFilterBar } from '../filters/DeviceFilterBar';
-import { FilterChipBar } from './FilterChipBar';
-import { QuickAddChips } from './QuickAddChips';
+import { DeviceFilterToolbar } from './DeviceFilterToolbar';
+import { type ListFilters, DEFAULT_LIST_FILTERS } from './deviceListFilters';
 import { decodeFilterFromHash, writeFilterToHash, isFiltersV2Enabled } from './filterUrl';
 import { fetchWithAuth } from '../../stores/auth';
 import { fetchAllDevices, fetchAllNetworkDevices } from '../../lib/devicesFetch';
 import { useOrgStore } from '../../stores/orgStore';
-import { PageScopeIndicator } from '../layout/PageScopeIndicator';
 import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle, isAccessDenied } from '@/lib/errorMessages';
@@ -59,8 +58,10 @@ function summarizeFailedDevices(names: string[]): string {
 }
 
 export default function DevicesPage() {
-  const { organizations: orgStoreOrgs, currentOrgId } = useOrgStore();
-  const currentOrg = orgStoreOrgs.find(o => o.id === currentOrgId) ?? null;
+  // Org scope is shown by the always-visible top-bar switcher (scope pill +
+  // org picker); the page header no longer repeats it. orgStoreOrgs is still
+  // used to name orgs in the run-script confirm dialog.
+  const { organizations: orgStoreOrgs } = useOrgStore();
 
   const [devices, setDevices] = useState<Device[]>([]);
   const [orgs, setOrgs] = useState<Org[]>([]);
@@ -87,6 +88,11 @@ export default function DevicesPage() {
     if (typeof window === 'undefined') return null;
     return decodeFilterFromHash(window.location.hash);
   });
+  // Inline ("instant") client-side filters — shared between DeviceFilterToolbar
+  // (the controls) and DeviceList (the filtering) so each dimension has a single
+  // source of truth. This is the hybrid model's client half; the group above is
+  // its server half.
+  const [listFilters, setListFilters] = useState<ListFilters>(DEFAULT_LIST_FILTERS);
   const filtersV2 = typeof window !== 'undefined' ? isFiltersV2Enabled() : false;
   // Resolve the advanced filter to the complete (uncapped) matching id set
   // once, here, so the list AND grid views render the same filtered fleet.
@@ -162,9 +168,26 @@ export default function DevicesPage() {
   // Grid view applies the advanced filter here; the list view passes the id
   // set into DeviceList, which combines it with its local quick-filters
   // (search/status/os/etc. stay list-only).
+  //
+  // Decommissioned devices are hidden by default (old list behavior). Show them
+  // only when the active filter group explicitly targets the 'decommissioned'
+  // status, so a user filtering FOR decommissioned still sees them.
+  const includeDecommissioned = useMemo(() => {
+    const conds = advancedFilter?.conditions ?? [];
+    return conds.some(c => {
+      if ('conditions' in c) return false; // nested groups: ignore (rare)
+      if (c.field !== 'status') return false;
+      return Array.isArray(c.value)
+        ? (c.value as unknown[]).includes('decommissioned')
+        : c.value === 'decommissioned';
+    });
+  }, [advancedFilter]);
   const gridDevices = useMemo(
-    () => (advancedFilterIds === null ? devices : devices.filter(d => advancedFilterIds.has(d.id))),
-    [devices, advancedFilterIds]
+    () => {
+      const base = includeDecommissioned ? devices : devices.filter(d => d.status !== 'decommissioned');
+      return advancedFilterIds === null ? base : base.filter(d => advancedFilterIds.has(d.id));
+    },
+    [devices, advancedFilterIds, includeDecommissioned]
   );
 
   const fetchDevices = useCallback(async (signal?: AbortSignal) => {
@@ -858,7 +881,6 @@ export default function DevicesPage() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Devices</h1>
-          <PageScopeIndicator pathname={typeof window !== 'undefined' ? window.location.pathname : '/devices'} orgName={currentOrg?.name} />
           <p className="text-muted-foreground">
             Manage and monitor your fleet.
           </p>
@@ -900,17 +922,18 @@ export default function DevicesPage() {
       </div>
 
       {filtersV2 ? (
-        <div className="flex flex-col gap-2">
-          <FilterChipBar
-            value={advancedFilter}
-            onChange={setAdvancedFilter}
-            orgs={orgs}
-            sites={sites}
-            softwareOptions={softwareOptions}
-            onSoftwareSearch={handleSoftwareSearch}
-          />
-          <QuickAddChips value={advancedFilter} onChange={setAdvancedFilter} />
-        </div>
+        <DeviceFilterToolbar
+          value={advancedFilter}
+          onChange={setAdvancedFilter}
+          listFilters={listFilters}
+          onListFiltersChange={setListFilters}
+          orgs={orgs}
+          sites={sites}
+          groups={deviceGroups}
+          softwareOptions={softwareOptions}
+          onSoftwareSearch={handleSoftwareSearch}
+          onCreateGroup={() => setShowCreateGroup(true)}
+        />
       ) : (
         <DeviceFilterBar
           value={advancedFilter}
@@ -964,6 +987,9 @@ export default function DevicesPage() {
           onBulkAction={handleBulkAction}
           serverFilterIds={advancedFilterIds}
           serverFilterLoading={advancedFilterLoading}
+          includeDecommissioned={includeDecommissioned}
+          listFilters={listFilters}
+          onListFiltersChange={setListFilters}
           onCreateGroup={() => setShowCreateGroup(true)}
           autoSelectGroupId={autoSelectGroupId}
           onAutoSelectConsumed={handleAutoSelectConsumed}

--- a/apps/web/src/components/devices/FilterAddDropdown.tsx
+++ b/apps/web/src/components/devices/FilterAddDropdown.tsx
@@ -1,5 +1,6 @@
 // "+ Add filter" popover. Lists all V2_FILTER_FIELDS grouped by category,
 // with a search-as-you-type box at top. Calls onSelect(field) when user picks.
+import type { ReactNode } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Search, Plus } from 'lucide-react';
 import type { FilterFieldDefinition } from '@breeze/shared';
@@ -8,9 +9,23 @@ import { useClickOutside } from '../../hooks/useClickOutside';
 
 export interface FilterAddDropdownProps {
   onSelect: (field: FilterFieldDefinition) => void;
+  // Custom trigger renderer. Receives the open state + a toggle so callers can
+  // present a differently-labeled button (e.g. the Devices toolbar's "More")
+  // while reusing the same field-picker popover. Defaults to the dashed
+  // "+ Add filter" pill used inside FilterChipBar.
+  renderTrigger?: (args: { open: boolean; toggle: () => void }) => ReactNode;
+  // Which edge the popover aligns to. Default 'left'; pass 'right' when the
+  // trigger sits near the right edge (the Devices toolbar) so the 320px menu
+  // doesn't spill off-screen.
+  align?: 'left' | 'right';
+  // Optional footer shortcut to create a new device group — restores the
+  // "+ New Group" affordance the old group-filter dropdown had. Shown only when
+  // provided. The "Device Group" field above is the start of the group-filter
+  // journey, so creating one from here keeps that flow in one place.
+  onCreateGroup?: () => void;
 }
 
-export function FilterAddDropdown({ onSelect }: FilterAddDropdownProps) {
+export function FilterAddDropdown({ onSelect, renderTrigger, align = 'left', onCreateGroup }: FilterAddDropdownProps) {
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
@@ -40,18 +55,22 @@ export function FilterAddDropdown({ onSelect }: FilterAddDropdownProps) {
 
   return (
     <div className="relative inline-block" ref={containerRef}>
-      <button
-        type="button"
-        data-testid="filter-add-button"
-        onClick={() => setOpen(o => !o)}
-        className="inline-flex items-center gap-1.5 rounded-full border border-dashed px-3 py-1 text-sm text-muted-foreground hover:bg-muted"
-      >
-        <Plus className="h-3.5 w-3.5" />
-        Add filter
-      </button>
+      {renderTrigger ? (
+        renderTrigger({ open, toggle: () => setOpen(o => !o) })
+      ) : (
+        <button
+          type="button"
+          data-testid="filter-add-button"
+          onClick={() => setOpen(o => !o)}
+          className="inline-flex items-center gap-1.5 rounded-full border border-dashed px-3 py-1 text-sm text-muted-foreground hover:bg-muted"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add filter
+        </button>
+      )}
 
       {open && (
-        <div className="absolute left-0 top-9 z-30 w-80 rounded-md border bg-popover shadow-lg" role="dialog">
+        <div className={`absolute top-9 z-30 w-80 rounded-md border bg-popover shadow-lg ${align === 'right' ? 'right-0' : 'left-0'}`} role="dialog">
           <div className="flex items-center gap-2 border-b px-3 py-2">
             <Search className="h-4 w-4 text-muted-foreground" />
             <input
@@ -94,6 +113,21 @@ export function FilterAddDropdown({ onSelect }: FilterAddDropdownProps) {
               </div>
             ))}
           </div>
+          {onCreateGroup && (
+            <button
+              type="button"
+              data-testid="filter-add-new-group"
+              onClick={() => {
+                onCreateGroup();
+                setOpen(false);
+                setQ('');
+              }}
+              className="flex w-full items-center gap-2 border-t px-3 py-2 text-left text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <Plus className="h-3.5 w-3.5 shrink-0" />
+              New group…
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/devices/FilterChipBar.tsx
+++ b/apps/web/src/components/devices/FilterChipBar.tsx
@@ -43,7 +43,7 @@ export interface FilterChipBarProps {
 
 const EMPTY_GROUP: FilterConditionGroup = { operator: 'AND', conditions: [] };
 
-function defaultConditionForField(field: FilterFieldDefinition): FilterCondition {
+export function defaultConditionForField(field: FilterFieldDefinition): FilterCondition {
   const op = field.operators[0];
   let value: FilterCondition['value'] = '';
   if (op === 'in' || op === 'notIn' || op === 'hasAny' || op === 'hasAll') value = [];
@@ -266,7 +266,7 @@ interface ChipProps {
   focused?: boolean;
 }
 
-function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, btnRef, onKeyDown, focused }: ChipProps) {
+export function Chip({ condition, onChange, onRemove, orgs, sites, softwareOptions, softwareOptionCounts, onSoftwareSearch, btnRef, onKeyDown, focused }: ChipProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const field = getFieldDef(condition.field)

--- a/apps/web/src/components/devices/QuickAddChips.tsx
+++ b/apps/web/src/components/devices/QuickAddChips.tsx
@@ -3,7 +3,7 @@
 // the condition is present the chip is marked active (check icon,
 // aria-pressed) and clicking again removes it.
 import type { FilterCondition, FilterConditionGroup } from '@breeze/shared';
-import { Check, Plus } from 'lucide-react';
+import { Check } from 'lucide-react';
 
 export interface QuickAddChip {
   id: string;
@@ -60,10 +60,15 @@ export function QuickAddChips({ value, onChange }: QuickAddChipsProps) {
   return (
     <div
       data-testid="quick-add-chips"
-      className="flex gap-2 overflow-x-auto pb-1"
+      className="flex items-center gap-2 overflow-x-auto pb-1"
       role="toolbar"
       aria-label="Quick-add filters"
     >
+      {/* Leading label so this strip reads as one-click toggles, distinct from
+          the "+ Add filter" builder below it. The chips toggle a filter on/off
+          (Check when active), so they deliberately drop the "+" glyph — "+"
+          means *create* elsewhere on this page (Add filter / Add Device). */}
+      <span className="shrink-0 text-xs font-medium text-muted-foreground">Quick filters</span>
       {QUICK_ADD_CHIPS.map(chip => {
         const added = isAdded(value, chip.condition);
         return (
@@ -73,11 +78,11 @@ export function QuickAddChips({ value, onChange }: QuickAddChipsProps) {
             data-testid={`quick-add-${chip.id}`}
             aria-pressed={added}
             onClick={() => handleToggle(chip)}
-            className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs ${
+            className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs transition-colors ${
               added ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'hover:bg-muted'
             }`}
           >
-            {added ? <Check className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+            {added && <Check className="h-3 w-3" />}
             {chip.label}
           </button>
         );

--- a/apps/web/src/components/devices/SavedViewsMenu.tsx
+++ b/apps/web/src/components/devices/SavedViewsMenu.tsx
@@ -1,0 +1,334 @@
+// SavedViewsMenu — the "Views" control for the Devices filter toolbar. Lets a
+// user save the current filter group as a named, reusable view and re-apply it
+// later in one click. Views are RECALL (pick from a list), kept in their own
+// ghost menu so they don't crowd the chip row (which is for BUILDING a filter).
+//
+// Persistence reuses the existing saved-filters backend (GET/POST/DELETE
+// /filters); the conditions column stores the FilterConditionGroup verbatim. The
+// hostname quick-search is deliberately NOT part of a view — it's a transient
+// lookup, not a reusable saved query.
+//
+// "Default view" has no backend column, so it's a per-browser preference in
+// localStorage (like density / page-size). When set and no filter is active on
+// load, the default view auto-applies once.
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Bookmark, Plus, Star, Trash2, Loader2, Check, ExternalLink } from 'lucide-react';
+import type { FilterConditionGroup, SavedFilter } from '@breeze/shared';
+import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { showToast } from '../shared/Toast';
+
+const DEFAULT_VIEW_KEY = 'breeze.devices.defaultView';
+
+function readDefaultViewId(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(DEFAULT_VIEW_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeDefaultViewId(id: string | null) {
+  try {
+    if (id) window.localStorage.setItem(DEFAULT_VIEW_KEY, id);
+    else window.localStorage.removeItem(DEFAULT_VIEW_KEY);
+  } catch {
+    // localStorage can throw in private mode / quota; the default view is a
+    // nicety, never block on it.
+  }
+}
+
+// Canonical JSON with recursively-sorted object keys. Saved conditions round-
+// trip through a Postgres `jsonb` column, which does NOT preserve object key
+// order, so a naive JSON.stringify compare against the live (in-memory) group
+// spuriously mismatches. Sorting keys makes the compare order-independent.
+function canonical(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(canonical);
+  if (v && typeof v === 'object') {
+    return Object.fromEntries(
+      Object.keys(v as Record<string, unknown>)
+        .sort()
+        .map(k => [k, canonical((v as Record<string, unknown>)[k])]),
+    );
+  }
+  return v;
+}
+
+// Stable structural compare so we can tell when the live filter exactly matches
+// a saved view (→ show its name as the active view). Conditions are small.
+function sameGroup(a: FilterConditionGroup | null, b: FilterConditionGroup | null): boolean {
+  return JSON.stringify(canonical(a ?? null)) === JSON.stringify(canonical(b ?? null));
+}
+
+export interface SavedViewsMenuProps {
+  // The current filter group (what a "Save current as view" would persist).
+  value: FilterConditionGroup | null;
+  // Apply a saved view's conditions (or null to clear).
+  onApply: (group: FilterConditionGroup | null) => void;
+}
+
+export function SavedViewsMenu({ value, onApply }: SavedViewsMenuProps) {
+  const currentOrgId = useOrgStore(s => s.currentOrgId);
+  const [open, setOpen] = useState(false);
+  const [views, setViews] = useState<SavedFilter[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [naming, setNaming] = useState(false);
+  const [name, setName] = useState('');
+  const [defaultId, setDefaultId] = useState<string | null>(() => readDefaultViewId());
+  const rootRef = useRef<HTMLDivElement>(null);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  // One-shot guard so the default view auto-applies at most once per mount.
+  const autoAppliedRef = useRef(false);
+
+  useClickOutside(open, rootRef, () => {
+    setOpen(false);
+    setNaming(false);
+  });
+
+  const fetchViews = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth('/filters');
+      if (res.ok) {
+        const data = await res.json();
+        setViews(data.data ?? data.filters ?? []);
+      }
+    } catch {
+      // Saved views are optional; a fetch failure shouldn't break filtering.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchViews();
+  }, [fetchViews]);
+
+  // Auto-apply the default view once, only when nothing is filtered yet (no URL
+  // hash seeded a group). Runs after the first fetch resolves.
+  useEffect(() => {
+    if (autoAppliedRef.current || loading) return;
+    if (value !== null) {
+      // A filter is already active (e.g. shared URL hash) — never override it.
+      autoAppliedRef.current = true;
+      return;
+    }
+    const def = defaultId ? views.find(v => v.id === defaultId) : null;
+    if (def) {
+      autoAppliedRef.current = true;
+      onApply(def.conditions);
+    }
+  }, [loading, views, defaultId, value, onApply]);
+
+  useEffect(() => {
+    if (naming) nameInputRef.current?.focus();
+  }, [naming]);
+
+  const activeView = useMemo(
+    () => views.find(v => sameGroup(v.conditions, value)) ?? null,
+    [views, value],
+  );
+
+  const hasFilter = value !== null && value.conditions.length > 0;
+
+  const apply = (view: SavedFilter) => {
+    onApply(view.conditions);
+    setOpen(false);
+  };
+
+  const saveCurrent = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || !value || saving) return;
+    setSaving(true);
+    try {
+      const res = await fetchWithAuth('/filters', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: trimmed,
+          conditions: value,
+          ...(currentOrgId ? { orgId: currentOrgId } : {}),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        showToast({ type: 'error', message: body.error ?? 'Could not save view' });
+        return;
+      }
+      showToast({ type: 'success', message: `Saved view "${trimmed}"` });
+      setName('');
+      setNaming(false);
+      await fetchViews();
+    } catch {
+      showToast({ type: 'error', message: 'Could not save view' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (view: SavedFilter) => {
+    try {
+      const res = await fetchWithAuth(`/filters/${view.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        showToast({ type: 'error', message: 'Could not delete view' });
+        return;
+      }
+      if (defaultId === view.id) {
+        writeDefaultViewId(null);
+        setDefaultId(null);
+      }
+      showToast({ type: 'success', message: `Deleted view "${view.name}"` });
+      await fetchViews();
+    } catch {
+      showToast({ type: 'error', message: 'Could not delete view' });
+    }
+  };
+
+  const toggleDefault = (view: SavedFilter) => {
+    const next = defaultId === view.id ? null : view.id;
+    writeDefaultViewId(next);
+    setDefaultId(next);
+  };
+
+  return (
+    <div ref={rootRef} className="relative shrink-0">
+      <button
+        type="button"
+        data-testid="saved-views-button"
+        aria-haspopup="true"
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+        className={`inline-flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+          open || activeView ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+        }`}
+        title="Saved views"
+      >
+        <Bookmark className="h-3.5 w-3.5" />
+        <span className="max-w-[10rem] truncate">{activeView ? activeView.name : 'Views'}</span>
+      </button>
+
+      {open && (
+        <div
+          data-testid="saved-views-menu"
+          role="menu"
+          className="absolute right-0 top-9 z-30 w-72 rounded-md border bg-popover p-1 shadow-lg"
+        >
+          <p className="px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Saved views
+          </p>
+
+          {loading ? (
+            <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+            </div>
+          ) : views.length === 0 ? (
+            <p className="px-2 py-3 text-sm text-muted-foreground">
+              No saved views yet. Build a filter, then save it as a view.
+            </p>
+          ) : (
+            <div className="max-h-64 overflow-y-auto">
+              {views.map(view => {
+                const isActive = sameGroup(view.conditions, value);
+                const isDefault = defaultId === view.id;
+                return (
+                  <div
+                    key={view.id}
+                    data-testid={`saved-view-${view.id}`}
+                    className={`group flex items-center gap-1 rounded px-2 py-1.5 text-sm hover:bg-muted ${
+                      isActive ? 'bg-muted' : ''
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => apply(view)}
+                      className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                      title={`Apply "${view.name}"`}
+                    >
+                      {isActive ? (
+                        <Check className="h-3.5 w-3.5 shrink-0 text-primary" />
+                      ) : (
+                        <span className="h-3.5 w-3.5 shrink-0" />
+                      )}
+                      <span className="truncate">{view.name}</span>
+                    </button>
+                    <button
+                      type="button"
+                      data-testid={`saved-view-default-${view.id}`}
+                      onClick={() => toggleDefault(view)}
+                      title={isDefault ? 'Default view — applied on load' : 'Set as default view'}
+                      aria-pressed={isDefault}
+                      className="shrink-0 rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground"
+                    >
+                      <Star className={`h-3.5 w-3.5 ${isDefault ? 'fill-warning text-warning' : ''}`} />
+                    </button>
+                    <button
+                      type="button"
+                      data-testid={`saved-view-delete-${view.id}`}
+                      onClick={() => remove(view)}
+                      title={`Delete "${view.name}"`}
+                      className="shrink-0 rounded p-1 text-muted-foreground hover:bg-background hover:text-destructive"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <hr className="my-1" />
+
+          {naming ? (
+            <div className="flex items-center gap-1.5 px-2 py-1.5">
+              <input
+                ref={nameInputRef}
+                type="text"
+                data-testid="saved-view-name-input"
+                placeholder="View name…"
+                value={name}
+                maxLength={200}
+                onChange={e => setName(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') void saveCurrent();
+                  if (e.key === 'Escape') { setNaming(false); setName(''); }
+                }}
+                className="h-8 w-full rounded border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <button
+                type="button"
+                data-testid="saved-view-save-confirm"
+                onClick={() => void saveCurrent()}
+                disabled={!name.trim() || saving}
+                className="inline-flex h-8 shrink-0 items-center rounded bg-primary px-2.5 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Save'}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              data-testid="saved-view-save-current"
+              onClick={() => setNaming(true)}
+              disabled={!hasFilter}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:text-muted-foreground disabled:hover:bg-transparent"
+              title={hasFilter ? 'Save the current filter as a view' : 'Build a filter first'}
+            >
+              <Plus className="h-3.5 w-3.5 shrink-0" />
+              Save current as view…
+            </button>
+          )}
+
+          <a
+            href="/settings/filters"
+            className="flex items-center gap-2 rounded px-2 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+            Manage all views
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/deviceListFilters.ts
+++ b/apps/web/src/components/devices/deviceListFilters.ts
@@ -1,0 +1,16 @@
+// Shared client-side ("inline") filter state for the Devices page. Owned by
+// DevicesPage and threaded into BOTH DeviceFilterToolbar (the search box) and
+// DeviceList (the filtering).
+//
+// In the chip-centric model every structured filter (status/os/role/org/site/
+// group/CPU/etc.) lives in the single server-resolved FilterConditionGroup and
+// renders as an editable chip. The ONLY inline/instant client filter left is
+// the hostname search box, so this object now carries just `search`.
+
+export interface ListFilters {
+  search: string;
+}
+
+export const DEFAULT_LIST_FILTERS: ListFilters = {
+  search: '',
+};

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -8779,6 +8779,17 @@ select {
     width: 6px;
   }
 
+  /* Hide the scrollbar while keeping horizontal scroll/swipe — used by the
+     device filter chip row, where a visible track would overlay the short
+     pill row. Content still scrolls via wheel/trackpad/touch. */
+  .no-scrollbar {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* old Edge / IE */
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    display: none; /* Chrome / Safari */
+  }
+
   /* Onboarding tour highlight */
   .tour-highlight {
     position: relative;


### PR DESCRIPTION
## Summary

Collapses the Devices page's **two parallel filter engines** (the server-side advanced filter + the list-local toolbar) into **one cohesive, chip-centric filter bar** — eliminating the bug class where the same dimension could be filtered two contradictory ways at once (e.g. `Online` chip + `Offline` dropdown → 0 devices).

Built iteratively with live verification in local docker at each step.

## What changed — UI

- **One filter bar:** borderless hostname search · quick-preset chips · `+ Add filter` picker (every field) · `Views` · `Advanced` (ghost). The old Chip/Advanced toggle, standing Status/OS dropdowns, and More-drawer of dropdowns are gone.
- **Editable chips:** every structured filter is a chip in a single `FilterConditionGroup`; click a chip to change its value, ✕ to remove.
- **Single-select status:** `Online`/`Offline` toggle one-or-the-other (a device has one status), matching the old dropdown.
- **Saved Views:** save the current filter as a named view, recall in one click, star a per-browser default (auto-applies on load when nothing else is filtered), delete. jsonb-safe active-view detection. Backed by the existing `/filters` endpoints (no new table; default is a localStorage pref).
- **`+ New group…`** shortcut restored in the Add-filter picker.
- **Chip row** hides its scrollbar (`.no-scrollbar` util) and shows left/right **fade affordances** for off-screen chips.
- **Decommissioned** devices stay hidden by default unless a status chip explicitly targets them (preserves prior behavior).

## What changed — safety / API

- **`normalizeGroup`** collapses contradictory same-field `equals`/`in` into one `in` (OR within a field) for the Advanced-drawer / chip-edit paths, so no entry point can build an always-empty AND. Blank/in-progress advanced rows and range filters are untouched.
- **filterEngine `in`/`notIn` fix (pre-existing bug):** built `= ANY($1)` which postgres.js rendered as a row tuple → Postgres 500 `op ANY/ALL (array) requires array on right side`. Now builds an explicit `IN (...)` list. **+4 regression tests.**

`DeviceList` is slimmed to controlled props (filters by `search ∩ class ∩ serverFilterIds`); pagination / sort / bulk / columns / class-facet preserved.

## Testing

- Web + API typecheck clean.
- **204** web devices tests + **38** API filterEngine tests pass.
- Verified live in local docker: presets, add/edit/remove chips, single-select switching, empty state, Advanced drawer, Saved Views save/recall/default/delete, decommissioned hiding, mobile, and the `in`-operator path returning 200.

## Known follow-ups (not in this PR)

- The **Device Group chip editor** doesn't yet resolve group names (only orgs/sites are wired into `FilterValueEditor`), so filtering *by* a group via a chip shows the raw id. Group creation works; proper group-name multi-select is a follow-up.
- `FilterChipBar` / `QuickAddChips` are now largely superseded (partially reused); delete once the legacy filter-flag path is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)