### PR TITLE
Ticketing Phase 6a — editing affordances (comment edit/delete, field edit UI, org reassign)

### DIFF
--- a/apps/api/migrations/2026-06-21-ticket-comment-edit.sql
+++ b/apps/api/migrations/2026-06-21-ticket-comment-edit.sql
@@ -1,0 +1,50 @@
+-- 2026-06-21: ticket_comments — editing & deletion support (Phase 6a).
+--
+-- Adds edited_at (deleted_at already exists) and the RLS UPDATE/DELETE
+-- policies that the earlier 2026-06-10-a migration deliberately left out
+-- ("technicians only edit/delete their OWN comments in Phase 1").
+--
+-- ticket_comments has NO org_id column — it is a child-via-parent (shape 5)
+-- table whose tenancy follows the parent ticket. So these policies mirror the
+-- parent-org EXISTS form of breeze_ticket_parent_select (same table, migration
+-- 2026-06-10-a) rather than a breeze_has_org_access(org_id) column check.
+-- Permissive policies OR with the existing Phase-6 user-isolation policies, so
+-- a staff author editing their own row is already allowed; these broaden the
+-- DB layer to admit edits/deletes of any org-accessible comment. AUTHOR/ROLE
+-- enforcement lives in ticketService (editTicketComment/deleteTicketComment) —
+-- NOT in WITH CHECK (lesson: rls_is_system_flag_write_policy_hole).
+--
+-- #1016/#1026 bound-param safety: tickets.org_id is NOT NULL and the tickets
+-- SELECT policy is a flat breeze_has_org_access(org_id) with no OR branches, so
+-- the EXISTS join is safe under postgres.js bound parameters — proven by
+-- apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts.
+--
+-- Fully idempotent — safe to re-run.
+
+ALTER TABLE ticket_comments ADD COLUMN IF NOT EXISTS edited_at timestamptz;
+
+DROP POLICY IF EXISTS breeze_ticket_parent_update ON ticket_comments;
+CREATE POLICY breeze_ticket_parent_update ON ticket_comments
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM tickets t
+       WHERE t.id = ticket_comments.ticket_id
+         AND public.breeze_has_org_access(t.org_id)
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM tickets t
+       WHERE t.id = ticket_comments.ticket_id
+         AND public.breeze_has_org_access(t.org_id)
+    )
+  );
+
+DROP POLICY IF EXISTS breeze_ticket_parent_delete ON ticket_comments;
+CREATE POLICY breeze_ticket_parent_delete ON ticket_comments
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM tickets t
+       WHERE t.id = ticket_comments.ticket_id
+         AND public.breeze_has_org_access(t.org_id)
+    )
+  );

--- a/apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * ticket_comments UPDATE/DELETE RLS — edit/delete policy forge
+ *
+ * Migration under test: 2026-06-21-ticket-comment-edit.sql
+ *
+ * The Phase 6a migration adds breeze_ticket_parent_update and
+ * breeze_ticket_parent_delete policies.  Both follow the EXISTS-join form:
+ * the comment's parent ticket must be org-accessible to the caller.
+ * ticket_comments has no org_id column — tenancy is inherited via the parent
+ * ticket (shape 5 / child-via-parent).
+ *
+ * These tests run through the REAL postgres.js driver (db pool connects as
+ * the unprivileged breeze_app role) with bound ticket-id parameters, on
+ * purpose: the #1016→#1026 bug class made EXISTS-join policies pass in psql
+ * but fail under postgres.js bound parameters.  tickets.org_id is NOT NULL
+ * and the tickets SELECT policy has no OR branches, so the join is expected
+ * to be safe — this suite is the proof.
+ *
+ * Each test re-seeds its own fixture inside the `it` body — NEVER module-scope
+ * fixtures.  setup.ts TRUNCATEs between tests, so a memoized fixture silently
+ * goes vacuous (rls-forge-test-memoized-fixture-vacuous).
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { ticketComments, tickets, portalUsers } from '../../db/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Seeds partner A → org A → ticket (in org A) → one comment.
+ * All inserts go through the privileged test role (BYPASSRLS) so the
+ * fixture is always visible regardless of the context under test.
+ */
+async function seedOrgATicketWithComment() {
+  const adminDb = getTestDb() as any;
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const partnerA = await createPartner();
+  const orgA = await createOrganization({ partnerId: partnerA.id });
+  const techA = await createUser({
+    partnerId: partnerA.id,
+    orgId: null, // MSP staff — partner axis only
+    email: `tc-edit-rls-tech-${unique}@example.test`,
+  });
+
+  const [portalUser] = await adminDb
+    .insert(portalUsers)
+    .values({
+      orgId: orgA.id,
+      email: `tc-edit-rls-portal-${unique}@example.test`,
+      name: 'Portal Customer',
+    })
+    .returning();
+
+  const [ticket] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId: orgA.id,
+      partnerId: partnerA.id,
+      ticketNumber: `TC-EDIT-RLS-${unique}`,
+      subject: 'ticket_comments edit/delete RLS test',
+      submittedBy: portalUser.id,
+      source: 'portal',
+    })
+    .returning();
+
+  const [comment] = await adminDb
+    .insert(ticketComments)
+    .values({
+      ticketId: ticket.id,
+      userId: techA.id,
+      authorType: 'technician',
+      content: 'original content',
+    })
+    .returning();
+
+  return { partnerA, orgA, techA, portalUser, ticket, comment };
+}
+
+/**
+ * Seeds a second, fully independent partner B → org B (no relationship to
+ * org A whatsoever — different partner, different org).  Returns both tenants
+ * plus a ticket+comment in org A so cross-tenant forge attempts are unambiguous.
+ */
+async function seedCrossTenant() {
+  const fixtureA = await seedOrgATicketWithComment();
+
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const partnerB = await createPartner();
+  const orgB = await createOrganization({ partnerId: partnerB.id });
+  const techB = await createUser({
+    partnerId: partnerB.id,
+    orgId: null,
+    email: `tc-edit-rls-other-${unique}@example.test`,
+  });
+
+  return { ...fixtureA, partnerB, orgB, techB };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ticket_comments UPDATE/DELETE RLS (2026-06-21-ticket-comment-edit.sql)', () => {
+  it('org-A-scoped connection can soft-delete (UPDATE deletedAt) a comment on an org-A ticket', async () => {
+    const { partnerA, orgA, comment } = await seedOrgATicketWithComment();
+
+    const ctxA: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [partnerA.id],
+      userId: null,
+    };
+
+    const softDeletedAt = new Date();
+    const result = await withDbAccessContext(ctxA, () =>
+      db
+        .update(ticketComments)
+        .set({ deletedAt: softDeletedAt })
+        .where(eq(ticketComments.id, comment.id))
+        .returning({ id: ticketComments.id, deletedAt: ticketComments.deletedAt })
+    );
+
+    // Org-A caller MUST be able to update its own comment.
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(comment.id);
+    expect(result[0].deletedAt).not.toBeNull();
+
+    // Admin read confirms the row was actually mutated.
+    const adminDb = getTestDb() as any;
+    const [row] = await adminDb
+      .select({ deletedAt: ticketComments.deletedAt })
+      .from(ticketComments)
+      .where(eq(ticketComments.id, comment.id));
+    expect(row.deletedAt).not.toBeNull();
+  });
+
+  it('org-B-scoped connection CANNOT update a comment on an org-A ticket (0 rows, content unchanged)', async () => {
+    const { orgB, partnerB, comment } = await seedCrossTenant();
+
+    const ctxB: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgB.id,
+      accessibleOrgIds: [orgB.id],
+      accessiblePartnerIds: [partnerB.id],
+      userId: null,
+    };
+
+    // RLS USING clause filters the row out of the update — no error, just 0 rows.
+    const result = await withDbAccessContext(ctxB, () =>
+      db
+        .update(ticketComments)
+        .set({ content: 'forged content' })
+        .where(eq(ticketComments.id, comment.id))
+        .returning({ id: ticketComments.id })
+    );
+
+    // The forge must affect 0 rows — if > 0, RLS is broken.
+    expect(result).toHaveLength(0);
+
+    // Admin read proves content is genuinely unchanged (not a vacuous pass).
+    const adminDb = getTestDb() as any;
+    const [row] = await adminDb
+      .select({ content: ticketComments.content })
+      .from(ticketComments)
+      .where(eq(ticketComments.id, comment.id));
+    expect(row.content).toBe('original content');
+  });
+
+  it('org-B-scoped connection CANNOT hard-delete a comment on an org-A ticket (0 rows, comment still present)', async () => {
+    const { orgB, partnerB, comment } = await seedCrossTenant();
+
+    const ctxB: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgB.id,
+      accessibleOrgIds: [orgB.id],
+      accessiblePartnerIds: [partnerB.id],
+      userId: null,
+    };
+
+    // RLS USING clause filters the row — delete affects 0 rows, no error.
+    const result = await withDbAccessContext(ctxB, () =>
+      db
+        .delete(ticketComments)
+        .where(eq(ticketComments.id, comment.id))
+        .returning({ id: ticketComments.id })
+    );
+
+    // Must be 0 rows — if > 0, RLS is broken.
+    expect(result).toHaveLength(0);
+
+    // Admin read proves the comment still exists (not a vacuous pass).
+    const adminDb = getTestDb() as any;
+    const [row] = await adminDb
+      .select({ id: ticketComments.id })
+      .from(ticketComments)
+      .where(eq(ticketComments.id, comment.id));
+    expect(row).toBeDefined();
+    expect(row.id).toBe(comment.id);
+  });
+});

