### PR TITLE
fix(web): surface warranty refresh feedback and auto-update card (#1723)

### DIFF
--- a/apps/web/src/components/devices/DeviceWarrantyCard.test.tsx
+++ b/apps/web/src/components/devices/DeviceWarrantyCard.test.tsx
@@ -118,6 +118,101 @@ describe('DeviceWarrantyCard — refresh feedback (#1723)', () => {
       },
       { timeout: 8000 }
     );
+    // A successful refresh surfaces a success toast.
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', message: 'Warranty information updated.' })
+    );
+  }, 12000);
+
+  it('surfaces an error toast when the worker reports a failure (lastSyncError) despite advancing lastSyncAt', async () => {
+    let payload = warrantyPayload({ lastSyncAt: '2026-06-20T00:00:00.000Z' });
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/warranty/refresh') && method === 'POST') {
+        return jsonResponse({ message: 'Warranty refresh queued' });
+      }
+      return jsonResponse(payload);
+    });
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+    const refreshBtn = await screen.findByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+
+    // Worker advances lastSyncAt but stamps a failure — this must NOT read as success.
+    payload = warrantyPayload({
+      lastSyncAt: '2026-06-21T00:00:00.000Z',
+      lastSyncError: 'Dell API returned 500',
+    });
+    await waitFor(
+      () => {
+        expect(showToastMock).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'error', message: expect.stringContaining('Dell API returned 500') })
+        );
+      },
+      { timeout: 8000 }
+    );
+    expect(showToastMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', message: 'Warranty information updated.' })
+    );
+  }, 12000);
+
+  it('surfaces an in-progress toast and stops the spinner when the poll times out', async () => {
+    // GET always returns the same lastSyncAt → the poll never detects an advance
+    // and must settle on the timeout branch. A tiny pollTimeoutMs makes it fast.
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/warranty/refresh') && method === 'POST') {
+        return jsonResponse({ message: 'Warranty refresh queued' });
+      }
+      return jsonResponse(warrantyPayload({ lastSyncAt: '2026-06-20T00:00:00.000Z' }));
+    });
+
+    render(<DeviceWarrantyCard deviceId={deviceId} pollTimeoutMs={1} />);
+    const refreshBtn = await screen.findByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+
+    await waitFor(
+      () => {
+        expect(showToastMock).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'warning', message: expect.stringContaining('still in progress') })
+        );
+      },
+      { timeout: 8000 }
+    );
+    // Spinner cleared even though no fresher sync ever arrived.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^refresh$/i })).toBeInTheDocument();
+    });
+  }, 12000);
+
+  it('cleans up the poll timer on unmount without erroring', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/warranty/refresh') && method === 'POST') {
+        return jsonResponse({ message: 'Warranty refresh queued' });
+      }
+      // Never advances → poll keeps scheduling until unmount.
+      return jsonResponse(warrantyPayload({ lastSyncAt: '2026-06-20T00:00:00.000Z' }));
+    });
+
+    const { unmount } = render(<DeviceWarrantyCard deviceId={deviceId} />);
+    const refreshBtn = await screen.findByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /checking/i })).toBeInTheDocument();
+    });
+
+    const callsBefore = fetchWithAuthMock.mock.calls.length;
+    unmount();
+    // Give a poll interval a chance to fire; the cleared timer must not run.
+    await new Promise((r) => setTimeout(r, 2500));
+    expect(fetchWithAuthMock.mock.calls.length).toBe(callsBefore);
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   }, 12000);
 
   it('surfaces an error toast when the queue request fails', async () => {

--- a/apps/web/src/components/devices/DeviceWarrantyCard.test.tsx
+++ b/apps/web/src/components/devices/DeviceWarrantyCard.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceWarrantyCard from './DeviceWarrantyCard';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+import { navigateTo } from '@/lib/navigation';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+// runAction calls showToast; mock it so we can assert feedback surfaces without
+// rendering a real toast.
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+const navigateToMock = vi.mocked(navigateTo);
+
+const deviceId = '22222222-2222-2222-2222-222222222222';
+
+function jsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+function warrantyPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    warranty: {
+      id: 'w1',
+      deviceId,
+      manufacturer: 'dell',
+      serialNumber: 'ABC123',
+      status: 'unknown',
+      warrantyStartDate: null,
+      warrantyEndDate: null,
+      entitlements: [],
+      dataSource: 'provider',
+      lastSyncAt: '2026-06-20T00:00:00.000Z',
+      lastSyncError: null,
+      ...overrides,
+    },
+  };
+}
+
+describe('DeviceWarrantyCard — refresh feedback (#1723)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('surfaces a queued toast on Refresh click', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/warranty/refresh') && method === 'POST') {
+        return jsonResponse({ message: 'Warranty refresh queued' });
+      }
+      return jsonResponse(warrantyPayload());
+    });
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+    const refreshBtn = await screen.findByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', message: 'Refreshing warranty…' })
+      );
+    });
+    // POST was sent to the refresh route.
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      `/devices/${deviceId}/warranty/refresh`,
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('shows the in-progress "Checking…" label after click, then settles once a newer sync arrives', async () => {
+    let syncStamp = '2026-06-20T00:00:00.000Z';
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/warranty/refresh') && method === 'POST') {
+        return jsonResponse({ message: 'Warranty refresh queued' });
+      }
+      return jsonResponse(warrantyPayload({ lastSyncAt: syncStamp }));
+    });
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+    const refreshBtn = await screen.findByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+
+    // The card flips to the in-progress label as soon as the refresh is queued.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /checking/i })).toBeInTheDocument();
+    });
+
+    // Worker stamps a newer lastSyncAt; the poll detects it and the card settles
+    // back to "Refresh" on its own (no manual reload). Default poll is 2s.
+    syncStamp = '2026-06-21T00:00:00.000Z';
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: /^refresh$/i })).toBeInTheDocument();
+      },
+      { timeout: 8000 }
+    );
+  }, 12000);
+
+  it('surfaces an error toast when the queue request fails', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/warranty/refresh') && method === 'POST') {
+        return jsonResponse({ error: 'boom' }, false, 500);
+      }
+      return jsonResponse(warrantyPayload());
+    });
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+    const refreshBtn = await screen.findByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' })
+      );
+    });
+    // Spinner resets after the failure (button returns to Refresh).
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^refresh$/i })).toBeInTheDocument();
+    });
+    expect(navigateToMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login on a 401 from the refresh route', async () => {
+    fetchWithAuthMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/warranty/refresh') && method === 'POST') {
+        return jsonResponse({ error: 'unauthorized' }, false, 401);
+      }
+      return jsonResponse(warrantyPayload());
+    });
+
+    render(<DeviceWarrantyCard deviceId={deviceId} />);
+    const refreshBtn = await screen.findByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => {
+      expect(navigateToMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/devices/DeviceWarrantyCard.tsx
+++ b/apps/web/src/components/devices/DeviceWarrantyCard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { ShieldCheck, RefreshCw } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 
@@ -33,6 +34,9 @@ type WarrantyData = {
 type DeviceWarrantyCardProps = {
   deviceId: string;
   compact?: boolean;
+  /** Override the refresh poll timeout (ms). Test seam only — defaults to
+   *  REFRESH_POLL_TIMEOUT_MS in production. */
+  pollTimeoutMs?: number;
 };
 
 const statusConfig: Record<string, { label: string; color: string }> = {
@@ -82,7 +86,22 @@ function timeAgo(dateStr: string | null): string {
 const REFRESH_POLL_INTERVAL_MS = 2000;
 const REFRESH_POLL_TIMEOUT_MS = 30000;
 
-export default function DeviceWarrantyCard({ deviceId, compact = false }: DeviceWarrantyCardProps) {
+// The worker stamps lastSyncAt on BOTH success and failure (a failed provider
+// lookup populates lastSyncError but still advances the timestamp), so a fresher
+// lastSyncAt alone does not mean the refresh succeeded — we must inspect
+// lastSyncError to avoid reporting a failed refresh as success (#1723).
+// The legacy "No configured provider" string is an expected, non-error outcome
+// (the manufacturer simply has no warranty provider) and is shown inline, not
+// toasted as an error.
+function isProviderNotConfigured(err: string | null): boolean {
+  return !!err && err.includes('No configured provider');
+}
+
+export default function DeviceWarrantyCard({
+  deviceId,
+  compact = false,
+  pollTimeoutMs = REFRESH_POLL_TIMEOUT_MS,
+}: DeviceWarrantyCardProps) {
   const [warranty, setWarranty] = useState<WarrantyData | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -151,13 +170,37 @@ export default function DeviceWarrantyCard({ deviceId, compact = false }: Device
     }
 
     // Poll until the worker stamps a newer lastSyncAt or we hit the timeout,
-    // then settle (success or "still working") and stop the spinner.
+    // then surface the outcome and stop the spinner. A fresher timestamp can
+    // mean success OR a worker-side failure, so inspect lastSyncError before
+    // declaring success — otherwise a failed refresh reads as success.
     const startedAt = Date.now();
     const poll = async () => {
       const next = await fetchWarranty();
-      const advanced = next?.lastSyncAt && next.lastSyncAt !== previousSyncAt;
-      if (advanced || Date.now() - startedAt >= REFRESH_POLL_TIMEOUT_MS) {
-        if (mountedRef.current) setRefreshing(false);
+      const advanced = !!next?.lastSyncAt && next.lastSyncAt !== previousSyncAt;
+      if (advanced) {
+        if (mountedRef.current) {
+          setRefreshing(false);
+          if (next?.lastSyncError && !isProviderNotConfigured(next.lastSyncError)) {
+            showToast({ message: `Warranty refresh failed: ${next.lastSyncError}`, type: 'error' });
+          } else if (isProviderNotConfigured(next?.lastSyncError ?? null)) {
+            showToast({ message: 'No warranty provider is configured for this manufacturer.', type: 'warning' });
+          } else {
+            showToast({ message: 'Warranty information updated.', type: 'success' });
+          }
+        }
+        return;
+      }
+      if (Date.now() - startedAt >= pollTimeoutMs) {
+        // Timed out before the worker produced a fresher result. Don't settle
+        // silently (that's the #1723 confusion) — tell the user it's still
+        // running and will update on its own.
+        if (mountedRef.current) {
+          setRefreshing(false);
+          showToast({
+            message: 'Warranty refresh is still in progress; the card will update when it completes.',
+            type: 'warning',
+          });
+        }
         return;
       }
       if (mountedRef.current) {

--- a/apps/web/src/components/devices/DeviceWarrantyCard.tsx
+++ b/apps/web/src/components/devices/DeviceWarrantyCard.tsx
@@ -1,6 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ShieldCheck, RefreshCw } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
 
 type WarrantyEntitlement = {
   provider: string;
@@ -70,45 +75,96 @@ function timeAgo(dateStr: string | null): string {
   return `${days}d ago`;
 }
 
+// The refresh runs asynchronously in a BullMQ worker (the route returns 200 the
+// moment the job is queued), so we poll the warranty endpoint after queuing and
+// stop as soon as the worker stamps a newer lastSyncAt — that way the card
+// updates on its own instead of leaving the user to reload (#1723).
+const REFRESH_POLL_INTERVAL_MS = 2000;
+const REFRESH_POLL_TIMEOUT_MS = 30000;
+
 export default function DeviceWarrantyCard({ deviceId, compact = false }: DeviceWarrantyCardProps) {
   const [warranty, setWarranty] = useState<WarrantyData | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState(false);
+  // Cleared on unmount / deviceId change so a late poll tick can't setState on
+  // an unmounted card or bleed across devices.
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
 
-  const fetchWarranty = async () => {
+  const clearPoll = () => {
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  };
+
+  const fetchWarranty = async (): Promise<WarrantyData | null> => {
     try {
       const res = await fetchWithAuth(`/devices/${deviceId}/warranty`);
       if (res.ok) {
         const data = await res.json();
-        setWarranty(data.warranty);
-        setError(false);
-      } else {
-        setError(true);
+        if (mountedRef.current) {
+          setWarranty(data.warranty);
+          setError(false);
+        }
+        return data.warranty ?? null;
       }
+      if (mountedRef.current) setError(true);
+      return null;
     } catch {
-      setError(true);
+      if (mountedRef.current) setError(true);
+      return null;
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   };
 
   useEffect(() => {
+    mountedRef.current = true;
     fetchWarranty();
+    return () => {
+      mountedRef.current = false;
+      clearPoll();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deviceId]);
 
   const handleRefresh = async () => {
+    if (refreshing) return;
+    clearPoll();
     setRefreshing(true);
+    // Capture the pre-refresh sync timestamp so we can detect when the worker
+    // produces a fresher result.
+    const previousSyncAt = warranty?.lastSyncAt ?? null;
     try {
-      await fetchWithAuth(`/devices/${deviceId}/warranty/refresh`, { method: 'POST' });
-      // Re-fetch after a short delay to allow the worker to process
-      setTimeout(() => {
-        fetchWarranty();
-        setRefreshing(false);
-      }, 3000);
-    } catch {
-      setRefreshing(false);
+      await runAction({
+        request: () => fetchWithAuth(`/devices/${deviceId}/warranty/refresh`, { method: 'POST' }),
+        errorFallback: 'Failed to queue warranty refresh',
+        successMessage: 'Refreshing warranty…',
+        onUnauthorized: UNAUTHORIZED,
+      });
+    } catch (err) {
+      handleActionError(err, 'Failed to queue warranty refresh');
+      if (mountedRef.current) setRefreshing(false);
+      return;
     }
+
+    // Poll until the worker stamps a newer lastSyncAt or we hit the timeout,
+    // then settle (success or "still working") and stop the spinner.
+    const startedAt = Date.now();
+    const poll = async () => {
+      const next = await fetchWarranty();
+      const advanced = next?.lastSyncAt && next.lastSyncAt !== previousSyncAt;
+      if (advanced || Date.now() - startedAt >= REFRESH_POLL_TIMEOUT_MS) {
+        if (mountedRef.current) setRefreshing(false);
+        return;
+      }
+      if (mountedRef.current) {
+        pollTimerRef.current = setTimeout(poll, REFRESH_POLL_INTERVAL_MS);
+      }
+    };
+    pollTimerRef.current = setTimeout(poll, REFRESH_POLL_INTERVAL_MS);
   };
 
   if (loading) {
@@ -201,7 +257,7 @@ export default function DeviceWarrantyCard({ deviceId, compact = false }: Device
           className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition hover:bg-muted disabled:opacity-50"
         >
           <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
-          {refreshing ? 'Refreshing...' : 'Refresh'}
+          {refreshing ? 'Checking…' : 'Refresh'}
         </button>
       </div>
 

--- a/apps/web/src/components/devices/DeviceWarrantyCard.tsx
+++ b/apps/web/src/components/devices/DeviceWarrantyCard.tsx
@@ -146,7 +146,8 @@ export default function DeviceWarrantyCard({
       mountedRef.current = false;
       clearPoll();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Re-run only when the device changes; fetchWarranty/clearPoll are stable
+    // closures recreated each render and intentionally excluded.
   }, [deviceId]);
 
   const handleRefresh = async () => {

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -41,6 +41,7 @@ const TARGET_GLOBS = [
   'src/components/dnsSecurity/DnsSecurityPoliciesTab.tsx',
   'src/components/dnsSecurity/AddDnsPolicyModal.tsx',
   'src/components/devices/DeviceSoftwareInventory.tsx',
+  'src/components/devices/DeviceWarrantyCard.tsx',
   'src/components/pam/PamRespondModal.tsx',
   'src/components/pam/PamRevokeModal.tsx',
   'src/components/pam/PamRuleModal.tsx',
@@ -263,7 +264,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(44);
+    expect(absoluteFiles.length).toBe(45);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/runActionAllowlist.ts
+++ b/apps/web/src/lib/runActionAllowlist.ts
@@ -21,7 +21,7 @@ export const RUN_ACTION_MIGRATION_BACKLOG: ReadonlyArray<string> = [
   // DevicePatchStatusTab.tsx migrated to runAction (patch scan/install) — now in TARGET_GLOBS.
   'apps/web/src/components/devices/DeviceSecurityTab.tsx',
   'apps/web/src/components/devices/DeviceSettingsModal.tsx',
-  'apps/web/src/components/devices/DeviceWarrantyCard.tsx',
+  // DeviceWarrantyCard.tsx migrated to runAction (#1723) — now in TARGET_GLOBS.
   'apps/web/src/components/alerts/AlertCorrelationView.tsx',
   'apps/web/src/components/alerts/AlertRuleEditor.tsx',
   'apps/web/src/components/alerts/AlertRulesPage.tsx',


### PR DESCRIPTION
## Summary

The Dell warranty **Refresh** button was fire-and-forget: it POSTed the queue request, **ignored the response**, and re-fetched once after a blind 3s `setTimeout`. With no toast on click, no in-progress signal, and no follow-through when the async BullMQ worker actually finished, the user saw a silent spinner and had to reload the page to ever see the result. The latest product-owner note on #1723 narrowed the issue to exactly this — the lookup *works*, it "needs better user feedback."

This is a contained frontend fix in `DeviceWarrantyCard.tsx` (no credential-UI / DB / API changes — those remain open design questions in the issue).

## Changes

- **Queue feedback:** wrap the refresh POST in `runAction`, so the click emits a `Refreshing warranty…` success toast, an error toast on failure, and redirects to login on 401 — per the repo mutation-handler convention.
- **Auto-update:** replace the single blind re-fetch with a bounded poll (2s interval, 30s cap) that watches for the worker to stamp a newer `lastSyncAt`, so the card refreshes itself instead of forcing a manual reload.
- **In-progress signal:** the button shows `Checking…` while polling; all `setState` is guarded behind a mounted ref and the poll timer is cleared on unmount / `deviceId` change.
- Migrated the component out of `RUN_ACTION_MIGRATION_BACKLOG` into the `no-silent-mutations` `TARGET_GLOBS` (count 44 → 45).
- Added `DeviceWarrantyCard.test.tsx` covering: queued toast, in-progress → settle transition, failure toast, and 401 redirect.

## Acceptance criteria addressed (from #1723's narrowed scope)

- [x] On click, immediately confirm the refresh was queued via `runAction`.
- [x] Reflect in-progress state on the card (`Checking…`).
- [x] When the job finishes, update the card automatically (poll until `lastSyncAt` advances) — no reload needed.
- [x] Surface failure explicitly via toast.

## Testing

- `vitest run DeviceWarrantyCard.test.tsx` — 4 passed.
- `vitest run no-silent-mutations.test.ts` — guard green with the migrated file (45 targeted files).
- `tsc --noEmit` — clean for all touched files (the 121 pre-existing errors are all in `packages/shared` zod `.guid()` drift, present on base `main`, unrelated to this change).

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)