### PR TITLE
fix(reliability): compute uptime from observed availability, not the current boot session

### DIFF
--- a/apps/api/src/__tests__/integration/reliabilityWeightProfile.integration.test.ts
+++ b/apps/api/src/__tests__/integration/reliabilityWeightProfile.integration.test.ts
@@ -41,9 +41,13 @@ async function insertDevice(
   return row.id;
 }
 
-// Seed a single low-uptime history snapshot: the device was up only ~50% of the
-// last reporting interval, with no crashes/hangs/service/hardware faults — i.e.
-// a "clean but normally-rebooting" device whose only weak factor is uptime.
+// Seed a single low-uptime history snapshot, with no crashes/hangs/service/
+// hardware faults — i.e. a "clean" device whose only weak factor is uptime.
+// Uptime is now real availability (observed up-days / window): a device enrolled
+// 120 days ago with just ONE day of reliability history is treated as offline
+// for the other ~90 days, so availability is a few percent and the uptime factor
+// scores 0. That is what isolates the device-type weighting in the assertions
+// below (the uptime factor matters for the infra profile, not the workstation).
 async function insertLowUptimeHistory(orgId: string, deviceId: string): Promise<void> {
   const collectedAt = new Date(Date.now() - 1 * DAY_MS);
   await getTestDb()
@@ -52,7 +56,6 @@ async function insertLowUptimeHistory(orgId: string, deviceId: string): Promise<
       orgId,
       deviceId,
       collectedAt,
-      // Up for 12h out of a 24h window -> drags the uptime factor toward 0.
       uptimeSeconds: 12 * 3600,
       bootTime: new Date(collectedAt.getTime() - 12 * 3600 * 1000),
     });

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -92,17 +92,19 @@ describe('reliabilityScoringInternals', () => {
     expect(trend.confidence).toBeGreaterThan(0);
   });
 