--- a/apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts
@@ -130,8 +130,9 @@ describe('ticket_comments UPDATE/DELETE RLS (2026-06-21-ticket-comment-edit.sql)
 
     // Org-A caller MUST be able to update its own comment.
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe(comment.id);
-    expect(result[0].deletedAt).not.toBeNull();
+    const [resultRow] = result;
+    expect(resultRow!.id).toBe(comment.id);
+    expect(resultRow!.deletedAt).not.toBeNull();
 
     // Admin read confirms the row was actually mutated.
     const adminDb = getTestDb() as any;

--- a/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Integration test: moveTicketOrg child re-stamp + cross-partner isolation + comment visibility.
+ *
+ * Proves:
+ *   (1) All three denormalized child tables (time_entries, ticket_parts, ticket_alert_links)
+ *       get their org_id re-stamped to the target org after moveTicketOrg.
+ *   (2) The ticket's deviceId is set to null after the move.
+ *   (3) A cross-partner target org is rejected with status 400.
+ *   (4) ticket_comments (no org_id column; parent-join tenancy) remain visible to the
+ *       target org scope after the move.
+ *
+ * Test strategy: seed all fixtures inside each `it` (setup.ts TRUNCATEs beforeEach).
+ * Call moveTicketOrg directly at the service level — no HTTP — wrapped in
+ * withSystemDbAccessContext (mirrors the trusted server-side call path the route uses).
+ * Read-back assertions use the privileged admin pool (getTestDb()) to bypass RLS.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  tickets,
+  ticketComments,
+  ticketAlertLinks,
+  ticketParts,
+  timeEntries,
+  alerts,
+  alertRules,
+  alertTemplates,
+  devices,
+  sites,
+} from '../../db/schema';
+import { moveTicketOrg, TicketServiceError } from '../../services/ticketService';
+import { createOrganization, createPartner, createSite, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+// ── Seed helpers ─────────────────────────────────────────────────────────────
+
+/** Unique-ifier for ticket numbers and emails within the same test run. */
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+interface MoveOrgFixture {
+  partner: { id: string };
+  orgA: { id: string };
+  orgB: { id: string };
+  actor: { userId: string };
+  ticket: { id: string; orgId: string; deviceId: string | null };
+  device: { id: string };
+  timeEntry: { id: string };
+  ticketPart: { id: string };
+  alertLink: { id: string };
+}
+
+/**
+ * Seeds partner P → orgA, orgB, device in orgA, ticket in orgA with device,
+ * plus one time_entry, one ticket_part, and one ticket_alert_link (with an
+ * alert) all tied to the ticket.
+ */
+async function seedMoveOrgFixture(): Promise<MoveOrgFixture> {
+  const adminDb = getTestDb() as any;
+  const unique = uid();
+
+  const partner = await createPartner();
+  const orgA = await createOrganization({ partnerId: partner.id });
+  const orgB = await createOrganization({ partnerId: partner.id });
+  const actor = await createUser({
+    partnerId: partner.id,
+    orgId: null,
+    email: `move-org-actor-${unique}@example.test`,
+  });
+
+  // Site and device in orgA (device_id FK on tickets references devices).
+  const siteA = await createSite({ orgId: orgA.id });
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: orgA.id,
+      siteId: siteA.id,
+      agentId: `move-org-device-${unique}`,
+      hostname: `host-${unique}`,
+      osType: 'windows',
+      osVersion: '10.0.19041',
+      architecture: 'x64',
+      agentVersion: '0.1.0',
+    })
+    .returning();
+
+  // Ticket in orgA, linked to the device.
+  const [ticket] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId: orgA.id,
+      partnerId: partner.id,
+      ticketNumber: `MO-${unique}`,
+      subject: `move-org test ${unique}`,
+      deviceId: device.id,
+      source: 'manual',
+    })
+    .returning();
+
+  // time_entry: partner-axis table; orgId is denormalized from the ticket.
+  const [timeEntry] = await adminDb
+    .insert(timeEntries)
+    .values({
+      partnerId: partner.id,
+      orgId: orgA.id,
+      ticketId: ticket.id,
+      userId: actor.id,
+      startedAt: new Date(Date.now() - 60_000),
+      endedAt: new Date(),
+      durationMinutes: 1,
+    })
+    .returning();
+
+  // ticket_part: org-axis table.
+  const [ticketPart] = await adminDb
+    .insert(ticketParts)
+    .values({
+      ticketId: ticket.id,
+      orgId: orgA.id,
+      description: 'test part',
+      quantity: '1.00',
+    })
+    .returning();
+
+  // Alert and alert_link: alerts requires a device_id; alert_rule is optional.
+  const [alertTemplate] = await adminDb
+    .insert(alertTemplates)
+    .values({
+      partnerId: partner.id,
+      name: `move-org-template-${unique}`,
+      conditions: {},
+      severity: 'info',
+      titleTemplate: 'test',
+      messageTemplate: 'test',
+    })
+    .returning();
+
+  const [alertRule] = await adminDb
+    .insert(alertRules)
+    .values({
+      orgId: orgA.id,
+      templateId: alertTemplate.id,
+      name: `move-org-rule-${unique}`,
+      targetType: 'device',
+      targetId: device.id,
+    })
+    .returning();
+
+  const [alert] = await adminDb
+    .insert(alerts)
+    .values({
+      ruleId: alertRule.id,
+      deviceId: device.id,
+      orgId: orgA.id,
+      severity: 'info',
+      title: `move-org alert ${unique}`,
+    })
+    .returning();
+
+  const [alertLink] = await adminDb
+    .insert(ticketAlertLinks)
+    .values({
+      ticketId: ticket.id,
+      orgId: orgA.id,
+      alertId: alert.id,
+      linkType: 'attached',
+    })
+    .returning();
+
+  return {
+    partner,
+    orgA,
+    orgB,
+    actor: { userId: actor.id },
+    ticket,
+    device,
+    timeEntry,
+    ticketPart,
+    alertLink,
+  };
+}
+
+interface CrossPartnerFixture {
+  ticket: { id: string };
+  orgOtherPartner: { id: string };
+}
+
+/**
+ * Seeds two completely separate partners (different partners, so cross-partner
+ * move is attempted). ticketP1 is in partner1/orgA; target is partner2/orgC.
+ */
+async function seedCrossPartnerFixture(): Promise<CrossPartnerFixture> {
+  const adminDb = getTestDb() as any;
+  const unique = uid();
+
+  const partner1 = await createPartner();
+  const partner2 = await createPartner();
+  const orgA = await createOrganization({ partnerId: partner1.id });
+  const orgC = await createOrganization({ partnerId: partner2.id });
+  const actor = await createUser({
+    partnerId: partner1.id,
+    orgId: null,
+    email: `cross-partner-actor-${unique}@example.test`,
+  });
+
+  const [ticket] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId: orgA.id,
+      partnerId: partner1.id,
+      ticketNumber: `CP-${unique}`,
+      subject: `cross-partner test ${unique}`,
+      source: 'manual',
+    })
+    .returning();
+
+  return { ticket, orgOtherPartner: orgC };
+}
+
+// ── Read-back helpers (admin pool, bypasses RLS) ──────────────────────────────
+
+async function readTicket(id: string) {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb.select().from(tickets).where(eq(tickets.id, id)).limit(1);
+  return row as (typeof tickets.$inferSelect) | undefined;
+}
+
+async function readTimeEntry(id: string) {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb.select().from(timeEntries).where(eq(timeEntries.id, id)).limit(1);
+  return row as (typeof timeEntries.$inferSelect) | undefined;
+}
+
+async function readTicketPart(id: string) {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb.select().from(ticketParts).where(eq(ticketParts.id, id)).limit(1);
+  return row as (typeof ticketParts.$inferSelect) | undefined;
+}
+
+async function readAlertLink(id: string) {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb
+    .select()
+    .from(ticketAlertLinks)
+    .where(eq(ticketAlertLinks.id, id))
+    .limit(1);
+  return row as (typeof ticketAlertLinks.$inferSelect) | undefined;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('moveTicketOrg — service-level integration', () => {
+  it('re-stamps org_id on all denormalized children and detaches the device', async () => {
+    const { orgB, actor, ticket, timeEntry, ticketPart, alertLink } =
+      await seedMoveOrgFixture();
+
+    await withSystemDbAccessContext(() =>
+      moveTicketOrg(ticket.id, orgB.id, actor)
+    );
+
+    const movedTicket = await readTicket(ticket.id);
+    expect(movedTicket?.orgId).toBe(orgB.id);
+    expect(movedTicket?.deviceId).toBeNull();
+
+    const movedTimeEntry = await readTimeEntry(timeEntry.id);
+    expect(movedTimeEntry?.orgId).toBe(orgB.id);
+
+    const movedPart = await readTicketPart(ticketPart.id);
+    expect(movedPart?.orgId).toBe(orgB.id);
+
+    const movedLink = await readAlertLink(alertLink.id);
+    expect(movedLink?.orgId).toBe(orgB.id);
+  });
+
+  it('rejects a cross-partner target org with status 400', async () => {
+    const { ticket, orgOtherPartner } = await seedCrossPartnerFixture();
+    const unique = uid();
+    const actor = { userId: (await createUser({
+      partnerId: (await createPartner()).id,
+      email: `cross-actor-${unique}@example.test`,
+    })).id };
+
+    await expect(
+      withSystemDbAccessContext(() =>
+        moveTicketOrg(ticket.id, orgOtherPartner.id, actor)
+      )
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('comments remain visible to target org after move (parent-join tenancy)', async () => {
+    const adminDb = getTestDb() as any;
+    const { partner, orgA, orgB, actor, ticket } = await seedMoveOrgFixture();
+    const unique = uid();
+
+    // Seed a comment on the ticket before the move.
+    const [comment] = await adminDb
+      .insert(ticketComments)
+      .values({
+        ticketId: ticket.id,
+        userId: actor.userId,
+        authorType: 'technician',
+        content: `pre-move comment ${unique}`,
+      })
+      .returning();
+
+    // Move the ticket from orgA to orgB.
+    await withSystemDbAccessContext(() =>
+      moveTicketOrg(ticket.id, orgB.id, actor)
+    );
+
+    // After the move the ticket belongs to orgB; a connection scoped to orgB
+    // should still see the comment via the ticket-parent RLS join.
+    const orgBContext: DbAccessContext = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [orgB.id],
+      accessiblePartnerIds: [partner.id],
+      userId: actor.userId,
+    };
+
+    const rows = await withDbAccessContext(orgBContext, () =>
+      db
+        .select({ id: ticketComments.id, content: ticketComments.content })
+        .from(ticketComments)
+        .where(eq(ticketComments.ticketId, ticket.id))
+    );
+
+    // The user-seeded comment plus the system "Moved to …" comment written by
+    // moveTicketOrg should both appear.
+    const commentIds = rows.map((r) => r.id);
+    expect(commentIds).toContain(comment.id);
+  });
+});

--- a/apps/api/src/db/schema/portal.ts
+++ b/apps/api/src/db/schema/portal.ts
@@ -110,6 +110,7 @@ export const ticketComments = pgTable('ticket_comments', {
   oldValue: text('old_value'),
   newValue: text('new_value'),
   deletedAt: timestamp('deleted_at'),
+  editedAt: timestamp('edited_at'),
   createdAt: timestamp('created_at').defaultNow().notNull()
 });
 

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -129,6 +129,7 @@ export const DEFAULT_PERMISSIONS = [
   // Tickets
   { resource: 'tickets', action: 'read', description: 'View tickets, comments, and categories' },
   { resource: 'tickets', action: 'write', description: 'Create and update tickets, comments, and categories' },
+  { resource: 'tickets', action: 'manage', description: 'Edit or delete any comment and reassign ticket organization' },
 
   // Catalog (billing/invoicing program)
   { resource: 'catalog', action: 'read', description: 'View product catalog items and pricing' },
@@ -256,7 +257,7 @@ export const SYSTEM_ROLES = [
       'devices:read', 'devices:write', 'devices:delete', 'devices:execute',
       'scripts:read', 'scripts:write', 'scripts:delete', 'scripts:execute',
       'alerts:read', 'alerts:write', 'alerts:acknowledge',
-      'tickets:read', 'tickets:write',
+      'tickets:read', 'tickets:write', 'tickets:manage',
       'reports:read', 'reports:write', 'reports:delete', 'reports:export',
       'users:read', 'users:write', 'users:delete', 'users:invite',
       'sites:read', 'sites:write', 'sites:delete',

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -121,6 +121,11 @@ export const ticketParamSchema = z.object({
   id: z.string().guid()
 });
 
+export const ticketCommentParamSchema = z.object({
+  id: z.string().guid(),
+  commentId: z.string().guid()
+});
+
 export const commentSchema = z.object({
   content: z.string().min(1).max(5000)
 });

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -15,19 +15,27 @@
  *
  * B1 fix: POST /tickets delegates to createTicket (mock) with source: 'portal',
  *   submitter fields mapped, and the response shape preserved.
+ *
+ * Task 7: portal comment edit/delete within until-staff-reply window.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-// ── createTicket mock ─────────────────────────────────────────────────────────
+// ── service mocks ─────────────────────────────────────────────────────────────
 
-const { createTicketMock } = vi.hoisted(() => ({
-  createTicketMock: vi.fn()
+const { createTicketMock, portalCommentMutableMock, editTicketCommentMock, deleteTicketCommentMock } = vi.hoisted(() => ({
+  createTicketMock: vi.fn(),
+  portalCommentMutableMock: vi.fn(),
+  editTicketCommentMock: vi.fn(),
+  deleteTicketCommentMock: vi.fn(),
 }));
 
 vi.mock('../../services/ticketService', () => ({
   createTicket: createTicketMock,
+  portalCommentMutable: portalCommentMutableMock,
+  editTicketComment: editTicketCommentMock,
+  deleteTicketComment: deleteTicketCommentMock,
   TicketServiceError: class TicketServiceError extends Error {
     status: number;
     constructor(message: string, status = 400) {
@@ -78,6 +86,7 @@ vi.mock('./helpers', () => ({
 }));
 
 import { ticketRoutes } from './tickets';
+import { validatePortalCookieCsrfRequest, writePortalAudit } from './helpers';
 
 // ── Test app ──────────────────────────────────────────────────────────────────
 
@@ -94,6 +103,7 @@ function buildApp() {
 }
 
 const TICKET_ID = '3f2f1d8e-1111-4222-8333-444455556666';
+const COMMENT_ID = 'aaaabbbb-1111-2222-3333-ccccdddd0000';
 
 const TICKET_ROW = {
   id: TICKET_ID,
@@ -104,6 +114,11 @@ const TICKET_ROW = {
   priority: 'normal',
   createdAt: new Date(),
   updatedAt: new Date()
+};
+
+// Valid UUID for route params (zValidator uses .guid())
+const portalJsonHeaders = {
+  'Content-Type': 'application/json',
 };
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -340,5 +355,210 @@ describe('POST /tickets — delegates to createTicket', () => {
     expect(res.status).toBe(404);
     const body = await res.json() as { error: string };
     expect(body.error).toMatch(/organization not found/i);
+  });
+});
+
+// ── PATCH /tickets/:id/comments/:commentId — Task 7 ──────────────────────────
+
+describe('portal PATCH /tickets/:id/comments/:commentId', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  const UPDATED_COMMENT = {
+    id: COMMENT_ID,
+    content: 'fixed typo',
+    editedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    // Default: window open
+    portalCommentMutableMock.mockResolvedValue({ ok: true });
+    editTicketCommentMock.mockResolvedValue(UPDATED_COMMENT);
+  });
+
+  it('edits own reply when window is open — 200', async () => {
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'fixed typo' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { comment: Record<string, unknown> };
+    expect(body.comment).toMatchObject({ id: COMMENT_ID, content: 'fixed typo' });
+  });
+
+  it('calls portalCommentMutable with (commentId, portalUserId)', async () => {
+    await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'fixed typo' }),
+    });
+    expect(portalCommentMutableMock).toHaveBeenCalledWith(COMMENT_ID, PORTAL_USER.id);
+  });
+
+  it('calls editTicketComment with canManageAny: true after ownership is proven', async () => {
+    await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'fixed typo' }),
+    });
+    expect(editTicketCommentMock).toHaveBeenCalledWith(
+      COMMENT_ID,
+      { content: 'fixed typo' },
+      expect.objectContaining({ userId: PORTAL_USER.id }),
+      { canManageAny: true }
+    );
+  });
+
+  it('writes portal audit on success', async () => {
+    await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'fixed typo' }),
+    });
+    expect(writePortalAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'portal.ticket.comment.edit',
+        resourceType: 'ticket_comment',
+        resourceId: COMMENT_ID,
+      })
+    );
+  });
+
+  it('409s once staff has replied (staff_replied)', async () => {
+    portalCommentMutableMock.mockResolvedValue({ ok: false, reason: 'staff_replied' });
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'too late' }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('404s on another user\'s comment (not_author)', async () => {
+    portalCommentMutableMock.mockResolvedValue({ ok: false, reason: 'not_author' });
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'x' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('404s when comment not found (not_found)', async () => {
+    portalCommentMutableMock.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'x' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('403s on CSRF failure', async () => {
+    vi.mocked(validatePortalCookieCsrfRequest).mockReturnValueOnce('csrf token mismatch');
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'x' }),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── DELETE /tickets/:id/comments/:commentId — Task 7 ─────────────────────────
+
+describe('portal DELETE /tickets/:id/comments/:commentId', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    // Default: window open
+    portalCommentMutableMock.mockResolvedValue({ ok: true });
+    deleteTicketCommentMock.mockResolvedValue({ id: COMMENT_ID });
+  });
+
+  it('deletes own reply when window is open — 200', async () => {
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it('calls portalCommentMutable with (commentId, portalUserId)', async () => {
+    await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(portalCommentMutableMock).toHaveBeenCalledWith(COMMENT_ID, PORTAL_USER.id);
+  });
+
+  it('calls deleteTicketComment with canManageAny: true after ownership is proven', async () => {
+    await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(deleteTicketCommentMock).toHaveBeenCalledWith(
+      COMMENT_ID,
+      expect.objectContaining({ userId: PORTAL_USER.id }),
+      { canManageAny: true }
+    );
+  });
+
+  it('writes portal audit on success', async () => {
+    await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(writePortalAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'portal.ticket.comment.delete',
+        resourceType: 'ticket_comment',
+        resourceId: COMMENT_ID,
+      })
+    );
+  });
+
+  it('409s once staff has replied (staff_replied)', async () => {
+    portalCommentMutableMock.mockResolvedValue({ ok: false, reason: 'staff_replied' });
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('404s on another user\'s comment (not_author)', async () => {
+    portalCommentMutableMock.mockResolvedValue({ ok: false, reason: 'not_author' });
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('404s when comment not found (not_found)', async () => {
+    portalCommentMutableMock.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('403s on CSRF failure', async () => {
+    vi.mocked(validatePortalCookieCsrfRequest).mockReturnValueOnce('csrf token mismatch');
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: portalJsonHeaders,
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -466,6 +466,33 @@ describe('portal PATCH /tickets/:id/comments/:commentId', () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it('rejects content exceeding 5000 chars with 400 (portal cap)', async () => {
+    // Portal create caps content at 5000; portal edit must enforce the same cap
+    // even though the shared editCommentSchema allows 50k. Staff edit stays at 50k.
+    const overLimit = 'a'.repeat(5001);
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: overLimit }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/5000/);
+    // editTicketComment must NOT have been called — rejection happens before service
+    expect(editTicketCommentMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts content of exactly 5000 chars (at boundary)', async () => {
+    const atLimit = 'b'.repeat(5000);
+    editTicketCommentMock.mockResolvedValueOnce({ id: COMMENT_ID, content: atLimit, editedAt: new Date() });
+    const res = await app.request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: atLimit }),
+    });
+    expect(res.status).toBe(200);
+  });
 });
 
 // ── DELETE /tickets/:id/comments/:commentId — Task 7 ─────────────────────────

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -407,7 +407,7 @@ describe('portal PATCH /tickets/:id/comments/:commentId', () => {
       COMMENT_ID,
       { content: 'fixed typo' },
       expect.objectContaining({ userId: PORTAL_USER.id }),
-      { canManageAny: true }
+      { canManageAny: true, expectedTicketId: TICKET_ID }
     );
   });
 
@@ -534,7 +534,7 @@ describe('portal DELETE /tickets/:id/comments/:commentId', () => {
     expect(deleteTicketCommentMock).toHaveBeenCalledWith(
       COMMENT_ID,
       expect.objectContaining({ userId: PORTAL_USER.id }),
-      { canManageAny: true }
+      { canManageAny: true, expectedTicketId: TICKET_ID }
     );
   });
 

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -321,7 +321,7 @@ ticketRoutes.patch(
       commentId,
       body,
       { userId: auth.user.id, name: auth.user.name ?? auth.user.email },
-      { canManageAny: true }
+      { canManageAny: true, expectedTicketId: id }
     );
 
     writePortalAudit(c, {
@@ -361,7 +361,7 @@ ticketRoutes.delete(
     await deleteTicketComment(
       commentId,
       { userId: auth.user.id },
-      { canManageAny: true }
+      { canManageAny: true, expectedTicketId: id }
     );
 
     writePortalAudit(c, {

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -7,6 +7,7 @@ import {
   listSchema,
   createTicketSchema,
   ticketParamSchema,
+  ticketCommentParamSchema,
   commentSchema,
 } from './schemas';
 import {
@@ -17,7 +18,8 @@ import {
   validatePortalCookieCsrfRequest,
   writePortalAudit,
 } from './helpers';
-import { createTicket, TicketServiceError } from '../../services/ticketService';
+import { createTicket, TicketServiceError, portalCommentMutable, editTicketComment, deleteTicketComment } from '../../services/ticketService';
+import { editCommentSchema } from '@breeze/shared';
 
 export const ticketRoutes = new Hono();
 
@@ -278,5 +280,94 @@ ticketRoutes.post(
     });
 
     return c.json({ comment }, 201);
+  }
+);
+
+ticketRoutes.patch(
+  '/tickets/:id/comments/:commentId',
+  zValidator('param', ticketCommentParamSchema),
+  zValidator('json', editCommentSchema),
+  async (c) => {
+    const csrfError = validatePortalCookieCsrfRequest(c);
+    if (csrfError) return c.json({ error: csrfError }, 403);
+
+    const auth = c.get('portalAuth');
+    const { id, commentId } = c.req.valid('param');
+    const body = c.req.valid('json');
+
+    const mutable = await portalCommentMutable(commentId, auth.user.id);
+    if (!mutable.ok) {
+      if (mutable.reason === 'staff_replied') {
+        return c.json({ error: 'This reply can no longer be edited — support has already responded.' }, 409);
+      }
+      return c.json({ error: 'Ticket not found' }, 404); // not_author / not_found
+    }
+
+    // Ownership already proven by portalCommentMutable (portal_user_id match).
+    // Pass canManageAny so the service's staff-author rule (keyed on user_id,
+    // which is NULL for portal rows) does not reject the legitimate edit.
+    //
+    // NOTE: audit_logs.actor_id has NO FK to users(id) — it is a plain NOT NULL
+    // uuid column. Passing a portal user id here is safe; the service audit row
+    // is supplementary (authoritative trail is writePortalAudit below).
+    const updated = await editTicketComment(
+      commentId,
+      body,
+      { userId: auth.user.id, name: auth.user.name ?? auth.user.email },
+      { canManageAny: true }
+    );
+
+    writePortalAudit(c, {
+      orgId: auth.user.orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: 'portal.ticket.comment.edit',
+      resourceType: 'ticket_comment',
+      resourceId: commentId,
+      details: { ticketId: id },
+    });
+
+    return c.json({ comment: { id: updated.id, content: updated.content, editedAt: updated.editedAt } });
+  }
+);
+
+ticketRoutes.delete(
+  '/tickets/:id/comments/:commentId',
+  zValidator('param', ticketCommentParamSchema),
+  async (c) => {
+    const csrfError = validatePortalCookieCsrfRequest(c);
+    if (csrfError) return c.json({ error: csrfError }, 403);
+
+    const auth = c.get('portalAuth');
+    const { id, commentId } = c.req.valid('param');
+
+    const mutable = await portalCommentMutable(commentId, auth.user.id);
+    if (!mutable.ok) {
+      if (mutable.reason === 'staff_replied') {
+        return c.json({ error: 'This reply can no longer be deleted — support has already responded.' }, 409);
+      }
+      return c.json({ error: 'Ticket not found' }, 404); // not_author / not_found
+    }
+
+    // Same audit_logs.actor_id FK caveat as PATCH above — no FK, portal id is safe.
+    await deleteTicketComment(
+      commentId,
+      { userId: auth.user.id },
+      { canManageAny: true }
+    );
+
+    writePortalAudit(c, {
+      orgId: auth.user.orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: 'portal.ticket.comment.delete',
+      resourceType: 'ticket_comment',
+      resourceId: commentId,
+      details: { ticketId: id },
+    });
+
+    return c.json({ success: true });
   }
 );

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -295,6 +295,13 @@ ticketRoutes.patch(
     const { id, commentId } = c.req.valid('param');
     const body = c.req.valid('json');
 
+    // Portal edit uses the shared editCommentSchema (50k), but portal CREATE caps
+    // content at 5,000 chars (commentSchema). Enforce the same 5k limit here so
+    // portal customers can't bypass it by editing instead of creating.
+    if (body.content.length > 5000) {
+      return c.json({ error: 'Comment content must be 5000 characters or fewer' }, 400);
+    }
+
     const mutable = await portalCommentMutable(commentId, auth.user.id);
     if (!mutable.ok) {
       if (mutable.reason === 'staff_replied') {

--- a/apps/api/src/routes/tickets/index.ts
+++ b/apps/api/src/routes/tickets/index.ts
@@ -4,6 +4,7 @@ import { ticketsRoutes as ticketsApiRoutes } from './tickets';
 import { ticketsBulkRoutes } from './bulk';
 import { ticketExportRoutes } from './export';
 import { ticketPartsRoutes } from './parts';
+import { ticketMoveOrgRoutes } from './moveOrg';
 
 export const ticketsRoutes = new Hono();
 
@@ -16,4 +17,7 @@ ticketsRoutes.use('*', authMiddleware);
 ticketsRoutes.route('/', ticketExportRoutes);  // /export/... before /:id
 ticketsRoutes.route('/', ticketPartsRoutes);   // /parts/:id + /:id/parts before generic /:id
 ticketsRoutes.route('/', ticketsBulkRoutes);   // /bulk before /:id
+// move-org BEFORE core /:id routes so POST /:id/move-org is not captured by
+// the generic /:id param matcher (mirrors devices/index.ts mount ordering).
+ticketsRoutes.route('/', ticketMoveOrgRoutes);
 ticketsRoutes.route('/', ticketsApiRoutes);

--- a/apps/api/src/routes/tickets/moveOrg.test.ts
+++ b/apps/api/src/routes/tickets/moveOrg.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { authRef, getScopedTicketOr404Mock, moveTicketOrgMock } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as string,
+      user: { id: 'u-1', name: 'Tess Tech', email: 'tess@msp.example', isPlatformAdmin: false },
+      partnerId: 'p-1' as string | null,
+      orgId: null as string | null,
+      accessibleOrgIds: ['org-1', 'org-b'] as string[] | null,
+      orgCondition: () => undefined,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  getScopedTicketOr404Mock: vi.fn(),
+  moveTicketOrgMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', async () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requireScope: () => async (c: any, next: any) => {
+    if (!c.get('auth')) return c.json({ error: 'Not authenticated' }, 401);
+    await next();
+  },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+  siteAccessCheck: (await vi.importActual<typeof import('../../middleware/auth')>('../../middleware/auth')).siteAccessCheck,
+}));
+
+vi.mock('./tickets', async () => {
+  const actual = await vi.importActual<typeof import('./tickets')>('./tickets');
+  return {
+    ...actual,
+    getScopedTicketOr404: getScopedTicketOr404Mock,
+  };
+});
+
+vi.mock('../../services/ticketService', async () => {
+  const actual = await vi.importActual<typeof import('../../services/ticketService')>('../../services/ticketService');
+  return { ...actual, moveTicketOrg: moveTicketOrgMock };
+});
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([])),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  tickets: {
+    id: 'id', orgId: 'orgId', partnerId: 'partnerId', status: 'status',
+    priority: 'priority', assignedTo: 'assignedTo', categoryId: 'categoryId',
+    internalNumber: 'internalNumber', subject: 'subject', createdAt: 'createdAt',
+    updatedAt: 'updatedAt', dueDate: 'dueDate', deviceId: 'deviceId',
+    source: 'source',
+  },
+  ticketComments: { ticketId: 'ticketId', deletedAt: 'deletedAt', createdAt: 'createdAt' },
+  ticketAlertLinks: { ticketId: 'ticketId', alertId: 'alertId', id: 'id', linkType: 'linkType' },
+  alerts: { id: 'id', title: 'title', severity: 'severity', status: 'status', deviceId: 'deviceId' },
+  devices: { id: 'id', hostname: 'hostname', orgId: 'orgId', siteId: 'siteId' },
+  organizations: { id: 'id', name: 'name' },
+  users: { id: 'id', name: 'name' },
+  ticketStatuses: { id: 'id', name: 'name', color: 'color' },
+  ticketCategories: {},
+  ticketParts: {
+    id: 'id', ticketId: 'ticketId', orgId: 'orgId', addedBy: 'addedBy',
+    description: 'description', quantity: 'quantity', unitPrice: 'unitPrice',
+    costBasis: 'costBasis', isBillable: 'isBillable', billingStatus: 'billingStatus',
+    createdAt: 'createdAt', updatedAt: 'updatedAt'
+  },
+  timeEntries: {
+    id: 'id', ticketId: 'ticketId', orgId: 'orgId', userId: 'userId', partnerId: 'partnerId',
+    startedAt: 'startedAt', endedAt: 'endedAt', durationMinutes: 'durationMinutes',
+    description: 'description', isBillable: 'isBillable', billingStatus: 'billingStatus',
+    hourlyRate: 'hourlyRate', isApproved: 'isApproved', addedBy: 'addedBy', runningTimerId: 'runningTimerId'
+  },
+}));
+
+import { ticketsRoutes } from './index';
+import { TicketServiceError } from '../../services/ticketService';
+
+const TICKET_ID = '3f2f1d8e-1111-4222-8333-444455556666';
+const ORG_B_ID  = 'aaaabbbb-cccc-dddd-eeee-ffff00001111';
+
+const STUB_TICKET = {
+  id: TICKET_ID,
+  orgId: 'org-1',
+  partnerId: 'p-1',
+  deviceId: null,
+  subject: 'Printer',
+};
+
+function jsonHeaders() {
+  return { 'Content-Type': 'application/json' };
+}
+
+function resetAuth() {
+  vi.clearAllMocks();
+  authRef.current = {
+    scope: 'partner',
+    user: { id: 'u-1', name: 'Tess Tech', email: 'tess@msp.example', isPlatformAdmin: false },
+    partnerId: 'p-1',
+    orgId: null,
+    accessibleOrgIds: ['org-1', ORG_B_ID],
+    orgCondition: () => undefined,
+    canAccessOrg: (_id: string) => true,
+  };
+}
+
+describe('POST /tickets/:id/move-org', () => {
+  beforeEach(resetAuth);
+
+  it('moves to a same-partner org and returns 200', async () => {
+    getScopedTicketOr404Mock.mockResolvedValue(STUB_TICKET);
+    moveTicketOrgMock.mockResolvedValue({ id: TICKET_ID, orgId: ORG_B_ID, deviceId: null });
+
+    const res = await ticketsRoutes.request(`/${TICKET_ID}/move-org`, {
+      method: 'POST',
+      headers: jsonHeaders(),
+      body: JSON.stringify({ orgId: ORG_B_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('data');
+    expect(moveTicketOrgMock).toHaveBeenCalledWith(
+      TICKET_ID,
+      ORG_B_ID,
+      expect.objectContaining({ userId: 'u-1' }),
+    );
+  });
+
+  it('404s when ticket is out of scope', async () => {
+    getScopedTicketOr404Mock.mockResolvedValue(null);
+
+    const res = await ticketsRoutes.request(`/${TICKET_ID}/move-org`, {
+      method: 'POST',
+      headers: jsonHeaders(),
+      body: JSON.stringify({ orgId: ORG_B_ID }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(moveTicketOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('403s when caller cannot access the target org', async () => {
+    getScopedTicketOr404Mock.mockResolvedValue(STUB_TICKET);
+    authRef.current = {
+      ...authRef.current,
+      canAccessOrg: (_id: string) => false,
+    };
+
+    const res = await ticketsRoutes.request(`/${TICKET_ID}/move-org`, {
+      method: 'POST',
+      headers: jsonHeaders(),
+      body: JSON.stringify({ orgId: ORG_B_ID }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(moveTicketOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces 400 on cross-partner move via handleServiceError', async () => {
+    getScopedTicketOr404Mock.mockResolvedValue(STUB_TICKET);
+    moveTicketOrgMock.mockRejectedValue(
+      new TicketServiceError('Cross-partner moves require system scope', 400),
+    );
+
+    const res = await ticketsRoutes.request(`/${TICKET_ID}/move-org`, {
+      method: 'POST',
+      headers: jsonHeaders(),
+      body: JSON.stringify({ orgId: ORG_B_ID }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/apps/api/src/routes/tickets/moveOrg.ts
+++ b/apps/api/src/routes/tickets/moveOrg.ts
@@ -1,0 +1,44 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { requireScope, requirePermission, requireMfa } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { moveTicketOrgSchema } from '@breeze/shared';
+import { moveTicketOrg } from '../../services/ticketService';
+import { getScopedTicketOr404, actorFrom, handleServiceError } from './tickets';
+
+const idParam = z.object({ id: z.string().guid() });
+
+export const ticketMoveOrgRoutes = new Hono();
+
+// POST /tickets/:id/move-org — reassign a ticket to another org of the SAME partner.
+// High-privilege: tickets:write + organizations:write at partner/system scope + MFA
+// (mirrors devices/moveOrg.ts). Same-partner validation + child org_id re-stamp in the service.
+ticketMoveOrgRoutes.post(
+  '/:id/move-org',
+  requireScope('partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('param', idParam),
+  zValidator('json', moveTicketOrgSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+    const { orgId: targetOrgId } = c.req.valid('json');
+
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+
+    if (!auth.canAccessOrg(targetOrgId)) {
+      return c.json({ error: 'Access to target organization denied' }, 403);
+    }
+
+    try {
+      const ticket = await moveTicketOrg(id, targetOrgId, actorFrom(c));
+      return c.json({ data: ticket });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  },
+);

--- a/apps/api/src/routes/tickets/parts.test.ts
+++ b/apps/api/src/routes/tickets/parts.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../middleware/auth', async () => ({
     await next();
   },
   requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
   siteAccessCheck: (await vi.importActual<typeof import('../../middleware/auth')>('../../middleware/auth')).siteAccessCheck,
 }));
 

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -133,7 +133,7 @@ vi.mock('../../db', () => ({
         where: vi.fn((...args: unknown[]) => {
           lastWhereArgs.push({ conditions: args });
           const result = {
-          orderBy: vi.fn(() => Promise.resolve([])),
+          orderBy: vi.fn(() => Promise.resolve(dbSelectMock())),
           groupBy: vi.fn(() => dbGroupByMock()),
           // getScopedTicketOr404 and GET /:id single-row lookups both use .limit(1)
           limit: vi.fn(() => dbSelectMock()),
@@ -567,6 +567,35 @@ describe('GET /tickets/:id — scoped pre-check', () => {
     expect(body.data.orgName).toBeNull();
     expect(body.data.deviceHostname).toBeNull();
     expect(body.data.assigneeName).toBeNull();
+  });
+
+  it('returns soft-deleted comments to staff as tombstones with empty content', async () => {
+    const deletedAt = new Date('2026-06-20T10:00:00Z').toISOString();
+    dbSelectMock
+      .mockResolvedValueOnce([STUB_TICKET])  // scoped ticket lookup
+      .mockResolvedValueOnce([])             // decoration query
+      .mockResolvedValueOnce([              // comments query
+        { id: 'c-1', ticketId: TICKET_ID, content: 'visible', deletedAt: null,  editedAt: null, createdAt: new Date().toISOString() },
+        { id: 'c-2', ticketId: TICKET_ID, content: 'secret',  deletedAt: deletedAt, editedAt: null, createdAt: new Date().toISOString() }
+      ])
+      .mockResolvedValue([]);               // alert links
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const comments = body.data.comments;
+
+    // Non-deleted comment: real content, deleted:false
+    const live = comments.find((c: any) => c.id === 'c-1');
+    expect(live).toBeTruthy();
+    expect(live.content).toBe('visible');
+    expect(live.deleted).toBe(false);
+
+    // Deleted comment: tombstone with empty content — prior text must not reach client
+    const tomb = comments.find((c: any) => c.id === 'c-2');
+    expect(tomb).toBeTruthy();
+    expect(tomb.deleted).toBe(true);
+    expect(tomb.content).toBe('');  // prior text must not leak to the client
   });
 });
 

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -75,6 +75,7 @@ vi.mock('../../middleware/auth', async () => ({
     await next();
   },
   requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
   // Real implementation, not a re-implementation: siteAccessCheck is a pure
   // function and the single source of truth for site-allowlist semantics —
   // re-exporting it keeps these route tests honest if those semantics change.

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -14,6 +14,8 @@ const { serviceMocks, ticketTriageMocks, dbSelectMock, dbGroupByMock, authRef, l
       unlinkAlertFromTicket: vi.fn(),
       updateTicketFields: vi.fn(),
       getAssigneeForValidation: vi.fn(),
+      editTicketComment: vi.fn(),
+      deleteTicketComment: vi.fn(),
     },
     ticketTriageMocks: {
       getTicketTriageSuggestion: vi.fn(),
@@ -1624,5 +1626,102 @@ describe('authMiddleware wiring', () => {
     expect(res.status).toBe(200);
     const { authMiddleware } = await import('../../middleware/auth');
     expect(authMiddleware).toHaveBeenCalledTimes(1);
+  });
+});
+
+const COMMENT_ID = 'cccccccc-1111-4222-8333-444455556666';
+const jsonHeaders = { 'Content-Type': 'application/json' };
+
+describe('PATCH /tickets/:id/comments/:commentId', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('edits a comment via the service and returns 200', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]); // getScopedTicketOr404
+    serviceMocks.editTicketComment.mockResolvedValue({
+      id: COMMENT_ID, content: 'new content', editedAt: new Date()
+    });
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: jsonHeaders,
+      body: JSON.stringify({ content: 'new content' })
+    });
+    expect(res.status).toBe(200);
+    expect(serviceMocks.editTicketComment).toHaveBeenCalledWith(
+      COMMENT_ID,
+      expect.objectContaining({ content: 'new content' }),
+      expect.objectContaining({ userId: 'u-1' }),
+      expect.objectContaining({ canManageAny: expect.any(Boolean) })
+    );
+  });
+
+  it('404s when the ticket is out of scope', async () => {
+    dbSelectMock.mockResolvedValueOnce([]); // getScopedTicketOr404 → not found
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: jsonHeaders,
+      body: JSON.stringify({ content: 'x' })
+    });
+    expect(res.status).toBe(404);
+    expect(serviceMocks.editTicketComment).not.toHaveBeenCalled();
+  });
+
+  it('maps TicketServiceError status through from service (403 forbidden)', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    serviceMocks.editTicketComment.mockRejectedValue(
+      new TicketServiceError('Not allowed to edit this comment', 403)
+    );
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'PATCH',
+      headers: jsonHeaders,
+      body: JSON.stringify({ content: 'x' })
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('DELETE /tickets/:id/comments/:commentId', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('soft-deletes and returns 200', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]); // getScopedTicketOr404
+    serviceMocks.deleteTicketComment.mockResolvedValue({ id: COMMENT_ID, deletedAt: new Date() });
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: jsonHeaders
+    });
+    expect(res.status).toBe(200);
+    expect(serviceMocks.deleteTicketComment).toHaveBeenCalledWith(
+      COMMENT_ID,
+      expect.objectContaining({ userId: 'u-1' }),
+      expect.objectContaining({ canManageAny: expect.any(Boolean) })
+    );
+  });
+
+  it('404s when the ticket is out of scope', async () => {
+    dbSelectMock.mockResolvedValueOnce([]); // getScopedTicketOr404 → not found
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: jsonHeaders
+    });
+    expect(res.status).toBe(404);
+    expect(serviceMocks.deleteTicketComment).not.toHaveBeenCalled();
+  });
+
+  it('maps TicketServiceError status through from service (403 forbidden)', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    serviceMocks.deleteTicketComment.mockRejectedValue(
+      new TicketServiceError('Not allowed to delete this comment', 403)
+    );
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/comments/${COMMENT_ID}`, {
+      method: 'DELETE',
+      headers: jsonHeaders
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -85,7 +85,7 @@ export function actorFrom(c: { get: (k: 'auth') => AuthContext }) {
   return { userId: auth.user.id, name: auth.user.name, email: auth.user.email };
 }
 
-function handleServiceError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
+export function handleServiceError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
   if (err instanceof TicketServiceError) {
     return c.json({ error: err.message }, err.status);
   }

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -6,14 +6,16 @@ import { db } from '../../db';
 import { tickets, ticketComments, ticketAlertLinks, devices, organizations, users, alerts, ticketStatuses } from '../../db/schema';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { deviceInSiteScope, ticketSiteScopeCondition } from './siteScope';
-import { PERMISSIONS } from '../../services/permissions';
+import { PERMISSIONS, hasPermission, type UserPermissions } from '../../services/permissions';
 import {
   createTicketSchema, updateTicketSchema, changeTicketStatusSchema,
-  assignTicketSchema, addTicketCommentSchema, listTicketsQuerySchema
+  assignTicketSchema, addTicketCommentSchema, listTicketsQuerySchema,
+  editCommentSchema
 } from '@breeze/shared';
 import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
   linkAlertToTicket, unlinkAlertFromTicket, updateTicketFields,
+  editTicketComment, deleteTicketComment,
   TicketServiceError
 } from '../../services/ticketService';
 import {
@@ -709,6 +711,61 @@ ticketsRoutes.post(
     try {
       const result = await addTicketComment(id, body, actorFrom(c));
       return c.json({ data: result.comment }, 201);
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  }
+);
+
+const commentParam = z.object({ id: z.string().guid(), commentId: z.string().guid() });
+
+// PATCH /tickets/:id/comments/:commentId — edit a comment body.
+// tickets:write to reach it; author-or-tickets:manage enforced in the service.
+ticketsRoutes.patch(
+  '/:id/comments/:commentId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('param', commentParam),
+  zValidator('json', editCommentSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id, commentId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const canManageAny = perms ? hasPermission(perms, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action) : false;
+    try {
+      const comment = await editTicketComment(commentId, body, actorFrom(c), { canManageAny });
+      return c.json({ data: comment });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  }
+);
+
+// DELETE /tickets/:id/comments/:commentId — soft-delete a comment.
+ticketsRoutes.delete(
+  '/:id/comments/:commentId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('param', commentParam),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id, commentId } = c.req.valid('param');
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const canManageAny = perms ? hasPermission(perms, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action) : false;
+    try {
+      const result = await deleteTicketComment(commentId, actorFrom(c), { canManageAny });
+      return c.json({ data: result });
     } catch (err) {
       return handleServiceError(c, err);
     }

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -439,11 +439,17 @@ ticketsRoutes.get(
       .limit(1);
     const { orgName = null, deviceHostname = null, assigneeName = null, statusName = null, statusColor = null } = decorationRows[0] ?? {};
 
-    const comments = await db
+    const commentRows = await db
       .select()
       .from(ticketComments)
-      .where(and(eq(ticketComments.ticketId, id), isNull(ticketComments.deletedAt)))
+      .where(eq(ticketComments.ticketId, id))
       .orderBy(asc(ticketComments.createdAt));
+    const comments = commentRows.map((row) => ({
+      ...row,
+      deleted: row.deletedAt != null,
+      // Never ship the prior text of a deleted comment to the client.
+      content: row.deletedAt != null ? '' : row.content,
+    }));
 
     const alertLinks = await db
       .select({

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -745,7 +745,7 @@ ticketsRoutes.patch(
     const perms = c.get('permissions') as UserPermissions | undefined;
     const canManageAny = perms ? hasPermission(perms, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action) : false;
     try {
-      const comment = await editTicketComment(commentId, body, actorFrom(c), { canManageAny });
+      const comment = await editTicketComment(commentId, body, actorFrom(c), { canManageAny, expectedTicketId: id });
       return c.json({ data: comment });
     } catch (err) {
       return handleServiceError(c, err);
@@ -770,7 +770,7 @@ ticketsRoutes.delete(
     const perms = c.get('permissions') as UserPermissions | undefined;
     const canManageAny = perms ? hasPermission(perms, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action) : false;
     try {
-      const result = await deleteTicketComment(commentId, actorFrom(c), { canManageAny });
+      const result = await deleteTicketComment(commentId, actorFrom(c), { canManageAny, expectedTicketId: id });
       return c.json({ data: result });
     } catch (err) {
       return handleServiceError(c, err);

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -91,8 +91,8 @@ vi.mock('../db/schema', () => ({
 import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
   linkAlertToTicket, unlinkAlertFromTicket, createTicketFromAlert,
-  updateTicketFields,
-  TicketServiceError, TICKET_STATUS_TRANSITIONS
+  updateTicketFields, editTicketComment, deleteTicketComment, portalCommentMutable,
+  TicketServiceError, TICKET_STATUS_TRANSITIONS, SYSTEM_COMMENT_TYPES
 } from './ticketService';
 
 const actor = { userId: 'u-1', name: 'Tess Tech' };
@@ -1627,5 +1627,284 @@ describe('changeTicketStatus — statusId path', () => {
     expect(err).toBeInstanceOf(TicketServiceError);
     expect(err.code).toBe('INVALID_INPUT');
     expect(err.status).toBe(400);
+  });
+});
+
+// Base comment and ticket fixture shared by comment-mutation tests.
+const BASE_COMMENT = {
+  id: 'c1', ticketId: 't1', userId: 'tech-1', portalUserId: null,
+  commentType: 'comment', content: 'old', deletedAt: null,
+  isPublic: true, authorType: 'staff', createdAt: new Date('2026-01-01T10:00:00Z'),
+  editedAt: null, authorName: 'Tech'
+};
+const BASE_TICKET = { id: 't1', orgId: 'o1', partnerId: 'p1', status: 'open' };
+
+describe('SYSTEM_COMMENT_TYPES', () => {
+  it('contains the four expected type strings', () => {
+    expect(SYSTEM_COMMENT_TYPES).toContain('status_change');
+    expect(SYSTEM_COMMENT_TYPES).toContain('assignment');
+    expect(SYSTEM_COMMENT_TYPES).toContain('time_entry');
+    expect(SYSTEM_COMMENT_TYPES).toContain('system');
+    expect(SYSTEM_COMMENT_TYPES.size).toBe(4);
+  });
+});
+
+describe('editTicketComment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+  });
+
+  it('lets the author edit their own comment and stamps editedAt + audit with previousContent', async () => {
+    const updatedRow = { ...BASE_COMMENT, content: 'new', editedAt: new Date() };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])  // loadCommentWithTicket: comment lookup
+      .mockResolvedValueOnce([BASE_TICKET]);  // loadCommentWithTicket: getTicketOrThrow
+    dbMocks.updateReturning.mockResolvedValue([updatedRow]);
+
+    const result = await editTicketComment('c1', { content: 'new' }, { userId: 'tech-1', name: 'Tech' }, { canManageAny: false });
+
+    expect(result.content).toBe('new');
+    expect(result.editedAt).toBeInstanceOf(Date);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.content).toBe('new');
+    expect(updatePayload.editedAt).toBeInstanceOf(Date);
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'ticket.comment.edit',
+      details: expect.objectContaining({ commentId: 'c1', previousContent: 'old' }),
+      result: 'success'
+    }));
+  });
+
+  it('rejects a non-author without canManageAny (403)', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+
+    const err = await editTicketComment('c1', { content: 'x' }, { userId: 'other-tech' }, { canManageAny: false }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(403);
+  });
+
+  it('allows a non-author WITH canManageAny', async () => {
+    const updatedRow = { ...BASE_COMMENT, content: 'x', editedAt: new Date() };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+    dbMocks.updateReturning.mockResolvedValue([updatedRow]);
+
+    const result = await editTicketComment('c1', { content: 'x' }, { userId: 'admin' }, { canManageAny: true });
+    expect(result.content).toBe('x');
+  });
+
+  it('rejects editing a system-type comment (400)', async () => {
+    const sysComment = { ...BASE_COMMENT, id: 'c-sys', commentType: 'system' };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([sysComment])
+      .mockResolvedValueOnce([BASE_TICKET]);
+
+    const err = await editTicketComment('c-sys', { content: 'x' }, { userId: 'tech-1' }, { canManageAny: true }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(400);
+  });
+
+  it('rejects editing an already-deleted comment (409)', async () => {
+    const deletedComment = { ...BASE_COMMENT, id: 'c-del', deletedAt: new Date() };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([deletedComment])
+      .mockResolvedValueOnce([BASE_TICKET]);
+
+    const err = await editTicketComment('c-del', { content: 'x' }, { userId: 'tech-1' }, { canManageAny: true }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(409);
+  });
+
+  it('throws 404 when the comment does not exist', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([]); // no comment found
+
+    const err = await editTicketComment('missing', { content: 'x' }, { userId: 'tech-1' }, { canManageAny: true }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+  });
+
+  it('rejects all SYSTEM_COMMENT_TYPES (status_change, assignment, time_entry)', async () => {
+    for (const type of ['status_change', 'assignment', 'time_entry']) {
+      vi.clearAllMocks();
+      const typedComment = { ...BASE_COMMENT, commentType: type };
+      dbMocks.selectResult
+        .mockResolvedValueOnce([typedComment])
+        .mockResolvedValueOnce([BASE_TICKET]);
+
+      const err = await editTicketComment('c1', { content: 'x' }, { userId: 'tech-1' }, { canManageAny: true }).catch(e => e);
+      expect(err.status).toBe(400);
+    }
+  });
+});
+
+describe('deleteTicketComment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+  });
+
+  it('soft-deletes (sets deletedAt) and audits with previousContent', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+    // delete path: update returns (no returning needed, but mock shape needs it)
+    dbMocks.updateReturning.mockResolvedValue([]);
+
+    const res = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: false });
+
+    expect(res.id).toBe('c1');
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.deletedAt).toBeInstanceOf(Date);
+    expect(updatePayload).not.toHaveProperty('content'); // only deletedAt stamped
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'ticket.comment.delete',
+      details: expect.objectContaining({ commentId: 'c1', previousContent: 'old' }),
+      result: 'success'
+    }));
+  });
+
+  it('rejects a non-author without canManageAny (403)', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+
+    const err = await deleteTicketComment('c1', { userId: 'other' }, { canManageAny: false }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(403);
+  });
+
+  it('allows a non-author WITH canManageAny', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+    dbMocks.updateReturning.mockResolvedValue([]);
+
+    const res = await deleteTicketComment('c1', { userId: 'admin' }, { canManageAny: true });
+    expect(res.id).toBe('c1');
+  });
+
+  it('rejects deleting a system-type comment (400)', async () => {
+    const sysComment = { ...BASE_COMMENT, commentType: 'status_change' };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([sysComment])
+      .mockResolvedValueOnce([BASE_TICKET]);
+
+    const err = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: true }).catch(e => e);
+    expect(err.status).toBe(400);
+  });
+
+  it('rejects deleting an already-deleted comment (409)', async () => {
+    const deletedComment = { ...BASE_COMMENT, deletedAt: new Date() };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([deletedComment])
+      .mockResolvedValueOnce([BASE_TICKET]);
+
+    const err = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: true }).catch(e => e);
+    expect(err.status).toBe(409);
+  });
+});
+
+describe('portalCommentMutable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+  });
+
+  it('returns ok:true when portal author has no later non-portal comments', async () => {
+    const portalComment = {
+      ...BASE_COMMENT,
+      userId: null,
+      portalUserId: 'pu-42',
+      authorType: 'portal',
+      createdAt: new Date('2026-01-01T10:00:00Z')
+    };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([portalComment])  // comment lookup
+      .mockResolvedValueOnce([]);              // later comments: none
+
+    const result = await portalCommentMutable('c1', 'pu-42');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns not_found when comment does not exist', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([]);
+
+    const result = await portalCommentMutable('missing', 'pu-42');
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('returns not_found when comment is soft-deleted', async () => {
+    const deletedComment = {
+      ...BASE_COMMENT,
+      userId: null,
+      portalUserId: 'pu-42',
+      authorType: 'portal',
+      deletedAt: new Date()
+    };
+    dbMocks.selectResult.mockResolvedValueOnce([deletedComment]);
+
+    const result = await portalCommentMutable('c1', 'pu-42');
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('returns not_author when portalUserId does not match', async () => {
+    const portalComment = {
+      ...BASE_COMMENT,
+      userId: null,
+      portalUserId: 'pu-99',
+      authorType: 'portal',
+      deletedAt: null
+    };
+    dbMocks.selectResult.mockResolvedValueOnce([portalComment]);
+
+    const result = await portalCommentMutable('c1', 'pu-42');
+    expect(result).toEqual({ ok: false, reason: 'not_author' });
+  });
+
+  it('returns staff_replied when a later comment exists with authorType !== portal', async () => {
+    const portalComment = {
+      ...BASE_COMMENT,
+      userId: null,
+      portalUserId: 'pu-42',
+      authorType: 'portal',
+      deletedAt: null,
+      createdAt: new Date('2026-01-01T10:00:00Z')
+    };
+    const laterStaffComment = { authorType: 'staff' };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([portalComment])        // comment lookup
+      .mockResolvedValueOnce([laterStaffComment]);   // later rows with authorType
+
+    const result = await portalCommentMutable('c1', 'pu-42');
+    expect(result).toEqual({ ok: false, reason: 'staff_replied' });
+  });
+
+  it('returns ok:true when later comments are all portal type', async () => {
+    const portalComment = {
+      ...BASE_COMMENT,
+      userId: null,
+      portalUserId: 'pu-42',
+      authorType: 'portal',
+      deletedAt: null,
+      createdAt: new Date('2026-01-01T10:00:00Z')
+    };
+    const laterPortalComment = { authorType: 'portal' };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([portalComment])
+      .mockResolvedValueOnce([laterPortalComment]);
+
+    const result = await portalCommentMutable('c1', 'pu-42');
+    expect(result).toEqual({ ok: true });
   });
 });

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -9,12 +9,14 @@ const { emitMock, emitTriageFeedbackMock, auditMock, allocateMock, dbMocks, conf
   const insertReturning = vi.fn();
   const updateReturning = vi.fn();
   const selectResult = vi.fn();
+  const txExecuteMock = vi.fn().mockResolvedValue(undefined);
+  const txUpdateReturning = vi.fn();
   return {
     emitMock: vi.fn().mockResolvedValue(undefined),
     emitTriageFeedbackMock: vi.fn().mockResolvedValue(undefined),
     auditMock: vi.fn().mockResolvedValue(undefined),
     allocateMock: vi.fn().mockResolvedValue('T-2026-0042'),
-    dbMocks: { insertReturning, updateReturning, selectResult },
+    dbMocks: { insertReturning, updateReturning, selectResult, txExecuteMock, txUpdateReturning },
     configMocks: {
       getOrgSlaOverride: vi.fn().mockResolvedValue({ responseMinutes: null, resolutionMinutes: null }),
       getPartnerPrioritySla: vi.fn().mockResolvedValue({ responseMinutes: null, resolutionMinutes: null }),
@@ -72,14 +74,40 @@ vi.mock('../db', () => ({
     })),
     delete: vi.fn(() => ({
       where: vi.fn(() => ({ returning: vi.fn(() => dbMocks.insertReturning()) }))
-    }))
+    })),
+    // Transaction mock: invokes callback with a tx stub that records SET/VALUES
+    // calls through the same recorders so tests can assert on child table UPDATEs.
+    transaction: vi.fn(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        update: vi.fn(() => ({
+          set: vi.fn((v) => {
+            setMock(v);
+            return {
+              where: vi.fn((w) => {
+                whereMock(w);
+                return { returning: vi.fn(() => dbMocks.txUpdateReturning()) };
+              })
+            };
+          })
+        })),
+        insert: vi.fn(() => ({
+          values: vi.fn((v) => {
+            valuesMock(v);
+            return { returning: vi.fn(() => dbMocks.insertReturning()) };
+          })
+        })),
+        execute: vi.fn((...args) => dbMocks.txExecuteMock(...args)),
+      };
+      return fn(tx);
+    })
   }
 }));
 vi.mock('../db/schema', () => ({
   tickets: { id: 'id', orgId: 'orgId', status: 'status', assignedTo: 'assignedTo', statusId: 'statusId' },
   ticketComments: {},
   ticketAlertLinks: { ticketId: 'ticketId', alertId: 'alertId' },
-  organizations: { id: 'id', partnerId: 'partnerId' },
+  ticketParts: { ticketId: 'ticketId', orgId: 'orgId' },
+  organizations: { id: 'id', partnerId: 'partnerId', name: 'name' },
   alerts: { id: 'id', orgId: 'orgId' },
   devices: { id: 'id', orgId: 'orgId' },
   users: { id: 'id', partnerId: 'partnerId' },
@@ -92,6 +120,7 @@ import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
   linkAlertToTicket, unlinkAlertFromTicket, createTicketFromAlert,
   updateTicketFields, editTicketComment, deleteTicketComment, portalCommentMutable,
+  moveTicketOrg,
   TicketServiceError, TICKET_STATUS_TRANSITIONS, SYSTEM_COMMENT_TYPES
 } from './ticketService';
 
@@ -1921,5 +1950,115 @@ describe('portalCommentMutable', () => {
 
     const result = await portalCommentMutable('c1', 'pu-42');
     expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('moveTicketOrg', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+    whereMock.mockClear();
+    dbMocks.txExecuteMock.mockClear();
+    dbMocks.txUpdateReturning.mockClear();
+  });
+
+  it('moves ticket to a same-partner org, detaches device, re-stamps child org_id on 3 tables', async () => {
+    // Ticket { id:'t1', orgId:'oA', partnerId:'p1', deviceId:'d1' }
+    // Target org { id:'oB', partnerId:'p1', name:'Beta Corp' }
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't1', orgId: 'oA', partnerId: 'p1', deviceId: 'd1' }]) // getTicketOrThrow
+      .mockResolvedValueOnce([                                                               // org lookup (IN clause)
+        { id: 'oA', partnerId: 'p1', name: 'Alpha Corp' },
+        { id: 'oB', partnerId: 'p1', name: 'Beta Corp' }
+      ]);
+    // txUpdateReturning returns the updated ticket row from the tx.update() call
+    dbMocks.txUpdateReturning.mockResolvedValue([{ id: 't1', orgId: 'oB', deviceId: null }]);
+    dbMocks.txExecuteMock.mockResolvedValue(undefined); // 3 child-table raw UPDATEs
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-sys' }]); // tx.insert ticketComments
+
+    const result = await moveTicketOrg('t1', 'oB', { userId: 'admin' });
+
+    expect(result.orgId).toBe('oB');
+    expect(result.deviceId).toBeNull();
+
+    // The tx.update call should have set orgId + deviceId:null
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'oB', deviceId: null }));
+
+    // 3 raw SQL executes for the child tables (time_entries, ticket_parts, ticket_alert_links)
+    expect(dbMocks.txExecuteMock).toHaveBeenCalledTimes(3);
+
+    // System feed comment inserted with "Moved to <org name>"
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+      ticketId: 't1',
+      commentType: 'system',
+      content: 'Moved to Beta Corp'
+    }));
+
+    // ticket.updated event emitted
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'ticket.updated',
+      ticketId: 't1',
+      orgId: 'oB',
+      payload: { changed: ['orgId'] }
+    }));
+
+    // Dual-org audit: source + target
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'oA',
+      action: 'ticket.move_org.source',
+      resourceId: 't1'
+    }));
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'oB',
+      action: 'ticket.move_org.target',
+      resourceId: 't1'
+    }));
+  });
+
+  it('rejects a cross-partner target (400)', async () => {
+    // Ticket in org oA (partner p1), target org oX (partner p2)
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't1', orgId: 'oA', partnerId: 'p1', deviceId: null }]) // ticket
+      .mockResolvedValueOnce([
+        { id: 'oA', partnerId: 'p1', name: 'Alpha Corp' },
+        { id: 'oX', partnerId: 'p2', name: 'Cross Corp' }  // different partner!
+      ]);
+
+    const err = await moveTicketOrg('t1', 'oX', { userId: 'admin' }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/same partner/i);
+    // No transaction started
+    expect(setMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when target equals the current org', async () => {
+    const ticket = { id: 't1', orgId: 'oA', partnerId: 'p1', deviceId: null };
+    dbMocks.selectResult.mockResolvedValueOnce([ticket]); // getTicketOrThrow
+
+    const result = await moveTicketOrg('t1', 'oA', { userId: 'admin' });
+    // Returns the existing ticket unchanged
+    expect(result).toBe(ticket);
+    // No org lookup, no transaction, no event, no audit
+    expect(dbMocks.selectResult).toHaveBeenCalledTimes(1);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when target org is not found (404)', async () => {
+    // Org lookup returns only the source org — target is missing
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't1', orgId: 'oA', partnerId: 'p1', deviceId: null }])
+      .mockResolvedValueOnce([{ id: 'oA', partnerId: 'p1', name: 'Alpha Corp' }]); // no oB row
+
+    const err = await moveTicketOrg('t1', 'oB', { userId: 'admin' }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+    expect(err.message).toMatch(/target organization not found/i);
+    expect(setMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -1755,8 +1755,8 @@ describe('deleteTicketComment', () => {
     dbMocks.selectResult
       .mockResolvedValueOnce([BASE_COMMENT])
       .mockResolvedValueOnce([BASE_TICKET]);
-    // delete path: update returns (no returning needed, but mock shape needs it)
-    dbMocks.updateReturning.mockResolvedValue([]);
+    // delete path: update returns the soft-deleted row (required by TOCTOU guard)
+    dbMocks.updateReturning.mockResolvedValue([{ id: 'c1' }]);
 
     const res = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: false });
 
@@ -1787,7 +1787,7 @@ describe('deleteTicketComment', () => {
     dbMocks.selectResult
       .mockResolvedValueOnce([BASE_COMMENT])
       .mockResolvedValueOnce([BASE_TICKET]);
-    dbMocks.updateReturning.mockResolvedValue([]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 'c1' }]);
 
     const res = await deleteTicketComment('c1', { userId: 'admin' }, { canManageAny: true });
     expect(res.id).toBe('c1');
@@ -1811,6 +1811,21 @@ describe('deleteTicketComment', () => {
 
     const err = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: true }).catch(e => e);
     expect(err.status).toBe(409);
+  });
+
+  it('throws 409 when the soft-delete update races and returns zero rows (TOCTOU)', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+    // Simulate concurrent soft-delete: the UPDATE matched nothing.
+    dbMocks.updateReturning.mockResolvedValue([]);
+
+    const err = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: false }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(409);
+    // Audit and event must NOT have fired.
+    expect(auditMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -1734,6 +1734,31 @@ describe('editTicketComment', () => {
     expect(result.content).toBe('x');
   });
 
+  it('throws 404 when expectedTicketId is provided but does not match the comment ticketId', async () => {
+    // Comment belongs to ticket 't1'; caller supplies a different URL ticket id.
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])  // loadCommentWithTicket: comment lookup (ticketId='t1')
+      .mockResolvedValueOnce([BASE_TICKET]);  // loadCommentWithTicket: getTicketOrThrow
+
+    const err = await editTicketComment('c1', { content: 'x' }, { userId: 'tech-1' }, { canManageAny: true, expectedTicketId: 'other-ticket-id' }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+    // Must not reveal the comment exists or write any audit/event
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it('passes through when expectedTicketId is omitted (backward-compat)', async () => {
+    const updatedRow = { ...BASE_COMMENT, content: 'compat', editedAt: new Date() };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+    dbMocks.updateReturning.mockResolvedValue([updatedRow]);
+
+    // No expectedTicketId in opts — must still succeed
+    const result = await editTicketComment('c1', { content: 'compat' }, { userId: 'tech-1' }, { canManageAny: false });
+    expect(result.content).toBe('compat');
+  });
+
   it('rejects editing a system-type comment (400)', async () => {
     const sysComment = { ...BASE_COMMENT, id: 'c-sys', commentType: 'system' };
     dbMocks.selectResult
@@ -1829,6 +1854,30 @@ describe('deleteTicketComment', () => {
     dbMocks.updateReturning.mockResolvedValue([{ id: 'c1' }]);
 
     const res = await deleteTicketComment('c1', { userId: 'admin' }, { canManageAny: true });
+    expect(res.id).toBe('c1');
+  });
+
+  it('throws 404 when expectedTicketId is provided but does not match the comment ticketId', async () => {
+    // Comment belongs to ticket 't1'; caller supplies a different URL ticket id.
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])  // loadCommentWithTicket: comment lookup (ticketId='t1')
+      .mockResolvedValueOnce([BASE_TICKET]);  // loadCommentWithTicket: getTicketOrThrow
+
+    const err = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: true, expectedTicketId: 'other-ticket-id' }).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+    // Must not reveal the comment exists or write any audit/event
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it('passes through when expectedTicketId is omitted (backward-compat)', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_COMMENT])
+      .mockResolvedValueOnce([BASE_TICKET]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 'c1' }]);
+
+    // No expectedTicketId in opts — must still succeed
+    const res = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: false });
     expect(res.id).toBe('c1');
   });
 

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -1706,6 +1706,11 @@ describe('editTicketComment', () => {
       details: expect.objectContaining({ commentId: 'c1', previousContent: 'old' }),
       result: 'success'
     }));
+
+    // Fix 1: edit must NOT emit a ticket event — doing so re-triggers "new reply"
+    // emails to the portal requester. Regression guard: if emitMock is called here
+    // the spurious customer notification bug has returned.
+    expect(emitMock).not.toHaveBeenCalled();
   });
 
   it('rejects a non-author without canManageAny (403)', async () => {
@@ -1800,6 +1805,11 @@ describe('deleteTicketComment', () => {
       details: expect.objectContaining({ commentId: 'c1', previousContent: 'old' }),
       result: 'success'
     }));
+
+    // Fix 1: delete must NOT emit a ticket event — doing so sends a ghost "new
+    // reply" email to the portal requester. Regression guard: if emitMock is called
+    // here the spurious customer notification bug has returned.
+    expect(emitMock).not.toHaveBeenCalled();
   });
 
   it('rejects a non-author without canManageAny (403)', async () => {

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -954,14 +954,11 @@ export async function editTicketComment(
   const row = updated[0];
   if (!row) throw new TicketServiceError('Comment not found', 404);
 
-  await emitTicketEvent({
-    type: 'ticket.commented',
-    ticketId: ticket.id,
-    orgId: ticket.orgId,
-    partnerId: ticket.partnerId ?? null,
-    actorUserId: actor.userId,
-    payload: { commentId, isPublic: row.isPublic }
-  });
+  // NOTE: no emitTicketEvent here — emitting 'ticket.commented' on an edit
+  // would re-trigger the notify worker's "new reply" email to the portal
+  // requester. The web UI re-fetches via load({background:true}) after edit.
+  // A future 'ticket.comment_edited' event type can be added when automation
+  // consumers need it.
   await createAuditLogAsync({
     orgId: ticket.orgId,
     actorId: actor.userId,
@@ -992,14 +989,11 @@ export async function deleteTicketComment(
     throw new TicketServiceError('Comment not found or already deleted', 409);
   }
 
-  await emitTicketEvent({
-    type: 'ticket.commented',
-    ticketId: ticket.id,
-    orgId: ticket.orgId,
-    partnerId: ticket.partnerId ?? null,
-    actorUserId: actor.userId,
-    payload: { commentId, isPublic: comment.isPublic }
-  });
+  // NOTE: no emitTicketEvent here — emitting 'ticket.commented' on a delete
+  // would send a ghost "new reply" email to the portal requester. The web UI
+  // re-fetches via load({background:true}) after delete.
+  // A future 'ticket.comment_deleted' event type can be added when automation
+  // consumers need it.
   await createAuditLogAsync({
     orgId: ticket.orgId,
     actorId: actor.userId,
@@ -1017,6 +1011,9 @@ export async function deleteTicketComment(
 // Child tables that denormalize org_id and reference a ticket. Mirrors the
 // device-move CUSTOM_ORG_REWRITE_TABLES set (core.ts) — keep in lockstep.
 // ticket_comments is intentionally absent: it has no org_id (child-via-parent).
+// invoice_lines is intentionally excluded: issued billing history must remain
+// stamped with the org that was billed (matches device CUSTOM_ORG_REWRITE_TABLES
+// exclusion); its ticket_id FK is ON DELETE SET NULL so moves do not orphan it.
 const TICKET_ORG_DENORMALIZED_TABLES = ['time_entries', 'ticket_parts', 'ticket_alert_links'] as const;
 
 /**

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1,7 +1,7 @@
-import { and, eq, gt, isNull } from 'drizzle-orm';
+import { and, eq, gt, isNull, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, ticketStatusEnum, ticketSourceEnum } from '../db/schema';
+import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, ticketStatusEnum, ticketSourceEnum, ticketParts, timeEntries } from '../db/schema';
 import { allocateInternalTicketNumber } from './ticketNumbers';
 import { emitTicketEvent } from './ticketEvents';
 import { createAuditLogAsync } from './auditService';
@@ -1010,6 +1010,78 @@ export async function deleteTicketComment(
     result: 'success'
   });
   return { id: commentId };
+}
+
+// ─── Org re-assignment (Phase 6a) ─────────────────────────────────────────────
+
+// Child tables that denormalize org_id and reference a ticket. Mirrors the
+// device-move CUSTOM_ORG_REWRITE_TABLES set (core.ts) — keep in lockstep.
+// ticket_comments is intentionally absent: it has no org_id (child-via-parent).
+const TICKET_ORG_DENORMALIZED_TABLES = ['time_entries', 'ticket_parts', 'ticket_alert_links'] as const;
+
+/**
+ * Reassigns a ticket to another organization of the SAME partner.
+ * - Detaches any linked device (device belongs to the source org).
+ * - Re-stamps org_id on all denormalized child tables.
+ * - Writes a system feed comment and dual-org audit log entries.
+ * - Emits ticket.updated.
+ * Rejects cross-partner moves with 400; unknown target with 404; same-org is a no-op.
+ */
+export async function moveTicketOrg(ticketId: string, targetOrgId: string, actor: TicketActor): Promise<typeof tickets.$inferSelect> {
+  const ticket = await getTicketOrThrow(ticketId);
+  if (ticket.orgId === targetOrgId) return ticket;
+
+  const orgRows = await db
+    .select({ id: organizations.id, partnerId: organizations.partnerId, name: organizations.name })
+    .from(organizations)
+    .where(sql`${organizations.id} IN (${ticket.orgId}::uuid, ${targetOrgId}::uuid)`)
+    .limit(2);
+  const sourceOrg = orgRows.find((r) => r.id === ticket.orgId);
+  const targetOrg = orgRows.find((r) => r.id === targetOrgId);
+  if (!targetOrg) throw new TicketServiceError('Target organization not found', 404);
+  if (!sourceOrg || sourceOrg.partnerId !== targetOrg.partnerId) {
+    throw new TicketServiceError('Tickets can only be moved between organizations of the same partner', 400);
+  }
+
+  let updated: typeof tickets.$inferSelect | undefined;
+  await db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(tickets)
+      .set({ orgId: targetOrgId, deviceId: null, updatedAt: new Date() })
+      .where(eq(tickets.id, ticketId))
+      .returning();
+    updated = row;
+    for (const table of TICKET_ORG_DENORMALIZED_TABLES) {
+      await tx.execute(
+        sql`UPDATE ${sql.identifier(table)} SET org_id = ${targetOrgId}::uuid WHERE ticket_id = ${ticketId}::uuid`
+      );
+    }
+    // System feed entry on the moved ticket.
+    await tx.insert(ticketComments).values({
+      ticketId,
+      userId: actor.userId,
+      authorName: actor.name ?? null,
+      authorType: 'internal',
+      commentType: 'system',
+      content: `Moved to ${targetOrg.name}`,
+      isPublic: false
+    });
+  });
+  if (!updated) throw new TicketServiceError('Ticket not found', 404);
+
+  await emitTicketEvent({
+    type: 'ticket.updated',
+    ticketId,
+    orgId: targetOrgId,
+    partnerId: ticket.partnerId ?? null,
+    actorUserId: actor.userId,
+    payload: { changed: ['orgId'] }
+  });
+  // Audit on BOTH orgs so the move shows in source and target feeds (device precedent).
+  const details = { fromOrgId: ticket.orgId, toOrgId: targetOrgId, detachedDeviceId: ticket.deviceId ?? null };
+  await createAuditLogAsync({ orgId: ticket.orgId, actorId: actor.userId, action: 'ticket.move_org.source', resourceType: 'ticket', resourceId: ticketId, details, result: 'success' });
+  await createAuditLogAsync({ orgId: targetOrgId, actorId: actor.userId, action: 'ticket.move_org.target', resourceType: 'ticket', resourceId: ticketId, details, result: 'success' });
+  return updated;
 }
 
 /**

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -983,11 +983,14 @@ export async function deleteTicketComment(
   assertCommentEditable(comment, actor, opts.canManageAny);
 
   const previousContent = comment.content;
-  await db
+  const deleted = await db
     .update(ticketComments)
     .set({ deletedAt: new Date() })
     .where(eq(ticketComments.id, commentId))
     .returning();
+  if (deleted.length === 0) {
+    throw new TicketServiceError('Comment not found or already deleted', 409);
+  }
 
   await emitTicketEvent({
     type: 'ticket.commented',
@@ -1029,6 +1032,7 @@ export async function portalCommentMutable(
 
   // Single query: select authorType for all later comments on this ticket.
   // If any has authorType !== 'portal' the edit window is closed.
+  // Deleted later comments still close the window — staff acted, then withdrew.
   const laterRows = await db
     .select({ authorType: ticketComments.authorType })
     .from(ticketComments)

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1,7 +1,7 @@
 import { and, eq, gt, isNull, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, ticketStatusEnum, ticketSourceEnum, ticketParts, timeEntries } from '../db/schema';
+import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, ticketStatusEnum, ticketSourceEnum } from '../db/schema';
 import { allocateInternalTicketNumber } from './ticketNumbers';
 import { emitTicketEvent } from './ticketEvents';
 import { createAuditLogAsync } from './auditService';
@@ -22,7 +22,7 @@ export const TICKET_STATUS_TRANSITIONS: Record<TicketStatus, readonly TicketStat
   closed: ['open']
 };
 
-export type TicketServiceErrorStatus = 400 | 404 | 409 | 500;
+export type TicketServiceErrorStatus = 400 | 403 | 404 | 409 | 500;
 
 /**
  * Machine-readable error codes for callers that aggregate outcomes (e.g. the

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, gt, isNull } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, ticketStatusEnum, ticketSourceEnum } from '../db/schema';
@@ -898,4 +898,147 @@ export async function createTicketFromAlert(
     );
   }
   return ticket;
+}
+
+// ─── Comment mutation primitives (Phase 6a) ───────────────────────────────────
+
+/**
+ * System-generated comment types that may never be edited or deleted by users.
+ */
+export const SYSTEM_COMMENT_TYPES = new Set(['status_change', 'assignment', 'time_entry', 'system']);
+
+async function loadCommentWithTicket(commentId: string) {
+  const rows = await db
+    .select()
+    .from(ticketComments)
+    .where(eq(ticketComments.id, commentId))
+    .limit(1);
+  const comment = rows[0];
+  if (!comment) throw new TicketServiceError('Comment not found', 404);
+  const ticket = await getTicketOrThrow(comment.ticketId);
+  return { comment, ticket };
+}
+
+function assertCommentEditable(
+  comment: typeof ticketComments.$inferSelect,
+  actor: TicketActor,
+  canManageAny: boolean
+) {
+  if (SYSTEM_COMMENT_TYPES.has(comment.commentType)) {
+    throw new TicketServiceError('System-generated entries cannot be edited or deleted', 400);
+  }
+  if (comment.deletedAt) {
+    throw new TicketServiceError('Comment already deleted', 409);
+  }
+  const isAuthor = comment.userId != null && comment.userId === actor.userId;
+  if (!isAuthor && !canManageAny) {
+    throw new TicketServiceError('You can only edit or delete your own comments', 403);
+  }
+}
+
+export async function editTicketComment(
+  commentId: string,
+  input: { content: string },
+  actor: TicketActor,
+  opts: { canManageAny: boolean }
+) {
+  const { comment, ticket } = await loadCommentWithTicket(commentId);
+  assertCommentEditable(comment, actor, opts.canManageAny);
+
+  const previousContent = comment.content;
+  const updated = await db
+    .update(ticketComments)
+    .set({ content: input.content, editedAt: new Date() })
+    .where(eq(ticketComments.id, commentId))
+    .returning();
+  const row = updated[0];
+  if (!row) throw new TicketServiceError('Comment not found', 404);
+
+  await emitTicketEvent({
+    type: 'ticket.commented',
+    ticketId: ticket.id,
+    orgId: ticket.orgId,
+    partnerId: ticket.partnerId ?? null,
+    actorUserId: actor.userId,
+    payload: { commentId, isPublic: row.isPublic }
+  });
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.comment.edit',
+    resourceType: 'ticket',
+    resourceId: ticket.id,
+    details: { commentId, previousContent },
+    result: 'success'
+  });
+  return row;
+}
+
+export async function deleteTicketComment(
+  commentId: string,
+  actor: TicketActor,
+  opts: { canManageAny: boolean }
+) {
+  const { comment, ticket } = await loadCommentWithTicket(commentId);
+  assertCommentEditable(comment, actor, opts.canManageAny);
+
+  const previousContent = comment.content;
+  await db
+    .update(ticketComments)
+    .set({ deletedAt: new Date() })
+    .where(eq(ticketComments.id, commentId))
+    .returning();
+
+  await emitTicketEvent({
+    type: 'ticket.commented',
+    ticketId: ticket.id,
+    orgId: ticket.orgId,
+    partnerId: ticket.partnerId ?? null,
+    actorUserId: actor.userId,
+    payload: { commentId, isPublic: comment.isPublic }
+  });
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.comment.delete',
+    resourceType: 'ticket',
+    resourceId: ticket.id,
+    details: { commentId, previousContent },
+    result: 'success'
+  });
+  return { id: commentId };
+}
+
+/**
+ * Checks whether a portal customer may still edit or delete their own comment.
+ * The window closes once any later comment on the ticket has authorType !== 'portal'
+ * (i.e. a staff member or system event has acted on the ticket after this comment).
+ */
+export async function portalCommentMutable(
+  commentId: string,
+  portalUserId: string
+): Promise<{ ok: boolean; reason?: 'not_found' | 'not_author' | 'staff_replied' }> {
+  const rows = await db
+    .select()
+    .from(ticketComments)
+    .where(eq(ticketComments.id, commentId))
+    .limit(1);
+  const comment = rows[0];
+  if (!comment || comment.deletedAt) return { ok: false, reason: 'not_found' };
+  if (comment.portalUserId !== portalUserId) return { ok: false, reason: 'not_author' };
+
+  // Single query: select authorType for all later comments on this ticket.
+  // If any has authorType !== 'portal' the edit window is closed.
+  const laterRows = await db
+    .select({ authorType: ticketComments.authorType })
+    .from(ticketComments)
+    .where(and(
+      eq(ticketComments.ticketId, comment.ticketId),
+      gt(ticketComments.createdAt, comment.createdAt)
+    ))
+    .limit(50);
+  if (laterRows.some((r) => r.authorType !== 'portal')) {
+    return { ok: false, reason: 'staff_replied' };
+  }
+  return { ok: true };
 }

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -940,9 +940,14 @@ export async function editTicketComment(
   commentId: string,
   input: { content: string },
   actor: TicketActor,
-  opts: { canManageAny: boolean }
+  opts: { canManageAny: boolean; expectedTicketId?: string }
 ) {
   const { comment, ticket } = await loadCommentWithTicket(commentId);
+  // Defense-in-depth: reject comment/ticket id mismatch before any
+  // existence-revealing check so the response is indistinguishable from missing.
+  if (opts.expectedTicketId !== undefined && comment.ticketId !== opts.expectedTicketId) {
+    throw new TicketServiceError('Comment not found', 404);
+  }
   assertCommentEditable(comment, actor, opts.canManageAny);
 
   const previousContent = comment.content;
@@ -974,9 +979,14 @@ export async function editTicketComment(
 export async function deleteTicketComment(
   commentId: string,
   actor: TicketActor,
-  opts: { canManageAny: boolean }
+  opts: { canManageAny: boolean; expectedTicketId?: string }
 ) {
   const { comment, ticket } = await loadCommentWithTicket(commentId);
+  // Defense-in-depth: reject comment/ticket id mismatch before any
+  // existence-revealing check so the response is indistinguishable from missing.
+  if (opts.expectedTicketId !== undefined && comment.ticketId !== opts.expectedTicketId) {
+    throw new TicketServiceError('Comment not found', 404);
+  }
   assertCommentEditable(comment, actor, opts.canManageAny);
 
   const previousContent = comment.content;

--- a/apps/web/src/components/tickets/TicketFeed.test.tsx
+++ b/apps/web/src/components/tickets/TicketFeed.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import TicketFeed from './TicketFeed';
 import type { TicketComment } from './ticketConfig';
@@ -124,5 +124,72 @@ describe('TicketFeed', () => {
       />
     );
     expect(screen.getByText('Technician logged time')).toBeInTheDocument();
+  });
+
+  it('shows an edited badge when editedAt is set', () => {
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ed-1', content: 'hi', editedAt: '2026-06-01T11:00:00.000Z' })]}
+      />
+    );
+    expect(screen.getByTestId('ticket-comment-edited-ed-1')).toBeInTheDocument();
+  });
+
+  it('does not show an edited badge when editedAt is absent', () => {
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ed-2', content: 'hi' })]}
+      />
+    );
+    expect(screen.queryByTestId('ticket-comment-edited-ed-2')).toBeNull();
+  });
+
+  it('renders a tombstone for a deleted comment and hides the body', () => {
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'del-1', content: '', deleted: true })]}
+      />
+    );
+    expect(screen.getByTestId('ticket-comment-deleted-del-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('ticket-comment-del-1')).toBeNull();
+  });
+
+  it('shows edit and delete controls when canManageComment returns true and handlers are provided', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ctrl-1', content: 'hi' })]}
+        onEditComment={onEdit}
+        onDeleteComment={onDelete}
+        canManageComment={() => true}
+      />
+    );
+    expect(screen.getByTestId('ticket-comment-edit-ctrl-1')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-comment-delete-ctrl-1')).toBeInTheDocument();
+  });
+
+  it('hides controls when canManageComment returns false', () => {
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ctrl-2', content: 'hi' })]}
+        onEditComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+        canManageComment={() => false}
+      />
+    );
+    expect(screen.queryByTestId('ticket-comment-edit-ctrl-2')).toBeNull();
+    expect(screen.queryByTestId('ticket-comment-delete-ctrl-2')).toBeNull();
+  });
+
+  it('hides controls when handler props are not provided even if canManageComment returns true', () => {
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ctrl-3', content: 'hi' })]}
+        canManageComment={() => true}
+      />
+    );
+    expect(screen.queryByTestId('ticket-comment-edit-ctrl-3')).toBeNull();
+    expect(screen.queryByTestId('ticket-comment-delete-ctrl-3')).toBeNull();
   });
 });

--- a/apps/web/src/components/tickets/TicketFeed.test.tsx
+++ b/apps/web/src/components/tickets/TicketFeed.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import TicketFeed from './TicketFeed';
@@ -191,5 +191,165 @@ describe('TicketFeed', () => {
     );
     expect(screen.queryByTestId('ticket-comment-edit-ctrl-3')).toBeNull();
     expect(screen.queryByTestId('ticket-comment-delete-ctrl-3')).toBeNull();
+  });
+});
+
+// ─── Inline comment editor ────────────────────────────────────────────────────
+
+describe('TicketFeed inline comment editor', () => {
+  it('clicking edit opens an inline textarea pre-filled with comment content', () => {
+    const onEdit = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ed-open', content: 'Original text' })]}
+        onEditComment={onEdit}
+        onDeleteComment={vi.fn()}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-ed-open'));
+
+    const textarea = screen.getByTestId('ticket-comment-edit-textarea-ed-open');
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue('Original text');
+  });
+
+  it('save calls onEditComment with id and new text, then closes the editor', async () => {
+    const onEdit = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ed-save', content: 'Original text' })]}
+        onEditComment={onEdit}
+        onDeleteComment={vi.fn()}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-ed-save'));
+    const textarea = screen.getByTestId('ticket-comment-edit-textarea-ed-save');
+    fireEvent.change(textarea, { target: { value: 'Updated text' } });
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-save-ed-save'));
+
+    expect(onEdit).toHaveBeenCalledWith('ed-save', 'Updated text');
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-comment-edit-textarea-ed-save')).toBeNull();
+    });
+  });
+
+  it('cancel closes the editor without calling onEditComment', () => {
+    const onEdit = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ed-cancel', content: 'Original text' })]}
+        onEditComment={onEdit}
+        onDeleteComment={vi.fn()}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-ed-cancel'));
+    const textarea = screen.getByTestId('ticket-comment-edit-textarea-ed-cancel');
+    fireEvent.change(textarea, { target: { value: 'Changed text' } });
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-cancel-ed-cancel'));
+
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('ticket-comment-edit-textarea-ed-cancel')).toBeNull();
+  });
+
+  it('save is a no-op if draft is unchanged', () => {
+    const onEdit = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ed-noop', content: 'Same text' })]}
+        onEditComment={onEdit}
+        onDeleteComment={vi.fn()}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-ed-noop'));
+    // Don't change the textarea value — leave it as-is
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-save-ed-noop'));
+
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it('save is a no-op if draft is empty', () => {
+    const onEdit = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'ed-empty', content: 'Some text' })]}
+        onEditComment={onEdit}
+        onDeleteComment={vi.fn()}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-ed-empty'));
+    fireEvent.change(screen.getByTestId('ticket-comment-edit-textarea-ed-empty'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-save-ed-empty'));
+
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Delete confirm dialog ────────────────────────────────────────────────────
+
+describe('TicketFeed delete confirm dialog', () => {
+  it('clicking delete opens a ConfirmDialog without calling onDeleteComment', () => {
+    const onDelete = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'del-dlg', content: 'Bye' })]}
+        onEditComment={vi.fn()}
+        onDeleteComment={onDelete}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-delete-del-dlg'));
+
+    // The confirm dialog should appear
+    expect(screen.getByText('Delete comment')).toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('confirming the dialog calls onDeleteComment with the comment id', () => {
+    const onDelete = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'del-confirm', content: 'Bye' })]}
+        onEditComment={vi.fn()}
+        onDeleteComment={onDelete}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-delete-del-confirm'));
+    fireEvent.click(screen.getByTestId('ticket-comment-delete-confirm'));
+
+    expect(onDelete).toHaveBeenCalledWith('del-confirm');
+  });
+
+  it('cancelling the dialog does NOT call onDeleteComment', async () => {
+    const onDelete = vi.fn();
+    render(
+      <TicketFeed
+        comments={[makeComment({ id: 'del-cancel-dlg', content: 'Bye' })]}
+        onEditComment={vi.fn()}
+        onDeleteComment={onDelete}
+        canManageComment={() => true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ticket-comment-delete-del-cancel-dlg'));
+    // Click the Cancel button in the dialog
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Delete comment')).toBeNull();
+    });
+    expect(onDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/tickets/TicketFeed.tsx
+++ b/apps/web/src/components/tickets/TicketFeed.tsx
@@ -62,7 +62,17 @@ function SystemRun({ items }: { items: TicketComment[] }) {
   );
 }
 
-export default function TicketFeed({ comments }: { comments: TicketComment[] }) {
+export default function TicketFeed({
+  comments,
+  onEditComment,
+  onDeleteComment,
+  canManageComment,
+}: {
+  comments: TicketComment[];
+  onEditComment?: (id: string, content: string) => void;
+  onDeleteComment?: (id: string) => void;
+  canManageComment?: (c: TicketComment) => boolean;
+}) {
   const blocks = useMemo(() => groupFeed(comments), [comments]);
 
   if (comments.length === 0) {
@@ -74,6 +84,14 @@ export default function TicketFeed({ comments }: { comments: TicketComment[] }) 
       {blocks.map((b, i) =>
         b.kind === 'system-run' ? (
           <SystemRun key={`run-${i}`} items={b.items} />
+        ) : b.item.deleted ? (
+          <div
+            key={b.item.id}
+            className="rounded-lg border border-dashed p-3 text-sm italic text-muted-foreground"
+            data-testid={`ticket-comment-deleted-${b.item.id}`}
+          >
+            {(b.item.authorName ?? 'A comment')} — deleted
+          </div>
         ) : (
           <div
             key={b.item.id}
@@ -86,9 +104,32 @@ export default function TicketFeed({ comments }: { comments: TicketComment[] }) 
             <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
               <span className="font-medium text-foreground">{b.item.authorName ?? (b.item.portalUserId ? 'Requester' : 'Technician')}</span>
               {!b.item.isPublic && <span className="font-medium text-warning">Internal</span>}
+              {b.item.editedAt && (
+                <span data-testid={`ticket-comment-edited-${b.item.id}`} title={formatDateTime(b.item.editedAt)}>edited</span>
+              )}
               <span className="ml-auto" title={formatDateTime(b.item.createdAt)}>
                 {formatDateTime(b.item.createdAt, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
               </span>
+              {canManageComment?.(b.item) && onEditComment && (
+                <button
+                  type="button"
+                  className="text-xs hover:text-foreground"
+                  data-testid={`ticket-comment-edit-${b.item.id}`}
+                  onClick={() => onEditComment(b.item.id, b.item.content)}
+                >
+                  Edit
+                </button>
+              )}
+              {canManageComment?.(b.item) && onDeleteComment && (
+                <button
+                  type="button"
+                  className="text-xs hover:text-destructive"
+                  data-testid={`ticket-comment-delete-${b.item.id}`}
+                  onClick={() => onDeleteComment(b.item.id)}
+                >
+                  Delete
+                </button>
+              )}
             </div>
             <p className="whitespace-pre-wrap text-sm">{b.item.content}</p>
           </div>

--- a/apps/web/src/components/tickets/TicketFeed.tsx
+++ b/apps/web/src/components/tickets/TicketFeed.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { statusConfig, type TicketComment, type TicketStatus } from './ticketConfig';
 import { formatDateTime, formatTime } from '@/lib/dateTimeFormat';
 
@@ -74,67 +75,137 @@ export default function TicketFeed({
   canManageComment?: (c: TicketComment) => boolean;
 }) {
   const blocks = useMemo(() => groupFeed(comments), [comments]);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   if (comments.length === 0) {
     return <p className="px-4 py-8 text-center text-sm text-muted-foreground" data-testid="ticket-feed-empty">No activity yet.</p>;
   }
 
+  const openEditor = (id: string, content: string) => {
+    setEditingId(id);
+    setDraft(content);
+  };
+
+  const closeEditor = () => {
+    setEditingId(null);
+    setDraft('');
+  };
+
+  const saveEdit = (id: string, originalContent: string) => {
+    if (!draft.trim() || draft === originalContent) {
+      closeEditor();
+      return;
+    }
+    onEditComment?.(id, draft);
+    closeEditor();
+  };
+
   return (
-    <div className="space-y-3 p-4" data-testid="ticket-feed">
-      {blocks.map((b, i) =>
-        b.kind === 'system-run' ? (
-          <SystemRun key={`run-${i}`} items={b.items} />
-        ) : b.item.deleted ? (
-          <div
-            key={b.item.id}
-            className="rounded-lg border border-dashed p-3 text-sm italic text-muted-foreground"
-            data-testid={`ticket-comment-deleted-${b.item.id}`}
-          >
-            {(b.item.authorName ?? 'A comment')} — deleted
-          </div>
-        ) : (
-          <div
-            key={b.item.id}
-            className={cn(
-              'rounded-lg border p-3',
-              !b.item.isPublic && 'border-warning/30 bg-warning/10'
-            )}
-            data-testid={`ticket-comment-${b.item.id}`}
-          >
-            <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="font-medium text-foreground">{b.item.authorName ?? (b.item.portalUserId ? 'Requester' : 'Technician')}</span>
-              {!b.item.isPublic && <span className="font-medium text-warning">Internal</span>}
-              {b.item.editedAt && (
-                <span data-testid={`ticket-comment-edited-${b.item.id}`} title={formatDateTime(b.item.editedAt)}>edited</span>
+    <>
+      <div className="space-y-3 p-4" data-testid="ticket-feed">
+        {blocks.map((b, i) =>
+          b.kind === 'system-run' ? (
+            <SystemRun key={`run-${i}`} items={b.items} />
+          ) : b.item.deleted ? (
+            <div
+              key={b.item.id}
+              className="rounded-lg border border-dashed p-3 text-sm italic text-muted-foreground"
+              data-testid={`ticket-comment-deleted-${b.item.id}`}
+            >
+              {(b.item.authorName ?? 'A comment')} — deleted
+            </div>
+          ) : (
+            <div
+              key={b.item.id}
+              className={cn(
+                'rounded-lg border p-3',
+                !b.item.isPublic && 'border-warning/30 bg-warning/10'
               )}
-              <span className="ml-auto" title={formatDateTime(b.item.createdAt)}>
-                {formatDateTime(b.item.createdAt, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
-              </span>
-              {canManageComment?.(b.item) && onEditComment && (
-                <button
-                  type="button"
-                  className="text-xs hover:text-foreground"
-                  data-testid={`ticket-comment-edit-${b.item.id}`}
-                  onClick={() => onEditComment(b.item.id, b.item.content)}
-                >
-                  Edit
-                </button>
-              )}
-              {canManageComment?.(b.item) && onDeleteComment && (
-                <button
-                  type="button"
-                  className="text-xs hover:text-destructive"
-                  data-testid={`ticket-comment-delete-${b.item.id}`}
-                  onClick={() => onDeleteComment(b.item.id)}
-                >
-                  Delete
-                </button>
+              data-testid={`ticket-comment-${b.item.id}`}
+            >
+              <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">{b.item.authorName ?? (b.item.portalUserId ? 'Requester' : 'Technician')}</span>
+                {!b.item.isPublic && <span className="font-medium text-warning">Internal</span>}
+                {b.item.editedAt && (
+                  <span data-testid={`ticket-comment-edited-${b.item.id}`} title={formatDateTime(b.item.editedAt)}>edited</span>
+                )}
+                <span className="ml-auto" title={formatDateTime(b.item.createdAt)}>
+                  {formatDateTime(b.item.createdAt, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                </span>
+                {canManageComment?.(b.item) && onEditComment && (
+                  <button
+                    type="button"
+                    className="text-xs hover:text-foreground"
+                    data-testid={`ticket-comment-edit-${b.item.id}`}
+                    onClick={() => openEditor(b.item.id, b.item.content)}
+                  >
+                    Edit
+                  </button>
+                )}
+                {canManageComment?.(b.item) && onDeleteComment && (
+                  <button
+                    type="button"
+                    className="text-xs hover:text-destructive"
+                    data-testid={`ticket-comment-delete-${b.item.id}`}
+                    onClick={() => setConfirmDeleteId(b.item.id)}
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+              {editingId === b.item.id ? (
+                <div className="space-y-2 mt-1">
+                  <textarea
+                    className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+                    rows={3}
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    data-testid={`ticket-comment-edit-textarea-${b.item.id}`}
+                    autoFocus
+                  />
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={closeEditor}
+                      className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                      data-testid={`ticket-comment-edit-cancel-${b.item.id}`}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => saveEdit(b.item.id, b.item.content)}
+                      className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white"
+                      data-testid={`ticket-comment-edit-save-${b.item.id}`}
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <p className="whitespace-pre-wrap text-sm">{b.item.content}</p>
               )}
             </div>
-            <p className="whitespace-pre-wrap text-sm">{b.item.content}</p>
-          </div>
-        )
-      )}
-    </div>
+          )
+        )}
+      </div>
+      <ConfirmDialog
+        open={confirmDeleteId !== null}
+        onClose={() => setConfirmDeleteId(null)}
+        onConfirm={() => {
+          if (confirmDeleteId) {
+            onDeleteComment?.(confirmDeleteId);
+          }
+          setConfirmDeleteId(null);
+        }}
+        title="Delete comment"
+        message="Are you sure you want to delete this comment? This action cannot be undone."
+        confirmLabel="Delete"
+        variant="destructive"
+        confirmTestId="ticket-comment-delete-confirm"
+      />
+    </>
   );
 }

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -1253,14 +1253,23 @@ describe('TicketWorkbench comment edit/delete', () => {
     }
   });
 
-  it('calls PATCH /tickets/:id/comments/:cid when a comment edit control is used', async () => {
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Updated comment text');
+  it('calls PATCH /tickets/:id/comments/:cid via inline editor: open → type → save', async () => {
     const comment = makeComment({ id: 'c-42', content: 'Original text', portalUserId: null });
     mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
 
+    // Click the edit button to open the inline editor
     await screen.findByTestId('ticket-comment-edit-c-42');
     fireEvent.click(screen.getByTestId('ticket-comment-edit-c-42'));
+
+    // Textarea should appear pre-filled
+    const textarea = screen.getByTestId('ticket-comment-edit-textarea-c-42');
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue('Original text');
+
+    // Type new content and save
+    fireEvent.change(textarea, { target: { value: 'Updated comment text' } });
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-save-c-42'));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -1268,11 +1277,9 @@ describe('TicketWorkbench comment edit/delete', () => {
         expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ content: 'Updated comment text' }) })
       );
     });
-    promptSpy.mockRestore();
   });
 
-  it('does NOT PATCH when prompt returns null (user cancels)', async () => {
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null);
+  it('does NOT PATCH when cancel is clicked in the inline editor', async () => {
     const comment = makeComment({ id: 'c-42', content: 'Original text', portalUserId: null });
     mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
@@ -1280,21 +1287,28 @@ describe('TicketWorkbench comment edit/delete', () => {
     await screen.findByTestId('ticket-comment-edit-c-42');
     fireEvent.click(screen.getByTestId('ticket-comment-edit-c-42'));
 
+    const textarea = screen.getByTestId('ticket-comment-edit-textarea-c-42');
+    fireEvent.change(textarea, { target: { value: 'Changed but cancelled' } });
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-cancel-c-42'));
+
     await new Promise((r) => setTimeout(r, 50));
     expect(
       fetchMock.mock.calls.filter(([url, init]) => init?.method === 'PATCH' && String(url).includes('/comments/'))
     ).toHaveLength(0);
-    promptSpy.mockRestore();
   });
 
-  it('calls DELETE /tickets/:id/comments/:cid when a comment delete control is used', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  it('calls DELETE /tickets/:id/comments/:cid via ConfirmDialog: open → confirm', async () => {
     const comment = makeComment({ id: 'c-99', content: 'Delete me', portalUserId: null });
     mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
 
     await screen.findByTestId('ticket-comment-delete-c-99');
     fireEvent.click(screen.getByTestId('ticket-comment-delete-c-99'));
+
+    // ConfirmDialog should be open; confirm it
+    const confirmBtn = screen.getByTestId('ticket-comment-delete-confirm');
+    expect(confirmBtn).toBeInTheDocument();
+    fireEvent.click(confirmBtn);
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -1302,11 +1316,9 @@ describe('TicketWorkbench comment edit/delete', () => {
         expect.objectContaining({ method: 'DELETE' })
       );
     });
-    confirmSpy.mockRestore();
   });
 
-  it('does NOT DELETE when confirm returns false (user cancels)', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+  it('does NOT DELETE when cancel is clicked in the ConfirmDialog', async () => {
     const comment = makeComment({ id: 'c-99', content: 'Delete me', portalUserId: null });
     mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
@@ -1314,11 +1326,15 @@ describe('TicketWorkbench comment edit/delete', () => {
     await screen.findByTestId('ticket-comment-delete-c-99');
     fireEvent.click(screen.getByTestId('ticket-comment-delete-c-99'));
 
-    await new Promise((r) => setTimeout(r, 50));
+    // Cancel the dialog
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-comment-delete-confirm')).toBeNull();
+    });
     expect(
       fetchMock.mock.calls.filter(([url, init]) => init?.method === 'DELETE' && String(url).includes('/comments/'))
     ).toHaveLength(0);
-    confirmSpy.mockRestore();
   });
 
   it('portal-authored comments do NOT show edit/delete controls (canManageComment gate)', async () => {

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -1074,3 +1074,270 @@ describe('TicketWorkbench custom-status select (config path)', () => {
     expect(statusCalls[0][1]?.body).not.toContain('statusId');
   });
 });
+
+// ─── Subject inline edit ──────────────────────────────────────────────────────
+
+const makeComment = (overrides: Partial<import('./ticketConfig').TicketComment> = {}): import('./ticketConfig').TicketComment => ({
+  id: 'c-1',
+  userId: 'u-1',
+  portalUserId: null,
+  authorName: 'Alice',
+  authorType: 'staff',
+  commentType: 'comment',
+  content: 'Hello world',
+  isPublic: true,
+  oldValue: null,
+  newValue: null,
+  createdAt: '2026-06-01T10:00:00.000Z',
+  editedAt: null,
+  deleted: false,
+  ...overrides,
+});
+
+describe('TicketWorkbench subject inline edit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Stub ResizeObserver in case any chart mounts in jsdom
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  it('renders an editable subject input with testid ticket-workbench-subject-edit', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ subject: 'Printer is down' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-subject-edit');
+    expect(screen.getByTestId('ticket-workbench-subject-edit')).toBeInTheDocument();
+  });
+
+  it('saves an edited subject via PATCH /tickets/:id on blur', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ subject: 'Printer is down' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    const input = await screen.findByTestId('ticket-workbench-subject-edit');
+    fireEvent.change(input, { target: { value: 'Printer is broken' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ subject: 'Printer is broken' }) })
+      );
+    });
+  });
+
+  it('saves an edited subject via PATCH on Enter key', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ subject: 'Printer is down' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    const input = await screen.findByTestId('ticket-workbench-subject-edit');
+    fireEvent.change(input, { target: { value: 'Network outage' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ subject: 'Network outage' }) })
+      );
+    });
+  });
+
+  it('does NOT PATCH when subject is unchanged on blur', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ subject: 'Printer is down' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    const input = await screen.findByTestId('ticket-workbench-subject-edit');
+    fireEvent.blur(input); // blur without changing value
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1' && (init?.body as string | undefined)?.includes('subject'))
+    ).toHaveLength(0);
+  });
+
+  it('does NOT PATCH when subject is cleared (empty) on blur', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ subject: 'Printer is down' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    const input = await screen.findByTestId('ticket-workbench-subject-edit');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1' && (init?.body as string | undefined)?.includes('subject'))
+    ).toHaveLength(0);
+  });
+});
+
+// ─── Description inline edit ─────────────────────────────────────────────────
+
+describe('TicketWorkbench description inline edit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows an "Edit description" button when description is present', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ description: 'Existing description text' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    expect(screen.getByTestId('ticket-workbench-description-edit-btn')).toBeInTheDocument();
+  });
+
+  it('shows an "Add description" button when description is null', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ description: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    expect(screen.getByTestId('ticket-workbench-description-edit-btn')).toBeInTheDocument();
+  });
+
+  it('clicking edit button shows a textarea; saving PATCHes description', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ description: 'Old description' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-workbench-description-edit-btn'));
+
+    const textarea = screen.getByTestId('ticket-workbench-description-textarea');
+    expect(textarea).toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: 'Updated description' } });
+    fireEvent.click(screen.getByTestId('ticket-workbench-description-save-btn'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ description: 'Updated description' }) })
+      );
+    });
+  });
+
+  it('cancel button closes the description editor without saving', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ description: 'Old description' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-workbench-description-edit-btn'));
+    expect(screen.getByTestId('ticket-workbench-description-textarea')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ticket-workbench-description-cancel-btn'));
+    expect(screen.queryByTestId('ticket-workbench-description-textarea')).toBeNull();
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1' && (init?.body as string | undefined)?.includes('description'))
+    ).toHaveLength(0);
+  });
+});
+
+// ─── Comment edit/delete handlers ────────────────────────────────────────────
+
+describe('TicketWorkbench comment edit/delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Stub ResizeObserver for jsdom
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  it('calls PATCH /tickets/:id/comments/:cid when a comment edit control is used', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Updated comment text');
+    const comment = makeComment({ id: 'c-42', content: 'Original text', portalUserId: null });
+    mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-comment-edit-c-42');
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-c-42'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/comments/c-42',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ content: 'Updated comment text' }) })
+      );
+    });
+    promptSpy.mockRestore();
+  });
+
+  it('does NOT PATCH when prompt returns null (user cancels)', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null);
+    const comment = makeComment({ id: 'c-42', content: 'Original text', portalUserId: null });
+    mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-comment-edit-c-42');
+    fireEvent.click(screen.getByTestId('ticket-comment-edit-c-42'));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(([url, init]) => init?.method === 'PATCH' && String(url).includes('/comments/'))
+    ).toHaveLength(0);
+    promptSpy.mockRestore();
+  });
+
+  it('calls DELETE /tickets/:id/comments/:cid when a comment delete control is used', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const comment = makeComment({ id: 'c-99', content: 'Delete me', portalUserId: null });
+    mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-comment-delete-c-99');
+    fireEvent.click(screen.getByTestId('ticket-comment-delete-c-99'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/comments/c-99',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+    confirmSpy.mockRestore();
+  });
+
+  it('does NOT DELETE when confirm returns false (user cancels)', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const comment = makeComment({ id: 'c-99', content: 'Delete me', portalUserId: null });
+    mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-comment-delete-c-99');
+    fireEvent.click(screen.getByTestId('ticket-comment-delete-c-99'));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(([url, init]) => init?.method === 'DELETE' && String(url).includes('/comments/'))
+    ).toHaveLength(0);
+    confirmSpy.mockRestore();
+  });
+
+  it('portal-authored comments do NOT show edit/delete controls (canManageComment gate)', async () => {
+    const comment = makeComment({ id: 'c-portal', content: 'Portal user comment', portalUserId: 'pu-1' });
+    mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-comment-c-portal');
+    expect(screen.queryByTestId('ticket-comment-edit-c-portal')).toBeNull();
+    expect(screen.queryByTestId('ticket-comment-delete-c-portal')).toBeNull();
+  });
+
+  it('staff-authored comments DO show edit/delete controls', async () => {
+    const comment = makeComment({ id: 'c-staff', content: 'Staff comment', portalUserId: null });
+    mockTicketApi({ 'tk-1': makeTicket({ comments: [comment] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-comment-edit-c-staff');
+    await screen.findByTestId('ticket-comment-delete-c-staff');
+    expect(screen.getByTestId('ticket-comment-edit-c-staff')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-comment-delete-c-staff')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -48,6 +48,7 @@ const makeTicket = (overrides: Partial<TicketDetail> = {}): TicketDetail => ({
   assigneeName: null,
   categoryId: null,
   dueDate: null,
+  tags: [],
   slaBreachedAt: null,
   firstResponseAt: null,
   createdAt: '2026-06-01T10:00:00.000Z',
@@ -1339,5 +1340,201 @@ describe('TicketWorkbench comment edit/delete', () => {
     await screen.findByTestId('ticket-comment-delete-c-staff');
     expect(screen.getByTestId('ticket-comment-edit-c-staff')).toBeInTheDocument();
     expect(screen.getByTestId('ticket-comment-delete-c-staff')).toBeInTheDocument();
+  });
+});
+
+// ─── Due date, tags, device editors ──────────────────────────────────────────
+
+describe('TicketWorkbench due-date editor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  it('renders a date input with testid ticket-workbench-due', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ dueDate: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    expect(screen.getByTestId('ticket-workbench-due')).toBeInTheDocument();
+  });
+
+  it('PATCHes dueDate when the date input changes', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ dueDate: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-due');
+    fireEvent.change(screen.getByTestId('ticket-workbench-due'), {
+      target: { value: '2026-07-15' },
+    });
+
+    await waitFor(() => {
+      const patchCalls = fetchMock.mock.calls.filter(
+        ([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1'
+      );
+      expect(patchCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(patchCalls[patchCalls.length - 1][1]?.body as string);
+      expect(body.dueDate).toBeTruthy();
+      expect(body.dueDate).toContain('2026-07-15');
+    });
+  });
+
+  it('PATCHes dueDate as null when the date input is cleared', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ dueDate: '2026-07-15T00:00:00.000Z' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-due');
+    fireEvent.change(screen.getByTestId('ticket-workbench-due'), {
+      target: { value: '' },
+    });
+
+    await waitFor(() => {
+      const patchCalls = fetchMock.mock.calls.filter(
+        ([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1'
+      );
+      expect(patchCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(patchCalls[patchCalls.length - 1][1]?.body as string);
+      expect(body.dueDate).toBeNull();
+    });
+  });
+});
+
+describe('TicketWorkbench tags editor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  it('renders the tag editor container with testid ticket-workbench-tags', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ tags: [] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    expect(screen.getByTestId('ticket-workbench-tags')).toBeInTheDocument();
+  });
+
+  it('PATCHes tags when a tag is added', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ tags: ['existing'] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-tags');
+    const tagInput = screen.getByTestId('ticket-workbench-tag-input');
+    fireEvent.change(tagInput, { target: { value: 'urgent' } });
+    fireEvent.keyDown(tagInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      const patchCalls = fetchMock.mock.calls.filter(
+        ([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1'
+      );
+      expect(patchCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(patchCalls[patchCalls.length - 1][1]?.body as string);
+      expect(body.tags).toEqual(['existing', 'urgent']);
+    });
+  });
+
+  it('does NOT add a duplicate tag', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ tags: ['existing'] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-tags');
+    const tagInput = screen.getByTestId('ticket-workbench-tag-input');
+    fireEvent.change(tagInput, { target: { value: 'existing' } });
+    fireEvent.keyDown(tagInput, { key: 'Enter' });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(
+        ([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1' && (init?.body as string | undefined)?.includes('tags')
+      )
+    ).toHaveLength(0);
+  });
+
+  it('PATCHes tags when a chip is removed', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ tags: ['alpha', 'beta'] }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-tags');
+    fireEvent.click(screen.getByTestId('ticket-workbench-tag-remove-alpha'));
+
+    await waitFor(() => {
+      const patchCalls = fetchMock.mock.calls.filter(
+        ([url, init]) => init?.method === 'PATCH' && String(url) === '/tickets/tk-1'
+      );
+      expect(patchCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(patchCalls[patchCalls.length - 1][1]?.body as string);
+      expect(body.tags).toEqual(['beta']);
+    });
+  });
+});
+
+describe('TicketWorkbench device link/unlink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  it('renders the device container with testid ticket-workbench-device', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ deviceId: null, deviceHostname: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    expect(screen.getByTestId('ticket-workbench-device')).toBeInTheDocument();
+  });
+
+  it('shows "No device" when deviceId is null', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ deviceId: null, deviceHostname: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-device');
+    expect(screen.getByTestId('ticket-workbench-device')).toHaveTextContent('No device');
+  });
+
+  it('shows the device hostname when linked', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ deviceId: 'dev-1', deviceHostname: 'DESKTOP-123' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-device');
+    expect(screen.getByTestId('ticket-workbench-device')).toHaveTextContent('DESKTOP-123');
+  });
+
+  it('clears the device link when Unlink is clicked (PATCHes {deviceId: null})', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ deviceId: 'dev-1', deviceHostname: 'DESKTOP-123' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-device');
+    fireEvent.click(screen.getByTestId('ticket-workbench-device-unlink'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ deviceId: null }) })
+      );
+    });
+  });
+
+  it('does NOT show an Unlink button when deviceId is null', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ deviceId: null, deviceHostname: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-device');
+    expect(screen.queryByTestId('ticket-workbench-device-unlink')).toBeNull();
   });
 });

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -1538,3 +1538,102 @@ describe('TicketWorkbench device link/unlink', () => {
     expect(screen.queryByTestId('ticket-workbench-device-unlink')).toBeNull();
   });
 });
+
+// ─── Move to another org ──────────────────────────────────────────────────────
+
+describe('TicketWorkbench move-org action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  /** Sets up fetchWithAuth to handle ticket GET, /orgs/organizations, triage, and mutations. */
+  function mockTicketApiWithOrgs(
+    ticket: TicketDetail,
+    orgs: Array<{ id: string; name: string }> = [
+      { id: 'org-1', name: 'Acme Corp' },
+      { id: 'org-2', name: 'Globex Inc' },
+    ]
+  ) {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith('/orgs/organizations')) {
+        return makeJsonResponse({ data: orgs });
+      }
+      if (!init?.method || init.method === 'GET') {
+        const match = url.match(/^\/tickets\/([^/]+)$/);
+        if (match && match[1] === ticket.id) {
+          return makeJsonResponse({ data: ticket });
+        }
+      }
+      return makeJsonResponse({ success: true });
+    });
+  }
+
+  it('POSTs move-org with the selected org', async () => {
+    const ticket = makeTicket({ id: 'tk-1', orgId: 'org-1', orgName: 'Acme Corp' });
+    mockTicketApiWithOrgs(ticket);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+
+    // Open the move-org UI
+    fireEvent.click(screen.getByTestId('ticket-workbench-move-org'));
+
+    // The picker should appear; select org-2 (Globex Inc)
+    const picker = await screen.findByTestId('ticket-workbench-move-org-select');
+    fireEvent.change(picker, { target: { value: 'org-2' } });
+
+    // Confirm the move
+    fireEvent.click(screen.getByTestId('ticket-workbench-move-org-confirm'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/move-org',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ orgId: 'org-2' }),
+        })
+      );
+    });
+  });
+
+  it('current org is excluded from the picker options', async () => {
+    const ticket = makeTicket({ id: 'tk-1', orgId: 'org-1', orgName: 'Acme Corp' });
+    mockTicketApiWithOrgs(ticket);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-workbench-move-org'));
+
+    const picker = await screen.findByTestId('ticket-workbench-move-org-select');
+    const options = Array.from(picker.querySelectorAll('option')).map((o) => (o as HTMLOptionElement).value);
+    expect(options).not.toContain('org-1');
+    expect(options).toContain('org-2');
+  });
+
+  it('cancel button closes the move-org form without POSTing', async () => {
+    const ticket = makeTicket({ id: 'tk-1', orgId: 'org-1', orgName: 'Acme Corp' });
+    mockTicketApiWithOrgs(ticket);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-workbench-move-org'));
+
+    await screen.findByTestId('ticket-workbench-move-org-select');
+    fireEvent.click(screen.getByTestId('ticket-workbench-move-org-cancel'));
+
+    expect(screen.queryByTestId('ticket-workbench-move-org-select')).toBeNull();
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      fetchMock.mock.calls.filter(([url, init]) => init?.method === 'POST' && String(url).includes('/move-org'))
+    ).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -63,6 +63,8 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   // Ticket configuration (custom statuses + priority labels). null = not loaded
   // or fetch failed; every render falls back to the static core config.
   const [config, setConfig] = useState<TicketConfig | null>(null);
+  const [editingDescription, setEditingDescription] = useState(false);
+  const descriptionTextareaRef = useRef<HTMLTextAreaElement>(null);
   const [triageSuggestion, setTriageSuggestion] = useState<TicketTriageSuggestion | null>(null);
   const [triageLoading, setTriageLoading] = useState(false);
   const [applyingTriage, setApplyingTriage] = useState(false);
@@ -351,6 +353,36 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     afterMutation();
   }, [ticketId, afterMutation]);
 
+  // Generic field PATCH — saves any { subject } / { description } / etc. patch.
+  // afterMutation with the optimistic patch paints the change locally and
+  // reconciles in the background (same pattern as priority/category PATCHes).
+  const handleFieldSave = useCallback((patch: Record<string, unknown>) => {
+    void runAction({
+      request: () => fetchWithAuth(`/tickets/${ticketId}`, { method: 'PATCH', body: JSON.stringify(patch) }),
+      errorFallback: 'Update failed. Retry.',
+      onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+    }).then(() => afterMutation(patch as Partial<TicketDetail>)).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+  }, [ticketId, afterMutation]);
+
+  const handleEditComment = useCallback((commentId: string, current: string) => {
+    const next = window.prompt('Edit comment', current);
+    if (next == null || next.trim() === '' || next === current) return;
+    void runAction({
+      request: () => fetchWithAuth(`/tickets/${ticketId}/comments/${commentId}`, { method: 'PATCH', body: JSON.stringify({ content: next }) }),
+      errorFallback: 'Comment edit failed. Retry.',
+      onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+    }).then(() => void load({ background: true })).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+  }, [ticketId, load]);
+
+  const handleDeleteComment = useCallback((commentId: string) => {
+    if (!window.confirm('Delete this comment?')) return;
+    void runAction({
+      request: () => fetchWithAuth(`/tickets/${ticketId}/comments/${commentId}`, { method: 'DELETE' }),
+      errorFallback: 'Comment delete failed. Retry.',
+      onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+    }).then(() => void load({ background: true })).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+  }, [ticketId, load]);
+
   // Skeleton only on the first load of a ticket. Refreshes (send, status
   // change, refreshToken bump) keep the tree mounted so composer state —
   // the public/internal tab in particular — survives; aria-busy marks them.
@@ -392,7 +424,32 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       <div className="border-b px-4 py-3">
         <div className="flex items-center gap-2">
           <span className="font-mono text-sm text-muted-foreground" data-testid="ticket-workbench-number">{ticket.internalNumber ?? ticket.id.slice(0, 8)}</span>
-          <h2 className="truncate text-base font-semibold">{ticket.subject}</h2>
+          <input
+            type="text"
+            defaultValue={ticket.subject}
+            key={ticket.subject}
+            className="min-w-0 flex-1 truncate bg-transparent text-base font-semibold outline-none hover:bg-muted/30 focus:bg-muted/30 focus:ring-1 focus:ring-ring rounded px-1 -mx-1"
+            data-testid="ticket-workbench-subject-edit"
+            aria-label="Ticket subject"
+            onBlur={(e) => {
+              const next = e.target.value.trim();
+              if (!next || next === ticket.subject) return;
+              handleFieldSave({ subject: next });
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                const next = (e.target as HTMLInputElement).value.trim();
+                if (!next || next === ticket.subject) return;
+                handleFieldSave({ subject: next });
+                (e.target as HTMLInputElement).blur();
+              }
+              if (e.key === 'Escape') {
+                (e.target as HTMLInputElement).value = ticket.subject;
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+          />
           {!expanded && (
             <a href={`/tickets/${ticket.id}`} className="ml-auto rounded p-1 text-muted-foreground hover:text-foreground" title="Open full page" data-testid="ticket-workbench-expand">
               <ExternalLink className="h-4 w-4" />
@@ -646,12 +703,64 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       <div className="flex min-h-0 flex-1">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <div className="min-h-0 flex-1 overflow-y-auto">
-            {ticket.description && (
-              <div className="border-b p-4">
-                <p className="whitespace-pre-wrap text-sm">{ticket.description}</p>
-              </div>
-            )}
-            <TicketFeed comments={ticket.comments} />
+            <div className="border-b p-4">
+              {editingDescription ? (
+                <div className="space-y-2">
+                  <textarea
+                    ref={descriptionTextareaRef}
+                    className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+                    rows={4}
+                    defaultValue={ticket.description ?? ''}
+                    data-testid="ticket-workbench-description-textarea"
+                    autoFocus
+                  />
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setEditingDescription(false)}
+                      className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                      data-testid="ticket-workbench-description-cancel-btn"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const next = descriptionTextareaRef.current?.value ?? '';
+                        handleFieldSave({ description: next });
+                        setEditingDescription(false);
+                      }}
+                      className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white"
+                      data-testid="ticket-workbench-description-save-btn"
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="group flex items-start gap-2">
+                  {ticket.description ? (
+                    <p className="flex-1 whitespace-pre-wrap text-sm">{ticket.description}</p>
+                  ) : (
+                    <p className="flex-1 text-sm text-muted-foreground italic">No description.</p>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => { setEditingDescription(true); }}
+                    className="shrink-0 rounded px-1.5 py-0.5 text-xs text-muted-foreground opacity-0 hover:text-foreground group-hover:opacity-100"
+                    data-testid="ticket-workbench-description-edit-btn"
+                  >
+                    {ticket.description ? 'Edit' : 'Add description'}
+                  </button>
+                </div>
+              )}
+            </div>
+            <TicketFeed
+              comments={ticket.comments}
+              onEditComment={handleEditComment}
+              onDeleteComment={handleDeleteComment}
+              canManageComment={(c) => !c.portalUserId}
+            />
           </div>
           <TicketComposer requesterName={ticket.submitterName} onSend={sendComment} />
         </div>

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -16,6 +16,63 @@ import { fetchTicketConfig, statusLabel, priorityLabel, activeStatusesByCore, ty
 import { onTimerChanged, onBillingChanged } from '../../lib/timerActions';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 
+// ─── TagEditor ───────────────────────────────────────────────────────────────
+
+interface TagEditorProps {
+  value: string[];
+  max?: number;
+  onChange: (tags: string[]) => void;
+  'data-testid'?: string;
+}
+
+function TagEditor({ value, max = 20, onChange, 'data-testid': testId }: TagEditorProps) {
+  const [input, setInput] = useState('');
+
+  const addTag = () => {
+    const trimmed = input.trim().slice(0, 50);
+    if (!trimmed || value.includes(trimmed) || value.length >= max) return;
+    onChange([...value, trimmed]);
+    setInput('');
+  };
+
+  return (
+    <div data-testid={testId} className="flex flex-wrap gap-1">
+      {value.map((tag) => (
+        <span key={tag} className="flex items-center gap-0.5 rounded border bg-muted px-1.5 py-0.5 text-xs">
+          {tag}
+          <button
+            type="button"
+            data-testid={`ticket-workbench-tag-remove-${tag}`}
+            className="ml-0.5 hover:text-destructive"
+            onClick={() => onChange(value.filter((t) => t !== tag))}
+            aria-label={`Remove tag ${tag}`}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      {value.length < max && (
+        <input
+          type="text"
+          data-testid="ticket-workbench-tag-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { e.preventDefault(); addTag(); }
+          }}
+          onBlur={addTag}
+          placeholder="Add tag…"
+          maxLength={50}
+          className="rounded border bg-background px-1.5 py-0.5 text-xs outline-none focus:ring-1 focus:ring-ring"
+          aria-label="Add tag"
+        />
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 interface Props {
   ticketId: string;
   onChanged?: () => void;       // queue refresh hook (debounced background reconcile)
@@ -775,7 +832,48 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
                 <div><dt className="text-xs text-muted-foreground">Requester</dt><dd>{ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}</dd></div>
                 <div><dt className="text-xs text-muted-foreground">Source</dt><dd className="capitalize">{ticket.source}</dd></div>
                 <div><dt className="text-xs text-muted-foreground">Created</dt><dd>{formatDateTime(ticket.createdAt)}</dd></div>
-                {ticket.dueDate && <div><dt className="text-xs text-muted-foreground">Due</dt><dd>{formatDateTime(ticket.dueDate)}</dd></div>}
+                <div>
+                  <dt className="text-xs text-muted-foreground">Due date</dt>
+                  <dd>
+                    <input
+                      type="date"
+                      data-testid="ticket-workbench-due"
+                      aria-label="Due date"
+                      value={ticket.dueDate ? ticket.dueDate.slice(0, 10) : ''}
+                      onChange={(e) => handleFieldSave({ dueDate: e.target.value ? new Date(e.target.value).toISOString() : null })}
+                      className="rounded-md border bg-background px-2 py-1 text-xs"
+                    />
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">Tags</dt>
+                  <dd>
+                    <TagEditor
+                      data-testid="ticket-workbench-tags"
+                      value={ticket.tags ?? []}
+                      max={20}
+                      onChange={(tags) => handleFieldSave({ tags })}
+                    />
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">Device</dt>
+                  <dd>
+                    <div data-testid="ticket-workbench-device" className="flex items-center gap-2 text-xs">
+                      <span>{ticket.deviceHostname ?? 'No device'}</span>
+                      {ticket.deviceId && (
+                        <button
+                          type="button"
+                          data-testid="ticket-workbench-device-unlink"
+                          className="hover:text-destructive"
+                          onClick={() => handleFieldSave({ deviceId: null })}
+                        >
+                          Unlink
+                        </button>
+                      )}
+                    </div>
+                  </dd>
+                </div>
                 {ticket.pendingReason && <div><dt className="text-xs text-muted-foreground">Waiting on</dt><dd>{ticket.pendingReason}</dd></div>}
                 {ticket.resolutionNote && (ticket.status === 'resolved' || ticket.status === 'closed') && (
                   <div><dt className="text-xs text-muted-foreground">Resolution</dt><dd>{ticket.resolutionNote}</dd></div>

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -117,6 +117,9 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   const [pendingStatusId, setPendingStatusId] = useState<string | null>(null);
   const [railOpen] = useState(true);
   const [creatingInvoice, setCreatingInvoice] = useState(false);
+  const [moveOrgOpen, setMoveOrgOpen] = useState(false);
+  const [moveOrgTargetId, setMoveOrgTargetId] = useState('');
+  const [orgs, setOrgs] = useState<Array<{ id: string; name: string }>>([]);
   // Ticket configuration (custom statuses + priority labels). null = not loaded
   // or fetch failed; every render falls back to the static core config.
   const [config, setConfig] = useState<TicketConfig | null>(null);
@@ -236,6 +239,23 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     return () => { cancelled = true; };
   }, [assigneesProvided]);
 
+  // Fetch org list for the move-org picker. Fails gracefully — if unavailable
+  // the picker just won't show any options (degrade to empty select).
+  useEffect(() => {
+    let cancelled = false;
+    void fetchWithAuth('/orgs/organizations?limit=100')
+      .then(async (r) => (r.ok ? r.json() : null))
+      .then((body) => {
+        if (cancelled || !body) return;
+        const rows = (body as { data?: Array<{ id: string; name: string }>; organizations?: Array<{ id: string; name: string }> }).data
+          ?? (body as { data?: Array<{ id: string; name: string }>; organizations?: Array<{ id: string; name: string }> }).organizations
+          ?? [];
+        if (Array.isArray(rows)) setOrgs((rows as Array<{ id: string; name: string }>).filter((o) => o.id && o.name));
+      })
+      .catch(() => { /* degrade gracefully */ });
+    return () => { cancelled = true; };
+  }, []);
+
   // Fetch ticket config once (module-cached across islands). Failure leaves
   // config null, which keeps the six-core-status fallback select fully working.
   useEffect(() => {
@@ -303,6 +323,14 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       setCreatingInvoice(false);
     }
   }, [ticketId, creatingInvoice]);
+
+  const handleMoveOrg = useCallback((targetOrgId: string) => {
+    void runAction({
+      request: () => fetchWithAuth(`/tickets/${ticketId}/move-org`, { method: 'POST', body: JSON.stringify({ orgId: targetOrgId }) }),
+      errorFallback: 'Move failed. Retry.',
+      onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+    }).then(() => void load({ background: true })).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+  }, [ticketId, load]);
 
   const applyTriageSuggestion = useCallback(async () => {
     if (!triageSuggestion || applyingTriage) return;
@@ -646,7 +674,51 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
           >
             {creatingInvoice ? 'Creating…' : 'Create invoice'}
           </button>
+          <button
+            type="button"
+            data-testid="ticket-workbench-move-org"
+            className="text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => { setMoveOrgOpen(true); setMoveOrgTargetId(''); }}
+          >
+            Move to another org…
+          </button>
         </div>
+        {moveOrgOpen && (
+          <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-workbench-move-org-form">
+            <label className="text-xs font-medium" htmlFor="move-org-select">Move to organization</label>
+            <select
+              id="move-org-select"
+              data-testid="ticket-workbench-move-org-select"
+              value={moveOrgTargetId}
+              onChange={(e) => setMoveOrgTargetId(e.target.value)}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-xs"
+            >
+              <option value="">Select organization…</option>
+              {orgs.filter((o) => o.id !== ticket.orgId).map((o) => (
+                <option key={o.id} value={o.id}>{o.name}</option>
+              ))}
+            </select>
+            <div className="mt-1.5 flex justify-end gap-2">
+              <button
+                type="button"
+                data-testid="ticket-workbench-move-org-cancel"
+                onClick={() => setMoveOrgOpen(false)}
+                className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="ticket-workbench-move-org-confirm"
+                disabled={!moveOrgTargetId}
+                onClick={() => { if (moveOrgTargetId) { handleMoveOrg(moveOrgTargetId); setMoveOrgOpen(false); } }}
+                className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+              >
+                Move
+              </button>
+            </div>
+          </div>
+        )}
         {(triageSuggestion || triageLoading) && (
           <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-triage-suggestion">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -449,18 +449,15 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     }).then(() => afterMutation(patch as Partial<TicketDetail>)).catch((err) => { if (!(err instanceof ActionError)) throw err; });
   }, [ticketId, afterMutation]);
 
-  const handleEditComment = useCallback((commentId: string, current: string) => {
-    const next = window.prompt('Edit comment', current);
-    if (next == null || next.trim() === '' || next === current) return;
+  const handleEditComment = useCallback((commentId: string, content: string) => {
     void runAction({
-      request: () => fetchWithAuth(`/tickets/${ticketId}/comments/${commentId}`, { method: 'PATCH', body: JSON.stringify({ content: next }) }),
+      request: () => fetchWithAuth(`/tickets/${ticketId}/comments/${commentId}`, { method: 'PATCH', body: JSON.stringify({ content }) }),
       errorFallback: 'Comment edit failed. Retry.',
       onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
     }).then(() => void load({ background: true })).catch((err) => { if (!(err instanceof ActionError)) throw err; });
   }, [ticketId, load]);
 
   const handleDeleteComment = useCallback((commentId: string) => {
-    if (!window.confirm('Delete this comment?')) return;
     void runAction({
       request: () => fetchWithAuth(`/tickets/${ticketId}/comments/${commentId}`, { method: 'DELETE' }),
       errorFallback: 'Comment delete failed. Retry.',

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -21,6 +21,7 @@ export interface TicketSummary {
   assigneeName: string | null;
   categoryId: string | null;
   dueDate: string | null;
+  tags: string[];
   slaBreachedAt: string | null;
   resolutionSlaMinutes?: number | null;
   responseSlaMinutes?: number | null;

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -44,6 +44,8 @@ export interface TicketComment {
   oldValue: string | null;
   newValue: string | null;
   createdAt: string;
+  editedAt?: string | null;
+  deleted?: boolean;
 }
 
 export interface TicketDetail extends TicketSummary {

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -21,7 +21,7 @@ export interface TicketSummary {
   assigneeName: string | null;
   categoryId: string | null;
   dueDate: string | null;
-  tags: string[];
+  tags?: string[];
   slaBreachedAt: string | null;
   resolutionSlaMinutes?: number | null;
   responseSlaMinutes?: number | null;

--- a/docs/superpowers/plans/2026-06-21-ticketing-phase6a-editing-affordances.md
+++ b/docs/superpowers/plans/2026-06-21-ticketing-phase6a-editing-affordances.md
@@ -1,0 +1,1595 @@
+# Ticketing Phase 6a — Editing Affordances Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let staff (and, narrowly, portal customers) correct tickets after creation — edit/delete comments, edit the remaining ticket fields from the workbench, and move a ticket to another customer org within the same partner.
+
+**Architecture:** Backend logic lives in `ticketService.ts` (routes/AI/MCP are equal consumers) and emits through the single `emitTicketEvent` dispatch point. Comment edit/delete is gated at two layers: RLS (parent-ticket tenant access) and the service (author identity OR `tickets:manage`). Org-reassign mirrors the proven device `moveOrg` pattern (same-partner validation, single transaction, `org_id` re-stamp on denormalized child rows, device detach, dual-org audit). The web adds inline-edit affordances to `TicketWorkbench.tsx`; the API already supports every ticket field via `PATCH /tickets/:id`.
+
+**Tech Stack:** Hono + Zod validators, Drizzle ORM over postgres.js (`breeze_app` role, RLS-forced), Vitest (unit + real-DB integration), React (apps/web), Playwright (e2e). Migrations are hand-written idempotent SQL.
+
+## Global Constraints
+
+- Migrations: date-prefixed `YYYY-MM-DD-<slug>.sql`, idempotent (`IF NOT EXISTS` / `DROP POLICY IF EXISTS` then recreate), no inner `BEGIN;/COMMIT;`, never edit a shipped migration. Today's prefix: `2026-06-21`.
+- All ticket mutations route through `ticketService`; never write `ticket_comments`/`tickets` directly from a route handler (portal create is the one pre-existing exception and is not extended here).
+- RLS: `ticket_comments` is shape-5 child-via-parent (it has **no `org_id` column**). New write policies mirror the existing `breeze_ticket_parent_select` parent-org `EXISTS` form (migration `2026-06-10-a`). Identity/role checks live in the service layer, never in `WITH CHECK` ([[rls_is_system_flag_write_policy_hole]]).
+- Real-DB tests go in `apps/api/src/__tests__/integration/*.integration.test.ts` (BLOCKING `integration-test` job). Re-seed fixtures per `it` — never memoize across tests ([[rls-forge-test-memoized-fixture-vacuous]]).
+- Permission imperative check pattern: `hasPermission(auth.permissions, PERMISSIONS.X.resource, PERMISSIONS.X.action)` (honors `*:*` admin). Imported from `../../services/permissions`.
+- No new tenant-scoped table is created → no `ORG_CASCADE_DELETE_ORDER` / allowlist churn.
+- Web has no client-side permission store: render edit affordances best-effort; the API is authoritative. Wrap every mutation in `runAction`; on `ActionError` rethrow non-`ActionError` only.
+- Run a single test file with: `pnpm --filter @breeze/api exec vitest run <path>` (the `test --` script runs the whole suite — [[migration-tooling-db-migrate-noop]]). Prefix node path per [[node_pinned_version]] if pnpm engine-strict errors.
+
+---
+
+## File Structure
+
+**Backend (apps/api):**
+- `packages/shared/src/constants/permissions.ts` — add `TICKETS_MANAGE` grant.
+- `apps/api/migrations/2026-06-21-ticket-comment-edit.sql` — `edited_at` column + RLS UPDATE/DELETE policies (new).
+- `apps/api/src/db/schema/portal.ts` — add `editedAt` to `ticketComments`.
+- `apps/api/src/services/ticketService.ts` — `editTicketComment`, `deleteTicketComment`, `portalCommentMutable`, `moveTicketOrg`.
+- `apps/api/src/routes/tickets/tickets.ts` — PATCH/DELETE comment routes; detail GET returns soft-deleted rows to staff.
+- `apps/api/src/routes/tickets/moveOrg.ts` — `POST /:id/move-org` (new); mounted in `apps/api/src/routes/tickets/index.ts`.
+- `apps/api/src/routes/portal/tickets.ts` — portal PATCH/DELETE comment routes with window.
+- `packages/shared/src/validators/tickets.ts` — `editCommentSchema`, `moveTicketOrgSchema`.
+- Tests: `*.test.ts` siblings + `apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts`, `ticket-move-org.integration.test.ts`.
+
+**Frontend (apps/web):**
+- `apps/web/src/components/tickets/ticketConfig.ts` — extend `TicketComment` type (`editedAt`, `deleted`).
+- `apps/web/src/components/tickets/TicketFeed.tsx` — edited badge, deleted tombstone, edit/delete controls.
+- `apps/web/src/components/tickets/TicketWorkbench.tsx` — subject/description/dueDate/tags/device inline edits + move-org action; owns comment edit/delete + field PATCH handlers.
+- Tests: `*.test.tsx` siblings.
+
+**E2E:**
+- `e2e-tests/tests/tickets.spec.ts` + `e2e-tests/pages/TicketsPage.ts`.
+
+---
+
+## Task 1: Add `tickets:manage` permission
+
+**Files:**
+- Modify: `packages/shared/src/constants/permissions.ts` (Tickets block, after `TICKETS_WRITE`)
+- Verify: `apps/api/src/services/permissions.ts` re-exports it as `PERMISSIONS.TICKETS_MANAGE`; `apps/api/src/lib/permissionsCatalog.ts` derives actions from `PERMISSION_GRANTS` (resource label `tickets` already exists, so no `RESOURCE_LABELS` change).
+
+**Interfaces:**
+- Produces: `PERMISSIONS.TICKETS_MANAGE = { resource: 'tickets', action: 'manage' }`.
+
+- [ ] **Step 1: Add the grant**
+
+In `packages/shared/src/constants/permissions.ts`, in the `// Tickets` block:
+
+```typescript
+  // Tickets
+  TICKETS_READ: { resource: 'tickets', action: 'read' },
+  TICKETS_WRITE: { resource: 'tickets', action: 'write' },
+  TICKETS_MANAGE: { resource: 'tickets', action: 'manage' },
+```
+
+- [ ] **Step 2: Verify the catalog auto-derives the action**
+
+Run: `grep -rn "TICKETS_MANAGE\|action: 'manage'" apps/api/src/lib/permissionsCatalog.ts packages/shared/src/constants/permissions.ts`
+Expected: the grant exists; confirm `permissionsCatalog.ts` builds its action list by iterating `PERMISSION_GRANTS` (not a hand-maintained per-resource action array). If it hand-maintains actions for `tickets`, add `'manage'` there too. Resource label `tickets` already present in `RESOURCE_LABELS` — no change needed.
+
+- [ ] **Step 3: Grant it to admin-capable default roles**
+
+Run: `grep -rn "TICKETS_WRITE" packages/shared/src apps/api/src --include=*.ts | grep -i "role\|grant\|default" | grep -v test`
+For each default-role definition that includes `TICKETS_WRITE` for a manager/admin role, add `TICKETS_MANAGE`. (A plain technician role keeps only read/write; self-edits don't need manage.) If no static role→permission map exists (roles are DB-seeded), note that operators grant `tickets:manage` via the roles UI and skip.
+
+- [ ] **Step 4: Typecheck shared**
+
+Run: `pnpm --filter @breeze/shared exec tsc --noEmit`
+Expected: PASS (no build script on shared — typecheck only, [[migration-tooling-db-migrate-noop]]).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/constants/permissions.ts
+git commit -m "feat(tickets): add tickets:manage permission for comment admin-override"
+```
+
+---
+
+## Task 2: Migration — `edited_at` column + RLS UPDATE/DELETE policies
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-21-ticket-comment-edit.sql`
+- Modify: `apps/api/src/db/schema/portal.ts` (`ticketComments` — add `editedAt`)
+
+**Interfaces:**
+- Produces: `ticket_comments.edited_at timestamptz NULL`; RLS policies `breeze_ticket_parent_update`, `breeze_ticket_parent_delete` admitting writes when the parent ticket is org-accessible.
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-21-ticket-comment-edit.sql`:
+
+```sql
+-- 2026-06-21: ticket_comments — editing & deletion support (Phase 6a).
+--
+-- Adds edited_at (deleted_at already exists) and the RLS UPDATE/DELETE
+-- policies that the earlier 2026-06-10-a migration deliberately left out
+-- ("technicians only edit/delete their OWN comments in Phase 1").
+--
+-- ticket_comments has NO org_id column — it is a child-via-parent (shape 5)
+-- table whose tenancy follows the parent ticket. So these policies mirror the
+-- parent-org EXISTS form of breeze_ticket_parent_select (same table, migration
+-- 2026-06-10-a) rather than a breeze_has_org_access(org_id) column check.
+-- Permissive policies OR with the existing Phase-6 user-isolation policies, so
+-- a staff author editing their own row is already allowed; these broaden the
+-- DB layer to admit edits/deletes of any org-accessible comment. AUTHOR/ROLE
+-- enforcement lives in ticketService (editTicketComment/deleteTicketComment) —
+-- NOT in WITH CHECK (lesson: rls_is_system_flag_write_policy_hole).
+--
+-- #1016/#1026 bound-param safety: tickets.org_id is NOT NULL and the tickets
+-- SELECT policy is a flat breeze_has_org_access(org_id) with no OR branches, so
+-- the EXISTS join is safe under postgres.js bound parameters — proven by
+-- apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts.
+--
+-- Fully idempotent — safe to re-run.
+
+ALTER TABLE ticket_comments ADD COLUMN IF NOT EXISTS edited_at timestamptz;
+
+DROP POLICY IF EXISTS breeze_ticket_parent_update ON ticket_comments;
+CREATE POLICY breeze_ticket_parent_update ON ticket_comments
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM tickets t
+       WHERE t.id = ticket_comments.ticket_id
+         AND public.breeze_has_org_access(t.org_id)
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM tickets t
+       WHERE t.id = ticket_comments.ticket_id
+         AND public.breeze_has_org_access(t.org_id)
+    )
+  );
+
+DROP POLICY IF EXISTS breeze_ticket_parent_delete ON ticket_comments;
+CREATE POLICY breeze_ticket_parent_delete ON ticket_comments
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM tickets t
+       WHERE t.id = ticket_comments.ticket_id
+         AND public.breeze_has_org_access(t.org_id)
+    )
+  );
+```
+
+> Note: `deleteTicketComment` is a SOFT delete (an UPDATE setting `deleted_at`), so the UPDATE policy covers it. The DELETE policy is added for completeness/forensic hard-deletes by system scope; it is not exercised by 6a service code. Keep it — a future hard-purge path will need it and adding it now keeps the policy set symmetric.
+
+- [ ] **Step 2: Add the column to the Drizzle schema**
+
+In `apps/api/src/db/schema/portal.ts`, `ticketComments`, add after `deletedAt`:
+
+```typescript
+  deletedAt: timestamp('deleted_at'),
+  editedAt: timestamp('edited_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull()
+```
+
+- [ ] **Step 3: Apply the migration locally and verify no drift**
+
+Run: `pnpm --filter @breeze/api exec tsx -e "import('./src/db/autoMigrate').then(m => m.autoMigrate())"` then `pnpm db:check-drift`
+Expected: migration applies; drift check reports schema matches migrations. (db:migrate is a no-op — apply via tsx, [[migration-tooling-db-migrate-noop]]. If checksum mismatch on a shared local DB, delete the `breeze_migrations` row and re-apply.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-21-ticket-comment-edit.sql apps/api/src/db/schema/portal.ts
+git commit -m "feat(tickets): migration for comment edited_at + RLS update/delete policies"
+```
+
+---
+
+## Task 3: `editCommentSchema` + `moveTicketOrgSchema` validators
+
+**Files:**
+- Modify: `packages/shared/src/validators/tickets.ts`
+- Test: `packages/shared/src/validators/tickets.test.ts`
+
+**Interfaces:**
+- Produces: `editCommentSchema = { content: string(1..50000) }`; `moveTicketOrgSchema = { orgId: guid }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/shared/src/validators/tickets.test.ts`:
+
+```typescript
+import { editCommentSchema, moveTicketOrgSchema } from './tickets';
+
+describe('editCommentSchema', () => {
+  it('accepts non-empty content', () => {
+    expect(editCommentSchema.parse({ content: 'updated' })).toEqual({ content: 'updated' });
+  });
+  it('rejects empty content', () => {
+    expect(editCommentSchema.safeParse({ content: '' }).success).toBe(false);
+  });
+});
+
+describe('moveTicketOrgSchema', () => {
+  it('accepts a uuid orgId', () => {
+    const id = '11111111-1111-1111-1111-111111111111';
+    expect(moveTicketOrgSchema.parse({ orgId: id })).toEqual({ orgId: id });
+  });
+  it('rejects a non-uuid orgId', () => {
+    expect(moveTicketOrgSchema.safeParse({ orgId: 'nope' }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @breeze/shared exec vitest run src/validators/tickets.test.ts`
+Expected: FAIL — `editCommentSchema`/`moveTicketOrgSchema` are not exported.
+
+- [ ] **Step 3: Add the schemas**
+
+In `packages/shared/src/validators/tickets.ts`, after `addTicketCommentSchema`:
+
+```typescript
+export const editCommentSchema = z.object({
+  content: z.string().min(1).max(50_000)
+});
+
+export const moveTicketOrgSchema = z.object({
+  orgId: z.string().guid()
+});
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/shared exec vitest run src/validators/tickets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/tickets.ts packages/shared/src/validators/tickets.test.ts
+git commit -m "feat(tickets): editComment + moveTicketOrg validators"
+```
+
+---
+
+## Task 4: `editTicketComment` + `deleteTicketComment` + `portalCommentMutable` (service)
+
+**Files:**
+- Modify: `apps/api/src/services/ticketService.ts`
+- Test: `apps/api/src/services/ticketService.test.ts` (or a new `ticketService.comments.test.ts` if the file is large)
+
+**Interfaces:**
+- Consumes: `db`, `ticketComments`, `tickets`, `eq`, `and`, `isNull`, `gt` (drizzle-orm), `emitTicketEvent`, `createAuditLogAsync`, `TicketServiceError`, `TicketActor`.
+- Produces:
+  - `editTicketComment(commentId: string, input: { content: string }, actor: TicketActor, opts: { canManageAny: boolean }): Promise<typeof ticketComments.$inferSelect>`
+  - `deleteTicketComment(commentId: string, actor: TicketActor, opts: { canManageAny: boolean }): Promise<{ id: string }>`
+  - `portalCommentMutable(commentId: string, portalUserId: string): Promise<{ ok: boolean; reason?: 'not_found' | 'not_author' | 'staff_replied' }>`
+  - `SYSTEM_COMMENT_TYPES = new Set(['status_change','assignment','time_entry','system'])`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the ticketService test file. Use the existing Drizzle-mock pattern in that file (mirror how `addTicketComment` / `updateTicketFields` are already tested — same `db` mock shape):
+
+```typescript
+import { editTicketComment, deleteTicketComment, SYSTEM_COMMENT_TYPES, TicketServiceError } from './ticketService';
+
+describe('editTicketComment', () => {
+  it('lets the author edit their own comment and stamps edited_at + audit with previousContent', async () => {
+    // Mock db: comment row { id, ticketId, userId: 'tech-1', portalUserId: null, commentType: 'comment', content: 'old', deletedAt: null }
+    // ticket row { id: 't1', orgId: 'o1', partnerId: 'p1' }
+    const actor = { userId: 'tech-1', name: 'Tech' };
+    const result = await editTicketComment('c1', { content: 'new' }, actor, { canManageAny: false });
+    expect(result.content).toBe('new');
+    expect(result.editedAt).toBeInstanceOf(Date);
+    // assert createAuditLogAsync called with action 'ticket.comment.edit' and details.previousContent === 'old'
+  });
+
+  it('rejects a non-author without manage (403)', async () => {
+    const actor = { userId: 'other-tech' };
+    await expect(editTicketComment('c1', { content: 'x' }, actor, { canManageAny: false }))
+      .rejects.toMatchObject({ status: 403 });
+  });
+
+  it('allows a non-author WITH canManageAny', async () => {
+    const actor = { userId: 'admin' };
+    const result = await editTicketComment('c1', { content: 'x' }, actor, { canManageAny: true });
+    expect(result.content).toBe('x');
+  });
+
+  it('rejects editing a system comment type', async () => {
+    // comment row commentType: 'system'
+    await expect(editTicketComment('c-sys', { content: 'x' }, { userId: 'tech-1' }, { canManageAny: true }))
+      .rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects editing an already-deleted comment', async () => {
+    // comment row deletedAt: new Date()
+    await expect(editTicketComment('c-del', { content: 'x' }, { userId: 'tech-1' }, { canManageAny: true }))
+      .rejects.toMatchObject({ status: 409 });
+  });
+});
+
+describe('deleteTicketComment', () => {
+  it('soft-deletes (sets deletedAt) and audits previousContent', async () => {
+    const res = await deleteTicketComment('c1', { userId: 'tech-1' }, { canManageAny: false });
+    expect(res.id).toBe('c1');
+    // assert update set deletedAt, audit action 'ticket.comment.delete', details.previousContent === 'old'
+  });
+  it('rejects a non-author without manage', async () => {
+    await expect(deleteTicketComment('c1', { userId: 'other' }, { canManageAny: false }))
+      .rejects.toMatchObject({ status: 403 });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/ticketService.test.ts`
+Expected: FAIL — functions not exported.
+
+- [ ] **Step 3: Implement the service functions**
+
+In `apps/api/src/services/ticketService.ts`. Ensure `gt` is in the drizzle-orm import (`import { and, eq, isNull, gt } from 'drizzle-orm';`). Add:
+
+```typescript
+export const SYSTEM_COMMENT_TYPES = new Set(['status_change', 'assignment', 'time_entry', 'system']);
+
+async function loadCommentWithTicket(commentId: string) {
+  const rows = await db
+    .select()
+    .from(ticketComments)
+    .where(eq(ticketComments.id, commentId))
+    .limit(1);
+  const comment = rows[0];
+  if (!comment) throw new TicketServiceError('Comment not found', 404);
+  const ticket = await getTicketOrThrow(comment.ticketId);
+  return { comment, ticket };
+}
+
+function assertCommentEditable(comment: typeof ticketComments.$inferSelect, actor: TicketActor, canManageAny: boolean) {
+  if (SYSTEM_COMMENT_TYPES.has(comment.commentType)) {
+    throw new TicketServiceError('System-generated entries cannot be edited or deleted', 400);
+  }
+  if (comment.deletedAt) {
+    throw new TicketServiceError('Comment already deleted', 409);
+  }
+  const isAuthor = comment.userId != null && comment.userId === actor.userId;
+  if (!isAuthor && !canManageAny) {
+    throw new TicketServiceError('You can only edit or delete your own comments', 403);
+  }
+}
+
+export async function editTicketComment(
+  commentId: string,
+  input: { content: string },
+  actor: TicketActor,
+  opts: { canManageAny: boolean }
+) {
+  const { comment, ticket } = await loadCommentWithTicket(commentId);
+  assertCommentEditable(comment, actor, opts.canManageAny);
+
+  const previousContent = comment.content;
+  const updated = await db
+    .update(ticketComments)
+    .set({ content: input.content, editedAt: new Date() })
+    .where(eq(ticketComments.id, commentId))
+    .returning();
+  const row = updated[0];
+  if (!row) throw new TicketServiceError('Comment not found', 404);
+
+  await emitTicketEvent({
+    type: 'ticket.commented',
+    ticketId: ticket.id,
+    orgId: ticket.orgId,
+    partnerId: ticket.partnerId ?? null,
+    actorUserId: actor.userId,
+    payload: { commentId, isPublic: row.isPublic }
+  });
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.comment.edit',
+    resourceType: 'ticket',
+    resourceId: ticket.id,
+    details: { commentId, previousContent },
+    result: 'success'
+  });
+  return row;
+}
+
+export async function deleteTicketComment(
+  commentId: string,
+  actor: TicketActor,
+  opts: { canManageAny: boolean }
+) {
+  const { comment, ticket } = await loadCommentWithTicket(commentId);
+  assertCommentEditable(comment, actor, opts.canManageAny);
+
+  await db
+    .update(ticketComments)
+    .set({ deletedAt: new Date() })
+    .where(eq(ticketComments.id, commentId));
+
+  await emitTicketEvent({
+    type: 'ticket.commented',
+    ticketId: ticket.id,
+    orgId: ticket.orgId,
+    partnerId: ticket.partnerId ?? null,
+    actorUserId: actor.userId,
+    payload: { commentId, isPublic: comment.isPublic }
+  });
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.comment.delete',
+    resourceType: 'ticket',
+    resourceId: ticket.id,
+    details: { commentId, previousContent: comment.content },
+    result: 'success'
+  });
+  return { id: commentId };
+}
+
+/**
+ * A portal customer may edit/delete their own public reply only until a staff
+ * member (or any system event) has acted on the ticket AFTER that comment.
+ */
+export async function portalCommentMutable(
+  commentId: string,
+  portalUserId: string
+): Promise<{ ok: boolean; reason?: 'not_found' | 'not_author' | 'staff_replied' }> {
+  const rows = await db
+    .select()
+    .from(ticketComments)
+    .where(eq(ticketComments.id, commentId))
+    .limit(1);
+  const comment = rows[0];
+  if (!comment || comment.deletedAt) return { ok: false, reason: 'not_found' };
+  if (comment.portalUserId !== portalUserId) return { ok: false, reason: 'not_author' };
+
+  // Any later comment whose authorType is not 'portal' (staff/technician or a
+  // system feed row) closes the window.
+  const laterStaff = await db
+    .select({ id: ticketComments.id })
+    .from(ticketComments)
+    .where(and(
+      eq(ticketComments.ticketId, comment.ticketId),
+      gt(ticketComments.createdAt, comment.createdAt)
+    ))
+    .limit(50);
+  const closed = laterStaff.length > 0
+    ? (await db
+        .select({ authorType: ticketComments.authorType })
+        .from(ticketComments)
+        .where(and(
+          eq(ticketComments.ticketId, comment.ticketId),
+          gt(ticketComments.createdAt, comment.createdAt)
+        )))
+        .some((r) => r.authorType !== 'portal')
+    : false;
+  if (closed) return { ok: false, reason: 'staff_replied' };
+  return { ok: true };
+}
+```
+
+> The `portalCommentMutable` two-query shape above is intentionally simple; if the mock pattern in the test file makes a single grouped query easier, collapse to one select returning `{ authorType }` for later rows and `.some(r => r.authorType !== 'portal')`. Keep the semantics identical.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/ticketService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketService.ts apps/api/src/services/ticketService.test.ts
+git commit -m "feat(tickets): editTicketComment/deleteTicketComment + portal window helper"
+```
+
+---
+
+## Task 5: Staff comment edit/delete routes
+
+**Files:**
+- Modify: `apps/api/src/routes/tickets/tickets.ts`
+- Test: `apps/api/src/routes/tickets/tickets.test.ts`
+
+**Interfaces:**
+- Consumes: `editTicketComment`, `deleteTicketComment` (Task 4); `hasPermission`, `PERMISSIONS` (`../../services/permissions`); `getScopedTicketOr404`, `actorFrom`, `handleServiceError`.
+- Produces: `PATCH /tickets/:id/comments/:commentId` (`{ content }`), `DELETE /tickets/:id/comments/:commentId`. Both require `tickets:write`; manage-override computed via `tickets:manage`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/src/routes/tickets/tickets.ts`' test file (mirror existing route-test wiring — these mock `requirePermission`/`requireScope` to pass-through and mock the service):
+
+```typescript
+describe('PATCH /tickets/:id/comments/:commentId', () => {
+  it('edits a comment via the service and returns 200', async () => {
+    // mock editTicketComment -> { id: 'c1', content: 'new', editedAt: new Date() }
+    const res = await app.request('/tickets/t1/comments/c1', {
+      method: 'PATCH', headers: jsonAuthHeaders, body: JSON.stringify({ content: 'new' })
+    });
+    expect(res.status).toBe(200);
+  });
+  it('404s when the ticket is out of scope', async () => {
+    // getScopedTicketOr404 -> null
+    const res = await app.request('/tickets/t1/comments/c1', {
+      method: 'PATCH', headers: jsonAuthHeaders, body: JSON.stringify({ content: 'x' })
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /tickets/:id/comments/:commentId', () => {
+  it('soft-deletes and returns 200', async () => {
+    const res = await app.request('/tickets/t1/comments/c1', { method: 'DELETE', headers: jsonAuthHeaders });
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/tickets/tickets.test.ts`
+Expected: FAIL — routes 404 (not registered).
+
+- [ ] **Step 3: Add the routes**
+
+In `apps/api/src/routes/tickets/tickets.ts`: extend the imports —
+
+```typescript
+import { editCommentSchema } from '@breeze/shared';
+import { hasPermission } from '../../services/permissions';
+import {
+  createTicket, changeTicketStatus, assignTicket, addTicketComment,
+  linkAlertToTicket, unlinkAlertFromTicket, updateTicketFields,
+  editTicketComment, deleteTicketComment,
+  TicketServiceError
+} from '../../services/ticketService';
+```
+
+Add a small param schema and the two handlers (place near the existing `POST /:id/comments`):
+
+```typescript
+const commentParam = z.object({ id: z.string().uuid(), commentId: z.string().uuid() });
+
+// PATCH /tickets/:id/comments/:commentId — edit a comment body.
+// tickets:write to reach it; author-or-tickets:manage enforced in the service.
+ticketsRoutes.patch(
+  '/:id/comments/:commentId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('param', commentParam),
+  zValidator('json', editCommentSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id, commentId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+    const canManageAny = hasPermission(auth.permissions, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action);
+    try {
+      const comment = await editTicketComment(commentId, body, actorFrom(c), { canManageAny });
+      return c.json({ data: comment });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  }
+);
+
+// DELETE /tickets/:id/comments/:commentId — soft-delete a comment.
+ticketsRoutes.delete(
+  '/:id/comments/:commentId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('param', commentParam),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id, commentId } = c.req.valid('param');
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+    const canManageAny = hasPermission(auth.permissions, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action);
+    try {
+      const result = await deleteTicketComment(commentId, actorFrom(c), { canManageAny });
+      return c.json({ data: result });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  }
+);
+```
+
+> `handleServiceError` is the existing helper used by sibling handlers (it maps `TicketServiceError.status`). Reuse it verbatim — do not introduce a new error mapper.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/tickets/tickets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/tickets/tickets.ts apps/api/src/routes/tickets/tickets.test.ts
+git commit -m "feat(tickets): staff comment edit/delete routes"
+```
+
+---
+
+## Task 6: Detail GET returns soft-deleted comments to staff as tombstones
+
+**Files:**
+- Modify: `apps/api/src/routes/tickets/tickets.ts` (GET `/:id` comment select, lines ~441–445)
+- Test: `apps/api/src/routes/tickets/tickets.test.ts`
+
+**Interfaces:**
+- Produces: staff detail `comments[]` now includes soft-deleted rows with `deleted: true`, `content: ''`, and the real `editedAt`. Portal GET (Task 7 covers portal edit; portal detail keeps hiding deleted rows) is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+it('returns soft-deleted comments to staff as tombstones with empty content', async () => {
+  // seed/mock: one normal comment, one with deletedAt set (content 'secret')
+  const res = await app.request('/tickets/t1', { headers: jsonAuthHeaders });
+  const body = await res.json();
+  const tomb = body.data.comments.find((c: any) => c.deleted === true);
+  expect(tomb).toBeTruthy();
+  expect(tomb.content).toBe('');           // prior text must not leak to the client
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/tickets/tickets.test.ts`
+Expected: FAIL — deleted rows are filtered out (`isNull(deletedAt)`).
+
+- [ ] **Step 3: Update the comment select + projection**
+
+In the GET `/:id` handler, replace the comments query (currently `.where(and(eq(...ticketId, id), isNull(ticketComments.deletedAt)))`) with an explicit projection that includes deleted rows, derives a `deleted` flag, and nulls deleted content:
+
+```typescript
+    const commentRows = await db
+      .select()
+      .from(ticketComments)
+      .where(eq(ticketComments.ticketId, id))
+      .orderBy(asc(ticketComments.createdAt));
+    const comments = commentRows.map((row) => ({
+      ...row,
+      deleted: row.deletedAt != null,
+      // Never ship the prior text of a deleted comment to the client.
+      content: row.deletedAt != null ? '' : row.content,
+    }));
+```
+
+(The `editedAt` field flows through `...row` automatically.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/tickets/tickets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/tickets/tickets.ts apps/api/src/routes/tickets/tickets.test.ts
+git commit -m "feat(tickets): staff detail returns deleted comments as tombstones"
+```
+
+---
+
+## Task 7: Portal comment edit/delete routes (until-staff-reply window)
+
+**Files:**
+- Modify: `apps/api/src/routes/portal/tickets.ts`
+- Test: `apps/api/src/routes/portal/tickets.test.ts` (create if absent, mirroring the existing portal route test setup)
+
+**Interfaces:**
+- Consumes: `portalCommentMutable`, `editTicketComment`, `deleteTicketComment` (Task 4); `validatePortalCookieCsrfRequest`, `writePortalAudit` (existing in this file).
+- Produces: `PATCH /tickets/:id/comments/:commentId`, `DELETE /tickets/:id/comments/:commentId` (portal). Closed window → 409; not-author → 404.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+describe('portal PATCH /tickets/:id/comments/:commentId', () => {
+  it('edits own reply when window is open', async () => {
+    // portalCommentMutable -> { ok: true }
+    const res = await portalApp.request('/tickets/t1/comments/c1', {
+      method: 'PATCH', headers: portalJsonHeaders, body: JSON.stringify({ content: 'fixed typo' })
+    });
+    expect(res.status).toBe(200);
+  });
+  it('409s once staff has replied', async () => {
+    // portalCommentMutable -> { ok: false, reason: 'staff_replied' }
+    const res = await portalApp.request('/tickets/t1/comments/c1', {
+      method: 'PATCH', headers: portalJsonHeaders, body: JSON.stringify({ content: 'too late' })
+    });
+    expect(res.status).toBe(409);
+  });
+  it('404s on another user\'s comment', async () => {
+    // portalCommentMutable -> { ok: false, reason: 'not_author' }
+    const res = await portalApp.request('/tickets/t1/comments/c1', {
+      method: 'PATCH', headers: portalJsonHeaders, body: JSON.stringify({ content: 'x' })
+    });
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/portal/tickets.test.ts`
+Expected: FAIL — routes not registered.
+
+- [ ] **Step 3: Add the portal routes**
+
+In `apps/api/src/routes/portal/tickets.ts`, import the service helpers and add handlers after the existing comment POST. The portal actor is the portal user; staff `canManageAny` is always false here, and `editTicketComment`/`deleteTicketComment` enforce author identity via `comment.userId` — but portal comments have `userId: null`, so we must pass the **portal authorization through `portalCommentMutable`** and then call the service with `canManageAny: true` scoped to the already-verified portal ownership. To keep the service's author rule intact, branch on a portal-author actor:
+
+```typescript
+import { editCommentSchema } from '@breeze/shared';
+import { portalCommentMutable, editTicketComment, deleteTicketComment } from '../../services/ticketService';
+
+ticketRoutes.patch(
+  '/tickets/:id/comments/:commentId',
+  zValidator('param', ticketCommentParamSchema), // { id, commentId } uuids
+  zValidator('json', editCommentSchema),
+  async (c) => {
+    const csrfError = validatePortalCookieCsrfRequest(c);
+    if (csrfError) return c.json({ error: csrfError }, 403);
+    const auth = c.get('portalAuth');
+    const { id, commentId } = c.req.valid('param');
+    const body = c.req.valid('json');
+
+    const mutable = await portalCommentMutable(commentId, auth.user.id);
+    if (!mutable.ok) {
+      if (mutable.reason === 'staff_replied') {
+        return c.json({ error: 'This reply can no longer be edited — support has already responded.' }, 409);
+      }
+      return c.json({ error: 'Ticket not found' }, 404); // not_author / not_found
+    }
+
+    // Ownership already proven by portalCommentMutable (portal_user_id match);
+    // pass canManageAny so the service's staff-author rule (keyed on user_id,
+    // which is NULL for portal rows) does not reject the legitimate edit.
+    const updated = await editTicketComment(
+      commentId, body, { userId: auth.user.id, name: auth.user.name ?? auth.user.email }, { canManageAny: true }
+    );
+    writePortalAudit(c, {
+      orgId: auth.user.orgId, actorType: 'user', actorId: auth.user.id, actorEmail: auth.user.email,
+      action: 'portal.ticket.comment.edit', resourceType: 'ticket_comment', resourceId: commentId,
+      details: { ticketId: id },
+    });
+    return c.json({ comment: { id: updated.id, content: updated.content, editedAt: updated.editedAt } });
+  }
+);
+
+ticketRoutes.delete(
+  '/tickets/:id/comments/:commentId',
+  zValidator('param', ticketCommentParamSchema),
+  async (c) => {
+    const csrfError = validatePortalCookieCsrfRequest(c);
+    if (csrfError) return c.json({ error: csrfError }, 403);
+    const auth = c.get('portalAuth');
+    const { id, commentId } = c.req.valid('param');
+
+    const mutable = await portalCommentMutable(commentId, auth.user.id);
+    if (!mutable.ok) {
+      if (mutable.reason === 'staff_replied') {
+        return c.json({ error: 'This reply can no longer be deleted — support has already responded.' }, 409);
+      }
+      return c.json({ error: 'Ticket not found' }, 404);
+    }
+    await deleteTicketComment(commentId, { userId: auth.user.id }, { canManageAny: true });
+    writePortalAudit(c, {
+      orgId: auth.user.orgId, actorType: 'user', actorId: auth.user.id, actorEmail: auth.user.email,
+      action: 'portal.ticket.comment.delete', resourceType: 'ticket_comment', resourceId: commentId,
+      details: { ticketId: id },
+    });
+    return c.json({ success: true });
+  }
+);
+```
+
+Define `ticketCommentParamSchema = z.object({ id: z.string().uuid(), commentId: z.string().uuid() })` near the existing param schemas if not already present.
+
+> **Audit `actorId` caveat:** `editTicketComment`/`deleteTicketComment` write an `audit_logs` row with `actorId: actor.userId`. For the portal path we pass `auth.user.id` (a portal user id) as `actorUserId` — confirm the `audit_logs.actor_id` FK tolerates a portal-user id or is unconstrained (it is text/uuid without an FK in this codebase). The additional `writePortalAudit` row is the authoritative portal trail; the service audit is supplementary. If the FK is strict, pass `actor: { userId: <a sentinel/null-safe id> }` — verify during implementation.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/portal/tickets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/portal/tickets.ts apps/api/src/routes/portal/tickets.test.ts
+git commit -m "feat(portal): customer comment edit/delete within until-staff-reply window"
+```
+
+---
+
+## Task 8: Integration test — comment edit/delete RLS forge
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts`
+
+**Interfaces:**
+- Consumes: the seeding helpers + `withDbAccessContext` pattern from `ticket-comments-rls.integration.test.ts` and `./db-utils`.
+
+- [ ] **Step 1: Write the integration test**
+
+Model on the existing `ticket-comments-rls.integration.test.ts` (same imports, `seedTicketWithMixedComments`-style helper re-seeded per test). Cover:
+
+```typescript
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { ticketComments } from '../../db/schema';
+// reuse a local seed helper that creates partner→orgA, orgB, a ticket in orgA with one comment
+
+describe('ticket_comments UPDATE/DELETE RLS', () => {
+  it('a connection scoped to org A can soft-delete (UPDATE deletedAt) a comment on an org-A ticket', async () => {
+    const { orgA, partner, comment } = await seed();
+    const ctxA: DbAccessContext = { scope: 'organization', orgId: orgA.id, accessibleOrgIds: [orgA.id], accessiblePartnerIds: [partner.id], userId: null };
+    await withDbAccessContext(ctxA, () =>
+      db.update(ticketComments).set({ deletedAt: new Date() }).where(eq(ticketComments.id, comment.id))
+    );
+    // verify (admin/bypass read) deletedAt is now set
+  });
+
+  it('a connection scoped to org B CANNOT update a comment on an org-A ticket (0 rows affected)', async () => {
+    const { orgB, partnerB, comment } = await seedCrossTenant();
+    const ctxB: DbAccessContext = { scope: 'organization', orgId: orgB.id, accessibleOrgIds: [orgB.id], accessiblePartnerIds: [partnerB.id], userId: null };
+    const result: any = await withDbAccessContext(ctxB, () =>
+      db.update(ticketComments).set({ content: 'forged' }).where(eq(ticketComments.id, comment.id)).returning()
+    );
+    expect(result.length).toBe(0); // RLS filtered the row out — no error, no rows
+    // and an admin read confirms content is unchanged
+  });
+
+  it('org B cannot DELETE a comment on an org-A ticket', async () => {
+    // same shape: db.delete(ticketComments).where(eq(id)) under ctxB -> 0 rows; admin read confirms still present
+  });
+});
+```
+
+Re-seed inside each `it` (never module scope — [[rls-forge-test-memoized-fixture-vacuous]]). Confirm the test role is non-BYPASSRLS before trusting a pass ([[worktree_env_test_rls_vacuous]]): the worktree needs the gitignored `.env.test` symlink.
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts`
+Expected: PASS (autoMigrate applies the Task 2 migration; forge cases prove isolation).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/ticket-comment-edit-rls.integration.test.ts
+git commit -m "test(tickets): RLS forge for comment update/delete policies"
+```
+
+---
+
+## Task 9: `moveTicketOrg` (service)
+
+**Files:**
+- Modify: `apps/api/src/services/ticketService.ts`
+- Test: `apps/api/src/services/ticketService.test.ts`
+
+**Interfaces:**
+- Consumes: `db` (`.transaction`), `tickets`, `organizations`, `ticketComments`, `sql`, `eq` (drizzle); `emitTicketEvent`, `createAuditLogAsync`, `TicketServiceError`, `getTicketOrThrow`.
+- Produces: `moveTicketOrg(ticketId: string, targetOrgId: string, actor: TicketActor): Promise<typeof tickets.$inferSelect>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { moveTicketOrg } from './ticketService';
+
+describe('moveTicketOrg', () => {
+  it('moves a ticket to a same-partner org, detaches device, re-stamps child org_id', async () => {
+    // ticket { id:'t1', orgId:'oA', partnerId:'p1', deviceId:'d1' }; target org { id:'oB', partnerId:'p1' }
+    const res = await moveTicketOrg('t1', 'oB', { userId: 'admin' });
+    expect(res.orgId).toBe('oB');
+    expect(res.deviceId).toBeNull();
+    // assert UPDATEs issued for time_entries / ticket_parts / ticket_alert_links WHERE ticket_id='t1'
+  });
+  it('rejects a cross-partner target (400)', async () => {
+    // target org partnerId 'p2' != ticket partnerId 'p1'
+    await expect(moveTicketOrg('t1', 'oX', { userId: 'admin' })).rejects.toMatchObject({ status: 400 });
+  });
+  it('no-ops when target equals current org', async () => {
+    const res = await moveTicketOrg('t1', 'oA', { userId: 'admin' });
+    expect(res.orgId).toBe('oA');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/ticketService.test.ts`
+Expected: FAIL — `moveTicketOrg` not exported.
+
+- [ ] **Step 3: Implement `moveTicketOrg`**
+
+Add `sql` to the drizzle import if absent (`import { and, eq, isNull, gt, sql } from 'drizzle-orm';`). The child tables to re-stamp mirror the `CUSTOM_ORG_REWRITE_TABLES` device precedent (`time_entries`, `ticket_parts`, `ticket_alert_links`) — keyed on `ticket_id` here. `ticket_comments` has **no `org_id` column** (tenancy via parent join) so it is intentionally absent.
+
+```typescript
+// Child tables that denormalize org_id and reference a ticket. Mirrors the
+// device-move CUSTOM_ORG_REWRITE_TABLES set (core.ts) — keep in lockstep.
+// ticket_comments is intentionally absent: it has no org_id (child-via-parent).
+const TICKET_ORG_DENORMALIZED_TABLES = ['time_entries', 'ticket_parts', 'ticket_alert_links'] as const;
+
+export async function moveTicketOrg(ticketId: string, targetOrgId: string, actor: TicketActor) {
+  const ticket = await getTicketOrThrow(ticketId);
+  if (ticket.orgId === targetOrgId) return ticket;
+
+  const orgRows = await db
+    .select({ id: organizations.id, partnerId: organizations.partnerId, name: organizations.name })
+    .from(organizations)
+    .where(sql`${organizations.id} IN (${ticket.orgId}::uuid, ${targetOrgId}::uuid)`);
+  const sourceOrg = orgRows.find((r) => r.id === ticket.orgId);
+  const targetOrg = orgRows.find((r) => r.id === targetOrgId);
+  if (!targetOrg) throw new TicketServiceError('Target organization not found', 404);
+  if (!sourceOrg || sourceOrg.partnerId !== targetOrg.partnerId) {
+    throw new TicketServiceError('Tickets can only be moved between organizations of the same partner', 400);
+  }
+
+  let updated: typeof tickets.$inferSelect | undefined;
+  await db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(tickets)
+      .set({ orgId: targetOrgId, deviceId: null, updatedAt: new Date() })
+      .where(eq(tickets.id, ticketId))
+      .returning();
+    updated = row;
+    for (const table of TICKET_ORG_DENORMALIZED_TABLES) {
+      await tx.execute(
+        sql`UPDATE ${sql.identifier(table)} SET org_id = ${targetOrgId}::uuid WHERE ticket_id = ${ticketId}::uuid`
+      );
+    }
+    // System feed entry on the moved ticket.
+    await tx.insert(ticketComments).values({
+      ticketId,
+      userId: actor.userId,
+      authorName: actor.name ?? null,
+      authorType: 'internal',
+      commentType: 'system',
+      content: `Moved to ${targetOrg.name}`,
+      isPublic: false
+    });
+  });
+  if (!updated) throw new TicketServiceError('Ticket not found', 404);
+
+  await emitTicketEvent({
+    type: 'ticket.updated',
+    ticketId,
+    orgId: targetOrgId,
+    partnerId: ticket.partnerId ?? null,
+    actorUserId: actor.userId,
+    payload: { changed: ['orgId'] }
+  });
+  // Audit on BOTH orgs so the move shows in source and target feeds (device precedent).
+  const details = { fromOrgId: ticket.orgId, toOrgId: targetOrgId, detachedDeviceId: ticket.deviceId ?? null };
+  await createAuditLogAsync({ orgId: ticket.orgId, actorId: actor.userId, action: 'ticket.move_org.source', resourceType: 'ticket', resourceId: ticketId, details, result: 'success' });
+  await createAuditLogAsync({ orgId: targetOrgId, actorId: actor.userId, action: 'ticket.move_org.target', resourceType: 'ticket', resourceId: ticketId, details, result: 'success' });
+  return updated;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/ticketService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketService.ts apps/api/src/services/ticketService.test.ts
+git commit -m "feat(tickets): moveTicketOrg service (same-partner, device detach, child org_id re-stamp)"
+```
+
+---
+
+## Task 10: `POST /:id/move-org` route + mount
+
+**Files:**
+- Create: `apps/api/src/routes/tickets/moveOrg.ts`
+- Modify: `apps/api/src/routes/tickets/index.ts` (mount BEFORE core routes)
+- Test: `apps/api/src/routes/tickets/moveOrg.test.ts`
+
+**Interfaces:**
+- Consumes: `moveTicketOrg` (Task 9); `getScopedTicketOr404`, `actorFrom` (export from `tickets.ts` if not already), `handleServiceError`; `requireScope`, `requirePermission`, `requireMfa`, `PERMISSIONS`; `moveTicketOrgSchema`.
+- Produces: `ticketMoveOrgRoutes` Hono router mounted at `/`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+describe('POST /tickets/:id/move-org', () => {
+  it('moves to a same-partner org and returns 200', async () => {
+    // mock getScopedTicketOr404 -> ticket; moveTicketOrg -> { id, orgId: 'oB', deviceId: null }
+    const res = await app.request('/tickets/t1/move-org', {
+      method: 'POST', headers: jsonAuthHeaders, body: JSON.stringify({ orgId: 'oB' })
+    });
+    expect(res.status).toBe(200);
+  });
+  it('404s when ticket out of scope', async () => {
+    const res = await app.request('/tickets/t1/move-org', {
+      method: 'POST', headers: jsonAuthHeaders, body: JSON.stringify({ orgId: 'oB' })
+    });
+    expect(res.status).toBe(404);
+  });
+  it('surfaces 400 on cross-partner via handleServiceError', async () => {
+    // moveTicketOrg throws TicketServiceError(.., 400)
+    const res = await app.request('/tickets/t1/move-org', {
+      method: 'POST', headers: jsonAuthHeaders, body: JSON.stringify({ orgId: 'oX' })
+    });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/tickets/moveOrg.test.ts`
+Expected: FAIL — route not registered.
+
+- [ ] **Step 3: Create the route file**
+
+`apps/api/src/routes/tickets/moveOrg.ts`:
+
+```typescript
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { requireScope, requirePermission, requireMfa } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { moveTicketOrgSchema } from '@breeze/shared';
+import { moveTicketOrg, TicketServiceError } from '../../services/ticketService';
+import { getScopedTicketOr404, actorFrom, handleServiceError } from './tickets';
+
+const idParam = z.object({ id: z.string().uuid() });
+
+export const ticketMoveOrgRoutes = new Hono();
+
+// POST /tickets/:id/move-org — reassign a ticket to another org of the SAME partner.
+// High-privilege: tickets:write + organizations:write at partner/system scope + MFA
+// (mirrors devices/moveOrg.ts). Same-partner validation + child org_id re-stamp in the service.
+ticketMoveOrgRoutes.post(
+  '/:id/move-org',
+  requireScope('partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('param', idParam),
+  zValidator('json', moveTicketOrgSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+    const { orgId: targetOrgId } = c.req.valid('json');
+
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+    if (!auth.canAccessOrg(targetOrgId)) {
+      return c.json({ error: 'Access to target organization denied' }, 403);
+    }
+    try {
+      const ticket = await moveTicketOrg(id, targetOrgId, actorFrom(c));
+      return c.json({ data: ticket });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  }
+);
+```
+
+Confirm `getScopedTicketOr404`, `actorFrom`, and `handleServiceError` are exported from `tickets.ts` (the first two are; export `handleServiceError` if it is currently file-local).
+
+- [ ] **Step 4: Mount it before core routes**
+
+In `apps/api/src/routes/tickets/index.ts`, mirroring the device precedent comment (mount move-org BEFORE the core `/:id` routes so `POST /:id/move-org` is not shadowed):
+
+```typescript
+import { ticketMoveOrgRoutes } from './moveOrg';
+// ... after auth middleware is applied on the hub, BEFORE ticketsRoutes:
+ticketsHub.route('/', ticketMoveOrgRoutes);
+ticketsHub.route('/', ticketsRoutes);
+```
+
+(Match the actual hub variable name in that file.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/tickets/moveOrg.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/tickets/moveOrg.ts apps/api/src/routes/tickets/index.ts apps/api/src/routes/tickets/moveOrg.test.ts
+git commit -m "feat(tickets): POST /:id/move-org route (mounted before core routes)"
+```
+
+---
+
+## Task 11: Integration test — move-org child re-stamp + isolation
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Seed (admin/bypass): partner P → orgA, orgB; a ticket in orgA with a device in orgA, one time_entry, one ticket_part, one alert+ticket_alert_link. Call `moveTicketOrg(ticket.id, orgB.id, actor)` directly (service-level — no HTTP needed). Assert:
+
+```typescript
+it('re-stamps org_id on all denormalized children and detaches the device', async () => {
+  const { ticket, orgB, timeEntry, ticketPart, alertLink } = await seed();
+  await moveTicketOrg(ticket.id, orgB.id, { userId: 'admin' });
+  // admin reads:
+  expect((await readTicket(ticket.id)).orgId).toBe(orgB.id);
+  expect((await readTicket(ticket.id)).deviceId).toBeNull();
+  expect((await readTimeEntry(timeEntry.id)).orgId).toBe(orgB.id);
+  expect((await readTicketPart(ticketPart.id)).orgId).toBe(orgB.id);
+  expect((await readAlertLink(alertLink.id)).orgId).toBe(orgB.id);
+});
+
+it('rejects a cross-partner target', async () => {
+  const { ticket, orgOtherPartner } = await seedCrossPartner();
+  await expect(moveTicketOrg(ticket.id, orgOtherPartner.id, { userId: 'admin' }))
+    .rejects.toMatchObject({ status: 400 });
+});
+
+it('comments remain visible after move (parent-join tenancy)', async () => {
+  // after move, a connection scoped to orgB sees the ticket's comments (they have no org_id; follow the parent)
+});
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/ticket-move-org.integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
+git commit -m "test(tickets): integration coverage for moveTicketOrg child re-stamp + isolation"
+```
+
+---
+
+## Task 12: Feed — edited badge, deleted tombstone, edit/delete controls
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/ticketConfig.ts` (`TicketComment` type)
+- Modify: `apps/web/src/components/tickets/TicketFeed.tsx`
+- Test: `apps/web/src/components/tickets/TicketFeed.test.tsx`
+
+**Interfaces:**
+- Consumes: `TicketComment` gains `editedAt?: string | null` and `deleted?: boolean`.
+- Produces: `TicketFeed` accepts new optional props `onEditComment?(id, content)`, `onDeleteComment?(id)`, `canManageComment?(c: TicketComment): boolean`. Renders `data-testid="ticket-comment-edited-<id>"` badge and `data-testid="ticket-comment-deleted-<id>"` tombstone.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/web/src/components/tickets/TicketFeed.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import TicketFeed from './TicketFeed';
+
+const base = { id: 'c1', ticketId: 't1', authorName: 'Tech', authorType: 'internal', isPublic: true, commentType: 'comment', createdAt: new Date().toISOString(), portalUserId: null };
+
+it('shows an edited badge when editedAt is set', () => {
+  render(<TicketFeed comments={[{ ...base, content: 'hi', editedAt: new Date().toISOString() }]} />);
+  expect(screen.getByTestId('ticket-comment-edited-c1')).toBeInTheDocument();
+});
+
+it('renders a tombstone for a deleted comment and hides the body', () => {
+  render(<TicketFeed comments={[{ ...base, content: '', deleted: true }]} />);
+  expect(screen.getByTestId('ticket-comment-deleted-c1')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketFeed.test.tsx`
+Expected: FAIL — no edited/deleted markers.
+
+- [ ] **Step 3: Extend the type**
+
+In `apps/web/src/components/tickets/ticketConfig.ts`, add to the `TicketComment` interface:
+
+```typescript
+  editedAt?: string | null;
+  deleted?: boolean;
+```
+
+- [ ] **Step 4: Render badge + tombstone + controls**
+
+In `TicketFeed.tsx`, update the props signature and the user-comment block:
+
+```typescript
+export default function TicketFeed({
+  comments,
+  onEditComment,
+  onDeleteComment,
+  canManageComment,
+}: {
+  comments: TicketComment[];
+  onEditComment?: (id: string, content: string) => void;
+  onDeleteComment?: (id: string) => void;
+  canManageComment?: (c: TicketComment) => boolean;
+}) {
+```
+
+Replace the user-comment render branch with one that handles the deleted case and adds the badge + controls:
+
+```typescript
+          b.item.deleted ? (
+            <div
+              key={b.item.id}
+              className="rounded-lg border border-dashed p-3 text-sm italic text-muted-foreground"
+              data-testid={`ticket-comment-deleted-${b.item.id}`}
+            >
+              {(b.item.authorName ?? 'A comment')} — deleted
+            </div>
+          ) : (
+            <div
+              key={b.item.id}
+              className={cn('rounded-lg border p-3', !b.item.isPublic && 'border-warning/30 bg-warning/10')}
+              data-testid={`ticket-comment-${b.item.id}`}
+            >
+              <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">{b.item.authorName ?? (b.item.portalUserId ? 'Requester' : 'Technician')}</span>
+                {!b.item.isPublic && <span className="font-medium text-warning">Internal</span>}
+                {b.item.editedAt && (
+                  <span data-testid={`ticket-comment-edited-${b.item.id}`} title={formatDateTime(b.item.editedAt)}>edited</span>
+                )}
+                <span className="ml-auto" title={formatDateTime(b.item.createdAt)}>
+                  {formatDateTime(b.item.createdAt, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                </span>
+                {canManageComment?.(b.item) && onEditComment && (
+                  <button type="button" className="text-xs hover:text-foreground" data-testid={`ticket-comment-edit-${b.item.id}`}
+                    onClick={() => onEditComment(b.item.id, b.item.content)}>Edit</button>
+                )}
+                {canManageComment?.(b.item) && onDeleteComment && (
+                  <button type="button" className="text-xs hover:text-destructive" data-testid={`ticket-comment-delete-${b.item.id}`}
+                    onClick={() => onDeleteComment(b.item.id)}>Delete</button>
+                )}
+              </div>
+              <p className="whitespace-pre-wrap text-sm">{b.item.content}</p>
+            </div>
+          )
+```
+
+(Keep `groupFeed` putting `deleted` comments through the `comment` branch — they are not `SYSTEM_TYPES`.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketFeed.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/tickets/ticketConfig.ts apps/web/src/components/tickets/TicketFeed.tsx apps/web/src/components/tickets/TicketFeed.test.tsx
+git commit -m "feat(web): ticket feed edited badge, deleted tombstone, edit/delete controls"
+```
+
+---
+
+## Task 13: Workbench — wire comment edit/delete + subject/description inline edit
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketWorkbench.tsx`
+- Test: `apps/web/src/components/tickets/TicketWorkbench.test.tsx`
+
+**Interfaces:**
+- Consumes: `runAction`, `ActionError`, `fetchWithAuth`, `afterMutation`, `loginPathWithNext`, `navigateTo` (all already used in this file); `TicketFeed` new props (Task 12).
+- Produces: handlers `handleEditComment`, `handleDeleteComment`, `handleSubjectSave`, `handleDescriptionSave`; passes `onEditComment`/`onDeleteComment`/`canManageComment` to `<TicketFeed>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+it('saves an edited subject via PATCH', async () => {
+  // render workbench with a ticket; mock fetchWithAuth to capture the PATCH
+  // click the subject (data-testid="ticket-workbench-subject-edit"), type, blur
+  // assert fetchWithAuth called with /tickets/<id> PATCH body { subject: 'New subject' }
+});
+it('calls DELETE when a comment delete control is used', async () => {
+  // assert fetchWithAuth called with DELETE /tickets/<id>/comments/<cid>
+});
+```
+
+(Follow the existing `TicketWorkbench.test.tsx` mocking of `fetchWithAuth`/`runAction`. Stub `ResizeObserver` per-test if any chart mounts — [[web_recharts_resizeobserver_jsdom]].)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the handlers + subject inline edit + pass feed props**
+
+Add comment + subject handlers (mirror the existing priority PATCH pattern verbatim):
+
+```typescript
+const handleEditComment = (commentId: string, current: string) => {
+  const next = window.prompt('Edit comment', current);
+  if (next == null || next.trim() === '' || next === current) return;
+  void runAction({
+    request: () => fetchWithAuth(`/tickets/${ticketId}/comments/${commentId}`, { method: 'PATCH', body: JSON.stringify({ content: next }) }),
+    errorFallback: 'Comment edit failed. Retry.',
+    onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+  }).then(() => refreshTicket()).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+};
+
+const handleDeleteComment = (commentId: string) => {
+  if (!window.confirm('Delete this comment?')) return;
+  void runAction({
+    request: () => fetchWithAuth(`/tickets/${ticketId}/comments/${commentId}`, { method: 'DELETE' }),
+    errorFallback: 'Comment delete failed. Retry.',
+    onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+  }).then(() => refreshTicket()).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+};
+
+const handleFieldSave = (patch: Record<string, unknown>) => {
+  void runAction({
+    request: () => fetchWithAuth(`/tickets/${ticketId}`, { method: 'PATCH', body: JSON.stringify(patch) }),
+    errorFallback: 'Update failed. Retry.',
+    onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+  }).then(() => afterMutation(patch)).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+};
+```
+
+Use `refreshTicket` if the component already has a full-refetch (comment edits change `comments`); otherwise reuse the existing post-bulk refresh path. Make the subject header an inline editable control with `data-testid="ticket-workbench-subject-edit"` that calls `handleFieldSave({ subject })` on blur/Enter (skip when unchanged or empty). Add a description editor (toggle a `<textarea>` calling `handleFieldSave({ description })`).
+
+Pass props to the feed:
+
+```tsx
+<TicketFeed
+  comments={ticket.comments}
+  onEditComment={handleEditComment}
+  onDeleteComment={handleDeleteComment}
+  canManageComment={(c) => !c.portalUserId /* staff-authored; API re-checks author/manage */}
+/>
+```
+
+> `canManageComment` is a best-effort client gate (the API enforces author-or-`tickets:manage`). Showing controls on staff-authored comments is acceptable — a non-author hitting Edit gets a toasted 403 via `runAction`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/TicketWorkbench.tsx apps/web/src/components/tickets/TicketWorkbench.test.tsx
+git commit -m "feat(web): inline subject/description edit + comment edit/delete wiring"
+```
+
+---
+
+## Task 14: Workbench — due date, tags, device editors
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketWorkbench.tsx`
+- Test: `apps/web/src/components/tickets/TicketWorkbench.test.tsx`
+
+**Interfaces:**
+- Consumes: `handleFieldSave` (Task 13).
+- Produces: a due-date `<input type="date">` (`data-testid="ticket-workbench-due"`), a tags chip editor (`ticket-workbench-tags`), and a device link/unlink control (`ticket-workbench-device`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+it('PATCHes dueDate when the date input changes', async () => {
+  // change the date input -> assert handleFieldSave({ dueDate: '<iso>' }) -> PATCH body has dueDate
+});
+it('PATCHes tags when a tag is added', async () => {
+  // add tag 'urgent' -> PATCH body { tags: [...existing, 'urgent'] }
+});
+it('clears the device link', async () => {
+  // click unlink -> PATCH body { deviceId: null }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the three editors**
+
+In the workbench header/detail metadata area:
+
+```tsx
+{/* Due date */}
+<input
+  type="date"
+  data-testid="ticket-workbench-due"
+  aria-label="Due date"
+  value={ticket.dueDate ? new Date(ticket.dueDate).toISOString().slice(0, 10) : ''}
+  onChange={(e) => handleFieldSave({ dueDate: e.target.value ? new Date(e.target.value).toISOString() : null })}
+  className="rounded-md border bg-background px-2 py-1 text-xs"
+/>
+
+{/* Tags */}
+<TagEditor
+  data-testid="ticket-workbench-tags"
+  value={ticket.tags ?? []}
+  max={20}
+  onChange={(tags) => handleFieldSave({ tags })}
+/>
+
+{/* Device link/unlink */}
+<div data-testid="ticket-workbench-device" className="flex items-center gap-2 text-xs">
+  <span>{ticket.deviceHostname ?? 'No device'}</span>
+  {ticket.deviceId && (
+    <button type="button" className="hover:text-destructive" onClick={() => handleFieldSave({ deviceId: null })}>Unlink</button>
+  )}
+</div>
+```
+
+Implement `TagEditor` inline (or as a small co-located component): renders existing tags as removable chips and an input that appends a trimmed, non-empty, non-duplicate tag (≤50 chars) up to `max`, calling `onChange(nextTags)`. Keep it minimal; the API enforces the 20×50 limits. For device *linking* (selecting a new device), reuse the existing device-select control if the workbench already has one for create; otherwise a follow-up can add a searchable picker — for 6a, unlink + display is sufficient and link-by-search is explicitly deferred (consistent with the prior "device-select searchable combobox" deferral).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/TicketWorkbench.tsx apps/web/src/components/tickets/TicketWorkbench.test.tsx
+git commit -m "feat(web): workbench due-date, tags, device editors"
+```
+
+---
+
+## Task 15: Workbench — "Move to another org" action
+
+**Files:**
+- Modify: `apps/web/src/components/tickets/TicketWorkbench.tsx`
+- Test: `apps/web/src/components/tickets/TicketWorkbench.test.tsx`
+
+**Interfaces:**
+- Consumes: `runAction`, `fetchWithAuth`; an org list source (reuse the same endpoint the create flow uses to populate org options — confirm during implementation, e.g. `/orgs/organizations`).
+- Produces: a "Move to another org…" control (`data-testid="ticket-workbench-move-org"`) → org picker → `POST /tickets/:id/move-org`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+it('POSTs move-org with the selected org', async () => {
+  // open move-org control, pick org 'oB', confirm -> assert POST /tickets/<id>/move-org body { orgId: 'oB' }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the move-org control**
+
+```tsx
+<button
+  type="button"
+  data-testid="ticket-workbench-move-org"
+  className="text-xs text-muted-foreground hover:text-foreground"
+  onClick={() => setMoveOrgOpen(true)}
+>
+  Move to another org…
+</button>
+```
+
+On confirm of the org picker (a `<select>` of orgs minus the current one):
+
+```typescript
+const handleMoveOrg = (targetOrgId: string) => {
+  void runAction({
+    request: () => fetchWithAuth(`/tickets/${ticketId}/move-org`, { method: 'POST', body: JSON.stringify({ orgId: targetOrgId }) }),
+    errorFallback: 'Move failed. Retry.',
+    onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+  }).then(() => refreshTicket()).catch((err) => { if (!(err instanceof ActionError)) throw err; });
+};
+```
+
+The control is rendered best-effort (no client permission store); a caller lacking `tickets:write`+`organizations:write`/MFA gets a toasted error from `runAction`. Moving detaches the device server-side, so refresh the full ticket after success.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/tickets/TicketWorkbench.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/tickets/TicketWorkbench.tsx apps/web/src/components/tickets/TicketWorkbench.test.tsx
+git commit -m "feat(web): workbench move-ticket-to-another-org action"
+```
+
+---
+
+## Task 16: E2E — comment edit/delete + inline field edit
+
+**Files:**
+- Modify: `e2e-tests/tests/tickets.spec.ts`
+- Modify: `e2e-tests/pages/TicketsPage.ts`
+
+**Interfaces:**
+- Consumes: the `data-testid`s added in Tasks 12–14 (`ticket-comment-edit-<id>`, `ticket-comment-delete-<id>`, `ticket-comment-edited-<id>`, `ticket-comment-deleted-<id>`, `ticket-workbench-subject-edit`).
+
+- [ ] **Step 1: Add Page Object helpers**
+
+In `e2e-tests/pages/TicketsPage.ts`, add methods: `editFirstComment(text)`, `deleteFirstComment()`, `editSubject(text)` — each driven by `data-testid` only (per `e2e-tests/README.md` convention).
+
+- [ ] **Step 2: Add the spec**
+
+Append to `e2e-tests/tests/tickets.spec.ts` a test that: creates a ticket, posts a public reply, edits it (asserts the `edited` badge appears), deletes it (asserts the tombstone), then edits the subject inline (asserts the new subject persists after reload).
+
+- [ ] **Step 3: Run e2e locally**
+
+Run: `cd e2e-tests && PUBLIC_API_URL=http://localhost pnpm test tickets.spec.ts` (per [[local_playwright_env_setup]] — use `http://localhost`, creds `admin@breeze.local/BreezeAdmin123!`).
+Expected: PASS (requires the local stack running with this branch's images — force-recreate web/api, [[e2e_local_docker_pr_testing]]).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e-tests/tests/tickets.spec.ts e2e-tests/pages/TicketsPage.ts
+git commit -m "test(e2e): ticket comment edit/delete + inline subject edit"
+```
+
+---
+
+## Task 17: Full-suite gate + drift + typecheck
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: API typecheck + targeted suites**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit` then re-run the touched unit + integration files. Expected: PASS. (Full `vitest run` has known parallel flakiness — verify via touched files; trust CI — [[api_test_suite_parallel_flakiness]].)
+
+- [ ] **Step 2: Web typecheck + touched tests**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit` and the two touched `.test.tsx` files. Expected: PASS.
+
+- [ ] **Step 3: Drift + shared typecheck**
+
+Run: `pnpm db:check-drift` and `pnpm --filter @breeze/shared exec tsc --noEmit`. Expected: no drift; PASS.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/ticketing-phase6
+gh pr create --title "Ticketing Phase 6a — editing affordances" --body "$(cat <<'EOF'
+Comment edit/delete (author + tickets:manage; soft-delete tombstone; audit captures prior content), ticket field edit UI (subject/description/due/tags/device), and same-partner org reassign (device-moveOrg pattern). Spec: docs/superpowers/specs/2026-06-21-ticketing-phase6a-editing-affordances-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Let CI run the BLOCKING `integration-test` job (RLS forge + tenantCascade) — it is SKIPPED on some PR paths; if it doesn't trigger, force it: `gh workflow run ci.yml --ref feat/ticketing-phase6` ([[ci_astro_check_and_integration_tests_gotchas]]).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Comment edit/delete (author + `tickets:manage`, soft-delete, edited badge, audit prior content, portal until-staff-reply window) → Tasks 1–8, 12–13. ✓
+- Ticket field edit UI (subject/description/due/tags/device) → Tasks 13–14. ✓
+- Org reassign (same-partner, child re-stamp, device detach, dual-org audit, high-privilege gate) → Tasks 3, 9–11, 15. ✓
+- Feed edited/deleted markers + staff sees tombstones, portal hides → Tasks 6, 12. ✓
+- RLS UPDATE/DELETE policies + forge tests → Tasks 2, 8. ✓
+- E2E additions → Task 16. ✓
+- `tickets:manage` permission wiring → Task 1. ✓
+
+**Corrections folded in vs. the spec:** `ticket_comments` has no `org_id` column, so org-reassign re-stamps only `time_entries`/`ticket_parts`/`ticket_alert_links` (comments follow the parent) — the spec's "re-stamp ticket_comments" line is superseded here.
+
+**Placeholder scan:** none — every code step shows real code. Integration-test seed helpers are described structurally (seed shape + assertions) because they mirror an existing file's helpers verbatim; the implementer copies that file's `db-utils` usage.
+
+**Type consistency:** `editTicketComment(commentId, {content}, actor, {canManageAny})`, `deleteTicketComment(commentId, actor, {canManageAny})`, `moveTicketOrg(ticketId, targetOrgId, actor)`, `portalCommentMutable(commentId, portalUserId)`, `TicketComment.editedAt/deleted`, testids `ticket-comment-{edit,delete,edited,deleted}-<id>` — consistent across service, routes, and web tasks.
+
+**Open verification flagged for implementer:** (1) `permissionsCatalog` action derivation (Task 1 Step 2); (2) `audit_logs.actor_id` accepting a portal-user id (Task 7 caveat); (3) exact tickets hub variable name + `handleServiceError` export (Tasks 10).

--- a/docs/superpowers/specs/2026-06-21-ticketing-phase6-program.md
+++ b/docs/superpowers/specs/2026-06-21-ticketing-phase6-program.md
@@ -1,0 +1,41 @@
+# Ticketing Phase 6 — Program Outline
+
+**Date:** 2026-06-21
+**Status:** Program framing. 6a spec'd alongside this doc; 6b–6d get their own spec → plan cycles when reached.
+
+## Background
+
+Native ticketing shipped through Phase 5 (P1a #1196, P1b #1223, P2 SLA #1250, P3 time+parts
+#1276/#1285, config #1287, P4 email-to-ticket #1360–62, P5 email routing/domain mapping #1715).
+A set of items was deferred without a formal next phase. Phase 6 collects them.
+
+Because the deferred set spans several independent subsystems, it is decomposed into sub-phases.
+Each sub-phase is built and reviewed independently; 6a and 6b have no ordering dependency, while
+6d (automation) consumes events produced by the others and is sequenced last.
+
+## Sub-phases
+
+| Sub-phase | Scope | Risk | Depends on |
+|---|---|---|---|
+| **6a — Editing affordances** | Comment edit/delete · wire missing ticket-field edit UI · org reassign | Med (org reassign) | — |
+| **6b — Business-hours SLA calendars** | Per-partner business-hours calendars; SLA deadline math honors them (today: 24×7 wall-clock) | Med | — |
+| **6c — Configurable status/transition workflow** | Custom transitions + required-fields-on-transition built on #1287 config tables; core six-state machine stays the logic source | Med-High (touches core state machine) | 6a (field edit semantics) helpful, not required |
+| **6d — Workflow automation rules** | Rules engine: on event → action (assign/notify/escalate/comment). Subsumes the deferred "escalation-policy wiring" item. Consumes the event bus | High | 6a/6b/6c events |
+
+Deferred items mapped:
+- *Ticket field editing / editing & workflow gap* → 6a (+ 6c for transition workflow).
+- *Business-hours SLA calendars* → 6b.
+- *Escalation-policy wiring* → 6d.
+- *Portal-side SLA visibility* → folded into 6b (SLA fields only become meaningful once business-hours
+  targets exist) — small read-path + portal UI addition.
+- *Ticketing e2e spec additions* → distributed across each sub-phase's own e2e coverage rather than
+  a standalone task.
+
+## Conventions for every sub-phase
+
+- New tenant-scoped tables follow the RLS shape rules in `CLAUDE.md` and are added to the relevant
+  allowlist + `ORG_CASCADE_DELETE_ORDER` in the same PR; verified by the Integration Tests job.
+- Real-DB tests go in `apps/api/src/__tests__/integration/*.integration.test.ts` (BLOCKING job).
+- Migrations are idempotent, date-prefixed, never edited after shipping.
+- All ticket mutations route through `ticketService`/`timeEntryService` (routes/AI tools/MCP are equal
+  consumers) and emit through the single `TicketEvent` dispatch point.

--- a/docs/superpowers/specs/2026-06-21-ticketing-phase6a-editing-affordances-design.md
+++ b/docs/superpowers/specs/2026-06-21-ticketing-phase6a-editing-affordances-design.md
@@ -1,0 +1,161 @@
+# Ticketing Phase 6a — Editing Affordances (Design)
+
+**Date:** 2026-06-21
+**Status:** Approved design → ready for implementation plan.
+**Program:** `2026-06-21-ticketing-phase6-program.md` (sub-phase 6a).
+**Worktree/branch:** `feat/ticketing-phase6` (off `origin/main` @ `684e78f2e`).
+
+## Goal
+
+Let staff (and, narrowly, portal customers) correct tickets after creation:
+
+1. **Comment edit & delete** — fully greenfield.
+2. **Ticket field editing UI** — the API already supports these fields via `PATCH /tickets/:id`;
+   only the web affordances are missing.
+3. **Org reassign** — move a ticket to another customer org within the same partner.
+
+Non-goals (deferred to later sub-phases): business-hours SLA, configurable status transitions,
+automation/escalation rules.
+
+## Current state (verified)
+
+- **`PATCH /tickets/:id`** (`apps/api/src/routes/tickets/tickets.ts:588`) → `updateTicketFields`
+  (`apps/api/src/services/ticketService.ts:544`) already edits **subject, description, categoryId,
+  priority, dueDate, response/resolutionSlaMinutes, deviceId, tags**, writing a `system` feed row +
+  `audit_logs` (`ticket.update`) + `ticket.updated` event. Validator:
+  `packages/shared/src/validators/tickets.ts:20`. `status`/`assignee` are excluded (dedicated routes).
+- **Workbench UI** (`apps/web/src/components/tickets/TicketWorkbench.tsx`) exposes inline edit only for
+  priority, category, status, assignee. Subject is read-only; description, due date, tags, device are
+  not surfaced.
+- **`ticket_comments`** (`apps/api/src/db/schema/portal.ts:99`) has `deleted_at timestamptz` already,
+  **no `edited_at`**, no edit/delete route or service fn. Detail GET filters `isNull(deletedAt)`
+  (`routes/tickets/tickets.ts:443`); portal GET filters it too (`routes/portal/tickets.ts:187`).
+  RLS today: `breeze_ticket_parent_select` (2026-06-10-a, parent-org SELECT) +
+  `breeze_ticket_parent_portal_insert` (2026-06-10-b). **No UPDATE/DELETE policy.**
+- **Permissions** (`packages/shared/src/constants/permissions.ts`): only `tickets:read` /
+  `tickets:write`. Precedents: `contracts:manage` exists; `ADMIN_ALL` is `*:*`. Device cross-org move
+  (`apps/api/src/routes/devices/moveOrg.ts:60`) gates `requireScope('partner','system')` +
+  `devices:write` + `organizations:write`, and re-stamps `org_id` via `CUSTOM_ORG_REWRITE_TABLES` /
+  detaches via `DEVICE_DETACH_DEVICE_ID_TABLES` (`apps/api/src/routes/devices/core.ts`).
+- **Feed** (`apps/web/src/components/tickets/TicketFeed.tsx`): `SYSTEM_TYPES =
+  {status_change, assignment, system, time_entry}`; user comments render as standalone blocks with an
+  "Internal" badge when not public. No edited/deleted markers.
+
+## Component 1 — Comment edit & delete (backend)
+
+### Migration (`<implementation-date>-ticket-comment-edit.sql`, date-prefixed at write time, idempotent)
+- `ALTER TABLE ticket_comments ADD COLUMN IF NOT EXISTS edited_at timestamptz;` (`deleted_at` exists).
+- Add RLS **UPDATE** and **DELETE** policies, `FOR ... TO breeze_app`, mirroring the canonical
+  parent-org form of `breeze_ticket_parent_select` (EXISTS join to `tickets` via
+  `breeze_has_org_access(tickets.org_id)`, with the system-scope short-circuit honored by the helper).
+  Per [[rls_is_system_flag_write_policy_hole]], the policy gates **only** on parent-ticket tenant
+  access — author identity and role checks live in the service layer, never in `WITH CHECK`.
+
+### Permission
+- Add `TICKETS_MANAGE: { resource: 'tickets', action: 'manage' }` to the canonical registry, mirroring
+  `CONTRACTS_MANAGE`. Wire it into `permissionsCatalog` and `RESOURCE_LABELS` (watch the dual-map drift
+  trap noted for prior ticket-permission work). Used for the admin override only; self-edits need just
+  `tickets:write` + ownership.
+
+### Service (`ticketService.ts`, routed through the existing dispatch point)
+- `editTicketComment(commentId, { content }, actor)`:
+  - Reject if the target comment's `commentType` is a system type (`status_change`/`assignment`/
+    `time_entry`/`system`) — those are machine-authored. Reject if already soft-deleted.
+  - **Authorization:** actor is the comment's author (matching `userId` for staff, or `portalUserId`
+    for portal) **OR** holds `tickets:manage`. Portal authors additionally require the *until-first-
+    staff-reply* window to be open (see below).
+  - Overwrite `content`, set `edited_at = now()`. Write `audit_logs` action `ticket.comment.edit` with
+    `details: { commentId, ticketId, previousContent }` (forensic trail; no new table). Emit a
+    `ticket.commented`-class event so notify/feed paths stay consistent.
+- `deleteTicketComment(commentId, actor)`:
+  - Same gating. **Soft-delete**: set `deleted_at = now()` (idempotent; second delete is a no-op).
+    Audit `ticket.comment.delete` with `details.previousContent`. Emit the same event class.
+- **Portal window helper** `portalCommentMutable(comment, ticket)`: true iff no comment with
+  `authorType IN ('internal','technician')` (or a `status_change`/`assignment`/`time_entry`/`system`
+  row) exists with `created_at > comment.created_at`. (Staff "reply" = any later staff-authored or
+  system feed activity.) Staff actors are not subject to the window.
+
+### Routes
+- Staff (`routes/tickets/tickets.ts`): `PATCH /tickets/:id/comments/:commentId`
+  (body `{ content }`, `tickets:write`) and `DELETE /tickets/:id/comments/:commentId`
+  (`tickets:write`). Both resolve the ticket via `getScopedTicketOr404` (inherits site-scope gating),
+  then call the service (which enforces author-or-`tickets:manage`). A non-author without
+  `tickets:manage` → 403.
+- Portal (`routes/portal/tickets.ts`): `PATCH`/`DELETE` equivalents scoped to the caller's own
+  `portalUserId`, honoring `portalCommentMutable`. Closed window → 409.
+
+## Component 2 — Org reassign (backend, high-privilege)
+
+- Route `POST /tickets/:id/move-org` (mounted BEFORE core `/:id` routes to avoid path collision, per
+  the device precedent), gate: `requireScope('partner','system')` + `tickets:write` +
+  `organizations:write` (identical bar to device `moveOrg`).
+- `moveTicketOrg(ticketId, targetOrgId, actor)` in `ticketService.ts`, one transaction:
+  1. Validate `targetOrgId` is in the **same partner** as the ticket (composite-FK invariant; reject
+     cross-partner with 400).
+  2. Re-stamp `org_id` on the ticket and denormalized child rows: `ticket_comments`, `time_entries`,
+     and `ticket_alert_links` — reusing the `CUSTOM_ORG_REWRITE_TABLES` machinery established in #1261.
+  3. **Detach `device_id`** (a device belongs to the source org). Null it; record in the move audit.
+  4. Write a `system` feed row ("Moved to <org>"), `audit_logs` `ticket.move_org`
+     (`details: { fromOrgId, toOrgId, detachedDeviceId }`), emit `ticket.updated`.
+- Same-org no-op short-circuits before any write.
+
+## Component 3 — Ticket field edit UI (frontend; API already exists)
+
+In `TicketWorkbench.tsx`, add inline-edit affordances, each PATCHing `/tickets/:id` wrapped in
+`runAction` with optimistic `afterMutation`:
+- **Subject** — click-to-edit header (save on blur/Enter, cancel on Esc).
+- **Description** — edit toggle in the detail body.
+- **Due date** — date picker (clearable → `dueDate: null`).
+- **Tags** — chip editor (add/remove, max 20 × 50 chars per the validator).
+- **Device** — link/unlink control (set/clear `deviceId`).
+- **"Move to another org…"** action, rendered only when the client holds `tickets:write` +
+  `organizations:write` (the web has no client-side permission store — render best-effort and let the
+  API enforce; on 403 surface the `runAction` error). Opens an org picker → Component 2.
+
+## Component 4 — Feed rendering (frontend)
+
+- **Edited badge:** when `edited_at` is set on a user comment, render an "edited" marker next to the
+  timestamp.
+- **Deleted tombstone:** soft-deleted user comments keep the author/timestamp row but replace the body
+  with a "(deleted)" placeholder. To render this, the **staff** detail GET must now **return**
+  soft-deleted rows with a `deleted: true` flag (drop the `isNull(deletedAt)` filter for staff, project
+  a `deleted` boolean, and null/omit `content` for deleted rows so prior text isn't shipped to the
+  client). **Portal** GET continues to exclude deleted rows entirely.
+- Edit/delete controls appear on a user comment only for its author or `tickets:manage` holders
+  (best-effort client check; API authoritative).
+
+## Component 5 — Testing
+
+- **API unit** (`*.test.ts`, mocked DB): PATCH coverage for newly-wired fields; comment edit/delete
+  authz matrix — author / `tickets:manage` / non-author-no-manage (403) / system-type-comment (reject)
+  / portal-window-open vs-closed (409); move-org same-partner pass + cross-partner reject + device
+  detach.
+- **Integration** (`apps/api/src/__tests__/integration/*.integration.test.ts`, real `breeze_app`):
+  - `ticket-comments-rls`: extend with **UPDATE/DELETE forge** cases — a cross-tenant connection must
+    fail to edit/delete a comment (`new row violates row-level security policy` / 0 rows), re-seeding
+    the fixture per test ([[rls-forge-test-memoized-fixture-vacuous]]).
+  - `ticket-move-org`: child `org_id` re-stamp on `ticket_comments`/`time_entries`/`ticket_alert_links`
+    is complete; cross-partner target rejected; device detached.
+  - No new table → `ORG_CASCADE_DELETE_ORDER`/tenantCascade unaffected (assert no churn needed).
+- **Web** (`apps/web`, jsdom): workbench inline-edit components (subject/description/due/tags/device);
+  feed edited-badge + deleted-tombstone rendering. Stub `ResizeObserver` per-test if any chart mounts
+  ([[web_recharts_resizeobserver_jsdom]]).
+- **E2E** (`e2e-tests/tests/tickets.spec.ts` + `pages/TicketsPage.ts`, `data-testid` only): edit a
+  comment → "edited" badge; delete a comment → tombstone; edit subject and description inline.
+
+## Risks & mitigations
+
+- **Org reassign** is the riskiest piece (multi-tenant data move). Mitigations: same-partner
+  validation, single transaction, reuse of the audited `CUSTOM_ORG_REWRITE_TABLES` path, dual-permission
+  high-privilege gate, device detach, full integration coverage.
+- **Returning soft-deleted rows to staff** widens the detail payload — guard by nulling `content` for
+  deleted rows server-side so deleted text never reaches the client; portal path stays unchanged.
+- **`tickets:manage` is a new permission** — must be wired into both `permissionsCatalog` and
+  `RESOURCE_LABELS` (dual-map drift trap) and granted to appropriate default roles, or admin override
+  silently fails closed.
+- **RLS UPDATE/DELETE policies** must copy the canonical `FOR ... TO breeze_app` + system-scope form;
+  only the Integration Tests job catches a malformed policy (rls-coverage does not).
+
+## Open follow-ups (out of 6a)
+- Versioned comment revision history (chose audit_logs trail instead).
+- Editing `status`/`assignee` semantics unchanged (dedicated routes already exist).

--- a/e2e-tests/pages/TicketsPage.ts
+++ b/e2e-tests/pages/TicketsPage.ts
@@ -20,6 +20,7 @@ export class TicketsPage {
   composerInternalTab = () => this.page.getByTestId('ticket-composer-tab-internal');
   composerInternalBanner = () => this.page.getByTestId('ticket-composer-internal-banner');
   composerSend = () => this.page.getByTestId('ticket-composer-send');
+  subjectEdit = () => this.page.getByTestId('ticket-workbench-subject-edit');
 
   // Create form
   formOrg = () => this.page.getByTestId('create-ticket-org-input');
@@ -29,5 +30,57 @@ export class TicketsPage {
   async goto() {
     await this.page.goto(this.url);
     await this.heading().waitFor();
+  }
+
+  /**
+   * Edit the first comment in the feed. The web UI uses window.prompt() for
+   * the edit dialog, so we register the dialog handler BEFORE clicking the
+   * edit button. The handler is one-shot (once: true) and calls d.accept(text)
+   * to confirm the prompt with the new content.
+   */
+  async editFirstComment(text: string): Promise<void> {
+    // Find the first edit button by matching the testid prefix.
+    const editBtn = this.page.locator('[data-testid^="ticket-comment-edit-"]').first();
+    await editBtn.waitFor();
+
+    // Register the prompt handler before clicking (native dialogs fire
+    // synchronously in some browsers; registering first prevents a race).
+    const dialogHandler = (dialog: import('@playwright/test').Dialog) => {
+      void dialog.accept(text);
+    };
+    this.page.once('dialog', dialogHandler);
+
+    await editBtn.click();
+  }
+
+  /**
+   * Delete the first comment in the feed. The web UI uses window.confirm() for
+   * the delete confirmation, so we register the dialog handler BEFORE clicking
+   * the delete button. The handler calls d.accept() to confirm the deletion.
+   */
+  async deleteFirstComment(): Promise<void> {
+    // Find the first delete button by matching the testid prefix.
+    const deleteBtn = this.page.locator('[data-testid^="ticket-comment-delete-"]').first();
+    await deleteBtn.waitFor();
+
+    // Register the confirm handler before clicking.
+    const dialogHandler = (dialog: import('@playwright/test').Dialog) => {
+      void dialog.accept();
+    };
+    this.page.once('dialog', dialogHandler);
+
+    await deleteBtn.click();
+  }
+
+  /**
+   * Edit the ticket subject using the inline input (ticket-workbench-subject-edit).
+   * Clears the current value, fills with the new text, and presses Enter to save.
+   */
+  async editSubject(text: string): Promise<void> {
+    const input = this.subjectEdit();
+    await input.waitFor();
+    await input.click({ clickCount: 3 }); // select all existing text
+    await input.fill(text);
+    await input.press('Enter');
   }
 }

--- a/e2e-tests/pages/TicketsPage.ts
+++ b/e2e-tests/pages/TicketsPage.ts
@@ -33,43 +33,43 @@ export class TicketsPage {
   }
 
   /**
-   * Edit the first comment in the feed. The web UI uses window.prompt() for
-   * the edit dialog, so we register the dialog handler BEFORE clicking the
-   * edit button. The handler is one-shot (once: true) and calls d.accept(text)
-   * to confirm the prompt with the new content.
+   * Edit the first comment in the feed using the inline textarea editor.
+   * Clicks the edit button to open the editor, fills in the new text, then
+   * clicks Save to submit.
    */
   async editFirstComment(text: string): Promise<void> {
     // Find the first edit button by matching the testid prefix.
     const editBtn = this.page.locator('[data-testid^="ticket-comment-edit-"]').first();
     await editBtn.waitFor();
-
-    // Register the prompt handler before clicking (native dialogs fire
-    // synchronously in some browsers; registering first prevents a race).
-    const dialogHandler = (dialog: import('@playwright/test').Dialog) => {
-      void dialog.accept(text);
-    };
-    this.page.once('dialog', dialogHandler);
+    const testId = await editBtn.getAttribute('data-testid');
+    const commentId = testId?.replace('ticket-comment-edit-', '') ?? '';
 
     await editBtn.click();
+
+    // The inline textarea should now be visible; fill it with the new text.
+    const textarea = this.page.getByTestId(`ticket-comment-edit-textarea-${commentId}`);
+    await textarea.waitFor();
+    await textarea.fill(text);
+
+    // Click the Save button.
+    await this.page.getByTestId(`ticket-comment-edit-save-${commentId}`).click();
   }
 
   /**
-   * Delete the first comment in the feed. The web UI uses window.confirm() for
-   * the delete confirmation, so we register the dialog handler BEFORE clicking
-   * the delete button. The handler calls d.accept() to confirm the deletion.
+   * Delete the first comment in the feed using the ConfirmDialog.
+   * Clicks the delete button, then clicks the confirm button in the dialog.
    */
   async deleteFirstComment(): Promise<void> {
     // Find the first delete button by matching the testid prefix.
     const deleteBtn = this.page.locator('[data-testid^="ticket-comment-delete-"]').first();
     await deleteBtn.waitFor();
 
-    // Register the confirm handler before clicking.
-    const dialogHandler = (dialog: import('@playwright/test').Dialog) => {
-      void dialog.accept();
-    };
-    this.page.once('dialog', dialogHandler);
-
     await deleteBtn.click();
+
+    // The ConfirmDialog should appear; click the confirm button.
+    const confirmBtn = this.page.getByTestId('ticket-comment-delete-confirm');
+    await confirmBtn.waitFor();
+    await confirmBtn.click();
   }
 
   /**

--- a/e2e-tests/tests/tickets.spec.ts
+++ b/e2e-tests/tests/tickets.spec.ts
@@ -62,4 +62,52 @@ test.describe('tickets', () => {
     await expect(tickets.workbenchNumber()).toHaveText(ticketNumber!);
     await expect(tickets.statusSelect()).toHaveValue('resolved');
   });
+
+  test('comment edit/delete + inline subject edit', async ({ cleanPage }) => {
+    test.setTimeout(120_000); // serial multi-step flow: login + create + reply + edit + delete + subject edit
+
+    const auth = new AuthPage(cleanPage);
+    await cleanPage.goto(`${auth.url}?next=${encodeURIComponent('/tickets')}`);
+    await auth.page_().waitFor();
+    await cleanPage.waitForFunction(() => {
+      const form = document.querySelector('form');
+      return !!form && Object.keys(form).some((k) => k.startsWith('__reactFiber$'));
+    });
+    await auth.signIn(process.env.E2E_ADMIN_EMAIL!, process.env.E2E_ADMIN_PASSWORD!, /\/tickets(\?|$|#)/);
+
+    const tickets = new TicketsPage(cleanPage);
+    await tickets.heading().waitFor();
+
+    // Create a ticket
+    await tickets.createButton().click();
+    await tickets.formSubject().waitFor();
+    await tickets.formOrg().selectOption({ index: 1 });
+    await tickets.formSubject().fill('E2E edit/delete smoke ticket');
+    await tickets.formSubmit().click();
+    await cleanPage.waitForURL(/\/tickets#/);
+    await tickets.workbench().waitFor();
+    await expect(tickets.workbenchNumber()).toContainText('T-');
+
+    // Post a public reply
+    await tickets.composerInput().fill('Reply to be edited');
+    await tickets.composerSend().click();
+    await expect(cleanPage.getByTestId('ticket-feed')).toContainText('Reply to be edited');
+
+    // Edit the reply — window.prompt fires; handler registered inside editFirstComment
+    await tickets.editFirstComment('Edited reply content');
+    // Wait for the feed to re-render with the edited badge
+    await cleanPage.locator('[data-testid^="ticket-comment-edited-"]').first().waitFor();
+
+    // Delete the reply — window.confirm fires; handler registered inside deleteFirstComment
+    await tickets.deleteFirstComment();
+    // The deleted tombstone should now appear (the comment row is replaced)
+    await cleanPage.locator('[data-testid^="ticket-comment-deleted-"]').first().waitFor();
+
+    // Edit the subject inline
+    await tickets.editSubject('Renamed subject via e2e');
+    // Reload to confirm the new subject persisted server-side
+    await cleanPage.reload();
+    await tickets.workbench().waitFor();
+    await expect(tickets.subjectEdit()).toHaveValue('Renamed subject via e2e');
+  });
 });

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -36,6 +36,7 @@ export const PERMISSION_GRANTS = {
   // Tickets
   TICKETS_READ: { resource: 'tickets', action: 'read' },
   TICKETS_WRITE: { resource: 'tickets', action: 'write' },
+  TICKETS_MANAGE: { resource: 'tickets', action: 'manage' },
 
   // Catalog (billing/invoicing program)
   CATALOG_READ: { resource: 'catalog', action: 'read' },

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createTicketSchema, updateTicketSchema, changeTicketStatusSchema,
   assignTicketSchema, addTicketCommentSchema, listTicketsQuerySchema,
-  ticketCategoryInputSchema, bulkTicketActionSchema
+  ticketCategoryInputSchema, bulkTicketActionSchema, editCommentSchema, moveTicketOrgSchema
 } from './tickets';
 
 describe('ticket validators', () => {
@@ -149,6 +149,25 @@ describe('ticket validators', () => {
       expect(bulkTicketActionSchema.safeParse({ ticketIds: ['not-a-uuid'], action: 'status', status: 'closed' }).success).toBe(false);
       const tooMany = Array.from({ length: 101 }, () => ID);
       expect(bulkTicketActionSchema.safeParse({ ticketIds: tooMany, action: 'status', status: 'closed' }).success).toBe(false);
+    });
+  });
+
+  describe('editCommentSchema', () => {
+    it('accepts non-empty content', () => {
+      expect(editCommentSchema.parse({ content: 'updated' })).toEqual({ content: 'updated' });
+    });
+    it('rejects empty content', () => {
+      expect(editCommentSchema.safeParse({ content: '' }).success).toBe(false);
+    });
+  });
+
+  describe('moveTicketOrgSchema', () => {
+    it('accepts a uuid orgId', () => {
+      const id = '11111111-1111-1111-1111-111111111111';
+      expect(moveTicketOrgSchema.parse({ orgId: id })).toEqual({ orgId: id });
+    });
+    it('rejects a non-uuid orgId', () => {
+      expect(moveTicketOrgSchema.safeParse({ orgId: 'nope' }).success).toBe(false);
     });
   });
 });

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -75,6 +75,14 @@ export const addTicketCommentSchema = z.object({
   isPublic: z.boolean().default(true)
 });
 
+export const editCommentSchema = z.object({
+  content: z.string().min(1).max(50_000)
+});
+
+export const moveTicketOrgSchema = z.object({
+  orgId: z.string().guid()
+});
+
 export const listTicketsQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(50),


### PR DESCRIPTION
First sub-phase of the Ticketing Phase 6 program. Lets staff (and, narrowly, portal customers) correct tickets after creation.

**What this adds:**
- **Comment edit & delete** — author **or** `tickets:manage` (new permission); soft-delete renders a `(deleted)` tombstone; edits show an `edited` badge. Audit (`ticket.comment.edit`/`.delete`) captures the prior content as the forensic trail (no revision table). Portal customers may edit/delete their **own** reply only until staff replies (`portalCommentMutable`).
- **Ticket field edit UI** — subject, description, due date, tags, and device unlink wired into `TicketWorkbench.tsx` (API already supported these via `PATCH /tickets/:id`).
- **Org reassign** — `POST /tickets/:id/move-org`, gated `tickets:write` + `organizations:write` at partner/system scope + MFA (device-`moveOrg` parity). Same-partner only; re-stamps `org_id` on `time_entries`/`ticket_parts`/`ticket_alert_links`, detaches the device, dual-org audit.

**Tenant isolation:** new RLS `UPDATE`/`DELETE` policies on `ticket_comments` use the parent-ticket org `EXISTS` form (the table has no `org_id`); author/role checks live in the service layer, never in `WITH CHECK`. Proven by real-`breeze_app` forge tests — cross-tenant edit/delete return 0 rows; move-org child re-stamp + cross-partner reject + comment-visibility-after-move are covered in `ticket-move-org.integration.test.ts`.

**Deleted-content non-leak:** staff detail returns deleted comments with blanked `content` + `deleted:true`; portal hides them entirely.

**Notify correctness:** comment edit/delete deliberately emit **no** `ticket.commented` event (with regression guards) — otherwise the notify worker would email the customer a wrong "new reply" on edit and a ghost notification on delete.

**Files:** `migrations/2026-06-21-ticket-comment-edit.sql`, `services/ticketService.ts`, `routes/tickets/{tickets,moveOrg,index}.ts`, `routes/portal/tickets.ts`, `constants/permissions.ts`, `validators/tickets.ts`, web `components/tickets/{TicketFeed,TicketWorkbench,ticketConfig}.tsx`, `e2e-tests/tests/tickets.spec.ts`.

**Tests:** API ticket/portal/service/move-org units + 2 real-DB RLS-forge/move-org integration suites (non-vacuous), web feed/workbench suites, e2e spec (collects clean; runs in CI). `@breeze/api` + `@breeze/web` `tsc --noEmit` green.

**Spec/plan:** `docs/superpowers/specs/2026-06-21-ticketing-phase6a-editing-affordances-design.md`, `docs/superpowers/plans/2026-06-21-ticketing-phase6a-editing-affordances.md` (+ Phase 6 program outline).

**Built subagent-driven** (16 tasks, per-task spec+quality review, final whole-branch review on Opus). Final review's one must-fix (notify-on-edit/delete) is resolved + re-reviewed.

**Deferred follow-ups (non-blocking):** comment edit/delete UX uses `window.prompt`/`confirm` (functional; an inline-edit modal is the polish follow-up); `ticketService.ts` ~1120 lines (cohesive single-domain); defense-in-depth `comment.ticketId === url id` guard (RLS already contains it, same-org bounded).

**Holding for Todd's UI test before merge** (user-facing UI per our merge/hold rule) — flag the prompt/confirm UX during that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)