### PR TITLE
feat(agents): explicit fleet-rollout promotion (decouple registration from isLatest)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -542,6 +542,13 @@ COTURN_IMAGE_REF=coturn/coturn:latest
 #           binaries from your own infrastructure (S3, CDN, etc.).
 # BINARY_SOURCE=github
 #
+# Controlled agent-fleet rollout. Default true: registering/syncing a release
+# immediately becomes the fleet upgrade target (agent_versions.isLatest). Set
+# false to decouple registration from promotion — new binaries are downloadable
+# but the fleet only moves to a new version via an explicit, platform-admin
+# POST /api/v1/agent-versions/promote { "version": "x.y.z" } after you verify it.
+# AGENT_AUTO_PROMOTE=true
+#
 # Version tagging works like this:
 #   git tag v0.3.0 && git push --tags   → stable release, tagged as "latest" + "0.3.0"
 #   git tag v0.3.0-rc.1 && git push --tags → prerelease, tagged as "0.3.0-rc.1" only

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -402,6 +402,15 @@ const envSchema = z
     BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: z.string().optional(),
     IS_HOSTED: z.string().optional(),
 
+    // Controlled agent-fleet rollout (decouple registration from promotion).
+    // When false, binarySync registers new binaries WITHOUT touching
+    // agent_versions.isLatest — the fleet upgrade target only changes via
+    // POST /agent-versions/promote. Defaults TRUE (preserve current behavior:
+    // sync = instant fleet upgrade target). Read at runtime by
+    // getAgentAutoPromote(); validated here only for boolean format so a typo
+    // is caught at boot instead of silently parsing to a surprising default.
+    AGENT_AUTO_PROMOTE: z.string().optional(),
+
     // MFA feature flag. When false, ALL requireMfa() gates become no-ops.
     // Warning is emitted in collectWarnings; we do NOT refuse boot (a
     // self-hosted operator may deliberately run 2FA-off).
@@ -1102,6 +1111,23 @@ const envSchema = z
           });
         }
       }
+    }
+
+    // AGENT_AUTO_PROMOTE (controlled fleet rollout). Independent of NODE_ENV —
+    // the value silently governs whether a sync promotes the fleet, so a typo
+    // (e.g. AGENT_AUTO_PROMOTE=falze, which parses as truthy → still
+    // auto-promotes) must be caught at boot rather than surprising an operator
+    // who believed they had disabled auto-promotion. Empty/unset is allowed
+    // (defaults to true). Mirrors getAgentAutoPromote() in binarySource.ts.
+    const autoPromoteRaw = (data.AGENT_AUTO_PROMOTE ?? '').trim().toLowerCase();
+    const boolValues = new Set(['true', 'false', '1', '0', 'yes', 'no', 'on', 'off']);
+    if (autoPromoteRaw && !boolValues.has(autoPromoteRaw)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['AGENT_AUTO_PROMOTE'],
+        message:
+          'AGENT_AUTO_PROMOTE must be a boolean (true/false, 1/0, yes/no, on/off) when set. Defaults to true (sync immediately becomes the fleet upgrade target). Set false to require explicit promotion via POST /agent-versions/promote.',
+      });
     }
   });
 

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -12,6 +12,7 @@ vi.mock("../db", () => ({
     select: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
+    transaction: vi.fn(),
   },
 }));
 
@@ -28,6 +29,22 @@ vi.mock("../services/auditEvents", () => ({
   writeRouteAudit: vi.fn(),
 }));
 
