### PR TITLE
fix(auth): repair forced-MFA enrollment authorization (0.83.1 hotfix)

### DIFF
--- a/apps/web/src/components/auth/ForcedMfaSetupPage.tsx
+++ b/apps/web/src/components/auth/ForcedMfaSetupPage.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import MFASetupForm from './MFASetupForm';
-import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import {
+  AuthSessionExpiredError,
+  fetchWithAuth,
+  restoreAccessTokenFromCookie,
+  useAuthStore,
+} from '../../stores/auth';
 import { extractApiError } from '../../lib/apiError';
 import { navigateTo } from '../../lib/navigation';
 
@@ -24,6 +29,20 @@ export default function ForcedMfaSetupPage() {
     setForced(params.get('forced') === '1');
   }, []);
 
+  // This page renders under AuthLayout (no AuthGuard/DashboardWrapper), and it
+  // is always reached via a full-page navigation, so the in-memory access token
+  // is gone on mount. Proactively trade the refresh cookie for a fresh access
+  // token now — mirroring AuthGuard — so the Bearer is in place before the user
+  // submits their password (rather than discovering a dead session only at
+  // submit time). If recovery fails, fetchWithAuth/AuthSessionExpiredError will
+  // bounce the user to /login on their first action.
+  useEffect(() => {
+    const { isAuthenticated, tokens } = useAuthStore.getState();
+    if (isAuthenticated && !tokens?.accessToken) {
+      void restoreAccessTokenFromCookie();
+    }
+  }, []);
+
   // Step 1: re-prompt for the current password and start TOTP enrollment.
   const handleStart = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -43,7 +62,10 @@ export default function ForcedMfaSetupPage() {
       setQrCodeDataUrl(data.qrCodeDataUrl);
       setRecoveryCodes(data.recoveryCodes);
       setStep('enroll');
-    } catch {
+    } catch (err) {
+      // Session died and fetchWithAuth is already redirecting to /login — don't
+      // flash a misleading "Network error" over the navigation.
+      if (err instanceof AuthSessionExpiredError) return;
       setError('Network error');
     } finally {
       setLoading(false);
@@ -72,7 +94,8 @@ export default function ForcedMfaSetupPage() {
           window.location.href = '/';
         });
       }, 1500);
