### PR TITLE
enhance(agent): rework agent and watchdog update/heal logic

### DIFF
--- a/agent/cmd/breeze-watchdog/failover_dispatch_test.go
+++ b/agent/cmd/breeze-watchdog/failover_dispatch_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -64,6 +67,14 @@ func TestExecuteFailoverCommands_HeartbeatBeforePollPreservingOrder(t *testing.T
 	}
 }
 
+func TestCurrentRestartStats_DisablesFlapDetectionWhenThresholdUnset(t *testing.T) {
+	recovery := watchdog.NewRecoveryManager(3, 0)
+	stats := currentRestartStats(recovery, 0)
+	if stats.FlapDetected {
+		t.Fatal("expected unset max restarts threshold to disable flap detection")
+	}
+}
+
 func TestProcessInitialFailoverHeartbeatResponse_ExecutesCommandsAndProcessesUpgrades(t *testing.T) {
 	journal, err := watchdog.NewJournal(t.TempDir(), 1, 1)
 	if err != nil {
@@ -107,6 +118,151 @@ func TestProcessInitialFailoverHeartbeatResponse_ExecutesCommandsAndProcessesUpg
 		if !hasJournalEvent(events, tc.event) {
 			t.Fatalf("expected %s event %q in journal, got %#v", tc.name, tc.event, events)
 		}
+	}
+}
+
+func TestHandleWatchdogCommandPoll_ExecutesCommandsWhileMonitoring(t *testing.T) {
+	var resultCommandID string
+	var resultStatus string
+	var heartbeatCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/agent-1/heartbeat":
+			if got := r.Header.Get("X-Breeze-Role"); got != "watchdog" {
+				t.Errorf("X-Breeze-Role = %q, want watchdog", got)
+				http.Error(w, "bad role header", http.StatusBadRequest)
+				return
+			}
+			var body struct {
+				Role          string `json:"role"`
+				WatchdogState string `json:"watchdogState"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode heartbeat body: %v", err)
+				http.Error(w, "bad heartbeat body", http.StatusBadRequest)
+				return
+			}
+			if body.Role != "watchdog" || body.WatchdogState != watchdog.StateMonitoring {
+				t.Errorf("heartbeat role/state = %q/%q, want watchdog/%s", body.Role, body.WatchdogState, watchdog.StateMonitoring)
+				http.Error(w, "bad heartbeat", http.StatusBadRequest)
+				return
+			}
+			heartbeatCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"commands": []watchdog.FailoverCommand{}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/agents/agent-1/commands":
+			if got := r.URL.Query().Get("role"); got != "watchdog" {
+				t.Errorf("role query = %q, want watchdog", got)
+				http.Error(w, "bad role", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("X-Breeze-Role"); got != "watchdog" {
+				t.Errorf("X-Breeze-Role = %q, want watchdog", got)
+				http.Error(w, "bad role header", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"commands": []watchdog.FailoverCommand{
+					{ID: "cmd-healthy", Type: "collect_diagnostics"},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/agent-1/logs":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/agent-1/commands/cmd-healthy/result":
+			var body struct {
+				Status string `json:"status"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode result body: %v", err)
+				http.Error(w, "bad result body", http.StatusBadRequest)
+				return
+			}
+			resultCommandID = "cmd-healthy"
+			resultStatus = body.Status
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	journal, err := watchdog.NewJournal(t.TempDir(), 1, 1)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	defer journal.Close()
+
+	cfg := &config.Config{
+		AgentID:   "agent-1",
+		ServerURL: server.URL,
+	}
+	cfg.Watchdog.MaxRestartsPer24h = 5
+	wd := watchdog.NewWatchdog(watchdog.Config{})
+	wd.HandleEvent(watchdog.EventIPCConnected)
+	recovery := watchdog.NewRecoveryManager(3, 0)
+	client := watchdog.NewFailoverClient(server.URL, "agent-1", "tok-watchdog", nil)
+
+	handleWatchdogCommandPoll(client, wd, journal, cfg, &tokenHolder{}, recovery)
+
+	if !heartbeatCalled {
+		t.Fatal("expected monitoring watchdog heartbeat before command poll")
+	}
+	if resultCommandID != "cmd-healthy" {
+		t.Fatalf("result command id = %q, want cmd-healthy", resultCommandID)
+	}
+	if resultStatus != "completed" {
+		t.Fatalf("result status = %q, want completed", resultStatus)
+	}
+}
+
+func TestHandleWatchdogCommandPoll_ExecutesHeartbeatCommandsWhileMonitoring(t *testing.T) {
+	var resultCommandID string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/agent-1/heartbeat":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"commands": []watchdog.FailoverCommand{
+					{ID: "cmd-heartbeat", Type: "collect_diagnostics"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/agents/agent-1/commands":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"commands": []watchdog.FailoverCommand{},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/agent-1/logs":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/agent-1/commands/cmd-heartbeat/result":
+			resultCommandID = "cmd-heartbeat"
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	journal, err := watchdog.NewJournal(t.TempDir(), 1, 1)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	defer journal.Close()
+
+	cfg := &config.Config{
+		AgentID:   "agent-1",
+		ServerURL: server.URL,
+	}
+	cfg.Watchdog.MaxRestartsPer24h = 5
+	wd := watchdog.NewWatchdog(watchdog.Config{})
+	wd.HandleEvent(watchdog.EventIPCConnected)
+	recovery := watchdog.NewRecoveryManager(3, 0)
+	client := watchdog.NewFailoverClient(server.URL, "agent-1", "tok-watchdog", nil)
+
+	handleWatchdogCommandPoll(client, wd, journal, cfg, &tokenHolder{}, recovery)
+
+	if resultCommandID != "cmd-heartbeat" {
+		t.Fatalf("result command id = %q, want cmd-heartbeat", resultCommandID)
 	}
 }
 

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -288,7 +288,9 @@ func runWatchdog(stopCh <-chan struct{}) {
 	heartbeatTicker := time.NewTicker(wdCfg.HeartbeatStaleThreshold)
 	defer heartbeatTicker.Stop()
 
-	// Failover poll ticker — only used in FAILOVER state.
+	// Watchdog command poll ticker. In FAILOVER it also carries heartbeat
+	// duties; while healthy it still claims operator-queued watchdog commands
+	// such as manual agent updates.
 	failoverTicker := time.NewTicker(wdCfg.FailoverPollInterval)
 	defer failoverTicker.Stop()
 
@@ -369,11 +371,23 @@ func runWatchdog(stopCh <-chan struct{}) {
 			handleIPCMessage(env, wd, journal, cfg, tokenStore)
 
 		case <-failoverTicker.C:
-			// Only poll in FAILOVER state.
-			if wd.State() != watchdog.StateFailover || failoverClient == nil {
+			if tokenStore.Reveal() == "" {
 				continue
 			}
-			handleFailoverPoll(failoverClient, wd, journal, cfg, tokenStore, recovery, cfg.Watchdog.MaxRestartsPer24h)
+			switch wd.State() {
+			case watchdog.StateFailover:
+				if failoverClient == nil {
+					failoverClient = watchdog.NewFailoverClient(
+						cfg.ServerURL, cfg.AgentID, tokenStore.Reveal(), nil,
+					)
+				}
+				handleFailoverPoll(failoverClient, wd, journal, cfg, tokenStore, recovery, cfg.Watchdog.MaxRestartsPer24h)
+			case watchdog.StateMonitoring:
+				commandClient := watchdog.NewFailoverClient(
+					cfg.ServerURL, cfg.AgentID, tokenStore.Reveal(), nil,
+				)
+				handleWatchdogCommandPoll(commandClient, wd, journal, cfg, tokenStore, recovery)
+			}
 		}
 
 		// State-driven actions after each tick.
@@ -413,7 +427,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 			}
 
 			// Flap-detection gate: if we've exceeded the 24h budget, jump to FAILOVER.
-			if recovery.Count24h() >= cfg.Watchdog.MaxRestartsPer24h {
+			if cfg.Watchdog.MaxRestartsPer24h > 0 && recovery.Count24h() >= cfg.Watchdog.MaxRestartsPer24h {
 				journal.Log(watchdog.LevelError, "recovery.flap_detected", map[string]any{
 					"count_24h": recovery.Count24h(),
 				})
@@ -581,6 +595,43 @@ func handleFailoverPoll(
 	pollCmds, err := fc.PollCommands()
 	if err != nil {
 		journal.Log(watchdog.LevelError, "failover.poll_failed", map[string]any{
+			"error": err.Error(),
+		})
+		pollCmds = nil
+	}
+
+	executeFailoverCommands(heartbeatCmds, pollCmds, func(cmd watchdog.FailoverCommand) {
+		handleFailoverCommand(fc, cmd, wd, journal, cfg, tokens, recovery)
+	})
+}
+
+// handleWatchdogCommandPoll reports watchdog presence and claims watchdog-targeted
+// commands while the main agent is healthy. Manual agent updates are queued to
+// targetRole=watchdog, so waiting for FAILOVER would leave healthy devices with
+// pending no-op updates. The monitoring heartbeat is also what lets the API
+// populate devices.watchdog_version for healthy agents.
+func handleWatchdogCommandPoll(
+	fc *watchdog.FailoverClient,
+	wd *watchdog.Watchdog,
+	journal *watchdog.Journal,
+	cfg *config.Config,
+	tokens *tokenHolder,
+	recovery *watchdog.RecoveryManager,
+) {
+	stats := currentRestartStats(recovery, cfg.Watchdog.MaxRestartsPer24h)
+	resp, err := fc.SendHeartbeat(version, wd.State(), journal.Recent(10), stats)
+	var heartbeatCmds []watchdog.FailoverCommand
+	if err != nil {
+		journal.Log(watchdog.LevelError, "monitoring.heartbeat_failed", map[string]any{
+			"error": err.Error(),
+		})
+	} else {
+		heartbeatCmds = processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
+	}
+
+	pollCmds, err := fc.PollCommands()
+	if err != nil {
+		journal.Log(watchdog.LevelError, "command.poll_failed", map[string]any{
 			"error": err.Error(),
 		})
 		pollCmds = nil
@@ -929,6 +980,6 @@ func currentRestartStats(rm *watchdog.RecoveryManager, maxPer24h int) watchdog.R
 	return watchdog.RestartStats{
 		Count24h:      count,
 		LastRestartAt: rm.LastRestartAt(),
-		FlapDetected:  count >= maxPer24h,
+		FlapDetected:  maxPer24h > 0 && count >= maxPer24h,
 	}
 }

--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -97,7 +97,8 @@ var handlerRegistry = map[string]CommandHandler{
 	tools.CmdSetLogLevel: handleSetLogLevel,
 
 	// Auto-update management
-	tools.CmdSetAutoUpdate: handleSetAutoUpdate,
+	tools.CmdSetAutoUpdate:  handleSetAutoUpdate,
+	tools.CmdUpdateWatchdog: handleUpdateWatchdog,
 }
 
 // dispatchCommand looks up the handler for a command type and executes it,

--- a/agent/internal/heartbeat/handlers_test.go
+++ b/agent/internal/heartbeat/handlers_test.go
@@ -92,7 +92,7 @@ var allCommandTypes = []string{
 	tools.CmdSetLogLevel,
 
 	// handlers_autoupdate.go
-	tools.CmdSetAutoUpdate,
+	tools.CmdSetAutoUpdate, tools.CmdUpdateWatchdog,
 
 	// handlers_devupdate.go init()
 	tools.CmdDevUpdate,

--- a/agent/internal/heartbeat/handlers_watchdog_update.go
+++ b/agent/internal/heartbeat/handlers_watchdog_update.go
@@ -1,0 +1,102 @@
+package heartbeat
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+const (
+	watchdogRepairDownloadFailed       = "download_failed"
+	watchdogRepairSignatureFailed      = "signature_failed"
+	watchdogRepairServiceInstallFailed = "service_install_failed"
+	watchdogRepairIPCTrustFailed       = "ipc_trust_failed"
+	watchdogRepairStartFailed          = "start_failed"
+	watchdogRepairPermissionDenied     = "permission_denied"
+	watchdogRepairAlreadyRunning       = "already_running"
+)
+
+func watchdogRepairReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return watchdogRepairPermissionDenied
+	}
+	lower := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(lower, "signature"),
+		strings.Contains(lower, "manifest"),
+		strings.Contains(lower, "checksum"),
+		strings.Contains(lower, "trusted"):
+		return watchdogRepairSignatureFailed
+	case strings.Contains(lower, "download"):
+		return watchdogRepairDownloadFailed
+	case strings.Contains(lower, "allowlist"),
+		strings.Contains(lower, "ipc"),
+		strings.Contains(lower, "hash"):
+		return watchdogRepairIPCTrustFailed
+	case strings.Contains(lower, "start"),
+		strings.Contains(lower, "restart"),
+		strings.Contains(lower, "launchctl"),
+		strings.Contains(lower, "systemctl"):
+		return watchdogRepairStartFailed
+	case strings.Contains(lower, "service install"),
+		strings.Contains(lower, "install service"):
+		return watchdogRepairServiceInstallFailed
+	default:
+		return "repair_failed"
+	}
+}
+
+func handleUpdateWatchdog(h *Heartbeat, cmd Command) tools.CommandResult {
+	start := time.Now()
+	targetVersion := strings.TrimSpace(tools.GetPayloadString(cmd.Payload, "version", ""))
+	if targetVersion == "" {
+		return tools.CommandResult{Status: "failed", Error: "missing version in payload"}
+	}
+	if strings.HasPrefix(targetVersion, "dev-") {
+		return tools.CommandResult{Status: "failed", Error: "refusing to install dev watchdog build"}
+	}
+	if _, _, _, ok := parseSemver(targetVersion); !ok {
+		return tools.CommandResult{Status: "failed", Error: "refusing to install non-semver watchdog build"}
+	}
+	if h.manifestTrustRotationRejected.Load() {
+		return tools.CommandResult{Status: "failed", Error: watchdogRepairSignatureFailed + ": manifest trust rotation rejection unresolved"}
+	}
+	if isDowngrade(targetVersion, h.agentVersion) {
+		return tools.CommandResult{Status: "failed", Error: "refusing to downgrade watchdog"}
+	}
+	if !h.watchdogUpgradeInProgress.CompareAndSwap(false, true) {
+		return tools.CommandResult{
+			Status: "failed",
+			Error:  watchdogRepairAlreadyRunning,
+		}
+	}
+	defer h.watchdogUpgradeInProgress.Store(false)
+
+	install := h.watchdogInstaller
+	if install == nil {
+		install = h.installAndRestartWatchdog
+	}
+	if err := install(targetVersion); err != nil {
+		reason := watchdogRepairReason(err)
+		return tools.CommandResult{
+			Status:     "failed",
+			Error:      reason + ": " + err.Error(),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
+	h.watchdogUpgradeMu.Lock()
+	h.watchdogInstalledVersion = targetVersion
+	h.watchdogUpgradeMu.Unlock()
+
+	return tools.NewSuccessResult(map[string]any{
+		"updated_to": targetVersion,
+		"component":  "watchdog",
+	}, time.Since(start).Milliseconds())
+}

--- a/agent/internal/heartbeat/handlers_watchdog_update_test.go
+++ b/agent/internal/heartbeat/handlers_watchdog_update_test.go
@@ -1,0 +1,162 @@
+package heartbeat
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+func TestHandleUpdateWatchdogInstallsThroughVerifiedInstaller(t *testing.T) {
+	var installed string
+	h := &Heartbeat{
+		config:       &config.Config{AutoUpdate: false},
+		agentVersion: "0.66.0",
+		watchdogInstaller: func(targetVersion string) error {
+			installed = targetVersion
+			return nil
+		},
+	}
+
+	result := handleUpdateWatchdog(h, Command{
+		Type: tools.CmdUpdateWatchdog,
+		Payload: map[string]any{
+			"version": "0.66.0",
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("Status = %q, Error = %q; want completed", result.Status, result.Error)
+	}
+	if installed != "0.66.0" {
+		t.Fatalf("installed = %q, want 0.66.0", installed)
+	}
+	if h.watchdogInstalledVersion != "0.66.0" {
+		t.Fatalf("watchdogInstalledVersion = %q, want 0.66.0", h.watchdogInstalledVersion)
+	}
+}
+
+func TestHandleUpdateWatchdogBypassesLocalAutoUpdateForManualCommand(t *testing.T) {
+	called := false
+	h := &Heartbeat{
+		config:       &config.Config{AutoUpdate: false},
+		agentVersion: "0.66.0",
+		watchdogInstaller: func(string) error {
+			called = true
+			return nil
+		},
+	}
+
+	result := handleUpdateWatchdog(h, Command{
+		Type: tools.CmdUpdateWatchdog,
+		Payload: map[string]any{
+			"version": "0.66.0",
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("Status = %q, Error = %q; want completed", result.Status, result.Error)
+	}
+	if !called {
+		t.Fatal("expected manual watchdog update to bypass local AutoUpdate=false")
+	}
+}
+
+func TestHandleUpdateWatchdogRejectsDevBuild(t *testing.T) {
+	h := &Heartbeat{config: &config.Config{}, agentVersion: "0.66.0"}
+
+	result := handleUpdateWatchdog(h, Command{
+		Type: tools.CmdUpdateWatchdog,
+		Payload: map[string]any{
+			"version": "dev-local",
+		},
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("Status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "refusing to install dev watchdog build") {
+		t.Fatalf("Error = %q, want dev-build refusal", result.Error)
+	}
+}
+
+func TestHandleUpdateWatchdogRejectsNonSemverTarget(t *testing.T) {
+	h := &Heartbeat{config: &config.Config{}, agentVersion: "0.66.0"}
+
+	result := handleUpdateWatchdog(h, Command{
+		Type: tools.CmdUpdateWatchdog,
+		Payload: map[string]any{
+			"version": "agent-watchdog-update-abc123",
+		},
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("Status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "non-semver") {
+		t.Fatalf("Error = %q, want non-semver refusal", result.Error)
+	}
+}
+
+func TestHandleUpdateWatchdogRejectsDowngrade(t *testing.T) {
+	h := &Heartbeat{config: &config.Config{}, agentVersion: "0.82.1"}
+
+	result := handleUpdateWatchdog(h, Command{
+		Type: tools.CmdUpdateWatchdog,
+		Payload: map[string]any{
+			"version": "0.70.0",
+		},
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("Status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "downgrade") {
+		t.Fatalf("Error = %q, want downgrade refusal", result.Error)
+	}
+}
+
+func TestHandleUpdateWatchdogReportsSignatureFailureReason(t *testing.T) {
+	h := &Heartbeat{
+		config:       &config.Config{},
+		agentVersion: "0.66.0",
+		watchdogInstaller: func(_ string) error {
+			return fmt.Errorf("manifest signature invalid")
+		},
+	}
+
+	result := handleUpdateWatchdog(h, Command{
+		Type: tools.CmdUpdateWatchdog,
+		Payload: map[string]any{
+			"version": "0.66.0",
+		},
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("Status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, watchdogRepairSignatureFailed) {
+		t.Fatalf("Error = %q, want %q", result.Error, watchdogRepairSignatureFailed)
+	}
+}
+
+func TestHandleUpdateWatchdogRejectsWhileInProgress(t *testing.T) {
+	h := &Heartbeat{config: &config.Config{}, agentVersion: "0.66.0"}
+	h.watchdogUpgradeInProgress.Store(true)
+
+	result := handleUpdateWatchdog(h, Command{
+		Type: tools.CmdUpdateWatchdog,
+		Payload: map[string]any{
+			"version": "0.66.0",
+		},
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("Status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, watchdogRepairAlreadyRunning) {
+		t.Fatalf("Error = %q, want %q", result.Error, watchdogRepairAlreadyRunning)
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -73,17 +73,17 @@ type HeartbeatPayload struct {
 	// pointer so an old-agent omission (nil) is distinguishable from a
 	// genuine "physical" report (false) — the server only overwrites the
 	// stored value when the agent actually sends one.
-	IsVirtual              *bool          `json:"isVirtual,omitempty"`
-	VirtualizationPlatform string         `json:"virtualizationPlatform,omitempty"`
-	HealthStatus           map[string]any `json:"healthStatus,omitempty"`
-	DroppedLogs      int64                     `json:"droppedLogs,omitempty"`
-	HelperVersion    string                    `json:"helperVersion,omitempty"`
-	TCCPermissions   *ipc.TCCStatus            `json:"tccPermissions,omitempty"`
-	DesktopAccess    *DesktopAccessState       `json:"desktopAccess,omitempty"`
-	Hostname         string                    `json:"hostname,omitempty"`
-	OSVersion        string                    `json:"osVersion,omitempty"`
-	OSBuild          string                    `json:"osBuild,omitempty"`
-	IsHeadless       bool                      `json:"isHeadless"`
+	IsVirtual              *bool               `json:"isVirtual,omitempty"`
+	VirtualizationPlatform string              `json:"virtualizationPlatform,omitempty"`
+	HealthStatus           map[string]any      `json:"healthStatus,omitempty"`
+	DroppedLogs            int64               `json:"droppedLogs,omitempty"`
+	HelperVersion          string              `json:"helperVersion,omitempty"`
+	TCCPermissions         *ipc.TCCStatus      `json:"tccPermissions,omitempty"`
+	DesktopAccess          *DesktopAccessState `json:"desktopAccess,omitempty"`
+	Hostname               string              `json:"hostname,omitempty"`
+	OSVersion              string              `json:"osVersion,omitempty"`
+	OSBuild                string              `json:"osBuild,omitempty"`
+	IsHeadless             bool                `json:"isHeadless"`
 }
 
 type DesktopAccessState struct {
@@ -181,9 +181,9 @@ type Heartbeat struct {
 	// drive SendInput/SetThreadDesktop against the same live consent.exe prompt
 	// concurrently (e.g. an await_remote technician approval firing
 	// actuate_elevation while a re-fired ETW event re-enters RunPamFlow).
-	pamActuateMu sync.Mutex
-	wsDesktopStart   func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
-	desktopOwners    sync.Map // desktop session ID -> helper session ID
+	pamActuateMu   sync.Mutex
+	wsDesktopStart func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
+	desktopOwners  sync.Map // desktop session ID -> helper session ID
 
 	// Resilience & observability
 	pool        *workerpool.Pool
@@ -3407,6 +3407,11 @@ func (h *Heartbeat) handleWatchdogUpgrade(targetVersion string) {
 
 	if !h.config.AutoUpdate {
 		log.Info("watchdog upgrade available but auto_update is disabled",
+			"targetVersion", targetVersion)
+		return
+	}
+	if h.manifestTrustRotationRejected.Load() {
+		log.Error("SECURITY: skipping watchdog update — manifest trust rotation rejection unresolved",
 			"targetVersion", targetVersion)
 		return
 	}

--- a/agent/internal/heartbeat/watchdog_install_darwin.go
+++ b/agent/internal/heartbeat/watchdog_install_darwin.go
@@ -27,8 +27,20 @@ func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
 	if err := replaceWatchdogBinaryUnix(tempPath, watchdogBinaryPathUnix); err != nil {
 		return err
 	}
+	if err := h.refreshWatchdogHashAllowlist(watchdogBinaryPathUnix); err != nil {
+		return err
+	}
 
 	if out, err := exec.Command("launchctl", "kickstart", "-k", "system/"+watchdogLaunchdLabel).CombinedOutput(); err != nil {
+		if watchdogServiceMissing(string(out), err) {
+			if installOut, installErr := exec.Command(watchdogBinaryPathUnix, "service", "install").CombinedOutput(); installErr != nil {
+				return fmt.Errorf("watchdog service install: %s: %w", strings.TrimSpace(string(installOut)), installErr)
+			}
+			if startOut, startErr := exec.Command("launchctl", "kickstart", "-k", "system/"+watchdogLaunchdLabel).CombinedOutput(); startErr != nil {
+				return fmt.Errorf("launchctl kickstart %s after install: %s: %w", watchdogLaunchdLabel, strings.TrimSpace(string(startOut)), startErr)
+			}
+			return nil
+		}
 		return fmt.Errorf("launchctl kickstart %s: %s: %w", watchdogLaunchdLabel, strings.TrimSpace(string(out)), err)
 	}
 	return nil

--- a/agent/internal/heartbeat/watchdog_install_hash.go
+++ b/agent/internal/heartbeat/watchdog_install_hash.go
@@ -1,0 +1,22 @@
+package heartbeat
+
+import "fmt"
+
+func (h *Heartbeat) refreshWatchdogHashAllowlist(installPath string) error {
+	if h.sessionBroker == nil {
+		log.Warn("session broker unavailable - watchdog installed but allowlist not refreshed; restart the agent to guarantee watchdog IPC is accepted")
+		return nil
+	}
+	if _, err := h.sessionBroker.RefreshAllowedHashes(); err != nil {
+		return fmt.Errorf("watchdog installed but broker allowlist refresh failed: %w", err)
+	}
+	installedHash, allowed, err := h.sessionBroker.HashAndVerifyAllowed(installPath)
+	if err != nil {
+		return fmt.Errorf("watchdog installed but hash verification failed: %w", err)
+	}
+	if !allowed {
+		return fmt.Errorf("watchdog installed but its hash %s is not in the refreshed allowlist; next IPC connection will be rejected", installedHash)
+	}
+	log.Info("watchdog hash verified in refreshed allowlist", "hash", installedHash)
+	return nil
+}

--- a/agent/internal/heartbeat/watchdog_install_linux.go
+++ b/agent/internal/heartbeat/watchdog_install_linux.go
@@ -23,8 +23,23 @@ func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
 	if err := replaceWatchdogBinaryUnix(tempPath, watchdogBinaryPathUnix); err != nil {
 		return err
 	}
+	if err := h.refreshWatchdogHashAllowlist(watchdogBinaryPathUnix); err != nil {
+		return err
+	}
 
 	if out, err := exec.Command("systemctl", "restart", "breeze-watchdog").CombinedOutput(); err != nil {
+		if watchdogServiceMissing(string(out), err) {
+			if installOut, installErr := exec.Command(watchdogBinaryPathUnix, "service", "install").CombinedOutput(); installErr != nil {
+				return fmt.Errorf("watchdog service install: %s: %w", strings.TrimSpace(string(installOut)), installErr)
+			}
+			if reloadOut, reloadErr := exec.Command("systemctl", "daemon-reload").CombinedOutput(); reloadErr != nil {
+				return fmt.Errorf("systemctl daemon-reload: %s: %w", strings.TrimSpace(string(reloadOut)), reloadErr)
+			}
+			if startOut, startErr := exec.Command("systemctl", "restart", "breeze-watchdog").CombinedOutput(); startErr != nil {
+				return fmt.Errorf("systemctl restart breeze-watchdog after install: %s: %w", strings.TrimSpace(string(startOut)), startErr)
+			}
+			return nil
+		}
 		return fmt.Errorf("systemctl restart breeze-watchdog: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil

--- a/agent/internal/heartbeat/watchdog_install_windows.go
+++ b/agent/internal/heartbeat/watchdog_install_windows.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/serviceinstall"
@@ -41,6 +43,22 @@ func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
 
 	s, err := m.OpenService(windowsWatchdogServiceName)
 	if err != nil {
+		if watchdogServiceMissing("", err) {
+			if err := replaceWatchdogBinaryWindows(tempPath, dest); err != nil {
+				return fmt.Errorf("watchdog install swap failed: %w", err)
+			}
+			hashErr := h.refreshWatchdogHashAllowlist(dest)
+			if out, installErr := exec.Command(dest, "service", "install").CombinedOutput(); installErr != nil {
+				return fmt.Errorf("watchdog service install: %s: %w", strings.TrimSpace(string(out)), installErr)
+			}
+			if err := startWatchdogServiceWindows(); err != nil {
+				return err
+			}
+			if hashErr != nil {
+				return hashErr
+			}
+			return nil
+		}
 		return fmt.Errorf("open service %q: %w", windowsWatchdogServiceName, err)
 	}
 	defer s.Close()
@@ -87,10 +105,32 @@ func (h *Heartbeat) installAndRestartWatchdog(targetVersion string) error {
 		return fmt.Errorf("watchdog swap failed (service restarted on old binary): %w", err)
 	}
 
+	if err := h.refreshWatchdogHashAllowlist(dest); err != nil {
+		if startErr := s.Start(); startErr != nil {
+			return fmt.Errorf(
+				"watchdog hash allowlist refresh failed AND restart failed — watchdog is DOWN: hash=%w; restart=%v",
+				err, startErr,
+			)
+		}
+		return err
+	}
+
 	if err := s.Start(); err != nil {
 		return fmt.Errorf("start service %q after swap: %w", windowsWatchdogServiceName, err)
 	}
 	return nil
+}
+
+func startWatchdogServiceWindows() error {
+	out, err := exec.Command("sc", "start", windowsWatchdogServiceName).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	lower := strings.ToLower(string(out) + " " + err.Error())
+	if strings.Contains(lower, "already running") || strings.Contains(lower, "instance of the service is already running") {
+		return nil
+	}
+	return fmt.Errorf("start service %q after install: %s: %w", windowsWatchdogServiceName, strings.TrimSpace(string(out)), err)
 }
 
 // replaceWatchdogBinaryWindows copies the verified bytes at srcTemp over dest.

--- a/agent/internal/heartbeat/watchdog_service_missing.go
+++ b/agent/internal/heartbeat/watchdog_service_missing.go
@@ -1,0 +1,16 @@
+package heartbeat
+
+import "strings"
+
+func watchdogServiceMissing(output string, err error) bool {
+	errText := ""
+	if err != nil {
+		errText = err.Error()
+	}
+	lower := strings.ToLower(output + " " + errText)
+	return strings.Contains(lower, "not found") ||
+		strings.Contains(lower, "not loaded") ||
+		strings.Contains(lower, "does not exist") ||
+		strings.Contains(lower, "could not be found") ||
+		strings.Contains(lower, "no such service")
+}

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -176,7 +176,8 @@ const (
 
 	// Dev push (fast dev binary update)
 	// Auto-update management
-	CmdSetAutoUpdate = "set_auto_update"
+	CmdSetAutoUpdate  = "set_auto_update"
+	CmdUpdateWatchdog = "update_watchdog"
 
 	CmdDevUpdate = "dev_update"
 

--- a/apps/api/migrations/2026-06-22-z-agent-version-build-tags.sql
+++ b/apps/api/migrations/2026-06-22-z-agent-version-build-tags.sql
@@ -1,0 +1,50 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'devices'
+      AND column_name = 'agent_version'
+      AND data_type = 'character varying'
+      AND character_maximum_length < 128
+  ) THEN
+    ALTER TABLE devices ALTER COLUMN agent_version TYPE varchar(128);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'devices'
+      AND column_name = 'watchdog_version'
+      AND data_type = 'character varying'
+      AND character_maximum_length < 128
+  ) THEN
+    ALTER TABLE devices ALTER COLUMN watchdog_version TYPE varchar(128);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'agent_logs'
+      AND column_name = 'agent_version'
+      AND data_type = 'character varying'
+      AND character_maximum_length < 128
+  ) THEN
+    ALTER TABLE agent_logs ALTER COLUMN agent_version TYPE varchar(128);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'agent_versions'
+      AND column_name = 'version'
+      AND data_type = 'character varying'
+      AND character_maximum_length < 128
+  ) THEN
+    ALTER TABLE agent_versions ALTER COLUMN version TYPE varchar(128);
+  END IF;
+END $$;

--- a/apps/api/src/db/schema/agentLogs.ts
+++ b/apps/api/src/db/schema/agentLogs.ts
@@ -14,7 +14,7 @@ export const agentLogs = pgTable('agent_logs', {
   component: varchar('component', { length: 100 }).notNull(),
   message: text('message').notNull(),
   fields: jsonb('fields'),
-  agentVersion: varchar('agent_version', { length: 50 }),
+  agentVersion: varchar('agent_version', { length: 128 }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
   deviceIdx: index('agent_logs_device_idx').on(table.deviceId),

--- a/apps/api/src/db/schema/agentVersions.ts
+++ b/apps/api/src/db/schema/agentVersions.ts
@@ -2,7 +2,7 @@ import { pgTable, uuid, varchar, text, timestamp, boolean, bigint, unique, index
 
 export const agentVersions = pgTable('agent_versions', {
   id: uuid('id').primaryKey().defaultRandom(),
-  version: varchar('version', { length: 20 }).notNull(),
+  version: varchar('version', { length: 128 }).notNull(),
   platform: varchar('platform', { length: 20 }).notNull(), // windows, macos, linux
   architecture: varchar('architecture', { length: 20 }).notNull(), // amd64, arm64
   downloadUrl: text('download_url').notNull(),

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -61,7 +61,7 @@ export const devices = pgTable('devices', {
   osVersion: varchar('os_version', { length: 100 }).notNull(),
   osBuild: varchar('os_build', { length: 100 }),
   architecture: varchar('architecture', { length: 20 }).notNull(),
-  agentVersion: varchar('agent_version', { length: 50 }).notNull(),
+  agentVersion: varchar('agent_version', { length: 128 }).notNull(),
   status: deviceStatusEnum('status').notNull().default('offline'),
   lastSeenAt: timestamp('last_seen_at'),
   enrolledAt: timestamp('enrolled_at').defaultNow().notNull(),
@@ -81,7 +81,7 @@ export const devices = pgTable('devices', {
   pendingReboot: boolean('pending_reboot').notNull().default(false),
   watchdogStatus: watchdogStatusEnum('watchdog_status'),
   watchdogLastSeen: timestamp('watchdog_last_seen'),
-  watchdogVersion: varchar('watchdog_version', { length: 50 }),
+  watchdogVersion: varchar('watchdog_version', { length: 128 }),
   // Asymmetry detector (#800): set when the watchdog is still reporting
   // in but the main agent has gone silent past the offline threshold.
   // Cleared when the main agent next heartbeats. Distinct from

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { createPublicKey, verify as verifySignature } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { db } from "../db";
 import { agentVersions } from "../db/schema";
 import {
@@ -29,6 +29,10 @@ const requireAgentVersionAdmin = requirePermission(
   PERMISSIONS.ORGS_WRITE.resource,
   PERMISSIONS.ORGS_WRITE.action,
 );
+const requireAgentVersionRead = requirePermission(
+  PERMISSIONS.ORGS_READ.resource,
+  PERMISSIONS.ORGS_READ.action,
+);
 
 // Validation schemas
 const platformEnum = z.enum(["windows", "macos", "linux", "darwin"]);
@@ -51,7 +55,7 @@ const latestQuerySchema = z.object({
 });
 
 const downloadParamsSchema = z.object({
-  version: z.string().min(1).max(20),
+  version: z.string().min(1).max(128),
 });
 
 const downloadQuerySchema = z.object({
@@ -61,7 +65,7 @@ const downloadQuerySchema = z.object({
 });
 
 const createVersionSchema = z.object({
-  version: z.string().min(1).max(20),
+  version: z.string().min(1).max(128),
   platform: platformEnum,
   architecture: architectureEnum,
   downloadUrl: z.string().url(),
@@ -90,6 +94,37 @@ type ReleaseArtifactManifest = {
   release?: unknown;
   assets?: unknown;
 };
+
+// GET /agent-versions - List registered agent/watchdog versions for settings UI
+agentVersionRoutes.get(
+  "/",
+  authMiddleware,
+  requireScope("organization", "partner", "system"),
+  requireAgentVersionRead,
+  async (c) => {
+    const rows = await db
+      .select({
+        id: agentVersions.id,
+        version: agentVersions.version,
+        platform: agentVersions.platform,
+        architecture: agentVersions.architecture,
+        component: agentVersions.component,
+        isLatest: agentVersions.isLatest,
+        releaseNotes: agentVersions.releaseNotes,
+        createdAt: agentVersions.createdAt,
+      })
+      .from(agentVersions)
+      .where(inArray(agentVersions.component, ["agent", "watchdog"]))
+      .orderBy(desc(agentVersions.createdAt));
+
+    return c.json({
+      data: rows.map((row) => ({
+        ...row,
+        createdAt: row.createdAt?.toISOString?.() ?? row.createdAt,
+      })),
+    });
+  },
+);
 
 async function getUpdateManifestPublicKeys(): Promise<Buffer[]> {
   const configured = [
@@ -256,7 +291,8 @@ function dbPlatformToRouteOs(dbPlatform: string): string {
 }
 
 // Construct the server-relative download URL the agent should use. Applies to
-// component=agent and component=helper: both are pulled by the agent's verified
+// component=agent, component=helper, and component=watchdog: all are pulled by
+// the agent's verified
 // downloader (updater.downloadFromURL), which enforces host equality with the
 // agent's configured ServerURL. Without this rewrite the response would hand
 // back the canonical github.com asset URL, which the agent rejects — and, more

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
 
 const updateRestoreJobFromResultMock = vi.fn().mockResolvedValue(true);
+const applyCompletedComponentUpdateVersionMock = vi.fn().mockResolvedValue(false);
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -24,6 +25,8 @@ vi.mock('../db/schema', () => ({
     previousWatchdogTokenHash: 'devices.previousWatchdogTokenHash',
     previousWatchdogTokenExpiresAt: 'devices.previousWatchdogTokenExpiresAt',
     orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    hostname: 'devices.hostname',
     status: 'devices.status',
     lastSeenAt: 'devices.lastSeenAt',
     updatedAt: 'devices.updatedAt'
@@ -123,6 +126,10 @@ vi.mock('../services/viewerTokenRevocation', () => ({
   revokeViewerSession: vi.fn(async () => undefined),
 }));
 
+vi.mock('../services/componentUpdateResults', () => ({
+  applyCompletedComponentUpdateVersion: (...args: unknown[]) => applyCompletedComponentUpdateVersionMock(...(args as [])),
+}));
+
 vi.mock('../services/rate-limit', () => ({
   rateLimiter: vi.fn().mockResolvedValue({ allowed: true, remaining: 5, resetAt: new Date() })
 }));
@@ -172,6 +179,7 @@ import { processBackupVerificationResult } from './backup/verificationService';
 import { updateRestoreJobFromResult } from '../services/restoreResultPersistence';
 import { rateLimiter } from '../services/rate-limit';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
+import { publishEvent } from '../services/eventBus';
 
 function wsMock() {
   return {
@@ -319,11 +327,45 @@ describe('agent websocket handshake', () => {
 
     expect(vi.mocked(handleTerminalOutput)).toHaveBeenCalledWith(sessionId, 'café\n');
   });
+
+  it('publishes a realtime updating status when the agent reports update_status', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    vi.mocked(db.update).mockReturnValue(updateResult([
+      { id: 'device-123', siteId: 'site-123', hostname: 'host-alpha' },
+    ]) as any);
+    vi.mocked(publishEvent).mockResolvedValue('event-id');
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'update_status',
+        targetVersion: '0.83.0',
+      }),
+    } as any, ws as any);
+
+    expect(publishEvent).toHaveBeenCalledWith(
+      'device.updated',
+      'org-123',
+      expect.objectContaining({
+        deviceId: 'device-123',
+        hostname: 'host-alpha',
+        fields: ['status'],
+        status: 'updating',
+        targetVersion: '0.83.0',
+      }),
+      'agent-ws',
+      { siteId: 'site-123' },
+    );
+  });
 });
 
 describe('agent websocket command results', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    applyCompletedComponentUpdateVersionMock.mockResolvedValue(false);
   });
 
   it('rejects cross-device command result updates', async () => {
@@ -383,6 +425,46 @@ describe('agent websocket command results', () => {
 
     expect(db.update).toHaveBeenCalledTimes(1);
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  it('post-processes completed component update results on the agent websocket', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectOwnedCommandResult([
+        {
+          id: 'cmd-watchdog',
+          type: 'update_watchdog',
+          payload: { version: '0.82.1' },
+          deviceId: 'device-123',
+          targetRole: 'agent',
+        }
+      ]) as any);
+
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: 'cmd-watchdog' }]) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '22222222-2222-4222-8222-222222222222',
+        status: 'completed',
+        exitCode: 0,
+        result: { updated_to: '0.82.1' },
+      })
+    } as any, ws as any);
+
+    expect(applyCompletedComponentUpdateVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'update_watchdog',
+        targetRole: 'agent',
+        payload: { version: '0.82.1' },
+      }),
+      'completed',
+      { updated_to: '0.82.1' },
+    );
   });
 
   it('rejects watchdog-targeted command results on the agent websocket', async () => {

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -37,6 +37,7 @@ import { publishEvent } from '../services/eventBus';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
 import { logSessionAudit, classifyConsentDenyAction, resolveConsentMarkerSessionId } from './remote/helpers';
 import { getActiveTrustKeyset } from '../services/manifestSigning';
+import { applyCompletedComponentUpdateVersion } from '../services/componentUpdateResults';
 
 /** Capabilities advertised to agents in the post-connect `connected` message. */
 export const AGENT_WS_CAPABILITIES = ['terminal_output_base64'] as const;
@@ -1448,6 +1449,13 @@ async function processCommandResult(
       command.payload && typeof command.payload === 'object' && !Array.isArray(command.payload)
         ? command.payload as Record<string, unknown>
         : {};
+    try {
+      await applyCompletedComponentUpdateVersion(command, normalizedResult.status, normalizedResult.result);
+    } catch (err) {
+      console.error(`[AgentWs] component update post-processing failed for ${result.commandId}:`, err);
+      captureException(err);
+    }
+
     if (DR_COMMAND_TYPES.has(command.type) && typeof commandPayload.drExecutionId === 'string') {
       try {
         const { handleDrCommandResult } = await import('./backup/drResultHandler');
@@ -1707,22 +1715,41 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
 
         // Handle update_status messages: agent is about to self-update
         if (message.type === 'update_status' && typeof message.targetVersion === 'string') {
+          let updatedDevice: { id: string; siteId: string | null; hostname: string | null } | undefined;
           if (agentDb) {
             await runWithAgentDbAccess(async () => {
               try {
-                await db
+                const [row] = await db
                   .update(devices)
                   .set({
                     status: 'updating',
                     lastSeenAt: new Date(),
                     updatedAt: new Date()
                   })
-                  .where(eq(devices.agentId, agentId));
+                  .where(eq(devices.agentId, agentId))
+                  .returning({
+                    id: devices.id,
+                    siteId: devices.siteId,
+                    hostname: devices.hostname,
+                  });
+                updatedDevice = row;
                 console.log(`[AgentWs] Agent ${agentId} entering update to ${message.targetVersion}`);
               } catch (error) {
                 console.error(`[AgentWs] Failed to set updating status for ${agentId}:`, error);
               }
             });
+            if (updatedDevice) {
+              publishEvent('device.updated', agentDb.orgId, {
+                deviceId: updatedDevice.id,
+                hostname: updatedDevice.hostname,
+                fields: ['status'],
+                status: 'updating',
+                targetVersion: message.targetVersion,
+              }, 'agent-ws', { siteId: updatedDevice.siteId ?? undefined }).catch(err => {
+                console.error('[AgentWs] Failed to publish device.updated update status:', err);
+                captureException(err);
+              });
+            }
           }
           return;
         }

--- a/apps/api/src/routes/agents/agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   normalizeAgentUpdatePolicy,
+  normalizeAgentUpdateSettings,
   parseMaintenanceWindow,
   isWithinMaintenanceWindow,
   shouldSendAgentUpgrade,
@@ -24,6 +25,83 @@ describe('normalizeAgentUpdatePolicy', () => {
     expect(normalizeAgentUpdatePolicy('')).toBe('staged');
     expect(normalizeAgentUpdatePolicy('bogus')).toBe('staged');
     expect(normalizeAgentUpdatePolicy(42)).toBe('staged');
+  });
+});
+
+describe('normalizeAgentUpdateSettings', () => {
+  it('maps legacy manual to structured manual', () => {
+    expect(normalizeAgentUpdateSettings({ agentUpdatePolicy: 'manual' })).toMatchObject({
+      mode: 'manual',
+      timing: 'asap',
+      schedule: null,
+    });
+  });
+
+  it('maps legacy automatic with a parseable day window to weekly', () => {
+    expect(normalizeAgentUpdateSettings({
+      agentUpdatePolicy: 'auto',
+      maintenanceWindow: 'Sun 02:00-04:00',
+    })).toMatchObject({
+      mode: 'automatic',
+      timing: 'weekly',
+      schedule: { windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }] },
+    });
+  });
+
+  it('maps legacy automatic without a window to the default weekly schedule', () => {
+    expect(normalizeAgentUpdateSettings({
+      agentUpdatePolicy: 'auto',
+    })).toMatchObject({
+      mode: 'automatic',
+      timing: 'weekly',
+      schedule: { windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }] },
+    });
+  });
+
+  it('maps malformed legacy windows to automatic asap with a warning flag', () => {
+    expect(normalizeAgentUpdateSettings({
+      agentUpdatePolicy: 'staged',
+      maintenanceWindow: 'sometime soon',
+    })).toMatchObject({
+      mode: 'automatic',
+      timing: 'asap',
+      schedule: null,
+      legacyWindowInvalid: true,
+    });
+  });
+
+  it('maps malformed legacy automatic windows to the default weekly schedule with a warning flag', () => {
+    expect(normalizeAgentUpdateSettings({
+      agentUpdatePolicy: 'auto',
+      maintenanceWindow: 'sometime soon',
+    })).toMatchObject({
+      mode: 'automatic',
+      timing: 'weekly',
+      schedule: { windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }] },
+      legacyWindowInvalid: true,
+    });
+  });
+
+  it('accepts structured schedules with multiple windows', () => {
+    expect(normalizeAgentUpdateSettings({
+      agentUpdateMode: 'automatic',
+      agentUpdateTiming: 'weekly',
+      agentUpdateSchedule: {
+        windows: [
+          { dayOfWeek: 'mon', start: '01:00', end: '03:00' },
+          { dayOfWeek: 'wed', start: '22:30', end: '01:30' },
+        ],
+      },
+    })).toMatchObject({
+      mode: 'automatic',
+      timing: 'weekly',
+      schedule: {
+        windows: [
+          { dayOfWeek: 'mon', start: '01:00', end: '03:00' },
+          { dayOfWeek: 'wed', start: '22:30', end: '01:30' },
+        ],
+      },
+    });
   });
 });
 
@@ -109,15 +187,60 @@ describe('shouldSendAgentUpgrade', () => {
     expect(shouldSendAgentUpgrade({ policy: 'auto', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0300))
       .toEqual({ allow: true, reason: 'allowed' });
     expect(shouldSendAgentUpgrade({ policy: 'auto', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0500))
-      .toEqual({ allow: false, reason: 'outside-maintenance-window' });
+      .toEqual({ allow: false, reason: 'outside-schedule' });
     expect(shouldSendAgentUpgrade({ policy: 'staged', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0300))
       .toEqual({ allow: true, reason: 'allowed' });
     expect(shouldSendAgentUpgrade({ policy: 'staged', maintenanceWindow: 'Sun 02:00-04:00' }, SUN_0500))
-      .toEqual({ allow: false, reason: 'outside-maintenance-window' });
+      .toEqual({ allow: false, reason: 'outside-schedule' });
   });
 
   it('staged with no window behaves like auto-anytime (non-breaking default)', () => {
     expect(shouldSendAgentUpgrade({ policy: 'staged', maintenanceWindow: null }, SUN_0500))
       .toEqual({ allow: true, reason: 'allowed' });
+  });
+
+  it('structured weekly allows any selected time window', () => {
+    expect(shouldSendAgentUpgrade({
+      mode: 'automatic',
+      timing: 'weekly',
+      schedule: {
+        windows: [
+          { dayOfWeek: 'mon', start: '01:00', end: '03:00' },
+          { dayOfWeek: 'sun', start: '02:00', end: '04:00' },
+        ],
+      },
+      pins: {},
+      legacyPolicy: null,
+      legacyMaintenanceWindow: null,
+      legacyWindowInvalid: false,
+    }, SUN_0300)).toEqual({ allow: true, reason: 'allowed' });
+    expect(shouldSendAgentUpgrade({
+      mode: 'automatic',
+      timing: 'weekly',
+      schedule: { windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }] },
+      pins: {},
+      legacyPolicy: null,
+      legacyMaintenanceWindow: null,
+      legacyWindowInvalid: false,
+    }, SUN_0500)).toEqual({ allow: false, reason: 'outside-schedule' });
+  });
+
+  it('structured weekly supports windows that wrap past midnight', () => {
+    const settings = {
+      mode: 'automatic' as const,
+      timing: 'weekly' as const,
+      schedule: { windows: [{ dayOfWeek: 'sat' as const, start: '22:00', end: '02:00' }] },
+      pins: {},
+      legacyPolicy: null,
+      legacyMaintenanceWindow: null,
+      legacyWindowInvalid: false,
+    };
+
+    expect(shouldSendAgentUpgrade(settings, new Date('2026-06-13T23:00:00Z')))
+      .toEqual({ allow: true, reason: 'allowed' });
+    expect(shouldSendAgentUpgrade(settings, new Date('2026-06-14T01:00:00Z')))
+      .toEqual({ allow: true, reason: 'allowed' });
+    expect(shouldSendAgentUpgrade(settings, new Date('2026-06-14T03:00:00Z')))
+      .toEqual({ allow: false, reason: 'outside-schedule' });
   });
 });

--- a/apps/api/src/routes/agents/agentUpdatePolicy.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.ts
@@ -1,42 +1,72 @@
 /**
  * Agent update policy resolution (pure logic).
  *
- * The org-level "Agent update policy" (Org > General) governs whether the
- * heartbeat handler is allowed to hand an agent an `upgradeTo` target:
+ * The org-level update settings (Org > General) govern whether heartbeat may
+ * hand an agent/watchdog an automatic update target:
  *
- *   - `manual`  → never auto-upgrade; upgrades happen only via explicit admin action
- *   - `auto`    → upgrade whenever a newer version exists
- *   - `staged`  → same as `auto`, but only while inside the configured
- *                 maintenance window (when one is set)
+ *   - `manual`           → never auto-upgrade or auto-heal
+ *   - `automatic`/`asap` → upgrade whenever a newer allowed target exists
+ *   - `automatic`/`weekly` → upgrade only during selected weekly windows
  *
- * In addition, a configured `maintenanceWindow` suppresses upgrades outside the
- * window for both `auto` and `staged`. A device with no maintenance window set
- * may upgrade at any time (this preserves the historical behaviour for orgs
- * that never configured the policy).
+ * Backward compatibility: legacy `agentUpdatePolicy` / `maintenanceWindow`
+ * values are still read and normalized into the structured shape below. The
+ * old `staged` label was not a real staged rollout; it only gated automatic
+ * updates on a free-text maintenance window.
  *
  * Timezone note: the org `maintenanceWindow` is a free-form string with no
  * timezone component (e.g. "Sun 02:00-04:00"), so it is evaluated against UTC
- * server time. Malformed windows fail open (no time restriction) so a typo
- * never permanently blocks updates.
+ * server time. New structured schedules are also evaluated against UTC.
  *
  * This module is pure and side-effect free so it can be unit tested without a
  * database. The DB read lives in `getOrgAgentUpdatePolicy` (helpers.ts).
  */
 
 export type AgentUpdatePolicy = 'auto' | 'staged' | 'manual';
+export type AgentUpdateMode = 'automatic' | 'manual';
+export type AgentUpdateTiming = 'asap' | 'weekly';
+export type AgentUpdateDayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+
+export interface AgentUpdateScheduleWindow {
+  dayOfWeek: AgentUpdateDayOfWeek;
+  start: string;
+  end: string;
+}
+
+export interface AgentUpdateSchedule {
+  windows: AgentUpdateScheduleWindow[];
+}
 
 export interface AgentUpdateSettings {
+  mode: AgentUpdateMode;
+  timing: AgentUpdateTiming;
+  schedule: AgentUpdateSchedule | null;
+  pins: {
+    agent?: string;
+    watchdog?: string;
+  };
+  legacyPolicy: AgentUpdatePolicy | null;
+  legacyMaintenanceWindow: string | null;
+  legacyWindowInvalid: boolean;
+}
+
+export interface LegacyAgentUpdateSettings {
   policy: AgentUpdatePolicy;
   maintenanceWindow: string | null;
 }
 
 export interface AgentUpdateGate {
   allow: boolean;
-  reason: 'allowed' | 'manual-approval' | 'outside-maintenance-window';
+  reason: 'allowed' | 'manual-approval' | 'outside-schedule';
 }
 
 const DAY_OF_WEEK: Record<string, number> = {
   sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+const DAY_KEYS: AgentUpdateDayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+const STRUCTURED_TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const VERSION_PIN_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
+const DEFAULT_WEEKLY_SCHEDULE: AgentUpdateSchedule = {
+  windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }],
 };
 
 interface ParsedWindow {
@@ -57,6 +87,164 @@ interface ParsedWindow {
 export function normalizeAgentUpdatePolicy(raw: unknown): AgentUpdatePolicy {
   if (raw === 'auto' || raw === 'staged' || raw === 'manual') return raw;
   return 'staged';
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeVersionPin(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
+}
+
+function minutesToTime(minutes: number): string {
+  const normalized = ((minutes % 1440) + 1440) % 1440;
+  const hours = Math.floor(normalized / 60);
+  const mins = normalized % 60;
+  return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
+}
+
+function addMinutesToTime(time: string, minutes: number): string {
+  const match = time.match(STRUCTURED_TIME_RE);
+  if (!match) return time;
+  return minutesToTime(Number(match[1]) * 60 + Number(match[2]) + minutes);
+}
+
+function parseScheduleWindow(raw: unknown): AgentUpdateScheduleWindow | null {
+  if (!isObject(raw)) return null;
+  const rawDay = raw.dayOfWeek;
+  const rawStart = raw.start ?? raw.time;
+  const rawEnd = raw.end ?? (typeof rawStart === 'string' ? addMinutesToTime(rawStart, 60) : undefined);
+  if (typeof rawDay !== 'string' || typeof rawStart !== 'string' || typeof rawEnd !== 'string') {
+    return null;
+  }
+  const day = rawDay.toLowerCase();
+  if (!DAY_KEYS.includes(day as AgentUpdateDayOfWeek)) return null;
+  if (!STRUCTURED_TIME_RE.test(rawStart) || !STRUCTURED_TIME_RE.test(rawEnd)) return null;
+  if (rawStart === rawEnd) return null;
+  return {
+    dayOfWeek: day as AgentUpdateDayOfWeek,
+    start: rawStart,
+    end: rawEnd,
+  };
+}
+
+function parseStructuredSchedule(raw: unknown): AgentUpdateSchedule | null {
+  if (!isObject(raw)) return null;
+  if (Array.isArray(raw.windows)) {
+    const windows = raw.windows
+      .map(parseScheduleWindow)
+      .filter((window): window is AgentUpdateScheduleWindow => window !== null);
+    return windows.length > 0 ? { windows } : null;
+  }
+  const legacyWindow = parseScheduleWindow(raw);
+  return legacyWindow ? { windows: [legacyWindow] } : null;
+}
+
+function scheduleFromLegacyWindow(raw: string | null): AgentUpdateSchedule | null {
+  const parsed = parseMaintenanceWindow(raw);
+  if (!parsed) return null;
+  const start = minutesToTime(parsed.startMin);
+  const end = minutesToTime(parsed.endMin);
+  if (parsed.day === null) {
+    return {
+      windows: DAY_KEYS.map((dayOfWeek) => ({ dayOfWeek, start, end })),
+    };
+  }
+  const dayOfWeek = DAY_KEYS[parsed.day];
+  return dayOfWeek ? { windows: [{ dayOfWeek, start, end }] } : null;
+}
+
+export function normalizeAgentUpdateSettings(defaultsRaw: unknown): AgentUpdateSettings {
+  const defaults = isObject(defaultsRaw) ? defaultsRaw : {};
+
+  const legacyPolicy =
+    defaults.agentUpdatePolicy === 'auto' ||
+    defaults.agentUpdatePolicy === 'staged' ||
+    defaults.agentUpdatePolicy === 'manual'
+      ? defaults.agentUpdatePolicy
+      : null;
+  const legacyMaintenanceWindow =
+    typeof defaults.maintenanceWindow === 'string' && defaults.maintenanceWindow.trim()
+      ? defaults.maintenanceWindow.trim()
+      : null;
+  const legacySchedule = scheduleFromLegacyWindow(legacyMaintenanceWindow);
+  const legacyWindowInvalid = legacyMaintenanceWindow !== null && legacySchedule === null;
+
+  const rawMode = defaults.agentUpdateMode;
+  const mode: AgentUpdateMode =
+    rawMode === 'automatic' || rawMode === 'manual'
+      ? rawMode
+      : legacyPolicy === 'manual'
+        ? 'manual'
+        : 'automatic';
+
+  const rawTiming = defaults.agentUpdateTiming;
+  const explicitSchedule = parseStructuredSchedule(defaults.agentUpdateSchedule);
+  const timing: AgentUpdateTiming =
+    mode === 'manual'
+      ? 'asap'
+      : rawTiming === 'weekly'
+        ? 'weekly'
+        : rawTiming === 'asap'
+          ? 'asap'
+          : legacyPolicy === 'auto' || legacySchedule
+            ? 'weekly'
+            : 'asap';
+
+  const pins = isObject(defaults.agentVersionPins) ? defaults.agentVersionPins : {};
+  return {
+    mode,
+    timing,
+    schedule: timing === 'weekly' ? (explicitSchedule ?? legacySchedule ?? DEFAULT_WEEKLY_SCHEDULE) : null,
+    pins: {
+      ...(normalizeVersionPin(pins.agent) ? { agent: normalizeVersionPin(pins.agent) } : {}),
+      ...(normalizeVersionPin(pins.watchdog) ? { watchdog: normalizeVersionPin(pins.watchdog) } : {}),
+    },
+    legacyPolicy,
+    legacyMaintenanceWindow,
+    legacyWindowInvalid,
+  };
+}
+
+export function validateAgentUpdateDefaults(defaultsRaw: unknown): string | null {
+  if (!isObject(defaultsRaw)) return null;
+
+  if (
+    defaultsRaw.agentUpdateMode !== undefined &&
+    defaultsRaw.agentUpdateMode !== 'automatic' &&
+    defaultsRaw.agentUpdateMode !== 'manual'
+  ) {
+    return 'agentUpdateMode must be automatic or manual';
+  }
+  if (
+    defaultsRaw.agentUpdateTiming !== undefined &&
+    defaultsRaw.agentUpdateTiming !== 'asap' &&
+    defaultsRaw.agentUpdateTiming !== 'weekly'
+  ) {
+    return 'agentUpdateTiming must be asap or weekly';
+  }
+  if (defaultsRaw.agentUpdateTiming === 'weekly' || defaultsRaw.agentUpdateSchedule !== undefined) {
+    if (!parseStructuredSchedule(defaultsRaw.agentUpdateSchedule)) {
+      return 'agentUpdateSchedule must include at least one window with dayOfWeek, start, and end in HH:MM format';
+    }
+  }
+  if (defaultsRaw.agentVersionPins !== undefined) {
+    if (!isObject(defaultsRaw.agentVersionPins)) {
+      return 'agentVersionPins must be an object';
+    }
+    for (const key of ['agent', 'watchdog'] as const) {
+      const raw = defaultsRaw.agentVersionPins[key];
+      if (raw === undefined || raw === null || raw === '') continue;
+      if (typeof raw !== 'string' || !VERSION_PIN_RE.test(raw.trim())) {
+        return `agentVersionPins.${key} must be a valid version string`;
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -123,12 +311,55 @@ export function isWithinMaintenanceWindow(raw: string | null | undefined, now: D
  * Decide whether the heartbeat handler may hand the agent an upgrade target
  * right now, given the org's update settings.
  */
-export function shouldSendAgentUpgrade(settings: AgentUpdateSettings, now: Date): AgentUpdateGate {
-  if (settings.policy === 'manual') {
+export function isWithinWeeklySchedule(schedule: AgentUpdateSchedule | null, now: Date): boolean {
+  if (!schedule || schedule.windows.length === 0) return false;
+  const nowMin = now.getUTCHours() * 60 + now.getUTCMinutes();
+  const nowDay = now.getUTCDay();
+
+  return schedule.windows.some((window) => {
+    const day = DAY_OF_WEEK[window.dayOfWeek];
+    if (day === undefined) return false;
+    const startMatch = window.start.match(STRUCTURED_TIME_RE);
+    const endMatch = window.end.match(STRUCTURED_TIME_RE);
+    if (!startMatch || !endMatch) return false;
+    const startMin = Number(startMatch[1]) * 60 + Number(startMatch[2]);
+    const endMin = Number(endMatch[1]) * 60 + Number(endMatch[2]);
+
+    if (startMin < endMin) {
+      return nowDay === day && nowMin >= startMin && nowMin < endMin;
+    }
+
+    const nextDay = (day + 1) % 7;
+    if (nowDay === day) return nowMin >= startMin;
+    if (nowDay === nextDay) return nowMin < endMin;
+    return false;
+  });
+}
+
+/**
+ * Decide whether the heartbeat handler may hand the agent an automatic update
+ * target right now. Accepts the legacy shape too so older tests/mocks and any
+ * transitional call sites continue to behave until they are migrated.
+ */
+export function shouldSendAgentUpgrade(
+  settings: AgentUpdateSettings | LegacyAgentUpdateSettings,
+  now: Date,
+): AgentUpdateGate {
+  if ('policy' in settings) {
+    if (settings.policy === 'manual') {
+      return { allow: false, reason: 'manual-approval' };
+    }
+    if (!isWithinMaintenanceWindow(settings.maintenanceWindow, now)) {
+      return { allow: false, reason: 'outside-schedule' };
+    }
+    return { allow: true, reason: 'allowed' };
+  }
+
+  if (settings.mode === 'manual') {
     return { allow: false, reason: 'manual-approval' };
   }
-  if (!isWithinMaintenanceWindow(settings.maintenanceWindow, now)) {
-    return { allow: false, reason: 'outside-maintenance-window' };
+  if (settings.timing === 'weekly' && !isWithinWeeklySchedule(settings.schedule, now)) {
+    return { allow: false, reason: 'outside-schedule' };
   }
   return { allow: true, reason: 'allowed' };
 }

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -6,6 +6,7 @@ const updateMock = vi.fn();
 const runOutsideDbContextMock = vi.fn((fn: () => unknown) => fn());
 const updateRestoreJobByCommandIdMock = vi.fn().mockResolvedValue(true);
 const claimPendingCommandsForDeviceMock = vi.fn();
+const applyCompletedComponentUpdateVersionMock = vi.fn().mockResolvedValue(false);
 
 function chainMock(resolvedValue: unknown = []) {
   const chain: Record<string, any> = {};
@@ -56,6 +57,10 @@ vi.mock('../../services/commandDispatch', () => ({
   claimPendingCommandsForDevice: (...args: unknown[]) => claimPendingCommandsForDeviceMock(...(args as [])),
 }));
 
+vi.mock('../../services/componentUpdateResults', () => ({
+  applyCompletedComponentUpdateVersion: (...args: unknown[]) => applyCompletedComponentUpdateVersionMock(...(args as [])),
+}));
+
 vi.mock('../../services/vaultSyncPersistence', () => ({
   applyVaultSyncCommandResult: vi.fn(),
 }));
@@ -88,6 +93,7 @@ describe('agent commands routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    applyCompletedComponentUpdateVersionMock.mockResolvedValue(false);
     app = new Hono();
     app.use('*', async (c, next) => {
       c.set('agent', {
@@ -200,5 +206,48 @@ describe('agent commands routes', () => {
 
     expect(res.status).toBe(403);
     expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('post-processes completed component update results', async () => {
+    selectMock.mockReturnValueOnce(
+      chainMock([
+        {
+          id: commandId,
+          deviceId: 'device-1',
+          type: 'update_watchdog',
+          status: 'sent',
+          targetRole: 'agent',
+          payload: { version: '0.82.1' },
+        },
+      ])
+    );
+    updateMock.mockReturnValueOnce(
+      chainMock([
+        {
+          id: commandId,
+        },
+      ])
+    );
+
+    const res = await app.request(`/agents/${agentId}/commands/${commandId}/result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        status: 'completed',
+        result: { updated_to: '0.82.1' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(applyCompletedComponentUpdateVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: commandId,
+        type: 'update_watchdog',
+        targetRole: 'agent',
+        payload: { version: '0.82.1' },
+      }),
+      'completed',
+      { updated_to: '0.82.1' },
+    );
   });
 });

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -28,6 +28,7 @@ import { applyVaultSyncCommandResult } from '../../services/vaultSyncPersistence
 import { processBackupVerificationResult } from '../backup/verificationService';
 import { updateRestoreJobByCommandId } from '../../services/restoreResultPersistence';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../../services/agentCommandResultValidation';
+import { applyCompletedComponentUpdateVersion } from '../../services/componentUpdateResults';
 
 export const commandsRoutes = new Hono();
 const ACCEPTED_COMMAND_RESULT_STATUSES = ['pending', 'sent'] as const;
@@ -266,6 +267,13 @@ commandsRoutes.post(
     if (validationError) {
       console.warn(`[agents] ${validationError}`);
       return c.json({ success: true });
+    }
+
+    try {
+      await applyCompletedComponentUpdateVersion(command, normalizedData.status, normalizedData.result);
+    } catch (err) {
+      console.error(`[agents] component update post-processing failed for ${commandId}:`, err);
+      captureException(err);
     }
 
     if (

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -3,7 +3,14 @@ import { statSync, createReadStream } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { VALID_OS, VALID_ARCH } from './schemas';
 import { isS3Configured, getPresignedUrl, isS3NotFound } from '../../services/s3Storage';
-import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubWatchdogUrl, HELPER_FILENAMES } from '../../services/binarySource';
+import {
+  getBinarySource,
+  getGithubAgentUrl,
+  getGithubAgentPkgUrl,
+  getGithubHelperUrl,
+  getGithubWatchdogUrl,
+  HELPER_FILENAMES,
+} from '../../services/binarySource';
 
 export const downloadRoutes = new Hono();
 
@@ -330,7 +337,7 @@ downloadRoutes.get('/download/watchdog/:os/:arch', async (c) => {
     }
   }
 
-  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  const binaryDir = resolve(process.env.WATCHDOG_BINARY_DIR || process.env.AGENT_BINARY_DIR || './agent/bin');
   const filePath = join(binaryDir, filename);
 
   let fileStat: ReturnType<typeof statSync>;

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1442,7 +1442,7 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   // gated version-to-version branch rather than the ungated bootstrap branch.
   const deviceWithWatchdog = {
     id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
-    architecture: 'amd64', agentVersion: '0.83.1', watchdogVersion: '0.65.0',
+    architecture: 'amd64', agentVersion: '0.83.2', watchdogVersion: '0.65.0',
     lastSeenAt: new Date(), mainAgentSilentSince: null,
   };
   // Fresh device missing both helper and watchdog — both take the bootstrap

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1442,7 +1442,7 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   // gated version-to-version branch rather than the ungated bootstrap branch.
   const deviceWithWatchdog = {
     id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
-    architecture: 'amd64', agentVersion: '0.83.0', watchdogVersion: '0.65.0',
+    architecture: 'amd64', agentVersion: '0.83.1', watchdogVersion: '0.65.0',
     lastSeenAt: new Date(), mainAgentSilentSince: null,
   };
   // Fresh device missing both helper and watchdog — both take the bootstrap

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import type { AgentUpdateSettings, AgentUpdateDayOfWeek } from './agentUpdatePolicy';
 
 // ---------- mocks ----------
 
@@ -13,11 +14,32 @@ const runOutsideDbContextMock = vi.fn(async (fn: () => unknown) => fn());
 // (the #1105 pool-poison fix). Reset per test.
 const callOrder: string[] = [];
 
+function updateSettings(
+  mode: AgentUpdateSettings['mode'],
+  timing: AgentUpdateSettings['timing'] = 'asap',
+  schedule: AgentUpdateSettings['schedule'] = null,
+): AgentUpdateSettings {
+  return {
+    mode,
+    timing: mode === 'manual' ? 'asap' : timing,
+    schedule: mode === 'manual' ? null : schedule,
+    pins: {},
+    legacyPolicy: null,
+    legacyMaintenanceWindow: null,
+    legacyWindowInvalid: false,
+  };
+}
+
 vi.mock('../../db', () => ({
   db: {
     select: (...args: unknown[]) => selectMock(...(args as [])),
     update: (...args: unknown[]) => updateMock(...(args as [])),
     insert: (...args: unknown[]) => insertMock(...(args as [])),
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn({
+      select: (...args: unknown[]) => selectMock(...(args as [])),
+      update: (...args: unknown[]) => updateMock(...(args as [])),
+      insert: (...args: unknown[]) => insertMock(...(args as [])),
+    }),
   },
   runOutsideDbContext: (...args: unknown[]) =>
     runOutsideDbContextMock(...(args as [any])),
@@ -55,6 +77,18 @@ vi.mock('../../db/schema', () => ({
     tokenIssuedAt: 'devices.token_issued_at',
   },
   deviceMetrics: { deviceId: 'device_metrics.device_id' },
+  deviceCommands: {
+    id: 'device_commands.id',
+    deviceId: 'device_commands.device_id',
+    type: 'device_commands.type',
+    payload: 'device_commands.payload',
+    status: 'device_commands.status',
+    targetRole: 'device_commands.target_role',
+    result: 'device_commands.result',
+    createdAt: 'device_commands.created_at',
+    executedAt: 'device_commands.executed_at',
+    completedAt: 'device_commands.completed_at',
+  },
   agentLogs: { deviceId: 'agent_logs.device_id' },
   agentVersions: {
     platform: 'agent_versions.platform',
@@ -156,6 +190,30 @@ function selectChainResolving(value: unknown) {
       })),
     })),
   };
+}
+
+function selectChainBySelectedFields(args: {
+  deviceRow: Record<string, unknown>;
+  version: string;
+  markerRow?: Record<string, unknown>;
+  setAutoUpdateRow?: Record<string, unknown>;
+  pendingComponentCommands?: Record<string, unknown>[];
+}) {
+  selectMock.mockImplementation((fields?: Record<string, unknown>) => {
+    if (fields?.id === 'device_commands.id' && Object.keys(fields).length === 1) {
+      return selectChainResolving(args.pendingComponentCommands ?? []);
+    }
+    if (fields?.payload === 'device_commands.payload') {
+      return selectChainResolving(args.markerRow ? [args.markerRow] : []);
+    }
+    if (fields?.type === 'device_commands.type' && fields?.result === 'device_commands.result') {
+      return selectChainResolving(args.setAutoUpdateRow ? [args.setAutoUpdateRow] : []);
+    }
+    if (fields?.version === 'agent_versions.version') {
+      return selectChainResolving([{ version: args.version }]);
+    }
+    return selectChainResolving([args.deviceRow]);
+  });
 }
 
 function buildApp(): Hono {
@@ -413,6 +471,38 @@ describe('POST /agents/:id/heartbeat — main-agent-silent asymmetry detector (#
     expect(publishEvent).not.toHaveBeenCalled();
   });
 
+  it('Watchdog heartbeat accepts long build-tag versions and stores the full watchdog version', async () => {
+    const longWatchdogVersion = 'agent-watchdog-update-b826573971401b7274407fb701a4e5059be17f7e';
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          hostname: 'TST-LAPTOP-01',
+          lastSeenAt: oneMinuteAgo,
+          mainAgentSilentSince: null,
+        },
+      ]),
+    );
+    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    updateMock.mockReturnValue({ set: setSpy });
+    selectMock.mockReturnValue(selectChainResolving([]));
+
+    const resp = await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentVersion: longWatchdogVersion,
+        role: 'watchdog',
+        watchdogState: 'MONITORING',
+      }),
+    });
+
+    expect(resp.status).toBe(200);
+    const updateArg = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.watchdogVersion).toBe(longWatchdogVersion);
+  });
+
   it('Watchdog heartbeat when device already mainAgentSilentSince → does NOT re-emit event (no spam)', async () => {
     // Already-silent state: subsequent watchdog ticks should idempotently
     // update watchdog cols without re-firing the event.
@@ -636,6 +726,32 @@ describe('POST /agents/:id/heartbeat — watchdog restart-stats logging (#799)',
     expect(capturedInsertTable).toBeUndefined();
     expect(capturedInsertValues).toBeUndefined();
   });
+
+  it('watchdog heartbeat still succeeds when command claiming fails', async () => {
+    const { claimPendingCommandsForDevice } = await import('../../services/commandDispatch');
+    const { captureException } = await import('../../services/sentry');
+    vi.mocked(claimPendingCommandsForDevice).mockRejectedValueOnce(new Error('dispatch unavailable'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const resp = await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          role: 'watchdog',
+          agentVersion: '0.65.20',
+          watchdogState: 'MONITORING',
+        }),
+      });
+
+      expect(resp.status).toBe(200);
+      const body = await resp.json() as { commands?: unknown[] };
+      expect(body.commands).toEqual([]);
+      expect(captureException).toHaveBeenCalledWith(expect.any(Error));
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------
@@ -749,6 +865,24 @@ describe('POST /agents/:id/heartbeat — watchdog-branch agent recovery upgradeT
     expect(resp.status).toBe(200);
     const body = await resp.json() as { upgradeTo?: string };
     expect(body.upgradeTo).toBeUndefined();
+  });
+
+  it('does not return watchdogUpgradeTo on watchdog heartbeats', async () => {
+    const { compareAgentVersions } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    primeSelects(
+      {
+        id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+        architecture: 'amd64', agentVersion: '0.82.2', watchdogVersion: '0.65.20',
+        lastSeenAt: oneMinuteAgo, mainAgentSilentSince: null,
+      },
+      [{ version: '0.82.3' }],
+    );
+
+    const resp = await post();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { watchdogUpgradeTo?: string };
+    expect(body.watchdogUpgradeTo).toBeUndefined();
   });
 });
 
@@ -997,7 +1131,7 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   it('manual policy → withholds agent upgradeTo even when a newer version exists', async () => {
     const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1); // latest > reported
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('manual'));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1007,10 +1141,228 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     expect(body.upgradeTo).toBeFalsy();
   });
 
+  it('manual legacy marker → returns upgradeTo after set_auto_update completes', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('manual'));
+    const legacyDevice = { ...deviceRow, agentVersion: '0.82.1', watchdogVersion: '0.82.1' };
+    selectChainBySelectedFields({
+      deviceRow: legacyDevice,
+      version: '0.83.0',
+      markerRow: {
+        id: 'cmd-legacy',
+        payload: { version: '0.83.0', setAutoUpdateCommandId: 'cmd-auto' },
+        status: 'pending',
+      },
+      setAutoUpdateRow: {
+        id: 'cmd-auto',
+        type: 'set_auto_update',
+        status: 'completed',
+        result: { enabled: true },
+      },
+    });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.82.1', metrics: minimalHeartbeatBody.metrics }),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBe('0.83.0');
+  });
+
+  it('manual legacy marker → withholds upgradeTo until set_auto_update completes', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('manual'));
+    const legacyDevice = { ...deviceRow, agentVersion: '0.82.1', watchdogVersion: '0.82.1' };
+    selectChainBySelectedFields({
+      deviceRow: legacyDevice,
+      version: '0.83.0',
+      markerRow: {
+        id: 'cmd-legacy',
+        payload: { version: '0.83.0', setAutoUpdateCommandId: 'cmd-auto' },
+        status: 'pending',
+      },
+      setAutoUpdateRow: {
+        id: 'cmd-auto',
+        type: 'set_auto_update',
+        status: 'pending',
+        result: null,
+      },
+    });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.82.1', metrics: minimalHeartbeatBody.metrics }),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBeFalsy();
+  });
+
+  it('manual legacy marker → completes when the agent reports the target version', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('manual'));
+    const updateSets: Array<Record<string, unknown>> = [];
+    const insertValues: Array<Record<string, unknown>> = [];
+    updateMock.mockImplementation(() => ({
+      set: vi.fn((value: Record<string, unknown>) => {
+        updateSets.push(value);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    }));
+    insertMock.mockImplementation(() => ({
+      values: vi.fn((value: Record<string, unknown>) => {
+        insertValues.push(value);
+        return Promise.resolve(undefined);
+      }),
+    }));
+    const upgradedDevice = { ...deviceRow, agentVersion: '0.82.1', watchdogVersion: '0.82.1' };
+    selectChainBySelectedFields({
+      deviceRow: upgradedDevice,
+      version: '0.83.0',
+      markerRow: {
+        id: 'cmd-legacy',
+        payload: { version: '0.83.0', setAutoUpdateCommandId: 'cmd-auto' },
+        status: 'sent',
+      },
+    });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.83.0', metrics: minimalHeartbeatBody.metrics }),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBeFalsy();
+    expect(updateSets).toContainEqual(expect.objectContaining({
+      status: 'completed',
+      result: expect.objectContaining({ updated_to: '0.83.0' }),
+    }));
+    expect(insertValues).toContainEqual(expect.objectContaining({
+      deviceId: 'device-1',
+      type: 'set_auto_update',
+      status: 'pending',
+      targetRole: 'agent',
+      createdBy: null,
+      payload: expect.objectContaining({
+        enabled: false,
+        reason: 'legacy_agent_update_complete',
+        sourceCommandId: 'cmd-legacy',
+        targetVersion: '0.83.0',
+      }),
+    }));
+  });
+
+  it('manual legacy marker → times out and restores org auto_update setting', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('manual'));
+    const updateSets: Array<Record<string, unknown>> = [];
+    const insertValues: Array<Record<string, unknown>> = [];
+    updateMock.mockImplementation(() => ({
+      set: vi.fn((value: Record<string, unknown>) => {
+        updateSets.push(value);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    }));
+    insertMock.mockImplementation(() => ({
+      values: vi.fn((value: Record<string, unknown>) => {
+        insertValues.push(value);
+        return Promise.resolve(undefined);
+      }),
+    }));
+    const legacyDevice = { ...deviceRow, agentVersion: '0.82.1', watchdogVersion: '0.82.1' };
+    selectChainBySelectedFields({
+      deviceRow: legacyDevice,
+      version: '0.82.2',
+      markerRow: {
+        id: 'cmd-legacy',
+        payload: { version: '0.82.2', setAutoUpdateCommandId: 'cmd-auto' },
+        status: 'sent',
+        executedAt: new Date(Date.now() - 31 * 60 * 1000),
+      },
+    });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.82.1', metrics: minimalHeartbeatBody.metrics }),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBeFalsy();
+    expect(updateSets).toContainEqual(expect.objectContaining({
+      status: 'failed',
+      result: { error: 'legacy agent update timed out' },
+    }));
+    expect(insertValues).toContainEqual(expect.objectContaining({
+      deviceId: 'device-1',
+      type: 'set_auto_update',
+      status: 'pending',
+      targetRole: 'agent',
+      createdBy: null,
+      payload: expect.objectContaining({
+        enabled: false,
+        reason: 'legacy_agent_update_failed',
+        sourceCommandId: 'cmd-legacy',
+        targetVersion: '0.82.2',
+        error: 'legacy agent update timed out',
+      }),
+    }));
+  });
+
+  it('automatic legacy marker → restores auto_update=true after the agent reports the target version', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('automatic', 'asap'));
+    const insertValues: Array<Record<string, unknown>> = [];
+    updateMock.mockImplementation(() => ({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    }));
+    insertMock.mockImplementation(() => ({
+      values: vi.fn((value: Record<string, unknown>) => {
+        insertValues.push(value);
+        return Promise.resolve(undefined);
+      }),
+    }));
+    const upgradedDevice = { ...deviceRow, agentVersion: '0.82.1', watchdogVersion: '0.82.1' };
+    selectChainBySelectedFields({
+      deviceRow: upgradedDevice,
+      version: '0.83.0',
+      markerRow: {
+        id: 'cmd-legacy',
+        payload: { version: '0.83.0', setAutoUpdateCommandId: 'cmd-auto' },
+        status: 'sent',
+      },
+    });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.83.0', metrics: minimalHeartbeatBody.metrics }),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(insertValues).toContainEqual(expect.objectContaining({
+      type: 'set_auto_update',
+      targetRole: 'agent',
+      payload: expect.objectContaining({
+        enabled: true,
+        reason: 'legacy_agent_update_complete',
+        sourceCommandId: 'cmd-legacy',
+      }),
+    }));
+  });
+
   it('auto policy with no maintenance window → offers agent upgradeTo when newer exists', async () => {
     const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('automatic', 'asap'));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1025,8 +1377,14 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     vi.mocked(compareAgentVersions).mockReturnValue(1);
     // A window on a different UTC day than "now" guarantees we're outside it.
     const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const otherDay = days[(new Date().getUTCDay() + 3) % 7];
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'staged', maintenanceWindow: `${otherDay} 02:00-04:00` });
+    const otherDay = days[(new Date().getUTCDay() + 3) % 7]!;
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('automatic', 'weekly', {
+      windows: [{
+        dayOfWeek: otherDay.toLowerCase() as AgentUpdateDayOfWeek,
+        start: '02:00',
+        end: '04:00',
+      }],
+    }));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1036,7 +1394,7 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     expect(body.upgradeTo).toBeFalsy();
   });
 
-  it('fails open (offers upgrade) when the policy lookup throws', async () => {
+  it('fails closed (withholds upgrade) when the policy lookup throws', async () => {
     const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
     vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
@@ -1046,7 +1404,7 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     const resp = await postAgentHeartbeat();
     expect(resp.status).toBe(200);
     const body = await resp.json() as { upgradeTo?: string | null };
-    expect(body.upgradeTo).toBe('0.66.0');
+    expect(body.upgradeTo).toBeFalsy();
   });
 
   // A dev-push build (dev-*) must never be auto-upgraded back to a release,
@@ -1055,7 +1413,7 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   it('dev- agent build is never upgraded even under auto policy', async () => {
     const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('automatic', 'asap'));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1084,7 +1442,7 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   // gated version-to-version branch rather than the ungated bootstrap branch.
   const deviceWithWatchdog = {
     id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
-    architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: '0.65.0',
+    architecture: 'amd64', agentVersion: '0.83.0', watchdogVersion: '0.65.0',
     lastSeenAt: new Date(), mainAgentSilentSince: null,
   };
   // Fresh device missing both helper and watchdog — both take the bootstrap
@@ -1114,13 +1472,12 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   async function postWithInstalledComponents(deviceRow: typeof deviceWithWatchdog) {
     const { compareAgentVersions } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1); // latest > reported, all components
-    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
-    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+    selectChainBySelectedFields({ deviceRow, version: '0.66.0' });
     return buildApp().request('/agents/device-1/heartbeat', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        role: 'agent', agentVersion: '0.65.10', helperVersion: '0.65.0',
+        role: 'agent', agentVersion: deviceRow.agentVersion, helperVersion: '0.65.0',
         metrics: minimalHeartbeatBody.metrics,
       }),
     });
@@ -1128,7 +1485,7 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
 
   it('manual policy → withholds helper and watchdog version-to-version upgrades', async () => {
     const { getOrgAgentUpdatePolicy } = await import('./helpers');
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('manual'));
 
     const resp = await postWithInstalledComponents(deviceWithWatchdog);
     expect(resp.status).toBe(200);
@@ -1137,26 +1494,47 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
     expect(body.watchdogUpgradeTo).toBeFalsy();
   });
 
-  it('auto policy → offers helper and watchdog version-to-version upgrades', async () => {
+  it('auto policy → offers helper upgrade and queues watchdog update through the agent command path', async () => {
     const { getOrgAgentUpdatePolicy } = await import('./helpers');
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('automatic', 'asap'));
+    const valuesMock = vi.fn().mockResolvedValue(undefined);
+    insertMock.mockReturnValue({ values: valuesMock });
 
     const resp = await postWithInstalledComponents(deviceWithWatchdog);
     expect(resp.status).toBe(200);
     const body = await resp.json() as { helperUpgradeTo?: string | null; watchdogUpgradeTo?: string | null };
     expect(body.helperUpgradeTo).toBe('0.66.0');
-    expect(body.watchdogUpgradeTo).toBe('0.66.0');
+    expect(body.watchdogUpgradeTo).toBeFalsy();
+
+    const queuedWatchdogCommand = valuesMock.mock.calls
+      .map(([row]) => row as Record<string, unknown>)
+      .find((row) => row.type === 'update_watchdog');
+    expect(queuedWatchdogCommand).toMatchObject({
+      deviceId: 'device-1',
+      type: 'update_watchdog',
+      status: 'pending',
+      targetRole: 'agent',
+      createdBy: null,
+    });
+    expect(queuedWatchdogCommand?.payload).toMatchObject({
+      component: 'watchdog',
+      version: '0.66.0',
+      manual: false,
+      automatic: true,
+      source: 'policy-autoheal',
+      reason: 'outdated',
+    });
   });
 
-  it('manual policy → STILL bootstraps a missing helper and watchdog (bootstrap is ungated)', async () => {
+  it('manual policy → bootstraps missing helper but withholds automatic watchdog repair', async () => {
     const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue(updateSettings('manual'));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceNeedingBootstrap]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
-    // No helperVersion in the body → helper bootstrap branch; watchdogVersion
-    // null on the device → watchdog bootstrap branch. Both must fire under manual.
+    // No helperVersion in the body → helper bootstrap branch. watchdogVersion
+    // null on the device → watchdog repair branch, now gated by manual mode.
     const resp = await buildApp().request('/agents/device-1/heartbeat', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -1167,8 +1545,8 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
       upgradeTo?: string | null; helperUpgradeTo?: string | null; watchdogUpgradeTo?: string | null;
     };
     expect(body.upgradeTo).toBeFalsy(); // agent version-to-version IS gated → withheld
-    expect(body.helperUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite manual
-    expect(body.watchdogUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite manual
+    expect(body.helperUpgradeTo).toBe('0.66.0'); // helper bootstrap remains unchanged
+    expect(body.watchdogUpgradeTo).toBeFalsy(); // watchdog autoheal is manual-gated
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { zValidator } from '@hono/zod-validator';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { db, withDbAccessContext } from '../../db';
 import {
   devices,
+  deviceCommands,
   deviceMetrics,
   agentVersions,
   agentLogs,
@@ -26,7 +27,13 @@ import {
   getOrgAgentUpdatePolicy,
   type OnedriveConfigUpdate,
 } from './helpers';
-import { shouldSendAgentUpgrade } from './agentUpdatePolicy';
+import { normalizeAgentUpdateSettings, shouldSendAgentUpgrade } from './agentUpdatePolicy';
+import {
+  compareAgentReleaseVersions,
+  isComparableReleaseVersion,
+  resolveComponentUpdateDecision,
+  type DeviceUpdateInput,
+} from '../../services/agentUpdateTargets';
 import { processDeviceIPHistoryUpdate } from '../../services/deviceIpHistory';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
 import { publishEvent } from '../../services/eventBus';
@@ -59,6 +66,284 @@ export function detectWatchdogStateCollapse(
 }
 
 export const heartbeatRoutes = new Hono();
+
+const COMMAND_LEGACY_AGENT_UPDATE = 'legacy_agent_update';
+const COMMAND_SET_AUTO_UPDATE = 'set_auto_update';
+const COMMAND_UPDATE_WATCHDOG = 'update_watchdog';
+const LEGACY_AGENT_UPDATE_TIMEOUT_MS = 30 * 60 * 1000;
+
+function payloadString(payload: unknown, key: string): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const value = (payload as Record<string, unknown>)[key];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function agentVersionSatisfiesTarget(currentVersion: string | null | undefined, targetVersion: string): boolean {
+  if (!currentVersion) return false;
+  if (currentVersion === targetVersion) return true;
+  if (isComparableReleaseVersion(currentVersion) && isComparableReleaseVersion(targetVersion)) {
+    return compareAgentReleaseVersions(currentVersion, targetVersion) >= 0;
+  }
+  return false;
+}
+
+async function completeLegacyAgentUpdateMarker(args: {
+  commandId: string;
+  deviceId: string;
+  targetVersion: string;
+  orgAutoUpdateEnabled: boolean;
+}): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .update(deviceCommands)
+      .set({
+        status: 'completed',
+        completedAt: new Date(),
+        result: {
+          updated_to: args.targetVersion,
+          transport: 'legacy-heartbeat-upgrade',
+        },
+      })
+      .where(eq(deviceCommands.id, args.commandId));
+
+    await tx
+      .insert(deviceCommands)
+      .values({
+        deviceId: args.deviceId,
+        type: COMMAND_SET_AUTO_UPDATE,
+        payload: {
+          enabled: args.orgAutoUpdateEnabled,
+          reason: 'legacy_agent_update_complete',
+          sourceCommandId: args.commandId,
+          targetVersion: args.targetVersion,
+        },
+        status: 'pending',
+        targetRole: 'agent',
+        createdBy: null,
+      });
+  });
+}
+
+async function failLegacyAgentUpdateMarker(args: {
+  commandId: string;
+  reason: string;
+  deviceId?: string;
+  targetVersion?: string;
+  orgAutoUpdateEnabled?: boolean;
+}): Promise<void> {
+  const completedAt = new Date();
+  const restoreAutoUpdate = args.deviceId !== undefined
+    && args.targetVersion !== undefined
+    && args.orgAutoUpdateEnabled !== undefined
+    ? {
+        deviceId: args.deviceId,
+        targetVersion: args.targetVersion,
+        enabled: args.orgAutoUpdateEnabled,
+      }
+    : null;
+
+  const markFailed = async (tx: Pick<typeof db, 'update' | 'insert'>) => {
+    await tx
+      .update(deviceCommands)
+      .set({
+        status: 'failed',
+        completedAt,
+        result: { error: args.reason },
+      })
+      .where(eq(deviceCommands.id, args.commandId));
+
+    if (restoreAutoUpdate) {
+      await tx
+        .insert(deviceCommands)
+        .values({
+          deviceId: restoreAutoUpdate.deviceId,
+          type: COMMAND_SET_AUTO_UPDATE,
+          payload: {
+            enabled: restoreAutoUpdate.enabled,
+            reason: 'legacy_agent_update_failed',
+            sourceCommandId: args.commandId,
+            targetVersion: restoreAutoUpdate.targetVersion,
+            error: args.reason,
+          },
+          status: 'pending',
+          targetRole: 'agent',
+          createdBy: null,
+        });
+    }
+  };
+
+  if (restoreAutoUpdate) {
+    await db.transaction(markFailed);
+    return;
+  }
+
+  await markFailed(db);
+}
+
+function legacyAgentUpdateTimedOut(marker: {
+  status: string | null;
+  executedAt?: Date | null;
+}, now = new Date()): boolean {
+  if (marker.status !== 'sent' || !marker.executedAt) return false;
+  return now.getTime() - marker.executedAt.getTime() > LEGACY_AGENT_UPDATE_TIMEOUT_MS;
+}
+
+async function resolveLegacyAgentHeartbeatUpgrade(args: {
+  deviceId: string;
+  reportedAgentVersion: string | null | undefined;
+  orgAutoUpdateEnabled: boolean;
+}): Promise<string | null> {
+  const [marker] = await db
+    .select({
+      id: deviceCommands.id,
+      payload: deviceCommands.payload,
+      status: deviceCommands.status,
+      executedAt: deviceCommands.executedAt,
+    })
+    .from(deviceCommands)
+    .where(
+      and(
+        eq(deviceCommands.deviceId, args.deviceId),
+        eq(deviceCommands.type, COMMAND_LEGACY_AGENT_UPDATE),
+        eq(deviceCommands.targetRole, 'server'),
+        inArray(deviceCommands.status, ['pending', 'sent']),
+      ),
+    )
+    .orderBy(desc(deviceCommands.createdAt))
+    .limit(1);
+  if (!marker || typeof marker.id !== 'string') return null;
+
+  const targetVersion = payloadString(marker.payload, 'version');
+  const setAutoUpdateCommandId = payloadString(marker.payload, 'setAutoUpdateCommandId');
+  if (!targetVersion || !setAutoUpdateCommandId) {
+    await failLegacyAgentUpdateMarker({
+      commandId: marker.id,
+      reason: 'invalid legacy update marker payload',
+    });
+    return null;
+  }
+
+  if (agentVersionSatisfiesTarget(args.reportedAgentVersion, targetVersion)) {
+    await completeLegacyAgentUpdateMarker({
+      commandId: marker.id,
+      deviceId: args.deviceId,
+      targetVersion,
+      orgAutoUpdateEnabled: args.orgAutoUpdateEnabled,
+    });
+    return null;
+  }
+
+  if (legacyAgentUpdateTimedOut(marker)) {
+    await failLegacyAgentUpdateMarker({
+      commandId: marker.id,
+      reason: 'legacy agent update timed out',
+      deviceId: args.deviceId,
+      targetVersion,
+      orgAutoUpdateEnabled: args.orgAutoUpdateEnabled,
+    });
+    return null;
+  }
+
+  const [setAutoUpdateCommand] = await db
+    .select({
+      id: deviceCommands.id,
+      type: deviceCommands.type,
+      status: deviceCommands.status,
+      result: deviceCommands.result,
+    })
+    .from(deviceCommands)
+    .where(eq(deviceCommands.id, setAutoUpdateCommandId))
+    .limit(1);
+  if (!setAutoUpdateCommand || setAutoUpdateCommand.type !== COMMAND_SET_AUTO_UPDATE) {
+    await failLegacyAgentUpdateMarker({
+      commandId: marker.id,
+      reason: 'set_auto_update command missing',
+    });
+    return null;
+  }
+  if (setAutoUpdateCommand.status === 'failed') {
+    await failLegacyAgentUpdateMarker({
+      commandId: marker.id,
+      reason: 'set_auto_update command failed',
+      deviceId: args.deviceId,
+      targetVersion,
+      orgAutoUpdateEnabled: args.orgAutoUpdateEnabled,
+    });
+    return null;
+  }
+  if (setAutoUpdateCommand.status !== 'completed') {
+    return null;
+  }
+
+  if (marker.status === 'pending') {
+    await db
+      .update(deviceCommands)
+      .set({ status: 'sent', executedAt: new Date() })
+      .where(eq(deviceCommands.id, marker.id));
+  }
+
+  return targetVersion;
+}
+
+async function queuePolicyWatchdogUpdateCommand(args: {
+  c: Parameters<typeof writeAuditEvent>[0];
+  deviceId: string;
+  orgId: string;
+  agentId: string;
+  targetVersion: string;
+  reason: 'missing' | 'outdated';
+}): Promise<void> {
+  const existing = await db
+    .select({ id: deviceCommands.id })
+    .from(deviceCommands)
+    .where(
+      and(
+        eq(deviceCommands.deviceId, args.deviceId),
+        eq(deviceCommands.type, COMMAND_UPDATE_WATCHDOG),
+        eq(deviceCommands.targetRole, 'agent'),
+        inArray(deviceCommands.status, ['pending', 'sent']),
+      ),
+    )
+    .limit(1);
+
+  if (existing[0]) return;
+
+  await db
+    .insert(deviceCommands)
+    .values({
+      deviceId: args.deviceId,
+      type: COMMAND_UPDATE_WATCHDOG,
+      payload: {
+        component: 'watchdog',
+        version: args.targetVersion,
+        requestedVersion: null,
+        manual: false,
+        automatic: true,
+        source: 'policy-autoheal',
+        reason: args.reason,
+      },
+      status: 'pending',
+      targetRole: 'agent',
+      createdBy: null,
+    });
+
+  writeAuditEvent(args.c, {
+    orgId: args.orgId,
+    actorType: 'system',
+    initiatedBy: 'schedule',
+    action: 'device.component_update.autoheal_queued',
+    resourceType: 'device',
+    resourceId: args.deviceId,
+    details: {
+      deviceId: args.deviceId,
+      agentId: args.agentId,
+      component: 'watchdog',
+      targetVersion: args.targetVersion,
+      targetRole: 'agent',
+      reason: args.reason,
+    },
+  });
+}
 
 heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }), zValidator('json', heartbeatSchema), async (c) => {
   const agentId = c.req.param('id');
@@ -231,40 +516,39 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       }
     }
 
-    // Claim watchdog-targeted commands (marks as sent to prevent duplicate delivery)
-    const watchdogCommands = await claimPendingCommandsForDevice(device.id, 10, 'watchdog');
-
-    // Check for watchdog upgrade
-    let watchdogUpgradeTo: string | undefined;
-    const normalizedArch = normalizeAgentArchitecture(device.architecture);
-    if (normalizedArch) {
-      try {
-        const [latestWatchdog] = await db
-          .select({ version: agentVersions.version })
-          .from(agentVersions)
-          .where(
-            and(
-              eq(agentVersions.platform, device.osType),
-              eq(agentVersions.architecture, normalizedArch),
-              eq(agentVersions.component, 'watchdog'),
-              eq(agentVersions.isLatest, true)
-            )
-          )
-          .orderBy(desc(agentVersions.createdAt)) // newest first if multiple isLatest rows exist
-          .limit(1);
-
-        if (latestWatchdog) {
-          if (!data.agentVersion.startsWith('dev-')) {
-            const cmp = compareAgentVersions(latestWatchdog.version, data.agentVersion);
-            if (cmp > 0) {
-              watchdogUpgradeTo = latestWatchdog.version;
-            }
-          }
-        }
-      } catch (err) {
-        console.error(`[agents] failed to evaluate watchdog upgrade target for ${agentId}:`, err);
-      }
+    // Claim watchdog-targeted commands (marks as sent to prevent duplicate
+    // delivery). Command dispatch must not make the watchdog health heartbeat
+    // fail: the heartbeat is also how we mark watchdog presence/version.
+    let watchdogCommands: Awaited<ReturnType<typeof claimPendingCommandsForDevice>> = [];
+    try {
+      watchdogCommands = await claimPendingCommandsForDevice(device.id, 10, 'watchdog');
+    } catch (err) {
+      console.error(`[agents] failed to claim watchdog commands for ${agentId}:`, err);
+      captureException(err);
     }
+
+    const normalizedArch = normalizeAgentArchitecture(device.architecture);
+    // Fail closed on policy lookup errors. Treating an unreadable org policy as
+    // automatic would bypass Manual mode during transient DB/settings failures.
+    let updateSettings = normalizeAgentUpdateSettings({ agentUpdateMode: 'manual' });
+    try {
+      updateSettings = await getOrgAgentUpdatePolicy(device.orgId);
+    } catch (err) {
+      console.error(`[agents] failed to resolve watchdog-branch update policy for ${agentId}:`, err);
+    }
+
+    // Do not send watchdog self-update directives on the watchdog heartbeat
+    // branch. On Windows the shared updater restart helper is agent-service
+    // oriented; policy-driven watchdog repair/update is owned by the main
+    // agent through targetRole='agent' update_watchdog commands.
+    const watchdogBranchInput: DeviceUpdateInput = {
+      id: device.id,
+      orgId: device.orgId,
+      osType: device.osType,
+      architecture: device.architecture,
+      agentVersion: device.agentVersion,
+      watchdogVersion: data.agentVersion,
+    };
 
     // #1104 — agent recovery via the watchdog. A live watchdog whose main
     // agent is wedged (silent past the #800 threshold) and behind the latest
@@ -283,22 +567,13 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       !device.agentVersion.startsWith('dev-')
     ) {
       try {
-        const [latestAgent] = await db
-          .select({ version: agentVersions.version })
-          .from(agentVersions)
-          .where(
-            and(
-              eq(agentVersions.platform, device.osType),
-              eq(agentVersions.architecture, normalizedArch),
-              eq(agentVersions.component, 'agent'),
-              eq(agentVersions.isLatest, true)
-            )
-          )
-          .orderBy(desc(agentVersions.createdAt))
-          .limit(1);
-
-        if (latestAgent && compareAgentVersions(latestAgent.version, device.agentVersion) > 0) {
-          agentUpgradeTo = latestAgent.version;
+        const agentDecision = await resolveComponentUpdateDecision({
+          device: watchdogBranchInput,
+          component: 'agent',
+          settings: updateSettings,
+        });
+        if (agentDecision.available && agentDecision.autoInstall && agentDecision.targetVersion) {
+          agentUpgradeTo = agentDecision.targetVersion;
         }
       } catch (err) {
         console.error(`[agents] failed to evaluate watchdog-branch agent recovery target for ${agentId}:`, err);
@@ -311,7 +586,6 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         type: cmd.type,
         payload: cmd.payload,
       })),
-      watchdogUpgradeTo,
       upgradeTo: agentUpgradeTo,
     });
   }
@@ -508,8 +782,6 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     }
   }
 
-  const commands = await claimPendingCommandsForDevice(device.id, 10);
-
   let configUpdate: PolicyProbeConfigUpdate | null = null;
   try {
     configUpdate = await buildPolicyProbeConfigUpdate(device.orgId);
@@ -517,59 +789,57 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     console.error(`[agents] failed to build policy probe config update for ${agentId}:`, err);
   }
 
-  // Org > General > Agent update policy. Governs whether we may hand the agent
-  // (or its helper/watchdog) an auto-upgrade target right now. `manual` blocks
-  // all auto-upgrades; `auto`/`staged` honour the maintenance window when set.
-  // Bootstrap installs (a component not yet present) are intentionally NOT
-  // gated below — a device must be able to finish installing regardless.
-  // Fails open: if the lookup throws we behave as before (upgrades allowed).
-  let updateGateAllows = true;
+  // Org > General > Agent update settings. Governs whether we may hand the
+  // agent/watchdog an auto-upgrade or auto-repair target right now. Manual
+  // blocks automatic upgrades and missing-watchdog autoheal; operators can
+  // still request an explicit manual component update from the UI/API.
+  // Helper is intentionally left on its existing path because the structured
+  // pin/manual controls only apply to agent + watchdog components.
+  // Fail closed on policy lookup errors. Manual mode is an update trust
+  // boundary, so an unreadable org policy must not silently become automatic.
+  let updateSettings = normalizeAgentUpdateSettings({ agentUpdateMode: 'manual' });
+  let updateGateAllows = false;
   try {
-    const updateSettings = await getOrgAgentUpdatePolicy(device.orgId);
+    updateSettings = await getOrgAgentUpdatePolicy(device.orgId);
     const gate = shouldSendAgentUpgrade(updateSettings, new Date());
     updateGateAllows = gate.allow;
-    if (!gate.allow) {
-      console.log(
-        `[agents] auto-upgrade withheld for ${agentId} by org update policy (${gate.reason})`,
-      );
-    }
   } catch (err) {
     console.error(`[agents] failed to resolve agent update policy for ${agentId}:`, err);
   }
 
+  const deviceUpdateInput: DeviceUpdateInput = {
+    id: device.id,
+    orgId: device.orgId,
+    osType: device.osType,
+    architecture: device.architecture,
+    agentVersion: data.agentVersion,
+    watchdogVersion: device.watchdogVersion,
+  };
+
   let upgradeTo: string | null = null;
   const normalizedArch = normalizeAgentArchitecture(device.architecture);
-  if (normalizedArch) {
-    try {
-      const [latestVersion] = await db
-        .select({ version: agentVersions.version })
-        .from(agentVersions)
-        .where(
-          and(
-            eq(agentVersions.platform, device.osType),
-            eq(agentVersions.architecture, normalizedArch),
-            eq(agentVersions.component, 'agent'),
-            eq(agentVersions.isLatest, true)
-          )
-        )
-        .orderBy(desc(agentVersions.createdAt))
-        .limit(1);
+  try {
+    const agentDecision = await resolveComponentUpdateDecision({
+      device: deviceUpdateInput,
+      component: 'agent',
+      settings: updateSettings,
+    });
+    if (agentDecision.available && agentDecision.autoInstall && agentDecision.targetVersion) {
+      upgradeTo = agentDecision.targetVersion;
+    }
+  } catch (err) {
+    console.error(`[agents] failed to evaluate upgrade target for ${agentId}:`, err);
+  }
 
-      if (latestVersion) {
-        // Dev builds (dev-*) are local dev-push binaries — never auto-upgrade
-        // them back to a release version. The dev-push flow disables auto_update
-        // on the agent side; the server also refrains from sending upgradeTo.
-        if (data.agentVersion.startsWith('dev-')) {
-          // no-op: leave upgradeTo null so agent stays on the dev build
-        } else if (updateGateAllows) {
-          const cmp = compareAgentVersions(latestVersion.version, data.agentVersion);
-          if (cmp > 0) {
-            upgradeTo = latestVersion.version;
-          }
-        }
-      }
+  if (!upgradeTo) {
+    try {
+      upgradeTo = await resolveLegacyAgentHeartbeatUpgrade({
+        deviceId: device.id,
+        reportedAgentVersion: data.agentVersion,
+        orgAutoUpdateEnabled: updateSettings.mode === 'automatic',
+      });
     } catch (err) {
-      console.error(`[agents] failed to evaluate upgrade target for ${agentId}:`, err);
+      console.error(`[agents] failed to evaluate legacy agent update marker for ${agentId}:`, err);
     }
   }
 
@@ -607,40 +877,27 @@ if (latestHelper) {
     }
   }
 
-  let watchdogUpgradeTo: string | null = null;
-  if (normalizedArch) {
-    try {
-      const [latestWatchdog] = await db
-        .select({ version: agentVersions.version })
-        .from(agentVersions)
-        .where(
-          and(
-            eq(agentVersions.platform, device.osType),
-            eq(agentVersions.architecture, normalizedArch),
-            eq(agentVersions.component, 'watchdog'),
-            eq(agentVersions.isLatest, true)
-          )
-        )
-        .orderBy(desc(agentVersions.createdAt))
-        .limit(1);
-
-      if (latestWatchdog && device.watchdogVersion) {
-        // Version-to-version upgrade is subject to the org update policy.
-        if (updateGateAllows && !device.watchdogVersion.startsWith('dev-')) {
-          const cmp = compareAgentVersions(latestWatchdog.version, device.watchdogVersion);
-          if (cmp > 0) {
-            watchdogUpgradeTo = latestWatchdog.version;
-          }
-        }
-      } else if (latestWatchdog && !device.watchdogVersion) {
-        // Watchdog not yet installed — signal to agent to install it. Bootstrap
-        // installs are NOT gated by the org update policy.
-        watchdogUpgradeTo = latestWatchdog.version;
-      }
-    } catch (err) {
-      console.error(`[agents] failed to evaluate watchdog upgrade target for ${agentId}:`, err);
+  try {
+    const watchdogDecision = await resolveComponentUpdateDecision({
+      device: deviceUpdateInput,
+      component: 'watchdog',
+      settings: updateSettings,
+    });
+    if (watchdogDecision.available && watchdogDecision.autoInstall && watchdogDecision.targetVersion) {
+      await queuePolicyWatchdogUpdateCommand({
+        c,
+        deviceId: device.id,
+        orgId: device.orgId,
+        agentId,
+        targetVersion: watchdogDecision.targetVersion,
+        reason: watchdogDecision.missing ? 'missing' : 'outdated',
+      });
     }
+  } catch (err) {
+    console.error(`[agents] failed to evaluate watchdog upgrade target for ${agentId}:`, err);
   }
+
+  const commands = await claimPendingCommandsForDevice(device.id, 10);
 
   let renewCert = false;
   if (device.mtlsCertExpiresAt && device.mtlsCertIssuedAt) {
@@ -729,7 +986,6 @@ if (latestHelper) {
       configUpdate: mergedConfigUpdate,
       upgradeTo,
       helperUpgradeTo: helperUpgradeTo ?? undefined,
-      watchdogUpgradeTo: watchdogUpgradeTo ?? undefined,
       renewCert: renewCert || undefined,
       rotateToken: rotateToken || undefined,
       helperEnabled: helperSettings?.enabled ?? false,

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -5,8 +5,8 @@
  * The pure gating logic lives in agentUpdatePolicy.ts (tested separately); this
  * file pins the JSONB extraction + normalization seam that the heartbeat tests
  * mock away: nested settings.defaults lookup, isObject guards at both levels,
- * unknown-policy fallback to `staged`, and whitespace-trim-to-null of the
- * maintenance window. That seam is the one most likely to silently break (a
+ * legacy-to-structured mapping, and warning flags for malformed legacy
+ * maintenance windows. That seam is the one most likely to silently break (a
  * renamed key → permissive default) on a settings-schema change.
  *
  * helpers.ts has a large import graph, so the mock harness below mirrors
@@ -121,57 +121,84 @@ describe('getOrgAgentUpdatePolicy', () => {
 
   it('reads a fully configured policy + maintenance window', async () => {
     dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 'Sun 02:00-04:00' } } }]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'manual', maintenanceWindow: 'Sun 02:00-04:00',
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'manual',
+      timing: 'asap',
+      schedule: null,
+      legacyPolicy: 'manual',
+      legacyMaintenanceWindow: 'Sun 02:00-04:00',
+      legacyWindowInvalid: false,
     });
   });
 
-  it('trims a maintenance window and passes through auto/staged', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: '  02:00-04:00  ' } } }]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'auto', maintenanceWindow: '02:00-04:00',
+  it('maps a parseable legacy window to weekly', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: '  Sun 02:00-04:00  ' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'automatic',
+      timing: 'weekly',
+      schedule: { windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }] },
+      legacyPolicy: 'auto',
+      legacyMaintenanceWindow: 'Sun 02:00-04:00',
     });
   });
 
   it('normalizes a whitespace-only window to null', async () => {
     dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'staged', maintenanceWindow: '   ' } } }]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'staged', maintenanceWindow: null,
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'automatic',
+      timing: 'asap',
+      schedule: null,
+      legacyPolicy: 'staged',
+      legacyMaintenanceWindow: null,
     });
   });
 
   it('normalizes a non-string window to null', async () => {
     dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 42 } } }]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'manual', maintenanceWindow: null,
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'manual',
+      timing: 'asap',
+      schedule: null,
+      legacyPolicy: 'manual',
+      legacyMaintenanceWindow: null,
     });
   });
 
-  it('falls back to the permissive default (staged + null) for an unknown policy', async () => {
+  it('falls back to the structured automatic/asap default for an unknown policy', async () => {
     dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'bogus' } } }]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'staged', maintenanceWindow: null,
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'automatic',
+      timing: 'asap',
+      schedule: null,
+      legacyPolicy: null,
+      legacyMaintenanceWindow: null,
     });
   });
 
   it('defaults when defaults sub-object is absent', async () => {
     dbMock._setResult([{ settings: { somethingElse: true } }]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'staged', maintenanceWindow: null,
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'automatic',
+      timing: 'asap',
+      schedule: null,
     });
   });
 
   it('defaults when settings is absent / non-object', async () => {
     dbMock._setResult([{ settings: null }]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'staged', maintenanceWindow: null,
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'automatic',
+      timing: 'asap',
+      schedule: null,
     });
   });
 
   it('defaults when the org row is missing entirely', async () => {
     dbMock._setResult([]);
-    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
-      policy: 'staged', maintenanceWindow: null,
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toMatchObject({
+      mode: 'automatic',
+      timing: 'asap',
+      schedule: null,
     });
   });
 });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -55,7 +55,7 @@ import { CloudflareMtlsService } from '../../services/cloudflareMtls';
 import { isAllowedPolicyConfigProbe } from './policyProbeSafety';
 import { PAM_DEFAULTS, parsePamSettings, type PamSettings } from './pamSettings';
 import {
-  normalizeAgentUpdatePolicy,
+  normalizeAgentUpdateSettings,
   type AgentUpdateSettings,
 } from './agentUpdatePolicy';
 import {
@@ -1994,10 +1994,9 @@ export function generateApiKey(): string {
 // ============================================
 
 /**
- * Read the org-level agent update policy from `organizations.settings.defaults`
- * (Org > General). Returns a normalized policy plus the raw maintenance-window
- * string; the gating decision lives in `shouldSendAgentUpgrade`. Unconfigured
- * orgs resolve to a permissive default (staged + no window = upgrade anytime).
+ * Read the org-level agent update settings from `organizations.settings.defaults`
+ * (Org > General). The normalizer accepts both the structured settings and the
+ * legacy policy/window keys so existing orgs do not need a migration.
  */
 export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdateSettings> {
   const [org] = await db
@@ -2007,12 +2006,7 @@ export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdat
     .limit(1);
   const settings = isObject(org?.settings) ? org.settings : {};
   const defaults = isObject(settings.defaults) ? settings.defaults : {};
-  const policy = normalizeAgentUpdatePolicy(defaults.agentUpdatePolicy);
-  const maintenanceWindow =
-    typeof defaults.maintenanceWindow === 'string' && defaults.maintenanceWindow.trim()
-      ? defaults.maintenanceWindow.trim()
-      : null;
-  return { policy, maintenanceWindow };
+  return normalizeAgentUpdateSettings(defaults);
 }
 
 export async function getOrgHelperSettings(orgId: string): Promise<{ enabled: boolean }> {

--- a/apps/api/src/routes/agents/logs.test.ts
+++ b/apps/api/src/routes/agents/logs.test.ts
@@ -195,5 +195,26 @@ describe('agent logs routes', () => {
         }),
       ]);
     });
+
+    it('accepts long custom build agentVersion values that fit the DB column', async () => {
+      mockDeviceLookup(true);
+      const values = mockInsertSuccess();
+      const agentVersion = 'agent-watchdog-update-78da86d2e807bfee475e96180af3d60ce7236b60';
+
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          logs: [
+            makeLogEntry({ agentVersion }),
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(values).toHaveBeenCalledWith([
+        expect.objectContaining({ agentVersion }),
+      ]);
+    });
   });
 });

--- a/apps/api/src/routes/agents/logs.ts
+++ b/apps/api/src/routes/agents/logs.ts
@@ -29,7 +29,7 @@ const agentLogEntrySchema = z.object({
     (val) => !val || JSON.stringify(val).length <= 32000,
     { message: 'fields object too large (max 32KB)' }
   ),
-  agentVersion: z.string().max(50).optional(),
+  agentVersion: z.string().max(128).optional(),
 });
 
 const agentLogIngestSchema = z.object({

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -555,7 +555,7 @@ export const agentLogEntrySchema = z.object({
     (val) => !val || JSON.stringify(val).length <= 65536,
     { message: 'Object too large (max 64KB)' }
   ),
-  agentVersion: z.string().max(50).optional(),
+  agentVersion: z.string().max(128).optional(),
 });
 
 export const agentLogIngestSchema = z.object({

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -87,7 +87,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
-  devices: { id: 'id', orgId: 'orgId', siteId: 'siteId', status: 'status', hostname: 'hostname', displayName: 'displayName', osType: 'osType', lastSeenAt: 'lastSeenAt', createdAt: 'createdAt', updatedAt: 'updatedAt', tags: 'tags', agentVersion: 'agentVersion' },
+  devices: { id: 'id', orgId: 'orgId', siteId: 'siteId', status: 'status', hostname: 'hostname', displayName: 'displayName', osType: 'osType', lastSeenAt: 'lastSeenAt', createdAt: 'createdAt', updatedAt: 'updatedAt', tags: 'tags', agentVersion: 'agentVersion', watchdogVersion: 'watchdogVersion' },
   deviceHardware: { deviceId: 'deviceId' },
   deviceReliability: { deviceId: 'deviceId', reliabilityScore: 'reliabilityScore', trendDirection: 'trendDirection' },
   deviceNetwork: { deviceId: 'deviceId' },
@@ -97,7 +97,16 @@ vi.mock('../db/schema', () => ({
   deviceGroupMemberships: { deviceId: 'deviceId', groupId: 'groupId' },
   deviceCommands: { id: 'id', deviceId: 'deviceId', type: 'type', status: 'status', createdAt: 'createdAt' },
   sites: { id: 'id', orgId: 'orgId' },
-  organizations: { id: 'id' },
+  organizations: { id: 'id', settings: 'settings' },
+  agentVersions: {
+    id: 'id',
+    platform: 'platform',
+    architecture: 'architecture',
+    component: 'component',
+    version: 'version',
+    isLatest: 'isLatest',
+    createdAt: 'createdAt',
+  },
   enrollmentKeys: { id: 'id', key: 'key', orgId: 'orgId' },
   discoveredAssetTypeEnum: { enumValues: ['workstation', 'server', 'printer', 'unknown'] },
   patchPolicies: {},
@@ -468,6 +477,7 @@ describe('device routes', () => {
           osBuild: 'build',
           architecture: 'x86_64',
           agentVersion: '2.0',
+          watchdogVersion: '2.0',
           status: 'online',
           lastSeenAt: new Date(),
           enrolledAt: new Date(),
@@ -491,6 +501,7 @@ describe('device routes', () => {
           osBuild: 'build2',
           architecture: 'arm64',
           agentVersion: '2.1',
+          watchdogVersion: '2.1',
           status: 'online',
           lastSeenAt: new Date(),
           enrolledAt: new Date(),
@@ -529,6 +540,57 @@ describe('device routes', () => {
               };
             })
           })
+        } as any)
+        // 3rd: org settings lookup for server-authoritative update metadata
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ id: 'org-123', settings: { defaults: { agentUpdateMode: 'manual' } } }])
+          })
+        } as any)
+        // 4th-7th: agent/watchdog latest version lookup for each returned device
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ version: '3.0' }])
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ version: '3.0' }])
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ version: '3.0' }])
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ version: '3.0' }])
+              })
+            })
+          })
+        } as any)
+        // 8th: pending component update command lookup
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([])
+            })
+          })
         } as any);
 
       // Latest-metrics LATERAL query goes through db.execute() with a
@@ -564,11 +626,10 @@ describe('device routes', () => {
         timestamp: metricsTimestamp.toISOString(),
       });
 
-      // Regression guard: the LATERAL replaces what used to be two
-      // db.select() chains (a GROUP BY MAX subquery + an innerJoin on
-      // the max timestamp). If a future refactor reverts to those, the
-      // db.select call count here will jump from 2 to 4.
-      expect(vi.mocked(db.select).mock.calls.length).toBe(2);
+      // Regression guard: the metrics path stays on one raw LATERAL query,
+      // while update metadata adds org-policy, target-version, and pending
+      // command lookups after the count/list queries.
+      expect(vi.mocked(db.select).mock.calls.length).toBe(8);
       expect(vi.mocked(db.execute).mock.calls.length).toBe(1);
     });
   });

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -1,16 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-vi.mock('../../db', () => ({
-  runOutsideDbContext: vi.fn((fn) => fn()),
-  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  db: {
+vi.mock('../../db', () => {
+  const dbMock = {
     select: vi.fn(),
     insert: vi.fn(),
-    update: vi.fn()
-  }
-}));
+    update: vi.fn(),
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(dbMock)),
+  };
+  return {
+    runOutsideDbContext: vi.fn((fn) => fn()),
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    db: dbMock,
+  };
+});
 
 // Wake-on-LAN brings a long transitive import chain through the API surface
 // (commands.ts -> wakeOnLan.ts -> agentWs.ts -> remoteAccessPolicy.ts ->
@@ -79,11 +83,17 @@ vi.mock('../../services/clientIp', () => ({
   getTrustedClientIpOrUndefined: vi.fn(() => '127.0.0.1'),
 }));
 
+vi.mock('../../services/agentUpdateTargets', () => ({
+  resolveLegacyAgentUpdateTarget: vi.fn(),
+  resolveManualComponentTarget: vi.fn(),
+}));
+
 import { commandsRoutes } from './commands';
 import { db } from '../../db';
 import { getDeviceWithOrgCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { dispatchWake } from '../../services/wakeOnLan';
+import { resolveLegacyAgentUpdateTarget, resolveManualComponentTarget } from '../../services/agentUpdateTargets';
 
 describe('device commands routes', () => {
   let app: Hono;
@@ -632,6 +642,309 @@ describe('device commands routes', () => {
         });
         expect(res.status).toBe(202);
       });
+    });
+  });
+
+  describe('POST /devices/:id/legacy-agent-update', () => {
+    it('queues set_auto_update plus a server marker for legacy agents', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.82.1',
+        watchdogVersion: '0.82.1',
+      } as never);
+      vi.mocked(resolveLegacyAgentUpdateTarget).mockResolvedValueOnce({
+        ok: true,
+        targetVersion: '0.83.0',
+        decision: {} as never,
+      });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+      const setAutoValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'cmd-auto',
+          deviceId: 'device-a',
+          type: 'set_auto_update',
+          payload: { enabled: true },
+          status: 'pending',
+          targetRole: 'agent',
+          createdAt: new Date(),
+        }]),
+      });
+      const legacyValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'cmd-legacy',
+          deviceId: 'device-a',
+          type: 'legacy_agent_update',
+          payload: { component: 'agent', version: '0.83.0', setAutoUpdateCommandId: 'cmd-auto' },
+          status: 'pending',
+          targetRole: 'server',
+          createdAt: new Date(),
+        }]),
+      });
+      vi.mocked(db.insert)
+        .mockReturnValueOnce({ values: setAutoValues } as never)
+        .mockReturnValueOnce({ values: legacyValues } as never);
+
+      const res = await app.request('/devices/device-a/legacy-agent-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(202);
+      expect(setAutoValues).toHaveBeenCalledWith(expect.objectContaining({
+        deviceId: 'device-a',
+        type: 'set_auto_update',
+        targetRole: 'agent',
+        payload: expect.objectContaining({
+          enabled: true,
+          reason: 'legacy_agent_update',
+          targetVersion: '0.83.0',
+        }),
+      }));
+      expect(legacyValues).toHaveBeenCalledWith(expect.objectContaining({
+        deviceId: 'device-a',
+        type: 'legacy_agent_update',
+        targetRole: 'server',
+        payload: expect.objectContaining({
+          component: 'agent',
+          version: '0.83.0',
+          setAutoUpdateCommandId: 'cmd-auto',
+          manual: true,
+        }),
+      }));
+      const body = await res.json();
+      expect(body).toMatchObject({
+        id: 'cmd-legacy',
+        type: 'legacy_agent_update',
+        targetRole: 'server',
+        targetVersion: '0.83.0',
+        setAutoUpdateCommandId: 'cmd-auto',
+      });
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        action: 'device.legacy_agent_update.request',
+        details: expect.objectContaining({
+          targetVersion: '0.83.0',
+          setAutoUpdateCommandId: 'cmd-auto',
+        }),
+      }));
+    });
+
+    it('rejects duplicate legacy agent markers', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.82.1',
+        watchdogVersion: '0.82.1',
+      } as never);
+      vi.mocked(resolveLegacyAgentUpdateTarget).mockResolvedValueOnce({
+        ok: true,
+        targetVersion: '0.83.0',
+        decision: {} as never,
+      });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'cmd-existing',
+              status: 'sent',
+              payload: { version: '0.83.0' },
+            }]),
+          }),
+        }),
+      } as never);
+
+      const res = await app.request('/devices/device-a/legacy-agent-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        code: 'ALREADY_PENDING',
+        commandId: 'cmd-existing',
+        existingVersion: '0.83.0',
+        status: 'sent',
+      });
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /devices/:id/component-update', () => {
+    it('queues manual agent updates to the watchdog role', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online',
+        osType: 'windows',
+        architecture: 'amd64',
+        agentVersion: '0.65.0',
+        watchdogVersion: '0.65.0',
+      } as never);
+      vi.mocked(resolveManualComponentTarget).mockResolvedValueOnce({
+        ok: true,
+        targetVersion: '0.66.0',
+        decision: {} as never,
+      });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+      const values = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'cmd-agent',
+          deviceId: 'device-a',
+          type: 'update_agent',
+          payload: { component: 'agent', version: '0.66.0', manual: true },
+          status: 'pending',
+          targetRole: 'watchdog',
+          createdAt: new Date(),
+        }]),
+      });
+      vi.mocked(db.insert).mockReturnValueOnce({ values } as never);
+
+      const res = await app.request('/devices/device-a/component-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ component: 'agent' }),
+      });
+
+      expect(res.status).toBe(202);
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        deviceId: 'device-a',
+        type: 'update_agent',
+        targetRole: 'watchdog',
+        payload: expect.objectContaining({
+          component: 'agent',
+          version: '0.66.0',
+          manual: true,
+        }),
+      }));
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        action: 'device.component_update.request',
+        details: expect.objectContaining({
+          component: 'agent',
+          targetVersion: '0.66.0',
+          targetRole: 'watchdog',
+        }),
+      }));
+    });
+
+    it('queues missing watchdog repair to the normal agent role', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online',
+        osType: 'windows',
+        architecture: 'amd64',
+        agentVersion: '0.65.0',
+        watchdogVersion: null,
+      } as never);
+      vi.mocked(resolveManualComponentTarget).mockResolvedValueOnce({
+        ok: true,
+        targetVersion: '0.66.0',
+        decision: {} as never,
+      });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+      const values = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'cmd-watchdog',
+          deviceId: 'device-a',
+          type: 'update_watchdog',
+          payload: { component: 'watchdog', version: '0.66.0', manual: true },
+          status: 'pending',
+          targetRole: 'agent',
+          createdAt: new Date(),
+        }]),
+      });
+      vi.mocked(db.insert).mockReturnValueOnce({ values } as never);
+
+      const res = await app.request('/devices/device-a/component-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ component: 'watchdog' }),
+      });
+
+      expect(res.status).toBe(202);
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        deviceId: 'device-a',
+        type: 'update_watchdog',
+        targetRole: 'agent',
+        payload: expect.objectContaining({
+          component: 'watchdog',
+          version: '0.66.0',
+          manual: true,
+        }),
+      }));
+    });
+
+    it('rejects a second pending update for the same component even when the target differs', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online',
+        osType: 'windows',
+        architecture: 'amd64',
+        agentVersion: '0.65.0',
+        watchdogVersion: '0.65.0',
+      } as never);
+      vi.mocked(resolveManualComponentTarget).mockResolvedValueOnce({
+        ok: true,
+        targetVersion: '0.67.0',
+        decision: {} as never,
+      });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'cmd-existing',
+              status: 'pending',
+              payload: { version: '0.66.0' },
+            }]),
+          }),
+        }),
+      } as never);
+
+      const res = await app.request('/devices/device-a/component-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ component: 'agent', version: '0.67.0' }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.code).toBe('ALREADY_PENDING');
+      expect(body.commandId).toBe('cmd-existing');
+      expect(body.existingVersion).toBe('0.66.0');
+      expect(db.insert).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { eq, sql, desc, and } from 'drizzle-orm';
+import { eq, sql, desc, and, inArray } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { db } from '../../db';
 import { deviceCommands, devices } from '../../db/schema';
@@ -11,14 +11,34 @@ import { getPagination, getDeviceWithOrgCheck, canAccessDeviceSite } from './hel
 import { createCommandSchema, bulkCommandSchema, maintenanceModeSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { commandAuditDetails, sanitizeCommandForHistory } from '../../services/commandAudit';
+import type { CommandPayload } from '../../services/commandQueue';
 import { dispatchWake, type WakeFailureCode } from '../../services/wakeOnLan';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
+import {
+  resolveLegacyAgentUpdateTarget,
+  resolveManualComponentTarget,
+  type AgentUpdateComponent,
+} from '../../services/agentUpdateTargets';
 
 export const commandsRoutes = new Hono();
 
 commandsRoutes.use('*', authMiddleware);
 
 const COMMAND_SET_AUTO_UPDATE = 'set_auto_update';
+const COMMAND_LEGACY_AGENT_UPDATE = 'legacy_agent_update';
+const COMPONENT_UPDATE_TYPES: Record<AgentUpdateComponent, { type: string; targetRole: 'agent' | 'watchdog' }> = {
+  agent: { type: 'update_agent', targetRole: 'watchdog' },
+  watchdog: { type: 'update_watchdog', targetRole: 'agent' },
+};
+
+const componentUpdateSchema = z.object({
+  component: z.enum(['agent', 'watchdog']),
+  version: z.string().min(1).max(64).optional(),
+});
+
+const legacyAgentUpdateSchema = z.object({
+  version: z.string().min(1).max(64).optional(),
+});
 
 // POST /devices/bulk/commands - Queue a command for multiple devices
 commandsRoutes.post(
@@ -237,6 +257,270 @@ commandsRoutes.post(
     }
 
     return c.json({ commands: commandList, failed, skipped }, 201);
+  }
+);
+
+// POST /devices/:id/legacy-agent-update - Queue the old heartbeat-based updater path.
+commandsRoutes.post(
+  '/:id/legacy-agent-update',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
+  zValidator('json', legacyAgentUpdateSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const data = c.req.valid('json');
+
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (device.status === 'decommissioned') {
+      return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    const target = await resolveLegacyAgentUpdateTarget({
+      device: {
+        id: device.id,
+        orgId: device.orgId,
+        osType: device.osType,
+        architecture: device.architecture,
+        agentVersion: device.agentVersion,
+        watchdogVersion: device.watchdogVersion,
+      },
+      version: data.version,
+    });
+    if (!target.ok) {
+      return c.json({ error: target.message, code: target.code, decision: target.decision }, target.status as 400 | 409);
+    }
+
+    const [existingPending] = await db
+      .select({
+        id: deviceCommands.id,
+        payload: deviceCommands.payload,
+        status: deviceCommands.status,
+      })
+      .from(deviceCommands)
+      .where(
+        and(
+          eq(deviceCommands.deviceId, deviceId),
+          eq(deviceCommands.type, COMMAND_LEGACY_AGENT_UPDATE),
+          eq(deviceCommands.targetRole, 'server'),
+          inArray(deviceCommands.status, ['pending', 'sent']),
+        ),
+      )
+      .limit(1);
+    if (existingPending) {
+      const payload = existingPending.payload as Record<string, unknown> | null;
+      const existingVersion = typeof payload?.version === 'string' ? payload.version : null;
+      return c.json({
+        error: 'Legacy agent update is already pending for this device',
+        code: 'ALREADY_PENDING',
+        commandId: existingPending.id,
+        existingVersion,
+        status: existingPending.status,
+      }, 409);
+    }
+
+    const queued = await db.transaction(async (tx) => {
+      const [setAutoUpdateCommand] = await tx
+        .insert(deviceCommands)
+        .values({
+          deviceId,
+          type: COMMAND_SET_AUTO_UPDATE,
+          payload: {
+            enabled: true,
+            reason: COMMAND_LEGACY_AGENT_UPDATE,
+            targetVersion: target.targetVersion,
+          },
+          status: 'pending',
+          targetRole: 'agent',
+          createdBy: auth.user.id,
+        })
+        .returning();
+      if (!setAutoUpdateCommand) return null;
+
+      const [legacyCommand] = await tx
+        .insert(deviceCommands)
+        .values({
+          deviceId,
+          type: COMMAND_LEGACY_AGENT_UPDATE,
+          payload: {
+            component: 'agent',
+            version: target.targetVersion,
+            requestedVersion: data.version ?? null,
+            manual: true,
+            setAutoUpdateCommandId: setAutoUpdateCommand.id,
+          },
+          status: 'pending',
+          targetRole: 'server',
+          createdBy: auth.user.id,
+        })
+        .returning();
+      if (!legacyCommand) return null;
+
+      return { legacyCommand, setAutoUpdateCommand };
+    });
+
+    if (!queued) {
+      return c.json({ error: 'Failed to queue legacy agent update' }, 500);
+    }
+    const { legacyCommand, setAutoUpdateCommand } = queued;
+
+    writeRouteAudit(c, {
+      orgId: device.orgId,
+      action: 'device.legacy_agent_update.request',
+      resourceType: 'device_command',
+      resourceId: legacyCommand.id,
+      resourceName: COMMAND_LEGACY_AGENT_UPDATE,
+      details: {
+        deviceId,
+        component: 'agent',
+        targetVersion: target.targetVersion,
+        setAutoUpdateCommandId: setAutoUpdateCommand.id,
+        ...commandAuditDetails(legacyCommand.id, COMMAND_LEGACY_AGENT_UPDATE, (legacyCommand.payload ?? {}) as CommandPayload),
+      },
+    });
+
+    return c.json({
+      id: legacyCommand.id,
+      deviceId: legacyCommand.deviceId,
+      type: legacyCommand.type,
+      status: legacyCommand.status,
+      targetRole: legacyCommand.targetRole,
+      targetVersion: target.targetVersion,
+      component: 'agent',
+      setAutoUpdateCommandId: setAutoUpdateCommand.id,
+      createdAt: legacyCommand.createdAt,
+    }, 202);
+  },
+);
+
+// POST /devices/:id/component-update - Queue an explicit agent/watchdog update or repair
+commandsRoutes.post(
+  '/:id/component-update',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_EXECUTE.resource, PERMISSIONS.DEVICES_EXECUTE.action),
+  requireMfa(),
+  zValidator('json', componentUpdateSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+    const data = c.req.valid('json');
+
+    const device = await getDeviceWithOrgCheck(deviceId, auth);
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    if (!canAccessDeviceSite(device, c.get('permissions') as UserPermissions | undefined)) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (device.status === 'decommissioned') {
+      return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+    if (data.component === 'agent' && !device.watchdogVersion) {
+      return c.json({
+        error: 'Watchdog is required to update the main agent. Repair watchdog first.',
+        code: 'WATCHDOG_REQUIRED',
+      }, 409);
+    }
+
+    const target = await resolveManualComponentTarget({
+      device: {
+        id: device.id,
+        orgId: device.orgId,
+        osType: device.osType,
+        architecture: device.architecture,
+        agentVersion: device.agentVersion,
+        watchdogVersion: device.watchdogVersion,
+      },
+      component: data.component,
+      version: data.version,
+    });
+    if (!target.ok) {
+      return c.json({ error: target.message, code: target.code, decision: target.decision }, target.status as 400 | 409);
+    }
+
+    const commandSpec = COMPONENT_UPDATE_TYPES[data.component];
+    const existingPending = await db
+      .select({
+        id: deviceCommands.id,
+        payload: deviceCommands.payload,
+        status: deviceCommands.status,
+      })
+      .from(deviceCommands)
+      .where(
+        and(
+          eq(deviceCommands.deviceId, deviceId),
+          eq(deviceCommands.type, commandSpec.type),
+          eq(deviceCommands.targetRole, commandSpec.targetRole),
+          inArray(deviceCommands.status, ['pending', 'sent']),
+        ),
+      )
+      .limit(20);
+    const duplicate = existingPending[0];
+    if (duplicate) {
+      const payload = duplicate.payload as Record<string, unknown> | null;
+      const existingVersion = typeof payload?.version === 'string' ? payload.version : null;
+      return c.json({
+        error: `${data.component} update is already pending for this device`,
+        code: 'ALREADY_PENDING',
+        commandId: duplicate.id,
+        existingVersion,
+        status: duplicate.status,
+      }, 409);
+    }
+
+    const [command] = await db
+      .insert(deviceCommands)
+      .values({
+        deviceId,
+        type: commandSpec.type,
+        payload: {
+          component: data.component,
+          version: target.targetVersion,
+          requestedVersion: data.version ?? null,
+          manual: true,
+        },
+        status: 'pending',
+        targetRole: commandSpec.targetRole,
+        createdBy: auth.user.id,
+      })
+      .returning();
+
+    if (!command) {
+      return c.json({ error: 'Failed to queue component update' }, 500);
+    }
+
+    writeRouteAudit(c, {
+      orgId: device.orgId,
+      action: 'device.component_update.request',
+      resourceType: 'device_command',
+      resourceId: command.id,
+      resourceName: commandSpec.type,
+      details: {
+        deviceId,
+        component: data.component,
+        targetVersion: target.targetVersion,
+        targetRole: commandSpec.targetRole,
+        ...commandAuditDetails(command.id, commandSpec.type, (command.payload ?? {}) as CommandPayload),
+      },
+    });
+
+    return c.json({
+      id: command.id,
+      deviceId: command.deviceId,
+      type: command.type,
+      status: command.status,
+      targetRole: command.targetRole,
+      targetVersion: target.targetVersion,
+      component: data.component,
+      createdAt: command.createdAt,
+    }, 202);
   }
 );
 

--- a/apps/api/src/routes/devices/core.list-response-shape.test.ts
+++ b/apps/api/src/routes/devices/core.list-response-shape.test.ts
@@ -81,11 +81,34 @@ vi.mock('../../services/commandQueue', () => ({
 vi.mock('../agents/enrollment', () => ({
   getGlobalEnrollmentSecret: vi.fn().mockReturnValue(null),
 }));
+vi.mock('../../services/agentUpdateTargets', () => ({
+  buildDeviceUpdateMetadata: vi.fn(async (devices: Array<{ id: string }>) => new Map(devices.map((device) => [device.id, {
+    agentUpdate: {
+      available: false,
+      currentVersion: null,
+      targetVersion: null,
+      mode: 'manual',
+      autoInstall: false,
+      pinned: false,
+      reason: 'current',
+    },
+    watchdogUpdate: {
+      available: false,
+      currentVersion: null,
+      targetVersion: null,
+      mode: 'manual',
+      autoInstall: false,
+      pinned: false,
+      reason: 'current',
+    },
+  }]))),
+}));
 
 import { coreRoutes } from './core';
 import { db } from '../../db';
+import { buildDeviceUpdateMetadata } from '../../services/agentUpdateTargets';
 
-function rigDeviceListRows(rows: unknown[]) {
+function rigDeviceListRows(rows: unknown[], componentCommandRows: unknown[] = []) {
   const offset = vi.fn().mockResolvedValue(rows);
   const limit = vi.fn().mockReturnValue({ offset });
   const orderBy = vi.fn().mockReturnValue({ limit });
@@ -97,7 +120,17 @@ function rigDeviceListRows(rows: unknown[]) {
   chain.leftJoin = leftJoin;
   chain.where = where;
   const from = vi.fn().mockReturnValue({ leftJoin });
-  vi.mocked(db.select).mockReturnValue({ from } as never);
+
+  const commandOrderBy = vi.fn().mockResolvedValue(componentCommandRows);
+  const commandWhere = vi.fn().mockReturnValue({ orderBy: commandOrderBy });
+  const commandFrom = vi.fn().mockReturnValue({ where: commandWhere });
+
+  vi.mocked(db.select).mockImplementation((fields?: Record<string, unknown>) => {
+    if (fields?.type && fields?.payload && fields?.status && fields?.createdAt) {
+      return { from: commandFrom } as never;
+    }
+    return { from } as never;
+  });
   vi.mocked(db.execute).mockResolvedValue([] as never);
 }
 
@@ -239,5 +272,170 @@ describe('GET /devices — response shape', () => {
     expect(row.mainAgentSilentSince).toBeNull();
     expect(row.watchdogVersion).toBeNull();
     expect(row.pendingReboot).toBe(false);
+  });
+
+  it('marks online rows with pending component commands as updating with operation-specific labels', async () => {
+    const deviceId = '22222222-2222-4222-8222-222222222222';
+    vi.mocked(buildDeviceUpdateMetadata).mockResolvedValueOnce(new Map([[deviceId, {
+      agentUpdate: {
+        available: false,
+        currentVersion: '0.82.1',
+        targetVersion: '0.82.1',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: false,
+        reason: 'current',
+      },
+      watchdogUpdate: {
+        available: true,
+        currentVersion: null,
+        targetVersion: '0.82.1',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: false,
+        missing: true,
+        reason: 'manual',
+      },
+    }]]));
+
+    rigDeviceListRows([
+      {
+        id: deviceId,
+        orgId: 'org-1',
+        siteId: 'site-1',
+        agentId: 'agent-linux-01',
+        hostname: 'linux-test-01',
+        displayName: null,
+        osType: 'linux',
+        deviceRole: 'workstation',
+        deviceRoleSource: 'auto',
+        osVersion: 'Debian 12',
+        osBuild: null,
+        architecture: 'amd64',
+        agentVersion: '0.82.1',
+        watchdogVersion: null,
+        status: 'online',
+        watchdogStatus: null,
+        mainAgentSilentSince: null,
+        pendingReboot: false,
+        lastSeenAt: new Date(),
+        enrolledAt: new Date(),
+        tags: [],
+        customFields: {},
+        desktopAccess: null,
+        lastUser: null,
+        uptimeSeconds: null,
+        isHeadless: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        cpuModel: null,
+        cpuCores: null,
+        ramTotalMb: null,
+        diskTotalGb: null,
+      },
+    ], [
+      {
+        deviceId,
+        type: 'update_watchdog',
+        payload: { component: 'watchdog', version: '0.82.1', reason: 'missing' },
+        status: 'sent',
+        createdAt: new Date(),
+      },
+    ]);
+
+    const res = await app.request('/devices?limit=50', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const row = body.data[0];
+
+    expect(row.status).toBe('updating');
+    expect(row.componentUpdateStatusLabel).toBe('Installing watchdog');
+    expect(row.componentUpdateStatusFullLabel).toBe('Installing watchdog');
+  });
+
+  it('does not mark a row as updating when a stale component command target is already installed', async () => {
+    const deviceId = '44444444-4444-4444-8444-444444444444';
+    vi.mocked(buildDeviceUpdateMetadata).mockResolvedValueOnce(new Map([[deviceId, {
+      agentUpdate: {
+        available: false,
+        currentVersion: '0.82.1',
+        targetVersion: '0.82.1',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: false,
+        reason: 'current',
+      },
+      watchdogUpdate: {
+        available: false,
+        currentVersion: '0.82.1',
+        targetVersion: '0.82.1',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: false,
+        reason: 'current',
+      },
+    }]]));
+
+    rigDeviceListRows([
+      {
+        id: deviceId,
+        orgId: 'org-1',
+        siteId: 'site-1',
+        agentId: 'agent-mac-01',
+        hostname: 'macbook-test-01',
+        displayName: null,
+        osType: 'macos',
+        deviceRole: 'workstation',
+        deviceRoleSource: 'auto',
+        osVersion: '15.0',
+        osBuild: null,
+        architecture: 'arm64',
+        agentVersion: '0.82.1',
+        watchdogVersion: '0.82.1',
+        status: 'online',
+        watchdogStatus: 'connected',
+        mainAgentSilentSince: null,
+        pendingReboot: false,
+        lastSeenAt: new Date(),
+        enrolledAt: new Date(),
+        tags: [],
+        customFields: {},
+        desktopAccess: null,
+        lastUser: null,
+        uptimeSeconds: null,
+        isHeadless: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        cpuModel: null,
+        cpuCores: null,
+        ramTotalMb: null,
+        diskTotalGb: null,
+      },
+    ], [
+      {
+        deviceId,
+        type: 'update_agent',
+        payload: { component: 'agent', version: '0.82.1' },
+        status: 'sent',
+        createdAt: new Date(),
+      },
+    ]);
+
+    const res = await app.request('/devices?limit=50', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const row = body.data[0];
+
+    expect(row.status).toBe('online');
+    expect(row.componentUpdateStatusLabel).toBeNull();
+    expect(row.componentUpdateStatusFullLabel).toBeNull();
   });
 });

--- a/apps/api/src/routes/devices/core.permissions.test.ts
+++ b/apps/api/src/routes/devices/core.permissions.test.ts
@@ -125,6 +125,7 @@ function rigDeviceLookup(device: unknown) {
   // identical `db.select().from(devices).where(eq(devices.id,...)).limit(1)`
   // call. The helper consumes the first row, so we return [device] (or []
   // when device is null) and stop there.
+  vi.mocked(db.select).mockReset();
   const limit = vi.fn().mockResolvedValue(device ? [device] : []);
   const where = vi.fn().mockReturnValue({ limit });
   const from = vi.fn().mockReturnValue({ where });
@@ -136,6 +137,7 @@ function rigDeviceThenSiteLookup(device: unknown, targetSite: unknown) {
   //   1. getDeviceWithOrgAndSiteCheck → fixture device
   //   2. target-site same-org validation → target site row
   // Return the device on the first call, the site on the second.
+  vi.mocked(db.select).mockReset();
   const deviceLimit = vi.fn().mockResolvedValue(device ? [device] : []);
   const deviceWhere = vi.fn().mockReturnValue({ limit: deviceLimit });
   const deviceFrom = vi.fn().mockReturnValue({ where: deviceWhere });
@@ -204,6 +206,8 @@ function rigPatchTransaction(updatedRow: unknown) {
 }
 
 function rigDeviceListRows(rows: unknown[]) {
+  vi.mocked(db.select).mockReset();
+
   const offset = vi.fn().mockResolvedValue(rows);
   const limit = vi.fn().mockReturnValue({ offset });
   const orderBy = vi.fn().mockReturnValue({ limit });
@@ -214,7 +218,18 @@ function rigDeviceListRows(rows: unknown[]) {
   const leftJoin = vi.fn().mockReturnValue(chain);
   chain.leftJoin = leftJoin;
   const from = vi.fn().mockReturnValue({ leftJoin });
-  vi.mocked(db.select).mockReturnValue({ from } as never);
+
+  const orgSettingsWhere = vi.fn().mockResolvedValue([{ id: 'org-123', settings: { defaults: { agentUpdateMode: 'manual' } } }]);
+  const orgSettingsFrom = vi.fn().mockReturnValue({ where: orgSettingsWhere });
+
+  const pendingOrderBy = vi.fn().mockResolvedValue([]);
+  const pendingWhere = vi.fn().mockReturnValue({ orderBy: pendingOrderBy });
+  const pendingFrom = vi.fn().mockReturnValue({ where: pendingWhere });
+
+  vi.mocked(db.select)
+    .mockReturnValueOnce({ from } as never)
+    .mockReturnValueOnce({ from: orgSettingsFrom } as never)
+    .mockReturnValueOnce({ from: pendingFrom } as never);
   vi.mocked(db.execute).mockResolvedValue([] as never);
   return { where };
 }

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -5,6 +5,7 @@ import { db, withSystemDbAccessContext } from '../../db';
 import { createHash, randomBytes } from 'crypto';
 import {
   devices,
+  deviceCommands,
   deviceHardware,
   deviceReliability,
   deviceNetwork,
@@ -52,6 +53,12 @@ import { sendCommandToAgent, isAgentConnected } from '../agentWs';
 import { terminateDeviceRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { CommandTypes } from '../../services/commandQueue';
 import { getGlobalEnrollmentSecret } from '../agents/enrollment';
+import {
+  buildDeviceUpdateMetadata,
+  compareAgentReleaseVersions,
+  isComparableReleaseVersion,
+} from '../../services/agentUpdateTargets';
+import type { DeviceUpdateMetadata } from '../../services/agentUpdateTargets';
 
 /**
  * Tables where linked_device_id (not device_id) references devices.id.
@@ -123,6 +130,88 @@ export const DEVICE_ORG_DENORMALIZED_TABLES = [
   'software_inventory', 'software_policy_audit', 'sql_instances',
   'tickets', 'time_series_metrics', 'tunnel_sessions',
 ] as const;
+
+type PendingComponentUpdateStatus = {
+  label: string;
+  fullLabel: string;
+};
+
+function pendingComponentUpdateStatusFromCommand(
+  command: Pick<typeof deviceCommands.$inferSelect, 'type' | 'payload'>,
+  updates: DeviceUpdateMetadata | undefined,
+): PendingComponentUpdateStatus | null {
+  const payload = command.payload && typeof command.payload === 'object' && !Array.isArray(command.payload)
+    ? command.payload as Record<string, unknown>
+    : {};
+  const targetVersion = typeof payload.version === 'string' && payload.version.trim()
+    ? payload.version.trim()
+    : null;
+
+  if (command.type === 'legacy_agent_update') {
+    if (!targetVersion || componentVersionSatisfiesTarget(updates?.agentUpdate.currentVersion, targetVersion)) {
+      return null;
+    }
+    return { label: 'Upgrading agent', fullLabel: 'Upgrading legacy agent' };
+  }
+
+  if (command.type !== 'update_agent' && command.type !== 'update_watchdog') return null;
+
+  const component = command.type === 'update_agent' ? 'agent' : 'watchdog';
+  const update = component === 'agent' ? updates?.agentUpdate : updates?.watchdogUpdate;
+  if (!targetVersion || componentVersionSatisfiesTarget(update?.currentVersion, targetVersion)) {
+    return null;
+  }
+
+  const payloadReason = typeof payload.reason === 'string' ? payload.reason : null;
+  const isInstall = component === 'watchdog' && (update?.missing === true || payloadReason === 'missing');
+  const isReinstall = update?.reason === 'non-release-version' || payloadReason === 'non-release-version';
+  const verb = isInstall ? 'Installing' : isReinstall ? 'Reinstalling' : 'Updating';
+  const label = `${verb} ${component}`;
+  return { label, fullLabel: label };
+}
+
+function componentVersionSatisfiesTarget(currentVersion: string | null | undefined, targetVersion: string): boolean {
+  if (!currentVersion) return false;
+  if (currentVersion === targetVersion) return true;
+  if (isComparableReleaseVersion(currentVersion) && isComparableReleaseVersion(targetVersion)) {
+    return compareAgentReleaseVersions(currentVersion, targetVersion) >= 0;
+  }
+  return false;
+}
+
+async function loadPendingComponentUpdateStatuses(
+  deviceIds: string[],
+  updateMetadata: Map<string, DeviceUpdateMetadata>,
+): Promise<Map<string, PendingComponentUpdateStatus>> {
+  const statuses = new Map<string, PendingComponentUpdateStatus>();
+  if (deviceIds.length === 0) return statuses;
+
+  const rows = await db
+    .select({
+      deviceId: deviceCommands.deviceId,
+      type: deviceCommands.type,
+      payload: deviceCommands.payload,
+      status: deviceCommands.status,
+      createdAt: deviceCommands.createdAt,
+    })
+    .from(deviceCommands)
+    .where(
+      and(
+        inArray(deviceCommands.deviceId, deviceIds),
+        inArray(deviceCommands.status, ['pending', 'sent']),
+        inArray(deviceCommands.type, ['update_agent', 'update_watchdog', 'legacy_agent_update']),
+      ),
+    )
+    .orderBy(desc(deviceCommands.createdAt));
+
+  for (const row of rows) {
+    if (statuses.has(row.deviceId)) continue;
+    const status = pendingComponentUpdateStatusFromCommand(row, updateMetadata.get(row.deviceId));
+    if (status) statuses.set(row.deviceId, status);
+  }
+
+  return statuses;
+}
 
 /**
  * Tables that denormalize `org_id` for RLS but have NO `device_id` column,
@@ -619,9 +708,24 @@ coreRoutes.get(
       }
     }
 
-    // Transform to include hardware and latest metrics as nested objects
+    const updateMetadata = await buildDeviceUpdateMetadata(deviceList.map((d) => ({
+      id: d.id,
+      orgId: d.orgId,
+      osType: d.osType,
+      architecture: d.architecture,
+      agentVersion: d.agentVersion,
+      watchdogVersion: d.watchdogVersion,
+    })));
+    const pendingComponentUpdateStatuses = await loadPendingComponentUpdateStatuses(deviceIds, updateMetadata);
+
+    // Transform to include hardware, latest metrics, and server-authoritative
+    // update metadata as nested objects.
     const data = deviceList.map(d => {
       const latestMetrics = latestMetricsByDevice.get(d.id);
+      const updates = updateMetadata.get(d.id);
+      const pendingComponentUpdate = d.status === 'offline' || d.status === 'decommissioned'
+        ? null
+        : pendingComponentUpdateStatuses.get(d.id);
 
       return {
         id: d.id,
@@ -638,7 +742,9 @@ coreRoutes.get(
         architecture: d.architecture,
         agentVersion: d.agentVersion,
         watchdogVersion: d.watchdogVersion,
-        status: d.status,
+        status: pendingComponentUpdate ? 'updating' : d.status,
+        componentUpdateStatusLabel: pendingComponentUpdate?.label ?? null,
+        componentUpdateStatusFullLabel: pendingComponentUpdate?.fullLabel ?? null,
         watchdogStatus: d.watchdogStatus,
         mainAgentSilentSince: d.mainAgentSilentSince,
         pendingReboot: d.pendingReboot,
@@ -670,7 +776,9 @@ coreRoutes.get(
             ramPercent: latestMetrics.ramPercent,
             timestamp: latestMetrics.timestamp
           }
-          : null
+          : null,
+        agentUpdate: updates?.agentUpdate ?? null,
+        watchdogUpdate: updates?.watchdogUpdate ?? null,
       };
     });
 
@@ -830,6 +938,16 @@ coreRoutes.get(
       remoteAccessLaunchSkipReason = 'config_error';
     }
 
+    const updateMetadata = await buildDeviceUpdateMetadata([{
+      id: device.id,
+      orgId: device.orgId,
+      osType: device.osType,
+      architecture: device.architecture,
+      agentVersion: device.agentVersion,
+      watchdogVersion: device.watchdogVersion,
+    }]);
+    const updates = updateMetadata.get(device.id);
+
     return c.json({
       ...stripSensitiveDeviceFields(device),
       hardware: hardware || null,
@@ -842,6 +960,8 @@ coreRoutes.get(
       remoteAccessPolicy,
       hasRemoteAccessLauncher,
       remoteAccessLaunchSkipReason,
+      agentUpdate: updates?.agentUpdate ?? null,
+      watchdogUpdate: updates?.watchdogUpdate ?? null,
     });
   }
 );

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -26,6 +26,8 @@ import { isValidIpOrCidr } from '../services/ipMatch';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { clearPartnerAllowlistCache, ipAllowlistMode, readPartnerAllowlist } from '../services/ipAllowlist';
+import { validateAgentUpdateDefaults } from './agents/agentUpdatePolicy';
+import { validateAgentVersionPinsAvailable } from '../services/agentUpdateTargets';
 import { registerOrgPortalSettingsRoutes } from './orgPortalSettings';
 import { registerOrgTicketSettingsRoutes } from './orgTicketSettings';
 
@@ -100,6 +102,15 @@ function preserveIpAllowlistOnOmit(
   return { ...incomingSettings, security: { ...security, ipAllowlist: currentList } };
 }
 
+async function validateAgentUpdateSettingsPayload(settings: unknown): Promise<string | null> {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return null;
+  const defaults = (settings as Record<string, unknown>).defaults;
+  if (!defaults || typeof defaults !== 'object' || Array.isArray(defaults)) return null;
+  const shapeError = validateAgentUpdateDefaults(defaults);
+  if (shapeError) return shapeError;
+  return validateAgentVersionPinsAvailable(defaults);
+}
+
 const createOrganizationSchema = z.object({
   partnerId: z.string().guid().optional(),
   name: z.string().min(1),
@@ -115,6 +126,32 @@ const createOrganizationSchema = z.object({
 });
 
 const updateOrganizationSchema = createOrganizationSchema.partial().omit({ partnerId: true });
+
+const agentUpdateScheduleWindowSchema = z.object({
+  dayOfWeek: z.enum(['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']),
+  start: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/),
+  end: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/),
+}).refine((window) => window.start !== window.end, {
+  message: 'start and end must be different',
+  path: ['end'],
+});
+
+const legacyAgentUpdateScheduleSchema = z.object({
+  dayOfWeek: z.enum(['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']),
+  time: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/),
+});
+
+const agentUpdateScheduleSchema = z.union([
+  legacyAgentUpdateScheduleSchema,
+  z.object({
+    windows: z.array(agentUpdateScheduleWindowSchema).min(1).max(14),
+  }),
+]);
+
+const agentVersionPinsSchema = z.object({
+  agent: z.union([z.string().max(64), z.literal('')]).optional(),
+  watchdog: z.union([z.string().max(64), z.literal('')]).optional(),
+}).optional();
 
 const listSitesSchema = z.object({
   orgId: z.string().guid().optional(),
@@ -376,6 +413,10 @@ const partnerSettingsSchema = z.object({
     }).optional(),
     agentUpdatePolicy: z.string().optional(),
     maintenanceWindow: z.string().optional(),
+    agentUpdateMode: z.enum(['automatic', 'manual']).optional(),
+    agentUpdateTiming: z.enum(['asap', 'weekly']).optional(),
+    agentUpdateSchedule: agentUpdateScheduleSchema.optional(),
+    agentVersionPins: agentVersionPinsSchema,
   }).optional(),
   branding: z.object({
     logoUrl: z.string().max(400_000, 'Logo data exceeds maximum size (400 KB)').optional(),
@@ -528,6 +569,11 @@ orgRoutes.patch('/partners/me', requireScope('partner'), requirePartner, require
     };
   }
 
+  const agentUpdateSettingsError = await validateAgentUpdateSettingsPayload(newSettings);
+  if (agentUpdateSettingsError) {
+    return c.json({ error: agentUpdateSettingsError }, 400);
+  }
+
   // Tenant-isolation guard: defaultTriageOrgId is stored verbatim, but the
   // future auto-triage path will route mail INTO that org. A cross-partner id
   // here would route a partner's inbound mail to an org outside their tenant.
@@ -611,6 +657,22 @@ orgRoutes.patch('/partners/me', requireScope('partner'), requirePartner, require
     details: { changedFields: Object.keys(body) }
   });
 
+  if (body.settings?.defaults) {
+    const defaults = body.settings.defaults as Record<string, unknown>;
+    const updateKeys = ['agentUpdateMode', 'agentUpdateTiming', 'agentUpdateSchedule', 'agentVersionPins']
+      .filter((key) => key in defaults);
+    if (updateKeys.length > 0) {
+      writeRouteAudit(c, {
+        orgId: auditOrgId,
+        action: 'partner.agent_update_settings.update',
+        resourceType: 'partner',
+        resourceId: partner.id,
+        resourceName: partner.name,
+        details: { changedFields: updateKeys },
+      });
+    }
+  }
+
   return c.json(partner);
 });
 
@@ -657,6 +719,11 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
           currentPartner.settings,
           updates.settings as Record<string, unknown>,
         );
+      }
+
+      const agentUpdateSettingsError = await validateAgentUpdateSettingsPayload(updates.settings);
+      if (agentUpdateSettingsError) {
+        return c.json({ error: agentUpdateSettingsError }, 400);
       }
 
       // Keep the first-class `partners.timezone` column in sync with the
@@ -733,6 +800,24 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
       changedFields: Object.keys(data)
     }
   });
+
+  if (data.settings?.defaults && typeof data.settings.defaults === 'object') {
+    const defaults = data.settings.defaults as Record<string, unknown>;
+    const updateKeys = ['agentUpdateMode', 'agentUpdateTiming', 'agentUpdateSchedule', 'agentVersionPins']
+      .filter((key) => key in defaults);
+    if (updateKeys.length > 0) {
+      writeAuditEvent(c, {
+        orgId: auditOrgId,
+        actorId: auth.user?.id,
+        actorEmail: auth.user?.email,
+        action: 'partner.agent_update_settings.update',
+        resourceType: 'partner',
+        resourceId: partner.id,
+        resourceName: partner.name,
+        details: { changedFields: updateKeys },
+      });
+    }
+  }
 
   return c.json(partner);
 });
@@ -980,6 +1065,11 @@ orgRoutes.post('/organizations', requireScope('partner', 'system'), requireOrgWr
   const auth = c.get('auth');
   const data = c.req.valid('json');
 
+  const agentUpdateSettingsError = await validateAgentUpdateSettingsPayload(data.settings);
+  if (agentUpdateSettingsError) {
+    return c.json({ error: agentUpdateSettingsError }, 400);
+  }
+
   let targetPartnerId: string | null = null;
 
   if (auth.scope === 'partner') {
@@ -1086,6 +1176,11 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
     return c.json({ error: 'Organization not found' }, 404);
   }
 
+  const agentUpdateSettingsError = await validateAgentUpdateSettingsPayload(data.settings);
+  if (agentUpdateSettingsError) {
+    return c.json({ error: agentUpdateSettingsError }, 400);
+  }
+
   // Enforce partner locks on settings categories (after auth check)
   if (data.settings) {
     const settingsObj = data.settings as Record<string, unknown>;
@@ -1147,6 +1242,22 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
     resourceName: organization.name,
     details: { changedFields: Object.keys(data) }
   });
+
+  if (data.settings?.defaults && typeof data.settings.defaults === 'object') {
+    const defaults = data.settings.defaults as Record<string, unknown>;
+    const updateKeys = ['agentUpdateMode', 'agentUpdateTiming', 'agentUpdateSchedule', 'agentVersionPins']
+      .filter((key) => key in defaults);
+    if (updateKeys.length > 0) {
+      writeRouteAudit(c, {
+        orgId: organization.id,
+        action: 'organization.agent_update_settings.update',
+        resourceType: 'organization',
+        resourceId: organization.id,
+        resourceName: organization.name,
+        details: { changedFields: updateKeys },
+      });
+    }
+  }
 
   return c.json(organization);
 }] as const;

--- a/apps/api/src/services/agentUpdateTargets.test.ts
+++ b/apps/api/src/services/agentUpdateTargets.test.ts
@@ -91,7 +91,7 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.83.0',
+        agentVersion: '0.83.1',
         watchdogVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
       },
       component: 'watchdog',
@@ -112,8 +112,8 @@ describe('resolveComponentUpdateDecision', () => {
     });
   });
 
-  it('flags old release agents for the legacy heartbeat upgrade path', async () => {
-    dbMocks.limit.mockResolvedValueOnce([{ version: '0.82.2' }]);
+  it('flags 0.83.0 release agents for the legacy heartbeat upgrade path', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.1' }]);
 
     const decision = await resolveComponentUpdateDecision({
       device: {
@@ -121,8 +121,8 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.82.1',
-        watchdogVersion: '0.82.1',
+        agentVersion: '0.83.0',
+        watchdogVersion: '0.83.0',
       },
       component: 'agent',
       settings: normalizeAgentUpdateSettings({
@@ -132,8 +132,8 @@ describe('resolveComponentUpdateDecision', () => {
 
     expect(decision).toMatchObject({
       available: true,
-      currentVersion: '0.82.1',
-      targetVersion: '0.82.2',
+      currentVersion: '0.83.0',
+      targetVersion: '0.83.1',
       mode: 'manual',
       autoInstall: false,
       pinned: false,
@@ -142,8 +142,8 @@ describe('resolveComponentUpdateDecision', () => {
     });
   });
 
-  it('treats 0.82.2 as component-update capable', async () => {
-    dbMocks.limit.mockResolvedValueOnce([{ version: '0.82.3' }]);
+  it('treats 0.83.1 as component-update capable', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.2' }]);
 
     const decision = await resolveComponentUpdateDecision({
       device: {
@@ -151,8 +151,8 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.82.2',
-        watchdogVersion: '0.82.2',
+        agentVersion: '0.83.1',
+        watchdogVersion: '0.83.1',
       },
       component: 'agent',
       settings: normalizeAgentUpdateSettings({
@@ -162,8 +162,8 @@ describe('resolveComponentUpdateDecision', () => {
 
     expect(decision).toMatchObject({
       available: true,
-      currentVersion: '0.82.2',
-      targetVersion: '0.82.3',
+      currentVersion: '0.83.1',
+      targetVersion: '0.83.2',
       mode: 'manual',
       autoInstall: false,
       pinned: false,
@@ -173,13 +173,15 @@ describe('resolveComponentUpdateDecision', () => {
   });
 
   it('blocks watchdog repair/update while the main agent is too old to execute it', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.1' }]);
+
     const decision = await resolveComponentUpdateDecision({
       device: {
         id: 'device-1',
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.82.1',
+        agentVersion: '0.83.0',
         watchdogVersion: null,
       },
       component: 'watchdog',
@@ -191,7 +193,7 @@ describe('resolveComponentUpdateDecision', () => {
     expect(decision).toMatchObject({
       available: true,
       currentVersion: null,
-      targetVersion: '0.70.0',
+      targetVersion: '0.83.1',
       mode: 'manual',
       autoInstall: false,
       pinned: false,
@@ -202,7 +204,7 @@ describe('resolveComponentUpdateDecision', () => {
   });
 
   it('blocks main-agent component updates while the watchdog cannot poll healthy commands', async () => {
-    dbMocks.limit.mockResolvedValueOnce([{ version: '0.84.0' }]);
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.2' }]);
 
     const decision = await resolveComponentUpdateDecision({
       device: {
@@ -210,8 +212,8 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.83.0',
-        watchdogVersion: '0.82.1',
+        agentVersion: '0.83.1',
+        watchdogVersion: '0.83.0',
       },
       component: 'agent',
       settings: normalizeAgentUpdateSettings({
@@ -221,8 +223,8 @@ describe('resolveComponentUpdateDecision', () => {
 
     expect(decision).toMatchObject({
       available: true,
-      currentVersion: '0.83.0',
-      targetVersion: '0.84.0',
+      currentVersion: '0.83.1',
+      targetVersion: '0.83.2',
       autoInstall: false,
       blockedBy: 'legacy-watchdog',
       reason: 'legacy-watchdog',
@@ -232,7 +234,7 @@ describe('resolveComponentUpdateDecision', () => {
   it('rejects normal manual component updates for legacy agents', async () => {
     dbMocks.limit
       .mockResolvedValueOnce([{ settings: { defaults: { agentUpdateMode: 'manual' } } }])
-      .mockResolvedValueOnce([{ version: '0.83.0' }]);
+      .mockResolvedValueOnce([{ version: '0.83.1' }]);
 
     const result = await resolveManualComponentTarget({
       device: {
@@ -240,8 +242,8 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.82.1',
-        watchdogVersion: '0.82.1',
+        agentVersion: '0.83.0',
+        watchdogVersion: '0.83.0',
       },
       component: 'agent',
     });

--- a/apps/api/src/services/agentUpdateTargets.test.ts
+++ b/apps/api/src/services/agentUpdateTargets.test.ts
@@ -91,7 +91,7 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.83.1',
+        agentVersion: '0.83.2',
         watchdogVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
       },
       component: 'watchdog',
@@ -112,37 +112,7 @@ describe('resolveComponentUpdateDecision', () => {
     });
   });
 
-  it('flags 0.83.0 release agents for the legacy heartbeat upgrade path', async () => {
-    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.1' }]);
-
-    const decision = await resolveComponentUpdateDecision({
-      device: {
-        id: 'device-1',
-        orgId: 'org-1',
-        osType: 'linux',
-        architecture: 'amd64',
-        agentVersion: '0.83.0',
-        watchdogVersion: '0.83.0',
-      },
-      component: 'agent',
-      settings: normalizeAgentUpdateSettings({
-        agentUpdateMode: 'manual',
-      }),
-    });
-
-    expect(decision).toMatchObject({
-      available: true,
-      currentVersion: '0.83.0',
-      targetVersion: '0.83.1',
-      mode: 'manual',
-      autoInstall: false,
-      pinned: false,
-      action: 'legacy-agent-update',
-      reason: 'legacy-agent',
-    });
-  });
-
-  it('treats 0.83.1 as component-update capable', async () => {
+  it('flags 0.83.1 release agents for the legacy heartbeat upgrade path', async () => {
     dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.2' }]);
 
     const decision = await resolveComponentUpdateDecision({
@@ -167,13 +137,13 @@ describe('resolveComponentUpdateDecision', () => {
       mode: 'manual',
       autoInstall: false,
       pinned: false,
-      action: 'component-update',
-      reason: 'manual',
+      action: 'legacy-agent-update',
+      reason: 'legacy-agent',
     });
   });
 
-  it('blocks watchdog repair/update while the main agent is too old to execute it', async () => {
-    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.1' }]);
+  it('treats 0.83.2 as component-update capable', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.3' }]);
 
     const decision = await resolveComponentUpdateDecision({
       device: {
@@ -181,7 +151,37 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.83.0',
+        agentVersion: '0.83.2',
+        watchdogVersion: '0.83.2',
+      },
+      component: 'agent',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'manual',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: '0.83.2',
+      targetVersion: '0.83.3',
+      mode: 'manual',
+      autoInstall: false,
+      pinned: false,
+      action: 'component-update',
+      reason: 'manual',
+    });
+  });
+
+  it('blocks watchdog repair/update while the main agent is too old to execute it', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.2' }]);
+
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.83.1',
         watchdogVersion: null,
       },
       component: 'watchdog',
@@ -193,7 +193,7 @@ describe('resolveComponentUpdateDecision', () => {
     expect(decision).toMatchObject({
       available: true,
       currentVersion: null,
-      targetVersion: '0.83.1',
+      targetVersion: '0.83.2',
       mode: 'manual',
       autoInstall: false,
       pinned: false,
@@ -204,7 +204,7 @@ describe('resolveComponentUpdateDecision', () => {
   });
 
   it('blocks main-agent component updates while the watchdog cannot poll healthy commands', async () => {
-    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.2' }]);
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.83.3' }]);
 
     const decision = await resolveComponentUpdateDecision({
       device: {
@@ -212,8 +212,8 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.83.1',
-        watchdogVersion: '0.83.0',
+        agentVersion: '0.83.2',
+        watchdogVersion: '0.83.1',
       },
       component: 'agent',
       settings: normalizeAgentUpdateSettings({
@@ -223,8 +223,8 @@ describe('resolveComponentUpdateDecision', () => {
 
     expect(decision).toMatchObject({
       available: true,
-      currentVersion: '0.83.1',
-      targetVersion: '0.83.2',
+      currentVersion: '0.83.2',
+      targetVersion: '0.83.3',
       autoInstall: false,
       blockedBy: 'legacy-watchdog',
       reason: 'legacy-watchdog',
@@ -234,7 +234,7 @@ describe('resolveComponentUpdateDecision', () => {
   it('rejects normal manual component updates for legacy agents', async () => {
     dbMocks.limit
       .mockResolvedValueOnce([{ settings: { defaults: { agentUpdateMode: 'manual' } } }])
-      .mockResolvedValueOnce([{ version: '0.83.1' }]);
+      .mockResolvedValueOnce([{ version: '0.83.2' }]);
 
     const result = await resolveManualComponentTarget({
       device: {
@@ -242,8 +242,8 @@ describe('resolveComponentUpdateDecision', () => {
         orgId: 'org-1',
         osType: 'linux',
         architecture: 'amd64',
-        agentVersion: '0.83.0',
-        watchdogVersion: '0.83.0',
+        agentVersion: '0.83.1',
+        watchdogVersion: '0.83.1',
       },
       component: 'agent',
     });

--- a/apps/api/src/services/agentUpdateTargets.test.ts
+++ b/apps/api/src/services/agentUpdateTargets.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => {
+  const limit = vi.fn();
+  const orderBy = vi.fn(() => ({ limit }));
+  const where = vi.fn(() => ({ orderBy, limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return {
+    select,
+    from,
+    where,
+    orderBy,
+    limit,
+  };
+});
+
+vi.mock('../db', () => ({
+  db: {
+    select: dbMocks.select,
+  },
+}));
+
+import { resolveComponentUpdateDecision, resolveManualComponentTarget } from './agentUpdateTargets';
+import { normalizeAgentUpdateSettings } from '../routes/agents/agentUpdatePolicy';
+
+describe('resolveComponentUpdateDecision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.limit.mockResolvedValue([{ version: '0.70.0' }]);
+  });
+
+  it('offers a manual reinstall target when an agent reports a non-release version string', async () => {
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: 'integration-smoke-agent',
+        watchdogVersion: '0.69.0',
+      },
+      component: 'agent',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'automatic',
+        agentUpdateTiming: 'asap',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: 'integration-smoke-agent',
+      targetVersion: '0.70.0',
+      mode: 'automatic',
+      autoInstall: false,
+      pinned: false,
+      reason: 'non-release-version',
+    });
+  });
+
+  it('does not auto-replace dev agent builds, but still exposes a manual reinstall target', async () => {
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: 'dev-integration-test',
+        watchdogVersion: '0.69.0',
+      },
+      component: 'agent',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'automatic',
+        agentUpdateTiming: 'asap',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: 'dev-integration-test',
+      targetVersion: '0.70.0',
+      autoInstall: false,
+      reason: 'non-release-version',
+    });
+  });
+
+  it('offers a manual reinstall target when a watchdog reports a non-release version string', async () => {
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.83.0',
+        watchdogVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
+      },
+      component: 'watchdog',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'automatic',
+        agentUpdateTiming: 'asap',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
+      targetVersion: '0.70.0',
+      mode: 'automatic',
+      autoInstall: false,
+      pinned: false,
+      reason: 'non-release-version',
+    });
+  });
+
+  it('flags old release agents for the legacy heartbeat upgrade path', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.82.2' }]);
+
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.82.1',
+        watchdogVersion: '0.82.1',
+      },
+      component: 'agent',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'manual',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: '0.82.1',
+      targetVersion: '0.82.2',
+      mode: 'manual',
+      autoInstall: false,
+      pinned: false,
+      action: 'legacy-agent-update',
+      reason: 'legacy-agent',
+    });
+  });
+
+  it('treats 0.82.2 as component-update capable', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.82.3' }]);
+
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.82.2',
+        watchdogVersion: '0.82.2',
+      },
+      component: 'agent',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'manual',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: '0.82.2',
+      targetVersion: '0.82.3',
+      mode: 'manual',
+      autoInstall: false,
+      pinned: false,
+      action: 'component-update',
+      reason: 'manual',
+    });
+  });
+
+  it('blocks watchdog repair/update while the main agent is too old to execute it', async () => {
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.82.1',
+        watchdogVersion: null,
+      },
+      component: 'watchdog',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'manual',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: null,
+      targetVersion: '0.70.0',
+      mode: 'manual',
+      autoInstall: false,
+      pinned: false,
+      missing: true,
+      blockedBy: 'legacy-agent',
+      reason: 'legacy-agent',
+    });
+  });
+
+  it('blocks main-agent component updates while the watchdog cannot poll healthy commands', async () => {
+    dbMocks.limit.mockResolvedValueOnce([{ version: '0.84.0' }]);
+
+    const decision = await resolveComponentUpdateDecision({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.83.0',
+        watchdogVersion: '0.82.1',
+      },
+      component: 'agent',
+      settings: normalizeAgentUpdateSettings({
+        agentUpdateMode: 'manual',
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      available: true,
+      currentVersion: '0.83.0',
+      targetVersion: '0.84.0',
+      autoInstall: false,
+      blockedBy: 'legacy-watchdog',
+      reason: 'legacy-watchdog',
+    });
+  });
+
+  it('rejects normal manual component updates for legacy agents', async () => {
+    dbMocks.limit
+      .mockResolvedValueOnce([{ settings: { defaults: { agentUpdateMode: 'manual' } } }])
+      .mockResolvedValueOnce([{ version: '0.83.0' }]);
+
+    const result = await resolveManualComponentTarget({
+      device: {
+        id: 'device-1',
+        orgId: 'org-1',
+        osType: 'linux',
+        architecture: 'amd64',
+        agentVersion: '0.82.1',
+        watchdogVersion: '0.82.1',
+      },
+      component: 'agent',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 409,
+      code: 'LEGACY_AGENT_UPDATE_REQUIRED',
+    });
+  });
+});

--- a/apps/api/src/services/agentUpdateTargets.ts
+++ b/apps/api/src/services/agentUpdateTargets.ts
@@ -1,0 +1,506 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { db } from '../db';
+import { agentVersions, organizations } from '../db/schema';
+import {
+  normalizeAgentUpdateSettings,
+  shouldSendAgentUpgrade,
+  type AgentUpdateMode,
+  type AgentUpdateSettings,
+  type LegacyAgentUpdateSettings,
+} from '../routes/agents/agentUpdatePolicy';
+
+export type AgentUpdateComponent = 'agent' | 'watchdog';
+
+export interface ComponentUpdateDecision {
+  available: boolean;
+  currentVersion: string | null;
+  targetVersion: string | null;
+  mode: AgentUpdateMode;
+  autoInstall: boolean;
+  pinned: boolean;
+  action?: 'component-update' | 'legacy-agent-update';
+  blockedBy?: 'legacy-agent' | 'legacy-watchdog' | 'missing-watchdog';
+  missing?: boolean;
+  reason?:
+    | 'current'
+    | 'downgrade'
+    | 'dev-build'
+    | 'manual'
+    | 'outside-schedule'
+    | 'unsupported-architecture'
+    | 'no-target'
+    | 'pin-unavailable'
+    | 'non-release-version'
+    | 'legacy-agent'
+    | 'legacy-watchdog'
+    | 'watchdog-required';
+}
+
+export interface DeviceUpdateMetadata {
+  agentUpdate: ComponentUpdateDecision;
+  watchdogUpdate: ComponentUpdateDecision;
+}
+
+export interface DeviceUpdateInput {
+  id: string;
+  orgId: string;
+  osType: string | null;
+  architecture: string | null;
+  agentVersion: string | null;
+  watchdogVersion: string | null;
+}
+
+const COMPONENTS: AgentUpdateComponent[] = ['agent', 'watchdog'];
+const COMPONENT_UPDATE_AGENT_MIN_VERSION = '0.82.2';
+const WATCHDOG_HEALTHY_COMMAND_MIN_VERSION = '0.82.2';
+
+function normalizeArchitecture(architecture: string | null | undefined): 'amd64' | 'arm64' | null {
+  if (!architecture) return null;
+  const normalized = architecture.trim().toLowerCase();
+  if (normalized === 'amd64' || normalized === 'x86_64' || normalized === 'x64') return 'amd64';
+  if (normalized === 'arm64' || normalized === 'aarch64') return 'arm64';
+  return null;
+}
+
+function normalizePlatform(platform: string | null | undefined): 'windows' | 'macos' | 'linux' | null {
+  if (!platform) return null;
+  const normalized = platform.trim().toLowerCase();
+  if (normalized === 'darwin') return 'macos';
+  if (normalized === 'windows' || normalized === 'macos' || normalized === 'linux') return normalized;
+  return null;
+}
+
+function parseComparableVersion(raw: string): { core: number[]; prerelease: string | null } | null {
+  const trimmed = raw.trim().replace(/^v/i, '');
+  if (!trimmed) return null;
+  const [rawCorePart, prereleasePart] = trimmed.split('-', 2);
+  if (!rawCorePart) return null;
+  const core = rawCorePart.split('.').map((part) => {
+    if (!/^\d+$/.test(part)) return Number.NaN;
+    return Number.parseInt(part, 10);
+  });
+  if (core.some((part) => !Number.isFinite(part))) return null;
+  return { core, prerelease: prereleasePart ?? null };
+}
+
+export function compareAgentReleaseVersions(leftRaw: string, rightRaw: string): number {
+  const left = parseComparableVersion(leftRaw);
+  const right = parseComparableVersion(rightRaw);
+  if (!left || !right) return 0;
+
+  const maxLen = Math.max(left.core.length, right.core.length);
+  for (let i = 0; i < maxLen; i += 1) {
+    const leftPart = left.core[i] ?? 0;
+    const rightPart = right.core[i] ?? 0;
+    if (leftPart !== rightPart) return leftPart > rightPart ? 1 : -1;
+  }
+  if (left.prerelease === right.prerelease) return 0;
+  if (!left.prerelease) return 1;
+  if (!right.prerelease) return -1;
+  return left.prerelease.localeCompare(right.prerelease);
+}
+
+export function isComparableReleaseVersion(raw: string | null | undefined): boolean {
+  return !!raw && parseComparableVersion(raw) !== null;
+}
+
+function isAtLeastComparableVersion(raw: string, minimum: string): boolean {
+  if (!isComparableReleaseVersion(raw)) return false;
+  return compareAgentReleaseVersions(raw, minimum) >= 0;
+}
+
+export function isMainAgentComponentUpdateCapable(raw: string | null | undefined): boolean {
+  if (!raw) return false;
+  if (raw.startsWith('dev-')) return false;
+  if (!isComparableReleaseVersion(raw)) return true;
+  return isAtLeastComparableVersion(raw, COMPONENT_UPDATE_AGENT_MIN_VERSION);
+}
+
+export function isWatchdogHealthyCommandCapable(raw: string | null | undefined): boolean {
+  if (!raw) return false;
+  if (raw.startsWith('dev-')) return false;
+  if (!isComparableReleaseVersion(raw)) return true;
+  return isAtLeastComparableVersion(raw, WATCHDOG_HEALTHY_COMMAND_MIN_VERSION);
+}
+
+function emptyDecision(
+  settings: AgentUpdateSettings,
+  currentVersion: string | null,
+  pinned: boolean,
+  reason: ComponentUpdateDecision['reason'],
+  missing = false,
+): ComponentUpdateDecision {
+  return {
+    available: false,
+    currentVersion,
+    targetVersion: null,
+    mode: settings.mode,
+    autoInstall: false,
+    pinned,
+    ...(missing ? { missing: true } : {}),
+    reason,
+  };
+}
+
+function coerceAgentUpdateSettings(settings: AgentUpdateSettings | LegacyAgentUpdateSettings): AgentUpdateSettings {
+  if ('policy' in settings) {
+    return normalizeAgentUpdateSettings({
+      agentUpdatePolicy: settings.policy,
+      maintenanceWindow: settings.maintenanceWindow,
+    });
+  }
+  return {
+    ...settings,
+    pins: settings.pins ?? {},
+  };
+}
+
+export async function getOrgAgentUpdateSettings(orgId: string): Promise<AgentUpdateSettings> {
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  const settings = org?.settings && typeof org.settings === 'object' && !Array.isArray(org.settings)
+    ? org.settings as Record<string, unknown>
+    : {};
+  return normalizeAgentUpdateSettings(settings.defaults);
+}
+
+export async function validateAgentVersionPinsAvailable(defaultsRaw: unknown): Promise<string | null> {
+  const settings = normalizeAgentUpdateSettings(defaultsRaw);
+  for (const component of COMPONENTS) {
+    const pin = settings.pins[component];
+    if (!pin) continue;
+    const [row] = await db
+      .select({ id: agentVersions.id })
+      .from(agentVersions)
+      .where(and(eq(agentVersions.component, component), eq(agentVersions.version, pin)))
+      .limit(1);
+    if (!row) {
+      return `${component} version pin ${pin} is not registered in agent_versions`;
+    }
+  }
+  return null;
+}
+
+async function findVersionTarget(args: {
+  platform: string;
+  architecture: 'amd64' | 'arm64';
+  component: AgentUpdateComponent;
+  version?: string;
+}): Promise<string | null> {
+  const conditions = [
+    eq(agentVersions.platform, args.platform),
+    eq(agentVersions.architecture, args.architecture),
+    eq(agentVersions.component, args.component),
+  ];
+  if (args.version) {
+    conditions.push(eq(agentVersions.version, args.version));
+  } else {
+    conditions.push(eq(agentVersions.isLatest, true));
+  }
+
+  const [row] = await db
+    .select({ version: agentVersions.version })
+    .from(agentVersions)
+    .where(and(...conditions))
+    .orderBy(desc(agentVersions.createdAt))
+    .limit(1);
+  return row?.version ?? null;
+}
+
+export async function resolveComponentUpdateDecision(args: {
+  device: DeviceUpdateInput;
+  component: AgentUpdateComponent;
+  settings: AgentUpdateSettings | LegacyAgentUpdateSettings;
+  now?: Date;
+  requestedVersion?: string;
+}): Promise<ComponentUpdateDecision> {
+  const settings = coerceAgentUpdateSettings(args.settings);
+  const platform = normalizePlatform(args.device.osType);
+  const architecture = normalizeArchitecture(args.device.architecture);
+  const currentVersion = args.component === 'agent' ? args.device.agentVersion : args.device.watchdogVersion;
+  const missing = args.component === 'watchdog' && !currentVersion;
+  const pin = settings.pins[args.component];
+  const pinned = !args.requestedVersion && typeof pin === 'string' && pin.length > 0;
+
+  if (!platform || !architecture) {
+    return emptyDecision(settings, currentVersion, pinned, 'unsupported-architecture', missing);
+  }
+
+  const targetVersion = await findVersionTarget({
+    platform,
+    architecture,
+    component: args.component,
+    version: args.requestedVersion ?? pin,
+  });
+  if (!targetVersion) {
+    return emptyDecision(settings, currentVersion, pinned, pinned ? 'pin-unavailable' : 'no-target', missing);
+  }
+
+  if (args.component === 'watchdog' && !isMainAgentComponentUpdateCapable(args.device.agentVersion)) {
+    return {
+      available: true,
+      currentVersion,
+      targetVersion,
+      mode: settings.mode,
+      autoInstall: false,
+      pinned,
+      blockedBy: 'legacy-agent',
+      ...(missing ? { missing: true } : {}),
+      reason: 'legacy-agent',
+    };
+  }
+
+  if (currentVersion && !isComparableReleaseVersion(currentVersion)) {
+    return {
+      available: true,
+      currentVersion,
+      targetVersion,
+      mode: settings.mode,
+      autoInstall: false,
+      pinned,
+      action: 'component-update',
+      reason: 'non-release-version',
+    };
+  }
+
+  if (currentVersion?.startsWith('dev-')) {
+    return {
+      ...emptyDecision(settings, currentVersion, pinned, 'dev-build', missing),
+      targetVersion,
+    };
+  }
+
+  if (currentVersion) {
+    const cmp = compareAgentReleaseVersions(targetVersion, currentVersion);
+    if (cmp < 0) {
+      return {
+        ...emptyDecision(settings, currentVersion, pinned, 'downgrade', missing),
+        targetVersion,
+      };
+    }
+    if (cmp === 0) {
+      return {
+        ...emptyDecision(settings, currentVersion, pinned, 'current', missing),
+        targetVersion,
+      };
+    }
+  }
+
+  const gate = shouldSendAgentUpgrade(settings, args.now ?? new Date());
+  if (args.component === 'agent' && !isMainAgentComponentUpdateCapable(currentVersion)) {
+    return {
+      available: true,
+      currentVersion,
+      targetVersion,
+      mode: settings.mode,
+      autoInstall: gate.allow,
+      pinned,
+      action: 'legacy-agent-update',
+      reason: 'legacy-agent',
+    };
+  }
+  if (args.component === 'agent' && !args.device.watchdogVersion) {
+    return {
+      available: true,
+      currentVersion,
+      targetVersion,
+      mode: settings.mode,
+      autoInstall: false,
+      pinned,
+      blockedBy: 'missing-watchdog',
+      reason: 'watchdog-required',
+    };
+  }
+  if (args.component === 'agent' && !isWatchdogHealthyCommandCapable(args.device.watchdogVersion)) {
+    return {
+      available: true,
+      currentVersion,
+      targetVersion,
+      mode: settings.mode,
+      autoInstall: false,
+      pinned,
+      blockedBy: 'legacy-watchdog',
+      reason: 'legacy-watchdog',
+    };
+  }
+  return {
+    available: true,
+    currentVersion,
+    targetVersion,
+    mode: settings.mode,
+    autoInstall: gate.allow,
+    pinned,
+    action: 'component-update',
+    ...(missing ? { missing: true } : {}),
+    ...(gate.allow ? {} : { reason: gate.reason === 'manual-approval' ? 'manual' : 'outside-schedule' }),
+  };
+}
+
+export async function buildDeviceUpdateMetadata(
+  devices: DeviceUpdateInput[],
+  now: Date = new Date(),
+): Promise<Map<string, DeviceUpdateMetadata>> {
+  const result = new Map<string, DeviceUpdateMetadata>();
+  if (devices.length === 0) return result;
+
+  const orgIds = [...new Set(devices.map((device) => device.orgId))];
+  const orgRows = await db
+    .select({ id: organizations.id, settings: organizations.settings })
+    .from(organizations)
+    .where(inArray(organizations.id, orgIds));
+
+  const settingsByOrg = new Map<string, AgentUpdateSettings>();
+  for (const org of orgRows) {
+    const settings = org.settings && typeof org.settings === 'object' && !Array.isArray(org.settings)
+      ? org.settings as Record<string, unknown>
+      : {};
+    settingsByOrg.set(org.id, normalizeAgentUpdateSettings(settings.defaults));
+  }
+
+  for (const device of devices) {
+    const settings = settingsByOrg.get(device.orgId) ?? normalizeAgentUpdateSettings({});
+    const [agentUpdate, watchdogUpdate] = await Promise.all([
+      resolveComponentUpdateDecision({
+        device,
+        component: 'agent',
+        settings,
+        now,
+      }),
+      resolveComponentUpdateDecision({
+        device,
+        component: 'watchdog',
+        settings,
+        now,
+      }),
+    ]);
+    result.set(device.id, { agentUpdate, watchdogUpdate });
+  }
+
+  return result;
+}
+
+export async function resolveManualComponentTarget(args: {
+  device: DeviceUpdateInput;
+  component: AgentUpdateComponent;
+  version?: string;
+}): Promise<
+  | { ok: true; targetVersion: string; decision: ComponentUpdateDecision }
+  | { ok: false; status: number; code: string; message: string; decision?: ComponentUpdateDecision }
+> {
+  const settings = await getOrgAgentUpdateSettings(args.device.orgId);
+  const requestedVersion = args.version?.trim() || undefined;
+  const decision = await resolveComponentUpdateDecision({
+    device: args.device,
+    component: args.component,
+    settings,
+    requestedVersion,
+  });
+
+  if (!decision.targetVersion) {
+    return {
+      ok: false,
+      status: decision.reason === 'unsupported-architecture' ? 400 : 409,
+      code: decision.reason ?? 'NO_TARGET',
+      message: decision.reason === 'pin-unavailable'
+        ? `Pinned ${args.component} version is not available for this device platform.`
+        : `No ${args.component} update target is available for this device platform.`,
+      decision,
+    };
+  }
+  if (decision.reason === 'dev-build') {
+    return {
+      ok: false,
+      status: 409,
+      code: 'DEV_BUILD',
+      message: `Refusing to replace dev ${args.component} builds through component update.`,
+      decision,
+    };
+  }
+  if (decision.reason === 'downgrade') {
+    return {
+      ok: false,
+      status: 409,
+      code: 'DOWNGRADE',
+      message: `Refusing to downgrade ${args.component} from ${decision.currentVersion} to ${decision.targetVersion}.`,
+      decision,
+    };
+  }
+  if (decision.action === 'legacy-agent-update') {
+    return {
+      ok: false,
+      status: 409,
+      code: 'LEGACY_AGENT_UPDATE_REQUIRED',
+      message: 'Legacy agents must be upgraded through the legacy agent update path first.',
+      decision,
+    };
+  }
+  if (decision.blockedBy) {
+    return {
+      ok: false,
+      status: 409,
+      code: decision.blockedBy === 'legacy-agent'
+        ? 'LEGACY_AGENT_REQUIRED'
+        : decision.blockedBy === 'legacy-watchdog'
+          ? 'LEGACY_WATCHDOG_REQUIRED'
+          : 'WATCHDOG_REQUIRED',
+      message: decision.blockedBy === 'legacy-agent'
+        ? 'Update the main agent before updating or repairing the watchdog.'
+        : decision.blockedBy === 'legacy-watchdog'
+          ? 'Update the watchdog before updating the main agent.'
+          : 'Watchdog is required to update the main agent. Repair watchdog first.',
+      decision,
+    };
+  }
+  if (!decision.available) {
+    return {
+      ok: false,
+      status: 409,
+      code: 'ALREADY_CURRENT',
+      message: `${args.component} is already on ${decision.targetVersion}.`,
+      decision,
+    };
+  }
+  return { ok: true, targetVersion: decision.targetVersion, decision };
+}
+
+export async function resolveLegacyAgentUpdateTarget(args: {
+  device: DeviceUpdateInput;
+  version?: string;
+}): Promise<
+  | { ok: true; targetVersion: string; decision: ComponentUpdateDecision }
+  | { ok: false; status: number; code: string; message: string; decision?: ComponentUpdateDecision }
+> {
+  const settings = await getOrgAgentUpdateSettings(args.device.orgId);
+  const requestedVersion = args.version?.trim() || undefined;
+  const decision = await resolveComponentUpdateDecision({
+    device: args.device,
+    component: 'agent',
+    settings,
+    requestedVersion,
+  });
+
+  if (!decision.targetVersion) {
+    return {
+      ok: false,
+      status: decision.reason === 'unsupported-architecture' ? 400 : 409,
+      code: decision.reason ?? 'NO_TARGET',
+      message: 'No legacy agent update target is available for this device platform.',
+      decision,
+    };
+  }
+  if (decision.action !== 'legacy-agent-update') {
+    return {
+      ok: false,
+      status: 409,
+      code: decision.reason === 'current' ? 'ALREADY_CURRENT' : 'NOT_LEGACY_AGENT',
+      message: decision.reason === 'current'
+        ? `Agent is already on ${decision.targetVersion}.`
+        : 'This agent already supports component updates.',
+      decision,
+    };
+  }
+  return { ok: true, targetVersion: decision.targetVersion, decision };
+}

--- a/apps/api/src/services/agentUpdateTargets.ts
+++ b/apps/api/src/services/agentUpdateTargets.ts
@@ -51,8 +51,10 @@ export interface DeviceUpdateInput {
 }
 
 const COMPONENTS: AgentUpdateComponent[] = ['agent', 'watchdog'];
-const COMPONENT_UPDATE_AGENT_MIN_VERSION = '0.82.2';
-const WATCHDOG_HEALTHY_COMMAND_MIN_VERSION = '0.82.2';
+// 0.83.0 shipped before the component-update plumbing in this branch merged,
+// so official release agents/watchdogs at 0.83.0 and below are still legacy.
+const COMPONENT_UPDATE_AGENT_MIN_VERSION = '0.83.1';
+const WATCHDOG_HEALTHY_COMMAND_MIN_VERSION = '0.83.1';
 
 function normalizeArchitecture(architecture: string | null | undefined): 'amd64' | 'arm64' | null {
   if (!architecture) return null;

--- a/apps/api/src/services/agentUpdateTargets.ts
+++ b/apps/api/src/services/agentUpdateTargets.ts
@@ -51,10 +51,10 @@ export interface DeviceUpdateInput {
 }
 
 const COMPONENTS: AgentUpdateComponent[] = ['agent', 'watchdog'];
-// 0.83.0 shipped before the component-update plumbing in this branch merged,
-// so official release agents/watchdogs at 0.83.0 and below are still legacy.
-const COMPONENT_UPDATE_AGENT_MIN_VERSION = '0.83.1';
-const WATCHDOG_HEALTHY_COMMAND_MIN_VERSION = '0.83.1';
+// 0.83.1 shipped before the component-update plumbing in this branch merged,
+// so official release agents/watchdogs at 0.83.1 and below are still legacy.
+const COMPONENT_UPDATE_AGENT_MIN_VERSION = '0.83.2';
+const WATCHDOG_HEALTHY_COMMAND_MIN_VERSION = '0.83.2';
 
 function normalizeArchitecture(architecture: string | null | undefined): 'amd64' | 'arm64' | null {
   if (!architecture) return null;

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -218,10 +218,16 @@ describe("binarySync", () => {
     // upserted row with the per-deployment Ed25519 key.
     process.env.BINARY_SOURCE = "local";
     process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+    process.env.WATCHDOG_BINARY_DIR = "/fake/watchdog/bin";
     process.env.BINARY_VERSION_FILE = "/fake/version";
     delete process.env.BREEZE_VERSION;
 
-    fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+    fsMocks.readdir.mockImplementation(async (dir: string) => {
+      if (dir === "/fake/agent/bin") return ["breeze-agent-linux-amd64"];
+      if (dir === "/fake/watchdog/bin")
+        return ["breeze-watchdog-linux-amd64"];
+      return [];
+    });
     fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
     fsMocks.readFile.mockResolvedValue("0.65.9" as any);
 
@@ -233,7 +239,11 @@ describe("binarySync", () => {
     const insertCalls = dbMocks.insertValues.mock.calls.map(
       (call: any[]) => call[0] as Record<string, unknown>,
     );
-    expect(insertCalls.length).toBeGreaterThan(0);
+    expect(insertCalls.length).toBe(2);
+    expect(insertCalls.map((values) => values.component).sort()).toEqual([
+      "agent",
+      "watchdog",
+    ]);
     for (const values of insertCalls) {
       expect(values.releaseManifest).toEqual(expect.any(String));
       expect(values.manifestSignature).toBe("test-signature-base64");
@@ -243,11 +253,15 @@ describe("binarySync", () => {
       const manifest = JSON.parse(values.releaseManifest as string);
       expect(manifest).toMatchObject({
         version: "0.65.9",
-        component: "agent",
+        component: values.component,
         platform: "linux",
         arch: "amd64",
       });
-      expect(manifest.url).toContain("/agents/download/linux/amd64");
+      if (values.component === "watchdog") {
+        expect(manifest.url).toContain("/agents/download/watchdog/linux/amd64");
+      } else {
+        expect(manifest.url).toContain("/agents/download/linux/amd64");
+      }
       expect(manifest.checksum).toEqual(expect.any(String));
     }
 
@@ -310,10 +324,9 @@ describe("binarySync", () => {
 
   // Issue #816 / PR #845: syncFromGitHub gained a USER_HELPER_TARGETS loop
   // that registers the windows/amd64 breeze-user-helper.exe asset as its own
-  // component=user-helper row. heartbeat.doUpgrade's prefetch then fetches
-  // it via GET /agent-versions/:v/download. The three tests below cover the
-  // load-bearing behaviors of that loop.
-  describe("syncFromGitHub user-helper loop (#816)", () => {
+  // component=user-helper row. The watchdog loop follows the same
+  // signed-release-asset registration pattern for component=watchdog rows.
+  describe("syncFromGitHub companion component loops", () => {
     function stubGitHubReleaseFetch(
       signed: ReturnType<typeof makeSignedReleaseManifestMulti>,
       assetBytes: Map<string, Buffer>,
@@ -404,6 +417,55 @@ describe("binarySync", () => {
         component: "user-helper",
         checksum: signed.checksums.get(userHelperAsset.name),
         downloadUrl: `https://github.com/LanternOps/breeze/releases/download/v1.2.3/${userHelperAsset.name}`,
+      });
+    });
+
+    it("registers component=watchdog when agent and watchdog assets are present", async () => {
+      const agentAsset = {
+        name: "breeze-agent-windows-amd64.exe",
+        buffer: Buffer.from("trusted windows agent bytes"),
+      };
+      const watchdogAsset = {
+        name: "breeze-watchdog-windows-amd64.exe",
+        buffer: Buffer.from("trusted watchdog bytes"),
+      };
+      const signed = makeSignedReleaseManifestMulti([
+        agentAsset,
+        watchdogAsset,
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      stubGitHubReleaseFetch(
+        signed,
+        new Map([
+          [agentAsset.name, agentAsset.buffer],
+          [watchdogAsset.name, watchdogAsset.buffer],
+        ]),
+      );
+
+      const result = await syncFromGitHub();
+
+      expect(result.version).toBe("1.2.3");
+      expect(result.synced).toEqual(
+        expect.arrayContaining([
+          "agent:windows/amd64",
+          "watchdog:windows/amd64",
+        ]),
+      );
+
+      const watchdogInsert = (
+        dbMocks.insertValues.mock.calls as any[][]
+      ).find(
+        (call) => (call[0] as { component: string }).component === "watchdog",
+      );
+      expect(watchdogInsert).toBeDefined();
+      expect(watchdogInsert![0]).toMatchObject({
+        version: "1.2.3",
+        platform: "windows",
+        architecture: "amd64",
+        component: "watchdog",
+        checksum: signed.checksums.get(watchdogAsset.name),
+        downloadUrl: `https://github.com/LanternOps/breeze/releases/download/v1.2.3/${watchdogAsset.name}`,
       });
     });
 
@@ -623,7 +685,7 @@ describe("binarySync", () => {
     });
   });
 
-  it("upserts local agent binaries with the full 4-column conflict target (regression: #617)", async () => {
+  it("upserts local agent/watchdog binaries with the full 4-column conflict target (regression: #617)", async () => {
     // The agent_versions table has a UNIQUE constraint on
     // (version, platform, architecture, component). The local-binary path used
     // to omit `component`, so Postgres rejected the upsert with
@@ -635,11 +697,19 @@ describe("binarySync", () => {
     process.env.BINARY_VERSION_FILE = "/fake/version";
     delete process.env.BREEZE_VERSION;
 
-    fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+    fsMocks.readdir.mockResolvedValue([
+      "breeze-agent-linux-amd64",
+      "breeze-watchdog-linux-amd64",
+    ] as any);
     fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
     fsMocks.readFile.mockResolvedValue("0.65.7" as any);
 
     await syncBinaries();
+
+    const components = dbMocks.insertValues.mock.calls
+      .map((call: any[]) => (call[0] as { component: string }).component)
+      .sort();
+    expect(components).toEqual(["agent", "watchdog"]);
 
     const targets = dbMocks.onConflictDoUpdate.mock.calls.map(
       (call: any[]) => (call[0] as { target: unknown[] }).target,

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -275,6 +275,54 @@ describe("binarySync", () => {
     }
   });
 
+  it("does not GitHub-sync over local agent metadata when local watchdog binaries are absent", async () => {
+    process.env.BINARY_SOURCE = "local";
+    process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+    process.env.WATCHDOG_BINARY_DIR = "/fake/watchdog/bin";
+    process.env.BINARY_VERSION_FILE = "/fake/version";
+    process.env.APP_VERSION = "0.65.9";
+    delete process.env.BREEZE_VERSION;
+
+    fsMocks.readdir.mockImplementation(async (dir: string) => {
+      if (dir === "/fake/agent/bin") return ["breeze-agent-linux-amd64"];
+      if (dir === "/fake/watchdog/bin") return [];
+      return [];
+    });
+    fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
+    fsMocks.readFile.mockResolvedValue("0.65.9" as any);
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error("GitHub should not be called after local registration");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await syncBinaries();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(manifestSigningMocks.ensureActiveSigningKey).toHaveBeenCalled();
+
+      const insertCalls = dbMocks.insertValues.mock.calls.map(
+        (call: any[]) => call[0] as Record<string, unknown>,
+      );
+      expect(insertCalls).toHaveLength(1);
+      expect(insertCalls[0]).toMatchObject({
+        version: "0.65.9",
+        platform: "linux",
+        architecture: "amd64",
+        component: "agent",
+        signingKeyId: "deploy-test-aaaaaaaa",
+        manifestSignature: "test-signature-base64",
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[binarySync] No local watchdog binaries found; watchdog update targets will be unavailable in local binary mode",
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("logs at console.error (not warn) when stale-volume detection + GitHub fallback both fail (#644)", async () => {
     // Stale-volume path: BREEZE_VERSION != VERSION-file value.
     // We force the GitHub fallback to throw by making fetch reject. The

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -459,16 +459,28 @@ export async function syncBinaries(): Promise<void> {
     console.log(
       `[binarySync] Registered ${binaries.length} local binaries (${countSummary}; version: ${version})`,
     );
+
+    const registeredComponents = new Set(binaries.map((bin) => bin.component));
+    if (!registeredComponents.has("agent")) {
+      console.warn(
+        "[binarySync] No local agent binaries found; agent update targets will be unavailable in local binary mode",
+      );
+    }
+    if (!registeredComponents.has("watchdog")) {
+      console.warn(
+        "[binarySync] No local watchdog binaries found; watchdog update targets will be unavailable in local binary mode",
+      );
+    }
   } else {
     console.log(
       "[binarySync] No local agent binaries found, falling back to GitHub sync",
     );
     await syncFromGitHub();
+    // Verify the current version is registered after the GitHub fallback. This
+    // catches stale volumes and missed syncs without mixing GitHub release
+    // metadata into a successful local-binary registration.
+    await ensureCurrentVersionRegistered();
   }
-
-  // Verify the current version is registered — catches stale volumes and missed syncs.
-  // This is the safety net for self-hosted deployments where binaries-init may not refresh.
-  await ensureCurrentVersionRegistered();
 
   // Sync to S3 if configured (runs regardless of whether agent binaries were found)
   if (isS3Configured()) {

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -3,7 +3,7 @@ import { createReadStream } from "node:fs";
 import { createHash } from "node:crypto";
 import { join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db";
 import { agentVersions } from "../db/schema";
 import { isS3Configured, syncDirectory } from "./s3Storage";
@@ -63,6 +63,7 @@ const WATCHDOG_TARGETS = AGENT_TARGETS;
 interface BinaryInfo {
   filename: string;
   filePath: string;
+  component: "agent" | "watchdog";
   platform: string;
   architecture: string;
   checksum: string;
@@ -90,16 +91,18 @@ const PLATFORM_MAP: Record<string, string> = {
 
 function parseBinaryFilename(
   filename: string,
-): { platform: string; architecture: string } | null {
-  // Expected format: breeze-agent-{os}-{arch}[.exe]
+): { component: "agent" | "watchdog"; platform: string; architecture: string } | null {
+  // Expected format: breeze-{agent|watchdog}-{os}-{arch}[.exe]
   const match = filename.match(
-    /^breeze-agent-(linux|darwin|windows)-(amd64|arm64)(\.exe)?$/,
+    /^breeze-(agent|watchdog)-(linux|darwin|windows)-(amd64|arm64)(\.exe)?$/,
   );
   if (!match) return null;
-  const os = match[1]!;
+  const component = match[1] as "agent" | "watchdog";
+  const os = match[2]!;
   return {
+    component,
     platform: PLATFORM_MAP[os] ?? os,
-    architecture: match[2]!,
+    architecture: match[3]!,
   };
 }
 
@@ -238,7 +241,10 @@ async function getReleaseAssetMetadata(args: {
   };
 }
 
-async function scanBinaryDir(dir: string): Promise<BinaryInfo[]> {
+async function scanBinaryDir(
+  dir: string,
+  label = "Binary",
+): Promise<BinaryInfo[]> {
   const results: BinaryInfo[] = [];
 
   let entries: string[];
@@ -247,7 +253,7 @@ async function scanBinaryDir(dir: string): Promise<BinaryInfo[]> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(
-      `[binarySync] Agent binary directory not found: ${dir} (${msg})`,
+      `[binarySync] ${label} binary directory not found: ${dir} (${msg})`,
     );
     return results;
   }
@@ -264,6 +270,7 @@ async function scanBinaryDir(dir: string): Promise<BinaryInfo[]> {
       results.push({
         filename,
         filePath,
+        component: parsed.component,
         platform: parsed.platform,
         architecture: parsed.architecture,
         checksum,
@@ -293,6 +300,9 @@ export async function syncBinaries(): Promise<void> {
   }
 
   const agentBinaryDir = resolve(process.env.AGENT_BINARY_DIR || "./agent/bin");
+  const watchdogBinaryDir = resolve(
+    process.env.WATCHDOG_BINARY_DIR || process.env.AGENT_BINARY_DIR || "./agent/bin",
+  );
   const viewerBinaryDir = resolve(
     process.env.VIEWER_BINARY_DIR || "./viewer/bin",
   );
@@ -342,8 +352,16 @@ export async function syncBinaries(): Promise<void> {
     }
   }
 
-  // Scan and register agent binaries in DB
-  const binaries = await scanBinaryDir(agentBinaryDir);
+  // Scan and register local agent/watchdog binaries in DB.
+  const binaries =
+    watchdogBinaryDir === agentBinaryDir
+      ? await scanBinaryDir(agentBinaryDir, "Agent/watchdog")
+      : [
+          ...(await scanBinaryDir(agentBinaryDir, "Agent")),
+          ...(await scanBinaryDir(watchdogBinaryDir, "Watchdog")).filter(
+            (bin) => bin.component === "watchdog",
+          ),
+        ];
   if (binaries.length > 0) {
     const serverUrl =
       process.env.PUBLIC_APP_URL ||
@@ -359,11 +377,15 @@ export async function syncBinaries(): Promise<void> {
     await db.transaction(async (tx) => {
       for (const bin of binaries) {
         const osParam = bin.platform === "macos" ? "darwin" : bin.platform;
-        const downloadUrl = `${serverUrl}/api/v1/agents/download/${osParam}/${bin.architecture}`;
+        const downloadPath =
+          bin.component === "watchdog"
+            ? `/api/v1/agents/download/watchdog/${osParam}/${bin.architecture}`
+            : `/api/v1/agents/download/${osParam}/${bin.architecture}`;
+        const downloadUrl = `${serverUrl}${downloadPath}`;
 
         const manifestObj = {
           version,
-          component: "agent",
+          component: bin.component,
           platform: bin.platform,
           arch: bin.architecture,
           url: downloadUrl,
@@ -381,6 +403,7 @@ export async function syncBinaries(): Promise<void> {
             and(
               eq(agentVersions.platform, bin.platform),
               eq(agentVersions.architecture, bin.architecture),
+              eq(agentVersions.component, bin.component),
               eq(agentVersions.isLatest, true),
             ),
           );
@@ -396,14 +419,14 @@ export async function syncBinaries(): Promise<void> {
             checksum: bin.checksum,
             fileSize: bin.fileSize,
             isLatest: true,
+            component: bin.component,
             releaseManifest,
             manifestSignature,
             signingKeyId: keyId,
           })
           .onConflictDoUpdate({
             // Match the actual unique constraint
-            // (version, platform, architecture, component). `component`
-            // defaults to 'agent' in the schema for the local-binary path.
+            // (version, platform, architecture, component).
             target: [
               agentVersions.version,
               agentVersions.platform,
@@ -423,8 +446,18 @@ export async function syncBinaries(): Promise<void> {
       }
     });
 
+    const countsByComponent = binaries.reduce<Record<string, number>>(
+      (counts, bin) => {
+        counts[bin.component] = (counts[bin.component] ?? 0) + 1;
+        return counts;
+      },
+      {},
+    );
+    const countSummary = Object.entries(countsByComponent)
+      .map(([component, count]) => `${component}: ${count}`)
+      .join(", ");
     console.log(
-      `[binarySync] Registered ${binaries.length} agent binaries (version: ${version})`,
+      `[binarySync] Registered ${binaries.length} local binaries (${countSummary}; version: ${version})`,
     );
   } else {
     console.log(
@@ -454,6 +487,9 @@ export async function syncBinaries(): Promise<void> {
 
     const agentSync = await syncDirectory(agentBinaryDir, "agent");
     logSyncResult("agent", agentSync);
+
+    const watchdogSync = await syncDirectory(watchdogBinaryDir, "watchdog");
+    logSyncResult("watchdog", watchdogSync);
 
     const viewerSync = await syncDirectory(viewerBinaryDir, "viewer");
     logSyncResult("viewer", viewerSync);
@@ -705,21 +741,29 @@ async function ensureCurrentVersionRegistered(): Promise<void> {
     return;
 
   try {
-    const [existing] = await db
-      .select({ version: agentVersions.version })
+    const existingRows = await db
+      .select({ component: agentVersions.component })
       .from(agentVersions)
       .where(
         and(
           eq(agentVersions.version, currentVersion),
-          eq(agentVersions.component, "agent"),
+          inArray(agentVersions.component, ["agent", "watchdog"]),
         ),
       )
-      .limit(1);
+      .limit(2);
 
-    if (existing) return; // Already registered
+    const existingComponents = new Set(
+      existingRows.map((row) => row.component),
+    );
+    if (
+      existingComponents.has("agent") &&
+      existingComponents.has("watchdog")
+    ) {
+      return; // Already registered
+    }
 
     console.log(
-      `[binarySync] Version ${currentVersion} not found in agentVersions, syncing from GitHub`,
+      `[binarySync] Version ${currentVersion} is missing agent/watchdog rows in agentVersions, syncing from GitHub`,
     );
     const result = await syncFromGitHub(`v${currentVersion}`);
     console.log(

--- a/apps/api/src/services/componentUpdateResults.test.ts
+++ b/apps/api/src/services/componentUpdateResults.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateMock = vi.fn();
+const runOutsideDbContextMock = vi.fn(async (fn: () => Promise<unknown> | unknown) => fn());
+const withSystemDbAccessContextMock = vi.fn(async (fn: () => Promise<unknown> | unknown) => fn());
+
+function updateChain() {
+  return {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+}
+
+vi.mock('../db', () => ({
+  db: {
+    update: (...args: unknown[]) => updateMock(...(args as [])),
+  },
+  runOutsideDbContext: (...args: unknown[]) => runOutsideDbContextMock(...(args as [any])),
+  withSystemDbAccessContext: (...args: unknown[]) => withSystemDbAccessContextMock(...(args as [any])),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    agentVersion: 'devices.agent_version',
+    watchdogVersion: 'devices.watchdog_version',
+    updatedAt: 'devices.updated_at',
+  },
+}));
+
+import { applyCompletedComponentUpdateVersion } from './componentUpdateResults';
+
+describe('applyCompletedComponentUpdateVersion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateMock.mockReturnValue(updateChain());
+    runOutsideDbContextMock.mockImplementation(async (fn: () => Promise<unknown> | unknown) => fn());
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown> | unknown) => fn());
+  });
+
+  it('stamps watchdogVersion after a completed watchdog reinstall/update', async () => {
+    const applied = await applyCompletedComponentUpdateVersion({
+      deviceId: 'device-1',
+      type: 'update_watchdog',
+      targetRole: 'agent',
+      payload: { version: '0.82.1' },
+    }, 'completed', { updated_to: '0.82.1' });
+
+    expect(applied).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      watchdogVersion: 'devices.watchdog_version',
+    }));
+    const chain = updateMock.mock.results[0]?.value;
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({
+      watchdogVersion: '0.82.1',
+      updatedAt: expect.any(Date),
+    }));
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stamps agentVersion after a completed agent update executed by the watchdog', async () => {
+    const applied = await applyCompletedComponentUpdateVersion({
+      deviceId: 'device-1',
+      type: 'update_agent',
+      targetRole: 'watchdog',
+      payload: { version: '0.82.1' },
+    }, 'completed', { updated_to: '0.82.1' });
+
+    expect(applied).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      agentVersion: 'devices.agent_version',
+    }));
+    const chain = updateMock.mock.results[0]?.value;
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({
+      agentVersion: '0.82.1',
+      updatedAt: expect.any(Date),
+    }));
+  });
+
+  it('does not stamp versions for failed or role-mismatched commands', async () => {
+    await expect(applyCompletedComponentUpdateVersion({
+      deviceId: 'device-1',
+      type: 'update_watchdog',
+      targetRole: 'agent',
+      payload: { version: '0.82.1' },
+    }, 'failed', { updated_to: '0.82.1' })).resolves.toBe(false);
+
+    await expect(applyCompletedComponentUpdateVersion({
+      deviceId: 'device-1',
+      type: 'update_watchdog',
+      targetRole: 'watchdog',
+      payload: { version: '0.82.1' },
+    }, 'completed', { updated_to: '0.82.1' })).resolves.toBe(false);
+
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not stamp versions when the executor does not confirm the installed target', async () => {
+    await expect(applyCompletedComponentUpdateVersion({
+      deviceId: 'device-1',
+      type: 'update_watchdog',
+      targetRole: 'agent',
+      payload: { version: '0.82.1' },
+    }, 'completed')).resolves.toBe(false);
+
+    await expect(applyCompletedComponentUpdateVersion({
+      deviceId: 'device-1',
+      type: 'update_watchdog',
+      targetRole: 'agent',
+      payload: { version: '0.82.1' },
+    }, 'completed', { updated_to: '0.82.0' })).resolves.toBe(false);
+
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/componentUpdateResults.ts
+++ b/apps/api/src/services/componentUpdateResults.ts
@@ -1,0 +1,64 @@
+import { eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { devices } from '../db/schema';
+
+type ComponentUpdateCommand = {
+  deviceId: string;
+  type: string;
+  targetRole?: string | null;
+  payload?: unknown;
+};
+
+function payloadVersion(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+  const version = (payload as Record<string, unknown>).version;
+  return typeof version === 'string' && version.trim() ? version.trim() : null;
+}
+
+function reportedUpdatedVersion(result: unknown): string | null {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    return null;
+  }
+  const data = result as Record<string, unknown>;
+  const version = data.updated_to ?? data.updatedTo;
+  return typeof version === 'string' && version.trim() ? version.trim() : null;
+}
+
+export async function applyCompletedComponentUpdateVersion(
+  command: ComponentUpdateCommand,
+  resultStatus: string,
+  result?: unknown,
+): Promise<boolean> {
+  if (resultStatus !== 'completed') return false;
+
+  const version = payloadVersion(command.payload);
+  if (!version) return false;
+
+  const updatedTo = reportedUpdatedVersion(result);
+  if (updatedTo !== version) return false;
+
+  const now = new Date();
+  if (command.type === 'update_agent' && command.targetRole === 'watchdog') {
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      db
+        .update(devices)
+        .set({ agentVersion: version, updatedAt: now })
+        .where(eq(devices.id, command.deviceId)),
+    ));
+    return true;
+  }
+
+  if (command.type === 'update_watchdog' && command.targetRole === 'agent') {
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      db
+        .update(devices)
+        .set({ watchdogVersion: version, updatedAt: now })
+        .where(eq(devices.id, command.deviceId)),
+    ));
+    return true;
+  }
+
+  return false;
+}

--- a/apps/web/src/components/devices/DeviceCard.tsx
+++ b/apps/web/src/components/devices/DeviceCard.tsx
@@ -27,6 +27,13 @@ const statusColors: Record<DeviceStatus, string> = {
   pending: 'bg-muted-foreground'
 };
 
+function deviceStatusText(device: Pick<Device, 'status' | 'componentUpdateStatusFullLabel'>): string {
+  if (device.status === 'updating' && device.componentUpdateStatusFullLabel) {
+    return device.componentUpdateStatusFullLabel;
+  }
+  return device.status.charAt(0).toUpperCase() + device.status.slice(1);
+}
+
 const osIcons: Record<OSType, React.ReactNode> = {
   windows: (
     <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
@@ -167,7 +174,7 @@ export default function DeviceCard({ device, timezone, onClick, onAction }: Devi
             <div className="flex items-center gap-2">
               <h3 className="font-medium">{device.hostname}</h3>
               <span className={`h-2 w-2 rounded-full ${statusColors[device.status]}`} aria-hidden="true" />
-              <span className="sr-only">{device.status.charAt(0).toUpperCase() + device.status.slice(1)}</span>
+              <span className="sr-only">{deviceStatusText(device)}</span>
             </div>
             <p className="text-xs text-muted-foreground">{device.osVersion}</p>
           </div>

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -121,6 +121,318 @@ describe('DeviceList — Device column display names', () => {
   });
 });
 
+describe('DeviceList — component update indicators', () => {
+  beforeEach(() => {
+    window.localStorage?.clear();
+  });
+
+  function showColumn(label: string) {
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+    fireEvent.click(screen.getByLabelText(label));
+  }
+
+  it('renders automatic agent updates as disabled with automatic-install tooltip copy', () => {
+    const device: Device = {
+      ...baseDevice,
+      agentUpdate: {
+        available: true,
+        currentVersion: '0.67.0',
+        targetVersion: '0.68.0',
+        mode: 'automatic',
+        autoInstall: true,
+        pinned: false,
+      },
+    };
+
+    render(<DeviceList devices={[device]} />);
+    showColumn('Agent Version');
+
+    const button = screen.getByRole('button', { name: 'Agent update available' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'Update will install automatically to 0.68.0.');
+  });
+
+  it('calls the manual update callback when a manual agent update indicator is clicked', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      agentUpdate: {
+        available: true,
+        currentVersion: '0.67.0',
+        targetVersion: '0.68.0',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: true,
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Agent Version');
+
+    const button = screen.getByRole('button', { name: 'Agent update available' });
+    expect(button).toHaveAttribute('title', 'Click to update to 0.68.0. Pinned target.');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).toHaveBeenCalledWith(expect.objectContaining({ id: device.id }), 'agent');
+  });
+
+  it('disables manual component updates when the device is down but keeps the update tooltip context', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      status: 'offline',
+      agentUpdate: {
+        available: true,
+        currentVersion: '0.67.0',
+        targetVersion: '0.68.0',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: true,
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Agent Version');
+
+    const button = screen.getByRole('button', { name: 'Agent update available' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Click to update to 0.68.0. Pinned target. Device status must be Up to update the agent.',
+    );
+    expect(button.parentElement).toHaveAttribute(
+      'title',
+      'Click to update to 0.68.0. Pinned target. Device status must be Up to update the agent.',
+    );
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('shows a clickable warning for legacy agents that need the heartbeat upgrade path', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      agentVersion: '0.82.1',
+      agentUpdate: {
+        available: true,
+        currentVersion: '0.82.1',
+        targetVersion: '0.83.0',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: false,
+        action: 'legacy-agent-update',
+        reason: 'legacy-agent',
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Agent Version');
+
+    const button = screen.getByRole('button', { name: 'Legacy agent upgrade available' });
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('title', 'Legacy agent. Click to upgrade to 0.83.0.');
+    expect(button).toHaveClass('text-warning');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).toHaveBeenCalledWith(expect.objectContaining({ id: device.id }), 'agent');
+  });
+
+  it('keeps automatic legacy agent warnings disabled while auto install is allowed', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      agentVersion: '0.82.1',
+      agentUpdate: {
+        available: true,
+        currentVersion: '0.82.1',
+        targetVersion: '0.83.0',
+        mode: 'automatic',
+        autoInstall: true,
+        pinned: false,
+        action: 'legacy-agent-update',
+        reason: 'legacy-agent',
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Agent Version');
+
+    const button = screen.getByRole('button', { name: 'Legacy agent upgrade available' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'Legacy agent will update automatically to 0.83.0.');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('shows watchdog repair/update as blocked until the legacy main agent is upgraded', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      agentVersion: '0.82.1',
+      watchdogVersion: null,
+      watchdogUpdate: {
+        available: true,
+        currentVersion: null,
+        targetVersion: '0.83.0',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: false,
+        missing: true,
+        blockedBy: 'legacy-agent',
+        reason: 'legacy-agent',
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Watchdog Version');
+
+    expect(screen.getByText('Missing')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Watchdog repair available' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Update the main agent first before updating or repairing the watchdog.',
+    );
+    expect(button).toHaveClass('text-destructive');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('offers a clickable reinstall when the installed agent version is not a release build', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      agentVersion: 'integration-smoke-agent',
+      agentUpdate: {
+        available: true,
+        currentVersion: 'integration-smoke-agent',
+        targetVersion: '0.68.0',
+        mode: 'automatic',
+        autoInstall: false,
+        pinned: false,
+        reason: 'non-release-version',
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Agent Version');
+
+    const button = screen.getByRole('button', { name: 'Agent reinstall available' });
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Installed agent version is not a release build. Click to reinstall 0.68.0.',
+    );
+    expect(button).toHaveClass('text-warning');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).toHaveBeenCalledWith(expect.objectContaining({ id: device.id }), 'agent');
+  });
+
+  it('disables reinstall actions when the device is down but preserves reinstall copy', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      status: 'offline',
+      agentVersion: 'integration-smoke-agent',
+      agentUpdate: {
+        available: true,
+        currentVersion: 'integration-smoke-agent',
+        targetVersion: '0.68.0',
+        mode: 'automatic',
+        autoInstall: false,
+        pinned: false,
+        reason: 'non-release-version',
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Agent Version');
+
+    const button = screen.getByRole('button', { name: 'Agent reinstall available' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Installed agent version is not a release build. Click to reinstall 0.68.0. Device status must be Up to reinstall the agent.',
+    );
+    expect(button).toHaveClass('text-warning');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('offers a clickable warning reinstall when the installed watchdog version is not a release build', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      watchdogVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
+      watchdogUpdate: {
+        available: true,
+        currentVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
+        targetVersion: '0.68.0',
+        mode: 'automatic',
+        autoInstall: false,
+        pinned: false,
+        reason: 'non-release-version',
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Watchdog Version');
+
+    const button = screen.getByRole('button', { name: 'Watchdog reinstall available' });
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Installed watchdog version is not a release build. Click to reinstall 0.68.0.',
+    );
+    expect(button).toHaveClass('text-warning');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).toHaveBeenCalledWith(expect.objectContaining({ id: device.id }), 'watchdog');
+  });
+
+  it('shows missing watchdog with a manual repair indicator', () => {
+    const onComponentUpdate = vi.fn();
+    const device: Device = {
+      ...baseDevice,
+      watchdogVersion: null,
+      watchdogUpdate: {
+        available: true,
+        currentVersion: null,
+        targetVersion: '0.68.0',
+        mode: 'manual',
+        autoInstall: false,
+        pinned: false,
+        missing: true,
+      },
+    };
+
+    render(<DeviceList devices={[device]} onComponentUpdate={onComponentUpdate} />);
+    showColumn('Watchdog Version');
+
+    expect(screen.getByText('Missing')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Watchdog repair available' });
+    expect(button).toHaveAttribute('title', 'Watchdog is missing. Click to install 0.68.0.');
+    expect(button).toHaveClass('text-destructive');
+
+    fireEvent.click(button);
+
+    expect(onComponentUpdate).toHaveBeenCalledWith(expect.objectContaining({ id: device.id }), 'watchdog');
+  });
+});
+
 describe('DeviceList — agent-silent (watchdog OK) badge (#800 web-UI gap)', () => {
   it('renders the amber badge when mainAgentSilentSince is set AND watchdog is reporting', () => {
     const device: Device = {
@@ -347,8 +659,27 @@ describe('DeviceList — sortable columns (every column sorts on header click)',
 
     const { container } = render(<DeviceList devices={devices} />);
 
+    expect(screen.getByText('Updating')).toBeInTheDocument();
+    expect(screen.queryByText('Upd')).toBeNull();
+
     clickHeader('Sort by status');
     expect(rowOrder(container)).toEqual(['host-on', 'host-upd', 'host-pend', 'host-maint', 'host-quar', 'host-off']);
+  });
+
+  it('renders an operation-specific label for an updating component row', () => {
+    const devices: Device[] = [
+      {
+        ...baseDevice,
+        status: 'updating',
+        componentUpdateStatusLabel: 'Reinstalling agent',
+        componentUpdateStatusFullLabel: 'Reinstalling agent',
+      },
+    ];
+
+    render(<DeviceList devices={devices} />);
+
+    expect(screen.getByText('Reinstalling agent')).toBeInTheDocument();
+    expect(screen.queryByText('Updating')).toBeNull();
   });
 
   it('keeps dash cells last in BOTH directions (offline device has no CPU reading)', () => {

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Network, Cpu } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Network, Cpu, ArrowUpCircle, CircleAlert } from 'lucide-react';
 import type { DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { widthPercentClass, formatUptime } from '@/lib/utils';
@@ -60,6 +60,8 @@ export type Device = {
   osBuild?: string;
   architecture?: string;
   status: DeviceStatus;
+  componentUpdateStatusLabel?: string | null;
+  componentUpdateStatusFullLabel?: string | null;
   cpuPercent: number;
   ramPercent: number;
   lastSeen: string;
@@ -69,6 +71,8 @@ export type Device = {
   siteName: string;
   agentVersion: string;
   watchdogVersion?: string | null;
+  agentUpdate?: ComponentUpdateInfo | null;
+  watchdogUpdate?: ComponentUpdateInfo | null;
   tags: string[];
   lastUser?: string;
   uptimeSeconds?: number;
@@ -118,6 +122,19 @@ export type Device = {
   reliabilityTrend?: 'improving' | 'stable' | 'degrading' | null;
 };
 
+export type ComponentUpdateInfo = {
+  available: boolean;
+  currentVersion: string | null;
+  targetVersion: string | null;
+  mode: 'automatic' | 'manual';
+  autoInstall: boolean;
+  pinned: boolean;
+  action?: 'component-update' | 'legacy-agent-update';
+  blockedBy?: 'legacy-agent' | 'legacy-watchdog' | 'missing-watchdog';
+  missing?: boolean;
+  reason?: string;
+};
+
 // Columns that only make sense for the network arm (#1322); hidden unless
 // networkDevicesEnabled. Module-level so it isn't reallocated each render.
 const NETWORK_ONLY_COLUMNS: ReadonlySet<ColumnId> = new Set<ColumnId>(['class', 'type']);
@@ -136,6 +153,7 @@ type DeviceListProps = {
   timezone?: string;
   onSelect?: (device: Device) => void;
   onAction?: (action: string, device: Device) => void;
+  onComponentUpdate?: (device: Device, component: 'agent' | 'watchdog') => void;
   onBulkAction?: (action: string, devices: Device[]) => void;
   // Controlled inline filter state — now just the device search box, owned by
   // DevicesPage and shared with DeviceFilterToolbar. Every other structured
@@ -183,7 +201,7 @@ const statusLabels: Record<DeviceStatus, string> = {
   maintenance: 'Maint',
   decommissioned: 'Decom',
   quarantined: 'Quar',
-  updating: 'Upd',
+  updating: 'Updating',
   pending: 'Pend'
 };
 const statusFullLabels: Record<DeviceStatus, string> = {
@@ -195,6 +213,18 @@ const statusFullLabels: Record<DeviceStatus, string> = {
   updating: 'Updating',
   pending: 'Pending'
 };
+
+function deviceStatusLabel(device: Pick<Device, 'status' | 'componentUpdateStatusLabel'>): string {
+  return device.status === 'updating' && device.componentUpdateStatusLabel
+    ? device.componentUpdateStatusLabel
+    : statusLabels[device.status];
+}
+
+function deviceStatusFullLabel(device: Pick<Device, 'status' | 'componentUpdateStatusFullLabel'>): string {
+  return device.status === 'updating' && device.componentUpdateStatusFullLabel
+    ? device.componentUpdateStatusFullLabel
+    : statusFullLabels[device.status];
+}
 
 // Cap visible tag chips per row; the rest collapse into a +N chip, with the
 // full comma-joined list on the cell's title attribute (same overflow trick
@@ -300,6 +330,7 @@ export default function DeviceList({
   timezone,
   onSelect,
   onAction,
+  onComponentUpdate,
   onBulkAction,
   pageSize = 10,
   includeDecommissioned = false,
@@ -645,6 +676,116 @@ export default function DeviceList({
   // attribute doesn't exist for a printer/router, so don't imply 0/blank.
   const agentCell = (device: Device, node: React.ReactNode): React.ReactNode =>
     (device.deviceClass ?? 'agent') === 'network' ? dash : node;
+  const updateTooltip = (component: 'agent' | 'watchdog', update: ComponentUpdateInfo) => {
+    const target = update.targetVersion ?? 'latest';
+    const pinText = update.pinned ? ' Pinned target.' : '';
+    const componentLabel = component === 'agent' ? 'agent' : 'watchdog';
+    if (update.blockedBy === 'legacy-agent') {
+      return `Update the main agent first before updating or repairing the watchdog.${pinText}`;
+    }
+    if (update.blockedBy === 'legacy-watchdog') {
+      return `Update the watchdog first before updating the main agent.${pinText}`;
+    }
+    if (update.blockedBy === 'missing-watchdog') {
+      return `Watchdog is required before updating the main agent.${pinText}`;
+    }
+    if (update.action === 'legacy-agent-update' || update.reason === 'legacy-agent') {
+      if (update.mode === 'automatic' || update.autoInstall) {
+        return `Legacy agent will update automatically to ${target}.${pinText}`;
+      }
+      return `Legacy agent. Click to upgrade to ${target}.${pinText}`;
+    }
+    if (update.missing) {
+      if (update.mode === 'automatic' || update.autoInstall) {
+        return `Watchdog is missing. Repair will install automatically to ${target}.${pinText}`;
+      }
+      return `Watchdog is missing. Click to install ${target}.${pinText}`;
+    }
+    if (update.reason === 'non-release-version') {
+      return `Installed ${componentLabel} version is not a release build. Click to reinstall ${target}.${pinText}`;
+    }
+    if (update.mode === 'automatic' || update.autoInstall) {
+      if (update.reason === 'outside-schedule') {
+        return `Update will install automatically during the configured schedule to ${target}.${pinText}`;
+      }
+      return `Update will install automatically to ${target}.${pinText}`;
+    }
+    return `Click to update to ${target}.${pinText}`;
+  };
+  const componentUpdateActionLabel = (component: 'agent' | 'watchdog', update: ComponentUpdateInfo) => {
+    const componentLabel = component === 'agent' ? 'agent' : 'watchdog';
+    if (component === 'agent' && (update.action === 'legacy-agent-update' || update.reason === 'legacy-agent')) {
+      return 'upgrade the legacy agent';
+    }
+    if (update.reason === 'non-release-version') {
+      return `reinstall the ${componentLabel}`;
+    }
+    if (component === 'watchdog' && update.missing) {
+      return 'install or repair the watchdog';
+    }
+    return `update the ${componentLabel}`;
+  };
+  const updateTooltipForDevice = (
+    device: Device,
+    component: 'agent' | 'watchdog',
+    update: ComponentUpdateInfo,
+  ) => {
+    const tooltip = updateTooltip(component, update);
+    if (device.status === 'online') return tooltip;
+    return `${tooltip} Device status must be Up to ${componentUpdateActionLabel(component, update)}.`;
+  };
+  const versionWithUpdate = (
+    device: Device,
+    component: 'agent' | 'watchdog',
+    versionNode: React.ReactNode,
+  ) => {
+    const update = component === 'agent' ? device.agentUpdate : device.watchdogUpdate;
+    const content = <span>{versionNode}</span>;
+    if (!update?.available) return content;
+    const manualReinstall = update.reason === 'non-release-version';
+    const legacyAgentAction = component === 'agent' && update.action === 'legacy-agent-update';
+    const manualLegacyAgentAction = legacyAgentAction && update.mode === 'manual' && !update.autoInstall;
+    const blocked = Boolean(update.blockedBy);
+    const statusBlocked = device.status !== 'online';
+    const disabled = statusBlocked || blocked || (!manualReinstall && !manualLegacyAgentAction && (update.mode === 'automatic' || update.autoInstall));
+    const missingWatchdog = component === 'watchdog' && update.missing === true;
+    const warningReinstall = update.reason === 'non-release-version';
+    const legacyAgentWarning = component === 'agent' && (update.action === 'legacy-agent-update' || update.reason === 'legacy-agent');
+    const blockedWarning = Boolean(update.blockedBy);
+    const UpdateIcon = missingWatchdog || warningReinstall || legacyAgentWarning || blockedWarning ? CircleAlert : ArrowUpCircle;
+    const tooltip = updateTooltipForDevice(device, component, update);
+    const ariaLabel = missingWatchdog
+      ? 'Watchdog repair available'
+      : legacyAgentWarning
+        ? 'Legacy agent upgrade available'
+        : blockedWarning
+          ? `${component === 'agent' ? 'Agent' : 'Watchdog'} update blocked`
+      : warningReinstall
+        ? `${component === 'agent' ? 'Agent' : 'Watchdog'} reinstall available`
+        : `${component === 'agent' ? 'Agent' : 'Watchdog'} update available`;
+    return (
+      <span className="inline-flex min-w-0 items-center gap-1.5">
+        {content}
+        <span className="inline-flex" title={tooltip}>
+          <button
+            type="button"
+            title={tooltip}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              if (!disabled) onComponentUpdate?.(device, component);
+            }}
+            className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition hover:bg-muted disabled:cursor-default disabled:pointer-events-none disabled:text-muted-foreground disabled:hover:bg-transparent ${
+              missingWatchdog ? 'text-destructive' : warningReinstall || legacyAgentWarning || blockedWarning ? 'text-warning' : 'text-primary'
+            }`}
+          >
+            <UpdateIcon className="h-4 w-4" />
+          </button>
+        </span>
+      </span>
+    );
+  };
   const columnDefs: Record<ColumnId, { header: () => React.ReactNode; cell: (device: Device) => React.ReactNode }> = {
     hostname: {
       header: () => sortHeader('hostname', 'Device', 'Sort by device'),
@@ -800,9 +941,9 @@ export default function DeviceList({
           <div className="flex flex-wrap items-center gap-1">
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusColors[device.status]}`}
-              title={statusFullLabels[device.status]}
+              title={deviceStatusFullLabel(device)}
             >
-              {statusLabels[device.status]}
+              {deviceStatusLabel(device)}
             </span>
             {shouldShowAgentSilentBadge(device) && (
               <span
@@ -898,7 +1039,7 @@ export default function DeviceList({
       header: () => sortHeader('agentVersion', 'Agent Version', 'Sort by agent version'),
       cell: (device) => (
         <td key="agentVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
-          {device.agentVersion || dash}
+          {agentCell(device, versionWithUpdate(device, 'agent', device.agentVersion || dash))}
         </td>
       ),
     },
@@ -906,7 +1047,11 @@ export default function DeviceList({
       header: () => sortHeader('watchdogVersion', 'Watchdog Version', 'Sort by watchdog version'),
       cell: (device) => (
         <td key="watchdogVersion" className="px-3 py-3 text-sm text-muted-foreground whitespace-nowrap">
-          {agentCell(device, fmtWatchdogVersion(device.watchdogVersion))}
+          {agentCell(device, versionWithUpdate(
+            device,
+            'watchdog',
+            device.watchdogUpdate?.missing ? 'Missing' : fmtWatchdogVersion(device.watchdogVersion),
+          ))}
         </td>
       ),
     },

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DevicesPage from './DevicesPage';
@@ -13,6 +13,11 @@ const flagState = vi.hoisted(() => ({
   ENABLE_ENDPOINT_AV_FEATURES: false,
 }));
 vi.mock('@/lib/featureFlags', () => flagState);
+
+const eventStreamMock = vi.hoisted(() => ({
+  subscribe: vi.fn(),
+  onEvent: null as null | ((event: { type: string; payload: Record<string, unknown> }) => void),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks — keep DevicesPage's own logic (including the real useAdvancedFilterIds
@@ -29,7 +34,10 @@ vi.mock('../../lib/devicesFetch', () => ({
 }));
 
 vi.mock('../../hooks/useEventStream', () => ({
-  useEventStream: () => ({ subscribe: vi.fn() }),
+  useEventStream: (options: { onEvent: typeof eventStreamMock.onEvent }) => {
+    eventStreamMock.onEvent = options.onEvent;
+    return { subscribe: eventStreamMock.subscribe };
+  },
 }));
 
 vi.mock('../../services/deviceActions', () => ({
@@ -43,6 +51,8 @@ vi.mock('../../services/deviceActions', () => ({
   permanentDeleteDevice: vi.fn(),
   sendWakeCommand: vi.fn(),
   sendBulkWakeCommand: vi.fn(),
+  sendComponentUpdate: vi.fn(),
+  sendLegacyAgentUpdate: vi.fn(),
   summarizeBulkWakeFailures: vi.fn(() => ''),
   summarizeBulkCommandFailures: vi.fn(() => ''),
   watchWakeOutcome: vi.fn(),
@@ -123,15 +133,47 @@ vi.mock('./DeviceCard', () => ({
 // action over the FULL device array it was given (mirroring the real
 // DeviceList, which hands the unfiltered selection to onBulkAction). Tests use
 // the per-action buttons to drive DevicesPage.handleBulkAction directly.
-type StubDevice = { id: string; deviceClass?: string; hostname?: string; displayName?: string; watchdogVersion?: string | null };
+type StubDevice = {
+  id: string;
+  deviceClass?: string;
+  hostname?: string;
+  displayName?: string;
+  status?: string;
+  componentUpdateStatusLabel?: string | null;
+  watchdogVersion?: string | null;
+  agentUpdate?: {
+    available: boolean;
+    targetVersion?: string | null;
+    reason?: string;
+    action?: string;
+  } | null;
+  watchdogUpdate?: {
+    available: boolean;
+    targetVersion?: string | null;
+    reason?: string;
+    action?: string;
+  } | null;
+};
 vi.mock('./DeviceList', () => ({
-  default: ({ devices, serverFilterIds, onBulkAction }: { devices: StubDevice[]; serverFilterIds?: Set<string> | null; onBulkAction?: (action: string, devices: StubDevice[]) => void }) => (
+  default: ({
+    devices,
+    serverFilterIds,
+    onBulkAction,
+    onComponentUpdate,
+  }: {
+    devices: StubDevice[];
+    serverFilterIds?: Set<string> | null;
+    onBulkAction?: (action: string, devices: StubDevice[]) => void;
+    onComponentUpdate?: (device: StubDevice, component: 'agent' | 'watchdog') => void;
+  }) => (
     <div
       data-testid="device-list"
       data-device-count={devices.length}
       data-filter-ids={serverFilterIds ? [...serverFilterIds].sort().join(',') : ''}
       data-hostnames={devices.map(d => d.hostname ?? '').join(',')}
       data-display-names={devices.map(d => d.displayName ?? '').join(',')}
+      data-statuses={devices.map(d => d.status ?? '').join(',')}
+      data-status-labels={devices.map(d => d.componentUpdateStatusLabel ?? d.status ?? '').join(',')}
       data-watchdog-versions={devices.map(d => d.watchdogVersion ?? '').join(',')}
     >
       {['maintenance-on', 'maintenance-off', 'decommission', 'reboot', 'run-script'].map(action => (
@@ -144,6 +186,24 @@ vi.mock('./DeviceList', () => ({
           {action}
         </button>
       ))}
+      <button
+        type="button"
+        data-testid="component-update-agent"
+        onClick={() => {
+          if (devices[0]) onComponentUpdate?.(devices[0], 'agent');
+        }}
+      >
+        agent component update
+      </button>
+      <button
+        type="button"
+        data-testid="component-update-watchdog"
+        onClick={() => {
+          if (devices[0]) onComponentUpdate?.(devices[0], 'watchdog');
+        }}
+      >
+        watchdog component update
+      </button>
     </div>
   ),
 }));
@@ -173,6 +233,7 @@ function jsonResponse(payload: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  eventStreamMock.onEvent = null;
   // Reset the network arm to ON; the flag-off case opts out explicitly.
   flagState.ENABLE_NETWORK_DEVICES_IN_LIST = true;
 
@@ -254,6 +315,292 @@ describe('DevicesPage — advanced filter applies to BOTH views', () => {
 
     const list = await screen.findByTestId('device-list');
     expect(list.getAttribute('data-watchdog-versions')).toBe('0.70.1,');
+  });
+
+  it('uses reinstall wording when confirming replacement of a non-release agent build', async () => {
+    vi.mocked(fetchAllDevices).mockResolvedValueOnce({
+      data: [
+        {
+          ...rawDevice(DEV_1, 'host-alpha'),
+          agentVersion: 'integration-smoke-agent',
+          agentUpdate: {
+            available: true,
+            currentVersion: 'integration-smoke-agent',
+            targetVersion: '0.68.0',
+            mode: 'automatic',
+            autoInstall: false,
+            pinned: false,
+            reason: 'non-release-version',
+          },
+        },
+      ],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    fireEvent.click(screen.getByTestId('component-update-agent'));
+
+    expect(await screen.findByRole('dialog', { name: 'Reinstall agent' })).toBeTruthy();
+    expect(screen.getByText('Queue agent reinstall to 0.68.0 for host-alpha?')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reinstall' })).toBeTruthy();
+    expect(screen.queryByText('Queue agent update to 0.68.0 for host-alpha?')).toBeNull();
+  });
+
+  it('keeps update wording when confirming a normal manual agent update', async () => {
+    vi.mocked(fetchAllDevices).mockResolvedValueOnce({
+      data: [
+        {
+          ...rawDevice(DEV_1, 'host-alpha'),
+          agentUpdate: {
+            available: true,
+            currentVersion: '0.67.0',
+            targetVersion: '0.68.0',
+            mode: 'manual',
+            autoInstall: false,
+            pinned: false,
+          },
+        },
+      ],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    fireEvent.click(screen.getByTestId('component-update-agent'));
+
+    expect(await screen.findByRole('dialog', { name: 'Update agent' })).toBeTruthy();
+    expect(screen.getByText('Queue agent update to 0.68.0 for host-alpha?')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Update' })).toBeTruthy();
+  });
+
+  it('shows the device as updating after a component update is queued', async () => {
+    const { sendComponentUpdate } = await import('../../services/deviceActions');
+    vi.mocked(sendComponentUpdate).mockResolvedValueOnce({
+      id: 'cmd-update',
+      deviceId: DEV_1,
+      type: 'update_agent',
+      status: 'pending',
+      targetVersion: '0.69.0',
+      component: 'agent',
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        {
+          ...rawDevice(DEV_1, 'host-alpha'),
+          agentVersion: '0.68.0',
+          agentUpdate: {
+            available: true,
+            currentVersion: '0.68.0',
+            targetVersion: '0.69.0',
+            mode: 'manual',
+            autoInstall: false,
+            pinned: false,
+          },
+        },
+      ],
+    } as never);
+
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    expect(list.getAttribute('data-statuses')).toBe('online');
+
+    fireEvent.click(screen.getByTestId('component-update-agent'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Update' }));
+
+    await waitFor(() => {
+      expect(sendComponentUpdate).toHaveBeenCalledWith(DEV_1, 'agent', '0.69.0');
+      expect(screen.getByTestId('device-list').getAttribute('data-statuses')).toBe('updating');
+      expect(screen.getByTestId('device-list').getAttribute('data-status-labels')).toBe('Updating agent');
+    });
+  });
+
+  it('shows reinstalling after a non-release agent replacement is queued', async () => {
+    const { sendComponentUpdate } = await import('../../services/deviceActions');
+    vi.mocked(sendComponentUpdate).mockResolvedValueOnce({
+      id: 'cmd-reinstall',
+      deviceId: DEV_1,
+      type: 'update_agent',
+      status: 'pending',
+      targetVersion: '0.69.0',
+      component: 'agent',
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+    vi.mocked(fetchAllDevices).mockResolvedValueOnce({
+      data: [
+        {
+          ...rawDevice(DEV_1, 'host-alpha'),
+          agentVersion: 'integration-smoke-agent',
+          agentUpdate: {
+            available: true,
+            currentVersion: 'integration-smoke-agent',
+            targetVersion: '0.69.0',
+            mode: 'automatic',
+            autoInstall: false,
+            pinned: false,
+            reason: 'non-release-version',
+          },
+        },
+      ],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    fireEvent.click(screen.getByTestId('component-update-agent'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Reinstall' }));
+
+    await waitFor(() => {
+      expect(sendComponentUpdate).toHaveBeenCalledWith(DEV_1, 'agent', '0.69.0');
+      expect(screen.getByTestId('device-list').getAttribute('data-status-labels')).toBe('Reinstalling agent,online,online');
+    });
+  });
+
+  it('shows installing after a missing watchdog repair is queued', async () => {
+    const { sendComponentUpdate } = await import('../../services/deviceActions');
+    vi.mocked(sendComponentUpdate).mockResolvedValueOnce({
+      id: 'cmd-install-watchdog',
+      deviceId: DEV_1,
+      type: 'update_watchdog',
+      status: 'pending',
+      targetVersion: '0.69.0',
+      component: 'watchdog',
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+    vi.mocked(fetchAllDevices).mockResolvedValueOnce({
+      data: [
+        {
+          ...rawDevice(DEV_1, 'host-alpha'),
+          watchdogVersion: null,
+          watchdogUpdate: {
+            available: true,
+            currentVersion: null,
+            targetVersion: '0.69.0',
+            mode: 'manual',
+            autoInstall: false,
+            pinned: false,
+            missing: true,
+          },
+        },
+      ],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    fireEvent.click(screen.getByTestId('component-update-watchdog'));
+
+    expect(await screen.findByRole('dialog', { name: 'Install watchdog' })).toBeTruthy();
+    expect(screen.getByText('Queue watchdog install to 0.69.0 for host-alpha?')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }));
+
+    await waitFor(() => {
+      expect(sendComponentUpdate).toHaveBeenCalledWith(DEV_1, 'watchdog', '0.69.0');
+      expect(screen.getByTestId('device-list').getAttribute('data-status-labels')).toBe('Installing watchdog,online,online');
+    });
+  });
+
+  it('uses the legacy agent update endpoint for legacy agent upgrades', async () => {
+    const { sendLegacyAgentUpdate, sendComponentUpdate } = await import('../../services/deviceActions');
+    const { showToast } = await import('../shared/Toast');
+    vi.mocked(sendLegacyAgentUpdate).mockResolvedValueOnce({
+      id: 'cmd-legacy',
+      deviceId: DEV_1,
+      type: 'legacy_agent_update',
+      status: 'pending',
+      targetVersion: '0.83.0',
+      component: 'agent',
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+    vi.mocked(fetchAllDevices).mockResolvedValueOnce({
+      data: [
+        {
+          ...rawDevice(DEV_1, 'host-alpha'),
+          agentVersion: '0.82.1',
+          agentUpdate: {
+            available: true,
+            currentVersion: '0.82.1',
+            targetVersion: '0.83.0',
+            mode: 'manual',
+            autoInstall: false,
+            pinned: false,
+            action: 'legacy-agent-update',
+            reason: 'legacy-agent',
+          },
+        },
+      ],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    fireEvent.click(screen.getByTestId('component-update-agent'));
+
+    expect(await screen.findByRole('dialog', { name: 'Upgrade legacy agent' })).toBeTruthy();
+    expect(screen.getByText('Queue agent upgrade to 0.83.0 for host-alpha?')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Upgrade' }));
+
+    await waitFor(() => {
+      expect(sendLegacyAgentUpdate).toHaveBeenCalledWith(DEV_1, '0.83.0');
+      expect(screen.getByTestId('device-list').getAttribute('data-status-labels')).toBe('Upgrading agent,online,online');
+    });
+    expect(sendComponentUpdate).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'Agent upgrade to 0.83.0 queued for host-alpha',
+    }));
+  });
+
+  it('uses reinstall wording when confirming replacement of a non-release watchdog build', async () => {
+    vi.mocked(fetchAllDevices).mockResolvedValueOnce({
+      data: [
+        {
+          ...rawDevice(DEV_1, 'host-alpha'),
+          watchdogVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
+          watchdogUpdate: {
+            available: true,
+            currentVersion: 'agent-watchdog-update-bbce5c5dab306bf0df72989a134441f104173945',
+            targetVersion: '0.68.0',
+            mode: 'automatic',
+            autoInstall: false,
+            pinned: false,
+            reason: 'non-release-version',
+          },
+        },
+      ],
+    } as never);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    fireEvent.click(screen.getByTestId('component-update-watchdog'));
+
+    expect(await screen.findByRole('dialog', { name: 'Reinstall watchdog' })).toBeTruthy();
+    expect(screen.getByText('Queue watchdog reinstall to 0.68.0 for host-alpha?')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reinstall' })).toBeTruthy();
+    expect(screen.queryByText('Queue watchdog update to 0.68.0 for host-alpha?')).toBeNull();
+  });
+
+  it('applies realtime device.updated status events to the Devices list', async () => {
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    expect(list.getAttribute('data-statuses')).toBe('online,online,online');
+
+    act(() => {
+      eventStreamMock.onEvent?.({
+        type: 'device.updated',
+        payload: {
+          deviceId: DEV_1,
+          fields: ['status'],
+          status: 'updating',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-list').getAttribute('data-statuses')).toBe('updating,online,online');
+    });
   });
 
   it('grid view shows all devices when no advanced filter is active', async () => {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -18,7 +18,7 @@ import { decodeFilterFromHash, writeFilterToHash, isFiltersV2Enabled } from './f
 import { fetchWithAuth } from '../../stores/auth';
 import { fetchAllDevices, fetchAllNetworkDevices } from '../../lib/devicesFetch';
 import { useOrgStore } from '../../stores/orgStore';
-import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
+import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage, sendComponentUpdate, sendLegacyAgentUpdate } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle, isAccessDenied } from '@/lib/errorMessages';
 import AccessDenied from '../shared/AccessDenied';
@@ -57,6 +57,105 @@ function summarizeFailedDevices(names: string[]): string {
   return rest > 0 ? `${shown.join(', ')} and ${rest} more` : shown.join(', ');
 }
 
+function isComponentReinstallRequest(update: Device['agentUpdate'] | Device['watchdogUpdate'] | null | undefined): boolean {
+  return update?.reason === 'non-release-version';
+}
+
+function isLegacyAgentUpdateRequest(
+  component: 'agent' | 'watchdog',
+  update: Device['agentUpdate'] | Device['watchdogUpdate'] | null | undefined,
+): boolean {
+  return component === 'agent' && update?.action === 'legacy-agent-update';
+}
+
+function isWatchdogInstallRequest(
+  component: 'agent' | 'watchdog',
+  update: Device['agentUpdate'] | Device['watchdogUpdate'] | null | undefined,
+): boolean {
+  return component === 'watchdog' && update?.missing === true;
+}
+
+type ComponentUpdateOperation = 'update' | 'reinstall' | 'upgrade' | 'install';
+
+function componentUpdateOperation(
+  component: 'agent' | 'watchdog',
+  update: Device['agentUpdate'] | Device['watchdogUpdate'] | null | undefined,
+): ComponentUpdateOperation {
+  if (isLegacyAgentUpdateRequest(component, update)) return 'upgrade';
+  if (isComponentReinstallRequest(update)) return 'reinstall';
+  if (isWatchdogInstallRequest(component, update)) return 'install';
+  return 'update';
+}
+
+function componentUpdateCopy(
+  component: 'agent' | 'watchdog',
+  update: Device['agentUpdate'] | Device['watchdogUpdate'] | null | undefined,
+) {
+  const label = component === 'agent' ? 'agent' : 'watchdog';
+  const action = componentUpdateOperation(component, update);
+  const target = update?.targetVersion ?? 'latest';
+  const titleAction = action === 'reinstall'
+    ? 'Reinstall'
+    : action === 'upgrade'
+      ? 'Upgrade'
+      : action === 'install'
+        ? 'Install'
+        : 'Update';
+  return {
+    title: `${titleAction} ${action === 'upgrade' ? 'legacy agent' : label}`,
+    confirmLabel: titleAction,
+    messageAction: `${label} ${action}`,
+    toastLabel: `${label[0].toUpperCase()}${label.slice(1)} ${action}`,
+    target,
+  };
+}
+
+function componentUpdateStatusCopy(
+  component: 'agent' | 'watchdog',
+  update: Device['agentUpdate'] | Device['watchdogUpdate'] | null | undefined,
+): Pick<QueuedComponentUpdate, 'statusLabel' | 'statusFullLabel'> {
+  const componentLabel = component === 'agent' ? 'agent' : 'watchdog';
+  const action = componentUpdateOperation(component, update);
+  if (action === 'upgrade') {
+    return { statusLabel: 'Upgrading agent', statusFullLabel: 'Upgrading legacy agent' };
+  }
+  const verb = action === 'reinstall'
+    ? 'Reinstalling'
+    : action === 'install'
+      ? 'Installing'
+      : 'Updating';
+  const label = `${verb} ${componentLabel}`;
+  return { statusLabel: label, statusFullLabel: label };
+}
+
+type QueuedComponentUpdate = {
+  component: 'agent' | 'watchdog';
+  targetVersion: string | null;
+  queuedAt: number;
+  statusLabel: string;
+  statusFullLabel: string;
+};
+
+const COMPONENT_UPDATE_OPTIMISTIC_STATUS_TTL_MS = 30 * 60 * 1000;
+
+function componentReachedTarget(device: Device, update: QueuedComponentUpdate): boolean {
+  if (!update.targetVersion) return false;
+  return update.component === 'agent'
+    ? device.agentVersion === update.targetVersion
+    : device.watchdogVersion === update.targetVersion;
+}
+
+function shouldKeepOptimisticComponentUpdate(
+  device: Device,
+  update: QueuedComponentUpdate,
+  now = Date.now(),
+): boolean {
+  if (now - update.queuedAt > COMPONENT_UPDATE_OPTIMISTIC_STATUS_TTL_MS) return false;
+  if (device.status === 'offline' || device.status === 'decommissioned') return false;
+  if (componentReachedTarget(device, update)) return false;
+  return true;
+}
+
 export default function DevicesPage() {
   // Org scope is shown by the always-visible top-bar switcher (scope pill +
   // org picker); the page header no longer repeats it. orgStoreOrgs is still
@@ -81,6 +180,8 @@ export default function DevicesPage() {
   const [scriptTargetDevices, setScriptTargetDevices] = useState<Device[]>([]);
   type PendingScriptRun = { script: Script; runAs: ScriptRunAsSelection; parameters?: Record<string, unknown>; devices: Device[] };
   const [pendingScriptRun, setPendingScriptRun] = useState<PendingScriptRun | null>(null);
+  const [pendingComponentUpdate, setPendingComponentUpdate] = useState<{ device: Device; component: 'agent' | 'watchdog' } | null>(null);
+  const [optimisticComponentUpdates, setOptimisticComponentUpdates] = useState<Record<string, QueuedComponentUpdate>>({});
   const [settingsDevice, setSettingsDevice] = useState<Device | null>(null);
   // v2 chip bar seeds its filter from the URL hash so a filtered view is
   // shareable; the legacy DeviceFilterBar owns its own state and ignores it.
@@ -182,12 +283,43 @@ export default function DevicesPage() {
         : c.value === 'decommissioned';
     });
   }, [advancedFilter]);
-  const gridDevices = useMemo(
+  useEffect(() => {
+    setOptimisticComponentUpdates(prev => {
+      let changed = false;
+      const next = { ...prev };
+      const byId = new Map(devices.map(device => [device.id, device]));
+      for (const [deviceId, update] of Object.entries(prev)) {
+        const device = byId.get(deviceId);
+        if (!device || !shouldKeepOptimisticComponentUpdate(device, update)) {
+          delete next[deviceId];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [devices]);
+
+  const devicesWithUpdateStatus = useMemo(() => (
+    devices.map(device => {
+      const update = optimisticComponentUpdates[device.id];
+      if (!update || !shouldKeepOptimisticComponentUpdate(device, update)) return device;
+      return {
+        ...device,
+        status: 'updating' as DeviceStatus,
+        componentUpdateStatusLabel: update.statusLabel,
+        componentUpdateStatusFullLabel: update.statusFullLabel,
+      };
+    })
+  ), [devices, optimisticComponentUpdates]);
+
+  const gridDevicesWithUpdateStatus = useMemo(
     () => {
-      const base = includeDecommissioned ? devices : devices.filter(d => d.status !== 'decommissioned');
+      const base = includeDecommissioned
+        ? devicesWithUpdateStatus
+        : devicesWithUpdateStatus.filter(d => d.status !== 'decommissioned');
       return advancedFilterIds === null ? base : base.filter(d => advancedFilterIds.has(d.id));
     },
-    [devices, advancedFilterIds, includeDecommissioned]
+    [devicesWithUpdateStatus, advancedFilterIds, includeDecommissioned]
   );
 
   const fetchDevices = useCallback(async (signal?: AbortSignal) => {
@@ -276,6 +408,10 @@ export default function DevicesPage() {
           siteName: '', // Will be resolved from sites
           agentVersion: (d.agentVersion ?? '') as string,
           watchdogVersion: (d.watchdogVersion ?? null) as string | null,
+          componentUpdateStatusLabel: (d.componentUpdateStatusLabel ?? null) as string | null,
+          componentUpdateStatusFullLabel: (d.componentUpdateStatusFullLabel ?? null) as string | null,
+          agentUpdate: (d.agentUpdate ?? null) as Device['agentUpdate'],
+          watchdogUpdate: (d.watchdogUpdate ?? null) as Device['watchdogUpdate'],
           tags: (d.tags ?? []) as string[],
           deviceRole: d.deviceRole as DeviceRole | undefined,
           deviceRoleSource: d.deviceRoleSource as string | undefined,
@@ -436,11 +572,19 @@ export default function DevicesPage() {
       ));
     } else if (type === 'device.updated') {
       const fields = payload.fields as string[] | undefined;
-      if (fields?.includes('agentVersion')) {
+      if (fields?.includes('agentVersion') || fields?.includes('status')) {
         setDevices(prev => prev.map(d =>
-          d.id === deviceId
-            ? { ...d, agentVersion: (payload.agentVersion as string) ?? d.agentVersion }
-            : d
+          d.id !== deviceId
+            ? d
+            : {
+              ...d,
+              ...(fields.includes('agentVersion')
+                ? { agentVersion: (payload.agentVersion as string) ?? d.agentVersion }
+                : {}),
+              ...(fields.includes('status') && typeof payload.status === 'string'
+                ? { status: payload.status as DeviceStatus }
+                : {}),
+            }
         ));
       }
       // NOTE: no live watchdogVersion handler — the heartbeat path only
@@ -517,6 +661,48 @@ export default function DevicesPage() {
       closeScriptPicker();
     } catch (err) {
       showToast({ type: 'error', message: err instanceof Error ? err.message : 'Failed to queue script' });
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+
+  const handleComponentUpdateRequest = (device: Device, component: 'agent' | 'watchdog') => {
+    setPendingComponentUpdate({ device, component });
+  };
+
+  const doComponentUpdate = async (pending: { device: Device; component: 'agent' | 'watchdog' }) => {
+    if (actionInProgress) return;
+    try {
+      setActionInProgress(true);
+      const update = pending.component === 'agent' ? pending.device.agentUpdate : pending.device.watchdogUpdate;
+      const copy = componentUpdateCopy(pending.component, update);
+      const result = isLegacyAgentUpdateRequest(pending.component, update)
+        ? await sendLegacyAgentUpdate(pending.device.id, update?.targetVersion ?? undefined)
+        : await sendComponentUpdate(
+          pending.device.id,
+          pending.component,
+          update?.targetVersion ?? undefined,
+        );
+      setOptimisticComponentUpdates(prev => ({
+        ...prev,
+        [pending.device.id]: {
+          component: pending.component,
+          targetVersion: result.targetVersion ?? update?.targetVersion ?? null,
+          queuedAt: Date.now(),
+          ...componentUpdateStatusCopy(pending.component, update),
+        },
+      }));
+      showToast({
+        type: 'success',
+        message: `${copy.toastLabel} to ${result.targetVersion ?? copy.target} queued for ${pending.device.hostname}`,
+      });
+      setPendingComponentUpdate(null);
+      await fetchDevices();
+    } catch (err) {
+      showToast({
+        type: 'error',
+        message: err instanceof Error ? err.message : `Failed to queue ${pending.component} update`,
+      });
     } finally {
       setActionInProgress(false);
     }
@@ -991,13 +1177,14 @@ export default function DevicesPage() {
         </div>
       ) : viewMode === 'list' ? (
         <DeviceList
-          devices={devices}
+          devices={devicesWithUpdateStatus}
           orgs={orgs}
           sites={sites}
           groups={deviceGroups}
           groupMembershipMap={groupMembershipMap}
           onSelect={handleSelectDevice}
           onAction={handleDeviceAction}
+          onComponentUpdate={handleComponentUpdateRequest}
           onBulkAction={handleBulkAction}
           serverFilterIds={advancedFilterIds}
           serverFilterLoading={advancedFilterLoading}
@@ -1011,7 +1198,7 @@ export default function DevicesPage() {
         />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {gridDevices.map(device => (
+          {gridDevicesWithUpdateStatus.map(device => (
             <DeviceCard
               key={device.id}
               device={device}
@@ -1061,6 +1248,28 @@ export default function DevicesPage() {
               deviceCount: pendingScriptRun.devices.length,
               orgNames: scriptOrgNames,
             })}
+            isLoading={actionInProgress}
+          />
+        );
+      })()}
+
+      {pendingComponentUpdate && (() => {
+        const update = pendingComponentUpdate.component === 'agent'
+          ? pendingComponentUpdate.device.agentUpdate
+          : pendingComponentUpdate.device.watchdogUpdate;
+        const copy = componentUpdateCopy(pendingComponentUpdate.component, update);
+        return (
+          <ConfirmDialog
+            open={true}
+            onClose={() => setPendingComponentUpdate(null)}
+            onConfirm={() => {
+              const pending = pendingComponentUpdate;
+              void doComponentUpdate(pending);
+            }}
+            title={copy.title}
+            variant="warning"
+            confirmLabel={copy.confirmLabel}
+            message={`Queue ${copy.messageAction} to ${copy.target} for ${pendingComponentUpdate.device.hostname}?`}
             isLoading={actionInProgress}
           />
         );

--- a/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrgDefaultsEditor from './OrgDefaultsEditor';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const versionsResponse = {
+  ok: true,
+  json: vi.fn().mockResolvedValue({ data: [] }),
+} as unknown as Response;
+
+describe('OrgDefaultsEditor agent update policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockResolvedValue(versionsResponse);
+  });
+
+  it('renders and saves legacy manual as manual', () => {
+    const onSave = vi.fn();
+
+    render(
+      <OrgDefaultsEditor
+        organizationName="Acme"
+        defaults={{ agentUpdatePolicy: 'manual' }}
+        onSave={onSave}
+      />,
+    );
+
+    const policy = screen.getByTestId('agent-update-policy-select') as HTMLSelectElement;
+    expect(policy.value).toBe('manual');
+
+    fireEvent.click(screen.getByTestId('org-defaults-save'));
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      agentUpdateMode: 'manual',
+      agentUpdateTiming: undefined,
+      agentUpdateSchedule: undefined,
+      agentUpdatePolicy: 'manual',
+      maintenanceWindow: undefined,
+    }));
+  });
+
+  it('renders and saves legacy automatic as weekly schedule', () => {
+    const onSave = vi.fn();
+
+    render(
+      <OrgDefaultsEditor
+        organizationName="Acme"
+        defaults={{ agentUpdatePolicy: 'auto', maintenanceWindow: 'Mon 01:00-03:00' }}
+        onSave={onSave}
+      />,
+    );
+
+    expect((screen.getByTestId('agent-update-policy-select') as HTMLSelectElement).value).toBe('weekly');
+    expect((screen.getByTestId('agent-update-window-day-0') as HTMLSelectElement).value).toBe('mon');
+    expect((screen.getByTestId('agent-update-window-start-0') as HTMLSelectElement).value).toBe('01:00');
+    expect((screen.getByTestId('agent-update-window-end-0') as HTMLSelectElement).value).toBe('03:00');
+
+    fireEvent.click(screen.getByTestId('org-defaults-save'));
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      agentUpdateMode: 'automatic',
+      agentUpdateTiming: 'weekly',
+      agentUpdatePolicy: 'auto',
+      maintenanceWindow: 'Mon 01:00-03:00',
+      agentUpdateSchedule: {
+        windows: [{ dayOfWeek: 'mon', start: '01:00', end: '03:00' }],
+      },
+    }));
+  });
+
+  it('saves multiple weekly update windows', () => {
+    const onSave = vi.fn();
+
+    render(
+      <OrgDefaultsEditor
+        organizationName="Acme"
+        defaults={{
+          agentUpdateMode: 'automatic',
+          agentUpdateTiming: 'weekly',
+          agentUpdateSchedule: {
+            windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }],
+          },
+        }}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('agent-update-window-add'));
+    fireEvent.change(screen.getByTestId('agent-update-window-day-1'), { target: { value: 'tue' } });
+    fireEvent.change(screen.getByTestId('agent-update-window-start-1'), { target: { value: '03:30' } });
+    fireEvent.change(screen.getByTestId('agent-update-window-end-1'), { target: { value: '05:00' } });
+    fireEvent.click(screen.getByTestId('org-defaults-save'));
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      agentUpdateMode: 'automatic',
+      agentUpdateTiming: 'weekly',
+      agentUpdatePolicy: 'auto',
+      agentUpdateSchedule: {
+        windows: [
+          { dayOfWeek: 'sun', start: '02:00', end: '04:00' },
+          { dayOfWeek: 'tue', start: '03:30', end: '05:00' },
+        ],
+      },
+    }));
+  });
+});

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -1,5 +1,23 @@
-import { useState } from 'react';
-import { Bell, Layers, RefreshCcw, Save, ShieldCheck, Sparkles } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Bell, Layers, Plus, RefreshCcw, Save, ShieldCheck, Sparkles, Trash2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+
+type DayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+
+type AgentUpdateScheduleWindow = {
+  dayOfWeek: DayOfWeek;
+  start: string;
+  end: string;
+};
+
+type AgentUpdateSchedule = {
+  windows: AgentUpdateScheduleWindow[];
+};
+
+type LegacyAgentUpdateSchedule = {
+  dayOfWeek: DayOfWeek;
+  time: string;
+};
 
 type DefaultsData = {
   policyDefaults?: Record<string, string>;
@@ -12,6 +30,13 @@ type DefaultsData = {
   };
   agentUpdatePolicy?: string;
   maintenanceWindow?: string;
+  agentUpdateMode?: 'automatic' | 'manual';
+  agentUpdateTiming?: 'asap' | 'weekly';
+  agentUpdateSchedule?: AgentUpdateSchedule | LegacyAgentUpdateSchedule;
+  agentVersionPins?: {
+    agent?: string;
+    watchdog?: string;
+  };
 };
 
 type OrgDefaultsEditorProps = {
@@ -34,8 +59,7 @@ const defaultValues: DefaultsData = {
     requireApproval: false,
     sendWelcome: true
   },
-  agentUpdatePolicy: 'staged',
-  maintenanceWindow: 'Sun 02:00-04:00'
+  agentVersionPins: {}
 };
 
 const policyOptions = [
@@ -51,18 +75,177 @@ const alertThresholds = [
   { value: 'high', label: 'High and critical' },
   { value: 'medium', label: 'Medium and above' }
 ];
+const dayOptions = [
+  { value: 'sun', label: 'Sunday' },
+  { value: 'mon', label: 'Monday' },
+  { value: 'tue', label: 'Tuesday' },
+  { value: 'wed', label: 'Wednesday' },
+  { value: 'thu', label: 'Thursday' },
+  { value: 'fri', label: 'Friday' },
+  { value: 'sat', label: 'Saturday' },
+] as const;
+const timeOptions = Array.from({ length: 48 }, (_, index) => {
+  const hour = Math.floor(index / 2);
+  const minute = index % 2 === 0 ? '00' : '30';
+  return `${String(hour).padStart(2, '0')}:${minute}`;
+});
+const defaultAgentUpdateSchedule: AgentUpdateSchedule = {
+  windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }],
+};
+
+type ComponentVersion = {
+  version: string;
+  component: 'agent' | 'watchdog';
+  isLatest?: boolean;
+};
+
+function addMinutes(time: string, minutes: number) {
+  const [hourText, minuteText] = time.split(':');
+  const total = ((Number(hourText) * 60 + Number(minuteText) + minutes) % 1440 + 1440) % 1440;
+  return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`;
+}
+
+function isValidTimeWindow(window: Partial<AgentUpdateScheduleWindow>): window is AgentUpdateScheduleWindow {
+  const timeRe = /^([01]\d|2[0-3]):([0-5]\d)$/;
+  return (
+    !!window.dayOfWeek &&
+    dayOptions.some(option => option.value === window.dayOfWeek) &&
+    typeof window.start === 'string' &&
+    typeof window.end === 'string' &&
+    timeRe.test(window.start) &&
+    timeRe.test(window.end) &&
+    window.start !== window.end
+  );
+}
+
+function parseLegacySchedule(windowText?: string): AgentUpdateSchedule | null {
+  const match = windowText?.trim().match(/^(sun|mon|tue|wed|thu|fri|sat)\s+(\d{1,2}):([0-5]\d)\s*-\s*(\d{1,2}):([0-5]\d)$/i);
+  if (!match) return null;
+  const [, day, rawStartHour, startMinute, rawEndHour, endMinute] = match;
+  if (!day || !rawStartHour || !startMinute || !rawEndHour || !endMinute) return null;
+  const startHour = Number(rawStartHour);
+  const endHour = Number(rawEndHour);
+  if (startHour < 0 || startHour > 23 || endHour < 0 || endHour > 23) return null;
+  return {
+    windows: [{
+      dayOfWeek: day.toLowerCase() as DayOfWeek,
+      start: `${String(startHour).padStart(2, '0')}:${startMinute}`,
+      end: `${String(endHour).padStart(2, '0')}:${endMinute}`,
+    }],
+  };
+}
+
+function legacyPolicyFor(mode: DefaultsData['agentUpdateMode'], _timing: DefaultsData['agentUpdateTiming']) {
+  if (mode === 'manual') return 'manual';
+  return 'auto';
+}
+
+function normalizeSchedule(raw: DefaultsData['agentUpdateSchedule'] | undefined, fallback?: AgentUpdateSchedule | null): AgentUpdateSchedule {
+  if (raw && 'windows' in raw && Array.isArray(raw.windows)) {
+    const windows = raw.windows.filter(isValidTimeWindow);
+    if (windows.length > 0) return { windows };
+  }
+  if (raw && 'dayOfWeek' in raw && 'time' in raw && isValidTimeWindow({
+    dayOfWeek: raw.dayOfWeek,
+    start: raw.time,
+    end: addMinutes(raw.time, 60),
+  })) {
+    return { windows: [{ dayOfWeek: raw.dayOfWeek, start: raw.time, end: addMinutes(raw.time, 60) }] };
+  }
+  return fallback ?? defaultAgentUpdateSchedule;
+}
+
+function legacyWindowFor(schedule: AgentUpdateSchedule) {
+  const first = schedule.windows[0];
+  if (!first) return undefined;
+  const day = first.dayOfWeek.charAt(0).toUpperCase() + first.dayOfWeek.slice(1);
+  return `${day} ${first.start}-${first.end}`;
+}
 
 export default function OrgDefaultsEditor({ organizationName, defaults, onDirty, onSave }: OrgDefaultsEditorProps) {
-  const initialData = { ...defaultValues, ...defaults };
+  const rawDefaults = defaults ?? {};
+  const initialData = { ...defaultValues, ...rawDefaults };
   const [policyDefaults, setPolicyDefaults] = useState(initialData.policyDefaults || defaultValues.policyDefaults!);
   const [deviceGroup, setDeviceGroup] = useState(initialData.deviceGroup || defaultValues.deviceGroup!);
   const [alertThreshold, setAlertThreshold] = useState(initialData.alertThreshold || defaultValues.alertThreshold!);
   const [autoEnrollment, setAutoEnrollment] = useState(initialData.autoEnrollment || defaultValues.autoEnrollment!);
-  const [agentUpdatePolicy, setAgentUpdatePolicy] = useState(initialData.agentUpdatePolicy || defaultValues.agentUpdatePolicy!);
-  const [maintenanceWindow, setMaintenanceWindow] = useState(initialData.maintenanceWindow || defaultValues.maintenanceWindow!);
+  const legacySchedule = parseLegacySchedule(rawDefaults.maintenanceWindow);
+  const resolvedAgentUpdateMode = rawDefaults.agentUpdateMode ?? (rawDefaults.agentUpdatePolicy === 'manual' ? 'manual' : 'automatic');
+  const [agentUpdateMode, setAgentUpdateMode] = useState<NonNullable<DefaultsData['agentUpdateMode']>>(
+    resolvedAgentUpdateMode
+  );
+  const [agentUpdateTiming, setAgentUpdateTiming] = useState<NonNullable<DefaultsData['agentUpdateTiming']>>(
+    rawDefaults.agentUpdateTiming ?? (
+      resolvedAgentUpdateMode === 'manual'
+        ? 'asap'
+        : rawDefaults.agentUpdatePolicy === 'auto' || legacySchedule
+          ? 'weekly'
+          : 'asap'
+    )
+  );
+  const [agentUpdateSchedule, setAgentUpdateSchedule] = useState<AgentUpdateSchedule>(
+    normalizeSchedule(rawDefaults.agentUpdateSchedule, legacySchedule)
+  );
+  const [agentVersionPins, setAgentVersionPins] = useState<NonNullable<DefaultsData['agentVersionPins']>>(
+    initialData.agentVersionPins ?? {}
+  );
+  const [versions, setVersions] = useState<ComponentVersion[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth('/agent-versions')
+      .then(async response => {
+        if (!response.ok) return;
+        const body = await response.json() as { data?: ComponentVersion[] };
+        if (!cancelled) setVersions(Array.isArray(body.data) ? body.data : []);
+      })
+      .catch(() => {
+        if (!cancelled) setVersions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const versionOptions = useMemo(() => {
+    const byComponent: Record<'agent' | 'watchdog', string[]> = { agent: [], watchdog: [] };
+    for (const row of versions) {
+      if (row.component !== 'agent' && row.component !== 'watchdog') continue;
+      if (!byComponent[row.component].includes(row.version)) byComponent[row.component].push(row.version);
+    }
+    return byComponent;
+  }, [versions]);
 
   const markDirty = () => {
     onDirty?.();
+  };
+
+  const updateScheduleWindow = (index: number, patch: Partial<AgentUpdateScheduleWindow>) => {
+    setAgentUpdateSchedule(prev => ({
+      windows: prev.windows.map((window, windowIndex) =>
+        windowIndex === index ? { ...window, ...patch } : window
+      ),
+    }));
+    markDirty();
+  };
+
+  const addScheduleWindow = () => {
+    setAgentUpdateSchedule(prev => ({
+      windows: [
+        ...prev.windows,
+        { dayOfWeek: 'sun', start: '02:00', end: '04:00' },
+      ],
+    }));
+    markDirty();
+  };
+
+  const removeScheduleWindow = (index: number) => {
+    setAgentUpdateSchedule(prev => ({
+      windows: prev.windows.length > 1
+        ? prev.windows.filter((_, windowIndex) => windowIndex !== index)
+        : prev.windows,
+    }));
+    markDirty();
   };
 
   const handleSave = () => {
@@ -71,8 +254,16 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
       deviceGroup,
       alertThreshold,
       autoEnrollment,
-      agentUpdatePolicy,
-      maintenanceWindow
+      agentUpdateMode,
+      agentUpdateTiming: agentUpdateMode === 'automatic' ? agentUpdateTiming : undefined,
+      agentUpdateSchedule: agentUpdateMode === 'automatic' && agentUpdateTiming === 'weekly'
+        ? agentUpdateSchedule
+        : undefined,
+      agentVersionPins,
+      agentUpdatePolicy: legacyPolicyFor(agentUpdateMode, agentUpdateTiming),
+      maintenanceWindow: agentUpdateMode === 'automatic' && agentUpdateTiming === 'weekly'
+        ? legacyWindowFor(agentUpdateSchedule)
+        : undefined,
     };
     onSave?.(data);
   };
@@ -89,6 +280,7 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
         <button
           type="button"
           onClick={handleSave}
+          data-testid="org-defaults-save"
           className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
         >
           <Save className="h-4 w-4" />
@@ -231,35 +423,119 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
             Agent update policy
           </div>
           <select
-            value={agentUpdatePolicy}
+            value={agentUpdateMode === 'manual' ? 'manual' : agentUpdateTiming}
+            data-testid="agent-update-policy-select"
             onChange={event => {
-              setAgentUpdatePolicy(event.target.value);
+              if (event.target.value === 'manual') {
+                setAgentUpdateMode('manual');
+                setAgentUpdateTiming('asap');
+              } else {
+                setAgentUpdateMode('automatic');
+                setAgentUpdateTiming(event.target.value as 'asap' | 'weekly');
+              }
               markDirty();
             }}
             className="h-10 w-full rounded-md border bg-background px-3 text-sm"
           >
-            <option value="auto">Automatic updates</option>
-            <option value="staged">Staged rollout</option>
-            <option value="manual">Manual approval</option>
+            <option value="asap">Automatic: as soon as possible</option>
+            <option value="weekly">Automatic: weekly schedule</option>
+            <option value="manual">Manual</option>
           </select>
-          <div className="space-y-2">
-            <label className="text-xs font-medium uppercase text-muted-foreground">
-              Maintenance window
-            </label>
-            <input
-              type="text"
-              value={maintenanceWindow}
-              onChange={event => {
-                setMaintenanceWindow(event.target.value);
-                markDirty();
-              }}
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              placeholder="Sun 02:00-04:00"
-            />
+          {agentUpdateMode === 'automatic' && agentUpdateTiming === 'weekly' ? (
+            <div className="space-y-3">
+              {agentUpdateSchedule.windows.map((window, index) => (
+                <div
+                  key={`${window.dayOfWeek}-${window.start}-${window.end}-${index}`}
+                  className="grid items-end gap-3 sm:grid-cols-[1fr_1fr_1fr_auto]"
+                  data-testid={`agent-update-window-${index}`}
+                >
+                  <label className="space-y-2 text-sm">
+                    <span className="text-xs font-medium uppercase text-muted-foreground">Day</span>
+                    <select
+                      value={window.dayOfWeek}
+                      onChange={event => updateScheduleWindow(index, { dayOfWeek: event.target.value as DayOfWeek })}
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                      data-testid={`agent-update-window-day-${index}`}
+                    >
+                      {dayOptions.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                    </select>
+                  </label>
+                  <label className="space-y-2 text-sm">
+                    <span className="text-xs font-medium uppercase text-muted-foreground">Start</span>
+                    <select
+                      value={window.start}
+                      onChange={event => updateScheduleWindow(index, { start: event.target.value })}
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                      data-testid={`agent-update-window-start-${index}`}
+                    >
+                      {timeOptions.map(time => <option key={time} value={time}>{time}</option>)}
+                    </select>
+                  </label>
+                  <label className="space-y-2 text-sm">
+                    <span className="text-xs font-medium uppercase text-muted-foreground">End</span>
+                    <select
+                      value={window.end}
+                      onChange={event => updateScheduleWindow(index, { end: event.target.value })}
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                      data-testid={`agent-update-window-end-${index}`}
+                    >
+                      {timeOptions.map(time => <option key={time} value={time}>{time}</option>)}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => removeScheduleWindow(index)}
+                    disabled={agentUpdateSchedule.windows.length === 1}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-md border text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                    title="Remove update window"
+                    aria-label="Remove update window"
+                    data-testid={`agent-update-window-remove-${index}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={addScheduleWindow}
+                className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition hover:bg-muted"
+                data-testid="agent-update-window-add"
+              >
+                <Plus className="h-4 w-4" />
+                Add window
+              </button>
+            </div>
+          ) : null}
+          <div className="grid gap-3 sm:grid-cols-2">
+            {(['agent', 'watchdog'] as const).map(component => (
+              <label key={component} className="space-y-2 text-sm">
+                <span className="text-xs font-medium uppercase text-muted-foreground">
+                  {component === 'agent' ? 'Agent pin' : 'Watchdog pin'}
+                </span>
+                <select
+                  value={agentVersionPins[component] ?? ''}
+                  onChange={event => {
+                    setAgentVersionPins(prev => ({ ...prev, [component]: event.target.value || undefined }));
+                    markDirty();
+                  }}
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="">Latest</option>
+                  {(versionOptions[component].includes(agentVersionPins[component] ?? '')
+                    ? versionOptions[component]
+                    : ([agentVersionPins[component], ...versionOptions[component]].filter(Boolean) as string[])
+                  ).map(version => (
+                    <option key={version} value={version}>{version}</option>
+                  ))}
+                </select>
+              </label>
+            ))}
           </div>
-          <p className="text-xs text-muted-foreground">
-            Agents update during the maintenance window when possible.
-          </p>
+          {rawDefaults.maintenanceWindow && !legacySchedule && !rawDefaults.agentUpdateSchedule ? (
+            <p className="text-xs text-amber-600">
+              Existing maintenance window could not be parsed. Review the selected update schedule before saving.
+            </p>
+          ) : null}
         </div>
       </div>
     </section>

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -137,6 +137,19 @@ type OrgDetails = {
       };
       agentUpdatePolicy?: string;
       maintenanceWindow?: string;
+      agentUpdateMode?: 'automatic' | 'manual';
+      agentUpdateTiming?: 'asap' | 'weekly';
+      agentUpdateSchedule?: {
+        windows: Array<{
+          dayOfWeek: 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+          start: string;
+          end: string;
+        }>;
+      };
+      agentVersionPins?: {
+        agent?: string;
+        watchdog?: string;
+      };
     };
     notifications?: {
       fromAddress?: string;

--- a/apps/web/src/components/settings/PartnerDefaultsTab.test.tsx
+++ b/apps/web/src/components/settings/PartnerDefaultsTab.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import PartnerDefaultsTab from './PartnerDefaultsTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+describe('PartnerDefaultsTab agent update policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockReturnValue(new Promise(() => undefined) as Promise<Response>);
+  });
+
+  it('renders legacy automatic as a weekly schedule', () => {
+    render(
+      <PartnerDefaultsTab
+        data={{ agentUpdatePolicy: 'auto', maintenanceWindow: 'Fri 04:00-06:00' }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect((screen.getByTestId('partner-agent-update-policy-select') as HTMLSelectElement).value).toBe('weekly');
+    expect((screen.getByTestId('partner-agent-update-window-day-0') as HTMLSelectElement).value).toBe('fri');
+    expect((screen.getByTestId('partner-agent-update-window-start-0') as HTMLSelectElement).value).toBe('04:00');
+    expect((screen.getByTestId('partner-agent-update-window-end-0') as HTMLSelectElement).value).toBe('06:00');
+  });
+
+  it('adds a second weekly window without writing staged policy', () => {
+    const onChange = vi.fn();
+
+    render(
+      <PartnerDefaultsTab
+        data={{ agentUpdateMode: 'automatic', agentUpdateTiming: 'weekly' }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('partner-agent-update-window-add'));
+
+    const patch = onChange.mock.calls[0]?.[0];
+    expect(patch).toEqual(expect.objectContaining({
+      agentUpdateTiming: 'weekly',
+      agentUpdateSchedule: {
+        windows: [
+          { dayOfWeek: 'sun', start: '02:00', end: '04:00' },
+          { dayOfWeek: 'sun', start: '02:00', end: '04:00' },
+        ],
+      },
+    }));
+    expect(patch?.agentUpdatePolicy).not.toBe('staged');
+  });
+});

--- a/apps/web/src/components/settings/PartnerDefaultsTab.tsx
+++ b/apps/web/src/components/settings/PartnerDefaultsTab.tsx
@@ -1,17 +1,166 @@
+import { useEffect, useMemo, useState } from 'react';
 import type { InheritableDefaultSettings } from '@breeze/shared';
+import { Plus, Trash2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
 
 type Props = {
   data: InheritableDefaultSettings;
   onChange: (data: InheritableDefaultSettings) => void;
 };
 
+type DayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+type AgentUpdateScheduleWindow = { dayOfWeek: DayOfWeek; start: string; end: string };
+type AgentUpdateSchedule = { windows: AgentUpdateScheduleWindow[] };
+type LegacyAgentUpdateSchedule = { dayOfWeek: DayOfWeek; time: string };
+
 const PLACEHOLDER = 'Not set — orgs configure individually';
+const dayOptions = [
+  { value: 'sun', label: 'Sunday' },
+  { value: 'mon', label: 'Monday' },
+  { value: 'tue', label: 'Tuesday' },
+  { value: 'wed', label: 'Wednesday' },
+  { value: 'thu', label: 'Thursday' },
+  { value: 'fri', label: 'Friday' },
+  { value: 'sat', label: 'Saturday' },
+] as const;
+const timeOptions = Array.from({ length: 48 }, (_, index) => {
+  const hour = Math.floor(index / 2);
+  const minute = index % 2 === 0 ? '00' : '30';
+  return `${String(hour).padStart(2, '0')}:${minute}`;
+});
+const defaultAgentUpdateSchedule: AgentUpdateSchedule = {
+  windows: [{ dayOfWeek: 'sun', start: '02:00', end: '04:00' }],
+};
+
+type ComponentVersion = {
+  version: string;
+  component: 'agent' | 'watchdog';
+};
+
+function addMinutes(time: string, minutes: number) {
+  const [hourText, minuteText] = time.split(':');
+  const total = ((Number(hourText) * 60 + Number(minuteText) + minutes) % 1440 + 1440) % 1440;
+  return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`;
+}
+
+function isValidTimeWindow(window: Partial<AgentUpdateScheduleWindow>): window is AgentUpdateScheduleWindow {
+  const timeRe = /^([01]\d|2[0-3]):([0-5]\d)$/;
+  return (
+    !!window.dayOfWeek &&
+    dayOptions.some(option => option.value === window.dayOfWeek) &&
+    typeof window.start === 'string' &&
+    typeof window.end === 'string' &&
+    timeRe.test(window.start) &&
+    timeRe.test(window.end) &&
+    window.start !== window.end
+  );
+}
+
+function parseLegacySchedule(windowText?: string): AgentUpdateSchedule | null {
+  const match = windowText?.trim().match(/^(sun|mon|tue|wed|thu|fri|sat)\s+(\d{1,2}):([0-5]\d)\s*-\s*(\d{1,2}):([0-5]\d)$/i);
+  if (!match) return null;
+  const [, day, rawStartHour, startMinute, rawEndHour, endMinute] = match;
+  if (!day || !rawStartHour || !startMinute || !rawEndHour || !endMinute) return null;
+  const startHour = Number(rawStartHour);
+  const endHour = Number(rawEndHour);
+  if (startHour < 0 || startHour > 23 || endHour < 0 || endHour > 23) return null;
+  return {
+    windows: [{
+      dayOfWeek: day.toLowerCase() as DayOfWeek,
+      start: `${String(startHour).padStart(2, '0')}:${startMinute}`,
+      end: `${String(endHour).padStart(2, '0')}:${endMinute}`,
+    }],
+  };
+}
+
+function legacyPolicyFor(mode?: InheritableDefaultSettings['agentUpdateMode'], _timing?: InheritableDefaultSettings['agentUpdateTiming']) {
+  if (mode === 'manual') return 'manual';
+  return mode === 'automatic' ? 'auto' : undefined;
+}
+
+function normalizeSchedule(raw: InheritableDefaultSettings['agentUpdateSchedule'] | LegacyAgentUpdateSchedule | undefined, fallback?: AgentUpdateSchedule | null): AgentUpdateSchedule {
+  if (raw && 'windows' in raw && Array.isArray(raw.windows)) {
+    const windows = raw.windows.filter(isValidTimeWindow);
+    if (windows.length > 0) return { windows };
+  }
+  if (raw && 'dayOfWeek' in raw && 'time' in raw && isValidTimeWindow({
+    dayOfWeek: raw.dayOfWeek,
+    start: raw.time,
+    end: addMinutes(raw.time, 60),
+  })) {
+    return { windows: [{ dayOfWeek: raw.dayOfWeek, start: raw.time, end: addMinutes(raw.time, 60) }] };
+  }
+  return fallback ?? defaultAgentUpdateSchedule;
+}
+
+function legacyWindowFor(schedule: AgentUpdateSchedule) {
+  const first = schedule.windows[0];
+  if (!first) return undefined;
+  const day = first.dayOfWeek.charAt(0).toUpperCase() + first.dayOfWeek.slice(1);
+  return `${day} ${first.start}-${first.end}`;
+}
 
 export default function PartnerDefaultsTab({ data, onChange }: Props) {
   const set = (patch: Partial<InheritableDefaultSettings>) =>
     onChange({ ...data, ...patch });
 
   const autoEnrollment = data.autoEnrollment ?? { enabled: false, requireApproval: true, sendWelcome: true };
+  const legacySchedule = parseLegacySchedule(data.maintenanceWindow);
+  const mode = data.agentUpdateMode ?? (
+    data.agentUpdatePolicy === 'manual'
+      ? 'manual'
+      : data.agentUpdatePolicy === 'auto' || data.agentUpdatePolicy === 'staged'
+        ? 'automatic'
+        : undefined
+  );
+  const timing = data.agentUpdateTiming ?? (
+    data.agentUpdatePolicy === 'auto'
+      ? 'weekly'
+      : data.agentUpdatePolicy === 'staged'
+        ? (legacySchedule ? 'weekly' : 'asap')
+        : legacySchedule
+          ? 'weekly'
+          : undefined
+  );
+  const schedule = normalizeSchedule(data.agentUpdateSchedule as InheritableDefaultSettings['agentUpdateSchedule'] | LegacyAgentUpdateSchedule | undefined, legacySchedule);
+  const pins = data.agentVersionPins ?? {};
+  const [versions, setVersions] = useState<ComponentVersion[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth('/agent-versions')
+      .then(async response => {
+        if (!response.ok) return;
+        const body = await response.json() as { data?: ComponentVersion[] };
+        if (!cancelled) setVersions(Array.isArray(body.data) ? body.data : []);
+      })
+      .catch(() => {
+        if (!cancelled) setVersions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const versionOptions = useMemo(() => {
+    const byComponent: Record<'agent' | 'watchdog', string[]> = { agent: [], watchdog: [] };
+    for (const row of versions) {
+      if (row.component !== 'agent' && row.component !== 'watchdog') continue;
+      if (!byComponent[row.component].includes(row.version)) byComponent[row.component].push(row.version);
+    }
+    return byComponent;
+  }, [versions]);
+
+  const setUpdatePolicy = (nextMode: 'automatic' | 'manual' | undefined, nextTiming: 'asap' | 'weekly' | undefined) => {
+    const patch: Partial<InheritableDefaultSettings> = {
+      agentUpdateMode: nextMode,
+      agentUpdateTiming: nextMode === 'automatic' ? nextTiming : undefined,
+      agentUpdateSchedule: nextMode === 'automatic' && nextTiming === 'weekly' ? schedule : undefined,
+      agentUpdatePolicy: nextMode ? legacyPolicyFor(nextMode, nextTiming) : undefined,
+      maintenanceWindow: nextMode === 'automatic' && nextTiming === 'weekly' ? legacyWindowFor(schedule) : undefined,
+    };
+    set(patch);
+  };
 
   return (
     <div className="space-y-6">
@@ -19,30 +168,167 @@ export default function PartnerDefaultsTab({ data, onChange }: Props) {
         <div className="space-y-2">
           <label className="text-sm font-medium">Agent Update Policy</label>
           <select
-            value={data.agentUpdatePolicy ?? ''}
-            onChange={e => set({ agentUpdatePolicy: e.target.value || undefined })}
+            value={!mode ? '' : mode === 'manual' ? 'manual' : (timing ?? 'asap')}
+            data-testid="partner-agent-update-policy-select"
+            onChange={e => {
+              if (!e.target.value) {
+                setUpdatePolicy(undefined, undefined);
+              } else if (e.target.value === 'manual') {
+                setUpdatePolicy('manual', undefined);
+              } else {
+                setUpdatePolicy('automatic', e.target.value as 'asap' | 'weekly');
+              }
+            }}
             className="h-10 w-full rounded-md border bg-background px-3 text-sm"
           >
             <option value="">{PLACEHOLDER}</option>
-            <option value="auto">Auto-update</option>
+            <option value="asap">Automatic: as soon as possible</option>
+            <option value="weekly">Automatic: weekly schedule</option>
             <option value="manual">Manual</option>
-            <option value="staged">Staged rollout</option>
           </select>
         </div>
 
-        <div className="space-y-2">
-          <label className="text-sm font-medium">Maintenance Window</label>
-          <input
-            type="text"
-            value={data.maintenanceWindow ?? ''}
-            onChange={e => set({ maintenanceWindow: e.target.value || undefined })}
-            placeholder="e.g. Sun 02:00-06:00"
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-          />
-          <p className="text-xs text-muted-foreground">
-            Time window for automatic updates and reboots.
+        {mode === 'automatic' && timing === 'weekly' ? (
+          <div className="space-y-3 sm:col-span-2">
+            {schedule.windows.map((window, index) => (
+              <div
+                key={`${window.dayOfWeek}-${window.start}-${window.end}-${index}`}
+                className="grid items-end gap-3 sm:grid-cols-[1fr_1fr_1fr_auto]"
+              >
+                <label className="space-y-2">
+                  <span className="text-sm font-medium">Day</span>
+                  <select
+                    value={window.dayOfWeek}
+                    data-testid={`partner-agent-update-window-day-${index}`}
+                    onChange={e => {
+                      const nextSchedule = {
+                        windows: schedule.windows.map((entry, windowIndex) =>
+                          windowIndex === index ? { ...entry, dayOfWeek: e.target.value as DayOfWeek } : entry
+                        ),
+                      };
+                      set({
+                        agentUpdateSchedule: nextSchedule,
+                        maintenanceWindow: legacyWindowFor(nextSchedule),
+                      });
+                    }}
+                    className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                  >
+                    {dayOptions.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                  </select>
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium">Start</span>
+                  <select
+                    value={window.start}
+                    data-testid={`partner-agent-update-window-start-${index}`}
+                    onChange={e => {
+                      const nextSchedule = {
+                        windows: schedule.windows.map((entry, windowIndex) =>
+                          windowIndex === index ? { ...entry, start: e.target.value } : entry
+                        ),
+                      };
+                      set({
+                        agentUpdateSchedule: nextSchedule,
+                        maintenanceWindow: legacyWindowFor(nextSchedule),
+                      });
+                    }}
+                    className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                  >
+                    {timeOptions.map(time => <option key={time} value={time}>{time}</option>)}
+                  </select>
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium">End</span>
+                  <select
+                    value={window.end}
+                    data-testid={`partner-agent-update-window-end-${index}`}
+                    onChange={e => {
+                      const nextSchedule = {
+                        windows: schedule.windows.map((entry, windowIndex) =>
+                          windowIndex === index ? { ...entry, end: e.target.value } : entry
+                        ),
+                      };
+                      set({
+                        agentUpdateSchedule: nextSchedule,
+                        maintenanceWindow: legacyWindowFor(nextSchedule),
+                      });
+                    }}
+                    className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                  >
+                    {timeOptions.map(time => <option key={time} value={time}>{time}</option>)}
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (schedule.windows.length <= 1) return;
+                    const nextSchedule = { windows: schedule.windows.filter((_, windowIndex) => windowIndex !== index) };
+                    set({
+                      agentUpdateSchedule: nextSchedule,
+                      maintenanceWindow: legacyWindowFor(nextSchedule),
+                    });
+                  }}
+                  disabled={schedule.windows.length === 1}
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-md border text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  title="Remove update window"
+                  aria-label="Remove update window"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                const nextSchedule = {
+                  windows: [
+                    ...schedule.windows,
+                    { dayOfWeek: 'sun' as const, start: '02:00', end: '04:00' },
+                  ],
+                };
+                set({
+                  agentUpdateSchedule: nextSchedule,
+                  maintenanceWindow: legacyWindowFor(nextSchedule),
+                });
+              }}
+              className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition hover:bg-muted"
+              data-testid="partner-agent-update-window-add"
+            >
+              <Plus className="h-4 w-4" />
+              Add window
+            </button>
+          </div>
+        ) : <div />}
+
+        {(['agent', 'watchdog'] as const).map(component => (
+          <div key={component} className="space-y-2">
+            <label className="text-sm font-medium">
+              {component === 'agent' ? 'Agent version pin' : 'Watchdog version pin'}
+            </label>
+            <select
+              value={pins[component] ?? ''}
+              onChange={e => set({
+                agentVersionPins: {
+                  ...pins,
+                  [component]: e.target.value || undefined,
+                },
+              })}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            >
+              <option value="">Latest</option>
+              {(versionOptions[component].includes(pins[component] ?? '')
+                ? versionOptions[component]
+                : ([pins[component], ...versionOptions[component]].filter(Boolean) as string[])
+              ).map(version => <option key={version} value={version}>{version}</option>)}
+            </select>
+          </div>
+        ))}
+
+        {data.maintenanceWindow && !legacySchedule && !data.agentUpdateSchedule ? (
+          <p className="text-xs text-amber-600 sm:col-span-2">
+            Existing maintenance window could not be parsed. Review the selected update schedule before saving.
           </p>
-        </div>
+        ) : null}
 
         <div className="space-y-2">
           <label className="text-sm font-medium">Default Device Group</label>

--- a/apps/web/src/services/__tests__/deviceActions.test.ts
+++ b/apps/web/src/services/__tests__/deviceActions.test.ts
@@ -6,7 +6,9 @@ import {
   executeScript,
   sendBulkCommand,
   sendBulkWakeCommand,
+  sendComponentUpdate,
   sendDeviceCommand,
+  sendLegacyAgentUpdate,
   sendWakeCommand,
   summarizeBulkWakeFailures,
   toggleMaintenanceMode,
@@ -62,6 +64,75 @@ describe('deviceActions service', () => {
       expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1/commands', {
         method: 'POST',
         body: JSON.stringify({ type: 'reboot' })
+      });
+    });
+  });
+
+  describe('sendComponentUpdate', () => {
+    it('posts component update requests with an explicit target version', async () => {
+      const command = {
+        id: 'cmd-1',
+        deviceId: 'dev-1',
+        type: 'update_watchdog',
+        status: 'pending',
+        targetVersion: '0.66.0',
+        component: 'watchdog',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      fetchWithAuthMock.mockResolvedValue(makeResponse(command));
+
+      const result = await sendComponentUpdate('dev-1', 'watchdog', '0.66.0');
+
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1/component-update', {
+        method: 'POST',
+        body: JSON.stringify({ component: 'watchdog', version: '0.66.0' }),
+      });
+      expect(result).toEqual(command);
+    });
+
+    it('throws the API error message when component update is rejected', async () => {
+      fetchWithAuthMock.mockResolvedValue(makeResponse({ error: 'Already pending' }, false, 409));
+
+      await expect(sendComponentUpdate('dev-1', 'agent')).rejects.toThrow('Already pending');
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1/component-update', {
+        method: 'POST',
+        body: JSON.stringify({ component: 'agent' }),
+      });
+    });
+  });
+
+  describe('sendLegacyAgentUpdate', () => {
+    it('posts legacy agent update requests with an explicit target version', async () => {
+      const command = {
+        id: 'cmd-legacy',
+        deviceId: 'dev-1',
+        type: 'legacy_agent_update',
+        status: 'pending',
+        targetVersion: '0.83.0',
+        component: 'agent',
+        setAutoUpdateCommandId: 'cmd-auto',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      fetchWithAuthMock.mockResolvedValue(makeResponse(command));
+
+      const result = await sendLegacyAgentUpdate('dev-1', '0.83.0');
+
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1/legacy-agent-update', {
+        method: 'POST',
+        body: JSON.stringify({ version: '0.83.0' }),
+      });
+      expect(result).toEqual(command);
+    });
+
+    it('throws the API error message when legacy agent update is rejected', async () => {
+      fetchWithAuthMock.mockResolvedValue(makeResponse({ error: 'Already pending' }, false, 409));
+
+      await expect(sendLegacyAgentUpdate('dev-1')).rejects.toThrow('Already pending');
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/devices/dev-1/legacy-agent-update', {
+        method: 'POST',
+        body: JSON.stringify({}),
       });
     });
   });

--- a/apps/web/src/services/deviceActions.ts
+++ b/apps/web/src/services/deviceActions.ts
@@ -94,6 +94,44 @@ export async function sendDeviceCommand(
   return data.command ?? data.data ?? data;
 }
 
+export async function sendComponentUpdate(
+  deviceId: string,
+  component: 'agent' | 'watchdog',
+  version?: string,
+): Promise<CommandResult & { targetVersion?: string; component?: 'agent' | 'watchdog' }> {
+  const response = await fetchWithAuth(`/devices/${deviceId}/component-update`, {
+    method: 'POST',
+    body: JSON.stringify({
+      component,
+      ...(version ? { version } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, `Failed to queue ${component} update`));
+  }
+
+  return response.json();
+}
+
+export async function sendLegacyAgentUpdate(
+  deviceId: string,
+  version?: string,
+): Promise<CommandResult & { targetVersion?: string; component?: 'agent'; setAutoUpdateCommandId?: string }> {
+  const response = await fetchWithAuth(`/devices/${deviceId}/legacy-agent-update`, {
+    method: 'POST',
+    body: JSON.stringify({
+      ...(version ? { version } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, 'Failed to queue legacy agent update'));
+  }
+
+  return response.json();
+}
+
 export type WakeFailureCode =
   | 'TARGET_NOT_FOUND'
   | 'NO_MACS'

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -557,6 +557,19 @@ export interface InheritableDefaultSettings {
   };
   agentUpdatePolicy?: string;
   maintenanceWindow?: string;
+  agentUpdateMode?: 'automatic' | 'manual';
+  agentUpdateTiming?: 'asap' | 'weekly';
+  agentUpdateSchedule?: {
+    windows: Array<{
+      dayOfWeek: 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+      start: string;
+      end: string;
+    }>;
+  };
+  agentVersionPins?: {
+    agent?: string;
+    watchdog?: string;
+  };
 }
 
 export interface InheritableBrandingSettings {


### PR DESCRIPTION
## Summary

- Reworks agent/watchdog update policy handling end to end: adds structured org/partner defaults for Automatic as soon as possible, Automatic scheduled windows, Manual mode, and per-component agent/watchdog version pins while preserving legacy settings behavior.
- Adds server-authoritative component update resolution and device metadata so the API, not the browser, decides whether an agent or watchdog is current, outdated, missing, pinned, legacy/custom, manually controlled, or eligible for automatic install.
- Adds bidirectional agent/watchdog repair flows: watchdog can update/reinstall the agent, the agent can install/update/reinstall watchdog, missing watchdogs get a stronger repair path, and legacy agents get a bridge path to upgrade into the new update system.
- Improves the Devices page update UX with inline agent/watchdog update indicators, warning icons for missing watchdogs or reinstall-required custom builds, disabled controls for offline devices, explanatory tooltips, in-app confirmation dialogs, and visible progress states such as updating agent, reinstalling agent, updating watchdog, and reinstalling watchdog.
- Updates organization and partner settings UI with explicit update modes, multi-day/time-window scheduling controls, and agent/watchdog version pin selectors instead of ambiguous free-text update windows.
- Hardens production behavior around duplicate commands, stale update state, malformed/unreadable policy handling, custom/dev build versions, and legacy component reporting gaps uncovered during Linux, Windows, and macOS validation.

## Type of Change

<!-- Check the one that applies: -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other: <!-- describe -->

## Testing

<!-- How did you verify this works? -->

- [x] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [x] Manual testing (describe below)

Automated checks run:

- `pnpm --dir apps/api test:run src/routes/agents/heartbeat.test.ts src/routes/devices.test.ts src/routes/devices/core.permissions.test.ts src/routes/devices/core.list-response-shape.test.ts src/routes/devices/commands.test.ts src/routes/agents/agentUpdatePolicy.test.ts src/routes/agents/helpers.agentUpdatePolicy.test.ts src/routes/agents/download.test.ts src/routes/agentVersions.test.ts src/routes/agentWs.test.ts src/services/agentUpdateTargets.test.ts src/services/componentUpdateResults.test.ts src/services/binarySync.test.ts`
  - 13 test files passed
  - 288 tests passed

- `pnpm --dir apps/web exec vitest run src/components/devices/DeviceList.test.tsx src/components/devices/DevicesPage.test.tsx src/components/settings/OrgDefaultsEditor.test.tsx src/components/settings/PartnerDefaultsTab.test.tsx src/services/__tests__/deviceActions.test.ts`
  - 5 test files passed
  - 94 tests passed

- `pnpm --dir apps/api lint`
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/api build`
- `pnpm --dir apps/web build`
- `go test ./...` from `agent/`

Manual testing performed:

- Built and deployed API/web test images from the throwaway branch during validation.
- Built and tested custom Linux, Windows, and macOS agent/watchdog binaries from the throwaway branch.
- Verified Linux watchdog install/update behavior and agent update via watchdog.
- Verified Linux agent can install/update watchdog.
- Verified Windows legacy agent update path from `0.81.0` to `0.82.1`.
- Verified Windows custom agent can install/update legacy watchdog, with the caveat that old watchdog versions do not reliably report their updated version back to the dashboard.
- Verified Windows custom watchdog can reinstall/update the agent.
- Verified macOS custom agent install path and watchdog install/update behavior.
- Verified macOS custom watchdog install path for testing agent reinstall/update.
- Verified Devices page shows update/reinstall progress states instead of leaving the user with no feedback.
- Verified offline/down devices show the action affordance disabled while still explaining why the update/reinstall action cannot run.
- Verified legacy/custom component versions show the intended reinstall/update affordances.
- Verified missing watchdog state uses a stronger warning indicator instead of only an up-arrow.
- Verified restarting agent/watchdog can clear stale in-progress state when an old unsupported watchdog had accepted an update command before the newer logic was installed.

Implemented changes include:

- Adds structured org update settings:
  - `agentUpdateMode`
  - `agentUpdateTiming`
  - multi-day/time-window weekly scheduling
  - `agentVersionPins.agent`
  - `agentVersionPins.watchdog`

- Preserves and normalizes legacy settings:
  - legacy manual remains manual
  - legacy automatic maps into the new automatic weekly/asap model as appropriate
  - invalid/unreadable policy state fails closed instead of silently enabling automatic updates

- Adds server-authoritative update target resolution for agent and watchdog components.

- Adds update metadata to device responses so the client does not decide target versions locally.

- Adds manual component update/reinstall command flow.

- Adds duplicate-command suppression for pending component updates.

- Adds component update result/status mapping so the UI can show:
  - updating agent
  - reinstalling agent
  - updating watchdog
  - reinstalling watchdog

- Adds legacy bridge behavior for old agents that do not support the new manual update protocol.

- Ensures legacy-update auto-update state returns to the org policy after the legacy update completes.

- Adds missing/custom/legacy watchdog handling in Devices UI.

- Adds disabled update/reinstall affordance for down/offline devices with explanatory tooltip messaging.

- Adds structured organization and partner default settings UI for update mode, timing, schedule windows, and version pins.

- Adds longer DB column support for custom/dev build version strings in:
  - `devices.agent_version`
  - `devices.watchdog_version`
  - `agent_versions.version`
  - `agent_logs.agent_version`

- Adds watchdog-side support for agent update/reinstall commands.

- Adds agent-side support for watchdog install/update/reinstall commands.

- Splits component update behavior so reinstalling the agent no longer unintentionally reinstalls/replaces the watchdog as part of the agent reinstall flow.

- Adds heartbeat/update hardening so org policy lookup failures do not bypass Manual mode.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included