### PR TITLE
fix(agent): make UAC discovery work on Windows 11 (correct LUA event ids + target extraction)

### DIFF
--- a/agent/internal/etwlua/consent_payload.go
+++ b/agent/internal/etwlua/consent_payload.go
@@ -1,0 +1,66 @@
+package etwlua
+
+import "strings"
+
+// parseConsentPayload extracts the target executable path and command line
+// from the raw UserData bytes of a Microsoft-Windows-LUA event 15028 (the
+// elevation-request detail raised when AppInfo shows a UAC consent on
+// Windows). The payload is a header (request id, session token, a
+// string-offset table) followed by UTF-16LE strings: the full target path
+// (emitted twice), then the quoted command line. The offset table layout is
+// version-specific, so instead of parsing it we scan the blob for UTF-16
+// strings and select by shape — the bare drive-rooted path is the target,
+// and the quoted string is the command line.
+//
+// This is pure (no syscalls) so it can be unit-tested off-Windows against
+// captured fixtures; the Windows-only caller wraps it with user/hash
+// resolution. Returns empty targetPath when no path-like string is present.
+func parseConsentPayload(raw []byte) (targetPath, commandLine string) {
+	for _, str := range utf16Strings(raw, 4) {
+		if commandLine == "" && strings.HasPrefix(str, `"`) {
+			commandLine = strings.TrimRight(str, " ")
+		}
+		if targetPath == "" && looksLikeWindowsPath(str) {
+			targetPath = str
+		}
+	}
+	return targetPath, commandLine
+}
+
+// looksLikeWindowsPath reports whether s is a drive-rooted path like
+// `C:\...` (and not a quoted command line).
+func looksLikeWindowsPath(s string) bool {
+	if len(s) < 4 || s[0] == '"' {
+		return false
+	}
+	c := s[0]
+	return ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) && s[1] == ':' && s[2] == '\\'
+}
+
+// utf16Strings scans b for runs of printable UTF-16LE characters (each run
+// implicitly terminated by a non-printable unit such as the NUL separator),
+// returning those at least minLen runes long.
+func utf16Strings(b []byte, minLen int) []string {
+	var out []string
+	var cur []uint16
+	flush := func() {
+		if len(cur) >= minLen {
+			r := make([]rune, 0, len(cur))
+			for _, u := range cur {
+				r = append(r, rune(u))
+			}
+			out = append(out, string(r))
+		}
+		cur = cur[:0]
+	}
+	for i := 0; i+1 < len(b); i += 2 {
+		u := uint16(b[i]) | uint16(b[i+1])<<8
+		if u >= 0x20 && u < 0xD800 { // printable BMP, excludes controls/surrogates
+			cur = append(cur, u)
+		} else {
+			flush()
+		}
+	}
+	flush()
+	return out
+}

