### PR TITLE
fix(scripts): preserve Monaco theme globally across View-Transition swaps (#1589)

### DIFF
--- a/apps/web/public/monaco-theme-persist.js
+++ b/apps/web/public/monaco-theme-persist.js
@@ -1,0 +1,37 @@
+(function () {
+  // Preserve Monaco's runtime theme colors across Astro View-Transition swaps
+  // (issue #1589, follow-up to #1186 and the partial #1593 fix).
+  //
+  // Monaco appends its theme colors — vs-dark token colors, editor background,
+  // selection background — as a runtime <style class="monaco-colors"> in
+  // document.head, distinct from the structural editor.main.css <link> that
+  // #1186 made swap-safe. Astro rebuilds <head> from the incoming page's markup
+  // on a View-Transition swap, dropping that runtime style, and Monaco's
+  // module-singleton theme service won't re-inject it for the recreated editor
+  // (it creates the global style element only once and short-circuits setTheme
+  // when the theme is unchanged). The editor then renders un-themed: white
+  // background, white text, invisible selection — until a full refresh.
+  //
+  // #1593 cloned the style forward but registered the listener INSIDE the React
+  // editor component (ScriptForm), so it was absent on the one navigation that
+  // actually fails: scripts-LIST -> editor, where ScriptForm is unmounted on the
+  // list page. This handler lives in the always-present Layout head instead, so
+  // it clones the style forward on EVERY swap regardless of which page or island
+  // is mounted. The style "rides along" through intermediate pages (list, etc.)
+  // to the next editor mount. Harmless elsewhere: the rules only match
+  // .monaco-editor descendants, which don't exist outside the editor.
+  if (window.__monacoThemePersist) return;
+  window.__monacoThemePersist = true;
+
+  document.addEventListener('astro:before-swap', function (event) {
+    var newDocument = event.newDocument;
+    if (!newDocument) return;
+    if (newDocument.head.querySelector('style.monaco-colors')) return;
+    var live = document.head.querySelector('style.monaco-colors');
+    if (!live) return;
+    var clone = newDocument.createElement('style');
+    clone.className = 'monaco-colors';
+    clone.textContent = live.textContent;
+    newDocument.head.appendChild(clone);
+  });
+})();

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -126,16 +126,16 @@ describe('ScriptForm Monaco theme preservation across View-Transition swap (issu
     vi.clearAllMocks();
   });
 
