### PR TITLE
feat(observability): beforeSend PII scrub + uncaughtException handler (#1379 B3+B4)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1387,6 +1387,20 @@ function installSignalHandlers(): void {
     console.error('[FATAL] Unhandled rejection:', reason);
     captureException(reason instanceof Error ? reason : new Error(String(reason)));
   });
+
+  // #1379 B4 — a synchronous uncaughtException otherwise tears the process
+  // down with no telemetry. Capture + flush before exit; reuse the benign
+  // suppression list so SDK races don't crash us.
+  process.on('uncaughtException', (err) => {
+    if (isBenignRejection(err)) {
+      console.warn('[SDK] Suppressed benign uncaught exception:', err.message);
+      return;
+    }
+    console.error('[FATAL] Uncaught exception:', err);
+    captureException(err);
+    // Best-effort drain, then exit non-zero so the supervisor restarts us.
+    void flushSentry().finally(() => process.exit(1));
+  });
 }
 
 async function bootstrap(): Promise<void> {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -143,6 +143,7 @@ import { adminRoutes } from './routes/admin';
 import { internalSyntheticRoutes } from './routes/internal/synthetic';
 import { bootstrapPlatformAdmins } from './services/platformAdminBootstrap';
 import { captureException, flushSentry, initSentry } from './services/sentry';
+import { isBenignRejection } from './services/rejectionSuppressions';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
 
@@ -1378,16 +1379,13 @@ function installSignalHandlers(): void {
   // the dead subprocess and throws "ProcessTransport is not ready for writing".
   // This is a benign race condition — log it instead of crashing the process.
   process.on('unhandledRejection', (reason) => {
-    const message = reason instanceof Error ? reason.message : String(reason);
-    // Only suppress SDK-specific benign rejections from session cleanup
-    if (message.includes('ProcessTransport is not ready for writing') ||
-        (reason instanceof Error && reason.name === 'AbortError') ||
-        (message.includes('Operation aborted') && message.includes('Transport'))) {
+    if (isBenignRejection(reason)) {
+      const message = reason instanceof Error ? reason.message : String(reason);
       console.warn('[SDK] Suppressed benign unhandled rejection (session already closed):', message);
       return;
     }
     console.error('[FATAL] Unhandled rejection:', reason);
-    captureException(reason instanceof Error ? reason : new Error(message));
+    captureException(reason instanceof Error ? reason : new Error(String(reason)));
   });
 }
 

--- a/apps/api/src/services/rejectionSuppressions.test.ts
+++ b/apps/api/src/services/rejectionSuppressions.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { isBenignRejection } from './rejectionSuppressions';
+
+describe('isBenignRejection', () => {
+  it('suppresses ProcessTransport-not-ready', () => {
+    expect(isBenignRejection(new Error('ProcessTransport is not ready for writing'))).toBe(true);
+  });
+  it('suppresses AbortError by name', () => {
+    const e = new Error('aborted'); e.name = 'AbortError';
+    expect(isBenignRejection(e)).toBe(true);
+  });
+  it('suppresses "Operation aborted" + Transport', () => {
+    expect(isBenignRejection(new Error('Operation aborted on Transport'))).toBe(true);
+  });
+  it('does NOT suppress a real error', () => {
+    expect(isBenignRejection(new Error('TypeError: cannot read x of undefined'))).toBe(false);
+  });
+});

--- a/apps/api/src/services/rejectionSuppressions.ts
+++ b/apps/api/src/services/rejectionSuppressions.ts
@@ -1,0 +1,13 @@
+/**
+ * Benign unhandled-rejection predicate (#1379 B3). Centralizes the SDK
+ * session-cleanup races previously inlined in index.ts so the
+ * unhandledRejection AND uncaughtException (B4) handlers share one list.
+ */
+export function isBenignRejection(reason: unknown): boolean {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  return (
+    message.includes('ProcessTransport is not ready for writing') ||
+    (reason instanceof Error && reason.name === 'AbortError') ||
+    (message.includes('Operation aborted') && message.includes('Transport'))
+  );
+}

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -179,6 +179,40 @@ describe('setSentryRequestContext', () => {
   });
 });
 
