### PR TITLE
fix(security): stop reporting unencrypted devices as encrypted (#1831)

### DIFF
--- a/apps/api/src/routes/security/helpers.test.ts
+++ b/apps/api/src/routes/security/helpers.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeEncryption } from './helpers';
+
+describe('normalizeEncryption', () => {
+  // Regression for #1831: 'encrypted' is a substring of 'unencrypted', so an
+  // unencrypted device must not be classified as encrypted.
+  it('maps "unencrypted" to unencrypted (not encrypted)', () => {
+    expect(normalizeEncryption('unencrypted')).toBe('unencrypted');
+  });
+
+  it('maps "encrypted" to encrypted', () => {
+    expect(normalizeEncryption('encrypted')).toBe('encrypted');
+  });
+
+  it('maps "partial" to partial', () => {
+    expect(normalizeEncryption('partial')).toBe('partial');
+  });
+
+  it('is case-insensitive', () => {
+    expect(normalizeEncryption('Unencrypted')).toBe('unencrypted');
+    expect(normalizeEncryption('ENCRYPTED')).toBe('encrypted');
+  });
+
+  it('treats unknown/empty as unencrypted (fail-safe default)', () => {
+    expect(normalizeEncryption('unknown')).toBe('unencrypted');
+    expect(normalizeEncryption('')).toBe('unencrypted');
+  });
+});

