### PR TITLE
fix(patches): repair Linux OS patch logic

### DIFF
--- a/agent/internal/heartbeat/handlers_patch.go
+++ b/agent/internal/heartbeat/handlers_patch.go
@@ -2,6 +2,7 @@ package heartbeat
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,19 +33,39 @@ func handlePatchScan(h *Heartbeat, cmd Command) tools.CommandResult {
 		log.Error("patch scan failed", "source", source, "error", err.Error())
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
+	if source != "" {
+		pendingItems = filterPatchInventoryItemsBySource(pendingItems, source)
+		installedItems = filterPatchInventoryItemsBySource(installedItems, source)
+	}
+	installedItems = installedPatchStateItems(installedItems)
 
-	h.sendInventoryData("patches", map[string]any{
-		"patches":   pendingItems,
-		"installed": installedItems,
-	}, fmt.Sprintf("patches (%d pending, %d installed)", len(pendingItems), len(installedItems)))
-
-	if err != nil {
-		log.Warn("patch scan completed with warning",
+	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, source, source == "")
+	if pendingErr != nil {
+		err = fmt.Errorf("pending patch inventory send failed: %w", pendingErr)
+		log.Error("patch scan inventory send failed",
 			"source", source,
 			"pendingCount", len(pendingItems),
 			"installedCount", len(installedItems),
 			"error", err.Error(),
 		)
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
+	if err != nil || installedErr != nil {
+		warning := errorString(err)
+		if installedErr != nil {
+			if warning != "" {
+				warning += "; "
+			}
+			warning += "installed patch inventory send failed: " + installedErr.Error()
+		}
+		log.Warn("patch scan completed with warning",
+			"source", source,
+			"pendingCount", len(pendingItems),
+			"installedCount", len(installedItems),
+			"error", warning,
+		)
+		err = errors.New(warning)
 	} else {
 		log.Info("patch scan completed",
 			"source", source,
@@ -58,6 +79,16 @@ func handlePatchScan(h *Heartbeat, cmd Command) tools.CommandResult {
 		"installedCount": len(installedItems),
 		"warning":        errorString(err),
 	}, time.Since(start).Milliseconds())
+}
+
+func filterPatchInventoryItemsBySource(items []map[string]any, source string) []map[string]any {
+	filtered := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if itemSource, ok := item["source"].(string); ok && itemSource == source {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
 }
 
 func handleInstallPatches(h *Heartbeat, cmd Command) tools.CommandResult {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -180,9 +180,9 @@ type Heartbeat struct {
 	// drive SendInput/SetThreadDesktop against the same live consent.exe prompt
 	// concurrently (e.g. an await_remote technician approval firing
 	// actuate_elevation while a re-fired ETW event re-enters RunPamFlow).
-	pamActuateMu sync.Mutex
-	wsDesktopStart   func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
-	desktopOwners    sync.Map // desktop session ID -> helper session ID
+	pamActuateMu   sync.Mutex
+	wsDesktopStart func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
+	desktopOwners  sync.Map // desktop session ID -> helper session ID
 
 	// Resilience & observability
 	pool        *workerpool.Pool
@@ -1059,11 +1059,11 @@ func (h *Heartbeat) authHeader() string {
 }
 
 // sendInventoryData marshals the payload and sends it to the given endpoint via PUT.
-func (h *Heartbeat) sendInventoryData(endpoint string, payload any, label string) {
+func (h *Heartbeat) sendInventoryData(endpoint string, payload any, label string) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		log.Error("failed to marshal inventory", "label", label, "error", err.Error())
-		return
+		return err
 	}
 
 	url := fmt.Sprintf("%s/api/v1/agents/%s/%s", h.config.ServerURL, h.config.AgentID, endpoint)
@@ -1078,15 +1078,17 @@ func (h *Heartbeat) sendInventoryData(endpoint string, payload any, label string
 	resp, err := httputil.Do(ctx, h.httpClient(), "PUT", url, body, headers, h.retryCfg)
 	if err != nil {
 		log.Error("failed to send inventory", "label", label, "error", err.Error())
-		return
+		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		log.Debug("inventory sent", "label", label)
+		return nil
 	} else {
 		log.Warn("inventory send failed", "label", label, "status", resp.StatusCode)
 	}
+	return fmt.Errorf("inventory send failed for %s: status %d", label, resp.StatusCode)
 }
 
 // processSampleTopN is the per-dimension top-N (CPU and RAM); the union is
@@ -1718,16 +1720,61 @@ func (h *Heartbeat) sendPatchInventory() {
 	if err != nil {
 		log.Warn("patch inventory collection warning", "error", err.Error())
 	}
+	installedItems = installedPatchStateItems(installedItems)
 
 	if len(pendingItems) == 0 && len(installedItems) == 0 {
 		log.Debug("no patches found")
 		return
 	}
 
-	h.sendInventoryData("patches", map[string]any{
-		"patches":   pendingItems,
-		"installed": installedItems,
-	}, fmt.Sprintf("patches (%d pending, %d installed)", len(pendingItems), len(installedItems)))
+	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, "", true)
+	if pendingErr != nil {
+		log.Warn("failed to send pending patch inventory", "error", pendingErr.Error())
+	}
+	if installedErr != nil {
+		log.Warn("failed to send installed patch inventory", "error", installedErr.Error())
+	}
+}
+
+func (h *Heartbeat) sendPatchInventoryData(pendingItems, installedItems []map[string]any, source string, full bool) (error, error) {
+	installedItems = installedPatchStateItems(installedItems)
+	pendingPayload := map[string]any{
+		"patches": pendingItems,
+	}
+	if source != "" {
+		pendingPayload["source"] = source
+	} else if full {
+		pendingPayload["full"] = true
+	}
+
+	pendingErr := h.sendInventoryData(
+		"patches/pending",
+		pendingPayload,
+		fmt.Sprintf("pending patches (%d)", len(pendingItems)),
+	)
+	if pendingErr != nil {
+		return pendingErr, nil
+	}
+	if len(installedItems) == 0 {
+		return nil, nil
+	}
+	installedErr := h.sendInventoryData(
+		"patches/installed",
+		map[string]any{"installed": installedItems},
+		fmt.Sprintf("installed patches (%d)", len(installedItems)),
+	)
+	return nil, installedErr
+}
+
+func installedPatchStateItems(items []map[string]any) []map[string]any {
+	filtered := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if source, ok := item["source"].(string); ok && source == "linux" {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
 }
 
 func (h *Heartbeat) collectPatchInventory() ([]map[string]any, []map[string]any, error) {
@@ -1761,6 +1808,7 @@ func (h *Heartbeat) availablePatchesToMaps(patches []patching.AvailablePatch) []
 		if severity == "" {
 			severity = "unknown"
 		}
+		source := h.mapPatchProviderSource(p.Provider)
 		category := p.Category
 		if category == "" {
 			category = h.mapPatchProviderCategory(p.Provider)
@@ -1777,6 +1825,9 @@ func (h *Heartbeat) availablePatchesToMaps(patches []patching.AvailablePatch) []
 		externalId := p.KBNumber
 		if externalId == "" {
 			externalId = p.ID
+			if source == "linux" && p.Version != "" {
+				externalId = p.ID + "@" + p.Version
+			}
 		}
 		items[i] = map[string]any{
 			"name":            p.Title,
@@ -1784,7 +1835,7 @@ func (h *Heartbeat) availablePatchesToMaps(patches []patching.AvailablePatch) []
 			"category":        category,
 			"severity":        severity,
 			"description":     p.Description,
-			"source":          h.mapPatchProviderSource(p.Provider),
+			"source":          source,
 			"externalId":      externalId,
 			"packageId":       p.ID,
 			"vendor":          extractVendor(p.Provider, p.ID),
@@ -3042,6 +3093,7 @@ type patchCommandRef struct {
 	ID         string
 	Source     string
 	ExternalID string
+	PackageID  string
 	Title      string
 }
 
@@ -3065,55 +3117,46 @@ func (h *Heartbeat) executePatchInstallCommand(payload map[string]any, rollback 
 		installID, resolveErr := h.resolvePatchInstallID(ref)
 		if resolveErr != nil {
 			failedCount++
-			results = append(results, map[string]any{
-				"id":     ref.ID,
-				"status": "failed",
-				"error":  resolveErr.Error(),
-			})
+			result := patchCommandResultFields(ref, "")
+			result["status"] = "failed"
+			result["error"] = resolveErr.Error()
+			results = append(results, result)
 			continue
 		}
 
 		if rollback {
 			if err := h.patchMgr.Uninstall(installID); err != nil {
 				failedCount++
-				results = append(results, map[string]any{
-					"id":        ref.ID,
-					"installId": installID,
-					"status":    "failed",
-					"error":     err.Error(),
-				})
+				result := patchCommandResultFields(ref, installID)
+				result["status"] = "failed"
+				result["error"] = err.Error()
+				results = append(results, result)
 				continue
 			}
 			successCount++
-			results = append(results, map[string]any{
-				"id":        ref.ID,
-				"installId": installID,
-				"status":    "rolled_back",
-			})
+			result := patchCommandResultFields(ref, installID)
+			result["status"] = "rolled_back"
+			results = append(results, result)
 			continue
 		}
 
 		installResult, err := h.patchMgr.Install(installID)
 		if err != nil {
 			failedCount++
-			results = append(results, map[string]any{
-				"id":        ref.ID,
-				"installId": installID,
-				"status":    "failed",
-				"error":     err.Error(),
-			})
+			result := patchCommandResultFields(ref, installID)
+			result["status"] = "failed"
+			result["error"] = err.Error()
+			results = append(results, result)
 			continue
 		}
 
 		successCount++
 		rebootRequired = rebootRequired || installResult.RebootRequired
-		results = append(results, map[string]any{
-			"id":             ref.ID,
-			"installId":      installID,
-			"status":         "installed",
-			"rebootRequired": installResult.RebootRequired,
-			"message":        installResult.Message,
-		})
+		result := patchCommandResultFields(ref, installID)
+		result["status"] = "installed"
+		result["rebootRequired"] = installResult.RebootRequired
+		result["message"] = installResult.Message
+		results = append(results, result)
 	}
 
 	summary := map[string]any{
@@ -3162,6 +3205,20 @@ func (h *Heartbeat) executePatchInstallCommand(payload map[string]any, rollback 
 	return tools.NewSuccessResult(summary, durationMs)
 }
 
+func patchCommandResultFields(ref patchCommandRef, installID string) map[string]any {
+	result := map[string]any{
+		"id":         ref.ID,
+		"source":     ref.Source,
+		"externalId": ref.ExternalID,
+		"packageId":  ref.PackageID,
+		"title":      ref.Title,
+	}
+	if installID != "" {
+		result["installId"] = installID
+	}
+	return result
+}
+
 func (h *Heartbeat) patchRefsFromPayload(payload map[string]any) []patchCommandRef {
 	refs := make([]patchCommandRef, 0)
 	seen := map[string]struct{}{}
@@ -3176,6 +3233,7 @@ func (h *Heartbeat) patchRefsFromPayload(payload map[string]any) []patchCommandR
 				ID:         tools.GetPayloadString(obj, "id", tools.GetPayloadString(obj, "patchId", "")),
 				Source:     tools.GetPayloadString(obj, "source", ""),
 				ExternalID: tools.GetPayloadString(obj, "externalId", ""),
+				PackageID:  tools.GetPayloadString(obj, "packageId", ""),
 				Title:      tools.GetPayloadString(obj, "title", ""),
 			}
 			key := fmt.Sprintf("%s|%s|%s", ref.ID, ref.Source, ref.ExternalID)
@@ -3232,6 +3290,9 @@ func (h *Heartbeat) resolvePatchInstallID(ref patchCommandRef) (string, error) {
 			}
 		default:
 			if h.patchMgr.HasProvider(provider) {
+				if (provider == "apt" || provider == "yum") && strings.Contains(local, "@") {
+					return provider + ":" + strings.SplitN(local, "@", 2)[0], nil
+				}
 				return provider + ":" + local, nil
 			}
 		}
@@ -3307,7 +3368,17 @@ func splitPatchID(value string) (string, string, bool) {
 }
 
 func patchLocalID(ref patchCommandRef) string {
+	if _, local, ok := splitPatchID(ref.PackageID); ok {
+		return local
+	}
+	if ref.PackageID != "" {
+		return ref.PackageID
+	}
 	if _, local, ok := splitPatchID(ref.ExternalID); ok {
+		prefix, _, _ := splitPatchID(ref.ExternalID)
+		if (prefix == "apt" || prefix == "yum") && strings.Contains(local, "@") {
+			return strings.SplitN(local, "@", 2)[0]
+		}
 		parts := strings.SplitN(ref.ExternalID, ":", 3)
 		if len(parts) == 3 && isSourcePrefix(parts[0]) && parts[1] != "" {
 			return parts[1]
@@ -3315,6 +3386,10 @@ func patchLocalID(ref patchCommandRef) string {
 		return local
 	}
 	if _, local, ok := splitPatchID(ref.ID); ok {
+		prefix, _, _ := splitPatchID(ref.ID)
+		if (prefix == "apt" || prefix == "yum") && strings.Contains(local, "@") {
+			return strings.SplitN(local, "@", 2)[0]
+		}
 		return local
 	}
 	if ref.ExternalID != "" {

--- a/agent/internal/heartbeat/heartbeat_patch_test.go
+++ b/agent/internal/heartbeat/heartbeat_patch_test.go
@@ -93,6 +93,23 @@ func TestResolvePatchInstallIDMapsLinuxSourceToApt(t *testing.T) {
 	}
 }
 
+func TestResolvePatchInstallIDUsesPackageIDForVersionedLinuxExternalID(t *testing.T) {
+	h := &Heartbeat{patchMgr: patching.NewPatchManager(&heartbeatMockProvider{id: "apt"})}
+
+	installID, err := h.resolvePatchInstallID(patchCommandRef{
+		ID:         "platform-patch-id",
+		Source:     "linux",
+		ExternalID: "apt:openssl@3.0.2-0ubuntu1.20",
+		PackageID:  "apt:openssl",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if installID != "apt:openssl" {
+		t.Fatalf("expected apt:openssl, got %s", installID)
+	}
+}
+
 func TestExecutePatchInstallCommandReportsPartialFailures(t *testing.T) {
 	provider := &heartbeatMockProvider{id: "apt"}
 	h := &Heartbeat{patchMgr: patching.NewPatchManager(provider)}

--- a/agent/internal/heartbeat/heartbeat_patchmap_test.go
+++ b/agent/internal/heartbeat/heartbeat_patchmap_test.go
@@ -94,6 +94,30 @@ func TestAvailablePatchesToMaps_WindowsUpdateKeepsKB(t *testing.T) {
 	}
 }
 
+func TestAvailablePatchesToMaps_LinuxExternalIdIncludesCandidateVersion(t *testing.T) {
+	h := &Heartbeat{}
+	items := h.availablePatchesToMaps([]patching.AvailablePatch{
+		{
+			ID:       "apt:openssl",
+			Provider: "apt",
+			Title:    "openssl",
+			Version:  "3.0.2-0ubuntu1.20",
+		},
+	})
+	if len(items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(items))
+	}
+	if got := items[0]["externalId"]; got != "apt:openssl@3.0.2-0ubuntu1.20" {
+		t.Errorf("externalId = %v, want apt:openssl@3.0.2-0ubuntu1.20", got)
+	}
+	if got := items[0]["packageId"]; got != "apt:openssl" {
+		t.Errorf("packageId = %v, want apt:openssl", got)
+	}
+	if got := items[0]["source"]; got != "linux" {
+		t.Errorf("source = %v, want linux", got)
+	}
+}
+
 func TestInstalledPatchesToMaps_WingetExternalId(t *testing.T) {
 	h := &Heartbeat{}
 	items := h.installedPatchesToMaps([]patching.InstalledPatch{

--- a/agent/internal/heartbeat/patch_inventory_test.go
+++ b/agent/internal/heartbeat/patch_inventory_test.go
@@ -1,0 +1,171 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/httputil"
+)
+
+type patchInventoryRequest struct {
+	path string
+	body []byte
+}
+
+func TestSendPatchInventoryDataSendsPendingThenInstalled(t *testing.T) {
+	var requests []patchInventoryRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		requests = append(requests, patchInventoryRequest{path: r.URL.Path, body: body})
+		if got, want := r.Header.Get("Authorization"), "Bearer token"; got != want {
+			t.Fatalf("Authorization = %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	h := New(&config.Config{AgentID: "agent-1", ServerURL: ts.URL, AuthToken: "token"})
+	h.retryCfg = httputil.RetryConfig{MaxRetries: 0}
+
+	installed := make([]map[string]any, 251)
+	for i := range installed {
+		installed[i] = map[string]any{"name": "KB5000001", "source": "microsoft"}
+	}
+
+	pendingErr, installedErr := h.sendPatchInventoryData(
+		[]map[string]any{{"name": "KB5000001", "source": "microsoft"}},
+		installed,
+		"microsoft",
+		false,
+	)
+	if pendingErr != nil {
+		t.Fatalf("pendingErr = %v", pendingErr)
+	}
+	if installedErr != nil {
+		t.Fatalf("installedErr = %v", installedErr)
+	}
+
+	if len(requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d: %#v", len(requests), requests)
+	}
+	if requests[0].path != "/api/v1/agents/agent-1/patches/pending" {
+		t.Fatalf("pending path = %q", requests[0].path)
+	}
+	var pendingPayload map[string]any
+	if err := json.Unmarshal(requests[0].body, &pendingPayload); err != nil {
+		t.Fatalf("pending JSON error = %v", err)
+	}
+	if pendingPayload["source"] != "microsoft" {
+		t.Fatalf("pending source = %#v", pendingPayload["source"])
+	}
+	if _, ok := pendingPayload["full"]; ok {
+		t.Fatal("targeted pending payload should not include full=true")
+	}
+
+	if requests[1].path != "/api/v1/agents/agent-1/patches/installed" {
+		t.Fatalf("installed path = %q", requests[1].path)
+	}
+
+	var installedPayload struct {
+		Installed []map[string]any `json:"installed"`
+	}
+	if err := json.Unmarshal(requests[1].body, &installedPayload); err != nil {
+		t.Fatalf("installed JSON error = %v", err)
+	}
+	if len(installedPayload.Installed) != len(installed) {
+		t.Fatalf("installed payload size = %d", len(installedPayload.Installed))
+	}
+}
+
+func TestSendPatchInventoryDataSkipsLinuxInstalledPackageInventory(t *testing.T) {
+	var requests []patchInventoryRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		requests = append(requests, patchInventoryRequest{path: r.URL.Path, body: body})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	h := New(&config.Config{AgentID: "agent-1", ServerURL: ts.URL, AuthToken: "token"})
+	h.retryCfg = httputil.RetryConfig{MaxRetries: 0}
+
+	pendingErr, installedErr := h.sendPatchInventoryData(
+		[]map[string]any{{"name": "openssl", "source": "linux"}},
+		[]map[string]any{{"name": "openssl", "source": "linux"}},
+		"linux",
+		false,
+	)
+	if pendingErr != nil {
+		t.Fatalf("pendingErr = %v", pendingErr)
+	}
+	if installedErr != nil {
+		t.Fatalf("installedErr = %v", installedErr)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected only pending request, got %d: %#v", len(requests), requests)
+	}
+	if requests[0].path != "/api/v1/agents/agent-1/patches/pending" {
+		t.Fatalf("path = %q", requests[0].path)
+	}
+}
+
+func TestSendPatchInventoryDataStopsWhenPendingUploadFails(t *testing.T) {
+	var requests []patchInventoryRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		requests = append(requests, patchInventoryRequest{path: r.URL.Path, body: body})
+		http.Error(w, "too large", http.StatusRequestEntityTooLarge)
+	}))
+	defer ts.Close()
+
+	h := New(&config.Config{AgentID: "agent-1", ServerURL: ts.URL, AuthToken: "token"})
+	h.retryCfg = httputil.RetryConfig{MaxRetries: 0}
+
+	pendingErr, installedErr := h.sendPatchInventoryData(
+		[]map[string]any{{"name": "openssl", "source": "linux"}},
+		[]map[string]any{{"name": "pkg", "source": "linux"}},
+		"linux",
+		false,
+	)
+	if pendingErr == nil {
+		t.Fatal("expected pendingErr")
+	}
+	if installedErr != nil {
+		t.Fatalf("installedErr = %v", installedErr)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected only pending request, got %d", len(requests))
+	}
+	if requests[0].path != "/api/v1/agents/agent-1/patches/pending" {
+		t.Fatalf("path = %q", requests[0].path)
+	}
+}
+
+func TestFilterPatchInventoryItemsBySource(t *testing.T) {
+	items := []map[string]any{
+		{"name": "openssl", "source": "linux"},
+		{"name": "Firefox", "source": "third_party"},
+		{"name": "unknown"},
+	}
+
+	filtered := filterPatchInventoryItemsBySource(items, "linux")
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 linux item, got %d", len(filtered))
+	}
+	if filtered[0]["name"] != "openssl" {
+		t.Fatalf("filtered item = %#v", filtered[0])
+	}
+}

--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -144,7 +144,6 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   'routes/agents/inventory.ts:PUT /:id/network',
   'routes/agents/inventory.ts:PUT /:id/software',
   'routes/agents/inventory.ts:PUT /:id/warranty-info',
-  'routes/agents/patches.ts:PUT /:id/patches',
   'routes/agents/sessions.ts:PUT /:id/sessions',
   'routes/agents/state.ts:PUT /:id/config-state',
   'routes/agents/state.ts:PUT /:id/registry-state',

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -46,14 +46,21 @@ const tables = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('drizzle-orm', () => ({
-  eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
-  and: (...conds: unknown[]) => ({ op: 'and', conds }),
-  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+const sqlMock = vi.hoisted(() => Object.assign(
+  (strings: TemplateStringsArray, ...values: unknown[]) => ({
     op: 'sql',
     strings: Array.from(strings),
     values,
   }),
+  {
+    join: (items: unknown[], separator: unknown) => ({ op: 'sql.join', items, separator }),
+  },
+));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
+  and: (...conds: unknown[]) => ({ op: 'and', conds }),
+  sql: sqlMock,
 }));
 
 vi.mock('../../db', () => ({
@@ -110,6 +117,61 @@ function selectRows(rows: unknown[]) {
   return Object.assign(Promise.resolve(rows), {
     limit: vi.fn().mockResolvedValue(rows),
   });
+}
+
+function mountAgentPatchRoutes(role: 'agent' | 'watchdog' = 'agent') {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('agent', {
+      deviceId: DEVICE_ID,
+      agentId: AGENT_ID,
+      orgId: ORG_ID,
+      siteId: 'site-1',
+      role,
+    } as never);
+    return next();
+  });
+  app.route('/agents', patchesRoutes);
+  return app;
+}
+
+function mockDeviceLookup(osType = 'linux') {
+  vi.mocked(db.select).mockImplementation(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => selectRows([
+        { id: DEVICE_ID, agentId: AGENT_ID, orgId: ORG_ID, osType },
+      ])),
+    })),
+  }) as never);
+}
+
+function mockPatchInsertTx() {
+  const insertedRows: Array<Record<string, unknown>> = [];
+  const tx = {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue(undefined),
+      })),
+    })),
+    insert: vi.fn((table) => ({
+      values: vi.fn((values) => ({
+        onConflictDoUpdate: vi.fn(() => {
+          if (table === patches) {
+            const row = { id: PATCH_ID, ...values };
+            insertedRows.push(row);
+            return {
+              returning: vi.fn().mockResolvedValue([row]),
+            };
+          }
+
+          return {
+            returning: vi.fn().mockResolvedValue([]),
+          };
+        }),
+      })),
+    })),
+  };
+  return { tx, insertedRows };
 }
 
 describe('PUT /agents/:id/patches - third-party fields', () => {
@@ -404,6 +466,126 @@ describe('PUT /agents/:id/patches - ENABLE_AI_PATCH_TESTING gating', () => {
       catalogId: 'cat-1',
       version: '121.0',
     });
+  });
+});
+
+describe('split patch ingest endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeviceLookup('linux');
+    vi.mocked(enrichmentModule.enrichFromCatalog).mockImplementation(async (input) => ({
+      title: input.title,
+      vendor: input.vendor,
+      severity: (input.severity as 'critical' | 'important' | 'moderate' | 'low' | 'unknown' | null) ?? null,
+      category: input.category ?? null,
+      matchedCatalogId: null,
+    }));
+  });
+
+  it('marks only pending rows missing for the submitted pending source', async () => {
+    const { tx } = mockPatchInsertTx();
+    let updateWhere: unknown;
+    tx.update = vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn((condition) => {
+          updateWhere = condition;
+          return Promise.resolve(undefined);
+        }),
+      })),
+    }));
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/pending`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: 'linux',
+        patches: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, pending: 0 });
+    expect(tx.update).toHaveBeenCalledWith(tables.devicePatches);
+    expect(tx.insert).not.toHaveBeenCalled();
+
+    const conditions = (updateWhere as { conds?: unknown[] }).conds ?? [];
+    expect(conditions).toContainEqual({ op: 'eq', left: tables.devicePatches.deviceId, right: DEVICE_ID });
+    expect(conditions).toContainEqual({ op: 'eq', left: tables.devicePatches.status, right: 'pending' });
+    expect(JSON.stringify(updateWhere)).toContain('linux');
+  });
+
+  it('does not tombstone pending rows for an empty partial pending payload', async () => {
+    const { tx } = mockPatchInsertTx();
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/pending`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        patches: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, pending: 0 });
+    expect(tx.update).not.toHaveBeenCalled();
+    expect(tx.insert).not.toHaveBeenCalled();
+  });
+
+  it('upserts non-Linux installed patch batches without tombstoning pending rows', async () => {
+    const { tx } = mockPatchInsertTx();
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/installed`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        installed: [
+          {
+            name: 'Security Intelligence Update',
+            source: 'microsoft',
+            packageId: 'KB5000001',
+            version: '1.2.3',
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, installed: 1, ignored: 0 });
+    expect(tx.update).not.toHaveBeenCalled();
+    expect(tx.insert).toHaveBeenCalledWith(tables.patches);
+    expect(tx.insert).toHaveBeenCalledWith(tables.devicePatches);
+  });
+
+  it('ignores Linux installed package inventory without touching patch state', async () => {
+    const { tx } = mockPatchInsertTx();
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/installed`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        installed: [
+          {
+            name: 'openssl',
+            source: 'linux',
+            packageId: 'apt:openssl',
+            version: '3.0.2-0ubuntu1.20',
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, installed: 0, ignored: 1 });
+    expect(tx.update).not.toHaveBeenCalled();
+    expect(tx.insert).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -589,29 +589,34 @@ describe('split patch ingest endpoints', () => {
   });
 });
 
