### PR TITLE
fix(download): surface S3 transport errors as 500 instead of masking as 404 (#1802)

### DIFF
--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -182,12 +182,39 @@ describe('S3 transport failures surface as 500, not a masked 404 (issue #1802)',
     );
   });
 
-  it('still falls back to disk and 404s when the S3 object genuinely does not exist', async () => {
-    vi.mocked(getPresignedUrl).mockRejectedValue(
-      Object.assign(new Error('missing'), { name: 'NotFound' }),
-    );
+  it.each([
+    ['agent', '/download/linux/amd64', '[agent-download]', 'NotFound'],
+    ['helper', '/download/helper/linux/amd64', '[helper-download]', 'NoSuchKey'],
+    ['watchdog', '/download/watchdog/linux/amd64', '[watchdog-download]', 'NotFound'],
+  ])(
+    'still falls back to disk and 404s for the %s route when the S3 object genuinely does not exist',
+    async (_name, path, logTag, errName) => {
+      vi.mocked(getPresignedUrl).mockRejectedValue(
+        Object.assign(new Error('missing'), { name: errName }),
+      );
+      const res = await downloadRoutes.request(path);
+
+      expect(res.status).toBe(404);
+      // The genuine miss must be a warn-level fall-through, never the 500 error path.
+      expect(console.error).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining(`${logTag} S3 object missing`),
+        expect.anything(),
+      );
+    },
+  );
+
+  it('treats an S3 error with no identifiable name as a transport fault (500), not a missing object', async () => {
+    // The whole fix hinges on the conservative default: anything we cannot
+    // positively classify as NotFound/NoSuchKey must surface as a 500, never be
+    // swallowed by the disk fallback. A future refactor that defaulted unknown
+    // errors to "not found" would silently reintroduce the #1802 masking bug —
+    // this pins the boundary. A bare Error has name 'Error' (not NotFound).
+    vi.mocked(getPresignedUrl).mockRejectedValue(new Error('opaque failure'));
     const res = await downloadRoutes.request('/download/linux/amd64');
-    expect(res.status).toBe(404);
+
+    expect(res.status).toBe(500);
+    expect(console.error).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -136,6 +136,61 @@ describe('public agent binary downloads', () => {
   });
 });
 
+describe('S3 transport failures surface as 500, not a masked 404 (issue #1802)', () => {
+  const originalAgentDir = process.env.AGENT_BINARY_DIR;
+  const originalHelperDir = process.env.HELPER_BINARY_DIR;
+
+  beforeEach(() => {
+    // Point at non-existent dirs so any disk fallback would 404 — proving the
+    // 500 comes from the S3 guard, not from a disk hit.
+    process.env.AGENT_BINARY_DIR = '/tmp/breeze-nonexistent-agent-binaries';
+    process.env.HELPER_BINARY_DIR = '/tmp/breeze-nonexistent-helper-binaries';
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.mocked(isS3Configured).mockReturnValue(true);
+    vi.mocked(getPresignedUrl).mockRejectedValue(
+      Object.assign(new Error('credentials expired'), { name: 'CredentialsProviderError' }),
+    );
+  });
+
+  afterEach(() => {
+    if (originalAgentDir === undefined) delete process.env.AGENT_BINARY_DIR;
+    else process.env.AGENT_BINARY_DIR = originalAgentDir;
+    if (originalHelperDir === undefined) delete process.env.HELPER_BINARY_DIR;
+    else process.env.HELPER_BINARY_DIR = originalHelperDir;
+    vi.restoreAllMocks();
+    vi.mocked(getBinarySource).mockReset();
+    vi.mocked(isS3Configured).mockReset();
+    vi.mocked(getPresignedUrl).mockReset();
+  });
+
+  it.each([
+    ['agent', '/download/linux/amd64', '[agent-download]'],
+    ['helper', '/download/helper/linux/amd64', '[helper-download]'],
+    ['watchdog', '/download/watchdog/linux/amd64', '[watchdog-download]'],
+  ])('returns 500 for the %s route on a non-NotFound S3 error', async (_name, path, logTag) => {
+    const res = await downloadRoutes.request(path);
+    const body = await res.text();
+
+    expect(res.status).toBe(500);
+    expect(body).not.toContain('not available');
+    expect(body).not.toContain('/tmp');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(`${logTag} S3 presign failed`),
+      expect.anything(),
+    );
+  });
+
+  it('still falls back to disk and 404s when the S3 object genuinely does not exist', async () => {
+    vi.mocked(getPresignedUrl).mockRejectedValue(
+      Object.assign(new Error('missing'), { name: 'NotFound' }),
+    );
+    const res = await downloadRoutes.request('/download/linux/amd64');
+    expect(res.status).toBe(404);
+  });
+});
+
 describe('public agent .pkg downloads — per-arch serving', () => {
   const originalAgentDir = process.env.AGENT_BINARY_DIR;
   let tmp: string;
@@ -214,6 +269,29 @@ describe('public agent .pkg downloads — per-arch serving', () => {
 
     expect(res.status).toBe(404);
     expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[pkg-download] S3 object missing'),
+      expect.anything(),
+    );
+  });
+
+  it('returns 500 (not a masked 404) when the S3 presign fails with a transport/auth error', async () => {
+    // issue #1802 item 3: a non-NotFound S3 fault (network/credentials/throttle)
+    // must NOT fall through to disk and 404 — on hosted infra there are no
+    // binaries on disk, so the real error would be hidden as "package not found".
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(isS3Configured).mockReturnValue(true);
+    vi.mocked(getPresignedUrl).mockRejectedValue(
+      Object.assign(new Error('connection reset'), { name: 'TimeoutError' }),
+    );
+
+    const res = await downloadRoutes.request('/download/darwin/amd64/pkg');
+    const body = await res.text();
+
+    expect(res.status).toBe(500);
+    // Must not be masked as a not-found, and must not leak internals.
+    expect(body).not.toContain('not found');
+    expect(body).not.toContain('/tmp');
+    expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('[pkg-download] S3 presign failed'),
       expect.anything(),
     );

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -7,6 +7,17 @@ import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelp
 
 export const downloadRoutes = new Hono();
 
+// A presigned-URL failure is only "the object isn't there" for NotFound /
+// NoSuchKey — anything else (network, credentials, throttling, DNS) is a real
+// S3 transport/auth fault. Distinguishing them matters because the disk
+// fallback below 404s when the binary isn't on local disk: on hosted infra
+// (S3-only, no binaries on disk) a transport fault would otherwise be masked as
+// a misleading "binary not found" 404 instead of surfacing as a 500 (issue #1802).
+function isS3NotFound(err: unknown): boolean {
+  const errName = (err as { name?: string }).name;
+  return errName === 'NotFound' || errName === 'NoSuchKey';
+}
+
 // ============================================
 // Agent Binary Download (public, no auth)
 // ============================================
@@ -50,10 +61,13 @@ downloadRoutes.get('/download/:os/:arch', async (c) => {
       const url = await getPresignedUrl(s3Key);
       return c.redirect(url, 302);
     } catch (err) {
-      const errName = (err as { name?: string }).name;
-      const isNotFound = errName === 'NotFound' || errName === 'NoSuchKey';
-      const level = isNotFound ? 'warn' : 'error';
-      console[level](`[agent-download] S3 presign failed for ${filename}, falling back to disk:`, err);
+      if (!isS3NotFound(err)) {
+        // Real S3 transport/auth fault — surface it instead of masking it as a
+        // disk-fallback 404. The binary may well exist in S3; we just couldn't reach it.
+        console.error(`[agent-download] S3 presign failed for ${filename}:`, err);
+        return c.json({ error: 'Internal server error', message: 'Failed to retrieve binary file' }, 500);
+      }
+      console.warn(`[agent-download] S3 object missing for ${filename}, falling back to disk:`, err);
     }
   }
 
@@ -141,10 +155,11 @@ downloadRoutes.get('/download/:os/:arch/pkg', async (c) => {
       const url = await getPresignedUrl(`agent/${filename}`);
       return c.redirect(url, 302);
     } catch (err) {
-      const errName = (err as { name?: string }).name;
-      const isNotFound = errName === 'NotFound' || errName === 'NoSuchKey';
-      const level = isNotFound ? 'warn' : 'error';
-      console[level](`[pkg-download] S3 presign failed for ${filename}, falling back to disk:`, err);
+      if (!isS3NotFound(err)) {
+        console.error(`[pkg-download] S3 presign failed for ${filename}:`, err);
+        return c.json({ error: 'Internal server error', message: 'Failed to retrieve installer package' }, 500);
+      }
+      console.warn(`[pkg-download] S3 object missing for ${filename}, falling back to disk:`, err);
     }
   }
 
@@ -230,10 +245,11 @@ downloadRoutes.get('/download/helper/:os/:arch', async (c) => {
       const url = await getPresignedUrl(s3Key);
       return c.redirect(url, 302);
     } catch (err) {
-      const errName = (err as { name?: string }).name;
-      const isNotFound = errName === 'NotFound' || errName === 'NoSuchKey';
-      const level = isNotFound ? 'warn' : 'error';
-      console[level](`[helper-download] S3 presign failed for ${filename}, falling back to disk:`, err);
+      if (!isS3NotFound(err)) {
+        console.error(`[helper-download] S3 presign failed for ${filename}:`, err);
+        return c.json({ error: 'Internal server error', message: 'Failed to retrieve binary file' }, 500);
+      }
+      console.warn(`[helper-download] S3 object missing for ${filename}, falling back to disk:`, err);
     }
   }
 
@@ -317,10 +333,11 @@ downloadRoutes.get('/download/watchdog/:os/:arch', async (c) => {
       const url = await getPresignedUrl(s3Key);
       return c.redirect(url, 302);
     } catch (err) {
-      const errName = (err as { name?: string }).name;
-      const isNotFound = errName === 'NotFound' || errName === 'NoSuchKey';
-      const level = isNotFound ? 'warn' : 'error';
-      console[level](`[watchdog-download] S3 presign failed for ${filename}, falling back to disk:`, err);
+      if (!isS3NotFound(err)) {
+        console.error(`[watchdog-download] S3 presign failed for ${filename}:`, err);
+        return c.json({ error: 'Internal server error', message: 'Failed to retrieve binary file' }, 500);
+      }
+      console.warn(`[watchdog-download] S3 object missing for ${filename}, falling back to disk:`, err);
     }
   }
 


### PR DESCRIPTION
## What

Fixes **item 3** of #1802: the public binary-download routes mask S3 transport/auth failures as a 404.

## Root cause

All four public download routes — `/download/:os/:arch` (agent), `/download/:os/:arch/pkg`, `/download/helper/:os/:arch`, `/download/watchdog/:os/:arch` in `apps/api/src/routes/agents/download.ts` — try an S3 presigned redirect first, then **fall through to disk** on *any* presign error. The catch block only used the NotFound-vs-other distinction to pick a log level (`warn` vs `error`); it fell through to disk regardless.

When the binary isn't on local disk — the normal case on hosted infra, where binaries live only in S3 — the disk fallback then returns **404 "binary not found."** So a real S3 transport/auth fault (network, expired credentials, throttling, DNS) surfaced to the agent/installer as a misleading "the binary doesn't exist," hiding the actual outage.

## Fix

Only a genuine `NotFound` / `NoSuchKey` now falls through to the disk fallback. Any other presign error returns **500** so the real fault is visible (and greppable in logs at `error` level). The NotFound check is extracted into a shared `isS3NotFound(err)` helper applied uniformly across all four routes. No change to the GitHub-redirect path, the genuine-missing path (still 404), or the disk-serving path. No leak of internal paths in the 500 body.

## Tests

`apps/api/src/routes/agents/download.test.ts`:
- New table-driven cases asserting **500** (not a masked 404) for the agent, helper, and watchdog routes on a non-NotFound S3 error, plus a pkg-route case.
- A guard that a genuine `NotFound` still falls back to disk and 404s (behavior preserved).
- Updated the existing "S3 object missing" assertion to the new `warn` log wording.

`vitest run src/routes/agents/download.test.ts` → 38 passed. `tsc --noEmit` clean.

## Scope note

This PR addresses only item 3 of #1802. The release gate (item 1, real-Windows watchdog-swap canary) and items 2 (heartbeat watchdog-version telemetry) and 4 (`BINARY_SOURCE=local` watchdog registration) are out of scope and the issue should remain open for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)