### PR TITLE
test(web): fix main-red Test Web — responsive double-render + leaked-mock isolation

### DIFF
--- a/apps/web/src/components/discovery/DiscoveryPage.test.tsx
+++ b/apps/web/src/components/discovery/DiscoveryPage.test.tsx
@@ -313,7 +313,12 @@ describe('DiscoveryPage', () => {
       rerender(<DiscoveryPage />);
 
       // Prompt is gone, the profiles tab mounts, and the org-scoped fetch fires.
-      expect(await screen.findByText('HQ sweep')).toBeInTheDocument();
+      // 'HQ sweep' renders in BOTH the desktop table and the mobile cards
+      // (ResponsiveTable, #1760), so wait for the async render then scope the
+      // assertion to the desktop table — matches the sibling tests in this file
+      // which use findAllByText + desktop(). A bare findByText sees 2 matches.
+      await screen.findAllByText('HQ sweep');
+      expect(desktop().getByText('HQ sweep')).toBeInTheDocument();
       expect(
         screen.queryByText('Select an organization to view network discovery')
       ).not.toBeInTheDocument();

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,6 +25,12 @@ export default defineConfig({
     setupFiles: ['src/__tests__/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     passWithNoTests: true,
+    // Reset mock call history + restore spied implementations between tests so a
+    // stub one test sets (e.g. fetchWithAuth.mockResolvedValue) can't leak into
+    // the next and break it. Without this the suite has order-dependent
+    // cross-file failures whose victim varies by shard ordering.
+    clearMocks: true,
+    restoreMocks: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Fixes `main`'s red **Test Web** (which also reds every open PR). Two independent root causes:

## 1. Deterministic — DiscoveryPage All-Orgs test
`DiscoveryPage.test.tsx:316` (added by #1748) asserts the org-scoped render with `screen.findByText('HQ sweep')`, but the `ResponsiveTable` sweep (#1760) renders each profile name in **both** the desktop table and the mobile cards — so `findByText` matches 2 elements and throws `Found multiple elements`. The sibling tests already handle this (`findAllByText` + the `desktop()` helper); this one was missed. Fix mirrors the file's convention.

## 2. Order-dependent flake — leaked mocks between tests
`apps/web/vitest.config.ts` had no `clearMocks`/`restoreMocks`, so a stub one test set (e.g. `fetchWithAuth.mockResolvedValue`) leaked into the next test. The failure was **order-dependent** — the victim varied by shard ordering (`PamRuleModal`'s preview-result and zod-ordering tests were the usual casualties), which is why it reddened CI intermittently while every test passed in isolation. Added `clearMocks: true` + `restoreMocks: true`.

## Verification
- `DiscoveryPage.test.tsx` isolation: 12/12.
- **Full web suite green across 3 consecutive runs: 248 files / 1963 tests each** — confirms the mock-reset both fixes the leak and breaks nothing that relied on persisted mock state.
- `astro check` clean; eslint clean. No production code changed.