-  // Monaco appends its theme colors (token colors, selection background) as a
-  // runtime <style class="monaco-colors"> in document.head — distinct from the
-  // structural editor.main.css link the #1186 fix made swap-safe. Astro rebuilds
-  // <head> from the new page's markup on a swap, dropping that runtime style, and
-  // Monaco's singleton theme service won't re-inject it for the recreated editor.
-  // ScriptForm must clone the live style into the incoming document so the colors
-  // survive the swap (otherwise: white text, invisible selection until refresh).
-  it('clones the live monaco-colors style into the incoming document on astro:before-swap', () => {
+  // The theme-color preservation now lives in the always-present global handler
+  // (public/monaco-theme-persist.js, wired into Layout.astro) — its behavior is
+  // covered by src/layouts/monacoThemePersist.test.ts. The earlier in-component
+  // listener (#1593) could not fire on the failing navigation (scripts-list ->
+  // editor) because ScriptForm is unmounted on the list page. Guard that the
+  // component does NOT re-introduce its own astro:before-swap monaco-colors
+  // listener: with no global handler loaded in this jsdom test, a swap must
+  // leave the incoming document untouched.
+  it('does not own a before-swap monaco-colors listener (deferred to the global handler)', () => {
     render(<ScriptForm />);
-    // Simulate Monaco's runtime theme injection into the current <head>.
     const live = document.createElement('style');
     live.className = 'monaco-colors';
     live.textContent = '.monaco-editor { color: #d4d4d4; }';
@@ -147,43 +147,15 @@ describe('ScriptForm Monaco theme preservation across View-Transition swap (issu
       document.dispatchEvent(event);
     });
 
-    const cloned = newDocument.head.querySelector('style.monaco-colors');
-    expect(cloned).not.toBeNull();
-    expect(cloned?.textContent).toBe('.monaco-editor { color: #d4d4d4; }');
-  });
-
-  it('does not duplicate the style when the incoming document already carries one', () => {
-    render(<ScriptForm />);
-    const live = document.createElement('style');
-    live.className = 'monaco-colors';
-    live.textContent = '.monaco-editor { color: #d4d4d4; }';
-    document.head.appendChild(live);
-
-    const newDocument = document.implementation.createHTMLDocument('');
-    const carried = newDocument.createElement('style');
-    carried.className = 'monaco-colors';
-    carried.textContent = '/* already present */';
-    newDocument.head.appendChild(carried);
-
-    const event = Object.assign(new Event('astro:before-swap'), { newDocument });
-    act(() => {
-      document.dispatchEvent(event);
-    });
-
-    expect(newDocument.head.querySelectorAll('style.monaco-colors')).toHaveLength(1);
-    expect(newDocument.head.querySelector('style.monaco-colors')?.textContent).toBe('/* already present */');
-  });
-
-  it('no-ops when no monaco-colors style is present (editor never mounted)', () => {
-    render(<ScriptForm />);
-    const newDocument = document.implementation.createHTMLDocument('');
-    const event = Object.assign(new Event('astro:before-swap'), { newDocument });
-    expect(() => {
-      act(() => {
-        document.dispatchEvent(event);
-      });
-    }).not.toThrow();
     expect(newDocument.head.querySelector('style.monaco-colors')).toBeNull();
+  });
+
+  // Build-mechanism guard: the cure must stay wired globally, not slip back into
+  // this component where it can't see the list -> editor navigation. Invisible
+  // to jsdom otherwise (the global script isn't loaded in unit tests).
+  it('points the theme-preservation cure at the global Layout handler', () => {
+    expect(scriptFormSource).toContain('monaco-theme-persist.js');
+    expect(scriptFormSource).not.toMatch(/addEventListener\(\s*['"]astro:before-swap['"]/);
   });
 });
 

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -125,34 +125,12 @@ export default function ScriptForm({
     return () => document.removeEventListener('astro:page-load', forceLayout);
   }, []);
 
-  // Preserve Monaco's theme colors across View Transition swaps (issue #1589,
-  // follow-up to #1186). The #1186 fix made Monaco's *structural* stylesheet
-  // (editor.main.css) a build-time <link> so it survives Astro rebuilding <head>
-  // from the new page's server markup. But Monaco injects its *theme* colors
-  // (vs-dark token colors, selection background) as a separate runtime <style
-  // class="monaco-colors"> appended to document.head — that one is still dropped
-  // by the swap. Monaco's standalone theme service is a module singleton that
-  // survives SPA navigation, and it only creates that global style element once
-  // (`if (!this._globalStyleElement)`) and short-circuits setTheme when the theme
-  // is unchanged (`this._theme === desiredTheme`), so the recreated editor never
-  // re-injects it. The editor then renders un-themed (white text, invisible
-  // selection) until a full refresh. Clone the live style into the incoming
-  // document on `astro:before-swap` so the rebuilt <head> keeps the colors.
-  useEffect(() => {
-    const preserveMonacoColors = (event: Event) => {
-      const newDocument = (event as Event & { newDocument?: Document }).newDocument;
-      if (!newDocument) return;
-      if (newDocument.head.querySelector('style.monaco-colors')) return;
-      const live = document.head.querySelector('style.monaco-colors');
-      if (!live) return;
-      const clone = newDocument.createElement('style');
-      clone.className = 'monaco-colors';
-      clone.textContent = live.textContent;
-      newDocument.head.appendChild(clone);
-    };
-    document.addEventListener('astro:before-swap', preserveMonacoColors);
-    return () => document.removeEventListener('astro:before-swap', preserveMonacoColors);
-  }, []);
+  // Monaco's runtime theme colors (issue #1589) are preserved across View
+  // Transition swaps by the always-present global handler in
+  // public/monaco-theme-persist.js (wired into Layout.astro), NOT here. The
+  // earlier in-component listener (#1593) could not fire on the failing
+  // navigation — scripts-list -> editor — because this component is unmounted
+  // on the list page. See that file for the full rationale.
 
   const {
     register,

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -23,6 +23,15 @@ const { title } = Astro.props;
       the script changes (see issue #618).
     -->
     <script is:inline src="/theme-bootstrap.js"></script>
+    <!--
+      Keep Monaco's runtime theme <style> alive across View-Transition swaps.
+      Must register globally (not inside the editor component) because the
+      failing navigation is scripts-list -> editor, where the editor island is
+      unmounted on the list page. External script so it's covered by
+      script-src 'self'. Ordered ahead of the client router below so the
+      listener is installed before the first swap can fire. See issue #1589.
+    -->
+    <script is:inline src="/monaco-theme-persist.js"></script>
     <title>{title} | Breeze RMM</title>
     <ClientRouter />
   </head>

--- a/apps/web/src/layouts/monacoThemePersist.test.ts
+++ b/apps/web/src/layouts/monacoThemePersist.test.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// The fix for #1589 lives in a standalone public script (loaded globally from
+// Layout.astro), not inside the React editor component. Load and execute the
+// real file so the test exercises shipped behavior, mirroring themeBootstrap.
+const SCRIPT_SOURCE = readFileSync(
+  join(process.cwd(), 'public/monaco-theme-persist.js'),
+  'utf8'
+);
+
+function runGlobalScript(): void {
+  // The IIFE reads/writes window + document, both provided by the jsdom env.
+  // SCRIPT_SOURCE is our own committed file read from disk (no interpolation,
+  // no external input) — this just executes the shipped script under test.
+  // eslint-disable-next-line no-new-func -- executes the trusted file under test
+  new Function(SCRIPT_SOURCE)();
+}
+
+function makeBeforeSwapEvent(): Event & { newDocument: Document } {
+  const newDocument = document.implementation.createHTMLDocument('');
+  return Object.assign(new Event('astro:before-swap'), { newDocument });
+}
+
+describe('monaco-theme-persist global handler (issue #1589)', () => {
+  beforeEach(() => {
+    // Window persists across Astro swaps; the script guards on this flag. Reset
+    // it (and any injected styles) so each test starts from a clean global.
+    delete (window as unknown as { __monacoThemePersist?: boolean }).__monacoThemePersist;
+    document.head.querySelectorAll('style.monaco-colors').forEach((el) => el.remove());
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll('style.monaco-colors').forEach((el) => el.remove());
+  });
+
+  // The headline regression #1593 missed: the failing navigation is
+  // scripts-list -> editor, where the editor component (and any listener it
+  // owns) is NOT mounted. This global handler must still clone the theme style
+  // forward with no component rendered at all.
+  it('clones the live monaco-colors style into the incoming document with no editor component mounted', () => {
+    runGlobalScript();
+
+    const live = document.createElement('style');
+    live.className = 'monaco-colors';
+    live.textContent = '.monaco-editor { color: #d4d4d4; }';
+    document.head.appendChild(live);
+
+    const event = makeBeforeSwapEvent();
+    document.dispatchEvent(event);
+
+    const cloned = event.newDocument.head.querySelector('style.monaco-colors');
+    expect(cloned).not.toBeNull();
+    expect(cloned?.textContent).toBe('.monaco-editor { color: #d4d4d4; }');
+  });
+
+  it('does not duplicate the style when the incoming document already carries one', () => {
+    runGlobalScript();
+
+    const live = document.createElement('style');
+    live.className = 'monaco-colors';
+    live.textContent = '.monaco-editor { color: #d4d4d4; }';
+    document.head.appendChild(live);
+
+    const event = makeBeforeSwapEvent();
+    const carried = event.newDocument.createElement('style');
+    carried.className = 'monaco-colors';
+    carried.textContent = '/* already present */';
+    event.newDocument.head.appendChild(carried);
+
+    document.dispatchEvent(event);
+
+    expect(event.newDocument.head.querySelectorAll('style.monaco-colors')).toHaveLength(1);
+    expect(event.newDocument.head.querySelector('style.monaco-colors')?.textContent).toBe(
+      '/* already present */'
+    );
+  });
+
+  it('no-ops when no monaco-colors style is present (editor never mounted this session)', () => {
+    runGlobalScript();
+
+    const event = makeBeforeSwapEvent();
+    expect(() => document.dispatchEvent(event)).not.toThrow();
+    expect(event.newDocument.head.querySelector('style.monaco-colors')).toBeNull();
+  });
+
+  it('registers the swap listener only once even if the script is evaluated again', () => {
+    runGlobalScript();
+    runGlobalScript(); // re-execution on a later page load must be a no-op
+
+    const live = document.createElement('style');
+    live.className = 'monaco-colors';
+    live.textContent = '.monaco-editor { color: #d4d4d4; }';
+    document.head.appendChild(live);
+
+    const event = makeBeforeSwapEvent();
+    document.dispatchEvent(event);
+
+    // A double-registered listener would still leave exactly one node (guarded
+    // by the existence check), so assert the guard flag instead.
+    expect((window as unknown as { __monacoThemePersist?: boolean }).__monacoThemePersist).toBe(true);
+    expect(event.newDocument.head.querySelectorAll('style.monaco-colors')).toHaveLength(1);
+  });
+});
+
+describe('Layout wires the monaco-theme-persist script (issue #1589)', () => {
+  it('loads the global handler before <ClientRouter /> so it is installed before the first swap', () => {
+    const source = readFileSync(join(process.cwd(), 'src/layouts/Layout.astro'), 'utf8');
+
+    expect(source).toContain('<script is:inline src="/monaco-theme-persist.js"></script>');
+    expect(source.indexOf('src="/monaco-theme-persist.js"')).toBeLessThan(
+      source.indexOf('<ClientRouter />')
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Reopened #1589 — the white/un-themed script editor is **still present in v0.82.1** despite #1593. Fresh load of an editor page is correctly dark; navigating **scripts list → a script** leaves the editor white (white background, white text, invisible selection) until a full page refresh.

## Why #1593 didn't fix it

**Root cause:** #1593 correctly identified that Monaco's runtime `<style class="monaco-colors">` (token colors, editor + selection background) is dropped when Astro rebuilds `<head>` on a View-Transition swap, and that Monaco's singleton theme service won't re-inject it for the recreated editor. Its fix cloned that style forward on `astro:before-swap`.

**The bug in the fix:** the listener was registered *inside* the editor React component (`ScriptForm`). `ScriptForm` only mounts on `/scripts/new` and `/scripts/[id]` — **not** on the `/scripts` list. The reported repro is exactly `list → editor`, the one navigation where `ScriptForm` is unmounted, so the listener never fires and the style is lost. The existing unit tests passed only because they `render(<ScriptForm />)`, which is precisely the condition that never holds on the failing hop.

## Fix

Move the preservation to an always-present global handler — `public/monaco-theme-persist.js`, wired into `Layout.astro` ahead of the client router (mirrors `theme-bootstrap.js`, so it stays under `script-src 'self'` with no CSP hash churn). It clones the theme style forward on **every** swap regardless of which page/island is mounted, so the style rides along through the list page to the next editor mount. The now-redundant in-component listener is removed.

## Tests

- **`src/layouts/monacoThemePersist.test.ts`** (new) — executes the shipped script and covers the headline regression (**clones the style with no editor component mounted**), no-duplicate, no-op-when-absent, single-registration guard, and Layout wiring order.
- **`ScriptForm.test.tsx`** — replaced the obsolete in-component tests with a guard that the component defers to the global handler and no longer owns a `before-swap` listener.

## Local verification

- `vitest` (both files): **16/16 pass**
- `eslint` on changed files: clean
- `astro check`: **0 errors**

**Not yet browser-verified** — the definitive check is the live `list → editor` flow with View Transitions. Holding for a UI test before merge.

## Out of scope (observed, not the cause)

The `CSP 'unsafe-eval'` console warning and the React #418 hydration warning seen alongside this are **separate pre-existing issues** — the first editor mount themes correctly without `eval`, so neither is the cause of the white editor. Worth their own follow-up.

Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)