### PR TITLE
feat(s1): partner-wide SentinelOne integration (#1735)

### DIFF
--- a/apps/api/migrations/2026-06-27-a-sentinelone-partner-mapping.sql
+++ b/apps/api/migrations/2026-06-27-a-sentinelone-partner-mapping.sql
@@ -1,0 +1,201 @@
+-- Promote SentinelOne integrations from org-owned credentials to partner-owned
+-- credentials with explicit S1 site -> Breeze organization mapping.
+-- Mirrors 2026-06-12-a-huntress-partner-mapping.sql.
+
+-- 1. Add partner_id, relax org_id to legacy nullable, backfill from org.
+ALTER TABLE s1_integrations
+  ADD COLUMN IF NOT EXISTS partner_id uuid;
+
+ALTER TABLE s1_integrations
+  ALTER COLUMN org_id DROP NOT NULL;
+
+UPDATE s1_integrations si
+SET partner_id = o.partner_id
+FROM organizations o
+WHERE si.partner_id IS NULL
+  AND si.org_id = o.id;
+
+DO $$
+BEGIN
+  ALTER TABLE s1_integrations
+    ADD CONSTRAINT s1_integrations_partner_id_fkey
+    FOREIGN KEY (partner_id) REFERENCES partners(id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+DECLARE
+  missing_count integer;
+BEGIN
+  SELECT COUNT(*)::int INTO missing_count
+  FROM s1_integrations
+  WHERE partner_id IS NULL;
+
+  IF missing_count > 0 THEN
+    RAISE EXCEPTION 'Cannot promote SentinelOne integrations: % row(s) have no resolvable partner_id from org_id', missing_count;
+  END IF;
+END $$;
+
+ALTER TABLE s1_integrations
+  ALTER COLUMN partner_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS s1_integrations_id_partner_idx
+  ON s1_integrations(id, partner_id);
+
+DROP INDEX IF EXISTS s1_integrations_org_idx;
+
+CREATE INDEX IF NOT EXISTS s1_integrations_legacy_org_idx
+  ON s1_integrations(org_id);
+
+-- 2. Dedup to one active integration per partner (most-recent wins), with count.
+DO $$
+DECLARE
+  deactivated integer;
+BEGIN
+  WITH ranked AS (
+    SELECT
+      id,
+      row_number() OVER (
+        PARTITION BY partner_id
+        ORDER BY
+          CASE WHEN is_active THEN 0 ELSE 1 END,
+          updated_at DESC,
+          created_at DESC,
+          id
+      ) AS rn
+    FROM s1_integrations
+  )
+  UPDATE s1_integrations si
+  SET is_active = false,
+      updated_at = now(),
+      last_sync_status = COALESCE(si.last_sync_status, 'inactive'),
+      last_sync_error = COALESCE(si.last_sync_error, 'Deactivated during partner-level SentinelOne promotion because another active integration exists for this partner.')
+  FROM ranked
+  WHERE si.id = ranked.id
+    AND ranked.rn > 1
+    AND si.is_active = true;
+  GET DIAGNOSTICS deactivated = ROW_COUNT;
+  IF deactivated > 0 THEN
+    RAISE WARNING 'Deactivated % duplicate SentinelOne integration(s) during partner promotion', deactivated;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS s1_integrations_partner_active_idx
+  ON s1_integrations(partner_id)
+  WHERE is_active = true;
+
+-- 3. Partner-axis discovery + mapping table.
+CREATE TABLE IF NOT EXISTS s1_org_mappings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  integration_id uuid NOT NULL,
+  partner_id uuid NOT NULL REFERENCES partners(id),
+  s1_site_id varchar(128) NOT NULL,
+  s1_site_name varchar(200),
+  org_id uuid REFERENCES organizations(id) ON DELETE SET NULL,
+  agents_count integer NOT NULL DEFAULT 0,
+  metadata jsonb,
+  last_seen_at timestamp,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT s1_org_mappings_integration_partner_fkey
+    FOREIGN KEY (integration_id, partner_id)
+    REFERENCES s1_integrations(id, partner_id)
+    ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS s1_org_mappings_integration_site_idx
+  ON s1_org_mappings(integration_id, s1_site_id);
+CREATE INDEX IF NOT EXISTS s1_org_mappings_org_idx
+  ON s1_org_mappings(org_id);
+CREATE INDEX IF NOT EXISTS s1_org_mappings_integration_idx
+  ON s1_org_mappings(integration_id);
+CREATE INDEX IF NOT EXISTS s1_org_mappings_partner_idx
+  ON s1_org_mappings(partner_id);
+
+-- 4. Backfill legacy name-keyed site mappings as PROVISIONAL rows. The first
+-- post-migration sync matches discovered sites by name, rewrites s1_site_id to
+-- the real id, and clears the provisional flag (carrying org_id forward).
+-- Only migrate rows belonging to a surviving active integration's partner.
+DO $$
+DECLARE
+  migrated integer;
+BEGIN
+  INSERT INTO s1_org_mappings (
+    integration_id, partner_id, s1_site_id, s1_site_name, org_id, metadata, last_seen_at, updated_at
+  )
+  SELECT
+    sm.integration_id,
+    si.partner_id,
+    'name:' || sm.site_name,
+    sm.site_name,
+    sm.org_id,
+    jsonb_build_object('source', 'migration', 'provisional', true),
+    now(),
+    now()
+  FROM s1_site_mappings sm
+  JOIN s1_integrations si ON si.id = sm.integration_id
+  ON CONFLICT (integration_id, s1_site_id) DO NOTHING;
+  GET DIAGNOSTICS migrated = ROW_COUNT;
+  RAISE WARNING 'Migrated % legacy SentinelOne site mapping(s) as provisional rows', migrated;
+END $$;
+
+-- 5. RLS: swap s1_integrations org-axis -> partner-axis.
+DROP POLICY IF EXISTS breeze_org_isolation_select ON s1_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON s1_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON s1_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_select ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_insert ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_update ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_delete ON s1_integrations;
+
+ALTER TABLE s1_integrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE s1_integrations FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_partner_isolation_select ON s1_integrations
+  FOR SELECT USING (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_insert ON s1_integrations
+  FOR INSERT WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_update ON s1_integrations
+  FOR UPDATE USING (public.breeze_has_partner_access(partner_id))
+  WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_delete ON s1_integrations
+  FOR DELETE USING (public.breeze_has_partner_access(partner_id));
+
+-- 6. RLS: s1_org_mappings partner-axis with FK-integrity on writes.
+DROP POLICY IF EXISTS breeze_partner_isolation_select ON s1_org_mappings;
+DROP POLICY IF EXISTS breeze_partner_isolation_insert ON s1_org_mappings;
+DROP POLICY IF EXISTS breeze_partner_isolation_update ON s1_org_mappings;
+DROP POLICY IF EXISTS breeze_partner_isolation_delete ON s1_org_mappings;
+
+ALTER TABLE s1_org_mappings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE s1_org_mappings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_partner_isolation_select ON s1_org_mappings
+  FOR SELECT USING (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_insert ON s1_org_mappings
+  FOR INSERT WITH CHECK (
+    public.breeze_has_partner_access(partner_id)
+    AND EXISTS (
+      SELECT 1 FROM s1_integrations si
+      WHERE si.id = s1_org_mappings.integration_id
+        AND si.partner_id = s1_org_mappings.partner_id
+    )
+  );
+CREATE POLICY breeze_partner_isolation_update ON s1_org_mappings
+  FOR UPDATE USING (public.breeze_has_partner_access(partner_id))
+  WITH CHECK (
+    public.breeze_has_partner_access(partner_id)
+    AND EXISTS (
+      SELECT 1 FROM s1_integrations si
+      WHERE si.id = s1_org_mappings.integration_id
+        AND si.partner_id = s1_org_mappings.partner_id
+    )
+  );
+CREATE POLICY breeze_partner_isolation_delete ON s1_org_mappings
+  FOR DELETE USING (public.breeze_has_partner_access(partner_id));
+
+-- NOTE: s1_site_mappings is intentionally retained (not dropped) so the legacy
+-- table remains as a forensic record post-migration. A follow-up migration may
+-- drop it once provisional reconciliation is confirmed in prod.

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -83,6 +83,10 @@ const ORG_AXIS_POLICY_EXCLUDED_TABLES: ReadonlySet<string> = new Set<string>([
   // quarantined Huntress orgs.
   'huntress_integrations',
   'huntress_org_mappings',
+  // SentinelOne credentials and discovered-site mappings are partner-scoped.
+  // org_id is retained only as legacy/mapping metadata and may be NULL.
+  's1_integrations',
+  's1_org_mappings',
   // Pax8 sync tables: partner-axis (Shape 3). The MSP partner owns the Pax8
   // integration; org_id is denormalized (nullable on mappings/snapshots, for the
   // resolved customer) for FK joins + filtering only — the RLS axis is partner_id
@@ -170,6 +174,11 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   // Functional cross-partner forge proof: update-rings-partner-scope.integration.test.ts.
   ['patch_policies', 'partner_id'],
   ['patch_approvals', 'partner_id'],
+  // SentinelOne (partner-wide re-key, #1735): credentials + site mappings are
+  // partner-axis (Shape 3). org_id is denormalized/nullable metadata only.
+  // Also listed in ORG_AXIS_POLICY_EXCLUDED_TABLES (dual-list trap).
+  ['s1_integrations', 'partner_id'],
+  ['s1_org_mappings', 'partner_id'],
 ]);
 
 // Tables whose policies reference both helpers (org OR partner). `users`

--- a/apps/api/src/__tests__/integration/sentinelOne-partner-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/sentinelOne-partner-rls.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Real-driver cross-tenant forge tests for the SentinelOne partner-axis tables.
+ *
+ * Runs under vitest.integration.config.ts — code-under-test connects as the
+ * unprivileged `breeze_app` role (rolbypassrls=f), so RLS is actually enforced.
+ * If `.env.test` is missing the symlink that pins this to the breeze_app role,
+ * these tests would pass vacuously on a BYPASSRLS admin connection (see memory:
+ * worktree_env_test_rls_vacuous) — the forged-insert assertions are the guard
+ * that catches that. The rls-coverage contract test does NOT catch a missing
+ * 2nd axis or a WITH CHECK hole on partner-axis tables; only a functional
+ * breeze_app insert (this file) does.
+ *
+ * Tables under test:
+ *   - s1_integrations  (partner-axis, RLS shape 3)
+ *   - s1_org_mappings  (partner-axis, RLS shape 3, with FK-integrity EXISTS
+ *                       clause on INSERT/UPDATE to prevent cross-partner
+ *                       integration references)
+ *
+ * Fixture topology (seeded fresh per test under system scope, which bypasses
+ * RLS):
+ *   partnerA → orgA → s1IntegrationA → s1OrgMappingA
+ *   partnerB → orgB
+ *
+ * Why NO memoization: setup.ts runs cleanupDatabase() in a beforeEach that
+ * TRUNCATE ... CASCADEs partners/organizations before every test, wiping every
+ * seeded row. A module-level cache would hand later cases rows that no longer
+ * exist, making the assertions vacuous. Each it() re-seeds fresh — matching
+ * every sibling *-rls.integration.test.ts.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import { s1Integrations, s1OrgMappings } from '../../db/schema';
+import { createPartner, createOrganization } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function partnerCtx(partnerId: string): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: null,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgCtx(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+// Re-seeds fresh on every call. Intentionally NOT memoized (see file header).
+async function seed() {
+  return withSystemDbAccessContext(async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+
+    const [integrationA] = await db
+      .insert(s1Integrations)
+      .values({
+        partnerId: partnerA.id,
+        name: 'S1 Test Integration',
+        apiTokenEncrypted: 'enc:test-token',
+        managementUrl: 'https://usea1.sentinelone.net',
+        isActive: true,
+      })
+      .returning();
+    if (!integrationA) throw new Error('failed to seed s1 integration');
+
+    const [mappingA] = await db
+      .insert(s1OrgMappings)
+      .values({
+        integrationId: integrationA.id,
+        partnerId: partnerA.id,
+        s1SiteId: 's1-site-001',
+        s1SiteName: 'Customer A Site',
+        orgId: orgA.id,
+      })
+      .returning();
+    if (!mappingA) throw new Error('failed to seed s1 org mapping');
+
+    return { partnerA, orgA, partnerB, orgB, integrationA, mappingA };
+  });
+}
+
+describe('SentinelOne partner-axis RLS (breeze_app)', () => {
+  runDb('partner B cannot SELECT partner A s1_integrations row (0 rows)', async () => {
+    const { partnerB, integrationA } = await seed();
+
+    const rows = await withDbAccessContext(partnerCtx(partnerB.id), () =>
+      db.select().from(s1Integrations).where(eq(s1Integrations.id, integrationA.id))
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  runDb('system scope CAN read partner A integration (existence probe — proves case above is genuine isolation)', async () => {
+    const { integrationA } = await seed();
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(s1Integrations).where(eq(s1Integrations.id, integrationA.id))
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  runDb('partner B cannot INSERT an s1_integrations row with partner_id = P1 (42501)', async () => {
+    const { partnerA, partnerB } = await seed();
+
+    await expect(
+      withDbAccessContext(partnerCtx(partnerB.id), () =>
+        db.insert(s1Integrations).values({
+          partnerId: partnerA.id, // forged — partner B context, partner A owner
+          name: 'forged-integration',
+          apiTokenEncrypted: 'enc:forged',
+          managementUrl: 'https://usea1.sentinelone.net',
+          isActive: false,
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  runDb('org-scope context cannot SELECT partner A s1_integrations credentials (0 rows)', async () => {
+    const { orgA, integrationA } = await seed();
+
+    const rows = await withDbAccessContext(orgCtx(orgA.id), () =>
+      db.select().from(s1Integrations).where(eq(s1Integrations.id, integrationA.id))
+    );
+    // org-scope context has no partner reach; partner-axis RLS returns 0 rows silently
+    expect(rows).toHaveLength(0);
+  });
+
+  runDb('partner B cannot INSERT into s1_org_mappings referencing partner A integration (FK-integrity EXISTS + partner policy = 42501)', async () => {
+    const { partnerA, partnerB, integrationA } = await seed();
+
+    // Insert s1_org_mappings with:
+    //   integration_id = partner A's integration (FK resolves at DB level)
+    //   partner_id = partner A (forged — partner B context)
+    // The s1_org_mappings INSERT policy requires BOTH:
+    //   1. breeze_has_partner_access(partner_id) — fails for partnerB trying to claim partnerA
+    //   2. EXISTS(SELECT 1 FROM s1_integrations WHERE id = integration_id AND partner_id = s1_org_mappings.partner_id)
+    // Either condition suffices to produce the 42501 rejection.
+    await expect(
+      withDbAccessContext(partnerCtx(partnerB.id), () =>
+        db.insert(s1OrgMappings).values({
+          integrationId: integrationA.id,
+          partnerId: partnerA.id, // forged — only RLS WITH CHECK can reject this
+          s1SiteId: 'forged-site-999',
+          s1SiteName: 'Forge Site',
+        })
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  runDb('partner A CAN: SELECT its own integration (1 row), INSERT its own s1_org_mappings, and map an org under P1', async () => {
+    const { partnerA, orgA, integrationA } = await seed();
+
+    // SELECT own integration
+    const rows = await withDbAccessContext(partnerCtx(partnerA.id), () =>
+      db.select().from(s1Integrations).where(eq(s1Integrations.id, integrationA.id))
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.partnerId).toBe(partnerA.id);
+
+    // INSERT own s1_org_mappings with org_id mapped to P1's org
+    const [newMapping] = await withDbAccessContext(partnerCtx(partnerA.id), () =>
+      db
+        .insert(s1OrgMappings)
+        .values({
+          integrationId: integrationA.id,
+          partnerId: partnerA.id,
+          s1SiteId: 's1-site-002',
+          s1SiteName: 'P1 Second Site',
+          orgId: orgA.id, // org under P1
+        })
+        .returning()
+    );
+    expect(newMapping).toBeDefined();
+    expect(newMapping?.partnerId).toBe(partnerA.id);
+    expect(newMapping?.orgId).toBe(orgA.id);
+  });
+});

--- a/apps/api/src/db/schema/sentinelOne.ts
+++ b/apps/api/src/db/schema/sentinelOne.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
   pgTable,
   uuid,
@@ -8,15 +9,17 @@ import {
   integer,
   jsonb,
   index,
-  uniqueIndex
+  uniqueIndex,
+  foreignKey
 } from 'drizzle-orm/pg-core';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 import { devices } from './devices';
 
 export const s1Integrations = pgTable('s1_integrations', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  legacyOrgId: uuid('org_id').references(() => organizations.id),
   name: varchar('name', { length: 200 }).notNull(),
   apiTokenEncrypted: text('api_token_encrypted').notNull(),
   managementUrl: text('management_url').notNull(),
@@ -28,7 +31,11 @@ export const s1Integrations = pgTable('s1_integrations', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 }, (table) => ({
-  orgIdx: uniqueIndex('s1_integrations_org_idx').on(table.orgId)
+  partnerActiveIdx: uniqueIndex('s1_integrations_partner_active_idx')
+    .on(table.partnerId)
+    .where(sql`${table.isActive} = true`),
+  idPartnerIdx: uniqueIndex('s1_integrations_id_partner_idx').on(table.id, table.partnerId),
+  legacyOrgIdx: index('s1_integrations_legacy_org_idx').on(table.legacyOrgId)
 }));
 
 export const s1Agents = pgTable('s1_agents', {
@@ -94,14 +101,26 @@ export const s1Actions = pgTable('s1_actions', {
   providerActionIdx: index('s1_actions_provider_action_idx').on(table.providerActionId)
 }));
 
-export const s1SiteMappings = pgTable('s1_site_mappings', {
+export const s1OrgMappings = pgTable('s1_org_mappings', {
   id: uuid('id').primaryKey().defaultRandom(),
-  integrationId: uuid('integration_id').notNull().references(() => s1Integrations.id),
-  siteName: varchar('site_name', { length: 200 }).notNull(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  integrationId: uuid('integration_id').notNull(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  s1SiteId: varchar('s1_site_id', { length: 128 }).notNull(),
+  s1SiteName: varchar('s1_site_name', { length: 200 }),
+  orgId: uuid('org_id').references(() => organizations.id, { onDelete: 'set null' }),
+  agentsCount: integer('agents_count').notNull().default(0),
+  metadata: jsonb('metadata'),
+  lastSeenAt: timestamp('last_seen_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 }, (table) => ({
-  uniqueSiteIdx: uniqueIndex('s1_site_mappings_integration_site_idx').on(table.integrationId, table.siteName),
-  orgIdx: index('s1_site_mappings_org_idx').on(table.orgId)
+  uniqueSiteIdx: uniqueIndex('s1_org_mappings_integration_site_idx').on(table.integrationId, table.s1SiteId),
+  orgIdx: index('s1_org_mappings_org_idx').on(table.orgId),
+  integrationIdx: index('s1_org_mappings_integration_idx').on(table.integrationId),
+  partnerIdx: index('s1_org_mappings_partner_idx').on(table.partnerId),
+  integrationPartnerFk: foreignKey({
+    columns: [table.integrationId, table.partnerId],
+    foreignColumns: [s1Integrations.id, s1Integrations.partnerId],
+    name: 's1_org_mappings_integration_partner_fkey'
+  }).onDelete('cascade')
 }));

--- a/apps/api/src/jobs/s1Sync.test.ts
+++ b/apps/api/src/jobs/s1Sync.test.ts
@@ -5,9 +5,6 @@ import {
   logSyncFailureServerSide,
   normalizeSeverity,
   normalizeThreatStatus,
-  normalizeS1SiteName,
-  resolveAgentSyncTarget,
-  resolveOrgIdForAgentSite,
   resolveDeviceIdForAgent,
   resolveAgentSyncTargetById,
   truncateError
@@ -198,46 +195,6 @@ describe('resolveDeviceIdForAgent', () => {
     };
     expect(resolveDeviceIdForAgent(agent, candidates)).toBe('device-aaa');
   });
-});
-
-describe('SentinelOne site-to-org mapping helpers', () => {
-  it('normalizes provider site names for case-insensitive lookup', () => {
-    expect(normalizeS1SiteName('  Denver Site  ')).toBe('denver site');
-    expect(normalizeS1SiteName('')).toBeNull();
-    expect(normalizeS1SiteName(null)).toBeNull();
-  });
-
-  it('resolves mapped sites to their target org and falls back to the integration org', () => {
-    const mappings = new Map([
-      ['denver site', 'org-denver'],
-      ['nyc', 'org-nyc'],
-    ]);
-
-    expect(resolveOrgIdForAgentSite('Denver Site', 'org-default', mappings)).toBe('org-denver');
-    expect(resolveOrgIdForAgentSite('unknown', 'org-default', mappings)).toBe('org-default');
-    expect(resolveOrgIdForAgentSite(null, 'org-default', mappings)).toBe('org-default');
-  });
-
-  it('uses the mapped org device candidates when resolving an agent', () => {
-    const target = resolveAgentSyncTarget(
-      { siteName: 'Denver Site', computerName: 'server-1' },
-      'org-default',
-      new Map([['denver site', 'org-denver']]),
-      new Map([
-        ['org-default', {
-          byHostname: new Map([['server-1', 'device-default']]),
-          byIp: new Map(),
-        }],
-        ['org-denver', {
-          byHostname: new Map([['server-1', 'device-denver']]),
-          byIp: new Map(),
-        }],
-      ])
-    );
-
-    expect(target).toEqual({ orgId: 'org-denver', deviceId: 'device-denver' });
-  });
-
 });
 
 describe('C2 site-id based routing helpers', () => {

--- a/apps/api/src/jobs/s1Sync.test.ts
+++ b/apps/api/src/jobs/s1Sync.test.ts
@@ -8,7 +8,6 @@ import {
   normalizeS1SiteName,
   resolveAgentSyncTarget,
   resolveOrgIdForAgentSite,
-  resolveThreatSyncTarget,
   resolveDeviceIdForAgent,
   resolveAgentSyncTargetById,
   truncateError
@@ -239,21 +238,6 @@ describe('SentinelOne site-to-org mapping helpers', () => {
     expect(target).toEqual({ orgId: 'org-denver', deviceId: 'device-denver' });
   });
 
-  it('uses the integration org and null device for unmapped threat agents', () => {
-    const mapped = resolveThreatSyncTarget(
-      'agent-denver',
-      'org-default',
-      new Map([['agent-denver', { orgId: 'org-denver', deviceId: 'device-denver' }]])
-    );
-    const unmapped = resolveThreatSyncTarget(
-      'missing-agent',
-      'org-default',
-      new Map([['agent-denver', { orgId: 'org-denver', deviceId: 'device-denver' }]])
-    );
-
-    expect(mapped).toEqual({ orgId: 'org-denver', deviceId: 'device-denver' });
-    expect(unmapped).toEqual({ orgId: 'org-default', deviceId: null });
-  });
 });
 
 describe('C2 site-id based routing helpers', () => {

--- a/apps/api/src/jobs/s1Sync.test.ts
+++ b/apps/api/src/jobs/s1Sync.test.ts
@@ -10,6 +10,7 @@ import {
   resolveOrgIdForAgentSite,
   resolveThreatSyncTarget,
   resolveDeviceIdForAgent,
+  resolveAgentSyncTargetById,
   truncateError
 } from './s1Sync';
 import { SentinelOneHttpError } from '../services/sentinelOne/client';
@@ -252,5 +253,50 @@ describe('SentinelOne site-to-org mapping helpers', () => {
 
     expect(mapped).toEqual({ orgId: 'org-denver', deviceId: 'device-denver' });
     expect(unmapped).toEqual({ orgId: 'org-default', deviceId: null });
+  });
+});
+
+describe('C2 site-id based routing helpers', () => {
+  const candidatesByOrg = new Map([
+    ['org-acme', {
+      byHostname: new Map([['desktop-acme', 'device-acme']]),
+      byIp: new Map(),
+    }],
+    ['org-other', {
+      byHostname: new Map(),
+      byIp: new Map(),
+    }],
+  ]);
+
+  it('routes agent to org via siteId when site is mapped', () => {
+    const siteOrgIds = new Map([['site-123', 'org-acme']]);
+    const agent = { id: 'a1', siteId: 'site-123', siteName: 'Acme', computerName: 'desktop-acme' } as Parameters<typeof resolveAgentSyncTargetById>[0];
+    const result = resolveAgentSyncTargetById(agent, siteOrgIds, candidatesByOrg);
+    expect(result).not.toBeNull();
+    expect(result!.orgId).toBe('org-acme');
+    expect(result!.deviceId).toBe('device-acme');
+  });
+
+  it('returns null (skip) when siteId is absent', () => {
+    const siteOrgIds = new Map([['site-123', 'org-acme']]);
+    const agent = { id: 'a2', siteId: null, siteName: 'Acme', computerName: 'desktop-acme' } as Parameters<typeof resolveAgentSyncTargetById>[0];
+    const result = resolveAgentSyncTargetById(agent, siteOrgIds, candidatesByOrg);
+    expect(result).toBeNull();
+  });
+
+  it('returns null (skip) when siteId is not mapped to an org (org_id IS NULL)', () => {
+    const siteOrgIds = new Map<string, string>(); // empty: no org mapped
+    const agent = { id: 'a3', siteId: 'site-123', siteName: 'Acme', computerName: 'desktop-acme' } as Parameters<typeof resolveAgentSyncTargetById>[0];
+    const result = resolveAgentSyncTargetById(agent, siteOrgIds, candidatesByOrg);
+    expect(result).toBeNull();
+  });
+
+  it('does not fall back to a default integration org when unmapped', () => {
+    // Regression guard: there is no "default org" in the partner-wide model.
+    // An unmapped site must produce null, never a fallback org.
+    const siteOrgIds = new Map([['site-999', 'org-acme']]);
+    const agent = { id: 'a4', siteId: 'site-999-different', siteName: 'Unknown', computerName: 'desktop-unknown' } as Parameters<typeof resolveAgentSyncTargetById>[0];
+    const result = resolveAgentSyncTargetById(agent, siteOrgIds, candidatesByOrg);
+    expect(result).toBeNull();
   });
 });

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -293,34 +293,6 @@ export function resolveDeviceIdForAgent(
   return null;
 }
 
-export function normalizeS1SiteName(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim().toLowerCase() : null;
-}
-
-export function resolveOrgIdForAgentSite(
-  siteName: unknown,
-  defaultOrgId: string,
-  siteOrgIds: Map<string, string>
-): string {
-  const normalized = normalizeS1SiteName(siteName);
-  if (!normalized) return defaultOrgId;
-  return siteOrgIds.get(normalized) ?? defaultOrgId;
-}
-
-export function resolveAgentSyncTarget(
-  agent: Record<string, unknown>,
-  defaultOrgId: string,
-  siteOrgIds: Map<string, string>,
-  candidatesByOrg: Map<string, DeviceCandidates>
-): AgentContext {
-  const orgId = resolveOrgIdForAgentSite(agent.siteName, defaultOrgId, siteOrgIds);
-  const candidates = candidatesByOrg.get(orgId) ?? { byHostname: new Map(), byIp: new Map() };
-  return {
-    orgId,
-    deviceId: resolveDeviceIdForAgent(agent, candidates)
-  };
-}
-
 /**
  * Load s1_org_mappings rows that have a mapped org, keyed by s1_site_id.
  * Only includes rows with non-null org_id (mirrors huntressSync loadMappedOrgIds).

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -7,7 +7,7 @@ import {
   s1Actions,
   s1Agents,
   s1Integrations,
-  s1SiteMappings,
+  s1OrgMappings,
   s1Threats
 } from '../db/schema';
 import { getBullMQConnection } from '../services/redis';
@@ -69,7 +69,7 @@ let s1SyncWorker: Worker<S1SyncJobData> | null = null;
 
 interface IntegrationForSync {
   id: string;
-  orgId: string;
+  partnerId: string;
   managementUrl: string;
   isActive: boolean;
   lastSyncAt: Date | null;
@@ -250,7 +250,7 @@ async function listActiveIntegrations(): Promise<IntegrationForSync[]> {
   return db
     .select({
       id: s1Integrations.id,
-      orgId: s1Integrations.orgId,
+      partnerId: s1Integrations.partnerId,
       managementUrl: s1Integrations.managementUrl,
       isActive: s1Integrations.isActive,
       lastSyncAt: s1Integrations.lastSyncAt
@@ -329,23 +329,173 @@ export function resolveThreatSyncTarget(
   return agentContext ?? { orgId: defaultOrgId, deviceId: null };
 }
 
-async function mapSiteOrgIds(integrationId: string): Promise<Map<string, string>> {
+/**
+ * Load s1_org_mappings rows that have a mapped org, keyed by s1_site_id.
+ * Only includes rows with non-null org_id (mirrors huntressSync loadMappedOrgIds).
+ * Excludes provisional rows (s1_site_id starting with 'name:') which will be
+ * reconciled by reconcileProvisionalSiteMappings before this is called.
+ */
+export async function mapSiteOrgIds(integrationId: string): Promise<Map<string, string>> {
   const rows = await db
     .select({
-      siteName: s1SiteMappings.siteName,
-      orgId: s1SiteMappings.orgId
+      s1SiteId: s1OrgMappings.s1SiteId,
+      orgId: s1OrgMappings.orgId
     })
-    .from(s1SiteMappings)
-    .where(eq(s1SiteMappings.integrationId, integrationId));
+    .from(s1OrgMappings)
+    .where(
+      and(
+        eq(s1OrgMappings.integrationId, integrationId),
+        isNotNull(s1OrgMappings.orgId)
+      )
+    );
 
   const result = new Map<string, string>();
   for (const row of rows) {
-    const normalized = normalizeS1SiteName(row.siteName);
-    if (normalized) {
-      result.set(normalized, row.orgId);
+    if (row.orgId) {
+      result.set(row.s1SiteId, row.orgId);
     }
   }
   return result;
+}
+
+/**
+ * Upsert discovered sites (derived from the fetched agent list) into s1_org_mappings.
+ * Sites are keyed on (integration_id, s1_site_id). On conflict, updates s1_site_name,
+ * agents_count, and last_seen_at but DOES NOT overwrite a mapped org_id with null —
+ * preserving any existing mapping.
+ */
+export async function upsertDiscoveredSites(params: {
+  integrationId: string;
+  partnerId: string;
+  sites: Array<{ siteId: string; siteName: string | null; count: number }>;
+}): Promise<void> {
+  if (params.sites.length === 0) return;
+
+  const now = new Date();
+  const values = params.sites.map((site) => ({
+    integrationId: params.integrationId,
+    partnerId: params.partnerId,
+    s1SiteId: site.siteId,
+    s1SiteName: site.siteName ?? null,
+    agentsCount: site.count,
+    lastSeenAt: now,
+    updatedAt: now,
+  }));
+
+  await db
+    .insert(s1OrgMappings)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [s1OrgMappings.integrationId, s1OrgMappings.s1SiteId],
+      set: {
+        s1SiteName: sql`excluded.s1_site_name`,
+        agentsCount: sql`excluded.agents_count`,
+        lastSeenAt: sql`excluded.last_seen_at`,
+        updatedAt: sql`excluded.updated_at`,
+        // partnerId is updated in case the composite FK partner changes (rare)
+        partnerId: sql`excluded.partner_id`,
+        // org_id is NOT included here — COALESCE preserves the existing mapped value.
+        // The full formula `COALESCE(s1_org_mappings.org_id, excluded.org_id)` would
+        // require a raw SET expression; omitting org_id from the set clause achieves
+        // the same effect (Drizzle leaves the column unchanged on conflict update).
+      }
+    });
+}
+
+/**
+ * For each discovered real site, find a provisional row
+ * (s1_site_id = 'name:' || siteName AND metadata->>'provisional' IS TRUE) for this
+ * integration and reconcile it:
+ *
+ * Collision rule:
+ *   - If NO real row yet exists for the discovered siteId: UPDATE the provisional row
+ *     → set s1_site_id to the real id, clear provisional flag, preserve org_id.
+ *   - If a real row ALREADY exists (would violate the unique index): DELETE the
+ *     provisional row instead (the real row wins). We do not attempt to merge org_id
+ *     because: (a) the real row was presumably created with the correct org_id or is
+ *     awaiting manual mapping; (b) the provisional org_id came from a name-match
+ *     heuristic and should not silently overwrite a deliberately-set real mapping.
+ *
+ * Run this BEFORE upsertDiscoveredSites so the carried org_id survives the upsert.
+ */
+export async function reconcileProvisionalSiteMappings(
+  integrationId: string,
+  discoveredSites: Array<{ siteId: string; siteName: string }>
+): Promise<void> {
+  if (discoveredSites.length === 0) return;
+
+  for (const site of discoveredSites) {
+    const provisionalKey = `name:${site.siteName}`;
+
+    // Find a provisional row for this integration + name
+    const [provisionalRow] = await db
+      .select({
+        id: s1OrgMappings.id,
+        orgId: s1OrgMappings.orgId,
+      })
+      .from(s1OrgMappings)
+      .where(
+        and(
+          eq(s1OrgMappings.integrationId, integrationId),
+          eq(s1OrgMappings.s1SiteId, provisionalKey),
+          // Only target rows flagged as provisional
+          sql`(${s1OrgMappings.metadata}->>'provisional')::boolean IS TRUE`
+        )
+      )
+      .limit(1);
+
+    if (!provisionalRow) continue;
+
+    // Check whether a real row for this siteId already exists
+    const [existingReal] = await db
+      .select({ id: s1OrgMappings.id })
+      .from(s1OrgMappings)
+      .where(
+        and(
+          eq(s1OrgMappings.integrationId, integrationId),
+          eq(s1OrgMappings.s1SiteId, site.siteId)
+        )
+      )
+      .limit(1);
+
+    if (existingReal) {
+      // Real row already exists — delete the provisional row (real wins).
+      await db
+        .delete(s1OrgMappings)
+        .where(eq(s1OrgMappings.id, provisionalRow.id));
+    } else {
+      // No real row yet — rewrite provisional row to real site id.
+      await db
+        .update(s1OrgMappings)
+        .set({
+          s1SiteId: site.siteId,
+          orgId: provisionalRow.orgId, // preserve mapped org
+          metadata: sql`${s1OrgMappings.metadata} - 'provisional'`,
+          updatedAt: new Date(),
+        })
+        .where(eq(s1OrgMappings.id, provisionalRow.id));
+    }
+  }
+}
+
+/**
+ * Resolve an S1 agent's sync target (orgId + deviceId) using the stable S1 site id.
+ * Returns null if the agent has no siteId or the site is not mapped to an org.
+ * A null return means the agent should be SKIPPED (counted but not written).
+ */
+export function resolveAgentSyncTargetById(
+  agent: { siteId: string | null; computerName?: string | null; networkInterfaces?: Array<{ inet?: string[] }> },
+  siteOrgIds: Map<string, string>,
+  candidatesByOrg: Map<string, DeviceCandidates>
+): AgentContext | null {
+  if (!agent.siteId) return null;
+  const orgId = siteOrgIds.get(agent.siteId);
+  if (!orgId) return null;
+  const candidates = candidatesByOrg.get(orgId) ?? { byHostname: new Map(), byIp: new Map() };
+  return {
+    orgId,
+    deviceId: resolveDeviceIdForAgent(agent as Record<string, unknown>, candidates)
+  };
 }
 
 async function mapDeviceCandidatesByOrg(orgIds: string[]): Promise<Map<string, DeviceCandidates>> {
@@ -385,25 +535,72 @@ async function mapDeviceCandidatesByOrg(orgIds: string[]): Promise<Map<string, D
 async function syncAgentsForIntegration(
   integration: IntegrationForSync,
   client: SentinelOneClient
-): Promise<{ fetched: number; upserted: number; truncated: boolean }> {
-  const siteOrgIds = await mapSiteOrgIds(integration.id);
-  const candidatesByOrg = await mapDeviceCandidatesByOrg([integration.orgId, ...siteOrgIds.values()]);
+): Promise<{ fetched: number; upserted: number; skipped: number; truncated: boolean }> {
   const agentResult = await client.listAgents(integration.lastSyncAt ?? undefined);
   const fetchedAgents = agentResult.results;
 
+  // Derive distinct sites from the fetched agent list (skip agents with no siteId).
+  const siteCountMap = new Map<string, { siteName: string | null; count: number }>();
+  for (const agent of fetchedAgents) {
+    if (!agent.siteId) continue;
+    const existing = siteCountMap.get(agent.siteId);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      siteCountMap.set(agent.siteId, { siteName: agent.siteName, count: 1 });
+    }
+  }
+  const discoveredSites = Array.from(siteCountMap.entries()).map(([siteId, info]) => ({
+    siteId,
+    siteName: info.siteName,
+    count: info.count,
+  }));
+
+  // Step 1: Reconcile provisional mappings BEFORE upsert so carried org_id survives.
+  await reconcileProvisionalSiteMappings(
+    integration.id,
+    discoveredSites.map((s) => ({ siteId: s.siteId, siteName: s.siteName ?? s.siteId }))
+  );
+
+  // Step 2: Upsert discovered sites (sets agents_count, last_seen_at; preserves org_id).
+  await upsertDiscoveredSites({
+    integrationId: integration.id,
+    partnerId: integration.partnerId,
+    sites: discoveredSites,
+  });
+
+  // Step 3: Load the org mapping keyed by s1_site_id (only rows with mapped org_id).
+  const siteOrgIds = await mapSiteOrgIds(integration.id);
+  const candidatesByOrg = await mapDeviceCandidatesByOrg([...siteOrgIds.values()]);
+
   let upserted = 0;
+  let skipped = 0;
   for (let i = 0; i < fetchedAgents.length; i += 300) {
     const batch = fetchedAgents.slice(i, i + 300);
 
-    const values = batch.map((agent) => {
-      const target = resolveAgentSyncTarget(
-        agent as unknown as Record<string, unknown>,
-        integration.orgId,
-        siteOrgIds,
-        candidatesByOrg
-      );
+    const values: Array<{
+      orgId: string;
+      integrationId: string;
+      s1AgentId: string;
+      deviceId: string | null;
+      status: string;
+      infected: boolean;
+      threatCount: number;
+      policyName: string | null;
+      lastSeenAt: Date | null;
+      metadata: Record<string, unknown>;
+      updatedAt: Date;
+    }> = [];
+
+    for (const agent of batch) {
+      // Resolve the agent to an org via its stable siteId (no fallback default org).
+      const target = resolveAgentSyncTargetById(agent, siteOrgIds, candidatesByOrg);
+      if (!target) {
+        skipped += 1;
+        continue;
+      }
       const threatCount = Number(agent.activeThreats ?? 0);
-      return {
+      values.push({
         orgId: target.orgId,
         integrationId: integration.id,
         s1AgentId: agent.id,
@@ -417,11 +614,12 @@ async function syncAgentsForIntegration(
           uuid: agent.uuid ?? null,
           computerName: agent.computerName ?? null,
           osName: agent.osName ?? null,
-          siteName: agent.siteName ?? null
+          siteName: agent.siteName ?? null,
+          siteId: agent.siteId ?? null,
         },
         updatedAt: new Date()
-      };
-    });
+      });
+    }
 
     if (values.length === 0) continue;
 
@@ -451,6 +649,7 @@ async function syncAgentsForIntegration(
   return {
     fetched: fetchedAgents.length,
     upserted,
+    skipped,
     truncated: agentResult.truncated
   };
 }
@@ -458,9 +657,13 @@ async function syncAgentsForIntegration(
 async function syncThreatsForIntegration(
   integration: IntegrationForSync,
   client: SentinelOneClient
-): Promise<{ fetched: number; upserted: number; emitted: number; emitFailures: number; truncated: boolean }> {
+): Promise<{ fetched: number; upserted: number; skipped: number; emitted: number; emitFailures: number; truncated: boolean }> {
   const threatResult = await client.listThreats(integration.lastSyncAt ?? undefined);
   const fetchedThreats = threatResult.results;
+
+  // Load agent contexts from already-synced s1_agents rows.
+  // If an agent was skipped during agent sync (unmapped site), it won't appear here
+  // and its threats will be skipped too — consistent with the partner-wide model.
   const agentRows = await db
     .select({
       s1AgentId: s1Agents.s1AgentId,
@@ -479,29 +682,56 @@ async function syncThreatsForIntegration(
   const threatsToEmit: Array<{ s1ThreatId: string; orgId: string; severity: string; deviceId: string | null; detectedAt: Date | null }> = [];
 
   let upserted = 0;
+  let skipped = 0;
   for (let i = 0; i < fetchedThreats.length; i += 300) {
     const batch = fetchedThreats.slice(i, i + 300);
-    const values = batch.map((threat) => {
+    const values: Array<{
+      orgId: string;
+      integrationId: string;
+      deviceId: string | null;
+      s1ThreatId: string;
+      classification: string | null;
+      severity: string;
+      threatName: string | null;
+      processName: string | null;
+      filePath: string | null;
+      mitreTactics: unknown;
+      status: string;
+      detectedAt: Date | null;
+      resolvedAt: Date | null;
+      details: unknown;
+      updatedAt: Date;
+    }> = [];
+
+    for (const threat of batch) {
       const detectedAt = toDateOrNull(threat.detectedAt);
       const resolvedAt = toDateOrNull(threat.resolvedAt);
       const status = normalizeThreatStatus(threat.mitigationStatus);
       const severity = normalizeSeverity(threat.threatSeverity);
-      const target = resolveThreatSyncTarget(threat.agentId, integration.orgId, agentContextByAgentId);
+
+      // Resolve the threat's org via its parent agent's already-written context.
+      // If the agent has no context (was skipped because its site is unmapped),
+      // skip this threat too — there is no fallback "default org" in the partner-wide model.
+      const agentContext = agentContextByAgentId.get(threat.agentId ?? '');
+      if (!agentContext) {
+        skipped += 1;
+        continue;
+      }
 
       if (status === 'active' && detectedAt && detectedAt >= emitSince) {
         threatsToEmit.push({
           s1ThreatId: threat.id,
-          orgId: target.orgId,
+          orgId: agentContext.orgId,
           severity,
-          deviceId: target.deviceId,
+          deviceId: agentContext.deviceId,
           detectedAt
         });
       }
 
-      return {
-        orgId: target.orgId,
+      values.push({
+        orgId: agentContext.orgId,
         integrationId: integration.id,
-        deviceId: target.deviceId,
+        deviceId: agentContext.deviceId,
         s1ThreatId: threat.id,
         classification: threat.classification ?? null,
         severity,
@@ -514,8 +744,8 @@ async function syncThreatsForIntegration(
         resolvedAt,
         details: threat,
         updatedAt: new Date()
-      };
-    });
+      });
+    }
 
     if (values.length === 0) continue;
 
@@ -573,6 +803,7 @@ async function syncThreatsForIntegration(
   return {
     fetched: fetchedThreats.length,
     upserted,
+    skipped,
     emitted,
     emitFailures,
     truncated: threatResult.truncated
@@ -590,7 +821,7 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
   const [integration] = await db
     .select({
       id: s1Integrations.id,
-      orgId: s1Integrations.orgId,
+      partnerId: s1Integrations.partnerId,
       managementUrl: s1Integrations.managementUrl,
       apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
       isActive: s1Integrations.isActive,
@@ -655,7 +886,7 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
     // Full detail (including the upstream response body, redacted) goes to the
     // SERVER-SIDE log only. The tenant-visible column gets a body-free message
     // via truncateError — a SentinelOneHttpError's `.message` carries no body.
-    logSyncFailureServerSide({ integrationId: integration.id, orgId: integration.orgId }, error);
+    logSyncFailureServerSide({ integrationId: integration.id, partnerId: integration.partnerId }, error);
     try {
       await db
         .update(s1Integrations)
@@ -718,20 +949,26 @@ async function processPollActions() {
     return { polled: 0, updated: 0 };
   }
 
+  // Legacy action polling: actions still carry org_id; find the integration via legacyOrgId.
+  // The partner-wide migration (C3+) will rework action dispatch; until then this uses the
+  // legacy org_id column that was preserved as s1Integrations.legacyOrgId.
   const orgIds = Array.from(new Set(pendingActions.map((row) => row.orgId)));
   const integrations = await db
     .select({
-      orgId: s1Integrations.orgId,
+      orgId: s1Integrations.legacyOrgId,
       managementUrl: s1Integrations.managementUrl,
       apiTokenEncrypted: s1Integrations.apiTokenEncrypted
     })
     .from(s1Integrations)
-    .where(and(inArray(s1Integrations.orgId, orgIds), eq(s1Integrations.isActive, true)));
+    .where(and(isNotNull(s1Integrations.legacyOrgId), eq(s1Integrations.isActive, true)));
 
   // Build a reusable client per org to avoid redundant decrypt + instantiation per action
   const clientByOrg = new Map<string, SentinelOneClient | null>();
   const clientErrorByOrg = new Map<string, string>();
   for (const integration of integrations) {
+    if (!integration.orgId) continue; // type guard: isNotNull filter ensures this
+    // Only include integrations whose legacy org_id matches a pending action
+    if (!orgIds.includes(integration.orgId)) continue;
     let token: string | null;
     try {
       token = decryptForColumn('s1_integrations', 'api_token_encrypted', integration.apiTokenEncrypted);

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -4,6 +4,7 @@ import * as dbModule from '../db';
 import {
   devices,
   deviceNetwork,
+  organizations,
   s1Actions,
   s1Agents,
   s1Integrations,
@@ -320,15 +321,6 @@ export function resolveAgentSyncTarget(
   };
 }
 
-export function resolveThreatSyncTarget(
-  agentId: string | null | undefined,
-  defaultOrgId: string,
-  agentContextByAgentId: Map<string, AgentContext>
-): AgentContext {
-  const agentContext = agentContextByAgentId.get(agentId ?? '');
-  return agentContext ?? { orgId: defaultOrgId, deviceId: null };
-}
-
 /**
  * Load s1_org_mappings rows that have a mapped org, keyed by s1_site_id.
  * Only includes rows with non-null org_id (mirrors huntressSync loadMappedOrgIds).
@@ -557,9 +549,14 @@ async function syncAgentsForIntegration(
   }));
 
   // Step 1: Reconcile provisional mappings BEFORE upsert so carried org_id survives.
+  // Skip sites with no siteName — a null siteName can never match a provisional row
+  // (which is keyed as 'name:<siteName>'), so attempting reconciliation would silently
+  // miss and build a 'name:<siteId>' key that matches nothing.
   await reconcileProvisionalSiteMappings(
     integration.id,
-    discoveredSites.map((s) => ({ siteId: s.siteId, siteName: s.siteName ?? s.siteId }))
+    discoveredSites
+      .filter((s): s is { siteId: string; siteName: string; count: number } => typeof s.siteName === 'string' && s.siteName.length > 0)
+      .map((s) => ({ siteId: s.siteId, siteName: s.siteName }))
   );
 
   // Step 2: Upsert discovered sites (sets agents_count, last_seen_at; preserves org_id).
@@ -926,7 +923,7 @@ async function processSyncAll(syncAgents: boolean, syncThreats: boolean) {
   return { queued: integrations.length };
 }
 
-async function processPollActions() {
+export async function processPollActions() {
   const pendingActions = await db
     .select({
       id: s1Actions.id,
@@ -949,44 +946,76 @@ async function processPollActions() {
     return { polled: 0, updated: 0 };
   }
 
-  // Legacy action polling: actions still carry org_id; find the integration via legacyOrgId.
-  // The partner-wide migration (C3+) will rework action dispatch; until then this uses the
-  // legacy org_id column that was preserved as s1Integrations.legacyOrgId.
+  // Resolve each action's org → partner → active integration.
+  // Actions carry org_id; s1_integrations is now partner-axis (legacyOrgId is often NULL).
+  // We look up partner_id via the organizations table, then fetch the active integration
+  // for each distinct partner. This correctly handles partner-wide integrations whose
+  // legacyOrgId is NULL (they would never be found by a legacyOrgId lookup).
   const orgIds = Array.from(new Set(pendingActions.map((row) => row.orgId)));
-  const integrations = await db
-    .select({
-      orgId: s1Integrations.legacyOrgId,
-      managementUrl: s1Integrations.managementUrl,
-      apiTokenEncrypted: s1Integrations.apiTokenEncrypted
-    })
-    .from(s1Integrations)
-    .where(and(isNotNull(s1Integrations.legacyOrgId), eq(s1Integrations.isActive, true)));
 
-  // Build a reusable client per org to avoid redundant decrypt + instantiation per action
-  const clientByOrg = new Map<string, SentinelOneClient | null>();
-  const clientErrorByOrg = new Map<string, string>();
-  for (const integration of integrations) {
-    if (!integration.orgId) continue; // type guard: isNotNull filter ensures this
-    // Only include integrations whose legacy org_id matches a pending action
-    if (!orgIds.includes(integration.orgId)) continue;
+  // Step 1: Resolve org_id → partner_id
+  const orgRows = await db
+    .select({
+      id: organizations.id,
+      partnerId: organizations.partnerId,
+    })
+    .from(organizations)
+    .where(inArray(organizations.id, orgIds));
+
+  const partnerIdByOrg = new Map<string, string>();
+  for (const row of orgRows) {
+    partnerIdByOrg.set(row.id, row.partnerId);
+  }
+
+  // Step 2: Fetch the active integration for each distinct partner (deduplicated)
+  const distinctPartnerIds = Array.from(new Set([...partnerIdByOrg.values()]));
+  const partnerIntegrations = distinctPartnerIds.length > 0
+    ? await db
+        .select({
+          partnerId: s1Integrations.partnerId,
+          managementUrl: s1Integrations.managementUrl,
+          apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
+        })
+        .from(s1Integrations)
+        .where(and(inArray(s1Integrations.partnerId, distinctPartnerIds), eq(s1Integrations.isActive, true)))
+    : [];
+
+  // Step 3: Build a reusable client per partner to avoid redundant decrypt + instantiation
+  const clientByPartner = new Map<string, SentinelOneClient | null>();
+  const clientErrorByPartner = new Map<string, string>();
+  for (const integration of partnerIntegrations) {
     let token: string | null;
     try {
       token = decryptForColumn('s1_integrations', 'api_token_encrypted', integration.apiTokenEncrypted);
     } catch (cryptoError) {
-      // Permanent failure — don't retry actions tied to this org
-      clientByOrg.set(integration.orgId, null);
-      clientErrorByOrg.set(integration.orgId, `Token decryption failed: ${truncateError(cryptoError)}`);
+      clientByPartner.set(integration.partnerId, null);
+      clientErrorByPartner.set(integration.partnerId, `Token decryption failed: ${truncateError(cryptoError)}`);
       continue;
     }
     if (!token) {
-      clientByOrg.set(integration.orgId, null);
-      clientErrorByOrg.set(integration.orgId, 'SentinelOne integration token is missing or invalid');
+      clientByPartner.set(integration.partnerId, null);
+      clientErrorByPartner.set(integration.partnerId, 'SentinelOne integration token is missing or invalid');
       continue;
     }
-    clientByOrg.set(integration.orgId, new SentinelOneClient({
+    clientByPartner.set(integration.partnerId, new SentinelOneClient({
       managementUrl: integration.managementUrl,
-      apiToken: token
+      apiToken: token,
     }));
+  }
+
+  // Step 4: Map each org to its partner's client (multiple orgs share one client)
+  const clientByOrg = new Map<string, SentinelOneClient | null>();
+  const clientErrorByOrg = new Map<string, string>();
+  for (const orgId of orgIds) {
+    const partnerId = partnerIdByOrg.get(orgId);
+    if (!partnerId) continue; // org not found in DB — leave clientByOrg undefined for this org
+    if (clientByPartner.has(partnerId)) {
+      clientByOrg.set(orgId, clientByPartner.get(partnerId) ?? null);
+      const err = clientErrorByPartner.get(partnerId);
+      if (err) clientErrorByOrg.set(orgId, err);
+    }
+    // If partner has no active integration, clientByOrg remains undefined for this org
+    // → will hit the "No integration found" branch below
   }
 
   let updated = 0;

--- a/apps/api/src/jobs/s1Sync_sites.test.ts
+++ b/apps/api/src/jobs/s1Sync_sites.test.ts
@@ -101,13 +101,14 @@ vi.mock('../services/sentinelOne/metrics', () => ({
 
 const listAgentsMock = vi.fn();
 const listThreatsMock = vi.fn().mockResolvedValue({ results: [], truncated: false });
+const getActivityStatusMock = vi.fn();
 
 vi.mock('../services/sentinelOne/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/sentinelOne/client')>();
   class MockSentinelOneClient {
     listAgents = listAgentsMock;
     listThreats = listThreatsMock;
-    getActivityStatus = vi.fn();
+    getActivityStatus = getActivityStatusMock;
   }
   return { ...actual, SentinelOneClient: MockSentinelOneClient };
 });
@@ -118,6 +119,7 @@ const {
   upsertDiscoveredSites,
   reconcileProvisionalSiteMappings,
   processSyncIntegration,
+  processPollActions,
 } = await import('./s1Sync');
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -343,5 +345,107 @@ describe('C2 sync: unmapped agents are skipped (not written to a fallback org)',
     expect(unmappedInsert).toBeUndefined();
     expect(mappedInsert).toBeDefined();
     expect(mappedInsert!.orgId).toBe('org-1');
+  });
+});
+
+describe('processPollActions — partner-axis integration resolution', () => {
+  /**
+   * Fix 1 regression guard: processPollActions must resolve integrations via
+   * org → partner → active integration, NOT via legacyOrgId. A partner-wide
+   * integration with legacyOrgId NULL was previously missed, causing pending
+   * actions to be permanently marked failed.
+   *
+   * SELECT call sequence inside processPollActions:
+   *   1. s1_actions WHERE status IN ('queued','in_progress') AND providerActionId IS NOT NULL
+   *   2. organizations WHERE id IN (orgIds) → partner_id lookup
+   *   3. s1_integrations WHERE partner_id IN (partnerIds) AND is_active = true
+   *   4. client.getActivityStatus() is called for each action
+   */
+
+  it('resolves a partner-wide integration (legacyOrgId NULL) and polls the action — not marked failed', async () => {
+    // Pending action under org-1
+    mockDb.select
+      // 1. pending actions
+      .mockReturnValueOnce(
+        selectReturning([{
+          id: 'action-1',
+          orgId: 'org-1',
+          deviceId: 'device-1',
+          action: 'quarantine',
+          payload: {},
+          providerActionId: 'provider-act-1',
+          status: 'queued',
+        }])
+      )
+      // 2. organizations lookup: org-1 → partner-A
+      .mockReturnValueOnce(
+        selectReturning([{ id: 'org-1', partnerId: 'partner-A' }])
+      )
+      // 3. s1_integrations: partner-A has active integration with legacyOrgId NULL
+      .mockReturnValueOnce(
+        selectReturning([{
+          partnerId: 'partner-A',
+          managementUrl: 'https://s1.example.com',
+          apiTokenEncrypted: 'enc',
+          legacyOrgId: null, // partner-wide: no legacy org_id
+        }])
+      )
+      .mockReturnValue(selectReturning([]));
+
+    // Client returns a successful poll result
+    getActivityStatusMock.mockResolvedValue({
+      status: 'completed',
+      details: null,
+    });
+
+    const result = await processPollActions();
+
+    // Action was polled (not skipped as "no integration")
+    expect(result.polled).toBe(1);
+    expect(result.updated).toBe(1);
+
+    // The DB update must have been called with 'completed', NOT 'failed'
+    const failedUpdate = updatedPayloads.find(
+      (p) => p.status === 'failed' && String(p.error ?? '').includes('no active SentinelOne integration')
+    );
+    expect(failedUpdate).toBeUndefined();
+
+    const completedUpdate = updatedPayloads.find((p) => p.status === 'completed');
+    expect(completedUpdate).toBeDefined();
+  });
+
+  it('marks an action failed when the org partner genuinely has no active integration', async () => {
+    // Pending action under org-2
+    mockDb.select
+      // 1. pending actions
+      .mockReturnValueOnce(
+        selectReturning([{
+          id: 'action-2',
+          orgId: 'org-2',
+          deviceId: 'device-2',
+          action: 'quarantine',
+          payload: {},
+          providerActionId: 'provider-act-2',
+          status: 'queued',
+        }])
+      )
+      // 2. organizations lookup: org-2 → partner-B
+      .mockReturnValueOnce(
+        selectReturning([{ id: 'org-2', partnerId: 'partner-B' }])
+      )
+      // 3. s1_integrations: no active integration for partner-B
+      .mockReturnValueOnce(selectReturning([]))
+      .mockReturnValue(selectReturning([]));
+
+    const result = await processPollActions();
+
+    expect(result.polled).toBe(1);
+    expect(result.updated).toBe(1);
+
+    // The action must be marked failed with the "no integration" message
+    const failedUpdate = updatedPayloads.find(
+      (p) => p.status === 'failed' && String(p.error ?? '').includes('no active SentinelOne integration')
+    );
+    expect(failedUpdate).toBeDefined();
   });
 });

--- a/apps/api/src/jobs/s1Sync_sites.test.ts
+++ b/apps/api/src/jobs/s1Sync_sites.test.ts
@@ -1,0 +1,347 @@
+/**
+ * C2 site-discovery and provisional-mapping reconciliation tests.
+ *
+ * Tests the DB-touching helpers:
+ *   - upsertDiscoveredSites: one row per distinct site, correct agents_count
+ *   - reconcileProvisionalSiteMappings: provisional row rewritten to real site id,
+ *     org_id preserved, no provisional row survives
+ *   - syncAgentsForIntegration: agents whose site is unmapped are SKIPPED (counted)
+ *
+ * Follows the s1Sync_syncError.test.ts pattern: module-level vi.mock + dynamic
+ * import so the DB mock is in place before the module resolves its `db` binding.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── DB mock ─────────────────────────────────────────────────────────────────
+
+const insertedValues: Array<Record<string, unknown>> = [];
+const updatedPayloads: Array<Record<string, unknown>> = [];
+const deletedWhere: Array<unknown> = [];
+
+/**
+ * Tracks args for INSERT ... values(...).onConflictDoUpdate chains.
+ * db.insert(table) → chain; chain.values(rows) captures rows and returns chain.
+ * Returns a chain whose final `.returning()` resolves to [].
+ */
+function makeInsertMock() {
+  return vi.fn().mockImplementation(() => {
+    // db.insert(table) — returns a chain with .values()
+    const chain = {
+      values: vi.fn().mockImplementation((rows: Record<string, unknown> | Record<string, unknown>[]) => {
+        const arr = Array.isArray(rows) ? rows : [rows];
+        insertedValues.push(...arr);
+        return chain;
+      }),
+      onConflictDoUpdate: vi.fn().mockReturnThis(),
+      onConflictDoNothing: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([]),
+    };
+    // make thenable so `await db.insert(t).values(v)` works without explicit .returning()
+    (chain as unknown as Record<string, unknown>).then = (resolve: (v: unknown[]) => unknown) => resolve([]);
+    return chain;
+  });
+}
+
+function makeUpdateMock() {
+  return vi.fn().mockImplementation(() => ({
+    set: vi.fn().mockImplementation((payload: Record<string, unknown>) => {
+      updatedPayloads.push(payload);
+      return { where: vi.fn().mockResolvedValue([]) };
+    }),
+  }));
+}
+
+function makeDeleteMock() {
+  return vi.fn().mockImplementation(() => ({
+    where: vi.fn().mockImplementation((clause: unknown) => {
+      deletedWhere.push(clause);
+      return Promise.resolve([]);
+    }),
+  }));
+}
+
+// SELECT chain: returns `rows` when awaited.
+function selectReturning(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  for (const method of ['from', 'where', 'innerJoin', 'leftJoin']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.limit = vi.fn().mockResolvedValue(rows);
+  chain.then = (resolve: (value: unknown[]) => unknown) => resolve(rows);
+  return chain;
+}
+
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: undefined,
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+}));
+
+vi.mock('../services/secretCrypto', () => ({
+  decryptForColumn: () => 'decrypted-token',
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../services/sentinelOne/metrics', () => ({
+  recordS1ActionDispatch: vi.fn(),
+  recordS1ActionPollTransition: vi.fn(),
+  recordS1SyncRun: vi.fn(),
+}));
+
+// ── Mock SentinelOneClient ───────────────────────────────────────────────────
+
+const listAgentsMock = vi.fn();
+const listThreatsMock = vi.fn().mockResolvedValue({ results: [], truncated: false });
+
+vi.mock('../services/sentinelOne/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/sentinelOne/client')>();
+  class MockSentinelOneClient {
+    listAgents = listAgentsMock;
+    listThreats = listThreatsMock;
+    getActivityStatus = vi.fn();
+  }
+  return { ...actual, SentinelOneClient: MockSentinelOneClient };
+});
+
+// ── Dynamic import (after mocks) ─────────────────────────────────────────────
+
+const {
+  upsertDiscoveredSites,
+  reconcileProvisionalSiteMappings,
+  processSyncIntegration,
+} = await import('./s1Sync');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Prime a single integration SELECT returning one row with partnerId. */
+function primeIntegration(extra: Partial<Record<string, unknown>> = {}) {
+  mockDb.select
+    .mockReturnValueOnce(
+      selectReturning([{
+        id: 'int-1',
+        partnerId: 'partner-1',
+        managementUrl: 'https://example.sentinelone.net',
+        apiTokenEncrypted: 'enc',
+        isActive: true,
+        lastSyncAt: null,
+        ...extra,
+      }])
+    )
+    .mockReturnValue(selectReturning([]));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertedValues.length = 0;
+  updatedPayloads.length = 0;
+  deletedWhere.length = 0;
+  mockDb.insert.mockImplementation(makeInsertMock());
+  mockDb.update.mockImplementation(makeUpdateMock());
+  mockDb.delete.mockImplementation(makeDeleteMock());
+  mockDb.select.mockReturnValue(selectReturning([]));
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('upsertDiscoveredSites', () => {
+  it('upserts one row per distinct site with correct agents_count', async () => {
+    await upsertDiscoveredSites({
+      integrationId: 'int-1',
+      partnerId: 'partner-1',
+      sites: [
+        { siteId: 'site-123', siteName: 'Acme', count: 3 },
+        { siteId: 'site-456', siteName: 'Beta Corp', count: 7 },
+      ],
+    });
+
+    // Two inserts (one per site)
+    expect(insertedValues).toHaveLength(2);
+    const site123 = insertedValues.find((v) => v.s1SiteId === 'site-123');
+    const site456 = insertedValues.find((v) => v.s1SiteId === 'site-456');
+    expect(site123).toBeDefined();
+    expect(site123!.agentsCount).toBe(3);
+    expect(site123!.s1SiteName).toBe('Acme');
+    expect(site123!.integrationId).toBe('int-1');
+    expect(site123!.partnerId).toBe('partner-1');
+    expect(site456).toBeDefined();
+    expect(site456!.agentsCount).toBe(7);
+  });
+
+  it('is a no-op when there are no sites', async () => {
+    await upsertDiscoveredSites({ integrationId: 'int-1', partnerId: 'partner-1', sites: [] });
+    expect(insertedValues).toHaveLength(0);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcileProvisionalSiteMappings', () => {
+  it('rewrites provisional row to real site id and preserves org_id (collision rule: UPDATE wins)', async () => {
+    // Provisional row found for this integration + name
+    mockDb.select.mockReturnValueOnce(
+      selectReturning([{
+        id: 'mapping-prov-1',
+        s1SiteId: 'name:Acme',
+        s1SiteName: 'Acme',
+        orgId: 'org-O1',
+        metadata: { provisional: true },
+      }])
+    );
+
+    // No existing real row for site-123 (no conflict)
+    mockDb.select.mockReturnValue(selectReturning([]));
+
+    await reconcileProvisionalSiteMappings('int-1', [
+      { siteId: 'site-123', siteName: 'Acme' },
+    ]);
+
+    // Should UPDATE the provisional row with the real site id
+    expect(updatedPayloads.length).toBeGreaterThan(0);
+    const rewrite = updatedPayloads.find((p) => p.s1SiteId === 'site-123');
+    expect(rewrite).toBeDefined();
+    // org_id must be preserved — the update does NOT null it out
+    expect(rewrite!.orgId).toBe('org-O1');
+  });
+
+  it('deletes provisional row when a real row already exists for that siteId', async () => {
+    // First SELECT: find provisional row matching 'name:Acme'
+    mockDb.select
+      .mockReturnValueOnce(
+        selectReturning([{
+          id: 'mapping-prov-1',
+          s1SiteId: 'name:Acme',
+          s1SiteName: 'Acme',
+          orgId: 'org-O1',
+          metadata: { provisional: true },
+        }])
+      )
+      // Second SELECT: existing real row already present for site-123
+      .mockReturnValueOnce(
+        selectReturning([{
+          id: 'mapping-real-1',
+          s1SiteId: 'site-123',
+          orgId: 'org-real',
+          metadata: null,
+        }])
+      )
+      .mockReturnValue(selectReturning([]));
+
+    await reconcileProvisionalSiteMappings('int-1', [
+      { siteId: 'site-123', siteName: 'Acme' },
+    ]);
+
+    // Provisional row must be deleted (real row wins)
+    expect(deletedWhere.length).toBeGreaterThan(0);
+    // Should NOT have written a rewrite update (real row stays)
+    const rewrite = updatedPayloads.find((p) => p.s1SiteId === 'site-123');
+    expect(rewrite).toBeUndefined();
+  });
+
+  it('is a no-op when there are no discovered sites', async () => {
+    await reconcileProvisionalSiteMappings('int-1', []);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('C2 sync: unmapped agents are skipped (not written to a fallback org)', () => {
+  it('agents whose site has no mapped org are skipped; no s1_agents row is written for them', async () => {
+    primeIntegration();
+
+    // Two agents: siteId 'site-mapped' has org-1 mapped, 'site-unmapped' has no mapping
+    listAgentsMock.mockResolvedValue({
+      results: [
+        {
+          id: 'agent-mapped',
+          siteId: 'site-mapped',
+          siteName: 'Mapped Site',
+          isActive: true,
+          infected: false,
+          activeThreats: 0,
+          policyName: null,
+          lastSeen: null,
+          uuid: null,
+          computerName: 'desktop-a',
+          machineType: null,
+          osName: null,
+          updatedAt: null,
+          networkInterfaces: [],
+        },
+        {
+          id: 'agent-unmapped',
+          siteId: 'site-unmapped',
+          siteName: 'Unmapped Site',
+          isActive: true,
+          infected: false,
+          activeThreats: 0,
+          policyName: null,
+          lastSeen: null,
+          uuid: null,
+          computerName: 'desktop-b',
+          machineType: null,
+          osName: null,
+          updatedAt: null,
+          networkInterfaces: [],
+        },
+      ],
+      truncated: false,
+    });
+
+    // Mock SELECT call sequence for processSyncIntegration:
+    //  1. integration row
+    //  2. reconcileProvisionalSiteMappings: provisional lookup for 'name:Mapped Site' → empty
+    //  3. reconcileProvisionalSiteMappings: provisional lookup for 'name:Unmapped Site' → empty
+    //  4. mapSiteOrgIds: s1OrgMappings rows (site-mapped → org-1)
+    //  5. mapDeviceCandidatesByOrg: empty devices
+    //  6+. update s1Integrations lastSyncAt → handled by update mock
+    mockDb.select
+      .mockReturnValueOnce(
+        selectReturning([{
+          id: 'int-1',
+          partnerId: 'partner-1',
+          managementUrl: 'https://example.sentinelone.net',
+          apiTokenEncrypted: 'enc',
+          isActive: true,
+          lastSyncAt: null,
+        }])
+      )
+      // reconcileProvisionalSiteMappings: no provisional rows for either site
+      .mockReturnValueOnce(selectReturning([]))
+      .mockReturnValueOnce(selectReturning([]))
+      // mapSiteOrgIds: one mapped org (site-mapped → org-1)
+      .mockReturnValueOnce(
+        selectReturning([{
+          s1SiteId: 'site-mapped',
+          orgId: 'org-1',
+        }])
+      )
+      // mapDeviceCandidatesByOrg: empty devices
+      .mockReturnValue(selectReturning([]));
+
+    await processSyncIntegration({
+      type: 'sync-integration',
+      integrationId: 'int-1',
+      syncAgents: true,
+      syncThreats: false,
+    });
+
+    // Check which agent rows were inserted
+    const agentInserts = insertedValues.filter(
+      (v) => 's1AgentId' in v || 'integrationId' in v
+    );
+
+    // Only the mapped agent should be inserted; unmapped must NOT appear
+    const unmappedInsert = agentInserts.find((v) => v.s1AgentId === 'agent-unmapped');
+    const mappedInsert = agentInserts.find((v) => v.s1AgentId === 'agent-mapped');
+    expect(unmappedInsert).toBeUndefined();
+    expect(mappedInsert).toBeDefined();
+    expect(mappedInsert!.orgId).toBe('org-1');
+  });
+});

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const { permissionGate, mfaGate, permsState } = vi.hoisted(() => ({
+const { permissionGate, mfaGate, permsState, authState } = vi.hoisted(() => ({
   permissionGate: { deny: false },
   mfaGate: { deny: false },
-  permsState: { permissions: undefined as { allowedSiteIds?: string[] } | undefined }
+  permsState: { permissions: undefined as { allowedSiteIds?: string[] } | undefined },
+  authState: {
+    scope: 'organization' as string,
+    orgId: '11111111-1111-4111-8111-111111111111' as string | undefined,
+    partnerId: 'a0000000-0000-4000-8000-000000000001' as string | undefined,
+    accessibleOrgIds: ['11111111-1111-4111-8111-111111111111'] as string[],
+    canAccessOrg: (orgId: string) => orgId === '11111111-1111-4111-8111-111111111111',
+    orgCondition: () => undefined as any,
+  }
 }));
 
 vi.mock('../db', () => ({
@@ -13,8 +21,7 @@ vi.mock('../db', () => ({
     insert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn()
-  }
-,
+  },
   runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
@@ -22,6 +29,7 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema', () => ({
   devices: { id: 'id', orgId: 'orgId', hostname: 'hostname', siteId: 'siteId' },
+  organizations: { id: 'id', name: 'name', partnerId: 'partnerId' },
   s1Actions: {
     id: 'id',
     orgId: 'orgId',
@@ -43,7 +51,8 @@ vi.mock('../db/schema', () => ({
   },
   s1Integrations: {
     id: 'id',
-    orgId: 'orgId',
+    partnerId: 'partnerId',
+    legacyOrgId: 'legacyOrgId',
     name: 'name',
     managementUrl: 'managementUrl',
     apiTokenEncrypted: 'apiTokenEncrypted',
@@ -54,6 +63,19 @@ vi.mock('../db/schema', () => ({
     createdAt: 'createdAt',
     updatedAt: 'updatedAt',
     createdBy: 'createdBy'
+  },
+  s1OrgMappings: {
+    id: 'id',
+    integrationId: 'integrationId',
+    partnerId: 'partnerId',
+    s1SiteId: 's1SiteId',
+    s1SiteName: 's1SiteName',
+    orgId: 'orgId',
+    agentsCount: 'agentsCount',
+    metadata: 'metadata',
+    lastSeenAt: 'lastSeenAt',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
   },
   s1Threats: {
     id: 'id',
@@ -69,11 +91,12 @@ vi.mock('../db/schema', () => ({
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {
-      scope: 'organization',
-      orgId: '11111111-1111-1111-1111-111111111111',
-      accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
-      canAccessOrg: (orgId: string) => orgId === '11111111-1111-1111-1111-111111111111',
-      orgCondition: () => undefined,
+      scope: authState.scope,
+      orgId: authState.orgId,
+      partnerId: authState.partnerId,
+      accessibleOrgIds: authState.accessibleOrgIds,
+      canAccessOrg: authState.canAccessOrg,
+      orgCondition: authState.orgCondition,
       user: { id: 'user-123', email: 'test@example.com' }
     });
     return next();
@@ -126,7 +149,7 @@ vi.mock('../services/permissions', () => ({
     !perms?.allowedSiteIds || perms.allowedSiteIds.includes(siteId)
 }));
 
-import { sentinelOneRoutes } from './sentinelOne';
+import { sentinelOneRoutes, requirePartnerManager, resolvePartnerId, resolveOrgId } from './sentinelOne';
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
 import {
@@ -136,6 +159,12 @@ import {
 } from '../services/sentinelOne/actions';
 import { encryptSecret } from '../services/secretCrypto';
 
+const PARTNER_ID = 'a0000000-0000-4000-8000-000000000001';
+const OTHER_PARTNER_ID = 'a0000000-0000-4000-8000-000000000002';
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const INTEGRATION_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const S1_SITE_ID = 's1-site-abc123';
+
 describe('sentinel one routes', () => {
   let app: Hono;
 
@@ -143,244 +172,935 @@ describe('sentinel one routes', () => {
     vi.clearAllMocks();
     permissionGate.deny = false;
     mfaGate.deny = false;
+    // Default: org-scope caller (reset all authState fields)
+    authState.scope = 'organization';
+    authState.orgId = ORG_ID;
+    authState.partnerId = PARTNER_ID;
+    authState.accessibleOrgIds = [ORG_ID];
+    authState.canAccessOrg = (orgId: string) => orgId === ORG_ID;
+    authState.orgCondition = () => undefined as any;
+    permsState.permissions = undefined;
 
     app = new Hono();
     app.route('/s1', sentinelOneRoutes);
   });
 
-  it('rejects integration save when permission check fails', async () => {
-    permissionGate.deny = true;
-
-    const res = await app.request('/s1/integration', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: 'SentinelOne Prod',
-        managementUrl: 'https://example.sentinelone.net',
-        apiToken: 'token'
-      })
+  // ───────────────────── B1: Helper unit tests ─────────────────────
+  describe('requirePartnerManager', () => {
+    it('rejects organization scope', () => {
+      const r = requirePartnerManager({ scope: 'organization', partnerId: 'p1' } as any);
+      expect(r).toEqual({ error: 'SentinelOne credentials and mappings are managed at partner scope', status: 403 });
     });
-
-    expect(res.status).toBe(403);
+    it('pins partner scope to its partnerId', () => {
+      const r = requirePartnerManager({ scope: 'partner', partnerId: 'p1' } as any);
+      expect(r).toEqual({ partnerId: 'p1' });
+    });
+    it('system scope requires explicit partnerId', () => {
+      const r = requirePartnerManager({ scope: 'system' } as any);
+      expect(r).toEqual({ error: 'partnerId is required for system scope', status: 400 });
+    });
+    it('system scope with explicit partnerId resolves', () => {
+      const r = requirePartnerManager({ scope: 'system' } as any, 'p1');
+      expect(r).toEqual({ partnerId: 'p1' });
+    });
+    it('rejects partner trying to access another partner', () => {
+      const r = requirePartnerManager({ scope: 'partner', partnerId: 'p1' } as any, 'p2');
+      expect(r).toEqual({ error: 'Access to this partner denied', status: 403 });
+    });
   });
 
-  it('fails integration save when token encryption fails', async () => {
-    vi.mocked(encryptSecret).mockReturnValueOnce(null);
-
-    const res = await app.request('/s1/integration', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: 'SentinelOne Prod',
-        managementUrl: 'https://example.sentinelone.net',
-        apiToken: 'token'
-      })
+  describe('resolvePartnerId', () => {
+    it('resolves org scope to its partnerId', () => {
+      const r = resolvePartnerId({ scope: 'organization', partnerId: 'p1' } as any);
+      expect(r).toEqual({ partnerId: 'p1' });
     });
-
-    expect(res.status).toBe(500);
+    it('org scope rejects cross-partner request', () => {
+      const r = resolvePartnerId({ scope: 'organization', partnerId: 'p1' } as any, 'p2');
+      expect(r).toEqual({ error: 'Access to this partner denied', status: 403 });
+    });
+    it('system scope with no requested partnerId returns error', () => {
+      const r = resolvePartnerId({ scope: 'system' } as any);
+      expect(r).toEqual({ error: 'partnerId is required for system scope', status: 400 });
+    });
   });
 
-  it('rejects non-HTTPS management URLs', async () => {
-    const res = await app.request('/s1/integration', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: 'SentinelOne Prod',
-        managementUrl: 'http://example.sentinelone.net',
-        apiToken: 'token'
-      })
+  describe('resolveOrgId', () => {
+    it('org scope returns its orgId', () => {
+      const r = resolveOrgId({ scope: 'organization', orgId: 'o1', accessibleOrgIds: ['o1'], canAccessOrg: () => true } as any);
+      expect(r).toEqual({ orgId: 'o1' });
     });
-
-    expect(res.status).toBe(400);
+    it('org scope rejects cross-org access', () => {
+      const r = resolveOrgId({ scope: 'organization', orgId: 'o1', accessibleOrgIds: ['o1'], canAccessOrg: (id: string) => id === 'o1' } as any, 'o2');
+      expect(r).toEqual({ error: 'Access to this organization denied', status: 403 });
+    });
   });
 
-  it('rejects management URLs not on the sentinelone.net allowlist (SSRF)', async () => {
-    const res = await app.request('/s1/integration', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: 'SentinelOne Prod',
-        managementUrl: 'https://internal-vault.cluster.local/',
-        apiToken: 'token'
-      })
+  // ───────────────────── B2: POST /integration ─────────────────────
+  describe('POST /integration', () => {
+    it('rejects org scope with 403', async () => {
+      // requireScope is mocked to always pass, but our route logic rejects org scope
+      authState.scope = 'organization';
+
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://example.sentinelone.net',
+          apiToken: 'token'
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain('partner scope');
     });
 
-    expect(res.status).toBe(400);
-  });
+    it('allows partner scope and inserts with partnerId', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
 
-  it('rejects management URLs pointing at cloud-metadata (SSRF)', async () => {
-    const res = await app.request('/s1/integration', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: 'SentinelOne Prod',
-        managementUrl: 'https://169.254.169.254/latest/meta-data/',
-        apiToken: 'token'
-      })
-    });
-
-    expect(res.status).toBe(400);
-  });
-
-  it('requires token re-entry when changing the SentinelOne management host', async () => {
-    vi.mocked(db.select).mockReturnValueOnce({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(async () => [{
-            id: 'integration-1',
-            managementUrl: 'https://old.sentinelone.net',
-            apiTokenEncrypted: 'enc:stored-token'
+      // First select: check existing (returns nothing)
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+      // insert returning
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: INTEGRATION_ID,
+            partnerId: PARTNER_ID,
+            name: 'SentinelOne Prod',
+            managementUrl: 'https://example.sentinelone.net',
+            isActive: true,
+            lastSyncAt: null,
+            lastSyncStatus: null,
+            lastSyncError: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
           }])
+        })
+      } as any);
+
+      const { scheduleS1Sync } = await import('../jobs/s1Sync');
+      vi.mocked(scheduleS1Sync).mockResolvedValueOnce('job-1');
+
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://example.sentinelone.net',
+          apiToken: 'token'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const resBody = await res.json();
+      expect(resBody.data.partnerId).toBe(PARTNER_ID);
+    });
+
+    it('updates when existing integration found (filters by partner_id)', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+
+      // First select: returns existing integration
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              managementUrl: 'https://example.sentinelone.net',
+              apiTokenEncrypted: 'enc:stored-token'
+            }])
+          })
+        })
+      } as any);
+      // update returning
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+              name: 'SentinelOne Prod',
+              managementUrl: 'https://example.sentinelone.net',
+              isActive: true,
+              lastSyncAt: null,
+              lastSyncStatus: null,
+              lastSyncError: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            }])
+          })
+        })
+      } as any);
+
+      const { scheduleS1Sync } = await import('../jobs/s1Sync');
+      vi.mocked(scheduleS1Sync).mockResolvedValueOnce('job-2');
+
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://example.sentinelone.net',
+          apiToken: 'new-token'
+        })
+      });
+
+      expect(res.status).toBe(200);
+      // update was called (not insert)
+      expect(db.update).toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects integration save when permission check fails', async () => {
+      permissionGate.deny = true;
+
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://example.sentinelone.net',
+          apiToken: 'token'
+        })
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('fails integration save when token encryption fails', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+      vi.mocked(encryptSecret).mockReturnValueOnce(null);
+
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://example.sentinelone.net',
+          apiToken: 'token'
+        })
+      });
+
+      expect(res.status).toBe(500);
+    });
+
+    it('rejects non-HTTPS management URLs', async () => {
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'http://example.sentinelone.net',
+          apiToken: 'token'
+        })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects management URLs not on the sentinelone.net allowlist (SSRF)', async () => {
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://internal-vault.cluster.local/',
+          apiToken: 'token'
+        })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects management URLs pointing at cloud-metadata (SSRF)', async () => {
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://169.254.169.254/latest/meta-data/',
+          apiToken: 'token'
+        })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('requires token re-entry when changing the SentinelOne management host', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [{
+              id: 'integration-1',
+              managementUrl: 'https://old.sentinelone.net',
+              apiTokenEncrypted: 'enc:stored-token'
+            }])
+          }))
         }))
-      }))
-    } as any);
+      } as any);
 
-    const res = await app.request('/s1/integration', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: 'SentinelOne Prod',
-        managementUrl: 'https://new.sentinelone.net'
-      })
+      const res = await app.request('/s1/integration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SentinelOne Prod',
+          managementUrl: 'https://new.sentinelone.net'
+        })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(String(body.error)).toContain('re-entered');
+      expect(db.insert).not.toHaveBeenCalled();
     });
-
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(String(body.error)).toContain('re-entered');
-    expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('rejects isolate action when MFA check fails', async () => {
-    mfaGate.deny = true;
+  // ───────────────────── B3: POST /organizations/map ─────────────────────
+  describe('POST /organizations/map', () => {
+    it('rejects org scope with 403', async () => {
+      authState.scope = 'organization';
 
-    const res = await app.request('/s1/isolate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        deviceIds: ['11111111-1111-1111-1111-111111111111']
-      })
+      const res = await app.request('/s1/organizations/map', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          integrationId: INTEGRATION_ID,
+          s1SiteId: S1_SITE_ID,
+          orgId: ORG_ID
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain('partner scope');
     });
 
-    expect(res.status).toBe(403);
-  });
+    it('partner maps own site to org successfully', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+      authState.canAccessOrg = (orgId: string) => orgId === ORG_ID;
 
-  it('rejects cross-org status access', async () => {
-    const res = await app.request('/s1/status?orgId=22222222-2222-2222-2222-222222222222');
-    expect(res.status).toBe(403);
-  });
+      // 1. Integration lookup
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+            }])
+          })
+        })
+      } as any);
+      // 2. Target org lookup
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: ORG_ID,
+              partnerId: PARTNER_ID,
+            }])
+          })
+        })
+      } as any);
+      // 3. Update s1OrgMappings
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              s1SiteId: S1_SITE_ID,
+              mappedOrgId: ORG_ID,
+            }])
+          })
+        })
+      } as any);
 
