### PR TITLE
feat(observability): dbWriteExpectingRows helper + apply to last_login_at (#1379 A2)

### DIFF
--- a/apps/api/src/db/dbWriteExpectingRows.test.ts
+++ b/apps/api/src/db/dbWriteExpectingRows.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/sentry', () => ({
+  captureMessage: vi.fn(),
+}));
+
+import { captureMessage } from '../services/sentry';
+import { dbWriteExpectingRows } from './dbWriteExpectingRows';
+
+describe('dbWriteExpectingRows', () => {
+  beforeEach(() => {
+    vi.mocked(captureMessage).mockClear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('returns rows untouched and does NOT warn when ≥1 row moved', async () => {
+    const out = await dbWriteExpectingRows('users.last_login_at', async () => [{ id: 'u-1' }]);
+    expect(out).toEqual([{ id: 'u-1' }]);
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns via captureMessage when 0 rows moved', async () => {
+    const out = await dbWriteExpectingRows('users.last_login_at', async () => []);
+    expect(out).toEqual([]);
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('users.last_login_at'),
+      'warning',
+      expect.any(Object)
+    );
+  });
+
+  it('returns empty array and calls console.warn when 0 rows affected', async () => {
+    const result = await dbWriteExpectingRows('test.label', () => Promise.resolve([]));
+    expect(result).toEqual([]);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('test.label'),
+    );
+  });
+
+  it('does not throw when 0 rows are returned', async () => {
+    await expect(
+      dbWriteExpectingRows('test.label', () => Promise.resolve([]))
+    ).resolves.toEqual([]);
+  });
+});

--- a/apps/api/src/db/dbWriteExpectingRows.ts
+++ b/apps/api/src/db/dbWriteExpectingRows.ts
@@ -1,0 +1,18 @@
+import { captureMessage } from '../services/sentry';
+
+/**
+ * Run a write that MUST move ≥1 row (use `.returning()`) and surface a 0-row
+ * result as a Sentry warning (#1379 A2). Catches an RLS regression that lets
+ * the context wrapper through but still denies the row — the #1375 class, at
+ * the call-site. Opt-in and non-throwing: zero false positives, only wrap
+ * sites you KNOW must affect a row (never idempotent upserts).
+ */
+export async function dbWriteExpectingRows<T>(label: string, run: () => Promise<T[]>): Promise<T[]> {
+  const rows = await run();
+  if (rows.length === 0) {
+    const message = `Expected-rows write affected 0 rows: ${label}`;
+    console.warn(message);
+    captureMessage(message, 'warning', { label, stack: new Error().stack });
+  }
+  return rows;
+}

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -176,7 +176,9 @@ function selectChain(rows: unknown[]) {
 function updateChain() {
   return {
     set: vi.fn().mockReturnValue({
-      where: vi.fn(async () => undefined),
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'user-1' }]),
+      }),
     }),
   };
 }

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -57,6 +57,7 @@ import { readMobileDeviceId, carryForwardBinding } from '../../services/mobileDe
 import { enforceIpAllowlist, IP_NOT_ALLOWED_BODY, isBlocked } from '../../services/ipAllowlist';
 import { captureException } from '../../services/sentry';
 import { cfAccessLoginMiddleware } from '../../middleware/cfAccessLogin';
+import { dbWriteExpectingRows } from '../../db/dbWriteExpectingRows';
 
 const { db, withSystemDbAccessContext } = dbModule;
 
@@ -491,10 +492,13 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
   // the bug that froze last_login_at platform-wide (#1375). System scope
   // satisfies RLS the same way the pre-auth user lookup above does.
   await withSystemDbAccessContext(() =>
-    db
-      .update(users)
-      .set({ lastLoginAt: new Date() })
-      .where(eq(users.id, user.id))
+    dbWriteExpectingRows('users.last_login_at', () =>
+      db
+        .update(users)
+        .set({ lastLoginAt: new Date() })
+        .where(eq(users.id, user.id))
+        .returning({ id: users.id })
+    )
   );
 
   // Task 10: clear the per-account failure counter on successful login so


### PR DESCRIPTION
## What

Phase **A2** of #1379. **Stacked on #1824 (B3+B4)** — merge after it. (A2 is functionally independent of B2/B3/B4; stacked only to keep one linear chain.)

A small, **opt-in, zero-false-positive** helper for the known self-write sites: it asserts a write actually moved ≥1 row, catching a future RLS regression that lets the DB-context wrapper through but still denies the row — the #1375 class, caught at the call-site (complementing the runtime functional check A3 will add).

## Changes

**`db/dbWriteExpectingRows.ts`** — `dbWriteExpectingRows<T>(label, run: () => Promise<T[]>): Promise<T[]>`. Awaits `run()`; on 0 rows → `console.warn` + `captureMessage(message, 'warning', { label, stack })`, then returns the empty array. **Never throws** (a real rejection from `run()` propagates; only the 0-row case is guarded). No generic "0-row UPDATE" warning anywhere — too noisy for idempotent upserts, per the issue.

**`routes/auth/login.ts`** — the canonical #1375 site (the `last_login_at` update) now routes through the helper with `.returning({ id: users.id })`, kept inside `withSystemDbAccessContext` (wrapper + the explanatory #1375 comment untouched).

**`routes/auth/login.test.ts`** — updated the shared `updateChain()` mock so `.where()` is chainable and `.returning()` resolves to `[{ id: 'user-1' }]`. Review traced the shared-mock risk: the two IP-deny / inactive-tenant describe blocks exit before the update (mock never resolved there), and the #1375 guard reaches `.returning()` correctly with its context assertion still valid.

## Tests

- `dbWriteExpectingRows.test.ts` — 4 (returns rows / warns on 0-row via captureMessage / no spurious warn on success / resolves-not-throws)
- `login.test.ts` — 10, all green (incl. the #1375 system-context guard)
- **tsc clean.**

Remaining #1379 items: **A1** (CI-throw escalation) and **A3** (functional contract test) — both need a live integration DB (`:5433`) and have discovery loops, so they ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)