### PR TITLE
feat(pam): reusable signer-group (trusted-publisher) catalog

### DIFF
--- a/apps/api/migrations/2026-06-28-pam-signer-groups.sql
+++ b/apps/api/migrations/2026-06-28-pam-signer-groups.sql
@@ -1,0 +1,63 @@
+-- Reusable trusted-publisher catalog (signer groups).
+--   * pam_signer_groups — per-org named set of signer (subject CN) patterns.
+--   * pam_rules.match_signer_group_id — reference a group as an alternative to
+--     match_signer (the rule matches when the candidate signer equals ANY
+--     member). Mutually exclusive with match_signer (enforced at the API layer).
+-- Resolution is entirely server-side; the agent never receives groups.
+-- Tenancy: pam_signer_groups is Shape 1 (direct org_id), RLS mirrors pam_rules.
+-- Idempotent: re-applying is a no-op.
+
+CREATE TABLE IF NOT EXISTS pam_signer_groups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Tenancy (Shape 1)
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+  name varchar(255) NOT NULL,
+  description text,
+  -- Signer subject-CN patterns; matched case-insensitively, exact.
+  signers jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+  created_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One group name per org.
+CREATE UNIQUE INDEX IF NOT EXISTS pam_signer_groups_org_id_name_unique
+  ON pam_signer_groups (org_id, name);
+
+-- Reference a group from a rule. ON DELETE RESTRICT: a group in use cannot be
+-- deleted out from under its rules (the API layer surfaces a clean 409).
+ALTER TABLE pam_rules ADD COLUMN IF NOT EXISTS match_signer_group_id uuid;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'pam_rules_match_signer_group_id_fkey'
+  ) THEN
+    ALTER TABLE pam_rules
+      ADD CONSTRAINT pam_rules_match_signer_group_id_fkey
+      FOREIGN KEY (match_signer_group_id) REFERENCES pam_signer_groups(id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+-- ============================================================
+-- RLS — pam_signer_groups (Shape 1, mirrors pam_rules #1163)
+-- ============================================================
+ALTER TABLE pam_signer_groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pam_signer_groups FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON pam_signer_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON pam_signer_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON pam_signer_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON pam_signer_groups;
+
+CREATE POLICY breeze_org_isolation_select ON pam_signer_groups
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON pam_signer_groups
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON pam_signer_groups
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON pam_signer_groups
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/src/db/schema/pam.ts
+++ b/apps/api/src/db/schema/pam.ts
@@ -54,6 +54,7 @@ export interface PamRuleTimeWindow {
  */
 export const PAM_RULE_NEGATE_KEYS = [
   'signer',
+  'signerGroup',
   'hash',
   'pathGlob',
   'parentImage',
@@ -70,6 +71,45 @@ export const pamUnmatchedVerdictEnum = pgEnum('pam_unmatched_verdict', [
   'require_approval',
   'auto_deny',
 ]);
+
+/**
+ * Reusable trusted-publisher catalog (signer groups). An org maintains a named
+ * set of Authenticode signer (subject CN) patterns once — e.g. a "Trusted
+ * Vendors" group with Intuit Inc., Microsoft Corporation, TeamViewer GmbH —
+ * and references it from many rules via pam_rules.match_signer_group_id. A rule
+ * with a group matches when the candidate's signer equals ANY member (OR within
+ * the group), while the rule's other criteria still AND. Resolution is entirely
+ * server-side (the engine receives the resolved member list); the agent never
+ * sees groups. Tenancy: Shape 1 (direct org_id), RLS mirrors pam_rules.
+ */
+export const pamSignerGroups = pgTable(
+  'pam_signer_groups',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 255 }).notNull(),
+    description: text('description'),
+    // Signer subject-CN patterns; matched case-insensitively, exact (same
+    // semantics as pam_rules.match_signer). Empty = matches nothing.
+    signers: jsonb('signers').$type<string[]>().notNull().default([]),
+    createdByUserId: uuid('created_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    orgNameUnique: uniqueIndex('pam_signer_groups_org_id_name_unique').on(
+      table.orgId,
+      table.name,
+    ),
+  }),
+);
+
+export type PamSignerGroup = typeof pamSignerGroups.$inferSelect;
+export type NewPamSignerGroup = typeof pamSignerGroups.$inferInsert;
 
 export const pamRules = pgTable(
   'pam_rules',
@@ -90,6 +130,13 @@ export const pamRules = pgTable(
     // Match criteria — all provided criteria must match (AND). A rule with
     // no criteria matches nothing (guarded at the API layer).
     matchSigner: varchar('match_signer', { length: 255 }),
+    // Alternative to matchSigner: match the candidate signer against ANY member
+    // of a reusable signer group (pam_signer_groups). Mutually exclusive with
+    // matchSigner (the API rejects setting both). Resolved server-side.
+    matchSignerGroupId: uuid('match_signer_group_id').references(
+      () => pamSignerGroups.id,
+      { onDelete: 'restrict' },
+    ),
     matchHash: varchar('match_hash', { length: 64 }),
     matchPathGlob: text('match_path_glob'),
     matchParentImage: text('match_parent_image'),

--- a/apps/api/src/routes/agents/elevationRequests.test.ts
+++ b/apps/api/src/routes/agents/elevationRequests.test.ts
@@ -40,6 +40,12 @@ vi.mock('../../db/schema', () => ({
     siteId: 'siteId',
     enabled: 'enabled',
     priority: 'priority',
+    matchSignerGroupId: 'matchSignerGroupId',
+  },
+  pamSignerGroups: {
+    id: 'id',
+    orgId: 'orgId',
+    signers: 'signers',
   },
   pamOrgConfig: {
     id: 'id',
@@ -171,6 +177,33 @@ function mockSelectsWithConfig(
           // pam_rules load awaits .from().where() directly → resolve [] (no match)
           const thenable: any = Promise.resolve([]);
           thenable.limit = vi.fn().mockResolvedValue(isConfig ? configRows : deviceRows);
+          return thenable;
+        }),
+      })),
+    } as any;
+  });
+}
+
+/**
+ * Rig db.select for the signer-group resolution path, which fires three selects
+ * in order: (1) device lookup [.limit() -> deviceRows], (2) pam_rules load
+ * [.where() awaited -> ruleRows], (3) pam_signer_groups load [.where() awaited
+ * -> groupRows]. Distinguishes (2) from (3) by call order.
+ */
+function mockSelectsWithSignerGroups(
+  deviceRows: Array<{ id: string; orgId: string; siteId: string | null }>,
+  ruleRows: unknown[],
+  groupRows: Array<{ id: string; signers: string[] }>,
+) {
+  let call = 0;
+  vi.mocked(db.select).mockImplementation(() => {
+    call += 1;
+    const isSignerGroupSelect = call >= 3;
+    return {
+      from: vi.fn(() => ({
+        where: vi.fn(() => {
+          const thenable: any = Promise.resolve(isSignerGroupSelect ? groupRows : ruleRows);
+          thenable.limit = vi.fn().mockResolvedValue(deviceRows);
           return thenable;
         }),
       })),
@@ -468,6 +501,69 @@ describe('ingest decisioning (#1163)', () => {
         denialReason: 'Blocked by PAM rule "Block mmc"',
         softwarePolicyMatchId: null,
       }),
+    );
+  });
+
+  it('pam rule matchSignerGroupId resolves the group -> auto_approved', async () => {
+    const rule = {
+      id: 'rule-sg',
+      orgId: 'org-1',
+      siteId: null,
+      name: 'Trusted vendors',
+      description: null,
+      enabled: true,
+      priority: 10,
+      matchSigner: null,
+      matchSignerGroupId: 'grp-1',
+      matchHash: null,
+      matchPathGlob: null,
+      matchParentImage: null,
+      matchCommandLine: null,
+      matchUser: null,
+      matchAdGroup: null,
+      matchToolName: null,
+      matchRiskTier: null,
+      matchNegate: null,
+      timeWindow: null,
+      verdict: 'auto_approve',
+      approvalDurationMinutes: null,
+      createdByUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    // The group's members include the candidate's signer (matched case-insensitively).
+    mockSelectsWithSignerGroups(
+      [{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }],
+      [rule],
+      [{ id: 'grp-1', signers: ['Other Vendor', 'Acme Corp'] }],
+    );
+    const { values } = happyPathInsert([{ id: 'req-sg', status: 'auto_approved' }]);
+
+    const res = await buildApp().request('/agents/agent-123/elevation-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...goodPayload, target_executable_signer: 'acme corp' }),
+    });
+
+    expect(res.status).toBe(201);
+    const call = vi
+      .mocked(values)
+      .mock.calls.find((args) => (args[0] as { status?: string }).status === 'auto_approved');
+    expect(call).toBeTruthy();
+    const inserted = call![0] as {
+      approvedAt: Date;
+      expiresAt: Date;
+      metadata: { pam_rule_id: string };
+    };
+    // The signer group resolved the candidate signer -> the rule matched.
+    expect(inserted.metadata.pam_rule_id).toBe('rule-sg');
+    expect(inserted.approvedAt).toBeInstanceOf(Date);
+    expect(inserted.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(pamMocks.publishEvent).toHaveBeenCalledWith(
+      'elevation.auto_approved',
+      'org-1',
+      expect.objectContaining({ elevationRequestId: 'req-sg' }),
+      'pam-ingest',
     );
   });
 

--- a/apps/api/src/routes/agents/elevationRequests.ts
+++ b/apps/api/src/routes/agents/elevationRequests.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, isNull, or } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
@@ -11,6 +11,7 @@ import {
   elevationRequests,
   pamOrgConfig,
   pamRules,
+  pamSignerGroups,
 } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { getRedis } from '../../services/redis';
@@ -366,15 +367,41 @@ elevationRequestsRoutes.post(
                 : isNull(pamRules.siteId),
             ),
           );