-  it('returns warning when isolate dispatch has no provider activity id', async () => {
-    vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
-      id: 'int-1',
-      orgId: '11111111-1111-1111-1111-111111111111',
-      name: 'S1',
-      lastSyncAt: null,
-      lastSyncStatus: null,
-      lastSyncError: null
-    } as any);
-    vi.mocked(executeS1IsolationForOrg).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      data: {
-        requestedDeviceIds: ['11111111-1111-1111-1111-111111111111'],
-        inaccessibleDeviceIds: [],
-        unmappedAccessibleDeviceIds: [],
-        requestedDevices: 1,
-        mappedAgents: 1,
-        providerActionId: null,
-        actions: [{ id: 'action-1', deviceId: '11111111-1111-1111-1111-111111111111' }],
-        warning: 'Provider did not return activityId; action cannot be tracked'
-      }
-    } as any);
+      const res = await app.request('/s1/organizations/map', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          integrationId: INTEGRATION_ID,
+          s1SiteId: S1_SITE_ID,
+          orgId: ORG_ID
+        })
+      });
 
-    const res = await app.request('/s1/isolate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        deviceIds: ['11111111-1111-1111-1111-111111111111']
-      })
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.s1SiteId).toBe(S1_SITE_ID);
+      expect(body.data.mappedOrgId).toBe(ORG_ID);
     });
 
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.warnings).toEqual(['Provider did not return activityId; action cannot be tracked']);
-    expect(body.data.providerActionId).toBeNull();
-  });
+    it('rejects mapping an org from a different partner (cross-partner org)', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+      authState.canAccessOrg = (orgId: string) => orgId === ORG_ID;
 
-  it('returns 502 with persisted action details when isolate dispatch fails', async () => {
-    vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
-      id: 'int-1',
-      orgId: '11111111-1111-1111-1111-111111111111',
-      name: 'S1',
-      lastSyncAt: null,
-      lastSyncStatus: null,
-      lastSyncError: null
-    } as any);
-    vi.mocked(executeS1IsolationForOrg).mockResolvedValueOnce({
-      ok: true,
-      status: 502,
-      data: {
-        requestedDeviceIds: ['11111111-1111-1111-1111-111111111111'],
-        inaccessibleDeviceIds: [],
-        unmappedAccessibleDeviceIds: [],
-        requestedDevices: 1,
-        mappedAgents: 1,
-        providerActionId: null,
-        actions: [{ id: 'action-err-1', deviceId: '11111111-1111-1111-1111-111111111111' }],
-        warning: 'SentinelOne action dispatch failed: provider timeout'
-      }
-    } as any);
+      // Integration belongs to PARTNER_ID
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+            }])
+          })
+        })
+      } as any);
+      // Target org belongs to OTHER_PARTNER_ID
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: ORG_ID,
+              partnerId: OTHER_PARTNER_ID,
+            }])
+          })
+        })
+      } as any);
 
