### PR TITLE
feat(web): reliability card Ask-AI CTA + Mark-outcome menu (#1721 parts 1-2)

### DIFF
--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -6,9 +6,15 @@ import { fetchWithAuth } from '../../stores/auth';
 
 const showToast = vi.fn();
 const useMlFeatureFlagsMock = vi.hoisted(() => vi.fn());
+const startDeviceTaskMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../../stores/aiStore', () => ({
+  useAiStore: (selector: (s: { startDeviceTask: unknown }) => unknown) =>
+    selector({ startDeviceTask: startDeviceTaskMock }),
 }));
 
 vi.mock('../../hooks/useMlFeatureFlags', () => ({
@@ -183,6 +189,45 @@ describe('DeviceReliabilityPanel', () => {
     render(<DeviceReliabilityPanel deviceId="dev-1" />);
 
     await screen.findByText('No reliability snapshot available yet.');
+  });
+
+  it('Ask AI button starts a device task seeded with the snapshot', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          hostname: 'host-1',
+          osType: 'windows',
+          status: 'online',
+          reliabilityScore: 44,
+          trendDirection: 'degrading',
+          trendConfidence: 0.8,
+          uptime30d: 94.2,
+          crashCount30d: 4,
+          hangCount30d: 1,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 1,
+          mtbfHours: 72,
+          topIssues: [{ type: 'crashes', count: 4, severity: 'critical' }],
+          drivers: [
+            { factor: 'crashes', label: 'Crashes', score: 20, weight: 36, lostPoints: 28.8, evidence: { crashCount30d: 4 } },
+          ],
+          computedAt: '2026-06-18T12:00:00.000Z',
+        },
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    fireEvent.click(await screen.findByTestId('reliability-ask-ai'));
+
+    expect(startDeviceTaskMock).toHaveBeenCalledTimes(1);
+    const [deviceId, ctx, seed] = startDeviceTaskMock.mock.calls[0];
+    expect(deviceId).toBe('dev-1');
+    expect(ctx).toMatchObject({ type: 'device', id: 'dev-1', hostname: 'host-1', os: 'windows', status: 'online' });
+    expect(seed).toContain('44/100');
+    expect(seed).toContain('Crashes');
   });
 
   it('shows a disabled state without fetching reliability when the feature flag is off', async () => {

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -36,6 +36,10 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
   }) as unknown as Response;
 
 describe('DeviceReliabilityPanel', () => {
+  const openOutcomeMenu = async () => {
+    fireEvent.click(await screen.findByTestId('reliability-outcome-trigger'));
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     showToast.mockReset();
@@ -115,8 +119,8 @@ describe('DeviceReliabilityPanel', () => {
 
     render(<DeviceReliabilityPanel deviceId="dev-1" />);
 
-    const falseAlarm = await screen.findByRole('button', { name: /false alarm/i });
-    fireEvent.click(falseAlarm);
+    await openOutcomeMenu();
+    fireEvent.click(screen.getByTestId('reliability-outcome-false_alarm'));
 
     await waitFor(() => {
       expect(fetchWithAuthMock).toHaveBeenCalledWith(
@@ -162,7 +166,8 @@ describe('DeviceReliabilityPanel', () => {
 
     render(<DeviceReliabilityPanel deviceId="dev-1" />);
 
-    fireEvent.click(await screen.findByRole('button', { name: /false alarm/i }));
+    await openOutcomeMenu();
+    fireEvent.click(screen.getByTestId('reliability-outcome-false_alarm'));
 
     await waitFor(() => {
       expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
@@ -250,6 +255,6 @@ describe('DeviceReliabilityPanel', () => {
 
     expect(await screen.findByText('Reliability scoring is disabled for this organization.')).toBeTruthy();
     expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/reliability/dev-1');
-    expect(screen.queryByRole('button', { name: /false alarm/i })).toBeNull();
+    expect(screen.queryByTestId('reliability-outcome-trigger')).toBeNull();
   });
 });

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -120,6 +120,7 @@ describe('DeviceReliabilityPanel', () => {
     render(<DeviceReliabilityPanel deviceId="dev-1" />);
 
     await openOutcomeMenu();
+    expect(screen.getByTestId('reliability-outcome-menu')).toBeTruthy();
     fireEvent.click(screen.getByTestId('reliability-outcome-false_alarm'));
 
     await waitFor(() => {
@@ -138,6 +139,11 @@ describe('DeviceReliabilityPanel', () => {
       type: 'success',
       message: 'False alarm label saved',
     }));
+
+    // Menu closes after selecting an outcome (close-on-select).
+    await waitFor(() => {
+      expect(screen.queryByTestId('reliability-outcome-menu')).toBeNull();
+    });
   });
 
   it('toasts an error when feedback submission fails (non-2xx)', async () => {
@@ -233,6 +239,41 @@ describe('DeviceReliabilityPanel', () => {
     expect(ctx).toMatchObject({ type: 'device', id: 'dev-1', hostname: 'host-1', os: 'windows', status: 'online' });
     expect(seed).toContain('44/100');
     expect(seed).toContain('Crashes');
+  });
+
+  it('seeds the AI prompt with healthy-device fallbacks (no MTBF, no drivers)', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          hostname: 'host-1',
+          osType: 'macos',
+          status: 'online',
+          reliabilityScore: 98,
+          trendDirection: 'stable',
+          trendConfidence: 0.2,
+          uptime30d: 99.9,
+          crashCount30d: 0,
+          hangCount30d: 0,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 0,
+          mtbfHours: null,
+          topIssues: [],
+          drivers: [],
+          computedAt: '2026-06-18T12:00:00.000Z',
+        },
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    fireEvent.click(await screen.findByTestId('reliability-ask-ai'));
+
+    const [, , seed] = startDeviceTaskMock.mock.calls[0];
+    expect(seed).toContain('98/100');
+    expect(seed).toContain('MTBF unknown');
+    expect(seed).toContain('none flagged');
   });
 
   it('shows a disabled state without fetching reliability when the feature flag is off', async () => {

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, CheckCircle, RefreshCw, ShieldCheck, Sparkles, Wrench, XCircle } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AlertTriangle, ChevronDown, RefreshCw, ShieldCheck, Sparkles, Wrench, XCircle } from 'lucide-react';
 
 import type { AiPageContext } from '@breeze/shared';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { useAiStore } from '../../stores/aiStore';
 
 type ReliabilityTopIssue = {
@@ -54,6 +55,17 @@ const issueLabels: Record<ReliabilityTopIssue['type'], string> = {
   hardware: 'Hardware errors',
   uptime: 'Uptime',
 };
+
+const OUTCOME_ITEMS: Array<{
+  outcome: 'failure_confirmed' | 'replaced' | 'false_alarm';
+  label: string;
+  Icon: typeof AlertTriangle;
+  iconClass: string;
+}> = [
+  { outcome: 'failure_confirmed', label: 'Device failed', Icon: AlertTriangle, iconClass: 'text-destructive' },
+  { outcome: 'replaced', label: 'Device replaced', Icon: Wrench, iconClass: 'text-muted-foreground' },
+  { outcome: 'false_alarm', label: 'False alarm', Icon: XCircle, iconClass: 'text-muted-foreground' },
+];
 
 function scoreClass(score: number): string {
   if (score <= 50) return 'text-destructive';
@@ -161,6 +173,15 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
     };
     void startDeviceTask(deviceId, ctx, buildReliabilitySeedPrompt(snapshot, drivers));
   }, [snapshot, deviceId, drivers, startDeviceTask]);
+
+  const [outcomeMenuOpen, setOutcomeMenuOpen] = useState(false);
+  const outcomeMenuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(outcomeMenuOpen, outcomeMenuRef, () => setOutcomeMenuOpen(false));
+
+  function handleOutcome(outcome: 'failure_confirmed' | 'replaced' | 'false_alarm') {
+    setOutcomeMenuOpen(false);
+    void submitFeedback(outcome);
+  }
 
   async function submitFeedback(outcome: 'failure_confirmed' | 'replaced' | 'false_alarm') {
     setLabeling(outcome);
@@ -296,34 +317,48 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
             <Sparkles className="h-4 w-4" />
             Ask AI about reliability
           </button>
-          <div className="flex flex-wrap gap-2">
+          <div ref={outcomeMenuRef} className="relative">
             <button
               type="button"
-              onClick={() => void submitFeedback('failure_confirmed')}
+              data-testid="reliability-outcome-trigger"
+              aria-haspopup="true"
+              aria-expanded={outcomeMenuOpen}
               disabled={labeling !== null}
-              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => setOutcomeMenuOpen((o) => !o)}
+              className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <CheckCircle className="h-4 w-4" />
-              Failure
+              Mark outcome
+              <ChevronDown className="h-3.5 w-3.5" />
             </button>
-            <button
-              type="button"
-              onClick={() => void submitFeedback('replaced')}
-              disabled={labeling !== null}
-              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <Wrench className="h-4 w-4" />
-              Replaced
-            </button>
-            <button
-              type="button"
-              onClick={() => void submitFeedback('false_alarm')}
-              disabled={labeling !== null}
-              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <XCircle className="h-4 w-4" />
-              False alarm
-            </button>
+
+            {outcomeMenuOpen && (
+              <div
+                role="menu"
+                data-testid="reliability-outcome-menu"
+                className="absolute right-0 top-9 z-30 w-64 rounded-md border bg-popover p-1 shadow-lg"
+              >
+                <p className="px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Was this accurate?
+                </p>
+                {OUTCOME_ITEMS.map(({ outcome, label, Icon, iconClass }) => (
+                  <button
+                    key={outcome}
+                    type="button"
+                    data-testid={`reliability-outcome-${outcome}`}
+                    disabled={labeling !== null}
+                    onClick={() => handleOutcome(outcome)}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <Icon className={`h-4 w-4 shrink-0 ${iconClass}`} />
+                    {label}
+                  </button>
+                ))}
+                <hr className="my-1" />
+                <p className="px-2 pb-1.5 pt-0.5 text-xs text-muted-foreground">
+                  These train the reliability model — they don't change the device.
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, CheckCircle, RefreshCw, ShieldCheck, Wrench, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle, RefreshCw, ShieldCheck, Sparkles, Wrench, XCircle } from 'lucide-react';
 
+import type { AiPageContext } from '@breeze/shared';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
+import { useAiStore } from '../../stores/aiStore';
 
 type ReliabilityTopIssue = {
   type: 'crashes' | 'hangs' | 'services' | 'hardware' | 'uptime';
@@ -24,6 +26,9 @@ type ReliabilityDriver = {
 
 type ReliabilitySnapshot = {
   deviceId: string;
+  hostname?: string;
+  osType?: 'windows' | 'macos' | 'linux';
+  status?: string;
   reliabilityScore: number;
   trendDirection: 'improving' | 'stable' | 'degrading';
   trendConfidence: number;
@@ -62,6 +67,27 @@ function scoreBarClass(score: number): string {
   if (score <= 70) return 'bg-warning';
   if (score <= 85) return 'bg-info';
   return 'bg-success';
+}
+
+function scoreBandLabel(score: number): string {
+  if (score <= 50) return 'critical';
+  if (score <= 70) return 'poor';
+  if (score <= 85) return 'fair';
+  return 'good';
+}
+
+function buildReliabilitySeedPrompt(snapshot: ReliabilitySnapshot, drivers: ReliabilityDriver[]): string {
+  const mtbf = snapshot.mtbfHours === null ? 'unknown' : `${Math.round(snapshot.mtbfHours)}h`;
+  const driverText = drivers.length > 0
+    ? drivers.map((d) => `${d.label} (score ${d.score})`).join('; ')
+    : 'none flagged';
+  return [
+    `Review this device's reliability and recommend what to do.`,
+    `Score ${snapshot.reliabilityScore}/100 (${scoreBandLabel(snapshot.reliabilityScore)}), trend ${snapshot.trendDirection}.`,
+    `30-day uptime ${snapshot.uptime30d.toFixed(1)}%, MTBF ${mtbf}.`,
+    `Top factors dragging the score: ${driverText}.`,
+    `What are the likely root causes, and what remediation — scripts, checks, or a ticket — do you recommend?`,
+  ].join(' ');
 }
 
 function formatDate(value: string): string {
@@ -121,6 +147,20 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
   }, [fetchReliability, mlFlags.loaded, reliabilityDisabled]);
 
   const drivers = useMemo(() => (snapshot?.drivers ?? []).slice(0, 3), [snapshot?.drivers]);
+
+  const startDeviceTask = useAiStore((s) => s.startDeviceTask);
+
+  const askAi = useCallback(() => {
+    if (!snapshot) return;
+    const ctx: AiPageContext = {
+      type: 'device',
+      id: deviceId,
+      hostname: snapshot.hostname ?? deviceId,
+      os: snapshot.osType,
+      status: snapshot.status,
+    };
+    void startDeviceTask(deviceId, ctx, buildReliabilitySeedPrompt(snapshot, drivers));
+  }, [snapshot, deviceId, drivers, startDeviceTask]);
 
   async function submitFeedback(outcome: 'failure_confirmed' | 'replaced' | 'false_alarm') {
     setLabeling(outcome);
@@ -246,34 +286,45 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
           <p className="mt-2 text-xs text-muted-foreground">Updated {formatDate(snapshot.computedAt)}</p>
         </div>
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-col items-start gap-2 xl:items-end">
           <button
             type="button"
-            onClick={() => void submitFeedback('failure_confirmed')}
-            disabled={labeling !== null}
-            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="reliability-ask-ai"
+            onClick={askAi}
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
           >
-            <CheckCircle className="h-4 w-4" />
-            Failure
+            <Sparkles className="h-4 w-4" />
+            Ask AI about reliability
           </button>
-          <button
-            type="button"
-            onClick={() => void submitFeedback('replaced')}
-            disabled={labeling !== null}
-            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <Wrench className="h-4 w-4" />
-            Replaced
-          </button>
-          <button
-            type="button"
-            onClick={() => void submitFeedback('false_alarm')}
-            disabled={labeling !== null}
-            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <XCircle className="h-4 w-4" />
-            False alarm
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void submitFeedback('failure_confirmed')}
+              disabled={labeling !== null}
+              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <CheckCircle className="h-4 w-4" />
+              Failure
+            </button>
+            <button
+              type="button"
+              onClick={() => void submitFeedback('replaced')}
+              disabled={labeling !== null}
+              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Wrench className="h-4 w-4" />
+              Replaced
+            </button>
+            <button
+              type="button"
+              onClick={() => void submitFeedback('false_alarm')}
+              disabled={labeling !== null}
+              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <XCircle className="h-4 w-4" />
+              False alarm
+            </button>
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/stores/aiStore.test.ts
+++ b/apps/web/src/stores/aiStore.test.ts
@@ -122,4 +122,47 @@ describe('ai store', () => {
     expect(useAiStore.getState().isStreaming).toBe(false);
     expect(useAiStore.getState().error).toContain('already being processed');
   });
+
+  it('startDeviceTask forwards initialMessage to sendMessage', async () => {
+    const state = useAiStore.getState();
+    const createSpy = vi.spyOn(state, 'createSession').mockImplementation(async () => {
+      useAiStore.setState({ sessionId: 'session-x' });
+    });
+    const sendSpy = vi.spyOn(state, 'sendMessage').mockResolvedValue();
+
+    await useAiStore.getState().startDeviceTask(
+      'dev-1',
+      { type: 'device', id: 'dev-1', hostname: 'host-1' },
+      'seed prompt',
+    );
+
+    expect(createSpy).toHaveBeenCalledWith({ deviceId: 'dev-1' });
+    expect(sendSpy).toHaveBeenCalledWith('seed prompt');
+    expect(useAiStore.getState().isOpen).toBe(true);
+    expect(useAiStore.getState().pageContext).toEqual({ type: 'device', id: 'dev-1', hostname: 'host-1' });
+  });
+
+  it('startDeviceTask does not send when initialMessage is omitted', async () => {
+    const state = useAiStore.getState();
+    vi.spyOn(state, 'createSession').mockImplementation(async () => {
+      useAiStore.setState({ sessionId: 'session-x' });
+    });
+    const sendSpy = vi.spyOn(state, 'sendMessage').mockResolvedValue();
+
+    await useAiStore.getState().startDeviceTask('dev-1', { type: 'device', id: 'dev-1', hostname: 'host-1' });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('startDeviceTask does not send when session creation failed', async () => {
+    const state = useAiStore.getState();
+    vi.spyOn(state, 'createSession').mockImplementation(async () => {
+      useAiStore.setState({ sessionId: null, error: 'nope' });
+    });
+    const sendSpy = vi.spyOn(state, 'sendMessage').mockResolvedValue();
+
+    await useAiStore.getState().startDeviceTask('dev-1', { type: 'device', id: 'dev-1', hostname: 'host-1' }, 'seed prompt');
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/stores/aiStore.ts
+++ b/apps/web/src/stores/aiStore.ts
@@ -56,7 +56,7 @@ interface AiState {
   close: () => void;
   setPageContext: (ctx: AiPageContext | null) => void;
   createSession: (opts?: { deviceId?: string }) => Promise<void>;
-  startDeviceTask: (deviceId: string, ctx: AiPageContext) => Promise<void>;
+  startDeviceTask: (deviceId: string, ctx: AiPageContext, initialMessage?: string) => Promise<void>;
   loadSession: (sessionId: string) => Promise<void>;
   loadSessions: () => Promise<void>;
   sendMessage: (content: string) => Promise<void>;
@@ -152,12 +152,18 @@ export const useAiStore = create<AiState>()(
     }
   },
 
-  // Start a fresh AI session bound to a specific device ("Fix with AI" on the
-  // device page). Sets the device page-context, opens the panel, and creates a
-  // device-scoped session; the user then types the instruction in the chat.
-  startDeviceTask: async (deviceId, ctx) => {
+  // Start a fresh AI session bound to a specific device ("Ask AI about reliability"
+  // on the device page). Sets the device page-context, opens the panel, creates a
+  // device-scoped session, and — when an initial message is supplied — auto-sends it
+  // so the tech gets an answer without retyping the context.
+  startDeviceTask: async (deviceId, ctx, initialMessage) => {
     set({ pageContext: ctx, sessionId: null, messages: [], isFlagged: false, flagReason: null, isOpen: true });
     await get().createSession({ deviceId });
+    // Only send if the session was actually created — createSession leaves
+    // sessionId null and sets `error` on failure; sending then would be session-less.
+    if (initialMessage && initialMessage.trim() && get().sessionId) {
+      await get().sendMessage(initialMessage);
+    }
   },
 
   loadSession: async (sessionId: string) => {

--- a/docs/superpowers/plans/2026-06-22-reliability-card-cta-feedback.md
+++ b/docs/superpowers/plans/2026-06-22-reliability-card-cta-feedback.md
@@ -1,0 +1,517 @@
+# Reliability Card CTA + Feedback UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Device Reliability card a primary "Ask AI about reliability" action (auto-seeded with the snapshot) and consolidate the three ML-feedback buttons into a de-emphasized "Mark outcome" menu.
+
+**Architecture:** Frontend-only. Extend `aiStore.startDeviceTask` to optionally auto-send a seed message after creating the device-scoped session. The `DeviceReliabilityPanel` builds a client-side seed prompt from the snapshot it already holds and wires the new CTA; the feedback buttons become a single click-outside menu matching the existing `SavedViewsMenu` idiom. No API or scoring changes (issue #1721 Part 3 shipped in #1804).
+
+**Tech Stack:** React + TypeScript, Zustand store, Tailwind, lucide-react icons, Vitest + Testing Library (jsdom).
+
+## Global Constraints
+
+- Node: prefix test/typecheck commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` (repo pins node 22.20.0; default node breaks pnpm engine-strict).
+- Do **not** change the ML-feedback API contract: outcome values stay `failure_confirmed` / `replaced` / `false_alarm`; endpoint stays `POST /reliability/:id/feedback`.
+- `AiPageContext` device shape (from `@breeze/shared`): `{ type: 'device'; id: string; hostname: string; os?: string; status?: string; ip?: string }`.
+- Reuse `useClickOutside(isActive, ref, onOutside)` from `apps/web/src/hooks/useClickOutside.ts` for the menu (do not hand-roll a listener).
+- Run affected web test files single-file (not the whole suite) to avoid known cross-file flakiness.
+
+---
+
+### Task 1: Auto-seed `startDeviceTask` in the AI store
+
+**Files:**
+- Modify: `apps/web/src/stores/aiStore.ts` (type decl ~line 59, implementation ~lines 155-161)
+- Test: `apps/web/src/stores/aiStore.test.ts`
+
+**Interfaces:**
+- Produces: `startDeviceTask(deviceId: string, ctx: AiPageContext, initialMessage?: string): Promise<void>` — when `initialMessage` is a non-empty string and session creation succeeded, it forwards the message to `sendMessage`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/web/src/stores/aiStore.test.ts` inside the `describe('ai store', …)` block:
+
+```ts
+  it('startDeviceTask forwards initialMessage to sendMessage', async () => {
+    const state = useAiStore.getState();
+    const createSpy = vi.spyOn(state, 'createSession').mockImplementation(async () => {
+      useAiStore.setState({ sessionId: 'session-x' });
+    });
+    const sendSpy = vi.spyOn(state, 'sendMessage').mockResolvedValue();
+
+    await useAiStore.getState().startDeviceTask(
+      'dev-1',
+      { type: 'device', id: 'dev-1', hostname: 'host-1' },
+      'seed prompt',
+    );
+
+    expect(createSpy).toHaveBeenCalledWith({ deviceId: 'dev-1' });
+    expect(sendSpy).toHaveBeenCalledWith('seed prompt');
+    expect(useAiStore.getState().isOpen).toBe(true);
+    expect(useAiStore.getState().pageContext).toEqual({ type: 'device', id: 'dev-1', hostname: 'host-1' });
+  });
+
+  it('startDeviceTask does not send when initialMessage is omitted', async () => {
+    const state = useAiStore.getState();
+    vi.spyOn(state, 'createSession').mockImplementation(async () => {
+      useAiStore.setState({ sessionId: 'session-x' });
+    });
+    const sendSpy = vi.spyOn(state, 'sendMessage').mockResolvedValue();
+
+    await useAiStore.getState().startDeviceTask('dev-1', { type: 'device', id: 'dev-1', hostname: 'host-1' });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('startDeviceTask does not send when session creation failed', async () => {
+    const state = useAiStore.getState();
+    vi.spyOn(state, 'createSession').mockImplementation(async () => {
+      useAiStore.setState({ sessionId: null, error: 'nope' });
+    });
+    const sendSpy = vi.spyOn(state, 'sendMessage').mockResolvedValue();
+
+    await useAiStore.getState().startDeviceTask('dev-1', { type: 'device', id: 'dev-1', hostname: 'host-1' }, 'seed prompt');
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/stores/aiStore.test.ts -t startDeviceTask`
+Expected: FAIL — the `startDeviceTask forwards initialMessage` test fails because the current implementation never calls `sendMessage`.
+
+- [ ] **Step 3: Update the type declaration**
+
+In `apps/web/src/stores/aiStore.ts`, change the `AiState` interface member (currently `startDeviceTask: (deviceId: string, ctx: AiPageContext) => Promise<void>;`) to:
+
+```ts
+  startDeviceTask: (deviceId: string, ctx: AiPageContext, initialMessage?: string) => Promise<void>;
+```
+
+- [ ] **Step 4: Update the implementation**
+
+Replace the existing `startDeviceTask` implementation (the block starting `startDeviceTask: async (deviceId, ctx) => {`) with:
+
+```ts
+  // Start a fresh AI session bound to a specific device ("Ask AI about reliability"
+  // on the device page). Sets the device page-context, opens the panel, creates a
+  // device-scoped session, and — when an initial message is supplied — auto-sends it
+  // so the tech gets an answer without retyping the context.
+  startDeviceTask: async (deviceId, ctx, initialMessage) => {
+    set({ pageContext: ctx, sessionId: null, messages: [], isFlagged: false, flagReason: null, isOpen: true });
+    await get().createSession({ deviceId });
+    // Only send if the session was actually created — createSession leaves
+    // sessionId null and sets `error` on failure; sending then would be session-less.
+    if (initialMessage && initialMessage.trim() && get().sessionId) {
+      await get().sendMessage(initialMessage);
+    }
+  },
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/stores/aiStore.test.ts`
+Expected: PASS (all existing tests plus the 3 new ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/stores/aiStore.ts apps/web/src/stores/aiStore.test.ts
+git commit -m "feat(web): auto-seed startDeviceTask with an initial message (#1721)"
+```
+
+---
+
+### Task 2: Primary "Ask AI about reliability" CTA on the card
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceReliabilityPanel.tsx`
+- Test: `apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAiStore` selector → `startDeviceTask(deviceId, ctx, initialMessage?)` from Task 1.
+- Produces: a `buildReliabilitySeedPrompt(snapshot, drivers)` helper and an `askAi()` handler within the component.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx`, add the store mock near the other `vi.mock` calls (top of file, after the existing mocks):
+
+```ts
+const startDeviceTaskMock = vi.hoisted(() => vi.fn());
+vi.mock('../../stores/aiStore', () => ({
+  useAiStore: (selector: (s: { startDeviceTask: unknown }) => unknown) =>
+    selector({ startDeviceTask: startDeviceTaskMock }),
+}));
+```
+
+Then add this test inside the `describe` block:
+
+```ts
+  it('Ask AI button starts a device task seeded with the snapshot', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          hostname: 'host-1',
+          osType: 'windows',
+          status: 'online',
+          reliabilityScore: 44,
+          trendDirection: 'degrading',
+          trendConfidence: 0.8,
+          uptime30d: 94.2,
+          crashCount30d: 4,
+          hangCount30d: 1,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 1,
+          mtbfHours: 72,
+          topIssues: [{ type: 'crashes', count: 4, severity: 'critical' }],
+          drivers: [
+            { factor: 'crashes', label: 'Crashes', score: 20, weight: 36, lostPoints: 28.8, evidence: { crashCount30d: 4 } },
+          ],
+          computedAt: '2026-06-18T12:00:00.000Z',
+        },
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    fireEvent.click(await screen.findByTestId('reliability-ask-ai'));
+
+    expect(startDeviceTaskMock).toHaveBeenCalledTimes(1);
+    const [deviceId, ctx, seed] = startDeviceTaskMock.mock.calls[0];
+    expect(deviceId).toBe('dev-1');
+    expect(ctx).toMatchObject({ type: 'device', id: 'dev-1', hostname: 'host-1', os: 'windows', status: 'online' });
+    expect(seed).toContain('44/100');
+    expect(seed).toContain('Crashes');
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/components/devices/DeviceReliabilityPanel.test.tsx -t "Ask AI"`
+Expected: FAIL — `Unable to find an element by: [data-testid="reliability-ask-ai"]`.
+
+- [ ] **Step 3: Extend the snapshot type and add helpers**
+
+In `DeviceReliabilityPanel.tsx`, add `hostname`, `osType`, `status` to the `ReliabilitySnapshot` type (these are already returned by `GET /reliability/:id`):
+
+```ts
+type ReliabilitySnapshot = {
+  deviceId: string;
+  hostname?: string;
+  osType?: 'windows' | 'macos' | 'linux';
+  status?: string;
+  reliabilityScore: number;
+  trendDirection: 'improving' | 'stable' | 'degrading';
+  trendConfidence: number;
+  uptime30d: number;
+  crashCount30d: number;
+  hangCount30d: number;
+  serviceFailureCount30d: number;
+  hardwareErrorCount30d: number;
+  mtbfHours: number | null;
+  topIssues: ReliabilityTopIssue[];
+  drivers?: ReliabilityDriver[];
+  computedAt: string;
+};
+```
+
+Add the imports at the top of the file:
+
+```ts
+import type { AiPageContext } from '@breeze/shared';
+import { Sparkles } from 'lucide-react';
+import { useAiStore } from '../../stores/aiStore';
+```
+
+(Merge `Sparkles` into the existing `lucide-react` import line rather than adding a duplicate import.)
+
+Add these module-level helpers (near `scoreClass`):
+
+```ts
+function scoreBandLabel(score: number): string {
+  if (score <= 50) return 'critical';
+  if (score <= 70) return 'poor';
+  if (score <= 85) return 'fair';
+  return 'good';
+}
+
+function buildReliabilitySeedPrompt(snapshot: ReliabilitySnapshot, drivers: ReliabilityDriver[]): string {
+  const mtbf = snapshot.mtbfHours === null ? 'unknown' : `${Math.round(snapshot.mtbfHours)}h`;
+  const driverText = drivers.length > 0
+    ? drivers.map((d) => `${d.label} (score ${d.score})`).join('; ')
+    : 'none flagged';
+  return [
+    `Review this device's reliability and recommend what to do.`,
+    `Score ${snapshot.reliabilityScore}/100 (${scoreBandLabel(snapshot.reliabilityScore)}), trend ${snapshot.trendDirection}.`,
+    `30-day uptime ${snapshot.uptime30d.toFixed(1)}%, MTBF ${mtbf}.`,
+    `Top factors dragging the score: ${driverText}.`,
+    `What are the likely root causes, and what remediation — scripts, checks, or a ticket — do you recommend?`,
+  ].join(' ');
+}
+```
+
+- [ ] **Step 4: Wire the handler and button**
+
+Inside the component, after the `drivers` memo, add:
+
+```ts
+  const startDeviceTask = useAiStore((s) => s.startDeviceTask);
+
+  const askAi = useCallback(() => {
+    if (!snapshot) return;
+    const ctx: AiPageContext = {
+      type: 'device',
+      id: deviceId,
+      hostname: snapshot.hostname ?? deviceId,
+      os: snapshot.osType,
+      status: snapshot.status,
+    };
+    void startDeviceTask(deviceId, ctx, buildReliabilitySeedPrompt(snapshot, drivers));
+  }, [snapshot, deviceId, drivers, startDeviceTask]);
+```
+
+In the JSX, replace the opening of the action container `<div className="flex flex-wrap gap-2">` (the wrapper around the three feedback buttons, around line 249) so the Ask AI button comes first inside a column wrapper. Change that wrapper to:
+
+```tsx
+        <div className="flex flex-col items-start gap-2 xl:items-end">
+          <button
+            type="button"
+            data-testid="reliability-ask-ai"
+            onClick={askAi}
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            <Sparkles className="h-4 w-4" />
+            Ask AI about reliability
+          </button>
+          <div className="flex flex-wrap gap-2">
+```
+
+Note: this adds one extra closing `</div>` requirement — the existing feedback-button group `</div>` now closes the inner `flex flex-wrap gap-2`, and you must add a second `</div>` to close the new outer column wrapper. (Task 3 replaces the inner group entirely, so the final structure is settled there; for this task just ensure the file compiles with balanced tags.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/components/devices/DeviceReliabilityPanel.test.tsx`
+Expected: PASS (existing tests still green — the three feedback buttons remain for now — plus the new Ask AI test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceReliabilityPanel.tsx apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+git commit -m "feat(web): add Ask AI about reliability CTA to the reliability card (#1721)"
+```
+
+---
+
+### Task 3: Consolidate feedback into a "Mark outcome" menu
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceReliabilityPanel.tsx`
+- Test: `apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `submitFeedback(outcome)` (unchanged), `useClickOutside` hook.
+- Produces: a click-outside dropdown with `data-testid` `reliability-outcome-trigger`, `reliability-outcome-menu`, and per-item `reliability-outcome-{outcome}`.
+
+- [ ] **Step 1: Rework the failing tests**
+
+In `DeviceReliabilityPanel.test.tsx`:
+
+(a) Add a helper near the top of the `describe` block:
+
+```ts
+  const openOutcomeMenu = async () => {
+    fireEvent.click(await screen.findByTestId('reliability-outcome-trigger'));
+  };
+```
+
+(b) In the **"posts false alarm feedback through runAction"** test, replace the lines that find and click the false-alarm button:
+
+```ts
+    const falseAlarm = await screen.findByRole('button', { name: /false alarm/i });
+    fireEvent.click(falseAlarm);
+```
+
+with:
+
+```ts
+    await openOutcomeMenu();
+    fireEvent.click(screen.getByTestId('reliability-outcome-false_alarm'));
+```
+
+(c) In the **"toasts an error when feedback submission fails (non-2xx)"** test, replace:
+
+```ts
+    fireEvent.click(await screen.findByRole('button', { name: /false alarm/i }));
+```
+
+with:
+
+```ts
+    await openOutcomeMenu();
+    fireEvent.click(screen.getByTestId('reliability-outcome-false_alarm'));
+```
+
+(d) In the **"shows a disabled state…"** test, replace the final assertion:
+
+```ts
+    expect(screen.queryByRole('button', { name: /false alarm/i })).toBeNull();
+```
+
+with:
+
+```ts
+    expect(screen.queryByTestId('reliability-outcome-trigger')).toBeNull();
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/components/devices/DeviceReliabilityPanel.test.tsx`
+Expected: FAIL — `reliability-outcome-trigger` testid does not exist yet.
+
+- [ ] **Step 3: Add menu state and item config**
+
+In `DeviceReliabilityPanel.tsx`:
+
+Add imports — `useRef` to the React import, `ChevronDown` to the lucide import, and the hook:
+
+```ts
+import { useClickOutside } from '../../hooks/useClickOutside';
+```
+
+Remove `CheckCircle` from the lucide-react import (it is no longer used after this task; `AlertTriangle`, `Wrench`, `XCircle`, `Sparkles`, `ShieldCheck`, `RefreshCw` remain).
+
+Add a module-level constant (near the other consts):
+
+```ts
+const OUTCOME_ITEMS: Array<{
+  outcome: 'failure_confirmed' | 'replaced' | 'false_alarm';
+  label: string;
+  Icon: typeof AlertTriangle;
+  iconClass: string;
+}> = [
+  { outcome: 'failure_confirmed', label: 'Device failed', Icon: AlertTriangle, iconClass: 'text-destructive' },
+  { outcome: 'replaced', label: 'Device replaced', Icon: Wrench, iconClass: 'text-muted-foreground' },
+  { outcome: 'false_alarm', label: 'False alarm', Icon: XCircle, iconClass: 'text-muted-foreground' },
+];
+```
+
+Inside the component, after the `askAi` handler, add:
+
+```ts
+  const [outcomeMenuOpen, setOutcomeMenuOpen] = useState(false);
+  const outcomeMenuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(outcomeMenuOpen, outcomeMenuRef, () => setOutcomeMenuOpen(false));
+
+  function handleOutcome(outcome: 'failure_confirmed' | 'replaced' | 'false_alarm') {
+    setOutcomeMenuOpen(false);
+    void submitFeedback(outcome);
+  }
+```
+
+- [ ] **Step 4: Replace the three buttons with the menu**
+
+Replace the inner feedback-button group (the `<div className="flex flex-wrap gap-2">` containing the three `submitFeedback` buttons) with this menu block (it lives inside the column wrapper added in Task 2):
+
+```tsx
+          <div ref={outcomeMenuRef} className="relative">
+            <button
+              type="button"
+              data-testid="reliability-outcome-trigger"
+              aria-haspopup="true"
+              aria-expanded={outcomeMenuOpen}
+              disabled={labeling !== null}
+              onClick={() => setOutcomeMenuOpen((o) => !o)}
+              className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Mark outcome
+              <ChevronDown className="h-3.5 w-3.5" />
+            </button>
+
+            {outcomeMenuOpen && (
+              <div
+                role="menu"
+                data-testid="reliability-outcome-menu"
+                className="absolute right-0 top-9 z-30 w-64 rounded-md border bg-popover p-1 shadow-lg"
+              >
+                <p className="px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Was this accurate?
+                </p>
+                {OUTCOME_ITEMS.map(({ outcome, label, Icon, iconClass }) => (
+                  <button
+                    key={outcome}
+                    type="button"
+                    data-testid={`reliability-outcome-${outcome}`}
+                    disabled={labeling !== null}
+                    onClick={() => handleOutcome(outcome)}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <Icon className={`h-4 w-4 shrink-0 ${iconClass}`} />
+                    {label}
+                  </button>
+                ))}
+                <hr className="my-1" />
+                <p className="px-2 pb-1.5 pt-0.5 text-xs text-muted-foreground">
+                  These train the reliability model — they don't change the device.
+                </p>
+              </div>
+            )}
+          </div>
+```
+
+Verify the action container now reads: outer `<div className="flex flex-col items-start gap-2 xl:items-end">` → Ask AI button → the `reliability-outcome` menu `<div>` → single closing `</div>` for the outer wrapper. (The inner `flex flex-wrap gap-2` wrapper from Task 2 is fully replaced by this menu block.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run src/components/devices/DeviceReliabilityPanel.test.tsx`
+Expected: PASS (all tests, including the reworked feedback tests and the Ask AI test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceReliabilityPanel.tsx apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+git commit -m "feat(web): consolidate reliability feedback into a Mark outcome menu (#1721)"
+```
+
+---
+
+### Task 4: Typecheck and final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck the web package**
+
+Run: `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm --filter @breeze/web typecheck`
+Expected: exit 0, no errors. (If the script name differs, run `cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec tsc --noEmit -p tsconfig.json`.)
+
+- [ ] **Step 2: Re-run both affected test files**
+
+Run:
+```bash
+cd apps/web && PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH pnpm exec vitest run \
+  src/stores/aiStore.test.ts \
+  src/components/devices/DeviceReliabilityPanel.test.tsx
+```
+Expected: PASS, no `CheckCircle`/unused-import or unbalanced-JSX errors.
+
+- [ ] **Step 3: Confirm no stray references to removed affordances**
+
+Run: `grep -n "CheckCircle\|flex flex-wrap gap-2" apps/web/src/components/devices/DeviceReliabilityPanel.tsx`
+Expected: no `CheckCircle`; the only `flex flex-wrap` matches are the unrelated header rows (score/trend/uptime), not a feedback-button group.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec "Part 1 — AI store extension" → Task 1. ✓
+- Spec "Part 1 — Card UI / seed prompt" → Task 2 (`buildReliabilitySeedPrompt`, `askAi`, `reliability-ask-ai` button, snapshot type extension). ✓
+- Spec "Part 2 — Mark outcome menu" (relabel, icons, heading, training note, click-outside, separated from CTA) → Task 3. ✓
+- Spec "Testing — panel + aiStore" → Tasks 1, 2, 3 tests + Task 4 verification. ✓
+- Spec "Non-Goals" (no API change, no deep-linking, tiles read-only) → respected; no task touches the API or tiles. ✓
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". All code blocks are concrete. ✓
+
+**Type consistency:** `startDeviceTask(deviceId, ctx, initialMessage?)` is defined identically in Task 1 (decl + impl) and consumed in Task 2. Outcome union `'failure_confirmed' | 'replaced' | 'false_alarm'` matches `submitFeedback`'s existing signature, `OUTCOME_ITEMS`, and `handleOutcome`. `AiPageContext` device fields (`hostname` required, `os`/`status` optional) match the shared type and the snapshot fields read in `askAi`. ✓

--- a/docs/superpowers/specs/2026-06-22-reliability-card-cta-feedback-design.md
+++ b/docs/superpowers/specs/2026-06-22-reliability-card-cta-feedback-design.md
@@ -1,0 +1,183 @@
+# Device Reliability Card — Primary CTA + Feedback UI (Issue #1721, Parts 1 & 2)
+
+**Date:** 2026-06-22
+**Issue:** #1721 — *"Device Reliability card: unclear actions + uptime should be device-type-aware"*
+**Status:** Design approved
+
+## Background
+
+Issue #1721 is a three-part product-owner UI walkthrough of the Device Reliability
+card (`apps/web/src/components/devices/DeviceReliabilityPanel.tsx`, mounted in
+`DeviceDetails.tsx`):
+
+1. **Unclear next action / weak CTA** — the card is read-only; a tech who sees a
+   reliability problem has nothing to *do* from the card.
+2. **Confusing ML-feedback buttons** — "Failure / Replaced / False alarm" read like
+   commands, have inverted icon semantics (failure = green check), and aren't
+   explained as model-training controls.
+3. **Uptime should be device-type-aware** — uptime was weighted 30% for every device,
+   unfairly tanking laptops/workstations that are expected to sleep.
+
+**Part 3 is already shipped** in PR #1804 (merged 2026-06-22): device-role-aware
+weight profiles (`infra` vs `workstation`), uptime dropped to 0% for workstation-class
+roles with the weight redistributed to fault factors, the chosen profile persisted in
+`details.weightProfile`/`details.factors`, and the uptime top-issue suppressed for
+workstation roles. The issue is intentionally left **open** for Parts 1 & 2.
+
+**This spec covers Parts 1 & 2 only** — a contained, frontend-focused change with a
+tiny AI-store extension. No API or scoring changes.
+
+## Goals
+
+- Give the card a clear primary action: **"Ask AI about reliability"**, opening the
+  device-scoped AI assistant **auto-seeded** with a prompt summarizing the snapshot.
+- Consolidate the three ML-feedback buttons into a single, de-emphasized
+  **"Mark outcome"** menu, visually separated from the remediation CTA, with
+  past-tense labels, corrected icon semantics, and a line clarifying the controls
+  train the model.
+
+## Non-Goals
+
+- No scoring / weight-profile changes (Part 3, done in #1804).
+- No driver-tile deep-linking. There are no dedicated crash/service/hardware detail
+  tabs in `DeviceDetails` today (only `#eventlog`, `#anomalies`, `#performance`), and
+  the approved CTA is the seeded AI assistant. Driver tiles remain read-only.
+- No change to the ML-feedback API contract. Outcome values
+  (`failure_confirmed` / `replaced` / `false_alarm`) and the
+  `POST /reliability/:id/feedback` endpoint are unchanged.
+- No backend change to `GET /reliability/:id`. The card already receives `hostname`,
+  `osType`, and `status` in the snapshot response (`getDeviceReliability` returns
+  them via `ReliabilityListItem`); only the panel's local TypeScript type needs to
+  surface them.
+
+## Part 1 — Primary CTA: "Ask AI about reliability" (auto-seeded)
+
+### AI store extension (`apps/web/src/stores/aiStore.ts`)
+
+`startDeviceTask` gains an optional third parameter `initialMessage`. It currently has
+**zero UI callers** (declared + implemented, never invoked), so extending the
+signature is safe.
+
+```ts
+startDeviceTask: (deviceId: string, ctx: AiPageContext, initialMessage?: string) => Promise<void>;
+
+startDeviceTask: async (deviceId, ctx, initialMessage) => {
+  set({ pageContext: ctx, sessionId: null, messages: [], isFlagged: false, flagReason: null, isOpen: true });
+  await get().createSession({ deviceId });
+  if (initialMessage && get().sessionId) {
+    await get().sendMessage(initialMessage);
+  }
+},
+```
+
+**Sequencing is safe:** `createSession` is awaited; on success it sets `sessionId`
+and clears `isLoading`. `sendMessage` then sees a valid `sessionId` with
+`isStreaming`/`isLoading` both false. If `createSession` failed (error set,
+`sessionId` still null), the `get().sessionId` guard skips the send rather than
+firing a session-less message.
+
+### Card UI
+
+Add a prominent primary button to the header action area (`Sparkles` icon,
+`bg-primary text-primary-foreground`), visually separated from the feedback menu.
+
+On click it:
+1. Builds an `AiPageContext` of `type: 'device'` from the snapshot — `id` (deviceId),
+   `hostname`, `os` (from `osType`), `status`. (The panel's `ReliabilitySnapshot`
+   type is extended with `hostname`, `osType`, `status`, which the API already
+   returns.)
+2. Builds a **client-side seed prompt** from the data already on the card and calls
+   `startDeviceTask(deviceId, ctx, seedPrompt)`.
+
+**Seed prompt** (assembled from snapshot fields the card already holds — score, band,
+trend, `uptime30d`, `mtbfHours`, and the top 3 `drivers` with their score + a couple
+of evidence values). Shape:
+
+> "Review this device's reliability and recommend what to do. Score {score}/100
+> ({band}), trend {trend}. 30-day uptime {uptime}%, MTBF {mtbf}. Top factors dragging
+> the score: {driver label (score N): key evidence}; … . What are the likely root
+> causes and what remediation — scripts, checks, or a ticket — do you recommend?"
+
+A small `buildReliabilitySeedPrompt(snapshot)` helper in the panel keeps this testable
+and out of the click handler. MTBF renders as `{n}h` or "unknown" when null.
+
+**Auto-send behavior is intended:** clicking immediately starts an AI turn (token
+usage, approval flow as configured). Approved by product owner.
+
+## Part 2 — Consolidate feedback into a "Mark outcome" menu
+
+Replace the three inline buttons (`DeviceReliabilityPanel.tsx:249-277`) with one
+low-prominence dropdown menu, matching the established `SavedViewsMenu` idiom:
+`useClickOutside(open, rootRef, …)`, `aria-haspopup`/`aria-expanded`, a
+`role="menu"` panel with `bg-popover`, and `data-testid`s throughout.
+
+- **Trigger:** a subtle/ghost button `Mark outcome ▾` (`ChevronDown`), preceded by a
+  small muted label **"Was this accurate?"**. Placed in the header, visually
+  separated from the primary CTA (e.g. its own group / divider).
+- **Menu items** (past-tense labels, corrected icons; outcome values unchanged):
+
+  | Label | Outcome | Icon | Tone |
+  |---|---|---|---|
+  | Device failed | `failure_confirmed` | `AlertTriangle` | destructive (was a green `CheckCircle`) |
+  | Device replaced | `replaced` | `Wrench` | neutral |
+  | False alarm | `false_alarm` | `XCircle` | muted |
+
+- **Footer helper line** inside the menu: *"These train the reliability model — they
+  don't change the device."*
+- Clicking an item calls the existing `submitFeedback(outcome)` unchanged (still wraps
+  the POST in `runAction` with the existing success/error toasts), then closes the
+  menu. The `labeling` disabled state still disables items while a submission is in
+  flight.
+
+## Components & data flow
+
+```
+DeviceReliabilityPanel (fetches GET /reliability/:id → snapshot)
+ ├─ header: score / trend / uptime / MTBF / score bar
+ ├─ actions:
+ │   ├─ [Ask AI about reliability]  ──click──▶ aiStore.startDeviceTask(deviceId, ctx, seedPrompt)
+ │   │                                            ├─ open panel + device-scoped session
+ │   │                                            └─ sendMessage(seedPrompt)  (auto-seed)
+ │   └─ "Was this accurate?"  [Mark outcome ▾] ──▶ submitFeedback(outcome) → POST /reliability/:id/feedback
+ └─ driver/top-issue tiles (read-only, unchanged)
+```
+
+No new network calls beyond the existing AI session/message endpoints and the
+unchanged feedback POST.
+
+## Error handling
+
+- **Ask AI:** `createSession` failure sets `aiStore.error` (surfaced in the sidebar)
+  and the `sessionId` guard prevents a session-less send. The card button itself does
+  no error toasting — it delegates to the AI sidebar's existing error UI.
+- **Feedback:** unchanged — `submitFeedback` keeps the `runAction` wrapper and the
+  existing success/error toasts and `handleActionError` catch.
+
+## Testing
+
+- **`DeviceReliabilityPanel.test.tsx`:**
+  - Rework the three feedback tests (false alarm / replaced / failure) to open the
+    "Mark outcome" menu, click the item, and assert the POST body
+    (`outcome` + `snapshotComputedAt`) — preserving existing coverage through the new
+    menu affordance.
+  - Add: the "Ask AI about reliability" button calls `startDeviceTask` with the
+    deviceId, a device-typed context, and a seed string containing the score (mock
+    `useAiStore`).
+  - Keep the existing error-state, empty-state (404), and disabled-flag tests.
+- **`aiStore` test:** add/extend coverage that `startDeviceTask` forwards a provided
+  `initialMessage` to `sendMessage` (and does not send when omitted or when session
+  creation failed). If no `aiStore` test file exists, add a focused one for this
+  method with `fetchWithAuth` mocked.
+
+## Acceptance criteria mapping (issue #1721)
+
+- [x] Part 3 — role-aware weights / uptime drop / persisted profile / suppressed
+  uptime top-issue (#1804, merged).
+- [ ] **Part 1** — card has a clear primary action: "Ask AI about reliability" seeded
+  with the snapshot. *(this spec)*
+- [ ] **Part 2** — ML-feedback consolidated into a de-emphasized "Mark outcome" menu,
+  past-tense labels, corrected icon semantics, heading clarifying it trains the model,
+  visually separated from remediation. *(this spec)*
+- [ ] Tests cover the updated card UI (`DeviceReliabilityPanel.test.tsx`) and the
+  `startDeviceTask` seeding (`aiStore`). *(this spec)*
+```


### PR DESCRIPTION
## Summary

Completes **parts 1 & 2** of #1721 (the Device Reliability card walkthrough). Part 3 — device-type-aware uptime weighting — already shipped in #1804, so this is the final piece and **closes the issue**. Frontend-only; no API or scoring changes.

**Part 1 — clear primary action.** The card was read-only. Added a prominent **"Ask AI about reliability"** CTA (`DeviceReliabilityPanel.tsx`) that opens the device-scoped AI assistant **auto-seeded** with a snapshot summary (score/band, trend, 30d uptime, MTBF, top drivers) built client-side from data the card already holds. To enable the seed, `aiStore.startDeviceTask` gains an optional `initialMessage` it auto-sends after the session is created (`aiStore.ts`) — it had zero UI callers, so widening the signature is safe.

**Part 2 — feedback buttons consolidated.** The three confusing buttons (Failure/Replaced/False alarm) are folded into one de-emphasized **"Mark outcome"** click-outside menu (reuses `useClickOutside`, matches the `SavedViewsMenu` idiom), visually separated from the CTA:
- Past-tense labels: **Device failed / Device replaced / False alarm**.
- Corrected icon semantics: failure is now `AlertTriangle` (destructive) — **was a green `CheckCircle`**.
- A **"Was this accurate?"** heading + a note clarifying the controls *train the model, don't change the device*.
- The ML API contract is unchanged — outcome values stay `failure_confirmed` / `replaced` / `false_alarm`.

## Acceptance criteria (#1721)

- [x] Part 1 — clear primary action (Ask AI seeded with the snapshot).
- [x] Part 2 — feedback distinguished from remediation, past-tense labels, corrected icons, training-clarifying heading.
- [x] Part 3 — role-aware weights / uptime drop / persisted profile / suppressed uptime top-issue (**#1804**, merged).
- [x] Tests cover the card UI (`DeviceReliabilityPanel.test.tsx`) and the `startDeviceTask` seeding (`aiStore.test.ts`).

## Testing

- `apps/web` affected files green single-file: `vitest run src/stores/aiStore.test.ts src/components/devices/DeviceReliabilityPanel.test.tsx` → **15/15 passing** (8 store + 7 panel; +3 store, +1 CTA, 3 feedback tests reworked to drive the menu).
- `tsc --noEmit -p apps/web/tsconfig.json` → **exit 0, clean**.
- TDD throughout (RED confirmed before each implementation).

## Notes

- Driver tiles stay read-only by design (no dedicated crash/service/hardware detail tabs exist to deep-link to; the seeded AI assistant is the chosen "now what?" path).
- Spec: `docs/superpowers/specs/2026-06-22-reliability-card-cta-feedback-design.md` · Plan: `docs/superpowers/plans/2026-06-22-reliability-card-cta-feedback.md`.
- Minor review nits (all confirmed harmless, left as-is): `sendMessage` re-trims the seed internally; `vi.clearAllMocks()` already resets the store mock; `mtbfHours` is typed `number|null` and API-populated.

Closes #1721

🤖 Generated with [Claude Code](https://claude.com/claude-code)