-describe('PUT /agents/:id/patches - requireAgentRole gate (F3)', () => {
+const patchIngestEndpoints = [
+  {
+    label: 'legacy combined patch ingest',
+    path: `/agents/${AGENT_ID}/patches`,
+    body: { patches: [] },
+  },
+  {
+    label: 'pending patch ingest',
+    path: `/agents/${AGENT_ID}/patches/pending`,
+    body: { patches: [] },
+  },
+  {
+    label: 'installed patch ingest',
+    path: `/agents/${AGENT_ID}/patches/installed`,
+    body: { installed: [] },
+  },
+] as const;
+
+describe('agent patch ingest - requireAgentRole gate (F3)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('rejects a watchdog-role token with 403 and does not touch the DB', async () => {
-    const app = new Hono();
-    app.use('*', async (c, next) => {
-      c.set('agent', {
-        deviceId: DEVICE_ID,
-        agentId: AGENT_ID,
-        orgId: ORG_ID,
-        siteId: 'site-1',
-        role: 'watchdog',
-      } as never);
-      return next();
-    });
-    app.route('/agents', patchesRoutes);
-
-    const res = await app.request(`/agents/${AGENT_ID}/patches`, {
+  it.each(patchIngestEndpoints)('rejects a watchdog-role token on $label with 403 and does not touch the DB', async ({ path, body }) => {
+    const res = await mountAgentPatchRoutes('watchdog').request(path, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ patches: [] }),
+      body: JSON.stringify(body),
     });
 
     expect(res.status).toBe(403);
@@ -619,14 +624,14 @@ describe('PUT /agents/:id/patches - requireAgentRole gate (F3)', () => {
     expect(db.transaction).not.toHaveBeenCalled();
   });
 
-  it('rejects when no agent credential is present (missing context)', async () => {
+  it.each(patchIngestEndpoints)('rejects $label when no agent credential is present', async ({ path, body }) => {
     const app = new Hono();
     app.route('/agents', patchesRoutes);
 
-    const res = await app.request(`/agents/${AGENT_ID}/patches`, {
+    const res = await app.request(path, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ patches: [] }),
+      body: JSON.stringify(body),
     });
 
     expect(res.status).toBe(403);

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 import { and, eq, sql } from 'drizzle-orm';
 import { db, type Database } from '../../db';
@@ -6,9 +7,14 @@ import { devices, patches, devicePatches } from '../../db/schema';
 import { enqueueWingetReleaseTest } from '../../jobs/wingetReleaseTestWorker';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { enrichFromCatalog } from '../../services/thirdPartyEnrichment';
-import { submitPatchesSchema } from './schemas';
+import { submitInstalledPatchesSchema, submitPatchesSchema, submitPendingPatchesSchema } from './schemas';
 import { inferPatchOsType, parseDate, sanitizeDate } from './helpers';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
+
+type PendingPatchData = z.infer<typeof submitPendingPatchesSchema>['patches'][number];
+type InstalledPatchData = z.infer<typeof submitInstalledPatchesSchema>['installed'][number];
+type PatchIngestDevice = { id: string; orgId: string; osType: string | null };
+type PatchIngestExecutor = Pick<Database, 'insert' | 'update'>;
 
 // Derive vendor from package id; ignore agent-supplied vendor for winget-style ids.
 function deriveVendor(packageId: string | null | undefined, fallback: string | null | undefined): string | null {
@@ -16,6 +22,244 @@ function deriveVendor(packageId: string | null | undefined, fallback: string | n
     return packageId.split('.')[0] ?? fallback ?? null;
   }
   return fallback ?? null;
+}
+
+async function getDeviceForPatchIngest(agentId: string): Promise<PatchIngestDevice | null> {
+  const [device] = await db
+    .select()
+    .from(devices)
+    .where(eq(devices.agentId, agentId))
+    .limit(1);
+
+  if (!device) {
+    return null;
+  }
+
+  return {
+    id: device.id,
+    orgId: device.orgId,
+    osType: device.osType ?? null,
+  };
+}
+
+function uniqueSourcesFromPendingPatches(patchList: PendingPatchData[]): string[] {
+  return [...new Set(patchList.map((patch) => patch.source))];
+}
+
+async function markAllDevicePatchesMissing(executor: PatchIngestExecutor, deviceId: string): Promise<void> {
+  await executor
+    .update(devicePatches)
+    .set({ status: 'missing', lastCheckedAt: new Date() })
+    .where(eq(devicePatches.deviceId, deviceId));
+}
+
+async function markPendingDevicePatchesMissing(
+  executor: PatchIngestExecutor,
+  deviceId: string,
+  sources: string[],
+): Promise<void> {
+  const conditions = [
+    eq(devicePatches.deviceId, deviceId),
+    eq(devicePatches.status, 'pending'),
+  ];
+
+  if (sources.length > 0) {
+    conditions.push(sql`${devicePatches.patchId} IN (
+      SELECT ${patches.id}
+      FROM ${patches}
+      WHERE ${patches.source} IN (${sql.join(sources.map((source) => sql`${source}`), sql`, `)})
+    )`);
+  }
+
+  await executor
+    .update(devicePatches)
+    .set({ status: 'missing', lastCheckedAt: new Date() })
+    .where(and(...conditions));
+}
+
+async function upsertPendingPatches(
+  executor: PatchIngestExecutor,
+  device: PatchIngestDevice,
+  patchList: PendingPatchData[],
+): Promise<void> {
+  for (const patchData of patchList) {
+    const externalId = patchData.externalId ||
+      patchData.kbNumber ||
+      `${patchData.source}:${patchData.name}:${patchData.version || 'latest'}`;
+    const inferredOsType = inferPatchOsType(patchData.source, device.osType);
+    const derivedVendor = deriveVendor(patchData.packageId, patchData.vendor);
+    const enriched = await enrichFromCatalog({
+      source: patchData.source,
+      packageId: patchData.packageId ?? null,
+      title: patchData.name,
+      vendor: derivedVendor,
+      severity: patchData.severity ?? null,
+      category: patchData.category ?? null,
+    });
+
+    const [patch] = await executor
+      .insert(patches)
+      .values({
+        source: patchData.source,
+        externalId: externalId,
+        title: enriched.title,
+        description: patchData.description || null,
+        severity: enriched.severity ?? 'unknown',
+        category: enriched.category,
+        releaseDate: sanitizeDate(patchData.releaseDate),
+        requiresReboot: patchData.requiresRestart || false,
+        downloadSizeMb: patchData.size ? Math.ceil(patchData.size / (1024 * 1024)) : null,
+        vendor: enriched.vendor,
+        packageId: patchData.packageId ?? null,
+        version: patchData.version ?? null,
+        ...(inferredOsType ? { osTypes: [inferredOsType] } : {})
+      })
+      .onConflictDoUpdate({
+        target: [patches.source, patches.externalId],
+        set: {
+          title: enriched.title,
+          description: patchData.description || null,
+          severity: enriched.severity ?? 'unknown',
+          category: enriched.category,
+          requiresReboot: patchData.requiresRestart || false,
+          vendor: enriched.vendor ?? sql`${patches.vendor}`,
+          packageId: patchData.packageId ?? sql`${patches.packageId}`,
+          version: patchData.version ?? sql`${patches.version}`,
+          ...(inferredOsType
+            ? {
+                osTypes: sql`CASE
+                  WHEN ${inferredOsType} = ANY(COALESCE(${patches.osTypes}, ARRAY[]::text[]))
+                  THEN COALESCE(${patches.osTypes}, ARRAY[]::text[])
+                  ELSE COALESCE(${patches.osTypes}, ARRAY[]::text[]) || ARRAY[${inferredOsType}]::text[]
+                END`
+              }
+            : {}),
+          updatedAt: new Date()
+        }
+      })
+      .returning();
+
+    if (!patch) {
+      continue;
+    }
+
+    if (
+      enriched.matchedCatalogId &&
+      patchData.version &&
+      process.env.ENABLE_AI_PATCH_TESTING === '1'
+    ) {
+      // Fire-and-forget - don't block the patch submit on test queueing.
+      enqueueWingetReleaseTest({
+        catalogId: enriched.matchedCatalogId,
+        version: patchData.version,
+      }).catch((err) => {
+        console.error('[ReleaseTest] enqueue failed', err);
+      });
+    }
+
+    await executor
+      .insert(devicePatches)
+      .values({
+        deviceId: device.id,
+        orgId: device.orgId,
+        patchId: patch.id,
+        status: 'pending',
+        lastCheckedAt: new Date()
+      })
+      .onConflictDoUpdate({
+        target: [devicePatches.deviceId, devicePatches.patchId],
+        set: {
+          status: 'pending',
+          lastCheckedAt: new Date(),
+          updatedAt: new Date()
+        }
+      });
+  }
+}
+
+async function upsertInstalledPatches(
+  executor: PatchIngestExecutor,
+  device: PatchIngestDevice,
+  patchList: InstalledPatchData[],
+): Promise<number> {
+  let processed = 0;
+  for (const patchData of patchList) {
+    // Linux package-manager inventories are owned by software_inventory. They
+    // are not installed patch/update records and must not be allowed to flip
+    // actionable Linux update rows from pending to installed.
+    if (patchData.source === 'linux') {
+      continue;
+    }
+
+    const externalId = patchData.externalId ||
+      patchData.kbNumber ||
+      `${patchData.source}:${patchData.name}:${patchData.version || 'latest'}`;
+    const inferredOsType = inferPatchOsType(patchData.source, device.osType);
+
+    const [patch] = await executor
+      .insert(patches)
+      .values({
+        source: patchData.source,
+        externalId: externalId,
+        title: patchData.name,
+        severity: 'unknown',
+        category: patchData.category || null,
+        vendor: deriveVendor(patchData.packageId, patchData.vendor),
+        packageId: patchData.packageId ?? null,
+        version: patchData.version ?? null,
+        ...(inferredOsType ? { osTypes: [inferredOsType] } : {})
+      })
+      .onConflictDoUpdate({
+        target: [patches.source, patches.externalId],
+        set: {
+          title: patchData.name,
+          category: patchData.category || null,
+          vendor: deriveVendor(patchData.packageId, patchData.vendor) ?? sql`${patches.vendor}`,
+          packageId: patchData.packageId ?? sql`${patches.packageId}`,
+          version: patchData.version ?? sql`${patches.version}`,
+          ...(inferredOsType
+            ? {
+                osTypes: sql`CASE
+                  WHEN ${inferredOsType} = ANY(COALESCE(${patches.osTypes}, ARRAY[]::text[]))
+                  THEN COALESCE(${patches.osTypes}, ARRAY[]::text[])
+                  ELSE COALESCE(${patches.osTypes}, ARRAY[]::text[]) || ARRAY[${inferredOsType}]::text[]
+                END`
+              }
+            : {}),
+          updatedAt: new Date()
+        }
+      })
+      .returning();
+
+    if (!patch) {
+      continue;
+    }
+
+    const installedAt = parseDate(patchData.installedAt);
+    await executor
+      .insert(devicePatches)
+      .values({
+        deviceId: device.id,
+        orgId: device.orgId,
+        patchId: patch.id,
+        status: 'installed',
+        installedAt: installedAt,
+        installedVersion: patchData.version || null,
+        lastCheckedAt: new Date()
+      })
+      .onConflictDoUpdate({
+        target: [devicePatches.deviceId, devicePatches.patchId],
+        set: {
+          status: 'installed',
+          installedAt: installedAt,
+          installedVersion: patchData.version || null,
+          lastCheckedAt: new Date(),
+          updatedAt: new Date()
+        }
+      });
+    processed++;
+  }
+  return processed;
 }
 
 /**
@@ -55,189 +299,96 @@ export const patchesRoutes = new Hono();
 // tokens so a weaker credential can't falsify operator-facing patch posture (F3).
 patchesRoutes.use('*', requireAgentRole);
 
-patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async (c) => {
+patchesRoutes.put('/:id/patches/pending', zValidator('json', submitPendingPatchesSchema), async (c) => {
   const agentId = c.req.param('id');
   const data = c.req.valid('json');
   const agent = c.get('agent') as { orgId?: string; agentId?: string } | undefined;
-  const installedCount = data.installed?.length || 0;
-  console.log(`[PATCHES] Agent ${agentId} submitting ${data.patches.length} pending, ${installedCount} installed`);
+  console.log(`[PATCHES] Agent ${agentId} submitting ${data.patches.length} pending`);
 
-  const [device] = await db
-    .select()
-    .from(devices)
-    .where(eq(devices.agentId, agentId))
-    .limit(1);
-
+  const device = await getDeviceForPatchIngest(agentId);
   if (!device) {
     return c.json({ error: 'Device not found' }, 404);
   }
 
+  const sources = data.source ? [data.source] : uniqueSourcesFromPendingPatches(data.patches);
+
   await db.transaction(async (tx) => {
-    await tx
-      .update(devicePatches)
-      .set({ status: 'missing', lastCheckedAt: new Date() })
-      .where(eq(devicePatches.deviceId, device.id));
-
-    for (const patchData of data.patches) {
-      const externalId = patchData.externalId ||
-        patchData.kbNumber ||
-        `${patchData.source}:${patchData.name}:${patchData.version || 'latest'}`;
-      const inferredOsType = inferPatchOsType(patchData.source, device.osType);
-      const derivedVendor = deriveVendor(patchData.packageId, patchData.vendor);
-      const enriched = await enrichFromCatalog({
-        source: patchData.source,
-        packageId: patchData.packageId ?? null,
-        title: patchData.name,
-        vendor: derivedVendor,
-        severity: patchData.severity ?? null,
-        category: patchData.category ?? null,
-      });
-
-      const [patch] = await tx
-        .insert(patches)
-        .values({
-          source: patchData.source,
-          externalId: externalId,
-          title: enriched.title,
-          description: patchData.description || null,
-          severity: enriched.severity ?? 'unknown',
-          category: enriched.category,
-          releaseDate: sanitizeDate(patchData.releaseDate),
-          requiresReboot: patchData.requiresRestart || false,
-          downloadSizeMb: patchData.size ? Math.ceil(patchData.size / (1024 * 1024)) : null,
-          vendor: enriched.vendor,
-          packageId: patchData.packageId ?? null,
-          version: patchData.version ?? null,
-          ...(inferredOsType ? { osTypes: [inferredOsType] } : {})
-        })
-        .onConflictDoUpdate({
-          target: [patches.source, patches.externalId],
-          set: {
-            title: enriched.title,
-            description: patchData.description || null,
-            severity: enriched.severity ?? 'unknown',
-            category: enriched.category,
-            requiresReboot: patchData.requiresRestart || false,
-            vendor: enriched.vendor ?? sql`${patches.vendor}`,
-            packageId: patchData.packageId ?? sql`${patches.packageId}`,
-            version: patchData.version ?? sql`${patches.version}`,
-            ...(inferredOsType
-              ? {
-                  osTypes: sql`CASE
-                    WHEN ${inferredOsType} = ANY(COALESCE(${patches.osTypes}, ARRAY[]::text[]))
-                    THEN COALESCE(${patches.osTypes}, ARRAY[]::text[])
-                    ELSE COALESCE(${patches.osTypes}, ARRAY[]::text[]) || ARRAY[${inferredOsType}]::text[]
-                  END`
-                }
-              : {}),
-            updatedAt: new Date()
-          }
-        })
-        .returning();
-
-      if (patch) {
-        if (
-          enriched.matchedCatalogId &&
-          patchData.version &&
-          process.env.ENABLE_AI_PATCH_TESTING === '1'
-        ) {
-          // Fire-and-forget - don't block the patch submit on test queueing.
-          enqueueWingetReleaseTest({
-            catalogId: enriched.matchedCatalogId,
-            version: patchData.version,
-          }).catch((err) => {
-            console.error('[ReleaseTest] enqueue failed', err);
-          });
-        }
-
-        await tx
-          .insert(devicePatches)
-          .values({
-            deviceId: device.id,
-            orgId: device.orgId,
-            patchId: patch.id,
-            status: 'pending',
-            lastCheckedAt: new Date()
-          })
-          .onConflictDoUpdate({
-            target: [devicePatches.deviceId, devicePatches.patchId],
-            set: {
-              status: 'pending',
-              lastCheckedAt: new Date(),
-              updatedAt: new Date()
-            }
-          });
-      }
+    if (data.full) {
+      await markPendingDevicePatchesMissing(tx, device.id, []);
+    } else if (sources.length > 0) {
+      await markPendingDevicePatchesMissing(tx, device.id, sources);
     }
+    await upsertPendingPatches(tx, device, data.patches);
+  });
 
-    if (data.installed && data.installed.length > 0) {
-      for (const patchData of data.installed) {
-        const externalId = patchData.externalId ||
-          patchData.kbNumber ||
-          `${patchData.source}:${patchData.name}:${patchData.version || 'latest'}`;
-        const inferredOsType = inferPatchOsType(patchData.source, device.osType);
+  await pruneStaleTombstones(db, device.id, device.orgId);
 
-        const [patch] = await tx
-          .insert(patches)
-          .values({
-            source: patchData.source,
-            externalId: externalId,
-            title: patchData.name,
-            severity: 'unknown',
-            category: patchData.category || null,
-            vendor: deriveVendor(patchData.packageId, patchData.vendor),
-            packageId: patchData.packageId ?? null,
-            version: patchData.version ?? null,
-            ...(inferredOsType ? { osTypes: [inferredOsType] } : {})
-          })
-          .onConflictDoUpdate({
-            target: [patches.source, patches.externalId],
-            set: {
-              title: patchData.name,
-              category: patchData.category || null,
-              vendor: deriveVendor(patchData.packageId, patchData.vendor) ?? sql`${patches.vendor}`,
-              packageId: patchData.packageId ?? sql`${patches.packageId}`,
-              version: patchData.version ?? sql`${patches.version}`,
-              ...(inferredOsType
-                ? {
-                    osTypes: sql`CASE
-                      WHEN ${inferredOsType} = ANY(COALESCE(${patches.osTypes}, ARRAY[]::text[]))
-                      THEN COALESCE(${patches.osTypes}, ARRAY[]::text[])
-                      ELSE COALESCE(${patches.osTypes}, ARRAY[]::text[]) || ARRAY[${inferredOsType}]::text[]
-                    END`
-                  }
-                : {}),
-              updatedAt: new Date()
-            }
-          })
-          .returning();
+  writeAuditEvent(c, {
+    orgId: agent?.orgId ?? device.orgId,
+    actorType: 'agent',
+    actorId: agent?.agentId ?? agentId,
+    action: 'agent.patches.pending.submit',
+    resourceType: 'device',
+    resourceId: device.id,
+    details: {
+      pendingCount: data.patches.length,
+      source: data.source ?? null,
+      full: data.full,
+    },
+  });
 
-        if (patch) {
-          const installedAt = parseDate(patchData.installedAt);
-          await tx
-            .insert(devicePatches)
-            .values({
-              deviceId: device.id,
-              orgId: device.orgId,
-              patchId: patch.id,
-              status: 'installed',
-              installedAt: installedAt,
-              installedVersion: patchData.version || null,
-              lastCheckedAt: new Date()
-            })
-            .onConflictDoUpdate({
-              target: [devicePatches.deviceId, devicePatches.patchId],
-              set: {
-                status: 'installed',
-                installedAt: installedAt,
-                installedVersion: patchData.version || null,
-                lastCheckedAt: new Date(),
-                updatedAt: new Date()
-              }
-            });
-        }
-      }
-    }
+  return c.json({ success: true, pending: data.patches.length });
+});
+
+patchesRoutes.put('/:id/patches/installed', zValidator('json', submitInstalledPatchesSchema), async (c) => {
+  const agentId = c.req.param('id');
+  const data = c.req.valid('json');
+  const agent = c.get('agent') as { orgId?: string; agentId?: string } | undefined;
+  console.log(`[PATCHES] Agent ${agentId} submitting ${data.installed.length} installed`);
+
+  const device = await getDeviceForPatchIngest(agentId);
+  if (!device) {
+    return c.json({ error: 'Device not found' }, 404);
+  }
+
+  let installedCount = 0;
+  await db.transaction(async (tx) => {
+    installedCount = await upsertInstalledPatches(tx, device, data.installed);
+  });
+
+  writeAuditEvent(c, {
+    orgId: agent?.orgId ?? device.orgId,
+    actorType: 'agent',
+    actorId: agent?.agentId ?? agentId,
+    action: 'agent.patches.installed.submit',
+    resourceType: 'device',
+    resourceId: device.id,
+    details: {
+      installedCount,
+      ignoredLinuxPackageCount: data.installed.length - installedCount,
+    },
+  });
+
+  return c.json({ success: true, installed: installedCount, ignored: data.installed.length - installedCount });
+});
+
+patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async (c) => {
+  const agentId = c.req.param('id');
+  const data = c.req.valid('json');
+  const agent = c.get('agent') as { orgId?: string; agentId?: string } | undefined;
+  const submittedInstalledCount = data.installed?.length || 0;
+  console.log(`[PATCHES] Agent ${agentId} submitting ${data.patches.length} pending, ${submittedInstalledCount} installed`);
+
+  const device = await getDeviceForPatchIngest(agentId);
+  if (!device) {
+    return c.json({ error: 'Device not found' }, 404);
+  }
+
+  let installedCount = 0;
+  await db.transaction(async (tx) => {
+    await markAllDevicePatchesMissing(tx, device.id);
+    await upsertPendingPatches(tx, device, data.patches);
+    installedCount = await upsertInstalledPatches(tx, device, data.installed ?? []);
   });
 
   // Prune stale tombstones after the scan commits. Outside the txn on purpose:
@@ -255,8 +406,14 @@ patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async
     details: {
       pendingCount: data.patches.length,
       installedCount,
+      ignoredLinuxPackageCount: submittedInstalledCount - installedCount,
     },
   });
 
-  return c.json({ success: true, pending: data.patches.length, installed: installedCount });
+  return c.json({
+    success: true,
+    pending: data.patches.length,
+    installed: installedCount,
+    ignored: submittedInstalledCount - installedCount
+  });
 });

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -495,34 +495,50 @@ export const submitSessionsSchema = z.object({
 // Patches
 // ============================================
 
+const patchSourceSchema = z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom']);
+
+const pendingPatchSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().optional(),
+  currentVersion: z.string().optional(),
+  packageId: z.string().max(256).optional(),
+  vendor: z.string().max(255).optional(),
+  kbNumber: z.string().optional(),
+  externalId: z.string().optional(),
+  category: z.string().optional(),
+  severity: z.enum(['critical', 'important', 'moderate', 'low', 'unknown']).optional(),
+  size: z.number().int().optional(),
+  requiresRestart: z.boolean().optional(),
+  releaseDate: z.string().optional(),
+  description: z.string().optional(),
+  source: patchSourceSchema.default('custom')
+});
+
+const installedPatchSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().optional(),
+  packageId: z.string().max(256).optional(),
+  vendor: z.string().max(255).optional(),
+  kbNumber: z.string().optional(),
+  externalId: z.string().optional(),
+  category: z.string().optional(),
+  source: patchSourceSchema.default('custom'),
+  installedAt: z.string().optional()
+});
+
+export const submitPendingPatchesSchema = z.object({
+  patches: z.array(pendingPatchSchema).max(5000),
+  source: patchSourceSchema.optional(),
+  full: z.boolean().optional().default(false)
+});
+
+export const submitInstalledPatchesSchema = z.object({
+  installed: z.array(installedPatchSchema).max(5000)
+});
+
 export const submitPatchesSchema = z.object({
-  patches: z.array(z.object({
-    name: z.string().min(1),
-    version: z.string().optional(),
-    currentVersion: z.string().optional(),
-    packageId: z.string().max(256).optional(),
-    vendor: z.string().max(255).optional(),
-    kbNumber: z.string().optional(),
-    externalId: z.string().optional(),
-    category: z.string().optional(),
-    severity: z.enum(['critical', 'important', 'moderate', 'low', 'unknown']).optional(),
-    size: z.number().int().optional(),
-    requiresRestart: z.boolean().optional(),
-    releaseDate: z.string().optional(),
-    description: z.string().optional(),
-    source: z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom']).default('custom')
-  })).max(5000),
-  installed: z.array(z.object({
-    name: z.string().min(1),
-    version: z.string().optional(),
-    packageId: z.string().max(256).optional(),
-    vendor: z.string().max(255).optional(),
-    kbNumber: z.string().optional(),
-    externalId: z.string().optional(),
-    category: z.string().optional(),
-    source: z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom']).default('custom'),
-    installedAt: z.string().optional()
-  })).max(5000).optional()
+  patches: z.array(pendingPatchSchema).max(5000),
+  installed: z.array(installedPatchSchema).max(5000).optional()
 });
 
 // ============================================

--- a/apps/api/src/routes/devices/patches.test.ts
+++ b/apps/api/src/routes/devices/patches.test.ts
@@ -10,8 +10,10 @@ const USER_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 vi.mock('drizzle-orm', () => ({
   and: (...conditions: unknown[]) => ({ op: 'and', conditions }),
   eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
+  gte: (left: unknown, right: unknown) => ({ op: 'gte', left, right }),
   inArray: (left: unknown, right: unknown) => ({ op: 'inArray', left, right }),
-  desc: (value: unknown) => ({ op: 'desc', value })
+  desc: (value: unknown) => ({ op: 'desc', value }),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ op: 'sql', strings, values })
 }));
 
 vi.mock('../../db', () => ({
@@ -30,6 +32,7 @@ vi.mock('../../db/schema', () => ({
     id: 'patches.id',
     source: 'patches.source',
     externalId: 'patches.externalId',
+    packageId: 'patches.packageId',
     title: 'patches.title',
     description: 'patches.description',
     severity: 'patches.severity',
@@ -51,6 +54,21 @@ vi.mock('../../db/schema', () => ({
     partnerId: 'patchApprovals.partnerId',
     patchId: 'patchApprovals.patchId',
     status: 'patchApprovals.status'
+  },
+  deviceCommands: {
+    id: 'deviceCommands.id',
+    deviceId: 'deviceCommands.deviceId',
+    type: 'deviceCommands.type',
+    payload: 'deviceCommands.payload',
+    status: 'deviceCommands.status',
+    createdAt: 'deviceCommands.createdAt',
+    completedAt: 'deviceCommands.completedAt',
+    result: 'deviceCommands.result',
+    createdBy: 'deviceCommands.createdBy'
+  },
+  users: {
+    id: 'users.id',
+    email: 'users.email'
   }
 }));
 
@@ -121,6 +139,34 @@ function selectWhereLimitResult(rows: unknown[]) {
   };
 }
 
+function selectWhereOrderLimitResult(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows)
+        })
+      })
+    })
+  };
+}
+
+function selectPatchHistoryRowsResult(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue(rows)
+            })
+          })
+        })
+      })
+    })
+  };
+}
+
 describe('device patch routes', () => {
   let app: Hono;
 
@@ -186,6 +232,13 @@ describe('device patch routes', () => {
         requiresReboot: false
       }
       ]) as any)
+      .mockReturnValueOnce(selectWhereOrderLimitResult([
+        {
+          status: 'completed',
+          createdAt: '2026-02-09T09:59:00.000Z',
+          completedAt: '2026-02-09T10:00:00.000Z'
+        }
+      ]) as any)
       .mockReturnValueOnce(selectWhereResult([
         { patchId: '11111111-1111-4111-8111-111111111111' }
       ]) as any);
@@ -211,13 +264,151 @@ describe('device patch routes', () => {
 
     expect(body.data.installed).toHaveLength(1);
     expect(body.data.compliancePercent).toBe(50);
+    expect(body.data.lastPatchScanAt).toBe('2026-02-09T10:00:00.000Z');
+    expect(body.data.lastPatchScanStatus).toBe('completed');
+  });
+
+  it('excludes Linux installed package inventory from patch compliance', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchStatusResult([
+        {
+          id: 'dp-linux-pending',
+          patchId: '11111111-1111-4111-8111-111111111111',
+          status: 'pending',
+          installedAt: null,
+          lastCheckedAt: '2026-02-09T10:00:00.000Z',
+          failureCount: 0,
+          lastError: null,
+          externalId: 'apt:openssl@3.0.2-0ubuntu1.20',
+          packageId: 'apt:openssl',
+          title: 'openssl',
+          description: null,
+          severity: 'unknown',
+          category: 'system',
+          source: 'linux',
+          releaseDate: null,
+          requiresReboot: false
+        },
+        {
+          id: 'dp-linux-installed',
+          patchId: '22222222-2222-4222-8222-222222222222',
+          status: 'installed',
+          installedAt: null,
+          lastCheckedAt: '2026-02-09T10:00:00.000Z',
+          failureCount: 0,
+          lastError: null,
+          externalId: 'apt:zlib1g',
+          packageId: 'apt:zlib1g',
+          title: 'zlib1g',
+          description: null,
+          severity: 'unknown',
+          category: 'system',
+          source: 'linux',
+          releaseDate: null,
+          requiresReboot: false
+        }
+      ]) as any)
+      .mockReturnValueOnce(selectWhereOrderLimitResult([]) as any)
+      .mockReturnValueOnce(selectWhereResult([]) as any);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/patches`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.data.pending).toHaveLength(1);
+    expect(body.data.pending[0].externalId).toBe('apt:openssl@3.0.2-0ubuntu1.20');
+    expect(body.data.installed).toHaveLength(0);
+    expect(body.data.compliancePercent).toBe(0);
+    expect(body.data.lastPatchScanAt).toBeNull();
+    expect(body.data.lastPatchScanStatus).toBeNull();
+  });
+
+  it('includes successful Linux software updates in install patch history', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+      id: DEVICE_ID,
+      orgId: '11111111-1111-1111-1111-111111111111',
+      osType: 'linux'
+    } as any);
+    const countWhere = vi.fn().mockResolvedValue([{ count: 1 }]);
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: countWhere
+        })
+      } as any)
+      .mockReturnValueOnce(selectPatchHistoryRowsResult([
+        {
+          id: 'cmd-software-1',
+          type: 'software_update',
+          payload: { name: 'netbird', source: 'device_software_tab' },
+          status: 'completed',
+          createdAt: '2026-06-22T02:45:00.000Z',
+          completedAt: '2026-06-22T02:46:00.000Z',
+          result: {
+            status: 'completed',
+            exitCode: 0,
+            stdout: JSON.stringify({
+              name: 'netbird',
+              version: '',
+              packageId: '',
+              action: 'update',
+              success: true
+            })
+          },
+          createdBy: USER_ID,
+          createdByEmail: 'test@example.com'
+        }
+      ]) as any);
+
+    const completedAfter = '2026-06-15T00:00:00.000Z';
+    const params = new URLSearchParams({
+      type: 'install',
+      status: 'completed',
+      completedAfter
+    });
+    const res = await app.request(`/devices/${DEVICE_ID}/patches/history?${params.toString()}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const whereClause = JSON.stringify(countWhere.mock.calls[0]?.[0]);
+    expect(whereClause).toContain('software_update');
+    expect(whereClause).toContain('"op":"gte"');
+    expect(whereClause).toContain(completedAfter);
+    expect(body.total).toBe(1);
+    expect(body.history).toHaveLength(1);
+    expect(body.history[0].type).toBe('software_update');
+    expect(body.history[0].result).toMatchObject({
+      installedCount: 1,
+      failedCount: 0,
+      success: true,
+      results: [
+        {
+          id: 'netbird',
+          installId: 'netbird',
+          name: 'netbird',
+          title: 'netbird',
+          source: 'linux',
+          externalId: 'netbird',
+          status: 'installed'
+        }
+      ]
+    });
   });
 
   it('queues install_patches command with patch metadata', async () => {
     vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
     vi.mocked(db.select)
       .mockReturnValueOnce(selectWhereResult([
-        { id: PATCH_ID, source: 'linux', externalId: 'apt:openssl', title: 'OpenSSL' }
+        { id: PATCH_ID, source: 'linux', externalId: 'apt:openssl@3.0.2-0ubuntu1.20', packageId: 'apt:openssl', title: 'OpenSSL' }
       ]) as any)
       .mockReturnValueOnce(selectWhereResult([
         { patchId: PATCH_ID }
@@ -248,7 +439,13 @@ describe('device patch routes', () => {
       'install_patches',
       {
         patchIds: [PATCH_ID],
-        patches: [{ id: PATCH_ID, source: 'linux', externalId: 'apt:openssl', title: 'OpenSSL' }]
+        patches: [{
+          id: PATCH_ID,
+          source: 'linux',
+          externalId: 'apt:openssl@3.0.2-0ubuntu1.20',
+          packageId: 'apt:openssl',
+          title: 'OpenSSL'
+        }]
       },
       { userId: USER_ID, preferHeartbeat: false }
     );
@@ -337,8 +534,10 @@ describe('device patch routes', () => {
   it('does not issue the approvals query when a device has no patches', async () => {
     vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
     // Device-patch list resolves to an empty array → patchIds is empty →
-    // getApprovedPatchIdsForPartner short-circuits without a second db.select call.
-    vi.mocked(db.select).mockReturnValueOnce(selectPatchStatusResult([]) as any);
+    // getApprovedPatchIdsForPartner short-circuits without an approvals query.
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectPatchStatusResult([]) as any)
+      .mockReturnValueOnce(selectWhereOrderLimitResult([]) as any);
 
     const res = await app.request(`/devices/${DEVICE_ID}/patches`, {
       method: 'GET',
@@ -352,8 +551,9 @@ describe('device patch routes', () => {
     expect(body.data.missing).toEqual([]);
     expect(body.data.installed).toEqual([]);
     expect(body.data.compliancePercent).toBe(100);
-    // Only the device-patch list query ran; the approvals query was skipped.
-    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(body.data.lastPatchScanAt).toBeNull();
+    // Only the device-patch list and last-scan queries ran; the approvals query was skipped.
+    expect(db.select).toHaveBeenCalledTimes(2);
   });
 
   it('queues rollback_patches command for a device patch', async () => {

--- a/apps/api/src/routes/devices/patches.ts
+++ b/apps/api/src/routes/devices/patches.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { eq, desc, inArray, and, sql } from 'drizzle-orm';
+import { eq, desc, inArray, and, sql, gte } from 'drizzle-orm';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
@@ -28,10 +28,12 @@ const patchHistoryQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(25),
   offset: z.coerce.number().int().min(0).default(0),
   type: z.enum(['install', 'scan', 'rollback', 'all']).default('all'),
-  status: z.enum(['completed', 'failed', 'pending', 'timeout', 'all']).default('all')
+  status: z.enum(['completed', 'failed', 'pending', 'timeout', 'all']).default('all'),
+  completedAfter: z.string().datetime({ offset: true }).optional()
 });
 
 const PATCH_COMMAND_TYPES = ['install_patches', 'patch_scan', 'rollback_patches', 'download_patches'] as const;
+const LINUX_SOFTWARE_UPDATE_COMMAND_TYPE = 'software_update';
 
 const TYPE_FILTER_MAP: Record<string, string[]> = {
   install: ['install_patches'],
@@ -39,6 +41,15 @@ const TYPE_FILTER_MAP: Record<string, string[]> = {
   rollback: ['rollback_patches'],
   all: [...PATCH_COMMAND_TYPES]
 };
+
+function commandTypesForPatchHistory(type: string, osType?: string | null): string[] {
+  const commandTypes = [...(TYPE_FILTER_MAP[type] ?? PATCH_COMMAND_TYPES)];
+  const normalizedOsType = (osType ?? '').toLowerCase();
+  if ((type === 'install' || type === 'all') && normalizedOsType === 'linux') {
+    commandTypes.push(LINUX_SOFTWARE_UPDATE_COMMAND_TYPE);
+  }
+  return commandTypes;
+}
 
 function safeParsePatchResult(result: unknown): unknown {
   if (!result || typeof result !== 'object') return result;
@@ -101,6 +112,65 @@ function safeParsePatchResult(result: unknown): unknown {
   return raw;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringField(record: Record<string, unknown> | null, key: string): string {
+  const value = record?.[key];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizePatchHistoryResult(
+  commandType: string,
+  payload: unknown,
+  result: unknown,
+  osType?: string | null
+): unknown {
+  const parsed = safeParsePatchResult(result);
+  if (commandType !== LINUX_SOFTWARE_UPDATE_COMMAND_TYPE || (osType ?? '').toLowerCase() !== 'linux') {
+    return parsed;
+  }
+
+  const raw = asRecord(parsed);
+  if (!raw) return parsed;
+
+  const stdout = asRecord(raw.stdout);
+  if (stdout?.success !== true) {
+    return parsed;
+  }
+
+  const payloadRecord = asRecord(payload);
+  const name = stringField(stdout, 'name') || stringField(payloadRecord, 'name');
+  if (!name) {
+    return parsed;
+  }
+
+  const packageId = stringField(stdout, 'packageId');
+  const version = stringField(stdout, 'version');
+  return {
+    ...raw,
+    installedCount: 1,
+    failedCount: 0,
+    success: true,
+    results: [
+      {
+        id: packageId || name,
+        installId: packageId || name,
+        name,
+        title: name,
+        source: 'linux',
+        externalId: packageId || name,
+        packageId: packageId || undefined,
+        version: version || undefined,
+        status: 'installed',
+      }
+    ]
+  };
+}
+
 /**
  * Resolve which of the given patch IDs carry an explicit partner-wide manual-approval
  * record (`patchApprovals.status = 'approved'`) for the partner.
@@ -150,7 +220,7 @@ patchesRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const deviceId = c.req.param('id')!;
-    const { limit, offset, type, status } = c.req.valid('query');
+    const { limit, offset, type, status, completedAfter } = c.req.valid('query');
 
     const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
     if (device === SITE_ACCESS_DENIED) {
@@ -160,7 +230,7 @@ patchesRoutes.get(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    const commandTypes = TYPE_FILTER_MAP[type] ?? PATCH_COMMAND_TYPES;
+    const commandTypes = commandTypesForPatchHistory(type, device.osType);
 
     const conditions = [
       eq(deviceCommands.deviceId, deviceId),
@@ -168,6 +238,9 @@ patchesRoutes.get(
     ];
     if (status !== 'all') {
       conditions.push(eq(deviceCommands.status, status));
+    }
+    if (completedAfter) {
+      conditions.push(gte(deviceCommands.completedAt, new Date(completedAfter)));
     }
     const whereClause = and(...conditions);
 
@@ -183,6 +256,7 @@ patchesRoutes.get(
       .select({
         id: deviceCommands.id,
         type: deviceCommands.type,
+        payload: deviceCommands.payload,
         status: deviceCommands.status,
         createdAt: deviceCommands.createdAt,
         completedAt: deviceCommands.completedAt,
@@ -203,7 +277,7 @@ patchesRoutes.get(
       status: row.status,
       createdAt: row.createdAt,
       completedAt: row.completedAt,
-      result: safeParsePatchResult(row.result),
+      result: normalizePatchHistoryResult(row.type, row.payload, row.result, device.osType),
       createdBy: row.createdBy,
       createdByEmail: row.createdByEmail
     }));
@@ -246,6 +320,7 @@ patchesRoutes.get(
         severity: patches.severity,
         category: patches.category,
         source: patches.source,
+        packageId: patches.packageId,
         releaseDate: patches.releaseDate,
         requiresReboot: patches.requiresReboot
       })
@@ -254,6 +329,24 @@ patchesRoutes.get(
       .where(eq(devicePatches.deviceId, deviceId))
       .orderBy(desc(devicePatches.lastCheckedAt));
 
+    const lastPatchScanRows = await db
+      .select({
+        status: deviceCommands.status,
+        createdAt: deviceCommands.createdAt,
+        completedAt: deviceCommands.completedAt,
+      })
+      .from(deviceCommands)
+      .where(
+        and(
+          eq(deviceCommands.deviceId, deviceId),
+          eq(deviceCommands.type, 'patch_scan'),
+          inArray(deviceCommands.status, ['completed', 'failed', 'timeout'])
+        )
+      )
+      .orderBy(desc(sql`coalesce(${deviceCommands.completedAt}, ${deviceCommands.createdAt})`))
+      .limit(1);
+
+    const lastPatchScan = lastPatchScanRows[0] ?? null;
     const patchIds = [...new Set(devicePatchList.map((patch) => patch.patchId))];
     // Derive the partner from the device's org. If the lookup returns null (no partner
     // found), treat the approved set as empty — all patches are unapproved (fail-safe).
@@ -270,6 +363,7 @@ patchesRoutes.get(
         name: p.title,
         title: p.title,
         externalId: p.externalId,
+        packageId: p.packageId,
         description: p.description,
         severity: p.severity,
         status: p.status,
@@ -287,6 +381,7 @@ patchesRoutes.get(
         name: p.title,
         title: p.title,
         externalId: p.externalId,
+        packageId: p.packageId,
         description: p.description,
         severity: p.severity,
         status: p.status,
@@ -298,12 +393,13 @@ patchesRoutes.get(
       }));
 
     const installed = devicePatchList
-      .filter(p => p.status === 'installed')
+      .filter(p => p.status === 'installed' && p.source !== 'linux')
       .map(p => ({
         id: p.patchId,
         name: p.title,
         title: p.title,
         externalId: p.externalId,
+        packageId: p.packageId,
         description: p.description,
         severity: p.severity,
         status: p.status,
@@ -335,6 +431,8 @@ patchesRoutes.get(
     return c.json({
       data: {
         compliancePercent,
+        lastPatchScanAt: lastPatchScan?.completedAt ?? lastPatchScan?.createdAt ?? null,
+        lastPatchScanStatus: lastPatchScan?.status ?? null,
         pending,
         missing,
         installed,
@@ -344,11 +442,13 @@ patchesRoutes.get(
           name: p.title,
           title: p.title,
           externalId: p.externalId,
+          packageId: p.packageId,
           description: p.description,
           severity: p.severity,
           status: p.status,
           releaseDate: p.releaseDate,
           installedAt: p.installedAt,
+          source: p.source,
           approvalStatus: approvedPatchIds.has(p.patchId) ? 'approved' : 'pending'
         }))
       }
@@ -381,6 +481,7 @@ patchesRoutes.post(
         id: patches.id,
         source: patches.source,
         externalId: patches.externalId,
+        packageId: patches.packageId,
         title: patches.title
       })
       .from(patches)

--- a/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
@@ -238,11 +238,158 @@ describe('DevicePatchStatusTab', () => {
     expect((installThirdPartyButton as HTMLButtonElement).disabled).toBe(true);
   });
 
+  it('shows Linux pending updates and recent install history without showing installed package inventory', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url.includes('/patches/history?') && url.includes('type=install')) {
+        return makeJsonResponse({
+          history: [
+            {
+              type: 'install_patches',
+              status: 'completed',
+              completedAt: '2026-06-21T22:47:00.000Z',
+              result: {
+                results: [
+                  {
+                    id: 'installed-1',
+                    title: 'bash',
+                    source: 'linux',
+                    externalId: 'apt:bash@5.1-6ubuntu1.1',
+                    packageId: 'apt:bash',
+                    installId: 'apt:bash',
+                    status: 'installed',
+                  },
+                ],
+              },
+            },
+            {
+              type: 'software_update',
+              status: 'completed',
+              completedAt: '2026-06-20T18:30:00.000Z',
+              result: {
+                results: [
+                  {
+                    id: 'installed-2',
+                    title: 'netbird',
+                    source: 'linux',
+                    externalId: 'netbird',
+                    installId: 'netbird',
+                    status: 'installed',
+                  },
+                ],
+              },
+            },
+          ],
+        });
+      }
+      if (url.includes('/patches/history')) {
+        return makeJsonResponse({ history: [], total: 0 });
+      }
+      return makeJsonResponse({
+        data: {
+          compliancePercent: 100,
+          pending: [
+            {
+              id: 'pending-1',
+              title: 'openssl',
+              source: 'linux',
+              externalId: 'apt:openssl@3.0.2-0ubuntu1.20',
+              packageId: 'apt:openssl',
+              category: 'system',
+              status: 'pending',
+            },
+          ],
+          installed: [
+            {
+              id: 'pkg-1',
+              title: 'zlib1g',
+              source: 'linux',
+              externalId: 'apt:zlib1g',
+              packageId: 'apt:zlib1g',
+              category: 'system',
+              status: 'installed',
+            },
+          ],
+        },
+      });
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="linux" />);
+
+    await screen.findByText('Pending Linux Updates');
+    await screen.findByText('openssl');
+    await screen.findByText('Recently Installed Linux Updates');
+    await screen.findByText('bash');
+    await screen.findByText('netbird');
+    expect(screen.queryByText('Installed Linux Updates')).toBeNull();
+    expect(screen.queryByText('zlib1g')).toBeNull();
+    expect(screen.queryByText('0% compliant')).not.toBeNull();
+    const historyUrl = fetchWithAuthMock.mock.calls
+      .map(([url]) => String(url))
+      .find((url) => url.includes('/patches/history?') && url.includes('type=install'));
+    expect(historyUrl).toBeTruthy();
+    const historyParams = new URL(`https://test.local${historyUrl}`).searchParams;
+    expect(historyParams.get('limit')).toBe('100');
+    expect(historyParams.get('completedAfter')).toBeTruthy();
+  });
+
+  it('refreshes recent Linux install history when patch data is refreshed', async () => {
+    let recentHistoryCalls = 0;
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url.includes('/patches/history?') && url.includes('type=install')) {
+        recentHistoryCalls += 1;
+        return makeJsonResponse({
+          history: recentHistoryCalls >= 2
+            ? [
+                {
+                  type: 'software_update',
+                  status: 'completed',
+                  completedAt: '2026-06-22T02:46:00.000Z',
+                  result: {
+                    results: [
+                      {
+                        id: 'netbird',
+                        title: 'netbird',
+                        name: 'netbird',
+                        source: 'linux',
+                        externalId: 'netbird',
+                        installId: 'netbird',
+                        status: 'installed',
+                      },
+                    ],
+                  },
+                },
+              ]
+            : [],
+        });
+      }
+      if (url.includes('/patches/history')) {
+        return makeJsonResponse({ history: [], total: 0 });
+      }
+      return makeJsonResponse({
+        data: {
+          compliancePercent: 100,
+          pending: [],
+          installed: [],
+        },
+      });
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="linux" />);
+
+    await screen.findByText('No recent Linux update installs.');
+    fireEvent.click(await screen.findByRole('button', { name: /Refresh patch data/i }));
+
+    await screen.findByText('netbird');
+    expect(recentHistoryCalls).toBeGreaterThanOrEqual(2);
+  });
+
   it('excludes missing records from pending install counts', async () => {
     fetchWithAuthMock.mockResolvedValue(
       makeJsonResponse({
         data: {
           compliancePercent: 100,
+          lastPatchScanAt: '2026-06-22T06:15:00.000Z',
+          lastPatchScanStatus: 'completed',
           pending: [],
           missing: [
             {
@@ -274,7 +421,11 @@ describe('DevicePatchStatusTab', () => {
 
     expect((installOsButton as HTMLButtonElement).disabled).toBe(true);
     expect((installThirdPartyButton as HTMLButtonElement).disabled).toBe(true);
-    await screen.findByText(/1 stale missing records are excluded from pending install counts\./i);
+    await screen.findByText((_content, node) =>
+      node?.textContent?.startsWith('Last scan:') === true &&
+      node.textContent.includes('Completed')
+    );
+    expect(screen.queryByText(/updates? from earlier scans/i)).not.toBeInTheDocument();
   });
 
   it('sends only approved pending OS patch ids to the install endpoint', async () => {
@@ -297,6 +448,14 @@ describe('DevicePatchStatusTab', () => {
             category: 'security',
             status: 'pending',
             approvalStatus: 'pending'
+          },
+          {
+            id: 'pending-third-party-1',
+            title: 'Google Chrome',
+            source: 'third_party',
+            category: 'application',
+            status: 'pending',
+            approvalStatus: 'pending'
           }
         ],
         installed: []
@@ -315,6 +474,19 @@ describe('DevicePatchStatusTab', () => {
     // Button count reflects only the approved patch, and surfaces the pending one.
     const installButton = await screen.findByRole('button', { name: /Install pending OS patches \(1\)/i });
     expect(installButton.textContent).toMatch(/1 pending approval/i);
+    expect(screen.getByText('Approved')).toBeTruthy();
+    expect(screen.getAllByText('Pending Approval')).toHaveLength(2);
+
+    const approvedRowInstall = screen.getByLabelText('Install 2026-01 Cumulative Update (KB5050001)');
+    expect((approvedRowInstall as HTMLButtonElement).disabled).toBe(false);
+    const unapprovedOsTitle = 'This org has not approved 2026-01 Feature Update (KB5050099). Approve the patch before installing.';
+    expect(screen.getByTitle(unapprovedOsTitle)).toBeTruthy();
+    const unapprovedOsRowInstall = screen.getByLabelText(unapprovedOsTitle);
+    expect((unapprovedOsRowInstall as HTMLButtonElement).disabled).toBe(true);
+    const unapprovedThirdPartyTitle = 'This org has not approved Google Chrome. Approve the patch before installing.';
+    expect(screen.getByTitle(unapprovedThirdPartyTitle)).toBeTruthy();
+    const unapprovedThirdPartyInstall = screen.getByLabelText(unapprovedThirdPartyTitle);
+    expect((unapprovedThirdPartyInstall as HTMLButtonElement).disabled).toBe(true);
 
     fireEvent.click(installButton);
     fireEvent.click(await screen.findByTestId('confirm-install-patches'));

--- a/apps/web/src/components/devices/DevicePatchStatusTab.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.tsx
@@ -26,7 +26,9 @@ type PatchItem = {
   title?: string;
   kb?: string;
   kbNumber?: string;
+  version?: string;
   externalId?: string;
+  packageId?: string;
   description?: string;
   severity?: string;
   status?: string;
@@ -43,6 +45,8 @@ type PatchItem = {
 type PatchPayload = {
   compliancePercent?: number;
   compliance?: number;
+  lastPatchScanAt?: string | null;
+  lastPatchScanStatus?: string | null;
   pending?: PatchItem[];
   pendingPatches?: PatchItem[];
   missing?: PatchItem[];
@@ -65,6 +69,32 @@ type PatchInstallResponse = {
   commandId?: string;
   commandStatus?: string;
   patchCount?: number;
+};
+
+type PatchHistoryResultItem = {
+  id?: string;
+  installId?: string;
+  name?: string;
+  title?: string;
+  version?: string;
+  source?: string;
+  externalId?: string;
+  packageId?: string;
+  status?: string;
+  rebootRequired?: boolean;
+};
+
+type PatchHistoryEntry = {
+  type?: string;
+  status?: string;
+  completedAt?: string;
+  result?: {
+    results?: PatchHistoryResultItem[];
+  };
+};
+
+type PatchHistoryResponse = {
+  history?: PatchHistoryEntry[];
 };
 
 type DevicePatchStatusTabProps = {
@@ -143,8 +173,8 @@ function getPatchDisplayCopy(osType: OSType): PatchDisplayCopy {
         pendingThirdPartyEmpty: 'No pending third-party updates.',
         pendingThirdPartyPrimaryColumn: 'Software',
         pendingThirdPartySecondaryColumn: 'Category',
-        installedNativeTitle: 'Installed Linux Updates',
-        installedNativeEmpty: 'No Linux updates reported.',
+        installedNativeTitle: 'Recently Installed Linux Updates',
+        installedNativeEmpty: 'No recent Linux update installs.',
         installedNativePrimaryColumn: 'Package',
         installedThirdPartyTitle: 'Installed Third-Party Updates'
       };
@@ -189,17 +219,38 @@ function readPatchIds(patches: PatchItem[]): string[] {
   return [...unique];
 }
 
-// A patch is awaiting approval only when the API explicitly says so. The
-// device-patches endpoint always sends approvalStatus ('approved' | 'pending'),
-// so an absent value (older payloads / tests) is treated as installable.
+// The device-patches endpoint sends approvalStatus for current payloads. Any
+// explicit non-approved status blocks install controls; an absent value (older
+// payloads / tests) is treated as installable.
 function isAwaitingApproval(patch: PatchItem): boolean {
-  return patch.approvalStatus === 'pending';
+  return !isPatchApprovedForInstall(patch);
 }
 
 // Only approved pending patches may be sent to the install endpoint. Mixing in
 // an unapproved id makes the server reject the whole batch with 409.
 function readApprovedPatchIds(patches: PatchItem[]): string[] {
   return readPatchIds(patches.filter(patch => !isAwaitingApproval(patch)));
+}
+
+function isPatchApprovedForInstall(patch: PatchItem): boolean {
+  // The API sends approvalStatus for current device-patch payloads. Older or
+  // test-only payloads without the field are treated as installable to preserve
+  // existing behavior.
+  return patch.approvalStatus == null || patch.approvalStatus === 'approved';
+}
+
+function getApprovalBadge(patch: PatchItem): { label: string; className: string } {
+  switch ((patch.approvalStatus ?? 'approved').toLowerCase()) {
+    case 'approved':
+      return { label: 'Approved', className: 'bg-success/15 text-success border-success/30' };
+    case 'declined':
+      return { label: 'Declined', className: 'bg-destructive/15 text-destructive border-destructive/30' };
+    case 'deferred':
+      return { label: 'Deferred', className: 'bg-blue-500/20 text-blue-700 border-blue-500/40' };
+    case 'pending':
+    default:
+      return { label: 'Pending Approval', className: 'bg-warning/15 text-warning border-warning/30' };
+  }
 }
 
 function getCategoryBadge(patch: PatchItem, osType: OSType) {
@@ -312,8 +363,91 @@ function formatDate(value?: string, timezone?: string, fallback = 'Not reported'
   return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString([], timezone ? { timeZone: timezone } : undefined);
 }
 
+function formatDateTime(value?: string | null, timezone?: string, fallback = 'Never') {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], {
+    ...(timezone ? { timeZone: timezone } : {}),
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
 function normalizePatchName(patch: PatchItem) {
   return patch.title || patch.name || patch.kb || patch.kbNumber || 'Unnamed patch';
+}
+
+function isInstalledResultStatus(status?: string) {
+  const normalized = (status || '').toLowerCase();
+  return normalized === 'installed' || normalized === 'success' || normalized === 'completed';
+}
+
+function isLinuxInstallResult(patch: PatchHistoryResultItem) {
+  const source = (patch.source || '').toLowerCase();
+  const installId = (patch.installId || '').toLowerCase();
+  const externalId = (patch.externalId || '').toLowerCase();
+  const packageId = (patch.packageId || '').toLowerCase();
+
+  return source === 'linux' ||
+    installId.startsWith('apt:') ||
+    installId.startsWith('yum:') ||
+    externalId.startsWith('apt:') ||
+    externalId.startsWith('yum:') ||
+    packageId.startsWith('apt:') ||
+    packageId.startsWith('yum:');
+}
+
+function sortPatchItemsByInstalledAtDesc(patches: PatchItem[]): PatchItem[] {
+  return [...patches].sort((a, b) => {
+    const aTime = a.installedAt ? new Date(a.installedAt).getTime() : 0;
+    const bTime = b.installedAt ? new Date(b.installedAt).getTime() : 0;
+    return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime);
+  });
+}
+
+function recentLinuxInstallsFromHistory(history: PatchHistoryEntry[]): PatchItem[] {
+  const installs: PatchItem[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of history) {
+    if ((entry.status || '').toLowerCase() !== 'completed') {
+      continue;
+    }
+    const results = entry.result?.results ?? [];
+    for (const patch of results) {
+      if (!isInstalledResultStatus(patch.status) || !isLinuxInstallResult(patch)) {
+        continue;
+      }
+
+      const installed: PatchItem = {
+        id: patch.id ?? patch.installId ?? patch.externalId ?? patch.packageId,
+        title: patch.title ?? patch.name ?? patch.packageId ?? patch.installId ?? patch.externalId,
+        name: patch.name ?? patch.title ?? patch.packageId ?? patch.installId ?? patch.externalId,
+        version: patch.version,
+        source: 'linux',
+        status: 'installed',
+        externalId: patch.externalId,
+        packageId: patch.packageId,
+        category: 'system',
+        installedAt: entry.completedAt,
+        requiresReboot: patch.rebootRequired,
+      };
+      const key = [
+        installed.id,
+        installed.externalId,
+        installed.packageId,
+        installed.name,
+        installed.installedAt,
+      ].filter(Boolean).join('|');
+      if (!seen.has(key)) {
+        seen.add(key);
+        installs.push(installed);
+      }
+    }
+  }
+
+  return sortPatchItemsByInstalledAtDesc(installs);
 }
 
 function getSeverityBadge(severity?: string) {
@@ -472,9 +606,13 @@ function getHomebrewUrl(patch: PatchItem, osType: OSType): string | null {
 // ---------------------------------------------------------------------------
 const INSTALL_POLL_INTERVAL_MS = 5_000;
 const INSTALL_POLL_MAX_DURATION_MS = 1_800_000;
+const RECENT_LINUX_INSTALL_DAYS = 7;
+const RECENT_LINUX_INSTALL_HISTORY_LIMIT = 100;
+const RECENT_LINUX_INSTALL_WINDOW_MS = RECENT_LINUX_INSTALL_DAYS * 24 * 60 * 60 * 1000;
 
 export default function DevicePatchStatusTab({ deviceId, timezone, osType }: DevicePatchStatusTabProps) {
   const [payload, setPayload] = useState<PatchPayload | null>(null);
+  const [recentLinuxInstalls, setRecentLinuxInstalls] = useState<PatchItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [siteTimezone, setSiteTimezone] = useState<string | undefined>(timezone);
@@ -498,9 +636,11 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollStartRef = useRef<number>(0);
   const priorPendingCountRef = useRef<number>(-1);
+  const recentLinuxInstallsRequestRef = useRef(0);
 
   // Use provided timezone, fetched siteTimezone, or browser default
   const effectiveTimezone = timezone ?? siteTimezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const normalizedOsType: OSType = osType ?? 'macos';
 
   const fetchPatchStatus = useCallback(async (silent = false) => {
     if (!silent) {
@@ -533,6 +673,60 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
     fetchPatchStatus();
   }, [fetchPatchStatus]);
 
+  const fetchRecentLinuxInstalls = useCallback(async (clear = false) => {
+    if (normalizedOsType !== 'linux') {
+      recentLinuxInstallsRequestRef.current += 1;
+      setRecentLinuxInstalls([]);
+      return [];
+    }
+
+    const requestId = recentLinuxInstallsRequestRef.current + 1;
+    recentLinuxInstallsRequestRef.current = requestId;
+
+    if (clear) {
+      setRecentLinuxInstalls([]);
+    }
+
+    try {
+      const completedAfter = new Date(Date.now() - RECENT_LINUX_INSTALL_WINDOW_MS).toISOString();
+      const params = new URLSearchParams({
+        limit: String(RECENT_LINUX_INSTALL_HISTORY_LIMIT),
+        offset: '0',
+        type: 'install',
+        status: 'completed',
+        completedAfter,
+      });
+      const response = await fetchWithAuth(`/devices/${deviceId}/patches/history?${params.toString()}`);
+      if (!response.ok) {
+        if (recentLinuxInstallsRequestRef.current === requestId) {
+          setRecentLinuxInstalls([]);
+        }
+        return [];
+      }
+      const json = await response.json() as PatchHistoryResponse;
+      const installs = recentLinuxInstallsFromHistory(json.history ?? []);
+      if (recentLinuxInstallsRequestRef.current === requestId) {
+        setRecentLinuxInstalls(installs);
+      }
+      return installs;
+    } catch {
+      if (recentLinuxInstallsRequestRef.current === requestId) {
+        setRecentLinuxInstalls([]);
+      }
+      return [];
+    }
+  }, [deviceId, normalizedOsType]);
+
+  useEffect(() => {
+    void fetchRecentLinuxInstalls(true);
+  }, [fetchRecentLinuxInstalls]);
+
+  const refreshPatchView = useCallback(async (silent = false) => {
+    const data = await fetchPatchStatus(silent);
+    await fetchRecentLinuxInstalls(false);
+    return data;
+  }, [fetchPatchStatus, fetchRecentLinuxInstalls]);
+
   // Clean up polling on unmount
   useEffect(() => {
     return () => {
@@ -543,25 +737,20 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
     };
   }, []);
 
-  const normalizedOsType: OSType = osType ?? 'macos';
   const displayCopy = useMemo(() => getPatchDisplayCopy(normalizedOsType), [normalizedOsType]);
   const NativeIcon = displayCopy.nativeIcon;
   const nativeSource = useMemo(() => getNativePatchSource(normalizedOsType), [normalizedOsType]);
   const nativeProviderLabel = useMemo(() => getNativePatchProviderLabel(normalizedOsType), [normalizedOsType]);
 
-  const { pendingNative, pendingOther, installedNative, installedThirdParty, compliancePercent, missingCount } = useMemo(() => {
+  const { pendingNative, pendingOther, installedNative, installedThirdParty, compliancePercent } = useMemo(() => {
     const data = payload ?? {};
     const pendingList = data.pending ?? data.pendingPatches ?? data.available ?? [];
-    const missingList = data.missing ?? data.missingPatches ?? [];
     const installedList = data.installed ?? data.installedPatches ?? data.applied ?? [];
     const patches = data.patches ?? [];
 
     const inferredPending = pendingList.length > 0
       ? pendingList
       : patches.filter(patch => (patch.status || '').toLowerCase() === 'pending' || (patch.status || '').toLowerCase() === 'available');
-    const inferredMissing = missingList.length > 0
-      ? missingList
-      : patches.filter(patch => (patch.status || '').toLowerCase() === 'missing');
     const inferredInstalled = installedList.length > 0
       ? installedList
       : patches.filter(patch => (patch.status || '').toLowerCase() === 'installed');
@@ -569,19 +758,26 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
     const nativePending = inferredPending.filter(patch => isNativePatchForOs(patch, normalizedOsType));
     const otherPending = inferredPending.filter(patch => !isNativePatchForOs(patch, normalizedOsType));
 
-    const nativeInstalled = inferredInstalled.filter(patch => isNativePatchForOs(patch, normalizedOsType));
-    const thirdPartyInstalled = inferredInstalled.filter(patch => !isNativePatchForOs(patch, normalizedOsType));
+    const effectiveInstalled = normalizedOsType === 'linux'
+      ? inferredInstalled.filter(patch => !isLinuxPatch(patch))
+      : inferredInstalled;
+    const nativeInstalled = normalizedOsType === 'linux'
+      ? []
+      : effectiveInstalled.filter(patch => isNativePatchForOs(patch, normalizedOsType));
+    const thirdPartyInstalled = effectiveInstalled.filter(patch => !isNativePatchForOs(patch, normalizedOsType));
 
-    const total = inferredPending.length + inferredInstalled.length;
-    const compliance = data.compliancePercent ?? data.compliance ?? (total > 0 ? Math.round((inferredInstalled.length / total) * 100) : 100);
+    const total = inferredPending.length + effectiveInstalled.length;
+    const computedCompliance = total > 0 ? Math.round((effectiveInstalled.length / total) * 100) : 100;
+    const compliance = normalizedOsType === 'linux'
+      ? computedCompliance
+      : data.compliancePercent ?? data.compliance ?? computedCompliance;
 
     return {
       pendingNative: nativePending,
       pendingOther: otherPending,
       installedNative: nativeInstalled,
       installedThirdParty: thirdPartyInstalled,
-      compliancePercent: compliance,
-      missingCount: inferredMissing.length
+      compliancePercent: compliance
     };
   }, [payload, normalizedOsType]);
 
@@ -591,6 +787,11 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
   const thirdPartyPendingIds = useMemo(() => readApprovedPatchIds(pendingOther), [pendingOther]);
   const nativeAwaitingApproval = useMemo(() => pendingNative.filter(isAwaitingApproval).length, [pendingNative]);
   const thirdPartyAwaitingApproval = useMemo(() => pendingOther.filter(isAwaitingApproval).length, [pendingOther]);
+  const displayedInstalledNative = normalizedOsType === 'linux' ? recentLinuxInstalls : installedNative;
+  const lastPatchScanLabel = formatDateTime(payload?.lastPatchScanAt, effectiveTimezone);
+  const lastPatchScanStatus = payload?.lastPatchScanStatus
+    ? payload.lastPatchScanStatus.charAt(0).toUpperCase() + payload.lastPatchScanStatus.slice(1)
+    : null;
 
   // -------------------------------------------------------------------------
   // Post-install polling: poll every 5s for up to 90s watching pending count
@@ -617,7 +818,7 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
         setIsPolling(false);
         setInstallingPatchIds(new Set());
         setControlNotice({ kind: 'info', message: 'Install is taking longer than expected. macOS updates can take 30+ minutes. Refresh the page later to check status.' });
-        await fetchPatchStatus(true);
+        await refreshPatchView(true);
         return;
       }
 
@@ -636,13 +837,14 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
         setIsPolling(false);
         setInstallingPatchIds(new Set());
         const installed = priorPendingCountRef.current - currentPendingCount;
+        await fetchRecentLinuxInstalls(false);
         setControlNotice({
           kind: 'success',
           message: `${installed} patch${installed !== 1 ? 'es' : ''} installed successfully. ${currentPendingCount} still pending.`
         });
       }
     }, INSTALL_POLL_INTERVAL_MS);
-  }, [fetchPatchStatus]);
+  }, [fetchPatchStatus, fetchRecentLinuxInstalls, refreshPatchView]);
 
   const queuePatchScan = useCallback(async (
     action: 'scan-native' | 'scan-third-party',
@@ -812,7 +1014,7 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
         <p className="text-sm text-destructive">{error}</p>
         <button
           type="button"
-          onClick={() => fetchPatchStatus()}
+          onClick={() => refreshPatchView()}
           className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
         >
           Retry
@@ -832,11 +1034,18 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h3 className="text-lg font-semibold">Patch Controls</h3>
-            <p className="text-sm text-muted-foreground">Queue scans and installs for this device</p>
+            <p className="text-sm text-muted-foreground">
+              Queue scans and installs for this device
+              <span className="mx-2 hidden sm:inline">|</span>
+              <span className="block sm:inline">
+                Last scan: {lastPatchScanLabel}
+                {lastPatchScanStatus && <span> ({lastPatchScanStatus})</span>}
+              </span>
+            </p>
           </div>
           <button
             type="button"
-            onClick={() => fetchPatchStatus()}
+            onClick={() => refreshPatchView()}
             disabled={isBusy}
             className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -912,11 +1121,6 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
           </div>
         )}
 
-        {missingCount > 0 && (
-          <p className="mt-3 text-xs text-muted-foreground">
-            {missingCount} stale missing records are excluded from pending install counts.
-          </p>
-        )}
       </div>
 
       {/* ================================================================ */}
@@ -939,7 +1143,7 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
           </div>
           <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
             <span>{pendingNative.length + pendingOther.length} pending</span>
-            <span>{installedNative.length + installedThirdParty.length} installed</span>
+            <span>{displayedInstalledNative.length + installedThirdParty.length} installed</span>
           </div>
         </div>
       </div>
@@ -959,7 +1163,7 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
             )}
           </div>
           <div className="mt-4 overflow-hidden rounded-md border">
-            <div className="max-h-64 overflow-y-auto">
+            <div className="max-h-64 overflow-x-auto overflow-y-auto">
               <table className="min-w-full divide-y">
                 <thead className="bg-muted/40 sticky top-0">
                   <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -967,13 +1171,14 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                     {normalizedOsType === 'windows' && <th className="px-4 py-3">KB#</th>}
                     <th className="px-4 py-3">Source</th>
                     <th className="px-4 py-3">Category</th>
+                    <th className="px-4 py-3">Approval</th>
                     <th className="w-16 px-2 py-3" />
                   </tr>
                 </thead>
                 <tbody className="divide-y">
                   {pendingNative.length === 0 ? (
                     <tr>
-                      <td colSpan={normalizedOsType === 'windows' ? 5 : 4} className="px-4 py-6 text-center text-sm text-muted-foreground">
+                      <td colSpan={normalizedOsType === 'windows' ? 6 : 5} className="px-4 py-6 text-center text-sm text-muted-foreground">
                         {displayCopy.pendingNativeEmpty}
                       </td>
                     </tr>
@@ -987,12 +1192,19 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                       const patchId = patch.id;
                       const isInstalling = patchId ? installingPatchIds.has(patchId) : false;
                       const notDownloaded = patch.isDownloaded === false;
+                      const approvalBadge = getApprovalBadge(patch);
+                      const isApproved = isPatchApprovedForInstall(patch);
+                      const patchName = normalizePatchName(patch);
+                      const installTitle = isApproved
+                        ? `Install ${patchName}`
+                        : `This org has not approved ${patchName}. Approve the patch before installing.`;
+
                       return (
                         <tr key={patch.id ?? `${patch.name ?? patch.title ?? 'pending-native'}-${index}`} className="text-sm">
                           <td className="px-4 py-3">
                             <div className="space-y-1">
                               <div className="flex items-center gap-1.5">
-                                <p className="font-medium">{normalizePatchName(patch)}</p>
+                                <p className="font-medium">{patchName}</p>
                                 {notDownloaded && (
                                   <span title="Not yet downloaded -- install will take longer" className="inline-flex items-center text-muted-foreground">
                                     <CloudDownload className="h-3.5 w-3.5" />
@@ -1053,21 +1265,28 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                               </span>
                             )}
                           </td>
+                          <td className="px-4 py-3">
+                            <span className={`inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-1 text-xs font-medium ${approvalBadge.className}`}>
+                              {approvalBadge.label}
+                            </span>
+                          </td>
                           <td className="px-2 py-3">
                             {patchId && (
-                              <button
-                                type="button"
-                                title={`Install ${normalizePatchName(patch)}`}
-                                disabled={isBusy || isInstalling}
-                                onClick={() => queueSinglePatchInstall(patchId, normalizePatchName(patch))}
-                                className="inline-flex items-center justify-center rounded-md border p-1.5 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-                              >
-                                {isInstalling ? (
-                                  <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
-                                ) : (
-                                  <Download className="h-3.5 w-3.5 text-green-600" />
-                                )}
-                              </button>
+                              <span title={installTitle} className="inline-flex">
+                                <button
+                                  type="button"
+                                  aria-label={installTitle}
+                                  disabled={isBusy || isInstalling || !isApproved}
+                                  onClick={() => queueSinglePatchInstall(patchId, patchName)}
+                                  className="inline-flex items-center justify-center rounded-md border p-1.5 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                  {isInstalling ? (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
+                                  ) : (
+                                    <Download className={`h-3.5 w-3.5 ${isApproved ? 'text-green-600' : 'text-muted-foreground'}`} />
+                                  )}
+                                </button>
+                              </span>
                             )}
                           </td>
                         </tr>
@@ -1094,20 +1313,21 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
             )}
           </div>
           <div className="mt-4 overflow-hidden rounded-md border">
-            <div className="max-h-64 overflow-y-auto">
+            <div className="max-h-64 overflow-x-auto overflow-y-auto">
               <table className="min-w-full divide-y">
                 <thead className="bg-muted/40 sticky top-0">
                   <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     <th className="px-4 py-3">{displayCopy.pendingThirdPartyPrimaryColumn}</th>
                     <th className="px-4 py-3">Source</th>
                     <th className="px-4 py-3">{displayCopy.pendingThirdPartySecondaryColumn}</th>
+                    <th className="px-4 py-3">Approval</th>
                     <th className="w-16 px-2 py-3" />
                   </tr>
                 </thead>
                 <tbody className="divide-y">
                   {pendingOther.length === 0 ? (
                     <tr>
-                      <td colSpan={4} className="px-4 py-6 text-center text-sm text-muted-foreground">
+                      <td colSpan={5} className="px-4 py-6 text-center text-sm text-muted-foreground">
                         {displayCopy.pendingThirdPartyEmpty}
                       </td>
                     </tr>
@@ -1123,6 +1343,13 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                       const patchId = patch.id;
                       const isInstalling = patchId ? installingPatchIds.has(patchId) : false;
                       const notDownloaded = patch.isDownloaded === false;
+                      const approvalBadge = getApprovalBadge(patch);
+                      const isApproved = isPatchApprovedForInstall(patch);
+                      const patchName = normalizePatchName(patch);
+                      const installTitle = isApproved
+                        ? `Install ${patchName}`
+                        : `This org has not approved ${patchName}. Approve the patch before installing.`;
+
                       return (
                         <tr key={patch.id ?? `${patch.name ?? patch.title ?? 'pending-other'}-${index}`} className="text-sm">
                           <td className="px-4 py-3">
@@ -1136,11 +1363,11 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                                       rel="noopener noreferrer"
                                       className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
                                     >
-                                      {normalizePatchName(patch)}
+                                      {patchName}
                                       <ExternalLink className="h-3 w-3" />
                                     </a>
                                   ) : (
-                                    normalizePatchName(patch)
+                                    patchName
                                   )}
                                 </div>
                                 {notDownloaded && (
@@ -1200,21 +1427,28 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                               </span>
                             )}
                           </td>
+                          <td className="px-4 py-3">
+                            <span className={`inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-1 text-xs font-medium ${approvalBadge.className}`}>
+                              {approvalBadge.label}
+                            </span>
+                          </td>
                           <td className="px-2 py-3">
                             {patchId && (
-                              <button
-                                type="button"
-                                title={`Install ${normalizePatchName(patch)}`}
-                                disabled={isBusy || isInstalling}
-                                onClick={() => queueSinglePatchInstall(patchId, normalizePatchName(patch))}
-                                className="inline-flex items-center justify-center rounded-md border p-1.5 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-                              >
-                                {isInstalling ? (
-                                  <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
-                                ) : (
-                                  <Download className="h-3.5 w-3.5 text-green-600" />
-                                )}
-                              </button>
+                              <span title={installTitle} className="inline-flex">
+                                <button
+                                  type="button"
+                                  aria-label={installTitle}
+                                  disabled={isBusy || isInstalling || !isApproved}
+                                  onClick={() => queueSinglePatchInstall(patchId, patchName)}
+                                  className="inline-flex items-center justify-center rounded-md border p-1.5 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                  {isInstalling ? (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
+                                  ) : (
+                                    <Download className={`h-3.5 w-3.5 ${isApproved ? 'text-green-600' : 'text-muted-foreground'}`} />
+                                  )}
+                                </button>
+                              </span>
                             )}
                           </td>
                         </tr>
@@ -1235,10 +1469,10 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
             <CheckCircle className="h-4 w-4 text-green-500" />
             <NativeIcon className="h-4 w-4 text-gray-600" />
             <h3 className="text-sm font-semibold">{displayCopy.installedNativeTitle}</h3>
-            <span className="text-xs text-muted-foreground">({installedNative.length})</span>
+            <span className="text-xs text-muted-foreground">({displayedInstalledNative.length})</span>
           </div>
           <div className="mt-4 overflow-hidden rounded-md border">
-            <div className="max-h-64 overflow-y-auto">
+            <div className="max-h-64 overflow-x-auto overflow-y-auto">
               <table className="min-w-full divide-y">
                 <thead className="bg-muted/40 sticky top-0">
                   <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -1249,14 +1483,14 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                   </tr>
                 </thead>
                 <tbody className="divide-y">
-                  {installedNative.length === 0 ? (
+                  {displayedInstalledNative.length === 0 ? (
                     <tr>
                       <td colSpan={normalizedOsType === 'windows' ? 4 : 3} className="px-4 py-6 text-center text-sm text-muted-foreground">
                         {displayCopy.installedNativeEmpty}
                       </td>
                     </tr>
                   ) : (
-                    installedNative.map((patch, index) => {
+                    displayedInstalledNative.map((patch, index) => {
                       const badge = getCategoryBadge(patch, normalizedOsType);
                       const kbLabel = getKbLabel(patch);
                       return (

--- a/apps/web/src/components/patches/PatchInstallHistory.tsx
+++ b/apps/web/src/components/patches/PatchInstallHistory.tsx
@@ -61,6 +61,7 @@ const POLL_INTERVAL_MS = 30000;
 
 const typeConfig: Record<string, { label: string; icon: typeof Download }> = {
   install_patches: { label: 'Install', icon: Download },
+  software_update: { label: 'Install', icon: Download },
   install: { label: 'Install', icon: Download },
   patch_scan: { label: 'Scan', icon: Search },
   scan_patches: { label: 'Scan', icon: Search },


### PR DESCRIPTION
## Summary

- Restores Linux OS patch functionality that was effectively inoperative: devices could report installed Linux package inventory, but pending apt updates were not reliably persisted or shown in the device Patches tab.
- Splits Linux patch reporting into distinct installed and pending inventory flows so installed package inventory no longer masks or displaces actionable pending updates.
- Updates the device Patches tab to show pending Linux updates, approval status, install actions, last OS patch scan time, and recently installed Linux updates from the last 7 days.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Testing

- [ ] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [x] Manual testing (describe below)

Verified with focused checks:

- `pnpm --filter @breeze/api test:run src/middleware/bodyLimit.test.ts src/routes/agents/patches.test.ts src/routes/devices/patches.test.ts`
- `pnpm --filter @breeze/web exec vitest run src/components/devices/DevicePatchStatusTab.test.tsx`
- `go test -race ./internal/heartbeat`
- `pnpm --filter @breeze/api lint`
- `pnpm --filter @breeze/web lint`
- `pnpm --filter @breeze/api build`
- `pnpm --filter @breeze/web build`

Full-suite note:

- `pnpm --filter @breeze/api test:run` still has unrelated upstream failures in `mcpServer.effectiveTier.test.ts` and `streamingUpload.test.ts`.
- `NODE_OPTIONS=--localstorage-file=/tmp/breeze-web-vitest-localstorage pnpm --filter @breeze/web exec vitest run` still has an unrelated upstream failure in `PamRuleModal.test.tsx`.
- The failing full-suite files are not touched by this PR.

Manual testing:

- Built test images from the throwaway branch for API, web, and Linux agent binaries.
- Tested against a Debian Linux host with available apt updates.
- Confirmed the Patches tab now populates pending Linux updates after an OS patch scan.
- Confirmed approved updates show active install actions and unapproved updates remain disabled.
- Confirmed recent Linux update installs appear after scan refresh.
- Confirmed internal stale/missing patch records are no longer exposed in the patch controls UI.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included