### PR TITLE
fix(api): backslash-safe ILIKE escaping for ticket/mobile search (#99)

### DIFF
--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -901,7 +901,7 @@ mobileRoutes.get(
     }
 
     if (query.search) {
-      conditions.push(like(devices.hostname, `%${query.search}%`));
+      conditions.push(like(devices.hostname, `%${escapeLike(query.search)}%`));
     }
 
     if (!query.status) {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -21,6 +21,7 @@ import { userRateLimit } from '../middleware/userRateLimit';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../services/alertCooldown';
 import { writeRouteAudit } from '../services/auditEvents';
 import { publishEvent } from '../services/eventBus';
+import { escapeLike } from '../utils/sql';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { dispatchWake } from '../services/wakeOnLan';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
@@ -1279,7 +1280,7 @@ mobileRoutes.get(
       return c.json({ results: [] });
     }
 
-    const term = `%${q.replace(/[%_]/g, (m) => `\\${m}`)}%`;
+    const term = `%${escapeLike(q)}%`;
     const cappedLimit = Math.min(50, Math.max(1, limit));
     // Distribute results so one kind never starves others. Each kind gets
     // up to ~ceil(limit/3) candidates; we then trim to cappedLimit total.

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -7,6 +7,7 @@ import { tickets, ticketComments, ticketAlertLinks, devices, organizations, user
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { deviceInSiteScope, ticketSiteScopeCondition } from './siteScope';
 import { PERMISSIONS, hasPermission, type UserPermissions } from '../../services/permissions';
+import { escapeLike } from '../../utils/sql';
 import {
   createTicketSchema, updateTicketSchema, changeTicketStatusSchema,
   assignTicketSchema, addTicketCommentSchema, listTicketsQuerySchema,
@@ -310,9 +311,10 @@ ticketsRoutes.get(
     else if (q.slaState === 'breaching') conditions.push(sql`(${SLA_BREACHED} OR ${SLA_AT_RISK})`);
     else if (q.slaState === 'ok') conditions.push(sql`(NOT ${SLA_BREACHED} AND NOT ${SLA_AT_RISK})`);
     if (q.search) {
-      // Escape ILIKE special chars so literal % and _ in the query aren't wildcards.
-      const escaped = q.search.replace(/[%_]/g, '\\$&');
-      const term = `%${escaped}%`;
+      // Escape ILIKE special chars (\, %, _) so they match literally, not as
+      // wildcards/escapes. Use the shared helper — the prior inline regex
+      // dropped backslash, so a trailing '\' could escape the closing '%'.
+      const term = `%${escapeLike(q.search)}%`;
       const searchCond = or(ilike(tickets.subject, term), ilike(tickets.internalNumber, term));
       if (searchCond) conditions.push(searchCond);
     }

--- a/apps/api/src/utils/sql.test.ts
+++ b/apps/api/src/utils/sql.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { escapeLike } from './sql';
+
+describe('escapeLike', () => {
+  it('escapes percent wildcards', () => {
+    expect(escapeLike('100%')).toBe('100\\%');
+  });
+
+  it('escapes underscore wildcards', () => {
+    expect(escapeLike('a_b')).toBe('a\\_b');
+  });
+
+  it('escapes backslash so a trailing backslash cannot escape a following wildcard', () => {
+    expect(escapeLike('a\\b')).toBe('a\\\\b');
+    // Regression for #99: a lone trailing backslash must be escaped, otherwise
+    // `%${escapeLike(s)}%` would let the input's `\` escape the closing `%`.
+    expect(escapeLike('foo\\')).toBe('foo\\\\');
+  });
+
+  it('escapes all special characters together', () => {
+    expect(escapeLike('%_\\')).toBe('\\%\\_\\\\');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(escapeLike('plain text 123')).toBe('plain text 123');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(escapeLike('')).toBe('');
+  });
+});


### PR DESCRIPTION
Closes CodeQL alert **#99** (`js/incomplete-sanitization`).

**Root cause:** The ticket list search (`tickets.ts:312`) built its ILIKE pattern with an inline `q.search.replace(/[%_]/g, '\\$&')` that escaped `%` and `_` but **not `\`**. A trailing `\` in the query could escape the closing `%` wildcard and alter the LIKE pattern. `mobile.ts:1282` (global mobile search) had the identical latent bug.

**Fix:** Both call sites now use the existing, backslash-aware `escapeLike()` helper in `apps/api/src/utils/sql.ts` — already the convention in ~20 other search routes. Removes the divergent inline reimplementations.

**Tests:** Adds the previously-missing unit test for `escapeLike` (incl. the trailing-`\` regression case). Existing `tickets.test.ts` + `mobile.test.ts` still pass (140), `tsc --noEmit` clean.

No behavior change for normal queries; bound params already prevented SQL injection — this closes the wildcard/escape-character gap only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)