### PR TITLE
feat(observability): opt-in contextless-write strict gate + login last_login_at contract test (#1379 A1+A3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,7 +822,6 @@ jobs:
           APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
           MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
           NODE_ENV: test
-          DB_CONTEXTLESS_WRITE_STRICT: 'true'
         run: pnpm --filter=@breeze/api test:integration
 
       # The rls-coverage contract test inspects pg_catalog to verify every
@@ -842,7 +841,6 @@ jobs:
           APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
           MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
           NODE_ENV: test
-          DB_CONTEXTLESS_WRITE_STRICT: 'true'
         run: pnpm --filter=@breeze/api test:rls-coverage
 
       - name: Show container logs on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,6 +822,7 @@ jobs:
           APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
           MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
           NODE_ENV: test
+          DB_CONTEXTLESS_WRITE_STRICT: 'true'
         run: pnpm --filter=@breeze/api test:integration
 
       # The rls-coverage contract test inspects pg_catalog to verify every
@@ -841,6 +842,7 @@ jobs:
           APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
           MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
           NODE_ENV: test
+          DB_CONTEXTLESS_WRITE_STRICT: 'true'
         run: pnpm --filter=@breeze/api test:rls-coverage
 
       - name: Show container logs on failure

--- a/apps/api/src/__tests__/integration/contextlessWriteStrict.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contextlessWriteStrict.integration.test.ts
@@ -22,8 +22,10 @@ const CONTEXTLESS_MSG = 'ran with no RLS access context';
 
 describe('#1379 A1 — DB_CONTEXTLESS_WRITE_STRICT', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
+  let originalStrict: string | undefined;
 
   beforeEach(() => {
+    originalStrict = process.env.DB_CONTEXTLESS_WRITE_STRICT;
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     // Reset dedup set so captureMessage path is eligible each test (console.warn
     // fires regardless, but clearing ensures consistent state).
@@ -32,11 +34,16 @@ describe('#1379 A1 — DB_CONTEXTLESS_WRITE_STRICT', () => {
 
   afterEach(() => {
     warnSpy.mockRestore();
-    delete process.env.DB_CONTEXTLESS_WRITE_STRICT;
+    if (originalStrict === undefined) {
+      delete process.env.DB_CONTEXTLESS_WRITE_STRICT;
+    } else {
+      process.env.DB_CONTEXTLESS_WRITE_STRICT = originalStrict;
+    }
   });
 
   it('warn-only by default: contextless write warns, does not throw', async () => {
-    // No strict env set — prod-safe default.
+    // Explicitly clear so this test is hermetic regardless of ambient CI env.
+    delete process.env.DB_CONTEXTLESS_WRITE_STRICT;
     await db.update(users).set({ updatedAt: new Date() }).where(eq(users.id, PHANTOM_ID));
 
     const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes(CONTEXTLESS_MSG));

--- a/apps/api/src/__tests__/integration/contextlessWriteStrict.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contextlessWriteStrict.integration.test.ts
@@ -1,0 +1,67 @@
+/**
+ * #1379 A1 — DB_CONTEXTLESS_WRITE_STRICT env gate.
+ *
+ * Verifies that reportContextlessWrite:
+ *   1. warns (no throw) by default — prod-safe behaviour unchanged.
+ *   2. throws under DB_CONTEXTLESS_WRITE_STRICT=true — CI gate.
+ *   3. is completely silent when the write is properly wrapped in a context.
+ *
+ * Uses a real contextless db.update() against a non-existent UUID row so no
+ * real data is touched but the guard is triggered at query-execution time.
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext, __resetContextlessWriteGuardForTests } from '../../db';
+import { users } from '../../db/schema';
+
+// A UUID that must not exist in the test DB.
+const PHANTOM_ID = '00000000-dead-beef-0000-000000000000';
+
+const CONTEXTLESS_MSG = 'ran with no RLS access context';
+
+describe('#1379 A1 — DB_CONTEXTLESS_WRITE_STRICT', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Reset dedup set so captureMessage path is eligible each test (console.warn
+    // fires regardless, but clearing ensures consistent state).
+    __resetContextlessWriteGuardForTests();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    delete process.env.DB_CONTEXTLESS_WRITE_STRICT;
+  });
+
+  it('warn-only by default: contextless write warns, does not throw', async () => {
+    // No strict env set — prod-safe default.
+    await db.update(users).set({ updatedAt: new Date() }).where(eq(users.id, PHANTOM_ID));
+
+    const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes(CONTEXTLESS_MSG));
+    expect(hit).toBeTruthy();
+    expect(String(hit![0])).toContain('#1375');
+  });
+
+  it('throws under DB_CONTEXTLESS_WRITE_STRICT=true', async () => {
+    process.env.DB_CONTEXTLESS_WRITE_STRICT = 'true';
+
+    // The guard throws synchronously at db.update() call time (before the chain
+    // is awaited), so wrap in an async fn so rejects.toThrow can catch it.
+    await expect(async () => {
+      await db.update(users).set({ updatedAt: new Date() }).where(eq(users.id, PHANTOM_ID));
+    }).rejects.toThrow(CONTEXTLESS_MSG);
+  });
+
+  it('no throw or warn when write is properly wrapped in withSystemDbAccessContext', async () => {
+    process.env.DB_CONTEXTLESS_WRITE_STRICT = 'true';
+
+    await withSystemDbAccessContext(async () => {
+      await db.update(users).set({ updatedAt: new Date() }).where(eq(users.id, PHANTOM_ID));
+    });
+
+    const hit = warnSpy.mock.calls.find((c: unknown[]) => String(c[0]).includes(CONTEXTLESS_MSG));
+    expect(hit).toBeUndefined();
+  });
+});

--- a/apps/api/src/__tests__/integration/silent-write-contract.integration.test.ts
+++ b/apps/api/src/__tests__/integration/silent-write-contract.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Silent-write contract: login persists last_login_at under real breeze_app RLS
+ *
+ * Context (#1375/#1379 A3):
+ *   The /auth/login route writes `users.last_login_at` via `withSystemDbAccessContext`.
+ *   Prior to #1375 it used the bare `db` pool (connects as `breeze_app`), which meant
+ *   the UPDATE matched 0 rows silently under RLS — the column stayed NULL platform-wide.
+ *
+ *   The RLS-coverage structural test cannot catch this class of bug (it only checks that
+ *   policies exist, not that a specific write actually moves the row). This functional
+ *   contract test fills that gap: it drives the real login route end-to-end against the
+ *   real `breeze_app` pool and asserts the row moved.
+ *
+ * Run:
+ *   cd apps/api
+ *   export DATABASE_URL="postgresql://breeze_test:breeze_test@localhost:5433/breeze_test"
+ *   export DATABASE_URL_APP="postgresql://breeze_app:breeze_test@localhost:5433/breeze_test"
+ *   export REDIS_URL="redis://localhost:6380"
+ *   export NODE_ENV=test
+ *   pnpm exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/silent-write-contract.integration.test.ts
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { authRoutes } from '../../routes/auth';
+import { createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+import { users } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+
+// Import setup to initialize database connection and register beforeAll/beforeEach hooks
+import './setup';
+
+describe('silent-write contract: login persists last_login_at under real breeze_app RLS (#1375/#1379 A3)', () => {
+  let app: Hono;
+  let testPartnerId: string;
+
+  beforeEach(async () => {
+    // Mount a fresh Hono app per test — cleanupDatabase() truncates partners
+    // in the setup.ts beforeEach, so recreate one here.
+    app = new Hono();
+    app.route('/auth', authRoutes);
+    const partner = await createPartner();
+    testPartnerId = partner.id;
+  });
+
+  it('POST /auth/login updates users.last_login_at under real breeze_app RLS', async () => {
+    // Seed a user with a known password and a membership (login requires one).
+    const user = await createUser({
+      partnerId: testPartnerId,
+      email: 'lastlogin-contract@example.com',
+      password: 'MyPassword123!',
+      withMembership: true
+    });
+
+    // Verify the seeded row starts with a NULL last_login_at.
+    expect(user.lastLoginAt).toBeNull();
+
+    // Drive the real login route. The handler internally wraps its UPDATE in
+    // withSystemDbAccessContext, which is exactly the fix from #1375. If that
+    // wrapper were ever removed or broken, the UPDATE would match 0 rows under
+    // breeze_app RLS — and the assertion below would catch it.
+    const res = await app.request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'lastlogin-contract@example.com',
+        password: 'MyPassword123!'
+      })
+    });
+
+    expect(res.status).toBe(200);
+
+    // Read the row back via the test-superuser connection (not breeze_app) so
+    // the SELECT itself is not gated by RLS — we are asserting the WRITE.
+    const db = getTestDb();
+    const [updatedUser] = await db
+      .select({ lastLoginAt: users.lastLoginAt })
+      .from(users)
+      .where(eq(users.id, user.id))
+      .limit(1);
+
+    expect(updatedUser).toBeDefined();
+    if (!updatedUser) throw new Error('Expected user row to exist after login');
+
+    // THE CONTRACT: last_login_at must not be null after a successful login.
+    // A future regression that silently 0-row-UPDATEs under breeze_app RLS
+    // will fail here rather than being invisible.
+    expect(updatedUser.lastLoginAt).not.toBeNull();
+  });
+});

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -241,11 +241,17 @@ function reportContextlessWrite(label: string): void {
   const message =
     `DB write ${label} ran with no RLS access context — `
     + `wrap in withDbAccessContext/withSystemDbAccessContext (#1375)`;
-  // #1379 A1 — escalate to a hard failure under an env gate so a contextless
-  // write reds CI instead of only warning. OFF by default (prod stays warn-only
-  // and never throws). The intentional contextless paths don't reach here:
-  // auditAdminPool bypasses this proxy, and device_commands writes under an
-  // explicit system context. Mirrors assertOutsideHeldDbContext's strict gate.
+  // #1379 A1 — opt-in escalation: set DB_CONTEXTLESS_WRITE_STRICT to make a
+  // contextless write THROW instead of only warning, so a targeted run (a
+  // developer hunting a #1375 regression) fails loudly. OFF by default — prod
+  // AND CI stay warn-only for now. Global CI enforcement is deferred: ~20 RLS
+  // negative-control integration tests deliberately issue contextless writes
+  // through this proxy to prove DB-layer rejection, and must be migrated off
+  // the proxy (or opt out) before the gate can be flipped on suite-wide
+  // (tracked as a #1379 follow-up). The genuinely-intentional production paths
+  // never reach here anyway: auditAdminPool bypasses this proxy, and
+  // device_commands writes under an explicit system context. Mirrors
+  // assertOutsideHeldDbContext's strict gate.
   if (STRICT_TRIPWIRE_VALUES.has((process.env.DB_CONTEXTLESS_WRITE_STRICT ?? '').trim().toLowerCase())) {
     throw new Error(message);
   }

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -236,17 +236,19 @@ export function __resetContextlessWriteGuardForTests(): void {
   reportedContextlessSites.clear();
 }
 
-// Warn-only (no throw) on purpose: it's a conservative, prod-safe rollout.
-// There ARE intentional contextless writers we must not break — the agent-WS
-// `device_commands` path is system-scoped, and the separate audit-admin pool
-// (auditAdminPool.ts) bypasses this proxy entirely — so a hard throw would
-// cause false-positive crashes. The throw-in-CI escalation is deferred to a
-// follow-up PR in #1379.
 function reportContextlessWrite(label: string): void {
   const stack = new Error().stack;
   const message =
     `DB write ${label} ran with no RLS access context — `
     + `wrap in withDbAccessContext/withSystemDbAccessContext (#1375)`;
+  // #1379 A1 — escalate to a hard failure under an env gate so a contextless
+  // write reds CI instead of only warning. OFF by default (prod stays warn-only
+  // and never throws). The intentional contextless paths don't reach here:
+  // auditAdminPool bypasses this proxy, and device_commands writes under an
+  // explicit system context. Mirrors assertOutsideHeldDbContext's strict gate.
+  if (STRICT_TRIPWIRE_VALUES.has((process.env.DB_CONTEXTLESS_WRITE_STRICT ?? '').trim().toLowerCase())) {
+    throw new Error(message);
+  }
   console.warn(message);
   const key = stack ?? label;
   if (reportedContextlessSites.has(key)) return;


### PR DESCRIPTION
## What

Phases **A1** (opt-in strict gate) and **A3** (functional contract test) of #1379. **Stacked on #1825 (A2)** — merge last in the chain.

## A1 — contextless-write strict gate (opt-in)

Adds a `DB_CONTEXTLESS_WRITE_STRICT` env gate to `reportContextlessWrite` (`apps/api/src/db/index.ts`): when truthy, a contextless `db.insert/update/delete/execute(write)` **throws** instead of only warning, so a targeted run (e.g. a developer hunting a #1375 regression) fails loudly. **OFF by default** — prod and CI stay warn-only. Mirrors the existing sibling gate `assertOutsideHeldDbContext` / `DB_CONTEXT_TRIPWIRE_STRICT` (reuses `STRICT_TRIPWIRE_VALUES`). New integration test `contextlessWriteStrict.integration.test.ts` proves warn-default / throw-under-strict / no-throw-when-wrapped (hermetic — restores the ambient env var, doesn't leak across files).

### Why global CI enablement is deferred (important)

I ran the full integration suite under strict to discover offenders. The authoritative finding: **zero production-code contextless writes** — the codebase's `#1375`/`#1591` hardening is complete. The only strict throws came from **~20 RLS negative-control integration tests** that *deliberately* issue contextless writes through the proxy to prove the DB layer (RLS `WITH CHECK`, append-only triggers, table GRANTs) rejects them. Enabling strict suite-wide would preempt those DB-layer rejections with the proxy-guard throw.

So the gate ships **opt-in**; flipping it on suite-wide is a tracked follow-up that first migrates those negative-control tests off the `db` proxy (or opts them out). (Methodology note: an initial *warn-mode* discovery run reported "0 offenders" — that was a **false negative**, because vitest suppresses `console.warn` from passing tests in captured output. The strict run is authoritative.)

## A3 — functional contract test

New `silent-write-contract.integration.test.ts` proves the login route's `last_login_at` write **actually persists** under real `breeze_app` RLS (seed null → drive real `POST /auth/login` → read back → assert not-null). This is the functional #1375 guard the structural RLS-coverage test can't provide. It also confirmed the `auth.integration.test.ts` exclusion ("lastLoginAt not persisting") is **stale** — that predates the #1375 fix; the write persists correctly now.

## Tests

- `contextlessWriteStrict.integration.test.ts` — 3/3 (verified green under both ambient-unset and ambient-set conditions)
- `silent-write-contract.integration.test.ts` — 1/1 (lastLoginAt null→not-null under real `breeze_app` RLS)
- `tsc --noEmit` clean. Net `ci.yml` diff is empty; no production call-site changes.

## Follow-up (to file)

Audit/migrate the ~20 RLS negative-control integration tests off the `db` proxy, then enable `DB_CONTEXTLESS_WRITE_STRICT=true` in the integration-test CI job. No production bug blocks this — it's test-infrastructure work.

This completes the #1379 work I'm carrying (B2 #1823 · B3+B4 #1824 · A2 #1825 · A1+A3 here). Remaining issue item B5 (tracing) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)