-    const res = await app.request('/s1/isolate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        deviceIds: ['11111111-1111-1111-1111-111111111111']
-      })
+      const res = await app.request('/s1/organizations/map', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          integrationId: INTEGRATION_ID,
+          s1SiteId: S1_SITE_ID,
+          orgId: ORG_ID
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain('does not belong to this partner');
     });
 
-    expect(res.status).toBe(502);
-    const body = await res.json();
-    expect(body.error).toContain('SentinelOne action dispatch failed');
-    expect(body.data.actions).toHaveLength(1);
-  });
+    it('returns 404 when discovered site not found (non-existent s1SiteId)', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+      authState.canAccessOrg = (orgId: string) => orgId === ORG_ID;
 
-  it('returns partial threat action results with unmatched threat ids', async () => {
-    vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
-      id: 'int-1',
-      orgId: '11111111-1111-1111-1111-111111111111',
-      name: 'S1',
-      lastSyncAt: null,
-      lastSyncStatus: null,
-      lastSyncError: null
-    } as any);
-    vi.mocked(executeS1ThreatActionForOrg).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      data: {
-        action: 'kill',
-        requestedThreats: 2,
-        matchedThreats: 1,
-        matchedThreatIds: ['s1-threat-1'],
-        unmatchedThreatIds: ['missing-threat'],
-        providerActionId: 'activity-1',
-        actions: [{ id: 'action-1', deviceId: 'device-1' }]
-      }
-    } as any);
+      // Integration lookup
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+            }])
+          })
+        })
+      } as any);
+      // Target org lookup
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: ORG_ID,
+              partnerId: PARTNER_ID,
+            }])
+          })
+        })
+      } as any);
+      // Update returns empty (no matching row)
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
 
-    const res = await app.request('/s1/threat-action', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        action: 'kill',
-        threatIds: ['s1-threat-1', 'missing-threat']
-      })
+      const res = await app.request('/s1/organizations/map', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          integrationId: INTEGRATION_ID,
+          s1SiteId: 'nonexistent-site-id',
+          orgId: ORG_ID
+        })
+      });
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toContain('Run sync first to discover sites');
     });
 
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.data.unmatchedThreatIds).toEqual(['missing-threat']);
-    expect(body.data.matchedThreatIds).toEqual(['s1-threat-1']);
+    it('partner can unmap by passing orgId=null', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+      authState.canAccessOrg = (orgId: string) => orgId === ORG_ID;
+
+      // Integration lookup
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+            }])
+          })
+        })
+      } as any);
+      // Update returns row with null orgId
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              s1SiteId: S1_SITE_ID,
+              mappedOrgId: null,
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/s1/organizations/map', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          integrationId: INTEGRATION_ID,
+          s1SiteId: S1_SITE_ID,
+          orgId: null
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.mappedOrgId).toBeNull();
+    });
+  });
+
+  // ───────────────────── B4: /status ─────────────────────
+  describe('GET /status', () => {
+    it('returns empty summary when no integration found', async () => {
+      authState.scope = 'organization';
+      authState.partnerId = PARTNER_ID;
+
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/s1/status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.integration).toBeNull();
+      expect(body.summary.totalAgents).toBe(0);
+    });
+
+    it('org scope returns empty summary when org is not mapped', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+      authState.partnerId = PARTNER_ID;
+
+      // Integration found
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+              name: 'S1',
+              managementUrl: 'https://example.sentinelone.net',
+              isActive: true,
+              lastSyncAt: null,
+              lastSyncStatus: null,
+              lastSyncError: null,
+            }])
+          })
+        })
+      } as any);
+      // No mapping for this org
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/s1/status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.mapped).toBe(false);
+      expect(body.summary.totalAgents).toBe(0);
+    });
+
+    it('partner scope returns cross-org coverage', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+
+      // Integration found
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+              name: 'S1',
+              managementUrl: 'https://example.sentinelone.net',
+              isActive: true,
+              lastSyncAt: null,
+              lastSyncStatus: null,
+              lastSyncError: null,
+            }])
+          })
+        })
+      } as any);
+
+      // Agent summary
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            totalAgents: 5,
+            mappedDevices: 3,
+            infectedAgents: 1,
+            totalThreatCount: 2
+          }])
+        })
+      } as any);
+      // Threat summary
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            activeThreats: 2,
+            highOrCritical: 1
+          }])
+        })
+      } as any);
+      // Action summary
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            pendingActions: 0
+          }])
+        })
+      } as any);
+
+      const res = await app.request('/s1/status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.mapped).toBe(true);
+      expect(body.summary.totalAgents).toBe(5);
+      expect(body.summary.activeThreats).toBe(2);
+    });
+
+    it('rejects cross-org status access for org scope', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+      authState.canAccessOrg = (orgId: string) => orgId === ORG_ID;
+
+      const res = await app.request('/s1/status?orgId=b0000000-0000-4000-8000-000000000099');
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ───────────────────── B4: /isolate ─────────────────────
+  describe('POST /isolate', () => {
+    it('rejects isolate action when MFA check fails', async () => {
+      mfaGate.deny = true;
+
+      const res = await app.request('/s1/isolate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceIds: [ORG_ID]
+        })
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('calls getActiveS1IntegrationForOrg with orgId and writes audit with orgId', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+
+      vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
+        id: INTEGRATION_ID,
+        orgId: ORG_ID,
+        name: 'S1',
+        lastSyncAt: null,
+        lastSyncStatus: null,
+        lastSyncError: null
+      } as any);
+      vi.mocked(executeS1IsolationForOrg).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          requestedDeviceIds: [ORG_ID],
+          inaccessibleDeviceIds: [],
+          unmappedAccessibleDeviceIds: [],
+          requestedDevices: 1,
+          mappedAgents: 1,
+          providerActionId: 'activity-1',
+          actions: [{ id: 'action-1', deviceId: ORG_ID }],
+          warning: null
+        }
+      } as any);
+
+      const { writeRouteAudit } = await import('../services/auditEvents');
+
+      const res = await app.request('/s1/isolate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceIds: [ORG_ID]
+        })
+      });
+
+      expect(res.status).toBe(200);
+      expect(getActiveS1IntegrationForOrg).toHaveBeenCalledWith(ORG_ID);
+      // Audit written with orgId
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ orgId: ORG_ID })
+      );
+    });
+
+    it('returns warning when isolate dispatch has no provider activity id', async () => {
+      vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
+        id: 'int-1',
+        orgId: ORG_ID,
+        name: 'S1',
+        lastSyncAt: null,
+        lastSyncStatus: null,
+        lastSyncError: null
+      } as any);
+      vi.mocked(executeS1IsolationForOrg).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          requestedDeviceIds: [ORG_ID],
+          inaccessibleDeviceIds: [],
+          unmappedAccessibleDeviceIds: [],
+          requestedDevices: 1,
+          mappedAgents: 1,
+          providerActionId: null,
+          actions: [{ id: 'action-1', deviceId: ORG_ID }],
+          warning: 'Provider did not return activityId; action cannot be tracked'
+        }
+      } as any);
+
+      const res = await app.request('/s1/isolate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceIds: [ORG_ID]
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.warnings).toEqual(['Provider did not return activityId; action cannot be tracked']);
+      expect(body.data.providerActionId).toBeNull();
+    });
+
+    it('returns 502 with persisted action details when isolate dispatch fails', async () => {
+      vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
+        id: 'int-1',
+        orgId: ORG_ID,
+        name: 'S1',
+        lastSyncAt: null,
+        lastSyncStatus: null,
+        lastSyncError: null
+      } as any);
+      vi.mocked(executeS1IsolationForOrg).mockResolvedValueOnce({
+        ok: true,
+        status: 502,
+        data: {
+          requestedDeviceIds: [ORG_ID],
+          inaccessibleDeviceIds: [],
+          unmappedAccessibleDeviceIds: [],
+          requestedDevices: 1,
+          mappedAgents: 1,
+          providerActionId: null,
+          actions: [{ id: 'action-err-1', deviceId: ORG_ID }],
+          warning: 'SentinelOne action dispatch failed: provider timeout'
+        }
+      } as any);
+
+      const res = await app.request('/s1/isolate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceIds: [ORG_ID]
+        })
+      });
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body.error).toContain('SentinelOne action dispatch failed');
+      expect(body.data.actions).toHaveLength(1);
+    });
+  });
+
+  // ───────────────────── B4: /threat-action ─────────────────────
+  describe('POST /threat-action', () => {
+    it('calls getActiveS1IntegrationForOrg and writes audit with orgId', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+
+      vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
+        id: INTEGRATION_ID,
+        orgId: ORG_ID,
+        name: 'S1',
+        lastSyncAt: null,
+        lastSyncStatus: null,
+        lastSyncError: null
+      } as any);
+      vi.mocked(executeS1ThreatActionForOrg).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          action: 'kill',
+          requestedThreats: 1,
+          matchedThreats: 1,
+          matchedThreatIds: ['s1-threat-1'],
+          unmatchedThreatIds: [],
+          providerActionId: 'activity-2',
+          actions: [{ id: 'action-2', deviceId: 'device-1' }]
+        }
+      } as any);
+
+      const { writeRouteAudit } = await import('../services/auditEvents');
+
+      const res = await app.request('/s1/threat-action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'kill',
+          threatIds: ['s1-threat-1']
+        })
+      });
+
+      expect(res.status).toBe(200);
+      expect(getActiveS1IntegrationForOrg).toHaveBeenCalledWith(ORG_ID);
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ orgId: ORG_ID })
+      );
+    });
+
+    it('returns partial threat action results with unmatched threat ids', async () => {
+      vi.mocked(getActiveS1IntegrationForOrg).mockResolvedValueOnce({
+        id: 'int-1',
+        orgId: ORG_ID,
+        name: 'S1',
+        lastSyncAt: null,
+        lastSyncStatus: null,
+        lastSyncError: null
+      } as any);
+      vi.mocked(executeS1ThreatActionForOrg).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          action: 'kill',
+          requestedThreats: 2,
+          matchedThreats: 1,
+          matchedThreatIds: ['s1-threat-1'],
+          unmatchedThreatIds: ['missing-threat'],
+          providerActionId: 'activity-1',
+          actions: [{ id: 'action-1', deviceId: 'device-1' }]
+        }
+      } as any);
+
+      const res = await app.request('/s1/threat-action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'kill',
+          threatIds: ['s1-threat-1', 'missing-threat']
+        })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.unmatchedThreatIds).toEqual(['missing-threat']);
+      expect(body.data.matchedThreatIds).toEqual(['s1-threat-1']);
+    });
+  });
+
+  // ───────────────────── B4: POST /sync ─────────────────────
+  describe('POST /sync', () => {
+    it('rejects org scope with 403', async () => {
+      authState.scope = 'organization';
+
+      const res = await app.request('/s1/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain('partner scope');
+    });
+
+    it('partner scope finds active integration and schedules sync', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: INTEGRATION_ID,
+              partnerId: PARTNER_ID,
+              name: 'S1',
+              isActive: true,
+            }])
+          })
+        })
+      } as any);
+
+      const { scheduleS1Sync } = await import('../jobs/s1Sync');
+      vi.mocked(scheduleS1Sync).mockResolvedValueOnce('sync-job-1');
+
+      const res = await app.request('/s1/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.integrationId).toBe(INTEGRATION_ID);
+      expect(body.data.jobId).toBe('sync-job-1');
+    });
+
+    it('returns 404 when no active integration found for partner', async () => {
+      authState.scope = 'partner';
+      authState.partnerId = PARTNER_ID;
+
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/s1/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+
+      expect(res.status).toBe(404);
+    });
   });
 
   // ───────────────────── GET /threats — site scope ─────────────────────
