### PR TITLE
fix(monitors): enqueue monitor checks outside the DB transaction (#1105)

### DIFF
--- a/apps/api/src/jobs/monitorWorker.test.ts
+++ b/apps/api/src/jobs/monitorWorker.test.ts
@@ -1,16 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDb } = vi.hoisted(() => ({
+const { mockDb, ctxState, queueMock } = vi.hoisted(() => ({
   mockDb: {
     select: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
     transaction: vi.fn()
-  }
+  },
+  // Tracks DB-access-context depth + an ordered event log so a test can prove
+  // the monitor scheduler READS inside a context but ENQUEUES outside one (#1105).
+  ctxState: { depth: 0, events: [] as string[] },
+  queueMock: {
+    getJob: vi.fn(async () => null),
+    add: vi.fn(async () => ({ id: 'job-1' })),
+    getRepeatableJobs: vi.fn(async () => []),
+    removeRepeatableByKey: vi.fn(async () => undefined),
+  },
 }));
 
 vi.mock('bullmq', () => ({
-  Queue: class {},
+  Queue: class {
+    getJob = queueMock.getJob;
+    add = queueMock.add;
+    getRepeatableJobs = queueMock.getRepeatableJobs;
+    removeRepeatableByKey = queueMock.removeRepeatableByKey;
+  },
   Worker: class {},
   Job: class {},
   UnrecoverableError: class extends Error {},
@@ -18,10 +32,23 @@ vi.mock('bullmq', () => ({
 
 vi.mock('../db', () => ({
   db: mockDb,
-  withSystemDbAccessContext: undefined,
-  // #1105 tripwire used by createInstrumentedQueue (getMonitorQueue now
-  // constructs through it). No-op here — no held context under test.
-  assertOutsideHeldDbContext: vi.fn()
+  // Real-ish context wrapper: tracks depth around fn so the scheduler test can
+  // assert which work runs inside the context vs after it closes.
+  withSystemDbAccessContext: async (fn: () => unknown) => {
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+    }
+  },
+  // #1105 tripwire wired into createInstrumentedQueue's add(). Mirror prod
+  // semantics: record a violation if an enqueue runs while a context is held.
+  assertOutsideHeldDbContext: (op: string) => {
+    if (ctxState.depth > 0) ctxState.events.push(`tripwire-violation:${op}`);
+  }
 }));
 
 vi.mock('../db/schema', () => ({
@@ -119,7 +146,63 @@ function selectWhereOrderLimitResolved(rows: unknown[]) {
   };
 }
 
-const { recordMonitorCheckResult } = await import('./monitorWorker');
+const { recordMonitorCheckResult, processScheduler } = await import('./monitorWorker');
+
+describe('processScheduler (#1105 connection-hold)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctxState.depth = 0;
+    ctxState.events = [];
+    queueMock.getJob.mockResolvedValue(null);
+    queueMock.add.mockImplementation(async () => {
+      ctxState.events.push(`enqueue@depth${ctxState.depth}`);
+      return { id: 'job-1' };
+    });
+  });
+
+  function mockDueMonitors(rows: unknown[]) {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation(async () => {
+          ctxState.events.push(`select@depth${ctxState.depth}`);
+          return rows;
+        })
+      })
+    } as any);
+  }
+
+  it('reads due monitors inside a DB context but enqueues OUTSIDE it', async () => {
+    mockDueMonitors([
+      { id: 'm1', orgId: 'o1', pollingInterval: 60, lastChecked: null },
+      { id: 'm2', orgId: 'o2', pollingInterval: 60, lastChecked: null },
+    ]);
+
+    const result = await processScheduler();
+
+    expect(result).toEqual({ enqueued: 2 });
+    // SELECT runs in-context (depth 1); the context CLOSES; then both enqueues
+    // run with no transaction held (depth 0). This is the #1105 fix.
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'select@depth1',
+      'ctx:exit',
+      'enqueue@depth0',
+      'enqueue@depth0',
+    ]);
+    // The prod held-context tripwire never fires for the enqueue path.
+    expect(ctxState.events.some((e) => e.startsWith('tripwire-violation'))).toBe(false);
+  });
+
+  it('returns early without enqueuing when no monitors are due', async () => {
+    mockDueMonitors([]);
+
+    const result = await processScheduler();
+
+    expect(result).toEqual({ enqueued: 0 });
+    expect(queueMock.add).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual(['ctx:enter', 'select@depth1', 'ctx:exit']);
+  });
+});
 
 describe('recordMonitorCheckResult', () => {
   beforeEach(() => {

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -103,22 +103,28 @@ function createMonitorWorker(): Worker<MonitorJobData> {
   return new Worker<MonitorJobData>(
     MONITOR_QUEUE,
     async (job: Job<MonitorJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        const data = parseQueueJobData(MONITOR_QUEUE, job, monitorQueueJobDataSchema);
-        switch (data.type) {
-          case 'monitor-scheduler':
-            assertQueueJobName(MONITOR_QUEUE, job, 'monitor-scheduler');
-            return await processScheduler();
-          case 'check-monitor':
+      const data = parseQueueJobData(MONITOR_QUEUE, job, monitorQueueJobDataSchema);
+      switch (data.type) {
+        case 'monitor-scheduler':
+          assertQueueJobName(MONITOR_QUEUE, job, 'monitor-scheduler');
+          // Self-manages its DB context: reads due monitors in a SHORT context,
+          // then runs the Redis enqueue loop OUTSIDE any transaction. A blanket
+          // wrap here would pin a pooled connection idle-in-transaction for the
+          // whole enqueue loop (~20s on the EU fleet), starving the pool (#1105).
+          return await processScheduler();
+        case 'check-monitor':
+          return await runWithSystemDbAccess(() => {
             assertQueueJobName(MONITOR_QUEUE, job, 'check-monitor');
-            return await processCheckMonitor(data);
-          case 'process-check-result':
+            return processCheckMonitor(data);
+          });
+        case 'process-check-result':
+          return await runWithSystemDbAccess(() => {
             assertQueueJobName(MONITOR_QUEUE, job, 'process-check-result');
-            return await processCheckResult(data);
-          default:
-            throw new Error(`Unknown job type: ${(data as { type: string }).type}`);
-        }
-      });
+            return processCheckResult(data);
+          });
+        default:
+          throw new Error(`Unknown job type: ${(data as { type: string }).type}`);
+      }
     },
     {
       connection: getBullMQConnection(),
@@ -444,26 +450,33 @@ async function processCheckResult(data: ProcessCheckResultJobData): Promise<{
   return { resultWritten: true };
 }
 
-async function processScheduler(): Promise<{ enqueued: number }> {
+export async function processScheduler(): Promise<{ enqueued: number }> {
   const now = new Date();
 
-  const dueMonitors = await db
-    .select({
-      id: networkMonitors.id,
-      orgId: networkMonitors.orgId,
-      pollingInterval: networkMonitors.pollingInterval,
-      lastChecked: networkMonitors.lastChecked
-    })
-    .from(networkMonitors)
-    .where(
-      and(
-        eq(networkMonitors.isActive, true),
-        sql`(${networkMonitors.lastChecked} IS NULL OR ${networkMonitors.lastChecked} + make_interval(secs => ${networkMonitors.pollingInterval}) <= ${now.toISOString()})`
+  // Phase 1 — read due monitors inside a short system DB context, then let it
+  // CLOSE. Everything after this is pure Redis/BullMQ work; holding it inside
+  // the context would pin a pooled connection idle-in-transaction for the whole
+  // enqueue loop, starving the connection pool (#1105).
+  const dueMonitors = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        id: networkMonitors.id,
+        orgId: networkMonitors.orgId,
+        pollingInterval: networkMonitors.pollingInterval,
+        lastChecked: networkMonitors.lastChecked
+      })
+      .from(networkMonitors)
+      .where(
+        and(
+          eq(networkMonitors.isActive, true),
+          sql`(${networkMonitors.lastChecked} IS NULL OR ${networkMonitors.lastChecked} + make_interval(secs => ${networkMonitors.pollingInterval}) <= ${now.toISOString()})`
+        )
       )
-    );
+  );
 
   if (dueMonitors.length === 0) return { enqueued: 0 };
 
+  // Phase 2 — enqueue checks with NO DB context open (pure Redis/BullMQ).
   let enqueued = 0;
   for (const monitor of dueMonitors) {
     try {


### PR DESCRIPTION
## Problem — EU droplet degraded performance

Investigating reported slowness on the DO **EU** droplet (v0.82.1):

- **Host is healthy** — load 0.21, 2.3 GiB free, all containers low-CPU, `/health` 200 in 0.37s. The degradation is **DB connection-pool starvation**, not the box.
- Managed EU Postgres (`max_connections=25`) was **pinned at 25/25**, with a `network_monitors` SELECT caught **idle-in-transaction** (`wait_event=Client`) aging steadily 11s → 20s.
- **~129** "held a pooled connection in an open transaction" warnings per 30 min, clustered at ~5s / ~10s / **~20s**.

## Root cause

`monitorWorker.ts` wrapped its **entire** job in one `withSystemDbAccessContext` transaction (`createMonitorWorker`). The `monitor-scheduler` job (every 30s) read all due monitors, then looped `await enqueueMonitorCheck()` doing sequential **Redis/BullMQ** round-trips (`getJob` → `getState` → `add`) **while the DB transaction stayed open** — pinning a pooled connection idle-in-transaction for ~20s of every 30s cycle.

This is the identical `#1105` anti-pattern that **#1697** fixed in the Huntress/DNS/Pax8 workers — but `monitorWorker` was never converted (it had zero `runOutsideDbContext`). The `createInstrumentedQueue` tripwire (`assertOutsideHeldDbContext`) added on main was already flagging this enqueue.

## Fix

- `processScheduler` now reads due monitors in a **short** system context, lets it **close**, then runs the enqueue loop with **no transaction held**.
- `check-monitor` and `process-check-result` keep their existing system-context wrap **unchanged** — the tenant-write / alert path is untouched (avoids the #1375 silent-0-row-write risk).
- New tests assert the scheduler **reads in-context** (depth 1) but **enqueues out-of-context** (depth 0), and that the #1105 tripwire never fires.

`apps/api` test file: **4 passed**. Type-check clean.

## Follow-ups (not in this PR)
- **`process-check-result` alert path** still interleaves Redis cooldown calls (`isCooldownActive`/`setCooldown`) inside its context — shorter, event-driven holds. Worth a phased read→redis→write split with its own tests.
- **Ops:** EU/US `DB_POOL_MAX` defaults to 30 but the managed DB only offers ~13–15 usable slots after DO's internal workers + reserved superuser connections. Recommend setting `DB_POOL_MAX≈15` explicitly on the droplets so the pool queues internally instead of overshooting into DB-side rejections under a heartbeat storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)