### PR TITLE
feat(contracts): auto-renew + renewal notices (v2)

### DIFF
--- a/apps/api/migrations/2026-06-21-contracts-auto-renew.sql
+++ b/apps/api/migrations/2026-06-21-contracts-auto-renew.sql
@@ -1,0 +1,50 @@
+-- Contracts auto-renew + renewal notices. Idempotent throughout.
+-- Sorts after 2026-06-15-d-recurring-contracts.sql (contracts table already exists).
+
+-- 1. New columns on contracts.
+ALTER TABLE contracts ADD COLUMN IF NOT EXISTS auto_renew BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE contracts ADD COLUMN IF NOT EXISTS renewal_term_months INTEGER;
+ALTER TABLE contracts ADD COLUMN IF NOT EXISTS renewal_notice_days INTEGER;
+DO $$ BEGIN
+  ALTER TABLE contracts ADD CONSTRAINT contracts_renewal_term_months_positive
+    CHECK (renewal_term_months IS NULL OR renewal_term_months > 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE contracts ADD CONSTRAINT contracts_renewal_notice_days_nonneg
+    CHECK (renewal_notice_days IS NULL OR renewal_notice_days >= 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- 2. Notice-kind enum + idempotency-ledger table.
+DO $$ BEGIN
+  CREATE TYPE contract_renewal_notice_kind AS ENUM ('advance','renewed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS contract_renewal_notices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_id UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  end_date DATE NOT NULL,
+  kind contract_renewal_notice_kind NOT NULL,
+  sent_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS contract_renewal_notices_uq
+  ON contract_renewal_notices (contract_id, end_date, kind);
+CREATE INDEX IF NOT EXISTS contract_renewal_notices_org_idx
+  ON contract_renewal_notices (org_id);
+
+-- 3. RLS: shape 1 (direct org_id).
+ALTER TABLE contract_renewal_notices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE contract_renewal_notices FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON contract_renewal_notices;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON contract_renewal_notices;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON contract_renewal_notices;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON contract_renewal_notices;
+CREATE POLICY breeze_org_isolation_select ON contract_renewal_notices
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON contract_renewal_notices
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON contract_renewal_notices
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON contract_renewal_notices
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/src/__tests__/integration/contract-renewal-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contract-renewal-rls.integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { db, withSystemDbAccessContext, withDbAccessContext } from '../../db';
+import { partners, organizations, contracts, contractRenewalNotices } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+
+function orgContext(orgId: string) {
+  return { scope: 'organization' as const, orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null };
+}
+
+async function seed() {
+  const sfx = Math.random().toString(36).slice(2, 8);
+  return withSystemDbAccessContext(async () => {
+    const [p] = await db.insert(partners).values({
+      name: `RN Partner ${sfx}`, slug: `rn-${sfx}`, type: 'msp', plan: 'pro', status: 'active'
+    }).returning({ id: partners.id });
+    const [orgA, orgB] = await db.insert(organizations).values([
+      { partnerId: p!.id, name: 'RN Org A', slug: `rn-a-${sfx}` },
+      { partnerId: p!.id, name: 'RN Org B', slug: `rn-b-${sfx}` }
+    ]).returning({ id: organizations.id });
+    const [c] = await db.insert(contracts).values({
+      partnerId: p!.id, orgId: orgA!.id, name: 'rn', status: 'active',
+      intervalMonths: 1, startDate: '2026-07-01', endDate: '2027-07-01',
+      autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: 30
+    }).returning({ id: contracts.id });
+    return { partnerId: p!.id, orgAId: orgA!.id, orgBId: orgB!.id, contractId: c!.id };
+  });
+}
+
+describe('contract_renewal_notices RLS forge (shape 1, org-axis)', () => {
+  it.runIf(!!process.env.DATABASE_URL)('org B INSERT with org A org_id is rejected by WITH CHECK', async () => {
+    const { orgAId, orgBId, contractId } = await seed();
+    let caught: unknown;
+    try {
+      await withDbAccessContext(orgContext(orgBId), async () =>
+        db.insert(contractRenewalNotices).values({
+          contractId, orgId: orgAId, endDate: '2027-07-01', kind: 'advance'
+        })
+      );
+    } catch (err) { caught = err; }
+    expect(caught).toBeDefined();
+    const c = caught as { cause?: { message?: string }; message?: string } | undefined;
+    const message = c?.cause?.message ?? c?.message ?? '';
+    expect(message).toMatch(/new row violates row-level security policy for table "contract_renewal_notices"/);
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)("org B cannot SELECT org A's renewal notice", async () => {
+    const { orgAId, orgBId, contractId } = await seed();
+    let id = '';
+    await withSystemDbAccessContext(async () => {
+      const [row] = await db.insert(contractRenewalNotices).values({
+        contractId, orgId: orgAId, endDate: '2027-07-01', kind: 'renewed'
+      }).returning({ id: contractRenewalNotices.id });
+      id = row!.id;
+    });
+    const visible = await withDbAccessContext(orgContext(orgBId), async () =>
+      db.select({ id: contractRenewalNotices.id }).from(contractRenewalNotices).where(eq(contractRenewalNotices.id, id))
+    );
+    expect(visible).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/contractService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contractService.integration.test.ts
@@ -125,6 +125,27 @@ describe('contractService CRUD', () => {
     expect(c.partnerId).not.toBe(corruptActor.partnerId);
   });
 
+  // Finding 1: createContract must persist auto-renew fields
+  it('createContract persists autoRenew, renewalTermMonths, and renewalNoticeDays', async () => {
+    const { actor, orgId } = await seedOrg();
+    const c = await withSystemDbAccessContext(() => createContract({
+      orgId, name: 'AutoRenewCreate', billingTiming: 'advance', intervalMonths: 12,
+      startDate: '2026-07-01', endDate: '2027-07-01',
+      autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: 30,
+    }, actor));
+    // Re-read the raw row under system context to assert persisted values.
+    const [row] = await withSystemDbAccessContext(() =>
+      db.select({
+        autoRenew: contracts.autoRenew,
+        renewalTermMonths: contracts.renewalTermMonths,
+        renewalNoticeDays: contracts.renewalNoticeDays,
+      }).from(contracts).where(eq(contracts.id, c.id)).limit(1)
+    );
+    expect(row!.autoRenew).toBe(true);
+    expect(row!.renewalTermMonths).toBe(12);
+    expect(row!.renewalNoticeDays).toBe(30);
+  });
+
   // Fix 2: listContracts defense-in-depth inArray filter
   it('listContracts returns only the calling actor\'s accessible org contracts', async () => {
     const a = await seedOrg();

--- a/apps/api/src/__tests__/integration/contractService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contractService.integration.test.ts
@@ -653,6 +653,46 @@ describe('contractService generation', () => {
   });
 });
 
+describe('contractService auto-renew invariant guard', () => {
+  it('rejects PATCH {autoRenew:true} when the persisted contract has no endDate or renewalTermMonths', async () => {
+    const { actor, orgId } = await seedOrg();
+    // Create a contract with no endDate (indefinite).
+    const c = await withSystemDbAccessContext(() => createContract({
+      orgId, name: 'AR Test', billingTiming: 'advance', intervalMonths: 1, startDate: '2026-07-01'
+    }, actor));
+    // Attempting to enable auto-renew without endDate/renewalTermMonths must throw 400.
+    await expect(
+      withSystemDbAccessContext(() => updateContract(c.id, { autoRenew: true } as never, actor))
+    ).rejects.toSatisfy((e: unknown) => {
+      expect(e).toBeInstanceOf(ContractServiceError);
+      expect((e as ContractServiceError).status).toBe(400);
+      return true;
+    });
+  });
+
+  it('accepts PATCH {autoRenew:true} when the persisted contract already has endDate and renewalTermMonths', async () => {
+    const { actor, orgId } = await seedOrg();
+    // Pre-seed a contract with endDate and renewalTermMonths already set via direct insert.
+    let contractId = '';
+    await withSystemDbAccessContext(async () => {
+      const [org] = await db.select({ partnerId: organizations.partnerId })
+        .from(organizations).where(eq(organizations.id, orgId)).limit(1);
+      const [c] = await db.insert(contracts).values({
+        partnerId: org!.partnerId, orgId, name: 'AR Ok', status: 'draft',
+        billingTiming: 'advance', intervalMonths: 1, startDate: '2026-07-01',
+        endDate: '2027-07-01', renewalTermMonths: 12,
+        autoIssue: false, currencyCode: 'USD', createdBy: null
+      }).returning({ id: contracts.id });
+      contractId = c!.id;
+    });
+    // Setting autoRenew:true when endDate and renewalTermMonths are already present must succeed.
+    const updated = await withSystemDbAccessContext(() =>
+      updateContract(contractId, { autoRenew: true } as never, actor)
+    );
+    expect(updated.autoRenew).toBe(true);
+  });
+});
+
 describe('contractService illegal lifecycle transitions', () => {
   // Table-driven tests for invalid state transitions that must throw ContractServiceError.
   // Each case brings the contract to the required starting state, then asserts the

--- a/apps/api/src/db/schema/contracts.ts
+++ b/apps/api/src/db/schema/contracts.ts
@@ -14,6 +14,9 @@ export const contractBillingTimingEnum = pgEnum('contract_billing_timing', [
 export const contractLineTypeEnum = pgEnum('contract_line_type', [
   'flat', 'per_device', 'per_seat', 'manual'
 ]);
+export const contractRenewalNoticeKindEnum = pgEnum('contract_renewal_notice_kind', [
+  'advance', 'renewed'
+]);
 
 export const contracts = pgTable('contracts', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -27,6 +30,9 @@ export const contracts = pgTable('contracts', {
   endDate: date('end_date'),
   nextBillingAt: date('next_billing_at'),
   autoIssue: boolean('auto_issue').notNull().default(false),
+  autoRenew: boolean('auto_renew').notNull().default(false),
+  renewalTermMonths: integer('renewal_term_months'),
+  renewalNoticeDays: integer('renewal_notice_days'),
   currencyCode: char('currency_code', { length: 3 }).notNull().default('USD'),
   notes: text('notes'),
   terms: text('terms'),
@@ -72,4 +78,19 @@ export const contractBillingPeriods = pgTable('contract_billing_periods', {
 }, (t) => [
   uniqueIndex('contract_billing_periods_contract_period_uq').on(t.contractId, t.periodStart),
   index('contract_billing_periods_org_idx').on(t.orgId)
+]);
+
+export const contractRenewalNotices = pgTable('contract_renewal_notices', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  contractId: uuid('contract_id').notNull().references(() => contracts.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  // The end_date the notice pertains to. For 'advance' this is the term about to lapse;
+  // for 'renewed' this is the NEW end_date after extension. (contract_id, end_date, kind)
+  // is UNIQUE — that triple is the once-per-term idempotency key.
+  endDate: date('end_date').notNull(),
+  kind: contractRenewalNoticeKindEnum('kind').notNull(),
+  sentAt: timestamp('sent_at').defaultNow().notNull()
+}, (t) => [
+  uniqueIndex('contract_renewal_notices_uq').on(t.contractId, t.endDate, t.kind),
+  index('contract_renewal_notices_org_idx').on(t.orgId)
 ]);

--- a/apps/api/src/jobs/contractWorker.renewal.integration.test.ts
+++ b/apps/api/src/jobs/contractWorker.renewal.integration.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Worker-level integration test: renewal pre-pass before billing sweep.
+ *
+ * Verifies that when the worker orchestration runs (renewal then billing),
+ * an auto-renew contract whose next bill lands at the term boundary:
+ *   1. has its end_date extended (not expired) by the renewal pre-pass, and
+ *   2. has a billing period claimed (billed, not expired) by the billing sweep.
+ *
+ * contractEvents is a fire-and-forget BullMQ side effect — mock it so the
+ * test doesn't require a live BullMQ connection (mirrors contractRenewal.integration.test.ts).
+ */
+import { vi } from 'vitest';
+vi.mock('../services/contractEvents', () => ({ emitContractEvent: vi.fn().mockResolvedValue(undefined) }));
+
+import { it, expect } from 'vitest';
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { partners, organizations, contracts, contractLines, contractBillingPeriods } from '../db/schema';
+import { eq } from 'drizzle-orm';
+import { runContractRenewalSweep } from '../services/contractRenewal';
+import { runContractBillingSweep } from './contractWorker';
+
+it.runIf(!!process.env.DATABASE_URL)(
+  'renewal before billing keeps an at-boundary auto-renew contract billing instead of expiring',
+  async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+
+    const { contractId } = await withSystemDbAccessContext(async () => {
+      const [p] = await db.insert(partners).values({
+        name: `W ${sfx}`, slug: `w-${sfx}`, type: 'msp', plan: 'pro', status: 'active'
+      }).returning({ id: partners.id });
+
+      const [o] = await db.insert(organizations).values({
+        partnerId: p!.id, name: 'WOrg', slug: `wo-${sfx}`
+      }).returning({ id: organizations.id });
+
+      // Contract whose next bill lands exactly at end_date — the renewal sweep
+      // must extend end_date BEFORE billing so it bills rather than expires.
+      const [c] = await db.insert(contracts).values({
+        partnerId: p!.id,
+        orgId: o!.id,
+        name: 'Boundary',
+        status: 'active',
+        billingTiming: 'advance',
+        intervalMonths: 1,
+        startDate: '2026-07-01',
+        endDate: '2027-07-01',
+        nextBillingAt: '2027-07-01',
+        autoRenew: true,
+        renewalTermMonths: 12,
+        renewalNoticeDays: 30,
+      }).returning({ id: contracts.id });
+
+      await db.insert(contractLines).values({
+        contractId: c!.id, orgId: o!.id, lineType: 'flat', description: 'svc', unitPrice: '100.00'
+      });
+
+      return { contractId: c!.id };
+    });
+
+    const asOf = new Date('2027-07-01T05:00:00Z');
+
+    // Run the same orchestration the BullMQ job runs.
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(asOf)));
+    await runContractBillingSweep(asOf);
+
+    // Contract must still be active with end_date extended by the renewal term.
+    const [after] = await withSystemDbAccessContext(() =>
+      db.select({ status: contracts.status, endDate: contracts.endDate })
+        .from(contracts)
+        .where(eq(contracts.id, contractId))
+    );
+    expect(after!.status).toBe('active');
+    expect(after!.endDate).toBe('2028-07-01');
+
+    // A billing period must have been claimed (i.e. the sweep billed it, not expired it).
+    const periods = await withSystemDbAccessContext(() =>
+      db.select().from(contractBillingPeriods).where(eq(contractBillingPeriods.contractId, contractId))
+    );
+    expect(periods.length).toBeGreaterThanOrEqual(1);
+  },
+  30000
+);

--- a/apps/api/src/jobs/contractWorker.renewal.integration.test.ts
+++ b/apps/api/src/jobs/contractWorker.renewal.integration.test.ts
@@ -76,7 +76,7 @@ it.runIf(!!process.env.DATABASE_URL)(
     const periods = await withSystemDbAccessContext(() =>
       db.select().from(contractBillingPeriods).where(eq(contractBillingPeriods.contractId, contractId))
     );
-    expect(periods.length).toBeGreaterThanOrEqual(1);
+    expect(periods.length).toBe(1);
   },
   30000
 );

--- a/apps/api/src/jobs/contractWorker.ts
+++ b/apps/api/src/jobs/contractWorker.ts
@@ -18,6 +18,7 @@ import { captureException } from '../services/sentry';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { contracts } from '../db/schema';
 import { generateDueInvoice } from '../services/contractService';
+import { runContractRenewalSweep } from '../services/contractRenewal';
 import { issueInvoice } from '../services/invoiceService';
 import { sendInvoiceEmail } from '../services/invoicePdf';
 
@@ -101,6 +102,9 @@ export function createContractWorker(): Worker {
     CONTRACT_QUEUE,
     async (job) => {
       if (job.name === 'billing-sweep') {
+        // Renewal pre-pass MUST run before billing so an about-to-expire auto-renew
+        // contract has its term extended before generateDueInvoice decides expiry.
+        await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep()));
         return runContractBillingSweep();
       }
       throw new Error(`Unknown contract job: ${job.name}`);

--- a/apps/api/src/services/contractEvents.ts
+++ b/apps/api/src/services/contractEvents.ts
@@ -10,7 +10,7 @@ import { captureException } from './sentry';
 export const CONTRACT_EVENTS_QUEUE = 'contract-events';
 
 export type ContractEvent = {
-  type: 'contract.activated' | 'contract.invoiced' | 'contract.paused' | 'contract.cancelled' | 'contract.expired';
+  type: 'contract.activated' | 'contract.invoiced' | 'contract.paused' | 'contract.cancelled' | 'contract.expired' | 'contract.auto_renewed' | 'contract.renewal_notice';
   contractId: string;
   orgId: string;
   partnerId: string;

--- a/apps/api/src/services/contractMath.test.ts
+++ b/apps/api/src/services/contractMath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { addMonthsClamped, computePeriod, periodIndexFor, nextBillingDate, isExpired } from './contractMath';
+import { addMonthsClamped, computePeriod, periodIndexFor, nextBillingDate, isExpired, addDaysISO, duePeriodStartFor, isWithinNoticeWindow, extendTermPastDue } from './contractMath';
 
 describe('addMonthsClamped', () => {
   it('preserves day-of-month when valid', () => {
@@ -60,5 +60,51 @@ describe('isExpired', () => {
   });
   it('false when no end date', () => {
     expect(isExpired({ endDate: null, periodStart: '2099-01-01' })).toBe(false);
+  });
+});
+
+describe('addDaysISO', () => {
+  it('adds and subtracts days across month/year boundaries (UTC)', () => {
+    expect(addDaysISO('2026-07-01', -30)).toBe('2026-06-01');
+    expect(addDaysISO('2026-12-31', 1)).toBe('2027-01-01');
+    expect(addDaysISO('2028-02-28', 1)).toBe('2028-02-29'); // leap
+  });
+});
+
+describe('duePeriodStartFor', () => {
+  it('advance ⇒ nextBillingAt itself', () => {
+    expect(duePeriodStartFor('advance', '2027-07-01', 1)).toBe('2027-07-01');
+  });
+  it('arrears ⇒ nextBillingAt minus one interval', () => {
+    expect(duePeriodStartFor('arrears', '2027-08-01', 1)).toBe('2027-07-01');
+    expect(duePeriodStartFor('arrears', '2027-10-01', 3)).toBe('2027-07-01');
+  });
+});
+
+describe('isWithinNoticeWindow', () => {
+  it('true inside [endDate - noticeDays, endDate)', () => {
+    expect(isWithinNoticeWindow('2026-06-15', '2026-07-01', 30)).toBe(true); // 16 days out
+    expect(isWithinNoticeWindow('2026-06-01', '2026-07-01', 30)).toBe(true); // exactly at window start
+  });
+  it('false before the window and on/after endDate', () => {
+    expect(isWithinNoticeWindow('2026-05-31', '2026-07-01', 30)).toBe(false);
+    expect(isWithinNoticeWindow('2026-07-01', '2026-07-01', 30)).toBe(false);
+  });
+});
+
+describe('extendTermPastDue', () => {
+  it('pushes endDate forward by whole terms until the due period no longer expires', () => {
+    // due period starts exactly at endDate ⇒ one 12-month roll
+    expect(extendTermPastDue({ endDate: '2027-07-01', duePeriodStart: '2027-07-01', termMonths: 12 }))
+      .toEqual({ newEndDate: '2028-07-01', renewed: true });
+  });
+  it('catches up multiple terms when the sweep was down (term < gap)', () => {
+    // due period is 2 months past a 1-month term ⇒ rolls 3 times to clear it
+    expect(extendTermPastDue({ endDate: '2027-07-01', duePeriodStart: '2027-09-01', termMonths: 1 }))
+      .toEqual({ newEndDate: '2027-10-01', renewed: true });
+  });
+  it('no-op when the due period is still inside the term', () => {
+    expect(extendTermPastDue({ endDate: '2027-07-01', duePeriodStart: '2027-06-01', termMonths: 12 }))
+      .toEqual({ newEndDate: '2027-07-01', renewed: false });
   });
 });

--- a/apps/api/src/services/contractMath.ts
+++ b/apps/api/src/services/contractMath.ts
@@ -57,3 +57,40 @@ export function isExpired(input: { endDate: string | null; periodStart: string }
   if (input.endDate === null) return false;
   return input.periodStart >= input.endDate;
 }
+
+/** Add (or subtract) whole days to an ISO YYYY-MM-DD date, in UTC. */
+export function addDaysISO(iso: string, days: number): string {
+  const segments = iso.split('-');
+  const y = Number(segments[0]);
+  const m = Number(segments[1]);
+  const d = Number(segments[2]);
+  const dt = new Date(Date.UTC(y, m - 1, d + days));
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${dt.getUTCFullYear()}-${mm}-${dd}`;
+}
+
+/** ISO start of the period the billing sweep is about to bill. */
+export function duePeriodStartFor(billingTiming: BillingTiming, nextBillingAt: string, intervalMonths: number): string {
+  return billingTiming === 'advance' ? nextBillingAt : addMonthsClamped(nextBillingAt, -intervalMonths);
+}
+
+/** True when asOf is in [endDate - noticeDays, endDate). */
+export function isWithinNoticeWindow(asOf: string, endDate: string, noticeDays: number): boolean {
+  const windowStart = addDaysISO(endDate, -noticeDays);
+  return asOf >= windowStart && asOf < endDate;
+}
+
+/** Roll endDate forward by whole terms until the due period no longer trips isExpired. */
+export function extendTermPastDue(input: { endDate: string; duePeriodStart: string; termMonths: number }):
+  { newEndDate: string; renewed: boolean } {
+  let endDate = input.endDate;
+  let renewed = false;
+  let guard = 0;
+  while (isExpired({ endDate, periodStart: input.duePeriodStart })) {
+    endDate = addMonthsClamped(endDate, input.termMonths);
+    renewed = true;
+    if (++guard > 100000) break; // runaway guard (mirrors periodIndexFor)
+  }
+  return { newEndDate: endDate, renewed };
+}

--- a/apps/api/src/services/contractRenewal.integration.test.ts
+++ b/apps/api/src/services/contractRenewal.integration.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Lifecycle events are fire-and-forget BullMQ side effects, not the correctness
+// under test here. Mock the emitter so these DB-correctness tests don't depend
+// on (and block on) a reachable BullMQ connection — mirrors the precedent in
+// invoiceService.issue.integration.test.ts. We still assert the emitter was
+// CALLED with contract.auto_renewed, which is the behaviour we care about.
+vi.mock('./contractEvents', () => ({ emitContractEvent: vi.fn().mockResolvedValue(undefined) }));
+
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { partners, organizations, contracts, contractLines, contractRenewalNotices } from '../db/schema';
+import { eq, and } from 'drizzle-orm';
+import { runContractRenewalSweep } from './contractRenewal';
+import { emitContractEvent } from './contractEvents';
+
+async function seedAutoRenew(opts: { nextBillingAt: string; endDate: string; noticeDays?: number }) {
+  const sfx = Math.random().toString(36).slice(2, 8);
+  return withSystemDbAccessContext(async () => {
+    const [p] = await db.insert(partners).values({ name: `R ${sfx}`, slug: `r-${sfx}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [o] = await db.insert(organizations).values({ partnerId: p!.id, name: 'ROrg', slug: `ro-${sfx}` }).returning({ id: organizations.id });
+    const [c] = await db.insert(contracts).values({
+      partnerId: p!.id, orgId: o!.id, name: 'Renew Me', status: 'active', billingTiming: 'advance',
+      intervalMonths: 1, startDate: '2026-07-01', endDate: opts.endDate, nextBillingAt: opts.nextBillingAt,
+      autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: opts.noticeDays ?? 30
+    }).returning({ id: contracts.id });
+    await db.insert(contractLines).values({ contractId: c!.id, orgId: o!.id, lineType: 'flat', description: 'svc', unitPrice: '500.00' });
+    return { orgId: o!.id, contractId: c!.id };
+  });
+}
+
+describe('runContractRenewalSweep', () => {
+  it.runIf(!!process.env.DATABASE_URL)('extends the term when the next bill would expire, logs a renewed notice, idempotent', async () => {
+    // Next bill lands exactly at endDate ⇒ would expire ⇒ must renew first.
+    const { contractId } = await seedAutoRenew({ nextBillingAt: '2027-07-01', endDate: '2027-07-01' });
+
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-07-01T05:00:00Z'))));
+
+    const [after] = await withSystemDbAccessContext(() =>
+      db.select({ endDate: contracts.endDate, status: contracts.status }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(after!.endDate).toBe('2028-07-01');
+    expect(after!.status).toBe('active');
+
+    // The auto_renewed lifecycle event must have been emitted for this contract.
+    expect(emitContractEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'contract.auto_renewed', contractId }));
+
+    const renewed = await withSystemDbAccessContext(() =>
+      db.select().from(contractRenewalNotices).where(and(eq(contractRenewalNotices.contractId, contractId), eq(contractRenewalNotices.kind, 'renewed'))));
+    expect(renewed).toHaveLength(1);
+
+    // Second run: no further extension, no duplicate notice.
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-07-01T05:00:00Z'))));
+    const [after2] = await withSystemDbAccessContext(() =>
+      db.select({ endDate: contracts.endDate }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(after2!.endDate).toBe('2028-07-01');
+    const renewed2 = await withSystemDbAccessContext(() =>
+      db.select().from(contractRenewalNotices).where(and(eq(contractRenewalNotices.contractId, contractId), eq(contractRenewalNotices.kind, 'renewed'))));
+    expect(renewed2).toHaveLength(1);
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)('emits a single advance notice inside the window and does not extend', async () => {
+    // 16 days before endDate; not yet at the billing boundary.
+    const { contractId } = await seedAutoRenew({ nextBillingAt: '2027-08-01', endDate: '2027-07-15' });
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-06-29T05:00:00Z'))));
+    const advance = await withSystemDbAccessContext(() =>
+      db.select().from(contractRenewalNotices).where(and(eq(contractRenewalNotices.contractId, contractId), eq(contractRenewalNotices.kind, 'advance'))));
+    expect(advance).toHaveLength(1);
+    const [c] = await withSystemDbAccessContext(() => db.select({ endDate: contracts.endDate }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(c!.endDate).toBe('2027-07-15'); // unchanged
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)('does nothing for a contract with auto_renew = false', async () => {
+    const { contractId } = await seedAutoRenew({ nextBillingAt: '2027-07-01', endDate: '2027-07-01' });
+    await withSystemDbAccessContext(() => db.update(contracts).set({ autoRenew: false }).where(eq(contracts.id, contractId)));
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-07-01T05:00:00Z'))));
+    const [c2] = await withSystemDbAccessContext(() => db.select({ endDate: contracts.endDate }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(c2!.endDate).toBe('2027-07-01'); // not extended — billing sweep will expire it normally
+  });
+});

--- a/apps/api/src/services/contractRenewal.ts
+++ b/apps/api/src/services/contractRenewal.ts
@@ -1,0 +1,137 @@
+import { and, eq, isNotNull, or, sql } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  contracts, contractRenewalNotices, organizations, organizationUsers, partnerUsers, users
+} from '../db/schema';
+import { emitContractEvent } from './contractEvents';
+import { sendInAppNotification } from './notificationSenders/inAppSender';
+import { getEmailService } from './email';
+import { buildContractRenewalEmail } from './contractRenewalTemplate';
+import { duePeriodStartFor, extendTermPastDue, isWithinNoticeWindow } from './contractMath';
+import { captureException } from './sentry';
+
+const WEB_BASE = process.env.PUBLIC_APP_URL ?? '';
+
+interface RenewalCandidate {
+  id: string; orgId: string; partnerId: string; name: string;
+  billingTiming: 'advance' | 'arrears'; intervalMonths: number;
+  endDate: string | null; nextBillingAt: string | null;
+  autoRenew: boolean; renewalTermMonths: number | null; renewalNoticeDays: number | null;
+}
+
+/** Resolve the MSP's notifiable users (active org users + active partner users with access). */
+async function resolveMspRecipients(orgId: string, partnerId: string): Promise<{ userId: string; email: string }[]> {
+  const orgUsersRows = await db.select({ userId: organizationUsers.userId, email: users.email })
+    .from(organizationUsers).innerJoin(users, eq(organizationUsers.userId, users.id))
+    .where(and(eq(organizationUsers.orgId, orgId), eq(users.status, 'active')));
+  const pUsersRows = await db.select({ userId: partnerUsers.userId, email: users.email })
+    .from(partnerUsers).innerJoin(users, eq(partnerUsers.userId, users.id))
+    .where(and(
+      eq(partnerUsers.partnerId, partnerId), eq(users.status, 'active'),
+      or(
+        eq(partnerUsers.orgAccess, 'all'),
+        and(eq(partnerUsers.orgAccess, 'selected'), sql`${orgId} = ANY(${partnerUsers.orgIds})`)
+      )
+    ));
+  const byId = new Map<string, string>();
+  for (const u of [...orgUsersRows, ...pUsersRows]) {
+    if (u.email) byId.set(u.userId, u.email);
+  }
+  return [...byId.entries()].map(([userId, email]) => ({ userId, email }));
+}
+
+/** Claim a (contract, end_date, kind) notice slot. Returns true iff this caller won the claim. */
+async function claimNotice(c: RenewalCandidate, endDate: string, kind: 'advance' | 'renewed'): Promise<boolean> {
+  const rows = await db.insert(contractRenewalNotices)
+    .values({ contractId: c.id, orgId: c.orgId, endDate, kind })
+    .onConflictDoNothing({
+      target: [contractRenewalNotices.contractId, contractRenewalNotices.endDate, contractRenewalNotices.kind]
+    })
+    .returning({ id: contractRenewalNotices.id });
+  return rows.length > 0;
+}
+
+/** Best-effort dispatch: in-app to MSP users + email to MSP users. Never throws. */
+async function dispatchNotice(c: RenewalCandidate, kind: 'advance' | 'renewed', endDate: string): Promise<void> {
+  try {
+    const [org] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, c.orgId)).limit(1);
+    const orgName = org?.name ?? 'your customer';
+    const contractUrl = `${WEB_BASE}/contracts/${c.id}`;
+    const summary = kind === 'advance'
+      ? `Contract "${c.name}" for ${orgName} auto-renews on ${endDate}.`
+      : `Contract "${c.name}" for ${orgName} auto-renewed through ${endDate}.`;
+
+    await sendInAppNotification({
+      alertId: `contract-renewal-${c.id}-${endDate}-${kind}`,
+      alertName: kind === 'advance' ? 'Contract renewal upcoming' : 'Contract renewed',
+      severity: 'info', message: summary, orgId: c.orgId, link: `/contracts/${c.id}`
+    });
+
+    const emailService = getEmailService();
+    if (emailService) {
+      const recipients = await resolveMspRecipients(c.orgId, c.partnerId);
+      if (recipients.length > 0) {
+        const tpl = buildContractRenewalEmail({
+          kind, contractName: c.name, orgName, endDate, contractUrl,
+          noticeDays: kind === 'advance' ? (c.renewalNoticeDays ?? undefined) : undefined
+        });
+        await emailService.sendEmail({ to: recipients.map((r) => r.email), subject: tpl.subject, html: tpl.html, text: tpl.text });
+      }
+    }
+  } catch (err) {
+    console.error('[ContractRenewal] notice dispatch failed', `contractId=${c.id}`, err instanceof Error ? err.message : err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+/**
+ * Renewal pre-pass. Runs (inside a system DB context) BEFORE the billing sweep so an
+ * about-to-expire auto-renew contract has its term extended before billing decides expiry.
+ *  Pass A: advance notice for contracts inside their notice window (keyed on current endDate).
+ *  Pass B: extend the term for contracts whose next billable period would expire, then
+ *          emit contract.auto_renewed and claim a 'renewed' notice keyed on the NEW endDate.
+ */
+export async function runContractRenewalSweep(asOf: Date = new Date()): Promise<{ noticed: number; renewed: number }> {
+  const today = asOf.toISOString().slice(0, 10);
+
+  const candidates = await db.select({
+    id: contracts.id, orgId: contracts.orgId, partnerId: contracts.partnerId, name: contracts.name,
+    billingTiming: contracts.billingTiming, intervalMonths: contracts.intervalMonths,
+    endDate: contracts.endDate, nextBillingAt: contracts.nextBillingAt,
+    autoRenew: contracts.autoRenew, renewalTermMonths: contracts.renewalTermMonths, renewalNoticeDays: contracts.renewalNoticeDays
+  }).from(contracts).where(and(eq(contracts.status, 'active' as never), eq(contracts.autoRenew, true), isNotNull(contracts.endDate)));
+
+  let noticed = 0;
+  let renewed = 0;
+
+  for (const c of candidates as RenewalCandidate[]) {
+    if (!c.endDate || c.renewalTermMonths == null) continue;
+
+    // Pass A — advance notice (based on the CURRENT end_date).
+    const noticeDays = c.renewalNoticeDays ?? 30;
+    if (isWithinNoticeWindow(today, c.endDate, noticeDays)) {
+      if (await claimNotice(c, c.endDate, 'advance')) {
+        await dispatchNotice(c, 'advance', c.endDate);
+        noticed++;
+      }
+    }
+
+    // Pass B — extend if the next billable period would expire.
+    // Only consider contracts whose billing sweep would run today (nextBillingAt <= today);
+    // a future nextBillingAt means the billing sweep hasn't reached this contract yet.
+    if (c.nextBillingAt && c.nextBillingAt <= today) {
+      const duePeriodStart = duePeriodStartFor(c.billingTiming, c.nextBillingAt, c.intervalMonths);
+      const { newEndDate, renewed: didRenew } = extendTermPastDue({ endDate: c.endDate, duePeriodStart, termMonths: c.renewalTermMonths });
+      if (didRenew) {
+        await db.update(contracts).set({ endDate: newEndDate, updatedAt: asOf }).where(eq(contracts.id, c.id));
+        await emitContractEvent({ type: 'contract.auto_renewed', contractId: c.id, orgId: c.orgId, partnerId: c.partnerId });
+        if (await claimNotice(c, newEndDate, 'renewed')) {
+          await dispatchNotice({ ...c, endDate: newEndDate }, 'renewed', newEndDate);
+        }
+        renewed++;
+      }
+    }
+  }
+
+  return { noticed, renewed };
+}

--- a/apps/api/src/services/contractRenewalTemplate.test.ts
+++ b/apps/api/src/services/contractRenewalTemplate.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { buildContractRenewalEmail } from './contractRenewalTemplate';
+
+describe('buildContractRenewalEmail', () => {
+  const base = { contractName: 'Acme Managed Services', orgName: 'Acme Inc', endDate: '2027-07-01', contractUrl: 'https://app/contracts/abc' };
+
+  it('advance notice names the contract, org, and date and has a plain-text fallback', () => {
+    const out = buildContractRenewalEmail({ ...base, kind: 'advance', noticeDays: 30 });
+    expect(out.subject).toMatch(/renew/i);
+    expect(out.subject).toContain('Acme Managed Services');
+    expect(out.html).toContain('Acme Inc');
+    expect(out.html).toContain('2027-07-01');
+    expect(out.text).toContain('Acme Managed Services');
+    expect(out.text.length).toBeGreaterThan(0);
+  });
+
+  it('renewed confirmation states the new term end date', () => {
+    const out = buildContractRenewalEmail({ ...base, kind: 'renewed', endDate: '2028-07-01' });
+    expect(out.subject).toMatch(/renewed/i);
+    expect(out.html).toContain('2028-07-01');
+  });
+});

--- a/apps/api/src/services/contractRenewalTemplate.ts
+++ b/apps/api/src/services/contractRenewalTemplate.ts
@@ -1,0 +1,41 @@
+import { renderLayout, renderButton } from './emailLayout';
+
+export interface ContractRenewalEmailParams {
+  kind: 'advance' | 'renewed';
+  contractName: string;
+  orgName: string;
+  endDate: string;       // advance: term about to lapse; renewed: the new term end
+  contractUrl: string;
+  noticeDays?: number;   // advance only
+}
+
+export interface ContractRenewalEmail { subject: string; html: string; text: string; }
+
+export function buildContractRenewalEmail(p: ContractRenewalEmailParams): ContractRenewalEmail {
+  if (p.kind === 'advance') {
+    const subject = `Contract "${p.contractName}" renews on ${p.endDate}`;
+    const lead = `The contract "${p.contractName}" for ${p.orgName} is set to auto-renew on ${p.endDate}` +
+      `${p.noticeDays != null ? ` (${p.noticeDays}-day notice)` : ''}. No action is needed to renew. ` +
+      `To stop the renewal, turn off auto-renew before that date.`;
+    const html = renderLayout({
+      title: 'Upcoming contract renewal',
+      preheader: `${p.contractName} auto-renews on ${p.endDate}.`,
+      heading: 'Upcoming contract renewal',
+      body: `<p>${lead}</p>${renderButton('View contract', p.contractUrl)}`,
+    });
+    const text = `${lead}\n\nView contract: ${p.contractUrl}`;
+    return { subject, html, text };
+  }
+
+  const subject = `Contract "${p.contractName}" renewed through ${p.endDate}`;
+  const lead = `The contract "${p.contractName}" for ${p.orgName} has auto-renewed. ` +
+    `Its term now runs through ${p.endDate} and billing continues uninterrupted.`;
+  const html = renderLayout({
+    title: 'Contract renewed',
+    preheader: `${p.contractName} has been renewed through ${p.endDate}.`,
+    heading: 'Contract renewed',
+    body: `<p>${lead}</p>${renderButton('View contract', p.contractUrl)}`,
+  });
+  const text = `${lead}\n\nView contract: ${p.contractUrl}`;
+  return { subject, html, text };
+}

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -37,6 +37,7 @@ function assertEditable(c: { status: string }): void {
 export async function createContract(input: {
   orgId: string; name: string; billingTiming: 'advance' | 'arrears'; intervalMonths: number;
   startDate: string; endDate?: string | null; autoIssue?: boolean; currencyCode?: string; notes?: string | null; terms?: string | null;
+  autoRenew?: boolean; renewalTermMonths?: number | null; renewalNoticeDays?: number | null;
 }, actor: ContractActor) {
   requireOrgAccess(actor, input.orgId);
   if (actor.partnerId === null) throw new ContractServiceError('Partner scope required', 403, 'ORG_DENIED');
@@ -49,7 +50,9 @@ export async function createContract(input: {
     billingTiming: input.billingTiming, intervalMonths: input.intervalMonths,
     startDate: input.startDate, endDate: input.endDate ?? null,
     autoIssue: input.autoIssue ?? false, currencyCode: input.currencyCode ?? 'USD',
-    notes: input.notes ?? null, terms: input.terms ?? null, createdBy: actor.userId
+    notes: input.notes ?? null, terms: input.terms ?? null, createdBy: actor.userId,
+    autoRenew: input.autoRenew ?? false, renewalTermMonths: input.renewalTermMonths ?? null,
+    renewalNoticeDays: input.renewalNoticeDays ?? null,
   }).returning();
   return row!;
 }

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -172,6 +172,19 @@ export async function updateContract(contractId: string, patch: UpdateContractIn
   if (patch.autoIssue !== undefined)      safeSet.autoIssue      = patch.autoIssue;
   if ('notes' in patch)                   safeSet.notes          = patch.notes ?? null;
   if ('terms' in patch)                   safeSet.terms          = patch.terms ?? null;
+  if (patch.autoRenew !== undefined)      safeSet.autoRenew      = patch.autoRenew;
+  if ('renewalTermMonths' in patch)       safeSet.renewalTermMonths = patch.renewalTermMonths ?? null;
+  if ('renewalNoticeDays' in patch)       safeSet.renewalNoticeDays = patch.renewalNoticeDays ?? null;
+  // Post-merge invariant: auto-renew requires both an end date and a renewal term.
+  // updateContractSchema is a bare object that cannot cross-validate against the persisted
+  // row (the patch may only send autoRenew:true without re-sending endDate). We compute
+  // the effective values by merging the patch over the persisted row and check here.
+  const effectiveAutoRenew   = safeSet.autoRenew   !== undefined ? safeSet.autoRenew   : c.autoRenew;
+  const effectiveEndDate     = safeSet.endDate      !== undefined ? safeSet.endDate     : c.endDate;
+  const effectiveTerm        = safeSet.renewalTermMonths !== undefined ? safeSet.renewalTermMonths : c.renewalTermMonths;
+  if (effectiveAutoRenew && (effectiveEndDate == null || effectiveTerm == null)) {
+    throw new ContractServiceError('auto-renew requires an end date and renewal term', 400);
+  }
   await db.update(contracts).set(safeSet).where(eq(contracts.id, contractId));
   return getOwnedContractOr404(contractId, actor);
 }

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -120,6 +120,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'configuration_policies',
   'contract_billing_periods',
   'contract_lines',
+  'contract_renewal_notices',
   'contracts',
   'custom_field_definitions',
   // NB: sorts AFTER custom_field_definitions — localeCompare puts the '_' in

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
       // is a MOCKED unit test that mocks `../db` and must NOT hook the real-DB
       // setup — it runs under the default unit config instead.
       'src/services/inboundEmail/**/*.integration.test.ts',
+      // Co-located real-DB integration test for the contract renewal sweep
+      // service. Follows the same pattern as the inboundEmail test above.
+      'src/services/contractRenewal.integration.test.ts',
     ],
     exclude: [
       // rls.integration.test.ts is a mocked unit test in integration's

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
       // Co-located real-DB integration test for the contract renewal sweep
       // service. Follows the same pattern as the inboundEmail test above.
       'src/services/contractRenewal.integration.test.ts',
+      // Worker-level integration test: renewal pre-pass runs before billing sweep
+      // so an at-boundary auto-renew contract bills instead of expiring.
+      'src/jobs/contractWorker.renewal.integration.test.ts',
     ],
     exclude: [
       // rls.integration.test.ts is a mocked unit test in integration's

--- a/apps/web/src/components/contracts/ContractDetail.permissions.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.permissions.test.tsx
@@ -42,7 +42,8 @@ function detail(status: ContractStatus): ContractDetailData {
     contract: {
       id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status,
       billingTiming: 'advance', intervalMonths: 1, startDate: '2026-06-01', endDate: null,
-      nextBillingAt: null, autoIssue: false, currencyCode: 'USD', notes: null, terms: null,
+      nextBillingAt: null, autoIssue: false, autoRenew: false, renewalTermMonths: null, renewalNoticeDays: null,
+      currencyCode: 'USD', notes: null, terms: null,
       createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
     },
     lines: [

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -150,6 +150,21 @@ export default function ContractDetail({ detail, onChanged }: Props) {
                 <dt className="text-xs uppercase text-muted-foreground">Auto-issue</dt>
                 <dd className="mt-1 font-medium">{contract.autoIssue ? 'Yes' : 'No (drafts)'}</dd>
               </div>
+              <div>
+                <dt className="text-xs uppercase text-muted-foreground">Renewal</dt>
+                <dd className="mt-1 font-medium" data-testid="contract-renewal-status">
+                  {contract.autoRenew ? (
+                    <>
+                      <span>Auto-renews</span>
+                      {' '}every {contract.renewalTermMonths ?? '—'} months
+                      {contract.endDate ? <> · current term ends {formatDate(contract.endDate)}</> : null}
+                      {contract.renewalNoticeDays != null ? <> · {contract.renewalNoticeDays}-day notice</> : null}
+                    </>
+                  ) : (
+                    <span className="text-muted-foreground">Does not auto-renew</span>
+                  )}
+                </dd>
+              </div>
               {/* Estimated value per billing period, from live device/seat counts. */}
               <div>
                 <dt className="text-xs uppercase text-muted-foreground">Est. / period</dt>

--- a/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
@@ -50,7 +50,8 @@ const draftDetail: ContractDetail = {
   contract: {
     id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status: 'draft',
     billingTiming: 'advance', intervalMonths: 1, startDate: '2026-06-01', endDate: null,
-    nextBillingAt: null, autoIssue: false, currencyCode: 'USD', notes: null, terms: null,
+    nextBillingAt: null, autoIssue: false, autoRenew: false, renewalTermMonths: null, renewalNoticeDays: null,
+    currencyCode: 'USD', notes: null, terms: null,
     createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
   },
   lines: [

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -399,7 +399,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
               <label className="flex flex-col gap-1 text-xs text-muted-foreground">
                 End date (optional)
                 <input
-                  type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)}
+                  type="date" value={endDate} onChange={(e) => { setEndDate(e.target.value); if (!e.target.value) setAutoRenew(false); }}
                   data-testid="contract-form-end"
                   className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 />

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
 import {
   createContract,
   updateContract,
@@ -71,6 +72,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   );
   const [endDate, setEndDate] = useState(contract?.endDate ?? '');
   const [autoIssue, setAutoIssue] = useState(contract?.autoIssue ?? false);
+  const [autoRenew, setAutoRenew] = useState<boolean>(contract?.autoRenew ?? false);
+  const [renewalTermMonths, setRenewalTermMonths] = useState<string>(contract?.renewalTermMonths != null ? String(contract.renewalTermMonths) : '');
+  const [renewalNoticeDays, setRenewalNoticeDays] = useState<string>(contract?.renewalNoticeDays != null ? String(contract.renewalNoticeDays) : '30');
   const [notes, setNotes] = useState(contract?.notes ?? '');
   const [terms, setTerms] = useState(contract?.terms ?? '');
   const [liveEstimate, setLiveEstimate] = useState<ContractEstimate | null>(null);
@@ -176,6 +180,10 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     if (busy || !canSaveHeader) return;
     setBusy(true);
     try {
+      if (autoRenew && !renewalTermMonths) {
+        showToast({ type: 'error', message: 'Enter a renewal term (months) before saving.' });
+        return;
+      }
       const result = await runAction<{ data: { id: string } }>({
         request: () => createContract({
           orgId,
@@ -185,6 +193,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           startDate,
           endDate: endDate || null,
           autoIssue,
+          autoRenew,
+          renewalTermMonths: autoRenew ? Number(renewalTermMonths) : null,
+          renewalNoticeDays: autoRenew ? (renewalNoticeDays === '' ? null : Number(renewalNoticeDays)) : null,
           notes: notes.trim() || null,
           terms: terms.trim() || null,
         }),
@@ -199,13 +210,17 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } finally {
       setBusy(false);
     }
-  }, [busy, canSaveHeader, orgId, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, notes, terms]);
+  }, [busy, canSaveHeader, orgId, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms]);
 
   // ---- edit flow -----------------------------------------------------------
   const saveHeader = useCallback(async () => {
     if (busy || !contract || !canSaveHeader) return;
     setBusy(true);
     try {
+      if (autoRenew && !renewalTermMonths) {
+        showToast({ type: 'error', message: 'Enter a renewal term (months) before saving.' });
+        return;
+      }
       await runAction({
         request: () => updateContract(contract.id, {
           name: name.trim(),
@@ -214,6 +229,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           startDate,
           endDate: endDate || null,
           autoIssue,
+          autoRenew,
+          renewalTermMonths: autoRenew ? Number(renewalTermMonths) : null,
+          renewalNoticeDays: autoRenew ? (renewalNoticeDays === '' ? null : Number(renewalNoticeDays)) : null,
           notes: notes.trim() || null,
           terms: terms.trim() || null,
         }),
@@ -227,7 +245,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } finally {
       setBusy(false);
     }
-  }, [busy, contract, canSaveHeader, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, notes, terms, refresh]);
+  }, [busy, contract, canSaveHeader, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms, refresh]);
 
   const addLine = useCallback(async () => {
     if (busy || !contract || !lineDesc.trim()) return;
@@ -393,6 +411,37 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                 />
                 Auto-issue generated invoices (otherwise they land as drafts)
               </label>
+              <div className="sm:col-span-2">
+                <label className="flex items-center gap-2 text-sm" data-testid="contract-auto-renew-toggle">
+                  <input
+                    type="checkbox" checked={autoRenew} disabled={!endDate}
+                    onChange={(e) => setAutoRenew(e.target.checked)}
+                  />
+                  <span>Auto-renew at end of term{!endDate ? ' (set an end date first)' : ''}</span>
+                </label>
+                {autoRenew && (
+                  <div className="mt-2 grid grid-cols-2 gap-3" data-testid="contract-renewal-fields">
+                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                      Renewal term (months)
+                      <input
+                        type="number" min={1} max={120} value={renewalTermMonths}
+                        onChange={(e) => setRenewalTermMonths(e.target.value)}
+                        data-testid="contract-renewal-term"
+                        className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                      Advance notice (days)
+                      <input
+                        type="number" min={0} max={365} value={renewalNoticeDays}
+                        onChange={(e) => setRenewalNoticeDays(e.target.value)}
+                        data-testid="contract-renewal-notice-days"
+                        className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </label>
+                  </div>
+                )}
+              </div>
               <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
                 Notes (optional)
                 <textarea

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -30,6 +30,9 @@ export interface ContractSummary {
   endDate: string | null;
   nextBillingAt: string | null;
   autoIssue: boolean;
+  autoRenew: boolean;
+  renewalTermMonths: number | null;
+  renewalNoticeDays: number | null;
   currencyCode: string;
   notes: string | null;
   terms: string | null;

--- a/docs/superpowers/plans/2026-06-21-contracts-auto-renew.md
+++ b/docs/superpowers/plans/2026-06-21-contracts-auto-renew.md
@@ -1,0 +1,1165 @@
+# Recurring Contracts — Auto-Renew + Renewal Notices Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MSP mark a fixed-term recurring contract as **auto-renewing**, so that when its term reaches `end_date` the contract rolls forward in place (term extended, billing uninterrupted) instead of expiring, and the MSP's own users receive an **advance renewal notice** (configurable lead time) plus a **renewal confirmation** — delivered both in-app and by email.
+
+**Architecture:** This is a pure *extension* of the shipped Recurring Contracts engine (PRs #1411/#1442). Three columns are added to `contracts` (`auto_renew`, `renewal_term_months`, `renewal_notice_days`) and one small idempotency-ledger table (`contract_renewal_notices`, `UNIQUE(contract_id, end_date, kind)`) is added — mirroring the bulletproof `contract_billing_periods` pattern. A new **renewal pre-pass** (`runContractRenewalSweep`) runs inside the existing daily `contract-jobs` worker *before* the billing sweep: it (a) emits advance notices for contracts inside their notice window, then (b) extends `end_date` for any auto-renew contract whose next billable period would otherwise trip the existing `isExpired` gate, emits a `contract.auto_renewed` event, and sends a renewal-confirmation notice. Because the extension runs before billing in the same sweep, a renewing contract never expires and the `contract_billing_periods` ledger stays continuous. Renewal mechanics are **extend-in-place** (no new contract rows, no proration). Notices target the **MSP only** (org + partner users with access) — no customer-facing email — reusing `sendInAppNotification()` and `getEmailService().sendEmail()`.
+
+**Tech Stack:** Hono + TypeScript (API), Drizzle ORM + PostgreSQL (RLS via `breeze_app`), BullMQ + Redis (daily sweep), Vitest (unit/RLS/integration), Zod (`@breeze/shared` validators), Astro + React islands (web).
+
+**Spec / lineage:** Roadmap item from `docs/superpowers/plans/2026-06-15-recurring-contracts.md` ("Deferred to v2 → Fixed-term + auto-renew with renewal notices"). The contracts engine, routes, web UI, and daily sweep already shipped; this plan adds only the auto-renew capability on top.
+
+## Global Constraints
+
+- **Node/tooling:** Prefix all `pnpm`/`vitest`/`tsx` commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (default node 23 breaks pnpm engine-strict). Fresh worktrees need `pnpm install`.
+- **API unit tests:** `cd apps/api && PATH=… pnpm exec vitest run <path>` (NOT `pnpm test -- <path>`, which runs the whole suite).
+- **Real-DB tests** (RLS forge, renewal-sweep integration) need a real `DATABASE_URL` and the gitignored `.env.test` symlink present in this worktree; confirm the DB role is **not** `BYPASSRLS` (`SELECT rolbypassrls FROM pg_roles WHERE rolname=current_user;` must be false) or forge/integration tests pass vacuously.
+- **Real-DB test placement:** real-DB tests MUST live in `apps/api/src/__tests__/integration/*.integration.test.ts` (the BLOCKING `Integration Tests` job; runs as `breeze_app`, autoMigrate + TRUNCATE-per-test, seed fresh per `it`). The unit `test-api` job has no `DATABASE_URL`, so `it.runIf(!!process.env.DATABASE_URL)` cases skip there.
+- **Migrations:** hand-written SQL under `apps/api/migrations/`, `YYYY-MM-DD-<slug>.sql`, idempotent (`IF NOT EXISTS` / `DO $$ … EXCEPTION`), no inner `BEGIN;`/`COMMIT;`, never edit a shipped migration. Applied by `autoMigrate` on boot/test-setup (there is no standalone `db:migrate`). New file: `2026-06-21-contracts-auto-renew.sql` (sorts after `2026-06-15-b-recurring-contracts.sql`).
+- **RLS:** the new `contract_renewal_notices` table is tenancy **shape 1** (direct `org_id`) — auto-discovered by rls-coverage, **no allowlist entry needed** — but RLS enabled+forced+policies must ship in the same migration, and a functional `breeze_app` cross-org forge test is the only thing that catches a missing axis.
+- **Cascade:** add `contract_renewal_notices` to `ORG_CASCADE_DELETE_ORDER` in `tenantCascade.ts`, **localeCompare-sorted** (it sorts right before `contracts`: `contract_billing_periods` < `contract_lines` < `contract_renewal_notices` < `contracts`).
+- **`@breeze/shared`** has no build step — typecheck with `pnpm --filter @breeze/shared exec tsc --noEmit`.
+- **`astro check`** (not plain `tsc`) is required to catch `.astro`/web type errors.
+- **Money/quantity** are fixed-2-decimal **strings** (`'150.00'`). Dates are ISO `YYYY-MM-DD` strings handled in UTC. `end_date` exclusive-of-term semantics: `isExpired` ⇔ `periodStart >= endDate`.
+- **Idempotency is mandatory** — the sweep runs daily; every notice and every extension is guarded so re-runs are no-ops (`contract_renewal_notices` unique claim for notices; the `isExpired` gate naturally bounds extension).
+- **Trigger the `Integration Tests` CI job** explicitly before merge (`gh workflow run ci.yml --ref <branch>`) — it is SKIPPED on `pull_request` and is the only job that runs tenantCascade + RLS forge.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/migrations/2026-06-21-contracts-auto-renew.sql` — `ALTER TABLE contracts ADD COLUMN` (×3) + `CREATE TABLE contract_renewal_notices` + indexes + RLS.
+- `apps/api/src/services/contractRenewal.ts` — the renewal pre-pass (`runContractRenewalSweep`), advance-notice + auto-extend logic, MSP recipient resolution, notice dispatch. Hub for this feature's impure logic.
+- `apps/api/src/services/contractRenewal.integration.test.ts` — local-only service tests (extend continuity, notice idempotency, opt-out). *(Note: local-only `*.integration.test.ts` next to source runs only with a local DB; the BLOCKING job runs `src/__tests__/integration/*`.)*
+- `apps/api/src/services/contractRenewalTemplate.ts` — `buildContractRenewalEmail(params)` → `{ subject, html, text }` (mirrors `buildInvoiceTemplate`).
+- `apps/api/src/services/contractRenewalTemplate.test.ts` — pure template unit tests.
+- `apps/api/src/__tests__/integration/contract-renewal-rls.integration.test.ts` — `breeze_app` cross-org forge for `contract_renewal_notices` (BLOCKING job).
+
+**Modify:**
+- `apps/api/src/db/schema/contracts.ts` — 3 new columns on `contracts`; new `contractRenewalNotices` table + `contractRenewalNoticeKindEnum`.
+- `apps/api/src/services/contractMath.ts` — add pure `addDaysISO`, `duePeriodStartFor`, `isWithinNoticeWindow`, `extendTermPastDue`.
+- `apps/api/src/services/contractMath.test.ts` — tests for the four new helpers.
+- `apps/api/src/services/contractEvents.ts` — extend `ContractEvent['type']` union with `'contract.auto_renewed'` and `'contract.renewal_notice'`.
+- `apps/api/src/jobs/contractWorker.ts` — run `runContractRenewalSweep()` before `runContractBillingSweep()` inside the `billing-sweep` job.
+- `apps/api/src/jobs/contractWorker.test.ts` — assert renewal runs before billing (if this file exists; otherwise add an integration test).
+- `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — forge block for `contract_renewal_notices`.
+- `apps/api/src/services/tenantCascade.ts` — add `contract_renewal_notices` to `ORG_CASCADE_DELETE_ORDER`.
+- `packages/shared/src/validators/contracts.ts` — `auto_renew`/`renewal_term_months`/`renewal_notice_days` on create + update schemas, with cross-field refinement.
+- `packages/shared/src/validators/contracts.test.ts` — validator cases (if this file exists; else create it).
+- `apps/web/src/lib/api/contracts.ts` — add the three fields to `ContractSummary`.
+- `apps/web/src/components/contracts/ContractEditor.tsx` — auto-renew toggle + term + notice-days inputs (shown when auto-renew is on).
+- `apps/web/src/components/contracts/ContractDetail.tsx` — read-only "Auto-renews / Renews on / Notice" panel.
+
+**Type vocabulary (used consistently across all tasks):**
+- `RenewalNoticeKind = 'advance' | 'renewed'`.
+- A contract is **auto-renewing** iff `auto_renew = true AND end_date IS NOT NULL AND renewal_term_months IS NOT NULL`. (Indefinite contracts — `end_date NULL` — never renew; the flag is inert.)
+- `renewal_term_months` (int > 0): months to push `end_date` forward per renewal. Stored explicitly because `end_date` moves on each renewal, so it cannot be re-derived from `end_date - start_date` after the first cycle.
+- `renewal_notice_days` (int ≥ 0, default 30): lead time for the advance notice.
+- `duePeriodStart`: the ISO start date of the period the billing sweep is about to bill — `advance` ⇒ `nextBillingAt`; `arrears` ⇒ `addMonthsClamped(nextBillingAt, -intervalMonths)`. The renewal extension gate is exactly `isExpired({ endDate, periodStart: duePeriodStart })`.
+
+---
+
+## Phase 1 — Schema, migration, RLS, cascade, validators
+
+Ships the data layer: three new `contracts` columns, the `contract_renewal_notices` idempotency ledger (RLS-forced), cascade + forge coverage, and the shared validators. After this phase `pnpm db:check-drift` is clean and the contracts API accepts the new fields.
+
+### Task 1.1: Drizzle schema — columns + ledger table
+
+**Files:**
+- Modify: `apps/api/src/db/schema/contracts.ts`
+
+- [ ] **Step 1: Add the three columns to the `contracts` table builder**
+
+In `apps/api/src/db/schema/contracts.ts`, inside the `contracts = pgTable('contracts', { … })` column object, add after `autoIssue`:
+
+```ts
+  autoRenew: boolean('auto_renew').notNull().default(false),
+  renewalTermMonths: integer('renewal_term_months'),
+  renewalNoticeDays: integer('renewal_notice_days'),
+```
+
+- [ ] **Step 2: Add the notice-kind enum + ledger table**
+
+At the top of the file, next to the existing contract enums, add:
+
+```ts
+export const contractRenewalNoticeKindEnum = pgEnum('contract_renewal_notice_kind', [
+  'advance', 'renewed'
+]);
+```
+
+After the `contractBillingPeriods` table definition, add:
+
+```ts
+export const contractRenewalNotices = pgTable('contract_renewal_notices', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  contractId: uuid('contract_id').notNull().references(() => contracts.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  // The end_date the notice pertains to. For 'advance' this is the term about to lapse;
+  // for 'renewed' this is the NEW end_date after extension. (contract_id, end_date, kind)
+  // is UNIQUE — that triple is the once-per-term idempotency key.
+  endDate: date('end_date').notNull(),
+  kind: contractRenewalNoticeKindEnum('kind').notNull(),
+  sentAt: timestamp('sent_at').defaultNow().notNull()
+}, (t) => [
+  uniqueIndex('contract_renewal_notices_uq').on(t.contractId, t.endDate, t.kind),
+  index('contract_renewal_notices_org_idx').on(t.orgId)
+]);
+```
+
+Confirm `pgEnum`, `date`, and `uniqueIndex` are already imported at the top of the file (they are used by the existing tables); add any that are missing.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec tsc --noEmit`
+Expected: PASS (no new errors from `contracts.ts`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/db/schema/contracts.ts
+git commit -m "feat(contracts): schema for auto-renew columns + renewal-notice ledger"
+```
+
+### Task 1.2: SQL migration
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-21-contracts-auto-renew.sql`
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-21-contracts-auto-renew.sql`:
+
+```sql
+-- Contracts auto-renew + renewal notices. Idempotent throughout.
+-- Sorts after 2026-06-15-b-recurring-contracts.sql (contracts table already exists).
+
+-- 1. New columns on contracts.
+ALTER TABLE contracts ADD COLUMN IF NOT EXISTS auto_renew BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE contracts ADD COLUMN IF NOT EXISTS renewal_term_months INTEGER;
+ALTER TABLE contracts ADD COLUMN IF NOT EXISTS renewal_notice_days INTEGER;
+DO $$ BEGIN
+  ALTER TABLE contracts ADD CONSTRAINT contracts_renewal_term_months_positive
+    CHECK (renewal_term_months IS NULL OR renewal_term_months > 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE contracts ADD CONSTRAINT contracts_renewal_notice_days_nonneg
+    CHECK (renewal_notice_days IS NULL OR renewal_notice_days >= 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- 2. Notice-kind enum + idempotency-ledger table.
+DO $$ BEGIN
+  CREATE TYPE contract_renewal_notice_kind AS ENUM ('advance','renewed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS contract_renewal_notices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_id UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  end_date DATE NOT NULL,
+  kind contract_renewal_notice_kind NOT NULL,
+  sent_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS contract_renewal_notices_uq
+  ON contract_renewal_notices (contract_id, end_date, kind);
+CREATE INDEX IF NOT EXISTS contract_renewal_notices_org_idx
+  ON contract_renewal_notices (org_id);
+
+-- 3. RLS: shape 1 (direct org_id).
+ALTER TABLE contract_renewal_notices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE contract_renewal_notices FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON contract_renewal_notices;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON contract_renewal_notices;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON contract_renewal_notices;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON contract_renewal_notices;
+CREATE POLICY breeze_org_isolation_select ON contract_renewal_notices
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON contract_renewal_notices
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON contract_renewal_notices
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON contract_renewal_notices
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+```
+
+- [ ] **Step 2: Apply migration & verify no drift**
+
+Run:
+```bash
+cd /Users/toddhebebrand/breeze/.claude/worktrees/contracts-web-ui-p5
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm db:check-drift
+```
+Expected: **no drift** between `apps/api/src/db/schema/*` and the migrated DB. (If the migration hasn't applied yet, boot the API once against the dev DB — autoMigrate applies pending files — then re-run.)
+
+- [ ] **Step 3: Verify migration-ordering regression test passes**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/db/autoMigrate.test.ts`
+Expected: PASS (confirms `2026-06-21-…` sorts after `2026-06-15-b-…`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-21-contracts-auto-renew.sql
+git commit -m "feat(contracts): migration — auto-renew columns + renewal-notice ledger + RLS"
+```
+
+### Task 1.3: tenantCascade ordering
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts`
+
+- [ ] **Step 1: Add `contract_renewal_notices` to `ORG_CASCADE_DELETE_ORDER`**
+
+In `apps/api/src/services/tenantCascade.ts`, add the entry to `ORG_CASCADE_DELETE_ORDER` in its localeCompare slot — immediately **before** `'contracts'` and after `'contract_lines'`:
+
+```ts
+  'contract_lines',
+  'contract_renewal_notices',
+  'contracts',
+```
+
+(`contract_billing_periods` < `contract_lines` < `contract_renewal_notices` < `contracts`; verify the surrounding entries match this ordering. The list-contract test in the BLOCKING `Integration Tests` job enforces the sort.)
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec tsc --noEmit`
+Expected: PASS.
+
+```bash
+git add apps/api/src/services/tenantCascade.ts
+git commit -m "feat(contracts): add contract_renewal_notices to org cascade-delete order"
+```
+
+### Task 1.4: RLS coverage forge tests
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`
+- Create: `apps/api/src/__tests__/integration/contract-renewal-rls.integration.test.ts`
+
+`contract_renewal_notices` is shape 1 (direct `org_id`) and auto-discovered — **no allowlist entry needed**. Add a functional `breeze_app` cross-org forge (only this catches a missing axis).
+
+- [ ] **Step 1: Confirm schema imports in rls-coverage test**
+
+In `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`, confirm `contractRenewalNotices` is importable from the schema; add it to the schema import alongside `contracts` / `contractLines` if missing. (The file already imports `partners`, `organizations`, `db`, `withSystemDbAccessContext`, `withDbAccessContext`, `eq`.)
+
+- [ ] **Step 2: Write the forge block**
+
+Create `apps/api/src/__tests__/integration/contract-renewal-rls.integration.test.ts`. Re-seed fixtures per the repo's "never memoize the fixture" lesson (TRUNCATE-per-test wipes module-scope fixtures), and gate every real-DB case on `DATABASE_URL`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { db, withSystemDbAccessContext, withDbAccessContext } from '../../db';
+import { partners, organizations, contracts, contractRenewalNotices } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+
+function orgContext(orgId: string) {
+  return { scope: 'organization' as const, orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null };
+}
+
+async function seed() {
+  const sfx = Math.random().toString(36).slice(2, 8);
+  return withSystemDbAccessContext(async () => {
+    const [p] = await db.insert(partners).values({
+      name: `RN Partner ${sfx}`, slug: `rn-${sfx}`, type: 'msp', plan: 'pro', status: 'active'
+    }).returning({ id: partners.id });
+    const [orgA, orgB] = await db.insert(organizations).values([
+      { partnerId: p!.id, name: 'RN Org A', slug: `rn-a-${sfx}` },
+      { partnerId: p!.id, name: 'RN Org B', slug: `rn-b-${sfx}` }
+    ]).returning({ id: organizations.id });
+    const [c] = await db.insert(contracts).values({
+      partnerId: p!.id, orgId: orgA!.id, name: 'rn', status: 'active',
+      intervalMonths: 1, startDate: '2026-07-01', endDate: '2027-07-01',
+      autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: 30
+    }).returning({ id: contracts.id });
+    return { partnerId: p!.id, orgAId: orgA!.id, orgBId: orgB!.id, contractId: c!.id };
+  });
+}
+
+describe('contract_renewal_notices RLS forge (shape 1, org-axis)', () => {
+  it.runIf(!!process.env.DATABASE_URL)('org B INSERT with org A org_id is rejected by WITH CHECK', async () => {
+    const { orgAId, orgBId, contractId } = await seed();
+    let caught: unknown;
+    try {
+      await withDbAccessContext(orgContext(orgBId), async () =>
+        db.insert(contractRenewalNotices).values({
+          contractId, orgId: orgAId, endDate: '2027-07-01', kind: 'advance'
+        })
+      );
+    } catch (err) { caught = err; }
+    expect(caught).toBeDefined();
+    const c = caught as { cause?: { message?: string }; message?: string } | undefined;
+    const message = c?.cause?.message ?? c?.message ?? '';
+    expect(message).toMatch(/new row violates row-level security policy for table "contract_renewal_notices"/);
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)("org B cannot SELECT org A's renewal notice", async () => {
+    const { orgAId, orgBId, contractId } = await seed();
+    let id = '';
+    await withSystemDbAccessContext(async () => {
+      const [row] = await db.insert(contractRenewalNotices).values({
+        contractId, orgId: orgAId, endDate: '2027-07-01', kind: 'renewed'
+      }).returning({ id: contractRenewalNotices.id });
+      id = row!.id;
+    });
+    const visible = await withDbAccessContext(orgContext(orgBId), async () =>
+      db.select({ id: contractRenewalNotices.id }).from(contractRenewalNotices).where(eq(contractRenewalNotices.id, id))
+    );
+    expect(visible).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 3: Add a coverage-scan presence check (rls-coverage file)**
+
+In `rls-coverage.integration.test.ts`, no allowlist change is required (shape 1). Just run the full coverage contract test to confirm the scanner finds RLS enabled+forced on the new table.
+
+- [ ] **Step 4: Run forge + coverage**
+
+Run:
+```bash
+cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH \
+  DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" \
+  pnpm exec vitest run --config vitest.config.rls-coverage.ts \
+  src/__tests__/integration/rls-coverage.integration.test.ts \
+  src/__tests__/integration/contract-renewal-rls.integration.test.ts
+```
+Expected: PASS — coverage scan finds RLS on `contract_renewal_notices`; forge rejects cross-org insert and returns empty cross-org select. If a case passes vacuously, confirm the DB role is not `BYPASSRLS` and `.env.test` symlink exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/contract-renewal-rls.integration.test.ts apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "test(contracts): RLS cross-org forge for contract_renewal_notices"
+```
+
+### Task 1.5: Shared Zod validators
+
+**Files:**
+- Modify: `packages/shared/src/validators/contracts.ts`
+- Modify/Create: `packages/shared/src/validators/contracts.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `packages/shared/src/validators/contracts.test.ts` (create the file with the standard `import { describe, it, expect } from 'vitest'` + `import { createContractSchema, updateContractSchema } from './contracts';` header if it does not exist):
+
+```ts
+describe('auto-renew fields', () => {
+  const base = {
+    orgId: '11111111-1111-1111-1111-111111111111',
+    name: 'Acme', billingTiming: 'advance' as const, intervalMonths: 1, startDate: '2026-07-01'
+  };
+  it('accepts a fixed-term auto-renew contract', () => {
+    const r = createContractSchema.safeParse({
+      ...base, endDate: '2027-07-01', autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: 30
+    });
+    expect(r.success).toBe(true);
+  });
+  it('rejects autoRenew without an endDate (cannot renew an indefinite contract)', () => {
+    const r = createContractSchema.safeParse({ ...base, autoRenew: true, renewalTermMonths: 12 });
+    expect(r.success).toBe(false);
+  });
+  it('rejects autoRenew without a renewalTermMonths', () => {
+    const r = createContractSchema.safeParse({ ...base, endDate: '2027-07-01', autoRenew: true });
+    expect(r.success).toBe(false);
+  });
+  it('rejects renewalTermMonths < 1', () => {
+    const r = createContractSchema.safeParse({
+      ...base, endDate: '2027-07-01', autoRenew: true, renewalTermMonths: 0
+    });
+    expect(r.success).toBe(false);
+  });
+  it('allows clearing auto-renew on update', () => {
+    expect(updateContractSchema.safeParse({ autoRenew: false }).success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/validators/contracts.test.ts`
+Expected: FAIL (new fields not yet on the schema).
+
+- [ ] **Step 3: Add the fields + refinement**
+
+In `packages/shared/src/validators/contracts.ts`, add to the `createContractSchema` object (before the closing `})`):
+
+```ts
+  autoRenew: z.boolean().optional(),
+  renewalTermMonths: z.number().int().min(1).max(120).nullable().optional(),
+  renewalNoticeDays: z.number().int().min(0).max(365).nullable().optional(),
+```
+
+Then add a `.refine` after the existing `endDate` refinement:
+
+```ts
+.refine(
+  (c) => !c.autoRenew || (c.endDate != null && c.renewalTermMonths != null),
+  { message: 'auto-renew requires both endDate and renewalTermMonths', path: ['autoRenew'] }
+)
+```
+
+Add the same three optional fields to `updateContractSchema`:
+
+```ts
+  autoRenew: z.boolean().optional(),
+  renewalTermMonths: z.number().int().min(1).max(120).nullable().optional(),
+  renewalNoticeDays: z.number().int().min(0).max(365).nullable().optional(),
+```
+
+> Note: `updateContractSchema` is a bare object (no cross-field refine today). A partial update can set `autoRenew:true` without re-sending `endDate`; the **service** (Task 3.4 / existing `updateContract`) must re-validate the post-merge invariant against the persisted row. Add that guard where `updateContract` applies the patch: after merging, if the resulting row has `auto_renew = true` then `end_date` and `renewal_term_months` must both be non-null, else throw `ContractServiceError('auto-renew requires an end date and renewal term', 400)`.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd packages/shared && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/validators/contracts.test.ts`
+Expected: PASS.
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/contracts.ts packages/shared/src/validators/contracts.test.ts
+git commit -m "feat(contracts): validators for auto-renew fields (TDD)"
+```
+
+---
+
+## Phase 2 — Pure renewal math (TDD)
+
+Four pure, DB-free helpers on `contractMath.ts`. Fast unit tests, no fixtures.
+
+### Task 2.1: Date + renewal helpers
+
+**Files:**
+- Modify: `apps/api/src/services/contractMath.ts`
+- Modify: `apps/api/src/services/contractMath.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `apps/api/src/services/contractMath.test.ts`:
+
+```ts
+import { addDaysISO, duePeriodStartFor, isWithinNoticeWindow, extendTermPastDue } from './contractMath';
+
+describe('addDaysISO', () => {
+  it('adds and subtracts days across month/year boundaries (UTC)', () => {
+    expect(addDaysISO('2026-07-01', -30)).toBe('2026-06-01');
+    expect(addDaysISO('2026-12-31', 1)).toBe('2027-01-01');
+    expect(addDaysISO('2028-02-28', 1)).toBe('2028-02-29'); // leap
+  });
+});
+
+describe('duePeriodStartFor', () => {
+  it('advance ⇒ nextBillingAt itself', () => {
+    expect(duePeriodStartFor('advance', '2027-07-01', 1)).toBe('2027-07-01');
+  });
+  it('arrears ⇒ nextBillingAt minus one interval', () => {
+    expect(duePeriodStartFor('arrears', '2027-08-01', 1)).toBe('2027-07-01');
+    expect(duePeriodStartFor('arrears', '2027-10-01', 3)).toBe('2027-07-01');
+  });
+});
+
+describe('isWithinNoticeWindow', () => {
+  it('true inside [endDate - noticeDays, endDate)', () => {
+    expect(isWithinNoticeWindow('2026-06-15', '2026-07-01', 30)).toBe(true); // 16 days out
+    expect(isWithinNoticeWindow('2026-06-01', '2026-07-01', 30)).toBe(true); // exactly at window start
+  });
+  it('false before the window and on/after endDate', () => {
+    expect(isWithinNoticeWindow('2026-05-31', '2026-07-01', 30)).toBe(false);
+    expect(isWithinNoticeWindow('2026-07-01', '2026-07-01', 30)).toBe(false);
+  });
+});
+
+describe('extendTermPastDue', () => {
+  it('pushes endDate forward by whole terms until the due period no longer expires', () => {
+    // due period starts exactly at endDate ⇒ one 12-month roll
+    expect(extendTermPastDue({ endDate: '2027-07-01', duePeriodStart: '2027-07-01', termMonths: 12 }))
+      .toEqual({ newEndDate: '2028-07-01', renewed: true });
+  });
+  it('catches up multiple terms when the sweep was down (term < gap)', () => {
+    // due period is 2 months past a 1-month term ⇒ rolls 3 times to clear it
+    expect(extendTermPastDue({ endDate: '2027-07-01', duePeriodStart: '2027-09-01', termMonths: 1 }))
+      .toEqual({ newEndDate: '2027-10-01', renewed: true });
+  });
+  it('no-op when the due period is still inside the term', () => {
+    expect(extendTermPastDue({ endDate: '2027-07-01', duePeriodStart: '2027-06-01', termMonths: 12 }))
+      .toEqual({ newEndDate: '2027-07-01', renewed: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/services/contractMath.test.ts`
+Expected: FAIL (helpers not exported).
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `apps/api/src/services/contractMath.ts` (reuses the file's existing `addMonthsClamped`, `isExpired`, and UTC `parts`/`fmt` helpers):
+
+```ts
+import type { BillingTiming } from './contractTypes';
+
+/** Add (or subtract) whole days to an ISO YYYY-MM-DD date, in UTC. */
+export function addDaysISO(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d + days));
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${dt.getUTCFullYear()}-${mm}-${dd}`;
+}
+
+/** ISO start of the period the billing sweep is about to bill. */
+export function duePeriodStartFor(billingTiming: BillingTiming, nextBillingAt: string, intervalMonths: number): string {
+  return billingTiming === 'advance' ? nextBillingAt : addMonthsClamped(nextBillingAt, -intervalMonths);
+}
+
+/** True when asOf is in [endDate - noticeDays, endDate). */
+export function isWithinNoticeWindow(asOf: string, endDate: string, noticeDays: number): boolean {
+  const windowStart = addDaysISO(endDate, -noticeDays);
+  return asOf >= windowStart && asOf < endDate;
+}
+
+/** Roll endDate forward by whole terms until the due period no longer trips isExpired. */
+export function extendTermPastDue(input: { endDate: string; duePeriodStart: string; termMonths: number }):
+  { newEndDate: string; renewed: boolean } {
+  let endDate = input.endDate;
+  let renewed = false;
+  let guard = 0;
+  while (isExpired({ endDate, periodStart: input.duePeriodStart })) {
+    endDate = addMonthsClamped(endDate, input.termMonths);
+    renewed = true;
+    if (++guard > 100000) break; // runaway guard (mirrors periodIndexFor)
+  }
+  return { newEndDate: endDate, renewed };
+}
+```
+
+> If `contractMath.ts` already imports from `./contractTypes`, merge the `BillingTiming` import into the existing import line rather than adding a duplicate.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/services/contractMath.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/contractMath.ts apps/api/src/services/contractMath.test.ts
+git commit -m "feat(contracts): pure renewal/date math helpers (TDD)"
+```
+
+---
+
+## Phase 3 — Renewal service, email template, events
+
+The core. A renewal pre-pass that emits advance notices and extends terms in place, idempotent via the ledger, dispatching MSP-only in-app + email notices.
+
+### Task 3.1: Extend the contract event union
+
+**Files:**
+- Modify: `apps/api/src/services/contractEvents.ts`
+
+- [ ] **Step 1: Add the two event types**
+
+In `apps/api/src/services/contractEvents.ts`, change the `type` union of `ContractEvent` to include the renewal events:
+
+```ts
+  type: 'contract.activated' | 'contract.invoiced' | 'contract.paused' | 'contract.cancelled' | 'contract.expired'
+      | 'contract.auto_renewed' | 'contract.renewal_notice';
+```
+
+(The bus is still an intentionally-unconsumed reserved queue — these events are emitted for the future webhook/notification worker. Delivery in this plan is direct, via Task 3.4, not via a consumer of this queue.)
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec tsc --noEmit`
+Expected: PASS.
+
+```bash
+git add apps/api/src/services/contractEvents.ts
+git commit -m "feat(contracts): add auto_renewed + renewal_notice event types"
+```
+
+### Task 3.2: Renewal email template
+
+**Files:**
+- Create: `apps/api/src/services/contractRenewalTemplate.ts`
+- Create: `apps/api/src/services/contractRenewalTemplate.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `apps/api/src/services/contractRenewalTemplate.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildContractRenewalEmail } from './contractRenewalTemplate';
+
+describe('buildContractRenewalEmail', () => {
+  const base = { contractName: 'Acme Managed Services', orgName: 'Acme Inc', endDate: '2027-07-01', contractUrl: 'https://app/contracts/abc' };
+
+  it('advance notice names the contract, org, and date and has a plain-text fallback', () => {
+    const out = buildContractRenewalEmail({ ...base, kind: 'advance', noticeDays: 30 });
+    expect(out.subject).toMatch(/renew/i);
+    expect(out.subject).toContain('Acme Managed Services');
+    expect(out.html).toContain('Acme Inc');
+    expect(out.html).toContain('2027-07-01');
+    expect(out.text).toContain('Acme Managed Services');
+    expect(out.text.length).toBeGreaterThan(0);
+  });
+
+  it('renewed confirmation states the new term end date', () => {
+    const out = buildContractRenewalEmail({ ...base, kind: 'renewed', endDate: '2028-07-01' });
+    expect(out.subject).toMatch(/renewed/i);
+    expect(out.html).toContain('2028-07-01');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/services/contractRenewalTemplate.test.ts`
+Expected: FAIL ("Cannot find module './contractRenewalTemplate'").
+
+- [ ] **Step 3: Implement the template**
+
+Create `apps/api/src/services/contractRenewalTemplate.ts`, reusing the shared email layout helpers (open `apps/api/src/services/email.ts` and `emailLayout.ts` to confirm the exact exported names — `renderLayout` / `renderButton` / `supportFooter` per the invoice template; if a name differs, use the actual one):
+
+```ts
+import { renderLayout, renderButton } from './emailLayout';
+
+export interface ContractRenewalEmailParams {
+  kind: 'advance' | 'renewed';
+  contractName: string;
+  orgName: string;
+  endDate: string;       // advance: term about to lapse; renewed: the new term end
+  contractUrl: string;
+  noticeDays?: number;   // advance only
+}
+
+export interface ContractRenewalEmail { subject: string; html: string; text: string; }
+
+export function buildContractRenewalEmail(p: ContractRenewalEmailParams): ContractRenewalEmail {
+  if (p.kind === 'advance') {
+    const subject = `Contract "${p.contractName}" renews on ${p.endDate}`;
+    const lead = `The contract "${p.contractName}" for ${p.orgName} is set to auto-renew on ${p.endDate}` +
+      `${p.noticeDays != null ? ` (${p.noticeDays}-day notice)` : ''}. No action is needed to renew. ` +
+      `To stop the renewal, turn off auto-renew before that date.`;
+    const html = renderLayout({
+      title: 'Upcoming contract renewal',
+      body: `<p>${lead}</p>${renderButton('View contract', p.contractUrl)}`
+    });
+    const text = `${lead}\n\nView contract: ${p.contractUrl}`;
+    return { subject, html, text };
+  }
+  const subject = `Contract "${p.contractName}" renewed through ${p.endDate}`;
+  const lead = `The contract "${p.contractName}" for ${p.orgName} has auto-renewed. ` +
+    `Its term now runs through ${p.endDate} and billing continues uninterrupted.`;
+  const html = renderLayout({
+    title: 'Contract renewed',
+    body: `<p>${lead}</p>${renderButton('View contract', p.contractUrl)}`
+  });
+  const text = `${lead}\n\nView contract: ${p.contractUrl}`;
+  return { subject, html, text };
+}
+```
+
+> `renderLayout`/`renderButton` parameter shapes vary — match the signatures actually used by `buildInvoiceTemplate` in `email.ts`. The test only asserts on `subject`/`html`/`text` content, so adapt the layout calls to whatever the real helpers expect while keeping the asserted strings present.
+
+- [ ] **Step 4: Run tests + commit**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/services/contractRenewalTemplate.test.ts`
+Expected: PASS.
+
+```bash
+git add apps/api/src/services/contractRenewalTemplate.ts apps/api/src/services/contractRenewalTemplate.test.ts
+git commit -m "feat(contracts): renewal email template (advance + renewed)"
+```
+
+### Task 3.3: Renewal service — sweep, extend, notices
+
+**Files:**
+- Create: `apps/api/src/services/contractRenewal.ts`
+- Create: `apps/api/src/services/contractRenewal.integration.test.ts` (local-only — runs with a local DB; see note in File Structure)
+
+This service assumes it is called **inside** a system DB-access context (the worker wraps it, exactly like `generateDueInvoice`). All DB calls use the ambient context — do not open a bare pool.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `apps/api/src/services/contractRenewal.integration.test.ts`. Seed a fixed-term auto-renew contract whose next bill lands at the term boundary, run the sweep, and assert the term extended, a `renewed` notice was logged, and a second run is a no-op:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { partners, organizations, contracts, contractLines, contractRenewalNotices } from '../db/schema';
+import { eq, and } from 'drizzle-orm';
+import { runContractRenewalSweep } from './contractRenewal';
+
+async function seedAutoRenew(opts: { nextBillingAt: string; endDate: string; noticeDays?: number }) {
+  const sfx = Math.random().toString(36).slice(2, 8);
+  return withSystemDbAccessContext(async () => {
+    const [p] = await db.insert(partners).values({ name: `R ${sfx}`, slug: `r-${sfx}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [o] = await db.insert(organizations).values({ partnerId: p!.id, name: 'ROrg', slug: `ro-${sfx}` }).returning({ id: organizations.id });
+    const [c] = await db.insert(contracts).values({
+      partnerId: p!.id, orgId: o!.id, name: 'Renew Me', status: 'active', billingTiming: 'advance',
+      intervalMonths: 1, startDate: '2026-07-01', endDate: opts.endDate, nextBillingAt: opts.nextBillingAt,
+      autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: opts.noticeDays ?? 30
+    }).returning({ id: contracts.id });
+    await db.insert(contractLines).values({ contractId: c!.id, orgId: o!.id, lineType: 'flat', description: 'svc', unitPrice: '500.00' });
+    return { orgId: o!.id, contractId: c!.id };
+  });
+}
+
+describe('runContractRenewalSweep', () => {
+  it.runIf(!!process.env.DATABASE_URL)('extends the term when the next bill would expire, logs a renewed notice, idempotent', async () => {
+    // Next bill lands exactly at endDate ⇒ would expire ⇒ must renew first.
+    const { contractId } = await seedAutoRenew({ nextBillingAt: '2027-07-01', endDate: '2027-07-01' });
+
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-07-01T05:00:00Z'))));
+
+    const [after] = await withSystemDbAccessContext(() =>
+      db.select({ endDate: contracts.endDate, status: contracts.status }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(after.endDate).toBe('2028-07-01');
+    expect(after.status).toBe('active');
+
+    const renewed = await withSystemDbAccessContext(() =>
+      db.select().from(contractRenewalNotices).where(and(eq(contractRenewalNotices.contractId, contractId), eq(contractRenewalNotices.kind, 'renewed'))));
+    expect(renewed).toHaveLength(1);
+
+    // Second run: no further extension, no duplicate notice.
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-07-01T05:00:00Z'))));
+    const [after2] = await withSystemDbAccessContext(() =>
+      db.select({ endDate: contracts.endDate }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(after2.endDate).toBe('2028-07-01');
+    const renewed2 = await withSystemDbAccessContext(() =>
+      db.select().from(contractRenewalNotices).where(and(eq(contractRenewalNotices.contractId, contractId), eq(contractRenewalNotices.kind, 'renewed'))));
+    expect(renewed2).toHaveLength(1);
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)('emits a single advance notice inside the window and does not extend', async () => {
+    // 16 days before endDate; not yet at the billing boundary.
+    const { contractId } = await seedAutoRenew({ nextBillingAt: '2027-08-01', endDate: '2027-07-15' });
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-06-29T05:00:00Z'))));
+    const advance = await withSystemDbAccessContext(() =>
+      db.select().from(contractRenewalNotices).where(and(eq(contractRenewalNotices.contractId, contractId), eq(contractRenewalNotices.kind, 'advance'))));
+    expect(advance).toHaveLength(1);
+    const [c] = await withSystemDbAccessContext(() => db.select({ endDate: contracts.endDate }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(c.endDate).toBe('2027-07-15'); // unchanged
+  });
+
+  it.runIf(!!process.env.DATABASE_URL)('does nothing for a contract with auto_renew = false', async () => {
+    const { contractId } = await seedAutoRenew({ nextBillingAt: '2027-07-01', endDate: '2027-07-01' });
+    await withSystemDbAccessContext(() => db.update(contracts).set({ autoRenew: false }).where(eq(contracts.id, contractId)));
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(new Date('2027-07-01T05:00:00Z'))));
+    const [c] = await withSystemDbAccessContext(() => db.select({ endDate: contracts.endDate }).from(contracts).where(eq(contracts.id, contractId)));
+    expect(c.endDate).toBe('2027-07-01'); // not extended — billing sweep will expire it normally
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm exec vitest run src/services/contractRenewal.integration.test.ts`
+Expected: FAIL ("Cannot find module './contractRenewal'").
+
+- [ ] **Step 3: Implement the renewal service**
+
+Create `apps/api/src/services/contractRenewal.ts`. Resolve MSP recipients by mirroring the query in `apps/api/src/services/notificationSenders/inAppSender.ts` (active org users + active partner users with access to the org). Read that file to copy the exact join/`orgAccess` predicate.
+
+```ts
+import { and, eq, isNotNull, or, sql } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  contracts, contractRenewalNotices, organizations, organizationUsers, partnerUsers, users
+} from '../db/schema';
+import { emitContractEvent } from './contractEvents';
+import { sendInAppNotification } from './notificationSenders/inAppSender';
+import { getEmailService } from './email';
+import { buildContractRenewalEmail } from './contractRenewalTemplate';
+import { duePeriodStartFor, extendTermPastDue, isWithinNoticeWindow } from './contractMath';
+import { captureException } from './sentry';
+
+const WEB_BASE = process.env.PUBLIC_WEB_URL ?? '';
+
+interface RenewalCandidate {
+  id: string; orgId: string; partnerId: string; name: string;
+  billingTiming: 'advance' | 'arrears'; intervalMonths: number;
+  endDate: string | null; nextBillingAt: string | null;
+  autoRenew: boolean; renewalTermMonths: number | null; renewalNoticeDays: number | null;
+}
+
+/** Resolve the MSP's notifiable users (active org users + active partner users with access). */
+async function resolveMspRecipients(orgId: string, partnerId: string): Promise<{ userId: string; email: string }[]> {
+  const orgUsers = await db.select({ userId: organizationUsers.userId, email: users.email })
+    .from(organizationUsers).innerJoin(users, eq(organizationUsers.userId, users.id))
+    .where(and(eq(organizationUsers.orgId, orgId), eq(users.status, 'active')));
+  const pUsers = await db.select({ userId: partnerUsers.userId, email: users.email })
+    .from(partnerUsers).innerJoin(users, eq(partnerUsers.userId, users.id))
+    .where(and(
+      eq(partnerUsers.partnerId, partnerId), eq(users.status, 'active'),
+      or(eq(partnerUsers.orgAccess, 'all'),
+         and(eq(partnerUsers.orgAccess, 'selected'), sql`${orgId} = ANY(${partnerUsers.orgIds})`))
+    ));
+  const byId = new Map<string, string>();
+  for (const u of [...orgUsers, ...pUsers]) if (u.email) byId.set(u.userId, u.email);
+  return [...byId.entries()].map(([userId, email]) => ({ userId, email }));
+}
+
+/** Claim a (contract, end_date, kind) notice slot. Returns true iff this caller won the claim. */
+async function claimNotice(c: RenewalCandidate, endDate: string, kind: 'advance' | 'renewed'): Promise<boolean> {
+  const rows = await db.insert(contractRenewalNotices)
+    .values({ contractId: c.id, orgId: c.orgId, endDate, kind })
+    .onConflictDoNothing({ target: [contractRenewalNotices.contractId, contractRenewalNotices.endDate, contractRenewalNotices.kind] })
+    .returning({ id: contractRenewalNotices.id });
+  return rows.length > 0;
+}
+
+/** Best-effort dispatch: in-app to MSP users + email to MSP users. Never throws. */
+async function dispatchNotice(c: RenewalCandidate, kind: 'advance' | 'renewed', endDate: string): Promise<void> {
+  try {
+    const [org] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, c.orgId)).limit(1);
+    const orgName = org?.name ?? 'your customer';
+    const contractUrl = `${WEB_BASE}/contracts/${c.id}`;
+    const summary = kind === 'advance'
+      ? `Contract "${c.name}" for ${orgName} auto-renews on ${endDate}.`
+      : `Contract "${c.name}" for ${orgName} auto-renewed through ${endDate}.`;
+
+    await sendInAppNotification({
+      alertId: `contract-renewal-${c.id}-${endDate}-${kind}`,
+      alertName: kind === 'advance' ? 'Contract renewal upcoming' : 'Contract renewed',
+      severity: 'info', message: summary, orgId: c.orgId, link: `/contracts/${c.id}`
+    });
+
+    const emailService = getEmailService();
+    if (emailService) {
+      const recipients = await resolveMspRecipients(c.orgId, c.partnerId);
+      if (recipients.length > 0) {
+        const tpl = buildContractRenewalEmail({
+          kind, contractName: c.name, orgName, endDate, contractUrl,
+          noticeDays: kind === 'advance' ? (c.renewalNoticeDays ?? undefined) : undefined
+        });
+        await emailService.sendEmail({ to: recipients.map((r) => r.email), subject: tpl.subject, html: tpl.html, text: tpl.text });
+      }
+    }
+  } catch (err) {
+    console.error('[ContractRenewal] notice dispatch failed', `contractId=${c.id}`, err instanceof Error ? err.message : err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+/**
+ * Renewal pre-pass. Runs (inside a system DB context) BEFORE the billing sweep so an
+ * about-to-expire auto-renew contract has its term extended before billing decides expiry.
+ *  Pass A: advance notice for contracts inside their notice window.
+ *  Pass B: extend the term for contracts whose next billable period would expire, then confirm.
+ */
+export async function runContractRenewalSweep(asOf: Date = new Date()): Promise<{ noticed: number; renewed: number }> {
+  const today = asOf.toISOString().slice(0, 10);
+
+  const candidates = await db.select({
+    id: contracts.id, orgId: contracts.orgId, partnerId: contracts.partnerId, name: contracts.name,
+    billingTiming: contracts.billingTiming, intervalMonths: contracts.intervalMonths,
+    endDate: contracts.endDate, nextBillingAt: contracts.nextBillingAt,
+    autoRenew: contracts.autoRenew, renewalTermMonths: contracts.renewalTermMonths, renewalNoticeDays: contracts.renewalNoticeDays
+  }).from(contracts).where(and(eq(contracts.status, 'active' as never), eq(contracts.autoRenew, true), isNotNull(contracts.endDate)));
+
+  let noticed = 0;
+  let renewed = 0;
+
+  for (const c of candidates as RenewalCandidate[]) {
+    if (!c.endDate || c.renewalTermMonths == null) continue;
+
+    // Pass A — advance notice (based on the CURRENT end_date).
+    const noticeDays = c.renewalNoticeDays ?? 30;
+    if (isWithinNoticeWindow(today, c.endDate, noticeDays)) {
+      if (await claimNotice(c, c.endDate, 'advance')) {
+        await dispatchNotice(c, 'advance', c.endDate);
+        noticed++;
+      }
+    }
+
+    // Pass B — extend if the next billable period would expire.
+    if (c.nextBillingAt) {
+      const duePeriodStart = duePeriodStartFor(c.billingTiming, c.nextBillingAt, c.intervalMonths);
+      const { newEndDate, renewed: didRenew } = extendTermPastDue({ endDate: c.endDate, duePeriodStart, termMonths: c.renewalTermMonths });
+      if (didRenew) {
+        await db.update(contracts).set({ endDate: newEndDate, updatedAt: asOf }).where(eq(contracts.id, c.id));
+        await emitContractEvent({ type: 'contract.auto_renewed', contractId: c.id, orgId: c.orgId, partnerId: c.partnerId });
+        if (await claimNotice(c, newEndDate, 'renewed')) {
+          await dispatchNotice({ ...c, endDate: newEndDate }, 'renewed', newEndDate);
+        }
+        renewed++;
+      }
+    }
+  }
+
+  return { noticed, renewed };
+}
+```
+
+> Confirm against the real source while implementing: (a) `sendInAppNotification`'s exact payload field names (`alertId`/`alertName`/`severity`/`message`/`orgId`/`link`) — match `inAppSender.ts`; (b) `getEmailService()`/`sendEmail` param names — match `email.ts`; (c) `partnerUsers.orgAccess` enum values (`'all'`/`'selected'`) and the array column name (`orgIds`) — match the schema; (d) the web base-URL env var actually used elsewhere for building absolute links (search for how invoice emails build `contractUrl`/links — reuse that exact env var instead of `PUBLIC_WEB_URL` if it differs).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm exec vitest run src/services/contractRenewal.integration.test.ts`
+Expected: PASS (extend continuity, single advance notice, opt-out no-op, idempotent re-run).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/contractRenewal.ts apps/api/src/services/contractRenewal.integration.test.ts
+git commit -m "feat(contracts): renewal sweep — extend-in-place + MSP advance/confirmation notices (TDD)"
+```
+
+---
+
+## Phase 4 — Worker wiring
+
+Run the renewal pre-pass before the billing sweep in the existing daily `contract-jobs` worker.
+
+### Task 4.1: Run renewal before billing
+
+**Files:**
+- Modify: `apps/api/src/jobs/contractWorker.ts`
+
+- [ ] **Step 1: Import + call the renewal sweep inside the `billing-sweep` job**
+
+In `apps/api/src/jobs/contractWorker.ts`, add the import near the other service imports:
+
+```ts
+import { runContractRenewalSweep } from '../services/contractRenewal';
+```
+
+Change the job handler in `createContractWorker` so the renewal pre-pass runs first (it manages its own system DB context internally is **not** assumed — wrap it the same way billing is wrapped):
+
+```ts
+    async (job) => {
+      if (job.name === 'billing-sweep') {
+        // Renewal pre-pass MUST run before billing so an about-to-expire auto-renew
+        // contract has its term extended before generateDueInvoice decides expiry.
+        await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep()));
+        return runContractBillingSweep();
+      }
+      throw new Error(`Unknown contract job: ${job.name}`);
+    },
+```
+
+(`runOutsideDbContext` and `withSystemDbAccessContext` are already imported in this file.)
+
+- [ ] **Step 2: Add a worker-level integration test (renewal runs before billing)**
+
+If `apps/api/src/jobs/contractWorker.test.ts` exists, append a case; otherwise create `apps/api/src/jobs/contractWorker.renewal.integration.test.ts`. Seed an auto-renew contract whose next bill is at the term boundary, invoke the same orchestration the job runs (call `runContractRenewalSweep(asOf)` then `runContractBillingSweep(asOf)`), and assert: the contract did **not** expire, its `end_date` advanced, and a billing period was claimed (it billed instead of expiring):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { partners, organizations, contracts, contractLines, contractBillingPeriods } from '../db/schema';
+import { eq } from 'drizzle-orm';
+import { runContractRenewalSweep, /* if exported */ } from '../services/contractRenewal';
+import { runContractBillingSweep } from './contractWorker';
+
+it.runIf(!!process.env.DATABASE_URL)('renewal before billing keeps an at-boundary contract billing instead of expiring', async () => {
+  const sfx = Math.random().toString(36).slice(2, 8);
+  const { contractId } = await withSystemDbAccessContext(async () => {
+    const [p] = await db.insert(partners).values({ name: `W ${sfx}`, slug: `w-${sfx}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [o] = await db.insert(organizations).values({ partnerId: p!.id, name: 'WOrg', slug: `wo-${sfx}` }).returning({ id: organizations.id });
+    const [c] = await db.insert(contracts).values({
+      partnerId: p!.id, orgId: o!.id, name: 'Boundary', status: 'active', billingTiming: 'advance',
+      intervalMonths: 1, startDate: '2026-07-01', endDate: '2027-07-01', nextBillingAt: '2027-07-01',
+      autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: 30
+    }).returning({ id: contracts.id });
+    await db.insert(contractLines).values({ contractId: c!.id, orgId: o!.id, lineType: 'flat', description: 'svc', unitPrice: '100.00' });
+    return { contractId: c!.id };
+  });
+
+  const asOf = new Date('2027-07-01T05:00:00Z');
+  await runOutsideDbContext(() => withSystemDbAccessContext(() => runContractRenewalSweep(asOf)));
+  await runContractBillingSweep(asOf);
+
+  const [c] = await withSystemDbAccessContext(() => db.select({ status: contracts.status, endDate: contracts.endDate }).from(contracts).where(eq(contracts.id, contractId)));
+  expect(c.status).toBe('active');
+  expect(c.endDate).toBe('2028-07-01');
+  const periods = await withSystemDbAccessContext(() => db.select().from(contractBillingPeriods).where(eq(contractBillingPeriods.contractId, contractId)));
+  expect(periods.length).toBe(1); // billed, not expired
+});
+```
+
+- [ ] **Step 3: Run + typecheck**
+
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm exec vitest run src/jobs/contractWorker.renewal.integration.test.ts`
+Expected: PASS.
+Run: `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/jobs/contractWorker.ts apps/api/src/jobs/contractWorker.renewal.integration.test.ts
+git commit -m "feat(contracts): run renewal pre-pass before the daily billing sweep"
+```
+
+---
+
+## Phase 5 — Web UI (extend the shipped editor + detail)
+
+The contracts web UI already exists (`ContractsList`/`ContractEditor`/`ContractDetail`/`ContractWorkspace`, `/contracts` route). This phase only surfaces the new fields. Mutations already flow through `runAction`; `ContractEditor.tsx`/`ContractDetail.tsx` are already in the `no-silent-mutations` `TARGET_GLOBS`, so no test-allowlist change is needed.
+
+### Task 5.1: API client types
+
+**Files:**
+- Modify: `apps/web/src/lib/api/contracts.ts`
+
+- [ ] **Step 1: Add the three fields to `ContractSummary`**
+
+In `apps/web/src/lib/api/contracts.ts`, add to the `ContractSummary` interface (after `autoIssue`):
+
+```ts
+  autoRenew: boolean;
+  renewalTermMonths: number | null;
+  renewalNoticeDays: number | null;
+```
+
+The create/update wrappers already take `body: unknown`, so no signature change is needed — the editor sends the new fields in its payload object.
+
+- [ ] **Step 2: Typecheck (astro check) + commit**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec astro check`
+Expected: PASS.
+
+```bash
+git add apps/web/src/lib/api/contracts.ts
+git commit -m "feat(contracts-web): auto-renew fields on ContractSummary type"
+```
+
+### Task 5.2: Editor — auto-renew controls
+
+**Files:**
+- Modify: `apps/web/src/components/contracts/ContractEditor.tsx`
+
+- [ ] **Step 1: Add form state + controls**
+
+Open `ContractEditor.tsx` and locate the header-form state and the existing `autoIssue` toggle + `endDate` field (use them as the styling template). Add local state initialized from the loaded contract:
+
+```tsx
+const [autoRenew, setAutoRenew] = useState<boolean>(contract?.autoRenew ?? false);
+const [renewalTermMonths, setRenewalTermMonths] = useState<string>(contract?.renewalTermMonths != null ? String(contract.renewalTermMonths) : '');
+const [renewalNoticeDays, setRenewalNoticeDays] = useState<string>(contract?.renewalNoticeDays != null ? String(contract.renewalNoticeDays) : '30');
+```
+
+Render (next to `autoIssue`, gated on an end date being set since auto-renew requires a fixed term):
+
+```tsx
+<label className="flex items-center gap-2" data-testid="contract-auto-renew-toggle">
+  <input type="checkbox" checked={autoRenew} disabled={!endDate}
+    onChange={(e) => setAutoRenew(e.target.checked)} />
+  <span>Auto-renew at end of term{!endDate ? ' (set an end date first)' : ''}</span>
+</label>
+{autoRenew && (
+  <div className="mt-2 grid grid-cols-2 gap-3" data-testid="contract-renewal-fields">
+    <label className="flex flex-col text-sm">
+      Renewal term (months)
+      <input type="number" min={1} max={120} value={renewalTermMonths}
+        onChange={(e) => setRenewalTermMonths(e.target.value)}
+        data-testid="contract-renewal-term" />
+    </label>
+    <label className="flex flex-col text-sm">
+      Advance notice (days)
+      <input type="number" min={0} max={365} value={renewalNoticeDays}
+        onChange={(e) => setRenewalNoticeDays(e.target.value)}
+        data-testid="contract-renewal-notice-days" />
+    </label>
+  </div>
+)}
+```
+
+- [ ] **Step 2: Thread the fields into the create/update payload**
+
+In the existing save/create handler (the one already wrapped in `runAction`), add the three fields to the request body object:
+
+```tsx
+  autoRenew,
+  renewalTermMonths: autoRenew ? Number(renewalTermMonths) : null,
+  renewalNoticeDays: autoRenew ? (renewalNoticeDays === '' ? null : Number(renewalNoticeDays)) : null,
+```
+
+Match the existing payload's null/number convention (the create form already sends `endDate || null`). Do **not** send `undefined` for these — send explicit `null` when auto-renew is off, mirroring the billing UI↔Zod money/null lesson. When `autoRenew` is true the client should also block submit if `renewalTermMonths` is empty (the server enforces it too via the validator refinement, but a pre-check gives a cleaner toast).
+
+- [ ] **Step 3: Verify build + commit**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec astro check`
+Expected: PASS.
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/lib/__tests__/no-silent-mutations.test.ts`
+Expected: PASS (no new bare mutations).
+
+```bash
+git add apps/web/src/components/contracts/ContractEditor.tsx
+git commit -m "feat(contracts-web): auto-renew toggle + term/notice inputs in editor"
+```
+
+### Task 5.3: Detail — read-only renewal panel
+
+**Files:**
+- Modify: `apps/web/src/components/contracts/ContractDetail.tsx`
+
+- [ ] **Step 1: Render renewal status**
+
+In `ContractDetail.tsx`, in the read-only header block (next to where `endDate`/`autoIssue` are shown), add:
+
+```tsx
+<div data-testid="contract-renewal-status" className="text-sm">
+  {contract.autoRenew ? (
+    <>
+      <span className="font-medium">Auto-renews</span>
+      {' '}every {contract.renewalTermMonths ?? '—'} months
+      {contract.endDate ? <> · current term ends {contract.endDate}</> : null}
+      {contract.renewalNoticeDays != null ? <> · {contract.renewalNoticeDays}-day notice</> : null}
+    </>
+  ) : (
+    <span className="text-muted-foreground">Does not auto-renew</span>
+  )}
+</div>
+```
+
+- [ ] **Step 2: Verify build + commit**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec astro check`
+Expected: PASS.
+
+```bash
+git add apps/web/src/components/contracts/ContractDetail.tsx
+git commit -m "feat(contracts-web): read-only renewal status on contract detail"
+```
+
+---
+
+## Final verification
+
+- [ ] **API typecheck:** `cd apps/api && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec tsc --noEmit` → PASS.
+- [ ] **Shared typecheck:** `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/shared exec tsc --noEmit` → PASS.
+- [ ] **Web check:** `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec astro check` → PASS.
+- [ ] **Schema drift:** `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm db:check-drift` → no drift.
+- [ ] **Unit tests (no DB):** contractMath + validators + template green via single-fork (`pnpm exec vitest run src/services/contractMath.test.ts src/services/contractRenewalTemplate.test.ts` and the shared validators) — avoids the known suite-parallel flakiness.
+- [ ] **Renewal + worker integration (with DB):** `pnpm exec vitest run src/services/contractRenewal.integration.test.ts src/jobs/contractWorker.renewal.integration.test.ts` → PASS.
+- [ ] **RLS forge + coverage:** `cd apps/api && PATH=… DATABASE_URL=… pnpm exec vitest run --config vitest.config.rls-coverage.ts src/__tests__/integration/rls-coverage.integration.test.ts src/__tests__/integration/contract-renewal-rls.integration.test.ts` → PASS (confirm DB role is not BYPASSRLS first).
+- [ ] **Integration job (CI):** push the branch and trigger `Integration Tests` explicitly (`gh workflow run ci.yml --ref <branch>`) — it is SKIPPED on `pull_request` and is the only job that runs tenantCascade (the `contract_renewal_notices` cascade ordering) + RLS forge.
+- [ ] **Manual breeze_app forge:** `docker exec -it breeze-postgres psql -U breeze_app -d breeze` and attempt a cross-tenant insert into `contract_renewal_notices` — must fail with `new row violates row-level security policy`.
+- [ ] **PR gate:** before `--admin` merge, hard-stop on any failing required check (Test API / Web / Agent, Integration, Type Check); ignore only Trivy/Cargo/doc-verify.
+
+## Self-review notes (coverage map)
+
+- **Auto-renew model (extend-in-place):** Tasks 1.1–1.2 (columns), 2.1 (`extendTermPastDue`), 3.3 (sweep extension), 4.1 (ordering before billing). ✓
+- **Renewal notices (MSP in-app + email, advance + confirmation):** 3.2 (template), 3.3 (`dispatchNotice`, both kinds, both channels), idempotency via `contract_renewal_notices` (1.1/1.2 + `claimNotice`). ✓
+- **Tenant safety:** RLS in 1.2, forge in 1.4, cascade in 1.3, coverage scan in 1.4. ✓
+- **Configurability + invariants:** validators + cross-field refine in 1.5; service re-check of the update invariant noted in 1.5 Step 3. ✓
+- **Web exposure:** 5.1–5.3. ✓
+
+## Explicitly out of scope (deferred)
+
+- Customer-facing renewal email (decision: MSP-only recipients). Adding it later = a second `dispatchNotice` branch resolving `organizations.billingContact` + a customer-tone template; no schema change.
+- Proration on renewal (extend-in-place bills the full next period at the count taken at generation time — consistent with the v1 no-proration rule).
+- Per-term repricing / line changes on renewal (would require the clone-into-new-contract model that was explicitly not chosen).
+- A consumer for the `contract-events` bus (the `contract.auto_renewed` / `contract.renewal_notice` events are emitted for a future webhook/notification worker; delivery here is direct).
+- Auto-renew cap (e.g. "renew at most N times") and renewal price escalation.

--- a/packages/shared/src/validators/contracts.test.ts
+++ b/packages/shared/src/validators/contracts.test.ts
@@ -33,6 +33,36 @@ describe('createContractSchema', () => {
   });
 });
 
+describe('auto-renew fields', () => {
+  const base = {
+    orgId: '11111111-1111-1111-1111-111111111111',
+    name: 'Acme', billingTiming: 'advance' as const, intervalMonths: 1, startDate: '2026-07-01'
+  };
+  it('accepts a fixed-term auto-renew contract', () => {
+    const r = createContractSchema.safeParse({
+      ...base, endDate: '2027-07-01', autoRenew: true, renewalTermMonths: 12, renewalNoticeDays: 30
+    });
+    expect(r.success).toBe(true);
+  });
+  it('rejects autoRenew without an endDate (cannot renew an indefinite contract)', () => {
+    const r = createContractSchema.safeParse({ ...base, autoRenew: true, renewalTermMonths: 12 });
+    expect(r.success).toBe(false);
+  });
+  it('rejects autoRenew without a renewalTermMonths', () => {
+    const r = createContractSchema.safeParse({ ...base, endDate: '2027-07-01', autoRenew: true });
+    expect(r.success).toBe(false);
+  });
+  it('rejects renewalTermMonths < 1', () => {
+    const r = createContractSchema.safeParse({
+      ...base, endDate: '2027-07-01', autoRenew: true, renewalTermMonths: 0
+    });
+    expect(r.success).toBe(false);
+  });
+  it('allows clearing auto-renew on update', () => {
+    expect(updateContractSchema.safeParse({ autoRenew: false }).success).toBe(true);
+  });
+});
+
 describe('contractLineInputSchema', () => {
   it('requires manualQuantity for manual lines', () => {
     expect(contractLineInputSchema.safeParse({

--- a/packages/shared/src/validators/contracts.ts
+++ b/packages/shared/src/validators/contracts.ts
@@ -32,10 +32,16 @@ export const createContractSchema = z.object({
   autoIssue: z.boolean().optional(),
   currencyCode: z.string().length(3).optional(),
   notes: z.string().max(5000).nullable().optional(),
-  terms: z.string().max(5000).nullable().optional()
+  terms: z.string().max(5000).nullable().optional(),
+  autoRenew: z.boolean().optional(),
+  renewalTermMonths: z.number().int().min(1).max(120).nullable().optional(),
+  renewalNoticeDays: z.number().int().min(0).max(365).nullable().optional(),
 }).refine(
   (c) => c.endDate == null || c.endDate > c.startDate,
   { message: 'endDate must be after startDate', path: ['endDate'] }
+).refine(
+  (c) => !c.autoRenew || (c.endDate != null && c.renewalTermMonths != null),
+  { message: 'auto-renew requires both endDate and renewalTermMonths', path: ['autoRenew'] }
 );
 
 export const updateContractSchema = z.object({
@@ -46,7 +52,10 @@ export const updateContractSchema = z.object({
   endDate: isoDate.nullable().optional(),
   autoIssue: z.boolean().optional(),
   notes: z.string().max(5000).nullable().optional(),
-  terms: z.string().max(5000).nullable().optional()
+  terms: z.string().max(5000).nullable().optional(),
+  autoRenew: z.boolean().optional(),
+  renewalTermMonths: z.number().int().min(1).max(120).nullable().optional(),
+  renewalNoticeDays: z.number().int().min(0).max(365).nullable().optional(),
 });
 
 export const listContractsQuerySchema = z.object({


### PR DESCRIPTION
## Recurring Contracts — Auto-Renew + Renewal Notices (v2)

Adds opt-in **auto-renew** to the shipped Recurring Contracts engine. A fixed-term contract marked auto-renew rolls its term forward in place at the boundary (billing uninterrupted) instead of expiring, and the MSP's own users get an advance notice + a renewal confirmation (in-app **and** email). Implements the `Fixed-term + auto-renew with renewal notices` item from the v2 backlog in `docs/superpowers/plans/2026-06-15-recurring-contracts.md`. Plan: `docs/superpowers/plans/2026-06-21-contracts-auto-renew.md`.

**Design decisions:**
- **Extend-in-place** — renewal pushes `contracts.end_date` forward by `renewal_term_months`; no new contract rows, the `contract_billing_periods` ledger stays continuous.
- **MSP-only notices** — no customer-facing mail. In-app via `sendInAppNotification` + email via `getEmailService`/`buildContractRenewalEmail`.
- **Renewal pre-pass before billing** — `runContractRenewalSweep` runs inside the daily `contract-jobs` worker *before* `runContractBillingSweep`, so an about-to-expire auto-renew contract has its term extended before `generateDueInvoice` decides expiry.
- **Idempotency** — new `contract_renewal_notices` ledger with `UNIQUE(contract_id, end_date, kind)` (mirrors the `contract_billing_periods` pattern); advance notice keyed on the current `end_date`, confirmation on the new one, so each fires at most once per term and daily re-runs are no-ops.

**Data layer:** migration `2026-06-21-contracts-auto-renew.sql` adds `auto_renew`/`renewal_term_months`/`renewal_notice_days` to `contracts` (back-compat: existing rows default `auto_renew=false`, inert) and the `contract_renewal_notices` table (RLS shape 1, enabled+forced + 4 policies; added to `ORG_CASCADE_DELETE_ORDER`; `breeze_app` cross-org forge test).

**Service/worker:** `contractMath.ts` gains pure `addDaysISO`/`duePeriodStartFor`/`isWithinNoticeWindow`/`extendTermPastDue`; `contractRenewal.ts` is the two-pass sweep; `contractEvents.ts` gains `contract.auto_renewed`/`contract.renewal_notice` (emitted for the future webhook consumer — delivery here is direct). Pass B carries a `nextBillingAt <= today` guard so only due contracts extend.

**Web:** `auto_renew` toggle + term/notice inputs in `ContractEditor.tsx` (sends explicit `null` when off; both `useCallback` deps updated; resets `autoRenew` when `endDate` is cleared) and a read-only renewal panel in `ContractDetail.tsx`.

**Process:** built task-by-task with a fresh implementer + spec/quality reviewer per task. The final whole-branch review caught a **critical** silent-data-loss bug the per-task reviews missed — `createContract` (`apps/api/src/services/contractService.ts`) never threaded/inserted the three new fields, so UI-created auto-renew contracts persisted `auto_renew=false`. Fixed in `1846d6a3` with a non-vacuous re-read test.

**Tests:** contractMath 21; validators (RED→GREEN); RLS forge 2/2 + coverage 45/45; renewal service 3 scenarios (extend continuity + idempotent re-run, advance-only, opt-out no-op); worker ordering (bills instead of expiring); `contractService` integration 26 (incl. create-persist); `no-silent-mutations` 58/58; API + shared `tsc` + web `astro check` clean.

**Note:** the renewal-service + worker integration tests are wired into `vitest.integration.config.ts`, so the BLOCKING `Integration Tests` job exercises them — trigger it explicitly before merge (`gh workflow run ci.yml --ref worktree-contracts-web-ui-p5`), since it's skipped on `pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