-        const ruleMatch = evaluatePamRules(orgRules, {
-          targetExecutablePath: payload.target_executable_path,
-          targetExecutableHash: payload.target_executable_hash,
-          targetExecutableSigner: payload.target_executable_signer,
-          subjectUsername: payload.subject_username,
-          parentImage: payload.parent_image,
-          commandLine: payload.command_line,
-          at: observedAt,
-        });
+        // Resolve any signer groups referenced by the candidate rules so the
+        // engine can match matchSignerGroupId against the group's members.
+        const signerGroupIds = [
+          ...new Set(
+            orgRules
+              .map((r) => r.matchSignerGroupId)
+              .filter((x): x is string => x != null),
+          ),
+        ];
+        let signerGroups: Map<string, string[]> | undefined;
+        if (signerGroupIds.length > 0) {
+          const groups = await db
+            .select({ id: pamSignerGroups.id, signers: pamSignerGroups.signers })
+            .from(pamSignerGroups)
+            .where(
+              and(
+                eq(pamSignerGroups.orgId, device.orgId),
+                inArray(pamSignerGroups.id, signerGroupIds),
+              ),
+            );
+          signerGroups = new Map(groups.map((g) => [g.id, g.signers]));
+        }
+        const ruleMatch = evaluatePamRules(
+          orgRules,
+          {
+            targetExecutablePath: payload.target_executable_path,
+            targetExecutableHash: payload.target_executable_hash,
+            targetExecutableSigner: payload.target_executable_signer,
+            subjectUsername: payload.subject_username,
+            parentImage: payload.parent_image,
+            commandLine: payload.command_line,
+            at: observedAt,
+          },
+          signerGroups,
+        );
         if (!ruleMatch) {
           // No software policy and no PAM rule matched — apply the org's
           // default verdict for unmatched elevations. The historical default

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -67,6 +67,17 @@ vi.mock('../db/schema', () => ({
     orgId: 'orgId',
     priority: 'priority',
     createdAt: 'createdAt',
+    matchSignerGroupId: 'matchSignerGroupId',
+  },
+  pamSignerGroups: {
+    id: 'id',
+    orgId: 'orgId',
+    name: 'name',
+    description: 'description',
+    signers: 'signers',
+    createdByUserId: 'createdByUserId',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
   },
   pamOrgConfig: {
     id: 'id',
@@ -1733,6 +1744,175 @@ describe('PAM org config — default unmatched verdict', () => {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ defaultUnmatchedVerdict: 'auto_approve' }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+});
+
+describe('Signer groups', () => {
+  const GROUP_ID = '7b41c9a2-0000-4000-8000-00000000000a';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+  });
+
+  it('GET /signer-groups lists the org groups', async () => {
+    const rows = [
+      { id: GROUP_ID, orgId: ORG_ID, name: 'Trusted vendors', description: null, signers: ['Acme Corp'] },
+    ];
+    // .select().from().where().orderBy() is awaited directly.
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn().mockResolvedValue(rows),
+        })),
+      })),
+    } as any);
+
+    const res = await app().request('/pam/signer-groups');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.signerGroups).toHaveLength(1);
+    expect(body.signerGroups[0].name).toBe('Trusted vendors');
+  });
+
+  it('POST /signer-groups trims and de-dupes signers before insert', async () => {
+    const returning = vi.fn().mockResolvedValue([
+      { id: GROUP_ID, name: 'Trusted vendors', signers: ['Acme Corp', 'Beta Inc'] },
+    ]);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn(() => ({ returning })),
+    } as any);
+
+    const res = await app().request('/pam/signer-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Trusted vendors',
+        // Whitespace + case-insensitive duplicate must be cleaned by the schema.
+        signers: ['  Acme Corp  ', 'ACME CORP', 'Beta Inc'],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { signers: string[]; orgId: string };
+    expect(valuesArg.signers).toEqual(['Acme Corp', 'Beta Inc']);
+    expect(valuesArg.orgId).toBe(ORG_ID);
+  });
+
+  it('PATCH /signer-groups/:id updates name and signers', async () => {
+    // (1) existing-row lookup .from().where().limit(), (2) update .returning().
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([{ id: GROUP_ID, orgId: ORG_ID, name: 'old' }]),
+        })),
+      })),
+    } as any);
+    const returning = vi.fn().mockResolvedValue([
+      { id: GROUP_ID, name: 'new name', signers: ['Gamma LLC'] },
+    ]);
+    const set = vi.fn(() => ({ where: vi.fn(() => ({ returning })) }));
+    vi.mocked(db.update).mockReturnValue({ set } as any);
+
+    const res = await app().request(`/pam/signer-groups/${GROUP_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'new name', signers: ['Gamma LLC', 'gamma llc'] }),
+    });
+
+    expect(res.status).toBe(200);
+    const setArg = (set as any).mock.calls[0][0] as { name: string; signers: string[] };
+    expect(setArg.name).toBe('new name');
+    expect(setArg.signers).toEqual(['Gamma LLC']);
+  });
+
+  it('DELETE /signer-groups/:id returns 200 when no rule references it', async () => {
+    // (1) existing-row lookup .limit(), (2) refs count .from().where() awaited -> 0.
+    let call = 0;
+    vi.mocked(db.select).mockImplementation((() => {
+      call += 1;
+      return {
+        from: vi.fn(() => ({
+          where: vi.fn(() => {
+            const thenable: any = Promise.resolve([{ refs: 0 }]);
+            thenable.limit = vi
+              .fn()
+              .mockResolvedValue([{ id: GROUP_ID, orgId: ORG_ID, name: 'Trusted vendors' }]);
+            return thenable;
+          }),
+        })),
+      };
+    }) as any);
+    const deleteWhere = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(db.delete).mockReturnValue({ where: deleteWhere } as any);
+
+    const res = await app().request(`/pam/signer-groups/${GROUP_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(deleteWhere).toHaveBeenCalledOnce();
+    void call;
+  });
+
+  it('DELETE /signer-groups/:id returns 409 when a rule references it', async () => {
+    vi.mocked(db.select).mockImplementation((() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => {
+          const thenable: any = Promise.resolve([{ refs: 2 }]);
+          thenable.limit = vi
+            .fn()
+            .mockResolvedValue([{ id: GROUP_ID, orgId: ORG_ID, name: 'Trusted vendors' }]);
+          return thenable;
+        }),
+      })),
+    })) as any);
+    vi.mocked(db.delete).mockReturnValue({ where: vi.fn() } as any);
+
+    const res = await app().request(`/pam/signer-groups/${GROUP_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('2 rule(s)');
+    expect(vi.mocked(db.delete)).not.toHaveBeenCalled();
+  });
+
+  it('POST /rules accepts matchSignerGroupId and passes it to the insert', async () => {
+    const returning = vi.fn().mockResolvedValue([
+      { id: 'rule-sg', name: 'allow vendor group', verdict: 'auto_approve', priority: 100 },
+    ]);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn(() => ({ returning })),
+    } as any);
+
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'allow vendor group',
+        verdict: 'auto_approve',
+        matchSignerGroupId: GROUP_ID,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { matchSignerGroupId: string };
+    expect(valuesArg.matchSignerGroupId).toBe(GROUP_ID);
+  });
+
+  it('POST /rules rejects setting both matchSigner and matchSignerGroupId (400)', async () => {
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'conflicting signer rule',
+        verdict: 'auto_approve',
+        matchSigner: 'Acme Corp',
+        matchSignerGroupId: GROUP_ID,
+      }),
     });
     expect(res.status).toBe(400);
     expect(vi.mocked(db.insert)).not.toHaveBeenCalled();

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -34,6 +34,7 @@ import {
   PAM_RULE_NEGATE_KEYS,
   pamOrgConfig,
   pamRules,
+  pamSignerGroups,
   sites,
   softwarePolicies,
   users,
@@ -803,6 +804,7 @@ pamRoutes.post(
 
 const ruleCriteriaFields = [
   'matchSigner',
+  'matchSignerGroupId',
   'matchHash',
   'matchPathGlob',
   'matchParentImage',
@@ -823,6 +825,7 @@ const timeWindowSchema = z.object({
 const ruleCriteriaValidators = {
   siteId: z.string().guid().nullable().optional(),
   matchSigner: z.string().min(1).max(255).nullable().optional(),
+  matchSignerGroupId: z.string().guid().nullable().optional(),
   matchHash: z
     .string()
     .regex(/^[0-9a-fA-F]{64}$/, 'must be a sha256 hex digest')
@@ -858,6 +861,7 @@ const ruleBaseSchema = z.object({
 
 type RuleCriteriaShape = {
   matchSigner?: string | null;
+  matchSignerGroupId?: string | null;
   matchHash?: string | null;
   matchPathGlob?: string | null;
   matchParentImage?: string | null;
@@ -880,6 +884,7 @@ function hasAnyCriterion(rule: RuleCriteriaShape): boolean {
 // group/time only narrow; they don't identify a binary).
 const executableCriteriaFields = [
   'matchSigner',
+  'matchSignerGroupId',
   'matchHash',
   'matchPathGlob',
   'matchParentImage',
@@ -906,6 +911,9 @@ function validateRuleShape(rule: RuleCriteriaShape): string | null {
   }
   if (hasExecutableShapeCriteria(rule) && hasToolActionCriteria(rule)) {
     return 'A rule cannot mix executable criteria with tool-action criteria';
+  }
+  if (rule.matchSigner && rule.matchSignerGroupId) {
+    return 'A rule cannot set both matchSigner and matchSignerGroupId — use one or the other';
   }
   if (hasToolActionCriteria(rule) && rule.verdict === 'ignore') {
     return "verdict 'ignore' is not valid for tool-action rules — a tool action must be decided";
@@ -965,6 +973,7 @@ pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', creat
       enabled: payload.enabled ?? true,
       priority: payload.priority ?? 100,
       matchSigner: payload.matchSigner ?? null,
+      matchSignerGroupId: payload.matchSignerGroupId ?? null,
       matchHash: payload.matchHash ? payload.matchHash.toLowerCase() : null,
       matchPathGlob: payload.matchPathGlob ?? null,
       matchParentImage: payload.matchParentImage ?? null,
@@ -1066,6 +1075,7 @@ pamRoutes.post(
       createdAt: new Date(),
       updatedAt: new Date(),
       matchSigner: body.matchSigner ?? null,
+      matchSignerGroupId: body.matchSignerGroupId ?? null,
       matchHash: body.matchHash ? body.matchHash.toLowerCase() : null,
       matchPathGlob: body.matchPathGlob ?? null,
       matchParentImage: body.matchParentImage ?? null,
@@ -1077,6 +1087,19 @@ pamRoutes.post(
       matchNegate: body.matchNegate ?? null,
       timeWindow: body.timeWindow ?? null,
     };
+
+    // Resolve the draft's signer group (if any) so the preview can match it.
+    // Org-scoped by RLS — a group the caller can't see yields no resolution
+    // and the draft's group criterion fails closed.
+    let previewSignerGroups: Map<string, string[]> | undefined;
+    if (draftRule.matchSignerGroupId) {
+      const [grp] = await db
+        .select({ id: pamSignerGroups.id, signers: pamSignerGroups.signers })
+        .from(pamSignerGroups)
+        .where(eq(pamSignerGroups.id, draftRule.matchSignerGroupId))
+        .limit(1);
+      if (grp) previewSignerGroups = new Map([[grp.id, grp.signers]]);
+    }
 
     let totalMatched = 0;
     const statusBreakdown: Record<string, number> = {
@@ -1103,7 +1126,7 @@ pamRoutes.post(
         riskTier: r.riskTier ?? undefined,
         at: r.requestedAt,
       };
-      if (evaluatePamRules([draftRule], candidate)) {
+      if (evaluatePamRules([draftRule], candidate, previewSignerGroups)) {
         totalMatched++;
         statusBreakdown[r.status] = (statusBreakdown[r.status] ?? 0) + 1;
         if (sample.length < PREVIEW_SAMPLE_CAP) {
@@ -1164,6 +1187,9 @@ pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', 
       ...(payload.enabled !== undefined ? { enabled: payload.enabled } : {}),
       ...(payload.priority !== undefined ? { priority: payload.priority } : {}),
       ...(payload.matchSigner !== undefined ? { matchSigner: payload.matchSigner } : {}),
+      ...(payload.matchSignerGroupId !== undefined
+        ? { matchSignerGroupId: payload.matchSignerGroupId }
+        : {}),
       ...(payload.matchHash !== undefined
         ? { matchHash: payload.matchHash ? payload.matchHash.toLowerCase() : null }
         : {}),
@@ -1305,3 +1331,172 @@ pamRoutes.put(
     return c.json({ success: true, config: saved });
   },
 );
+
+// ============================================================
+// Signer groups — reusable trusted-publisher catalog
+// ============================================================
+// A named, org-scoped set of signer (subject CN) patterns referenced from
+// rules via matchSignerGroupId. Manage vendors once, reference everywhere.
+const signerListSchema = z
+  .array(z.string().trim().min(1).max(255))
+  .max(500)
+  // Drop blanks and de-duplicate case-insensitively, preserving first spelling.
+  .transform((arr) => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const s of arr) {
+      const key = s.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(s);
+      }
+    }
+    return out;
+  });
+
+const createSignerGroupSchema = z.object({
+  orgId: z.string().guid().optional(),
+  name: z.string().trim().min(1).max(255),
+  description: z.string().max(2000).nullable().optional(),
+  signers: signerListSchema.optional(),
+});
+
+const updateSignerGroupSchema = z.object({
+  name: z.string().trim().min(1).max(255).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  signers: signerListSchema.optional(),
+});
+
+pamRoutes.get('/signer-groups', requirePamRead, async (c) => {
+  const auth = c.get('auth');
+  const rows = await db
+    .select()
+    .from(pamSignerGroups)
+    .where(auth.orgCondition(pamSignerGroups.orgId))
+    .orderBy(pamSignerGroups.name);
+  return c.json({ success: true, signerGroups: rows });
+});
+
+pamRoutes.post(
+  '/signer-groups',
+  requirePamWrite,
+  requireMfa(),
+  zValidator('json', createSignerGroupSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const payload = c.req.valid('json');
+    const resolvedOrg = resolveOrgIdForWrite(
+      auth,
+      payload.orgId ?? c.req.query('orgId') ?? undefined,
+    );
+    if (!resolvedOrg.orgId) {
+      return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
+    }
+    const [created] = await db
+      .insert(pamSignerGroups)
+      .values({
+        orgId: resolvedOrg.orgId,
+        name: payload.name,
+        description: payload.description ?? null,
+        signers: payload.signers ?? [],
+        createdByUserId: auth.user.id,
+      })
+      .returning();
+    if (!created) {
+      return c.json({ error: 'Signer group insert returned no row' }, 500);
+    }
+    writeAuditEvent(c, {
+      orgId: resolvedOrg.orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      action: 'pam.signer_group.create',
+      resourceType: 'pam_signer_group',
+      resourceId: created.id,
+      details: { name: created.name, signerCount: created.signers.length },
+    });
+    return c.json({ success: true, signerGroup: created }, 201);
+  },
+);
+
+pamRoutes.patch(
+  '/signer-groups/:id',
+  requirePamWrite,
+  requireMfa(),
+  zValidator('json', updateSignerGroupSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const id = c.req.param('id');
+    const payload = c.req.valid('json');
+    if (!z.string().guid().safeParse(id).success) {
+      return c.json({ error: 'Invalid signer group id' }, 400);
+    }
+    const [existing] = await db
+      .select()
+      .from(pamSignerGroups)
+      .where(eq(pamSignerGroups.id, id!))
+      .limit(1);
+    if (!existing || !auth.canAccessOrg(existing.orgId)) {
+      return c.json({ error: 'Signer group not found' }, 404);
+    }
+    const [updated] = await db
+      .update(pamSignerGroups)
+      .set({
+        ...(payload.name !== undefined ? { name: payload.name } : {}),
+        ...(payload.description !== undefined ? { description: payload.description } : {}),
+        ...(payload.signers !== undefined ? { signers: payload.signers } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(pamSignerGroups.id, id!))
+      .returning();
+    writeAuditEvent(c, {
+      orgId: existing.orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      action: 'pam.signer_group.update',
+      resourceType: 'pam_signer_group',
+      resourceId: id,
+      details: { changed: Object.keys(payload) },
+    });
+    return c.json({ success: true, signerGroup: updated });
+  },
+);
+
+pamRoutes.delete('/signer-groups/:id', requirePamWrite, requireMfa(), async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+  if (!z.string().guid().safeParse(id).success) {
+    return c.json({ error: 'Invalid signer group id' }, 400);
+  }
+  const [existing] = await db
+    .select()
+    .from(pamSignerGroups)
+    .where(eq(pamSignerGroups.id, id!))
+    .limit(1);
+  if (!existing || !auth.canAccessOrg(existing.orgId)) {
+    return c.json({ error: 'Signer group not found' }, 404);
+  }
+  // A group referenced by any rule cannot be deleted (would orphan the rule's
+  // only signer criterion). Surface a clean 409 instead of an FK error.
+  const refsRows = await db
+    .select({ refs: sql<number>`count(*)::int` })
+    .from(pamRules)
+    .where(eq(pamRules.matchSignerGroupId, id!));
+  const refs = refsRows[0]?.refs ?? 0;
+  if (refs > 0) {
+    return c.json(
+      { error: `Signer group is used by ${refs} rule(s); remove those references first` },
+      409,
+    );
+  }
+  await db.delete(pamSignerGroups).where(eq(pamSignerGroups.id, id!));
+  writeAuditEvent(c, {
+    orgId: existing.orgId,
+    actorType: 'user',
+    actorId: auth.user.id,
+    action: 'pam.signer_group.delete',
+    resourceType: 'pam_signer_group',
+    resourceId: id,
+    details: { name: existing.name },
+  });
+  return c.json({ success: true });
+});

--- a/apps/api/src/services/pamRuleEngine.test.ts
+++ b/apps/api/src/services/pamRuleEngine.test.ts
@@ -22,6 +22,7 @@ function rule(overrides: Partial<PamRule>): PamRule {
     enabled: true,
     priority: 100,
     matchSigner: null,
+    matchSignerGroupId: null,
     matchHash: null,
     matchPathGlob: null,
     matchParentImage: null,
@@ -415,5 +416,96 @@ describe('rule negation (match_negate)', () => {
     const uninstalling: PamRuleCandidate = { ...installing, commandLine: 'setup.exe --uninstall' };
     expect(evaluatePamRules([r], installing)?.verdict).toBe('auto_approve');
     expect(evaluatePamRules([r], uninstalling)).toBeNull();
+  });
+});
+
+describe('signer group matching (matchSignerGroupId)', () => {
+  const GROUP_ID = '11111111-1111-1111-1111-111111111111';
+  const groups = new Map<string, readonly string[]>([
+    [GROUP_ID, ['Intuit Inc.', 'Microsoft Corporation', 'TeamViewer GmbH']],
+  ]);
+
+  it('matches when the candidate signer is any member of the group', () => {
+    const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Microsoft Corporation' }, groups)
+        ?.verdict,
+    ).toBe('auto_approve');
+    // case-insensitive
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'intuit inc.' }, groups),
+    ).not.toBeNull();
+  });
+
+  it('does not match a signer outside the group', () => {
+    const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Evil Corp' }, groups),
+    ).toBeNull();
+  });
+
+  it('fails closed when the group is not provided to the engine', () => {
+    const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+    // no resolver passed → unresolvable → no match
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Intuit Inc.' }),
+    ).toBeNull();
+    // empty group → no match
+    const empty = new Map<string, readonly string[]>([[GROUP_ID, []]]);
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Intuit Inc.' }, empty),
+    ).toBeNull();
+  });
+
+  it('fails closed when the candidate has no signer', () => {
+    const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+    expect(
+      evaluatePamRules([r], { subjectUsername: 'CORP\\x', targetExecutablePath: 'C:\\a.exe' }, groups),
+    ).toBeNull();
+  });
+
+  it('ANDs with other criteria', () => {
+    const r = rule({
+      matchSignerGroupId: GROUP_ID,
+      matchPathGlob: 'C:\\Program Files\\**',
+      verdict: 'auto_approve',
+    });
+    expect(
+      evaluatePamRules(
+        [r],
+        {
+          ...candidate,
+          targetExecutableSigner: 'TeamViewer GmbH',
+          targetExecutablePath: 'C:\\Program Files\\TeamViewer\\tv.exe',
+        },
+        groups,
+      ),
+    ).not.toBeNull();
+    // signer in group but path doesn't match → no match
+    expect(
+      evaluatePamRules(
+        [r],
+        { ...candidate, targetExecutableSigner: 'TeamViewer GmbH', targetExecutablePath: 'C:\\Temp\\tv.exe' },
+        groups,
+      ),
+    ).toBeNull();
+  });
+
+  it('inverts via negation (signer NOT in the group)', () => {
+    const r = rule({
+      matchPathGlob: 'C:\\**',
+      matchSignerGroupId: GROUP_ID,
+      matchNegate: ['signerGroup'],
+      verdict: 'auto_deny',
+    });
+    // signer is a member → negated criterion fails → no match
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Intuit Inc.', targetExecutablePath: 'C:\\a.exe' }, groups),
+    ).toBeNull();
+    // signer not a member → negated criterion holds → match
+    expect(
+      evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Random LLC', targetExecutablePath: 'C:\\a.exe' }, groups)
+        ?.verdict,
+    ).toBe('auto_deny');
   });
 });

--- a/apps/api/src/services/pamRuleEngine.ts
+++ b/apps/api/src/services/pamRuleEngine.ts
@@ -61,6 +61,14 @@ export interface PamRuleMatch {
 
 const eqCi = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
 
+/**
+ * Resolved signer groups: groupId → member signer patterns. The caller
+ * (ingest / preview) fetches the org's referenced pam_signer_groups and passes
+ * this map so the pure engine can evaluate matchSignerGroupId without DB access.
+ * A rule whose group is absent from the map (or has no members) fails closed.
+ */
+export type SignerGroupResolver = ReadonlyMap<string, readonly string[]>;
+
 // A time window NARROWS a rule; it is not an identifying criterion on its
 // own. A rule whose only "criterion" is a time window would match every
 // elevation in the org while active — catastrophic for verdict=auto_approve.
@@ -68,6 +76,7 @@ const eqCi = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
 function hasAnyCriteria(rule: PamRule): boolean {
   return Boolean(
     rule.matchSigner ||
+      rule.matchSignerGroupId ||
       rule.matchHash ||
       rule.matchPathGlob ||
       rule.matchParentImage ||
@@ -135,7 +144,11 @@ export function isWithinTimeWindow(window: PamRuleTimeWindow, at: Date): boolean
     : minutes >= start || minutes <= end;
 }
 
-function ruleMatches(rule: PamRule, candidate: PamRuleCandidate): boolean {
+function ruleMatches(
+  rule: PamRule,
+  candidate: PamRuleCandidate,
+  signerGroups?: SignerGroupResolver,
+): boolean {
   if (!hasAnyCriteria(rule)) return false;
 
   const negate = new Set<PamRuleNegateKey>(rule.matchNegate ?? []);
@@ -157,6 +170,17 @@ function ruleMatches(rule: PamRule, candidate: PamRuleCandidate): boolean {
     const present = candidate.targetExecutableSigner != null;
     const positive = present && eqCi(rule.matchSigner, candidate.targetExecutableSigner!);
     if (!satisfied('signer', present, positive)) return false;
+  }
+  if (rule.matchSignerGroupId) {
+    // Match the candidate signer against ANY member of the resolved group.
+    // Unresolvable (group missing from the map or empty) or no candidate signer
+    // → not present → fails closed, even when negated.
+    const members = signerGroups?.get(rule.matchSignerGroupId);
+    const present =
+      candidate.targetExecutableSigner != null && members != null && members.length > 0;
+    const positive =
+      present && members!.some((s) => eqCi(s, candidate.targetExecutableSigner!));
+    if (!satisfied('signerGroup', present, positive)) return false;
   }
   if (rule.matchPathGlob) {
     const present = candidate.targetExecutablePath != null;
@@ -211,6 +235,7 @@ function ruleMatches(rule: PamRule, candidate: PamRuleCandidate): boolean {
 export function evaluatePamRules(
   rules: PamRule[],
   candidate: PamRuleCandidate,
+  signerGroups?: SignerGroupResolver,
 ): PamRuleMatch | null {
   const ordered = [...rules].sort((a, b) => {
     if (a.priority !== b.priority) return a.priority - b.priority;
@@ -221,7 +246,7 @@ export function evaluatePamRules(
   });
   for (const rule of ordered) {
     if (!rule.enabled) continue;
-    if (ruleMatches(rule, candidate)) {
+    if (ruleMatches(rule, candidate, signerGroups)) {
       return {
         ruleId: rule.id,
         ruleName: rule.name,

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -210,6 +210,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'organization_users',
   'pam_org_config',
   'pam_rules',
+  'pam_signer_groups',
   'patch_compliance_reports',
   'patch_compliance_snapshots',
   'patch_jobs',

--- a/apps/web/src/components/pam/PamPage.tsx
+++ b/apps/web/src/components/pam/PamPage.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Activity, Inbox, ListChecks, ScrollText } from 'lucide-react';
+import { Activity, Inbox, ListChecks, ScrollText, ShieldCheck } from 'lucide-react';
 import { useEventStream } from '../../hooks/useEventStream';
 import PamOverviewTab from './PamOverviewTab';
 import PamRequestsTab from './PamRequestsTab';
 import PamRulesTab from './PamRulesTab';
+import PamSignerGroupsTab from './PamSignerGroupsTab';
 import PamAuditTab from './PamAuditTab';
 
-const VALID_TABS = ['overview', 'requests', 'rules', 'audit'] as const;
+const VALID_TABS = ['overview', 'requests', 'rules', 'signer-groups', 'audit'] as const;
 type Tab = (typeof VALID_TABS)[number];
 
 const ELEVATION_EVENTS = [
@@ -111,6 +112,14 @@ export default function PamPage() {
           Rules
         </TabButton>
         <TabButton
+          active={activeTab === 'signer-groups'}
+          onClick={() => switchTab('signer-groups')}
+          icon={<ShieldCheck className="h-4 w-4" />}
+          testId="pam-tab-signer-groups"
+        >
+          Signer Groups
+        </TabButton>
+        <TabButton
           active={activeTab === 'audit'}
           onClick={() => switchTab('audit')}
           icon={<ScrollText className="h-4 w-4" />}
@@ -123,6 +132,7 @@ export default function PamPage() {
       {activeTab === 'overview' && <PamOverviewTab liveTick={liveTick} />}
       {activeTab === 'requests' && <PamRequestsTab liveTick={liveTick} />}
       {activeTab === 'rules' && <PamRulesTab liveTick={liveTick} />}
+      {activeTab === 'signer-groups' && <PamSignerGroupsTab liveTick={liveTick} />}
       {activeTab === 'audit' && <PamAuditTab liveTick={liveTick} />}
     </div>
   );

--- a/apps/web/src/components/pam/PamRuleModal.test.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.test.tsx
@@ -324,4 +324,118 @@ describe('PamRuleModal', () => {
       expect(screen.getByRole('alert').textContent).not.toContain('HTTP 400');
     });
   });
+
+  describe('signer group selector', () => {
+    const signerGroups = [
+      { id: 'grp-1', orgId: 'org-1', name: 'Trusted vendors', signers: ['Acme Corp'], createdAt: '', updatedAt: '' },
+      { id: 'grp-2', orgId: 'org-1', name: 'Microsoft', signers: ['Microsoft Corporation'], createdAt: '', updatedAt: '' },
+    ];
+
+    function installWithGroups(captured: { postBody: Record<string, unknown> | null }) {
+      fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        if (url.startsWith('/orgs/organizations')) return makeJsonResponse({ data: [{ id: 'org-1', name: 'Acme' }] });
+        if (url.startsWith('/orgs/sites')) return makeJsonResponse({ data: [] });
+        if (url.startsWith('/pam/signer-groups') && method === 'GET') {
+          return makeJsonResponse({ success: true, signerGroups });
+        }
+        if (url === '/pam/rules' && method === 'POST') {
+          captured.postBody = JSON.parse(init!.body as string);
+          return makeJsonResponse({ success: true, rule: {} }, true, 201);
+        }
+        return makeJsonResponse({ success: true });
+      });
+    }
+
+    it('fetches and lists the org signer groups as options', async () => {
+      installWithGroups({ postBody: null });
+      render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+
+      await waitFor(() => {
+        const select = screen.getByTestId('pam-rule-match-signer-group') as HTMLSelectElement;
+        // blank "— none —" plus the two groups
+        expect(select.options.length).toBe(3);
+      });
+      const select = screen.getByTestId('pam-rule-match-signer-group') as HTMLSelectElement;
+      expect(Array.from(select.options).map((o) => o.value)).toEqual(['', 'grp-1', 'grp-2']);
+    });
+
+    it('picking a group clears and disables the free-text signer, and sends matchSignerGroupId', async () => {
+      const user = userEvent.setup();
+      const captured: { postBody: Record<string, unknown> | null } = { postBody: null };
+      installWithGroups(captured);
+      render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+
+      await waitFor(() => {
+        expect(
+          (screen.getByTestId('pam-rule-match-signer-group') as HTMLSelectElement).options.length,
+        ).toBe(3);
+      });
+
+      // Type a signer first, then pick a group — the signer must be cleared.
+      await user.type(screen.getByTestId('pam-rule-signer'), 'Some Corp');
+      await user.selectOptions(screen.getByTestId('pam-rule-match-signer-group'), 'grp-1');
+
+      expect((screen.getByTestId('pam-rule-signer') as HTMLInputElement).value).toBe('');
+      expect((screen.getByTestId('pam-rule-signer') as HTMLInputElement).disabled).toBe(true);
+
+      await user.type(screen.getByTestId('pam-rule-name'), 'Vendor group rule');
+      await user.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => expect(captured.postBody).not.toBeNull());
+      expect(captured.postBody!.matchSignerGroupId).toBe('grp-1');
+      expect(captured.postBody!.matchSigner).toBe(null);
+    });
+
+    it('typing a signer clears a previously selected group', async () => {
+      const user = userEvent.setup();
+      const captured: { postBody: Record<string, unknown> | null } = { postBody: null };
+      installWithGroups(captured);
+      render(<PamRuleModal rule={null} onClose={() => {}} onSaved={() => {}} />);
+
+      await waitFor(() => {
+        expect(
+          (screen.getByTestId('pam-rule-match-signer-group') as HTMLSelectElement).options.length,
+        ).toBe(3);
+      });
+
+      await user.selectOptions(screen.getByTestId('pam-rule-match-signer-group'), 'grp-2');
+      expect((screen.getByTestId('pam-rule-match-signer-group') as HTMLSelectElement).value).toBe('grp-2');
+
+      // The signer input is disabled while a group is set; clearing the group
+      // re-enables it. Reset the select, then type.
+      await user.selectOptions(screen.getByTestId('pam-rule-match-signer-group'), '');
+      await user.type(screen.getByTestId('pam-rule-signer'), 'Acme Corp');
+      expect((screen.getByTestId('pam-rule-match-signer-group') as HTMLSelectElement).value).toBe('');
+
+      await user.type(screen.getByTestId('pam-rule-name'), 'Signer text rule');
+      await user.click(screen.getByTestId('pam-rule-submit'));
+
+      await waitFor(() => expect(captured.postBody).not.toBeNull());
+      expect(captured.postBody!.matchSigner).toBe('Acme Corp');
+      expect(captured.postBody!.matchSignerGroupId).toBe(null);
+    });
+
+    it('seeds the selected group from rule.matchSignerGroupId on edit', async () => {
+      installWithGroups({ postBody: null });
+      const rule = {
+        id: 'rule-g',
+        orgId: 'org-1',
+        name: 'Existing group rule',
+        enabled: true,
+        priority: 10,
+        matchSignerGroupId: 'grp-2',
+        verdict: 'auto_approve' as const,
+        createdAt: '2026-06-10T00:00:00.000Z',
+        updatedAt: '2026-06-10T00:00:00.000Z',
+      };
+      render(<PamRuleModal rule={rule} onClose={() => {}} onSaved={() => {}} />);
+
+      await waitFor(() => {
+        expect((screen.getByTestId('pam-rule-match-signer-group') as HTMLSelectElement).value).toBe('grp-2');
+      });
+      // Signer text is disabled because a group is selected.
+      expect((screen.getByTestId('pam-rule-signer') as HTMLInputElement).disabled).toBe(true);
+    });
+  });
 });

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -9,6 +9,7 @@ import {
   type PamRule,
   type PamRuleDraft,
   type PamRuleNegateKey,
+  type PamSignerGroup,
   type PamVerdict,
   STATUS_LABELS,
   VERDICT_LABELS,
@@ -114,6 +115,12 @@ export default function PamRuleModal({
       : seed?.shape ?? 'executable',
   );
   const [matchSigner, setMatchSigner] = useState(rule?.matchSigner ?? seedExec?.matchSigner ?? '');
+  // Alternative to the free-text signer: reference a reusable signer group.
+  // Mutually exclusive with matchSigner (mirrors validateRuleShape).
+  const [matchSignerGroupId, setMatchSignerGroupId] = useState(
+    rule?.matchSignerGroupId ?? seedExec?.matchSignerGroupId ?? '',
+  );
+  const [signerGroups, setSignerGroups] = useState<PamSignerGroup[]>([]);
   const [matchHash, setMatchHash] = useState(rule?.matchHash ?? seedExec?.matchHash ?? '');
   const [matchPathGlob, setMatchPathGlob] = useState(rule?.matchPathGlob ?? seedExec?.matchPathGlob ?? '');
   const [matchParentImage, setMatchParentImage] = useState(
@@ -170,6 +177,7 @@ export default function PamRuleModal({
   const verdictId = useId();
   const orgSelectId = useId();
   const siteSelectId = useId();
+  const signerGroupSelectId = useId();
   const timezoneId = useId();
 
   useEffect(() => {
@@ -220,6 +228,22 @@ export default function PamRuleModal({
       .catch(() => {});
   }, [isEdit, orgsLoaded, sitesOrgId]);
 
+  // Signer groups belong to the rule's org (same scoping as sites). A selected
+  // group that no longer belongs to the org is left as-is for display; the
+  // server rejects a cross-org reference on submit.
+  useEffect(() => {
+    if (!isEdit && !orgsLoaded) return;
+    const query = sitesOrgId ? `?orgId=${encodeURIComponent(sitesOrgId)}` : '';
+    fetchWithAuth(`/pam/signer-groups${query}`)
+      .then(async (res) => {
+        if (res.ok) {
+          const data = await res.json();
+          setSignerGroups((data.signerGroups ?? []) as PamSignerGroup[]);
+        }
+      })
+      .catch(() => {});
+  }, [isEdit, orgsLoaded, sitesOrgId]);
+
   // Reset days/tz when the time window is fully cleared so stale values don't
   // invisibly resurface if a start/end is re-entered later. Safe on mount: a
   // rule without a window initializes these empty anyway, and a rule with a
@@ -238,6 +262,7 @@ export default function PamRuleModal({
   }, [
     shape,
     matchSigner,
+    matchSignerGroupId,
     matchHash,
     matchPathGlob,
     matchParentImage,
@@ -282,6 +307,7 @@ export default function PamRuleModal({
   } | null => {
     const executable = {
       matchSigner: matchSigner.trim() || null,
+      matchSignerGroupId: matchSignerGroupId || null,
       matchHash: matchHash.trim() || null,
       matchPathGlob: matchPathGlob.trim() || null,
       matchParentImage: matchParentImage.trim() || null,
@@ -301,6 +327,7 @@ export default function PamRuleModal({
         ? { ...executable, matchToolName: null, matchRiskTier: null, ...common }
         : {
             matchSigner: null,
+            matchSignerGroupId: null,
             matchHash: null,
             matchPathGlob: null,
             matchParentImage: null,
@@ -618,7 +645,44 @@ export default function PamRuleModal({
 
         {shape === 'executable' ? (
           <div className="grid gap-4 sm:grid-cols-2">
-            <Field label="Signer" value={matchSigner} onChange={setMatchSigner} placeholder="e.g. Microsoft Corporation" testId="pam-rule-signer" negateKey="signer" negated={negate.has('signer')} onToggleNegate={toggleNegate} />
+            <Field
+              label="Signer"
+              value={matchSigner}
+              onChange={(v) => {
+                setMatchSigner(v);
+                // Mutually exclusive with a signer group (mirrors the server).
+                if (v) setMatchSignerGroupId('');
+              }}
+              placeholder="e.g. Microsoft Corporation"
+              testId="pam-rule-signer"
+              disabled={Boolean(matchSignerGroupId)}
+              negateKey="signer"
+              negated={negate.has('signer')}
+              onToggleNegate={toggleNegate}
+            />
+            <div>
+              <label htmlFor={signerGroupSelectId} className="mb-1 block text-sm font-medium">
+                Signer group
+              </label>
+              <select
+                id={signerGroupSelectId}
+                value={matchSignerGroupId}
+                onChange={(e) => {
+                  setMatchSignerGroupId(e.target.value);
+                  // Picking a group clears (and disables) the free-text signer.
+                  if (e.target.value) setMatchSigner('');
+                }}
+                data-testid="pam-rule-match-signer-group"
+                className={inputClass}
+              >
+                <option value="">— none —</option>
+                {signerGroups.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+            </div>
             <Field label="SHA-256 hash" value={matchHash} onChange={setMatchHash} placeholder="64 hex chars" testId="pam-rule-hash" negateKey="hash" negated={negate.has('hash')} onToggleNegate={toggleNegate} />
             <Field label="Path glob" value={matchPathGlob} onChange={setMatchPathGlob} placeholder="C:\\Program Files\\**" testId="pam-rule-path" negateKey="pathGlob" negated={negate.has('pathGlob')} onToggleNegate={toggleNegate} />
             <Field label="Parent image" value={matchParentImage} onChange={setMatchParentImage} placeholder="explorer.exe" testId="pam-rule-parent" negateKey="parentImage" negated={negate.has('parentImage')} onToggleNegate={toggleNegate} />
@@ -789,6 +853,7 @@ function Field({
   placeholder,
   testId,
   type = 'text',
+  disabled = false,
   negateKey,
   negated,
   onToggleNegate,
@@ -799,6 +864,7 @@ function Field({
   placeholder?: string;
   testId: string;
   type?: string;
+  disabled?: boolean;
   // When provided, a small "does not match" toggle renders under the input,
   // marking this criterion for engine-side negation (PAM_RULE_NEGATE_KEYS).
   negateKey?: PamRuleNegateKey;
@@ -817,8 +883,9 @@ function Field({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        disabled={disabled}
         data-testid={testId}
-        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-50"
       />
       {negateKey && onToggleNegate && (
         <label className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/apps/web/src/components/pam/PamRulesTab.tsx
+++ b/apps/web/src/components/pam/PamRulesTab.tsx
@@ -8,9 +8,11 @@ import { ConfirmDialog } from '../shared/ConfirmDialog';
 import PamRuleModal from './PamRuleModal';
 import { type PamRule, type PamUnmatchedVerdict, VERDICT_LABELS } from './types';
 
-function ruleCriteriaSummary(rule: PamRule): string {
+function ruleCriteriaSummary(rule: PamRule, signerGroupNames: Record<string, string> = {}): string {
   const parts: string[] = [];
   if (rule.matchSigner) parts.push(`signer=${rule.matchSigner}`);
+  if (rule.matchSignerGroupId)
+    parts.push(`signer group=${signerGroupNames[rule.matchSignerGroupId] ?? rule.matchSignerGroupId}`);
   if (rule.matchHash) parts.push(`hash=${rule.matchHash.slice(0, 12)}…`);
   if (rule.matchPathGlob) parts.push(`path=${rule.matchPathGlob}`);
   if (rule.matchParentImage) parts.push(`parent=${rule.matchParentImage}`);
@@ -35,6 +37,9 @@ export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number }) {
   // siteId → name, resolved once for the Scope column (GET /pam/rules returns
   // only siteId; no per-row lookups).
   const [siteNames, setSiteNames] = useState<Record<string, string>>({});
+  // signerGroupId → name, resolved once so the Criteria cell can show a group's
+  // name instead of a bare uuid (GET /pam/rules returns only the id).
+  const [signerGroupNames, setSignerGroupNames] = useState<Record<string, string>>({});
   // Org default verdict for an elevation matching no policy and no rule.
   const [defaultVerdict, setDefaultVerdict] = useState<PamUnmatchedVerdict>('require_approval');
   const [savingDefault, setSavingDefault] = useState(false);
@@ -46,6 +51,17 @@ export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number }) {
         const data = await res.json();
         const list = (data.data ?? data.sites ?? data ?? []) as Array<{ id: string; name: string }>;
         setSiteNames(Object.fromEntries(list.map((s) => [s.id, s.name])));
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetchWithAuth('/pam/signer-groups')
+      .then(async (res) => {
+        if (!res.ok) return;
+        const body = await res.json();
+        const list = (body.signerGroups ?? []) as Array<{ id: string; name: string }>;
+        setSignerGroupNames(Object.fromEntries(list.map((g) => [g.id, g.name])));
       })
       .catch(() => {});
   }, []);
@@ -251,8 +267,8 @@ export default function PamRulesTab({ liveTick = 0 }: { liveTick?: number }) {
                       </div>
                     )}
                   </td>
-                  <td className="max-w-[320px] truncate px-3 py-2 text-xs text-muted-foreground" title={ruleCriteriaSummary(rule)}>
-                    {ruleCriteriaSummary(rule) || '—'}
+                  <td className="max-w-[320px] truncate px-3 py-2 text-xs text-muted-foreground" title={ruleCriteriaSummary(rule, signerGroupNames)}>
+                    {ruleCriteriaSummary(rule, signerGroupNames) || '—'}
                   </td>
                   <td
                     className="whitespace-nowrap px-3 py-2 text-xs text-muted-foreground"

--- a/apps/web/src/components/pam/PamSignerGroupsTab.test.tsx
+++ b/apps/web/src/components/pam/PamSignerGroupsTab.test.tsx
@@ -1,0 +1,250 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PamSignerGroupsTab from './PamSignerGroupsTab';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+import type { PamSignerGroup } from './types';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+const trustedGroup: PamSignerGroup = {
+  id: 'grp-1',
+  orgId: 'org-1',
+  name: 'Trusted vendors',
+  description: 'Approved publishers',
+  signers: ['Acme Corp', 'Microsoft Corporation'],
+  createdAt: '2026-06-10T00:00:00.000Z',
+  updatedAt: '2026-06-10T00:00:00.000Z',
+};
+
+/** URL-routed fetch mock, mirroring PamRulesTab.test. */
+function installFetchRoutes({
+  groups = [] as PamSignerGroup[],
+  deleteResponse,
+}: {
+  groups?: PamSignerGroup[];
+  deleteResponse?: () => Response;
+} = {}) {
+  fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    if (url.startsWith('/pam/signer-groups/') && method === 'DELETE') {
+      return deleteResponse ? deleteResponse() : makeJsonResponse({ success: true });
+    }
+    if (url.startsWith('/pam/signer-groups/') && method === 'PATCH') {
+      return makeJsonResponse({ success: true, signerGroup: groups[0] ?? trustedGroup });
+    }
+    if (url === '/pam/signer-groups' && method === 'POST') {
+      return makeJsonResponse({ success: true, signerGroup: groups[0] ?? trustedGroup }, true, 201);
+    }
+    return makeJsonResponse({ success: true, signerGroups: groups });
+  });
+}
+
+function findMutationCall(urlPrefix: string, method: string) {
+  return fetchWithAuthMock.mock.calls.find(
+    (c) =>
+      typeof c[0] === 'string' &&
+      c[0].startsWith(urlPrefix) &&
+      (c[1] as RequestInit | undefined)?.method === method,
+  );
+}
+
+function bodyOf(call: ReturnType<typeof findMutationCall>): Record<string, unknown> {
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+}
+
+async function openCreateModal() {
+  await waitFor(() => screen.getByTestId('pam-add-signer-group-btn'));
+  fireEvent.click(screen.getByTestId('pam-add-signer-group-btn'));
+}
+
+describe('PamSignerGroupsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the empty state when no groups exist', async () => {
+    installFetchRoutes({ groups: [] });
+    render(<PamSignerGroupsTab />);
+    await waitFor(() => {
+      expect(screen.getByText('No signer groups yet')).toBeInTheDocument();
+    });
+  });
+
+  it('lists groups with name, signer count, and members', async () => {
+    installFetchRoutes({ groups: [trustedGroup] });
+    render(<PamSignerGroupsTab />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pam-signer-group-row-grp-1')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('pam-signer-group-name-grp-1')).toHaveTextContent('Trusted vendors');
+    const cell = screen.getByTestId('pam-signer-group-signers-grp-1');
+    expect(cell).toHaveTextContent('2');
+    expect(cell).toHaveTextContent('Acme Corp, Microsoft Corporation');
+  });
+
+  it('re-fetches when the liveTick prop changes', async () => {
+    installFetchRoutes({ groups: [trustedGroup] });
+    const { rerender } = render(<PamSignerGroupsTab liveTick={0} />);
+    await waitFor(() => screen.getByTestId('pam-signer-group-row-grp-1'));
+    const before = fetchWithAuthMock.mock.calls.filter((c) => c[0] === '/pam/signer-groups').length;
+
+    rerender(<PamSignerGroupsTab liveTick={1} />);
+    await waitFor(() => {
+      const after = fetchWithAuthMock.mock.calls.filter((c) => c[0] === '/pam/signer-groups').length;
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  it('creates a group with name, description, and signer rows', async () => {
+    const user = userEvent.setup();
+    installFetchRoutes({ groups: [] });
+    render(<PamSignerGroupsTab />);
+    await openCreateModal();
+
+    await user.type(screen.getByTestId('pam-signer-group-name'), 'Trusted vendors');
+    await user.type(screen.getByTestId('pam-signer-group-description'), 'Approved publishers');
+    await user.type(screen.getByTestId('pam-signer-group-signer-0'), 'Acme Corp');
+    // Add a second signer row.
+    fireEvent.click(screen.getByTestId('pam-signer-group-add-signer'));
+    await user.type(screen.getByTestId('pam-signer-group-signer-1'), 'Microsoft Corporation');
+
+    fireEvent.click(screen.getByTestId('pam-signer-group-save'));
+
+    await waitFor(() => {
+      expect(findMutationCall('/pam/signer-groups', 'POST')).toBeDefined();
+    });
+    const payload = bodyOf(findMutationCall('/pam/signer-groups', 'POST'));
+    expect(payload).toMatchObject({
+      name: 'Trusted vendors',
+      description: 'Approved publishers',
+      signers: ['Acme Corp', 'Microsoft Corporation'],
+    });
+  });
+
+  it('drops blank signer rows from the create payload', async () => {
+    const user = userEvent.setup();
+    installFetchRoutes({ groups: [] });
+    render(<PamSignerGroupsTab />);
+    await openCreateModal();
+
+    await user.type(screen.getByTestId('pam-signer-group-name'), 'One signer');
+    await user.type(screen.getByTestId('pam-signer-group-signer-0'), 'Acme Corp');
+    // Add an empty second row and leave it blank.
+    fireEvent.click(screen.getByTestId('pam-signer-group-add-signer'));
+    fireEvent.click(screen.getByTestId('pam-signer-group-save'));
+
+    await waitFor(() => {
+      expect(findMutationCall('/pam/signer-groups', 'POST')).toBeDefined();
+    });
+    expect(bodyOf(findMutationCall('/pam/signer-groups', 'POST')).signers).toEqual(['Acme Corp']);
+  });
+
+  it('removes a signer row', async () => {
+    const user = userEvent.setup();
+    installFetchRoutes({ groups: [] });
+    render(<PamSignerGroupsTab />);
+    await openCreateModal();
+
+    await user.type(screen.getByTestId('pam-signer-group-name'), 'Two then one');
+    await user.type(screen.getByTestId('pam-signer-group-signer-0'), 'Acme Corp');
+    fireEvent.click(screen.getByTestId('pam-signer-group-add-signer'));
+    await user.type(screen.getByTestId('pam-signer-group-signer-1'), 'Beta Inc');
+    // Remove the first row.
+    fireEvent.click(screen.getByTestId('pam-signer-group-remove-signer-0'));
+    fireEvent.click(screen.getByTestId('pam-signer-group-save'));
+
+    await waitFor(() => {
+      expect(findMutationCall('/pam/signer-groups', 'POST')).toBeDefined();
+    });
+    expect(bodyOf(findMutationCall('/pam/signer-groups', 'POST')).signers).toEqual(['Beta Inc']);
+  });
+
+  it('edits a group via PATCH, pre-filling existing signers', async () => {
+    const user = userEvent.setup();
+    installFetchRoutes({ groups: [trustedGroup] });
+    render(<PamSignerGroupsTab />);
+    await waitFor(() => screen.getByTestId('pam-signer-group-edit-grp-1'));
+    fireEvent.click(screen.getByTestId('pam-signer-group-edit-grp-1'));
+
+    await waitFor(() => {
+      expect((screen.getByTestId('pam-signer-group-signer-0') as HTMLInputElement).value).toBe('Acme Corp');
+    });
+    expect((screen.getByTestId('pam-signer-group-signer-1') as HTMLInputElement).value).toBe(
+      'Microsoft Corporation',
+    );
+
+    await user.clear(screen.getByTestId('pam-signer-group-name'));
+    await user.type(screen.getByTestId('pam-signer-group-name'), 'Trusted vendors v2');
+    fireEvent.click(screen.getByTestId('pam-signer-group-save'));
+
+    await waitFor(() => {
+      expect(findMutationCall('/pam/signer-groups/grp-1', 'PATCH')).toBeDefined();
+    });
+    expect(bodyOf(findMutationCall('/pam/signer-groups/grp-1', 'PATCH')).name).toBe('Trusted vendors v2');
+  });
+
+  it('gates deletion behind a confirm dialog', async () => {
+    installFetchRoutes({ groups: [trustedGroup] });
+    render(<PamSignerGroupsTab />);
+    await waitFor(() => screen.getByTestId('pam-signer-group-delete-grp-1'));
+
+    fireEvent.click(screen.getByTestId('pam-signer-group-delete-grp-1'));
+    await waitFor(() => screen.getByTestId('pam-signer-group-delete-confirm'));
+    expect(findMutationCall('/pam/signer-groups/grp-1', 'DELETE')).toBeUndefined();
+
+    fireEvent.click(screen.getByTestId('pam-signer-group-delete-confirm'));
+    await waitFor(() => {
+      expect(findMutationCall('/pam/signer-groups/grp-1', 'DELETE')).toBeDefined();
+    });
+  });
+
+  it('surfaces a 409 "in use" error via toast on delete', async () => {
+    installFetchRoutes({
+      groups: [trustedGroup],
+      deleteResponse: () =>
+        makeJsonResponse(
+          { error: 'Signer group is used by 2 rule(s); remove those references first' },
+          false,
+          409,
+        ),
+    });
+    render(<PamSignerGroupsTab />);
+    await waitFor(() => screen.getByTestId('pam-signer-group-delete-grp-1'));
+
+    fireEvent.click(screen.getByTestId('pam-signer-group-delete-grp-1'));
+    await waitFor(() => screen.getByTestId('pam-signer-group-delete-confirm'));
+    fireEvent.click(screen.getByTestId('pam-signer-group-delete-confirm'));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('used by 2 rule(s)'),
+        }),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/pam/PamSignerGroupsTab.tsx
+++ b/apps/web/src/components/pam/PamSignerGroupsTab.tsx
@@ -1,0 +1,397 @@
+import { useCallback, useEffect, useId, useState } from 'react';
+import { Plus, ShieldCheck, Trash2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { showToast } from '../shared/Toast';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { Dialog } from '../shared/Dialog';
+import { type PamSignerGroup } from './types';
+
+/**
+ * Manage reusable signer groups (trusted-publisher catalog). A group is a named
+ * list of Authenticode signer (subject CN) patterns referenced from PAM rules
+ * via matchSignerGroupId. Manage vendors once, reference everywhere.
+ */
+export default function PamSignerGroupsTab({ liveTick = 0 }: { liveTick?: number }) {
+  const [groups, setGroups] = useState<PamSignerGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<PamSignerGroup | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<PamSignerGroup | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchGroups = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth('/pam/signer-groups', { signal });
+      if (!res.ok) {
+        if (res.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        throw new Error(`Failed to load signer groups (HTTP ${res.status})`);
+      }
+      const body = await res.json();
+      const list = ((body.signerGroups ?? []) as PamSignerGroup[]).slice();
+      list.sort((a, b) => a.name.localeCompare(b.name));
+      setGroups(list);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load signer groups');
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchGroups(controller.signal);
+    return () => controller.abort();
+  }, [fetchGroups, liveTick]);
+
+  const confirmDelete = async () => {
+    if (!deleteTarget || deleting) return;
+    const group = deleteTarget;
+    setDeleting(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/pam/signer-groups/${group.id}`, { method: 'DELETE' }),
+        errorFallback: 'Failed to delete signer group',
+        successMessage: `Signer group "${group.name}" deleted`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      void fetchGroups();
+    } catch (err) {
+      // A 409 ("used by N rule(s)") is surfaced by runAction's toast — just
+      // don't re-toast it here.
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) {
+        showToast({ type: 'error', message: 'Failed to delete signer group' });
+      }
+    } finally {
+      setDeleting(false);
+      setDeleteTarget(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          A signer group is a named list of trusted Authenticode signers. Reference one from a rule
+          instead of repeating the same publisher across many rules.
+        </p>
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          data-testid="pam-add-signer-group-btn"
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus className="h-4 w-4" />
+          Add signer group
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-md border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading signer groups…
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-card px-4 py-8 text-center">
+          <ShieldCheck className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-2 text-sm font-medium">No signer groups yet</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Create one to reuse a trusted-publisher list across multiple rules.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border bg-card">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Name</th>
+                <th className="px-3 py-2 font-medium">Signers</th>
+                <th className="px-3 py-2 font-medium" />
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map((group) => (
+                <tr
+                  key={group.id}
+                  className="border-b last:border-0"
+                  data-testid={`pam-signer-group-row-${group.id}`}
+                >
+                  <td className="px-3 py-2">
+                    <div className="font-medium" data-testid={`pam-signer-group-name-${group.id}`}>
+                      {group.name}
+                    </div>
+                    {group.description && (
+                      <div
+                        className="mt-0.5 max-w-[280px] truncate text-xs text-muted-foreground"
+                        title={group.description}
+                      >
+                        {group.description}
+                      </div>
+                    )}
+                  </td>
+                  <td
+                    className="max-w-[360px] px-3 py-2 text-xs text-muted-foreground"
+                    data-testid={`pam-signer-group-signers-${group.id}`}
+                    title={group.signers.join(', ')}
+                  >
+                    <span className="font-medium">{group.signers.length}</span>
+                    {group.signers.length > 0 && (
+                      <span className="ml-1.5 truncate">· {group.signers.join(', ')}</span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => setEditing(group)}
+                      data-testid={`pam-signer-group-edit-${group.id}`}
+                      className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setDeleteTarget(group)}
+                      data-testid={`pam-signer-group-delete-${group.id}`}
+                      className="ml-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive hover:bg-destructive/10"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => void confirmDelete()}
+        title="Delete signer group"
+        message={`Delete signer group "${deleteTarget?.name ?? ''}"? Rules referencing it must be updated first.`}
+        confirmLabel="Delete group"
+        variant="destructive"
+        isLoading={deleting}
+        confirmTestId="pam-signer-group-delete-confirm"
+      />
+
+      {(creating || editing) && (
+        <PamSignerGroupModal
+          group={editing}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+          onSaved={() => {
+            setCreating(false);
+            setEditing(null);
+            void fetchGroups();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Create/edit modal for a signer group. */
+function PamSignerGroupModal({
+  group,
+  onClose,
+  onSaved,
+}: {
+  group: PamSignerGroup | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const isEdit = group !== null;
+  const [name, setName] = useState(group?.name ?? '');
+  const [description, setDescription] = useState(group?.description ?? '');
+  // One editable row per signer pattern; always keep at least one (blank) row so
+  // the add/remove controls have something to anchor to.
+  const [signers, setSigners] = useState<string[]>(
+    group?.signers && group.signers.length > 0 ? group.signers : [''],
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const nameId = useId();
+  const descId = useId();
+
+  const inputClass = 'w-full rounded-md border bg-background px-3 py-2 text-sm';
+
+  const updateSigner = (i: number, value: string) => {
+    setSigners((prev) => prev.map((s, idx) => (idx === i ? value : s)));
+  };
+  const addSigner = () => setSigners((prev) => [...prev, '']);
+  const removeSigner = (i: number) => {
+    setSigners((prev) => {
+      const next = prev.filter((_, idx) => idx !== i);
+      return next.length > 0 ? next : [''];
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    setError(null);
+
+    // The server trims/de-dupes; send the non-blank rows.
+    const cleaned = signers.map((s) => s.trim()).filter((s) => s.length > 0);
+
+    const payload: Record<string, unknown> = {
+      name: name.trim(),
+      description: description.trim() || null,
+      signers: cleaned,
+    };
+
+    setSubmitting(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(isEdit ? `/pam/signer-groups/${group.id}` : '/pam/signer-groups', {
+            method: isEdit ? 'PATCH' : 'POST',
+            body: JSON.stringify(payload),
+          }),
+        errorFallback: isEdit ? 'Failed to update signer group' : 'Failed to create signer group',
+        successMessage: `Signer group "${name.trim()}" ${isEdit ? 'updated' : 'created'}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      onSaved();
+    } catch (err) {
+      if (err instanceof ActionError) {
+        if (err.status === 401) return;
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : 'Network error');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      title={isEdit ? 'Edit signer group' : 'New signer group'}
+      maxWidth="lg"
+      className="max-h-[90vh] overflow-y-auto p-6"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor={nameId} className="mb-1 block text-sm font-medium">
+            Name
+          </label>
+          <input
+            id={nameId}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            maxLength={255}
+            data-testid="pam-signer-group-name"
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor={descId} className="mb-1 block text-sm font-medium">
+            Description (optional)
+          </label>
+          <input
+            id={descId}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={2000}
+            data-testid="pam-signer-group-description"
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <span className="mb-1 block text-sm font-medium">Signers</span>
+          <p className="mb-2 text-xs text-muted-foreground">
+            One Authenticode signer (subject CN) per row; matched case-insensitively.
+          </p>
+          <div className="space-y-2">
+            {signers.map((signer, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <input
+                  value={signer}
+                  onChange={(e) => updateSigner(i, e.target.value)}
+                  placeholder="e.g. Microsoft Corporation"
+                  maxLength={255}
+                  data-testid={`pam-signer-group-signer-${i}`}
+                  className={inputClass}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeSigner(i)}
+                  aria-label="Remove signer"
+                  data-testid={`pam-signer-group-remove-signer-${i}`}
+                  className="rounded-md border border-destructive/40 p-2 text-destructive hover:bg-destructive/10"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={addSigner}
+            data-testid="pam-signer-group-add-signer"
+            className="mt-2 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-accent"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add signer
+          </button>
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !name.trim()}
+            data-testid="pam-signer-group-save"
+            className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create group'}
+          </button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/pam/types.ts
+++ b/apps/web/src/components/pam/types.ts
@@ -102,6 +102,7 @@ export interface PamRule {
   enabled: boolean;
   priority: number;
   matchSigner?: string | null;
+  matchSignerGroupId?: string | null;
   matchHash?: string | null;
   matchPathGlob?: string | null;
   matchParentImage?: string | null;
@@ -114,6 +115,21 @@ export interface PamRule {
   timeWindow?: PamTimeWindow | null;
   verdict: PamVerdict;
   approvalDurationMinutes?: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * A reusable, org-scoped catalog of signer (subject CN) patterns. A rule
+ * references one via matchSignerGroupId; the engine matches when the candidate
+ * signer equals ANY member. Mirrors routes/pam.ts signer-group responses.
+ */
+export interface PamSignerGroup {
+  id: string;
+  orgId: string;
+  name: string;
+  description?: string | null;
+  signers: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -131,6 +147,7 @@ export type PamRuleDraft =
       orgId?: string;
       siteId?: string | null;
       matchSigner?: string | null;
+      matchSignerGroupId?: string | null;
       matchHash?: string | null;
       matchPathGlob?: string | null;
       matchParentImage?: string | null;


### PR DESCRIPTION

## What

A reusable **trusted-publisher catalog**: an org maintains a named set of signer (subject CN) patterns once — e.g. a "Trusted Vendors" group with **Intuit Inc.**, **Microsoft Corporation**, **TeamViewer GmbH**, **Adobe Inc.** — and references it from many rules, instead of repeating signers rule-by-rule. This is the scale tool for managing auto-elevation across the many apps that come up frequently.

- **`pam_signer_groups`** (Shape 1 RLS) — `{ name, description, signers: string[] }` per org.
- **`pam_rules.match_signer_group_id`** — reference a group as an alternative to `match_signer`. **Mutually exclusive** with `match_signer` (server rejects both). FK `ON DELETE RESTRICT` so a group in use can't be deleted out from under its rules.
- **Engine:** a rule's signer group matches when the candidate signer equals **any** member (OR within the group; the rule's other criteria still AND). Resolution is **entirely server-side** via a `SignerGroupResolver` map the ingest/preview builds — the engine stays pure. Negation supported (`signerGroup`). **Fails closed** when the group is unresolvable, empty, or the candidate has no signer.
- **Ingest + preview** resolve the referenced groups before evaluating.
- **CRUD** (`/pam/signer-groups`): list / create / update / delete, MFA-gated writes, signer list deduped + trimmed, and a clean **409** when deleting a group still referenced by a rule.
- **UI:** a "Signer Groups" tab to manage groups, and a group selector in the rule modal (mutually exclusive with the Signer field).

## Why server-side only (no agent change)

Verified from `agent/internal/heartbeat/pam_flow.go`: the agent acts on **the server's ingest decision** and never receives the rule list — `buildPamConfigUpdate` resolves only PAM *settings*, not rules. So groups are resolved server-side and the agent never sees them. Zero agent surface.

## Verification (local, green)

- **API** full suite: 9403 passed / 44 skipped, 0 fail. **Web** full suite: 1879 passed, 0 fail.
- `tsc --noEmit` clean (api, cache cleared) + `astro check` 0 errors (web); eslint clean.
- New engine unit tests: group match (any member, case-insensitive), fail-closed (no resolver / empty group / no candidate signer), ANDs with other criteria, negation.
- Migration applies cleanly (234 in sequence) + idempotent; `db:check-drift` → no drift (299 files).
- **Real-Postgres proofs** as the unprivileged `breeze_app` role: signer-group insert in an accessible org **succeeds**, in a non-accessible org is **denied** (`new row violates row-level security policy`); a rule references a group → deleting that group **fails** (`Key is still referenced`), and after removing the rule it **deletes cleanly**.
- Added `pam_signer_groups` to `ORG_CASCADE_DELETE_ORDER` (GDPR cascade).
- No dependency changes.

## Migration

`2026-06-28-pam-signer-groups.sql` — creates the table (Shape 1 RLS) + the nullable `match_signer_group_id` FK (`ON DELETE RESTRICT`). Idempotent.