+// Platform-admin gate for the promote/list routes. Toggle `platformAdminAllow`
+// per-test: when false the middleware throws a 403 HTTPException exactly like
+// the real one does for a non-platform-admin caller.
+const platformAdminState = vi.hoisted(() => ({ allow: true }));
+vi.mock("../middleware/platformAdmin", () => ({
+  platformAdminMiddleware: vi.fn(async (_c: any, next: any) => {
+    if (!platformAdminState.allow) {
+      const { HTTPException } = await import("hono/http-exception");
+      throw new HTTPException(403, {
+        message: "platform admin access required",
+      });
+    }
+    await next();
+  }),
+}));
+
 vi.mock("../middleware/auth", () => ({
   authMiddleware: vi.fn(async (_c: any, next: any) => next()),
   requireScope: () => vi.fn(async (_c: any, next: any) => next()),
@@ -42,6 +59,7 @@ import {
 } from "./agentVersions";
 import { db } from "../db";
 import * as manifestSigning from "../services/manifestSigning";
+import { writeRouteAudit } from "../services/auditEvents";
 
 function makeSignedReleaseManifest(overrides: Record<string, unknown> = {}) {
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
@@ -104,6 +122,7 @@ describe("agentVersions routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    platformAdminState.allow = true;
     delete process.env.AGENT_UPDATE_MANIFEST_PUBLIC_KEYS;
     delete process.env.BREEZE_UPDATE_MANIFEST_PUBLIC_KEYS;
     delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
@@ -119,6 +138,219 @@ describe("agentVersions routes", () => {
       await next();
     });
     app.route("/agent-versions", agentVersionRoutes);
+  });
+
+  // Helper: build a db.select chain that resolves to `rows` for a single
+  // .from().where() lookup, and a configurable one for the promote endpoint's
+  // multiple sequential selects.
+  function selectResolving(rows: unknown[]) {
+    // `where()` must be awaitable on its own (the promote target-rows query has
+    // no .limit()) AND expose .limit() (the in-tx "current isLatest" lookup).
+    const whereResult: any = Promise.resolve(rows);
+    whereResult.limit = vi.fn().mockResolvedValue(rows);
+    return {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue(whereResult),
+        orderBy: vi.fn().mockResolvedValue(rows),
+      }),
+    };
+  }
+
+  describe("GET /agent-versions (platform-admin list)", () => {
+    it("non-platform-admin → 403", async () => {
+      platformAdminState.allow = false;
+      const res = await app.request("/agent-versions");
+      expect(res.status).toBe(403);
+    });
+
+    it("lists registered versions and the promoted set", async () => {
+      vi.mocked(db.select).mockReturnValue(
+        selectResolving([
+          {
+            id: "v1",
+            version: "0.70.0",
+            platform: "linux",
+            architecture: "amd64",
+            component: "agent",
+            isLatest: true,
+            fileSize: BigInt(100),
+            releaseNotes: null,
+            createdAt: new Date("2026-06-20"),
+          },
+          {
+            id: "v2",
+            version: "0.71.0",
+            platform: "linux",
+            architecture: "amd64",
+            component: "agent",
+            isLatest: false,
+            fileSize: BigInt(200),
+            releaseNotes: null,
+            createdAt: new Date("2026-06-22"),
+          },
+        ]) as any,
+      );
+
+      const res = await app.request("/agent-versions");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.versions).toHaveLength(2);
+      // fileSize serialized to number.
+      expect(body.versions[0].fileSize).toBe(100);
+      // promoted map only includes the isLatest row.
+      expect(body.promoted).toEqual([
+        {
+          component: "agent",
+          platform: "linux",
+          architecture: "amd64",
+          version: "0.70.0",
+        },
+      ]);
+    });
+  });
+
+  describe("POST /agent-versions/promote", () => {
+    // Build a fake transaction whose tx.select/tx.update record calls so we can
+    // assert demote-then-promote happened. `priorByTuple` controls what the
+    // "current isLatest" lookup returns inside the tx.
+    function makeTx(prior: { version: string } | undefined) {
+      const updateSet = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      const txUpdate = vi.fn().mockReturnValue({ set: updateSet });
+      const txSelect = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(prior ? [prior] : []),
+          }),
+        }),
+      });
+      return { tx: { update: txUpdate, select: txSelect }, updateSet, txUpdate };
+    }
+
+    it("non-platform-admin → 403", async () => {
+      platformAdminState.allow = false;
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "0.71.0" }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("404 when the version has no registered rows", async () => {
+      vi.mocked(db.select).mockReturnValue(selectResolving([]) as any);
+
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "9.9.9" }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("promotes all components of a version atomically (demote old + promote new) and audits", async () => {
+      // The pre-tx target-rows lookup: two components on the same platform/arch.
+      vi.mocked(db.select).mockReturnValue(
+        selectResolving([
+          { component: "agent", platform: "linux", architecture: "amd64" },
+          { component: "watchdog", platform: "linux", architecture: "amd64" },
+        ]) as any,
+      );
+
+      const { tx, txUpdate } = makeTx({ version: "0.70.0" });
+      vi.mocked(db.transaction).mockImplementation(
+        async (fn: any) => fn(tx) as any,
+      );
+
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "0.71.0" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Promoted both tuples.
+      expect(body.promoted).toEqual(
+        expect.arrayContaining([
+          {
+            component: "agent",
+            platform: "linux",
+            architecture: "amd64",
+            version: "0.71.0",
+          },
+          {
+            component: "watchdog",
+            platform: "linux",
+            architecture: "amd64",
+            version: "0.71.0",
+          },
+        ]),
+      );
+      // Prior target recorded as demoted.
+      expect(body.demoted).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ component: "agent", version: "0.70.0" }),
+          expect.objectContaining({ component: "watchdog", version: "0.70.0" }),
+        ]),
+      );
+
+      // Each tuple ran a demote UPDATE (isLatest:false) AND a promote UPDATE
+      // (isLatest:true) → 2 tuples × 2 updates = 4 update calls.
+      expect(txUpdate).toHaveBeenCalledTimes(4);
+
+      // Audit row written for the promotion.
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "agent_version.promote",
+          resourceName: "0.71.0",
+          details: expect.objectContaining({
+            version: "0.71.0",
+            component: "all",
+          }),
+        }),
+      );
+    });
+
+    it("promotes only the requested single component", async () => {
+      vi.mocked(db.select).mockReturnValue(
+        selectResolving([
+          { component: "agent", platform: "linux", architecture: "amd64" },
+        ]) as any,
+      );
+
+      const { tx, txUpdate } = makeTx({ version: "0.70.0" });
+      vi.mocked(db.transaction).mockImplementation(
+        async (fn: any) => fn(tx) as any,
+      );
+
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "0.71.0", component: "agent" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.promoted).toEqual([
+        {
+          component: "agent",
+          platform: "linux",
+          architecture: "amd64",
+          version: "0.71.0",
+        },
+      ]);
+      // One tuple → demote + promote = 2 update calls.
+      expect(txUpdate).toHaveBeenCalledTimes(2);
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          details: expect.objectContaining({ component: "agent" }),
+        }),
+      );
+    });
   });
 
   describe("GET /agent-versions/latest", () => {

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -697,6 +697,7 @@ agentVersionRoutes.get("/", platformAdminMiddleware, async (c) => {
 agentVersionRoutes.post(
   "/promote",
   platformAdminMiddleware,
+  requireMfa(),
   zValidator("json", promoteSchema),
   async (c) => {
     const { version, component } = c.req.valid("json");

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { createPublicKey, verify as verifySignature } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, desc } from "drizzle-orm";
 import { db } from "../db";
 import { agentVersions } from "../db/schema";
 import {
@@ -11,6 +11,7 @@ import {
   requirePermission,
   requireScope,
 } from "../middleware/auth";
+import { platformAdminMiddleware } from "../middleware/platformAdmin";
 import { writeRouteAudit } from "../services/auditEvents";
 import { syncFromGitHub } from "../services/binarySync";
 import { PERMISSIONS } from "../services/permissions";
@@ -73,6 +74,14 @@ const createVersionSchema = z.object({
   releaseNotes: z.string().optional(),
   isLatest: z.boolean().optional().default(false),
   component: componentEnum.optional().default("agent"),
+});
+
+// Controlled fleet rollout: explicitly promote a registered version to the
+// fleet upgrade target. Omitting `component` promotes ALL components of the
+// version. See docs/superpowers/specs/2026-06-23-controlled-agent-fleet-rollout.md.
+const promoteSchema = z.object({
+  version: z.string().min(1).max(20),
+  component: componentEnum.optional(),
 });
 
 type ReleaseManifest = {
@@ -635,5 +644,190 @@ agentVersionRoutes.post(
       const status = msg.includes("GitHub API error") ? 502 : 422;
       return c.json({ error: msg }, status);
     }
+  },
+);
+
+// GET /agent-versions - List registered versions and the currently-promoted
+// fleet target per (component, platform, architecture). Platform-admin only.
+// This is the operator view used to decide what to promote after a release is
+// registered (with AGENT_AUTO_PROMOTE=false). Returns every registered row,
+// newest-first, with an isLatest flag marking the current upgrade target.
+agentVersionRoutes.get("/", platformAdminMiddleware, async (c) => {
+  const rows = await db
+    .select({
+      id: agentVersions.id,
+      version: agentVersions.version,
+      platform: agentVersions.platform,
+      architecture: agentVersions.architecture,
+      component: agentVersions.component,
+      isLatest: agentVersions.isLatest,
+      fileSize: agentVersions.fileSize,
+      releaseNotes: agentVersions.releaseNotes,
+      createdAt: agentVersions.createdAt,
+    })
+    .from(agentVersions)
+    .orderBy(desc(agentVersions.createdAt));
+
+  return c.json({
+    versions: rows.map((r) => ({
+      ...r,
+      fileSize: r.fileSize != null ? Number(r.fileSize) : null,
+    })),
+    // Convenience map: the version currently promoted (isLatest=true) for each
+    // component/platform/arch tuple, so the UI can show "current target".
+    promoted: rows
+      .filter((r) => r.isLatest)
+      .map((r) => ({
+        component: r.component,
+        platform: r.platform,
+        architecture: r.architecture,
+        version: r.version,
+      })),
+  });
+});
+
+// POST /agent-versions/promote - Explicitly promote a registered version to the
+// fleet upgrade target. Platform-admin only. This is the deliberate lever that
+// AGENT_AUTO_PROMOTE=false hands to operators: registration no longer auto-
+// promotes, so the fleet only moves to a new version when this endpoint runs.
+// Body: { version, component? }. Omitting component promotes every component of
+// the version. Per affected (component, platform, architecture), the current
+// isLatest=true rows are demoted and the target version's rows are promoted —
+// all in a single transaction so heartbeat never observes a split target.
+agentVersionRoutes.post(
+  "/promote",
+  platformAdminMiddleware,
+  zValidator("json", promoteSchema),
+  async (c) => {
+    const { version, component } = c.req.valid("json");
+
+    // Target rows for this version (optionally narrowed to one component).
+    const targetRows = await db
+      .select({
+        component: agentVersions.component,
+        platform: agentVersions.platform,
+        architecture: agentVersions.architecture,
+      })
+      .from(agentVersions)
+      .where(
+        component
+          ? and(
+              eq(agentVersions.version, version),
+              eq(agentVersions.component, component),
+            )
+          : eq(agentVersions.version, version),
+      );
+
+    if (targetRows.length === 0) {
+      return c.json(
+        {
+          error: component
+            ? `No registered rows for version ${version} (component=${component})`
+            : `No registered rows for version ${version}`,
+        },
+        404,
+      );
+    }
+
+    // Distinct (component, platform, architecture) tuples affected by this
+    // promotion. Each tuple is an independent isLatest "slot".
+    const tuples = Array.from(
+      new Map(
+        targetRows.map((r) => [
+          `${r.component}|${r.platform}|${r.architecture}`,
+          r,
+        ]),
+      ).values(),
+    );
+
+    const result = await db.transaction(async (tx) => {
+      const demoted: Array<{
+        component: string;
+        platform: string;
+        architecture: string;
+        version: string;
+      }> = [];
+
+      for (const t of tuples) {
+        // Capture the version currently promoted in this slot (the prior
+        // target) before demoting it, so the response/audit records what the
+        // fleet was moving FROM.
+        const [prior] = await tx
+          .select({ version: agentVersions.version })
+          .from(agentVersions)
+          .where(
+            and(
+              eq(agentVersions.component, t.component),
+              eq(agentVersions.platform, t.platform),
+              eq(agentVersions.architecture, t.architecture),
+              eq(agentVersions.isLatest, true),
+            ),
+          )
+          .limit(1);
+
+        if (prior && prior.version !== version) {
+          demoted.push({
+            component: t.component,
+            platform: t.platform,
+            architecture: t.architecture,
+            version: prior.version,
+          });
+        }
+
+        // Demote the current target for this slot.
+        await tx
+          .update(agentVersions)
+          .set({ isLatest: false })
+          .where(
+            and(
+              eq(agentVersions.component, t.component),
+              eq(agentVersions.platform, t.platform),
+              eq(agentVersions.architecture, t.architecture),
+              eq(agentVersions.isLatest, true),
+            ),
+          );
+
+        // Promote the requested version for this slot.
+        await tx
+          .update(agentVersions)
+          .set({ isLatest: true })
+          .where(
+            and(
+              eq(agentVersions.version, version),
+              eq(agentVersions.component, t.component),
+              eq(agentVersions.platform, t.platform),
+              eq(agentVersions.architecture, t.architecture),
+            ),
+          );
+      }
+
+      return {
+        promoted: tuples.map((t) => ({
+          component: t.component,
+          platform: t.platform,
+          architecture: t.architecture,
+          version,
+        })),
+        demoted,
+      };
+    });
+
+    const components = Array.from(new Set(tuples.map((t) => t.component)));
+    writeRouteAudit(c, {
+      orgId: null,
+      action: "agent_version.promote",
+      resourceType: "agent_version",
+      resourceId: version,
+      resourceName: version,
+      details: {
+        version,
+        component: component ?? "all",
+        components,
+        promotedCount: result.promoted.length,
+        demotedTargets: result.demoted,
+      },
+    });
+
+    return c.json(result);
   },
 );

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -753,6 +753,84 @@ describe('POST /agents/:id/heartbeat — watchdog-branch agent recovery upgradeT
 });
 
 
+// ---------------------------------------------------------------------
+// Controlled fleet rollout — heartbeat is UNCHANGED but must remain correct
+// under it. The agent-version upgrade query selects WHERE isLatest=true, so a
+// merely-registered-but-un-promoted newer version (isLatest=false) is invisible
+// to heartbeat and yields NO upgradeTo. Only the explicitly-promoted version
+// (isLatest=true) is offered. These tests pin that contract.
+// ---------------------------------------------------------------------
+describe('POST /agents/:id/heartbeat — controlled fleet rollout (promotion gates upgradeTo)', () => {
+  const agentDeviceRow = {
+    id: 'device-1',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    hostname: 'host-1',
+    osType: 'windows',
+    osVersion: 'Windows 11',
+    osBuild: null,
+    architecture: 'amd64',
+    agentVersion: '0.70.0',
+    deviceRole: 'workstation',
+    deviceRoleSource: 'auto',
+    agentTokenHash: 'hash',
+    tokenIssuedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    updateMock.mockReset();
+    insertMock.mockReset();
+    getActiveTrustKeysetMock.mockReset();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+  });
+
+  // device lookup (once), then the agentVersions upgrade lookups resolve to
+  // `promotedRows`. An empty array models "no isLatest=true row" — i.e. the
+  // newer version exists in the table but was never promoted.
+  function prime(promotedRows: unknown[]) {
+    selectMock.mockReturnValueOnce(selectChainResolving([agentDeviceRow]));
+    selectMock.mockReturnValue(selectChainResolving(promotedRows));
+  }
+
+  async function beat() {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...minimalHeartbeatBody, agentVersion: '0.70.0' }),
+    });
+  }
+
+  it('offers upgradeTo for the explicitly-promoted (isLatest=true) version', async () => {
+    const { compareAgentVersions } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1); // promoted > reported
+    prime([{ version: '0.71.0' }]); // a promoted row exists
+
+    const resp = await beat();
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBe('0.71.0');
+  });
+
+  it('does NOT offer upgradeTo when the newer version is merely registered but un-promoted (no isLatest=true row)', async () => {
+    const { compareAgentVersions } = await import('./helpers');
+    // Even if a comparison WOULD say newer, the isLatest=true query returns no
+    // row, so the handler never reaches the comparison for a target.
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    prime([]); // no promoted row — 0.71.0 is registered with isLatest=false
+
+    const resp = await beat();
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { upgradeTo?: string | null };
+    expect(body.upgradeTo).toBeFalsy();
+  });
+});
+
 describe('detectWatchdogStateCollapse (#1121)', () => {
   it('reports a collapse when raw body carried watchdogState but validation dropped it', async () => {
     const { detectWatchdogStateCollapse } = await import('./heartbeat');

--- a/apps/api/src/services/binarySource.ts
+++ b/apps/api/src/services/binarySource.ts
@@ -15,6 +15,21 @@ export function getBinarySource(): BinarySource {
   return 'github';
 }
 
+/**
+ * Controls whether binarySync auto-promotes a newly-registered binary to the
+ * fleet upgrade target (agent_versions.isLatest=true). Defaults TRUE so existing
+ * self-host behavior is unchanged: publishing/syncing a release immediately
+ * becomes the upgrade target. Set AGENT_AUTO_PROMOTE=false to decouple
+ * registration from promotion — new binaries become downloadable but the fleet
+ * upgrade target only changes via the explicit POST /agent-versions/promote
+ * endpoint. See docs/superpowers/specs/2026-06-23-controlled-agent-fleet-rollout.md.
+ */
+export function getAgentAutoPromote(): boolean {
+  const raw = process.env.AGENT_AUTO_PROMOTE?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return true; // default: preserve current behavior
+  return !['false', '0', 'no', 'off'].includes(raw);
+}
+
 export function getGithubReleaseVersion(): string {
   return process.env.BINARY_VERSION || process.env.BREEZE_VERSION || 'latest';
 }

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -623,6 +623,146 @@ describe("binarySync", () => {
     });
   });
 
+  // Controlled fleet rollout (AGENT_AUTO_PROMOTE). Default (unset/true) keeps
+  // sync == instant fleet upgrade target. When false, binarySync registers the
+  // binary but never touches isLatest — the demote UPDATE is skipped, the
+  // insert uses isLatest:false, and the conflict `set` omits isLatest.
+  describe("AGENT_AUTO_PROMOTE controlled rollout", () => {
+    it("local-binary path: AGENT_AUTO_PROMOTE=false registers isLatest:false and does NOT demote", async () => {
+      process.env.BINARY_SOURCE = "local";
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      process.env.AGENT_AUTO_PROMOTE = "false";
+      delete process.env.BREEZE_VERSION;
+
+      fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
+      fsMocks.readFile.mockResolvedValue("0.70.0" as any);
+
+      await syncBinaries();
+
+      // No demote: the tx.update (demote existing isLatest) must NOT run.
+      expect(dbMocks.txUpdate).not.toHaveBeenCalled();
+
+      // Insert registers the row with isLatest:false.
+      const insertCalls = dbMocks.insertValues.mock.calls.map(
+        (call: any[]) => call[0] as Record<string, unknown>,
+      );
+      expect(insertCalls.length).toBeGreaterThan(0);
+      for (const values of insertCalls) {
+        expect(values.isLatest).toBe(false);
+      }
+
+      // Conflict set OMITS isLatest entirely so re-sync never changes target.
+      const conflictSets = dbMocks.onConflictDoUpdate.mock.calls.map(
+        (call: any[]) => (call[0] as { set: Record<string, unknown> }).set,
+      );
+      expect(conflictSets.length).toBeGreaterThan(0);
+      for (const set of conflictSets) {
+        expect("isLatest" in set).toBe(false);
+        // Still updates the registration fields.
+        expect(set.checksum).toEqual(expect.any(String));
+        expect(set.downloadUrl).toEqual(expect.any(String));
+      }
+    });
+
+    it("local-binary path: default (AGENT_AUTO_PROMOTE unset) promotes — demotes + isLatest:true (unchanged)", async () => {
+      process.env.BINARY_SOURCE = "local";
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.AGENT_AUTO_PROMOTE;
+      delete process.env.BREEZE_VERSION;
+
+      fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
+      fsMocks.readFile.mockResolvedValue("0.70.0" as any);
+
+      await syncBinaries();
+
+      // Demote ran.
+      expect(dbMocks.txUpdate).toHaveBeenCalled();
+      expect(dbMocks.updateSet).toHaveBeenCalledWith({ isLatest: false });
+
+      const insertCalls = dbMocks.insertValues.mock.calls.map(
+        (call: any[]) => call[0] as Record<string, unknown>,
+      );
+      for (const values of insertCalls) {
+        expect(values.isLatest).toBe(true);
+      }
+      const conflictSets = dbMocks.onConflictDoUpdate.mock.calls.map(
+        (call: any[]) => (call[0] as { set: Record<string, unknown> }).set,
+      );
+      for (const set of conflictSets) {
+        expect(set.isLatest).toBe(true);
+      }
+    });
+
+    it("GitHub path: AGENT_AUTO_PROMOTE=false registers isLatest:false and does NOT demote", async () => {
+      process.env.AGENT_AUTO_PROMOTE = "false";
+      const assetName = "breeze-agent-linux-amd64";
+      const asset = Buffer.from("trusted linux agent");
+      const signed = makeSignedReleaseManifest(assetName, asset);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url.includes("/releases/latest")) {
+            return new Response(
+              JSON.stringify({
+                tag_name: "v1.2.3",
+                body: "release notes",
+                assets: [
+                  {
+                    name: assetName,
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/v1.2.3/${assetName}`,
+                    size: asset.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json",
+                    browser_download_url:
+                      "https://github.com/LanternOps/breeze/releases/download/v1.2.3/release-artifact-manifest.json",
+                    size: signed.manifest.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json.ed25519",
+                    browser_download_url:
+                      "https://github.com/LanternOps/breeze/releases/download/v1.2.3/release-artifact-manifest.json.ed25519",
+                    size: signed.signature.length,
+                  },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith("/release-artifact-manifest.json"))
+            return new Response(signed.manifest);
+          if (url.endsWith("/release-artifact-manifest.json.ed25519"))
+            return new Response(signed.signature);
+          return new Response("not found", { status: 404 });
+        }),
+      );
+
+      const result = await syncFromGitHub();
+
+      // Still synced/registered.
+      expect(result.synced).toContain("agent:linux/amd64");
+      // No demote UPDATE.
+      expect(dbMocks.txUpdate).not.toHaveBeenCalled();
+      // Insert with isLatest:false.
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          version: "1.2.3",
+          component: "agent",
+          isLatest: false,
+        }),
+      );
+      // Conflict set omits isLatest but keeps registration fields.
+      const set = (dbMocks.onConflictDoUpdate.mock.calls[0]![0] as any).set;
+      expect("isLatest" in set).toBe(false);
+      expect(set.checksum).toBe(signed.checksum);
+    });
+  });
+
   it("upserts local agent binaries with the full 4-column conflict target (regression: #617)", async () => {
     // The agent_versions table has a UNIQUE constraint on
     // (version, platform, architecture, component). The local-binary path used

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -7,7 +7,7 @@ import { eq, and } from "drizzle-orm";
 import { db } from "../db";
 import { agentVersions } from "../db/schema";
 import { isS3Configured, syncDirectory } from "./s3Storage";
-import { getBinarySource } from "./binarySource";
+import { getBinarySource, getAgentAutoPromote } from "./binarySource";
 import {
   isReleaseArtifactManifestVerificationConfigured,
   verifyReleaseArtifactManifestAsset,
@@ -356,6 +356,13 @@ export async function syncBinaries(): Promise<void> {
     // across the loop. See docs/deploy/agent-update-trust-bootstrap.md.
     const { keyId } = await ensureActiveSigningKey();
 
+    // Controlled fleet rollout (AGENT_AUTO_PROMOTE=false): register the binary
+    // but never promote it to the fleet upgrade target. We skip the demote
+    // UPDATE, insert with isLatest:false, and OMIT isLatest from the conflict
+    // `set` so re-registering an already-promoted version never demotes it.
+    // When auto-promote is on (default) behavior is byte-for-byte unchanged.
+    const autoPromote = getAgentAutoPromote();
+
     await db.transaction(async (tx) => {
       for (const bin of binaries) {
         const osParam = bin.platform === "macos" ? "darwin" : bin.platform;
@@ -374,18 +381,22 @@ export async function syncBinaries(): Promise<void> {
         const manifestSignature = await signManifest(releaseManifest);
 
         // Demote existing "isLatest" entries for this platform/arch
-        await tx
-          .update(agentVersions)
-          .set({ isLatest: false })
-          .where(
-            and(
-              eq(agentVersions.platform, bin.platform),
-              eq(agentVersions.architecture, bin.architecture),
-              eq(agentVersions.isLatest, true),
-            ),
-          );
+        if (autoPromote) {
+          await tx
+            .update(agentVersions)
+            .set({ isLatest: false })
+            .where(
+              and(
+                eq(agentVersions.platform, bin.platform),
+                eq(agentVersions.architecture, bin.architecture),
+                eq(agentVersions.isLatest, true),
+              ),
+            );
+        }
 
-        // Upsert the new version
+        // Upsert the new version. The conflict `set` deliberately omits
+        // isLatest when auto-promote is off so re-syncing the binary updates
+        // its URL/checksum/manifest without ever changing the promotion state.
         await tx
           .insert(agentVersions)
           .values({
@@ -395,7 +406,7 @@ export async function syncBinaries(): Promise<void> {
             downloadUrl,
             checksum: bin.checksum,
             fileSize: bin.fileSize,
-            isLatest: true,
+            isLatest: autoPromote,
             releaseManifest,
             manifestSignature,
             signingKeyId: keyId,
@@ -414,10 +425,10 @@ export async function syncBinaries(): Promise<void> {
               downloadUrl,
               checksum: bin.checksum,
               fileSize: bin.fileSize,
-              isLatest: true,
               releaseManifest,
               manifestSignature,
               signingKeyId: keyId,
+              ...(autoPromote ? { isLatest: true } : {}),
             },
           });
       }
@@ -754,18 +765,25 @@ async function upsertVersion(
   },
   releaseNotes?: string | null,
 ) {
+  // Controlled fleet rollout (AGENT_AUTO_PROMOTE=false): register but do not
+  // promote. Skip the demote UPDATE, insert isLatest:false, and OMIT isLatest
+  // from the conflict `set` so an existing promoted row keeps its target.
+  // When auto-promote is on (default) behavior is byte-for-byte unchanged.
+  const autoPromote = getAgentAutoPromote();
   await db.transaction(async (tx) => {
-    await tx
-      .update(agentVersions)
-      .set({ isLatest: false })
-      .where(
-        and(
-          eq(agentVersions.platform, platform),
-          eq(agentVersions.architecture, arch),
-          eq(agentVersions.component, component),
-          eq(agentVersions.isLatest, true),
-        ),
-      );
+    if (autoPromote) {
+      await tx
+        .update(agentVersions)
+        .set({ isLatest: false })
+        .where(
+          and(
+            eq(agentVersions.platform, platform),
+            eq(agentVersions.architecture, arch),
+            eq(agentVersions.component, component),
+            eq(agentVersions.isLatest, true),
+          ),
+        );
+    }
 
     await tx
       .insert(agentVersions)
@@ -780,7 +798,7 @@ async function upsertVersion(
         signingKeyId: metadata.signingKeyId,
         fileSize: BigInt(metadata.size),
         releaseNotes: releaseNotes ?? null,
-        isLatest: true,
+        isLatest: autoPromote,
         component,
       })
       .onConflictDoUpdate({
@@ -798,7 +816,7 @@ async function upsertVersion(
           signingKeyId: metadata.signingKeyId,
           fileSize: BigInt(metadata.size),
           releaseNotes: releaseNotes ?? null,
-          isLatest: true,
+          ...(autoPromote ? { isLatest: true } : {}),
         },
       });
   });

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -90,6 +90,13 @@ MFA_RECOVERY_CODE_PEPPER=
 # embedded in the agent and CI); leave it as-is unless you sign your own binaries.
 RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
 
+# Controlled agent-fleet rollout. Default true: registering/syncing a release
+# immediately becomes the fleet upgrade target. Set false to require an explicit
+# platform-admin POST /api/v1/agent-versions/promote before the fleet moves to a
+# new version (registration still makes binaries downloadable). Recommended for
+# hosted deploys that want a verify-then-promote runbook step.
+# AGENT_AUTO_PROMOTE=true
+
 # Kill-switches for the launch-readiness MFA and lockout features.
 # Defaults are secure (gate ON, lockout 5-in-15min). Operators can flip
 # either off without a code deploy if an enrollment outage or stuck-out

--- a/docs/superpowers/specs/2026-06-23-controlled-agent-fleet-rollout.md
+++ b/docs/superpowers/specs/2026-06-23-controlled-agent-fleet-rollout.md
@@ -1,0 +1,81 @@
+# Controlled Agent Fleet Rollout
+
+**Date:** 2026-06-23
+**Status:** Implemented
+**Branch:** `feat/controlled-agent-fleet-rollout`
+
+## Problem
+
+`apps/api/src/services/binarySync.ts` (both the local-binary path and the GitHub
+path, the demote+upsert block) unconditionally demotes the current
+`agent_versions.isLatest` rows and promotes the newest version to
+`isLatest=true`. `apps/api/src/routes/agents/heartbeat.ts` then offers every
+agent `upgradeTo=<isLatest>`. So publishing a release = instant uncontrolled
+fleet update. Fix: make promotion explicit.
+
+## Design
+
+### 1. Config flag `AGENT_AUTO_PROMOTE`
+
+Boolean, **default TRUE** (preserves current self-host behavior).
+
+- Validation/parsing in `apps/api/src/config/validate.ts` next to
+  `BINARY_SOURCE`/`IS_HOSTED` (boolean-format check in all environments so a
+  typo is caught at boot rather than silently parsing to a surprising default).
+- Runtime getter `getAgentAutoPromote(): boolean` in
+  `apps/api/src/services/binarySource.ts` next to `getBinarySource()`, reading
+  the env, default true.
+
+### 2. binarySync — gate promotion, never registration
+
+In BOTH the local-binary path and the GitHub path (`upsertVersion`):
+
+- When `getAgentAutoPromote() === true`: behavior UNCHANGED (byte-for-byte
+  equivalent to today — demote old `isLatest`, upsert with `isLatest:true`).
+- When false: do NOT run the "demote existing isLatest" UPDATE; upsert the
+  binary with `isLatest:false`; in the `onConflictDoUpdate.set`, update
+  downloadUrl/checksum/fileSize/manifest fields but OMIT `isLatest` entirely
+  (never touch it). Net: new binaries downloadable, current target unchanged
+  until explicit promote.
+
+### 3. Promote endpoint
+
+`apps/api/src/routes/agentVersions.ts`, platform-admin-only (reuse
+`apps/api/src/middleware/platformAdmin.ts`).
+
+- `POST /api/v1/agent-versions/promote` body
+  `{ version: string, component?: 'agent'|'helper'|'user-helper'|'watchdog'|'viewer' }`.
+  Omitting `component` promotes ALL components of that version.
+- Single transaction: per affected (component, platform, architecture), demote
+  current `isLatest=true` rows, then set `isLatest=true` for the target
+  version's rows. 404 if the version has no registered rows (for the requested
+  component). Audit-logged (`agent_version.promote`, resourceName=version,
+  details=components/counts/prior demoted target). Returns promoted rows + the
+  prior demoted target.
+- `GET /api/v1/agent-versions` — platform-admin list of registered versions and
+  which is currently promoted per component/platform/arch.
+
+### 4. Heartbeat / org agent-update policy
+
+Unchanged. Heartbeat continues to offer `upgradeTo` based on `isLatest=true`;
+gating an un-promoted version is achieved purely by NOT setting `isLatest` on it.
+
+### 5. Migration
+
+None — `is_latest` already exists on `agent_versions`.
+
+## Ops note
+
+To enable controlled rollout on the EU + US droplets:
+
+1. Set `AGENT_AUTO_PROMOTE=false` in `/opt/breeze/.env`.
+2. Map it explicitly in the `api` service `environment:` block of
+   `/opt/breeze/docker-compose.yml` (compose interpolation only happens for
+   listed vars — value in `.env` is necessary but not sufficient).
+3. New runbook step: after a release is registered (binarySync / `sync-github`),
+   verify the new version on a canary, then **promote** it with
+   `POST /api/v1/agent-versions/promote { "version": "<x.y.z>" }` (platform
+   admin). Until promoted, the fleet stays on the prior target.
+
+Leaving `AGENT_AUTO_PROMOTE` unset/true preserves today's behavior (sync =
+instant fleet upgrade target), so self-host deploys are unaffected.


### PR DESCRIPTION
## Problem

`binarySync.ts` (local-binary path and GitHub `upsertVersion`) unconditionally demotes the current `agent_versions.isLatest` rows and promotes the newest version. `heartbeat.ts` then offers every agent `upgradeTo=<isLatest>`. So publishing a release = instant uncontrolled fleet update.

## Fix — make promotion explicit

**1. Config flag `AGENT_AUTO_PROMOTE` (default TRUE — preserves current self-host behavior)**
- `apps/api/src/config/validate.ts`: registered next to `BINARY_SOURCE`/`IS_HOSTED` + boolean-format check (all envs) so a typo fails at boot.
- `apps/api/src/services/binarySource.ts`: `getAgentAutoPromote()` runtime getter, default true.

**2. binarySync — gate promotion, never registration** (both local-binary path and GitHub `upsertVersion`)
- `true` (default): behavior **byte-for-byte unchanged** — demote old `isLatest`, upsert `isLatest:true`.
- `false`: skip the demote UPDATE, insert `isLatest:false`, and **omit `isLatest` from the `onConflictDoUpdate.set`** (re-sync updates url/checksum/manifest but never touches the target).

**3. Promote endpoint** — `apps/api/src/routes/agentVersions.ts`, platform-admin-only (reuses `platformAdmin.ts`)
- `POST /api/v1/agent-versions/promote { version, component? }` — omitting `component` promotes all components. Single transaction: per (component, platform, arch) demote current `isLatest=true` then promote target rows. 404 on unknown version. Audit-logged `agent_version.promote`. Returns promoted rows + prior demoted target.
- `GET /api/v1/agent-versions` — platform-admin list + currently-promoted set.

**4. Heartbeat & org update policy:** unchanged. Gating is achieved purely by not setting `isLatest` on an un-promoted version.

**5. Migration:** none (`is_latest` already exists).

## Tests (84 pass across the 3 touched files)
- binarySync: `AGENT_AUTO_PROMOTE=false` registers `isLatest:false` and does NOT demote (local + GitHub); default path still promotes.
- promote endpoint: non-admin → 403; atomic demote+promote for all components and a single component; 404 unknown version; audit row written.
- heartbeat: offers `upgradeTo` for the promoted version, NOT for a merely-registered un-promoted newer version.

## Validation
- `pnpm exec tsc --noEmit -p apps/api/tsconfig.json` — clean.
- binarySync (12), agentVersions (32), heartbeat (40) — all green. config validate/env (138) unaffected.

## Ops note
To enable controlled rollout on the EU + US droplets:
1. `AGENT_AUTO_PROMOTE=false` in `/opt/breeze/.env`.
2. Map it in the `api` service `environment:` block of `/opt/breeze/docker-compose.yml` (compose interpolation only happens for listed vars).
3. Runbook: after a release is registered, verify on a canary, then `POST /api/v1/agent-versions/promote { "version": "x.y.z" }`. Until promoted, the fleet stays on the prior target.

Leaving the flag unset/true preserves today's behavior, so self-host deploys are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)