--- a/apps/api/src/routes/security/helpers.ts
+++ b/apps/api/src/routes/security/helpers.ts
@@ -110,6 +110,10 @@ export function mapThreatFilterToDb(status: ThreatStatus): string[] {
 export function normalizeEncryption(encryptionStatus: string): 'encrypted' | 'partial' | 'unencrypted' {
   const value = encryptionStatus.toLowerCase();
   if (value.includes('partial')) return 'partial';
+  // 'unencrypted' must be checked before 'encrypted' -- 'encrypted' is a
+  // substring of 'unencrypted', so the original order classified every
+  // unencrypted device as encrypted across the security views (#1831).
+  if (value.includes('unencrypted')) return 'unencrypted';
   if (value.includes('encrypted')) return 'encrypted';
   return 'unencrypted';
 }

--- a/apps/api/src/services/securityPosture.test.ts
+++ b/apps/api/src/services/securityPosture.test.ts
@@ -51,6 +51,21 @@ describe('scoreEncryption', () => {
     expect(scoreEncryption(deviceInputWithEncryption('disabled') as never).score).toBe(0);
   });
 
+  it('classifies mixed-case unencrypted as unencrypted (score 0)', () => {
+    expect(scoreEncryption(deviceInputWithEncryption('Unencrypted') as never).score).toBe(0);
+  });
+
+  // "unknown" must stay distinct from "unencrypted": it is a low-confidence
+  // data gap (score 50), not a definite 0. Guards against a fail-safe
+  // overcorrection that collapses unknown -> 0 (or -> 100).
+  it('treats unknown/missing status as a 50-score data gap, not 0 or 100', () => {
+    for (const status of ['unknown', '', null] as const) {
+      const result = scoreEncryption(deviceInputWithEncryption(status) as never);
+      expect(result.score).toBe(50);
+      expect(result.dataGap).toBeTruthy();
+    }
+  });
+
   it('prefers volume coverage over the status string when details are present', () => {
     const result = scoreEncryption(
       deviceInputWithEncryption('unencrypted', { volumes: [{ protected: true }, { protected: true }] }) as never

--- a/apps/api/src/services/securityPosture.test.ts
+++ b/apps/api/src/services/securityPosture.test.ts
@@ -1,6 +1,63 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeTrendPoint } from './securityPosture';
+import { computeTrendPoint, scoreEncryption } from './securityPosture';
+
+function deviceInputWithEncryption(encryptionStatus: string | null, encryptionDetails: unknown = null) {
+  return {
+    orgId: 'org-1',
+    deviceId: 'dev-1',
+    deviceName: 'host-1',
+    osType: 'windows' as const,
+    deviceStatus: 'online' as const,
+    osVersion: '10.0.19045',
+    security: {
+      realTimeProtection: true,
+      definitionsDate: null,
+      threatCount: 0,
+      firewallEnabled: true,
+      encryptionStatus,
+      encryptionDetails,
+      localAdminSummary: null,
+      passwordPolicySummary: null
+    },
+    patchStats: { totalCriticalAndImportant: 0, installedCriticalAndImportant: 0 },
+    activeThreats: 0,
+    portStats: { listeningPortCount: 0, riskyPortCount: 0 }
+  };
+}
+
+describe('scoreEncryption', () => {
+  // Regression for #1831: 'encrypted' is a substring of 'unencrypted', so the
+  // original substring-order classified unencrypted devices as encrypted and
+  // scored them 100 in the posture score. An unencrypted device must score 0.
+  it('scores an unencrypted device 0, not 100', () => {
+    const result = scoreEncryption(deviceInputWithEncryption('unencrypted') as never);
+    expect(result.score).toBe(0);
+    expect(result.evidence?.encryptionStatus).toBe('unencrypted');
+  });
+
+  it('still scores an encrypted device 100', () => {
+    const result = scoreEncryption(deviceInputWithEncryption('encrypted') as never);
+    expect(result.score).toBe(100);
+  });
+
+  it('scores a partially encrypted device 60', () => {
+    const result = scoreEncryption(deviceInputWithEncryption('partial') as never);
+    expect(result.score).toBe(60);
+  });
+
+  it('treats off/disabled as unencrypted (score 0)', () => {
+    expect(scoreEncryption(deviceInputWithEncryption('off') as never).score).toBe(0);
+    expect(scoreEncryption(deviceInputWithEncryption('disabled') as never).score).toBe(0);
+  });
+
+  it('prefers volume coverage over the status string when details are present', () => {
+    const result = scoreEncryption(
+      deviceInputWithEncryption('unencrypted', { volumes: [{ protected: true }, { protected: true }] }) as never
+    );
+    expect(result.score).toBe(100);
+  });
+});
 
 describe('computeTrendPoint', () => {
   it('derives vulnerability_management from open_ports and os_currency averages', () => {

--- a/apps/api/src/services/securityPosture.ts
+++ b/apps/api/src/services/securityPosture.ts
@@ -132,8 +132,12 @@ function normalizeEncryptionStatus(raw?: string | null): 'encrypted' | 'partial'
   if (!raw) return 'unknown';
   const value = raw.toLowerCase();
   if (value.includes('partial')) return 'partial';
-  if (value.includes('encrypted')) return 'encrypted';
+  // 'unencrypted' must be checked before 'encrypted' -- 'encrypted' is a
+  // substring of 'unencrypted', so the original order classified every
+  // unencrypted device as encrypted and scored it 100 in the posture score
+  // (the same #1831 substring bug fixed in routes/security/helpers.ts).
   if (value.includes('unencrypted') || value.includes('off') || value.includes('disabled')) return 'unencrypted';
+  if (value.includes('encrypted')) return 'encrypted';
   return 'unknown';
 }
 
@@ -172,7 +176,7 @@ function scorePatchCompliance(input: DeviceInput): FactorResult {
   };
 }
 
-function scoreEncryption(input: DeviceInput): FactorResult {
+export function scoreEncryption(input: DeviceInput): FactorResult {
   const volumeCoverage = getEncryptionVolumeCoverage(input.security.encryptionDetails);
   if (volumeCoverage !== null) {
     return {


### PR DESCRIPTION
Closes #1831.

## Problem

A fresh Windows 11 25H2 box with BitLocker **off** showed **"Disk Encryption: Encrypted"** in the Security tab. The agent was correct — the bug is server-side display normalization.

`normalizeEncryption()` (`apps/api/src/routes/security/helpers.ts`) classified status by substring, checking `encrypted` before the unencrypted case:

```ts
if (value.includes('partial')) return 'partial';
if (value.includes('encrypted')) return 'encrypted';   // "unencrypted".includes("encrypted") === true
return 'unencrypted';
```

`"encrypted"` is a substring of `"unencrypted"`, so every device the agent correctly reported as `unencrypted` was normalized to `encrypted`. This drives `toStatusResponse()` (the device Security tab), the compliance dashboard's encrypted/unencrypted counts (`compliance.ts`), and `computeSecurityScore()` — so it under-counts unencrypted devices fleet-wide, not just on one tab.

## Root-cause trace (verified)

On Windows 11 **25H2 (build 26200)**, BitLocker off:
- `Get-BitLockerVolume -MountPoint $env:SystemDrive | Select -ExpandProperty ProtectionStatus` → `Off`, both as an admin shell and as `NT AUTHORITY\SYSTEM` (the agent's context).
- `getEncryptionStatusWindows()` → `parseBitLockerProtectionStatus("Off")` → `unencrypted`. Correct, and identical in v0.81.0 (the reporter's version) and `main`.
- Stored value: `unencrypted`. Then `normalizeEncryption("unencrypted")` → `encrypted`. ← the bug.

## Fix

Check `unencrypted` before `encrypted`. Adds `helpers.test.ts` covering the substring regression plus the encrypted / partial / unknown / empty paths.

## Verification

`vitest src/routes/security/helpers.test.ts` (5/5), `eslint`, and `tsc --noEmit` (api) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)