### PR TITLE
fix(agent,api): make the watchdog component auto-update

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2478,9 +2478,12 @@ func (h *Heartbeat) sendHeartbeat() {
 	// that the on-disk watchdog is behind the latest published watchdog
 	// component — see apps/api heartbeat.ts. The watchdog historically could not
 	// self-update on the hosted (BINARY_SOURCE=github) path (its bundled updater
-	// had no watchdog asset-name case, and the component was never registered),
-	// so the reliably-updating agent drives it instead, recovering already-stuck
-	// fleets whose watchdog is frozen at install-time version.
+	// had no watchdog asset-name case, and the component was never registered) —
+	// and even fully wired up, the watchdog's own doUpdateWatchdog only runs
+	// while it is in FAILOVER (the only state in which it heartbeats and receives
+	// WatchdogUpgradeTo), so a HEALTHY watchdog would never self-heal. The
+	// reliably-updating agent drives it instead, recovering already-stuck fleets
+	// whose watchdog is frozen at install-time version.
 	if response.WatchdogUpgradeTo != "" {
 		go h.handleWatchdogUpgrade(response.WatchdogUpgradeTo)
 	}
@@ -3354,6 +3357,18 @@ func (h *Heartbeat) handleWatchdogUpgrade(targetVersion string) {
 
 	if !h.config.AutoUpdate {
 		log.Info("watchdog upgrade available but auto_update is disabled",
+			"targetVersion", targetVersion)
+		return
+	}
+
+	// SECURITY: the target always originates from the control plane and must be
+	// a real release semver. Fail CLOSED on an unparseable target (matching the
+	// helper-upgrade guard's posture) so a compromised/MITM'd control plane
+	// can't slip a non-semver value past the downgrade check below — isDowngrade
+	// fails OPEN on unparseable input, which is the right call for agent "dev"
+	// builds but wrong for a server-directed privileged swap.
+	if _, _, _, ok := parseSemver(targetVersion); !ok {
+		log.Error("SECURITY: refusing watchdog upgrade to non-semver target",
 			"targetVersion", targetVersion)
 		return
 	}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -285,6 +285,18 @@ type Heartbeat struct {
 	// installAndRestartWatchdog (which downloads the watchdog component, swaps
 	// the on-disk binary, and restarts the watchdog service). nil in production.
 	watchdogInstaller func(targetVersion string) error
+
+	// watchdog upgrade bookkeeping, guarded by watchdogUpgradeMu. The server
+	// keeps sending watchdogUpgradeTo until a watchdog FAILOVER heartbeat
+	// reports the new version — but a healthy (monitoring) watchdog doesn't
+	// heartbeat, so the signal can repeat indefinitely after a successful swap.
+	// watchdogInstalledVersion is a permanent (process-lifetime) skip for a
+	// target we already installed; watchdogLastAttempt* throttles retries of a
+	// FAILING target so we don't re-download + restart the service every tick.
+	watchdogUpgradeMu        sync.Mutex
+	watchdogInstalledVersion string
+	watchdogLastAttemptVer   string
+	watchdogLastAttemptAt    time.Time
 }
 
 func New(cfg *config.Config) *Heartbeat {
@@ -3336,10 +3348,7 @@ func errorString(err error) string {
 func (h *Heartbeat) handleWatchdogUpgrade(targetVersion string) {
 	defer observability.Recoverer("heartbeat.handleWatchdogUpgrade")
 
-	if targetVersion == "" || targetVersion == h.agentVersion {
-		// Already matches the running agent (the steady state once recovered) —
-		// nothing to do. The server stops sending watchdogUpgradeTo once the
-		// watchdog's failover heartbeat reports the new version.
+	if targetVersion == "" {
 		return
 	}
 
@@ -3353,12 +3362,33 @@ func (h *Heartbeat) handleWatchdogUpgrade(targetVersion string) {
 	// binds manifest.Release == requested version, so a compromised/MITM'd
 	// control plane could otherwise replay an older, validly-signed,
 	// known-vulnerable watchdog. The watchdog ships in lockstep with the agent,
-	// so the running agent's version is a safe floor.
+	// so the running agent's version is a safe floor. (Note: the target normally
+	// EQUALS the agent version — both at latest — which is exactly when a stale
+	// watchdog needs swapping, so equality must NOT be treated as a no-op.)
 	if isDowngrade(targetVersion, h.agentVersion) {
 		log.Error("SECURITY: refusing server-directed watchdog downgrade",
 			"agentVersion", h.agentVersion, "targetVersion", targetVersion)
 		return
 	}
+
+	// Dedupe / throttle: the server re-sends watchdogUpgradeTo every heartbeat
+	// until a watchdog failover heartbeat reports the new version, but a healthy
+	// watchdog doesn't heartbeat — so guard against re-swapping on a loop.
+	h.watchdogUpgradeMu.Lock()
+	if h.watchdogInstalledVersion == targetVersion {
+		h.watchdogUpgradeMu.Unlock()
+		return // already installed this target this run
+	}
+	if h.watchdogLastAttemptVer == targetVersion &&
+		time.Since(h.watchdogLastAttemptAt) < watchdogUpgradeRetryCooldown {
+		h.watchdogUpgradeMu.Unlock()
+		log.Debug("watchdog upgrade recently attempted; backing off",
+			"targetVersion", targetVersion)
+		return
+	}
+	h.watchdogLastAttemptVer = targetVersion
+	h.watchdogLastAttemptAt = time.Now()
+	h.watchdogUpgradeMu.Unlock()
 
 	if !h.watchdogUpgradeInProgress.CompareAndSwap(false, true) {
 		log.Debug("watchdog upgrade already in progress", "targetVersion", targetVersion)
@@ -3373,11 +3403,23 @@ func (h *Heartbeat) handleWatchdogUpgrade(targetVersion string) {
 
 	log.Info("watchdog upgrade requested", "targetVersion", targetVersion)
 	if err := install(targetVersion); err != nil {
+		// Leave watchdogInstalledVersion unset so a transient failure retries
+		// after the cooldown rather than every tick.
 		log.Error("failed to update watchdog", "targetVersion", targetVersion, "error", err.Error())
 		return
 	}
+	h.watchdogUpgradeMu.Lock()
+	h.watchdogInstalledVersion = targetVersion
+	h.watchdogUpgradeMu.Unlock()
 	log.Info("watchdog upgrade applied", "targetVersion", targetVersion)
 }
+
+// watchdogUpgradeRetryCooldown bounds how often a FAILING watchdog upgrade
+// target is retried. A successful install is deduped permanently for the
+// process lifetime via watchdogInstalledVersion; this only throttles repeated
+// failures so a stuck device doesn't re-download + restart the watchdog service
+// every heartbeat.
+const watchdogUpgradeRetryCooldown = 30 * time.Minute
 
 // downloadWatchdogBinary fetches the watchdog component at targetVersion to a
 // temp file using the standard updater download path, which verifies the

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -99,6 +99,7 @@ type HeartbeatResponse struct {
 	UacInterceptionEnabled *bool                  `json:"uacInterceptionEnabled,omitempty"`
 	HelperSettings         *HelperSettings        `json:"helperSettings,omitempty"`
 	HelperUpgradeTo        string                 `json:"helperUpgradeTo,omitempty"`
+	WatchdogUpgradeTo      string                 `json:"watchdogUpgradeTo,omitempty"`
 	ManageRemoteManagement bool                   `json:"manageRemoteManagement,omitempty"`
 	ManifestTrustKeys      []api.ManifestTrustKey `json:"manifestTrustKeys,omitempty"`
 }
@@ -273,6 +274,17 @@ type Heartbeat struct {
 	// distinct, greppable ERROR instead of looping at WARN forever. Reset to 0
 	// on the first success.
 	userHelperReconcileFailures atomic.Int32
+
+	// watchdogUpgradeInProgress guards handleWatchdogUpgrade so overlapping
+	// heartbeat-delivered watchdogUpgradeTo signals don't run the
+	// download→replace→service-restart sequence concurrently.
+	watchdogUpgradeInProgress atomic.Bool
+
+	// watchdogInstaller is an optional test seam: when non-nil,
+	// handleWatchdogUpgrade calls this instead of the real platform-specific
+	// installAndRestartWatchdog (which downloads the watchdog component, swaps
+	// the on-disk binary, and restarts the watchdog service). nil in production.
+	watchdogInstaller func(targetVersion string) error
 }
 
 func New(cfg *config.Config) *Heartbeat {
@@ -2449,6 +2461,18 @@ func (h *Heartbeat) sendHeartbeat() {
 		}
 	}
 
+	// Handle watchdog upgrade if requested. The server only sets
+	// watchdogUpgradeTo once it has learned (from a watchdog failover heartbeat)
+	// that the on-disk watchdog is behind the latest published watchdog
+	// component — see apps/api heartbeat.ts. The watchdog historically could not
+	// self-update on the hosted (BINARY_SOURCE=github) path (its bundled updater
+	// had no watchdog asset-name case, and the component was never registered),
+	// so the reliably-updating agent drives it instead, recovering already-stuck
+	// fleets whose watchdog is frozen at install-time version.
+	if response.WatchdogUpgradeTo != "" {
+		go h.handleWatchdogUpgrade(response.WatchdogUpgradeTo)
+	}
+
 	// Update tunnel manager policy flag
 	h.tunnelMgr.SetManagedByPolicy(response.ManageRemoteManagement)
 
@@ -3298,6 +3322,79 @@ func errorString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+// handleWatchdogUpgrade swaps the on-disk breeze-watchdog binary to
+// targetVersion and restarts the watchdog service. Invoked when the server sets
+// watchdogUpgradeTo in the heartbeat response (it does so only after a watchdog
+// failover heartbeat told it the on-disk watchdog is behind the latest
+// published watchdog component). Mirrors the helper-upgrade flow's security
+// posture: refuses to install a watchdog OLDER than the running agent so a
+// compromised/replayed control-plane response can't push a known-vulnerable,
+// validly-signed older watchdog. The actual binary fetch is signature- and
+// checksum-verified by the updater against the signed release manifest.
+func (h *Heartbeat) handleWatchdogUpgrade(targetVersion string) {
+	defer observability.Recoverer("heartbeat.handleWatchdogUpgrade")
+
+	if targetVersion == "" || targetVersion == h.agentVersion {
+		// Already matches the running agent (the steady state once recovered) —
+		// nothing to do. The server stops sending watchdogUpgradeTo once the
+		// watchdog's failover heartbeat reports the new version.
+		return
+	}
+
+	if !h.config.AutoUpdate {
+		log.Info("watchdog upgrade available but auto_update is disabled",
+			"targetVersion", targetVersion)
+		return
+	}
+
+	// SECURITY: never auto-downgrade the watchdog. The signed manifest only
+	// binds manifest.Release == requested version, so a compromised/MITM'd
+	// control plane could otherwise replay an older, validly-signed,
+	// known-vulnerable watchdog. The watchdog ships in lockstep with the agent,
+	// so the running agent's version is a safe floor.
+	if isDowngrade(targetVersion, h.agentVersion) {
+		log.Error("SECURITY: refusing server-directed watchdog downgrade",
+			"agentVersion", h.agentVersion, "targetVersion", targetVersion)
+		return
+	}
+
+	if !h.watchdogUpgradeInProgress.CompareAndSwap(false, true) {
+		log.Debug("watchdog upgrade already in progress", "targetVersion", targetVersion)
+		return
+	}
+	defer h.watchdogUpgradeInProgress.Store(false)
+
+	install := h.watchdogInstaller
+	if install == nil {
+		install = h.installAndRestartWatchdog
+	}
+
+	log.Info("watchdog upgrade requested", "targetVersion", targetVersion)
+	if err := install(targetVersion); err != nil {
+		log.Error("failed to update watchdog", "targetVersion", targetVersion, "error", err.Error())
+		return
+	}
+	log.Info("watchdog upgrade applied", "targetVersion", targetVersion)
+}
+
+// downloadWatchdogBinary fetches the watchdog component at targetVersion to a
+// temp file using the standard updater download path, which verifies the
+// Ed25519 release-manifest signature AND the SHA-256 file checksum before
+// returning. The caller owns the returned temp file (must remove it) and is
+// responsible for the platform-specific swap + service restart. Shared across
+// the per-OS installAndRestartWatchdog implementations so the trust-verified
+// download lives in one place.
+func (h *Heartbeat) downloadWatchdogBinary(targetVersion string) (string, error) {
+	u := updater.New(&updater.Config{
+		ServerURL:             h.config.ServerURL,
+		AuthToken:             h.secureToken,
+		CurrentVersion:        h.agentVersion,
+		Component:             "watchdog",
+		PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
+	})
+	return u.DownloadBinary(targetVersion)
 }
 
 // handleUpgrade performs an auto-update to the specified version.

--- a/agent/internal/heartbeat/watchdog_install_darwin.go
+++ b/agent/internal/heartbeat/watchdog_install_darwin.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package heartbeat
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// watchdogLaunchdLabel is the launchd label of the watchdog LaunchDaemon
+// (matches breeze-watchdog's own service install).
+const watchdogLaunchdLabel = "com.breeze.watchdog"
+
+// installAndRestartWatchdog downloads the verified watchdog binary, swaps it in
+// place, and kickstarts the watchdog LaunchDaemon so the new binary is
+// re-exec'd. The agent runs as root (system domain), so it has rights over
+// /usr/local/bin and launchctl.
+func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
+	tempPath, err := h.downloadWatchdogBinary(targetVersion)
+	if err != nil {
+		return fmt.Errorf("download watchdog: %w", err)
+	}
+	defer func() { _ = os.Remove(tempPath) }()
+
+	if err := replaceWatchdogBinaryUnix(tempPath, watchdogBinaryPathUnix); err != nil {
+		return err
+	}
+
+	if out, err := exec.Command("launchctl", "kickstart", "-k", "system/"+watchdogLaunchdLabel).CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl kickstart %s: %s: %w", watchdogLaunchdLabel, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/agent/internal/heartbeat/watchdog_install_linux.go
+++ b/agent/internal/heartbeat/watchdog_install_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package heartbeat
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// installAndRestartWatchdog downloads the verified watchdog binary, swaps it in
+// place, and restarts the breeze-watchdog systemd service so the new binary is
+// re-exec'd. The agent runs as root, so it has rights over /usr/local/bin and
+// systemctl.
+func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
+	tempPath, err := h.downloadWatchdogBinary(targetVersion)
+	if err != nil {
+		return fmt.Errorf("download watchdog: %w", err)
+	}
+	defer func() { _ = os.Remove(tempPath) }()
+
+	if err := replaceWatchdogBinaryUnix(tempPath, watchdogBinaryPathUnix); err != nil {
+		return err
+	}
+
+	if out, err := exec.Command("systemctl", "restart", "breeze-watchdog").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl restart breeze-watchdog: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/agent/internal/heartbeat/watchdog_install_other.go
+++ b/agent/internal/heartbeat/watchdog_install_other.go
@@ -1,0 +1,11 @@
+//go:build !linux && !darwin && !windows
+
+package heartbeat
+
+import "fmt"
+
+// installAndRestartWatchdog is unsupported on platforms without a breeze-watchdog
+// service. The agent only ships a watchdog on Linux, macOS, and Windows.
+func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
+	return fmt.Errorf("watchdog auto-update is not supported on this platform")
+}

--- a/agent/internal/heartbeat/watchdog_install_unix.go
+++ b/agent/internal/heartbeat/watchdog_install_unix.go
@@ -1,0 +1,62 @@
+//go:build linux || darwin
+
+package heartbeat
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// watchdogBinaryPathUnix is where the watchdog service binary lives on
+// Linux/macOS (matches breeze-watchdog's own service install paths).
+const watchdogBinaryPathUnix = "/usr/local/bin/breeze-watchdog"
+
+// replaceWatchdogBinaryUnix atomically swaps the watchdog binary at dest with
+// the verified bytes at srcTemp. It copies into a sibling temp in dest's
+// directory (so the final rename is same-filesystem and atomic) then renames
+// over dest. Replacing the file of a RUNNING process is safe on POSIX — the
+// running watchdog keeps its open inode until the service restart re-execs the
+// new file. Mode is forced to 0755 so the service manager can execute it.
+func replaceWatchdogBinaryUnix(srcTemp, dest string) error {
+	src, err := os.Open(srcTemp)
+	if err != nil {
+		return fmt.Errorf("open downloaded watchdog: %w", err)
+	}
+	defer src.Close()
+
+	destDir := filepath.Dir(dest)
+	staging, err := os.CreateTemp(destDir, ".breeze-watchdog-*.new")
+	if err != nil {
+		return fmt.Errorf("create staging file in %s: %w", destDir, err)
+	}
+	stagingPath := staging.Name()
+	// Best-effort cleanup if we bail before the rename.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(stagingPath)
+		}
+	}()
+
+	if _, err := io.Copy(staging, src); err != nil {
+		staging.Close()
+		return fmt.Errorf("copy watchdog bytes: %w", err)
+	}
+	if err := staging.Sync(); err != nil {
+		staging.Close()
+		return fmt.Errorf("sync staging watchdog: %w", err)
+	}
+	if err := staging.Close(); err != nil {
+		return fmt.Errorf("close staging watchdog: %w", err)
+	}
+	if err := os.Chmod(stagingPath, 0o755); err != nil {
+		return fmt.Errorf("chmod staging watchdog: %w", err)
+	}
+	if err := os.Rename(stagingPath, dest); err != nil {
+		return fmt.Errorf("rename watchdog into place: %w", err)
+	}
+	cleanup = false
+	return nil
+}

--- a/agent/internal/heartbeat/watchdog_install_unix_test.go
+++ b/agent/internal/heartbeat/watchdog_install_unix_test.go
@@ -1,0 +1,75 @@
+//go:build linux || darwin
+
+package heartbeat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceWatchdogBinaryUnix_SwapsContentAndMode(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "breeze-watchdog")
+	if err := os.WriteFile(dest, []byte("OLD watchdog"), 0o755); err != nil {
+		t.Fatalf("seed dest: %v", err)
+	}
+	src := filepath.Join(dir, "downloaded.tmp")
+	if err := os.WriteFile(src, []byte("NEW watchdog bytes"), 0o600); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+
+	if err := replaceWatchdogBinaryUnix(src, dest); err != nil {
+		t.Fatalf("replaceWatchdogBinaryUnix: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != "NEW watchdog bytes" {
+		t.Fatalf("dest content = %q, want the new bytes", string(got))
+	}
+
+	fi, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	// Must be executable so the service manager can re-exec it — a non-exec
+	// watchdog is exactly the fleet-stuck failure this feature exists to fix.
+	if fi.Mode().Perm() != 0o755 {
+		t.Fatalf("dest mode = %o, want 0755", fi.Mode().Perm())
+	}
+
+	// No staging file may be left behind on the success path.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		name := e.Name()
+		if name != "breeze-watchdog" && name != "downloaded.tmp" {
+			t.Fatalf("unexpected leftover file in dir: %q", name)
+		}
+	}
+}
+
+func TestReplaceWatchdogBinaryUnix_MissingSourceLeavesNoStaging(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "breeze-watchdog")
+	if err := os.WriteFile(dest, []byte("OLD"), 0o755); err != nil {
+		t.Fatalf("seed dest: %v", err)
+	}
+
+	err := replaceWatchdogBinaryUnix(filepath.Join(dir, "does-not-exist"), dest)
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+
+	// dest must be untouched and no staging file left behind.
+	got, _ := os.ReadFile(dest)
+	if string(got) != "OLD" {
+		t.Fatalf("dest content = %q, want it unchanged on failure", string(got))
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Fatalf("expected only dest to remain, found %d entries", len(entries))
+	}
+}

--- a/agent/internal/heartbeat/watchdog_install_windows.go
+++ b/agent/internal/heartbeat/watchdog_install_windows.go
@@ -1,0 +1,115 @@
+//go:build windows
+
+package heartbeat
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/serviceinstall"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const windowsWatchdogServiceName = "BreezeWatchdog"
+
+// installAndRestartWatchdog downloads the verified watchdog binary and swaps it
+// into the protected Program Files location. Windows holds an exclusive lock on
+// a running .exe, so unlike the Unix path this must STOP the service before
+// replacing the file, then START it again. The agent runs as LocalSystem, so it
+// can drive the SCM and write to the protected directory.
+func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
+	tempPath, err := h.downloadWatchdogBinary(targetVersion)
+	if err != nil {
+		return fmt.Errorf("download watchdog: %w", err)
+	}
+	defer func() { _ = os.Remove(tempPath) }()
+
+	dest, err := serviceinstall.ProtectedBinaryPath("breeze-watchdog.exe")
+	if err != nil {
+		return fmt.Errorf("resolve protected watchdog path: %w", err)
+	}
+
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect to SCM: %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(windowsWatchdogServiceName)
+	if err != nil {
+		return fmt.Errorf("open service %q: %w", windowsWatchdogServiceName, err)
+	}
+	defer s.Close()
+
+	// Stop the service so the .exe is unlocked (ignore the control error — it
+	// may already be stopped), then wait for it to actually reach Stopped.
+	_, _ = s.Control(svc.Stop)
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		st, qErr := s.Query()
+		if qErr != nil {
+			return fmt.Errorf("query service state: %w", qErr)
+		}
+		if st.State == svc.Stopped {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if err := replaceWatchdogBinaryWindows(tempPath, dest); err != nil {
+		// Best effort: bring the service back up on the OLD binary so a failed
+		// swap doesn't leave the watchdog down.
+		_ = s.Start()
+		return err
+	}
+
+	if err := s.Start(); err != nil {
+		return fmt.Errorf("start service %q after swap: %w", windowsWatchdogServiceName, err)
+	}
+	return nil
+}
+
+// replaceWatchdogBinaryWindows copies the verified bytes at srcTemp over dest.
+// The service is already stopped by the caller, so the file is no longer locked.
+// Copies into a sibling staging file then renames over dest (Go's os.Rename uses
+// MoveFileEx with replace-existing on Windows).
+func replaceWatchdogBinaryWindows(srcTemp, dest string) error {
+	src, err := os.Open(srcTemp)
+	if err != nil {
+		return fmt.Errorf("open downloaded watchdog: %w", err)
+	}
+	defer src.Close()
+
+	staging, err := os.CreateTemp(filepath.Dir(dest), "breeze-watchdog-*.new")
+	if err != nil {
+		return fmt.Errorf("create staging file: %w", err)
+	}
+	stagingPath := staging.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(stagingPath)
+		}
+	}()
+
+	if _, err := io.Copy(staging, src); err != nil {
+		staging.Close()
+		return fmt.Errorf("copy watchdog bytes: %w", err)
+	}
+	if err := staging.Sync(); err != nil {
+		staging.Close()
+		return fmt.Errorf("sync staging watchdog: %w", err)
+	}
+	if err := staging.Close(); err != nil {
+		return fmt.Errorf("close staging watchdog: %w", err)
+	}
+	if err := os.Rename(stagingPath, dest); err != nil {
+		return fmt.Errorf("rename watchdog into place: %w", err)
+	}
+	cleanup = false
+	return nil
+}

--- a/agent/internal/heartbeat/watchdog_install_windows.go
+++ b/agent/internal/heartbeat/watchdog_install_windows.go
@@ -49,22 +49,42 @@ func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
 	// may already be stopped), then wait for it to actually reach Stopped.
 	_, _ = s.Control(svc.Stop)
 	deadline := time.Now().Add(15 * time.Second)
+	stopped := false
 	for time.Now().Before(deadline) {
 		st, qErr := s.Query()
 		if qErr != nil {
 			return fmt.Errorf("query service state: %w", qErr)
 		}
 		if st.State == svc.Stopped {
+			stopped = true
 			break
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	if !stopped {
+		// Do NOT attempt the swap against a still-running (locked) .exe: the
+		// rename would fail with a sharing violation and the real cause (the
+		// service never stopped — e.g. a hung shutdown or an ACCESS_DENIED on
+		// the stop control) would be lost. The service is left running on the
+		// OLD binary, which is the safe state.
+		return fmt.Errorf(
+			"watchdog service %q did not reach Stopped within 15s; aborting swap (left running on old binary)",
+			windowsWatchdogServiceName,
+		)
+	}
 
 	if err := replaceWatchdogBinaryWindows(tempPath, dest); err != nil {
-		// Best effort: bring the service back up on the OLD binary so a failed
-		// swap doesn't leave the watchdog down.
-		_ = s.Start()
-		return err
+		// Bring the service back up on the OLD binary so a failed swap doesn't
+		// leave the watchdog down. If that recovery ALSO fails, the watchdog is
+		// now down with no supervisor — surface both errors so the DOWN state is
+		// greppable in agent_logs rather than silently swallowed.
+		if startErr := s.Start(); startErr != nil {
+			return fmt.Errorf(
+				"watchdog swap failed AND recovery restart failed — watchdog is DOWN: swap=%w; recoveryStart=%v",
+				err, startErr,
+			)
+		}
+		return fmt.Errorf("watchdog swap failed (service restarted on old binary): %w", err)
 	}
 
 	if err := s.Start(); err != nil {

--- a/agent/internal/heartbeat/watchdog_upgrade_test.go
+++ b/agent/internal/heartbeat/watchdog_upgrade_test.go
@@ -1,11 +1,14 @@
 package heartbeat
 
 import (
+	"errors"
 	"sync/atomic"
 	"testing"
 
 	"github.com/breeze-rmm/agent/internal/config"
 )
+
+var errInstallFailed = errors.New("simulated watchdog install failure")
 
 // newWatchdogTestHeartbeat builds a Heartbeat wired with a fake watchdog
 // installer that records the version it was asked to install. The returned
@@ -37,13 +40,39 @@ func TestHandleWatchdogUpgrade_InstallsNewerVersion(t *testing.T) {
 	}
 }
 
-func TestHandleWatchdogUpgrade_SkipsEmptyOrSameVersion(t *testing.T) {
-	for _, target := range []string{"", "0.82.1"} {
-		h, calls, _ := newWatchdogTestHeartbeat("0.82.1", true)
-		h.handleWatchdogUpgrade(target)
-		if calls.Load() != 0 {
-			t.Fatalf("target %q: expected installer NOT called, got %d", target, calls.Load())
-		}
+func TestHandleWatchdogUpgrade_SkipsEmptyVersion(t *testing.T) {
+	h, calls, _ := newWatchdogTestHeartbeat("0.82.1", true)
+	h.handleWatchdogUpgrade("")
+	if calls.Load() != 0 {
+		t.Fatalf("expected installer NOT called for empty target, got %d", calls.Load())
+	}
+}
+
+// The common recovery case: agent and the latest watchdog are BOTH at the same
+// version (e.g. 0.82.1) while the on-disk watchdog is stale (0.69.0). The server
+// sends watchdogUpgradeTo=0.82.1; target == agentVersion must NOT be treated as
+// a no-op (regression guard for the original bad early-return).
+func TestHandleWatchdogUpgrade_InstallsWhenTargetEqualsAgentVersion(t *testing.T) {
+	h, calls, lastTarget := newWatchdogTestHeartbeat("0.82.1", true)
+	h.handleWatchdogUpgrade("0.82.1")
+	if calls.Load() != 1 {
+		t.Fatalf("expected installer called once for target==agentVersion, got %d", calls.Load())
+	}
+	if got := lastTarget.Load().(string); got != "0.82.1" {
+		t.Fatalf("expected install target 0.82.1, got %q", got)
+	}
+}
+
+// After a successful install the same target must be deduped, so a server that
+// keeps re-sending watchdogUpgradeTo (a healthy watchdog stops heartbeating, so
+// device.watchdogVersion never updates) doesn't cause a re-swap loop.
+func TestHandleWatchdogUpgrade_DedupesAfterSuccess(t *testing.T) {
+	h, calls, _ := newWatchdogTestHeartbeat("0.82.1", true)
+	h.handleWatchdogUpgrade("0.82.1")
+	h.handleWatchdogUpgrade("0.82.1")
+	h.handleWatchdogUpgrade("0.82.1")
+	if calls.Load() != 1 {
+		t.Fatalf("expected installer called exactly once across repeats, got %d", calls.Load())
 	}
 }
 
@@ -63,6 +92,29 @@ func TestHandleWatchdogUpgrade_RefusesDowngrade(t *testing.T) {
 	h.handleWatchdogUpgrade("0.69.0")
 	if calls.Load() != 0 {
 		t.Fatalf("expected installer NOT called for downgrade, got %d", calls.Load())
+	}
+}
+
+// A FAILING install must not be deduped (so transient failures recover) but is
+// throttled by the retry cooldown so a stuck device doesn't re-swap every tick.
+func TestHandleWatchdogUpgrade_FailedInstallIsCooldownThrottled(t *testing.T) {
+	calls := &atomic.Int32{}
+	h := &Heartbeat{
+		config:       &config.Config{AutoUpdate: true},
+		agentVersion: "0.82.1",
+		watchdogInstaller: func(string) error {
+			calls.Add(1)
+			return errInstallFailed
+		},
+	}
+	h.handleWatchdogUpgrade("0.82.1") // attempt 1 — fails
+	h.handleWatchdogUpgrade("0.82.1") // within cooldown — throttled
+	if calls.Load() != 1 {
+		t.Fatalf("expected installer called once (cooldown throttles the retry), got %d", calls.Load())
+	}
+	// Not recorded as installed, so it remains eligible to retry after cooldown.
+	if h.watchdogInstalledVersion == "0.82.1" {
+		t.Fatal("a failed install must not be recorded as installed")
 	}
 }
 

--- a/agent/internal/heartbeat/watchdog_upgrade_test.go
+++ b/agent/internal/heartbeat/watchdog_upgrade_test.go
@@ -1,0 +1,78 @@
+package heartbeat
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+// newWatchdogTestHeartbeat builds a Heartbeat wired with a fake watchdog
+// installer that records the version it was asked to install. The returned
+// counter tracks invocations; the Value holds the last target version.
+func newWatchdogTestHeartbeat(agentVersion string, autoUpdate bool) (*Heartbeat, *atomic.Int32, *atomic.Value) {
+	calls := &atomic.Int32{}
+	lastTarget := &atomic.Value{}
+	lastTarget.Store("")
+	h := &Heartbeat{
+		config:       &config.Config{AutoUpdate: autoUpdate},
+		agentVersion: agentVersion,
+		watchdogInstaller: func(targetVersion string) error {
+			calls.Add(1)
+			lastTarget.Store(targetVersion)
+			return nil
+		},
+	}
+	return h, calls, lastTarget
+}
+
+func TestHandleWatchdogUpgrade_InstallsNewerVersion(t *testing.T) {
+	h, calls, lastTarget := newWatchdogTestHeartbeat("0.82.1", true)
+	h.handleWatchdogUpgrade("0.83.0")
+	if calls.Load() != 1 {
+		t.Fatalf("expected installer called once, got %d", calls.Load())
+	}
+	if got := lastTarget.Load().(string); got != "0.83.0" {
+		t.Fatalf("expected install target 0.83.0, got %q", got)
+	}
+}
+
+func TestHandleWatchdogUpgrade_SkipsEmptyOrSameVersion(t *testing.T) {
+	for _, target := range []string{"", "0.82.1"} {
+		h, calls, _ := newWatchdogTestHeartbeat("0.82.1", true)
+		h.handleWatchdogUpgrade(target)
+		if calls.Load() != 0 {
+			t.Fatalf("target %q: expected installer NOT called, got %d", target, calls.Load())
+		}
+	}
+}
+
+func TestHandleWatchdogUpgrade_SkipsWhenAutoUpdateDisabled(t *testing.T) {
+	h, calls, _ := newWatchdogTestHeartbeat("0.82.1", false)
+	h.handleWatchdogUpgrade("0.83.0")
+	if calls.Load() != 0 {
+		t.Fatalf("expected installer NOT called when auto_update disabled, got %d", calls.Load())
+	}
+}
+
+// SECURITY: a watchdog older than the running agent must be refused so a
+// replayed/compromised control-plane response can't push a known-vulnerable,
+// validly-signed older watchdog.
+func TestHandleWatchdogUpgrade_RefusesDowngrade(t *testing.T) {
+	h, calls, _ := newWatchdogTestHeartbeat("0.82.1", true)
+	h.handleWatchdogUpgrade("0.69.0")
+	if calls.Load() != 0 {
+		t.Fatalf("expected installer NOT called for downgrade, got %d", calls.Load())
+	}
+}
+
+// The in-progress guard prevents overlapping heartbeat-delivered signals from
+// running the swap concurrently.
+func TestHandleWatchdogUpgrade_SkipsWhenInProgress(t *testing.T) {
+	h, calls, _ := newWatchdogTestHeartbeat("0.82.1", true)
+	h.watchdogUpgradeInProgress.Store(true)
+	h.handleWatchdogUpgrade("0.83.0")
+	if calls.Load() != 0 {
+		t.Fatalf("expected installer NOT called while an upgrade is in progress, got %d", calls.Load())
+	}
+}

--- a/agent/internal/heartbeat/watchdog_upgrade_test.go
+++ b/agent/internal/heartbeat/watchdog_upgrade_test.go
@@ -1,9 +1,11 @@
 package heartbeat
 
 import (
+	"encoding/json"
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/breeze-rmm/agent/internal/config"
 )
@@ -95,18 +97,23 @@ func TestHandleWatchdogUpgrade_RefusesDowngrade(t *testing.T) {
 	}
 }
 
-// A FAILING install must not be deduped (so transient failures recover) but is
-// throttled by the retry cooldown so a stuck device doesn't re-swap every tick.
-func TestHandleWatchdogUpgrade_FailedInstallIsCooldownThrottled(t *testing.T) {
+func newFailingWatchdogHeartbeat(agentVersion string) (*Heartbeat, *atomic.Int32) {
 	calls := &atomic.Int32{}
 	h := &Heartbeat{
 		config:       &config.Config{AutoUpdate: true},
-		agentVersion: "0.82.1",
+		agentVersion: agentVersion,
 		watchdogInstaller: func(string) error {
 			calls.Add(1)
 			return errInstallFailed
 		},
 	}
+	return h, calls
+}
+
+// A FAILING install must not be deduped (so transient failures recover) but is
+// throttled by the retry cooldown so a stuck device doesn't re-swap every tick.
+func TestHandleWatchdogUpgrade_FailedInstallIsCooldownThrottled(t *testing.T) {
+	h, calls := newFailingWatchdogHeartbeat("0.82.1")
 	h.handleWatchdogUpgrade("0.82.1") // attempt 1 — fails
 	h.handleWatchdogUpgrade("0.82.1") // within cooldown — throttled
 	if calls.Load() != 1 {
@@ -115,6 +122,56 @@ func TestHandleWatchdogUpgrade_FailedInstallIsCooldownThrottled(t *testing.T) {
 	// Not recorded as installed, so it remains eligible to retry after cooldown.
 	if h.watchdogInstalledVersion == "0.82.1" {
 		t.Fatal("a failed install must not be recorded as installed")
+	}
+}
+
+// Once the cooldown elapses, a previously-failing target must be retried — a
+// stuck device must not be stranded forever.
+func TestHandleWatchdogUpgrade_RetriesAfterCooldownExpiry(t *testing.T) {
+	h, calls := newFailingWatchdogHeartbeat("0.82.1")
+	h.handleWatchdogUpgrade("0.82.1") // attempt 1 — fails, records attempt time
+	// Simulate the cooldown having elapsed.
+	h.watchdogUpgradeMu.Lock()
+	h.watchdogLastAttemptAt = time.Now().Add(-2 * watchdogUpgradeRetryCooldown)
+	h.watchdogUpgradeMu.Unlock()
+	h.handleWatchdogUpgrade("0.82.1") // cooldown expired — retries
+	if calls.Load() != 2 {
+		t.Fatalf("expected installer retried after cooldown, got %d calls", calls.Load())
+	}
+}
+
+// The cooldown is keyed on the target version, so a NEW target must not be
+// throttled by a recent failure of a different target.
+func TestHandleWatchdogUpgrade_DifferentTargetBypassesCooldown(t *testing.T) {
+	h, calls := newFailingWatchdogHeartbeat("0.82.1")
+	h.handleWatchdogUpgrade("0.83.0") // fails, records 0.83.0 attempt
+	h.handleWatchdogUpgrade("0.83.1") // different target — not throttled
+	if calls.Load() != 2 {
+		t.Fatalf("expected a different target to bypass the cooldown, got %d calls", calls.Load())
+	}
+}
+
+// Contract guard: the server emits "watchdogUpgradeTo"; the agent must decode it
+// into HeartbeatResponse.WatchdogUpgradeTo. A field-name drift between the Go
+// struct tag and the server JSON would otherwise pass both suites yet break in
+// production.
+func TestHeartbeatResponse_DecodesWatchdogUpgradeTo(t *testing.T) {
+	var resp HeartbeatResponse
+	if err := json.Unmarshal([]byte(`{"watchdogUpgradeTo":"0.83.0"}`), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.WatchdogUpgradeTo != "0.83.0" {
+		t.Fatalf("WatchdogUpgradeTo = %q, want 0.83.0", resp.WatchdogUpgradeTo)
+	}
+}
+
+// Defense-in-depth: a non-semver target from a compromised control plane must be
+// refused (fail-closed), not passed through to the fail-open downgrade check.
+func TestHandleWatchdogUpgrade_RefusesNonSemverTarget(t *testing.T) {
+	h, calls, _ := newWatchdogTestHeartbeat("0.82.1", true)
+	h.handleWatchdogUpgrade("garbage-not-semver")
+	if calls.Load() != 0 {
+		t.Fatalf("expected installer NOT called for non-semver target, got %d", calls.Load())
 	}
 }
 

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -177,6 +177,21 @@ func (u *Updater) expectedReleaseAssetNames() map[string]struct{} {
 				fmt.Sprintf("breeze-user-helper-%s-%s.exe", runtime.GOOS, runtime.GOARCH): {},
 			}
 		}
+	case "watchdog":
+		// breeze-watchdog is the supervisor sibling of breeze-agent, shipped
+		// per-arch on every platform with the same asset-name shape as the
+		// agent. Used by doUpdateWatchdog (the watchdog's failover self-update)
+		// and by the agent's reconcileWatchdog self-heal. Without this case the
+		// GitHub multi-asset manifest verification fails ("no expected release
+		// asset names configured for component watchdog"), which is why watchdog
+		// auto-update never worked on the hosted (BINARY_SOURCE=github) path.
+		suffix := ""
+		if runtime.GOOS == "windows" {
+			suffix = ".exe"
+		}
+		return map[string]struct{}{
+			fmt.Sprintf("breeze-watchdog-%s-%s%s", runtime.GOOS, runtime.GOARCH, suffix): {},
+		}
 	}
 	return map[string]struct{}{}
 }

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -181,7 +181,7 @@ func (u *Updater) expectedReleaseAssetNames() map[string]struct{} {
 		// breeze-watchdog is the supervisor sibling of breeze-agent, shipped
 		// per-arch on every platform with the same asset-name shape as the
 		// agent. Used by doUpdateWatchdog (the watchdog's failover self-update)
-		// and by the agent's reconcileWatchdog self-heal. Without this case the
+		// and by the agent's handleWatchdogUpgrade self-heal. Without this case the
 		// GitHub multi-asset manifest verification fails ("no expected release
 		// asset names configured for component watchdog"), which is why watchdog
 		// auto-update never worked on the hosted (BINARY_SOURCE=github) path.

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -986,6 +986,28 @@ func TestExpectedReleaseAssetNames_Agent(t *testing.T) {
 	}
 }
 
+// TestExpectedReleaseAssetNames_Watchdog covers the component=watchdog branch.
+// Unlike user-helper, the watchdog ships per-arch on every platform, so the
+// allowlist must be populated on all GOOS. Without this case the GitHub
+// multi-asset manifest verification fails ("no expected release asset names
+// configured for component watchdog") — the root cause of watchdog auto-update
+// never working on the hosted path.
+func TestExpectedReleaseAssetNames_Watchdog(t *testing.T) {
+	u := &Updater{config: &Config{Component: "watchdog"}}
+	got := u.expectedReleaseAssetNames()
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	expected := "breeze-watchdog-" + runtime.GOOS + "-" + runtime.GOARCH + suffix
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 watchdog asset name on %s, got %d (%v)", runtime.GOOS, len(got), got)
+	}
+	if _, ok := got[expected]; !ok {
+		t.Fatalf("expected %q in watchdog asset name set, got %v", expected, got)
+	}
+}
+
 // TestUpdateToWithOptions_CleansHelperTempOnFailure regression-tests the
 // fix for the orphan-temp-file bug flagged in the #845 follow-up review:
 // when UpdateTo returns an error AND the caller pre-downloaded a user-helper

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -507,6 +507,57 @@ describe("agentVersions routes", () => {
       }
     });
 
+    it("rewrites downloadUrl to server-relative for component=watchdog (so the agent host-match guard accepts the watchdog download)", async () => {
+      const canonical =
+        "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-watchdog-linux-amd64";
+      const checksum = "c".repeat(64);
+      const signed = makeSignedReleaseManifest({
+        component: "watchdog",
+        platform: "linux",
+        arch: "amd64",
+        url: canonical,
+        checksum,
+        size: 2048,
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "linux",
+                architecture: "amd64",
+                component: "watchdog",
+                downloadUrl: canonical,
+                checksum,
+                fileSize: BigInt(2048),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "test-key",
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=linux&arch=amd64&component=watchdog",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/watchdog/linux/amd64",
+        );
+        expect(body.checksum).toBe(checksum);
+        expect(body.manifest).toBe(signed.manifest);
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
     it("maps platform=macos to /darwin in the server-relative helper URL", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-helper-macos.dmg";

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -33,14 +33,21 @@ const requireAgentVersionAdmin = requirePermission(
 // Validation schemas
 const platformEnum = z.enum(["windows", "macos", "linux", "darwin"]);
 const architectureEnum = z.enum(["amd64", "arm64"]);
+// "watchdog" lets the agent's reconcile path (and the watchdog's own failover
+// self-update) resolve and download the watchdog component. Omitting it here is
+// why watchdog auto-update 400'd server-side regardless of registration.
+const componentEnum = z.enum([
+  "agent",
+  "helper",
+  "viewer",
+  "user-helper",
+  "watchdog",
+]);
 
 const latestQuerySchema = z.object({
   platform: platformEnum,
   arch: architectureEnum,
-  component: z
-    .enum(["agent", "helper", "viewer", "user-helper"])
-    .optional()
-    .default("agent"),
+  component: componentEnum.optional().default("agent"),
 });
 
 const downloadParamsSchema = z.object({
@@ -50,10 +57,7 @@ const downloadParamsSchema = z.object({
 const downloadQuerySchema = z.object({
   platform: platformEnum,
   arch: architectureEnum,
-  component: z
-    .enum(["agent", "helper", "viewer", "user-helper"])
-    .optional()
-    .default("agent"),
+  component: componentEnum.optional().default("agent"),
 });
 
 const createVersionSchema = z.object({
@@ -68,10 +72,7 @@ const createVersionSchema = z.object({
   fileSize: z.number().int().positive().optional(),
   releaseNotes: z.string().optional(),
   isLatest: z.boolean().optional().default(false),
-  component: z
-    .enum(["agent", "helper", "viewer", "user-helper"])
-    .optional()
-    .default("agent"),
+  component: componentEnum.optional().default("agent"),
 });
 
 type ReleaseManifest = {
@@ -271,7 +272,11 @@ function buildServerRelativeAgentDownloadUrl(
   architecture: string,
   component: string,
 ): string | null {
-  if (component !== "agent" && component !== "helper") {
+  if (
+    component !== "agent" &&
+    component !== "helper" &&
+    component !== "watchdog"
+  ) {
     return null;
   }
   const origin = getServerOriginForDownloadResponse();
@@ -281,6 +286,9 @@ function buildServerRelativeAgentDownloadUrl(
   const os = dbPlatformToRouteOs(dbPlatform);
   if (component === "helper") {
     return `${origin}/api/v1/agents/download/helper/${os}/${architecture}`;
+  }
+  if (component === "watchdog") {
+    return `${origin}/api/v1/agents/download/watchdog/${os}/${architecture}`;
   }
   return `${origin}/api/v1/agents/download/${os}/${architecture}`;
 }

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../services/binarySource', () => ({
   getGithubAgentUrl: vi.fn(),
   getGithubAgentPkgUrl: vi.fn(),
   getGithubHelperUrl: vi.fn(),
+  getGithubWatchdogUrl: vi.fn(),
   HELPER_FILENAMES: {
     linux: 'breeze-desktop-helper-linux-amd64',
     darwin: 'breeze-desktop-helper-darwin',
@@ -24,7 +25,7 @@ import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { downloadRoutes } from './download';
-import { getBinarySource, getGithubAgentPkgUrl } from '../../services/binarySource';
+import { getBinarySource, getGithubAgentPkgUrl, getGithubWatchdogUrl } from '../../services/binarySource';
 import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
 
 describe('public agent binary downloads', () => {
@@ -69,6 +70,50 @@ describe('public agent binary downloads', () => {
       '[helper-download] Local binary missing',
       { filename: 'breeze-desktop-helper-linux-amd64' },
     );
+  });
+
+  it('does not disclose AGENT_BINARY_DIR in public watchdog 404 responses', async () => {
+    // The watchdog binary is served from the same dir as the agent. The route
+    // must exist (404, not 404-route-not-found) and not leak the path.
+    const res = await downloadRoutes.request('/download/watchdog/linux/amd64');
+    const body = await res.text();
+
+    expect(res.status).toBe(404);
+    expect(body).not.toContain('/tmp/breeze-secret-agent-binaries');
+    expect(console.warn).toHaveBeenCalledWith(
+      '[watchdog-download] Local binary missing',
+      { filename: 'breeze-watchdog-linux-amd64' },
+    );
+  });
+
+  it('redirects watchdog downloads to GitHub in github mode (per-arch, .exe on windows)', async () => {
+    vi.mocked(getBinarySource).mockReturnValue('github');
+    vi.mocked(getGithubWatchdogUrl).mockImplementation(
+      (os: string, arch: string) =>
+        `https://github.test/${os}-${arch}/breeze-watchdog`,
+    );
+
+    try {
+      const lin = await downloadRoutes.request('/download/watchdog/linux/amd64');
+      expect(lin.status).toBe(302);
+      expect(lin.headers.get('location')).toBe('https://github.test/linux-amd64/breeze-watchdog');
+      expect(getGithubWatchdogUrl).toHaveBeenCalledWith('linux', 'amd64');
+
+      const win = await downloadRoutes.request('/download/watchdog/windows/amd64');
+      expect(win.status).toBe(302);
+      expect(getGithubWatchdogUrl).toHaveBeenCalledWith('windows', 'amd64');
+    } finally {
+      // Restore the module-mock default so later tests still see 'local'
+      // (vi.restoreAllMocks does not reset vi.mock factory fns).
+      vi.mocked(getBinarySource).mockReturnValue('local');
+    }
+  });
+
+  it('rejects invalid OS/arch on the watchdog route', async () => {
+    const badOs = await downloadRoutes.request('/download/watchdog/solaris/amd64');
+    expect(badOs.status).toBe(400);
+    const badArch = await downloadRoutes.request('/download/watchdog/linux/sparc');
+    expect(badArch.status).toBe(400);
   });
 
   it('serves the architecture-matched pkg from local disk in non-github mode', async () => {

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -3,7 +3,7 @@ import { statSync, createReadStream } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { VALID_OS, VALID_ARCH } from './schemas';
 import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
-import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, HELPER_FILENAMES } from '../../services/binarySource';
+import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubWatchdogUrl, HELPER_FILENAMES } from '../../services/binarySource';
 
 export const downloadRoutes = new Hono();
 
@@ -267,6 +267,93 @@ downloadRoutes.get('/download/helper/:os/:arch', async (c) => {
       stream.on('end', () => { controller.close(); });
       stream.on('error', (err) => {
         console.error(`[helper-download] Stream error while serving ${filename}:`, err);
+        controller.error(err);
+      });
+    },
+    cancel() { stream.destroy(); },
+  });
+
+  return new Response(webStream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Content-Length': String(fileStat.size),
+      'Cache-Control': 'no-cache',
+    },
+  });
+});
+
+// ============================================
+// Watchdog Binary Download (public, no auth)
+// ============================================
+// Per-arch like the agent (breeze-watchdog-{os}-{arch}[.exe]). The agent's
+// reconcileWatchdog and the watchdog's own failover self-update fetch this via
+// /agent-versions/:version/download?component=watchdog, which hands back this
+// same-origin URL so the downloader's host-match guard passes (see
+// buildServerRelativeAgentDownloadUrl + issue #646).
+downloadRoutes.get('/download/watchdog/:os/:arch', async (c) => {
+  const os = c.req.param('os');
+  const arch = c.req.param('arch');
+
+  if (!VALID_OS.has(os)) {
+    return c.json({ error: 'Invalid OS', message: `Supported values: linux, darwin, windows. Got: ${os}` }, 400);
+  }
+
+  if (!VALID_ARCH.has(arch)) {
+    return c.json({ error: 'Invalid architecture', message: `Supported values: amd64, arm64. Got: ${arch}` }, 400);
+  }
+
+  const extension = os === 'windows' ? '.exe' : '';
+  const filename = `breeze-watchdog-${os}-${arch}${extension}`;
+
+  if (getBinarySource() === 'github') {
+    return c.redirect(getGithubWatchdogUrl(os, arch), 302);
+  }
+
+  if (isS3Configured()) {
+    try {
+      const s3Key = `watchdog/${filename}`;
+      const url = await getPresignedUrl(s3Key);
+      return c.redirect(url, 302);
+    } catch (err) {
+      const errName = (err as { name?: string }).name;
+      const isNotFound = errName === 'NotFound' || errName === 'NoSuchKey';
+      const level = isNotFound ? 'warn' : 'error';
+      console[level](`[watchdog-download] S3 presign failed for ${filename}, falling back to disk:`, err);
+    }
+  }
+
+  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  const filePath = join(binaryDir, filename);
+
+  let fileStat: ReturnType<typeof statSync>;
+  let stream: ReturnType<typeof createReadStream>;
+  try {
+    fileStat = statSync(filePath);
+    stream = createReadStream(filePath);
+  } catch (err) {
+    const isNotFound = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    if (!isNotFound) {
+      console.error(`[watchdog-download] Failed to read binary ${filename}:`, err);
+      return c.json({ error: 'Internal server error', message: 'Failed to read binary file' }, 500);
+    }
+    console.warn('[watchdog-download] Local binary missing', { filename });
+    return c.json({
+      error: 'Binary not found',
+      message: `Watchdog binary "${filename}" is not available.`,
+    }, 404);
+  }
+
+  const webStream = new ReadableStream({
+    start(controller) {
+      stream.on('data', (chunk: string | Buffer) => {
+        const bytes = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+        controller.enqueue(new Uint8Array(bytes));
+      });
+      stream.on('end', () => { controller.close(); });
+      stream.on('error', (err) => {
+        console.error(`[watchdog-download] Stream error while serving ${filename}:`, err);
         controller.error(err);
       });
     },

--- a/apps/api/src/services/binarySource.ts
+++ b/apps/api/src/services/binarySource.ts
@@ -70,6 +70,12 @@ export function getGithubAgentPkgUrl(os: string, arch: string): string {
   return `${githubDownloadBase()}/${filename}`;
 }
 
+export function getGithubWatchdogUrl(os: string, arch: string): string {
+  const extension = os === 'windows' ? '.exe' : '';
+  const filename = `breeze-watchdog-${os}-${arch}${extension}`;
+  return `${githubDownloadBase()}/${filename}`;
+}
+
 export function getGithubRegularMsiUrl(): string {
   return `${githubDownloadBase()}/breeze-agent.msi`;
 }

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -513,6 +513,116 @@ describe("binarySync", () => {
     });
   });
 
+  // The watchdog sync loop registers breeze-watchdog as its own
+  // component=watchdog row so the server can drive watchdog upgrades and the
+  // agent's reconcile path can fetch the matching binary. Without this, the
+  // watchdog could never auto-update on the hosted (BINARY_SOURCE=github) path.
+  describe("syncFromGitHub watchdog loop", () => {
+    function stubGitHubReleaseFetch(
+      signed: ReturnType<typeof makeSignedReleaseManifestMulti>,
+      assetBytes: Map<string, Buffer>,
+    ) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url.includes("/releases/latest")) {
+            return new Response(
+              JSON.stringify({
+                tag_name: signed.release,
+                body: "release notes",
+                assets: [
+                  ...Array.from(assetBytes.entries()).map(([name, buf]) => ({
+                    name,
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/${name}`,
+                    size: buf.length,
+                  })),
+                  {
+                    name: "release-artifact-manifest.json",
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/release-artifact-manifest.json`,
+                    size: signed.manifest.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json.ed25519",
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/release-artifact-manifest.json.ed25519`,
+                    size: signed.signature.length,
+                  },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith("/release-artifact-manifest.json"))
+            return new Response(signed.manifest);
+          if (url.endsWith("/release-artifact-manifest.json.ed25519"))
+            return new Response(signed.signature);
+          return new Response("not found", { status: 404 });
+        }),
+      );
+    }
+
+    it("registers component=watchdog when the watchdog asset is present", async () => {
+      const agentAsset = {
+        name: "breeze-agent-linux-amd64",
+        buffer: Buffer.from("trusted linux agent bytes"),
+      };
+      const watchdogAsset = {
+        name: "breeze-watchdog-linux-amd64",
+        buffer: Buffer.from("trusted linux watchdog bytes"),
+      };
+      const signed = makeSignedReleaseManifestMulti([agentAsset, watchdogAsset]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      stubGitHubReleaseFetch(
+        signed,
+        new Map([
+          [agentAsset.name, agentAsset.buffer],
+          [watchdogAsset.name, watchdogAsset.buffer],
+        ]),
+      );
+
+      const result = await syncFromGitHub();
+
+      expect(result.synced).toEqual(
+        expect.arrayContaining(["agent:linux/amd64", "watchdog:linux/amd64"]),
+      );
+
+      const watchdogInsert = (dbMocks.insertValues.mock.calls as any[][]).find(
+        (call) => (call[0] as { component: string }).component === "watchdog",
+      );
+      expect(watchdogInsert).toBeDefined();
+      expect(watchdogInsert![0]).toMatchObject({
+        version: "1.2.3",
+        platform: "linux",
+        architecture: "amd64",
+        component: "watchdog",
+        checksum: signed.checksums.get(watchdogAsset.name),
+        downloadUrl: `https://github.com/LanternOps/breeze/releases/download/v1.2.3/${watchdogAsset.name}`,
+      });
+    });
+
+    it("succeeds without a watchdog row when the asset is missing (backward-compat)", async () => {
+      const agentAsset = {
+        name: "breeze-agent-linux-amd64",
+        buffer: Buffer.from("agent only bytes"),
+      };
+      const signed = makeSignedReleaseManifestMulti([agentAsset]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      stubGitHubReleaseFetch(
+        signed,
+        new Map([[agentAsset.name, agentAsset.buffer]]),
+      );
+
+      const result = await syncFromGitHub();
+
+      expect(result.synced).toContain("agent:linux/amd64");
+      expect(result.synced).not.toContain("watchdog:linux/amd64");
+      const watchdogInserts = dbMocks.insertValues.mock.calls.filter(
+        (call: any[]) => (call[0] as { component: string }).component === "watchdog",
+      );
+      expect(watchdogInserts).toHaveLength(0);
+    });
+  });
+
   it("upserts local agent binaries with the full 4-column conflict target (regression: #617)", async () => {
     // The agent_versions table has a UNIQUE constraint on
     // (version, platform, architecture, component). The local-binary path used

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -50,6 +50,16 @@ const USER_HELPER_TARGETS = [
   },
 ] as const;
 
+// breeze-watchdog is the supervisor sibling of breeze-agent, shipped as its own
+// per-arch GitHub release asset on every platform. It was historically only
+// placed by the full installer, so once an agent auto-upgraded its watchdog
+// stayed frozen at install-time version (the agent's in-place upgrade never
+// touched it, and the watchdog component was never registered here). Registering
+// it lets the server drive watchdog upgrades (heartbeat.ts watchdogUpgradeTo)
+// and lets the agent's reconcileWatchdog self-heal fetch the matching binary.
+// Same asset-name shape as the agent: breeze-watchdog-{goos}-{goarch}[.exe].
+const WATCHDOG_TARGETS = AGENT_TARGETS;
+
 interface BinaryInfo {
   filename: string;
   filePath: string;
@@ -621,6 +631,50 @@ export async function syncFromGitHub(
     } catch (err) {
       console.error(
         `[binarySync] Failed to upsert user-helper version for ${platform}/${target.goarch}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  // Sync watchdog binaries. Same per-arch asset shape as the agent. Missing for
+  // any release predating the watchdog component being published — the
+  // `release.assets.find` returns undefined and the loop body short-circuits.
+  for (const target of WATCHDOG_TARGETS) {
+    const suffix = target.goos === "windows" ? ".exe" : "";
+    const assetName = `breeze-watchdog-${target.goos}-${target.goarch}${suffix}`;
+    const asset = release.assets.find((a) => a.name === assetName);
+    if (!asset) continue;
+    const metadata = await getReleaseAssetMetadata({
+      asset,
+      trustedManifest,
+      fallbackChecksums,
+      releaseTag: release.tag_name,
+    });
+    if (!metadata) {
+      // See agent loop above: `!metadata` after `!asset` passed indicates an
+      // unexpected manifest/checksums inconsistency, not a missing artifact.
+      console.warn(
+        `[binarySync] Missing metadata for watchdog asset (release=${release.tag_name}, asset=${assetName}, component=watchdog); skipping`,
+      );
+      continue;
+    }
+    const platform = GH_PLATFORM_MAP[target.goos];
+    if (!platform) continue;
+
+    try {
+      await upsertVersion(
+        version,
+        platform,
+        target.goarch,
+        "watchdog",
+        asset.browser_download_url,
+        metadata,
+        release.body,
+      );
+      synced.push(`watchdog:${platform}/${target.goarch}`);
+    } catch (err) {
+      console.error(
+        `[binarySync] Failed to upsert watchdog version for ${platform}/${target.goarch}:`,
         err instanceof Error ? err.message : err,
       );
     }

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -56,7 +56,7 @@ const USER_HELPER_TARGETS = [
 // stayed frozen at install-time version (the agent's in-place upgrade never
 // touched it, and the watchdog component was never registered here). Registering
 // it lets the server drive watchdog upgrades (heartbeat.ts watchdogUpgradeTo)
-// and lets the agent's reconcileWatchdog self-heal fetch the matching binary.
+// and lets the agent's handleWatchdogUpgrade self-heal fetch the matching binary.
 // Same asset-name shape as the agent: breeze-watchdog-{goos}-{goarch}[.exe].
 const WATCHDOG_TARGETS = AGENT_TARGETS;
 


### PR DESCRIPTION
## Problem

Users reported the watchdog "is not updating." Confirmed against US prod (device `DRJJ-CHECKOUT`, `5672423a-…`) and fleet-wide:

- Agents auto-update fine — uniformly on **0.82.1**.
- Watchdogs are **frozen at install-time version**: `0.69.0` ×8, plus `0.65.15`, `0.62.24`, `0.81.0`. **11/13** online Windows devices have `watchdog_version ≠ agent_version`.
- **14/15** online devices sit in `watchdog_status = failover` with a *current* `watchdog_last_seen` — a stale watchdog can't supervise the much newer agent, so it's stuck in permanent failover (and not actually protecting the agent).

## Root cause (three layers)

1. **Server never registered a `watchdog` component** in `agent_versions` — `binarySync` syncs only `agent`/`helper`/`user-helper`. So the existing `heartbeat.ts` `watchdogUpgradeTo` logic always found no latest row, and the agent self-update never touched the watchdog binary either.
2. **Server couldn't serve it** — no `/download/watchdog/:os/:arch` route, the `component` zod enums omitted `"watchdog"` (would 400), and `buildServerRelativeAgentDownloadUrl` only handled `agent`/`helper` (so the URL fell back to `github.com` and the agent's host-match guard rejected it).
3. **Agent updater** `expectedReleaseAssetNames()` had no `watchdog` case → GitHub multi-asset manifest verification failed (`no expected release asset names configured for component watchdog`).

The watchdog binary **is** published on every release (`breeze-watchdog-{linux,darwin}-{amd64,arm64}`, `breeze-watchdog-windows-amd64.exe`) — it was just never wired into the update path.

## Fix

**Server (`apps/api`)**
- `binarySync`: register `breeze-watchdog` as `component=watchdog`; add `getGithubWatchdogUrl`.
- `download.ts`: add `/download/watchdog/:os/:arch` (github-redirect / S3 / local-disk, mirroring the agent route).
- `agentVersions`: shared `componentEnum` incl. `watchdog`; server-relative download URL for `watchdog` so the agent host-guard passes (#646 pattern).

**Agent (Go)**
- `updater`: add the `watchdog` asset-name case.
- Handle server-driven `watchdogUpgradeTo` in the heartbeat response → download the **signature- and checksum-verified** watchdog binary, swap it, and restart the watchdog service (per-OS; **stop → replace → start** on Windows since the running `.exe` is locked). Refuses to install a watchdog **older than the running agent** (anti-downgrade, mirrors the helper-upgrade security posture).

This recovers **already-stuck fleets**: the agent updates reliably and drives the watchdog forward; the server only emits `watchdogUpgradeTo` once a failover heartbeat shows the on-disk watchdog is behind.

## Tests

- `updater`: watchdog asset-name case (all platforms).
- `handleWatchdogUpgrade`: guard matrix — skip empty/same, skip when auto_update off, refuse downgrade, in-progress guard, installs newer.
- `binarySync`: registers `component=watchdog`; backward-compat when asset absent.
- `download` route: 404 (no path leak), github redirect (per-arch, `.exe` on windows), OS/arch validation.
- `agentVersions`: server-relative URL for `component=watchdog`.

All green: API `tsc` clean; agent `go test -race ./internal/updater ./internal/heartbeat` + `go vet` across linux/darwin/windows.

## Caveats / follow-ups

- The `BINARY_SOURCE=local` scan path does **not** yet register the watchdog (consistent with helper/user-helper) — follow-up.
- The Windows **SCM stop→replace→start** path is unit-tested via an injected installer seam but should get **real-Windows verification** before we lean on it for the live fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)