### PR TITLE
fix(web): safelist runtime-built u-*-N utilities so prod CSS keeps them (#1829)

### DIFF
--- a/apps/web/tailwind.config.mjs
+++ b/apps/web/tailwind.config.mjs
@@ -1,6 +1,16 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  // The `u-*-<n>` utilities in src/styles/globals.css (@layer utilities) are
+  // referenced only via runtime string interpolation in src/lib/utils.ts
+  // (e.g. heightPxClass -> `u-h-px-${n}`), so the content scanner never sees a
+  // concrete class name and prod purges every rule, collapsing any element
+  // sized through those helpers (#1829). Safelist the whole family so the
+  // generated rules survive the production build. Covers all helpers in
+  // utils.ts: u-h-px / u-min-h-px / u-w-pct / u-h-pct / u-pl-px / u-ml-px /
+  // u-left-px / u-top-px / u-gap-px / u-grid-cols / u-grid-auto-rows-px /
+  // u-col-start / u-col-span / u-row-start / u-row-span.
+  safelist: [{ pattern: /^u-[a-z]+(?:-[a-z]+)*-\d+$/ }],
   darkMode: 'class',
   theme: {
     extend: {


### PR DESCRIPTION
Closes #1829.

## Problem

The positional utility helpers in `apps/web/src/lib/utils.ts` build class names by string interpolation (`heightPxClass` → `u-h-px-${n}`, and siblings). The concrete class names only ever exist at runtime, so Tailwind's content scanner never sees them. With no `safelist`, Tailwind tree-shakes the entire `.u-*-N` family (defined under `@layer utilities` in `src/styles/globals.css`) out of the production build. Any element sized through these helpers collapses (e.g. height → 0) in prod, while JIT dev (no purge) looks correct — which is why it only reproduces in prod.

## Fix

Safelist the whole `u-<segments>-<number>` family with one pattern:

```js
safelist: [{ pattern: /^u-[a-z]+(?:-[a-z]+)*-\d+$/ }],
```

This covers **all 15** helper prefixes — including the nine the issue's draft regex didn't enumerate: `u-w-pct`, `u-h-pct`, `u-pl-px`, `u-ml-px`, `u-gap-px`, `u-col-start`, `u-col-span`, `u-row-start`, `u-row-span` — so every consumer (`ChartWidget`, `DashboardGrid`, `ScriptCategoryTree`, `FileManager`, …) is unblocked at once, not just the height ones.

I went with Option 1 (safelist) over Options 2/3 because it's the smallest change and keeps the helper API untouched. I did confirm the concern that a `pattern` safelist might not retain *custom* `@layer utilities` — it does, in 3.4.17 (see below).

## Verification

Ran **tailwindcss 3.4.17** (the pinned version) with this exact config against the real `src/` content scan + `globals.css` (`@astrojs/tailwind` feeds the same config to the same engine, and the content scan can only *add* detected classes, never drop safelisted ones):

| | `u-*-N` rules in emitted CSS |
|---|---|
| without safelist | **0** (all 8489 purged — reproduces the bug) |
| with safelist | **8489** (1:1 with source, no over-match) |

Spot-checked across families: `u-h-px-560`, `u-min-h-px-100`, `u-w-pct-50`, `u-col-span-3`, `u-gap-px-16`, `u-grid-auto-rows-px-200` all present after the change, absent before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)