@@ -389,28 +1109,21 @@ describe('sentinel one routes', () => {
   // their allowlist, nor target a foreign-site device via ?deviceId=.
   // Site is an app-layer concept only — Postgres RLS does not defend it.
   describe('GET /threats — site scope', () => {
-    const ORG_ID = '11111111-1111-1111-1111-111111111111';
     const SITE_ALLOWED = 'aaaaaaaa-0000-0000-0000-000000000001';
     const SITE_DENIED = 'bbbbbbbb-0000-0000-0000-000000000002';
-    const DEVICE_ALLOWED = '33333333-3333-3333-3333-333333333333';
-    const DEVICE_DENIED = '55555555-5555-5555-5555-555555555555';
+    const DEVICE_ALLOWED = 'd0000000-0000-4000-8000-000000000001';
+    const DEVICE_DENIED = 'd0000000-0000-4000-8000-000000000002';
 
     function setAuth(allowedSiteIds?: string[]) {
       // `permissions` is populated by requirePermission (see global mock), not
       // authMiddleware — faithful to prod, so a route lacking the permission
       // gate will not receive site scoping and its tests will fail.
       permsState.permissions = allowedSiteIds ? { allowedSiteIds } : undefined;
-      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
-        c.set('auth', {
-          scope: 'organization',
-          orgId: ORG_ID,
-          accessibleOrgIds: [ORG_ID],
-          canAccessOrg: (orgId: string) => orgId === ORG_ID,
-          orgCondition: () => undefined,
-          user: { id: 'user-123', email: 'test@example.com' }
-        });
-        return next();
-      });
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+      authState.accessibleOrgIds = [ORG_ID];
+      authState.canAccessOrg = (orgId: string) => orgId === ORG_ID;
+      authState.orgCondition = () => undefined as any;
     }
     const setRestricted = (allowedSiteIds: string[]) => setAuth(allowedSiteIds);
 

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -467,6 +467,112 @@ describe('sentinel one routes', () => {
     });
   });
 