--- a/agent/internal/etwlua/consent_payload_test.go
+++ b/agent/internal/etwlua/consent_payload_test.go
@@ -1,0 +1,102 @@
+package etwlua
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+// realLUA15028BreezeAgent is the raw UserData of a Microsoft-Windows-LUA
+// event 15028, captured live on Windows 11 (build 26200) when a UAC consent
+// was raised for `breeze-agent.exe version`. Used as a ground-truth fixture
+// so the parser is exercised in CI (which runs on Linux and can't compile
+// the Windows ETW subscriber).
+const realLUA15028BreezeAgent = "e201000000000000020000000000000000000000000000000c0200000000000006000000010000001002000000000000960000001ddaba324d32436f6d57364b4f303230542b724d7478504448512e300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000078e077b0ce0000001005000000000000f8000000000000003e010000000000008401000000000000e001000000000000749b00000000000043003a005c0062007200650065007a0065002d00700061006d0074006500730074005c0062007200650065007a0065002d006100670065006e0074002e00650078006500000043003a005c0062007200650065007a0065002d00700061006d0074006500730074005c0062007200650065007a0065002d006100670065006e0074002e006500780065000000220043003a005c0062007200650065007a0065002d00700061006d0074006500730074005c0062007200650065007a0065002d006100670065006e0074002e0065007800650022002000760065007200730069006f006e00200000000000"
+
+func utf16Payload(strs ...string) []byte {
+	var b []byte
+	for _, s := range strs {
+		for _, r := range s {
+			b = binary.LittleEndian.AppendUint16(b, uint16(r))
+		}
+		b = append(b, 0, 0) // UTF-16 NUL separator
+	}
+	return b
+}
+
+func TestParseConsentPayload(t *testing.T) {
+	realBytes, err := hex.DecodeString(realLUA15028BreezeAgent)
+	if err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		raw         []byte
+		wantPath    string
+		wantCmdLine string
+	}{
+		{
+			name:        "real Win11 15028 (with args)",
+			raw:         realBytes,
+			wantPath:    `C:\breeze-pamtest\breeze-agent.exe`,
+			wantCmdLine: `"C:\breeze-pamtest\breeze-agent.exe" version`,
+		},
+		{
+			name:        "synthetic no-args (trailing space trimmed)",
+			raw:         utf16Payload(`C:\Windows\System32\notepad.exe`, `C:\Windows\System32\notepad.exe`, `"C:\Windows\System32\notepad.exe" `),
+			wantPath:    `C:\Windows\System32\notepad.exe`,
+			wantCmdLine: `"C:\Windows\System32\notepad.exe"`,
+		},
+		{
+			name:        "lowercase drive letter",
+			raw:         utf16Payload(`d:\tools\app.exe`),
+			wantPath:    `d:\tools\app.exe`,
+			wantCmdLine: "",
+		},
+		{
+			name:        "no path-like string yields empty",
+			raw:         utf16Payload("ConsentUI", "some token text"),
+			wantPath:    "",
+			wantCmdLine: "",
+		},
+		{
+			name:        "empty input",
+			raw:         nil,
+			wantPath:    "",
+			wantCmdLine: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath, gotCmd := parseConsentPayload(tc.raw)
+			if gotPath != tc.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tc.wantPath)
+			}
+			if gotCmd != tc.wantCmdLine {
+				t.Errorf("cmdline = %q, want %q", gotCmd, tc.wantCmdLine)
+			}
+		})
+	}
+}
+
+func TestLooksLikeWindowsPath(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{`C:\Windows\notepad.exe`, true},
+		{`z:\x`, true},
+		{`"C:\quoted\path.exe"`, false}, // quoted = command line, not the bare path
+		{`\\server\share\file`, false},  // UNC is not drive-rooted
+		{`notepad.exe`, false},
+		{`C:`, false}, // too short
+		{``, false},
+	}
+	for _, tc := range tests {
+		if got := looksLikeWindowsPath(tc.s); got != tc.want {
+			t.Errorf("looksLikeWindowsPath(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}

--- a/agent/internal/etwlua/etwlua_windows.go
+++ b/agent/internal/etwlua/etwlua_windows.go
@@ -9,35 +9,35 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/0xrawsec/golang-etw/etw"
+	"golang.org/x/sys/windows"
 )
 
-// providerGUID is the Microsoft-Windows-LUA ETW provider. Documented in
-// the Windows SDK (microsoft-windows-lua.manifest) and stable since
-// Windows 7. We pin the literal GUID here rather than name-resolving via
-// TdhEnumerateProviders — the GUID will never change and resolution adds
-// a runtime dependency we don't want.
+// providerGUID is the Microsoft-Windows-LUA ETW provider (lives in
+// appinfo.dll). Stable since Windows 7; we pin the literal GUID rather
+// than name-resolving via TdhEnumerateProviders.
 const providerGUID = "{93c05d69-51a3-485e-877f-1806a8731346}"
 
-// consentEventIDs are the ETW event IDs raised when the consent UI is
-// shown for elevation. Sourced from the Windows-Internals reference for
-// the LUA provider: 4100/4101/4102 cover the "consent prompted" /
-// "consent granted" / "consent denied" tuple. We watch all three so a
-// denied prompt also produces a discovery event (Tracks 4-6 will use
-// the denial signal to drive policy tuning).
-var consentEventIDs = map[uint16]string{
-	4100: "consent_prompted",
-	4101: "consent_granted",
-	4102: "consent_denied",
-}
+// consentRequestEventID is the Microsoft-Windows-LUA event that carries the
+// elevation-request detail (the target executable path + command line) when
+// AppInfo raises a UAC consent. Verified empirically on Windows 11 (build
+// 26200) against a live trace, and via the provider manifest
+// (`wevtutil gp Microsoft-Windows-LUA /ge`): the LUA provider defines events
+// in the 15001-16002 range on the `ConsentUI/Diagnostic` channel. It does
+// NOT define 4100/4101/4102 — the values this code previously watched, which
+// matched nothing, so UAC discovery captured zero events on the entire
+// Windows fleet. Event 15028 is the request detail; 16001 (shown) and 16002
+// (result) bracket it but carry only a correlation id + the exe basename /
+// result code, so 15028 is the one self-contained event with the target.
+const consentRequestEventID uint16 = 15028
 
 // etwSession wraps a golang-etw Consumer for the Microsoft-Windows-LUA
-// provider. The session runs in its own goroutine started by Subscribe;
-// Stop signals the consumer to abort and waits for the goroutine to exit.
+// provider. The session runs in its own goroutine started by run(); Stop
+// signals the consumer to abort and waits for the goroutine to exit.
 type etwSession struct {
 	consumer *etw.Consumer
 	session  *etw.RealTimeSession
@@ -47,11 +47,10 @@ type etwSession struct {
 }
 
 // NewETWSubscriber creates a live subscription to the Microsoft-Windows-LUA
-// provider. Returns ErrNotPrivileged if the caller is not SYSTEM/Admin
-// (the ETW session call would fail with ERROR_ACCESS_DENIED anyway, but
-// we surface the cause clearly).
+// provider. Returns an error if the caller is not SYSTEM/Admin (the ETW
+// session call fails with ERROR_ACCESS_DENIED).
 //
-// The returned Subscriber owns one TraceLogging RealTime session named
+// The returned Subscriber owns one RealTime session named
 // "Breeze-LUA-Discovery". Two callers on the same machine would conflict;
 // we assume only one agent process per host (enforced elsewhere).
 func NewETWSubscriber() (Subscriber, error) {
@@ -66,12 +65,8 @@ func NewETWSubscriber() (Subscriber, error) {
 		return nil, fmt.Errorf("etwlua: enable LUA provider: %w", err)
 	}
 
-	// NewRealTimeConsumer derives its context via context.WithCancel(parent)
-	// and PANICS on a nil parent ("cannot create context from nil parent"),
-	// which crashed the agent on startup on every Windows host running as
-	// SYSTEM. The consumer is explicitly torn down by etwSession.Stop()
-	// (consumer.Stop()), invoked from etwlua.Start's `defer sub.Stop()` on
-	// ctx.Done(), so context.Background() here is sufficient and leak-free.
+	// NewRealTimeConsumer PANICS on a nil parent context; Background() is
+	// torn down via consumer.Stop() in etwSession.Stop().
 	consumer := etw.NewRealTimeConsumer(context.Background()).FromSessions(session)
 
 	s := &etwSession{
@@ -85,38 +80,54 @@ func NewETWSubscriber() (Subscriber, error) {
 	return s, nil
 }
 
-// run pumps events from the consumer's channel through decode() into
-// s.events until Stop closes the consumer. Exits when the consumer's
-// channel is closed.
+// run installs the low-level EventRecordHelper callback and starts the
+// consumer. We use the raw EventRecord path (not the high-level
+// consumer.Events channel) because the target executable path lives in
+// event 15028's UserData blob, which TDH does not surface as a named
+// property — the high-level parser only exposes an opaque "Parameters"
+// field. We read the raw UserData bytes directly and scan them.
 func (s *etwSession) run() {
 	defer close(s.doneCh)
 	defer close(s.events)
+
+	s.consumer.EventRecordHelperCallback = func(h *etw.EventRecordHelper) error {
+		if h.EventID() != consentRequestEventID {
+			h.Skip()
+			return nil
+		}
+		er := h.EventRec
+		n := int(er.UserDataLength)
+		if er.UserData == 0 || n <= 0 {
+			h.Skip()
+			return nil
+		}
+		// UserData is only valid for the lifetime of this callback; decode
+		// copies the strings out before we return, so no use-after-free.
+		raw := unsafe.Slice((*byte)(unsafe.Pointer(er.UserData)), n)
+		ev, ok := decodeConsentRequest(raw)
+		h.Skip()
+		if !ok {
+			return nil
+		}
+		select {
+		case s.events <- ev:
+		default:
+			// Buffer full — drop rather than block the ETW callback.
+			log.Warn("etwlua: event channel full, dropping event",
+				"path", ev.TargetExecutablePath,
+			)
+		}
+		return nil
+	}
 
 	if err := s.consumer.Start(); err != nil {
 		log.Error("etwlua: consumer start failed", "error", err.Error())
 		return
 	}
-
-	for ee := range s.consumer.Events {
-		// Filter by event ID before doing any expensive decode work.
-		if _, ok := consentEventIDs[ee.System.EventID]; !ok {
-			continue
-		}
-		ev, ok := decodeConsentEvent(ee)
-		if !ok {
-			continue
-		}
-		select {
-		case s.events <- ev:
-		default:
-			// Buffer full — drop the event rather than block ETW. ETW
-			// real-time sessions tolerate slow consumers but a blocked
-			// reader will eventually start losing kernel events, which
-			// is worse than losing one user-mode UAC event here.
-			log.Warn("etwlua: event channel full, dropping event",
-				"path", ev.TargetExecutablePath,
-			)
-		}
+	// The callback above does all the work and Skip()s every event, so
+	// nothing is pushed to consumer.Events. Ranging it blocks until Stop
+	// closes the channel, which is how this goroutine exits.
+	for range s.consumer.Events {
 	}
 }
 
@@ -136,86 +147,94 @@ func (s *etwSession) Stop() {
 	})
 }
 
-// decodeConsentEvent extracts the fields we care about from a parsed ETW
-// event. Returns ok=false if required fields are missing — better to drop
-// than emit a half-decoded event.
+// decodeConsentRequest extracts the target executable path + command line
+// from event 15028's raw UserData. The payload is a header (request id,
+// session token, string-offset table) followed by UTF-16LE strings: the
+// full target path (twice) and the quoted command line. Rather than parse
+// the version-specific offset table, we scan the blob for UTF-16 strings
+// and pick the one that looks like a drive-rooted path (target) and the one
+// that starts with a quote (command line). Verified against two live Win11
+// samples (`"C:\…\app.exe" version` and `"C:\Windows\System32\notepad.exe" `).
 //
-// The LUA provider's ConsentUI events expose these properties (names
-// stable across Windows 10/11):
-//
-//	SubjectUserName / SubjectUserSid  — who raised the prompt
-//	ApplicationName                   — target executable path
-//	CommandLine                       — full command line (may be empty)
-//	ProcessId / ParentProcessName     — process metadata
-//
-// We hash the target file at observation time. The hash is best-effort:
-// on a fast machine the file is already paged in, but if it's on a slow
-// mount or has been deleted between the prompt and our read, the hash
-// is empty (server accepts nullable).
-func decodeConsentEvent(ee *etw.Event) (Event, bool) {
-	props := ee.EventData
-	if props == nil {
-		// Some LUA events use UserData instead of EventData.
-		props = ee.UserData
-	}
-	if props == nil {
+// Returns ok=false if no path is found or the requesting user can't be
+// resolved — the server requires a non-empty subject_username, so an event
+// without one would be rejected on POST anyway.
+func decodeConsentRequest(raw []byte) (Event, bool) {
+	targetPath, commandLine := parseConsentPayload(raw)
+	if targetPath == "" {
 		return Event{}, false
 	}
 
-	exePath := stringProp(props, "ApplicationName")
-	user := stringProp(props, "SubjectUserName")
-	if exePath == "" || user == "" {
+	user := resolveConsentUser()
+	if user == "" {
+		// No interactive console user to attribute the prompt to; the server
+		// requires a subject, so drop rather than post a half record.
 		return Event{}, false
 	}
 
 	ev := Event{
 		SubjectUsername:      user,
-		TargetExecutablePath: exePath,
-		CommandLine:          stringProp(props, "CommandLine"),
-		ParentImage:          stringProp(props, "ParentProcessName"),
+		TargetExecutablePath: targetPath,
+		CommandLine:          commandLine,
 		ObservedAt:           time.Now().UTC(),
 	}
-
-	if pidStr := stringProp(props, "ProcessId"); pidStr != "" {
-		var pid uint32
-		if _, err := fmt.Sscanf(pidStr, "%d", &pid); err == nil {
-			ev.PID = pid
-		}
-	}
-
-	if hash, err := hashFile(exePath); err == nil {
+	if hash, err := hashFile(targetPath); err == nil {
 		ev.TargetExecutableHash = hash
 	}
-
-	// Authenticode signer extraction would require WinTrust/CryptoAPI
-	// (golang-x/sys/windows.WinVerifyTrust) — significant code surface
-	// and a tested-on-Windows-only path. Track 3 leaves this empty;
-	// signer is a "best-effort" field and the server schema accepts
-	// NULL. A follow-up PR can wire it in once we have a Windows CI
-	// runner to validate.
-
+	// Authenticode signer extraction is deferred (WinTrust/CryptoAPI) — see
+	// #1776. The server schema accepts a NULL signer.
 	return ev, true
 }
 
-// stringProp pulls a string value from an ETW property bag, tolerating
-// either map[string]any or map[string]string shapes that golang-etw may
-// emit depending on event manifest types.
-func stringProp(props map[string]any, key string) string {
-	v, ok := props[key]
-	if !ok {
-		return ""
+// consentUser caches the active console-session user; resolving it is a
+// syscall we don't want to run per consent event, and the console user
+// rarely changes.
+var (
+	consentUserMu    sync.Mutex
+	consentUserCache string
+	consentUserAt    time.Time
+)
+
+// resolveConsentUser returns the active console session's user as
+// "DOMAIN\\user". A UAC consent prompt is, by construction, raised in the
+// interactive session, so the console user is the requester in the common
+// case. Empty if there is no interactive session or the lookup fails.
+func resolveConsentUser() string {
+	consentUserMu.Lock()
+	defer consentUserMu.Unlock()
+	if consentUserCache != "" && time.Since(consentUserAt) < 60*time.Second {
+		return consentUserCache
 	}
-	switch s := v.(type) {
-	case string:
-		return strings.TrimSpace(s)
-	case fmt.Stringer:
-		return strings.TrimSpace(s.String())
+	if u := lookupConsoleUser(); u != "" {
+		consentUserCache = u
+		consentUserAt = time.Now()
+		return u
 	}
-	return strings.TrimSpace(fmt.Sprintf("%v", v))
+	return ""
 }
 
-// hashFile returns the SHA-256 of the file at path as hex. Returns an
-// error if the file cannot be opened or read.
+func lookupConsoleUser() string {
+	sid := windows.WTSGetActiveConsoleSessionId()
+	if sid == 0xFFFFFFFF { // no active console session
+		return ""
+	}
+	var token windows.Token
+	if err := windows.WTSQueryUserToken(sid, &token); err != nil {
+		return ""
+	}
+	defer token.Close()
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return ""
+	}
+	account, domain, _, err := tokenUser.User.Sid.LookupAccount("")
+	if err != nil {
+		return ""
+	}
+	return domain + `\` + account
+}
+
+// hashFile returns the SHA-256 of the file at path as hex.
 func hashFile(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
## Problem

UAC discovery on Windows has been capturing **zero** events, so the entire PAM auto-elevation pipeline (rule engine, signer groups, mobile/web approval) is inert on Windows.

Root cause: the `etwlua` subscriber watched Microsoft-Windows-LUA event ids **4100/4101/4102**, which the provider does not define. Verified two ways:

- Against the provider manifest: `wevtutil gp Microsoft-Windows-LUA /ge` lists no such ids.
- Against a live Windows 11 trace (build 26200): real consents emit ids in the **15001–16002** range on the `ConsentUI/Diagnostic` channel.

## Fix

- Watch event **15028** (the elevation-request detail), which is the one self-contained event carrying the target executable path + command line. (16001 "shown" / 16002 "result" bracket it but only carry a correlation id + the exe basename / a result code.)
- The target path lives in 15028's `UserData` blob, which TDH does not surface as a named property (the high-level parser only exposes an opaque `Parameters` field). We read the raw `UserData` via the low-level `EventRecordHelper` callback and scan it for the UTF-16 target path + quoted command line.
- Resolve the requesting user from the active console session (`WTSGetActiveConsoleSessionId` → `WTSQueryUserToken` → SID lookup), since the server requires a non-empty `subject_username`.
- The byte-parsing is split into a pure, cross-platform `consent_payload.go` and unit-tested against a **real captured Win11 15028 payload**, so CI (which runs on Linux and can't compile the Windows ETW subscriber) exercises it.

## Verification

End-to-end on Windows 11 build 26200 against a local Breeze-from-main stack:

- Real UAC consent for `notepad.exe` (via `Start-Process -Verb RunAs`, launched as SYSTEM into the interactive session) → agent extracts path `C:\Windows\System32\notepad.exe`, user `VM\bdunn`, the quoted command line, and the SHA-256 → posts a `uac_intercept`.
- The rule engine evaluated it and **auto-approved** against a `match_command_line` rule (`status = auto_approved` in the DB).
- Unit tests: `CGO_ENABLED=0 go test ./internal/etwlua/` passes, including the real-fixture parse test.
- `GOOS=windows go build ./...` clean; `gofmt -l` clean.

Authenticode signer extraction remains deferred (#1776) — the server schema accepts a NULL signer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
