### PR TITLE
feat(observability): per-request tenant/user Sentry context (#1379 B2)

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -10,6 +10,7 @@ import type { PgColumn } from 'drizzle-orm/pg-core';
 import { ENABLE_2FA } from '../routes/auth/schemas';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 import { writeAuditEvent } from '../services/auditEvents';
+import { setSentryRequestContext } from '../services/sentry';
 import { mfaForcePartnerAdmin } from '../config/env';
 import { ipAllowlistGuard } from './ipAllowlistGuard';
 import { isSelfManagedDbContextRoute } from './selfManagedDbContextRoutes';
@@ -455,6 +456,15 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     canAccessOrg,
     allowedSiteIds,
     canAccessSite
+  });
+
+  // #1379 B2 — tag this request's Sentry isolation scope with the tenant so
+  // any event captured downstream is attributable. Non-secret ids only.
+  setSentryRequestContext({
+    userId: user.id,
+    scope: payload.scope,
+    orgId: payload.orgId,
+    partnerId: payload.partnerId
   });
 
   // The return value matters: ipAllowlistGuard returns its deny/error

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -10,7 +10,7 @@ import type { PgColumn } from 'drizzle-orm/pg-core';
 import { ENABLE_2FA } from '../routes/auth/schemas';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 import { writeAuditEvent } from '../services/auditEvents';
-import { setSentryRequestContext } from '../services/sentry';
+import { withSentryRequestScope } from '../services/sentry';
 import { mfaForcePartnerAdmin } from '../config/env';
 import { ipAllowlistGuard } from './ipAllowlistGuard';
 import { isSelfManagedDbContextRoute } from './selfManagedDbContextRoutes';
@@ -458,15 +458,6 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     canAccessSite
   });
 
-  // #1379 B2 — tag this request's Sentry isolation scope with the tenant so
-  // any event captured downstream is attributable. Non-secret ids only.
-  setSentryRequestContext({
-    userId: user.id,
-    scope: payload.scope,
-    orgId: payload.orgId,
-    partnerId: payload.partnerId
-  });
-
   // The return value matters: ipAllowlistGuard returns its deny/error
   // Response as a value (it does not throw). Dropping it leaves the Hono
   // context unfinalized — every gated request then 500s with "Context is
@@ -479,24 +470,33 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
   // class). They run with NO ambient context and manage their own short DB
   // access contexts; auth is still set above so requireScope/requirePermission
   // and the handler's actor still work.
-  if (isSelfManagedDbContextRoute(c.req.method, c.req.path)) {
-    return runGuardedHandler();
-  }
+  const dispatch = () => {
+    if (isSelfManagedDbContextRoute(c.req.method, c.req.path)) {
+      return runGuardedHandler();
+    }
+    return withDbAccessContext(
+      {
+        scope: payload.scope,
+        orgId: payload.orgId,
+        accessibleOrgIds,
+        accessiblePartnerIds,
+        userId: user.id,
+        // Own partner — enables read-only visibility of the partner's
+        // partner-wide catalog rows for org-scope (and partner-scope) users.
+        // NOT an access grant; partner-axis write access stays governed by
+        // accessiblePartnerIds.
+        currentPartnerId: payload.partnerId ?? null
+      },
+      runGuardedHandler
+    );
+  };
 
-  return withDbAccessContext(
-    {
-      scope: payload.scope,
-      orgId: payload.orgId,
-      accessibleOrgIds,
-      accessiblePartnerIds,
-      userId: user.id,
-      // Own partner — enables read-only visibility of the partner's
-      // partner-wide catalog rows for org-scope (and partner-scope) users.
-      // NOT an access grant; partner-axis write access stays governed by
-      // accessiblePartnerIds.
-      currentPartnerId: payload.partnerId ?? null
-    },
-    runGuardedHandler
+  // #1379 B2 — run the entire downstream dispatch inside an explicit Sentry
+  // isolation scope so tenant tags are confined to THIS request's
+  // AsyncLocalStorage context and cannot bleed into concurrent requests.
+  return withSentryRequestScope(
+    { userId: user.id, scope: payload.scope, orgId: payload.orgId, partnerId: payload.partnerId },
+    dispatch
   );
 }
 

