### PR TITLE
docs: sharpen Codex delegation guidance from benchmark

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ cd e2e-tests && pnpm test
 
 ## Codex Delegation
 
-This project uses OpenAI Codex CLI for isolated, well-scoped tasks (file operations, utility generation, CRUD endpoints, code analysis). Keep with Claude: multi-tenant isolation, auth/authz, cross-module refactoring, and task coordination. For commands, reasoning levels, and the full delegation matrix, use the **`delegating-to-codex`** skill.
+This project uses OpenAI Codex CLI for **read-only analysis (bug-hunting, security review, design-from-plan — its strongest uses) and well-scoped single-file edits** (utilities, co-located tests, CRUD endpoints, mechanical renames). Keep with Claude: repo-wide sweeps/enumeration, cross-module refactors (codex misses existing canonical code), UI work, and the *architecture* of multi-tenant/auth changes — though codex may *execute* an RLS migration once Claude hands it the tenancy contract. Default to `high`; reserve `xhigh` for open-ended design. For commands, reasoning levels, and the benchmarked delegation matrix, use the **`delegating-to-codex`** skill.
 
 ---
 


### PR DESCRIPTION
Refines the **Codex Delegation** section of `CLAUDE.md` based on an empirical benchmark.

**What I did:** ran 10 representative Breeze tasks through `codex exec` (gpt-5.5) at both `high` and `xhigh` — each in an isolated git worktree, graded objectively (typecheck / tests / findings verified against the real code).

**Findings that drove the wording:**
- **Strongest:** read-only bug-hunting/correctness analysis (found a real tenant-isolation bug, zero hallucinations), security review of a self-contained file, and design-from-a-plan-doc.
- Also reliable: co-located unit tests, single well-scoped endpoints, mechanical cross-file renames.
- **Weak / keep with Claude:** repo-wide enumeration (56% recall at high, ~3% at xhigh — it silently under-scopes); cross-module refactors (created a redundant module instead of reusing the existing canonical util, missed 2/16 sites); large UI splits (plausible but unverifiable without real QA).
- **RLS/tenancy:** codex *can* produce a correct Shape-1 migration, but only when handed the tenancy contract — it never self-discovers RLS obligations. So Claude owns the architecture decision; codex may execute.
- **Effort:** `high` is the best quality/cost point; `xhigh` is not a strict upgrade (1.5–3× slower, worse on enumeration).

Companion change: the `delegating-to-codex` skill (in `~/.claude`, not this repo) now carries the full benchmarked matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)