### PR TITLE
fix(web): orange dot for pending-reboot in device status column; "Upd"→"Updating"

### DIFF
--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -637,7 +637,7 @@ describe('DeviceList — pending reboot badge', () => {
     render(<DeviceList devices={[device]} />);
 
     const badge = screen.getByTestId(`device-${device.id}-pending-reboot-badge`);
-    expect(badge.textContent).toMatch(/Reboot pending/i);
+    expect(badge).toHaveAttribute('aria-label', 'Reboot pending');
   });
 
   it('renders no badge when pendingReboot is false or absent', () => {

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -183,7 +183,7 @@ const statusLabels: Record<DeviceStatus, string> = {
   maintenance: 'Maint',
   decommissioned: 'Decom',
   quarantined: 'Quar',
-  updating: 'Upd',
+  updating: 'Updating',
   pending: 'Pend'
 };
 const statusFullLabels: Record<DeviceStatus, string> = {
@@ -817,10 +817,10 @@ export default function DeviceList({
               <span
                 data-testid={`device-${device.id}-pending-reboot-badge`}
                 title="The OS reports a pending reboot (Windows registry / Linux reboot-required markers)."
-                className="inline-flex items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium bg-warning/15 text-warning border-warning/30"
-              >
-                Reboot pending
-              </span>
+                aria-label="Reboot pending"
+                role="img"
+                className="inline-block h-2 w-2 shrink-0 rounded-full bg-warning"
+              />
             )}
           </div>
         </td>


### PR DESCRIPTION
## What

Two small device-list UI tweaks:

1. **Pending-reboot indicator → orange dot.** In the `DeviceList` **status** column, the "Reboot pending" pill is replaced with a compact orange dot (`bg-warning`). The hover `title` tooltip is preserved, and `aria-label="Reboot pending"` + `role="img"` are added so the meaning stays exposed to screen readers (and tests) now that there's no visible text.
2. **"Upd" → "Updating".** The compact `updating` status label now reads `Updating`.

The standalone **"Pending Reboot" column** (separate from the status column) is intentionally left as a labeled pill.

## Tests

Updated the badge assertion to check `aria-label` instead of text content. `DeviceList.test.tsx` passes 39/39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)