-  it('computes MTBF from aggregated failures and uptime window', () => {
+  it('computes MTBF from aggregated failures and observed up-days', () => {
     const now = new Date('2026-02-21T00:00:00.000Z');
-    const latest = {
-      collectedAt: now,
-      uptimeSeconds: 90 * 24 * 3600,
-      bootTime: new Date('2025-11-23T00:00:00.000Z'),
-    };
+    // 90 observed up-days (operating hours = 90*24 = 2160) and 9 failures → 240h.
     const buckets = [makeBucket({ date: '2026-02-20', crashCount: 9 })] as any[];
 
-    const mtbfHours = reliabilityScoringInternals.computeMtbfHours(buckets, latest as any, now);
+    const mtbfHours = reliabilityScoringInternals.computeMtbfHours(buckets, 90, now);
     expect(mtbfHours).toBe(240);
+  });
+
+  it('returns null MTBF when there are no observed up-days', () => {
+    const now = new Date('2026-02-21T00:00:00.000Z');
+    const buckets = [makeBucket({ date: '2026-02-20', crashCount: 9 })] as any[];
+    expect(reliabilityScoringInternals.computeMtbfHours(buckets, 0, now)).toBeNull();
   });
 
   it('parses stored aggregate state and prunes out-of-window buckets', () => {
@@ -137,6 +139,7 @@ describe('computeUptimePercent', () => {
   const { computeUptimePercent } = reliabilityScoringInternals;
   const now = new Date('2026-02-20T00:00:00.000Z');
   const DAY = 24 * 60 * 60;
+  const NONE = new Set<string>(); // no observed-online days (no reliability buckets)
 
   function makeLatest(uptimeSeconds: number, bootOffsetSeconds: number) {
     return {
@@ -147,56 +150,82 @@ describe('computeUptimePercent', () => {
     };
   }
 
+  // Day-keys (UTC) for the `now - n*DAY` calendar days, used to build the
+  // "observed online" set for the established-device cases.
+  function dayKeyOffset(daysAgo: number): string {
+    return new Date(now.getTime() - daysAgo * DAY * 1000).toISOString().slice(0, 10);
+  }
+
   it('returns 100 with no history snapshot', () => {
-    expect(computeUptimePercent(null, 90, now)).toBe(100);
-    expect(computeUptimePercent(null, 90, now, new Date(now.getTime() - 2 * DAY * 1000))).toBe(100);
+    expect(computeUptimePercent(null, NONE, 90, now)).toBe(100);
+    expect(computeUptimePercent(null, NONE, 90, now, new Date(now.getTime() - 2 * DAY * 1000))).toBe(100);
   });
 
   it('penalizes a young device against the full window when enrollment is ignored', () => {
-    // Device enrolled 2 days ago, up its whole life, but no enrollment clamp:
-    // 2 days of uptime against a 90-day denominator ≈ 2.2%.
+    // Device booted 2 days ago, no observed history, no enrollment clamp: only
+    // the 3 calendar days covered by the current boot span count as up, against
+    // a 91-day window ≈ 3.3%.
     const latest = makeLatest(2 * DAY, 2 * DAY);
-    expect(computeUptimePercent(latest, 90, now)).toBeCloseTo((2 / 90) * 100, 1);
+    expect(computeUptimePercent(latest, NONE, 90, now)).toBeCloseTo((3 / 91) * 100, 1);
   });
 
   it('clamps the window to enrollment so a 2-day-old all-up device scores 100%', () => {
     // Enrolled 2 days ago, booted at enrollment, up the whole time → 100%.
     const enrolledAt = new Date(now.getTime() - 2 * DAY * 1000);
     const latest = makeLatest(2 * DAY, 2 * DAY);
-    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(100);
-    expect(computeUptimePercent(latest, 30, now, enrolledAt)).toBe(100);
+    expect(computeUptimePercent(latest, NONE, 90, now, enrolledAt)).toBe(100);
+    expect(computeUptimePercent(latest, NONE, 30, now, enrolledAt)).toBe(100);
   });
 
-  it('counts a reboot within a young device lifetime as partial downtime', () => {
-    // Enrolled 4 days ago but only up 2 days (rebooted 2 days ago) →
-    // 2 days up over a 4-day clamped window = 50%.
+  it('counts unobserved days within a young device lifetime as downtime', () => {
+    // Enrolled 4 days ago, booted 2 days ago, and NO reliability samples for the
+    // 2 pre-reboot days → only the 3 boot-covered calendar days count as up over
+    // the 5-day clamped window = 60%. (Had it been reporting those days, they'd
+    // be in `observedDays` and it would score ~100 — see the reboot case below.)
     const enrolledAt = new Date(now.getTime() - 4 * DAY * 1000);
     const latest = makeLatest(2 * DAY, 2 * DAY);
-    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(50);
+    expect(computeUptimePercent(latest, NONE, 90, now, enrolledAt)).toBe(60);
   });
 
-  it('leaves an old device (older than the window) unchanged', () => {
-    // Enrolled 200 days ago — older than the 90-day window. Continuously up
-    // for the full window → 100% either way; enrollment clamp is a no-op.
+  it('does NOT crater uptime for an established device that merely rebooted (the core fix)', () => {
+    // Enrolled 200 days ago, reported reliability every day for the last 90 days,
+    // but rebooted 5 days ago (current boot span only covers ~5 days). Under the
+    // old boot-snapshot model this scored ~5/90 ≈ 5.6%. With day-coverage, every
+    // day has an observed sample, so it is ~100%.
+    const enrolledAt = new Date(now.getTime() - 200 * DAY * 1000);
+    const latest = makeLatest(5 * DAY, 5 * DAY); // booted 5 days ago
+    const observed = new Set<string>();
+    for (let d = 0; d <= 90; d += 1) observed.add(dayKeyOffset(d));
+    expect(computeUptimePercent(latest, observed, 90, now, enrolledAt)).toBe(100);
+  });
+
+  it('reflects real offline gaps for an established device', () => {
+    // Enrolled long ago, booted 5 days ago, but only reported on 81 of the 91
+    // window days (offline ~10 days) → ~81 up-days + the boot span, ≈ 89%.
+    const enrolledAt = new Date(now.getTime() - 200 * DAY * 1000);
+    const latest = makeLatest(5 * DAY, 5 * DAY);
+    const observed = new Set<string>();
+    // Report days 5..90 (86 days), leaving days 0..4 to the boot span; drop 10
+    // older days (days 81..90 absent) to simulate an offline stretch.
+    for (let d = 5; d <= 80; d += 1) observed.add(dayKeyOffset(d));
+    const pct = computeUptimePercent(latest, observed, 90, now, enrolledAt);
+    expect(pct).toBeGreaterThan(85);
+    expect(pct).toBeLessThan(95);
+  });
+
+  it('leaves an old continuously-up device at 100', () => {
+    // Enrolled 200 days ago, booted 120 days ago, up continuously → boot span
+    // covers the whole window → 100% with or without observed buckets.
     const enrolledAt = new Date(now.getTime() - 200 * DAY * 1000);
     const latest = makeLatest(120 * DAY, 120 * DAY);
-    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(computeUptimePercent(latest, 90, now));
-    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(100);
-  });
-
-  it('is a no-op when enrollment falls exactly on the window start (boundary)', () => {
-    // enrolledAt === now - windowDays: the clamp Math.max picks fixedStartSeconds,
-    // so the denominator stays the full window — identical to the no-enrollment call.
-    const enrolledAt = new Date(now.getTime() - 90 * DAY * 1000);
-    const latest = makeLatest(120 * DAY, 120 * DAY);
-    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(computeUptimePercent(latest, 90, now));
-    expect(computeUptimePercent(latest, 90, now, enrolledAt)).toBe(100);
+    expect(computeUptimePercent(latest, NONE, 90, now, enrolledAt)).toBe(computeUptimePercent(latest, NONE, 90, now));
+    expect(computeUptimePercent(latest, NONE, 90, now, enrolledAt)).toBe(100);
   });
 
   it('returns 100 when enrollment is at or after now (zero-length window)', () => {
     const latest = makeLatest(0, 0);
-    expect(computeUptimePercent(latest, 90, now, now)).toBe(100);
-    expect(computeUptimePercent(latest, 90, now, new Date(now.getTime() + DAY * 1000))).toBe(100);
+    expect(computeUptimePercent(latest, NONE, 90, now, now)).toBe(100);
+    expect(computeUptimePercent(latest, NONE, 90, now, new Date(now.getTime() + DAY * 1000))).toBe(100);
   });
 });
 
@@ -213,11 +242,14 @@ describe('scoreHangs', () => {
   const { scoreHangs } = reliabilityScoringInternals;
 
   it('returns 100 with no hangs', () => expect(scoreHangs(0, 0)).toBe(100));
-  it('unresolved hangs carry 2x penalty vs resolved', () => {
+  it('unresolved hangs carry 2x penalty vs resolved (no double-count)', () => {
+    // A resolved hang costs 10 (→90); an unresolved hang costs 10 + 10 = 20
+    // (→80), NOT 30. `unresolvedHangCount` is a subset of `hangCount`, so it adds
+    // a single extra 10 rather than being penalised twice.
     const oneResolved = scoreHangs(1, 0);
     const oneUnresolved = scoreHangs(1, 1);
     expect(oneResolved).toBe(90);
-    expect(oneUnresolved).toBe(70);
+    expect(oneUnresolved).toBe(80);
   });
   it('clamps to 0', () => expect(scoreHangs(20, 20)).toBe(0));
 });

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -273,35 +273,76 @@ function maxTimestamp(values: Array<string | undefined>): string | undefined {
   return raw;
 }
 
+// The set of UTC day-keys on which the device was observed online — any day
+// with at least one reliability-history sample. A reboot is an intra-day event,
+// so the day's bucket still exists; this is what lets a routine reboot stop
+// erasing days the device was clearly up.
+function observedUpDayKeys(dailyBuckets: DailyAggregateBucket[]): Set<string> {
+  const days = new Set<string>();
+  for (const bucket of dailyBuckets) {
+    if (bucket.sampleCount > 0) days.add(bucket.date);
+  }
+  return days;
+}
+
+// Uptime is real availability over the (enrollment-clamped) window: the fraction
+// of calendar days the device was up. A day counts as "up" when EITHER we
+// observed a reliability sample that day (the device reported, so it was online)
+// OR the day falls inside the current continuous boot span [bootTime, now].
+//
+// This replaces the old single-boot-snapshot model, where uptime% was
+// (now - bootTime) / window. That treated every day before the latest boot as
+// downtime, so a single reboot N days ago collapsed a 90-day uptime to ~N/90
+// even for a device that had been online and reporting the whole time — a
+// routine reboot cratered the score of an otherwise-reliable established device.
+//
+// The enrollment clamp (#1738) is preserved: a device cannot be "up" before it
+// existed, so the window start is clamped forward to `enrolledAt`. If enrolledAt
+// is missing we fall back to the fixed window start (unclamped, pre-#1738).
+function computeUptimeAvailability(
+  latest: LatestHistorySnapshot | null,
+  observedDays: Set<string>,
+  windowDays: number,
+  now: Date,
+  enrolledAt?: Date | null
+): { percent: number; upDays: number; expectedDays: number } {
+  if (!latest && observedDays.size === 0) return { percent: 100, upDays: 0, expectedDays: 0 };
+
+  const fixedStartMs = now.getTime() - windowDays * DAY_MS;
+  const enrolledMs = enrolledAt ? enrolledAt.getTime() : fixedStartMs;
+  const windowStartMs = Math.max(fixedStartMs, enrolledMs);
+  const startKey = toDayKey(new Date(windowStartMs));
+  const nowKey = toDayKey(now);
+  // Zero/negative window (enrolled at or after now) → nothing to measure.
+  if (startKey > nowKey) return { percent: 100, upDays: 0, expectedDays: 0 };
+
+  const bootKey = latest ? toDayKey(latest.bootTime) : null;
+  let expectedDays = 0;
+  let upDays = 0;
+  // Walk one UTC calendar day at a time from the clamped window start to now.
+  for (let ms = windowStartMs; toDayKey(new Date(ms)) <= nowKey; ms += DAY_MS) {
+    const key = toDayKey(new Date(ms));
+    if (key < startKey) continue;
+    expectedDays += 1;
+    const coveredByCurrentBoot = bootKey !== null && key >= bootKey;
+    if (observedDays.has(key) || coveredByCurrentBoot) upDays += 1;
+  }
+  if (expectedDays <= 0) return { percent: 100, upDays: 0, expectedDays: 0 };
+  return {
+    percent: round2(Math.min(100, (upDays / expectedDays) * 100)),
+    upDays,
+    expectedDays,
+  };
+}
+
 function computeUptimePercent(
   latest: LatestHistorySnapshot | null,
+  observedDays: Set<string>,
   windowDays: number,
   now: Date,
   enrolledAt?: Date | null
 ): number {
-  if (!latest) return 100;
-  const fullWindowSeconds = windowDays * 24 * 60 * 60;
-  const nowSeconds = Math.floor(now.getTime() / 1000);
-  // The measurement window starts at `now - windowDays`, but a device cannot be
-  // "up" before it was enrolled, so clamp the window start forward to the
-  // enrollment timestamp. This keeps pre-existence time out of the denominator
-  // (#1738) — a device enrolled 2 days ago is measured over ~2 days, not 90.
-  const fixedStartSeconds = nowSeconds - fullWindowSeconds;
-  // `devices.enrolledAt` is NOT NULL (defaults to now()), so in practice it is
-  // always supplied. If it is ever missing we deliberately fall back to the
-  // fixed window start, i.e. the unclamped pre-#1738 behavior, rather than
-  // guess an enrollment time.
-  const enrolledSeconds = enrolledAt ? Math.floor(enrolledAt.getTime() / 1000) : fixedStartSeconds;
-  const windowStartSeconds = Math.max(fixedStartSeconds, enrolledSeconds);
-  // Denominator is the length of the (possibly shortened) measurement window.
-  // Guard against a zero/negative window (enrolledAt at or after now).
-  const windowSeconds = Math.min(fullWindowSeconds, Math.max(0, nowSeconds - windowStartSeconds));
-  if (windowSeconds <= 0) return 100;
-  const bootSeconds = Math.floor(latest.bootTime.getTime() / 1000);
-  const uptimeStart = Math.max(windowStartSeconds, bootSeconds);
-  const uptimeSecondsFromBoot = Math.max(0, nowSeconds - uptimeStart);
-  const boundedUptimeSeconds = Math.min(windowSeconds, Math.min(uptimeSecondsFromBoot, Math.max(0, latest.uptimeSeconds)));
-  return round2((boundedUptimeSeconds / windowSeconds) * 100);
+  return computeUptimeAvailability(latest, observedDays, windowDays, now, enrolledAt).percent;
 }
 
 function scoreUptime(uptimePercent: number): number {
@@ -316,7 +357,12 @@ function scoreCrashes(crashCount7d: number, crashCount30d: number): number {
 }
 
 function scoreHangs(hangCount30d: number, unresolvedHangCount30d: number): number {
-  return clampScore(100 - hangCount30d * 10 - unresolvedHangCount30d * 20);
+  // Every hang costs 10; unresolved hangs cost an extra 10 on top (20 total).
+  // `unresolvedHangCount30d` is a subset of `hangCount30d`, so the extra penalty
+  // is +10, NOT +20 — the old *20 here double-counted unresolved hangs against
+  // the base *10 (30 each) and disagreed with `scoreDailyBucket`'s per-day
+  // weighting (10 each). This aligns the two.
+  return clampScore(100 - hangCount30d * 10 - unresolvedHangCount30d * 10);
 }
 
 function scoreServiceFailures(serviceFailureCount30d: number, recoveredCount30d: number): number {
@@ -567,13 +613,19 @@ function sumBucketsInWindow(
 }
 
 function scoreDailyBucket(bucket: DailyAggregateBucket): number {
+  // Per-day score used only to compute the trend slope. Penalty weights are kept
+  // in lockstep with the headline factor scorers (scoreCrashes/scoreHangs/
+  // scoreServiceFailures/scoreHardwareErrors) so the trend reflects the same
+  // notion of "bad day" as the score itself. Service-failure/recovery were 12/+4
+  // here vs 15/+5 in scoreServiceFailures — aligned to 15/+5. Uptime is
+  // intentionally absent: it is not a per-day-bucket quantity.
   return clampScore(
     100
     - bucket.crashCount * 20
     - bucket.hangCount * 10
     - bucket.unresolvedHangCount * 10
-    - bucket.serviceFailureCount * 12
-    + bucket.recoveredServiceCount * 4
+    - bucket.serviceFailureCount * 15
+    + bucket.recoveredServiceCount * 5
     - bucket.hardwareCriticalCount * 30
     - bucket.hardwareErrorSeverityCount * 15
     - bucket.hardwareWarningCount * 5
@@ -628,8 +680,7 @@ function computeTrend(dailyBuckets: DailyAggregateBucket[], now: Date): { direct
   };
 }
 
-function computeMtbfHours(dailyBuckets: DailyAggregateBucket[], latest: LatestHistorySnapshot | null, now: Date): number | null {
-  if (!latest) return null;
+function computeMtbfHours(dailyBuckets: DailyAggregateBucket[], upDays90: number, now: Date): number | null {
   const crashes90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.crashCount);
   const hangs90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.hangCount);
   const service90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.serviceFailureCount);
@@ -637,7 +688,11 @@ function computeMtbfHours(dailyBuckets: DailyAggregateBucket[], latest: LatestHi
   const failures = crashes90d + hangs90d + service90d + hardware90d;
   if (failures <= 0) return null;
 
-  const operatingHours = Math.min(90 * 24, Math.max(0, latest.uptimeSeconds) / 3600);
+  // Operating hours = the device's actual observed up-days in the 90-day window,
+  // not the current boot session's uptimeSeconds (which understated MTBF the
+  // same way the old uptime% did — a 5-day-uptime device with 90 days of history
+  // looked like it had only operated 5 days).
+  const operatingHours = Math.min(90 * 24, Math.max(0, upDays90) * 24);
   if (operatingHours <= 0) return null;
   return round2(operatingHours / failures);
 }
@@ -941,9 +996,11 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
   const dailyBuckets = sortDailyBuckets(dailyBucketMap);
 
   const enrolledAt = device.enrolledAt ?? null;
-  const uptime7d = computeUptimePercent(latest, 7, now, enrolledAt);
-  const uptime30d = computeUptimePercent(latest, 30, now, enrolledAt);
-  const uptime90d = computeUptimePercent(latest, 90, now, enrolledAt);
+  const observedDays = observedUpDayKeys(dailyBuckets);
+  const uptime7d = computeUptimePercent(latest, observedDays, 7, now, enrolledAt);
+  const uptime30d = computeUptimePercent(latest, observedDays, 30, now, enrolledAt);
+  const availability90d = computeUptimeAvailability(latest, observedDays, 90, now, enrolledAt);
+  const uptime90d = availability90d.percent;
 
   const crashCount7d = sumBucketsInWindow(dailyBuckets, 7, now, (bucket) => bucket.crashCount);
   const crashCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.crashCount);
@@ -987,7 +1044,7 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
   );
 
   const trend = computeTrend(dailyBuckets, now);
-  const mtbfHours = computeMtbfHours(dailyBuckets, latest, now);
+  const mtbfHours = computeMtbfHours(dailyBuckets, availability90d.upDays, now);
   const topIssues = computeTopIssues({
     dailyBuckets,
     now,
@@ -1532,6 +1589,8 @@ export const reliabilityScoringInternals = {
   computeTrend,
   computeMtbfHours,
   computeUptimePercent,
+  computeUptimeAvailability,
+  observedUpDayKeys,
   scoreUptime,
   scoreCrashes,
   scoreHangs,


### PR DESCRIPTION
**Problem:** The v0 reliability heuristic derived uptime% from a single boot snapshot — `(now − bootTime) / window` (`reliabilityScoring.ts` `computeUptimePercent`). It treated every day before the latest boot as downtime, so one routine reboot N days ago collapsed a 90-day uptime to ~N/90 even for a device online and reporting the whole time. A device up ~5 days (a post-update reboot) but enrolled >90 days ago reads `uptime90d = 5.6%`, which zeroes the 30%-weighted uptime factor and drags an otherwise-healthy server to **55 / "At risk"**. The screenshot numbers match this to the decimal (5.04d ÷ {7,30,90} = 71.9 / 16.8 / 5.6%). The #1738 enrollment clamp can't help (enrolledAt is old) and #1721's workstation profile only helps `role='workstation'`.

This is the original-design "Phase 1 v0" heuristic — fixing it keeps the at-risk ranking (and the label/evaluation foundation a future model will train on) trustworthy.

**Fix** (all in `apps/api/src/services/reliabilityScoring.ts`):
- **Uptime = real availability** over the enrollment-clamped window: the fraction of calendar days the device was up, where a day counts as up if a reliability sample was observed that day (device reported ⇒ online) **or** the day falls in the current boot span `[bootTime, now]`. A reboot is intra-day, so it no longer erases history. The #1738 clamp is preserved (a device can't be up before it existed).
- **MTBF** operating-hours derive from observed up-days, not the current boot's `uptimeSeconds` (same understatement: loki's "7h" was 17 faults ÷ 5 days instead of ÷ ~90).
- **`scoreHangs`** no longer double-counts unresolved hangs (`unresolvedHangCount` is a subset of `hangCount`; was 10+20=30 each, now 10+10=20) — matches `scoreDailyBucket`.
- **`scoreDailyBucket`** service-failure weights aligned to the headline scorer (12/+4 → 15/+5) so the trend reflects the same penalties as the score.

**Effect:** only ever *raises* unfairly-penalized scores — no new false "at-risk" flags. For a device reporting daily, the screenshot case goes ~55 → **~88 ("Good")**. A device with genuinely sparse history stays low, which is now correct (no evidence it was up).

**Tests:**
- `reliabilityScoring.test.ts`: updated for the day-coverage model + new regression — an established device that merely rebooted scores ~100 uptime instead of ~5.6%; offline gaps still reflected.
- `reliabilityWeightProfile.integration.test.ts`: premise still holds (sparse history ⇒ low availability ⇒ uptime factor 0 isolates the device-type weighting); stale comment corrected.
- 68 unit tests pass; `tsc --noEmit` clean.

**Out of scope (noted, not changed):** the steep 90→100% `scoreUptime` curve (now only bites genuinely-offline devices, which is correct) and the 1-day-inclusive window boundary (minor, consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)