-    } catch {
+    } catch (err) {
+      if (err instanceof AuthSessionExpiredError) return;
       setError('Network error');
     } finally {
       setLoading(false);

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -7,6 +7,7 @@ import {
   apiPreviewInvite,
   apiResetPassword,
   apiVerifyMFA,
+  AuthSessionExpiredError,
   fetchWithAuth,
   resolveApiOrigin,
   restoreAccessTokenFromCookie,
@@ -258,6 +259,70 @@ describe('auth store fetchWithAuth', () => {
     expect(useAuthStore.getState().isAuthenticated).toBe(false);
     expect(useAuthStore.getState().tokens).toBeNull();
     expect(useAuthStore.getState().user).toBeNull();
+  });
+
+  // Regression (0.83.1 forced-MFA enrollment hotfix): when the store is
+  // authenticated but holds no in-memory access token (always true on the
+  // forced-MFA page after a full-page nav) and the cookie-backed refresh
+  // FAILS, fetchWithAuth must NOT fire the request with no Authorization
+  // header (the old behavior produced a confusing API 401 "Missing or invalid
+  // authorization header" that stranded the user). It must instead clear the
+  // dead session, redirect to /login, and throw AuthSessionExpiredError.
+  it('does not send a headerless request when authenticated but refresh fails; bounces to login', async () => {
+    useAuthStore.setState({
+      user: baseUser,
+      tokens: null,
+      isAuthenticated: true,
+      isLoading: false,
+      mfaPending: false,
+      mfaTempToken: null
+    });
+
+    // Only the /auth/refresh recovery attempt should ever be fetched; it 401s.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(makeResponse({ error: 'unauthorized' }, false, 401));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hrefSetter = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        pathname: '/auth/mfa/setup',
+        search: '?forced=1',
+        get href() {
+          return '';
+        },
+        set href(value: string) {
+          hrefSetter(value);
+        }
+      }
+    });
+
+    try {
+      await expect(fetchWithAuth('/auth/mfa/setup', { method: 'POST' })).rejects.toBeInstanceOf(
+        AuthSessionExpiredError
+      );
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation
+      });
+    }
+
+    // The real endpoint (/auth/mfa/setup) was NEVER fetched — only the refresh
+    // recovery attempt fired, then we bailed.
+    expect(
+      fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/api/v1/auth/mfa/setup'))
+    ).toHaveLength(0);
+    // Session cleared and a /login redirect (with returnTo) was issued.
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().tokens).toBeNull();
+    expect(hrefSetter).toHaveBeenCalledWith(
+      `/login?returnTo=${encodeURIComponent('/auth/mfa/setup?forced=1')}`
+    );
   });
 
   it('deduplicates concurrent refresh requests', async () => {

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -443,6 +443,23 @@ export async function bootstrapFromCfAccessRedirect(): Promise<boolean> {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const UPLOAD_TIMEOUT_MS = 10 * 60_000;
 
+/**
+ * Thrown by `fetchWithAuth` when the store claims to be authenticated but the
+ * refresh cookie can no longer mint an access token, so there is no Bearer to
+ * attach. Rather than fire a knowingly-unauthenticated request (which the API
+ * answers with a confusing "Missing or invalid authorization header" 401),
+ * `fetchWithAuth` clears the session, redirects to /login, and throws this so
+ * callers can short-circuit. Callers that already special-case auth failures
+ * can `instanceof`-check it; most callers can ignore it (the page is navigating
+ * away to /login anyway).
+ */
+export class AuthSessionExpiredError extends Error {
+  constructor(message = 'Session expired') {
+    super(message);
+    this.name = 'AuthSessionExpiredError';
+  }
+}
+
 export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): Promise<Response> {
   // Auto-inject orgId from the org store so partner/system users always scope API calls
   let url = rawUrl;
@@ -458,11 +475,40 @@ export async function fetchWithAuth(rawUrl: string, options: RequestInit = {}): 
 
   // During app bootstrap we can have a persisted authenticated user but no in-memory access token yet.
   // Recover from refresh cookie first to avoid firing unauthenticated API calls.
+  //
+  // This is the ONLY token-recovery point for pages rendered outside the
+  // dashboard shell — most importantly the forced-MFA enrollment page
+  // (`/auth/mfa/setup`, AuthLayout), which has no AuthGuard/DashboardWrapper to
+  // proactively call restoreAccessTokenFromCookie() on mount. That page is
+  // always reached via a full-page navigation (`window.location.href`), so the
+  // in-memory access token is always gone and enrollment depends entirely on
+  // this refresh succeeding here.
   if (!tokens?.accessToken && isAuthenticated) {
     const restoredTokens = await requestTokenRefreshShared();
     if (restoredTokens) {
       setTokens(restoredTokens);
       tokens = restoredTokens;
+    } else {
+      // The session claims to be authenticated but the refresh cookie can no
+      // longer mint an access token (rotated/revoked/expired, or — as seen in
+      // the 0.83.0 forced-MFA enrollment regression — the rotated cookie failed
+      // to round-trip so every subsequent /auth/refresh replays a revoked jti
+      // and 401s). Falling through here would fire the request with NO
+      // Authorization header, and the API answers 401 "Missing or invalid
+      // authorization header" — a confusing dead end that strands the user on
+      // the forced-MFA page (its only recovery is a clean re-login).
+      //
+      // Fail closed instead: clear the dead session and bounce to /login so the
+      // user re-authenticates and re-enters the flow with a fresh token. This
+      // does NOT weaken auth — protected endpoints (including /auth/mfa/setup)
+      // still require a valid Bearer; we simply refuse to send a request we know
+      // can't carry one.
+      logout();
+      if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+        const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
+        window.location.href = `/login?returnTo=${returnTo}`;
+      }
+      throw new AuthSessionExpiredError();
     }
   }
 


### PR DESCRIPTION
## Summary

Repairs the forced-MFA enrollment regression observed on prod EU running **0.83.0** (not present in 0.82.1): a user whose role/org requires MFA is sent to the forced-enrollment screen, and confirming their password to start TOTP setup fails with **"Missing or invalid authorization header"** — enrollment is impossible. Rolling back to 0.82.1 made it work again.

## Root cause

The server auth path is **byte-identical** between `v0.82.1` and `v0.83.0` (`middleware/auth.ts`, `routes/auth/login.ts` incl. `/auth/refresh`, `routes/auth/helpers.ts`, `routes/auth/mfa.ts`, and the web store's refresh logic all diff to nothing). The hono / `@hono/node-server` patch bump in the range was empirically ruled out (its only behavioral delta — a Response-clone status-preservation fix — is structurally unreachable through Hono's request machinery; a faithful two-Set-Cookie `/auth/refresh` repro behaves identically on 2.0.5 and 2.0.6).

What 0.83.0 changed was the **deployment runtime**, which broke the refresh-cookie round-trip in prod: the prod trace shows `/auth/refresh` succeeding **once** (rotating + revoking the old jti) and then **401 on every subsequent refresh** (the rotated cookie didn't round-trip, so each later refresh replays the now-revoked jti). That server-side trigger is environmental and can't be fixed from the repo.

But it exposed a real, code-level fragility in the **web** forced-MFA flow that turns a recoverable refresh failure into an unrecoverable dead end:

1. `ForcedMfaSetupPage` renders under `AuthLayout` (no `AuthGuard`/`DashboardWrapper`), so — unlike every protected page — it **never proactively calls `restoreAccessTokenFromCookie()` on mount**. It's reached via a full-page nav, so the in-memory access token is always gone; the only token recovery is `fetchWithAuth`'s lazy refresh at password-submit time.
2. When that refresh fails, `fetchWithAuth` **fell through and sent `/auth/mfa/setup` with NO `Authorization` header** → API returns 401 "Missing or invalid authorization header" (`middleware/auth.ts:298`). No re-login path was offered.

## Fix (web only)

- **`fetchWithAuth`**: when the store is authenticated but cookie-backed token recovery yields no access token, **fail closed** — clear the dead session, redirect to `/login?returnTo=…`, and throw a new `AuthSessionExpiredError` instead of firing a knowingly-unauthenticated request. This does **not** weaken auth: `/auth/mfa/setup` and every protected endpoint still require a valid Bearer; we simply refuse to send a request that can't carry one, and surface a clean re-login instead of a misleading 401. (Pre-fix, the end state was already `logout()` one step later — this just makes it immediate and clean.)
- **`ForcedMfaSetupPage`**: proactively restore the token on mount (mirroring `AuthGuard`), and swallow `AuthSessionExpiredError` in the submit handlers so the redirect isn't masked by a spurious "Network error".

## Test

Adds a regression test in `auth.test.ts` — *authenticated + no in-memory token + refresh fails*. It **fails without the fix** (the headerless request reaches the API and resolves to a 401) and **passes with it** (no real request fired, session cleared, `/login?returnTo=…` redirect, `AuthSessionExpiredError` thrown). Verified both directions.

## Validation

- `tsc --noEmit -p apps/api/tsconfig.json` → 0 errors
- `astro check` (web) → **0 errors** (exit 0)
- `apps/web` auth store tests: 24/24 · auth components: 23/23 · `no-silent-mutations`: 60/60 · web `middleware.test.ts`: 5/5

## Note for the hotfix

This resolves the user-facing dead end and makes forced-MFA enrollment resilient to a flaky refresh. The underlying **server-side** reason `/auth/refresh` stopped round-tripping its rotated cookie in 0.83.0 prod (likely a node base-image / undici / Caddy-HTTP2 interaction — no app code changed) is **not** addressed here and should be investigated separately on the droplets; this fix means an affected user gets a clean re-login loop instead of being stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)