### PR TITLE
docs(issue-fixer): warn about the spawn-inside-an-existing-worktree trap

### DIFF
--- a/.claude/agents/issue-fixer.md
+++ b/.claude/agents/issue-fixer.md
@@ -30,7 +30,13 @@ runbook; this prompt only sets expectations.
     You have no separate GitHub identity, so never treat the operator's own
     assigned issues as poaching.
 - **Work in an isolated git worktree off fresh `main`.** Never edit the shared
-  main working copy in place.
+  main working copy in place. **You are likely spawned with your CWD already
+  inside an existing worktree that belongs to a *different* task — do NOT work
+  there and do NOT reach back into `/Users/toddhebebrand/breeze`. Create your
+  OWN new worktree off freshly-fetched `origin/main`, `cd` into it, and verify
+  the base commit before branching.** (Both failure modes — reusing the spawn
+  worktree and editing the shared checkout — have silently reverted other PRs'
+  files this session.)
 - **Verify with real evidence** (affected tests single-fork + typecheck) before
   claiming the fix is ready. Never report ready on red tests.
 - **Never merge the PR. Never close the issue.** Those are the user's calls.

--- a/.claude/skills/issue-to-pr/SKILL.md
+++ b/.claude/skills/issue-to-pr/SKILL.md
@@ -132,6 +132,16 @@ copy at `/Users/toddhebebrand/breeze` is shared across sessions and drifts —
 **verify your base is fresh `main`** before branching (a stale base has nearly
 shipped dozens of unrelated commits in a PR).
 
+**Spawn-location trap (read this):** When an orchestrator fans you out, your
+CWD is very likely **already inside an existing worktree under
+`.claude/worktrees/` that belongs to a *different* task**. That is NOT your
+workspace. Do **not** edit there, and do **not** reach back into the shared
+`/Users/toddhebebrand/breeze` checkout (it may be on a stale branch). Always
+`git fetch origin main`, then create your **own** new worktree off
+`origin/main`, `cd` into it, and confirm `git rev-parse HEAD` equals
+`origin/main` before you branch. Editing the spawn worktree or the shared
+checkout has silently reverted other in-flight PRs' files.
+
 Branch naming (AGENTS.md — no `codex/` / `claude/` prefixes):
 `fix/N-short-slug`, `feat/N-short-slug`, `docs/short-slug`, `chore/short-slug`.
 
@@ -208,6 +218,7 @@ are the user's judgment calls — see the merge/hold rules. The issue stays
 - "Someone's assigned but they seem stalled, I'll take it." → **Abort & report** — don't poach. (But an issue assigned to the operator's own `@me` account is *not* poaching — work it; see step 1.)
 - "No *open* PR, so nobody's fixed it." → Check **merged/closed** PRs + commits on `main` too. Open-only is a blind spot.
 - "I'll skip the worktree, the main copy is fine." → No. Stale base + shared copy = wrong-commit PR.
+- "I'm already inside a worktree, I'll just use this one." → No — it's another task's worktree. Make your *own* off fresh `origin/main`.
 - "Affected tests pass, skip the rest / skip typecheck." → Run typecheck (and astro check) too.
 - "Posting 'ready for review' is enough." → No. Record *which review ran and what it found*.
 


### PR DESCRIPTION
The `issue-to-pr` skill already mandates an isolated worktree, but agents fanned out by an orchestrator are spawned with their CWD **already inside an existing worktree that belongs to a different task**. Twice in one session an `issue-fixer` either reused that spawn worktree or reached back into the shared `/Users/toddhebebrand/breeze` checkout (on a stale branch), silently reverting other in-flight PRs' files (one nearly re-broke a PR that had just merged).

This adds an explicit **"spawn-location trap"** callout in three places:
- `.claude/skills/issue-to-pr/SKILL.md` §3 — fetch + create your *own* worktree off `origin/main`, `cd` in, verify `HEAD == origin/main` before branching.
- `.claude/agents/issue-fixer.md` — same warning in the agent's hard rules.
- the skill's rationalization-guard table — "I'm already inside a worktree, I'll just use this one." → No.

Docs/tooling only; no app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)