### PR TITLE
fix(api): stop masking S3 transport faults in viewer/software download paths (#1808)

### DIFF
--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../../services/s3Storage', () => ({
   isS3Configured: vi.fn(() => false),
   getPresignedUrl: vi.fn(),
+  isS3NotFound: (err: unknown) => {
+    const name = (err as { name?: string }).name;
+    return name === 'NotFound' || name === 'NoSuchKey';
+  },
 }));
 
 vi.mock('../../services/binarySource', () => ({

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -2,21 +2,10 @@ import { Hono } from 'hono';
 import { statSync, createReadStream } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { VALID_OS, VALID_ARCH } from './schemas';
-import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
+import { isS3Configured, getPresignedUrl, isS3NotFound } from '../../services/s3Storage';
 import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubWatchdogUrl, HELPER_FILENAMES } from '../../services/binarySource';
 
 export const downloadRoutes = new Hono();
-
-// A presigned-URL failure is only "the object isn't there" for NotFound /
-// NoSuchKey — anything else (network, credentials, throttling, DNS) is a real
-// S3 transport/auth fault. Distinguishing them matters because the disk
-// fallback below 404s when the binary isn't on local disk: on hosted infra
-// (S3-only, no binaries on disk) a transport fault would otherwise be masked as
-// a misleading "binary not found" 404 instead of surfacing as a 500 (issue #1802).
-function isS3NotFound(err: unknown): boolean {
-  const errName = (err as { name?: string }).name;
-  return errName === 'NotFound' || errName === 'NoSuchKey';
-}
 
 // ============================================
 // Agent Binary Download (public, no auth)

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -14,7 +14,7 @@ import {
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
-import { uploadBinary, getPresignedUrl, isS3Configured } from '../services/s3Storage';
+import { uploadBinary, getPresignedUrl, isS3Configured, isS3NotFound } from '../services/s3Storage';
 import { sendCommandToAgent, type AgentCommand } from './agentWs';
 import {
   parseStreamingMultipart,
@@ -1028,7 +1028,14 @@ softwareRoutes.post(
       if (versionRecord.s3Key && isS3Configured()) {
         try {
           downloadUrl = await getPresignedUrl(versionRecord.s3Key, 3600);
-        } catch { /* S3 may not be available */ }
+        } catch (err) {
+          // Don't swallow: a transport/auth fault must be visible even though we
+          // still fall back to the stored downloadUrl below (#1808).
+          console[isS3NotFound(err) ? 'warn' : 'error'](
+            `[software-deploy] S3 presign failed for ${versionRecord.s3Key}, falling back to stored downloadUrl:`,
+            err,
+          );
+        }
       }
       downloadUrl = downloadUrl ?? versionRecord.downloadUrl;
 
@@ -1176,7 +1183,16 @@ softwareRoutes.post(
       if (scheduleType === 'immediate') {
         let downloadUrl: string | null = null;
         if (versionRecord.s3Key && isS3Configured()) {
-          try { downloadUrl = await getPresignedUrl(versionRecord.s3Key, 3600); } catch { /* */ }
+          try {
+            downloadUrl = await getPresignedUrl(versionRecord.s3Key, 3600);
+          } catch (err) {
+            // Don't swallow: surface transport/auth faults even though we still
+            // fall back to the stored downloadUrl below (#1808).
+            console[isS3NotFound(err) ? 'warn' : 'error'](
+              `[software-deploy] S3 presign failed for ${versionRecord.s3Key}, falling back to stored downloadUrl:`,
+              err,
+            );
+          }
         }
         downloadUrl = downloadUrl ?? versionRecord.downloadUrl;
 

--- a/apps/api/src/routes/viewers/download.test.ts
+++ b/apps/api/src/routes/viewers/download.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../../services/s3Storage', () => ({
   isS3Configured: vi.fn(() => false),
   getPresignedUrl: vi.fn(),
+  isS3NotFound: (err: unknown) => {
+    const name = (err as { name?: string }).name;
+    return name === 'NotFound' || name === 'NoSuchKey';
+  },
 }));
 
 vi.mock('../../services/binarySource', () => ({
@@ -16,6 +20,7 @@ vi.mock('../../services/binarySource', () => ({
 }));
 
 import { viewerDownloadRoutes } from './download';
+import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
 
 describe('public viewer downloads', () => {
   const originalViewerDir = process.env.VIEWER_BINARY_DIR;
@@ -23,11 +28,14 @@ describe('public viewer downloads', () => {
   beforeEach(() => {
     process.env.VIEWER_BINARY_DIR = '/tmp/breeze-secret-viewer-binaries';
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     if (originalViewerDir === undefined) delete process.env.VIEWER_BINARY_DIR;
     else process.env.VIEWER_BINARY_DIR = originalViewerDir;
+    vi.mocked(isS3Configured).mockReset();
+    vi.mocked(getPresignedUrl).mockReset();
     vi.restoreAllMocks();
   });
 
@@ -42,5 +50,32 @@ describe('public viewer downloads', () => {
       '[viewer-download] Local installer missing',
       { filename: 'Breeze Viewer.AppImage' },
     );
+  });
+
+  it('returns 500 on a non-NotFound S3 presign error (not a masked 404) (#1808)', async () => {
+    vi.mocked(isS3Configured).mockReturnValue(true);
+    vi.mocked(getPresignedUrl).mockRejectedValue(Object.assign(new Error('denied'), { name: 'AccessDenied' }));
+
+    const res = await viewerDownloadRoutes.request('/download/linux');
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).not.toContain('/tmp/breeze-secret-viewer-binaries');
+  });
+
+  it('treats a bare Error as a transport fault and returns 500', async () => {
+    vi.mocked(isS3Configured).mockReturnValue(true);
+    vi.mocked(getPresignedUrl).mockRejectedValue(new Error('opaque'));
+
+    const res = await viewerDownloadRoutes.request('/download/linux');
+    expect(res.status).toBe(500);
+  });
+
+  it('falls through to disk on a genuine NotFound S3 error', async () => {
+    vi.mocked(isS3Configured).mockReturnValue(true);
+    vi.mocked(getPresignedUrl).mockRejectedValue(Object.assign(new Error('missing'), { name: 'NotFound' }));
+
+    // Disk dir is empty, so the fall-through ends in the normal 404 (not a 500).
+    const res = await viewerDownloadRoutes.request('/download/linux');
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/api/src/routes/viewers/download.ts
+++ b/apps/api/src/routes/viewers/download.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { statSync, createReadStream } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
+import { isS3Configured, getPresignedUrl, isS3NotFound } from '../../services/s3Storage';
 import { getBinarySource, getGithubViewerUrl, VIEWER_FILENAMES } from '../../services/binarySource';
 
 export const viewerDownloadRoutes = new Hono();
@@ -35,10 +35,14 @@ viewerDownloadRoutes.get('/download/:platform', async (c) => {
       const url = await getPresignedUrl(s3Key);
       return c.redirect(url, 302);
     } catch (err) {
-      const errName = (err as { name?: string }).name;
-      const isNotFound = errName === 'NotFound' || errName === 'NoSuchKey';
-      const level = isNotFound ? 'warn' : 'error';
-      console[level](`[viewer-download] S3 presign failed for ${filename}, falling back to disk:`, err);
+      if (!isS3NotFound(err)) {
+        // Real S3 transport/auth fault — surface it instead of masking it as a
+        // disk-fallback 404. The viewer may well exist in S3; we just couldn't
+        // reach it (#1808).
+        console.error(`[viewer-download] S3 presign failed for ${filename}:`, err);
+        return c.json({ error: 'Internal server error', message: 'Failed to retrieve viewer file' }, 500);
+      }
+      console.warn(`[viewer-download] S3 object missing for ${filename}, falling back to disk:`, err);
     }
   }
 

--- a/apps/api/src/services/s3Storage.ts
+++ b/apps/api/src/services/s3Storage.ts
@@ -38,6 +38,15 @@ export function isS3Configured(): boolean {
   return !!(process.env.S3_BUCKET && process.env.S3_ACCESS_KEY && process.env.S3_SECRET_KEY);
 }
 
+// Distinguishes a genuine "object not present" from a transport/auth fault.
+// Only NotFound/NoSuchKey mean the key is absent; anything else (timeouts,
+// AccessDenied, DNS, 5xx) is a real fault that callers must surface instead of
+// masking as a 404 / silent disk fallback (#1807, #1808).
+export function isS3NotFound(err: unknown): boolean {
+  const errName = (err as { name?: string }).name;
+  return errName === 'NotFound' || errName === 'NoSuchKey';
+}
+
 async function computeFileChecksum(filePath: string): Promise<string> {
   const hash = createHash('sha256');
   const stream = createReadStream(filePath);


### PR DESCRIPTION
Closes #1808. Follow-up to #1807 (which fixed the same masking in `agents/download.ts`); the #1807 review flagged the identical pattern in two more file-serving paths.

## Problem

A presigned-URL failure is only "the object isn't there" for `NotFound`/`NoSuchKey`. Any other error (timeout, `AccessDenied`, DNS, 5xx) is a real transport/auth fault. The flagged paths swallowed those:

- `viewers/download.ts` — fell through to the disk fallback on **any** S3 error, surfacing a transport fault as a misleading 404 on hosted (S3-only, no on-disk binaries) infra.
- `software.ts` — two empty `catch {}` blocks in the deployment-dispatch path swallowed the error entirely (Todd flagged `software.ts:1179`; the same swallow also existed a few lines up, fixed both).

## Fix

- **Extract `isS3NotFound()` to `services/s3Storage.ts`** (the shared home Todd suggested) and have `agents/download.ts` import it instead of its local copy — no behavior change there.
- **`viewers/download.ts`**: return **500** on a non-NotFound S3 error; only a genuine `NotFound`/`NoSuchKey` falls through to disk (mirrors `agents/download.ts`).
- **`software.ts`**: replace both empty `catch {}` with explicit logging (`error` for transport/auth faults, `warn` for NotFound). These **deliberately keep** the existing fallback to the stored `downloadUrl` — a deployment shouldn't 500 over an S3 presign hiccup when a fallback URL exists — but the fault is now logged instead of silently swallowed, which is the actual concern the review raised.

## Verification (local gate green)

- `vitest viewers/download.test.ts agents/download.test.ts` → **45/45**, including new viewer cases: transport-error → 500, bare `Error` → 500, genuine `NotFound` → disk fallback (404). Both download test mocks now provide `isS3NotFound`.
- `vitest software.test.ts` → 16/16.
- `eslint` + `tsc --noEmit` (api) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)