### PR TITLE
feat(reliability): device-type-aware uptime weighting (#1721)

### DIFF
--- a/apps/api/src/__tests__/integration/reliabilityWeightProfile.integration.test.ts
+++ b/apps/api/src/__tests__/integration/reliabilityWeightProfile.integration.test.ts
@@ -1,0 +1,139 @@
+import './setup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+import { withSystemDbAccessContext } from '../../db';
+import { deviceReliability, deviceReliabilityHistory, devices } from '../../db/schema';
+import { computeAndPersistDeviceReliability } from '../../services/reliabilityScoring';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+let agentCounter = 0;
+async function insertDevice(
+  orgId: string,
+  siteId: string,
+  deviceRole: string,
+): Promise<string> {
+  agentCounter++;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `reliability-weights-${Date.now()}-${agentCounter}`,
+      hostname: `reliability-weights-host-${agentCounter}`,
+      displayName: `reliability-weights-host-${agentCounter}`,
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      deviceRole,
+      // Enrolled well before the lookback window so uptime is computed over the
+      // full 30/90 day windows rather than clamped to "up since enrollment".
+      enrolledAt: new Date(Date.now() - 120 * DAY_MS),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice returned no row');
+  return row.id;
+}
+
+// Seed a single low-uptime history snapshot: the device was up only ~50% of the
+// last reporting interval, with no crashes/hangs/service/hardware faults — i.e.
+// a "clean but normally-rebooting" device whose only weak factor is uptime.
+async function insertLowUptimeHistory(orgId: string, deviceId: string): Promise<void> {
+  const collectedAt = new Date(Date.now() - 1 * DAY_MS);
+  await getTestDb()
+    .insert(deviceReliabilityHistory)
+    .values({
+      orgId,
+      deviceId,
+      collectedAt,
+      // Up for 12h out of a 24h window -> drags the uptime factor toward 0.
+      uptimeSeconds: 12 * 3600,
+      bootTime: new Date(collectedAt.getTime() - 12 * 3600 * 1000),
+    });
+}
+
+async function getPersistedReliability(deviceId: string) {
+  const [row] = await getTestDb()
+    .select({
+      reliabilityScore: deviceReliability.reliabilityScore,
+      details: deviceReliability.details,
+      topIssues: deviceReliability.topIssues,
+    })
+    .from(deviceReliability)
+    .where(eq(deviceReliability.deviceId, deviceId))
+    .limit(1);
+  return row ?? null;
+}
+
+describe('reliability device-type-aware weight profile integration (#1721)', () => {
+  let orgId: string;
+  let siteId: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id, name: 'Reliability Weights Org' });
+    orgId = org.id;
+    const site = await createSite({ orgId, name: 'Reliability Weights Site' });
+    siteId = site.id;
+  });
+
+  it('persists the infra weight profile (uptime weighted 30) for a server device', async () => {
+    const deviceId = await insertDevice(orgId, siteId, 'server');
+    await insertLowUptimeHistory(orgId, deviceId);
+
+    const computed = await withSystemDbAccessContext(() =>
+      computeAndPersistDeviceReliability(deviceId),
+    );
+    expect(computed).toBe(true);
+
+    const row = await getPersistedReliability(deviceId);
+    expect(row).not.toBeNull();
+    const details = row!.details as { weightProfile?: string; factors?: Record<string, { weight?: number }> };
+    expect(details.weightProfile).toBe('infra');
+    expect(details.factors?.uptime?.weight).toBe(30);
+  });
+
+  it('persists the workstation profile (uptime weighted 0) and suppresses the uptime top-issue', async () => {
+    const deviceId = await insertDevice(orgId, siteId, 'workstation');
+    await insertLowUptimeHistory(orgId, deviceId);
+
+    const computed = await withSystemDbAccessContext(() =>
+      computeAndPersistDeviceReliability(deviceId),
+    );
+    expect(computed).toBe(true);
+
+    const row = await getPersistedReliability(deviceId);
+    expect(row).not.toBeNull();
+    const details = row!.details as { weightProfile?: string; factors?: Record<string, { weight?: number }> };
+    expect(details.weightProfile).toBe('workstation');
+    expect(details.factors?.uptime?.weight).toBe(0);
+
+    const topIssues = (row!.topIssues ?? []) as Array<{ type: string }>;
+    expect(topIssues.find((issue) => issue.type === 'uptime')).toBeUndefined();
+  });
+
+  it('a clean low-uptime workstation scores higher than the same device as a server', async () => {
+    const serverId = await insertDevice(orgId, siteId, 'server');
+    const workstationId = await insertDevice(orgId, siteId, 'workstation');
+    await insertLowUptimeHistory(orgId, serverId);
+    await insertLowUptimeHistory(orgId, workstationId);
+
+    await withSystemDbAccessContext(async () => {
+      await computeAndPersistDeviceReliability(serverId);
+      await computeAndPersistDeviceReliability(workstationId);
+    });
+
+    const serverRow = await getPersistedReliability(serverId);
+    const workstationRow = await getPersistedReliability(workstationId);
+    expect(serverRow).not.toBeNull();
+    expect(workstationRow).not.toBeNull();
+    // Uptime no longer drags the workstation's weighted total down.
+    expect(workstationRow!.reliabilityScore).toBeGreaterThan(serverRow!.reliabilityScore);
+  });
+});

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -346,6 +346,121 @@ describe('computeTopIssues', () => {
     const uptime = issues.find((i) => i.type === 'uptime');
     expect(uptime?.severity).toBe('critical');
   });