--- a/apps/api/src/services/sentry.isolation.test.ts
+++ b/apps/api/src/services/sentry.isolation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Concurrency isolation test for withSentryRequestScope (#1379 B2 review).
+ *
+ * This file intentionally does NOT mock @sentry/node. It exercises the REAL
+ * Sentry SDK (with a fake DSN so no network calls are made) to verify that
+ * two concurrent requests cannot bleed tenant tags into each other's events.
+ *
+ * The mechanism under test: Sentry.init() installs an AsyncLocalStorage-based
+ * async-context strategy. withIsolationScope() forks a new scope into that
+ * ALS context, so every setUser/setTag call inside the callback is visible
+ * only within that async subtree — not to sibling requests running concurrently.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as Sentry from '@sentry/node';
+
+// Recorded events intercepted before transport delivery.
+const recorded: Sentry.Event[] = [];
+
+let withSentryRequestScope: <T>(
+  ctx: {
+    userId: string;
+    scope: 'system' | 'partner' | 'organization';
+    orgId: string | null;
+    partnerId: string | null;
+  },
+  run: () => T
+) => T;
+
+beforeAll(async () => {
+  // Set a fake-but-valid-format DSN so Sentry.init() actually initialises.
+  // No real network connection is made — we intercept events via an event
+  // processor registered on the client BEFORE they reach the transport layer.
+  process.env.SENTRY_DSN = 'https://abc123@o0.ingest.sentry.io/0';
+
+  // Dynamically import so the module picks up the env var above.
+  const sentryModule = await import('./sentry');
+  sentryModule.initSentry();
+  withSentryRequestScope = sentryModule.withSentryRequestScope;
+
+  // Register an event processor that records events and drops them (returning
+  // null) so they never reach the Sentry transport (no network). The processor
+  // captures tags and user from the event as Sentry enriches them from the
+  // active scope before calling processors.
+  Sentry.addEventProcessor((event) => {
+    // Deep-copy so scope mutations after capture don't affect what we recorded.
+    recorded.push(JSON.parse(JSON.stringify(event)) as Sentry.Event);
+    // Return null to drop the event — prevents any transport delivery.
+    return null;
+  });
+});
+
+afterAll(async () => {
+  // Flush any remaining buffered events, then close the transport.
+  await Sentry.close(500);
+  delete process.env.SENTRY_DSN;
+});
+
+describe('withSentryRequestScope — concurrent tenant isolation', () => {
+  it('keeps tenant tags request-local even when two requests interleave', async () => {
+    // Run two withSentryRequestScope calls concurrently. Each introduces an
+    // async yield inside the callback (Promise.resolve()) to force interleaving
+    // of microtasks, proving that the ALS boundary actually isolates them.
+    await Promise.all([
+      withSentryRequestScope(
+        { userId: 'uA', scope: 'organization', orgId: 'oA', partnerId: null },
+        async () => {
+          // Yield to allow the other request's callback to interleave.
+          await Promise.resolve();
+          Sentry.captureException(new Error('event-A'));
+        }
+      ),
+      withSentryRequestScope(
+        { userId: 'uB', scope: 'partner', orgId: null, partnerId: 'pB' },
+        async () => {
+          await Promise.resolve();
+          Sentry.captureException(new Error('event-B'));
+        }
+      ),
+    ]);
+
+    // Flush Sentry's internal processing pipeline so event processors fire
+    // and populate `recorded` before we assert. Without this, captureException
+    // enqueues events asynchronously and the assertions would race.
+    await Sentry.flush(1000);
+
+    // Both events should have been recorded by the processor above.
+    const eventA = recorded.find(
+      (e) => e.exception?.values?.[0]?.value?.includes('event-A')
+    );
+    const eventB = recorded.find(
+      (e) => e.exception?.values?.[0]?.value?.includes('event-B')
+    );
+
+    expect(eventA).toBeDefined();
+    expect(eventB).toBeDefined();
+
+    // Event A must carry oA's tags and uA's user — NOT oB/uB.
+    expect(eventA?.tags?.['orgId']).toBe('oA');
+    expect(eventA?.tags?.['partnerId']).toBe('none');
+    expect(eventA?.user?.id).toBe('uA');
+
+    // Event B must carry pB's tags and uB's user — NOT oA/uA.
+    expect(eventB?.tags?.['orgId']).toBe('none');
+    expect(eventB?.tags?.['partnerId']).toBe('pB');
+    expect(eventB?.user?.id).toBe('uB');
+
+    // Cross-check: no bleed between scopes.
+    expect(eventA?.tags?.['orgId']).not.toBe('none');  // A has a real orgId
+    expect(eventB?.user?.id).not.toBe('uA');           // B didn't pick up A's user
+  });
+});

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -8,6 +8,8 @@ const initMock = vi.fn();
 const captureMock = vi.fn();
 const flushMock = vi.fn().mockResolvedValue(true);
 const setTagMock = vi.fn();
+const setUserMock = vi.fn();
+const moduleSetTagMock = vi.fn();
 const withScopeMock = vi.fn((cb: (scope: unknown) => void) =>
   cb({ setTag: setTagMock, setContext: vi.fn() }),
 );
@@ -17,6 +19,8 @@ vi.mock('@sentry/node', () => ({
   captureException: (...args: unknown[]) => captureMock(...args),
   flush: (...args: unknown[]) => flushMock(...args),
   withScope: (cb: (scope: unknown) => void) => withScopeMock(cb),
+  setUser: (...args: unknown[]) => setUserMock(...args),
+  setTag: (...args: unknown[]) => moduleSetTagMock(...args),
 }));
 
 const ORIGINAL_ENV = { ...process.env };
@@ -130,6 +134,48 @@ describe('sentry service', () => {
     expect(setTagMock).not.toHaveBeenCalledWith('pg_code', expect.anything());
     expect(setTagMock).not.toHaveBeenCalledWith('rls_deny', expect.anything());
     expect(captureMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setSentryRequestContext', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setUserMock.mockClear();
+    moduleSetTagMock.mockClear();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('is a no-op when Sentry is not initialized', async () => {
+    // Ensure no DSN so initSentry does NOT mark initialized.
+    delete process.env.SENTRY_DSN;
+    const { setSentryRequestContext } = await import('./sentry');
+    setSentryRequestContext({ userId: 'u-1', scope: 'organization', orgId: 'o-1', partnerId: 'p-1' });
+    expect(setUserMock).not.toHaveBeenCalled();
+    expect(moduleSetTagMock).not.toHaveBeenCalled();
+  });
+
+  it('sets user id + tenant tags when initialized', async () => {
+    process.env.SENTRY_DSN = 'https://example@o0.ingest.sentry.io/0';
+    const { initSentry, setSentryRequestContext } = await import('./sentry');
+    initSentry();
+    setSentryRequestContext({ userId: 'u-1', scope: 'organization', orgId: 'o-1', partnerId: 'p-1' });
+    expect(setUserMock).toHaveBeenCalledWith({ id: 'u-1' });
+    expect(moduleSetTagMock).toHaveBeenCalledWith('scope', 'organization');
+    expect(moduleSetTagMock).toHaveBeenCalledWith('orgId', 'o-1');
+    expect(moduleSetTagMock).toHaveBeenCalledWith('partnerId', 'p-1');
+  });
+
+  it('maps null orgId and partnerId to "none"', async () => {
+    process.env.SENTRY_DSN = 'https://example@o0.ingest.sentry.io/0';
+    const { initSentry, setSentryRequestContext } = await import('./sentry');
+    initSentry();
+    setSentryRequestContext({ userId: 'u-2', scope: 'system', orgId: null, partnerId: null });
+    expect(moduleSetTagMock).toHaveBeenCalledWith('orgId', 'none');
+    expect(moduleSetTagMock).toHaveBeenCalledWith('partnerId', 'none');
   });
 });
 

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -107,6 +107,30 @@ export function captureMessage(
   });
 }
 
