### PR TITLE
fix(helper): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/apps/helper/src-tauri/Cargo.lock
+++ b/apps/helper/src-tauri/Cargo.lock
@@ -2791,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Problem

The **Cargo Audit** CI job (`cargo audit --deny warnings` in `apps/helper/src-tauri`) is failing on **every open PR**, because `quinn-proto` 0.11.14 is flagged by **RUSTSEC-2026-0185** (published 2026-06-22):

> Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly — a peer sending fragments with many gaps forces high buffer overhead, enabling memory exhaustion (DoS).

CVSS 3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H. Patched in **0.11.15**.

## Fix

`quinn-proto` is a transitive dependency (via `quinn` 0.11.9, whose `^0.11` requirement is satisfied by 0.11.15), so this is a **lockfile-only** patch bump — `cargo update -p quinn-proto` resolves 0.11.14 → 0.11.15 with no other churn (2 lines changed: version + checksum).

## Verification

Local, matching the CI step exactly (`cargo audit` 0.22.2, fresh advisory-db):

- `apps/helper/src-tauri`: `cargo audit --deny warnings` → **RC=0** (was: 1 vulnerability)
- `apps/viewer/src-tauri`: `cargo audit --deny warnings` → **RC=0** (confirmed no separate advisory there)

This unblocks the Security Scanning / Cargo Audit job fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)