### PR TITLE
fix(deps): de-duplicate corrupted hono@4.12.26 lockfile entries (fixes #1792)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6533,26 +6533,6 @@ packages:
     resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -16772,16 +16752,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.12.26: {}
-
-  hono@4.12.26: {}
-
-  hono@4.12.26: {}
-
-  hono@4.12.26: {}
-
-  hono@4.12.26: {}
 
   hono@4.12.26: {}
 


### PR DESCRIPTION
**Root cause:** the bulk admin-merge of the dependabot root-lockfile group (#1777 hono bump + siblings #1782/#1786/#1788/#1789) left `pnpm-lock.yaml` with `hono@4.12.26` duplicated **6×** in both the `packages:` and `snapshots:` sections. A duplicated YAML mapping key makes `pnpm install --frozen-lockfile` fail with `ERR_PNPM_BROKEN_LOCKFILE: duplicated mapping key (6536:3)` at the **install step of every CI job** — which is why main went red on `dac12020` with ~10 unrelated jobs failing at once (Lint, Test API/Web, all 5 Office add-ins, Check Migrations, Security Audit). Admin-merge bypassed the combined-CI recheck that would have caught it.

**Fix:** keep the first `hono@4.12.26` block in each section, drop the 5 byte-identical duplicates (30 lines). No version changes, no re-resolution.

**Verified locally:** `pnpm install --frozen-lockfile` now exits 0 and leaves the lockfile unmodified.

Fixes #1792.