### PR TITLE
fix(web): bump no-silent-mutations count to 46 (red main)

### DIFF
--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -265,7 +265,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(45);
+    expect(absoluteFiles.length).toBe(46);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }


### PR DESCRIPTION
**Root cause:** main is red on **Test Web** as of `95a9163a0`. `no-silent-mutations.test.ts` asserts `absoluteFiles.length).toBe(45)` but `TARGET_GLOBS` now has **46** entries.

#1803 (`DeviceWarrantyCard.tsx`) and #1791 (`SecurityIntegration.tsx`) each added one `TARGET_GLOBS` entry and each bumped the count `44→45`. Both squash-merged cleanly (different array lines, identical `toBe` change → no conflict), so main ended up with 46 entries + `toBe(45)`. Both PRs were green individually — classic bulk-admin-merge interaction ([[workflow_bulk_admin_merge_reds_main]]).

**Fix:** bump the expected count to 46. Both entries are legitimate, unique, and pass their own mutation checks.

**Verified:** `vitest run no-silent-mutations.test.ts` → 60/60 pass.