+/**
+ * Attach the authenticated tenant/user to the current request's Sentry
+ * isolation scope (#1379 B2). Every event captured later in the request —
+ * route throws, contextless-write warnings, RLS-deny tags — inherits these,
+ * so triage on a multi-tenant RMM stops being guesswork. Only non-secret
+ * identifiers are tagged (no token, no password, no mfaSecret).
+ */
+export function setSentryRequestContext(ctx: {
+  userId: string;
+  scope: 'system' | 'partner' | 'organization';
+  orgId: string | null;
+  partnerId: string | null;
+}): void {
+  if (!initialized) {
+    return;
+  }
+  // Module-level setters target the per-request isolation scope under the
+  // node http integration — safe across concurrent requests and async hops.
+  Sentry.setUser({ id: ctx.userId });
+  Sentry.setTag('scope', ctx.scope);
+  Sentry.setTag('orgId', ctx.orgId ?? 'none');
+  Sentry.setTag('partnerId', ctx.partnerId ?? 'none');
+}
+
 export async function flushSentry(timeoutMs = 2000): Promise<void> {
   if (!initialized) {
     return;

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -108,11 +108,18 @@ export function captureMessage(
 }
 
 /**
- * Attach the authenticated tenant/user to the current request's Sentry
- * isolation scope (#1379 B2). Every event captured later in the request —
- * route throws, contextless-write warnings, RLS-deny tags — inherits these,
- * so triage on a multi-tenant RMM stops being guesswork. Only non-secret
- * identifiers are tagged (no token, no password, no mfaSecret).
+ * Attach the authenticated tenant/user to the active Sentry isolation scope
+ * (#1379 B2). Every event captured later in the same scope — route throws,
+ * contextless-write warnings, RLS-deny tags — inherits these, so triage on a
+ * multi-tenant RMM stops being guesswork. Only non-secret identifiers are
+ * tagged (no token, no password, no mfaSecret).
+ *
+ * IMPORTANT: these module-level setters write to whatever isolation scope is
+ * currently active. Call this function only from INSIDE a
+ * `withSentryRequestScope` callback so the writes are confined to that
+ * request's scope rather than the global scope. Calling it at module level
+ * or outside an isolation scope can mis-attribute tags across concurrent
+ * requests.
  */
 export function setSentryRequestContext(ctx: {
   userId: string;
@@ -123,12 +130,37 @@ export function setSentryRequestContext(ctx: {
   if (!initialized) {
     return;
   }
-  // Module-level setters target the per-request isolation scope under the
-  // node http integration — safe across concurrent requests and async hops.
   Sentry.setUser({ id: ctx.userId });
   Sentry.setTag('scope', ctx.scope);
   Sentry.setTag('orgId', ctx.orgId ?? 'none');
   Sentry.setTag('partnerId', ctx.partnerId ?? 'none');
+}
+
+/**
+ * Run the rest of a request inside a dedicated Sentry isolation scope, tagged
+ * with the tenant (#1379 B2). Using an EXPLICIT isolation scope (rather than
+ * relying on httpIntegration to fork one per request) guarantees the tags set
+ * by setSentryRequestContext stay confined to THIS request even under
+ * concurrency — Sentry.init() installs the AsyncLocalStorage async-context
+ * strategy that makes withIsolationScope request-local. Passthrough (no scope)
+ * when Sentry is disabled.
+ */
+export function withSentryRequestScope<T>(
+  ctx: {
+    userId: string;
+    scope: 'system' | 'partner' | 'organization';
+    orgId: string | null;
+    partnerId: string | null;
+  },
+  run: () => T
+): T {
+  if (!initialized) {
+    return run();
+  }
+  return Sentry.withIsolationScope(() => {
+    setSentryRequestContext(ctx);
+    return run();
+  });
 }
 
 export async function flushSentry(timeoutMs = 2000): Promise<void> {


### PR DESCRIPTION
## What

Phase **B2** of #1379 (silent-failure observability): attach the authenticated tenant/user to every request's Sentry events so triage on a multi-tenant RMM stops being guesswork. Until now `services/sentry.ts` tagged only `method`/`path` — no `setUser`, no org/partner tags.

**Builds on the already-shipped pieces:** B1 worker observability (#1380), B6 RLS-deny `42501` tagging (#1805). This is the next item in the issue's own rollout order (B1 → B2 → …).

## Changes

- **`setSentryRequestContext(ctx)`** (`apps/api/src/services/sentry.ts`) — sets `Sentry.setUser({ id })` + `scope`/`orgId`/`partnerId` tags. Non-secret identifiers only (no token/password/cookie/mfaSecret). No-op when Sentry is disabled.
- **`withSentryRequestScope(ctx, run)`** (`apps/api/src/services/sentry.ts`) — wraps the downstream request in an explicit `Sentry.withIsolationScope()`. See **Isolation note** below.
- **`authMiddleware`** (`apps/api/src/middleware/auth.ts`) — wraps the entire downstream dispatch (both the self-managed-db-context branch and the `withDbAccessContext` branch) in `withSentryRequestScope`, right after `c.set('auth', …)`. Auth logic, the auth payload, and return semantics are unchanged.

## Isolation note (review finding, fixed)

The first pass relied on `httpIntegration` auto-forking a per-request isolation scope. Whole-branch review found that premise unreliable in this server: `initSentry()` runs late in `bootstrap()` (`index.ts:1398`), there's no `--import` preload, and we run `@hono/node-server` — so module-level `setUser`/`setTag` could land on the **global** scope and mis-attribute tenant tags across concurrent requests (telemetry-only blast radius, gated on `SENTRY_DSN`, no RLS/data-path impact). 

**Fix:** an explicit `Sentry.withIsolationScope()` wrapper, which uses the AsyncLocalStorage async-context strategy that `Sentry.init()` installs independent of httpIntegration timing. `withDbAccessContext`'s own ALS nests inside it without interference.

## Tests

- `sentry.test.ts` — 13 (no-op-when-disabled guard, tag values, `null → 'none'` coalescing)
- `sentry.isolation.test.ts` — real (unmocked) `@sentry/node`, two concurrent tenants with interleaved captures, asserts each event carries its own tags. **Verified non-vacuous** — review empirically confirmed it fails (`expected 'none' to be 'oA'`) if the isolation scope is removed.
- `auth.test.ts` — 51, unchanged, still green.
- **64/64 passing, `tsc --noEmit` clean.**

Remaining #1379 items (A1 CI-throw, A3 contract test, B3 `beforeSend`, B4 `uncaughtException`, A2 `dbWriteExpectingRows`) ship as separate PRs per the plan.

Closes nothing — #1379 stays open until the remaining phases land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)