### PR TITLE
fix(docker): revert node base image to fb71d01 (0.83.1 hotfix)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================
 
 # Stage 1: Base image with pnpm
-FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS base
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS base
 RUN npm install -g pnpm@10.33.4
 RUN apk add --no-cache libc6-compat python3 make g++
 WORKDIR /app
@@ -42,7 +42,7 @@ WORKDIR /app/apps/api
 RUN pnpm build
 
 # Stage 4: Production runner
-FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS runner
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS runner
 WORKDIR /app
 
 # Install wget for healthcheck; remove the bundled npm (and its vendored undici,

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================
 
 # Stage 1: Base image with pnpm
-FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS base
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS base
 RUN npm install -g pnpm@10.33.4
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -49,7 +49,7 @@ WORKDIR /app/apps/web
 RUN pnpm build
 
 # Stage 4: Production runner
-FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS runner
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS runner
 WORKDIR /app
 
 # Install wget for healthcheck; remove the bundled npm (and its vendored undici,

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS base
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS base
 RUN npm install -g pnpm@10.33.4
 
 FROM base AS deps

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS base
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS base
 RUN npm install -g pnpm@10.33.4
 
 FROM base AS deps


### PR DESCRIPTION
Reverts the 0.83.0 node digest bump (156b55f → fb71d01) across all Dockerfiles. fb71d01 is the image v0.82.1 runs on and the suspected environmental cause of the forced-MFA /auth/refresh regression. Pairs with #1844. Part of the 0.83.1 hotfix.