+describe('scrubEvent', () => {
+  it('redacts authorization and cookie headers', async () => {
+    const { scrubEvent } = await import('./sentry');
+    const out = scrubEvent({
+      request: { headers: { authorization: 'Bearer brz_secret', cookie: 'session=abc', 'user-agent': 'x' } },
+    } as any);
+    expect(out.request.headers.authorization).toBe('[redacted]');
+    expect(out.request.headers.cookie).toBe('[redacted]');
+    expect(out.request.headers['user-agent']).toBe('x');
+  });
+
+  it('redacts password and mfaSecret in extra', async () => {
+    const { scrubEvent } = await import('./sentry');
+    const out = scrubEvent({ extra: { password: 'p', mfaSecret: 's', orgId: 'o-1' } } as any);
+    expect(out.extra.password).toBe('[redacted]');
+    expect(out.extra.mfaSecret).toBe('[redacted]');
+    expect(out.extra.orgId).toBe('o-1');
+  });
+
+  it('redacts extra values starting with brz_', async () => {
+    const { scrubEvent } = await import('./sentry');
+    const out = scrubEvent({ extra: { apiKey: 'brz_abc123', orgId: 'o-1' } } as any);
+    expect(out.extra.apiKey).toBe('[redacted]');
+    expect(out.extra.orgId).toBe('o-1');
+  });
+
+  it('does not throw on events missing request/headers/extra', async () => {
+    const { scrubEvent } = await import('./sentry');
+    expect(() => scrubEvent({} as any)).not.toThrow();
+    expect(() => scrubEvent({ request: {} } as any)).not.toThrow();
+    expect(() => scrubEvent({ request: { headers: {} } } as any)).not.toThrow();
+  });
+});
+
 describe('sentry bootstrap wiring (index.ts)', () => {
   const indexSource = readFileSync(
     fileURLToPath(new URL('../index.ts', import.meta.url)),

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -18,6 +18,28 @@ const RLS_DENY_SQLSTATE = '42501';
 
 let initialized = false;
 
+const SENSITIVE_KEYS = new Set(['password', 'passwordhash', 'mfasecret', 'token', 'authorization', 'cookie']);
+
+/** Redact secrets before an event leaves the process (#1379 B3). Exported for test. */
+export function scrubEvent<T extends Record<string, any>>(event: T): T {
+  const headers = event?.request?.headers;
+  if (headers) {
+    for (const k of Object.keys(headers)) {
+      if (k.toLowerCase() === 'authorization' || k.toLowerCase() === 'cookie') headers[k] = '[redacted]';
+    }
+  }
+  const extra = event?.extra;
+  if (extra) {
+    for (const k of Object.keys(extra)) {
+      const v = extra[k];
+      if (SENSITIVE_KEYS.has(k.toLowerCase()) || (typeof v === 'string' && v.startsWith('brz_'))) {
+        extra[k] = '[redacted]';
+      }
+    }
+  }
+  return event;
+}
+
 function parseSampleRate(raw: string | undefined): number {
   if (!raw) return 0;
   const parsed = Number(raw);
@@ -45,7 +67,9 @@ export function initSentry(): void {
     // hand-maintained and went stale on the droplets (pinned at 0.64.1 while the
     // fleet ran 0.69.0), mistagging every event — so we no longer read it.
     release: API_VERSION,
-    tracesSampleRate
+    tracesSampleRate,
+    profilesSampleRate: parseSampleRate(process.env.SENTRY_PROFILES_SAMPLE_RATE),
+    beforeSend: (event) => scrubEvent(event)
   });
 
   initialized = true;


### PR DESCRIPTION
## What

Phases **B3 + B4** of #1379. **Stacked on #1823 (B2)** — base this PR's review on the B2 branch; its own diff is the 3 commits below. Merge after #1823.

- **B3 — `beforeSend` PII scrub + centralized suppression + profiles knob**
- **B4 — `uncaughtException` handler**

## Changes

**`rejectionSuppressions.ts`** (`isBenignRejection`) — pure predicate centralizing the SDK session-cleanup races previously inlined in the `unhandledRejection` handler. The handler now calls the predicate; suppression behavior is **byte-for-byte preserved** (verified in review).

**`sentry.ts` `scrubEvent` + `beforeSend`** — redacts `authorization`/`cookie` request headers (case-insensitive) and `password`/`passwordhash`/`mfasecret`/`token`/`authorization`/`cookie` keys plus any `brz_*` string value in `event.extra`. Registered as `beforeSend`. Adds a `profilesSampleRate` knob (`SENTRY_PROFILES_SAMPLE_RATE`, reusing `parseSampleRate`).

**`index.ts` `uncaughtException` handler** — benign (per `isBenignRejection`) → `console.warn` + return; otherwise `console.error` + `captureException` + `void flushSentry().finally(() => process.exit(1))` so a sync crash is captured and the flush isn't truncated before exit. Previously only `unhandledRejection` was handled.

## Tests

- `rejectionSuppressions.test.ts` — 4 (one per suppression branch + a real-error negative)
- `sentry.test.ts` — 16 (B2's 12 + 4 new `scrubEvent`: header redact, extra-key redact, `brz_` value redact, no-throw on sparse events)
- `uncaughtException` registers a process listener — no process-killing test (out of scope); gated by `tsc --noEmit` clean + existing suites green.
- **All green, tsc clean.**

## Known follow-up (out of scope, audited safe today)

`scrubEvent` walks `extra` + `request.headers` but not `event.contexts`. A call-site audit confirmed every `setContext` payload in the API carries only non-secret identifiers today (request `{method,path,userAgent}`, worker `{name}`, `oauth/log.ts` IDs + `uid.slice(0,8)`). The one untyped caller-controlled surface is `oauth/log.ts:69` — safe now, but worth a later issue to either scrub `contexts` in `scrubEvent` or constrain `logOauthError`'s context type.

Remaining #1379 items: A1 (CI-throw), A3 (contract test), A2 (`dbWriteExpectingRows`) — separate PRs (A1/A3 need a live integration DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)