+
+  // Issue #1721: workstation/laptop roles should not be flagged with an uptime
+  // top-issue, since regular sleep/shutdown is expected for those devices.
+  it('suppresses the uptime issue when suppressUptimeIssue is true (low uptime)', () => {
+    const issues = computeTopIssues({
+      dailyBuckets: [],
+      now,
+      uptime30d: 80,
+      crashCount30d: 0,
+      hangCount30d: 0,
+      serviceFailureCount30d: 0,
+      hardwareErrorCount30d: 0,
+      criticalHardwareCount30d: 0,
+      suppressUptimeIssue: true,
+    });
+    expect(issues.find((i) => i.type === 'uptime')).toBeUndefined();
+  });
+
+  it('still flags non-uptime issues when suppressUptimeIssue is true', () => {
+    const issues = computeTopIssues({
+      dailyBuckets: [],
+      now,
+      uptime30d: 80,
+      crashCount30d: 3,
+      hangCount30d: 0,
+      serviceFailureCount30d: 0,
+      hardwareErrorCount30d: 0,
+      criticalHardwareCount30d: 0,
+      suppressUptimeIssue: true,
+    });
+    expect(issues.find((i) => i.type === 'uptime')).toBeUndefined();
+    expect(issues.find((i) => i.type === 'crashes')?.severity).toBe('critical');
+  });
+
+  it('still flags the uptime issue when suppressUptimeIssue is false (default behaviour preserved)', () => {
+    const issues = computeTopIssues({
+      dailyBuckets: [],
+      now,
+      uptime30d: 80,
+      crashCount30d: 0,
+      hangCount30d: 0,
+      serviceFailureCount30d: 0,
+      hardwareErrorCount30d: 0,
+      criticalHardwareCount30d: 0,
+      suppressUptimeIssue: false,
+    });
+    expect(issues.find((i) => i.type === 'uptime')?.severity).toBe('critical');
+  });
+});
+
+// Issue #1721: device-type-aware reliability weight profiles.
+describe('device-role weight profiles', () => {
+  const {
+    resolveFactorWeights,
+    isWorkstationRole,
+    INFRA_FACTOR_WEIGHTS,
+    WORKSTATION_FACTOR_WEIGHTS,
+  } = reliabilityScoringInternals;
+
+  const sum = (w: typeof INFRA_FACTOR_WEIGHTS) =>
+    w.uptime + w.crashes + w.hangs + w.serviceFailures + w.hardwareErrors;
+
+  it('both profiles sum to 100', () => {
+    expect(sum(INFRA_FACTOR_WEIGHTS)).toBe(100);
+    expect(sum(WORKSTATION_FACTOR_WEIGHTS)).toBe(100);
+  });
+
+  it('the infra profile keeps the historical uptime weight of 30', () => {
+    expect(INFRA_FACTOR_WEIGHTS.uptime).toBe(30);
+  });
+
+  it('the workstation profile drops uptime to zero', () => {
+    expect(WORKSTATION_FACTOR_WEIGHTS.uptime).toBe(0);
+  });
+
+  it('classifies only the workstation role as workstation-class', () => {
+    expect(isWorkstationRole('workstation')).toBe(true);
+    expect(isWorkstationRole('server')).toBe(false);
+    expect(isWorkstationRole('nas')).toBe(false);
+    expect(isWorkstationRole('unknown')).toBe(false);
+    expect(isWorkstationRole(null)).toBe(false);
+    expect(isWorkstationRole(undefined)).toBe(false);
+  });
+
+  it('resolves the workstation profile for workstation devices', () => {
+    expect(resolveFactorWeights('workstation')).toBe(WORKSTATION_FACTOR_WEIGHTS);
+  });
+
+  it.each(['server', 'nas', 'router', 'switch', 'firewall', 'printer', 'unknown', null, undefined])(
+    'resolves the infra profile for role %s',
+    (role) => {
+      expect(resolveFactorWeights(role as string | null | undefined)).toBe(INFRA_FACTOR_WEIGHTS);
+    }
+  );
+
+  // A normally-rebooting laptop (low uptime, otherwise clean) should score far
+  // higher under the workstation profile than under the infra profile, because
+  // uptime no longer drags the weighted total down.
+  it('a low-uptime but otherwise-clean device scores higher under the workstation profile', () => {
+    const uptimeScore = 0; // <=90% uptime -> 0 on the uptime factor
+    const cleanScore = 100; // no crashes/hangs/service/hardware faults
+    const weighted = (w: typeof INFRA_FACTOR_WEIGHTS) =>
+      (uptimeScore * w.uptime
+        + cleanScore * w.crashes
+        + cleanScore * w.hangs
+        + cleanScore * w.serviceFailures
+        + cleanScore * w.hardwareErrors) / 100;
+
+    const infra = weighted(INFRA_FACTOR_WEIGHTS);
+    const workstation = weighted(WORKSTATION_FACTOR_WEIGHTS);
+
+    expect(infra).toBe(70); // 30% uptime weight lost entirely
+    expect(workstation).toBe(100); // uptime carries no weight
+    expect(workstation).toBeGreaterThan(infra);
+  });
 });
 
 describe('reliability explanation drivers', () => {

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -399,7 +399,7 @@ describe('computeTopIssues', () => {
 // Issue #1721: device-type-aware reliability weight profiles.
 describe('device-role weight profiles', () => {
   const {
-    resolveFactorWeights,
+    resolveWeightProfile,
     isWorkstationRole,
     INFRA_FACTOR_WEIGHTS,
     WORKSTATION_FACTOR_WEIGHTS,
@@ -430,14 +430,18 @@ describe('device-role weight profiles', () => {
     expect(isWorkstationRole(undefined)).toBe(false);
   });
 
-  it('resolves the workstation profile for workstation devices', () => {
-    expect(resolveFactorWeights('workstation')).toBe(WORKSTATION_FACTOR_WEIGHTS);
+  it('resolves the workstation profile (name + weights) for workstation devices', () => {
+    const profile = resolveWeightProfile('workstation');
+    expect(profile.name).toBe('workstation');
+    expect(profile.weights).toBe(WORKSTATION_FACTOR_WEIGHTS);
   });
 
   it.each(['server', 'nas', 'router', 'switch', 'firewall', 'printer', 'unknown', null, undefined])(
-    'resolves the infra profile for role %s',
+    'resolves the infra profile (name + weights) for role %s',
     (role) => {
-      expect(resolveFactorWeights(role as string | null | undefined)).toBe(INFRA_FACTOR_WEIGHTS);
+      const profile = resolveWeightProfile(role as string | null | undefined);
+      expect(profile.name).toBe('infra');
+      expect(profile.weights).toBe(INFRA_FACTOR_WEIGHTS);
     }
   );
 

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -14,13 +14,70 @@ import { shouldProduceMlOutput } from './mlFeatureFlags';
 import { captureException } from './sentry';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const RELIABILITY_FACTOR_WEIGHTS = {
+
+type ReliabilityFactorWeights = {
+  uptime: number;
+  crashes: number;
+  hangs: number;
+  serviceFailures: number;
+  hardwareErrors: number;
+};
+
+// Issue #1721: scoring weights are device-type-aware. Uptime is a meaningful
+// reliability signal for always-on infrastructure (servers, NAS, network gear)
+// but NOT for workstations/laptops, which are *expected* to sleep and shut down
+// daily — penalising a normally-rebooting laptop on uptime (30% of the score)
+// produces a misleading low reliability score. So workstation-class roles drop
+// the uptime weight to zero and redistribute it across the fault factors that
+// actually indicate a problem (crashes/hangs/service/hardware).
+//
+// Each profile MUST sum to 100 (asserted by assertWeightsSumTo100 at module load).
+
+// Always-on infrastructure: the historical default. Uptime carries real signal.
+const INFRA_FACTOR_WEIGHTS: ReliabilityFactorWeights = {
   uptime: 30,
   crashes: 25,
   hangs: 15,
   serviceFailures: 15,
   hardwareErrors: 15,
-} as const;
+};
+
+// Workstations/laptops: uptime is not a fault signal, so its 30 points are
+// redistributed onto the remaining factors (proportionally to the infra
+// profile's non-uptime weights: 25/15/15/15 of 70 → +10.7/+6.4/+6.4/+6.4).
+const WORKSTATION_FACTOR_WEIGHTS: ReliabilityFactorWeights = {
+  uptime: 0,
+  crashes: 36,
+  hangs: 21,
+  serviceFailures: 21,
+  hardwareErrors: 22,
+};
+
+function assertWeightsSumTo100(label: string, weights: ReliabilityFactorWeights): void {
+  const total = weights.uptime + weights.crashes + weights.hangs + weights.serviceFailures + weights.hardwareErrors;
+  if (total !== 100) {
+    throw new Error(`[ReliabilityScoring] weight profile "${label}" must sum to 100 (got ${total})`);
+  }
+}
+assertWeightsSumTo100('infra', INFRA_FACTOR_WEIGHTS);
+assertWeightsSumTo100('workstation', WORKSTATION_FACTOR_WEIGHTS);
+
+// Roles whose uptime is not a reliability signal (expected to sleep/shut down).
+// Everything else (server, nas, router, switch, firewall, access_point, printer,
+// camera, iot, phone, unknown) keeps the always-on infra profile.
+const WORKSTATION_ROLES = new Set(['workstation']);
+
+function isWorkstationRole(deviceRole: string | null | undefined): boolean {
+  return deviceRole != null && WORKSTATION_ROLES.has(deviceRole);
+}
+
+/**
+ * Pick the reliability weight profile for a device role. Workstation-class roles
+ * drop the uptime factor; all other roles use the always-on infra profile.
+ */
+function resolveFactorWeights(deviceRole: string | null | undefined): ReliabilityFactorWeights {
+  return isWorkstationRole(deviceRole) ? WORKSTATION_FACTOR_WEIGHTS : INFRA_FACTOR_WEIGHTS;
+}
 
 export type ReliabilityTrendDirection = 'improving' | 'stable' | 'degrading';
 export type ReliabilityScoreRange = 'critical' | 'poor' | 'fair' | 'good';
@@ -583,6 +640,10 @@ function computeTopIssues(input: {
   serviceFailureCount30d: number;
   hardwareErrorCount30d: number;
   criticalHardwareCount30d: number;
+  // Issue #1721: suppress the `uptime` top-issue for roles where regular
+  // sleep/shutdown is expected (workstations/laptops). Defaults to false so
+  // every existing caller keeps the original behaviour.
+  suppressUptimeIssue?: boolean;
 }): ReliabilityTopIssue[] {
   const issues: ReliabilityTopIssue[] = [];
   const recentBuckets = bucketsInWindow(input.dailyBuckets, 30, input.now);
@@ -627,7 +688,7 @@ function computeTopIssues(input: {
     });
   }
 
-  if (input.uptime30d < 95) {
+  if (!input.suppressUptimeIssue && input.uptime30d < 95) {
     issues.push({
       type: 'uptime',
       count: Math.max(1, Math.round(100 - input.uptime30d)),
@@ -826,6 +887,7 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
       id: devices.id,
       orgId: devices.orgId,
       enrolledAt: devices.enrolledAt,
+      deviceRole: devices.deviceRole,
     })
     .from(devices)
     .where(eq(devices.id, deviceId))
@@ -900,12 +962,17 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
     warningHardwareCount30d
   );
 
+  // Issue #1721: pick a device-type-aware weight profile so a normally-rebooting
+  // workstation/laptop isn't penalised on uptime the way an always-on server is.
+  const weights = resolveFactorWeights(device.deviceRole);
+  const suppressUptimeIssue = isWorkstationRole(device.deviceRole);
+
   const reliabilityScore = clampScore(
-    uptimeScore * (RELIABILITY_FACTOR_WEIGHTS.uptime / 100)
-    + crashScore * (RELIABILITY_FACTOR_WEIGHTS.crashes / 100)
-    + hangScore * (RELIABILITY_FACTOR_WEIGHTS.hangs / 100)
-    + serviceFailureScore * (RELIABILITY_FACTOR_WEIGHTS.serviceFailures / 100)
-    + hardwareErrorScore * (RELIABILITY_FACTOR_WEIGHTS.hardwareErrors / 100)
+    uptimeScore * (weights.uptime / 100)
+    + crashScore * (weights.crashes / 100)
+    + hangScore * (weights.hangs / 100)
+    + serviceFailureScore * (weights.serviceFailures / 100)
+    + hardwareErrorScore * (weights.hardwareErrors / 100)
   );
 
   const trend = computeTrend(dailyBuckets, now);
@@ -919,6 +986,7 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
     serviceFailureCount30d,
     hardwareErrorCount30d,
     criticalHardwareCount30d,
+    suppressUptimeIssue,
   });
 
   const latestProcessedAt = maxTimestamp([
@@ -928,20 +996,24 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
   ]) ?? now.toISOString();
 
   const detailsPayload = {
+    // Issue #1721: record which device-type-aware weight profile was applied so
+    // the card's per-factor "% weight" (read from factors[*].weight) and any
+    // downstream consumer can see the role-specific weighting that was used.
+    weightProfile: isWorkstationRole(device.deviceRole) ? 'workstation' : 'infra',
     factors: {
-      uptime: { score: uptimeScore, weight: RELIABILITY_FACTOR_WEIGHTS.uptime, uptime7d, uptime30d, uptime90d },
-      crashes: { score: crashScore, weight: RELIABILITY_FACTOR_WEIGHTS.crashes, crashCount7d, crashCount30d, crashCount90d },
-      hangs: { score: hangScore, weight: RELIABILITY_FACTOR_WEIGHTS.hangs, hangCount7d, hangCount30d, unresolvedHangCount30d },
+      uptime: { score: uptimeScore, weight: weights.uptime, uptime7d, uptime30d, uptime90d },
+      crashes: { score: crashScore, weight: weights.crashes, crashCount7d, crashCount30d, crashCount90d },
+      hangs: { score: hangScore, weight: weights.hangs, hangCount7d, hangCount30d, unresolvedHangCount30d },
       serviceFailures: {
         score: serviceFailureScore,
-        weight: RELIABILITY_FACTOR_WEIGHTS.serviceFailures,
+        weight: weights.serviceFailures,
         serviceFailureCount7d,
         serviceFailureCount30d,
         recoveredServiceCount30d,
       },
       hardwareErrors: {
         score: hardwareErrorScore,
-        weight: RELIABILITY_FACTOR_WEIGHTS.hardwareErrors,
+        weight: weights.hardwareErrors,
         hardwareErrorCount7d,
         hardwareErrorCount30d,
         criticalHardwareCount30d,
@@ -1456,4 +1528,8 @@ export const reliabilityScoringInternals = {
   computeTopIssues,
   buildReliabilityDrivers,
   computeReliabilityEvaluationSummary,
+  resolveFactorWeights,
+  isWorkstationRole,
+  INFRA_FACTOR_WEIGHTS,
+  WORKSTATION_FACTOR_WEIGHTS,
 };

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -43,8 +43,10 @@ const INFRA_FACTOR_WEIGHTS: ReliabilityFactorWeights = {
 };
 
 // Workstations/laptops: uptime is not a fault signal, so its 30 points are
-// redistributed onto the remaining factors (proportionally to the infra
-// profile's non-uptime weights: 25/15/15/15 of 70 → +10.7/+6.4/+6.4/+6.4).
+// redistributed onto the remaining factors, roughly in proportion to the infra
+// profile's non-uptime weights (25/15/15/15 of 70 → ≈ +10.7/+6.4/+6.4/+6.4),
+// with the leftover rounding point assigned to hardwareErrors so the profile
+// sums to exactly 100.
 const WORKSTATION_FACTOR_WEIGHTS: ReliabilityFactorWeights = {
   uptime: 0,
   crashes: 36,
@@ -52,6 +54,8 @@ const WORKSTATION_FACTOR_WEIGHTS: ReliabilityFactorWeights = {
   serviceFailures: 21,
   hardwareErrors: 22,
 };
+
+type ReliabilityWeightProfileName = 'infra' | 'workstation';
 
 function assertWeightsSumTo100(label: string, weights: ReliabilityFactorWeights): void {
   const total = weights.uptime + weights.crashes + weights.hangs + weights.serviceFailures + weights.hardwareErrors;
@@ -74,9 +78,16 @@ function isWorkstationRole(deviceRole: string | null | undefined): boolean {
 /**
  * Pick the reliability weight profile for a device role. Workstation-class roles
  * drop the uptime factor; all other roles use the always-on infra profile.
+ * Returns both the weights and the profile name so callers persist a label that
+ * cannot drift from the weights actually applied.
  */
-function resolveFactorWeights(deviceRole: string | null | undefined): ReliabilityFactorWeights {
-  return isWorkstationRole(deviceRole) ? WORKSTATION_FACTOR_WEIGHTS : INFRA_FACTOR_WEIGHTS;
+function resolveWeightProfile(deviceRole: string | null | undefined): {
+  name: ReliabilityWeightProfileName;
+  weights: ReliabilityFactorWeights;
+} {
+  return isWorkstationRole(deviceRole)
+    ? { name: 'workstation', weights: WORKSTATION_FACTOR_WEIGHTS }
+    : { name: 'infra', weights: INFRA_FACTOR_WEIGHTS };
 }
 
 export type ReliabilityTrendDirection = 'improving' | 'stable' | 'degrading';
@@ -964,7 +975,7 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
 
   // Issue #1721: pick a device-type-aware weight profile so a normally-rebooting
   // workstation/laptop isn't penalised on uptime the way an always-on server is.
-  const weights = resolveFactorWeights(device.deviceRole);
+  const { name: weightProfile, weights } = resolveWeightProfile(device.deviceRole);
   const suppressUptimeIssue = isWorkstationRole(device.deviceRole);
 
   const reliabilityScore = clampScore(
@@ -999,7 +1010,9 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
     // Issue #1721: record which device-type-aware weight profile was applied so
     // the card's per-factor "% weight" (read from factors[*].weight) and any
     // downstream consumer can see the role-specific weighting that was used.
-    weightProfile: isWorkstationRole(device.deviceRole) ? 'workstation' : 'infra',
+    // Derived from the same resolveWeightProfile() result as `weights` above so
+    // the label can never drift from the weights actually applied.
+    weightProfile,
     factors: {
       uptime: { score: uptimeScore, weight: weights.uptime, uptime7d, uptime30d, uptime90d },
       crashes: { score: crashScore, weight: weights.crashes, crashCount7d, crashCount30d, crashCount90d },
@@ -1528,7 +1541,7 @@ export const reliabilityScoringInternals = {
   computeTopIssues,
   buildReliabilityDrivers,
   computeReliabilityEvaluationSummary,
-  resolveFactorWeights,
+  resolveWeightProfile,
   isWorkstationRole,
   INFRA_FACTOR_WEIGHTS,
   WORKSTATION_FACTOR_WEIGHTS,


### PR DESCRIPTION
## Summary

Addresses **part 3** of #1721 — *"Uptime factor should be device-type-aware."* Reliability scoring previously applied one flat weight profile to every device, weighting uptime at 30% regardless of role. A normally-rebooting workstation/laptop (expected to sleep and shut down) landed near 0 on the uptime factor and was unfairly dragged down, plus got a misleading "low uptime" top-issue flag.

**This PR scopes to the backend scoring change only.** The UI/CTA and ML-feedback-button relabeling (parts 1 & 2 of the issue) are intentionally left for a follow-up so this stays a contained, reviewable change.

## Changes

- **Device-role-aware weight profiles** (`reliabilityScoring.ts`):
  - `infra` — the historical default (uptime 30 / crashes 25 / hangs 15 / services 15 / hardware 15). Used by `server`, `nas`, network gear, `unknown`, etc.
  - `workstation` — uptime dropped to **0**, its 30 points redistributed across the fault factors (crashes 36 / hangs 21 / services 21 / hardware 22).
  - Both profiles MUST sum to 100, asserted at module load (`assertWeightsSumTo100`).
- `computeAndPersistDeviceReliability` now selects `devices.deviceRole`, resolves the profile via `resolveFactorWeights`, and uses it for **both** the weighted score and the per-factor `weight` values persisted in `details.factors` — so the card's per-factor "% weight" reflects the role-specific weighting. The chosen profile is recorded in `details.weightProfile`.
- `computeTopIssues` gains an optional `suppressUptimeIssue` flag (default `false`, fully back-compat). Workstation-class roles suppress the `uptime` top-issue so techs don't see "low uptime" flagged on a machine that's supposed to sleep.

Only the `workstation` role is treated as workstation-class today; every other role keeps the always-on infra profile.

## Acceptance criteria (issue #1721)

- [x] Reliability scoring reads `devices.device_role` and applies a device-type-aware weight profile; uptime is dropped for `workstation` roles vs `server`/infra roles.
- [x] The weight profile actually used is persisted in `details.factors` (and `details.weightProfile`) so the card's per-factor "% weight" reflects the role-specific weighting.
- [x] The `uptime` top-issue is not flagged for workstation roles where regular sleep/shutdown is expected.
- [x] Tests cover the role-based weight selection in `reliabilityScoring.test.ts`.
- [ ] _(Parts 1 & 2 — card CTA + ML-feedback button relabeling — deferred to a follow-up.)_

## Testing

- `apps/api` affected suites green single-fork: `vitest run src/services/reliabilityScoring.test.ts` (66 passed, +14 new) and `reliabilityScoring.featureFlag.test.ts` (2 passed).
- `tsc --noEmit -p apps/api/tsconfig.json` clean (exit 0).

Refs #1721 (part 3 of 3; parts 1 & 2 deferred to a follow-up — do not auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