+  // ───────────────────── B2: GET /integration ─────────────────────
+  describe('GET /integration', () => {
+    const INTEGRATION_ROW = {
+      id: INTEGRATION_ID,
+      partnerId: PARTNER_ID,
+      name: 'S1 Prod',
+      managementUrl: 'https://example.sentinelone.net',
+      isActive: true,
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      hasApiToken: true,
+    };
+
+    // Mocks the integration lookup (db.select from s1Integrations)
+    function mockIntegrationLookup(result: typeof INTEGRATION_ROW | null) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(result ? [result] : [])
+          })
+        })
+      } as any);
+    }
+
+    // Mocks the s1OrgMappings mapped-check (db.select from s1OrgMappings)
+    function mockMappingLookup(found: boolean) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(found ? [{ id: 'mapping-1' }] : [])
+          })
+        })
+      } as any);
+    }
+
+    it('(a) org-scope caller whose org IS mapped returns 200 with integration data', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+      authState.partnerId = PARTNER_ID;
+
+      mockIntegrationLookup(INTEGRATION_ROW);
+      mockMappingLookup(true);
+
+      const res = await app.request('/s1/integration');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).not.toBeNull();
+      expect(body.data.id).toBe(INTEGRATION_ID);
+      expect(body.data.partnerId).toBe(PARTNER_ID);
+      // Verify the mapping check ran (db.select called twice: integration + mapping)
+      expect(db.select).toHaveBeenCalledTimes(2);
+    });
+
+    it('(b) org-scope caller whose org is NOT mapped returns 200 with mapped:false and data:null', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+      authState.partnerId = PARTNER_ID;
+
+      mockIntegrationLookup(INTEGRATION_ROW);
+      mockMappingLookup(false);
+
+      const res = await app.request('/s1/integration');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toBeNull();
+      expect(body.mapped).toBe(false);
+      // Verify the mapping check did run (not skipped)
+      expect(db.select).toHaveBeenCalledTimes(2);
+    });
+
+    it('(c) org-scope caller passing a different orgId than their own gets 403', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+      authState.partnerId = PARTNER_ID;
+
+      // Integration lookup runs first (before resolveOrgId is called)
+      mockIntegrationLookup(INTEGRATION_ROW);
+      // No mapping lookup should run — the 403 fires first
+
+      const OTHER_ORG_ID = '22222222-2222-4222-8222-222222222222';
+      const res = await app.request(`/s1/integration?orgId=${OTHER_ORG_ID}`);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/organization/i);
+      // Mapping check must NOT have run (only 1 select: the integration lookup)
+      expect(db.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('(d) org-scope caller passing a partnerId that does not match their own gets 403', async () => {
+      authState.scope = 'organization';
+      authState.orgId = ORG_ID;
+      authState.partnerId = PARTNER_ID;
+
+      // resolvePartnerId fires before the DB lookup — no select should run
+      const res = await app.request(`/s1/integration?partnerId=${OTHER_PARTNER_ID}`);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/partner/i);
+      // No DB calls should have been made
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
   // ───────────────────── B3: POST /organizations/map ─────────────────────
   describe('POST /organizations/map', () => {
     it('rejects org scope with 403', async () => {

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -536,6 +536,9 @@ describe('sentinel one routes', () => {
       const body = await res.json();
       expect(body.data).toBeNull();
       expect(body.mapped).toBe(false);
+      // `connected: true` lets the web distinguish "your org isn't mapped"
+      // (partner IS connected) from "no integration at all" (`{ data: null }`).
+      expect(body.connected).toBe(true);
       // Verify the mapping check did run (not skipped)
       expect(db.select).toHaveBeenCalledTimes(2);
     });
@@ -805,6 +808,9 @@ describe('sentinel one routes', () => {
       const body = await res.json();
       expect(body.integration).toBeNull();
       expect(body.summary.totalAgents).toBe(0);
+      // Shape must match the success branch so the web tiles never render blank.
+      expect(body.summary.highOrCriticalThreats).toBe(0);
+      expect(body.summary.reportedThreatCount).toBe(0);
     });
 
     it('org scope returns empty summary when org is not mapped', async () => {

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -847,7 +847,6 @@ sentinelOneRoutes.post(
   '/sync',
   requireScope('partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
-  requireMfa(),
   zValidator('json', syncSchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -298,7 +298,7 @@ sentinelOneRoutes.get(
           eq(s1OrgMappings.orgId, orgResult.orgId)
         ))
         .limit(1);
-      if (!mapping) return c.json({ data: null, mapped: false });
+      if (!mapping) return c.json({ data: null, mapped: false, connected: true });
     }
 
     return c.json({ data: integration });
@@ -508,7 +508,9 @@ sentinelOneRoutes.get(
           mappedDevices: 0,
           infectedAgents: 0,
           activeThreats: 0,
-          pendingActions: 0
+          highOrCriticalThreats: 0,
+          pendingActions: 0,
+          reportedThreatCount: 0
         }
       });
     }

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, desc, eq, gte, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
-import { devices, organizations, s1Actions, s1Agents, s1Integrations, s1SiteMappings, s1Threats } from '../db/schema';
+import { devices, organizations, s1Actions, s1Agents, s1Integrations, s1OrgMappings, s1Threats } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import {
   isThreatAction,
@@ -28,6 +28,73 @@ import { S1_HOSTNAME_ALLOWLIST } from '../services/sentinelOne/constants';
 
 export const sentinelOneRoutes = new Hono();
 sentinelOneRoutes.use('*', authMiddleware);
+
+type RouteAuth = Pick<AuthContext, 'scope' | 'partnerId' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>;
+
+// B1: Partner-scope resolution helpers
+
+export function resolvePartnerId(
+  auth: RouteAuth,
+  requested?: string
+): { partnerId: string } | { error: string; status: 400 | 403 } {
+  if (auth.scope === 'partner') {
+    if (!auth.partnerId) return { error: 'Partner context required', status: 403 };
+    if (requested && requested !== auth.partnerId) return { error: 'Access to this partner denied', status: 403 };
+    return { partnerId: auth.partnerId };
+  }
+
+  if (auth.scope === 'organization') {
+    if (!auth.partnerId) return { error: 'Partner context required', status: 403 };
+    if (requested && requested !== auth.partnerId) return { error: 'Access to this partner denied', status: 403 };
+    return { partnerId: auth.partnerId };
+  }
+
+  if (!requested) return { error: 'partnerId is required for system scope', status: 400 };
+  return { partnerId: requested };
+}
+
+export function requirePartnerManager(
+  auth: RouteAuth,
+  requested?: string
+): { partnerId: string } | { error: string; status: 400 | 403 } {
+  if (auth.scope === 'organization') {
+    return { error: 'SentinelOne credentials and mappings are managed at partner scope', status: 403 };
+  }
+  return resolvePartnerId(auth, requested);
+}
+
+export function resolveOrgId(
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>,
+  requestedOrgId?: string
+): { orgId: string } | { error: string; status: 400 | 403 } {
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) {
+      return { error: 'Organization context required', status: 403 };
+    }
+    if (requestedOrgId && requestedOrgId !== auth.orgId) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: auth.orgId };
+  }
+
+  if (requestedOrgId) {
+    if (!auth.canAccessOrg(requestedOrgId)) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { orgId: requestedOrgId };
+  }
+
+  if (auth.orgId) {
+    return { orgId: auth.orgId };
+  }
+
+  const orgIds = auth.accessibleOrgIds ?? [];
+  if (orgIds.length === 1 && orgIds[0]) {
+    return { orgId: orgIds[0] };
+  }
+
+  return { error: 'orgId is required for this scope', status: 400 };
+}
 
 function withOrgCondition(conditions: SQL[], condition: SQL | undefined): void {
   if (condition) conditions.push(condition);
@@ -93,41 +160,18 @@ async function hasDeniedThreatDeviceSite(
   return hasDeniedDeviceSite(orgId, deviceIds, permissions);
 }
 
-function resolveOrgId(
-  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>,
-  requestedOrgId?: string
-): { orgId: string } | { error: string; status: 400 | 403 } {
-  if (auth.scope === 'organization') {
-    if (!auth.orgId) {
-      return { error: 'Organization context required', status: 403 };
-    }
-    if (requestedOrgId && requestedOrgId !== auth.orgId) {
-      return { error: 'Access to this organization denied', status: 403 };
-    }
-    return { orgId: auth.orgId };
-  }
-
-  if (requestedOrgId) {
-    if (!auth.canAccessOrg(requestedOrgId)) {
-      return { error: 'Access to this organization denied', status: 403 };
-    }
-    return { orgId: requestedOrgId };
-  }
-
-  if (auth.orgId) {
-    return { orgId: auth.orgId };
-  }
-
-  const orgIds = auth.accessibleOrgIds ?? [];
-  if (orgIds.length === 1 && orgIds[0]) {
-    return { orgId: orgIds[0] };
-  }
-
-  return { error: 'orgId is required for this scope', status: 400 };
+function requestedPartnerId(c: { req: { query: (key: string) => string | undefined } }): string | undefined {
+  return c.req.query('partnerId');
 }
 
+function requestedOrgId(c: { req: { query: (key: string) => string | undefined } }): string | undefined {
+  return c.req.query('orgId');
+}
+
+// B2: Updated integration schemas — partner-scoped
+
 const integrationUpsertSchema = z.object({
-  orgId: z.string().guid().optional(),
+  partnerId: z.string().guid().optional(),
   name: z.string().min(1).max(200),
   managementUrl: z.string().url().max(2_000).superRefine((value, ctx) => {
     const result = checkSsrfSafe(value, {
@@ -146,6 +190,7 @@ const integrationUpsertSchema = z.object({
 });
 
 const listThreatsQuerySchema = z.object({
+  partnerId: z.string().guid().optional(),
   orgId: z.string().guid().optional(),
   integrationId: z.string().guid().optional(),
   deviceId: z.string().guid().optional(),
@@ -170,19 +215,35 @@ const threatActionSchema = z.object({
   threatIds: z.array(z.string().min(1).max(128)).min(1).max(200)
 });
 
+// B4: /sync — partner-scoped
 const syncSchema = z.object({
-  orgId: z.string().guid().optional(),
+  partnerId: z.string().guid().optional(),
   integrationId: z.string().guid().optional()
 });
 
+// B2: GET /integration — partner resolves; org callers also get mapped status
 const integrationQuerySchema = z.object({
-  orgId: z.string().guid().optional()
+  partnerId: z.string().guid().optional(),
+  orgId: z.string().guid().optional(),
 });
 
-const siteMapSchema = z.object({
+// B3: /organizations/map schema (replaces /sites/map)
+const organizationMapSchema = z.object({
   integrationId: z.string().guid(),
-  siteName: z.string().min(1).max(200),
+  s1SiteId: z.string().min(1).max(128),
   orgId: z.string().guid().nullable()
+});
+
+// B3: /sites query schema (partner-scope)
+const sitesQuerySchema = z.object({
+  partnerId: z.string().guid().optional(),
+  integrationId: z.string().guid().optional(),
+});
+
+// B4: status query schema
+const statusQuerySchema = z.object({
+  partnerId: z.string().guid().optional(),
+  orgId: z.string().guid().optional(),
 });
 
 function normalizedHost(value: string): string {
@@ -190,6 +251,7 @@ function normalizedHost(value: string): string {
   return parsed.host.toLowerCase();
 }
 
+// B2: GET /integration — dual-scope: partner resolves integration; org-scope also returns mapped status
 sentinelOneRoutes.get(
   '/integration',
   requireScope('organization', 'partner', 'system'),
@@ -197,15 +259,13 @@ sentinelOneRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const query = c.req.valid('query');
-    const orgResult = resolveOrgId(auth, query.orgId);
-    if ('error' in orgResult) {
-      return c.json({ error: orgResult.error }, orgResult.status);
-    }
+    const partnerResult = resolvePartnerId(auth, query.partnerId ?? requestedPartnerId(c));
+    if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
 
     const [integration] = await db
       .select({
         id: s1Integrations.id,
-        orgId: s1Integrations.orgId,
+        partnerId: s1Integrations.partnerId,
         name: s1Integrations.name,
         managementUrl: s1Integrations.managementUrl,
         isActive: s1Integrations.isActive,
@@ -213,19 +273,42 @@ sentinelOneRoutes.get(
         lastSyncStatus: s1Integrations.lastSyncStatus,
         lastSyncError: s1Integrations.lastSyncError,
         createdAt: s1Integrations.createdAt,
-        updatedAt: s1Integrations.updatedAt
+        updatedAt: s1Integrations.updatedAt,
+        hasApiToken: sql<boolean>`(${s1Integrations.apiTokenEncrypted} is not null and ${s1Integrations.apiTokenEncrypted} != '')`,
       })
       .from(s1Integrations)
-      .where(eq(s1Integrations.orgId, orgResult.orgId))
+      .where(and(
+        eq(s1Integrations.partnerId, partnerResult.partnerId),
+        eq(s1Integrations.isActive, true)
+      ))
       .limit(1);
 
-    return c.json({ data: integration ?? null });
+    if (!integration) {
+      return c.json({ data: null });
+    }
+
+    if (auth.scope === 'organization') {
+      const orgResult = resolveOrgId(auth, query.orgId ?? requestedOrgId(c));
+      if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+      const [mapping] = await db
+        .select({ id: s1OrgMappings.id })
+        .from(s1OrgMappings)
+        .where(and(
+          eq(s1OrgMappings.integrationId, integration.id),
+          eq(s1OrgMappings.orgId, orgResult.orgId)
+        ))
+        .limit(1);
+      if (!mapping) return c.json({ data: null, mapped: false });
+    }
+
+    return c.json({ data: integration });
   }
 );
 
+// B2: POST /integration — partner-only scope; writes partnerId, leaves legacyOrgId untouched
 sentinelOneRoutes.post(
   '/integration',
-  requireScope('organization', 'partner', 'system'),
+  requireScope('partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
   requireMfa(),
   zValidator('json', integrationUpsertSchema),
@@ -233,10 +316,8 @@ sentinelOneRoutes.post(
     const auth = c.get('auth');
     const body = c.req.valid('json');
 
-    const orgResult = resolveOrgId(auth, body.orgId);
-    if ('error' in orgResult) {
-      return c.json({ error: orgResult.error }, orgResult.status);
-    }
+    const partnerResult = requirePartnerManager(auth, body.partnerId ?? requestedPartnerId(c));
+    if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
 
     // Token is required for new integrations, optional for updates
     const hasToken = typeof body.apiToken === 'string' && body.apiToken.length > 0;
@@ -253,10 +334,14 @@ sentinelOneRoutes.post(
       .select({
         id: s1Integrations.id,
         managementUrl: s1Integrations.managementUrl,
-        apiTokenEncrypted: s1Integrations.apiTokenEncrypted
+        apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
+        isActive: s1Integrations.isActive,
       })
       .from(s1Integrations)
-      .where(eq(s1Integrations.orgId, orgResult.orgId))
+      .where(and(
+        eq(s1Integrations.partnerId, partnerResult.partnerId),
+        eq(s1Integrations.isActive, true)
+      ))
       .limit(1);
 
     if (!existing && !encryptedToken) {
@@ -264,6 +349,13 @@ sentinelOneRoutes.post(
     }
     if (existing && !encryptedToken && normalizedHost(existing.managementUrl) !== normalizedHost(body.managementUrl)) {
       return c.json({ error: 'API token must be re-entered when changing the SentinelOne management host' }, 400);
+    }
+
+    // For new integrations, encryptedToken is guaranteed non-null by the guard above.
+    // For updates, use the existing encrypted token as fallback.
+    const tokenForInsert = encryptedToken ?? existing?.apiTokenEncrypted;
+    if (!tokenForInsert) {
+      return c.json({ error: 'API token is required for new integrations' }, 400);
     }
 
     const now = new Date();
@@ -277,35 +369,53 @@ sentinelOneRoutes.post(
       conflictSet.apiTokenEncrypted = sql`excluded.api_token_encrypted`;
     }
 
-    // For new integrations, encryptedToken is guaranteed non-null by the guard above.
-    // For updates, use the existing encrypted token as fallback so the INSERT row
-    // satisfies NOT NULL even though the conflict path preserves the existing value.
-    const tokenForInsert = encryptedToken ?? existing?.apiTokenEncrypted;
-    if (!tokenForInsert) {
-      return c.json({ error: 'API token is required for new integrations' }, 400);
-    }
-
-    const [integration] = await db
-      .insert(s1Integrations)
-      .values({
-        orgId: orgResult.orgId,
-        name: body.name,
-        managementUrl: body.managementUrl,
-        apiTokenEncrypted: tokenForInsert,
-        isActive: body.isActive ?? true,
-        createdBy: auth.user.id,
-        updatedAt: now
-      })
-      .onConflictDoUpdate({
-        target: s1Integrations.orgId,
-        set: conflictSet
-      })
-      .returning({
-        id: s1Integrations.id,
-        orgId: s1Integrations.orgId,
-        name: s1Integrations.name,
-        isActive: s1Integrations.isActive
-      });
+    const [integration] = existing
+      ? await db
+        .update(s1Integrations)
+        .set({
+          name: body.name,
+          managementUrl: body.managementUrl,
+          isActive: body.isActive ?? existing.isActive ?? true,
+          ...(encryptedToken ? { apiTokenEncrypted: encryptedToken } : {}),
+          updatedAt: now,
+        })
+        .where(eq(s1Integrations.id, existing.id))
+        .returning({
+          id: s1Integrations.id,
+          partnerId: s1Integrations.partnerId,
+          name: s1Integrations.name,
+          managementUrl: s1Integrations.managementUrl,
+          isActive: s1Integrations.isActive,
+          lastSyncAt: s1Integrations.lastSyncAt,
+          lastSyncStatus: s1Integrations.lastSyncStatus,
+          lastSyncError: s1Integrations.lastSyncError,
+          createdAt: s1Integrations.createdAt,
+          updatedAt: s1Integrations.updatedAt,
+        })
+      : await db
+        .insert(s1Integrations)
+        .values({
+          partnerId: partnerResult.partnerId,
+          name: body.name,
+          managementUrl: body.managementUrl,
+          apiTokenEncrypted: tokenForInsert,
+          isActive: body.isActive ?? true,
+          createdBy: auth.user.id,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning({
+          id: s1Integrations.id,
+          partnerId: s1Integrations.partnerId,
+          name: s1Integrations.name,
+          managementUrl: s1Integrations.managementUrl,
+          isActive: s1Integrations.isActive,
+          lastSyncAt: s1Integrations.lastSyncAt,
+          lastSyncStatus: s1Integrations.lastSyncStatus,
+          lastSyncError: s1Integrations.lastSyncError,
+          createdAt: s1Integrations.createdAt,
+          updatedAt: s1Integrations.updatedAt,
+        });
 
     if (!integration) {
       return c.json({ error: 'Failed to save SentinelOne integration' }, 500);
@@ -313,21 +423,28 @@ sentinelOneRoutes.post(
 
     let syncJobId: string | null = null;
     let warning: string | undefined;
-    try {
-      syncJobId = await scheduleS1Sync(integration.id);
-    } catch (error) {
-      warning = `Integration saved but sync could not be scheduled: ${error instanceof Error ? error.message : String(error)}`;
-      console.error('[s1-route] Failed to schedule initial sync:', error);
+    if (integration.isActive) {
+      try {
+        syncJobId = await scheduleS1Sync(integration.id);
+      } catch (error) {
+        warning = `Integration saved but sync could not be scheduled: ${error instanceof Error ? error.message : String(error)}`;
+        console.error('[s1-route] Failed to schedule initial sync:', error);
+        captureException(error instanceof Error ? error : new Error(String(error)));
+      }
     }
 
     try {
       writeRouteAudit(c, {
-        orgId: integration.orgId,
-        action: 's1.integration.upsert',
+        orgId: null,
+        action: existing ? 's1.integration.update' : 's1.integration.create',
         resourceType: 's1_integration',
         resourceId: integration.id,
         resourceName: integration.name,
-        details: { isActive: integration.isActive, syncJobId }
+        details: {
+          partnerId: integration.partnerId,
+          isActive: integration.isActive,
+          syncJobId
+        }
       });
     } catch (auditErr) {
       console.error('[s1-route] Audit write failed:', auditErr);
@@ -337,29 +454,38 @@ sentinelOneRoutes.post(
     return c.json({
       data: {
         ...integration,
-        syncJobId
+        hasApiToken: true,
+        syncJobId,
       },
-      warning
-    });
+      ...(warning ? { warning } : {})
+    }, existing ? 200 : 201);
   }
 );
 
+// B4: GET /status — dual-scope: resolves partner's active integration; org-scope scopes to org
 sentinelOneRoutes.get(
   '/status',
   requireScope('organization', 'partner', 'system'),
-  zValidator('query', integrationQuerySchema),
+  zValidator('query', statusQuerySchema),
   async (c) => {
     const auth = c.get('auth');
     const query = c.req.valid('query');
-    const orgResult = resolveOrgId(auth, query.orgId);
-    if ('error' in orgResult) {
+    const partnerResult = resolvePartnerId(auth, query.partnerId ?? requestedPartnerId(c));
+    if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
+
+    const requestedOrg = query.orgId ?? requestedOrgId(c);
+    const orgResult = requestedOrg || auth.scope === 'organization'
+      ? resolveOrgId(auth, requestedOrg)
+      : null;
+    if (orgResult && 'error' in orgResult) {
       return c.json({ error: orgResult.error }, orgResult.status);
     }
+    const scopedOrgId = orgResult && 'orgId' in orgResult ? orgResult.orgId : null;
 
     const [integration] = await db
       .select({
         id: s1Integrations.id,
-        orgId: s1Integrations.orgId,
+        partnerId: s1Integrations.partnerId,
         name: s1Integrations.name,
         managementUrl: s1Integrations.managementUrl,
         isActive: s1Integrations.isActive,
@@ -368,7 +494,10 @@ sentinelOneRoutes.get(
         lastSyncError: s1Integrations.lastSyncError
       })
       .from(s1Integrations)
-      .where(eq(s1Integrations.orgId, orgResult.orgId))
+      .where(and(
+        eq(s1Integrations.partnerId, partnerResult.partnerId),
+        eq(s1Integrations.isActive, true)
+      ))
       .limit(1);
 
     if (!integration) {
@@ -384,6 +513,48 @@ sentinelOneRoutes.get(
       });
     }
 
+    // For org-scope callers, confirm the org is mapped before returning data
+    if (scopedOrgId) {
+      const [mapping] = await db
+        .select({ id: s1OrgMappings.id })
+        .from(s1OrgMappings)
+        .where(and(
+          eq(s1OrgMappings.integrationId, integration.id),
+          eq(s1OrgMappings.orgId, scopedOrgId)
+        ))
+        .limit(1);
+      if (!mapping) {
+        return c.json({
+          integration,
+          mapped: false,
+          summary: {
+            totalAgents: 0,
+            mappedDevices: 0,
+            infectedAgents: 0,
+            activeThreats: 0,
+            pendingActions: 0
+          }
+        });
+      }
+    }
+
+    const agentConditions: SQL[] = [eq(s1Agents.integrationId, integration.id)];
+    const threatConditions: SQL[] = [eq(s1Threats.integrationId, integration.id)];
+    const actionConditions: SQL[] = [];
+
+    if (scopedOrgId) {
+      agentConditions.push(eq(s1Agents.orgId, scopedOrgId));
+      threatConditions.push(eq(s1Threats.orgId, scopedOrgId));
+      actionConditions.push(eq(s1Actions.orgId, scopedOrgId));
+    } else {
+      const agentOrgCondition = auth.orgCondition(s1Agents.orgId);
+      const threatOrgCondition = auth.orgCondition(s1Threats.orgId);
+      const actionOrgCondition = auth.orgCondition(s1Actions.orgId);
+      if (agentOrgCondition) agentConditions.push(agentOrgCondition);
+      if (threatOrgCondition) threatConditions.push(threatOrgCondition);
+      if (actionOrgCondition) actionConditions.push(actionOrgCondition);
+    }
+
     const [agentSummary, threatSummary, actionSummary] = await Promise.all([
       db
         .select({
@@ -393,24 +564,25 @@ sentinelOneRoutes.get(
           totalThreatCount: sql<number>`coalesce(sum(${s1Agents.threatCount}), 0)::int`
         })
         .from(s1Agents)
-        .where(eq(s1Agents.integrationId, integration.id)),
+        .where(and(...agentConditions)),
       db
         .select({
           activeThreats: sql<number>`count(*) filter (where ${s1Threats.status} in ('active', 'in_progress'))::int`,
           highOrCritical: sql<number>`count(*) filter (where ${s1Threats.severity} in ('high', 'critical'))::int`
         })
         .from(s1Threats)
-        .where(eq(s1Threats.integrationId, integration.id)),
+        .where(and(...threatConditions)),
       db
         .select({
           pendingActions: sql<number>`count(*) filter (where ${s1Actions.status} in ('queued', 'in_progress'))::int`
         })
         .from(s1Actions)
-        .where(eq(s1Actions.orgId, integration.orgId))
+        .where(actionConditions.length > 0 ? and(...actionConditions) : undefined)
     ]);
 
     return c.json({
       integration,
+      mapped: true,
       summary: {
         totalAgents: Number(agentSummary[0]?.totalAgents ?? 0),
         mappedDevices: Number(agentSummary[0]?.mappedDevices ?? 0),
@@ -548,6 +720,8 @@ sentinelOneRoutes.post(
     if ('error' in orgResult) {
       return c.json({ error: orgResult.error }, orgResult.status);
     }
+    // getActiveS1IntegrationForOrg internals will be updated in Task C3;
+    // the route keeps its call signature unchanged.
     const integration = await getActiveS1IntegrationForOrg(orgResult.orgId);
 
     if (!integration) {
@@ -611,6 +785,8 @@ sentinelOneRoutes.post(
     if ('error' in orgResult) {
       return c.json({ error: orgResult.error }, orgResult.status);
     }
+    // getActiveS1IntegrationForOrg internals will be updated in Task C3;
+    // the route keeps its call signature unchanged.
     const integration = await getActiveS1IntegrationForOrg(orgResult.orgId);
 
     if (!integration) {
@@ -666,52 +842,50 @@ sentinelOneRoutes.post(
   }
 );
 
+// B4: POST /sync — partner-scoped; loads partner's active integration
 sentinelOneRoutes.post(
   '/sync',
-  requireScope('organization', 'partner', 'system'),
+  requireScope('partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
   zValidator('json', syncSchema),
   async (c) => {
     const auth = c.get('auth');
     const body = c.req.valid('json');
 
-    let integrationId = body.integrationId;
-    let orgId: string;
+    const partnerResult = requirePartnerManager(auth, body.partnerId ?? requestedPartnerId(c));
+    if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
 
-    if (integrationId) {
-      const [integration] = await db
-        .select({ id: s1Integrations.id, orgId: s1Integrations.orgId })
-        .from(s1Integrations)
-        .where(eq(s1Integrations.id, integrationId))
-        .limit(1);
+    const conditions: SQL[] = [
+      eq(s1Integrations.partnerId, partnerResult.partnerId),
+      eq(s1Integrations.isActive, true),
+    ];
+    if (body.integrationId) {
+      conditions.push(eq(s1Integrations.id, body.integrationId));
+    }
 
-      if (!integration || !auth.canAccessOrg(integration.orgId)) {
-        return c.json({ error: 'Integration not found or access denied' }, 404);
-      }
+    const [integration] = await db
+      .select({
+        id: s1Integrations.id,
+        partnerId: s1Integrations.partnerId,
+        name: s1Integrations.name,
+        isActive: s1Integrations.isActive,
+      })
+      .from(s1Integrations)
+      .where(and(...conditions))
+      .limit(1);
 
-      orgId = integration.orgId;
-    } else {
-      const orgResult = resolveOrgId(auth, body.orgId);
-      if ('error' in orgResult) {
-        return c.json({ error: orgResult.error }, orgResult.status);
-      }
-      orgId = orgResult.orgId;
+    if (!integration) {
+      return c.json({ error: 'SentinelOne integration not found' }, 404);
+    }
 
-      const [integration] = await db
-        .select({ id: s1Integrations.id })
-        .from(s1Integrations)
-        .where(and(eq(s1Integrations.orgId, orgId), eq(s1Integrations.isActive, true)))
-        .limit(1);
-
-      if (!integration) {
-        return c.json({ error: 'No active SentinelOne integration found for this organization' }, 404);
-      }
-      integrationId = integration.id;
+    if (!integration.isActive) {
+      return c.json({ error: 'Integration is inactive. Activate it before syncing.' }, 400);
     }
 
     let jobId: string;
     try {
-      jobId = await scheduleS1Sync(integrationId);
+      jobId = await scheduleS1Sync(integration.id);
     } catch (syncError) {
       console.error('[s1-route] Failed to schedule S1 sync:', syncError);
       captureException(syncError);
@@ -720,164 +894,143 @@ sentinelOneRoutes.post(
 
     try {
       writeRouteAudit(c, {
-        orgId,
+        orgId: null,
         action: 's1.sync.manual',
         resourceType: 's1_integration',
-        resourceId: integrationId,
-        details: { jobId }
+        resourceId: integration.id,
+        resourceName: integration.name,
+        details: { partnerId: integration.partnerId, jobId }
       });
     } catch (auditErr) {
       console.error('[s1-route] Audit write failed:', auditErr);
       captureException(auditErr);
     }
 
-    return c.json({ data: { integrationId, jobId } });
+    return c.json({ data: { integrationId: integration.id, jobId } });
   }
 );
 
+// B3: GET /sites — partner-scope; lists discovered s1OrgMappings rows for partner's active integration
 sentinelOneRoutes.get(
   '/sites',
-  requireScope('organization', 'partner', 'system'),
-  zValidator('query', integrationQuerySchema),
+  requireScope('partner', 'system'),
+  zValidator('query', sitesQuerySchema),
   async (c) => {
     const auth = c.get('auth');
     const query = c.req.valid('query');
-    const orgResult = resolveOrgId(auth, query.orgId);
-    if ('error' in orgResult) {
-      return c.json({ error: orgResult.error }, orgResult.status);
-    }
+    const partnerResult = requirePartnerManager(auth, query.partnerId ?? requestedPartnerId(c));
+    if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
+
+    const integrationConditions: SQL[] = [
+      eq(s1Integrations.partnerId, partnerResult.partnerId),
+      eq(s1Integrations.isActive, true),
+    ];
+    if (query.integrationId) integrationConditions.push(eq(s1Integrations.id, query.integrationId));
 
     const [integration] = await db
       .select({ id: s1Integrations.id })
       .from(s1Integrations)
-      .where(eq(s1Integrations.orgId, orgResult.orgId))
+      .where(and(...integrationConditions))
       .limit(1);
 
-    if (!integration) {
-      return c.json({ data: [] });
-    }
+    if (!integration) return c.json({ data: [], integrationId: null });
 
-    const siteRows = await db
+    const rows = await db
       .select({
-        siteName: sql<string>`metadata->>'siteName'`,
-        agentCount: sql<number>`count(*)::int`
+        s1SiteId: s1OrgMappings.s1SiteId,
+        s1SiteName: s1OrgMappings.s1SiteName,
+        agentsCount: s1OrgMappings.agentsCount,
+        mappedOrgId: s1OrgMappings.orgId,
+        mappedOrgName: organizations.name,
+        provisional: sql<boolean>`coalesce((${s1OrgMappings.metadata}->>'provisional')::boolean, false)`,
+        lastSeenAt: s1OrgMappings.lastSeenAt,
+        updatedAt: s1OrgMappings.updatedAt,
       })
-      .from(s1Agents)
-      .where(
-        and(
-          eq(s1Agents.integrationId, integration.id),
-          sql`metadata->>'siteName' IS NOT NULL`,
-          sql`metadata->>'siteName' != ''`
-        )
-      )
-      .groupBy(sql`metadata->>'siteName'`)
-      .orderBy(sql`metadata->>'siteName'`);
+      .from(s1OrgMappings)
+      .leftJoin(organizations, eq(s1OrgMappings.orgId, organizations.id))
+      .where(eq(s1OrgMappings.integrationId, integration.id))
+      .orderBy(s1OrgMappings.s1SiteName, s1OrgMappings.s1SiteId);
 
-    const mappings = await db
-      .select({
-        siteName: s1SiteMappings.siteName,
-        orgId: s1SiteMappings.orgId,
-        orgName: organizations.name
-      })
-      .from(s1SiteMappings)
-      .leftJoin(organizations, eq(s1SiteMappings.orgId, organizations.id))
-      .where(eq(s1SiteMappings.integrationId, integration.id));
-
-    const mappingBySite = new Map(mappings.map((m) => [m.siteName, { orgId: m.orgId, orgName: m.orgName }]));
-
-    const data = siteRows.map((row) => {
-      const mapping = mappingBySite.get(row.siteName);
-      return {
-        siteName: row.siteName,
-        agentCount: row.agentCount,
-        mappedOrgId: mapping?.orgId ?? null,
-        mappedOrgName: mapping?.orgName ?? null
-      };
-    });
-
-    return c.json({ data, integrationId: integration.id });
+    return c.json({ data: rows, integrationId: integration.id });
   }
 );
 
+// B3: POST /organizations/map — partner-only; body { integrationId, s1SiteId, orgId | null }
 sentinelOneRoutes.post(
-  '/sites/map',
-  requireScope('organization', 'partner', 'system'),
+  '/organizations/map',
+  requireScope('partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
-  zValidator('json', siteMapSchema),
+  requireMfa(),
+  zValidator('json', organizationMapSchema),
   async (c) => {
     const auth = c.get('auth');
     const body = c.req.valid('json');
 
+    // Early scope gate: org callers are rejected before any DB fetch.
+    // (In prod requireScope already blocks them; this guard makes the in-route
+    // requirePartnerManager check consistent even when requireScope is bypassed
+    // in tests.)
+    const earlyPartnerCheck = requirePartnerManager(auth);
+    if ('error' in earlyPartnerCheck) return c.json({ error: earlyPartnerCheck.error }, earlyPartnerCheck.status);
+
     const [integration] = await db
-      .select({ id: s1Integrations.id, orgId: s1Integrations.orgId })
+      .select({
+        id: s1Integrations.id,
+        partnerId: s1Integrations.partnerId,
+      })
       .from(s1Integrations)
-      .where(eq(s1Integrations.id, body.integrationId))
+      .where(and(
+        eq(s1Integrations.id, body.integrationId),
+        eq(s1Integrations.isActive, true)
+      ))
       .limit(1);
 
-    if (!integration || !auth.canAccessOrg(integration.orgId)) {
-      return c.json({ error: 'Integration not found or access denied' }, 404);
+    if (!integration) return c.json({ error: 'SentinelOne integration not found' }, 404);
+
+    // Full partner validation: confirm caller can manage this specific integration's partner
+    const partnerResult = requirePartnerManager(auth, integration.partnerId);
+    if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
+
+    if (body.orgId !== null) {
+      if (!auth.canAccessOrg(body.orgId)) {
+        return c.json({ error: 'Access to target organization denied' }, 403);
+      }
+
+      const [targetOrg] = await db
+        .select({ id: organizations.id, partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, body.orgId))
+        .limit(1);
+      if (!targetOrg || targetOrg.partnerId !== integration.partnerId) {
+        return c.json({ error: 'Target organization does not belong to this partner' }, 403);
+      }
     }
 
-    if (body.orgId === null) {
-      await db
-        .delete(s1SiteMappings)
-        .where(
-          and(
-            eq(s1SiteMappings.integrationId, body.integrationId),
-            eq(s1SiteMappings.siteName, body.siteName)
-          )
-        );
-
-      try {
-        writeRouteAudit(c, {
-          orgId: integration.orgId,
-          action: 's1.site.unmap',
-          resourceType: 's1_site_mapping',
-          resourceName: body.siteName,
-          details: { integrationId: body.integrationId }
-        });
-      } catch (auditErr) {
-      console.error('[s1-route] Audit write failed:', auditErr);
-      captureException(auditErr);
-    }
-
-      return c.json({ data: { siteName: body.siteName, mappedOrgId: null } });
-    }
-
-    if (!auth.canAccessOrg(body.orgId)) {
-      return c.json({ error: 'Access to target organization denied' }, 403);
-    }
-
-    const now = new Date();
-    await db
-      .insert(s1SiteMappings)
-      .values({
-        integrationId: body.integrationId,
-        siteName: body.siteName,
-        orgId: body.orgId,
-        updatedAt: now
-      })
-      .onConflictDoUpdate({
-        target: [s1SiteMappings.integrationId, s1SiteMappings.siteName],
-        set: {
-          orgId: sql`excluded.org_id`,
-          updatedAt: now
-        }
+    const updated = await db
+      .update(s1OrgMappings)
+      .set({ orgId: body.orgId, updatedAt: new Date() })
+      .where(and(
+        eq(s1OrgMappings.integrationId, body.integrationId),
+        eq(s1OrgMappings.partnerId, integration.partnerId),
+        eq(s1OrgMappings.s1SiteId, body.s1SiteId)
+      ))
+      .returning({
+        s1SiteId: s1OrgMappings.s1SiteId,
+        mappedOrgId: s1OrgMappings.orgId,
       });
 
-    try {
-      writeRouteAudit(c, {
-        orgId: integration.orgId,
-        action: 's1.site.map',
-        resourceType: 's1_site_mapping',
-        resourceName: body.siteName,
-        details: { integrationId: body.integrationId, targetOrgId: body.orgId }
-      });
-    } catch (auditErr) {
-      console.error('[s1-route] Audit write failed:', auditErr);
-      captureException(auditErr);
+    if (updated.length === 0) {
+      return c.json({ error: 'SentinelOne site mapping not found. Run sync first to discover sites.' }, 404);
     }
 
-    return c.json({ data: { siteName: body.siteName, mappedOrgId: body.orgId } });
+    writeRouteAudit(c, {
+      orgId: body.orgId,
+      action: body.orgId ? 's1.site.map' : 's1.site.unmap',
+      resourceType: 's1_org_mapping',
+      resourceName: body.s1SiteId,
+      details: { integrationId: body.integrationId, partnerId: integration.partnerId }
+    });
+
+    return c.json({ data: updated[0] });
   }
 );

--- a/apps/api/src/services/sentinelOne/actions.test.ts
+++ b/apps/api/src/services/sentinelOne/actions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as DbModule from '../../db';
 import { SentinelOneHttpError } from './client';
 
 // actions.ts pulls in ../../db (and transitively ../../jobs/s1Sync) at import
@@ -113,6 +114,43 @@ describe('getActiveS1IntegrationForOrg — partner-axis resolution', () => {
     const result = await getActiveS1IntegrationForOrg('org-3');
 
     expect(result).toBeNull();
+  });
+
+  it('regression(#1735): partner-axis reads (steps 2&3) use system DB context so org-scoped callers are not blocked by RLS', async () => {
+    // Arrange: all three steps return data so the function returns a result.
+    selectQueue.push([{ id: 'org-1', partnerId: 'partner-1' }]);
+    selectQueue.push([{
+      id: 'int-1',
+      partnerId: 'partner-1',
+      name: 'My S1 Integration',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    }]);
+    selectQueue.push([{ id: 'mapping-1' }]);
+
+    // Import the mocked db module so we can inspect call counts.
+    const dbMod = await import('../../db') as unknown as typeof DbModule & {
+      runOutsideDbContext: ReturnType<typeof vi.fn>;
+      withSystemDbAccessContext: ReturnType<typeof vi.fn>;
+    };
+
+    const result = await getActiveS1IntegrationForOrg('org-1');
+
+    // The function must return the integration (not null, which would be the
+    // buggy org-scoped-caller outcome when partner rows are hidden by RLS).
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('int-1');
+
+    // CRITICAL: runOutsideDbContext + withSystemDbAccessContext must have been
+    // called for steps 2 & 3. This test FAILS if the system-scope wrap is
+    // removed, proving the regression guard is not vacuous.
+    expect(dbMod.runOutsideDbContext).toHaveBeenCalled();
+    expect(dbMod.withSystemDbAccessContext).toHaveBeenCalled();
+    // Both step 2 (integration lookup) and step 3 (mapping check) each call the
+    // pair once, so we expect at least 2 calls each.
+    expect(dbMod.runOutsideDbContext).toHaveBeenCalledTimes(2);
+    expect(dbMod.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/api/src/services/sentinelOne/actions.test.ts
+++ b/apps/api/src/services/sentinelOne/actions.test.ts
@@ -1,16 +1,36 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SentinelOneHttpError } from './client';
 
 // actions.ts pulls in ../../db (and transitively ../../jobs/s1Sync) at import
 // time. We only exercise the pure helpers (truncateError /
 // logActionDispatchFailureServerSide), so stub the heavy deps to keep this a
 // fast unit test rather than wiring a full DB/queue mock.
-vi.mock('../../db', () => ({
-  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
-  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-}));
+
+// Queued select results for getActiveS1IntegrationForOrg tests. Must be
+// declared via vi.hoisted so it is available inside the hoisted vi.mock factory.
+const { selectQueue } = vi.hoisted(() => {
+  const selectQueue: unknown[][] = [];
+  return { selectQueue };
+});
+
+vi.mock('../../db', () => {
+  const mockSelect = vi.fn(() => {
+    const rows = selectQueue.shift() ?? [];
+    const chain: Record<string, unknown> = {};
+    for (const method of ['from', 'where', 'innerJoin', 'leftJoin']) {
+      chain[method] = vi.fn().mockReturnValue(chain);
+    }
+    chain.limit = vi.fn().mockResolvedValue(rows);
+    chain.then = (resolve: (value: unknown[]) => unknown) => resolve(rows);
+    return chain;
+  });
+  return {
+    db: { select: mockSelect, insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+});
 
 vi.mock('../../jobs/s1Sync', () => ({
   dispatchS1Isolation: vi.fn(),
@@ -18,12 +38,82 @@ vi.mock('../../jobs/s1Sync', () => ({
   scheduleS1ActionPoll: vi.fn(),
 }));
 
-import { truncateError, logActionDispatchFailureServerSide } from './actions';
+import { truncateError, logActionDispatchFailureServerSide, getActiveS1IntegrationForOrg } from './actions';
 
 const UPSTREAM_BODY_MARKER = 'UPSTREAM_BODY_MARKER_should_never_reach_tenant';
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectQueue.length = 0;
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe('getActiveS1IntegrationForOrg — partner-axis resolution', () => {
+  it('returns the partner active integration (with orgId = passed-in orgId) when org belongs to a partner with an active integration', async () => {
+    // Step 1: org lookup returns partner_id
+    selectQueue.push([{ id: 'org-1', partnerId: 'partner-1' }]);
+    // Step 2: active integration for partner
+    selectQueue.push([{
+      id: 'int-1',
+      partnerId: 'partner-1',
+      name: 'My S1 Integration',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    }]);
+    // Step 3: s1_org_mappings existence check
+    selectQueue.push([{ id: 'mapping-1' }]);
+
+    const result = await getActiveS1IntegrationForOrg('org-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('int-1');
+    expect(result!.orgId).toBe('org-1'); // caller-provided orgId preserved in return
+    expect(result!.name).toBe('My S1 Integration');
+  });
+
+  it('returns null when the org is not found in the DB', async () => {
+    // org lookup returns empty
+    selectQueue.push([]);
+
+    const result = await getActiveS1IntegrationForOrg('org-missing');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the partner has no active integration', async () => {
+    // org lookup returns partner_id
+    selectQueue.push([{ id: 'org-2', partnerId: 'partner-no-integration' }]);
+    // no active integration found
+    selectQueue.push([]);
+
+    const result = await getActiveS1IntegrationForOrg('org-2');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the org has no s1_org_mappings row under the integration (defense-in-depth)', async () => {
+    // org lookup returns partner_id
+    selectQueue.push([{ id: 'org-3', partnerId: 'partner-1' }]);
+    // active integration exists
+    selectQueue.push([{
+      id: 'int-1',
+      partnerId: 'partner-1',
+      name: 'My S1 Integration',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    }]);
+    // but no s1_org_mappings row for this org
+    selectQueue.push([]);
+
+    const result = await getActiveS1IntegrationForOrg('org-3');
+
+    expect(result).toBeNull();
+  });
 });
 
 describe('truncateError', () => {

--- a/apps/api/src/services/sentinelOne/actions.ts
+++ b/apps/api/src/services/sentinelOne/actions.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, or, type SQL } from 'drizzle-orm';
-import { db } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { devices, organizations, s1Actions, s1Agents, s1Integrations, s1OrgMappings, s1Threats } from '../../db/schema';
 import {
   dispatchS1Isolation,
@@ -111,29 +111,44 @@ export async function getActiveS1IntegrationForOrg(orgId: string): Promise<S1Act
 
   if (!orgRow) return null;
 
-  // Step 2: Fetch the partner's active integration.
-  const [integration] = await db
-    .select({
-      id: s1Integrations.id,
-      partnerId: s1Integrations.partnerId,
-      name: s1Integrations.name,
-      lastSyncAt: s1Integrations.lastSyncAt,
-      lastSyncStatus: s1Integrations.lastSyncStatus,
-      lastSyncError: s1Integrations.lastSyncError
-    })
-    .from(s1Integrations)
-    .where(and(eq(s1Integrations.partnerId, orgRow.partnerId), eq(s1Integrations.isActive, true)))
-    .limit(1);
+  // Steps 2 & 3 read partner-axis tables (s1_integrations, s1_org_mappings) gated
+  // by breeze_has_partner_access(partner_id). An org-scoped caller's request DB
+  // context has no partner access (accessiblePartnerIds = []), so those reads would
+  // return 0 rows under RLS. The org lookup above (Step 1) IS the security gate —
+  // it runs in the caller's context so org RLS ensures orgRow.partnerId belongs to a
+  // partner the caller can see. After that gate, we escalate to system context for
+  // the partner-axis reads. Pattern mirrors mobileDeviceBlocked.ts.
+  const [integration] = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      // Step 2: Fetch the partner's active integration.
+      db
+        .select({
+          id: s1Integrations.id,
+          partnerId: s1Integrations.partnerId,
+          name: s1Integrations.name,
+          lastSyncAt: s1Integrations.lastSyncAt,
+          lastSyncStatus: s1Integrations.lastSyncStatus,
+          lastSyncError: s1Integrations.lastSyncError
+        })
+        .from(s1Integrations)
+        .where(and(eq(s1Integrations.partnerId, orgRow.partnerId), eq(s1Integrations.isActive, true)))
+        .limit(1)
+    )
+  );
 
   if (!integration) return null;
 
-  // Step 3 (defense-in-depth): Confirm the org has at least one s1_org_mappings row
-  // under this integration. Prevents acting on orgs the partner hasn't mapped.
-  const [mappingRow] = await db
-    .select({ id: s1OrgMappings.id })
-    .from(s1OrgMappings)
-    .where(and(eq(s1OrgMappings.integrationId, integration.id), eq(s1OrgMappings.orgId, orgId)))
-    .limit(1);
+  const [mappingRow] = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      // Step 3 (defense-in-depth): Confirm the org has at least one s1_org_mappings row
+      // under this integration. Prevents acting on orgs the partner hasn't mapped.
+      db
+        .select({ id: s1OrgMappings.id })
+        .from(s1OrgMappings)
+        .where(and(eq(s1OrgMappings.integrationId, integration.id), eq(s1OrgMappings.orgId, orgId)))
+        .limit(1)
+    )
+  );
 
   if (!mappingRow) return null;
 

--- a/apps/api/src/services/sentinelOne/actions.ts
+++ b/apps/api/src/services/sentinelOne/actions.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
-import { devices, s1Actions, s1Agents, s1Integrations, s1Threats } from '../../db/schema';
+import { devices, organizations, s1Actions, s1Agents, s1Integrations, s1OrgMappings, s1Threats } from '../../db/schema';
 import {
   dispatchS1Isolation,
   dispatchS1ThreatAction,
@@ -101,20 +101,52 @@ export function logActionDispatchFailureServerSide(
 }
 
 export async function getActiveS1IntegrationForOrg(orgId: string): Promise<S1ActiveIntegration | null> {
+  // Step 1: Resolve org → partner_id.
+  // s1_integrations is now partner-axis (legacyOrgId is often NULL after migration).
+  const [orgRow] = await db
+    .select({ id: organizations.id, partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  if (!orgRow) return null;
+
+  // Step 2: Fetch the partner's active integration.
   const [integration] = await db
     .select({
       id: s1Integrations.id,
-      orgId: s1Integrations.orgId,
+      partnerId: s1Integrations.partnerId,
       name: s1Integrations.name,
       lastSyncAt: s1Integrations.lastSyncAt,
       lastSyncStatus: s1Integrations.lastSyncStatus,
       lastSyncError: s1Integrations.lastSyncError
     })
     .from(s1Integrations)
-    .where(and(eq(s1Integrations.orgId, orgId), eq(s1Integrations.isActive, true)))
+    .where(and(eq(s1Integrations.partnerId, orgRow.partnerId), eq(s1Integrations.isActive, true)))
     .limit(1);
 
-  return integration ?? null;
+  if (!integration) return null;
+
+  // Step 3 (defense-in-depth): Confirm the org has at least one s1_org_mappings row
+  // under this integration. Prevents acting on orgs the partner hasn't mapped.
+  const [mappingRow] = await db
+    .select({ id: s1OrgMappings.id })
+    .from(s1OrgMappings)
+    .where(and(eq(s1OrgMappings.integrationId, integration.id), eq(s1OrgMappings.orgId, orgId)))
+    .limit(1);
+
+  if (!mappingRow) return null;
+
+  // Preserve the caller's orgId in the return value — callers use this field as
+  // "the org I'm operating on"; the integration itself is partner-scoped.
+  return {
+    id: integration.id,
+    orgId,
+    name: integration.name,
+    lastSyncAt: integration.lastSyncAt,
+    lastSyncStatus: integration.lastSyncStatus,
+    lastSyncError: integration.lastSyncError,
+  };
 }
 
 export async function executeS1IsolationForOrg(params: {

--- a/apps/api/src/services/sentinelOne/client.test.ts
+++ b/apps/api/src/services/sentinelOne/client.test.ts
@@ -222,6 +222,47 @@ describe('SentinelOneClient error handling', () => {
   });
 });
 
+describe('SentinelOneClient agent normalization', () => {
+  it('extracts siteId from a raw agent row (C1)', async () => {
+    safeFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'a1', siteId: 'site-123', siteName: 'Acme' }],
+        pagination: {}
+      })
+    });
+
+    const client = new SentinelOneClient({
+      managementUrl: 'https://example.sentinelone.net',
+      apiToken: 'token'
+    });
+    const { results } = await client.listAgents();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.siteId).toBe('site-123');
+    expect(results[0]!.siteName).toBe('Acme');
+  });
+
+  it('normalizes siteId to null when absent from the raw row', async () => {
+    safeFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'a2', siteName: 'OtherSite' }],
+        pagination: {}
+      })
+    });
+
+    const client = new SentinelOneClient({
+      managementUrl: 'https://example.sentinelone.net',
+      apiToken: 'token'
+    });
+    const { results } = await client.listAgents();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.siteId).toBeNull();
+  });
+});
+
 describe('SentinelOneClient activity status mapping', () => {
   it('maps SentinelOne activity status to internal statuses', async () => {
     const makeClient = () => new SentinelOneClient({

--- a/apps/api/src/services/sentinelOne/client.ts
+++ b/apps/api/src/services/sentinelOne/client.ts
@@ -24,6 +24,7 @@ export interface S1Agent {
   uuid: string | null;
   computerName: string | null;
   machineType: string | null;
+  siteId: string | null;
   siteName: string | null;
   osName: string | null;
   networkInterfaces?: Array<{ inet?: string[] }>;
@@ -299,6 +300,7 @@ export class SentinelOneClient {
       uuid: str(row.uuid),
       computerName: str(row.computerName) ?? str(row.hostname),
       machineType: str(row.machineType),
+      siteId: str(row.siteId),
       siteName: str(row.siteName),
       osName: str(row.osName),
       networkInterfaces: Array.isArray(row.networkInterfaces) ? row.networkInterfaces as Array<{ inet?: string[] }> : undefined,

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -244,6 +244,10 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   's1_actions',
   's1_agents',
   's1_integrations',
+  's1_org_mappings',
+  // s1_site_mappings is the legacy org-keyed mapping table retained as a
+  // forensic record post-migration (see 2026-06-27-a-sentinelone-partner-mapping.sql).
+  // It still carries org_id, so it must remain in the cascade list until dropped.
   's1_site_mappings',
   's1_threats',
   'saved_filters',

--- a/apps/web/src/components/integrations/SecurityIntegration.test.tsx
+++ b/apps/web/src/components/integrations/SecurityIntegration.test.tsx
@@ -147,7 +147,8 @@ describe('SecurityIntegration', () => {
   it('renders read-only status in org view when the org is mapped', async () => {
     // org scope (currentOrgId set in beforeEach)
     fetchWithAuth.mockImplementation(async (url: string) => {
-      if (url === '/s1/integration') return jsonResponse({ data: existingIntegration, mapped: true });
+      // Real route: mapped org → full integration object, no `mapped`/`connected` flags.
+      if (url === '/s1/integration') return jsonResponse({ data: existingIntegration });
       if (url === '/s1/status') return jsonResponse({ summary, mapped: true });
       return jsonResponse({}, 404);
     });
@@ -167,8 +168,12 @@ describe('SecurityIntegration', () => {
   });
 
   it('renders the amber "not mapped" notice in org view when unmapped (not a switch-scope prompt)', async () => {
+    // Real route: org connected to a partner integration but THIS org isn't
+    // mapped → `{ data: null, mapped: false, connected: true }`. `data` is null
+    // (no managementUrl/token leak) but `connected` distinguishes it from
+    // "partner not connected" (`{ data: null }`).
     fetchWithAuth.mockImplementation(async (url: string) => {
-      if (url === '/s1/integration') return jsonResponse({ data: existingIntegration, mapped: false });
+      if (url === '/s1/integration') return jsonResponse({ data: null, mapped: false, connected: true });
       if (url === '/s1/status') return jsonResponse({ summary: null, mapped: false });
       return jsonResponse({}, 404);
     });
@@ -177,8 +182,30 @@ describe('SecurityIntegration', () => {
 
     await waitFor(() => expect(screen.getByTestId('s1-org-unmapped')).toBeInTheDocument());
     expect(screen.getByText(/isn't mapped to a SentinelOne site yet/i)).toBeInTheDocument();
+    // Not the "switch scope to connect" prompt — the partner IS connected.
+    expect(screen.queryByTestId('s1-org-not-connected')).not.toBeInTheDocument();
     expect(screen.queryByText('Partner connection')).not.toBeInTheDocument();
     expect(screen.queryByTestId('s1-name')).not.toBeInTheDocument();
+  });
+
+  it('renders the "not connected yet" prompt in org view when the partner has no integration', async () => {
+    // Real route "no integration": `{ data: null }` with no `connected` flag.
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/s1/integration') return jsonResponse({ data: null });
+      if (url === '/s1/status') {
+        return jsonResponse({
+          summary: { totalAgents: 0, mappedDevices: 0, infectedAgents: 0, activeThreats: 0, highOrCriticalThreats: 0, pendingActions: 0, reportedThreatCount: 0 }
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(<SecurityIntegration />);
+
+    await waitFor(() => expect(screen.getByTestId('s1-org-not-connected')).toBeInTheDocument());
+    // Not the amber "unmapped" notice — the partner has no integration at all.
+    expect(screen.queryByTestId('s1-org-unmapped')).not.toBeInTheDocument();
+    expect(screen.queryByText('Partner connection')).not.toBeInTheDocument();
   });
 
   it('saves credentials via runAction with the right body', async () => {

--- a/apps/web/src/components/integrations/SecurityIntegration.test.tsx
+++ b/apps/web/src/components/integrations/SecurityIntegration.test.tsx
@@ -1,0 +1,236 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+const showToast = vi.fn();
+const navigateTo = vi.fn();
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
+  registerOrgIdProvider: vi.fn(),
+  resolveApiOrigin: vi.fn(() => 'https://us.2breeze.app')
+}));
+vi.mock('../shared/Toast', () => ({ showToast: (...args: unknown[]) => showToast(...args) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+import SecurityIntegration from './SecurityIntegration';
+import { useOrgStore } from '../../stores/orgStore';
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const existingIntegration = {
+  id: 's1-1',
+  partnerId: 'partner-1',
+  name: 'Production S1',
+  managementUrl: 'https://acme.sentinelone.net',
+  isActive: true,
+  lastSyncAt: '2026-06-18T12:00:00.000Z',
+  lastSyncStatus: 'success',
+  lastSyncError: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z'
+};
+
+const breezeOrg = { id: '00000000-0000-4000-8000-000000000001', name: 'Acme Corp' };
+
+const summary = {
+  totalAgents: 10,
+  mappedDevices: 8,
+  infectedAgents: 0,
+  activeThreats: 0,
+  highOrCriticalThreats: 0,
+  pendingActions: 0,
+  reportedThreatCount: 0
+};
+
+const discoveredSite = {
+  s1SiteId: 's1-site-1',
+  s1SiteName: 'Acme Site',
+  agentsCount: 5,
+  mappedOrgId: null,
+  mappedOrgName: null,
+  provisional: false
+};
+
+/** Mock the partner-scope load fan-out: integration + status + sites + orgs. */
+function mockPartnerLoad(
+  options: { integration?: typeof existingIntegration | null; sites?: unknown[] } = {}
+) {
+  const integration = options.integration === undefined ? null : options.integration;
+  const sites = options.sites ?? [];
+  fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (url === '/s1/integration' && init?.method === 'POST') {
+      return jsonResponse({ data: { ...existingIntegration } }, integration ? 200 : 201);
+    }
+    if (url === '/s1/organizations/map' && init?.method === 'POST') {
+      return jsonResponse({ data: { ...discoveredSite, mappedOrgId: breezeOrg.id, mappedOrgName: breezeOrg.name } });
+    }
+    if (url === '/s1/sync' && init?.method === 'POST') return jsonResponse({ queued: true });
+    if (url === '/s1/integration') return jsonResponse({ data: integration });
+    if (url === '/s1/status') return jsonResponse({ summary, mapped: true });
+    if (url === '/s1/sites') return jsonResponse({ data: sites, integrationId: integration?.id ?? null });
+    if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+    return jsonResponse({}, 404);
+  });
+}
+
+describe('SecurityIntegration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useOrgStore.setState({ currentOrgId: breezeOrg.id });
+  });
+
+  it('renders the credential form and a mapping row in partner view', async () => {
+    useOrgStore.setState({ currentOrgId: null });
+    mockPartnerLoad({ integration: existingIntegration, sites: [discoveredSite] });
+
+    render(<SecurityIntegration />);
+
+    await waitFor(() => expect(screen.getByText('Partner connection')).toBeInTheDocument());
+    // Credential form
+    expect(screen.getByTestId('s1-name')).toBeInTheDocument();
+    expect(screen.getByTestId('s1-management-url')).toBeInTheDocument();
+    expect(screen.getByTestId('s1-api-token')).toBeInTheDocument();
+    // Mapping table + discovered site row
+    expect(screen.getByText('Site mapping')).toBeInTheDocument();
+    expect(screen.getByText('Acme Site')).toBeInTheDocument();
+    expect(screen.getByTestId('s1-site-s1-site-1')).toBeInTheDocument();
+
+    expect(fetchWithAuth).toHaveBeenCalledWith('/s1/integration');
+    expect(fetchWithAuth).toHaveBeenCalledWith('/s1/sites');
+    expect(fetchWithAuth).toHaveBeenCalledWith('/orgs/organizations');
+  });
+
+  it('shows a "pending sync" hint for provisional sites', async () => {
+    useOrgStore.setState({ currentOrgId: null });
+    mockPartnerLoad({
+      integration: existingIntegration,
+      sites: [{ ...discoveredSite, s1SiteId: 'name:Legacy', s1SiteName: 'Legacy', provisional: true }]
+    });
+
+    render(<SecurityIntegration />);
+    await waitFor(() => expect(screen.getByText('Site mapping')).toBeInTheDocument());
+    expect(screen.getByText(/pending sync/i)).toBeInTheDocument();
+  });
+
+  it('maps a discovered site to a Breeze org and posts the right body', async () => {
+    useOrgStore.setState({ currentOrgId: null });
+    mockPartnerLoad({ integration: existingIntegration, sites: [discoveredSite] });
+
+    render(<SecurityIntegration />);
+    await waitFor(() => expect(screen.getByText('Site mapping')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('s1-site-map-s1-site-1'), { target: { value: breezeOrg.id } });
+
+    await waitFor(() => {
+      expect(
+        fetchWithAuth.mock.calls.some(([url, init]) => url === '/s1/organizations/map' && init?.method === 'POST')
+      ).toBe(true);
+    });
+    const mapCall = fetchWithAuth.mock.calls.find(
+      ([url, init]) => url === '/s1/organizations/map' && init?.method === 'POST'
+    );
+    expect(JSON.parse(String(mapCall?.[1]?.body))).toMatchObject({
+      integrationId: 's1-1',
+      s1SiteId: 's1-site-1',
+      orgId: breezeOrg.id
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('renders read-only status in org view when the org is mapped', async () => {
+    // org scope (currentOrgId set in beforeEach)
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/s1/integration') return jsonResponse({ data: existingIntegration, mapped: true });
+      if (url === '/s1/status') return jsonResponse({ summary, mapped: true });
+      return jsonResponse({}, 404);
+    });
+
+    render(<SecurityIntegration />);
+
+    await waitFor(() => expect(screen.getByTestId('s1-sync-status')).toBeInTheDocument());
+    // No credential form / mapping table in org scope.
+    expect(screen.queryByText('Partner connection')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('s1-name')).not.toBeInTheDocument();
+    expect(screen.queryByText('Site mapping')).not.toBeInTheDocument();
+    // Coverage is shown read-only.
+    expect(screen.getByTestId('s1-coverage')).toBeInTheDocument();
+    // Partner-only endpoints are not called in org scope.
+    expect(fetchWithAuth).not.toHaveBeenCalledWith('/s1/sites');
+    expect(fetchWithAuth).not.toHaveBeenCalledWith('/orgs/organizations');
+  });
+
+  it('renders the amber "not mapped" notice in org view when unmapped (not a switch-scope prompt)', async () => {
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/s1/integration') return jsonResponse({ data: existingIntegration, mapped: false });
+      if (url === '/s1/status') return jsonResponse({ summary: null, mapped: false });
+      return jsonResponse({}, 404);
+    });
+
+    render(<SecurityIntegration />);
+
+    await waitFor(() => expect(screen.getByTestId('s1-org-unmapped')).toBeInTheDocument());
+    expect(screen.getByText(/isn't mapped to a SentinelOne site yet/i)).toBeInTheDocument();
+    expect(screen.queryByText('Partner connection')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('s1-name')).not.toBeInTheDocument();
+  });
+
+  it('saves credentials via runAction with the right body', async () => {
+    useOrgStore.setState({ currentOrgId: null });
+    mockPartnerLoad({ integration: null });
+
+    render(<SecurityIntegration />);
+    await screen.findByTestId('s1-panel');
+    await waitFor(() => expect(screen.getByText('Partner connection')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('s1-name'), { target: { value: 'My Tenant' } });
+    fireEvent.change(screen.getByTestId('s1-management-url'), { target: { value: 'https://t.sentinelone.net' } });
+    fireEvent.change(screen.getByTestId('s1-api-token'), { target: { value: 'tok-123' } });
+    fireEvent.click(screen.getByTestId('s1-save'));
+
+    await waitFor(() => {
+      expect(fetchWithAuth.mock.calls.some(([url, init]) => url === '/s1/integration' && init?.method === 'POST')).toBe(true);
+    });
+    const postCall = fetchWithAuth.mock.calls.find(([url, init]) => url === '/s1/integration' && init?.method === 'POST');
+    expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({
+      name: 'My Tenant',
+      managementUrl: 'https://t.sentinelone.net',
+      apiToken: 'tok-123',
+      isActive: true
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('surfaces a failed save to the user via an error toast', async () => {
+    useOrgStore.setState({ currentOrgId: null });
+    fetchWithAuth.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/s1/integration' && init?.method === 'POST') {
+        return jsonResponse({ error: 'Invalid SentinelOne credentials' }, 400);
+      }
+      if (url === '/s1/integration') return jsonResponse({ data: null });
+      if (url === '/s1/status') return jsonResponse({ summary: null });
+      if (url === '/s1/sites') return jsonResponse({ data: [] });
+      if (url === '/orgs/organizations') return jsonResponse({ data: [breezeOrg] });
+      return jsonResponse({}, 404);
+    });
+
+    render(<SecurityIntegration />);
+    await waitFor(() => expect(screen.getByText('Partner connection')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('s1-name'), { target: { value: 'My Tenant' } });
+    fireEvent.change(screen.getByTestId('s1-management-url'), { target: { value: 'https://t.sentinelone.net' } });
+    fireEvent.change(screen.getByTestId('s1-api-token'), { target: { value: 'bad-token' } });
+    fireEvent.click(screen.getByTestId('s1-save'));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', message: 'Invalid SentinelOne credentials' }))
+    );
+    expect(screen.getByTestId('s1-save-message')).toHaveTextContent('Invalid SentinelOne credentials');
+  });
+});

--- a/apps/web/src/components/integrations/SecurityIntegration.tsx
+++ b/apps/web/src/components/integrations/SecurityIntegration.tsx
@@ -106,6 +106,11 @@ export default function SecurityIntegration() {
 
   const [integration, setIntegration] = useState<Integration | null>(null);
   const [mappedForOrg, setMappedForOrg] = useState(true);
+  // Whether the PARTNER has a SentinelOne integration connected at all. In org
+  // scope an unmapped org receives `{ data: null, mapped: false, connected: true }`
+  // — `data` is null (no managementUrl/token leak) but the partner IS connected,
+  // which is what distinguishes "your org isn't mapped" from "not connected yet".
+  const [partnerConnected, setPartnerConnected] = useState(false);
   const [summary, setSummary] = useState<StatusSummary | null>(null);
   const [sites, setSites] = useState<SiteRow[]>([]);
   const [integrationId, setIntegrationId] = useState<string | null>(null);
@@ -137,7 +142,12 @@ export default function SecurityIntegration() {
     const json = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(readError(json, `Failed to load integration (${res.status})`));
     const data = (json as { data?: Integration | null }).data ?? null;
-    setMappedForOrg((json as { mapped?: boolean }).mapped !== false);
+    const mapped = (json as { mapped?: boolean }).mapped !== false;
+    // Partner is connected if we got the full integration object back, or the
+    // org-unmapped branch flagged `connected: true`.
+    const connected = data !== null || (json as { connected?: boolean }).connected === true;
+    setMappedForOrg(mapped);
+    setPartnerConnected(connected);
     setIntegration(data);
     if (data) {
       setName(data.name);
@@ -304,8 +314,8 @@ export default function SecurityIntegration() {
         </div>
       )}
 
-      {/* Org scope, not connected: SentinelOne is partner-level. */}
-      {!isPartnerView && !integration && (
+      {/* Org scope, partner not connected: SentinelOne is partner-level. */}
+      {!isPartnerView && !partnerConnected && (
         <div className="rounded-xl border bg-card p-8 text-center shadow-sm" data-testid="s1-org-not-connected">
           <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
             <Unplug className="h-5 w-5" />
@@ -318,8 +328,8 @@ export default function SecurityIntegration() {
         </div>
       )}
 
-      {/* Org scope, connected but this org isn't mapped to a site. */}
-      {!isPartnerView && integration && !mappedForOrg && (
+      {/* Org scope, partner connected but this org isn't mapped to a site. */}
+      {!isPartnerView && partnerConnected && !mappedForOrg && (
         <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800" data-testid="s1-org-unmapped">
           This organization isn&apos;t mapped to a SentinelOne site yet. Switch to All orgs as a partner admin to map it.
         </div>
@@ -447,12 +457,12 @@ export default function SecurityIntegration() {
             <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="s1-coverage">
               <h2 className="text-lg font-semibold">Coverage</h2>
               <div className="mt-4 grid grid-cols-2 gap-4">
-                <Metric label="S1 Agents" value={summary.totalAgents} />
-                <Metric label="Mapped Devices" value={summary.mappedDevices} />
-                <Metric label="Infected" value={summary.infectedAgents} warn={summary.infectedAgents > 0} danger />
-                <Metric label="Active Threats" value={summary.activeThreats} warn={summary.activeThreats > 0} danger />
-                <Metric label="Pending Actions" value={summary.pendingActions} />
-                <Metric label="High/Critical" value={summary.highOrCriticalThreats} warn={summary.highOrCriticalThreats > 0} />
+                <Metric label="S1 Agents" value={summary.totalAgents ?? 0} />
+                <Metric label="Mapped Devices" value={summary.mappedDevices ?? 0} />
+                <Metric label="Infected" value={summary.infectedAgents ?? 0} warn={(summary.infectedAgents ?? 0) > 0} danger />
+                <Metric label="Active Threats" value={summary.activeThreats ?? 0} warn={(summary.activeThreats ?? 0) > 0} danger />
+                <Metric label="Pending Actions" value={summary.pendingActions ?? 0} />
+                <Metric label="High/Critical" value={summary.highOrCriticalThreats ?? 0} warn={(summary.highOrCriticalThreats ?? 0) > 0} />
               </div>
             </div>
           )}

--- a/apps/web/src/components/integrations/SecurityIntegration.tsx
+++ b/apps/web/src/components/integrations/SecurityIntegration.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
@@ -12,12 +12,15 @@ import {
   Unplug
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
-import { useOrgStore } from '../../stores/orgStore';
+import { runAction, handleActionError, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+import { type Organization, useOrgStore } from '../../stores/orgStore';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type Integration = {
   id: string;
-  orgId: string;
+  partnerId: string;
   name: string;
   managementUrl: string;
   isActive: boolean;
@@ -38,490 +41,489 @@ type StatusSummary = {
   reportedThreatCount: number;
 };
 
+// One discovered SentinelOne site (from s1_org_mappings). `provisional` rows are
+// legacy name-keyed mappings awaiting the next sync to bind their real site id.
 type SiteRow = {
-  siteName: string;
-  agentCount: number;
+  s1SiteId: string;
+  s1SiteName: string;
+  agentsCount: number;
   mappedOrgId: string | null;
   mappedOrgName: string | null;
+  provisional: boolean;
 };
 
-type OrgOption = {
-  id: string;
-  name: string;
-};
+type SaveState = { status: 'idle' | 'saving' | 'saved' | 'error'; message?: string };
+type SyncState = { status: 'idle' | 'syncing' | 'done' | 'error'; message?: string };
 
-type SaveState = {
-  status: 'idle' | 'saving' | 'saved' | 'error';
-  message?: string;
-};
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
 
-type SyncState = {
-  status: 'idle' | 'syncing' | 'done' | 'error';
-  message?: string;
-};
+function readError(json: unknown, fallback: string): string {
+  if (json && typeof json === 'object' && 'error' in json) {
+    return String((json as { error?: unknown }).error ?? fallback);
+  }
+  return fallback;
+}
+
+function syncStatusBadge(integration: Integration | null) {
+  if (!integration) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600">
+        <Unplug className="h-3.5 w-3.5" /> Not configured
+      </span>
+    );
+  }
+  if (integration.lastSyncStatus === 'success' || integration.lastSyncStatus === 'partial') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-700">
+        <CheckCircle2 className="h-3.5 w-3.5" /> Connected
+      </span>
+    );
+  }
+  if (integration.lastSyncStatus === 'running') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs text-amber-700">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" /> Syncing
+      </span>
+    );
+  }
+  if (integration.lastSyncStatus === 'error') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs text-red-700">
+        <AlertTriangle className="h-3.5 w-3.5" /> Error
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600">
+      <Activity className="h-3.5 w-3.5" /> Pending
+    </span>
+  );
+}
 
 export default function SecurityIntegration() {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [integration, setIntegration] = useState<Integration | null>(null);
+  const [mappedForOrg, setMappedForOrg] = useState(true);
+  const [summary, setSummary] = useState<StatusSummary | null>(null);
+  const [sites, setSites] = useState<SiteRow[]>([]);
+  const [integrationId, setIntegrationId] = useState<string | null>(null);
+  const [orgOptions, setOrgOptions] = useState<Organization[]>([]);
+
   const [name, setName] = useState('');
   const [managementUrl, setManagementUrl] = useState('');
   const [apiToken, setApiToken] = useState('');
   const [showToken, setShowToken] = useState(false);
 
-  const [integration, setIntegration] = useState<Integration | null>(null);
-  const [summary, setSummary] = useState<StatusSummary | null>(null);
-  const [sites, setSites] = useState<SiteRow[]>([]);
-  const [integrationId, setIntegrationId] = useState<string | null>(null);
-  const [orgs, setOrgs] = useState<OrgOption[]>([]);
-
-  const [isLoading, setIsLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<SaveState>({ status: 'idle' });
   const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
-  const [siteMapSaving, setSiteMapSaving] = useState<Record<string, boolean>>({});
-  const [siteMapError, setSiteMapError] = useState<string | null>(null);
+  const [mappingSaving, setMappingSaving] = useState<Record<string, boolean>>({});
+  const [mappingError, setMappingError] = useState<string | null>(null);
 
-  // The SentinelOne integration is per organization. When no org is selected
-  // (null) there is no single org to load, and the API returns a 400; show a
-  // prompt instead of firing a doomed call.
+  // SentinelOne is configured once at the partner level (no org selected) and
+  // shared across every organization. Org scope is read-only.
   const currentOrgId = useOrgStore((s) => s.currentOrgId);
-  const isAllOrgs = !currentOrgId;
+  const isPartnerView = !currentOrgId;
+
+  const unmappedCount = useMemo(() => sites.filter((row) => !row.mappedOrgId).length, [sites]);
+  const canSave =
+    name.trim().length > 0 &&
+    managementUrl.trim().length > 0 &&
+    (apiToken.trim().length > 0 || !!integration);
 
   const fetchIntegration = useCallback(async () => {
-    try {
-      const res = await fetchWithAuth('/s1/integration');
-      if (!res.ok) {
-        const json = await res.json().catch(() => ({}));
-        setLoadError(`Failed to load integration: ${json.error ?? `HTTP ${res.status}`}`);
-        return;
-      }
-      const json = await res.json();
-      const data = json.data as Integration | null;
-      setIntegration(data);
-      if (data) {
-        setName(data.name);
-        setManagementUrl(data.managementUrl);
-        setApiToken('');
-      }
-    } catch (err) {
-      setLoadError(`Failed to load integration: ${err instanceof Error ? err.message : 'Network error'}`);
+    const res = await fetchWithAuth('/s1/integration');
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(readError(json, `Failed to load integration (${res.status})`));
+    const data = (json as { data?: Integration | null }).data ?? null;
+    setMappedForOrg((json as { mapped?: boolean }).mapped !== false);
+    setIntegration(data);
+    if (data) {
+      setName(data.name);
+      setManagementUrl(data.managementUrl);
+      setApiToken('');
     }
   }, []);
 
   const fetchStatus = useCallback(async () => {
-    try {
-      const res = await fetchWithAuth('/s1/status');
-      if (!res.ok) {
-        console.error(`[SecurityIntegration] Status fetch failed: HTTP ${res.status}`);
-        return;
-      }
-      const json = await res.json();
-      setSummary(json.summary as StatusSummary);
-    } catch (err) {
-      console.error('[SecurityIntegration] Failed to fetch status:', err);
+    const res = await fetchWithAuth('/s1/status');
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      console.error(`[SecurityIntegration] Status fetch failed: HTTP ${res.status}`);
+      return;
     }
+    setMappedForOrg((json as { mapped?: boolean }).mapped !== false);
+    setSummary((json as { summary?: StatusSummary }).summary ?? null);
   }, []);
 
   const fetchSites = useCallback(async () => {
-    try {
-      const res = await fetchWithAuth('/s1/sites');
-      if (!res.ok) {
-        console.error(`[SecurityIntegration] Sites fetch failed: HTTP ${res.status}`);
-        return;
-      }
-      const json = await res.json();
-      setSites(json.data as SiteRow[]);
-      if (json.integrationId) setIntegrationId(json.integrationId);
-    } catch (err) {
-      console.error('[SecurityIntegration] Failed to fetch sites:', err);
-    }
-  }, []);
-
-  const fetchOrgs = useCallback(async () => {
-    try {
-      const res = await fetchWithAuth('/orgs/organizations');
-      if (!res.ok) {
-        console.error(`[SecurityIntegration] Organizations fetch failed: HTTP ${res.status}`);
-        return;
-      }
-      const json = await res.json();
-      const list = (json.data ?? json) as Array<{ id: string; name: string }>;
-      setOrgs(list.map((o) => ({ id: o.id, name: o.name })));
-    } catch (err) {
-      console.error('[SecurityIntegration] Failed to fetch organizations:', err);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isAllOrgs) {
-      setIsLoading(false);
-      setLoadError(null);
+    if (!isPartnerView) return;
+    const res = await fetchWithAuth('/s1/sites');
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      console.error(`[SecurityIntegration] Sites fetch failed: HTTP ${res.status}`);
       return;
     }
-    const load = async () => {
-      setIsLoading(true);
-      setLoadError(null);
+    setSites((json as { data?: SiteRow[] }).data ?? []);
+    const id = (json as { integrationId?: string }).integrationId;
+    if (id) setIntegrationId(id);
+  }, [isPartnerView]);
+
+  const fetchOrgs = useCallback(async () => {
+    if (!isPartnerView) return;
+    const res = await fetchWithAuth('/orgs/organizations');
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      console.error(`[SecurityIntegration] Organizations fetch failed: HTTP ${res.status}`);
+      return;
+    }
+    const data = (json as { data?: Organization[] }).data;
+    setOrgOptions(Array.isArray(data) ? data : []);
+  }, [isPartnerView]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
       await fetchIntegration();
       await Promise.all([fetchStatus(), fetchSites(), fetchOrgs()]);
-      setIsLoading(false);
-    };
-    load();
-  }, [fetchIntegration, fetchStatus, fetchSites, fetchOrgs, currentOrgId]);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to load SentinelOne integration');
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchIntegration, fetchStatus, fetchSites, fetchOrgs]);
 
-  const handleSave = async () => {
+  useEffect(() => {
+    void load();
+  }, [load, currentOrgId, isPartnerView]);
+
+  const handleSave = useCallback(async () => {
+    if (!isPartnerView) return;
     setSaveState({ status: 'saving' });
     try {
-      const payload: Record<string, unknown> = {
-        name,
-        managementUrl,
+      const body: Record<string, unknown> = {
+        name: name.trim(),
+        managementUrl: managementUrl.trim(),
         isActive: true
       };
-      if (apiToken.trim().length > 0) {
-        payload.apiToken = apiToken;
-      }
-      const res = await fetchWithAuth('/s1/integration', {
-        method: 'POST',
-        body: JSON.stringify(payload)
-      });
-      const json = await res.json();
-      if (!res.ok) {
-        setSaveState({ status: 'error', message: json.error ?? 'Failed to save' });
-        return;
-      }
-      setSaveState({ status: 'saved', message: json.warning ?? 'Integration saved' });
-      setApiToken('');
-      await fetchIntegration();
-      await Promise.all([fetchStatus(), fetchSites()]);
-    } catch (err) {
-      setSaveState({ status: 'error', message: err instanceof Error ? err.message : 'Network error' });
-    }
-  };
+      if (apiToken.trim().length > 0) body.apiToken = apiToken.trim();
 
-  const handleSync = async () => {
+      const result = await runAction<{ warning?: string }>({
+        request: () => fetchWithAuth('/s1/integration', { method: 'POST', body: JSON.stringify(body) }),
+        errorFallback: 'Failed to save the SentinelOne integration.',
+        successMessage: integration ? 'SentinelOne integration updated' : 'SentinelOne integration connected',
+        onUnauthorized: UNAUTHORIZED
+      });
+      setSaveState({ status: 'saved', message: result?.warning ?? 'Integration saved' });
+      setApiToken('');
+      await load();
+    } catch (err) {
+      const message = err instanceof ActionError ? err.message : 'Network error';
+      setSaveState({ status: 'error', message });
+      handleActionError(err, 'Failed to save the SentinelOne integration.');
+    }
+  }, [isPartnerView, name, managementUrl, apiToken, integration, load]);
+
+  const handleSync = useCallback(async () => {
+    if (!isPartnerView) return;
     setSyncState({ status: 'syncing' });
     try {
-      const res = await fetchWithAuth('/s1/sync', {
-        method: 'POST',
-        body: JSON.stringify({})
+      await runAction({
+        request: () => fetchWithAuth('/s1/sync', { method: 'POST', body: JSON.stringify({}) }),
+        errorFallback: 'Failed to schedule a SentinelOne sync.',
+        successMessage: 'SentinelOne sync triggered',
+        onUnauthorized: UNAUTHORIZED
       });
-      if (!res.ok) {
-        const json = await res.json();
-        setSyncState({ status: 'error', message: json.error ?? 'Sync failed' });
-        return;
-      }
       setSyncState({ status: 'done', message: 'Sync triggered' });
+      // The sync runs in the background; re-load shortly to surface lastSync*.
       setTimeout(() => {
-        Promise.all([fetchIntegration(), fetchStatus(), fetchSites()]).catch((err) => {
-          console.error('[SecurityIntegration] Post-sync refresh failed:', err);
-        });
+        void load();
       }, 3000);
     } catch (err) {
-      setSyncState({ status: 'error', message: err instanceof Error ? err.message : 'Network error' });
+      const message = err instanceof ActionError ? err.message : 'Network error';
+      setSyncState({ status: 'error', message });
+      handleActionError(err, 'Failed to schedule a SentinelOne sync.');
     }
-  };
+  }, [isPartnerView, load]);
 
-  const handleSiteMap = async (siteName: string, orgId: string | null) => {
-    if (!integrationId) return;
-    setSiteMapSaving((prev) => ({ ...prev, [siteName]: true }));
-    setSiteMapError(null);
-    try {
-      const res = await fetchWithAuth('/s1/sites/map', {
-        method: 'POST',
-        body: JSON.stringify({ integrationId, siteName, orgId })
-      });
-      if (res.ok) {
+  const handleMap = useCallback(
+    async (s1SiteId: string, orgId: string | null) => {
+      if (!integrationId) return;
+      setMappingSaving((prev) => ({ ...prev, [s1SiteId]: true }));
+      setMappingError(null);
+      try {
+        await runAction({
+          request: () =>
+            fetchWithAuth('/s1/organizations/map', {
+              method: 'POST',
+              body: JSON.stringify({ integrationId, s1SiteId, orgId })
+            }),
+          errorFallback: 'Failed to map the SentinelOne site.',
+          successMessage: orgId ? 'SentinelOne site mapped' : 'SentinelOne site unmapped',
+          onUnauthorized: UNAUTHORIZED
+        });
         await fetchSites();
-      } else {
-        const json = await res.json().catch(() => ({}));
-        setSiteMapError(`Failed to map "${siteName}": ${json.error ?? 'Unknown error'}`);
+        await fetchStatus();
+      } catch (err) {
+        setMappingError(err instanceof ActionError ? err.message : 'Network error');
+        handleActionError(err, 'Failed to map the SentinelOne site.');
+      } finally {
+        setMappingSaving((prev) => ({ ...prev, [s1SiteId]: false }));
       }
-    } catch (err) {
-      setSiteMapError(`Failed to map "${siteName}": ${err instanceof Error ? err.message : 'Network error'}`);
-    } finally {
-      setSiteMapSaving((prev) => ({ ...prev, [siteName]: false }));
-    }
-  };
+    },
+    [integrationId, fetchSites, fetchStatus]
+  );
 
-  if (isAllOrgs) {
+  if (loading) {
     return (
-      <div className="space-y-6">
-        <div>
-          <h1 className="text-2xl font-semibold">SentinelOne Integration</h1>
-          <p className="text-sm text-muted-foreground">Connect your SentinelOne tenant for endpoint detection and response.</p>
-        </div>
-        <div className="rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
-          The SentinelOne integration is configured per organization. Switch the scope in the top bar
-          from <span className="font-medium text-foreground">All orgs</span> to a single organization
-          to view or edit its connection.
-        </div>
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-20">
+      <div className="flex items-center justify-center py-20" data-testid="s1-loading">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
       </div>
     );
   }
 
-  const syncStatusBadge = () => {
-    if (!integration) {
-      return (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600">
-          <Unplug className="h-3.5 w-3.5" /> Not configured
-        </span>
-      );
-    }
-    if (integration.lastSyncStatus === 'success' || integration.lastSyncStatus === 'partial') {
-      return (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-700">
-          <CheckCircle2 className="h-3.5 w-3.5" /> Connected
-        </span>
-      );
-    }
-    if (integration.lastSyncStatus === 'running') {
-      return (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs text-amber-700">
-          <Loader2 className="h-3.5 w-3.5 animate-spin" /> Syncing
-        </span>
-      );
-    }
-    if (integration.lastSyncStatus === 'error') {
-      return (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs text-red-700">
-          <AlertTriangle className="h-3.5 w-3.5" /> Error
-        </span>
-      );
-    }
-    return (
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600">
-        <Activity className="h-3.5 w-3.5" /> Pending
-      </span>
-    );
-  };
-
-  const canSave = name.trim().length > 0 && managementUrl.trim().length > 0 && (apiToken.trim().length > 0 || !!integration);
-
   return (
-    <div className="space-y-6">
-      {/* Header */}
+    <div className="space-y-6" data-testid="s1-panel">
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
           <Shield className="h-5 w-5" />
         </div>
         <div>
           <h1 className="text-2xl font-semibold">SentinelOne Integration</h1>
-          <p className="text-sm text-muted-foreground">Connect your SentinelOne tenant for endpoint detection and response.</p>
+          <p className="text-sm text-muted-foreground">
+            Connect one partner-level SentinelOne tenant and map SentinelOne sites to Breeze organizations.
+          </p>
         </div>
       </div>
 
       {loadError && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700" data-testid="s1-load-error">
           {loadError}
         </div>
       )}
 
-      {/* Connection Setup */}
-      <div className="rounded-xl border bg-card p-6 shadow-sm">
-        <h2 className="text-lg font-semibold">Connection</h2>
-        <p className="mb-4 text-sm text-muted-foreground">
-          Enter your SentinelOne management console URL and API token.
-          {!integration && ' Saving requires MFA verification.'}
-        </p>
+      {/* Org scope, not connected: SentinelOne is partner-level. */}
+      {!isPartnerView && !integration && (
+        <div className="rounded-xl border bg-card p-8 text-center shadow-sm" data-testid="s1-org-not-connected">
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+            <Unplug className="h-5 w-5" />
+          </div>
+          <h2 className="mt-3 text-lg font-semibold">SentinelOne isn&apos;t connected yet</h2>
+          <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+            SentinelOne is configured once at the partner level and shared across every organization. Switch your
+            scope to <span className="font-medium text-foreground">All orgs</span> to add the management URL and API token.
+          </p>
+        </div>
+      )}
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label className="mb-1 block text-sm font-medium">Name</label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="My S1 Tenant"
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
+      {/* Org scope, connected but this org isn't mapped to a site. */}
+      {!isPartnerView && integration && !mappedForOrg && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800" data-testid="s1-org-unmapped">
+          This organization isn&apos;t mapped to a SentinelOne site yet. Switch to All orgs as a partner admin to map it.
+        </div>
+      )}
+
+      {/* Partner connection form */}
+      {isPartnerView && (
+        <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="s1-connection">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold">Partner connection</h2>
+              <p className="text-sm text-muted-foreground">
+                One management URL and API token covers every SentinelOne site under this partner account.
+              </p>
+            </div>
+            {syncStatusBadge(integration)}
           </div>
-          <div>
-            <label className="mb-1 block text-sm font-medium">Management URL</label>
-            <input
-              type="url"
-              value={managementUrl}
-              onChange={(e) => setManagementUrl(e.target.value)}
-              placeholder="https://your-tenant.sentinelone.net"
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
-          </div>
-          <div className="md:col-span-2">
-            <label className="mb-1 block text-sm font-medium">
-              API Token
-              {integration && <span className="ml-1 text-xs text-muted-foreground">(leave blank to keep existing)</span>}
-            </label>
-            <div className="relative">
+
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-sm font-medium">Name</label>
               <input
-                type={showToken ? 'text' : 'password'}
-                value={apiToken}
-                onChange={(e) => setApiToken(e.target.value)}
-                placeholder={integration ? '••••••••••••••••' : 'Paste your API token'}
-                className="h-10 w-full rounded-md border bg-background px-3 pr-10 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My S1 Tenant"
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                data-testid="s1-name"
               />
-              <button
-                type="button"
-                onClick={() => setShowToken(!showToken)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              >
-                {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </button>
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Management URL</label>
+              <input
+                type="url"
+                value={managementUrl}
+                onChange={(e) => setManagementUrl(e.target.value)}
+                placeholder="https://your-tenant.sentinelone.net"
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                data-testid="s1-management-url"
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label className="mb-1 block text-sm font-medium">
+                API Token
+                {integration && <span className="ml-1 text-xs text-muted-foreground">(leave blank to keep existing)</span>}
+              </label>
+              <div className="relative">
+                <input
+                  type={showToken ? 'text' : 'password'}
+                  value={apiToken}
+                  onChange={(e) => setApiToken(e.target.value)}
+                  placeholder={integration ? '••••••••••••••••' : 'Paste your API token'}
+                  className="h-10 w-full rounded-md border bg-background px-3 pr-10 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                  data-testid="s1-api-token"
+                />
+                <button
+                  type="button"
+                  aria-label={showToken ? 'Hide API token' : 'Show API token'}
+                  onClick={() => setShowToken((value) => !value)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="mt-4 flex items-center gap-3">
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={!canSave || saveState.status === 'saving'}
-            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-          >
-            {saveState.status === 'saving' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-            {integration ? 'Update' : 'Save & Connect'}
-          </button>
-          {saveState.status === 'saved' && (
-            <span className="text-sm text-emerald-600">{saveState.message}</span>
-          )}
-          {saveState.status === 'error' && (
-            <span className="text-sm text-red-600">{saveState.message}</span>
-          )}
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!canSave || saveState.status === 'saving'}
+              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              data-testid="s1-save"
+            >
+              {saveState.status === 'saving' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              {integration ? 'Update' : 'Save & Connect'}
+            </button>
+            {integration && (
+              <button
+                type="button"
+                onClick={() => void handleSync()}
+                disabled={syncState.status === 'syncing'}
+                className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                data-testid="s1-sync"
+              >
+                {syncState.status === 'syncing' ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                Sync Now
+              </button>
+            )}
+            {saveState.message && (
+              <span className={`text-sm ${saveState.status === 'error' ? 'text-red-600' : 'text-emerald-600'}`} data-testid="s1-save-message">
+                {saveState.message}
+              </span>
+            )}
+            {syncState.message && (
+              <span className={`text-sm ${syncState.status === 'error' ? 'text-red-600' : 'text-emerald-600'}`}>
+                {syncState.message}
+              </span>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
-      {/* Status + Summary (only when integration exists) */}
+      {/* Sync status + coverage (any scope, once connected) */}
       {integration && (
         <div className="grid gap-6 lg:grid-cols-[1fr_1fr]">
-          {/* Sync Status */}
-          <div className="rounded-xl border bg-card p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold">Sync Status</h2>
-              {syncStatusBadge()}
+          <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="s1-sync-status">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-lg font-semibold">Sync status</h2>
+              {syncStatusBadge(integration)}
             </div>
             <div className="mt-4 space-y-2 text-sm">
               <div className="flex justify-between text-muted-foreground">
                 <span>Last sync</span>
-                <span className="text-foreground">
-                  {integration.lastSyncAt
-                    ? formatDateTime(integration.lastSyncAt)
-                    : 'Never'}
-                </span>
+                <span className="text-foreground">{integration.lastSyncAt ? formatDateTime(integration.lastSyncAt) : 'Never'}</span>
               </div>
               {integration.lastSyncError && (
-                <div className="mt-2 rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700">
-                  {integration.lastSyncError}
-                </div>
-              )}
-            </div>
-            <div className="mt-4">
-              <button
-                type="button"
-                onClick={handleSync}
-                disabled={syncState.status === 'syncing'}
-                className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
-              >
-                {syncState.status === 'syncing'
-                  ? <Loader2 className="h-4 w-4 animate-spin" />
-                  : <RefreshCw className="h-4 w-4" />}
-                Sync Now
-              </button>
-              {syncState.message && (
-                <span className={`ml-3 text-xs ${syncState.status === 'error' ? 'text-red-600' : 'text-emerald-600'}`}>
-                  {syncState.message}
-                </span>
+                <div className="rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700">{integration.lastSyncError}</div>
               )}
             </div>
           </div>
 
-          {/* Coverage Summary */}
           {summary && (
-            <div className="rounded-xl border bg-card p-6 shadow-sm">
+            <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="s1-coverage">
               <h2 className="text-lg font-semibold">Coverage</h2>
               <div className="mt-4 grid grid-cols-2 gap-4">
-                <div>
-                  <p className="text-2xl font-bold">{summary.totalAgents}</p>
-                  <p className="text-xs text-muted-foreground">S1 Agents</p>
-                </div>
-                <div>
-                  <p className="text-2xl font-bold">{summary.mappedDevices}</p>
-                  <p className="text-xs text-muted-foreground">Mapped Devices</p>
-                </div>
-                <div>
-                  <p className={`text-2xl font-bold ${summary.infectedAgents > 0 ? 'text-red-600' : ''}`}>
-                    {summary.infectedAgents}
-                  </p>
-                  <p className="text-xs text-muted-foreground">Infected</p>
-                </div>
-                <div>
-                  <p className={`text-2xl font-bold ${summary.activeThreats > 0 ? 'text-red-600' : ''}`}>
-                    {summary.activeThreats}
-                  </p>
-                  <p className="text-xs text-muted-foreground">Active Threats</p>
-                </div>
-                <div>
-                  <p className="text-2xl font-bold">{summary.pendingActions}</p>
-                  <p className="text-xs text-muted-foreground">Pending Actions</p>
-                </div>
-                <div>
-                  <p className={`text-2xl font-bold ${summary.highOrCriticalThreats > 0 ? 'text-amber-600' : ''}`}>
-                    {summary.highOrCriticalThreats}
-                  </p>
-                  <p className="text-xs text-muted-foreground">High/Critical</p>
-                </div>
+                <Metric label="S1 Agents" value={summary.totalAgents} />
+                <Metric label="Mapped Devices" value={summary.mappedDevices} />
+                <Metric label="Infected" value={summary.infectedAgents} warn={summary.infectedAgents > 0} danger />
+                <Metric label="Active Threats" value={summary.activeThreats} warn={summary.activeThreats > 0} danger />
+                <Metric label="Pending Actions" value={summary.pendingActions} />
+                <Metric label="High/Critical" value={summary.highOrCriticalThreats} warn={summary.highOrCriticalThreats > 0} />
               </div>
             </div>
           )}
         </div>
       )}
 
-      {/* Site Mapping (only when sites exist) */}
-      {integration && sites.length > 0 && (
-        <div className="rounded-xl border bg-card p-6 shadow-sm">
-          <h2 className="text-lg font-semibold">Site-to-Organization Mapping</h2>
-          <p className="mb-4 text-sm text-muted-foreground">
-            Map each SentinelOne site to a Breeze organization. Unmapped sites will inherit the integration's default org.
-          </p>
+      {/* Site → organization mapping (partner scope, once connected) */}
+      {isPartnerView && integration && (
+        <div className="rounded-xl border bg-card p-6 shadow-sm" data-testid="s1-mapping">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold">Site mapping</h2>
+              <p className="text-sm text-muted-foreground">
+                Map each SentinelOne site to a Breeze organization. Unmapped sites stay quarantined until assigned.
+              </p>
+            </div>
+            {unmappedCount > 0 && (
+              <span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs text-amber-700">
+                {unmappedCount} unmapped
+              </span>
+            )}
+          </div>
 
-          {siteMapError && (
-            <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-              {siteMapError}
+          {mappingError && (
+            <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700" data-testid="s1-mapping-error">
+              {mappingError}
             </div>
           )}
 
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full min-w-[720px] text-sm">
               <thead>
                 <tr className="border-b text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  <th className="pb-2 pr-4">S1 Site</th>
+                  <th className="pb-2 pr-4">S1 site</th>
                   <th className="pb-2 pr-4">Agents</th>
-                  <th className="pb-2 pr-4">Breeze Organization</th>
+                  <th className="pb-2 pr-4">Breeze organization</th>
                   <th className="pb-2">Status</th>
                 </tr>
               </thead>
               <tbody>
                 {sites.map((site) => (
-                  <tr key={site.siteName} className="border-b last:border-0">
-                    <td className="py-3 pr-4 font-medium">{site.siteName}</td>
-                    <td className="py-3 pr-4 text-muted-foreground">{site.agentCount}</td>
+                  <tr key={site.s1SiteId} className="border-b last:border-0" data-testid={`s1-site-${site.s1SiteId}`}>
+                    <td className="py-3 pr-4">
+                      <div className="font-medium">{site.s1SiteName || site.s1SiteId}</div>
+                      <div className="text-xs text-muted-foreground">
+                        ID {site.s1SiteId}
+                        {site.provisional && (
+                          <span className="ml-2 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700">
+                            pending sync
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="py-3 pr-4 text-muted-foreground">{site.agentsCount}</td>
                     <td className="py-3 pr-4">
                       <select
                         value={site.mappedOrgId ?? ''}
-                        onChange={(e) => handleSiteMap(site.siteName, e.target.value || null)}
-                        disabled={siteMapSaving[site.siteName]}
+                        onChange={(e) => void handleMap(site.s1SiteId, e.target.value || null)}
+                        disabled={mappingSaving[site.s1SiteId]}
                         className="h-9 w-full max-w-xs rounded-md border bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+                        data-testid={`s1-site-map-${site.s1SiteId}`}
+                        aria-label={`Map ${site.s1SiteName || site.s1SiteId} to a Breeze organization`}
                       >
-                        <option value="">— Select organization —</option>
-                        {orgs.map((org) => (
+                        <option value="">Select organization</option>
+                        {orgOptions.map((org) => (
                           <option key={org.id} value={org.id}>{org.name}</option>
                         ))}
                       </select>
                     </td>
                     <td className="py-3">
-                      {siteMapSaving[site.siteName] ? (
+                      {mappingSaving[site.s1SiteId] ? (
                         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                       ) : site.mappedOrgId ? (
                         <CheckCircle2 className="h-4 w-4 text-emerald-600" />
@@ -531,11 +533,28 @@ export default function SecurityIntegration() {
                     </td>
                   </tr>
                 ))}
+                {sites.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="py-6 text-sm text-muted-foreground" data-testid="s1-sites-empty">
+                      No SentinelOne sites discovered yet. Save credentials and run Sync Now.
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function Metric({ label, value, warn = false, danger = false }: { label: string; value: number; warn?: boolean; danger?: boolean }) {
+  const color = warn ? (danger ? 'text-red-600' : 'text-amber-600') : '';
+  return (
+    <div>
+      <p className={`text-2xl font-bold ${color}`}>{value}</p>
+      <p className="text-xs text-muted-foreground">{label}</p>
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -72,6 +72,7 @@ const TARGET_GLOBS = [
   'src/components/billing/quotes/QuotesPage.tsx',
   'src/components/billing/quotes/QuoteEditor.tsx',
   'src/components/alerts/CorrelatedAlertGroups.tsx',
+  'src/components/integrations/SecurityIntegration.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -263,7 +264,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(44);
+    expect(absoluteFiles.length).toBe(45);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/docs/superpowers/plans/2026-06-21-sentinelone-partner-wide.md
+++ b/docs/superpowers/plans/2026-06-21-sentinelone-partner-wide.md
@@ -1,0 +1,798 @@
+# SentinelOne Partner-Wide Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-key the SentinelOne (S1) integration from per-org to partner-wide scope, so an MSP configures one S1 console (token + management URL) per partner and maps S1 console **Sites** down to Breeze orgs — mirroring the shipped Huntress partner-axis pattern.
+
+**Architecture:** S1 moves from RLS tenancy shape #1 (direct `org_id`) to shape #3 (partner-axis) for the credential + mapping tables, while child tables (`s1_agents`/`s1_threats`/`s1_actions`) keep their denormalized `org_id` (shape #1) for per-org attribution. `s1_integrations` is re-keyed to `partner_id` (org_id retained as nullable legacy column); `s1_site_mappings` is promoted to a partner-axis discovery+mapping table `s1_org_mappings` keyed off the stable **S1 site id**. Routes invert from org-scope resolution to partner-scope credential management with dual-scope reads. The sync job — which already fans agents/threats out to per-org rows via site mappings — gains S1 site-id capture and partner-based credential resolution.
+
+**Tech Stack:** PostgreSQL 16 + RLS (forced), Drizzle ORM (types only — hand-written SQL migrations), Hono routes, BullMQ sync workers, Vitest (unit + RLS + integration), Astro + React Islands web UI.
+
+**Reference implementation (copy its shape beat-for-beat):**
+- Schema: `apps/api/src/db/schema/huntress.ts`
+- Migration: `apps/api/migrations/2026-06-12-a-huntress-partner-mapping.sql`
+- Routes: `apps/api/src/routes/huntress.ts` (`resolvePartnerId`, `requirePartnerManager`, dual-scope reads)
+- Sync: `apps/api/src/jobs/huntressSync.ts` (`runWithSystemDbAccess`, discover→upsert mappings→fan-out)
+- Web: `apps/web/src/components/integrations/HuntressIntegration.tsx` (`isPartnerView`, mapping table)
+
+## Global Constraints
+
+- **RLS is mandatory, in the same migration that alters the table** — never defer. Partner-axis tables use `public.breeze_has_partner_access(partner_id)` (flat, never tree traversal). API connects as unprivileged `breeze_app`; a missing policy = silent 0-row reads/writes, not an error.
+- **Dual-list registration:** any `s1_*` table carrying BOTH `partner_id` AND a denormalized `org_id` MUST be added to BOTH `PARTNER_TENANT_TABLES` and `ORG_AXIS_POLICY_EXCLUDED_TABLES` in `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` in this PR (the pax8 #1594→#1612 trap; only the **Integration Tests** job catches it, and it is BLOCKING on PR).
+- **Migrations:** idempotent (`IF NOT EXISTS` / `DO $$ … EXCEPTION` / `pg_policies` checks); no inner `BEGIN;`/`COMMIT;` (autoMigrate wraps each file); cleanup/dedup statements report row counts via `GET DIAGNOSTICS … RAISE WARNING`. Filename `YYYY-MM-DD-<slug>.sql` must sort **after** the latest existing migration (currently `2026-06-26-sso-verified-domains.sql`). Never edit a shipped migration.
+- **No `gen_random_bytes`/pgcrypto** in migrations (only `gen_random_uuid` + `pg_trgm` are available). The reference migration uses `gen_random_uuid()` for the mapping table PK — keep that.
+- **Web mutations** must use `runAction` (`apps/web/src/lib/runAction.ts`). The current `SecurityIntegration.tsx` does NOT — adopt it (Pax8Integration.tsx is the in-repo example).
+- **Credentials are partner-only:** org-scope request contexts cannot read partner rows under RLS. Credential read/decrypt in the sync path runs in **system-scope** DB context (`withSystemDbAccessContext` / `runWithSystemDbAccess`), never the bare pool. This is the #1375/#1591 silent-RLS trap.
+- **Run real-DB tests correctly:** RLS forge + integration tests need `--config vitest.integration.config.ts` (or `vitest.config.rls.ts` for forge) and a `breeze_app` connection on the test DB; the plain `test-api` job has no DATABASE_URL and skips real-DB cases vacuously. Fresh worktree needs the gitignored `.env.test` symlink and `pnpm install` (prefix `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`).
+
+## Locked Design Decisions (from issue #1735 triage)
+
+1. **Consolidation:** auto-consolidate, most-recent active wins (Huntress dedup). Duplicate per-partner integrations are deactivated with a logged reason; rows retained.
+2. **Mapping unit/key:** map S1 **Sites**, keyed by stable **S1 site id** (`s1_site_id`), storing `s1_site_name` for display. Site discovery stays agent-metadata-derived — S1 agent API rows already carry `siteId` + `siteName`; the client just needs to extract `siteId` (one field). No new S1 API endpoint.
+3. **Cardinality:** one active integration per partner (partial-unique index `WHERE is_active = true`).
+4. **Legacy reconciliation:** existing `s1_site_mappings` rows (name-keyed, no site id) migrate into `s1_org_mappings` as **provisional** rows (`s1_site_id = 'name:' || site_name`, `metadata->>'provisional' = 'true'`). The first post-migration sync matches discovered sites by name to provisional rows, rewrites `s1_site_id` to the real id, preserves the existing `org_id`, and clears the provisional flag. No mapping is lost; no duplicate survives.
+
+---
+
+## File Structure
+
+**Database / schema**
+- Modify: `apps/api/src/db/schema/sentinelOne.ts` — re-key `s1Integrations` (partnerId + legacyOrgId, partial-unique), add `s1OrgMappings`, drop `s1SiteMappings` export.
+- Create: `apps/api/migrations/2026-06-27-a-sentinelone-partner-mapping.sql` — promote + backfill + dedup + mapping table + RLS swap (verify the prefix sorts last at implementation time).
+
+**RLS / cascade contracts**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — add `s1_integrations` + `s1_org_mappings` to `PARTNER_TENANT_TABLES` and `ORG_AXIS_POLICY_EXCLUDED_TABLES`.
+- Modify: `apps/api/src/services/tenantCascade.ts` — rename `s1_site_mappings` → `s1_org_mappings` in `ORG_CASCADE_DELETE_ORDER` (same alpha slot).
+- Create: `apps/api/src/__tests__/integration/sentinelOne-partner-rls.integration.test.ts` — partner-axis forge tests (cross-partner read/write denial; org-scope cannot read credentials).
+
+**API routes**
+- Modify: `apps/api/src/routes/sentinelOne.ts` — replace `resolveOrgId` with `resolvePartnerId` + `requirePartnerManager`; re-point `/integration` to partner; rename `/sites`→`/sites` listing to partner discovery, `/sites/map`→`/organizations/map`; keep `/threats`/`/isolate`/`/threat-action`/`/status` dual-scope.
+- Modify: `apps/api/src/routes/sentinelOne.test.ts` — update mocked-auth expectations to partner scope.
+
+**Sync / services**
+- Modify: `apps/api/src/services/sentinelOne/client.ts` — extract `siteId` on normalized agents.
+- Modify: `apps/api/src/jobs/s1Sync.ts` — capture site id, upsert `s1_org_mappings`, reconcile provisional rows, resolve org via mapping by site id, partner-aware integration load (system-scope).
+- Modify: `apps/api/src/services/sentinelOne/actions.ts` — `getActiveS1IntegrationForOrg` → resolve the partner's active integration that covers a given org (via mapping); keep org-scoped action rows.
+- Modify: `apps/api/src/services/aiToolsSentinelOne.ts` — status/threats tools resolve via partner integration + org mapping.
+
+**Web UI**
+- Modify: `apps/web/src/components/integrations/SecurityIntegration.tsx` — `isPartnerView` UX: partner sees creds + site→org mapping table; org sees read-only mapped status; adopt `runAction`.
+
+---
+
+## Phase A — Database layer (schema, migration, contracts)
+
+### Task A1: Re-key the Drizzle schema
+
+**Files:**
+- Modify: `apps/api/src/db/schema/sentinelOne.ts`
+
+**Interfaces:**
+- Produces: `s1Integrations` with `partnerId: uuid('partner_id') NOT NULL → partners.id`, `legacyOrgId: uuid('org_id')` (nullable), partial-unique `s1_integrations_partner_active_idx`, composite-unique `s1_integrations_id_partner_idx`. New `s1OrgMappings` table (exported) with `integrationId`, `partnerId`, `s1SiteId`, `s1SiteName`, `orgId` (nullable, `onDelete: 'set null'`), `agentsCount`, `metadata`, `lastSeenAt`. `s1SiteMappings` export removed.
+
+> Schema files are type-only (no migration generated from them). This task has no standalone test; it is validated by `pnpm db:check-drift` after the migration (Task A2) and by typecheck. Commit it together with A2.
+
+- [ ] **Step 1: Add `partners` import and re-key `s1Integrations`**
+
+In `apps/api/src/db/schema/sentinelOne.ts`, add `import { partners } from './partners';` (verify the export name/path: `grep -n "export const partners" apps/api/src/db/schema/*.ts`) and replace the `s1Integrations` definition:
+
+```typescript
+export const s1Integrations = pgTable('s1_integrations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  legacyOrgId: uuid('org_id').references(() => organizations.id),
+  name: varchar('name', { length: 200 }).notNull(),
+  apiTokenEncrypted: text('api_token_encrypted').notNull(),
+  managementUrl: text('management_url').notNull(),
+  isActive: boolean('is_active').notNull().default(true),
+  lastSyncAt: timestamp('last_sync_at'),
+  lastSyncStatus: varchar('last_sync_status', { length: 20 }),
+  lastSyncError: text('last_sync_error'),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  partnerActiveIdx: uniqueIndex('s1_integrations_partner_active_idx')
+    .on(table.partnerId)
+    .where(sql`${table.isActive} = true`),
+  idPartnerIdx: uniqueIndex('s1_integrations_id_partner_idx').on(table.id, table.partnerId),
+  legacyOrgIdx: index('s1_integrations_legacy_org_idx').on(table.legacyOrgId)
+}));
+```
+
+Add `sql` to the `drizzle-orm` import at the top: `import { sql } from 'drizzle-orm';` (verify it isn't already imported).
+
+- [ ] **Step 2: Replace `s1SiteMappings` with `s1OrgMappings`**
+
+Delete the `s1SiteMappings` export (lines ~97-107) and add:
+
+```typescript
+export const s1OrgMappings = pgTable('s1_org_mappings', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  integrationId: uuid('integration_id').notNull(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  s1SiteId: varchar('s1_site_id', { length: 128 }).notNull(),
+  s1SiteName: varchar('s1_site_name', { length: 200 }),
+  orgId: uuid('org_id').references(() => organizations.id, { onDelete: 'set null' }),
+  agentsCount: integer('agents_count').notNull().default(0),
+  metadata: jsonb('metadata'),
+  lastSeenAt: timestamp('last_seen_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  uniqueSiteIdx: uniqueIndex('s1_org_mappings_integration_site_idx').on(table.integrationId, table.s1SiteId),
+  orgIdx: index('s1_org_mappings_org_idx').on(table.orgId),
+  integrationIdx: index('s1_org_mappings_integration_idx').on(table.integrationId),
+  partnerIdx: index('s1_org_mappings_partner_idx').on(table.partnerId),
+  integrationPartnerFk: foreignKey({
+    columns: [table.integrationId, table.partnerId],
+    foreignColumns: [s1Integrations.id, s1Integrations.partnerId],
+    name: 's1_org_mappings_integration_partner_fkey'
+  }).onDelete('cascade')
+}));
+```
+
+Add `foreignKey` to the `drizzle-orm/pg-core` import list at the top of the file.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: PASS (or only pre-existing unrelated errors). Resolve any reference to the removed `s1SiteMappings` symbol — they are addressed in Phase B/C; for now it is acceptable for `s1Sync.ts`/`sentinelOne.ts` to still reference it (typecheck will flag, fixed in later tasks). If you want a green typecheck at this commit, do A1+A2 then proceed straight into Phase C; otherwise commit A1 alongside the route/sync edits. Recommended: commit A1+A2 and accept that full typecheck goes green at end of Phase C.
+
+- [ ] **Step 4: Commit (with A2)** — see A2 Step 6.
+
+---
+
+### Task A2: Promotion migration
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-27-a-sentinelone-partner-mapping.sql`
+
+**Interfaces:**
+- Produces: `s1_integrations.partner_id` (NOT NULL after backfill), nullable `org_id`, partial-unique + composite-unique indexes, partner-axis RLS policies. New `s1_org_mappings` table with partner-axis RLS + FK-integrity INSERT/UPDATE checks. Legacy `s1_site_mappings` rows migrated as provisional `s1_org_mappings` rows.
+
+- [ ] **Step 1: Verify the filename sorts last**
+
+Run: `ls apps/api/migrations/ | grep -E '^\d{4}-' | sort | tail -3`
+Confirm `2026-06-27-a-sentinelone-partner-mapping.sql` would sort after the last entry. If a later-dated migration exists, bump the date so it sorts last.
+
+- [ ] **Step 2: Write the migration**
+
+Create `apps/api/migrations/2026-06-27-a-sentinelone-partner-mapping.sql`:
+
+```sql
+-- Promote SentinelOne integrations from org-owned credentials to partner-owned
+-- credentials with explicit S1 site -> Breeze organization mapping.
+-- Mirrors 2026-06-12-a-huntress-partner-mapping.sql.
+
+-- 1. Add partner_id, relax org_id to legacy nullable, backfill from org.
+ALTER TABLE s1_integrations
+  ADD COLUMN IF NOT EXISTS partner_id uuid;
+
+ALTER TABLE s1_integrations
+  ALTER COLUMN org_id DROP NOT NULL;
+
+UPDATE s1_integrations si
+SET partner_id = o.partner_id
+FROM organizations o
+WHERE si.partner_id IS NULL
+  AND si.org_id = o.id;
+
+DO $$
+BEGIN
+  ALTER TABLE s1_integrations
+    ADD CONSTRAINT s1_integrations_partner_id_fkey
+    FOREIGN KEY (partner_id) REFERENCES partners(id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+DECLARE
+  missing_count integer;
+BEGIN
+  SELECT COUNT(*)::int INTO missing_count
+  FROM s1_integrations
+  WHERE partner_id IS NULL;
+
+  IF missing_count > 0 THEN
+    RAISE EXCEPTION 'Cannot promote SentinelOne integrations: % row(s) have no resolvable partner_id from org_id', missing_count;
+  END IF;
+END $$;
+
+ALTER TABLE s1_integrations
+  ALTER COLUMN partner_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS s1_integrations_id_partner_idx
+  ON s1_integrations(id, partner_id);
+
+DROP INDEX IF EXISTS s1_integrations_org_idx;
+
+CREATE INDEX IF NOT EXISTS s1_integrations_legacy_org_idx
+  ON s1_integrations(org_id);
+
+-- 2. Dedup to one active integration per partner (most-recent wins), with count.
+DO $$
+DECLARE
+  deactivated integer;
+BEGIN
+  WITH ranked AS (
+    SELECT
+      id,
+      row_number() OVER (
+        PARTITION BY partner_id
+        ORDER BY
+          CASE WHEN is_active THEN 0 ELSE 1 END,
+          updated_at DESC,
+          created_at DESC,
+          id
+      ) AS rn
+    FROM s1_integrations
+  )
+  UPDATE s1_integrations si
+  SET is_active = false,
+      updated_at = now(),
+      last_sync_status = COALESCE(si.last_sync_status, 'inactive'),
+      last_sync_error = COALESCE(si.last_sync_error, 'Deactivated during partner-level SentinelOne promotion because another active integration exists for this partner.')
+  FROM ranked
+  WHERE si.id = ranked.id
+    AND ranked.rn > 1
+    AND si.is_active = true;
+  GET DIAGNOSTICS deactivated = ROW_COUNT;
+  IF deactivated > 0 THEN
+    RAISE WARNING 'Deactivated % duplicate SentinelOne integration(s) during partner promotion', deactivated;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS s1_integrations_partner_active_idx
+  ON s1_integrations(partner_id)
+  WHERE is_active = true;
+
+-- 3. Partner-axis discovery + mapping table.
+CREATE TABLE IF NOT EXISTS s1_org_mappings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  integration_id uuid NOT NULL,
+  partner_id uuid NOT NULL REFERENCES partners(id),
+  s1_site_id varchar(128) NOT NULL,
+  s1_site_name varchar(200),
+  org_id uuid REFERENCES organizations(id) ON DELETE SET NULL,
+  agents_count integer NOT NULL DEFAULT 0,
+  metadata jsonb,
+  last_seen_at timestamp,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT s1_org_mappings_integration_partner_fkey
+    FOREIGN KEY (integration_id, partner_id)
+    REFERENCES s1_integrations(id, partner_id)
+    ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS s1_org_mappings_integration_site_idx
+  ON s1_org_mappings(integration_id, s1_site_id);
+CREATE INDEX IF NOT EXISTS s1_org_mappings_org_idx
+  ON s1_org_mappings(org_id);
+CREATE INDEX IF NOT EXISTS s1_org_mappings_integration_idx
+  ON s1_org_mappings(integration_id);
+CREATE INDEX IF NOT EXISTS s1_org_mappings_partner_idx
+  ON s1_org_mappings(partner_id);
+
+-- 4. Backfill legacy name-keyed site mappings as PROVISIONAL rows. The first
+-- post-migration sync matches discovered sites by name, rewrites s1_site_id to
+-- the real id, and clears the provisional flag (carrying org_id forward).
+-- Only migrate rows belonging to a surviving active integration's partner.
+DO $$
+DECLARE
+  migrated integer;
+BEGIN
+  INSERT INTO s1_org_mappings (
+    integration_id, partner_id, s1_site_id, s1_site_name, org_id, metadata, last_seen_at, updated_at
+  )
+  SELECT
+    sm.integration_id,
+    si.partner_id,
+    'name:' || sm.site_name,
+    sm.site_name,
+    sm.org_id,
+    jsonb_build_object('source', 'migration', 'provisional', true),
+    now(),
+    now()
+  FROM s1_site_mappings sm
+  JOIN s1_integrations si ON si.id = sm.integration_id
+  ON CONFLICT (integration_id, s1_site_id) DO NOTHING;
+  GET DIAGNOSTICS migrated = ROW_COUNT;
+  RAISE WARNING 'Migrated % legacy SentinelOne site mapping(s) as provisional rows', migrated;
+END $$;
+
+-- 5. RLS: swap s1_integrations org-axis -> partner-axis.
+DROP POLICY IF EXISTS breeze_org_isolation_select ON s1_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON s1_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON s1_integrations;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_select ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_insert ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_update ON s1_integrations;
+DROP POLICY IF EXISTS breeze_partner_isolation_delete ON s1_integrations;
+
+ALTER TABLE s1_integrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE s1_integrations FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_partner_isolation_select ON s1_integrations
+  FOR SELECT USING (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_insert ON s1_integrations
+  FOR INSERT WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_update ON s1_integrations
+  FOR UPDATE USING (public.breeze_has_partner_access(partner_id))
+  WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_delete ON s1_integrations
+  FOR DELETE USING (public.breeze_has_partner_access(partner_id));
+
+-- 6. RLS: s1_org_mappings partner-axis with FK-integrity on writes.
+DROP POLICY IF EXISTS breeze_partner_isolation_select ON s1_org_mappings;
+DROP POLICY IF EXISTS breeze_partner_isolation_insert ON s1_org_mappings;
+DROP POLICY IF EXISTS breeze_partner_isolation_update ON s1_org_mappings;
+DROP POLICY IF EXISTS breeze_partner_isolation_delete ON s1_org_mappings;
+
+ALTER TABLE s1_org_mappings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE s1_org_mappings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_partner_isolation_select ON s1_org_mappings
+  FOR SELECT USING (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_insert ON s1_org_mappings
+  FOR INSERT WITH CHECK (
+    public.breeze_has_partner_access(partner_id)
+    AND EXISTS (
+      SELECT 1 FROM s1_integrations si
+      WHERE si.id = s1_org_mappings.integration_id
+        AND si.partner_id = s1_org_mappings.partner_id
+    )
+  );
+CREATE POLICY breeze_partner_isolation_update ON s1_org_mappings
+  FOR UPDATE USING (public.breeze_has_partner_access(partner_id))
+  WITH CHECK (
+    public.breeze_has_partner_access(partner_id)
+    AND EXISTS (
+      SELECT 1 FROM s1_integrations si
+      WHERE si.id = s1_org_mappings.integration_id
+        AND si.partner_id = s1_org_mappings.partner_id
+    )
+  );
+CREATE POLICY breeze_partner_isolation_delete ON s1_org_mappings
+  FOR DELETE USING (public.breeze_has_partner_access(partner_id));
+
+-- NOTE: s1_site_mappings is intentionally retained (not dropped) so the legacy
+-- table remains as a forensic record post-migration. A follow-up migration may
+-- drop it once provisional reconciliation is confirmed in prod.
+```
+
+- [ ] **Step 3: Validate idempotency + apply against empty Postgres**
+
+The `Check Migrations` CI job applies migrations against an empty DB. Validate locally with a throwaway container:
+
+Run:
+```bash
+docker run -d --name s1-mig-test -e POSTGRES_PASSWORD=pw -p 55432:5432 postgres:16 >/dev/null && sleep 4
+# Apply ALL migrations in order against the throwaway DB, then re-apply this file to prove idempotency.
+PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH DATABASE_URL="postgresql://postgres:pw@localhost:55432/postgres" pnpm --filter @breeze/api exec tsx scripts/apply-migrations.ts 2>&1 | tail -20
+```
+(Use the repo's actual migration-apply entrypoint — confirm with `grep -rn "autoMigrate\|applyMigrations" apps/api/scripts apps/api/src/db | head`. The `apps/api db:migrate` script is a no-op export per repo notes.)
+Expected: applies cleanly; re-applying the new file is a no-op (no errors, policies/indexes already exist).
+Cleanup: `docker rm -f s1-mig-test`
+
+- [ ] **Step 4: Drift check**
+
+Run: `export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm db:check-drift`
+Expected: no drift between `sentinelOne.ts` (Task A1) and the migration.
+
+- [ ] **Step 5: autoMigrate ordering regression test**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run src/db/autoMigrate.test.ts`
+Expected: PASS (confirms the new filename sorts correctly).
+
+- [ ] **Step 6: Commit A1 + A2**
+
+```bash
+git add apps/api/src/db/schema/sentinelOne.ts apps/api/migrations/2026-06-27-a-sentinelone-partner-mapping.sql
+git commit -m "feat(s1): re-key SentinelOne integration to partner-axis (schema + migration)
+
+Promote s1_integrations to partner_id (org_id retained as legacy nullable),
+add s1_org_mappings discovery/mapping table keyed off S1 site id, partner-axis
+RLS, dedup to one active integration per partner. Mirrors Huntress pattern.
+
+Refs #1735"
+```
+
+---
+
+### Task A3: RLS coverage contract entries
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`
+
+**Interfaces:**
+- Consumes: tables created in A2.
+- Produces: `s1_integrations` + `s1_org_mappings` registered in both `PARTNER_TENANT_TABLES` (value `'partner_id'`) and `ORG_AXIS_POLICY_EXCLUDED_TABLES`.
+
+- [ ] **Step 1: Add to `ORG_AXIS_POLICY_EXCLUDED_TABLES`**
+
+Find the `ORG_AXIS_POLICY_EXCLUDED_TABLES` set (the block listing `huntress_integrations`, `huntress_org_mappings`, `pax8_company_mappings`). Add, with a comment mirroring the Huntress one:
+
+```typescript
+  // SentinelOne credentials and discovered-site mappings are partner-scoped.
+  // org_id is retained only as legacy/mapping metadata and may be NULL.
+  's1_integrations',
+  's1_org_mappings',
+```
+
+- [ ] **Step 2: Add to `PARTNER_TENANT_TABLES`**
+
+Find the `PARTNER_TENANT_TABLES` map (listing `['huntress_integrations', 'partner_id']`, `['huntress_org_mappings', 'partner_id']`). Add:
+
+```typescript
+  ['s1_integrations', 'partner_id'],
+  ['s1_org_mappings', 'partner_id'],
+```
+
+- [ ] **Step 3: Run the contract test (real DB)**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts`
+Expected: PASS. (Requires the test DB on :5433 via the `.env.test` symlink; if it skips, the symlink/env is missing — fix before trusting green. The org-axis check will FAIL here if either list entry is missing — that is the exact regression this guards.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "test(s1): register partner-axis S1 tables in rls-coverage allowlists
+
+Refs #1735"
+```
+
+---
+
+### Task A4: Cascade list rename
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts:247`
+
+**Interfaces:**
+- Consumes: `s1_org_mappings` from A2.
+
+- [ ] **Step 1: Rename the cascade entry**
+
+In `ORG_CASCADE_DELETE_ORDER`, replace `'s1_site_mappings',` with `'s1_org_mappings',`. The alpha slot is identical (`s1_actions`, `s1_agents`, `s1_integrations`, `s1_org_mappings`, `s1_threats` — `o` < `t`, so it stays between `s1_integrations` and `s1_threats`). `s1_integrations` stays in the list (it keeps the legacy `org_id` column, exactly like `huntress_integrations`).
+
+- [ ] **Step 2: Run cascade list contract + tenancy tests**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/ -t "cascade"`
+Expected: PASS — the contract asserts every `org_id`-bearing table is present and the list is `localeCompare`-sorted. `s1_org_mappings` has a (nullable) `org_id`, so it must be present; `s1_site_mappings` no longer exists, so its absence is required.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/services/tenantCascade.ts
+git commit -m "fix(s1): rename s1_site_mappings -> s1_org_mappings in org cascade order
+
+Refs #1735"
+```
+
+---
+
+### Task A5: Partner-axis RLS forge test
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/sentinelOne-partner-rls.integration.test.ts`
+
+**Interfaces:**
+- Consumes: A2 tables/policies. Uses the integration test harness (breeze_app conn, autoMigrate + TRUNCATE-per-test, seed fresh per `it`). Model it on the existing huntress/pax8 partner-RLS integration test — find it: `grep -rln "huntress_integrations\|breeze_has_partner_access" apps/api/src/__tests__/integration`.
+
+- [ ] **Step 1: Write the forge test (fails until policies exist — they do after A2)**
+
+Create the file with these cases (re-seed fixtures inside each `it`, never module scope — the per-test TRUNCATE wipes them, causing vacuous passes; see the rls-forge memoized-fixture trap):
+
+```typescript
+// Seed two partners (P1, P2), each with an org and an active s1_integrations row.
+// Use the breeze_app connection with partner-scope GUCs set per case.
+
+it('partner cannot SELECT another partner\'s S1 integration', async () => {
+  // set context to P2; SELECT s1_integrations WHERE partner_id = P1 -> 0 rows
+});
+
+it('partner cannot INSERT an s1_integrations row for another partner', async () => {
+  // set context to P2; INSERT ... partner_id = P1 -> "new row violates row-level security policy"
+});
+
+it('org-scope context cannot SELECT partner S1 credentials', async () => {
+  // set org-scope context (no partner reach); SELECT s1_integrations -> 0 rows
+});
+
+it('partner cannot map an S1 site into another partner\'s integration', async () => {
+  // set context to P2; INSERT s1_org_mappings (integration_id = P1's, partner_id = P2) -> RLS violation (FK-integrity EXISTS fails)
+});
+
+it('partner CAN read+map its own S1 integration and sites', async () => {
+  // set context to P1; SELECT own integration -> 1 row; INSERT own s1_org_mappings -> ok; map org_id under P1 -> ok
+});
+```
+
+Implement each case using the exact GUC-setting + breeze_app query helpers used by the neighbouring huntress/pax8 integration test (copy its `setPartnerContext` / `setOrgContext` helpers). Cross-partner asserts must be self-verifying (expect 0 rows / 42501), not BYPASSRLS-vacuous — confirm `rolbypassrls=false` for the test role.
+
+- [ ] **Step 2: Run it**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/sentinelOne-partner-rls.integration.test.ts`
+Expected: PASS. To prove the test isn't vacuous, temporarily comment out the `breeze_partner_isolation_select` policy creation in a throwaway DB and confirm case 1 FAILS, then restore.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/sentinelOne-partner-rls.integration.test.ts
+git commit -m "test(s1): partner-axis RLS forge tests for S1 integration + site mappings
+
+Refs #1735"
+```
+
+---
+
+## Phase B — API routes
+
+### Task B1: Partner-scope resolution helpers
+
+**Files:**
+- Modify: `apps/api/src/routes/sentinelOne.ts:96-127` (replace `resolveOrgId`)
+
+**Interfaces:**
+- Produces:
+  - `resolvePartnerId(auth, requested?) → { partnerId } | { error, status }` — partner/org scope pin to `auth.partnerId`; system scope requires explicit `requested`.
+  - `requirePartnerManager(auth, requested?) → { partnerId } | { error, status }` — rejects `auth.scope === 'organization'` with 403 "SentinelOne credentials and mappings are managed at partner scope".
+  - Keep a `resolveOrgId(auth, requested?)` for the dual-scope **read** endpoints (org callers see only their org's mapped data) — copy Huntress's version verbatim.
+
+- [ ] **Step 1: Add helper tests** to `apps/api/src/routes/sentinelOne.test.ts`
+
+```typescript
+describe('requirePartnerManager', () => {
+  it('rejects organization scope', () => {
+    const r = requirePartnerManager({ scope: 'organization', partnerId: 'p1' } as any);
+    expect(r).toEqual({ error: 'SentinelOne credentials and mappings are managed at partner scope', status: 403 });
+  });
+  it('pins partner scope to its partnerId', () => {
+    const r = requirePartnerManager({ scope: 'partner', partnerId: 'p1' } as any);
+    expect(r).toEqual({ partnerId: 'p1' });
+  });
+  it('system scope requires explicit partnerId', () => {
+    const r = requirePartnerManager({ scope: 'system' } as any);
+    expect(r).toEqual({ error: 'partnerId is required for system scope', status: 400 });
+  });
+});
+```
+
+Export the helpers (or test via the route) — match how `sentinelOne.test.ts` currently imports `resolveOrgId`.
+
+- [ ] **Step 2: Run, expect fail** — `vitest run src/routes/sentinelOne.test.ts -t requirePartnerManager` → FAIL (not defined).
+
+- [ ] **Step 3: Implement** — replace `resolveOrgId` (lines 96-127) by copying `resolvePartnerId` + `requirePartnerManager` from `apps/api/src/routes/huntress.ts:44-104`, renaming the user-facing strings to "SentinelOne". Keep the Huntress `resolveOrgId` too (needed for dual-scope reads). Replace `s1`-specific text where Huntress says "Huntress".
+
+- [ ] **Step 4: Run, expect pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): partner-scope resolution helpers for routes (refs #1735)"`
+
+---
+
+### Task B2: Credential endpoints (`GET`/`POST /integration`)
+
+**Files:**
+- Modify: `apps/api/src/routes/sentinelOne.ts:193-345`
+
+**Interfaces:**
+- `GET /integration` — `requireScope('organization','partner','system')`; resolves `partnerId`; returns the partner's active integration. Org-scope callers additionally get `mapped: boolean` for their org.
+- `POST /integration` — `requireScope('partner','system')` + `requirePermission(ORGS_WRITE)` + `requireMfa()` + `requirePartnerManager`; upsert by `partnerId` (not orgId); set `partnerId`, leave `legacyOrgId` untouched. Audit with `partnerId`.
+
+- [ ] **Step 1: Update route tests** in `sentinelOne.test.ts` — assert `POST /integration` returns 403 for org scope, 200 for partner scope; assert the insert/update filters on `partner_id`. Mirror the huntress route test assertions.
+
+- [ ] **Step 2: Run, expect fail.**
+
+- [ ] **Step 3: Implement** — re-point both handlers to partner: replace every `eq(s1Integrations.orgId, orgResult.orgId)` with `eq(s1Integrations.partnerId, partnerResult.partnerId)` + `eq(s1Integrations.isActive, true)`; change `POST` scope guard to `requireScope('partner','system')` and resolve via `requirePartnerManager`; write `partnerId` on insert/update; change audit `orgId:` to `partnerId:`. For `GET` org-scope, add the mapped-status sub-query against `s1OrgMappings` (copy Huntress `GET /integration` lines 283-336). `scheduleS1Sync(integration.id)` call stays.
+
+- [ ] **Step 4: Run, expect pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): partner-scoped credential endpoints (refs #1735)"`
+
+---
+
+### Task B3: Site discovery + mapping endpoints
+
+**Files:**
+- Modify: `apps/api/src/routes/sentinelOne.ts:738-883` (`GET /sites`, `POST /sites/map`)
+
+**Interfaces:**
+- `GET /sites` — partner-scope; lists discovered `s1_org_mappings` rows for the partner's active integration (s1SiteId, s1SiteName, agentsCount, mappedOrgId, mappedOrgName, provisional flag). Replaces the agent-metadata grouping with a read of the mapping table.
+- `POST /organizations/map` (renamed from `/sites/map`) — `requireScope('partner','system')` + `requirePermission(ORGS_WRITE)` + `requireMfa()`; body `{ integrationId, s1SiteId, orgId | null }`; validates the integration's partner, validates `orgId` belongs to that partner (`auth.canAccessOrg` + partner match), updates `s1_org_mappings.org_id`. Copy `huntress POST /organizations/map` (lines 579-648) structure exactly.
+
+- [ ] **Step 1: Tests** — assert org-scope gets 403 on map; partner maps own site→org ok; mapping an org from a different partner → 403; mapping a non-existent discovered site → 404 "Run sync first to discover sites."
+
+- [ ] **Step 2: Run, expect fail.**
+
+- [ ] **Step 3: Implement** both handlers per the Huntress reference; update the web-facing path constant to `/organizations/map`. Keep a backward-compat note: the old `/sites/map` path is removed (single in-repo caller is the web component, updated in Phase E).
+
+- [ ] **Step 4: Run, expect pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): partner site-discovery + org-mapping endpoints (refs #1735)"`
+
+---
+
+### Task B4: Dual-scope read endpoints (`/status`, `/threats`, `/isolate`, `/threat-action`, `/sync`)
+
+**Files:**
+- Modify: `apps/api/src/routes/sentinelOne.ts:347-736`
+
+**Interfaces:**
+- These keep operating on per-org child rows (`s1_agents`/`s1_threats`/`s1_actions` still carry `org_id`). They must resolve the **partner's** active integration but continue to scope rows by org for org-scope callers (via `resolveOrgId` + `auth.orgCondition`).
+
+- [ ] **Step 1: Tests** — for `/status`: partner scope returns cross-org coverage; org scope returns only its org's coverage (or empty if unmapped). For `/threats`: org-scope still site-narrowed (the existing `resolveSiteAllowedDeviceIds` device-level narrowing is unchanged). For `/isolate` + `/threat-action`: resolve the integration via the partner (using the `getActiveS1IntegrationForOrg` replacement from Task C3) but keep writing `org_id` on `s1_actions`.
+
+- [ ] **Step 2: Run, expect fail.**
+
+- [ ] **Step 3: Implement** — replace integration lookups that did `eq(s1Integrations.orgId, X)` with: resolve partner → load the partner's active integration → for org-scope callers, confirm the org is mapped (via `s1_org_mappings`) before returning data. The action endpoints call the updated service from Task C3. Audit rows keep `orgId`. `/sync` (manual trigger): partner-scope; load the partner's active integration and `scheduleS1Sync(integration.id)`.
+
+- [ ] **Step 4: Run, expect pass; then full route file test.** `vitest run src/routes/sentinelOne.test.ts` → PASS.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): partner-aware dual-scope read/action endpoints (refs #1735)"`
+
+---
+
+## Phase C — Sync & services
+
+### Task C1: Capture S1 `siteId` in the client
+
+**Files:**
+- Modify: `apps/api/src/services/sentinelOne/client.ts:27` (type) and `:288-312` (`normalizeAgent`)
+
+**Interfaces:**
+- Produces: `S1Agent.siteId: string | null` populated from the raw row's `siteId`.
+
+- [ ] **Step 1: Test** in `apps/api/src/services/sentinelOne/client.test.ts` — feed a raw agent row `{ id:'a1', siteId:'site-123', siteName:'Acme' }` through the client's agent-list parse and assert the normalized agent has `siteId === 'site-123'`.
+
+- [ ] **Step 2: Run, expect fail.**
+
+- [ ] **Step 3: Implement** — add `siteId: string | null;` to the `S1Agent` interface (line ~27, next to `siteName`) and `siteId: str(row.siteId),` in `normalizeAgent` (next to `siteName: str(row.siteName)`).
+
+- [ ] **Step 4: Run, expect pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): extract S1 site id on normalized agents (refs #1735)"`
+
+---
+
+### Task C2: Sync — discover sites, reconcile provisional mappings, resolve org by site id
+
+**Files:**
+- Modify: `apps/api/src/jobs/s1Sync.ts` (`mapSiteOrgIds` ~332-349, `resolveAgentSyncTarget`, `syncAgentsForIntegration` ~385-456, `processSyncIntegration` ~589-674)
+
+**Interfaces:**
+- Consumes: `s1OrgMappings`, `S1Agent.siteId` (C1).
+- Produces: per-sync, the job (a) upserts discovered sites into `s1_org_mappings` keyed by `(integration_id, s1_site_id)` with `s1_site_name` + `agents_count` + `last_seen_at`; (b) reconciles provisional rows (`s1_site_id LIKE 'name:%'`) by matching `s1_site_name` to a discovered real site id, rewriting the id and clearing `metadata->>'provisional'`, preserving `org_id`; (c) routes each agent to `org_id` via `siteId → s1_org_mappings.org_id` (falls back to skip/unmapped, NOT to a hard-coded integration org — there is no single integration org anymore).
+
+- [ ] **Step 1: Tests** in `apps/api/src/jobs/s1Sync.test.ts` (extend existing):
+  - Given agents with `siteId` S1 returns, the sync upserts one `s1_org_mappings` row per distinct site with the right `agents_count`.
+  - Given a provisional row `{ s1_site_id:'name:Acme', s1_site_name:'Acme', org_id:O1 }` and a discovered site `{ siteId:'site-123', siteName:'Acme' }`, after sync there is ONE row `{ s1_site_id:'site-123', org_id:O1 }` and no provisional row (org mapping preserved).
+  - Agents whose site is unmapped (`org_id IS NULL`) are skipped (counted), not written to a fallback org.
+
+- [ ] **Step 2: Run, expect fail.**
+
+- [ ] **Step 3: Implement** — model on `huntressSync.ts`'s `upsertDiscoveredOrganizations` + `loadMappedOrgIds` + `groupByMappedOrg`:
+  - Add `upsertDiscoveredSites({ integrationId, partnerId, sites })` (sites derived from the agent list: distinct `{ siteId, siteName, count }`), upserting on `(integration_id, s1_site_id)`.
+  - Add `reconcileProvisionalSiteMappings(integrationId, discoveredSites)` — for each discovered site, `UPDATE s1_org_mappings SET s1_site_id = <real>, metadata = metadata - 'provisional', updated_at = now() WHERE integration_id = $ AND s1_site_id = 'name:' || <discoveredName> AND (metadata->>'provisional')::boolean IS TRUE` and `ON CONFLICT` guard (if a real row already exists, delete the provisional one instead). Run this BEFORE the upsert so the carried `org_id` survives.
+  - Replace `mapSiteOrgIds` to key the returned map by `s1SiteId` (not lowercased name).
+  - `resolveAgentSyncTarget`: look up `agent.siteId` in the map → `org_id`; if absent, return null (skip + count), removing the old "fall back to integration.orgId" branch.
+  - `processSyncIntegration` must load the integration including `partnerId` (system-scope) and pass it through.
+  - All DB work stays inside `withSystemDbAccessContext` (as today via `initializeS1SyncJob`).
+
+- [ ] **Step 4: Run, expect pass** (`vitest run src/jobs/s1Sync.test.ts src/jobs/s1Sync_syncError.test.ts`).
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): sync discovers sites by id, reconciles provisional mappings, routes agents by site (refs #1735)"`
+
+---
+
+### Task C3: Actions service — resolve integration via partner+org mapping
+
+**Files:**
+- Modify: `apps/api/src/services/sentinelOne/actions.ts:103-118` (`getActiveS1IntegrationForOrg`) and callers (`:120-441`)
+
+**Interfaces:**
+- Produces: `getActiveS1IntegrationForOrg(orgId)` now resolves the **partner's** active integration that covers `orgId` (the org must have at least one `s1_org_mappings` row mapped to it, or — looser — belong to a partner with an active integration). Return shape (`S1ActiveIntegration`) keeps `orgId` field meaning "the org the action targets" (unchanged for callers); add nothing breaking. Action rows (`s1_actions`) keep `org_id`.
+
+- [ ] **Step 1: Tests** in `apps/api/src/services/sentinelOne/actions.test.ts` — given org O1 mapped under partner P1's active integration, `getActiveS1IntegrationForOrg(O1)` returns that integration; given an org with no active partner integration, returns null. Existing isolate/threat-action tests should still pass with the new lookup (the device/threat queries already filter by `integrationId` + `orgId`).
+
+- [ ] **Step 2: Run, expect fail.**
+
+- [ ] **Step 3: Implement** — change the query from `where(and(eq(orgId, X), eq(isActive, true)))` to: resolve the org's `partner_id` (`organizations`), then select the partner's active `s1_integrations` row (`where(and(eq(partnerId, p), eq(isActive, true)))`). Optionally require an `s1_org_mappings` row for the org and return null if unmapped (recommended — prevents acting on orgs the partner hasn't mapped). Keep the function signature stable. Wrap reads in the existing DB-context helper used here.
+
+- [ ] **Step 4: Run, expect pass** (`vitest run src/services/sentinelOne/`).
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): resolve S1 integration via partner+org mapping in actions service (refs #1735)"`
+
+---
+
+### Task C4: AI tools — partner-aware status/threats/actions
+
+**Files:**
+- Modify: `apps/api/src/services/aiToolsSentinelOne.ts`
+
+**Interfaces:**
+- The four S1 AI tools resolve org via `resolveWritableToolOrgId`/`auth.orgCondition` (unchanged) but the integration lookup uses the partner-aware `getActiveS1IntegrationForOrg` from C3. `get_s1_status` should report "not connected" when the org's partner has no active integration OR the org is unmapped.
+
+- [ ] **Step 1: Tests** — extend `apps/api/src/services/aiTools.sentinelOneActions.test.ts` + `aiToolsSentinelOne.siteScope.test.ts`: a mapped org returns status/threats; an unmapped org returns the "not connected / not mapped" path; site-scope narrowing still applies.
+
+- [ ] **Step 2: Run, expect fail.**
+
+- [ ] **Step 3: Implement** — swap the integration resolution to C3's function; adjust the "no integration" branch wording to distinguish "partner not connected" vs "org not mapped." No change to the org-condition row filtering.
+
+- [ ] **Step 4: Run, expect pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(s1): partner-aware S1 AI tools (refs #1735)"`
+
+- [ ] **Step 6: Full API typecheck + unit suite (affected files)**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/api exec tsc --noEmit` → PASS (the removed `s1SiteMappings` symbol is now fully replaced).
+Run the S1-affected unit files single-fork (the full suite is flaky in parallel — see api_test_suite_parallel_flakiness): `vitest run src/routes/sentinelOne.test.ts src/jobs/s1Sync.test.ts src/services/sentinelOne/ src/services/aiTools.sentinelOneActions.test.ts src/services/aiToolsSentinelOne.siteScope.test.ts` → PASS.
+
+---
+
+## Phase D — Web UI
+
+### Task D1: SecurityIntegration partner-wide UX
+
+**Files:**
+- Modify: `apps/web/src/components/integrations/SecurityIntegration.tsx`
+
+**Interfaces:**
+- Consumes: `GET /s1/integration` (partner), `GET /s1/sites` (discovered mappings), `POST /s1/integration`, `POST /s1/organizations/map`, `POST /s1/sync`, `GET /orgs/organizations`.
+- Behaviour: detect `isPartnerView = !currentOrgId` (rename from `isAllOrgs`). Partner view renders the credential form (name, management URL, API token) + a **Site → Breeze org** mapping table (per `s1_org_mappings`: site name, agent count, org `<select>`, status badge, "provisional" hint). Org view renders read-only mapped status (or an amber "ask your partner admin to map this org" notice when unmapped) instead of the current "switch scope" dead-end. All mutations go through `runAction`.
+
+- [ ] **Step 1: Component tests** in `apps/web/src/components/integrations/SecurityIntegration.test.tsx` (create if absent; jsdom + the repo's web test setup). Cases:
+  - Partner view (`currentOrgId = null`) renders the credential form and a mapping table row for a discovered site; selecting an org in the `<select>` calls `POST /s1/organizations/map`.
+  - Org view with a mapped org renders read-only status; org view unmapped renders the amber notice (NOT a "switch scope" prompt).
+  - A failed save surfaces an error toast (assert via `runAction` mock / toast spy).
+  - Mock `fetchWithAuth`/`runAction`; if the status panel renders any recharts `<ResponsiveContainer>`, stub `ResizeObserver` per the jsdom memo.
+
+- [ ] **Step 2: Run, expect fail** — `PATH=…/bin:$PATH pnpm --filter @breeze/web exec vitest run src/components/integrations/SecurityIntegration.test.tsx`.
+
+- [ ] **Step 3: Implement** — restructure the component on the `HuntressIntegration.tsx` template:
+  - Rename `isAllOrgs` → `isPartnerView` (`!currentOrgId`); delete the early-return "switch scope" block (lines ~243-257).
+  - Partner branch: credential card + mapping table (copy Huntress `Organization mapping` table markup ~511-583, swapping columns to `S1 site` / `Agents` / `Breeze organization` / `Status`, binding the `<select>` to `handleMap(s1SiteId, orgId|null)`).
+  - Org branch: read-only status + amber "not mapped" notice (Huntress lines ~346-362).
+  - Convert `POST /s1/integration`, `POST /s1/organizations/map`, `POST /s1/sync` to `runAction({ request, successMessage, errorFallback, onUnauthorized })` (Pax8Integration.tsx is the example).
+  - Update the site-map fetch to read `s1_org_mappings` shape (`s1SiteId`, `s1SiteName`, `agentsCount`, `mappedOrgId`, `mappedOrgName`, `provisional`).
+
+- [ ] **Step 4: Run, expect pass.**
+
+- [ ] **Step 5: Web typecheck** — `PATH=…/bin:$PATH pnpm --filter @breeze/web exec tsc --noEmit` (and `astro check` if any `.astro` file changed) → PASS.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(s1): partner-wide SentinelOne integration UI with site mapping (refs #1735)"`
+
+---
+
+## Phase E — Verification & docs
+
+### Task E1: Full verification pass
+
+- [ ] **Step 1: Integration tests (real DB, blocking job locally)** — `pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/` → PASS (rls-coverage, cascade contract, S1 forge).
+- [ ] **Step 2: RLS forge config** — also run the forge under `vitest.config.rls.ts` if the new test targets that config; confirm the breeze_app role has `rolbypassrls=false` so asserts aren't vacuous.
+- [ ] **Step 3: Manual breeze_app cross-tenant probe** — `docker exec -it breeze-postgres psql -U breeze_app -d breeze`, set a P2 partner context, attempt `INSERT INTO s1_integrations (..., partner_id = <P1>)` → must fail `new row violates row-level security policy`.
+- [ ] **Step 4: Agent / shared** — no Go agent changes expected; run `pnpm --filter @breeze/shared exec tsc --noEmit` if any shared type touched (none planned).
+- [ ] **Step 5: Local e2e smoke (optional)** — bring up the worktree stack (`worktree-stack` skill), connect S1 at partner scope with a fake token, confirm the UI shows the mapping table and an org-scope view shows read-only status. Token can be invalid — we're verifying scope/UX, not live S1.
+
+### Task E2: Docs + release note
+
+- [ ] **Step 1:** Update integration docs via the `update-breeze-docs` skill (SentinelOne is now partner-wide; site→org mapping; one console per partner).
+- [ ] **Step 2:** Add a migration/upgrade note: existing per-org S1 configs auto-consolidate to one active integration per partner (most-recent wins; others deactivated, recoverable); legacy site mappings reconcile to stable site ids on first sync. Self-hosters with multiple per-org S1 tokens under one partner should re-verify the surviving credential.
+- [ ] **Step 3: Open the PR** (do not merge). Title: `feat(s1): partner-wide SentinelOne integration (#1735)`. Body: summary, the four locked decisions, the migration consolidation behavior, the RLS dual-list + cascade contract notes, test counts. Then run PR review.
+
+---
+
+## Self-Review (against issue #1735 acceptance criteria)
+
+- ✅ *Configured once per partner (token + URL at partner level):* Tasks A1/A2 (schema/migration re-key), B2 (`POST /integration` partner-scoped), D1 (partner credential form).
+- ✅ *Visible/usable across all the partner's orgs with sites mapped down:* A1/A2 (`s1_org_mappings`), B3 (discovery + map endpoints), C2 (sync routes agents by site→org), D1 (mapping table).
+- ✅ *Only partner-scope users can view/manage credentials:* B1 (`requirePartnerManager`), B2 (`requireScope('partner','system')`), A5 (forge test: org-scope cannot read creds).
+- ✅ *Existing per-org configs migrated (config + mappings preserved), behavior documented:* A2 (backfill + dedup + provisional mapping migration), C2 (provisional reconciliation), E2 (upgrade note).
+- ✅ *RLS correct for the new axis (partner policies, dual-list entries, Integration Test passes):* A2 (policies), A3 (`PARTNER_TENANT_TABLES` + `ORG_AXIS_POLICY_EXCLUDED_TABLES`), A4 (cascade), A5 (forge), E1 (verification).
+- ✅ *Open questions resolved:* site mapping keys off S1 **site id** (decision 2); consolidation = most-recent-active wins (decision 1); one active integration per partner (decision 3).
+
+**Type consistency check:** `s1OrgMappings` columns (`s1SiteId`/`s1SiteName`/`partnerId`/`orgId`) are referenced identically in A1/A2/B3/C2/D1. `getActiveS1IntegrationForOrg` keeps its signature across C3/C4/B4. `requirePartnerManager`/`resolvePartnerId` names match across B1–B4.


### PR DESCRIPTION
Makes the SentinelOne integration **partner-wide** (configure one S1 console per partner, map S1 console Sites down to Breeze orgs) instead of per-org — mirroring the shipped Huntress/Pax8 partner-axis pattern. Closes #1735.

**Why:** an S1 console is almost always held at the MSP (partner) level and covers many customers; re-entering credentials per org was the wrong shape.

**Locked decisions** (from issue triage): auto-consolidate existing per-org configs (most-recent active wins, others deactivated and recoverable); map S1 **Sites keyed by stable site id** (name stored for display); one active integration per partner (partial-unique); legacy name-keyed mappings migrate as *provisional* rows reconciled to real site ids on first sync.

**What changed, by layer:**
- **Schema + migration** — `apps/api/src/db/schema/sentinelOne.ts` re-keys `s1_integrations` to `partner_id` (org_id retained as nullable `legacyOrgId`, partial-unique one-active-per-partner) and adds partner-axis `s1_org_mappings` (composite FK `(integration_id, partner_id)`, nullable `org_id ON DELETE SET NULL`). Migration `2026-06-27-a-sentinelone-partner-mapping.sql` backfills partner_id, dedups to one active per partner (row-count `RAISE WARNING`), creates the mapping table, swaps `breeze_org_isolation_*` → `breeze_partner_isolation_*` policies (`breeze_has_partner_access(partner_id)`, FK-integrity `EXISTS` on mapping writes), and migrates legacy `s1_site_mappings` rows as provisional. Idempotent; applies clean against empty Postgres.
- **RLS contracts** — `s1_integrations` + `s1_org_mappings` added to BOTH `PARTNER_TENANT_TABLES` and `ORG_AXIS_POLICY_EXCLUDED_TABLES` (the pax8 #1594→#1612 dual-list trap). New forge `sentinelOne-partner-rls.integration.test.ts` proves cross-partner read/write denial and org-scope credential blackout (breeze_app `rolbypassrls=f`, real 42501s, system-scope existence probe → non-vacuous). `tenantCascade.ts` renamed in-place (`s1_site_mappings` retained alongside `s1_org_mappings` since the legacy table keeps `org_id`).
- **Routes** (`apps/api/src/routes/sentinelOne.ts`) — `resolveOrgId` → `resolvePartnerId` + `requirePartnerManager` (org scope rejected from credential/mapping writes); `POST /integration` partner-only; `/sites/map` → `/organizations/map`; `/status`/`/threats`/`/isolate`/`/threat-action` stay dual-scope (partner cross-org, org scoped to its own mapped data). `GET /integration` returns a `connected` flag so an org user sees "ask your partner to map this org" vs "not connected" without leaking creds.
- **Sync/services** — `s1Sync.ts` discovers sites (captures S1 `siteId` in `client.ts`), reconciles provisional mappings by name → real id (preserving org_id, no mapping lost), routes agents/threats to orgs by site id (no fallback-to-default-org), and `processPollActions` + `getActiveS1IntegrationForOrg` (`actions.ts`) resolve the integration via org → partner → active integration. Partner-axis reads run in `runOutsideDbContext(()=>withSystemDbAccessContext(...))` gated behind an org-RLS Step-1 check, so org-scoped techs can still isolate their own devices without exposing partner creds. AI tools needed no change (they delegate to the now-partner-aware resolver).
- **Web** (`SecurityIntegration.tsx`) — Huntress-style UX: partner view = credential form + Site→org mapping table; org view = read-only status or amber "not mapped" notice (no more "switch scope" dead-end). All mutations wrapped in `runAction`; component added to the `no-silent-mutations` guard.

**Self-hoster / migration note:** existing per-org S1 configs auto-consolidate to one active integration per partner (most-recent active wins; others deactivated with a logged reason, rows retained/recoverable). Legacy site mappings reconcile to stable site ids on first sync. A partner that had multiple per-org S1 tokens should re-verify the surviving credential.

**`/sync` MFA:** the original S1 `/sync` and Huntress `/sync` never required MFA; an MFA middleware briefly added during the route rewrite was removed to match precedent. `/sync` still requires auth + partner/system scope + `ORGS_WRITE`; the credential and destructive-action endpoints (`/integration`, `/isolate`, `/threat-action`, `/organizations/map`) retain `requireMfa()`. Net MFA coverage vs main is unchanged.

**Review:** built via subagent-driven development with per-task adversarial review + a final whole-branch review (verdict: ready, no Critical/Important) — caught and fixed a Critical org-scope-callers-get-404 RLS-context bug and the web↔API contract mismatches before this PR.

**Verification:** API + Web `tsc` 0 errors; integration (cascade + S1 partner-RLS forge) 11/11; rls-coverage 45/45; S1 unit suite 117/117 (routes, sync, actions, client, AI tools); drift clean (306 migrations match ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
