### PR TITLE
fix(installer): Windows install.bat must require elevation + stop reporting false success (#1832)

### DIFF
--- a/apps/api/src/services/installerBuilder.test.ts
+++ b/apps/api/src/services/installerBuilder.test.ts
@@ -320,4 +320,29 @@ describe('buildWindowsInstallerZip', () => {
     const batScript = await zipInstance.files['install.bat']!.async('string');
     expect(batScript).toContain(`set ENROLLMENT_KEY="${validKey}"`);
   });
+
+  it('gates install.bat on elevation before running msiexec (#1832)', async () => {
+    const zip = await buildWindowsInstallerZip(Buffer.from('msi'), {
+      serverUrl: 'https://breeze.example.com',
+      enrollmentKey: realEnrollmentKey(),
+      enrollmentSecret: 'secret456',
+      siteId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+    const zipInstance = await JSZip.loadAsync(zip);
+    const batScript = await zipInstance.files['install.bat']!.async('string');
+
+    // Admin gate exists and runs before the msiexec install line.
+    expect(batScript).toContain('net session >nul 2>&1');
+    expect(batScript).toMatch(/must be run as Administrator/i);
+    expect(batScript.indexOf('net session')).toBeLessThan(batScript.indexOf('msiexec /i'));
+
+    // Success is no longer printed unconditionally: it must come after the
+    // enroll exit-code guard, and msiexec failures abort the run.
+    expect(batScript).toContain('set "MSI_RC=!errorlevel!"');
+    expect(batScript).toContain('set "ENROLL_RC=!errorlevel!"');
+    const guardIdx = batScript.indexOf('if not "!ENROLL_RC!"=="0"');
+    const successIdx = batScript.indexOf('installed and enrolled successfully');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(successIdx);
+  });
 });

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -30,6 +30,18 @@ function generateWindowsInstallScript(enrollmentKey: string): string {
   return `@echo off
 setlocal EnableDelayedExpansion
 
+REM This installer runs msiexec, which requires elevation. Run unelevated it
+REM silently fails, the agent binary never lands in %ProgramFiles%\\Breeze, and
+REM the enroll step below then errors with a confusing "path not found" -- yet
+REM the script used to still print "installed successfully" (#1832). Fail fast
+REM with a clear message instead.
+net session >nul 2>&1
+if errorlevel 1 (
+    echo Error: this installer must be run as Administrator.
+    echo Right-click install.bat and choose "Run as administrator", or run it from an elevated command prompt.
+    exit /b 1
+)
+
 set "SCRIPT_DIR=%~dp0"
 set "ENROLLMENT_JSON=%SCRIPT_DIR%enrollment.json"
 set "MSI_PATH=%SCRIPT_DIR%breeze-agent.msi"
@@ -41,6 +53,12 @@ if not exist "%ENROLLMENT_JSON%" (
 
 echo Installing Breeze Agent...
 msiexec /i "%MSI_PATH%" /quiet /norestart
+REM msiexec: 0 = success, 3010 = success but reboot pending; anything else failed.
+set "MSI_RC=!errorlevel!"
+if not "!MSI_RC!"=="0" if not "!MSI_RC!"=="3010" (
+    echo Error: agent installation failed ^(msiexec exit code !MSI_RC!^).
+    exit /b 1
+)
 
 REM Wait for install to complete
 timeout /t 5 /nobreak >nul
@@ -66,9 +84,15 @@ if defined ENROLLMENT_SECRET if not "%ENROLLMENT_SECRET%"=="" (
 
 echo Enrolling agent...
 %ENROLL_CMD%
+set "ENROLL_RC=!errorlevel!"
 
-REM Clean up credentials
+REM Clean up credentials regardless of outcome (they must not be left behind).
 del "%ENROLLMENT_JSON%" 2>nul
+
+if not "!ENROLL_RC!"=="0" (
+    echo Error: agent enrollment failed ^(exit code !ENROLL_RC!^).
+    exit /b 1
+)
 
 echo Breeze agent installed and enrolled successfully.
 `;


### PR DESCRIPTION
Closes #1832.

## Problem

Running the Windows zip-bundle `install.bat` from a **non-elevated** prompt silently fails. `msiexec /i ... /quiet` needs admin, so:
1. the install silently fails,
2. the agent binary never lands in `%ProgramFiles%\Breeze`, so the enroll step errors with a confusing **"path not found"**, and
3. the script nonetheless prints **"Breeze agent installed and enrolled successfully."**

(As reported: misleading path error, then a false success.)

## Fix

Brings the Windows `.bat` up to the same "surface failures, don't swallow them" standard the macOS/Linux installer already follows:

- **Administrator gate** (`net session`) at the top — if not elevated, print a clear *"run as Administrator"* message and `exit /b 1` **before** touching msiexec.
- **Check msiexec's exit code** — `0` and `3010` (reboot-pending) are success; anything else aborts with the code.
- **Capture the enroll exit code** and only print the success line when enrollment actually succeeded. Credentials (`enrollment.json`) are still deleted regardless of outcome.

## Verification

- `installerBuilder` unit tests: **16/16 pass**, including a new test asserting the gate precedes the `msiexec /i` line and the success message is guarded by the enroll exit code.
- `eslint` and `tsc --noEmit` (api) both clean.
- Behavioral: on a Windows 11 **25H2 (build 26200)** box, the elevated path (`net session` → errorlevel `0` → proceed) was confirmed both as an admin shell and as `NT AUTHORITY\SYSTEM`. The unelevated branch relies on `net session`'s standard admin-only semantics (the conventional batch admin check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)